### PR TITLE
feat(app): import legacy source manifests

### DIFF
--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1442,14 +1442,18 @@ mod tests {
             .upsert_source(&workspace, &source, 7)
             .await
             .expect("write source without manifest row");
-        tx.state_migrations()
-            .try_claim(WORKSPACE_CATALOG_CUTOVER_ID, 7)
-            .await
-            .expect("claim workspace cutover");
-        tx.state_migrations()
-            .try_claim(&source_catalog_import_id(&layout), 7)
-            .await
-            .expect("claim source import");
+        assert!(
+            tx.state_migrations()
+                .try_claim(WORKSPACE_CATALOG_CUTOVER_ID, 7)
+                .await
+                .expect("mark workspace cutover complete")
+        );
+        assert!(
+            tx.state_migrations()
+                .try_claim(&source_catalog_import_id(&layout), 7)
+                .await
+                .expect("mark source import complete")
+        );
         tx.commit().await.expect("commit source");
 
         run_state_migrations(&db, &config_store, &layout)
@@ -1493,14 +1497,18 @@ mod tests {
             .upsert_source(&workspace, &source, 7)
             .await
             .expect("write source without manifest row");
-        tx.state_migrations()
-            .try_claim(WORKSPACE_CATALOG_CUTOVER_ID, 7)
-            .await
-            .expect("claim workspace cutover");
-        tx.state_migrations()
-            .try_claim(&source_catalog_import_id(&layout), 7)
-            .await
-            .expect("claim source import");
+        assert!(
+            tx.state_migrations()
+                .try_claim(WORKSPACE_CATALOG_CUTOVER_ID, 7)
+                .await
+                .expect("mark workspace cutover complete")
+        );
+        assert!(
+            tx.state_migrations()
+                .try_claim(&source_catalog_import_id(&layout), 7)
+                .await
+                .expect("mark source import complete")
+        );
         tx.commit().await.expect("commit source");
 
         run_state_migrations(&db, &config_store, &layout)

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1,11 +1,15 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::ErrorKind;
 
 use sha2::{Digest as _, Sha256};
 
 use super::session::DbRepos;
 use super::{CoralDb, CoralTx, now_unix_nanos_i64};
 use crate::bootstrap::AppError;
-use crate::sources::model::InstalledSource;
+use crate::sources::SourceName;
+use crate::sources::catalog::validate_imported_manifest_database_persistence;
+use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::{WorkspaceName, WorkspaceRecord};
 
@@ -30,7 +34,9 @@ pub(crate) async fn run_state_migrations(
     layout: &AppStateLayout,
 ) -> Result<(), AppError> {
     cutover_legacy_workspace_catalog(db, config_store, layout).await?;
-    import_config_source_catalog(db, config_store, layout, now_unix_nanos_i64()?).await?;
+    let now_unix_nanos = now_unix_nanos_i64()?;
+    import_config_source_catalog(db, config_store, layout, now_unix_nanos).await?;
+    import_filesystem_source_manifests(db, layout, now_unix_nanos).await?;
     remove_legacy_task_jsonl(config_store, layout)?;
     Ok(())
 }
@@ -191,7 +197,8 @@ async fn import_config_source_catalog(
                 .map(move |source| (workspace.name.clone(), source))
         })
         .collect::<Vec<_>>();
-    let source_count = import_config_sources(&mut tx, &source_entries, now_unix_nanos).await?;
+    let source_count =
+        import_config_sources(&mut tx, layout, &source_entries, now_unix_nanos).await?;
     tx.commit().await?;
     clear_legacy_source_catalog_config(config_store, source_entries.len());
 
@@ -225,6 +232,7 @@ where
 
 async fn import_config_sources(
     session: &mut CoralTx<'_>,
+    layout: &AppStateLayout,
     entries: &[(WorkspaceName, InstalledSource)],
     now_unix_nanos: i64,
 ) -> Result<usize, AppError> {
@@ -246,10 +254,27 @@ async fn import_config_sources(
         {
             continue;
         }
+
+        let manifest_yaml = match source.origin {
+            SourceOrigin::Bundled => None,
+            SourceOrigin::Imported => {
+                read_optional_imported_manifest_file(layout, workspace_name, &source.name)?
+            }
+        };
+        if let Some(manifest_yaml) = manifest_yaml.as_deref() {
+            validate_imported_manifest_database_persistence(manifest_yaml, &source.variables)?;
+        }
+
         session
             .sources()
             .upsert_source(workspace_name, source, now_unix_nanos)
             .await?;
+        if let Some(manifest_yaml) = manifest_yaml {
+            session
+                .source_manifests()
+                .upsert(workspace_name, &source.name, &manifest_yaml, now_unix_nanos)
+                .await?;
+        }
         let imported = session
             .sources()
             .get_source(workspace_name, &source.name)
@@ -291,6 +316,130 @@ where
     )))
 }
 
+async fn import_filesystem_source_manifests(
+    db: &CoralDb,
+    layout: &AppStateLayout,
+    now_unix_nanos: i64,
+) -> Result<(), AppError> {
+    let mut session = db;
+    let workspaces = session.workspaces().list().await?;
+    for workspace in workspaces {
+        let workspace_name = WorkspaceName::parse(&workspace.id)?;
+        let sources = session
+            .sources()
+            .list_workspace_sources(&workspace_name)
+            .await?;
+        for source in sources
+            .into_iter()
+            .filter(|source| source.origin == SourceOrigin::Imported)
+        {
+            if session
+                .source_manifests()
+                .get(&workspace_name, &source.name)
+                .await?
+                .is_some()
+            {
+                continue;
+            }
+
+            let Some(manifest_yaml) = read_validated_manifest_for_backfill(
+                layout,
+                &workspace_name,
+                &source.name,
+                &source.variables,
+            ) else {
+                continue;
+            };
+            let mut tx = db.begin().await?;
+            tx.source_manifests()
+                .upsert(
+                    &workspace_name,
+                    &source.name,
+                    &manifest_yaml,
+                    now_unix_nanos,
+                )
+                .await?;
+            tx.commit().await?;
+        }
+    }
+    Ok(())
+}
+
+fn read_validated_manifest_for_backfill(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    source_variables: &BTreeMap<String, String>,
+) -> Option<String> {
+    let manifest_yaml = match read_optional_imported_manifest_file(
+        layout,
+        workspace_name,
+        source_name,
+    ) {
+        Ok(Some(manifest_yaml)) => manifest_yaml,
+        Ok(None) => return None,
+        Err(error) => {
+            tracing::warn!(
+                workspace = %workspace_name,
+                source = %source_name,
+                detail = %error,
+                "skipping imported source manifest database backfill because the legacy manifest could not be read"
+            );
+            return None;
+        }
+    };
+
+    if let Err(error) =
+        validate_imported_manifest_database_persistence(&manifest_yaml, source_variables)
+    {
+        tracing::warn!(
+            workspace = %workspace_name,
+            source = %source_name,
+            detail = %error,
+            "skipping imported source manifest database backfill because the legacy manifest is invalid"
+        );
+        return None;
+    }
+
+    Some(manifest_yaml)
+}
+
+fn read_imported_manifest_file(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+) -> Result<String, AppError> {
+    let manifest_path = layout.manifest_file(workspace_name, source_name);
+    fs::read_to_string(&manifest_path).map_err(|error| {
+        if error.kind() == ErrorKind::NotFound {
+            AppError::SourceNotFound(format!(
+                "manifest for imported source '{workspace_name}:{source_name}' at {}",
+                manifest_path.display()
+            ))
+        } else {
+            AppError::Io(error)
+        }
+    })
+}
+
+fn read_optional_imported_manifest_file(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+) -> Result<Option<String>, AppError> {
+    match read_imported_manifest_file(layout, workspace_name, source_name) {
+        Ok(manifest_yaml) => Ok(Some(manifest_yaml)),
+        Err(AppError::SourceNotFound(message)) => {
+            tracing::warn!(
+                detail = %message,
+                "imported source manifest file is missing; source metadata will remain without a database manifest row"
+            );
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
 fn clear_legacy_source_catalog_config(config_store: &ConfigStore, source_count: usize) {
     if source_count != 0
         && let Err(error) = config_store.clear_source_catalog_unlocked()
@@ -304,6 +453,7 @@ fn clear_legacy_source_catalog_config(config_store: &ConfigStore, source_count: 
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::fs;
 
     use tempfile::tempdir;
 
@@ -347,6 +497,8 @@ mod tests {
         config_store
             .upsert_source(&workspace, source.clone())
             .expect("write config source");
+        let manifest_yaml = imported_manifest_yaml("github", "1.2.3");
+        write_manifest_file(&layout, &workspace, &source.name, &manifest_yaml);
         let db = open_sqlite(&layout).await;
 
         cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 11)
@@ -376,6 +528,16 @@ mod tests {
                 .expect("get source"),
             Some(source.clone())
         );
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get source manifest")
+                .expect("source manifest")
+                .manifest_yaml,
+            manifest_yaml
+        );
         assert!(
             session
                 .state_migrations()
@@ -394,6 +556,60 @@ mod tests {
             config_store.get_source(&workspace, &source.name),
             Err(crate::bootstrap::AppError::SourceNotFound(_))
         ));
+        assert!(
+            layout.manifest_file(&workspace, &source.name).exists(),
+            "legacy manifest file should be preserved for rollback compatibility"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_imported_config_manifest_rolls_back_catalog_import() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = unsafe_secret_endpoint_source();
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        let manifest_yaml = unsafe_secret_endpoint_manifest_yaml("github", "1.2.3");
+        write_manifest_file(&layout, &workspace, &source.name, &manifest_yaml);
+        let db = open_sqlite(&layout).await;
+        cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 10)
+            .await
+            .expect("cut over legacy workspace catalog");
+
+        let error = import_config_source_catalog(&db, &config_store, &layout, 11)
+            .await
+            .expect_err("unsafe legacy manifest should fail active config import");
+        let crate::bootstrap::AppError::InvalidInput(message) = error else {
+            panic!("expected invalid input error, got {error:?}");
+        };
+        assert!(message.contains("base_url must use https"));
+        let mut session = &db;
+        assert!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get source after rollback")
+                .is_none()
+        );
+        assert!(
+            session
+                .state_migrations()
+                .has_completed(WORKSPACE_CATALOG_CUTOVER_ID)
+                .await
+                .expect("workspace cutover marker should remain complete")
+        );
+        assert!(
+            !session
+                .state_migrations()
+                .has_completed(&source_catalog_import_id(&layout))
+                .await
+                .expect("source import marker should not be inserted")
+        );
     }
 
     #[tokio::test]
@@ -587,7 +803,6 @@ mod tests {
         reason = "The cleanup contract keeps its committed database and retained filesystem assertions in one fixture."
     )]
     async fn cleanup_failure_does_not_fail_committed_source_import() {
-        use std::fs;
         use std::os::unix::fs::PermissionsExt;
 
         let temp = tempdir().expect("temp dir");
@@ -1137,6 +1352,172 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn imported_config_source_without_manifest_file_keeps_source_without_manifest_row() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source("github", None, [], [], None, SourceOrigin::Imported);
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        let db = open_sqlite(&layout).await;
+        cutover_legacy_workspace_catalog_at(&db, &config_store, &layout, 10)
+            .await
+            .expect("cut over legacy workspace catalog");
+
+        let report = import_config_source_catalog(&db, &config_store, &layout, 11)
+            .await
+            .expect("missing imported manifest should not block source catalog import");
+
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                source_count: 1,
+                import_performed: true,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get source"),
+            Some(source.clone())
+        );
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get missing source manifest"),
+            None
+        );
+        assert!(matches!(
+            config_store.get_source(&workspace, &source.name),
+            Err(crate::bootstrap::AppError::SourceNotFound(_))
+        ));
+
+        run_state_migrations(&db, &config_store, &layout)
+            .await
+            .expect("missing imported manifest should not block later backfill attempts");
+        let mut session = &db;
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get still-missing source manifest"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn backfills_manifest_for_already_imported_database_source() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            [],
+            None,
+            SourceOrigin::Imported,
+        );
+        let manifest_yaml = imported_manifest_yaml("github", "1.2.3");
+        write_manifest_file(&layout, &workspace, &source.name, &manifest_yaml);
+        let db = open_sqlite(&layout).await;
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 7)
+            .await
+            .expect("write source without manifest row");
+        tx.state_migrations()
+            .try_claim(WORKSPACE_CATALOG_CUTOVER_ID, 7)
+            .await
+            .expect("claim workspace cutover");
+        tx.state_migrations()
+            .try_claim(&source_catalog_import_id(&layout), 7)
+            .await
+            .expect("claim source import");
+        tx.commit().await.expect("commit source");
+
+        run_state_migrations(&db, &config_store, &layout)
+            .await
+            .expect("backfill manifest");
+
+        let mut session = &db;
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get source manifest")
+                .expect("source manifest")
+                .manifest_yaml,
+            manifest_yaml
+        );
+        assert!(
+            layout.manifest_file(&workspace, &source.name).exists(),
+            "legacy manifest file should be preserved after DB backfill"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_filesystem_manifest_backfill_skips_source_manifest() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = unsafe_secret_endpoint_source();
+        let manifest_yaml = unsafe_secret_endpoint_manifest_yaml("github", "1.2.3");
+        write_manifest_file(&layout, &workspace, &source.name, &manifest_yaml);
+        let db = open_sqlite(&layout).await;
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 7)
+            .await
+            .expect("write source without manifest row");
+        tx.state_migrations()
+            .try_claim(WORKSPACE_CATALOG_CUTOVER_ID, 7)
+            .await
+            .expect("claim workspace cutover");
+        tx.state_migrations()
+            .try_claim(&source_catalog_import_id(&layout), 7)
+            .await
+            .expect("claim source import");
+        tx.commit().await.expect("commit source");
+
+        run_state_migrations(&db, &config_store, &layout)
+            .await
+            .expect("invalid backfill manifest should not fail bootstrap");
+
+        let mut session = &db;
+        assert!(
+            session
+                .source_manifests()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get skipped source manifest")
+                .is_none()
+        );
+    }
+
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
         let config = DatabaseConfig::load(layout).expect("db config");
         let DatabaseConfig::Sqlite { path } = config else {
@@ -1169,5 +1550,60 @@ mod tests {
             credential_revision: uuid::Uuid::from_u128(1),
             origin,
         }
+    }
+
+    fn write_manifest_file(
+        layout: &AppStateLayout,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        manifest_yaml: &str,
+    ) {
+        let manifest_path = layout.manifest_file(workspace, source_name);
+        fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create manifest parent");
+        fs::write(manifest_path, manifest_yaml).expect("write manifest file");
+    }
+
+    fn imported_manifest_yaml(name: &str, version: &str) -> String {
+        format!(
+            r"
+name: {name}
+version: {version}
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Demo messages
+    request:
+      method: GET
+      path: /messages
+    response: {{}}
+    columns:
+      - name: id
+        type: Utf8
+"
+        )
+    }
+
+    fn unsafe_secret_endpoint_source() -> InstalledSource {
+        source(
+            "github",
+            Some("1.2.3"),
+            [("API_BASE", "http://api.example.com")],
+            ["API_TOKEN"],
+            Some(CredentialStorageKind::Keychain),
+            SourceOrigin::Imported,
+        )
+    }
+
+    fn unsafe_secret_endpoint_manifest_yaml(name: &str, version: &str) -> String {
+        imported_manifest_yaml(name, version).replacen(
+            "base_url: https://example.com",
+            r#"base_url: "{{input.API_BASE}}"
+inputs: { API_BASE: { kind: variable }, API_TOKEN: { kind: secret } }
+auth: { type: HeaderAuth, headers: [{ name: Authorization, from: template, template: "Bearer {{input.API_TOKEN}}" }] }"#,
+            1,
+        )
     }
 }

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -97,13 +97,6 @@ pub(crate) trait DbRepos: DbSession + Sized {
         SourcesRepo::new(self)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "imported manifest repository lands before manager wiring in the stacked PR sequence"
-        )
-    )]
     fn source_manifests(&mut self) -> SourceManifestsRepo<'_, Self> {
         SourceManifestsRepo::new(self)
     }


### PR DESCRIPTION
Intent

Move legacy imported source manifest YAML into the new source_manifests repository during database bootstrap without deleting the rollback-compatible manifest file.

What it enables

Existing imported sources can be backfilled into database-backed catalog state, repeated startup imports stay idempotent, and rollback to the prior runtime can still read the legacy manifest artifact.

Usage examples

Start Coral with database-backed state and an imported source in the legacy config; startup records its manifest in source_manifests while preserving workspaces/<workspace>/sources/<source>/manifest.yaml.