### PR TITLE
feat(search): wire observed values into app lifecycle

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -408,6 +408,7 @@ fn resolve_database_config(layout: &AppStateLayout) -> Result<ResolvedDatabaseCo
 pub struct RunningServer {
     endpoint_uri: String,
     local_trace_store_dir: Option<PathBuf>,
+    search_observations: Mutex<Option<SearchObservationHandle>>,
     shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
     task: Mutex<Option<JoinHandle<Result<(), tonic::transport::Error>>>>,
 }
@@ -456,6 +457,14 @@ impl RunningServer {
         let task = self.task.lock().expect("task mutex poisoned").take();
         if let Some(task) = task {
             task.await??;
+        }
+        if let Some(search_observations) = self
+            .search_observations
+            .lock()
+            .expect("search observation mutex poisoned")
+            .take()
+        {
+            search_observations.shutdown()?;
         }
         Ok(())
     }
@@ -513,9 +522,9 @@ async fn start_server(
         feedback,
         task,
     } = managers;
+    let source = source.with_search_observation_handle(search_observations.clone());
     let query = query.with_search_observation_handle(search_observations.clone());
-    let source_service = SourceService::new(source, query.clone(), workspace.clone())
-        .with_search_observation_handle(search_observations);
+    let source_service = SourceService::new(source, query.clone(), workspace.clone());
     let workspace_service = WorkspaceService::new(workspace);
     let catalog_service = CatalogService::new(query.clone());
     let function_service = FunctionService::new(query.clone());
@@ -569,6 +578,7 @@ async fn start_server(
     Ok(RunningServer {
         endpoint_uri,
         local_trace_store_dir,
+        search_observations: Mutex::new(Some(search_observations)),
         shutdown_tx: Mutex::new(Some(shutdown_tx)),
         task: Mutex::new(Some(task)),
     })

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -55,6 +55,7 @@ use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::search::manager::SearchManager;
+use crate::search::observed::SearchObservationHandle;
 use crate::search::service::SearchService;
 use crate::sources::manager::SourceManager;
 use crate::sources::materialization::SourceDiagnosticReporter;
@@ -340,6 +341,7 @@ impl ServerBuilder {
             self.config.engine_extensions_providers,
             diagnostic_reporter.clone(),
         );
+        let search_observations = SearchObservationHandle::new(layout.clone());
         let search_manager = SearchManager::with_diagnostic_reporter(
             layout,
             &config_store,
@@ -359,6 +361,7 @@ impl ServerBuilder {
                 workspace: workspace_manager,
                 query: query_manager,
                 search: search_manager,
+                search_observations,
                 feedback: feedback_manager,
                 task: task_manager,
             },
@@ -486,6 +489,7 @@ struct ServerManagers {
     workspace: WorkspaceManager,
     query: QueryManager,
     search: SearchManager,
+    search_observations: SearchObservationHandle,
     feedback: FeedbackManager,
     task: TaskManager,
 }
@@ -505,10 +509,13 @@ async fn start_server(
         workspace,
         query,
         search,
+        search_observations,
         feedback,
         task,
     } = managers;
-    let source_service = SourceService::new(source, query.clone(), workspace.clone());
+    let query = query.with_search_observation_handle(search_observations.clone());
+    let source_service = SourceService::new(source, query.clone(), workspace.clone())
+        .with_search_observation_handle(search_observations);
     let workspace_service = WorkspaceService::new(workspace);
     let catalog_service = CatalogService::new(query.clone());
     let function_service = FunctionService::new(query.clone());
@@ -789,6 +796,7 @@ mod tests {
     use crate::feedback::manager::FeedbackManager;
     use crate::query::manager::QueryManager;
     use crate::search::manager::SearchManager;
+    use crate::search::observed::SearchObservationHandle;
     use crate::sources::manager::SourceManager;
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
     use crate::state::{AppStateLayout, ConfigStore};
@@ -1001,6 +1009,7 @@ backend = "unsupported"
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
+        let search_observations = SearchObservationHandle::new(layout.clone());
         let search_manager =
             SearchManager::new(layout.clone(), &config_store, workspace_manager.clone());
         let trace_service =
@@ -1011,6 +1020,7 @@ backend = "unsupported"
                 workspace: workspace_manager,
                 query: query_manager,
                 search: search_manager,
+                search_observations,
                 feedback: feedback_manager,
                 task: task_manager,
             },
@@ -1444,6 +1454,7 @@ tables:
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
+        let search_observations = SearchObservationHandle::new(layout.clone());
         let search_manager =
             SearchManager::new(layout.clone(), &config_store, workspace_manager.clone());
         let running = start_server(
@@ -1452,6 +1463,7 @@ tables:
                 workspace: workspace_manager,
                 query: query_manager,
                 search: search_manager,
+                search_observations,
                 feedback: feedback_manager,
                 task: task_manager,
             },
@@ -1561,6 +1573,7 @@ tables:
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
+        let search_observations = SearchObservationHandle::new(layout.clone());
         let search_manager =
             SearchManager::new(layout.clone(), &config_store, workspace_manager.clone());
         let running = start_server(
@@ -1569,6 +1582,7 @@ tables:
                 workspace: workspace_manager,
                 query: query_manager,
                 search: search_manager,
+                search_observations,
                 feedback: feedback_manager,
                 task: task_manager,
             },
@@ -1678,6 +1692,7 @@ tables:
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
+        let search_observations = SearchObservationHandle::new(layout.clone());
         let search_manager =
             SearchManager::new(layout.clone(), &config_store, workspace_manager.clone());
         let running = start_server(
@@ -1686,6 +1701,7 @@ tables:
                 workspace: workspace_manager,
                 query: query_manager,
                 search: search_manager,
+                search_observations,
                 feedback: feedback_manager,
                 task: task_manager,
             },

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -455,16 +455,28 @@ impl RunningServer {
         }
 
         let task = self.task.lock().expect("task mutex poisoned").take();
-        if let Some(task) = task {
-            task.await??;
-        }
-        if let Some(search_observations) = self
+        let task_result = match task {
+            Some(task) => match task.await {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(error)) => Err(AppError::from(error)),
+                Err(error) => Err(AppError::from(error)),
+            },
+            None => Ok(()),
+        };
+        let search_observations_result = self.shutdown_search_observations().await;
+        task_result?;
+        search_observations_result?;
+        Ok(())
+    }
+
+    async fn shutdown_search_observations(&self) -> Result<(), AppError> {
+        let search_observations = self
             .search_observations
             .lock()
             .expect("search observation mutex poisoned")
-            .take()
-        {
-            search_observations.shutdown()?;
+            .take();
+        if let Some(search_observations) = search_observations {
+            tokio::task::spawn_blocking(move || search_observations.shutdown()).await??;
         }
         Ok(())
     }
@@ -780,7 +792,7 @@ mod tests {
     use std::borrow::Cow;
     use std::net::{Ipv4Addr, TcpListener};
     use std::path::Path;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use coral_api::v1::query_service_client::QueryServiceClient;
@@ -799,9 +811,11 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        ServerBuilder, ServerManagers, ServerMode, StaticAsset, StaticAssetsProvider,
-        TraceServerComponents, is_grpc_web_content_type, is_native_grpc_content_type, start_server,
+        RunningServer, ServerBuilder, ServerManagers, ServerMode, StaticAsset,
+        StaticAssetsProvider, TraceServerComponents, is_grpc_web_content_type,
+        is_native_grpc_content_type, start_server,
     };
+    use crate::bootstrap::AppError;
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::feedback::manager::FeedbackManager;
     use crate::query::manager::QueryManager;
@@ -866,6 +880,37 @@ enabled = false
             .await
             .expect("run state migrations");
         Arc::new(db)
+    }
+
+    #[tokio::test]
+    async fn shutdown_attempts_observed_values_shutdown_after_server_task_error() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let search_observations = SearchObservationHandle::new(layout);
+        let task = tokio::spawn(async {
+            let should_panic = true;
+            assert!(!should_panic, "server task panicked");
+            Ok::<(), tonic::transport::Error>(())
+        });
+        let server = RunningServer {
+            endpoint_uri: "http://127.0.0.1:0".to_string(),
+            local_trace_store_dir: None,
+            search_observations: Mutex::new(Some(search_observations)),
+            shutdown_tx: Mutex::new(None),
+            task: Mutex::new(Some(task)),
+        };
+
+        let result = server.shutdown_inner().await;
+
+        assert!(matches!(result, Err(AppError::TaskJoin(_))));
+        assert!(
+            server
+                .search_observations
+                .lock()
+                .expect("search observation mutex")
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -45,6 +45,7 @@ use crate::EngineExtensionsProvider;
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
 use crate::credentials::{CredentialManager, CredentialStore};
+use crate::features::{Feature, FeatureOverrides, FeatureStore};
 use crate::feedback::manager::FeedbackManager;
 use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
@@ -97,6 +98,7 @@ pub(crate) struct ServerConfig {
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
+    feature_overrides: FeatureOverrides,
     enable_stderr_logs: bool,
 }
 
@@ -114,6 +116,7 @@ impl ServerConfig {
             engine_extensions_providers: Vec::new(),
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
+            feature_overrides: FeatureOverrides::default(),
             enable_stderr_logs: false,
         }
     }
@@ -140,6 +143,11 @@ impl ServerConfig {
     #[must_use]
     pub(crate) fn with_stderr_logs(mut self, enable_stderr_logs: bool) -> Self {
         self.enable_stderr_logs = enable_stderr_logs;
+        self
+    }
+
+    pub(crate) fn with_feature_overrides(mut self, feature_overrides: FeatureOverrides) -> Self {
+        self.feature_overrides = feature_overrides;
         self
     }
 }
@@ -257,6 +265,13 @@ impl ServerBuilder {
         self
     }
 
+    #[must_use]
+    /// Applies process-local runtime feature overrides to this server instance.
+    pub fn with_feature_overrides(mut self, feature_overrides: FeatureOverrides) -> Self {
+        self.config = self.config.with_feature_overrides(feature_overrides);
+        self
+    }
+
     /// Disables hosted feedback upload for tests and controlled local harnesses.
     #[doc(hidden)]
     #[must_use]
@@ -279,6 +294,8 @@ impl ServerBuilder {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir)?;
         layout.ensure()?;
+        let features = FeatureStore::from_layout(layout.clone())
+            .load_with_overrides(&self.config.feature_overrides)?;
         let coral_db = init_database(&layout).await?;
         let config_store = ConfigStore::new(layout.clone());
         run_state_migrations(&coral_db, &config_store).await?;
@@ -341,7 +358,9 @@ impl ServerBuilder {
             self.config.engine_extensions_providers,
             diagnostic_reporter.clone(),
         );
-        let search_observations = SearchObservationHandle::new(layout.clone());
+        let search_observations = features
+            .enabled(Feature::ObservedValuesSearch)
+            .then(|| SearchObservationHandle::new(layout.clone()));
         let search_manager = SearchManager::with_diagnostic_reporter(
             layout,
             &config_store,
@@ -510,7 +529,7 @@ struct ServerDependencies {
     workspace: WorkspaceManager,
     query: QueryManager,
     search: SearchManager,
-    search_observations: SearchObservationHandle,
+    search_observations: Option<SearchObservationHandle>,
     feedback: FeedbackManager,
     task: TaskManager,
 }
@@ -534,8 +553,13 @@ async fn start_server(
         feedback,
         task,
     } = dependencies;
-    let source = source.with_search_observation_handle(search_observations.clone());
-    let query = query.with_search_observation_handle(search_observations.clone());
+    let (source, query) = match &search_observations {
+        Some(search_observations) => (
+            source.with_search_observation_handle(search_observations.clone()),
+            query.with_search_observation_handle(search_observations.clone()),
+        ),
+        None => (source, query),
+    };
     let source_service = SourceService::new(source, query.clone(), workspace.clone());
     let workspace_service = WorkspaceService::new(workspace);
     let catalog_service = CatalogService::new(query.clone());
@@ -590,7 +614,7 @@ async fn start_server(
     Ok(RunningServer {
         endpoint_uri,
         local_trace_store_dir,
-        search_observations: Mutex::new(Some(search_observations)),
+        search_observations: Mutex::new(search_observations),
         shutdown_tx: Mutex::new(Some(shutdown_tx)),
         task: Mutex::new(Some(task)),
     })
@@ -817,6 +841,7 @@ mod tests {
     };
     use crate::bootstrap::AppError;
     use crate::credentials::{CredentialManager, CredentialStore};
+    use crate::features::{Feature, FeatureOverrides};
     use crate::feedback::manager::FeedbackManager;
     use crate::query::manager::QueryManager;
     use crate::search::manager::SearchManager;
@@ -850,6 +875,33 @@ enabled = false
 ",
         )
         .expect("write telemetry config");
+    }
+
+    fn configure_observed_values_search(config_dir: &Path, enabled: bool) {
+        std::fs::create_dir_all(config_dir).expect("create config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            format!(
+                r"
+version = 1
+
+[features]
+observed_values_search = {enabled}
+
+[trace_history]
+enabled = false
+"
+            ),
+        )
+        .expect("write feature config");
+    }
+
+    fn has_search_observation_handle(server: &RunningServer) -> bool {
+        server
+            .search_observations
+            .lock()
+            .expect("search observation mutex")
+            .is_some()
     }
 
     #[derive(Debug)]
@@ -911,6 +963,72 @@ enabled = false
                 .expect("search observation mutex")
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn server_builder_leaves_observation_handle_detached_by_default() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        disable_internal_tracing(&config_dir);
+
+        let server = ServerBuilder::new()
+            .with_config_dir(config_dir)
+            .start()
+            .await
+            .expect("start server");
+
+        assert!(!has_search_observation_handle(&server));
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn server_builder_attaches_observation_handle_when_config_enabled() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        configure_observed_values_search(&config_dir, true);
+
+        let server = ServerBuilder::new()
+            .with_config_dir(config_dir)
+            .start()
+            .await
+            .expect("start server");
+
+        assert!(has_search_observation_handle(&server));
+        server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn server_builder_process_overrides_control_observation_handle() {
+        let temp = TempDir::new().expect("temp dir");
+        let disabled_config_dir = temp.path().join("disabled-config");
+        configure_observed_values_search(&disabled_config_dir, false);
+        let mut enable_override = FeatureOverrides::default();
+        enable_override.set(Feature::ObservedValuesSearch, true);
+
+        let enabled_server = ServerBuilder::new()
+            .with_config_dir(disabled_config_dir)
+            .with_feature_overrides(enable_override)
+            .start()
+            .await
+            .expect("start process-enabled server");
+
+        assert!(has_search_observation_handle(&enabled_server));
+        enabled_server.shutdown().await.expect("shutdown");
+
+        let enabled_config_dir = temp.path().join("enabled-config");
+        configure_observed_values_search(&enabled_config_dir, true);
+        let mut disable_override = FeatureOverrides::default();
+        disable_override.set(Feature::ObservedValuesSearch, false);
+
+        let disabled_server = ServerBuilder::new()
+            .with_config_dir(enabled_config_dir)
+            .with_feature_overrides(disable_override)
+            .start()
+            .await
+            .expect("start process-disabled server");
+
+        assert!(!has_search_observation_handle(&disabled_server));
+        disabled_server.shutdown().await.expect("shutdown");
     }
 
     #[tokio::test]
@@ -1075,7 +1193,7 @@ backend = "unsupported"
                 workspace: workspace_manager,
                 query: query_manager,
                 search: search_manager,
-                search_observations,
+                search_observations: Some(search_observations),
                 feedback: feedback_manager,
                 task: task_manager,
             },
@@ -1518,7 +1636,7 @@ tables:
                 workspace: workspace_manager,
                 query: query_manager,
                 search: search_manager,
-                search_observations,
+                search_observations: Some(search_observations),
                 feedback: feedback_manager,
                 task: task_manager,
             },
@@ -1637,7 +1755,7 @@ tables:
                 workspace: workspace_manager,
                 query: query_manager,
                 search: search_manager,
-                search_observations,
+                search_observations: Some(search_observations),
                 feedback: feedback_manager,
                 task: task_manager,
             },
@@ -1756,7 +1874,7 @@ tables:
                 workspace: workspace_manager,
                 query: query_manager,
                 search: search_manager,
-                search_observations,
+                search_observations: Some(search_observations),
                 feedback: feedback_manager,
                 task: task_manager,
             },

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -356,7 +356,7 @@ impl ServerBuilder {
                 }
             });
         start_server(
-            ServerManagers {
+            ServerDependencies {
                 source: source_manager,
                 workspace: workspace_manager,
                 query: query_manager,
@@ -505,7 +505,7 @@ struct TraceServerComponents {
     local_trace_store_dir: Option<PathBuf>,
 }
 
-struct ServerManagers {
+struct ServerDependencies {
     source: SourceManager,
     workspace: WorkspaceManager,
     query: QueryManager,
@@ -516,7 +516,7 @@ struct ServerManagers {
 }
 
 async fn start_server(
-    managers: ServerManagers,
+    dependencies: ServerDependencies,
     trace_components: TraceServerComponents,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     mode: ServerMode,
@@ -525,7 +525,7 @@ async fn start_server(
         service: trace_service,
         local_trace_store_dir,
     } = trace_components;
-    let ServerManagers {
+    let ServerDependencies {
         source,
         workspace,
         query,
@@ -533,7 +533,7 @@ async fn start_server(
         search_observations,
         feedback,
         task,
-    } = managers;
+    } = dependencies;
     let source = source.with_search_observation_handle(search_observations.clone());
     let query = query.with_search_observation_handle(search_observations.clone());
     let source_service = SourceService::new(source, query.clone(), workspace.clone());
@@ -811,7 +811,7 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        RunningServer, ServerBuilder, ServerManagers, ServerMode, StaticAsset,
+        RunningServer, ServerBuilder, ServerDependencies, ServerMode, StaticAsset,
         StaticAssetsProvider, TraceServerComponents, is_grpc_web_content_type,
         is_native_grpc_content_type, start_server,
     };
@@ -1070,7 +1070,7 @@ backend = "unsupported"
         let trace_service =
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
         let server = start_server(
-            ServerManagers {
+            ServerDependencies {
                 source: source_manager,
                 workspace: workspace_manager,
                 query: query_manager,
@@ -1513,7 +1513,7 @@ tables:
         let search_manager =
             SearchManager::new(layout.clone(), &config_store, workspace_manager.clone());
         let running = start_server(
-            ServerManagers {
+            ServerDependencies {
                 source: source_manager,
                 workspace: workspace_manager,
                 query: query_manager,
@@ -1632,7 +1632,7 @@ tables:
         let search_manager =
             SearchManager::new(layout.clone(), &config_store, workspace_manager.clone());
         let running = start_server(
-            ServerManagers {
+            ServerDependencies {
                 source: source_manager,
                 workspace: workspace_manager,
                 query: query_manager,
@@ -1751,7 +1751,7 @@ tables:
         let search_manager =
             SearchManager::new(layout.clone(), &config_store, workspace_manager.clone());
         let running = start_server(
-            ServerManagers {
+            ServerDependencies {
                 source: source_manager,
                 workspace: workspace_manager,
                 query: query_manager,

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -84,7 +84,7 @@ const FEATURE_SPECS: &[FeatureSpec] = &[
         feature: Feature::ObservedValuesSearch,
         key: "observed_values_search",
         default_enabled: false,
-        description: "Enables observed-value collection, storage, retrieval, and maintenance for Universal Search. Off by default.",
+        description: "Enables collecting, indexing, retrieving, and maintaining values observed during earlier queries. Off by default.",
         enable_flag: "enable-observed-values-search",
         disable_flag: "disable-observed-values-search",
     },
@@ -223,6 +223,12 @@ pub struct FeatureStore {
 }
 
 impl FeatureStore {
+    /// Creates a feature store for an already-discovered Coral app state layout.
+    #[must_use]
+    pub(crate) fn from_layout(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
     /// Discovers the Coral app state layout used for runtime feature config.
     ///
     /// # Errors

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -506,6 +506,7 @@ impl QueryManager {
         ))
     }
 
+    #[cfg(test)]
     fn runtime_config(
         &self,
         workspace_name: &WorkspaceName,
@@ -618,7 +619,11 @@ impl QueryManager {
         let sources = query_sources_from_loaded(&loaded_sources);
         self.function_manager
             .list_functions(workspace_name, &sources, || {
-                self.runtime_config(workspace_name, &loaded_sources, &config)
+                self.runtime_config_without_source_observations(
+                    workspace_name,
+                    &loaded_sources,
+                    &config,
+                )
             })
             .await
             .map_err(QueryManagerError::App)
@@ -730,7 +735,13 @@ impl QueryManager {
             .validate_user_function_sql(
                 workspace_name,
                 &sources,
-                || self.runtime_config(workspace_name, loaded_sources, config),
+                || {
+                    self.runtime_config_without_source_observations(
+                        workspace_name,
+                        loaded_sources,
+                        config,
+                    )
+                },
                 raw_sql,
             )
             .await
@@ -1568,6 +1579,66 @@ mod tests {
         assert!(
             manager.layout.search_sqlite_file(&workspace_name).exists(),
             "execution runtime config should open the observed-values SQLite store"
+        );
+    }
+
+    #[tokio::test]
+    async fn function_metadata_runtimes_do_not_open_observed_values_store() {
+        let fake_home = tempfile::tempdir().expect("fake home");
+        let fixture = query_manager_with(
+            QueryRuntimeContext {
+                home_dir: Some(fake_home.path().to_path_buf()),
+                ..QueryRuntimeContext::default()
+            },
+            Vec::new(),
+        )
+        .await;
+        let workspace_name = WorkspaceName::default();
+        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        let function_sql = r"/*
+name: demo_items
+schema: functions
+description: Returns demo messages
+*/
+
+select text from function_demo.messages
+";
+        let validated = fixture
+            .manager
+            .validate_udf_sql(&workspace_name, function_sql)
+            .await
+            .expect("validate function without observations");
+        fixture
+            .manager
+            .function_manager
+            .install_validated_user_function(&workspace_name, function_sql, &validated)
+            .expect("install function");
+
+        let manager =
+            fixture
+                .manager
+                .clone()
+                .with_search_observation_handle(SearchObservationHandle::new(
+                    fixture.manager.layout.clone(),
+                ));
+        let observed_values_path = manager.layout.search_sqlite_file(&workspace_name);
+        manager
+            .validate_udf_sql(&workspace_name, function_sql)
+            .await
+            .expect("validate function with observations enabled");
+        assert!(
+            !observed_values_path.exists(),
+            "function validation should not open the observed-values SQLite store"
+        );
+
+        let functions = manager
+            .list_functions(&workspace_name)
+            .await
+            .expect("list functions with observations enabled");
+        assert_eq!(functions.len(), 1);
+        assert!(
+            !observed_values_path.exists(),
+            "function listing should not open the observed-values SQLite store"
         );
     }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -25,6 +25,7 @@ use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_p
 use crate::query::input_resolver::{
     CredentialRefreshingInputResolver, SourceCredentialSnapshot, StoredCredentialInputResolver,
 };
+use crate::search::observed::SearchObservationHandle;
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::materialization::{
@@ -75,6 +76,7 @@ pub(crate) struct QueryManager {
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     diagnostic_reporter: SourceDiagnosticReporter,
+    search_observations: Option<SearchObservationHandle>,
 }
 
 impl QueryManager {
@@ -146,7 +148,16 @@ impl QueryManager {
             layout,
             engine_extensions_providers,
             diagnostic_reporter,
+            search_observations: None,
         }
+    }
+
+    pub(crate) fn with_search_observation_handle(
+        mut self,
+        search_observations: SearchObservationHandle,
+    ) -> Self {
+        self.search_observations = Some(search_observations);
+        self
     }
 
     pub(crate) async fn list_tables(
@@ -550,6 +561,13 @@ impl QueryManager {
         let query_sources = query_sources_from_loaded(selected_sources);
         let mut extensions =
             engine_extensions_for_providers(&self.engine_extensions_providers, &query_sources);
+        if let Some(search_observations) = &self.search_observations {
+            let observed_extensions =
+                search_observations.extensions_for(workspace_name, &query_sources);
+            extensions
+                .source_observation_publishers
+                .extend(observed_extensions.source_observation_publishers);
+        }
         let provider_input_resolver = extensions.source_input_resolver.take();
         let source_credentials = selected_sources
             .iter()

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -8,8 +8,7 @@ use std::time::Instant;
 use coral_engine::{
     CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, PreparedQueryRuntime, QueryExecution,
     QueryExecutionProvenance, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-    RuntimeSourcePackage, SourceInputResolver, SourceValidationReport, StatusCode, TableInfo,
-    UdfRuntimeDefinition,
+    SourceInputResolver, SourceValidationReport, StatusCode, TableInfo, UdfRuntimeDefinition,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::trace::Status as OtelStatus;
@@ -28,12 +27,11 @@ use crate::query::input_resolver::{
 use crate::search::observed::SearchObservationHandle;
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
-use crate::sources::materialization::{
-    SourceDiagnosticReporter, SourceLoadDiagnosticStage, incompatible_materialization_error,
-    load_v4_materialization,
-};
+use crate::sources::materialization::{SourceDiagnosticReporter, SourceLoadDiagnosticStage};
 use crate::sources::model::InstalledSource;
-use crate::sources::runtime_package::runtime_components_for_v4_source;
+use crate::sources::runtime_package::{
+    RuntimeContractFingerprint, query_source_from_installed_manifest,
+};
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::task::id::TaskId;
 use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
@@ -62,6 +60,7 @@ enum CredentialResolutionMode {
 struct LoadedQuerySource {
     source: InstalledSource,
     query_source: QuerySource,
+    runtime_contract_fingerprint: RuntimeContractFingerprint,
     credential_material: BTreeMap<String, String>,
 }
 
@@ -453,34 +452,7 @@ impl QueryManager {
         source: &InstalledSource,
     ) -> Result<(LoadedQuerySource, Option<String>), AppError> {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
-        let source_spec = installed.source_spec;
-        let v4_runtime_components = if let Some(v4) = source_spec.as_v4() {
-            let materialized = load_v4_materialization(
-                &self.layout,
-                workspace_name,
-                &source.name,
-                &installed.manifest_yaml,
-                v4,
-                &self.diagnostic_reporter,
-            )?;
-            Some(
-                runtime_components_for_v4_source(
-                    workspace_name,
-                    &source.name,
-                    v4,
-                    &materialized,
-                    &self.diagnostic_reporter,
-                )
-                .map_err(|error| {
-                    incompatible_materialization_error(
-                        &source.name,
-                        format!("failed to assemble runtime package: {error}"),
-                    )
-                })?,
-            )
-        } else {
-            None
-        };
+        let source_spec = &installed.source_spec;
         validate_required_variables(source, source_spec.declared_inputs())?;
         let stored_secrets =
             if let Some(credential_storage) = source.credential_storage_for_material() {
@@ -515,27 +487,19 @@ impl QueryManager {
                 resolved_secrets.insert(secret_name, value.clone());
             }
         }
-        let query_source = if let Some(components) = v4_runtime_components {
-            QuerySource::from_runtime_components(
-                RuntimeSourcePackage {
-                    source_name: source_spec.schema_name().to_string(),
-                    authored_version: source_spec.source_version().map(ToString::to_string),
-                    description: source_spec.description().to_string(),
-                    declared_inputs: source_spec.declared_inputs().to_vec(),
-                    test_queries: source_spec.test_queries().to_vec(),
-                    components,
-                },
-                source.variables.clone(),
-                resolved_secrets,
-            )
-            .map_err(|error| AppError::FailedPrecondition(error.to_string()))?
-        } else {
-            QuerySource::from_manifest(&source_spec, source.variables.clone(), resolved_secrets)
-        };
+        let loaded_runtime = query_source_from_installed_manifest(
+            &self.layout,
+            workspace_name,
+            source,
+            &installed,
+            &self.diagnostic_reporter,
+            resolved_secrets,
+        )?;
         Ok((
             LoadedQuerySource {
                 source: source.clone(),
-                query_source,
+                query_source: loaded_runtime.query_source,
+                runtime_contract_fingerprint: loaded_runtime.runtime_contract_fingerprint,
                 credential_material: stored_secrets,
             },
             installed.candidate.version,
@@ -1177,6 +1141,7 @@ mod tests {
                     variables: BTreeMap::new(),
                     secrets: vec!["GITHUB_TOKEN".to_string()],
                     credential_storage: Some(CredentialStorageKind::Keychain),
+                    credential_revision: Default::default(),
                     origin: SourceOrigin::Bundled,
                 },
             )
@@ -1650,6 +1615,7 @@ tables:
             variables: BTreeMap::new(),
             secrets: vec!["API_KEY".to_string(), "OAUTH_TOKEN".to_string()],
             credential_storage: Some(CredentialStorageKind::File),
+            credential_revision: Default::default(),
             origin: SourceOrigin::Imported,
         };
         fixture
@@ -2164,6 +2130,7 @@ surfaces:
                     variables: BTreeMap::new(),
                     secrets: Vec::new(),
                     credential_storage: None,
+                    credential_revision: Default::default(),
                     origin: SourceOrigin::Imported,
                 },
             )
@@ -2374,6 +2341,7 @@ select 1 as value
             variables: BTreeMap::new(),
             secrets: vec!["API_TOKEN".to_string()],
             credential_storage: Some(CredentialStorageKind::File),
+            credential_revision: Default::default(),
             origin: SourceOrigin::Bundled,
         };
         fixture
@@ -2417,6 +2385,7 @@ tables:
         let loaded_source = LoadedQuerySource {
             source: installed_source,
             query_source: QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new()),
+            runtime_contract_fingerprint: RuntimeContractFingerprint::for_test("contract"),
             credential_material: BTreeMap::from([(
                 "API_TOKEN".to_string(),
                 "snapshot-token".to_string(),
@@ -2455,6 +2424,92 @@ tables:
         assert_eq!(
             resolved_inputs.get("API_TOKEN").map(String::as_str),
             Some("snapshot-token")
+        );
+    }
+
+    #[test]
+    fn runtime_contract_fingerprint_ignores_refreshed_credential_material() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::default();
+        let source_name = SourceName::parse("secured_messages").expect("source name");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let installed_source = InstalledSource {
+            name: source_name.clone(),
+            version: Some("0.1.0".to_string()),
+            variables: BTreeMap::new(),
+            secrets: vec!["API_TOKEN".to_string()],
+            credential_storage: Some(CredentialStorageKind::File),
+            credential_revision: uuid::Uuid::new_v4(),
+            origin: SourceOrigin::Imported,
+        };
+        std::fs::create_dir_all(fixture.manager.layout.source_dir(&workspace, &source_name))
+            .expect("source directory");
+        std::fs::write(
+            fixture
+                .manager
+                .layout
+                .manifest_file(&workspace, &source_name),
+            r"
+name: secured_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+inputs:
+  API_TOKEN:
+    kind: secret
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Secured messages
+    request:
+      path: /messages
+    columns:
+      - name: id
+        type: Utf8
+",
+        )
+        .expect("write manifest");
+        fixture
+            .manager
+            .config_store
+            .upsert_source(&workspace, installed_source.clone())
+            .expect("persist source");
+        fixture
+            .manager
+            .credential_manager
+            .replace_material(
+                &workspace,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &BTreeMap::from([("API_TOKEN".to_string(), "first-token".to_string())]),
+            )
+            .expect("first credential material");
+        let first = fixture
+            .manager
+            .load_query_source(&workspace, &installed_source)
+            .expect("first runtime")
+            .0;
+
+        fixture
+            .manager
+            .credential_manager
+            .replace_material(
+                &workspace,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &BTreeMap::from([("API_TOKEN".to_string(), "refreshed-token".to_string())]),
+            )
+            .expect("refreshed credential material");
+        let refreshed = fixture
+            .manager
+            .load_query_source(&workspace, &installed_source)
+            .expect("refreshed runtime")
+            .0;
+
+        assert_eq!(
+            first.runtime_contract_fingerprint,
+            refreshed.runtime_contract_fingerprint
         );
     }
 
@@ -2503,9 +2558,11 @@ tables:
                 variables: BTreeMap::new(),
                 secrets: vec!["API_TOKEN".to_string()],
                 credential_storage: None,
+                credential_revision: Default::default(),
                 origin: SourceOrigin::Bundled,
             },
             query_source: QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new()),
+            runtime_contract_fingerprint: RuntimeContractFingerprint::for_test("contract"),
             credential_material: BTreeMap::from([(
                 "API_TOKEN".to_string(),
                 "stored-token".to_string(),
@@ -2579,9 +2636,11 @@ tables:
                 variables: BTreeMap::new(),
                 secrets: Vec::new(),
                 credential_storage: None,
+                credential_revision: Default::default(),
                 origin: SourceOrigin::Bundled,
             },
             query_source: QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new()),
+            runtime_contract_fingerprint: RuntimeContractFingerprint::for_test("contract"),
             credential_material: BTreeMap::new(),
         }
     }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -24,7 +24,7 @@ use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_p
 use crate::query::input_resolver::{
     CredentialRefreshingInputResolver, SourceCredentialSnapshot, StoredCredentialInputResolver,
 };
-use crate::search::observed::SearchObservationHandle;
+use crate::search::observed::{SearchObservationHandle, SearchObservationSource};
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::materialization::{SourceDiagnosticReporter, SourceLoadDiagnosticStage};
@@ -550,8 +550,18 @@ impl QueryManager {
         if matches!(source_observation_mode, SourceObservationMode::Enabled)
             && let Some(search_observations) = &self.search_observations
         {
+            let observation_sources = selected_sources
+                .iter()
+                .map(|source| {
+                    SearchObservationSource::new(
+                        &source.query_source,
+                        source.runtime_contract_fingerprint.as_str(),
+                        source.source.credential_revision,
+                    )
+                })
+                .collect::<Vec<_>>();
             let observed_extensions =
-                search_observations.extensions_for(workspace_name, &query_sources);
+                search_observations.extensions_for(workspace_name, &observation_sources);
             extensions
                 .source_observation_publishers
                 .extend(observed_extensions.source_observation_publishers);

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -184,6 +184,7 @@ impl QueryManager {
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::StoredOnly,
+                        SourceObservationMode::Disabled,
                     )
                     .await?;
                 Ok(runtime.list_tables(schema_filter, table_filter))
@@ -217,6 +218,7 @@ impl QueryManager {
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::StoredOnly,
+                        SourceObservationMode::Disabled,
                     )
                     .await?;
                 Ok(runtime.list_catalog(schema_filter))
@@ -261,6 +263,7 @@ impl QueryManager {
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::Refreshing,
+                        SourceObservationMode::Disabled,
                     )
                     .await?;
                 Ok(runtime.describe_table(schema_name, table_name))
@@ -293,6 +296,7 @@ impl QueryManager {
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::Refreshing,
+                        SourceObservationMode::Enabled,
                     )
                     .await?;
                 runtime
@@ -328,6 +332,7 @@ impl QueryManager {
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::Refreshing,
+                        SourceObservationMode::Disabled,
                     )
                     .await?;
                 runtime
@@ -548,6 +553,22 @@ impl QueryManager {
             selected_sources,
             config,
             CredentialResolutionMode::Refreshing,
+            SourceObservationMode::Enabled,
+        )
+    }
+
+    fn runtime_config_without_source_observations(
+        &self,
+        workspace_name: &WorkspaceName,
+        selected_sources: &[LoadedQuerySource],
+        config: &AppConfig,
+    ) -> Result<QueryRuntimeConfig, AppError> {
+        self.runtime_config_with_credential_mode(
+            workspace_name,
+            selected_sources,
+            config,
+            CredentialResolutionMode::Refreshing,
+            SourceObservationMode::Disabled,
         )
     }
 
@@ -557,11 +578,14 @@ impl QueryManager {
         selected_sources: &[LoadedQuerySource],
         config: &AppConfig,
         credential_resolution_mode: CredentialResolutionMode,
+        source_observation_mode: SourceObservationMode,
     ) -> Result<QueryRuntimeConfig, AppError> {
         let query_sources = query_sources_from_loaded(selected_sources);
         let mut extensions =
             engine_extensions_for_providers(&self.engine_extensions_providers, &query_sources);
-        if let Some(search_observations) = &self.search_observations {
+        if matches!(source_observation_mode, SourceObservationMode::Enabled)
+            && let Some(search_observations) = &self.search_observations
+        {
             let observed_extensions =
                 search_observations.extensions_for(workspace_name, &query_sources);
             extensions
@@ -745,6 +769,7 @@ impl QueryManager {
         selected_sources: &[LoadedQuerySource],
         config: &AppConfig,
         credential_resolution_mode: CredentialResolutionMode,
+        source_observation_mode: SourceObservationMode,
     ) -> Result<PreparedQueryRuntime, QueryManagerError> {
         let runtime_config = self
             .runtime_config_with_credential_mode(
@@ -752,6 +777,7 @@ impl QueryManager {
                 selected_sources,
                 config,
                 credential_resolution_mode,
+                source_observation_mode,
             )
             .map_err(QueryManagerError::App)?;
         let query_sources = query_sources_from_loaded(selected_sources);
@@ -784,6 +810,12 @@ enum QueryOperation {
     ListTables,
     ListCatalog,
     DescribeTable,
+}
+
+#[derive(Clone, Copy)]
+enum SourceObservationMode {
+    Enabled,
+    Disabled,
 }
 
 impl QueryOperation {
@@ -1506,6 +1538,62 @@ mod tests {
             .body_capture_max_bytes
             .expect("body capture config");
         assert_eq!(config, 42);
+    }
+
+    #[tokio::test]
+    async fn metadata_runtime_config_skips_observed_values_publishers() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
+        let workspace_name = WorkspaceName::default();
+        let manager =
+            fixture
+                .manager
+                .clone()
+                .with_search_observation_handle(SearchObservationHandle::new(
+                    fixture.manager.layout.clone(),
+                ));
+        let loaded_source = observed_values_loaded_source();
+
+        let runtime = manager
+            .runtime_config_without_source_observations(
+                &workspace_name,
+                std::slice::from_ref(&loaded_source),
+                &AppConfig::default(),
+            )
+            .expect("metadata runtime config");
+
+        assert!(runtime.extensions.source_observation_publishers.is_empty());
+        assert!(
+            !manager.layout.search_sqlite_file(&workspace_name).exists(),
+            "metadata runtime config should not open the observed-values SQLite store"
+        );
+    }
+
+    #[tokio::test]
+    async fn execution_runtime_config_attaches_observed_values_publishers() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
+        let workspace_name = WorkspaceName::default();
+        let manager =
+            fixture
+                .manager
+                .clone()
+                .with_search_observation_handle(SearchObservationHandle::new(
+                    fixture.manager.layout.clone(),
+                ));
+        let loaded_source = observed_values_loaded_source();
+
+        let runtime = manager
+            .runtime_config(
+                &workspace_name,
+                std::slice::from_ref(&loaded_source),
+                &AppConfig::default(),
+            )
+            .expect("execution runtime config");
+
+        assert_eq!(runtime.extensions.source_observation_publishers.len(), 1);
+        assert!(
+            manager.layout.search_sqlite_file(&workspace_name).exists(),
+            "execution runtime config should open the observed-values SQLite store"
+        );
     }
 
     #[tokio::test]
@@ -2463,5 +2551,38 @@ tables:
                 .as_deref(),
             Some("stored-token")
         );
+    }
+
+    fn observed_values_loaded_source() -> LoadedQuerySource {
+        let source_spec = parse_source_manifest_yaml(
+            r"
+name: github
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://api.github.com
+tables:
+  - name: issues
+    description: Issues
+    request:
+      path: /issues
+    columns:
+      - name: title
+        type: Utf8
+",
+        )
+        .expect("parse source manifest");
+        LoadedQuerySource {
+            source: InstalledSource {
+                name: SourceName::parse("github").expect("source name"),
+                version: None,
+                variables: BTreeMap::new(),
+                secrets: Vec::new(),
+                credential_storage: None,
+                origin: SourceOrigin::Bundled,
+            },
+            query_source: QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new()),
+            credential_material: BTreeMap::new(),
+        }
     }
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -373,7 +373,7 @@ impl QueryManager {
             (source, loaded_source, version, config)
         };
         let runtime = self
-            .runtime_config(
+            .runtime_config_without_source_observations(
                 workspace_name,
                 std::slice::from_ref(&loaded_source),
                 &config,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -2437,9 +2437,9 @@ tables:
         );
     }
 
-    #[test]
-    fn runtime_contract_fingerprint_ignores_refreshed_credential_material() {
-        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+    #[tokio::test]
+    async fn runtime_contract_fingerprint_ignores_refreshed_credential_material() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace = WorkspaceName::default();
         let source_name = SourceName::parse("secured_messages").expect("source name");

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1151,7 +1151,7 @@ mod tests {
                     variables: BTreeMap::new(),
                     secrets: vec!["GITHUB_TOKEN".to_string()],
                     credential_storage: Some(CredentialStorageKind::Keychain),
-                    credential_revision: Default::default(),
+                    credential_revision: uuid::Uuid::default(),
                     origin: SourceOrigin::Bundled,
                 },
             )
@@ -1625,7 +1625,7 @@ tables:
             variables: BTreeMap::new(),
             secrets: vec!["API_KEY".to_string(), "OAUTH_TOKEN".to_string()],
             credential_storage: Some(CredentialStorageKind::File),
-            credential_revision: Default::default(),
+            credential_revision: uuid::Uuid::default(),
             origin: SourceOrigin::Imported,
         };
         fixture
@@ -2140,7 +2140,7 @@ surfaces:
                     variables: BTreeMap::new(),
                     secrets: Vec::new(),
                     credential_storage: None,
-                    credential_revision: Default::default(),
+                    credential_revision: uuid::Uuid::default(),
                     origin: SourceOrigin::Imported,
                 },
             )
@@ -2351,7 +2351,7 @@ select 1 as value
             variables: BTreeMap::new(),
             secrets: vec!["API_TOKEN".to_string()],
             credential_storage: Some(CredentialStorageKind::File),
-            credential_revision: Default::default(),
+            credential_revision: uuid::Uuid::default(),
             origin: SourceOrigin::Bundled,
         };
         fixture
@@ -2568,7 +2568,7 @@ tables:
                 variables: BTreeMap::new(),
                 secrets: vec!["API_TOKEN".to_string()],
                 credential_storage: None,
-                credential_revision: Default::default(),
+                credential_revision: uuid::Uuid::default(),
                 origin: SourceOrigin::Bundled,
             },
             query_source: QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new()),
@@ -2646,7 +2646,7 @@ tables:
                 variables: BTreeMap::new(),
                 secrets: Vec::new(),
                 credential_storage: None,
-                credential_revision: Default::default(),
+                credential_revision: uuid::Uuid::default(),
                 origin: SourceOrigin::Bundled,
             },
             query_source: QuerySource::new(source_spec, BTreeMap::new(), BTreeMap::new()),

--- a/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
@@ -324,6 +324,7 @@ fn loader_fails_closed_when_installed_manifest_cannot_be_read() {
                 variables: BTreeMap::new(),
                 secrets: Vec::new(),
                 credential_storage: None,
+                credential_revision: Default::default(),
                 origin: SourceOrigin::Imported,
             },
         )
@@ -420,6 +421,7 @@ fn install_imported_source(
                 variables: BTreeMap::new(),
                 secrets: Vec::new(),
                 credential_storage: None,
+                credential_revision: Default::default(),
                 origin: SourceOrigin::Imported,
             },
         )

--- a/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
@@ -324,7 +324,7 @@ fn loader_fails_closed_when_installed_manifest_cannot_be_read() {
                 variables: BTreeMap::new(),
                 secrets: Vec::new(),
                 credential_storage: None,
-                credential_revision: Default::default(),
+                credential_revision: uuid::Uuid::default(),
                 origin: SourceOrigin::Imported,
             },
         )
@@ -421,7 +421,7 @@ fn install_imported_source(
                 variables: BTreeMap::new(),
                 secrets: Vec::new(),
                 credential_storage: None,
-                credential_revision: Default::default(),
+                credential_revision: uuid::Uuid::default(),
                 origin: SourceOrigin::Imported,
             },
         )

--- a/crates/coral-app/src/search/observed/collector.rs
+++ b/crates/coral-app/src/search/observed/collector.rs
@@ -1,10 +1,5 @@
 //! Observed-values batch collection.
 
-#![allow(
-    dead_code,
-    reason = "observed-values provider substrate is staged before app wiring in the next PR"
-)]
-
 use std::collections::HashSet;
 
 use arrow::array::{

--- a/crates/coral-app/src/search/observed/mod.rs
+++ b/crates/coral-app/src/search/observed/mod.rs
@@ -8,6 +8,6 @@ mod sqlite_queue;
 mod sqlite_store;
 mod writer;
 
-pub(crate) use publisher::SearchObservationHandle;
+pub(crate) use publisher::{SearchObservationHandle, SearchObservationSource};
 #[cfg(test)]
 pub(crate) use sqlite_store::SqliteObservedValuesStore;

--- a/crates/coral-app/src/search/observed/mod.rs
+++ b/crates/coral-app/src/search/observed/mod.rs
@@ -7,3 +7,5 @@ mod source_scope;
 mod sqlite_queue;
 mod sqlite_store;
 mod writer;
+
+pub(crate) use publisher::SearchObservationHandle;

--- a/crates/coral-app/src/search/observed/mod.rs
+++ b/crates/coral-app/src/search/observed/mod.rs
@@ -9,3 +9,5 @@ mod sqlite_store;
 mod writer;
 
 pub(crate) use publisher::SearchObservationHandle;
+#[cfg(test)]
+pub(crate) use sqlite_store::SqliteObservedValuesStore;

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -1,10 +1,5 @@
 //! Source-scan observed-values publisher wiring.
 
-#![allow(
-    dead_code,
-    reason = "observed-values provider substrate is staged before app wiring in the next PR"
-)]
-
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -7,6 +7,7 @@ use coral_engine::{
     EngineExtensions, QuerySource, SourceObservationPublisher, SourceObservationSurfaceKind,
     SourceScanObservation,
 };
+use uuid::Uuid;
 
 use crate::bootstrap::AppError;
 use crate::search::observed::collector::ObservedValuesCollector;
@@ -30,6 +31,32 @@ pub(crate) struct SearchObservationHandle {
     collector: ObservedValuesCollector,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SearchObservationSource<'a> {
+    query_source: &'a QuerySource,
+    runtime_contract_fingerprint: &'a str,
+    credential_revision: Uuid,
+}
+
+impl<'a> SearchObservationSource<'a> {
+    pub(crate) const fn new(
+        query_source: &'a QuerySource,
+        runtime_contract_fingerprint: &'a str,
+        credential_revision: Uuid,
+    ) -> Self {
+        Self {
+            query_source,
+            runtime_contract_fingerprint,
+            credential_revision,
+        }
+    }
+
+    #[cfg(test)]
+    fn for_test(query_source: &'a QuerySource) -> Self {
+        Self::new(query_source, "v1:test-runtime-contract", Uuid::nil())
+    }
+}
+
 impl SearchObservationHandle {
     pub(crate) fn new(layout: AppStateLayout) -> Self {
         let store = SqliteObservedValuesStore::new(layout);
@@ -44,11 +71,13 @@ impl SearchObservationHandle {
     pub(crate) fn extensions_for(
         &self,
         workspace_name: &WorkspaceName,
-        selected_sources: &[QuerySource],
+        selected_sources: &[SearchObservationSource<'_>],
     ) -> EngineExtensions {
         let epochs = match self.store.capture_epochs_for_sources(
             workspace_name,
-            selected_sources.iter().map(QuerySource::source_name),
+            selected_sources
+                .iter()
+                .map(|source| source.query_source.source_name()),
         ) {
             Ok(epochs) => epochs,
             Err(error) => {
@@ -62,10 +91,14 @@ impl SearchObservationHandle {
         };
         let mut scopes = HashMap::new();
         for source in selected_sources {
-            let Some(epoch) = epochs.get(source.source_name()).copied() else {
+            let Some(epoch) = epochs.get(source.query_source.source_name()).copied() else {
                 continue;
             };
-            for scope in source_surface_scopes(source, SourceScopeSeed::PRE_ACTIVATION) {
+            let seed = SourceScopeSeed::new(
+                source.runtime_contract_fingerprint,
+                source.credential_revision,
+            );
+            for scope in source_surface_scopes(source.query_source, seed) {
                 scopes.insert(scope.key(), RegisteredSurface { scope, epoch });
             }
         }
@@ -252,7 +285,7 @@ mod tests {
     use tempfile::tempdir;
     use uuid::Uuid;
 
-    use super::SearchObservationHandle;
+    use super::{SearchObservationHandle, SearchObservationSource};
     use crate::search::observed::source_scope::{SourceScopeSeed, source_surface_scopes};
     use crate::search::observed::sqlite_queue::{
         ObservedValueCandidate, ObservedValuesQueuePayload,
@@ -316,7 +349,8 @@ mod tests {
         let workspace = WorkspaceName::default();
         let handle = SearchObservationHandle::new(layout.clone());
         let source = secret_input_query_source();
-        let extensions = handle.extensions_for(&workspace, &[source]);
+        let extensions =
+            handle.extensions_for(&workspace, &[SearchObservationSource::for_test(&source)]);
         let publisher = extensions
             .source_observation_publishers
             .first()
@@ -362,7 +396,9 @@ mod tests {
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let workspace = WorkspaceName::default();
         let handle = SearchObservationHandle::new(layout.clone());
-        let extensions = handle.extensions_for(&workspace, &[secret_input_query_source()]);
+        let source = secret_input_query_source();
+        let extensions =
+            handle.extensions_for(&workspace, &[SearchObservationSource::for_test(&source)]);
         let publisher = extensions
             .source_observation_publishers
             .first()
@@ -404,7 +440,8 @@ mod tests {
         let workspace = WorkspaceName::default();
         let handle = SearchObservationHandle::new(layout.clone());
         let source = multi_surface_v4_query_source();
-        let extensions = handle.extensions_for(&workspace, &[source]);
+        let extensions =
+            handle.extensions_for(&workspace, &[SearchObservationSource::for_test(&source)]);
         let publisher = extensions
             .source_observation_publishers
             .first()
@@ -465,7 +502,8 @@ mod tests {
         let workspace = WorkspaceName::default();
         let handle = SearchObservationHandle::new(layout.clone());
         let source = secret_input_query_source();
-        let extensions = handle.extensions_for(&workspace, &[source]);
+        let extensions =
+            handle.extensions_for(&workspace, &[SearchObservationSource::for_test(&source)]);
         let publisher = extensions
             .source_observation_publishers
             .first()

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -102,6 +102,14 @@ impl SearchObservationHandle {
             .clear_source_and_advance_epoch(workspace_name, source_name)
             .map_err(|error| observed_values_store_error(&error))
     }
+
+    pub(crate) fn shutdown(&self) -> Result<(), AppError> {
+        self.writer.shutdown().map_err(|error| {
+            AppError::Unavailable(format!(
+                "observed-values background writer failed during shutdown: {error}"
+            ))
+        })
+    }
 }
 
 fn observed_values_store_error(error: &SqliteSearchError) -> AppError {
@@ -445,6 +453,42 @@ mod tests {
                 .expect("queue count"),
             0
         );
+    }
+
+    #[test]
+    fn shutdown_drains_observed_values_writer_queue() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let handle = SearchObservationHandle::new(layout.clone());
+        let source = secret_input_query_source();
+        let extensions = handle.extensions_for(&workspace, &[source]);
+        let publisher = extensions
+            .source_observation_publishers
+            .first()
+            .expect("publisher");
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, false)])),
+            vec![Arc::new(StringArray::from(vec!["Grace"]))],
+        )
+        .expect("batch");
+
+        publisher.publish_source_scan(SourceScanObservation {
+            source_name: "github",
+            surface_kind: SourceObservationSurfaceKind::Table,
+            surface_name: "issues",
+            batch: &batch,
+        });
+        handle.shutdown().expect("shutdown drains writer");
+
+        let store = SqliteObservedValuesStore::new(layout);
+        let payloads = store
+            .queue_payloads(&workspace)
+            .expect("queued observed-values payloads");
+        assert_eq!(payloads.len(), 1);
+        let payload = payloads.first().expect("one payload");
+        assert!(payload.contains("Grace"));
     }
 
     #[test]

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -46,22 +46,24 @@ impl SearchObservationHandle {
         workspace_name: &WorkspaceName,
         selected_sources: &[QuerySource],
     ) -> EngineExtensions {
+        let epochs = match self.store.capture_epochs_for_sources(
+            workspace_name,
+            selected_sources.iter().map(QuerySource::source_name),
+        ) {
+            Ok(epochs) => epochs,
+            Err(error) => {
+                tracing::debug!(
+                    workspace = %workspace_name.as_str(),
+                    error = %error,
+                    "skipping observed-values publishers"
+                );
+                return EngineExtensions::default();
+            }
+        };
         let mut scopes = HashMap::new();
         for source in selected_sources {
-            let epoch = match self
-                .store
-                .capture_epoch(workspace_name, source.source_name())
-            {
-                Ok(epoch) => epoch,
-                Err(error) => {
-                    tracing::debug!(
-                        workspace = %workspace_name.as_str(),
-                        source = %source.source_name(),
-                        error = %error,
-                        "skipping observed-values publisher for source"
-                    );
-                    continue;
-                }
+            let Some(epoch) = epochs.get(source.source_name()).copied() else {
+                continue;
             };
             for scope in source_surface_scopes(source, SourceScopeSeed::PRE_ACTIVATION) {
                 scopes.insert(scope.key(), RegisteredSurface { scope, epoch });

--- a/crates/coral-app/src/search/observed/source_scope.rs
+++ b/crates/coral-app/src/search/observed/source_scope.rs
@@ -8,6 +8,7 @@ use crate::hash::sha256_hex;
 use crate::search::observed::sqlite_queue::ObservedValuesSurfaceKind;
 
 const SOURCE_SCOPE_FORMAT_VERSION: u8 = 1;
+#[cfg(test)]
 const PRE_ACTIVATION_RUNTIME_CONTRACT_FINGERPRINT: &str = "observed-values/pre-activation/v0";
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -28,6 +29,7 @@ pub(super) struct SourceScopeSeed<'a> {
     credential_revision: Uuid,
 }
 
+#[cfg(test)]
 impl SourceScopeSeed<'static> {
     pub(super) const PRE_ACTIVATION: Self =
         Self::new(PRE_ACTIVATION_RUNTIME_CONTRACT_FINGERPRINT, Uuid::nil());

--- a/crates/coral-app/src/search/observed/sqlite_queue.rs
+++ b/crates/coral-app/src/search/observed/sqlite_queue.rs
@@ -1,10 +1,5 @@
 //! Durable observed-values queue records.
 
-#![allow(
-    dead_code,
-    reason = "observed-values provider substrate is staged before app wiring in the next PR"
-)]
-
 use serde::{Deserialize, Serialize};
 
 /// Snapshot of the workspace-wide and source-local invalidation counters.

--- a/crates/coral-app/src/search/observed/sqlite_store.rs
+++ b/crates/coral-app/src/search/observed/sqlite_store.rs
@@ -1,5 +1,7 @@
 //! `SQLite` observed-values queue and governance operations.
 
+use std::collections::BTreeMap;
+
 use rusqlite::{Connection, OptionalExtension as _, Transaction, TransactionBehavior, params};
 
 use crate::search::observed::sqlite_queue::{
@@ -24,14 +26,34 @@ impl SqliteObservedValuesStore {
         Self { layout }
     }
 
+    #[cfg(test)]
     pub(crate) fn capture_epoch(
         &self,
         workspace_name: &WorkspaceName,
         owner_source_name: &str,
     ) -> Result<ObservedValuesEpoch, SqliteSearchError> {
+        let mut epochs = self.capture_epochs_for_sources(workspace_name, [owner_source_name])?;
+        let Some(epoch) = epochs.remove(owner_source_name) else {
+            return Ok(ObservedValuesEpoch::ZERO);
+        };
+        Ok(epoch)
+    }
+
+    pub(crate) fn capture_epochs_for_sources<'a>(
+        &self,
+        workspace_name: &WorkspaceName,
+        owner_source_names: impl IntoIterator<Item = &'a str>,
+    ) -> Result<BTreeMap<String, ObservedValuesEpoch>, SqliteSearchError> {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let connection = store.connect()?;
-        read_epoch(&connection, workspace_name, owner_source_name)
+        let mut epochs = BTreeMap::new();
+        for owner_source_name in owner_source_names {
+            epochs.insert(
+                owner_source_name.to_string(),
+                read_epoch(&connection, workspace_name, owner_source_name)?,
+            );
+        }
+        Ok(epochs)
     }
 
     pub(crate) fn enqueue_if_current(
@@ -619,6 +641,48 @@ mod tests {
             }
             Err(error) => SqliteSearchError::from(error).is_lock_contention(),
         }
+    }
+
+    #[test]
+    fn capture_epochs_for_sources_reads_all_sources_with_one_store_open() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let store = SqliteObservedValuesStore::new(layout);
+
+        store
+            .clear_source_and_advance_epoch(&workspace, "github")
+            .expect("clear github");
+        store
+            .clear_source_and_advance_epoch(&workspace, "slack")
+            .expect("clear slack");
+        store
+            .clear_source_and_advance_epoch(&workspace, "slack")
+            .expect("clear slack again");
+
+        let epochs = store
+            .capture_epochs_for_sources(&workspace, ["github", "slack", "notion"])
+            .expect("epochs");
+
+        assert_eq!(
+            epochs
+                .get("github")
+                .expect("github epoch")
+                .source_generation,
+            1
+        );
+        assert_eq!(
+            epochs.get("slack").expect("slack epoch").source_generation,
+            2
+        );
+        assert_eq!(
+            epochs
+                .get("notion")
+                .expect("notion epoch")
+                .source_generation,
+            0
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/search/observed/sqlite_store.rs
+++ b/crates/coral-app/src/search/observed/sqlite_store.rs
@@ -1,10 +1,5 @@
 //! `SQLite` observed-values queue and governance operations.
 
-#![allow(
-    dead_code,
-    reason = "observed-values provider substrate is staged before app wiring in the next PR"
-)]
-
 use rusqlite::{Connection, OptionalExtension as _, Transaction, TransactionBehavior, params};
 
 use crate::search::observed::sqlite_queue::{

--- a/crates/coral-app/src/search/observed/writer.rs
+++ b/crates/coral-app/src/search/observed/writer.rs
@@ -1,5 +1,8 @@
 //! Bounded observed-values writer lifecycle and durable queue handoff.
 
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+
 use serde::Serialize;
 use tokio::sync::mpsc::{self, Receiver, Sender, error::TrySendError};
 
@@ -14,7 +17,13 @@ const OBSERVED_VALUES_WRITE_QUEUE_CAPACITY: usize = 128;
 
 #[derive(Debug, Clone)]
 pub(super) struct ObservedValuesWriter {
-    sender: Sender<ObservedValuesWrite>,
+    shared: Arc<ObservedValuesWriterShared>,
+}
+
+#[derive(Debug)]
+struct ObservedValuesWriterShared {
+    sender: Mutex<Option<Sender<ObservedValuesWrite>>>,
+    join_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
 #[derive(Debug)]
@@ -35,41 +44,94 @@ pub(super) enum ObservedValuesTryReserveError {
     Disconnected,
 }
 
-pub(super) struct ObservedValuesWritePermit<'a> {
-    permit: mpsc::Permit<'a, ObservedValuesWrite>,
+pub(super) struct ObservedValuesWritePermit {
+    permit: mpsc::OwnedPermit<ObservedValuesWrite>,
 }
 
-impl ObservedValuesWritePermit<'_> {
+impl ObservedValuesWritePermit {
     pub(super) fn send(self, write: ObservedValuesWrite) {
         self.permit.send(write);
+    }
+}
+
+#[derive(Debug)]
+pub(super) enum ObservedValuesWriterShutdownError {
+    MutexPoisoned,
+    Panicked,
+}
+
+impl std::fmt::Display for ObservedValuesWriterShutdownError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MutexPoisoned => f.write_str("writer mutex poisoned"),
+            Self::Panicked => f.write_str("writer thread panicked"),
+        }
     }
 }
 
 impl ObservedValuesWriter {
     pub(super) fn start(store: SqliteObservedValuesStore) -> Self {
         let (sender, receiver) = mpsc::channel(OBSERVED_VALUES_WRITE_QUEUE_CAPACITY);
-        if let Err(error) = std::thread::Builder::new()
+        let join_handle = match std::thread::Builder::new()
             .name("coral-observed-values-writer".to_string())
             .spawn(move || run_observed_values_writer(&store, receiver))
         {
-            tracing::warn!(
-                error = %error,
-                "failed to start observed-values background writer"
-            );
+            Ok(join_handle) => Some(join_handle),
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    "failed to start observed-values background writer"
+                );
+                None
+            }
+        };
+        Self {
+            shared: Arc::new(ObservedValuesWriterShared {
+                sender: Mutex::new(Some(sender)),
+                join_handle: Mutex::new(join_handle),
+            }),
         }
-        Self { sender }
     }
 
     pub(super) fn try_reserve(
         &self,
-    ) -> Result<ObservedValuesWritePermit<'_>, ObservedValuesTryReserveError> {
-        self.sender
-            .try_reserve()
+    ) -> Result<ObservedValuesWritePermit, ObservedValuesTryReserveError> {
+        let Ok(sender) = self.shared.sender.lock() else {
+            return Err(ObservedValuesTryReserveError::Disconnected);
+        };
+        let Some(sender) = sender.as_ref() else {
+            return Err(ObservedValuesTryReserveError::Disconnected);
+        };
+        sender
+            .clone()
+            .try_reserve_owned()
             .map(|permit| ObservedValuesWritePermit { permit })
             .map_err(|error| match error {
-                TrySendError::Full(()) => ObservedValuesTryReserveError::Full,
-                TrySendError::Closed(()) => ObservedValuesTryReserveError::Disconnected,
+                TrySendError::Full(_) => ObservedValuesTryReserveError::Full,
+                TrySendError::Closed(_) => ObservedValuesTryReserveError::Disconnected,
             })
+    }
+
+    pub(super) fn shutdown(&self) -> Result<(), ObservedValuesWriterShutdownError> {
+        let mut sender = self
+            .shared
+            .sender
+            .lock()
+            .map_err(|_poisoned| ObservedValuesWriterShutdownError::MutexPoisoned)?;
+        drop(sender.take());
+        drop(sender);
+        let join_handle = self
+            .shared
+            .join_handle
+            .lock()
+            .map_err(|_poisoned| ObservedValuesWriterShutdownError::MutexPoisoned)?
+            .take();
+        if let Some(join_handle) = join_handle {
+            join_handle
+                .join()
+                .map_err(|_panic_payload| ObservedValuesWriterShutdownError::Panicked)?;
+        }
+        Ok(())
     }
 }
 
@@ -161,14 +223,24 @@ fn payload_json_for_values(values: &[ObservedValueCandidate]) -> Result<String, 
 
 #[cfg(test)]
 mod tests {
-    use super::{ObservedValuesTryReserveError, ObservedValuesWrite, ObservedValuesWriter};
+    use std::sync::{Arc, Mutex};
+
+    use super::{
+        ObservedValuesTryReserveError, ObservedValuesWrite, ObservedValuesWriter,
+        ObservedValuesWriterShared,
+    };
     use crate::search::observed::sqlite_queue::{ObservedValuesEpoch, ObservedValuesSurfaceKind};
     use crate::workspaces::WorkspaceName;
 
     #[test]
     fn writer_capacity_is_reserved_before_a_write_is_built() {
         let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
-        let writer = ObservedValuesWriter { sender };
+        let writer = ObservedValuesWriter {
+            shared: Arc::new(ObservedValuesWriterShared {
+                sender: Mutex::new(Some(sender)),
+                join_handle: Mutex::new(None),
+            }),
+        };
 
         let permit = writer.try_reserve().expect("first reservation");
         assert!(matches!(

--- a/crates/coral-app/src/search/observed/writer.rs
+++ b/crates/coral-app/src/search/observed/writer.rs
@@ -54,19 +54,12 @@ impl ObservedValuesWritePermit {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub(super) enum ObservedValuesWriterShutdownError {
+    #[error("writer mutex poisoned")]
     MutexPoisoned,
+    #[error("writer thread panicked")]
     Panicked,
-}
-
-impl std::fmt::Display for ObservedValuesWriterShutdownError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::MutexPoisoned => f.write_str("writer mutex poisoned"),
-            Self::Panicked => f.write_str("writer thread panicked"),
-        }
-    }
 }
 
 impl ObservedValuesWriter {

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -183,18 +183,24 @@ fn clear_response_to_proto(
 }
 
 fn maintenance_result_to_proto(result: SearchMaintenanceResult) -> ProtoSearchMaintenanceResult {
+    let SearchMaintenanceResult {
+        provider,
+        state,
+        note,
+        detail,
+    } = result;
     ProtoSearchMaintenanceResult {
-        provider: provider_kind_to_proto(result.provider) as i32,
-        state: maintenance_state_to_proto(result.state) as i32,
-        note: result.note,
-        detail: result.detail.as_ref().map(maintenance_detail_to_proto),
+        provider: provider_kind_to_proto(provider) as i32,
+        state: maintenance_state_to_proto(state) as i32,
+        note,
+        detail: detail.as_ref().map(maintenance_detail_to_proto),
     }
 }
 
 fn maintenance_detail_to_proto(detail: &SearchMaintenanceDetail) -> ProtoMaintenanceDetail {
     match detail {
         SearchMaintenanceDetail::CatalogRebuild(result) => {
-            ProtoMaintenanceDetail::CatalogRebuild(catalog_rebuild_to_proto(*result))
+            ProtoMaintenanceDetail::CatalogRebuild(catalog_rebuild_to_proto(result))
         }
         SearchMaintenanceDetail::CatalogClear(result) => {
             ProtoMaintenanceDetail::CatalogClear(catalog_clear_to_proto(*result))
@@ -202,7 +208,7 @@ fn maintenance_detail_to_proto(detail: &SearchMaintenanceDetail) -> ProtoMainten
     }
 }
 
-fn catalog_rebuild_to_proto(result: CatalogRebuildMaintenanceResult) -> ProtoCatalogRebuildResult {
+fn catalog_rebuild_to_proto(result: &CatalogRebuildMaintenanceResult) -> ProtoCatalogRebuildResult {
     ProtoCatalogRebuildResult {
         old_document_count: result.old_document_count,
         new_document_count: result.new_document_count,

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -2439,7 +2439,7 @@ surfaces:
                     variables: BTreeMap::new(),
                     secrets: vec!["OTHER_TOKEN".to_string()],
                     credential_storage: Some(CredentialStorageKind::Keychain),
-                    credential_revision: Default::default(),
+                    credential_revision: uuid::Uuid::default(),
                     origin: SourceOrigin::Imported,
                 },
             )

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -799,9 +799,6 @@ impl SourceManager {
         let Some(search_observations) = &self.search_observations else {
             return;
         };
-        if !self.layout.search_sqlite_file(workspace_name).exists() {
-            return;
-        }
         if let Err(error) = search_observations.clear_source(workspace_name, source_name.as_str()) {
             warn!(
                 workspace = %workspace_name,
@@ -1658,6 +1655,7 @@ mod tests {
         CredentialManager, CredentialSetId, CredentialStorageKind, CredentialStoragePreference,
         CredentialStore,
     };
+    use crate::search::observed::{SearchObservationHandle, SqliteObservedValuesStore};
     use crate::sources::SourceName;
     use crate::sources::catalog::describe_manifest;
     use crate::sources::materialization::{FINGERPRINT_FILENAME, PROJECTIONS_FILENAME};
@@ -2458,6 +2456,34 @@ surfaces:
         .expect("stored material check");
 
         assert!(needs_stored);
+    }
+
+    #[test]
+    fn observed_cleanup_advances_source_epoch_when_sqlite_file_is_absent() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let search_observations = SearchObservationHandle::new(layout.clone());
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone())
+                .with_search_observation_handle(search_observations.clone());
+        let workspace_name = default_workspace();
+        let source_name = SourceName::parse("github").expect("source name");
+
+        assert!(!layout.search_sqlite_file(&workspace_name).exists());
+        manager
+            .clear_observed_values_for_source_lifecycle_best_effort(&workspace_name, &source_name);
+
+        assert!(layout.search_sqlite_file(&workspace_name).exists());
+        let epoch = SqliteObservedValuesStore::new(layout)
+            .capture_epoch(&workspace_name, source_name.as_str())
+            .expect("observed-values epoch");
+        assert_eq!(epoch.source_generation, 1);
+        search_observations.shutdown().expect("shutdown writer");
     }
 
     #[test]

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -35,6 +35,7 @@ use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthC
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
+use uuid::Uuid;
 
 #[derive(Clone)]
 pub(crate) struct SourceManager {
@@ -648,6 +649,11 @@ impl SourceManager {
         };
         let previous =
             self.load_source_rollback_state(workspace_name, &source_name, &credential_guard)?;
+        let previous_credential_revision = previous
+            .as_ref()
+            .map(|state| state.source.credential_revision)
+            .unwrap_or_default();
+        let is_new_install = previous.is_none();
         if let Err(error) =
             self.persist_manifest_artifact(workspace_name, &source_name, request.manifest_yaml)
         {
@@ -748,6 +754,13 @@ impl SourceManager {
             variables,
             secrets: visible_secret_keys,
             credential_storage,
+            credential_revision: if credential_storage.is_none() {
+                Uuid::nil()
+            } else if is_new_install || !replaced_oauth_inputs.is_empty() {
+                Uuid::new_v4()
+            } else {
+                previous_credential_revision
+            },
             origin: request.origin,
         };
         if let Err(error) = self
@@ -2426,6 +2439,7 @@ surfaces:
                     variables: BTreeMap::new(),
                     secrets: vec!["OTHER_TOKEN".to_string()],
                     credential_storage: Some(CredentialStorageKind::Keychain),
+                    credential_revision: Default::default(),
                     origin: SourceOrigin::Imported,
                 },
             )
@@ -3057,6 +3071,64 @@ surfaces:
             std::fs::read_to_string(&secret_path).expect("read replaced credential material"),
             "API_TOKEN=new-token\n"
         );
+    }
+
+    #[test]
+    fn credential_revision_rotates_only_when_credential_material_is_replaced() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let workspace = default_workspace();
+
+        let first = manager
+            .import_source(
+                &workspace,
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_with_secret(),
+                    bindings: SourceBindings {
+                        variables: Vec::new(),
+                        secrets: vec![SourceBinding {
+                            key: "API_TOKEN".to_string(),
+                            value: "first-token".to_string(),
+                        }],
+                    },
+                },
+            )
+            .expect("initial import");
+        assert!(!first.credential_revision.is_nil());
+
+        let unchanged = manager
+            .import_source(
+                &workspace,
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_with_secret(),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect("reimport with stored credential material");
+        assert_eq!(unchanged.credential_revision, first.credential_revision);
+
+        let replaced = manager
+            .import_source(
+                &workspace,
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_with_secret(),
+                    bindings: SourceBindings {
+                        variables: Vec::new(),
+                        secrets: vec![SourceBinding {
+                            key: "API_TOKEN".to_string(),
+                            value: "second-token".to_string(),
+                        }],
+                    },
+                },
+            )
+            .expect("credential replacement");
+        assert_ne!(replaced.credential_revision, first.credential_revision);
     }
 
     #[test]

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -15,6 +15,7 @@ use crate::credentials::{
     CORAL_INTERNAL_KEY_PREFIX, CredentialManager, CredentialMaterialGuard,
     CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialsError,
 };
+use crate::search::observed::SearchObservationHandle;
 use crate::search::sqlite_store::SqliteSearchStore;
 use crate::sources::SourceName;
 use crate::sources::catalog::{
@@ -43,6 +44,7 @@ pub(crate) struct SourceManager {
     layout: AppStateLayout,
     lifecycle_lock: WorkspaceLifecycleLock,
     diagnostic_reporter: SourceDiagnosticReporter,
+    search_observations: Option<SearchObservationHandle>,
 }
 
 pub(crate) struct CreateBundledSourceCommand {
@@ -218,7 +220,16 @@ impl SourceManager {
             layout,
             lifecycle_lock,
             diagnostic_reporter,
+            search_observations: None,
         }
+    }
+
+    pub(crate) fn with_search_observation_handle(
+        mut self,
+        search_observations: SearchObservationHandle,
+    ) -> Self {
+        self.search_observations = Some(search_observations);
+        self
     }
 
     pub(crate) fn list_workspace_sources(
@@ -595,7 +606,7 @@ impl SourceManager {
         drop(state_lock);
         self.diagnostic_reporter
             .clear_source(workspace_name, source_name);
-        self.clear_catalog_projection_for_source_lifecycle_best_effort(workspace_name, source_name);
+        self.clear_source_lifecycle_search_state_best_effort(workspace_name, source_name);
         Ok(removed)
     }
 
@@ -767,11 +778,37 @@ impl SourceManager {
         let mut resolved = stored;
         resolved.version.clone_from(&request.candidate.version);
         drop(state_lock);
-        self.clear_catalog_projection_for_source_lifecycle_best_effort(
-            workspace_name,
-            &source_name,
-        );
+        self.clear_source_lifecycle_search_state_best_effort(workspace_name, &source_name);
         Ok(resolved)
+    }
+
+    fn clear_source_lifecycle_search_state_best_effort(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        self.clear_observed_values_for_source_lifecycle_best_effort(workspace_name, source_name);
+        self.clear_catalog_projection_for_source_lifecycle_best_effort(workspace_name, source_name);
+    }
+
+    fn clear_observed_values_for_source_lifecycle_best_effort(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        let Some(search_observations) = &self.search_observations else {
+            return;
+        };
+        if !self.layout.search_sqlite_file(workspace_name).exists() {
+            return;
+        }
+        if let Err(error) = search_observations.clear_source(workspace_name, source_name.as_str()) {
+            warn!(
+                workspace = %workspace_name,
+                source = %source_name,
+                "source lifecycle changed, but failed to clear observed-values state: {error}"
+            );
+        }
     }
 
     fn clear_catalog_projection_for_source_lifecycle_best_effort(

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use coral_spec::ManifestInputSpec;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::credentials::CredentialStorageKind;
 use crate::sources::SourceName;
@@ -43,6 +44,13 @@ pub(crate) struct InstalledSource {
     /// storage until the source is removed and re-added.
     #[serde(default)]
     pub(crate) credential_storage: Option<CredentialStorageKind>,
+    /// Non-secret account identity used to invalidate derived local state when
+    /// credential material is explicitly replaced.
+    ///
+    /// Existing source configurations deserialize to the nil UUID. Ordinary
+    /// OAuth access-token refreshes do not mutate this value.
+    #[serde(default)]
+    pub(crate) credential_revision: Uuid,
     /// Where this installed source came from.
     pub(crate) origin: SourceOrigin,
 }

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -896,7 +896,7 @@ mod tests {
             projections: ProjectionCatalog {
                 artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
                 source_name: "demo".to_string(),
-                generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+                generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
                 projections: Vec::new(),
                 diagnostics: Vec::new(),
             },

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use coral_engine::RuntimeSourceComponent;
+use coral_engine::{QuerySource, RuntimeSourceComponent, RuntimeSourcePackage};
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 use coral_spec::backends::mcp::{
     McpSourceManifest, McpTableFilterBinding, McpTableFunctionSpec, McpTableSpec,
@@ -18,11 +18,167 @@ use coral_spec::{
     PaginationSpec, ParsedTemplate, RequestSpec, ResponseSpec, SourceManifestCommon,
     SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon,
 };
+use serde::Serialize;
 
 use crate::bootstrap::AppError;
+use crate::hash::sha256_hex;
 use crate::sources::SourceName;
-use crate::sources::materialization::SourceDiagnosticReporter;
+use crate::sources::catalog::InstalledSourceManifest;
+use crate::sources::materialization::{
+    SourceDiagnosticReporter, incompatible_materialization_error, load_v4_materialization,
+};
+use crate::sources::model::InstalledSource;
+use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
+
+const RUNTIME_CONTRACT_FINGERPRINT_VERSION: u32 = 1;
+
+/// Versioned, non-secret identity for the installed runtime contract used by
+/// query execution and derived local state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeContractFingerprint(String);
+
+impl RuntimeContractFingerprint {
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LoadedRuntimeSource {
+    pub(crate) query_source: QuerySource,
+    pub(crate) runtime_contract_fingerprint: RuntimeContractFingerprint,
+}
+
+#[derive(Serialize)]
+struct RuntimeContractFingerprintInput<'a> {
+    version: u32,
+    manifest_sha256: String,
+    variables: &'a BTreeMap<String, String>,
+    v4_runtime: Option<V4RuntimeFingerprintInput<'a>>,
+}
+
+#[derive(Serialize)]
+struct V4RuntimeFingerprintInput<'a> {
+    fingerprint: Option<&'a coral_spec::v4::Fingerprint>,
+    surfaces: Vec<V4SurfaceFingerprintInput<'a>>,
+    projections: &'a coral_spec::v4::ProjectionCatalog,
+}
+
+#[derive(Serialize)]
+struct V4SurfaceFingerprintInput<'a> {
+    surface_id: &'a str,
+    semantic_ir: &'a coral_spec::v4::SemanticIr,
+    source_document_sha256: Option<&'a str>,
+}
+
+/// Fingerprints authored manifest content, deterministic non-secret variable
+/// bindings, and the materialised v4 runtime contract. Filesystem paths and
+/// resolved credential material are deliberately excluded.
+pub(crate) fn runtime_contract_fingerprint(
+    manifest_yaml: &str,
+    variables: &BTreeMap<String, String>,
+    v4_materialized: Option<&V4MaterializedSource>,
+) -> Result<RuntimeContractFingerprint, AppError> {
+    let input = RuntimeContractFingerprintInput {
+        version: RUNTIME_CONTRACT_FINGERPRINT_VERSION,
+        manifest_sha256: sha256_hex(manifest_yaml.as_bytes()),
+        variables,
+        v4_runtime: v4_materialized.map(|materialized| V4RuntimeFingerprintInput {
+            fingerprint: materialized.fingerprint.as_ref(),
+            surfaces: materialized
+                .surfaces
+                .iter()
+                .map(|surface| V4SurfaceFingerprintInput {
+                    surface_id: &surface.surface_id,
+                    semantic_ir: &surface.semantic_ir,
+                    source_document_sha256: surface.source_document_sha256.as_deref(),
+                })
+                .collect(),
+            projections: &materialized.projections,
+        }),
+    };
+    let bytes = serde_json::to_vec(&input).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "failed to fingerprint installed source runtime contract: {error}"
+        ))
+    })?;
+    Ok(RuntimeContractFingerprint(format!(
+        "v{RUNTIME_CONTRACT_FINGERPRINT_VERSION}:{}",
+        sha256_hex(&bytes)
+    )))
+}
+
+/// Loads exactly the runtime package used for query execution and returns its
+/// non-secret contract fingerprint alongside it. Observation and retrieval
+/// scope code must consume this result instead of independently rebuilding the
+/// runtime contract.
+pub(crate) fn query_source_from_installed_manifest(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source: &InstalledSource,
+    installed: &InstalledSourceManifest,
+    diagnostic_reporter: &SourceDiagnosticReporter,
+    resolved_secrets: BTreeMap<String, String>,
+) -> Result<LoadedRuntimeSource, AppError> {
+    let source_spec = &installed.source_spec;
+    let (query_source, v4_materialized) = if let Some(v4) = source_spec.as_v4() {
+        let materialized = load_v4_materialization(
+            layout,
+            workspace_name,
+            &source.name,
+            &installed.manifest_yaml,
+            v4,
+            diagnostic_reporter,
+        )?;
+        let components = runtime_components_for_v4_source(
+            workspace_name,
+            &source.name,
+            v4,
+            &materialized,
+            diagnostic_reporter,
+        )
+        .map_err(|error| {
+            incompatible_materialization_error(
+                &source.name,
+                format!("failed to assemble runtime package: {error}"),
+            )
+        })?;
+        let query_source = QuerySource::from_runtime_components(
+            RuntimeSourcePackage {
+                source_name: source_spec.schema_name().to_string(),
+                authored_version: source_spec.source_version().map(ToString::to_string),
+                description: source_spec.description().to_string(),
+                declared_inputs: source_spec.declared_inputs().to_vec(),
+                test_queries: source_spec.test_queries().to_vec(),
+                components,
+            },
+            source.variables.clone(),
+            resolved_secrets,
+        )
+        .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
+        (query_source, Some(materialized))
+    } else {
+        (
+            QuerySource::from_manifest(source_spec, source.variables.clone(), resolved_secrets),
+            None,
+        )
+    };
+    let runtime_contract_fingerprint = runtime_contract_fingerprint(
+        &installed.manifest_yaml,
+        &source.variables,
+        v4_materialized.as_ref(),
+    )?;
+    Ok(LoadedRuntimeSource {
+        query_source,
+        runtime_contract_fingerprint,
+    })
+}
 
 pub(crate) fn runtime_components_for_v4_source(
     workspace_name: &WorkspaceName,
@@ -454,6 +610,7 @@ fn validate_surface_base_url_template(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::path::PathBuf;
 
     use coral_spec::backends::http::{AuthSpec, RateLimitSpec};
@@ -469,7 +626,10 @@ mod tests {
     };
     use coral_spec::{PageSizeSpec, PaginationMode, PaginationSpec, ResponseSpec};
 
-    use super::{runtime_components_for_v4_source as build_runtime_components, surface_base_url};
+    use super::{
+        runtime_components_for_v4_source as build_runtime_components, runtime_contract_fingerprint,
+        surface_base_url,
+    };
 
     fn runtime_components_for_v4_source(
         manifest: &V4SourceManifest,
@@ -693,6 +853,89 @@ mod tests {
             detail_hints: Vec::new(),
             diagnostics: Vec::new(),
         }
+    }
+
+    #[test]
+    fn runtime_contract_fingerprint_tracks_manifest_and_non_secret_variables() {
+        let first = runtime_contract_fingerprint(
+            "name: demo\nliteral: one\n",
+            &BTreeMap::from([("REGION".to_string(), "eu".to_string())]),
+            None,
+        )
+        .expect("first fingerprint");
+        let different_literal = runtime_contract_fingerprint(
+            "name: demo\nliteral: two\n",
+            &BTreeMap::from([("REGION".to_string(), "eu".to_string())]),
+            None,
+        )
+        .expect("literal fingerprint");
+        let different_variable = runtime_contract_fingerprint(
+            "name: demo\nliteral: one\n",
+            &BTreeMap::from([("REGION".to_string(), "us".to_string())]),
+            None,
+        )
+        .expect("variable fingerprint");
+
+        assert!(first.as_str().starts_with("v1:"));
+        assert_ne!(first, different_literal);
+        assert_ne!(first, different_variable);
+    }
+
+    #[test]
+    fn runtime_contract_fingerprint_tracks_v4_runtime_but_not_artifact_paths() {
+        let mut materialized = V4MaterializedSource {
+            fingerprint: Some(Fingerprint {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "demo".to_string(),
+                manifest_sha256: "manifest".to_string(),
+                surfaces: Vec::new(),
+                importer_version: SURFACE_IMPORTER_VERSION.to_string(),
+                projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+            }),
+            surfaces: vec![materialized_surface(PathBuf::from("/first/raw.json"))],
+            projections: ProjectionCatalog {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "demo".to_string(),
+                generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+                projections: Vec::new(),
+                diagnostics: Vec::new(),
+            },
+            diagnostics: Vec::new(),
+        };
+        let surface = materialized.surfaces.first_mut().expect("surface");
+        surface.source_document_sha256 = Some("document-one".to_string());
+        let first =
+            runtime_contract_fingerprint("name: demo", &BTreeMap::new(), Some(&materialized))
+                .expect("first fingerprint");
+
+        let surface = materialized.surfaces.first_mut().expect("surface");
+        surface.raw_source_document_path = PathBuf::from("/second/raw.json");
+        surface.normalized_source_document_path = PathBuf::from("/second/normalized.json");
+        let moved =
+            runtime_contract_fingerprint("name: demo", &BTreeMap::new(), Some(&materialized))
+                .expect("moved fingerprint");
+        assert_eq!(first, moved);
+
+        materialized
+            .surfaces
+            .first_mut()
+            .expect("surface")
+            .source_document_sha256 = Some("document-two".to_string());
+        let changed =
+            runtime_contract_fingerprint("name: demo", &BTreeMap::new(), Some(&materialized))
+                .expect("changed fingerprint");
+        assert_ne!(first, changed);
+
+        materialized.fingerprint = None;
+        materialized
+            .surfaces
+            .first_mut()
+            .expect("surface")
+            .source_document_sha256 = None;
+        let without_optional_provenance =
+            runtime_contract_fingerprint("name: demo", &BTreeMap::new(), Some(&materialized))
+                .expect("fingerprint without optional provenance");
+        assert!(without_optional_provenance.as_str().starts_with("v1:"));
     }
 
     #[test]

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -36,6 +36,7 @@ use tonic::{Request, Response, Status};
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
 use crate::query::manager::QueryManager;
+use crate::search::observed::SearchObservationHandle;
 use crate::sources::SourceName;
 use crate::sources::manager::{
     CreateBundledSourceCommand, CreateBundledSourceWithOAuthCommand, ImportSourceCommand,
@@ -59,6 +60,7 @@ pub(crate) struct SourceService {
     sources: SourceManager,
     queries: QueryManager,
     workspaces: WorkspaceManager,
+    search_observations: Option<SearchObservationHandle>,
 }
 
 impl SourceService {
@@ -71,7 +73,16 @@ impl SourceService {
             sources: source_manager,
             queries: query_manager,
             workspaces: workspace_manager,
+            search_observations: None,
         }
+    }
+
+    pub(crate) fn with_search_observation_handle(
+        mut self,
+        search_observations: SearchObservationHandle,
+    ) -> Self {
+        self.search_observations = Some(search_observations);
+        self
     }
 }
 
@@ -175,10 +186,13 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
+        let search_observations = self.search_observations.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             require_workspace(&workspaces, &workspace_name).await?;
+            let operation_workspace_name = workspace_name.clone();
+            let observation_workspace_name = workspace_name.clone();
             let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
             let command = CreateBundledSourceCommand {
                 name: bundled_name,
@@ -186,9 +200,15 @@ impl SourceServiceApi for SourceService {
             };
             let response_workspace_name = workspace_name.clone();
             let installed = run_blocking_source_operation(move || {
-                sources.create_bundled_source(&workspace_name, &command)
+                sources.create_bundled_source(&operation_workspace_name, &command)
             })
             .await?;
+            clear_source_observations(
+                search_observations,
+                observation_workspace_name,
+                installed.name.as_str().to_string(),
+            )
+            .await;
             Ok(Response::new(CreateBundledSourceResponse {
                 source: Some(installed_source_to_proto(
                     &response_workspace_name,
@@ -206,11 +226,13 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
+        let search_observations = self.search_observations.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             require_workspace(&workspaces, &workspace_name).await?;
             let response_workspace_name = workspace_name.clone();
+            let observation_workspace_name = workspace_name.clone();
             let command = CreateBundledSourceWithOAuthCommand {
                 name: SourceName::parse(&request.name).map_err(app_status)?,
                 bindings: source_bindings_from_proto(request.variables, request.secrets),
@@ -224,14 +246,21 @@ impl SourceServiceApi for SourceService {
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
-                        sources
+                        let installed = sources
                             .create_bundled_source_with_oauth(
                                 &workspace_name,
                                 command,
                                 event_sender,
                             )
                             .await
-                            .map_err(app_status)
+                            .map_err(app_status)?;
+                        clear_source_observations(
+                            search_observations,
+                            observation_workspace_name,
+                            installed.name.as_str().to_string(),
+                        )
+                        .await;
+                        Ok(installed)
                     })
                 });
             Ok(Response::new(Box::pin(stream.map(|response| {
@@ -249,20 +278,29 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
+        let search_observations = self.search_observations.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             require_workspace(&workspaces, &workspace_name).await?;
             let response_workspace_name = workspace_name.clone();
             if request.oauth_credential_retrievals.is_empty() {
+                let operation_workspace_name = workspace_name.clone();
+                let observation_workspace_name = workspace_name.clone();
                 let command = ImportSourceCommand {
                     manifest_yaml: request.manifest_yaml,
                     bindings: source_bindings_from_proto(request.variables, request.secrets),
                 };
                 let installed = run_blocking_source_operation(move || {
-                    sources.import_source(&workspace_name, &command)
+                    sources.import_source(&operation_workspace_name, &command)
                 })
                 .await?;
+                clear_source_observations(
+                    search_observations,
+                    observation_workspace_name,
+                    installed.name.as_str().to_string(),
+                )
+                .await;
                 let response = ImportSourceResponse {
                     event: Some(import_source_response::Event::Source(
                         installed_source_to_proto(&response_workspace_name, installed),
@@ -282,13 +320,21 @@ impl SourceServiceApi for SourceService {
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(app_status)?,
             };
+            let observation_workspace_name = workspace_name.clone();
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
-                        sources
+                        let installed = sources
                             .import_source_with_credentials(&workspace_name, command, event_sender)
                             .await
-                            .map_err(app_status)
+                            .map_err(app_status)?;
+                        clear_source_observations(
+                            search_observations,
+                            observation_workspace_name,
+                            installed.name.as_str().to_string(),
+                        )
+                        .await;
+                        Ok(installed)
                     })
                 });
             Ok(Response::new(stream))
@@ -303,15 +349,25 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
+        let search_observations = self.search_observations.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             require_workspace(&workspaces, &workspace_name).await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
+            let source_name_text = source_name.as_str().to_string();
+            let operation_workspace_name = workspace_name.clone();
+            let observation_workspace_name = workspace_name.clone();
             run_blocking_source_operation(move || {
-                sources.delete_source(&workspace_name, &source_name)
+                sources.delete_source(&operation_workspace_name, &source_name)
             })
             .await?;
+            clear_source_observations(
+                search_observations,
+                observation_workspace_name,
+                source_name_text,
+            )
+            .await;
             Ok(Response::new(DeleteSourceResponse {}))
         })
         .await
@@ -371,6 +427,31 @@ where
         .await
         .map_err(|error| Status::internal(format!("source operation task failed: {error}")))?
         .map_err(app_status)
+}
+
+async fn clear_source_observations(
+    search_observations: Option<SearchObservationHandle>,
+    workspace_name: WorkspaceName,
+    source_name: String,
+) {
+    let Some(search_observations) = search_observations else {
+        return;
+    };
+
+    let workspace_label = workspace_name.as_str().to_string();
+    let source_label = source_name.clone();
+    if let Err(error) = run_blocking_source_operation(move || {
+        search_observations.clear_source(&workspace_name, &source_name)
+    })
+    .await
+    {
+        tracing::debug!(
+            workspace = %workspace_label,
+            source = %source_label,
+            error = %error,
+            "failed to clear observed-values state after source lifecycle operation"
+        );
+    }
 }
 
 fn import_source_response_stream<F, Fut>(

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -179,7 +179,6 @@ impl SourceServiceApi for SourceService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             require_workspace(&workspaces, &workspace_name).await?;
-            let operation_workspace_name = workspace_name.clone();
             let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
             let command = CreateBundledSourceCommand {
                 name: bundled_name,
@@ -187,7 +186,7 @@ impl SourceServiceApi for SourceService {
             };
             let response_workspace_name = workspace_name.clone();
             let installed = run_blocking_source_operation(move || {
-                sources.create_bundled_source(&operation_workspace_name, &command)
+                sources.create_bundled_source(&workspace_name, &command)
             })
             .await?;
             Ok(Response::new(CreateBundledSourceResponse {
@@ -256,13 +255,12 @@ impl SourceServiceApi for SourceService {
             require_workspace(&workspaces, &workspace_name).await?;
             let response_workspace_name = workspace_name.clone();
             if request.oauth_credential_retrievals.is_empty() {
-                let operation_workspace_name = workspace_name.clone();
                 let command = ImportSourceCommand {
                     manifest_yaml: request.manifest_yaml,
                     bindings: source_bindings_from_proto(request.variables, request.secrets),
                 };
                 let installed = run_blocking_source_operation(move || {
-                    sources.import_source(&operation_workspace_name, &command)
+                    sources.import_source(&workspace_name, &command)
                 })
                 .await?;
                 let response = ImportSourceResponse {
@@ -310,9 +308,8 @@ impl SourceServiceApi for SourceService {
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             require_workspace(&workspaces, &workspace_name).await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
-            let operation_workspace_name = workspace_name.clone();
             run_blocking_source_operation(move || {
-                sources.delete_source(&operation_workspace_name, &source_name)
+                sources.delete_source(&workspace_name, &source_name)
             })
             .await?;
             Ok(Response::new(DeleteSourceResponse {}))

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -36,7 +36,6 @@ use tonic::{Request, Response, Status};
 use crate::bootstrap::{AppError, app_status};
 use crate::credentials::CredentialStorageKind;
 use crate::query::manager::QueryManager;
-use crate::search::observed::SearchObservationHandle;
 use crate::sources::SourceName;
 use crate::sources::manager::{
     CreateBundledSourceCommand, CreateBundledSourceWithOAuthCommand, ImportSourceCommand,
@@ -60,7 +59,6 @@ pub(crate) struct SourceService {
     sources: SourceManager,
     queries: QueryManager,
     workspaces: WorkspaceManager,
-    search_observations: Option<SearchObservationHandle>,
 }
 
 impl SourceService {
@@ -73,16 +71,7 @@ impl SourceService {
             sources: source_manager,
             queries: query_manager,
             workspaces: workspace_manager,
-            search_observations: None,
         }
-    }
-
-    pub(crate) fn with_search_observation_handle(
-        mut self,
-        search_observations: SearchObservationHandle,
-    ) -> Self {
-        self.search_observations = Some(search_observations);
-        self
     }
 }
 
@@ -186,13 +175,11 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
-        let search_observations = self.search_observations.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             require_workspace(&workspaces, &workspace_name).await?;
             let operation_workspace_name = workspace_name.clone();
-            let observation_workspace_name = workspace_name.clone();
             let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
             let command = CreateBundledSourceCommand {
                 name: bundled_name,
@@ -203,12 +190,6 @@ impl SourceServiceApi for SourceService {
                 sources.create_bundled_source(&operation_workspace_name, &command)
             })
             .await?;
-            clear_source_observations(
-                search_observations,
-                observation_workspace_name,
-                installed.name.as_str().to_string(),
-            )
-            .await;
             Ok(Response::new(CreateBundledSourceResponse {
                 source: Some(installed_source_to_proto(
                     &response_workspace_name,
@@ -226,13 +207,11 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
-        let search_observations = self.search_observations.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             require_workspace(&workspaces, &workspace_name).await?;
             let response_workspace_name = workspace_name.clone();
-            let observation_workspace_name = workspace_name.clone();
             let command = CreateBundledSourceWithOAuthCommand {
                 name: SourceName::parse(&request.name).map_err(app_status)?,
                 bindings: source_bindings_from_proto(request.variables, request.secrets),
@@ -246,21 +225,14 @@ impl SourceServiceApi for SourceService {
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
-                        let installed = sources
+                        sources
                             .create_bundled_source_with_oauth(
                                 &workspace_name,
                                 command,
                                 event_sender,
                             )
                             .await
-                            .map_err(app_status)?;
-                        clear_source_observations(
-                            search_observations,
-                            observation_workspace_name,
-                            installed.name.as_str().to_string(),
-                        )
-                        .await;
-                        Ok(installed)
+                            .map_err(app_status)
                     })
                 });
             Ok(Response::new(Box::pin(stream.map(|response| {
@@ -278,7 +250,6 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
-        let search_observations = self.search_observations.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -286,7 +257,6 @@ impl SourceServiceApi for SourceService {
             let response_workspace_name = workspace_name.clone();
             if request.oauth_credential_retrievals.is_empty() {
                 let operation_workspace_name = workspace_name.clone();
-                let observation_workspace_name = workspace_name.clone();
                 let command = ImportSourceCommand {
                     manifest_yaml: request.manifest_yaml,
                     bindings: source_bindings_from_proto(request.variables, request.secrets),
@@ -295,12 +265,6 @@ impl SourceServiceApi for SourceService {
                     sources.import_source(&operation_workspace_name, &command)
                 })
                 .await?;
-                clear_source_observations(
-                    search_observations,
-                    observation_workspace_name,
-                    installed.name.as_str().to_string(),
-                )
-                .await;
                 let response = ImportSourceResponse {
                     event: Some(import_source_response::Event::Source(
                         installed_source_to_proto(&response_workspace_name, installed),
@@ -320,21 +284,13 @@ impl SourceServiceApi for SourceService {
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(app_status)?,
             };
-            let observation_workspace_name = workspace_name.clone();
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
-                        let installed = sources
+                        sources
                             .import_source_with_credentials(&workspace_name, command, event_sender)
                             .await
-                            .map_err(app_status)?;
-                        clear_source_observations(
-                            search_observations,
-                            observation_workspace_name,
-                            installed.name.as_str().to_string(),
-                        )
-                        .await;
-                        Ok(installed)
+                            .map_err(app_status)
                     })
                 });
             Ok(Response::new(stream))
@@ -349,25 +305,16 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         let workspaces = self.workspaces.clone();
-        let search_observations = self.search_observations.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             require_workspace(&workspaces, &workspace_name).await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
-            let source_name_text = source_name.as_str().to_string();
             let operation_workspace_name = workspace_name.clone();
-            let observation_workspace_name = workspace_name.clone();
             run_blocking_source_operation(move || {
                 sources.delete_source(&operation_workspace_name, &source_name)
             })
             .await?;
-            clear_source_observations(
-                search_observations,
-                observation_workspace_name,
-                source_name_text,
-            )
-            .await;
             Ok(Response::new(DeleteSourceResponse {}))
         })
         .await
@@ -427,31 +374,6 @@ where
         .await
         .map_err(|error| Status::internal(format!("source operation task failed: {error}")))?
         .map_err(app_status)
-}
-
-async fn clear_source_observations(
-    search_observations: Option<SearchObservationHandle>,
-    workspace_name: WorkspaceName,
-    source_name: String,
-) {
-    let Some(search_observations) = search_observations else {
-        return;
-    };
-
-    let workspace_label = workspace_name.as_str().to_string();
-    let source_label = source_name.clone();
-    if let Err(error) = run_blocking_source_operation(move || {
-        search_observations.clear_source(&workspace_name, &source_name)
-    })
-    .await
-    {
-        tracing::debug!(
-            workspace = %workspace_label,
-            source = %source_label,
-            error = %error,
-            "failed to clear observed-values state after source lifecycle operation"
-        );
-    }
 }
 
 fn import_source_response_stream<F, Fut>(

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -6,6 +6,7 @@ use coral_engine::{DependentJoinConfig, DependentJoinSourceConfig, MemorySize, Q
 use serde::{Deserialize, Serialize};
 use toml_edit::{DocumentMut, InlineTable, Item, Value, value};
 use tracing::{info_span, warn};
+use uuid::Uuid;
 
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialStorageKind;
@@ -204,6 +205,8 @@ struct PersistedInstalledSource {
     secrets: Vec<String>,
     #[serde(default)]
     credential_storage: Option<CredentialStorageKind>,
+    #[serde(default, skip_serializing_if = "Uuid::is_nil")]
+    credential_revision: Uuid,
     origin: SourceOrigin,
 }
 
@@ -215,6 +218,7 @@ impl PersistedInstalledSource {
             variables: self.variables,
             secrets: self.secrets,
             credential_storage: self.credential_storage,
+            credential_revision: self.credential_revision,
             origin: self.origin,
         }
     }
@@ -227,6 +231,7 @@ impl From<&InstalledSource> for PersistedInstalledSource {
             variables: value.variables.clone(),
             secrets: value.secrets.clone(),
             credential_storage: value.credential_storage,
+            credential_revision: value.credential_revision,
             origin: value.origin,
         }
     }
@@ -874,6 +879,14 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
                     .expect("source config entry should be a table after initialization");
                 source_table.remove("credential_storage");
             }
+            if source.credential_revision.is_nil() {
+                let source_table = source_item
+                    .as_table_mut()
+                    .expect("source config entry should be a table after initialization");
+                source_table.remove("credential_revision");
+            } else {
+                source_item["credential_revision"] = value(source.credential_revision.to_string());
+            }
             source_item["origin"] = value(source.origin.as_config_value());
         }
 
@@ -1233,6 +1246,7 @@ mod tests {
             )]),
             secrets: vec!["GITHUB_TOKEN".to_string()],
             credential_storage: None,
+            credential_revision: Default::default(),
             origin: SourceOrigin::Imported,
         }
     }
@@ -1902,6 +1916,57 @@ max_concurrency = 0
             sources[0].credential_storage,
             Some(CredentialStorageKind::Keychain)
         );
+    }
+
+    #[test]
+    fn round_trips_non_nil_source_credential_revision() {
+        let workspace_name = default_workspace();
+        let mut source = installed_source("github");
+        source.credential_revision = uuid::Uuid::parse_str("c59a9c41-0e51-45d4-bfb7-f05df71eed53")
+            .expect("credential revision");
+        let mut catalog = SourceCatalog::default();
+        catalog.upsert_source(&workspace_name, source.clone());
+        let config = AppConfig {
+            version: 1,
+            engine: PersistedEngineConfig::default(),
+            workspaces: WorkspaceCatalog::default(),
+            catalog,
+        };
+
+        let raw = render_config(&PersistedAppConfig::from(&config), None);
+        assert!(raw.contains(&format!(
+            "credential_revision = \"{}\"",
+            source.credential_revision
+        )));
+
+        let loaded = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(&raw).expect("config should parse"),
+        )
+        .expect("config");
+        let sources = loaded.catalog.workspace_sources(&workspace_name);
+        assert_eq!(sources[0].credential_revision, source.credential_revision);
+    }
+
+    #[test]
+    fn source_config_without_credential_revision_defaults_to_nil() {
+        let raw = r#"
+version = 1
+
+[workspaces.default]
+
+[workspaces.default.sources.github]
+variables = {}
+secrets = ["GITHUB_TOKEN"]
+credential_storage = "file"
+origin = "imported"
+"#;
+        let loaded = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(raw).expect("legacy config should parse"),
+        )
+        .expect("config");
+        let sources = loaded.catalog.workspace_sources(&default_workspace());
+
+        assert!(sources[0].credential_revision.is_nil());
     }
 
     #[test]

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -1246,7 +1246,7 @@ mod tests {
             )]),
             secrets: vec!["GITHUB_TOKEN".to_string()],
             credential_storage: None,
-            credential_revision: Default::default(),
+            credential_revision: uuid::Uuid::default(),
             origin: SourceOrigin::Imported,
         }
     }

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -1931,6 +1931,7 @@ max_concurrency = 0
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog,
+            functions: FunctionCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -299,7 +299,7 @@ mod tests {
             variables: BTreeMap::new(),
             secrets: vec!["TOKEN".to_string()],
             credential_storage: None,
-            credential_revision: Default::default(),
+            credential_revision: uuid::Uuid::default(),
             origin: SourceOrigin::Imported,
         }
     }

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -299,6 +299,7 @@ mod tests {
             variables: BTreeMap::new(),
             secrets: vec!["TOKEN".to_string()],
             credential_storage: None,
+            credential_revision: Default::default(),
             origin: SourceOrigin::Imported,
         }
     }

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use coral_app::AwsEngineExtensionsProvider;
+use coral_app::{AwsEngineExtensionsProvider, features::FeatureOverrides};
 use coral_client::{
     AppClient, ClientError,
     local::{LocalServerError, RunningServer, ServerBuilder},
@@ -11,9 +11,10 @@ pub(crate) struct Bootstrap {
     server: Option<RunningServer>,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct BootstrapOptions {
     pub(crate) enable_stderr_logs: bool,
+    pub(crate) feature_overrides: FeatureOverrides,
 }
 
 impl Bootstrap {
@@ -51,10 +52,16 @@ pub(crate) async fn bootstrap(options: BootstrapOptions) -> Result<Bootstrap, Bo
 }
 
 #[cfg(feature = "embedded-ui")]
-pub(crate) async fn start_ui_server(port: u16) -> Result<RunningServer, BootstrapError> {
+pub(crate) async fn start_ui_server(
+    port: u16,
+    feature_overrides: FeatureOverrides,
+) -> Result<RunningServer, BootstrapError> {
     let server = configure_server_builder(
         ServerBuilder::embedded_ui_loopback(port, crate::embedded_ui_assets()),
-        BootstrapOptions::default(),
+        BootstrapOptions {
+            feature_overrides,
+            ..BootstrapOptions::default()
+        },
     )
     .start()
     .await?;
@@ -64,6 +71,7 @@ pub(crate) async fn start_ui_server(port: u16) -> Result<RunningServer, Bootstra
 fn configure_server_builder(builder: ServerBuilder, options: BootstrapOptions) -> ServerBuilder {
     builder
         .with_stderr_logs(options.enable_stderr_logs)
+        .with_feature_overrides(options.feature_overrides)
         .add_engine_extensions_provider(Arc::new(AwsEngineExtensionsProvider))
 }
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -622,6 +622,7 @@ pub async fn run_from_env() -> Result<(), CliError> {
             let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
             let bootstrap = bootstrap::bootstrap(bootstrap::BootstrapOptions {
                 enable_stderr_logs: command.enables_stderr_logs(),
+                feature_overrides: feature_overrides.clone(),
             })
             .await
             .map_err(anyhow::Error::from)?;
@@ -682,8 +683,11 @@ pub fn open_url(url: &str) -> Result<(), std::io::Error> {
 }
 
 #[cfg(feature = "embedded-ui")]
-async fn run_ui(args: UiArgs) -> Result<(), anyhow::Error> {
-    let server = bootstrap::start_ui_server(args.port).await?;
+async fn run_ui(
+    args: UiArgs,
+    feature_overrides: coral_app::features::FeatureOverrides,
+) -> Result<(), anyhow::Error> {
+    let server = bootstrap::start_ui_server(args.port, feature_overrides).await?;
     let endpoint = server.endpoint_uri().to_string();
 
     println!("Coral UI listening on {endpoint}");
@@ -720,7 +724,9 @@ async fn run_no_runtime_command(
         }
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
-        Command::Ui(args) => run_ui(args).await.map_err(Into::into),
+        Command::Ui(args) => run_ui(args, feature_overrides.clone())
+            .await
+            .map_err(Into::into),
         Command::Sql(_)
         | Command::Search(_)
         | Command::SearchIndex(_)


### PR DESCRIPTION
## Summary

- creates one `SearchObservationHandle` during server bootstrap and passes narrow handles into the source/query lifecycle paths
- loads a canonical `LoadedRuntimeSource` containing the exact `QuerySource` plus a versioned, non-secret runtime-contract fingerprint
- fingerprints manifest bytes, deterministic non-secret variables, and materialized v4 runtime artifacts; paths and resolved secrets are excluded
- persists a non-secret credential revision that rotates on new/replaced credentials or reauthentication, remains stable for stored-credential reimport, and does not rotate during ordinary token refresh
- teaches `QueryManager` to install source-scan observed-values publishers with the canonical runtime fingerprint and credential revision for query execution over selected sources
- keeps metadata, catalog, explain, describe, and validation paths from installing observed-values publishers
- clears/increments observed-values source state from source lifecycle operations; cleanup is best effort and does not depend on a pre-existing SQLite search DB
- drains the observed-values background writer during server shutdown without blocking the async runtime, including when the server task returns an error
- keeps projection, retrieval, queue-drain processing, retention, and adapter behavior out of scope; observed values are collected into the durable queue but are still not returned by search

## Split boundary

PR #1472 owns the opaque SQLite observed-values substrate. PR #1761 owns source-authored `do_not_index` and is this PR's direct parent. This PR owns final write-side runtime identity and app lifecycle wiring. PR #1593 later reuses the same canonical loader for live read-side scope checks.

MCP and CLI remain thin: neither adapter opens SQLite, drains observed-values queues, ranks observed values, or owns observed-values lifecycle behavior.

## Validation

- credential revision lifecycle and runtime-fingerprint mutation tests
- writer/live scope identity parity tests on the retrieval child
- full `coral-app` test suite
- strict Clippy and rustdoc through top-of-stack `make rust-checks`
- isolated real-source observation/search smoke through the final stack


## Feature flag

Constructs and attaches `SearchObservationHandle` only when the effective `observed_values_search` feature is enabled. Default-off means no source/query publishers, no background writer, and no observation collection; config and process overrides use the shared feature system.
