### PR TITLE
feat(spec): support parameter metadata overrides

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1284,6 +1284,171 @@ surfaces:
         );
     }
 
+    #[tokio::test]
+    async fn installed_v4_source_uses_parameter_metadata_pagination_override() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/widgets"))
+            .respond_with(|request: &wiremock::Request| {
+                let page = request
+                    .url
+                    .query_pairs()
+                    .find_map(|(key, value)| (key == "page_number").then_some(value.into_owned()));
+                match page.as_deref() {
+                    Some("1") => ResponseTemplate::new(200).set_body_json(json!([
+                        {"id": 1},
+                        {"id": 2}
+                    ])),
+                    Some("2") => ResponseTemplate::new(200).set_body_json(json!([
+                        {"id": 3},
+                        {"id": 4}
+                    ])),
+                    other => ResponseTemplate::new(400)
+                        .set_body_string(format!("unexpected page_number {other:?}")),
+                }
+            })
+            .mount(&server)
+            .await;
+
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let source_manager = SourceManager::new_for_tests(
+            fixture.manager.config_store.clone(),
+            fixture.manager.credential_manager.clone(),
+            fixture.manager.layout.clone(),
+        );
+        let workspace_name = WorkspaceName::default();
+        let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
+        let openapi_file = descriptor_temp.path().join("widgets-openapi.yaml");
+        std::fs::write(&openapi_file, widgets_pagination_openapi(&server.uri()))
+            .expect("write OpenAPI fixture");
+        source_manager
+            .import_source(
+                &workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: format!(
+                        r"
+name: github_v4_pagination_override
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+",
+                        openapi_file.display()
+                    ),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect("import v4 source");
+
+        let source_name = SourceName::parse("github_v4_pagination_override").expect("source name");
+        write_widgets_parameter_metadata_override(
+            &fixture.manager.layout,
+            &workspace_name,
+            &source_name,
+        );
+
+        let execution = fixture
+            .manager
+            .execute_sql(
+                &workspace_name,
+                "SELECT id FROM github_v4_pagination_override.widgets LIMIT 3",
+                &QueryAttribution::default(),
+            )
+            .await
+            .expect("query executes");
+
+        assert_eq!(
+            execution_to_rows(&execution),
+            vec![json!({"id": 1}), json!({"id": 2}), json!({"id": 3})]
+        );
+        let requests = server
+            .received_requests()
+            .await
+            .expect("request recording should be enabled");
+        let pages = request_query_values(&requests, "page_number");
+        let page_sizes = request_query_values(&requests, "per_page");
+        assert_eq!(pages, ["1", "2"]);
+        assert_eq!(page_sizes, ["2", "2"]);
+    }
+
+    fn widgets_pagination_openapi(server_uri: &str) -> String {
+        format!(
+            r"
+openapi: 3.0.3
+info:
+  title: Widgets
+servers:
+  - url: {server_uri}
+paths:
+  /widgets:
+    get:
+      operationId: widgets/list
+      parameters:
+        - name: page_number
+          in: query
+          required: true
+          schema: {{type: integer}}
+        - name: per_page
+          in: query
+          required: true
+          schema: {{type: integer}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {{type: integer}}
+"
+        )
+    }
+
+    fn write_widgets_parameter_metadata_override(
+        layout: &AppStateLayout,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        let override_path =
+            layout.v4_parameter_metadata_override_file(workspace_name, source_name, "rest");
+        std::fs::create_dir_all(override_path.parent().expect("override parent"))
+            .expect("create override dir");
+        std::fs::write(
+            &override_path,
+            r"
+pagination:
+  - name: widgets_page_number
+    match:
+      operation_ids: [widgets/list]
+    mode: page
+    page_param: page_number
+    page_start: 1
+    page_size:
+      default: 2
+      max: 2
+      query_param: per_page
+",
+        )
+        .expect("write parameter metadata override");
+    }
+
+    fn request_query_values(requests: &[wiremock::Request], query_key: &str) -> Vec<String> {
+        requests
+            .iter()
+            .map(|request| {
+                request
+                    .url
+                    .query_pairs()
+                    .find_map(|(key, value)| (key == query_key).then_some(value.into_owned()))
+                    .expect("query param")
+            })
+            .collect()
+    }
+
     #[test]
     fn load_query_sources_fails_closed_for_missing_v4_materialization() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1293,7 +1293,7 @@ surfaces:
                 let page = request
                     .url
                     .query_pairs()
-                    .find_map(|(key, value)| (key == "page_number").then_some(value.into_owned()));
+                    .find_map(|(key, value)| (key == "page").then_some(value.into_owned()));
                 match page.as_deref() {
                     Some("1") => ResponseTemplate::new(200).set_body_json(json!([
                         {"id": 1},
@@ -1304,7 +1304,7 @@ surfaces:
                         {"id": 4}
                     ])),
                     other => ResponseTemplate::new(400)
-                        .set_body_string(format!("unexpected page_number {other:?}")),
+                        .set_body_string(format!("unexpected page {other:?}")),
                 }
             })
             .mount(&server)
@@ -1367,7 +1367,7 @@ surfaces:
             .received_requests()
             .await
             .expect("request recording should be enabled");
-        let pages = request_query_values(&requests, "page_number");
+        let pages = request_query_values(&requests, "page");
         let page_sizes = request_query_values(&requests, "per_page");
         assert_eq!(pages, ["1", "2"]);
         assert_eq!(page_sizes, ["2", "2"]);
@@ -1386,7 +1386,7 @@ paths:
     get:
       operationId: widgets/list
       parameters:
-        - name: page_number
+        - name: page
           in: query
           required: true
           schema: {{type: integer}}
@@ -1421,11 +1421,11 @@ paths:
             &override_path,
             r"
 pagination:
-  - name: widgets_page_number
+  - name: widgets_page
     match:
       operation_ids: [widgets/list]
     mode: page
-    page_param: page_number
+    page_param: page
     page_start: 1
     page_size:
       default: 2

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -183,7 +183,6 @@ pub(crate) fn load_v4_materialization(
     let diagnostics: Vec<Diagnostic> =
         read_artifact_yaml(source_name, "diagnostics", &diagnostics_path)?;
     let mut surfaces = Vec::new();
-    let mut semantic_irs = Vec::new();
     for fingerprint_surface in &fingerprint.surfaces {
         let surface = manifest
             .surface(&fingerprint_surface.surface_id)
@@ -212,7 +211,6 @@ pub(crate) fn load_v4_materialization(
             &surface.id,
             &mut semantic_ir,
         )?;
-        semantic_irs.push(semantic_ir.clone());
         surfaces.push(MaterializedSurface {
             surface_id: surface.id.clone(),
             semantic_ir,
@@ -226,7 +224,11 @@ pub(crate) fn load_v4_materialization(
     } else {
         ProjectionPaginationInputSyncMode::RecomputeRestInputExposure
     };
-    sync_projection_pagination_inputs(&semantic_irs, &mut projections, projection_sync_mode);
+    sync_projection_pagination_inputs(
+        surfaces.iter().map(|surface| &surface.semantic_ir),
+        &mut projections,
+        projection_sync_mode,
+    );
     let materialized = V4MaterializedSource {
         fingerprint,
         surfaces,

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -8,11 +8,13 @@ use std::time::Duration;
 use coral_spec::v4::{
     Diagnostic, DiagnosticSeverity, Fingerprint, FingerprintSurface, MCP_IMPORTER_VERSION,
     MaterializedSurface, McpToolCatalog, OPENAPI_IMPORTER_VERSION, PROJECTION_GENERATOR_VERSION,
-    ProjectionCatalog, SURFACE_IMPORTER_VERSION, SemanticIr, SurfaceType,
-    V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceManifest,
-    generate_projection_catalog, import_mcp_surface, import_openapi_surface,
-    normalize_mcp_tool_catalog, normalize_source_document, openapi_document_metadata,
-    validate_materialized_source, validate_openapi_base_url_template,
+    ProjectionCatalog, ProjectionPaginationInputSyncMode, SURFACE_IMPORTER_VERSION, SemanticIr,
+    SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceManifest,
+    apply_parameter_metadata_overrides, generate_projection_catalog, import_mcp_surface,
+    import_openapi_surface, normalize_mcp_tool_catalog, normalize_source_document,
+    openapi_document_metadata, parse_parameter_metadata_overrides_yaml,
+    sync_projection_pagination_inputs, validate_materialized_source,
+    validate_openapi_base_url_template,
 };
 use coral_spec::{
     ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestInputKind, ManifestInputSpec,
@@ -35,6 +37,7 @@ const DESCRIPTOR_USER_AGENT: &str = "coral-dsl-v4-materializer";
 pub(crate) const PROJECTIONS_FILENAME: &str = "projections.yaml";
 pub(crate) const FINGERPRINT_FILENAME: &str = "fingerprint.yaml";
 pub(crate) const DIAGNOSTICS_FILENAME: &str = "diagnostics.yaml";
+pub(crate) const PARAMETER_METADATA_OVERRIDE_FILENAME: &str = "parameter_metadata.yaml";
 
 #[derive(Debug)]
 pub(crate) struct MaterializationBuild {
@@ -155,6 +158,8 @@ pub(crate) fn load_v4_materialization(
 ) -> Result<V4MaterializedSource, AppError> {
     let fingerprint_path = layout.v4_fingerprint_file(workspace_name, source_name);
     let projections_path = layout.v4_projections_file(workspace_name, source_name);
+    let projections_override_path =
+        layout.v4_projections_override_file(workspace_name, source_name);
     let diagnostics_path = layout.v4_diagnostics_file(workspace_name, source_name);
     if !fingerprint_path.exists() || !projections_path.exists() || !diagnostics_path.exists() {
         return Err(incompatible_materialization_error(
@@ -172,12 +177,13 @@ pub(crate) fn load_v4_materialization(
         ));
     }
     let fingerprint_surfaces = validate_fingerprint_surfaces(source_name, manifest, &fingerprint)?;
-    let projections: ProjectionCatalog =
+    let mut projections: ProjectionCatalog =
         read_artifact_yaml(source_name, "projection catalog", &projections_path)?;
     validate_projection_catalog_header(source_name, manifest, &projections)?;
     let diagnostics: Vec<Diagnostic> =
         read_artifact_yaml(source_name, "diagnostics", &diagnostics_path)?;
     let mut surfaces = Vec::new();
+    let mut semantic_irs = Vec::new();
     for fingerprint_surface in &fingerprint.surfaces {
         let surface = manifest
             .surface(&fingerprint_surface.surface_id)
@@ -197,8 +203,16 @@ pub(crate) fn load_v4_materialization(
         require_file(source_name, &raw_source_document_path)?;
         require_file(source_name, &normalized_source_document_path)?;
         require_file(source_name, &semantic_ir_path)?;
-        let semantic_ir: SemanticIr =
+        let mut semantic_ir: SemanticIr =
             read_artifact_yaml(source_name, "semantic IR", &semantic_ir_path)?;
+        apply_parameter_metadata_override_file(
+            layout,
+            workspace_name,
+            source_name,
+            &surface.id,
+            &mut semantic_ir,
+        )?;
+        semantic_irs.push(semantic_ir.clone());
         surfaces.push(MaterializedSurface {
             surface_id: surface.id.clone(),
             semantic_ir,
@@ -207,6 +221,12 @@ pub(crate) fn load_v4_materialization(
             raw_source_document_path,
         });
     }
+    let projection_sync_mode = if projections_override_path.exists() {
+        ProjectionPaginationInputSyncMode::PreserveExistingExposure
+    } else {
+        ProjectionPaginationInputSyncMode::RecomputeRestInputExposure
+    };
+    sync_projection_pagination_inputs(&semantic_irs, &mut projections, projection_sync_mode);
     let materialized = V4MaterializedSource {
         fingerprint,
         surfaces,
@@ -369,6 +389,38 @@ fn read_raw_source_document_artifact(
                 path.display()
             ),
         )
+    })
+}
+
+fn apply_parameter_metadata_override_file(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    surface_id: &str,
+    semantic_ir: &mut SemanticIr,
+) -> Result<(), AppError> {
+    let path = layout.v4_parameter_metadata_override_file(workspace_name, source_name, surface_id);
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let raw = std::fs::read_to_string(&path).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "failed to read DSL v4 parameter metadata override '{}': {error}",
+            path.display()
+        ))
+    })?;
+    let overrides = parse_parameter_metadata_overrides_yaml(&raw).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "failed to parse DSL v4 parameter metadata override '{}': {error}",
+            path.display()
+        ))
+    })?;
+    apply_parameter_metadata_overrides(semantic_ir, &overrides).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "failed to apply DSL v4 parameter metadata override '{}': {error}",
+            path.display()
+        ))
     })
 }
 
@@ -1533,6 +1585,69 @@ surfaces:
         assert!(
             message.contains("Re-add the source"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn load_v4_materialization_applies_parameter_metadata_override_without_rewriting_artifact() {
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        let override_path =
+            layout.v4_parameter_metadata_override_file(&workspace_name(), &source_name(), "rest");
+        std::fs::create_dir_all(override_path.parent().expect("override parent"))
+            .expect("create override dir");
+        std::fs::write(
+            &override_path,
+            r"
+operation_overrides:
+  issues/list:
+    pagination:
+      mode: page
+      page_param: page_number
+      page_start: 1
+      page_size:
+        default: 50
+        max: 100
+        query_param: per_page
+",
+        )
+        .expect("write parameter metadata override");
+
+        let materialized = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect("load materialization with override");
+        let operation = materialized
+            .surfaces
+            .first()
+            .expect("surface")
+            .semantic_ir
+            .operations
+            .first()
+            .expect("operation");
+        let coral_spec::v4::IrExecutionAttachment::Rest(rest) = &operation.execution else {
+            panic!("expected REST operation");
+        };
+        assert_eq!(rest.pagination.mode, coral_spec::PaginationMode::Page);
+        assert_eq!(rest.pagination.page_param.as_deref(), Some("page_number"));
+
+        let semantic_ir_path = layout
+            .v4_surface_dir(&workspace_name(), &source_name(), "rest")
+            .join("semantic-ir.yaml");
+        let artifact_ir: SemanticIr =
+            read_yaml(&semantic_ir_path).expect("read persisted semantic IR");
+        let artifact_operation = artifact_ir.operations.first().expect("artifact operation");
+        let coral_spec::v4::IrExecutionAttachment::Rest(artifact_rest) =
+            &artifact_operation.execution
+        else {
+            panic!("expected REST operation");
+        };
+        assert_eq!(
+            artifact_rest.pagination.mode,
+            coral_spec::PaginationMode::None
         );
     }
 

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -7,7 +7,8 @@ use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_native_strateg
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
 use crate::sources::materialization::{
-    DIAGNOSTICS_FILENAME, FINGERPRINT_FILENAME, PROJECTIONS_FILENAME,
+    DIAGNOSTICS_FILENAME, FINGERPRINT_FILENAME, PARAMETER_METADATA_OVERRIDE_FILENAME,
+    PROJECTIONS_FILENAME,
 };
 use crate::storage::fs::ensure_dir;
 use crate::workspaces::{WorkspaceName, WorkspacePaths};
@@ -198,6 +199,15 @@ impl AppStateLayout {
         self.v4_overridden_or_materialized(workspace_name, source_name, PROJECTIONS_FILENAME)
     }
 
+    pub(crate) fn v4_projections_override_file(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> PathBuf {
+        self.v4_override_dir(workspace_name, source_name)
+            .join(PROJECTIONS_FILENAME)
+    }
+
     pub(crate) fn v4_diagnostics_file(
         &self,
         workspace_name: &WorkspaceName,
@@ -205,6 +215,18 @@ impl AppStateLayout {
     ) -> PathBuf {
         self.v4_materialized_dir(workspace_name, source_name)
             .join(DIAGNOSTICS_FILENAME)
+    }
+
+    pub(crate) fn v4_parameter_metadata_override_file(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        surface_id: &str,
+    ) -> PathBuf {
+        self.v4_override_dir(workspace_name, source_name)
+            .join("surfaces")
+            .join(surface_id)
+            .join(PARAMETER_METADATA_OVERRIDE_FILENAME)
     }
 
     pub(crate) fn v4_surface_dir(
@@ -305,6 +327,16 @@ mod tests {
         assert_eq!(
             layout.v4_projections_file(&workspace_name, &source_name),
             override_file
+        );
+        assert_eq!(
+            layout.v4_projections_override_file(&workspace_name, &source_name),
+            override_file
+        );
+        assert_eq!(
+            layout.v4_parameter_metadata_override_file(&workspace_name, &source_name, "rest"),
+            config_dir
+                .join("workspaces/default/sources/github/overrides/surfaces/rest")
+                .join("parameter_metadata.yaml")
         );
     }
 }

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -14,6 +14,7 @@ mod diagnostics;
 mod ir;
 mod manifest;
 mod naming;
+mod parameter_metadata;
 mod projections;
 mod schema;
 mod surfaces;
@@ -43,6 +44,11 @@ pub use manifest::{
     V4SourceCommon, V4SourceManifest, V4Surface, validate_openapi_base_url_template,
 };
 pub use naming::normalize_identifier;
+pub use parameter_metadata::{
+    ParameterMetadataOverrides, ProjectionPaginationInputSyncMode,
+    apply_parameter_metadata_overrides, parse_parameter_metadata_overrides_yaml,
+    sync_projection_pagination_inputs,
+};
 pub use projections::{
     Projection, ProjectionCatalog, ProjectionColumn, ProjectionInput, ProjectionKind,
     ProjectionVisibility, SqlInputExposure, generate_projection_catalog, manifest_data_type_name,

--- a/crates/coral-spec/src/v4/parameter_metadata.rs
+++ b/crates/coral-spec/src/v4/parameter_metadata.rs
@@ -6,7 +6,7 @@ use crate::v4::ir::{HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperat
 use crate::v4::projections::{
     ProjectionCatalog, ProjectionInput, ProjectionKind, SqlInputExposure,
 };
-use crate::{ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result};
+use crate::{ManifestError, PaginationSpec, Result};
 
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
@@ -24,7 +24,7 @@ pub struct NamedPaginationOverride {
     #[serde(rename = "match")]
     pub match_rules: PaginationStrategyMatch,
     #[serde(flatten)]
-    pagination: PaginationOverride,
+    pagination: PaginationSpec,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -43,69 +43,7 @@ pub struct PaginationStrategyMatch {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct OperationParameterMetadataOverride {
-    pub pagination: PaginationOverride,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PaginationOverride {
-    #[serde(default)]
-    pub mode: PaginationMode,
-    #[serde(default)]
-    pub page_size: Option<PageSizeOverride>,
-    #[serde(default)]
-    pub cursor_param: Option<String>,
-    #[serde(default)]
-    pub cursor_body_path: Vec<String>,
-    #[serde(default)]
-    pub response_cursor_path: Vec<String>,
-    #[serde(default)]
-    pub page_param: Option<String>,
-    #[serde(default)]
-    pub page_start: i64,
-    #[serde(default = "default_page_step")]
-    pub page_step: i64,
-    #[serde(default)]
-    pub offset_param: Option<String>,
-    #[serde(default)]
-    pub offset_start: i64,
-    #[serde(default)]
-    pub offset_step: Option<i64>,
-    #[serde(default)]
-    pub link_header_require_results: bool,
-    #[serde(default)]
-    pub max_pages: Option<usize>,
-}
-
-impl Default for PaginationOverride {
-    fn default() -> Self {
-        Self {
-            mode: PaginationMode::default(),
-            page_size: None,
-            cursor_param: None,
-            cursor_body_path: Vec::new(),
-            response_cursor_path: Vec::new(),
-            page_param: None,
-            page_start: 0,
-            page_step: default_page_step(),
-            offset_param: None,
-            offset_start: 0,
-            offset_step: None,
-            link_header_require_results: false,
-            max_pages: None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PageSizeOverride {
-    pub default: usize,
-    pub max: usize,
-    #[serde(default)]
-    pub query_param: Option<String>,
-    #[serde(default)]
-    pub body_path: Vec<String>,
+    pub pagination: PaginationSpec,
 }
 
 pub fn parse_parameter_metadata_overrides_yaml(raw: &str) -> Result<ParameterMetadataOverrides> {
@@ -125,7 +63,7 @@ pub fn apply_parameter_metadata_overrides(
         let mut matched = None;
         for strategy in &overrides.pagination {
             if strategy.matches_operation(operation) {
-                matched = Some(strategy.pagination_spec());
+                matched = Some(strategy.pagination.clone());
                 break;
             }
         }
@@ -148,7 +86,7 @@ pub fn apply_parameter_metadata_overrides(
                 ))
             })?;
         if let IrExecutionAttachment::Rest(rest) = &mut operation.execution {
-            rest.pagination = operation_override.pagination.pagination_spec();
+            rest.pagination = operation_override.pagination.clone();
         }
     }
 
@@ -235,7 +173,7 @@ impl ParameterMetadataOverrides {
 
     fn validate_for_surface(&self, ir: &SemanticIr) -> Result<()> {
         for strategy in &self.pagination {
-            strategy.pagination_spec().validated(
+            strategy.pagination.validated(
                 &ir.source_name,
                 &format!(
                     "{} parameter_metadata pagination '{}'",
@@ -259,7 +197,7 @@ impl ParameterMetadataOverrides {
                 "operation override",
                 operation_id,
             )?;
-            operation_override.pagination.pagination_spec().validated(
+            operation_override.pagination.validated(
                 &ir.source_name,
                 &format!(
                     "{} parameter_metadata operation override '{}'",
@@ -273,10 +211,6 @@ impl ParameterMetadataOverrides {
 }
 
 impl NamedPaginationOverride {
-    fn pagination_spec(&self) -> PaginationSpec {
-        self.pagination.pagination_spec()
-    }
-
     fn matches_operation(&self, operation: &IrOperation) -> bool {
         let IrExecutionAttachment::Rest(rest) = &operation.execution else {
             return false;
@@ -375,40 +309,6 @@ impl PaginationStrategyMatch {
         }
 
         Ok(())
-    }
-}
-
-impl PaginationOverride {
-    fn pagination_spec(&self) -> PaginationSpec {
-        PaginationSpec {
-            mode: self.mode,
-            page_size: self
-                .page_size
-                .as_ref()
-                .map(PageSizeOverride::page_size_spec),
-            cursor_param: self.cursor_param.clone(),
-            cursor_body_path: self.cursor_body_path.clone(),
-            response_cursor_path: self.response_cursor_path.clone(),
-            page_param: self.page_param.clone(),
-            page_start: self.page_start,
-            page_step: self.page_step,
-            offset_param: self.offset_param.clone(),
-            offset_start: self.offset_start,
-            offset_step: self.offset_step,
-            link_header_require_results: self.link_header_require_results,
-            max_pages: self.max_pages,
-        }
-    }
-}
-
-impl PageSizeOverride {
-    fn page_size_spec(&self) -> PageSizeSpec {
-        PageSizeSpec {
-            default: self.default,
-            max: self.max,
-            query_param: self.query_param.clone(),
-            body_path: self.body_path.clone(),
-        }
     }
 }
 
@@ -557,10 +457,6 @@ fn path_pattern_matches(pattern: &str, path: &str) -> bool {
     } else {
         parts.last().is_some_and(|last| remainder.ends_with(last))
     }
-}
-
-fn default_page_step() -> i64 {
-    1
 }
 
 #[cfg(test)]
@@ -970,6 +866,7 @@ operation_overrides:
                 row_path: Vec::new(),
             },
             entity: None,
+            naming: None,
             execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
                 method: HttpMethod::Get,
                 path_template: path_template.to_string(),

--- a/crates/coral-spec/src/v4/parameter_metadata.rs
+++ b/crates/coral-spec/src/v4/parameter_metadata.rs
@@ -100,13 +100,13 @@ pub enum ProjectionPaginationInputSyncMode {
     PreserveExistingExposure,
 }
 
-pub fn sync_projection_pagination_inputs(
-    surfaces: &[SemanticIr],
+pub fn sync_projection_pagination_inputs<'a>(
+    surfaces: impl IntoIterator<Item = &'a SemanticIr>,
     projections: &mut ProjectionCatalog,
     mode: ProjectionPaginationInputSyncMode,
 ) {
     let pagination_by_operation = surfaces
-        .iter()
+        .into_iter()
         .flat_map(|surface| {
             surface.operations.iter().filter_map(|operation| {
                 let IrExecutionAttachment::Rest(rest) = &operation.execution else {

--- a/crates/coral-spec/src/v4/parameter_metadata.rs
+++ b/crates/coral-spec/src/v4/parameter_metadata.rs
@@ -77,15 +77,15 @@ pub fn apply_parameter_metadata_overrides(
     }
 
     for (operation_id, operation_override) in &overrides.operation_overrides {
-        let operation = ir
+        let Some(operation) = ir
             .operations
             .iter_mut()
             .find(|operation| operation_matches_identifier(operation, operation_id))
-            .ok_or_else(|| {
-                ManifestError::validation(format!(
-                    "parameter metadata operation override '{operation_id}' references unknown operation '{operation_id}'"
-                ))
-            })?;
+        else {
+            unreachable!(
+                "operation override target was validated before application: {operation_id}"
+            );
+        };
         if let IrExecutionAttachment::Rest(rest) = &mut operation.execution {
             rest.pagination = operation_override.pagination.clone();
         }

--- a/crates/coral-spec/src/v4/parameter_metadata.rs
+++ b/crates/coral-spec/src/v4/parameter_metadata.rs
@@ -1,8 +1,9 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use serde::Deserialize;
 
 use crate::v4::ir::{HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, SemanticIr};
+use crate::v4::projections::pagination_query_param_names;
 use crate::v4::projections::{
     ProjectionCatalog, ProjectionInput, ProjectionKind, SqlInputExposure,
 };
@@ -315,7 +316,7 @@ impl PaginationStrategyMatch {
 fn projection_input_sql_exposure(
     input: &ProjectionInput,
     default_exposure: SqlInputExposure,
-    pagination_query_params: &BTreeSet<String>,
+    pagination_query_params: &HashSet<&str>,
 ) -> SqlInputExposure {
     let pagination_owned_query_input = input.source_location == IrInputLocation::Query
         && pagination_query_params.contains(input.wire_name.as_str());
@@ -328,25 +329,6 @@ fn projection_input_sql_exposure(
             SqlInputExposure::Internal
         }
     }
-}
-
-fn pagination_query_param_names(pagination: &PaginationSpec) -> BTreeSet<String> {
-    let mut names = BTreeSet::new();
-    if let Some(name) = pagination.page_param.as_deref() {
-        names.insert(name.to_string());
-    }
-    if let Some(name) = pagination.offset_param.as_deref() {
-        names.insert(name.to_string());
-    }
-    if let Some(name) = pagination.cursor_param.as_deref() {
-        names.insert(name.to_string());
-    }
-    if let Some(page_size) = &pagination.page_size
-        && let Some(name) = page_size.query_param.as_deref()
-    {
-        names.insert(name.to_string());
-    }
-    names
 }
 
 fn validate_rest_operation_target(

--- a/crates/coral-spec/src/v4/parameter_metadata.rs
+++ b/crates/coral-spec/src/v4/parameter_metadata.rs
@@ -1,0 +1,1066 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Deserialize;
+
+use crate::v4::ir::{HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, SemanticIr};
+use crate::v4::projections::{
+    ProjectionCatalog, ProjectionInput, ProjectionKind, SqlInputExposure,
+};
+use crate::{ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result};
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ParameterMetadataOverrides {
+    #[serde(default)]
+    pub pagination: Vec<NamedPaginationOverride>,
+    #[serde(default)]
+    pub operation_overrides: BTreeMap<String, OperationParameterMetadataOverride>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NamedPaginationOverride {
+    pub name: String,
+    #[serde(rename = "match")]
+    pub match_rules: PaginationStrategyMatch,
+    #[serde(flatten)]
+    pagination: PaginationOverride,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct PaginationStrategyMatch {
+    #[serde(default)]
+    pub operation_ids: Vec<String>,
+    #[serde(default)]
+    pub methods: Vec<String>,
+    #[serde(default)]
+    pub path_patterns: Vec<String>,
+    #[serde(default)]
+    pub required_query_params: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OperationParameterMetadataOverride {
+    pub pagination: PaginationOverride,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PaginationOverride {
+    #[serde(default)]
+    pub mode: PaginationMode,
+    #[serde(default)]
+    pub page_size: Option<PageSizeOverride>,
+    #[serde(default)]
+    pub cursor_param: Option<String>,
+    #[serde(default)]
+    pub cursor_body_path: Vec<String>,
+    #[serde(default)]
+    pub response_cursor_path: Vec<String>,
+    #[serde(default)]
+    pub page_param: Option<String>,
+    #[serde(default)]
+    pub page_start: i64,
+    #[serde(default = "default_page_step")]
+    pub page_step: i64,
+    #[serde(default)]
+    pub offset_param: Option<String>,
+    #[serde(default)]
+    pub offset_start: i64,
+    #[serde(default)]
+    pub offset_step: Option<i64>,
+    #[serde(default)]
+    pub link_header_require_results: bool,
+    #[serde(default)]
+    pub max_pages: Option<usize>,
+}
+
+impl Default for PaginationOverride {
+    fn default() -> Self {
+        Self {
+            mode: PaginationMode::default(),
+            page_size: None,
+            cursor_param: None,
+            cursor_body_path: Vec::new(),
+            response_cursor_path: Vec::new(),
+            page_param: None,
+            page_start: 0,
+            page_step: default_page_step(),
+            offset_param: None,
+            offset_start: 0,
+            offset_step: None,
+            link_header_require_results: false,
+            max_pages: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PageSizeOverride {
+    pub default: usize,
+    pub max: usize,
+    #[serde(default)]
+    pub query_param: Option<String>,
+    #[serde(default)]
+    pub body_path: Vec<String>,
+}
+
+pub fn parse_parameter_metadata_overrides_yaml(raw: &str) -> Result<ParameterMetadataOverrides> {
+    let overrides: ParameterMetadataOverrides =
+        serde_yaml::from_str(raw).map_err(ManifestError::parse_yaml)?;
+    overrides.validate_shape()?;
+    Ok(overrides)
+}
+
+pub fn apply_parameter_metadata_overrides(
+    ir: &mut SemanticIr,
+    overrides: &ParameterMetadataOverrides,
+) -> Result<()> {
+    overrides.validate_for_surface(ir)?;
+
+    for operation in &mut ir.operations {
+        let mut matched = None;
+        for strategy in &overrides.pagination {
+            if strategy.matches_operation(operation) {
+                matched = Some(strategy.pagination_spec());
+                break;
+            }
+        }
+
+        if let Some(pagination) = matched
+            && let IrExecutionAttachment::Rest(rest) = &mut operation.execution
+        {
+            rest.pagination = pagination;
+        }
+    }
+
+    for (operation_id, operation_override) in &overrides.operation_overrides {
+        let operation = ir
+            .operations
+            .iter_mut()
+            .find(|operation| operation_matches_identifier(operation, operation_id))
+            .ok_or_else(|| {
+                ManifestError::validation(format!(
+                    "parameter metadata operation override '{operation_id}' references unknown operation '{operation_id}'"
+                ))
+            })?;
+        if let IrExecutionAttachment::Rest(rest) = &mut operation.execution {
+            rest.pagination = operation_override.pagination.pagination_spec();
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectionPaginationInputSyncMode {
+    RecomputeRestInputExposure,
+    PreserveExistingExposure,
+}
+
+pub fn sync_projection_pagination_inputs(
+    surfaces: &[SemanticIr],
+    projections: &mut ProjectionCatalog,
+    mode: ProjectionPaginationInputSyncMode,
+) {
+    let pagination_by_operation = surfaces
+        .iter()
+        .flat_map(|surface| {
+            surface.operations.iter().filter_map(|operation| {
+                let IrExecutionAttachment::Rest(rest) = &operation.execution else {
+                    return None;
+                };
+                Some((
+                    (surface.surface_id.as_str(), operation.id.as_str()),
+                    pagination_query_param_names(&rest.pagination),
+                ))
+            })
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    for projection in &mut projections.projections {
+        let Some(pagination_query_params) = pagination_by_operation.get(&(
+            projection.surface_id.as_str(),
+            projection.operation_id.as_str(),
+        )) else {
+            continue;
+        };
+        let default_exposure = match projection.kind {
+            ProjectionKind::Table => SqlInputExposure::Filter,
+            ProjectionKind::TableFunction { .. } => SqlInputExposure::FunctionArg,
+        };
+        for input in &mut projection.inputs {
+            match mode {
+                ProjectionPaginationInputSyncMode::RecomputeRestInputExposure => {
+                    input.sql_exposure = projection_input_sql_exposure(
+                        input,
+                        default_exposure,
+                        pagination_query_params,
+                    );
+                }
+                ProjectionPaginationInputSyncMode::PreserveExistingExposure => {
+                    if input.source_location == IrInputLocation::Query
+                        && pagination_query_params.contains(input.wire_name.as_str())
+                    {
+                        input.sql_exposure = SqlInputExposure::Internal;
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl ParameterMetadataOverrides {
+    fn validate_shape(&self) -> Result<()> {
+        let mut names = BTreeSet::new();
+        for strategy in &self.pagination {
+            if strategy.name.trim().is_empty() {
+                return Err(ManifestError::validation(
+                    "parameter metadata pagination strategy name must not be empty",
+                ));
+            }
+            if !names.insert(strategy.name.as_str()) {
+                return Err(ManifestError::validation(format!(
+                    "parameter metadata pagination strategy '{}' is repeated",
+                    strategy.name
+                )));
+            }
+            strategy.match_rules.validate(&strategy.name)?;
+        }
+        Ok(())
+    }
+
+    fn validate_for_surface(&self, ir: &SemanticIr) -> Result<()> {
+        for strategy in &self.pagination {
+            strategy.pagination_spec().validated(
+                &ir.source_name,
+                &format!(
+                    "{} parameter_metadata pagination '{}'",
+                    ir.surface_id, strategy.name
+                ),
+            )?;
+            for operation_id in &strategy.match_rules.operation_ids {
+                validate_rest_operation_target(
+                    &ir.operations,
+                    operation_id,
+                    "pagination strategy",
+                    &strategy.name,
+                )?;
+            }
+        }
+
+        for (operation_id, operation_override) in &self.operation_overrides {
+            validate_rest_operation_target(
+                &ir.operations,
+                operation_id,
+                "operation override",
+                operation_id,
+            )?;
+            operation_override.pagination.pagination_spec().validated(
+                &ir.source_name,
+                &format!(
+                    "{} parameter_metadata operation override '{}'",
+                    ir.surface_id, operation_id
+                ),
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+impl NamedPaginationOverride {
+    fn pagination_spec(&self) -> PaginationSpec {
+        self.pagination.pagination_spec()
+    }
+
+    fn matches_operation(&self, operation: &IrOperation) -> bool {
+        let IrExecutionAttachment::Rest(rest) = &operation.execution else {
+            return false;
+        };
+
+        if !self.match_rules.operation_ids.is_empty()
+            && !self
+                .match_rules
+                .operation_ids
+                .iter()
+                .any(|operation_id| operation_matches_identifier(operation, operation_id))
+        {
+            return false;
+        }
+
+        if !self.match_rules.methods.is_empty()
+            && !self.match_rules.methods.iter().any(|method| {
+                parse_override_http_method(method).is_some_and(|method| method == rest.method)
+            })
+        {
+            return false;
+        }
+
+        if !self.match_rules.path_patterns.is_empty()
+            && !self
+                .match_rules
+                .path_patterns
+                .iter()
+                .any(|pattern| path_pattern_matches(pattern, &rest.path_template))
+        {
+            return false;
+        }
+
+        if !self.match_rules.required_query_params.is_empty() {
+            let query_params = operation
+                .inputs
+                .iter()
+                .filter(|input| input.location == IrInputLocation::Query)
+                .map(|input| input.name.as_str())
+                .collect::<BTreeSet<_>>();
+            if !self
+                .match_rules
+                .required_query_params
+                .iter()
+                .all(|param| query_params.contains(param.as_str()))
+            {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+impl PaginationStrategyMatch {
+    fn validate(&self, strategy_name: &str) -> Result<()> {
+        if self.operation_ids.is_empty()
+            && self.methods.is_empty()
+            && self.path_patterns.is_empty()
+            && self.required_query_params.is_empty()
+        {
+            return Err(ManifestError::validation(format!(
+                "parameter metadata pagination strategy '{strategy_name}' must define at least one match criterion"
+            )));
+        }
+
+        validate_non_empty_values(
+            &self.operation_ids,
+            "operation_ids",
+            "pagination strategy",
+            strategy_name,
+        )?;
+        validate_non_empty_values(
+            &self.path_patterns,
+            "path_patterns",
+            "pagination strategy",
+            strategy_name,
+        )?;
+        validate_non_empty_values(
+            &self.required_query_params,
+            "required_query_params",
+            "pagination strategy",
+            strategy_name,
+        )?;
+        for method in &self.methods {
+            if method.trim().is_empty() {
+                return Err(ManifestError::validation(format!(
+                    "parameter metadata pagination strategy '{strategy_name}' has an empty HTTP method"
+                )));
+            }
+            if parse_override_http_method(method).is_none() {
+                return Err(ManifestError::validation(format!(
+                    "parameter metadata pagination strategy '{strategy_name}' has unsupported HTTP method '{method}'"
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl PaginationOverride {
+    fn pagination_spec(&self) -> PaginationSpec {
+        PaginationSpec {
+            mode: self.mode,
+            page_size: self
+                .page_size
+                .as_ref()
+                .map(PageSizeOverride::page_size_spec),
+            cursor_param: self.cursor_param.clone(),
+            cursor_body_path: self.cursor_body_path.clone(),
+            response_cursor_path: self.response_cursor_path.clone(),
+            page_param: self.page_param.clone(),
+            page_start: self.page_start,
+            page_step: self.page_step,
+            offset_param: self.offset_param.clone(),
+            offset_start: self.offset_start,
+            offset_step: self.offset_step,
+            link_header_require_results: self.link_header_require_results,
+            max_pages: self.max_pages,
+        }
+    }
+}
+
+impl PageSizeOverride {
+    fn page_size_spec(&self) -> PageSizeSpec {
+        PageSizeSpec {
+            default: self.default,
+            max: self.max,
+            query_param: self.query_param.clone(),
+            body_path: self.body_path.clone(),
+        }
+    }
+}
+
+fn projection_input_sql_exposure(
+    input: &ProjectionInput,
+    default_exposure: SqlInputExposure,
+    pagination_query_params: &BTreeSet<String>,
+) -> SqlInputExposure {
+    let pagination_owned_query_input = input.source_location == IrInputLocation::Query
+        && pagination_query_params.contains(input.wire_name.as_str());
+    match input.source_location {
+        IrInputLocation::Query if pagination_owned_query_input => SqlInputExposure::Internal,
+        IrInputLocation::Path | IrInputLocation::Query | IrInputLocation::ToolArg => {
+            default_exposure
+        }
+        IrInputLocation::Header | IrInputLocation::Cookie | IrInputLocation::Body => {
+            SqlInputExposure::Internal
+        }
+    }
+}
+
+fn pagination_query_param_names(pagination: &PaginationSpec) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    if let Some(name) = pagination.page_param.as_deref() {
+        names.insert(name.to_string());
+    }
+    if let Some(name) = pagination.offset_param.as_deref() {
+        names.insert(name.to_string());
+    }
+    if let Some(name) = pagination.cursor_param.as_deref() {
+        names.insert(name.to_string());
+    }
+    if let Some(page_size) = &pagination.page_size
+        && let Some(name) = page_size.query_param.as_deref()
+    {
+        names.insert(name.to_string());
+    }
+    names
+}
+
+fn validate_rest_operation_target(
+    operations: &[IrOperation],
+    operation_id: &str,
+    owner_kind: &str,
+    owner_name: &str,
+) -> Result<()> {
+    let matches = operations
+        .iter()
+        .filter(|operation| operation_matches_identifier(operation, operation_id))
+        .collect::<Vec<_>>();
+    if matches.is_empty() {
+        return Err(ManifestError::validation(format!(
+            "parameter metadata {owner_kind} '{owner_name}' references unknown operation '{operation_id}'"
+        )));
+    }
+    if matches.len() > 1 {
+        return Err(ManifestError::validation(format!(
+            "parameter metadata {owner_kind} '{owner_name}' references ambiguous operation '{operation_id}'"
+        )));
+    }
+    let Some(operation) = matches.first() else {
+        return Err(ManifestError::validation(format!(
+            "parameter metadata {owner_kind} '{owner_name}' references unknown operation '{operation_id}'"
+        )));
+    };
+    if !matches!(operation.execution, IrExecutionAttachment::Rest(_)) {
+        return Err(ManifestError::validation(format!(
+            "parameter metadata {owner_kind} '{owner_name}' references non-REST operation '{operation_id}'"
+        )));
+    }
+    Ok(())
+}
+
+fn operation_matches_identifier(operation: &IrOperation, identifier: &str) -> bool {
+    operation.id == identifier || operation.method_name == identifier
+}
+
+fn validate_non_empty_values(
+    values: &[String],
+    field: &str,
+    owner_kind: &str,
+    owner_name: &str,
+) -> Result<()> {
+    for value in values {
+        if value.trim().is_empty() {
+            return Err(ManifestError::validation(format!(
+                "parameter metadata {owner_kind} '{owner_name}' has an empty {field} value"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn parse_override_http_method(method: &str) -> Option<HttpMethod> {
+    match method.trim().to_ascii_lowercase().as_str() {
+        "get" => Some(HttpMethod::Get),
+        "head" => Some(HttpMethod::Head),
+        "options" => Some(HttpMethod::Options),
+        "post" => Some(HttpMethod::Post),
+        "put" => Some(HttpMethod::Put),
+        "patch" => Some(HttpMethod::Patch),
+        "delete" => Some(HttpMethod::Delete),
+        "trace" => Some(HttpMethod::Trace),
+        _ => None,
+    }
+}
+
+fn path_pattern_matches(pattern: &str, path: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if !pattern.contains('*') {
+        return pattern == path;
+    }
+
+    let parts = pattern.split('*').collect::<Vec<_>>();
+    let mut remainder = path;
+    let mut middle_start = 0usize;
+
+    if !pattern.starts_with('*') {
+        let Some(first) = parts.first() else {
+            return false;
+        };
+        let Some(stripped) = remainder.strip_prefix(first) else {
+            return false;
+        };
+        remainder = stripped;
+        middle_start = 1;
+    }
+
+    let last_index = parts.len().saturating_sub(1);
+    for part in parts.iter().take(last_index).skip(middle_start) {
+        if !part.is_empty() {
+            let Some(found) = remainder.find(part) else {
+                return false;
+            };
+            let Some(stripped) = remainder.get(found + part.len()..) else {
+                return false;
+            };
+            remainder = stripped;
+        }
+    }
+
+    if pattern.ends_with('*') {
+        true
+    } else {
+        parts.last().is_some_and(|last| remainder.ends_with(last))
+    }
+}
+
+fn default_page_step() -> i64 {
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::v4::ir::{
+        HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
+        IrOperationOutput, IrScalarType, OutputCardinality, RestExecutionAttachment,
+        RestParameterBinding, RestResponseAttachment, SemanticIr,
+    };
+    use crate::v4::manifest::SurfaceType;
+    use crate::v4::projections::{
+        Projection, ProjectionCatalog, ProjectionInput, ProjectionKind, ProjectionVisibility,
+        SqlInputExposure,
+    };
+    use crate::v4::{OPENAPI_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
+    use crate::{ManifestDataType, PaginationMode, PaginationSpec, ResponseSpec};
+
+    use super::{
+        ProjectionPaginationInputSyncMode, apply_parameter_metadata_overrides,
+        parse_parameter_metadata_overrides_yaml, path_pattern_matches,
+        sync_projection_pagination_inputs,
+    };
+
+    #[test]
+    fn surface_strategy_matches_required_query_params() {
+        let mut ir = semantic_ir(vec![rest_operation(
+            "widgets/list",
+            "/widgets",
+            vec![query_input("page_number"), query_input("per_page")],
+            PaginationSpec::default(),
+        )]);
+        let overrides = parse_parameter_metadata_overrides_yaml(
+            r"
+pagination:
+  - name: page_number
+    match:
+      required_query_params: [page_number, per_page]
+    mode: page
+    page_param: page_number
+    page_size:
+      default: 50
+      max: 100
+      query_param: per_page
+",
+        )
+        .expect("parse overrides");
+
+        apply_parameter_metadata_overrides(&mut ir, &overrides).expect("apply overrides");
+
+        let pagination = rest_pagination(first_operation(&ir));
+        assert_eq!(pagination.mode, PaginationMode::Page);
+        assert_eq!(pagination.page_param.as_deref(), Some("page_number"));
+        assert_eq!(
+            pagination
+                .page_size
+                .as_ref()
+                .and_then(|page_size| page_size.query_param.as_deref()),
+            Some("per_page")
+        );
+    }
+
+    #[test]
+    fn explicit_non_param_match_supports_link_header_strategy() {
+        let mut ir = semantic_ir(vec![rest_operation(
+            "issues/list",
+            "/repos/{owner}/{repo}/issues",
+            vec![query_input("per_page")],
+            PaginationSpec::default(),
+        )]);
+        let overrides = parse_parameter_metadata_overrides_yaml(
+            r"
+pagination:
+  - name: github_link_header
+    match:
+      methods: [GET]
+      path_patterns: ['/repos/*/issues']
+    mode: link_header
+    page_size:
+      default: 100
+      max: 100
+      query_param: per_page
+",
+        )
+        .expect("parse overrides");
+
+        apply_parameter_metadata_overrides(&mut ir, &overrides).expect("apply overrides");
+
+        let pagination = rest_pagination(first_operation(&ir));
+        assert_eq!(pagination.mode, PaginationMode::LinkHeader);
+    }
+
+    #[test]
+    fn first_matching_strategy_wins() {
+        let mut ir = semantic_ir(vec![rest_operation(
+            "widgets/list",
+            "/widgets",
+            vec![query_input("page"), query_input("per_page")],
+            PaginationSpec::default(),
+        )]);
+        let overrides = parse_parameter_metadata_overrides_yaml(
+            r"
+pagination:
+  - name: first
+    match:
+      methods: [GET]
+    mode: page
+    page_param: page
+    page_size:
+      default: 25
+      max: 25
+      query_param: per_page
+  - name: second
+    match:
+      required_query_params: [page, per_page]
+    mode: page
+    page_param: page
+    page_size:
+      default: 100
+      max: 100
+      query_param: per_page
+",
+        )
+        .expect("parse overrides");
+
+        apply_parameter_metadata_overrides(&mut ir, &overrides).expect("apply overrides");
+
+        let page_size = rest_pagination(first_operation(&ir))
+            .page_size
+            .as_ref()
+            .expect("page size");
+        assert_eq!(page_size.default, 25);
+    }
+
+    #[test]
+    fn operation_override_wins_over_surface_strategy() {
+        let mut ir = semantic_ir(vec![rest_operation(
+            "widgets/list",
+            "/widgets",
+            vec![
+                query_input("page"),
+                query_input("page_number"),
+                query_input("per_page"),
+            ],
+            PaginationSpec::default(),
+        )]);
+        let overrides = parse_parameter_metadata_overrides_yaml(
+            r"
+pagination:
+  - name: generic
+    match:
+      methods: [GET]
+    mode: page
+    page_param: page
+    page_size:
+      default: 50
+      max: 100
+      query_param: per_page
+operation_overrides:
+  widgets/list:
+    pagination:
+      mode: page
+      page_param: page_number
+      page_size:
+        default: 50
+        max: 100
+        query_param: per_page
+",
+        )
+        .expect("parse overrides");
+
+        apply_parameter_metadata_overrides(&mut ir, &overrides).expect("apply overrides");
+
+        assert_eq!(
+            rest_pagination(first_operation(&ir)).page_param.as_deref(),
+            Some("page_number")
+        );
+    }
+
+    #[test]
+    fn sync_projection_pagination_inputs_keeps_projection_query_inputs_in_step() {
+        let mut ir = semantic_ir(vec![rest_operation(
+            "widgets_list",
+            "/widgets",
+            vec![
+                query_input("page_number"),
+                query_input("per_page"),
+                query_input("state"),
+            ],
+            PaginationSpec::default(),
+        )]);
+        let overrides = parse_parameter_metadata_overrides_yaml(
+            r"
+pagination:
+  - name: page_number
+    match:
+      operation_ids: [widgets_list]
+    mode: page
+    page_param: page_number
+    page_size:
+      default: 50
+      max: 100
+      query_param: per_page
+",
+        )
+        .expect("parse overrides");
+        let mut projections = projection_catalog(vec![
+            projection_input("page_number", "page_number", SqlInputExposure::Filter),
+            projection_input("per_page", "per_page", SqlInputExposure::Filter),
+            projection_input("state", "state", SqlInputExposure::Filter),
+            projection_input("debug", "debug", SqlInputExposure::Internal),
+        ]);
+
+        apply_parameter_metadata_overrides(&mut ir, &overrides).expect("apply overrides");
+        sync_projection_pagination_inputs(
+            std::slice::from_ref(&ir),
+            &mut projections,
+            ProjectionPaginationInputSyncMode::RecomputeRestInputExposure,
+        );
+
+        assert_eq!(
+            projection_input_exposure(&projections, "page_number"),
+            SqlInputExposure::Internal
+        );
+        assert_eq!(
+            projection_input_exposure(&projections, "per_page"),
+            SqlInputExposure::Internal
+        );
+        assert_eq!(
+            projection_input_exposure(&projections, "state"),
+            SqlInputExposure::Filter
+        );
+        assert_eq!(
+            projection_input_exposure(&projections, "debug"),
+            SqlInputExposure::Filter
+        );
+
+        let mut overridden_projections = projection_catalog(vec![
+            projection_input("page_number", "page_number", SqlInputExposure::Filter),
+            projection_input("debug", "debug", SqlInputExposure::Internal),
+        ]);
+        sync_projection_pagination_inputs(
+            std::slice::from_ref(&ir),
+            &mut overridden_projections,
+            ProjectionPaginationInputSyncMode::PreserveExistingExposure,
+        );
+
+        assert_eq!(
+            projection_input_exposure(&overridden_projections, "page_number"),
+            SqlInputExposure::Internal
+        );
+        assert_eq!(
+            projection_input_exposure(&overridden_projections, "debug"),
+            SqlInputExposure::Internal
+        );
+    }
+
+    #[test]
+    fn non_matching_strategy_leaves_operation_unchanged() {
+        let mut ir = semantic_ir(vec![rest_operation(
+            "widgets/list",
+            "/widgets",
+            vec![query_input("limit")],
+            PaginationSpec::default(),
+        )]);
+        let overrides = parse_parameter_metadata_overrides_yaml(
+            r"
+pagination:
+  - name: page_number
+    match:
+      required_query_params: [page_number, per_page]
+    mode: page
+    page_param: page_number
+    page_size:
+      default: 50
+      max: 100
+      query_param: per_page
+",
+        )
+        .expect("parse overrides");
+
+        apply_parameter_metadata_overrides(&mut ir, &overrides).expect("apply overrides");
+
+        assert_eq!(
+            rest_pagination(first_operation(&ir)).mode,
+            PaginationMode::None
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_override_shapes() {
+        let duplicate_name = parse_parameter_metadata_overrides_yaml(
+            r"
+pagination:
+  - name: repeated
+    match:
+      methods: [GET]
+  - name: repeated
+    match:
+      methods: [GET]
+",
+        )
+        .expect_err("duplicate names should fail");
+        assert!(duplicate_name.to_string().contains("repeated"));
+
+        let empty_match = parse_parameter_metadata_overrides_yaml(
+            r"
+pagination:
+  - name: no_match
+    match: {}
+",
+        )
+        .expect_err("empty match should fail");
+        assert!(
+            empty_match
+                .to_string()
+                .contains("at least one match criterion")
+        );
+
+        let unknown_field = parse_parameter_metadata_overrides_yaml(
+            r"
+pagination:
+  - name: bad
+    match:
+      methods: [GET]
+    not_a_pagination_field: true
+",
+        )
+        .expect_err("unknown field should fail");
+        assert!(unknown_field.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn rejects_unknown_operation_override_target() {
+        let mut ir = semantic_ir(vec![rest_operation(
+            "widgets/list",
+            "/widgets",
+            vec![query_input("page"), query_input("per_page")],
+            PaginationSpec::default(),
+        )]);
+        let overrides = parse_parameter_metadata_overrides_yaml(
+            r"
+operation_overrides:
+  widgets/missing:
+    pagination:
+      mode: page
+      page_param: page
+",
+        )
+        .expect("parse overrides");
+
+        let error = apply_parameter_metadata_overrides(&mut ir, &overrides)
+            .expect_err("missing operation should fail");
+
+        assert!(error.to_string().contains("unknown operation"));
+    }
+
+    #[test]
+    fn path_patterns_use_simple_star_globs() {
+        assert!(path_pattern_matches(
+            "/repos/*/issues",
+            "/repos/{owner}/{repo}/issues"
+        ));
+        assert!(path_pattern_matches("/repos/*", "/repos/{owner}/{repo}"));
+        assert!(path_pattern_matches("*issues", "/repos/{owner}/issues"));
+        assert!(!path_pattern_matches("/users/*", "/repos/{owner}/issues"));
+    }
+
+    fn semantic_ir(operations: Vec<IrOperation>) -> SemanticIr {
+        SemanticIr {
+            artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+            source_name: "demo".to_string(),
+            surface_id: "rest".to_string(),
+            surface_type: SurfaceType::OpenApi,
+            importer_version: OPENAPI_IMPORTER_VERSION.to_string(),
+            operations,
+            types: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn rest_operation(
+        id: &str,
+        path_template: &str,
+        inputs: Vec<IrOperationInput>,
+        pagination: PaginationSpec,
+    ) -> IrOperation {
+        let parameters = inputs
+            .iter()
+            .map(|input| RestParameterBinding {
+                input_name: input.name.clone(),
+                location: input.location,
+                wire_name: input.name.clone(),
+                required: input.required,
+                data_type: input.data_type,
+            })
+            .collect();
+        IrOperation {
+            id: id.to_string(),
+            method_name: "GET".to_string(),
+            description: String::new(),
+            deprecated: false,
+            read_only: true,
+            inputs,
+            output: IrOperationOutput {
+                cardinality: OutputCardinality::List,
+                type_ref: "item".to_string(),
+                row_path: Vec::new(),
+            },
+            entity: None,
+            execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
+                method: HttpMethod::Get,
+                path_template: path_template.to_string(),
+                parameters,
+                request_body: None,
+                response: RestResponseAttachment {
+                    status_code: 200,
+                    media_type: "application/json".to_string(),
+                    response: ResponseSpec::default(),
+                },
+                pagination,
+            })),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn query_input(name: &str) -> IrOperationInput {
+        IrOperationInput {
+            name: name.to_string(),
+            location: IrInputLocation::Query,
+            required: false,
+            data_type: IrScalarType::String,
+            default_value: None,
+            description: String::new(),
+        }
+    }
+
+    fn rest_pagination(operation: &IrOperation) -> &PaginationSpec {
+        let IrExecutionAttachment::Rest(rest) = &operation.execution else {
+            panic!("expected REST operation");
+        };
+        &rest.pagination
+    }
+
+    fn first_operation(ir: &SemanticIr) -> &IrOperation {
+        ir.operations.first().expect("operation")
+    }
+
+    fn projection_catalog(inputs: Vec<ProjectionInput>) -> ProjectionCatalog {
+        ProjectionCatalog {
+            artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+            source_name: "demo".to_string(),
+            generator_version: "test".to_string(),
+            projections: vec![Projection {
+                name: "widgets".to_string(),
+                namespace: "demo".to_string(),
+                kind: ProjectionKind::Table,
+                description: String::new(),
+                guide: String::new(),
+                surface_id: "rest".to_string(),
+                operation_id: "widgets_list".to_string(),
+                visibility: ProjectionVisibility::Published,
+                inputs,
+                columns: Vec::new(),
+                search_limits: None,
+                detail_hints: Vec::new(),
+                diagnostics: Vec::new(),
+            }],
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn projection_input(
+        name: &str,
+        wire_name: &str,
+        sql_exposure: SqlInputExposure,
+    ) -> ProjectionInput {
+        ProjectionInput {
+            name: name.to_string(),
+            sql_exposure,
+            source_location: IrInputLocation::Query,
+            wire_name: wire_name.to_string(),
+            required: false,
+            data_type: ManifestDataType::Utf8,
+            default_value: None,
+            description: String::new(),
+        }
+    }
+
+    fn projection_input_exposure(
+        catalog: &ProjectionCatalog,
+        input_name: &str,
+    ) -> SqlInputExposure {
+        catalog
+            .projections
+            .first()
+            .expect("projection")
+            .inputs
+            .iter()
+            .find(|input| input.name == input_name)
+            .map(|input| input.sql_exposure)
+            .expect("projection input")
+    }
+}

--- a/crates/coral-spec/src/v4/projections/mod.rs
+++ b/crates/coral-spec/src/v4/projections/mod.rs
@@ -6,6 +6,7 @@ mod runtime;
 
 pub use derive::generate_projection_catalog;
 pub use model::*;
+pub(super) use pagination::pagination_query_param_names;
 pub use runtime::{
     manifest_data_type_name, mcp_projection_arg_specs, projection_arg_specs,
     projection_column_specs, projection_filter_specs, request_spec_for_projection,

--- a/crates/coral-spec/src/v4/projections/pagination.rs
+++ b/crates/coral-spec/src/v4/projections/pagination.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::PaginationSpec;
 
-pub(super) fn pagination_query_param_names(pagination: &PaginationSpec) -> HashSet<&str> {
+pub(in crate::v4) fn pagination_query_param_names(pagination: &PaginationSpec) -> HashSet<&str> {
     let mut names = HashSet::new();
     if let Some(name) = pagination.page_param.as_deref() {
         names.insert(name);


### PR DESCRIPTION
## Summary

- Add DSL v4 `parameter_metadata.yaml` pagination overrides at `workspaces/{workspace}/sources/{source}/overrides/surfaces/{surface}/parameter_metadata.yaml`.
- Support ordered surface-wide pagination strategies plus per-operation overrides, with matching by operation id, HTTP method, path pattern, and required query params.
- Allow overrides for query-param pagination and non-query pagination metadata, including body cursor paths, response cursor paths, page-size body paths, link-header mode, and max page limits.
- Apply overrides when loading materialized v4 sources without rewriting generated artifacts, then sync projection input exposure to the effective pagination contract.

Closes #[**1233**](https://github.com/withcoral/coral/issues/1233)

## Behavior Notes

- Surface-level strategies are evaluated in order; the first matching strategy applies.
- `operation_overrides` take precedence for inconsistent individual operations.
- Generated projections recompute REST input exposure so stale inferred pagination params are restored/hidden correctly.
- Explicit `overrides/projections.yaml` files keep their custom exposure choices, while current pagination-owned query inputs remain internal.

## Example Override File

Save this as `workspaces/{workspace}/sources/{source}/overrides/surfaces/rest/parameter_metadata.yaml`:

```yaml
# Ordered surface-wide strategies. The first matching strategy wins.
pagination:
  # Match operations by explicit operation id and override page pagination params.
  - name: page_number_params
    match:
      operation_ids: [widgets/list]
    mode: page
    page_param: page_number
    page_start: 1
    page_step: 1
    page_size:
      default: 50
      max: 100
      query_param: per_page
    max_pages: 20

  # Match by HTTP method, path glob, and required query params; use offset pagination.
  - name: offset_limit_params
    match:
      methods: [GET]
      path_patterns: [/v1/events*]
      required_query_params: [offset, limit]
    mode: offset
    offset_param: offset
    offset_start: 0
    offset_step: 100
    page_size:
      default: 100
      max: 500
      query_param: limit

  # Match any operation that has the provider's cursor query params.
  - name: cursor_query_params
    match:
      required_query_params: [cursor, limit]
    mode: cursor_query
    cursor_param: cursor
    response_cursor_path: [meta, next_cursor]
    page_size:
      default: 100
      max: 100
      query_param: limit

  # Link-header pagination has no cursor query param, but can still own page size.
  - name: github_link_header
    match:
      methods: [GET]
      path_patterns: [/repos/*/issues]
    mode: link_header
    link_header_require_results: true
    page_size:
      default: 100
      max: 100
      query_param: per_page

# Per-operation overrides win over any matching surface strategy.
operation_overrides:
  reports/search:
    pagination:
      mode: cursor_body
      cursor_body_path: [page, cursor]
      response_cursor_path: [pagination, next]
      page_size:
        default: 25
        max: 100
        body_path: [page, size]
      max_pages: 10

  audit/export:
    pagination:
      mode: none
```

## Validation

- `cargo test -p coral-spec parameter_metadata --all-features`
- `cargo test -p coral-app parameter_metadata --all-features`
- `cargo clippy -p coral-spec --all-targets --all-features --locked -- -D warnings`
- `cargo clippy -p coral-app --all-targets --all-features --locked -- -D warnings`
- `make rust-checks`