### PR TITLE
feat(engine): infer function SQL signatures

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -369,7 +369,7 @@ fn serialize_search_limits(limits: &SearchLimitsSpec) -> String {
 }
 
 pub(crate) fn arrow_type_for_column(column: &ColumnSpec) -> DataType {
-    crate::types::arrow_column_type(column.data_type)
+    crate::types::arrow_data_type(column.data_type)
 }
 
 pub(crate) fn schema_from_columns(

--- a/crates/coral-engine/src/backends/file/partitions.rs
+++ b/crates/coral-engine/src/backends/file/partitions.rs
@@ -14,7 +14,7 @@ use coral_spec::backends::file::{FilePartitionDataType, PartitionColumnSpec, Par
 use super::listing::parse_bool;
 
 fn arrow_type(data_type: FilePartitionDataType) -> DataType {
-    crate::types::arrow_column_type(data_type.into())
+    crate::types::arrow_data_type(data_type.into())
 }
 
 fn scalar_from_path(

--- a/crates/coral-engine/src/backends/mcp/function.rs
+++ b/crates/coral-engine/src/backends/mcp/function.rs
@@ -20,6 +20,7 @@ use crate::backends::SourceFunctionProviderFactory;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::json_exec::JsonExec;
 use crate::backends::shared::mapping::convert_items;
+use crate::backends::shared::scalar::timestamp_to_rfc3339;
 
 #[derive(Clone)]
 pub(super) struct McpSourceTableFunction {
@@ -325,7 +326,7 @@ fn scalar_value_to_json(value: &ScalarValue) -> Option<Value> {
         ScalarValue::Float64(Some(value)) => {
             serde_json::Number::from_f64(*value).map(Value::Number)
         }
-        _ => None,
+        value => timestamp_to_rfc3339(value).map(Value::String),
     }
 }
 
@@ -355,5 +356,21 @@ fn value_for_allowed_value_check(value: &Value) -> String {
     match value {
         Value::String(value) => value.clone(),
         other => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timestamp_scalar_serializes_as_json_string() {
+        let timestamp =
+            ScalarValue::TimestampMicrosecond(Some(1_704_067_200_000_000), Some("+00:00".into()));
+
+        assert_eq!(
+            scalar_value_to_json(&timestamp),
+            Some(Value::String("2024-01-01T00:00:00Z".to_string()))
+        );
     }
 }

--- a/crates/coral-engine/src/backends/shared/filter_expr.rs
+++ b/crates/coral-engine/src/backends/shared/filter_expr.rs
@@ -7,6 +7,8 @@ use datafusion::scalar::ScalarValue;
 
 use coral_spec::{FilterMode, FilterSpec};
 
+use super::scalar::timestamp_to_rfc3339;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum FilterExtraction {
     Values(HashMap<String, String>),
@@ -408,6 +410,7 @@ pub(crate) fn literal_to_string(expr: &Expr) -> Option<String> {
         Expr::Literal(ScalarValue::Float64(Some(v)), _) => Some(v.to_string()),
         Expr::Literal(ScalarValue::Float32(Some(v)), _) => Some(v.to_string()),
         Expr::Literal(ScalarValue::Boolean(Some(v)), _) => Some(v.to_string()),
+        Expr::Literal(value, _) => timestamp_to_rfc3339(value),
         Expr::Cast(cast) => literal_to_string(cast.expr.as_ref()),
         Expr::TryCast(cast) => literal_to_string(cast.expr.as_ref()),
         _ => None,

--- a/crates/coral-engine/src/backends/shared/mod.rs
+++ b/crates/coral-engine/src/backends/shared/mod.rs
@@ -5,5 +5,6 @@ pub(crate) mod json_exec;
 pub(crate) mod json_path;
 pub(crate) mod mapping;
 pub(crate) mod response_rows;
+pub(crate) mod scalar;
 pub(crate) mod template;
 pub(crate) mod trace;

--- a/crates/coral-engine/src/backends/shared/scalar.rs
+++ b/crates/coral-engine/src/backends/shared/scalar.rs
@@ -1,0 +1,26 @@
+//! Scalar conversions shared by provider request boundaries.
+
+use coral_spec::ManifestDataType;
+use datafusion::arrow::datatypes::DataType;
+use datafusion::scalar::ScalarValue;
+
+pub(crate) fn timestamp_to_rfc3339(value: &ScalarValue) -> Option<String> {
+    if !matches!(
+        value,
+        ScalarValue::TimestampSecond(_, _)
+            | ScalarValue::TimestampMillisecond(_, _)
+            | ScalarValue::TimestampMicrosecond(_, _)
+            | ScalarValue::TimestampNanosecond(_, _)
+    ) {
+        return None;
+    }
+
+    value
+        .cast_to(&crate::types::arrow_data_type(ManifestDataType::Timestamp))
+        .ok()?
+        .cast_to(&DataType::Utf8)
+        .ok()?
+        .try_as_str()
+        .flatten()
+        .map(str::to_owned)
+}

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -4,6 +4,7 @@ mod catalog;
 mod error;
 mod query;
 mod query_error;
+mod udfs;
 
 pub use catalog::{
     CatalogInfo, ColumnInfo, DescribeTableInfo, TableFunctionArgumentInfo, TableFunctionInfo,
@@ -18,6 +19,10 @@ pub use query::{
     RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
+pub use udfs::{
+    UdfRuntimeArgument, UdfRuntimeImplementation, UdfRuntimeResultColumn, UdfRuntimeSignature,
+    UdfRuntimeSqlDefinition,
+};
 
 #[cfg(test)]
 pub(crate) use query_error::UNKNOWN_COLUMN_REASON;

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -446,6 +446,8 @@ pub enum QueryParameterValue {
     Float(Option<f64>),
     /// Boolean value, or a typed boolean NULL.
     Boolean(Option<bool>),
+    /// UTC timestamp as microseconds since the Unix epoch, or a typed timestamp NULL.
+    Timestamp(Option<i64>),
 }
 
 impl QueryParameterValue {
@@ -495,6 +497,18 @@ impl QueryParameterValue {
     #[must_use]
     pub fn null_boolean() -> Self {
         Self::Boolean(None)
+    }
+
+    /// Builds a non-null UTC timestamp from microseconds since the Unix epoch.
+    #[must_use]
+    pub fn timestamp_micros(value: i64) -> Self {
+        Self::Timestamp(Some(value))
+    }
+
+    /// Builds a typed timestamp NULL.
+    #[must_use]
+    pub fn null_timestamp() -> Self {
+        Self::Timestamp(None)
     }
 }
 

--- a/crates/coral-engine/src/contracts/udfs.rs
+++ b/crates/coral-engine/src/contracts/udfs.rs
@@ -1,0 +1,61 @@
+//! Engine runtime UDF contracts supplied by the app layer.
+
+use coral_spec::ManifestDataType;
+
+/// Typed UDF signature inferred by planning its SQL body.
+#[derive(Debug, Clone)]
+pub struct UdfRuntimeSignature {
+    /// Arguments referenced by the UDF SQL body.
+    pub arguments: Vec<UdfRuntimeArgument>,
+    /// Columns returned by the UDF SQL body.
+    pub result_columns: Vec<UdfRuntimeResultColumn>,
+}
+
+/// One SQL UDF body to validate before runtime registration.
+#[derive(Debug, Clone)]
+pub struct UdfRuntimeSqlDefinition {
+    /// Stable UDF id within one workspace.
+    pub name: String,
+    /// Executable UDF implementation.
+    pub implementation: UdfRuntimeImplementation,
+}
+
+impl UdfRuntimeSqlDefinition {
+    /// Returns the SQL body for this definition.
+    #[must_use]
+    pub fn sql(&self) -> &str {
+        let UdfRuntimeImplementation::CoralSql { query } = &self.implementation;
+        query
+    }
+}
+
+/// One typed UDF argument.
+#[derive(Debug, Clone)]
+pub struct UdfRuntimeArgument {
+    /// Argument name.
+    pub name: String,
+    /// Argument type in manifest spelling.
+    pub data_type: ManifestDataType,
+}
+
+/// One column returned by a UDF table function.
+#[derive(Debug, Clone)]
+pub struct UdfRuntimeResultColumn {
+    /// Column name.
+    pub name: String,
+    /// Arrow/DataFusion type expected for the column.
+    pub data_type: arrow::datatypes::DataType,
+    /// Whether the column can contain null values.
+    pub nullable: bool,
+}
+
+/// Executable UDF implementation.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum UdfRuntimeImplementation {
+    /// Read-only Coral SQL using `DataFusion` value parameters like `$argument`.
+    CoralSql {
+        /// SQL query executed by Coral after typed argument binding.
+        query: String,
+    },
+}

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -75,6 +75,8 @@ pub use contracts::{
     QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
     RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
     TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
+    UdfRuntimeArgument, UdfRuntimeImplementation, UdfRuntimeResultColumn, UdfRuntimeSignature,
+    UdfRuntimeSqlDefinition,
 };
 
 /// High-level query operations for the local query engine.
@@ -181,6 +183,28 @@ impl CoralQuery {
             .await?
             .execute_sql(sql, &params)
             .await
+    }
+
+    /// Infers the typed signature for one UDF by planning its SQL against selected sources.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if source compilation fails, if the UDF SQL cannot
+    /// plan against the selected sources, or if any SQL parameter has no
+    /// inferred type.
+    pub async fn infer_udf_signature(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+        udf: UdfRuntimeSqlDefinition,
+    ) -> Result<UdfRuntimeSignature, CoreError> {
+        if udf.sql().trim().is_empty() {
+            return Err(CoreError::InvalidInput(format!(
+                "udf '{}' SQL body cannot be empty",
+                udf.name
+            )));
+        }
+        let query_runtime = runtime::query::build_runtime(sources, runtime).await?;
+        runtime::udfs::infer_udf_signature(&query_runtime, &udf).await
     }
 
     /// Explains one `SQL` statement with logical and physical plan renderings.

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -13,3 +13,4 @@ pub(crate) mod registry;
 pub(crate) mod schema_provider;
 pub(crate) mod scoped_table_functions;
 pub(crate) mod source_functions;
+pub(crate) mod udfs;

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -3,6 +3,8 @@
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
+use arrow::datatypes::{Field, FieldRef};
+use coral_spec::ManifestDataType;
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::common::{ScalarValue, TableReference};
 use datafusion::dataframe::DataFrame;
@@ -52,6 +54,12 @@ pub(crate) struct QueryRuntimeAdapter {
     failures: Vec<SourceRegistrationFailure>,
     schema_to_source: HashMap<String, String>,
     query_result_observers: Vec<Arc<dyn QueryResultObserver>>,
+}
+
+pub(crate) struct InferredSqlSignature {
+    pub(crate) parameter_fields: HashMap<String, Option<FieldRef>>,
+    pub(crate) declared_parameter_types: HashMap<String, ManifestDataType>,
+    pub(crate) planned_schema: Arc<arrow::datatypes::Schema>,
 }
 
 struct FallbackRuntime {
@@ -415,6 +423,44 @@ impl QueryRuntimeAdapter {
         }
     }
 
+    pub(crate) async fn infer_sql_signature(
+        &self,
+        sql: &str,
+    ) -> Result<InferredSqlSignature, CoreError> {
+        let plan_error = |err| {
+            datafusion_to_core_with_sql_and_table_functions(
+                &err,
+                &self.tables,
+                &self.table_functions,
+                Some(sql),
+            )
+        };
+        let df = self
+            .ctx
+            .sql_with_options(sql, read_only_sql_options())
+            .await
+            .map_err(plan_error)?;
+        let mut parameter_fields = df
+            .logical_plan()
+            .get_parameter_fields()
+            .map_err(plan_error)?;
+        infer_cast_parameter_fields(df.logical_plan(), &mut parameter_fields)
+            .map_err(plan_error)?;
+        let mut declared_parameter_types = HashMap::new();
+        infer_source_function_parameter_fields(
+            df.logical_plan(),
+            &mut parameter_fields,
+            &mut declared_parameter_types,
+        )
+        .map_err(plan_error)?;
+
+        Ok(InferredSqlSignature {
+            parameter_fields,
+            declared_parameter_types,
+            planned_schema: Arc::new(df.logical_plan().schema().as_arrow().clone()),
+        })
+    }
+
     async fn execute_sql_once(
         &self,
         ctx: &SessionContext,
@@ -631,6 +677,113 @@ impl QueryRuntimeAdapter {
                 Some(sql),
             )
         })
+    }
+}
+
+fn infer_cast_parameter_fields(
+    plan: &LogicalPlan,
+    parameter_fields: &mut HashMap<String, Option<FieldRef>>,
+) -> Result<(), DataFusionError> {
+    plan.apply_with_subqueries(|node| {
+        node.apply_expressions(|expr| {
+            expr.apply(|expr| {
+                let (cast_expr, data_type) = match expr {
+                    Expr::Cast(cast) => (cast.expr.as_ref(), cast.data_type.clone()),
+                    Expr::TryCast(cast) => (cast.expr.as_ref(), cast.data_type.clone()),
+                    _ => return Ok(TreeNodeRecursion::Continue),
+                };
+                let Expr::Placeholder(placeholder) = cast_expr else {
+                    return Ok(TreeNodeRecursion::Continue);
+                };
+                set_parameter_field(
+                    parameter_fields,
+                    &placeholder.id,
+                    Arc::new(Field::new("", data_type, true)),
+                )?;
+                Ok(TreeNodeRecursion::Continue)
+            })
+        })
+    })?;
+    Ok(())
+}
+
+fn infer_source_function_parameter_fields(
+    plan: &LogicalPlan,
+    parameter_fields: &mut HashMap<String, Option<FieldRef>>,
+    declared_parameter_types: &mut HashMap<String, ManifestDataType>,
+) -> Result<(), DataFusionError> {
+    plan.apply_with_subqueries(|node| {
+        let LogicalPlan::Extension(extension) = node else {
+            return Ok(TreeNodeRecursion::Continue);
+        };
+        let Some(function) = extension.node.as_any().downcast_ref::<SourceFunctionNode>() else {
+            return Ok(TreeNodeRecursion::Continue);
+        };
+        for (argument, expr) in function.declared_args_with_call_exprs() {
+            let Expr::Placeholder(placeholder) = expr else {
+                continue;
+            };
+            set_parameter_field(
+                parameter_fields,
+                &placeholder.id,
+                Arc::new(Field::new(
+                    "",
+                    crate::types::arrow_parameter_type(argument.data_type),
+                    true,
+                )),
+            )?;
+            set_declared_parameter_type(
+                declared_parameter_types,
+                &placeholder.id,
+                argument.data_type,
+            )?;
+        }
+        Ok(TreeNodeRecursion::Continue)
+    })?;
+    Ok(())
+}
+
+fn set_declared_parameter_type(
+    declared_parameter_types: &mut HashMap<String, ManifestDataType>,
+    parameter: &str,
+    data_type: ManifestDataType,
+) -> Result<(), DataFusionError> {
+    match declared_parameter_types.get(parameter) {
+        Some(existing) if *existing != data_type => Err(DataFusionError::Plan(format!(
+            "conflicting types for parameter {parameter}: {} and {}; use explicit casts so every use has one type",
+            existing.as_manifest_str(),
+            data_type.as_manifest_str()
+        ))),
+        Some(_) => Ok(()),
+        None => {
+            declared_parameter_types.insert(parameter.to_string(), data_type);
+            Ok(())
+        }
+    }
+}
+
+fn set_parameter_field(
+    parameter_fields: &mut HashMap<String, Option<FieldRef>>,
+    parameter: &str,
+    field: FieldRef,
+) -> Result<(), DataFusionError> {
+    match parameter_fields.get(parameter) {
+        Some(Some(existing))
+            if existing.data_type() != field.data_type()
+                && !(crate::types::is_string_family(existing.data_type())
+                    && crate::types::is_string_family(field.data_type())) =>
+        {
+            Err(DataFusionError::Plan(format!(
+                "conflicting types for parameter {parameter}: {} and {}; use explicit casts so every use has one type",
+                existing.data_type(),
+                field.data_type()
+            )))
+        }
+        Some(Some(_)) => Ok(()),
+        _ => {
+            parameter_fields.insert(parameter.to_string(), Some(field));
+            Ok(())
+        }
     }
 }
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
-use arrow::datatypes::{Field, FieldRef};
+use arrow::datatypes::{DataType, Field, FieldRef};
 use coral_spec::ManifestDataType;
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::common::{ScalarValue, TableReference};
@@ -728,7 +728,7 @@ fn infer_source_function_parameter_fields(
                 &placeholder.id,
                 Arc::new(Field::new(
                     "",
-                    crate::types::arrow_parameter_type(argument.data_type),
+                    crate::types::arrow_data_type(argument.data_type),
                     true,
                 )),
             )?;
@@ -769,9 +769,7 @@ fn set_parameter_field(
 ) -> Result<(), DataFusionError> {
     match parameter_fields.get(parameter) {
         Some(Some(existing))
-            if existing.data_type() != field.data_type()
-                && !(crate::types::is_string_family(existing.data_type())
-                    && crate::types::is_string_family(field.data_type())) =>
+            if !parameter_types_are_compatible(existing.data_type(), field.data_type()) =>
         {
             Err(DataFusionError::Plan(format!(
                 "conflicting types for parameter {parameter}: {} and {}; use explicit casts so every use has one type",
@@ -784,6 +782,20 @@ fn set_parameter_field(
             parameter_fields.insert(parameter.to_string(), Some(field));
             Ok(())
         }
+    }
+}
+
+fn parameter_types_are_compatible(left: &DataType, right: &DataType) -> bool {
+    if left == right {
+        return true;
+    }
+
+    match (
+        crate::types::manifest_data_type_for_arrow(left),
+        crate::types::manifest_data_type_for_arrow(right),
+    ) {
+        (Some(left), Some(right)) => left == right,
+        _ => false,
     }
 }
 
@@ -853,6 +865,9 @@ fn query_parameter_scalar_value(value: &QueryParameterValue) -> ScalarValue {
         QueryParameterValue::Integer(value) => ScalarValue::Int64(*value),
         QueryParameterValue::Float(value) => ScalarValue::Float64(*value),
         QueryParameterValue::Boolean(value) => ScalarValue::Boolean(*value),
+        QueryParameterValue::Timestamp(value) => {
+            ScalarValue::TimestampMicrosecond(*value, Some("+00:00".into()))
+        }
     }
 }
 

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -1,0 +1,60 @@
+//! UDF SQL signature inference orchestration.
+
+use crate::runtime::query::QueryRuntimeAdapter;
+use crate::{
+    CoreError, UdfRuntimeArgument, UdfRuntimeResultColumn, UdfRuntimeSignature,
+    UdfRuntimeSqlDefinition,
+};
+use arrow::datatypes::Schema;
+
+pub(crate) async fn infer_udf_signature(
+    query_runtime: &QueryRuntimeAdapter,
+    udf: &UdfRuntimeSqlDefinition,
+) -> Result<UdfRuntimeSignature, CoreError> {
+    let signature = query_runtime.infer_sql_signature(udf.sql()).await?;
+    let mut arguments = Vec::new();
+    for (placeholder, field) in signature.parameter_fields {
+        let name = placeholder
+            .strip_prefix('$')
+            .unwrap_or(&placeholder)
+            .to_string();
+        let Some(field) = field else {
+            return Err(CoreError::InvalidInput(format!(
+                "udf '{}' SQL parameter '{}' has no inferred type; cast it in SQL, for example CAST({} AS VARCHAR)",
+                udf.name, placeholder, placeholder
+            )));
+        };
+        let data_type = match signature.declared_parameter_types.get(&placeholder) {
+            Some(declared) => *declared,
+            None => {
+                crate::types::manifest_data_type_for_arrow(field.data_type()).ok_or_else(|| {
+                    CoreError::InvalidInput(format!(
+                        "udf '{}' SQL parameter '{}' inferred unsupported type {}",
+                        udf.name,
+                        placeholder,
+                        field.data_type()
+                    ))
+                })?
+            }
+        };
+        arguments.push(UdfRuntimeArgument { name, data_type });
+    }
+    arguments.sort_by(|left, right| left.name.cmp(&right.name));
+
+    Ok(UdfRuntimeSignature {
+        arguments,
+        result_columns: result_columns(signature.planned_schema.as_ref()),
+    })
+}
+
+fn result_columns(schema: &Schema) -> Vec<UdfRuntimeResultColumn> {
+    schema
+        .fields()
+        .iter()
+        .map(|field| UdfRuntimeResultColumn {
+            name: field.name().clone(),
+            data_type: field.data_type().clone(),
+            nullable: field.is_nullable(),
+        })
+        .collect()
+}

--- a/crates/coral-engine/src/types.rs
+++ b/crates/coral-engine/src/types.rs
@@ -1,11 +1,8 @@
 //! Canonical conversions between the coral-spec scalar vocabulary and
 //! Arrow/DataFusion types.
 //!
-//! This module is the home for `ManifestDataType`-to-Arrow *type-level*
-//! policies, so that when more than one lowering exists (column schemas
-//! want real Arrow types; string-shaped parameter binding wants plain
-//! strings) the policies sit adjacent and reviewable. It holds column-schema
-//! lowering, SQL parameter binding lowering, and Arrow-to-manifest inference.
+//! This module is the home for the canonical `ManifestDataType`-to-Arrow
+//! type-level policy and Arrow-to-manifest inference.
 //! Value-level `ManifestDataType` switches still live with their backends
 //! (`convert_items` in `backends/shared/mapping.rs` builds Arrow arrays per
 //! variant, and `coerce_filter_value` / `coerce_call_arg_value` in the MCP
@@ -15,12 +12,11 @@
 use coral_spec::ManifestDataType;
 use datafusion::arrow::datatypes::{DataType, TimeUnit};
 
-/// Lowers a manifest data type into the Arrow type used for table and
-/// result-column schemas.
+/// Lowers a manifest data type into its canonical Arrow type.
 ///
-/// This is the column-schema policy: `Timestamp` becomes a real
-/// microsecond-precision UTC Arrow timestamp, and `Json` is stored as text.
-pub(crate) fn arrow_column_type(data_type: ManifestDataType) -> DataType {
+/// `Timestamp` becomes a microsecond-precision UTC Arrow timestamp, and
+/// `Json` is stored as text.
+pub(crate) fn arrow_data_type(data_type: ManifestDataType) -> DataType {
     match data_type {
         ManifestDataType::Utf8 | ManifestDataType::Json => DataType::Utf8,
         ManifestDataType::Int64 => DataType::Int64,
@@ -29,22 +25,6 @@ pub(crate) fn arrow_column_type(data_type: ManifestDataType) -> DataType {
         ManifestDataType::Timestamp => {
             DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into()))
         }
-    }
-}
-
-/// Lowers a manifest data type into the Arrow type used while binding SQL
-/// parameter placeholders.
-///
-/// This is the parameter-binding policy: `Json` and `Timestamp` are declared
-/// manifest types, but they bind through `DataFusion` as string-shaped values.
-pub(crate) fn arrow_parameter_type(data_type: ManifestDataType) -> DataType {
-    match data_type {
-        ManifestDataType::Utf8 | ManifestDataType::Json | ManifestDataType::Timestamp => {
-            DataType::Utf8
-        }
-        ManifestDataType::Int64 => DataType::Int64,
-        ManifestDataType::Boolean => DataType::Boolean,
-        ManifestDataType::Float64 => DataType::Float64,
     }
 }
 
@@ -98,33 +78,25 @@ mod tests {
     }
 
     #[test]
-    fn every_lowering_resolves_to_some_manifest_type() {
+    fn every_manifest_type_lowers_to_a_supported_arrow_type() {
         for data_type in ALL {
             assert_all_manifest_data_types_covered(data_type);
 
             assert!(
-                manifest_data_type_for_arrow(&arrow_parameter_type(data_type)).is_some(),
-                "{data_type} parameter lowering should resolve to some manifest type"
-            );
-            assert!(
-                manifest_data_type_for_arrow(&arrow_column_type(data_type)).is_some(),
-                "{data_type} column lowering should resolve to some manifest type"
+                manifest_data_type_for_arrow(&arrow_data_type(data_type)).is_some(),
+                "{data_type} lowering should resolve to some manifest type"
             );
         }
     }
 
     #[test]
-    fn string_shaped_lowerings_resolve_to_utf8_not_their_semantic_type() {
+    fn arrow_resolution_preserves_timestamp_and_erases_json_semantics() {
         assert_eq!(
-            manifest_data_type_for_arrow(&arrow_parameter_type(ManifestDataType::Json)),
+            manifest_data_type_for_arrow(&arrow_data_type(ManifestDataType::Json)),
             Some(ManifestDataType::Utf8)
         );
         assert_eq!(
-            manifest_data_type_for_arrow(&arrow_parameter_type(ManifestDataType::Timestamp)),
-            Some(ManifestDataType::Utf8)
-        );
-        assert_eq!(
-            manifest_data_type_for_arrow(&arrow_column_type(ManifestDataType::Timestamp)),
+            manifest_data_type_for_arrow(&arrow_data_type(ManifestDataType::Timestamp)),
             Some(ManifestDataType::Timestamp)
         );
         assert_eq!(

--- a/crates/coral-engine/src/types.rs
+++ b/crates/coral-engine/src/types.rs
@@ -5,13 +5,12 @@
 //! policies, so that when more than one lowering exists (column schemas
 //! want real Arrow types; string-shaped parameter binding wants plain
 //! strings) the policies sit adjacent and reviewable. It holds column-schema
-//! lowering, SQL parameter binding lowering, Arrow-to-manifest inference, and
-//! type-claim compatibility. Value-level `ManifestDataType` switches still live
-//! with their backends (`convert_items` in `backends/shared/mapping.rs` builds
-//! Arrow arrays per variant, and `coerce_filter_value` / `coerce_call_arg_value`
-//! in the MCP backend coerce JSON values). All of those matches are
-//! wildcard-free, so adding a `ManifestDataType` variant breaks each of them
-//! loudly.
+//! lowering, SQL parameter binding lowering, and Arrow-to-manifest inference.
+//! Value-level `ManifestDataType` switches still live with their backends
+//! (`convert_items` in `backends/shared/mapping.rs` builds Arrow arrays per
+//! variant, and `coerce_filter_value` / `coerce_call_arg_value` in the MCP
+//! backend coerce JSON values). All of those matches are wildcard-free, so
+//! adding a `ManifestDataType` variant breaks each of them loudly.
 
 use coral_spec::ManifestDataType;
 use datafusion::arrow::datatypes::{DataType, TimeUnit};
@@ -51,13 +50,6 @@ pub(crate) fn arrow_parameter_type(data_type: ManifestDataType) -> DataType {
 
 /// Resolves a DataFusion/Arrow inferred parameter type into Coral manifest
 /// spelling when the type can be expressed in function metadata.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Used by the function signature inference PR stacked on this one"
-    )
-)]
 pub(crate) fn manifest_data_type_for_arrow(data_type: &DataType) -> Option<ManifestDataType> {
     match data_type {
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Some(ManifestDataType::Utf8),
@@ -67,22 +59,6 @@ pub(crate) fn manifest_data_type_for_arrow(data_type: &DataType) -> Option<Manif
         DataType::Timestamp(_, _) => Some(ManifestDataType::Timestamp),
         _ => None,
     }
-}
-
-/// Whether a declared manifest type is compatible with one Arrow-inferred
-/// claim for the same SQL placeholder.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Used by the function signature inference PR stacked on this one"
-    )
-)]
-pub(crate) fn manifest_claim_accepts_arrow(declared: ManifestDataType, arrow: &DataType) -> bool {
-    let declared_arrow = arrow_parameter_type(declared);
-    declared_arrow == *arrow
-        || (is_string_family(&declared_arrow) && is_string_family(arrow))
-        || (declared == ManifestDataType::Timestamp && matches!(arrow, DataType::Timestamp(_, _)))
 }
 
 /// Whether an Arrow type is one of the string representations
@@ -118,22 +94,6 @@ mod tests {
             | ManifestDataType::Float64
             | ManifestDataType::Boolean
             | ManifestDataType::Timestamp => {}
-        }
-    }
-
-    #[test]
-    fn every_variant_accepts_its_own_lowerings() {
-        for data_type in ALL {
-            assert_all_manifest_data_types_covered(data_type);
-
-            assert!(
-                manifest_claim_accepts_arrow(data_type, &arrow_parameter_type(data_type)),
-                "{data_type} should accept its parameter lowering"
-            );
-            assert!(
-                manifest_claim_accepts_arrow(data_type, &arrow_column_type(data_type)),
-                "{data_type} should accept its column lowering"
-            );
         }
     }
 

--- a/crates/coral-engine/tests/engine.rs
+++ b/crates/coral-engine/tests/engine.rs
@@ -33,3 +33,5 @@ mod query_result_observer_tests;
 mod structured_error_tests;
 #[path = "engine/test_source_tests.rs"]
 mod test_source_tests;
+#[path = "engine/udf_tests.rs"]
+mod udf_tests;

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -3379,13 +3379,18 @@ async fn query_parameters_bind_typed_scalar_values() {
         ("count".to_string(), QueryParameterValue::integer(7)),
         ("score".to_string(), QueryParameterValue::float(9.5)),
         ("enabled".to_string(), QueryParameterValue::boolean(true)),
+        (
+            "created_at".to_string(),
+            QueryParameterValue::timestamp_micros(1_704_067_200_000_000),
+        ),
     ]);
 
     let rows = execution_to_rows(
         &CoralQuery::execute_sql_with_params(
             &[],
             test_runtime(),
-            "SELECT $count AS count, $score AS score, $enabled AS enabled \
+            "SELECT $count AS count, $score AS score, $enabled AS enabled, \
+             date_part('year', $created_at) AS created_year \
              WHERE $count = 7 AND $score > 9.0 AND $enabled",
             params,
         )
@@ -3398,27 +3403,37 @@ async fn query_parameters_bind_typed_scalar_values() {
         vec![json!({
             "count": 7,
             "score": 9.5,
-            "enabled": true
+            "enabled": true,
+            "created_year": 2024
         })]
     );
 }
 
 #[tokio::test]
 async fn query_parameters_bind_typed_null_values() {
-    let params = QueryParameters::from([("value".to_string(), QueryParameterValue::null_string())]);
+    let params = QueryParameters::from([
+        ("value".to_string(), QueryParameterValue::null_string()),
+        (
+            "timestamp".to_string(),
+            QueryParameterValue::null_timestamp(),
+        ),
+    ]);
 
     let rows = execution_to_rows(
         &CoralQuery::execute_sql_with_params(
             &[],
             test_runtime(),
-            "SELECT $value IS NULL AS is_null",
+            "SELECT $value IS NULL AS is_null, $timestamp IS NULL AS timestamp_is_null",
             params,
         )
         .await
         .expect("typed null parameters should bind"),
     );
 
-    assert_eq!(rows, vec![json!({ "is_null": true })]);
+    assert_eq!(
+        rows,
+        vec![json!({ "is_null": true, "timestamp_is_null": true })]
+    );
 }
 
 #[tokio::test]

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -3207,6 +3207,64 @@ async fn source_scoped_table_function_binds_query_parameters() {
 }
 
 #[tokio::test]
+async fn source_scoped_table_function_serializes_timestamp_query_parameter() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky"))
+        .and(query_param("since", "2024-01-01T00:00:00Z"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = search_function_manifest("timestamp_param_search", &server.uri());
+    manifest["functions"][0]["args"]
+        .as_array_mut()
+        .expect("function args are an array")
+        .push(json!({
+            "name": "since",
+            "type": "Timestamp",
+            "bind": { "arg": "since" }
+        }));
+    manifest["functions"][0]["request"]["query"]
+        .as_array_mut()
+        .expect("request query bindings are an array")
+        .push(json!({ "name": "since", "from": "arg", "key": "since" }));
+
+    let source = build_source(manifest);
+    let params = QueryParameters::from([(
+        "since".to_string(),
+        QueryParameterValue::timestamp_micros(1_704_067_200_000_000),
+    )]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql_with_params(
+            &[source],
+            test_runtime(),
+            "SELECT title, score FROM timestamp_param_search.search_issues(\
+             q => 'flaky', since => $since)",
+            params,
+        )
+        .await
+        .expect("timestamp query parameter should bind and execute"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
 async fn explain_sql_binds_query_parameters() {
     let server = MockServer::start().await;
     let source = build_source(search_function_manifest(

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -223,6 +223,28 @@ async fn infer_udf_signature_uses_explicit_cast_for_argument_type() {
 }
 
 #[tokio::test]
+async fn infer_udf_signature_accepts_timestamp_source_argument_and_cast() {
+    let source = build_source(search_function_manifest("mixed_timestamp_search"));
+
+    let signature = CoralQuery::infer_udf_signature(
+        &[source],
+        test_runtime(),
+        udf(
+            "mixed_timestamp",
+            "select cast($since as TIMESTAMP) as since \
+             from mixed_timestamp_search.search_issues(q => 'open', since => $since)",
+        ),
+    )
+    .await
+    .expect("timestamp source argument and timestamp cast should agree");
+
+    assert_eq!(
+        argument_types(&signature),
+        [("since", ManifestDataType::Timestamp)]
+    );
+}
+
+#[tokio::test]
 async fn infer_udf_signature_uses_column_comparison_for_argument_type() {
     let temp = tempfile::tempdir().expect("temp dir");
     write_jsonl_file(

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -1,0 +1,307 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use arrow::datatypes::{DataType, Schema};
+use arrow::record_batch::RecordBatch;
+use coral_engine::{
+    CoralQuery, EngineExtensions, QueryExecutionProvenance, QueryResultObserver,
+    QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext, StatusCode,
+    UdfRuntimeImplementation, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
+};
+use coral_spec::ManifestDataType;
+use serde_json::{Value, json};
+
+use crate::harness::{build_source, dir_url, test_runtime, write_jsonl_file};
+
+#[derive(Debug, Default)]
+struct RowCountObserver {
+    calls: AtomicUsize,
+}
+
+impl RowCountObserver {
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl QueryResultObserver for RowCountObserver {
+    fn name(&self) -> &'static str {
+        "row_count"
+    }
+
+    fn observe_result(
+        &self,
+        _sql: &str,
+        _schema: &Schema,
+        _batches: &[RecordBatch],
+        _provenance: &QueryExecutionProvenance,
+    ) -> Result<(), QueryResultObserverError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+fn events_manifest(name: &str, dir: &Path) -> Value {
+    json!({
+        "name": name,
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "file",
+        "tables": [{
+            "name": "events",
+            "description": "Event rows",
+            "format": "jsonl",
+            "source": {
+                "location": dir_url(dir),
+                "glob": "**/*.jsonl"
+            },
+            "columns": [
+                { "name": "id", "type": "Int64" }
+            ]
+        }]
+    })
+}
+
+fn search_function_manifest(name: &str) -> Value {
+    json!({
+        "name": name,
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": "https://example.test",
+        "functions": [{
+            "name": "search_issues",
+            "description": "Search issues",
+            "args": [
+                {
+                    "name": "q",
+                    "required": true,
+                    "bind": { "arg": "q" }
+                },
+                {
+                    "name": "min_score",
+                    "type": "Float64",
+                    "bind": { "arg": "min_score" }
+                },
+                {
+                    "name": "max_items",
+                    "type": "Int64",
+                    "bind": { "arg": "max_items" }
+                },
+                {
+                    "name": "payload",
+                    "type": "Json",
+                    "bind": { "arg": "payload" }
+                },
+                {
+                    "name": "since",
+                    "type": "Timestamp",
+                    "bind": { "arg": "since" }
+                }
+            ],
+            "request": {
+                "method": "GET",
+                "path": "/api/search/issues",
+                "query": [
+                    { "name": "q", "from": "arg", "key": "q" },
+                    { "name": "min_score", "from": "arg", "key": "min_score" },
+                    { "name": "max_items", "from": "arg", "key": "max_items" },
+                    { "name": "payload", "from": "arg", "key": "payload" },
+                    { "name": "since", "from": "arg", "key": "since" }
+                ]
+            },
+            "response": {
+                "rows_path": ["items"]
+            },
+            "columns": [
+                { "name": "title", "type": "Utf8" },
+                { "name": "score", "type": "Float64" }
+            ]
+        }]
+    })
+}
+
+fn udf(name: &str, query: impl Into<String>) -> UdfRuntimeSqlDefinition {
+    UdfRuntimeSqlDefinition {
+        name: name.to_string(),
+        implementation: UdfRuntimeImplementation::CoralSql {
+            query: query.into(),
+        },
+    }
+}
+
+fn min_id_udf(source_name: &str) -> UdfRuntimeSqlDefinition {
+    udf(
+        "min_id_events",
+        format!("select id from {source_name}.events where id >= $min_id order by id"),
+    )
+}
+
+fn review_queue_udf(source_name: &str) -> UdfRuntimeSqlDefinition {
+    udf(
+        "review_queue",
+        format!(
+            "select title, score from {source_name}.search_issues(q => $query, min_score => $min_score, payload => $payload, since => $since)"
+        ),
+    )
+}
+
+fn argument_types(signature: &UdfRuntimeSignature) -> Vec<(&str, ManifestDataType)> {
+    signature
+        .arguments
+        .iter()
+        .map(|argument| (argument.name.as_str(), argument.data_type))
+        .collect()
+}
+
+fn column_types(signature: &UdfRuntimeSignature) -> Vec<(&str, &DataType)> {
+    signature
+        .result_columns
+        .iter()
+        .map(|column| (column.name.as_str(), &column.data_type))
+        .collect()
+}
+
+fn runtime_with_observer(observer: Arc<dyn QueryResultObserver>) -> QueryRuntimeConfig {
+    let mut extensions = EngineExtensions::default();
+    extensions.query_result_observers.push(observer);
+    QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions)
+}
+
+#[tokio::test]
+async fn infer_udf_signature_uses_source_function_schema_with_parameters() {
+    let source = build_source(search_function_manifest("signature_param_search"));
+
+    let signature = CoralQuery::infer_udf_signature(
+        &[source],
+        test_runtime(),
+        review_queue_udf("signature_param_search"),
+    )
+    .await
+    .expect("udf signature inference should use source function schema without binding params");
+
+    assert_eq!(
+        argument_types(&signature),
+        [
+            ("min_score", ManifestDataType::Float64),
+            ("payload", ManifestDataType::Json),
+            ("query", ManifestDataType::Utf8),
+            ("since", ManifestDataType::Timestamp),
+        ]
+    );
+
+    let columns = column_types(&signature);
+    assert!(matches!(
+        columns.as_slice(),
+        [
+            ("title", DataType::Utf8 | DataType::Utf8View),
+            ("score", DataType::Float64)
+        ]
+    ));
+}
+
+#[tokio::test]
+async fn infer_udf_signature_uses_explicit_cast_for_argument_type() {
+    let signature = CoralQuery::infer_udf_signature(
+        &[],
+        test_runtime(),
+        udf("cast_label", "select cast($label as VARCHAR) as label"),
+    )
+    .await
+    .expect("udf schema inference should use cast type");
+
+    assert_eq!(
+        argument_types(&signature),
+        [("label", ManifestDataType::Utf8)]
+    );
+    let columns = column_types(&signature);
+    let [("label", column_type)] = columns.as_slice() else {
+        panic!("expected label result column");
+    };
+    assert!(matches!(column_type, DataType::Utf8 | DataType::Utf8View));
+}
+
+#[tokio::test]
+async fn infer_udf_signature_uses_column_comparison_for_argument_type() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "events.jsonl",
+        &[json!({"id": 1}), json!({"id": 2})],
+    );
+    let source = build_source(events_manifest("schema_udf_events", temp.path()));
+    let observer = Arc::new(RowCountObserver::default());
+
+    let signature = CoralQuery::infer_udf_signature(
+        &[source],
+        runtime_with_observer(observer.clone()),
+        min_id_udf("schema_udf_events"),
+    )
+    .await
+    .expect("udf signature inference should plan without collection");
+
+    assert_eq!(
+        argument_types(&signature),
+        [("min_id", ManifestDataType::Int64)]
+    );
+    assert!(matches!(
+        column_types(&signature).as_slice(),
+        [("id", DataType::Int64)]
+    ));
+    assert_eq!(observer.calls(), 0);
+}
+
+#[tokio::test]
+async fn infer_udf_signature_rejects_ambiguous_argument_type() {
+    let error = CoralQuery::infer_udf_signature(
+        &[],
+        test_runtime(),
+        udf("ambiguous_value", "select $value as value"),
+    )
+    .await
+    .expect_err("ambiguous udf argument should fail");
+
+    assert_eq!(error.status_code(), StatusCode::InvalidArgument);
+    assert!(
+        error
+            .to_string()
+            .contains("SQL parameter '$value' has no inferred type"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        error.to_string().contains("CAST($value AS VARCHAR)"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        !error.to_string().contains("Error during planning"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn infer_udf_signature_rejects_conflicting_argument_types() {
+    let source = build_source(search_function_manifest("conflicting_param_search"));
+    let error = CoralQuery::infer_udf_signature(
+        &[source],
+        test_runtime(),
+        udf(
+            "conflicting_param",
+            "select title from conflicting_param_search.search_issues(q => $value, min_score => $value)",
+        ),
+    )
+    .await
+    .expect_err("conflicting udf argument types should fail");
+
+    assert_eq!(error.status_code(), StatusCode::InvalidArgument);
+    assert!(
+        error
+            .to_string()
+            .contains("conflicting types for parameter"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        error.to_string().contains("use explicit casts"),
+        "unexpected error: {error}"
+    );
+}


### PR DESCRIPTION
## Intent

Infer a Coral SQL UDF's argument and result contract by planning its SQL body. Nothing is registered or executed.

For example, DataFusion can infer `$min_id` from `events.id >= $min_id`. If a body only projects `SELECT $value`, the type is unclear: inference returns `InvalidInput` and asks the author to write an explicit cast such as `CAST($value AS VARCHAR)`.

## Contract

- DataFusion's planned parameter fields are the source of truth for ordinary SQL expressions.
- Direct source-function arguments use the function's declared `ManifestDataType`; this preserves semantic types such as `Json` and `Timestamp`.
- Explicit `CAST` and `TRY_CAST` expressions provide a type when the planner cannot.
- An unresolved parameter fails with concrete cast guidance.
- Contradictory uses fail instead of applying Coral-specific widening or precedence rules; the author must cast uses consistently.
- Result columns retain the Arrow types and nullability from the planned output schema.

This deliberately does not implement a second type-evidence resolver in Coral. The later lifecycle PR treats inference failure as an add failure.

## What changed

- Added the engine-side SQL definition and inferred-signature contracts.
- Added `CoralQuery::infer_udf_signature`.
- Added planner-led extraction for parameters and result columns.
- Added five contract tests: source declarations, explicit casts, ordinary planner inference, unresolved parameters, and conflicting parameters.

## Review order

1. `contracts/udfs.rs` — the engine contract.
2. `runtime/query.rs` — planner-led signature extraction.
3. `runtime/udfs.rs` — conversion into the public signature.
4. `tests/engine/udf_tests.rs` — the five supported/failure paths.

## Not in this PR

- Runtime argument binding.
- Table-function registration or execution.
- Storage, lifecycle, API, app, or CLI changes.
- Numeric widening, occurrence-order recovery, positional-placeholder policy, or other custom inference heuristics.

## Validation

- `cargo test -p coral-engine --test engine 'udf_tests::infer_udf_signature_'`
- `cargo clippy -p coral-engine --all-targets --all-features --locked -- -D warnings`
- `make rust-checks` from the top of the restacked series: 1,537 tests passed
- `make perf-check`: 274.7 ms mean against the 750 ms limit
