### PR TITLE
feat(engine): type source table-function arguments

### DIFF
--- a/apps/docs/reference/source-spec-reference.mdx
+++ b/apps/docs/reference/source-spec-reference.mdx
@@ -520,6 +520,10 @@ operations that do not map cleanly to a stable table. If the endpoint is a
 provider search surface, such as GitHub issue search, use `kind: search` and
 declare `search_limits`.
 
+Function args accept an optional `type` field using Coral manifest data type
+names. It defaults to `Utf8`; set it when the provider argument is numeric,
+boolean, timestamp-shaped, or JSON-shaped.
+
 ```yaml
 functions:
   - name: search_issues
@@ -531,10 +535,12 @@ functions:
       max_calls_per_query: 1
     args:
       - name: q
+        type: Utf8
         required: true
         bind:
           arg: q
       - name: mode
+        type: Utf8
         values: [lexical, semantic, hybrid]
         bind:
           arg: search_type
@@ -1041,6 +1047,7 @@ functions:
 ```yaml
 args:
   - name: issue
+    type: Utf8
     required: true
     bind:
       arg: issue

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -488,15 +488,16 @@ mod tests {
 
     use super::{
         GrpcMethodMetadata, GrpcServerMethod, annotate_request_context, grpc_method, query_status,
-        query_test_result_to_proto, table_summary_to_proto, table_to_proto,
-        workspace_name_from_proto, workspace_to_proto,
+        query_test_result_to_proto, table_function_to_proto, table_summary_to_proto,
+        table_to_proto, workspace_name_from_proto, workspace_to_proto,
     };
     use crate::bootstrap::AppError;
     use crate::episode::EpisodeId;
     use crate::query::manager::QueryManagerError;
     use crate::workspaces::WorkspaceName;
     use coral_engine::{
-        ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableInfo,
+        ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableFunctionInfo,
+        TableInfo,
     };
 
     #[test]
@@ -685,6 +686,33 @@ mod tests {
         assert_eq!(proto.description, "User records");
         assert_eq!(proto.guide, "Filter by org_id.");
         assert_eq!(proto.required_filters, vec!["org_id"]);
+    }
+
+    #[test]
+    fn table_function_to_proto_preserves_argument_metadata() {
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let function = TableFunctionInfo {
+            schema_name: "demo".to_string(),
+            function_name: "search".to_string(),
+            description: "Search demo records".to_string(),
+            arguments: vec![coral_engine::TableFunctionArgumentInfo {
+                name: "payload".to_string(),
+                required: true,
+                values: Vec::new(),
+            }],
+            result_columns: Vec::new(),
+        };
+
+        let proto = table_function_to_proto(&workspace_name, function);
+
+        assert_eq!(proto.workspace, Some(workspace_to_proto(&workspace_name)));
+        assert_eq!(proto.schema_name, "demo");
+        assert_eq!(proto.name, "search");
+        assert_eq!(proto.description, "Search demo records");
+        assert_eq!(proto.arguments.len(), 1);
+        assert_eq!(proto.arguments[0].name, "payload");
+        assert!(proto.arguments[0].required);
+        assert!(proto.arguments[0].values.is_empty());
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, OnceLock};
 use crate::{QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceInputResolver};
 use async_trait::async_trait;
 use coral_spec::{
-    ColumnSpec, FilterSpec, ManifestInputKind, ManifestInputSpec, SearchLimitsSpec, SourceBackend,
-    SourceTableFunctionSpec, TableCommon,
+    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec,
+    SearchLimitsSpec, SourceBackend, SourceTableFunctionSpec, TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::datasource::TableProvider;
@@ -61,7 +61,6 @@ pub(crate) struct RegisteredTableFunction {
     pub(crate) description: String,
     pub(crate) arguments: Vec<RegisteredTableFunctionArgument>,
     pub(crate) result_columns: Vec<RegisteredTableFunctionResultColumn>,
-    pub(crate) arg_names: Vec<String>,
     pub(crate) search_limits_json: Option<String>,
 }
 
@@ -77,6 +76,7 @@ pub(crate) struct RegisteredFilter {
 #[derive(Debug, Clone)]
 pub(crate) struct RegisteredTableFunctionArgument {
     pub(crate) name: String,
+    pub(crate) data_type: ManifestDataType,
     pub(crate) required: bool,
     pub(crate) values: Vec<String>,
 }
@@ -337,6 +337,7 @@ pub(crate) fn build_registered_table_function(
         .iter()
         .map(|arg| RegisteredTableFunctionArgument {
             name: arg.name.clone(),
+            data_type: arg.data_type,
             required: arg.required,
             values: arg.values.clone(),
         })
@@ -359,7 +360,6 @@ pub(crate) fn build_registered_table_function(
         description: function.description.clone(),
         arguments,
         result_columns,
-        arg_names: function.args.iter().map(|arg| arg.name.clone()).collect(),
         search_limits_json: function.search_limits.as_ref().map(serialize_search_limits),
     }
 }

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -245,21 +245,25 @@ fn mcp_typed_args_manifest() -> coral_spec::ValidatedSourceManifest {
             "args": [
                 {
                     "name": "query",
+                    "type": "Utf8",
                     "required": true,
                     "bind": { "arg": "query" }
                 },
                 {
                     "name": "limit",
+                    "type": "Int64",
                     "required": true,
                     "bind": { "arg": "limit" }
                 },
                 {
                     "name": "include_archived",
+                    "type": "Boolean",
                     "required": true,
                     "bind": { "arg": "include_archived" }
                 },
                 {
                     "name": "threshold",
+                    "type": "Float64",
                     "required": true,
                     "bind": { "arg": "threshold" }
                 }
@@ -362,7 +366,7 @@ async fn executes_mcp_table_function_with_bound_args() {
 }
 
 #[tokio::test]
-async fn mcp_table_function_preserves_json_scalar_arg_types() {
+async fn mcp_table_function_declared_arg_types_keep_existing_call_behavior() {
     let ctx = SessionContext::new();
     let caller = Arc::new(FakeMcpCaller {
         calls: Mutex::new(Vec::new()),

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -81,10 +81,10 @@ mod composite;
 pub(crate) use common::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
     BackendSchemaRegistration, CompiledBackendSource, RegisteredInput, RegisteredSource,
-    RegisteredTable, RegisteredTableFunction, SourceFunctionProviderFactory,
-    build_registered_inputs, build_registered_table, build_registered_table_function,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
-    schema_from_columns, validate_lookup_key_filter_backend_support,
+    RegisteredTable, RegisteredTableFunction, RegisteredTableFunctionArgument,
+    SourceFunctionProviderFactory, build_registered_inputs, build_registered_table,
+    build_registered_table_function, registered_columns_from_schema, registered_columns_from_specs,
+    required_filter_names, schema_from_columns, validate_lookup_key_filter_backend_support,
 };
 
 pub(crate) mod file;

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -960,7 +960,6 @@ mod tests {
                 description: String::new(),
                 arguments: Vec::new(),
                 result_columns: Vec::new(),
-                arg_names: Vec::new(),
                 search_limits_json: None,
             }],
             inputs: Vec::new(),

--- a/crates/coral-engine/src/runtime/scoped_table_functions.rs
+++ b/crates/coral-engine/src/runtime/scoped_table_functions.rs
@@ -16,7 +16,8 @@ use crate::backends::RegisteredTableFunction;
 
 pub(crate) trait ScopedTableFunctionSignature {
     fn display_name(&self) -> &str;
-    fn arg_names(&self) -> &[String];
+    fn arg_count(&self) -> usize;
+    fn arg_name(&self, index: usize) -> Option<&str>;
     fn contains(&self, name: &str) -> bool;
 }
 
@@ -193,14 +194,31 @@ pub(crate) fn lower_named_args_to_positional_exprs(
 ) -> Result<Vec<Expr>> {
     let mut supplied = collect_named_args(function, args, context)?;
 
-    function
-        .arg_names()
-        .iter()
-        .map(|name| match supplied.remove(name) {
-            Some(sql_expr) => context.sql_to_expr(sql_expr, &DFSchema::empty()),
-            None => Ok(Expr::Literal(ScalarValue::Null, None)),
-        })
+    (0..function.arg_count())
+        .map(|index| lower_positional_arg(function, index, &mut supplied, context))
         .collect()
+}
+
+fn lower_positional_arg(
+    function: &dyn ScopedTableFunctionSignature,
+    index: usize,
+    supplied: &mut HashMap<String, SqlExpr>,
+    context: &mut dyn RelationPlannerContext,
+) -> Result<Expr> {
+    let name = declared_arg_name(function, index)?;
+    match supplied.remove(name) {
+        Some(sql_expr) => context.sql_to_expr(sql_expr, &DFSchema::empty()),
+        None => Ok(Expr::Literal(ScalarValue::Null, None)),
+    }
+}
+
+fn declared_arg_name(function: &dyn ScopedTableFunctionSignature, index: usize) -> Result<&str> {
+    function.arg_name(index).ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "{} argument index {index} missing from signature",
+            function.display_name()
+        ))
+    })
 }
 
 fn collect_named_args(

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -31,12 +31,15 @@ use datafusion::logical_expr::{
 use datafusion::optimizer::AnalyzerRule;
 use datafusion::prelude::SessionContext;
 
-use crate::backends::{RegisteredTableFunction, SourceFunctionProviderFactory};
+use crate::backends::{
+    RegisteredTableFunction, RegisteredTableFunctionArgument, SourceFunctionProviderFactory,
+};
 use crate::runtime::scoped_table_functions::{
     ScopedTableFunctionCall, ScopedTableFunctionName, ScopedTableFunctionSignature, call_parts,
     find_placeholder, lower_named_args_to_positional_exprs, original_relation, qualified_name,
     reject_settings, reject_unsupported_modifiers,
 };
+use coral_spec::ManifestDataType;
 
 pub(crate) const SOURCE_FUNCTION_NODE_NAME: &str = "CoralSourceFunction";
 
@@ -126,15 +129,15 @@ impl RelationPlanner for SourceFunctionRegistry {
         let (call_args, alias) = call_parts(relation);
         reject_settings(&call, &call_args)?;
 
-        let args = lower_named_args_to_positional_exprs(function, &call_args, context)?;
-        let node = SourceFunctionNode::new(function, args)?;
+        let lowered_args = lower_named_args_to_positional_exprs(function, &call_args, context)?;
+        let node = SourceFunctionNode::new(function, lowered_args)?;
 
         // Fully-literal calls validate eagerly so argument-value errors keep
         // surfacing at planning time, exactly as they did when binding ran
         // inside SQL planning. Binding is pure value capture (no I/O), so the
         // analyzer repeating it later is cheap.
         if !node.has_parameter_placeholders() {
-            node.factory.provider_for_args(&node.args)?;
+            node.factory.provider_for_args(&node.call_args)?;
         }
 
         let plan = LogicalPlan::Extension(Extension {
@@ -150,28 +153,45 @@ impl RelationPlanner for SourceFunctionRegistry {
 struct SourceFunction {
     display_name: String,
     table_reference: TableReference,
-    arg_names: Vec<String>,
-    known_args: HashSet<String>,
+    arguments: Vec<SourceFunctionArgument>,
     factory: Arc<dyn SourceFunctionProviderFactory>,
 }
 
 impl SourceFunction {
     fn from_registered(function: &RegisteredTableFunction) -> Self {
-        let arg_names = function.arg_names.clone();
+        let arguments = function
+            .arguments
+            .iter()
+            .map(SourceFunctionArgument::from_registered)
+            .collect::<Vec<_>>();
         Self {
             display_name: qualified_name(&function.schema_name, &function.function_name),
             table_reference: TableReference::partial(
                 function.schema_name.clone(),
                 function.function_name.clone(),
             ),
-            known_args: arg_names.iter().cloned().collect(),
-            arg_names,
+            arguments,
             factory: Arc::clone(&function.factory),
         }
     }
 
     fn contains(&self, name: &str) -> bool {
-        self.known_args.contains(name)
+        self.arguments.iter().any(|argument| argument.name == name)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct SourceFunctionArgument {
+    pub(crate) name: String,
+    pub(crate) data_type: ManifestDataType,
+}
+
+impl SourceFunctionArgument {
+    fn from_registered(argument: &RegisteredTableFunctionArgument) -> Self {
+        Self {
+            name: argument.name.clone(),
+            data_type: argument.data_type,
+        }
     }
 }
 
@@ -180,8 +200,14 @@ impl ScopedTableFunctionSignature for SourceFunction {
         &self.display_name
     }
 
-    fn arg_names(&self) -> &[String] {
-        &self.arg_names
+    fn arg_count(&self) -> usize {
+        self.arguments.len()
+    }
+
+    fn arg_name(&self, index: usize) -> Option<&str> {
+        self.arguments
+            .get(index)
+            .map(|argument| argument.name.as_str())
     }
 
     fn contains(&self, name: &str) -> bool {
@@ -205,14 +231,14 @@ pub(crate) struct SourceFunctionNode {
     /// Two-part `schema.function` reference, so result columns qualify the
     /// same way table columns do (`github.pulls.id`, `pulls.id`).
     table_reference: TableReference,
-    arg_names: Vec<String>,
-    args: Vec<Expr>,
+    declared_args: Vec<SourceFunctionArgument>,
+    call_args: Vec<Expr>,
     schema: DFSchemaRef,
     factory: Arc<dyn SourceFunctionProviderFactory>,
 }
 
 impl SourceFunctionNode {
-    fn new(function: &SourceFunction, args: Vec<Expr>) -> Result<Self> {
+    fn new(function: &SourceFunction, call_args: Vec<Expr>) -> Result<Self> {
         let schema = Arc::new(DFSchema::try_from_qualified_schema(
             function.table_reference.clone(),
             function.factory.schema().as_ref(),
@@ -220,28 +246,36 @@ impl SourceFunctionNode {
         Ok(Self {
             display_name: function.display_name.clone(),
             table_reference: function.table_reference.clone(),
-            arg_names: function.arg_names.clone(),
-            args,
+            declared_args: function.arguments.clone(),
+            call_args,
             schema,
             factory: Arc::clone(&function.factory),
         })
     }
 
     fn has_parameter_placeholders(&self) -> bool {
-        self.args.iter().any(|arg| find_placeholder(arg).is_some())
+        self.call_args
+            .iter()
+            .any(|arg| find_placeholder(arg).is_some())
     }
 
     pub(crate) fn table_reference(&self) -> &TableReference {
         &self.table_reference
     }
 
+    pub(crate) fn declared_args_with_call_exprs(
+        &self,
+    ) -> impl Iterator<Item = (&SourceFunctionArgument, &Expr)> {
+        self.declared_args.iter().zip(&self.call_args)
+    }
+
     fn reject_unbound_parameters(&self) -> Result<()> {
-        for (name, arg) in self.arg_names.iter().zip(&self.args) {
-            if let Some(placeholder) = find_placeholder(arg) {
+        for (declared_arg, call_expr) in self.declared_args_with_call_exprs() {
+            if let Some(placeholder) = find_placeholder(call_expr) {
                 return Err(DataFusionError::Plan(format!(
-                    "{} argument '{name}' is bound to parameter {placeholder}, \
+                    "{} argument '{}' is bound to parameter {placeholder}, \
                      but no value was provided for it",
-                    self.display_name
+                    self.display_name, declared_arg.name
                 )));
             }
         }
@@ -250,7 +284,7 @@ impl SourceFunctionNode {
 
     fn to_provider_scan(&self) -> Result<LogicalPlan> {
         self.reject_unbound_parameters()?;
-        let provider = self.factory.provider_for_args(&self.args)?;
+        let provider = self.factory.provider_for_args(&self.call_args)?;
         LogicalPlanBuilder::scan(
             self.table_reference.clone(),
             provider_as_source(provider),
@@ -260,14 +294,15 @@ impl SourceFunctionNode {
     }
 }
 
-// Node identity is the function name plus its argument expressions; `schema`
-// participates so renamed manifests never compare equal. The remaining fields
-// are derived from the same registry entry as `display_name` (and `factory`
-// cannot implement `PartialEq`), so they are deliberately excluded.
+// Node identity is the function name plus its declared argument signature and
+// call expressions. `schema` participates so renamed manifests never compare
+// equal. The factory is derived from the same registry entry as `display_name`
+// and cannot implement `PartialEq`, so it is deliberately excluded.
 impl PartialEq for SourceFunctionNode {
     fn eq(&self, other: &Self) -> bool {
         self.display_name == other.display_name
-            && self.args == other.args
+            && self.call_args == other.call_args
+            && self.declared_args == other.declared_args
             && self.schema == other.schema
     }
 }
@@ -277,7 +312,8 @@ impl Eq for SourceFunctionNode {}
 impl Hash for SourceFunctionNode {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.display_name.hash(state);
-        self.args.hash(state);
+        self.call_args.hash(state);
+        self.declared_args.hash(state);
         self.schema.hash(state);
     }
 }
@@ -305,7 +341,7 @@ impl UserDefinedLogicalNodeCore for SourceFunctionNode {
     }
 
     fn expressions(&self) -> Vec<Expr> {
-        self.args.clone()
+        self.call_args.clone()
     }
 
     fn fmt_for_explain(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -319,11 +355,11 @@ impl UserDefinedLogicalNodeCore for SourceFunctionNode {
                 self.display_name
             )));
         }
-        if exprs.len() != self.args.len() {
+        if exprs.len() != self.call_args.len() {
             return Err(DataFusionError::Plan(format!(
                 "source function {} expected {} argument expressions, got {}",
                 self.display_name,
-                self.args.len(),
+                self.call_args.len(),
                 exprs.len()
             )));
         }
@@ -332,7 +368,7 @@ impl UserDefinedLogicalNodeCore for SourceFunctionNode {
         // positional here, so the alias carries no meaning -- strip it before
         // binding sees the value.
         Ok(Self {
-            args: exprs.into_iter().map(Expr::unalias).collect(),
+            call_args: exprs.into_iter().map(Expr::unalias).collect(),
             ..self.clone()
         })
     }

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -393,6 +393,19 @@ fn http_manifest_with_function() -> Value {
                     "name": "mode",
                     "values": ["lexical", "semantic", "hybrid"],
                     "bind": { "arg": "search_type" }
+                },
+                // OpenAPI v4 generation does not produce Json HTTP function args.
+                // This fixture verifies typed args still register and list even
+                // though public catalog metadata does not expose arg types yet.
+                {
+                    "name": "metadata",
+                    "type": "Json",
+                    "bind": { "arg": "metadata" }
+                },
+                {
+                    "name": "since",
+                    "type": "Timestamp",
+                    "bind": { "arg": "since" }
                 }
             ],
             "request": {
@@ -486,7 +499,9 @@ async fn coral_table_functions_lists_source_functions() {
         serde_json::from_str::<Value>(row["arguments_json"].as_str().unwrap()).unwrap(),
         json!([
             { "name": "q", "required": true, "values": [] },
-            { "name": "mode", "required": false, "values": ["lexical", "semantic", "hybrid"] }
+            { "name": "mode", "required": false, "values": ["lexical", "semantic", "hybrid"] },
+            { "name": "metadata", "required": false, "values": [] },
+            { "name": "since", "required": false, "values": [] }
         ])
     );
     assert_eq!(
@@ -744,13 +759,15 @@ async fn list_catalog_matches_table_function_metadata() {
     assert_eq!(function.schema_name, "searchy");
     assert_eq!(function.function_name, "search_issues");
     assert_eq!(function.description, "Search issues");
-    assert_eq!(function.arguments.len(), 2);
+    assert_eq!(function.arguments.len(), 4);
     assert_eq!(function.arguments[0].name, "q");
     assert!(function.arguments[0].required);
     assert_eq!(
         function.arguments[1].values,
         ["lexical", "semantic", "hybrid"]
     );
+    assert_eq!(function.arguments[2].name, "metadata");
+    assert_eq!(function.arguments[3].name, "since");
     assert_eq!(function.result_columns.len(), 3);
     assert_eq!(function.result_columns[0].name, "id");
     assert_eq!(function.result_columns[1].name, "title");

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -90,7 +90,7 @@ pub enum SourceBackend {
 /// (Arrow) types. The variant spellings ("Utf8", "Int64", ...) are a wire
 /// contract pinned by the `PascalCase` serde representation and the manifest
 /// JSON schema.
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "PascalCase")]
 pub enum ManifestDataType {
     Utf8,
@@ -347,11 +347,17 @@ pub struct SourceTableFunctionSpec {
 #[derive(Debug, Clone, Deserialize)]
 pub struct TableFunctionArgSpec {
     pub name: String,
+    #[serde(rename = "type", default = "default_table_function_arg_data_type")]
+    pub data_type: ManifestDataType,
     #[serde(default)]
     pub required: bool,
     #[serde(default)]
     pub values: Vec<String>,
     pub bind: FunctionArgBinding,
+}
+
+fn default_table_function_arg_data_type() -> ManifestDataType {
+    ManifestDataType::Utf8
 }
 
 /// How a table function argument contributes to the provider request.
@@ -1264,6 +1270,25 @@ mod tests {
         .unwrap();
         assert_eq!(spec.kind, SourceTableFunctionKind::Search);
         assert_eq!(spec.search_limits.unwrap().default_top_k, 10);
+    }
+
+    #[test]
+    fn table_function_arg_data_type_defaults_to_utf8_and_deserializes() {
+        let spec: SourceTableFunctionSpec = serde_json::from_value(serde_json::json!({
+            "name": "search_issues",
+            "args": [
+                { "name": "q", "bind": { "arg": "query" } },
+                { "name": "include_archived", "type": "Boolean", "bind": { "arg": "archived" } }
+            ],
+            "request": { "path": "/search/issues" }
+        }))
+        .unwrap();
+
+        let [query, include_archived] = spec.args.as_slice() else {
+            panic!("expected two table function args");
+        };
+        assert_eq!(query.data_type, ManifestDataType::Utf8);
+        assert_eq!(include_archived.data_type, ManifestDataType::Boolean);
     }
 
     #[test]

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -148,6 +148,32 @@ functions:
     }
 
     #[test]
+    fn validate_manifest_schema_accepts_table_function_arg_type() {
+        let manifest = manifest_json(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+functions:
+  - name: search_messages
+    args:
+      - name: include_archived
+        type: Boolean
+        bind:
+          arg: include_archived
+    request:
+      method: GET
+      path: /messages/search
+",
+        );
+
+        validate_manifest_schema(&manifest)
+            .expect("table function argument data types should pass schema validation");
+    }
+
+    #[test]
     fn validate_manifest_schema_directly_rejects_v4_manifest() {
         let manifest = manifest_json(
             r"

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -863,6 +863,7 @@
       "required": ["name", "bind"],
       "properties": {
         "name": { "type": "string", "minLength": 1 },
+        "type": { "$ref": "#/$defs/manifest_data_type" },
         "required": { "type": "boolean" },
         "values": {
           "type": "array",

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -765,6 +765,16 @@ components:
         .get("pulls_list_commits")
         .expect("pulls_list_commits projection");
     assert_eq!(pull_commits.0, "repos_pulls_commits");
+    let pull_commits_projection = catalog
+        .projections
+        .iter()
+        .find(|projection| projection.operation_id == "pulls_list_commits")
+        .expect("pull commits projection");
+    let pull_number_arg = projection_arg_specs(pull_commits_projection)
+        .into_iter()
+        .find(|arg| arg.name == "pull_number")
+        .expect("pull_number arg");
+    assert_eq!(pull_number_arg.data_type, ManifestDataType::Int64);
 
     let catalog_collision_diagnostics = catalog
         .diagnostics

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -33,6 +33,7 @@ pub fn projection_arg_specs(projection: &Projection) -> Vec<TableFunctionArgSpec
         .filter(|input| input.sql_exposure == SqlInputExposure::FunctionArg)
         .map(|input| TableFunctionArgSpec {
             name: input.name.clone(),
+            data_type: input.data_type,
             required: input.required,
             values: Vec::new(),
             bind: FunctionArgBinding {
@@ -49,6 +50,7 @@ pub fn mcp_projection_arg_specs(projection: &Projection) -> Vec<TableFunctionArg
         .filter(|input| input.sql_exposure == SqlInputExposure::FunctionArg)
         .map(|input| TableFunctionArgSpec {
             name: input.name.clone(),
+            data_type: input.data_type,
             required: input.required,
             values: Vec::new(),
             bind: FunctionArgBinding {

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -1144,6 +1144,7 @@ mod tests {
             detail_hints: Vec::new(),
             args: vec![TableFunctionArgSpec {
                 name: "query".to_string(),
+                data_type: ManifestDataType::Utf8,
                 required: true,
                 values: vec![],
                 bind: FunctionArgBinding {

--- a/plugins/coral/skills/coral-create-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-create-source-spec/SKILL.md
@@ -99,6 +99,7 @@ Only switch to Coral repo layout when the user is explicitly editing the Coral r
 - Mark filters as required only when the API truly requires them.
 - Use default table functions for parameterized non-retrieval operations, such as scoped child collections, time-range logs, metrics queries, or detail operations that do not map cleanly to a stable table.
 - Use `kind: search` table functions for provider endpoints that accept query text and return ranked candidates.
+- Set a table-function arg `type` when the provider argument is not string-shaped; omitted arg types default to `Utf8`.
 - Do not model provider search as a table filter. Use `mode: contains` only for ordinary provider-side substring filters. Provider-ranked retrieval belongs in a `kind: search` function.
 - Include `search_limits` on every `kind: search` function and expose stable result identifiers for follow-up detail queries.
 - Prefer explicit pagination when the API shape is known.

--- a/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
+++ b/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
@@ -81,6 +81,7 @@ Additional hint guidance:
 - Use `functions` with `kind: search` for provider-native search endpoints that accept query text and return provider-ranked candidates.
 - Add `search_limits` to every `kind: search` function.
 - Keep search function arguments close to the provider API, and use `bind.arg` when the SQL argument name should differ from the request argument name.
+- Set a function arg `type` when the provider argument is not string-shaped; omitted arg types default to `Utf8`.
 - Search result columns should include stable identifiers and useful candidate metadata such as title, URL, score, rank, or timestamps when the provider returns them.
 - Do not model provider-native search as a table filter. Use `mode: contains` only for ordinary substring filters on normal list/detail tables. Provider-ranked retrieval belongs in a `kind: search` function.
 - If a search result is not a complete entity, make sure the returned identifier can be used with ordinary detail tables or required filters.


### PR DESCRIPTION
## Intent

Preserve declared argument types for source-scoped table functions.

Today source table-function arguments are registered as names plus required/value metadata. That is enough to execute calls like:

```sql
select *
from github.search_issues(q => 'repo:withcoral/coral is:pr')
```

but it loses the source manifest's declared argument type. DSL v4 projections can know that an argument is `Int64`, `Float64`, `Boolean`, `Timestamp`, `Json`, or `Utf8`; the engine should keep that metadata instead of collapsing every argument into an untyped/string-shaped value.

This PR adds that metadata path without changing the public catalog shape or provider execution behavior.

## What Changed

- Added an optional `type` field to source table-function args in the source manifest model.
- Defaulted omitted arg types to `Utf8` for compatibility with existing v3 manifests.
- Preserved DSL v4 runtime-projected source-function input types when generating the runtime source package.
- Carried `ManifestDataType` through engine registration in `RegisteredTableFunctionArgument` and `SourceFunctionArgument`.
- Kept source-function logical nodes paired with their declared argument signature so engine analysis can inspect the call's declared argument types alongside the call expressions.
- Removed duplicate source-function argument caches (`arg_names` / `known_args`) so the registered `arguments` list is the single source of truth.
- Added `ManifestDataType::as_manifest_str()` and `ManifestDataType::ALL` so manifest spelling and round-trip checks have one canonical source.

## Compatibility / User Impact

Existing source table-function calls should behave the same.

- Existing manifests that omit arg types still parse and behave as `Utf8`.
- `coral.table_functions.arguments_json` keeps its current public JSON shape in this PR.
- `TableFunctionArgumentInfo` and catalog proto keep their current public shape.
- HTTP and MCP source-function execution keep their existing argument binding behavior.
- This PR does not introduce typed provider coercion.

## Boundaries

This is an internal metadata preservation change across `coral-spec` and `coral-engine`.

It does not add a new user-facing function surface, public catalog field, transport API, or CLI behavior. The metadata becomes available to engine analysis and future validation code, but this PR only preserves and carries the source-declared type information.

## Not in This PR

- Public catalog/proto exposure for source-function argument types.
- New SQL function/UDF registration behavior.
- SQL signature inference or validation for user-defined functions.
- MCP or HTTP runtime coercion based on declared source-function arg types.
- Correlated source table-function arguments such as `linear.issue_comments(issue => i.identifier)`.

## Validation

- Default workspace, v3 HTTP sources: `source test github` and `source test linear` both passed against live credentials.
- Default workspace, v3 source functions: `github.search_issues(...)` and `linear.team_issues(...)` returned live rows.
- Default workspace, v3 source-function errors: duplicate, unknown, and unbound-placeholder args failed with source-function-specific errors.
- Temporary workspace, v4 OpenAPI/HTTP source: installed a no-auth `github_v4_public` manifest from the live GitHub OpenAPI description; source validation and live GitHub queries passed.
- Temporary workspace, v4 MCP source: installed a local stdio MCP source; source validation, table-function calls, duplicate arg, unknown arg, and unbound-placeholder checks behaved as expected.

