### PR TITLE
fix(v4): make required REST inputs table functions

### DIFF
--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use super::*;
-use crate::parse_source_manifest_yaml;
+use crate::{SourceTableFunctionKind, parse_source_manifest_yaml};
 
 #[test]
 fn extracts_openapi_document_metadata() {
@@ -243,7 +243,12 @@ components:
         .find(|projection| projection.operation_id == "listincidents")
         .expect("projection");
     assert_eq!(projection.name, "incidents");
-    assert!(matches!(projection.kind, ProjectionKind::Table));
+    assert!(matches!(
+        projection.kind,
+        ProjectionKind::TableFunction {
+            function_kind: SourceTableFunctionKind::Table
+        }
+    ));
 }
 
 #[test]
@@ -302,7 +307,12 @@ components:
     let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
     let projection = catalog.projections.first().expect("projection");
     assert_eq!(projection.name, "repositories");
-    assert!(matches!(projection.kind, ProjectionKind::Table));
+    assert!(matches!(
+        projection.kind,
+        ProjectionKind::TableFunction {
+            function_kind: SourceTableFunctionKind::Table
+        }
+    ));
 }
 
 #[test]
@@ -512,7 +522,12 @@ components:
         .expect("projection");
     assert_eq!(projection.name, "issues");
     assert_eq!(projection.visibility, ProjectionVisibility::Published);
-    assert!(matches!(projection.kind, ProjectionKind::Table));
+    assert!(matches!(
+        projection.kind,
+        ProjectionKind::TableFunction {
+            function_kind: SourceTableFunctionKind::Table
+        }
+    ));
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -268,9 +268,9 @@ surfaces:
         .iter()
         .map(|input| (input.wire_name.as_str(), input.sql_exposure))
         .collect::<BTreeMap<_, _>>();
-    assert_eq!(exposures.get("owner"), Some(&SqlInputExposure::Filter));
-    assert_eq!(exposures.get("repo"), Some(&SqlInputExposure::Filter));
-    assert_eq!(exposures.get("state"), Some(&SqlInputExposure::Filter));
+    assert_eq!(exposures.get("owner"), Some(&SqlInputExposure::FunctionArg));
+    assert_eq!(exposures.get("repo"), Some(&SqlInputExposure::FunctionArg));
+    assert_eq!(exposures.get("state"), Some(&SqlInputExposure::FunctionArg));
     assert_eq!(exposures.get("page"), Some(&SqlInputExposure::Internal));
     assert_eq!(exposures.get("per_page"), Some(&SqlInputExposure::Internal));
 
@@ -278,8 +278,14 @@ surfaces:
         .into_iter()
         .map(|filter| filter.name)
         .collect::<BTreeSet<_>>();
+    assert!(filter_names.is_empty());
+
+    let arg_names = projection_arg_specs(projection)
+        .into_iter()
+        .map(|arg| arg.name)
+        .collect::<BTreeSet<_>>();
     assert_eq!(
-        filter_names,
+        arg_names,
         BTreeSet::from(["owner".to_string(), "repo".to_string(), "state".to_string()])
     );
 
@@ -287,8 +293,8 @@ surfaces:
         .into_iter()
         .map(|column| column.name)
         .collect::<BTreeSet<_>>();
-    assert!(column_names.contains("owner"));
-    assert!(column_names.contains("repo"));
+    assert!(!column_names.contains("owner"));
+    assert!(!column_names.contains("repo"));
     assert!(column_names.contains("state"));
     assert!(!column_names.contains("page"));
     assert!(!column_names.contains("per_page"));
@@ -300,6 +306,15 @@ surfaces:
         .map(|param| param.name.as_str())
         .collect::<BTreeSet<_>>();
     assert_eq!(query_names, BTreeSet::from(["state"]));
+    assert!(matches!(
+        &request
+            .query
+            .iter()
+            .find(|param| param.name == "state")
+            .expect("state query")
+            .value,
+        crate::ValueSourceSpec::Arg { .. }
+    ));
     assert!(
         !projection.guide.contains("paginate"),
         "projection guide should not describe pagination: {}",
@@ -462,27 +477,28 @@ components:
     )
     .expect("import");
     let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
-    let table_projection = catalog
+    let list_projection = catalog
         .projections
         .iter()
         .find(|projection| projection.operation_id == "list_items")
-        .expect("table projection");
-    let table_operation = ir
+        .expect("list projection");
+    let list_operation = ir
         .operations
         .iter()
-        .find(|operation| operation.id == table_projection.operation_id)
-        .expect("table operation");
-    let table_request =
-        request_spec_for_projection(table_projection, table_operation).expect("table request");
+        .find(|operation| operation.id == list_projection.operation_id)
+        .expect("list operation");
+    let list_request =
+        request_spec_for_projection(list_projection, list_operation).expect("list request");
     assert_eq!(
-        table_request.path.raw(),
-        "/tenants/{{filter.tenant|%7Cpublic%7D%7D}}/items"
+        list_request.path.raw(),
+        "/tenants/{{arg.tenant|%7Cpublic%7D%7D}}/items"
     );
-    let table_filter = projection_filter_specs(table_projection)
+    assert!(projection_filter_specs(list_projection).is_empty());
+    let list_arg = projection_arg_specs(list_projection)
         .into_iter()
-        .find(|filter| filter.name == "tenant")
-        .expect("tenant filter");
-    assert!(!table_filter.required);
+        .find(|arg| arg.name == "tenant")
+        .expect("tenant arg");
+    assert!(!list_arg.required);
 
     let search_projection = catalog
         .projections
@@ -520,7 +536,7 @@ components:
         .expect("namespace request");
     assert_eq!(
         namespace_request.path.raw(),
-        "/namespaces/{{filter.namespace|%252E}}/items"
+        "/namespaces/{{arg.namespace|%252E}}/items"
     );
 }
 
@@ -659,7 +675,12 @@ components:
         .get("pulls_list")
         .expect("pulls_list projection");
     assert_eq!(pulls.0, "pull_requests");
-    assert!(matches!(pulls.1, ProjectionKind::Table));
+    assert!(matches!(
+        pulls.1,
+        ProjectionKind::TableFunction {
+            function_kind: SourceTableFunctionKind::Table
+        }
+    ));
     let commits = names_by_operation
         .get("repos_list_commits")
         .expect("repos_list_commits projection");

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -69,14 +69,14 @@ fn generate_projection(
     let rest = rest_execution(operation);
     let mut visibility = initial_projection_visibility(operation, rest);
     let mut projection_diagnostics = operation.diagnostics.clone();
-    let kind = projection_kind(operation, is_search);
+    let pagination = rest.map_or_else(PaginationSpec::default, |rest| rest.pagination.clone());
+    let pagination_query_params = pagination_query_param_names(&pagination);
+    let kind = projection_kind(operation, is_search, &pagination_query_params);
     let sql_exposure = if matches!(kind, ProjectionKind::Table) {
         SqlInputExposure::Filter
     } else {
         SqlInputExposure::FunctionArg
     };
-    let pagination = rest.map_or_else(PaginationSpec::default, |rest| rest.pagination.clone());
-    let pagination_query_params = pagination_query_param_names(&pagination);
     let mut used_input_names = HashSet::new();
     let use_sql_input_normalization = matches!(operation.execution, IrExecutionAttachment::Mcp(_));
     let inputs = operation
@@ -85,7 +85,7 @@ fn generate_projection(
         .map(|input| {
             let (exposure, pagination_owned_input) = match &operation.execution {
                 IrExecutionAttachment::Rest(_) => {
-                    projection_input_sql_exposure(input, sql_exposure, &pagination_query_params)
+                    rest_input_exposure(input, sql_exposure, &pagination_query_params)
                 }
                 IrExecutionAttachment::Mcp(mcp) if mcp_pagination_owns_input(mcp, input) => {
                     (SqlInputExposure::Internal, true)
@@ -175,14 +175,17 @@ fn initial_projection_visibility(
     }
 }
 
-fn projection_kind(operation: &IrOperation, is_search: bool) -> ProjectionKind {
+fn projection_kind(
+    operation: &IrOperation,
+    is_search: bool,
+    pagination_query_params: &HashSet<&str>,
+) -> ProjectionKind {
     let function_kind = match &operation.execution {
         IrExecutionAttachment::Rest(_) | IrExecutionAttachment::Mcp(_) if is_search => {
             Some(SourceTableFunctionKind::Search)
         }
         IrExecutionAttachment::Rest(_)
-            if operation.output.cardinality == OutputCardinality::Singleton
-                && operation.inputs.iter().any(|input| input.required) =>
+            if has_required_public_rest_input(operation, pagination_query_params) =>
         {
             Some(SourceTableFunctionKind::Table)
         }
@@ -192,6 +195,17 @@ fn projection_kind(operation: &IrOperation, is_search: bool) -> ProjectionKind {
     };
     function_kind.map_or(ProjectionKind::Table, |function_kind| {
         ProjectionKind::TableFunction { function_kind }
+    })
+}
+
+fn has_required_public_rest_input(
+    operation: &IrOperation,
+    pagination_query_params: &HashSet<&str>,
+) -> bool {
+    operation.inputs.iter().any(|input| {
+        input.required
+            && rest_input_exposure(input, SqlInputExposure::Filter, pagination_query_params).0
+                == SqlInputExposure::Filter
     })
 }
 
@@ -219,7 +233,7 @@ fn projection_input_required(input: &IrOperationInput) -> bool {
     input.required && (input.default_value.is_none() || input.location == IrInputLocation::ToolArg)
 }
 
-fn projection_input_sql_exposure(
+fn rest_input_exposure(
     input: &IrOperationInput,
     default_exposure: SqlInputExposure,
     pagination_query_params: &HashSet<&str>,

--- a/sources/core-v4/github_v4/manifest.yaml
+++ b/sources/core-v4/github_v4/manifest.yaml
@@ -48,5 +48,5 @@ test_queries:
   - SELECT result, result_json FROM github_v4_mcp.list_pull_requests(owner => 'withcoral', repo => 'coral', state => 'open', per_page => 10) LIMIT 5
   # REST surface
   - SELECT id, number, title, state FROM github_v4.search_issues_and_pull_requests(q => 'repo:octocat/Hello-World is:issue') LIMIT 5
-  - SELECT id, number, title, state FROM github_v4.issues_list_for_repo WHERE owner = 'octocat' AND repo = 'Hello-World' LIMIT 5
+  - SELECT id, number, title, state FROM github_v4.issues_list_for_repo(owner => 'octocat', repo => 'Hello-World') LIMIT 5
   - SELECT id, number, title FROM github_v4.issues_get(owner => 'octocat', repo => 'Hello-World', issue_number => 1)


### PR DESCRIPTION
## Summary

DSL v4 preview projections should not expose provider-required request inputs as ordinary table filters. If a REST endpoint cannot be called without a public input such as a path parameter, the SQL surface should make that requirement explicit by generating a table function.

This updates v4 projection derivation so REST operations with required public inputs become `kind: table` table functions. Pagination-owned query parameters stay internal, search projections keep their existing search-function behavior, and runtime registration remains unchanged.

## Before / After

Before, required request inputs could appear as `WHERE` filters on a plain table:

```sql
SELECT id, number, title, state
FROM github_v4.issues_list_for_repo
WHERE owner = 'octocat'
  AND repo = 'Hello-World'
LIMIT 5;
```

After, the same endpoint is represented as a table function with explicit arguments:

```sql
SELECT id, number, title, state
FROM github_v4.issues_list_for_repo(owner => 'octocat', repo => 'Hello-World')
LIMIT 5;
```

For GitHub pull requests, the generated projection now has the same shape:

```sql
SELECT id, number, title, state
FROM github_v4.pull_requests(owner => 'withcoral', repo => 'coral', state => 'open')
LIMIT 20;
```

Pagination parameters such as `page` and `per_page` remain Coral-managed internal inputs, not public function arguments.

## Validation

- `cargo test -p coral-spec v4::projection_tests --locked`
- `cargo test -p coral-spec v4::openapi_tests --locked`
- `cargo test -p coral-app sources::runtime_package --locked`
- `cargo run --locked -p coral-cli -- source lint sources/core-v4/github_v4/manifest.yaml`
- `git diff --check`
- `make rust-checks`
