### PR TITLE
fix(v4): preserve scalar row projection types

### DIFF
--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -43,6 +43,82 @@ surfaces:
 }
 
 #[test]
+fn top_level_scalar_rows_use_scalar_projection_types() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: scalar_rows
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /strings:
+    get:
+      operationId: list_strings
+      responses: {'200': {content: {application/json: {schema: {type: array, items: {type: string}}}}}}
+  /integers:
+    get:
+      operationId: list_integers
+      responses: {'200': {content: {application/json: {schema: {type: array, items: {type: integer}}}}}}
+  /numbers:
+    get:
+      operationId: list_numbers
+      responses: {'200': {content: {application/json: {schema: {type: array, items: {type: number}}}}}}
+  /booleans:
+    get:
+      operationId: list_booleans
+      responses: {'200': {content: {application/json: {schema: {type: array, items: {type: boolean}}}}}}
+  /timestamps:
+    get:
+      operationId: list_timestamps
+      responses: {'200': {content: {application/json: {schema: {type: array, items: {type: string, format: date-time}}}}}}
+".as_bytes(),
+    )
+    .expect("import");
+
+    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
+    let column_types = catalog
+        .projections
+        .iter()
+        .map(|projection| {
+            let [column] = projection.columns.as_slice() else {
+                panic!("expected one value column for {}", projection.operation_id);
+            };
+            assert_eq!(column.name, "value", "{}", projection.operation_id);
+            assert!(
+                column.source_path.is_empty(),
+                "{} should read the scalar row itself",
+                projection.operation_id
+            );
+            (projection.operation_id.as_str(), column.data_type)
+        })
+        .collect::<HashMap<_, _>>();
+
+    assert_eq!(
+        column_types,
+        HashMap::from([
+            ("list_booleans", ManifestDataType::Boolean),
+            ("list_integers", ManifestDataType::Int64),
+            ("list_numbers", ManifestDataType::Float64),
+            ("list_strings", ManifestDataType::Utf8),
+            ("list_timestamps", ManifestDataType::Timestamp),
+        ])
+    );
+}
+
+#[test]
 #[expect(
     clippy::too_many_lines,
     reason = "The OpenAPI fixture keeps issue regression cases together."

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{
     HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
-    IrScalarType, IrTypeShape, OutputCardinality, RestExecutionAttachment, SemanticIr,
+    IrScalarType, IrType, IrTypeShape, OutputCardinality, RestExecutionAttachment, SemanticIr,
 };
 use crate::v4::manifest::V4SourceManifest;
 use crate::v4::naming::{normalize_identifier, normalize_sql_identifier, stable_suffix};
@@ -331,7 +331,7 @@ fn projection_columns(ir: &SemanticIr, operation: &IrOperation) -> Vec<Projectio
     let IrTypeShape::Object { fields } = &row_type.shape else {
         return vec![ProjectionColumn {
             name: "value".to_string(),
-            data_type: ManifestDataType::Json,
+            data_type: projection_data_type(row_type),
             source_path: Vec::new(),
             nullable: true,
             description: row_type.description.clone(),
@@ -345,17 +345,9 @@ fn projection_columns(ir: &SemanticIr, operation: &IrOperation) -> Vec<Projectio
             let suffix = stable_suffix(&field.name);
             name = format!("{name}__{suffix}");
         }
-        let data_type =
-            type_by_id
-                .get(field.type_ref.as_str())
-                .map_or(ManifestDataType::Json, |ty| match &ty.shape {
-                    IrTypeShape::Scalar(scalar) => manifest_type(*scalar),
-                    IrTypeShape::Enum { .. } => ManifestDataType::Utf8,
-                    IrTypeShape::Json
-                    | IrTypeShape::Object { .. }
-                    | IrTypeShape::List { .. }
-                    | IrTypeShape::Map { .. } => ManifestDataType::Json,
-                });
+        let data_type = type_by_id
+            .get(field.type_ref.as_str())
+            .map_or(ManifestDataType::Json, |ty| projection_data_type(ty));
         columns.push(ProjectionColumn {
             name,
             data_type,
@@ -366,6 +358,18 @@ fn projection_columns(ir: &SemanticIr, operation: &IrOperation) -> Vec<Projectio
     }
     columns
 }
+
+fn projection_data_type(ty: &IrType) -> ManifestDataType {
+    match &ty.shape {
+        IrTypeShape::Scalar(scalar) => manifest_type(*scalar),
+        IrTypeShape::Enum { .. } => ManifestDataType::Utf8,
+        IrTypeShape::Json
+        | IrTypeShape::Object { .. }
+        | IrTypeShape::List { .. }
+        | IrTypeShape::Map { .. } => ManifestDataType::Json,
+    }
+}
+
 fn manifest_type(scalar: IrScalarType) -> ManifestDataType {
     match scalar {
         IrScalarType::String | IrScalarType::Id => ManifestDataType::Utf8,


### PR DESCRIPTION
Fixes DSL v4 projection generation for OpenAPI endpoints whose row type is a top-level scalar value.

Before this change, scalar row responses were always exposed as a single `value` column with `Json` type. That erased useful type information for endpoints that return arrays of strings, integers, numbers, booleans, or timestamps.

This now preserves the scalar type when generating the synthetic `value` column, using the same type mapping already used for scalar object fields.

## Before / After

Given an OpenAPI response like:

```yaml
/strings:
  get:
    operationId: list_strings
    responses:
      '200':
        content:
          application/json:
            schema:
              type: array
              items:
                type: string
```

Before:

```sql
SELECT column_name, data_type
FROM coral.columns
WHERE schema_name = 'scalar_rows'
  AND table_name = 'list_strings';
```

```text
column_name | data_type
------------+----------
value       | Json
```

After:

```text
column_name | data_type
------------+----------
value       | Utf8
```

The same now applies across the scalar shapes imported by v4:

```text
OpenAPI row item                 Before   After
-------------------------------  -------  ---------
type: string                     Json     Utf8
type: integer                    Json     Int64
type: number                     Json     Float64
type: boolean                    Json     Boolean
type: string, format: date-time  Json     Timestamp
```

That means generated SQL surfaces can expose scalar rows as typed values directly:

```sql
SELECT value
FROM scalar_rows.list_integers;
```

Before, `value` was a JSON column even though each row was an integer. After, `value` is `Int64`, so downstream queries can use it as a normal numeric column.

```sql
SELECT value
FROM scalar_rows.list_timestamps
WHERE value >= timestamp '2026-01-01T00:00:00Z';
```

Before, this required JSON handling or casts because the generated column type was `Json`. After, the column is generated as `Timestamp`.

## Implementation Notes

- Adds a shared projection type mapper for v4 projection columns.
- Uses that mapper for both object fields and top-level scalar row projections.
- Keeps non-scalar row shapes as `Json`.
- Adds coverage for string, integer, number, boolean, and timestamp scalar rows.