### PR TITLE
feat(engine): bind UDF runtime arguments

### DIFF
--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -433,8 +433,9 @@ fn register_test_sources(ctx: &SessionContext, sources: Vec<CompiledQuerySource>
             .flat_map(|source| source.table_functions.iter()),
     );
     source_functions
-        .install(ctx)
+        .install_relation_planner(ctx)
         .expect("source function planner should register");
+    SourceFunctionRegistry::install_analyzer(ctx);
 }
 
 fn register_test_sources_with_catalog(ctx: &SessionContext, sources: Vec<CompiledQuerySource>) {
@@ -447,8 +448,9 @@ fn register_test_sources_with_catalog(ctx: &SessionContext, sources: Vec<Compile
             .flat_map(|source| source.table_functions.iter()),
     );
     source_functions
-        .install(ctx)
+        .install_relation_planner(ctx)
         .expect("source function planner should register");
+    SourceFunctionRegistry::install_analyzer(ctx);
 }
 
 fn mcp_table_manifest() -> coral_spec::ValidatedSourceManifest {

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -433,9 +433,8 @@ fn register_test_sources(ctx: &SessionContext, sources: Vec<CompiledQuerySource>
             .flat_map(|source| source.table_functions.iter()),
     );
     source_functions
-        .install_relation_planner(ctx)
+        .install(ctx)
         .expect("source function planner should register");
-    SourceFunctionRegistry::install_analyzer(ctx);
 }
 
 fn register_test_sources_with_catalog(ctx: &SessionContext, sources: Vec<CompiledQuerySource>) {
@@ -448,9 +447,8 @@ fn register_test_sources_with_catalog(ctx: &SessionContext, sources: Vec<Compile
             .flat_map(|source| source.table_functions.iter()),
     );
     source_functions
-        .install_relation_planner(ctx)
+        .install(ctx)
         .expect("source function planner should register");
-    SourceFunctionRegistry::install_analyzer(ctx);
 }
 
 fn mcp_table_manifest() -> coral_spec::ValidatedSourceManifest {

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -20,8 +20,9 @@ pub use query::{
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 pub use udfs::{
-    UdfRuntimeArgument, UdfRuntimeImplementation, UdfRuntimeResultColumn, UdfRuntimeSignature,
-    UdfRuntimeSqlDefinition,
+    UdfRuntimeArgument, UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimePublish,
+    UdfRuntimeResultColumn, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
+    UdfRuntimeTableFunctionPublish,
 };
 
 #[cfg(test)]

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -401,6 +401,12 @@ impl QueryParameters {
         self.values.insert(name.into(), value)
     }
 
+    /// Returns one parameter value by name.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&QueryParameterValue> {
+        self.values.get(name)
+    }
+
     /// Iterates over parameter names and values in deterministic order.
     pub fn iter(&self) -> impl Iterator<Item = (&String, &QueryParameterValue)> {
         self.values.iter()

--- a/crates/coral-engine/src/contracts/udfs.rs
+++ b/crates/coral-engine/src/contracts/udfs.rs
@@ -29,6 +29,23 @@ impl UdfRuntimeSqlDefinition {
     }
 }
 
+/// One validated UDF made available to the query runtime.
+#[derive(Debug, Clone)]
+pub struct UdfRuntimeDefinition {
+    /// Stable UDF id within one workspace.
+    pub name: String,
+    /// User-facing UDF description.
+    pub description: String,
+    /// Typed arguments accepted by the UDF.
+    pub arguments: Vec<UdfRuntimeArgument>,
+    /// Executable UDF implementation.
+    pub implementation: UdfRuntimeImplementation,
+    /// Public surfaces requested by the UDF.
+    pub publish: UdfRuntimePublish,
+    /// Columns inferred by planning the UDF SQL body.
+    pub result_columns: Vec<UdfRuntimeResultColumn>,
+}
+
 /// One typed UDF argument.
 #[derive(Debug, Clone)]
 pub struct UdfRuntimeArgument {
@@ -58,4 +75,22 @@ pub enum UdfRuntimeImplementation {
         /// SQL query executed by Coral after typed argument binding.
         query: String,
     },
+}
+
+/// Public surfaces requested by one UDF.
+#[derive(Debug, Clone)]
+pub struct UdfRuntimePublish {
+    /// Canonical public SQL table-function wrapper.
+    pub table_function: UdfRuntimeTableFunctionPublish,
+}
+
+/// Canonical SQL table-function surface for one UDF.
+#[derive(Debug, Clone)]
+pub struct UdfRuntimeTableFunctionPublish {
+    /// SQL schema.
+    pub schema: String,
+    /// SQL function name.
+    pub name: String,
+    /// Optional publish-target-specific description.
+    pub description: String,
 }

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -75,8 +75,9 @@ pub use contracts::{
     QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
     RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
     TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
-    UdfRuntimeArgument, UdfRuntimeImplementation, UdfRuntimeResultColumn, UdfRuntimeSignature,
-    UdfRuntimeSqlDefinition,
+    UdfRuntimeArgument, UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimePublish,
+    UdfRuntimeResultColumn, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
+    UdfRuntimeTableFunctionPublish,
 };
 
 /// High-level query operations for the local query engine.

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -182,9 +182,8 @@ async fn build_registered_runtime(
     );
     if !source_functions.is_empty() {
         source_functions
-            .install_relation_planner(&ctx)
+            .install(&ctx)
             .map_err(|err| datafusion_to_core(&err, &tables))?;
-        SourceFunctionRegistry::install_analyzer(&ctx);
     }
     for failure in &registration.failures {
         tracing::warn!(
@@ -860,7 +859,7 @@ fn is_parameterized_source_function_call(plan: &LogicalPlan) -> bool {
     extension.node.name() == SOURCE_FUNCTION_NODE_NAME
 }
 
-fn query_parameter_scalar_value(value: &QueryParameterValue) -> ScalarValue {
+pub(crate) fn query_parameter_scalar_value(value: &QueryParameterValue) -> ScalarValue {
     match value {
         QueryParameterValue::String(value) => ScalarValue::Utf8(value.clone()),
         QueryParameterValue::Integer(value) => ScalarValue::Int64(*value),

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -182,8 +182,9 @@ async fn build_registered_runtime(
     );
     if !source_functions.is_empty() {
         source_functions
-            .install(&ctx)
+            .install_relation_planner(&ctx)
             .map_err(|err| datafusion_to_core(&err, &tables))?;
+        SourceFunctionRegistry::install_analyzer(&ctx);
     }
     for failure in &registration.failures {
         tracing::warn!(

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -42,6 +42,7 @@ use crate::runtime::scoped_table_functions::{
 use coral_spec::ManifestDataType;
 
 pub(crate) const SOURCE_FUNCTION_NODE_NAME: &str = "CoralSourceFunction";
+const SOURCE_FUNCTION_ANALYZER_RULE_NAME: &str = "coral_source_functions";
 
 #[derive(Debug)]
 pub(crate) struct SourceFunctionRegistry {
@@ -72,12 +73,40 @@ impl SourceFunctionRegistry {
         self.functions.is_empty()
     }
 
+    /// Installs source-function planning and binding for one session.
+    ///
+    /// The two hooks are a pair: any session that can plan source-function
+    /// calls must also be able to bind parked [`SourceFunctionNode`] plans.
+    pub(crate) fn install(self, ctx: &SessionContext) -> Result<()> {
+        self.install_relation_planner(ctx)?;
+        Self::install_analyzer(ctx);
+        Ok(())
+    }
+
+    /// Installs only the relation planner that parks source-function calls.
+    ///
+    /// Use this only when the caller installs the analyzer separately for the
+    /// same session.
     pub(crate) fn install_relation_planner(self, ctx: &SessionContext) -> Result<()> {
         ctx.register_relation_planner(Arc::new(self))
     }
 
+    /// Installs the analyzer that resolves parked source-function calls.
+    ///
+    /// `DataFusion` appends analyzer rules, so keep this idempotent for callers
+    /// that share one session across source-function and UDF planning hooks.
     pub(crate) fn install_analyzer(ctx: &SessionContext) {
-        ctx.add_analyzer_rule(Arc::new(SourceFunctionAnalyzerRule));
+        let state_ref = ctx.state_ref();
+        let mut state = state_ref.write();
+        if state
+            .analyzer()
+            .rules
+            .iter()
+            .any(|rule| rule.name() == SOURCE_FUNCTION_ANALYZER_RULE_NAME)
+        {
+            return;
+        }
+        state.add_analyzer_rule(Arc::new(SourceFunctionAnalyzerRule));
     }
 
     fn find(&self, call: &ScopedTableFunctionCall) -> Option<&SourceFunction> {
@@ -399,6 +428,28 @@ impl AnalyzerRule for SourceFunctionAnalyzerRule {
     }
 
     fn name(&self) -> &'static str {
-        "coral_source_functions"
+        SOURCE_FUNCTION_ANALYZER_RULE_NAME
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_analyzer_is_idempotent() {
+        let ctx = SessionContext::new();
+
+        SourceFunctionRegistry::install_analyzer(&ctx);
+        SourceFunctionRegistry::install_analyzer(&ctx);
+
+        let count = ctx
+            .state()
+            .analyzer()
+            .rules
+            .iter()
+            .filter(|rule| rule.name() == SOURCE_FUNCTION_ANALYZER_RULE_NAME)
+            .count();
+        assert_eq!(count, 1);
     }
 }

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -72,13 +72,12 @@ impl SourceFunctionRegistry {
         self.functions.is_empty()
     }
 
-    /// Installs this relation planner together with the analyzer rule that
-    /// resolves the nodes it parks. The two are a pair: any session that can
-    /// plan source-function calls must also be able to bind them.
-    pub(crate) fn install(self, ctx: &SessionContext) -> Result<()> {
-        ctx.register_relation_planner(Arc::new(self))?;
+    pub(crate) fn install_relation_planner(self, ctx: &SessionContext) -> Result<()> {
+        ctx.register_relation_planner(Arc::new(self))
+    }
+
+    pub(crate) fn install_analyzer(ctx: &SessionContext) {
         ctx.add_analyzer_rule(Arc::new(SourceFunctionAnalyzerRule));
-        Ok(())
     }
 
     fn find(&self, call: &ScopedTableFunctionCall) -> Option<&SourceFunction> {

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -296,7 +296,7 @@ impl UdfParameterTypeBinding {
         }
 
         if self.is_string_shaped()
-            && let Some(value) = string_shaped_literal_value(value, self.data_type)
+            && let Some(value) = value.try_as_str().flatten()
         {
             return Some(QueryParameterValue::string(value));
         }
@@ -315,7 +315,8 @@ impl UdfParameterTypeBinding {
                 ScalarValue::Boolean(Some(value)) => Some(QueryParameterValue::boolean(*value)),
                 _ => None,
             },
-            ManifestDataType::Utf8 | ManifestDataType::Json | ManifestDataType::Timestamp => None,
+            ManifestDataType::Timestamp => timestamp_parameter_from_scalar(value),
+            ManifestDataType::Utf8 | ManifestDataType::Json => None,
         }
     }
 
@@ -328,7 +329,10 @@ impl UdfParameterTypeBinding {
             }
             (ManifestDataType::Int64, QueryParameterValue::Integer(_))
             | (ManifestDataType::Float64, QueryParameterValue::Float(_))
-            | (ManifestDataType::Boolean, QueryParameterValue::Boolean(_)) => Some(value.clone()),
+            | (ManifestDataType::Boolean, QueryParameterValue::Boolean(_))
+            | (ManifestDataType::Timestamp, QueryParameterValue::Timestamp(_)) => {
+                Some(value.clone())
+            }
             (ManifestDataType::Float64, QueryParameterValue::Integer(value)) => {
                 float_parameter_from_integer(*value)
             }
@@ -345,6 +349,7 @@ impl UdfParameterTypeBinding {
             ManifestDataType::Int64 => QueryParameterValue::null_integer(),
             ManifestDataType::Float64 => QueryParameterValue::null_float(),
             ManifestDataType::Boolean => QueryParameterValue::null_boolean(),
+            ManifestDataType::Timestamp => QueryParameterValue::null_timestamp(),
             _ => unreachable!("string-binding manifest types returned above"),
         }
     }
@@ -385,29 +390,12 @@ fn float_parameter_from_integer(value: Option<i64>) -> Option<QueryParameterValu
     Some(QueryParameterValue::float(value))
 }
 
-fn string_shaped_literal_value(value: &ScalarValue, data_type: ManifestDataType) -> Option<String> {
-    if let Some(value) = value.try_as_str().flatten() {
-        return Some(value.to_string());
-    }
-
-    if data_type == ManifestDataType::Timestamp
-        && matches!(
-            value,
-            ScalarValue::TimestampSecond(_, _)
-                | ScalarValue::TimestampMillisecond(_, _)
-                | ScalarValue::TimestampMicrosecond(_, _)
-                | ScalarValue::TimestampNanosecond(_, _)
-        )
-    {
-        return value
-            .cast_to(&DataType::Utf8)
-            .ok()?
-            .try_as_str()
-            .flatten()
-            .map(str::to_string);
-    }
-
-    None
+fn timestamp_parameter_from_scalar(value: &ScalarValue) -> Option<QueryParameterValue> {
+    let data_type = crate::types::arrow_data_type(ManifestDataType::Timestamp);
+    let ScalarValue::TimestampMicrosecond(Some(value), _) = value.cast_to(&data_type).ok()? else {
+        return None;
+    };
+    Some(QueryParameterValue::timestamp_micros(value))
 }
 
 fn query_parameter_value_kind(value: &QueryParameterValue) -> &'static str {
@@ -416,6 +404,7 @@ fn query_parameter_value_kind(value: &QueryParameterValue) -> &'static str {
         QueryParameterValue::Integer(_) => "integer",
         QueryParameterValue::Float(_) => "float",
         QueryParameterValue::Boolean(_) => "boolean",
+        QueryParameterValue::Timestamp(_) => "timestamp",
     }
 }
 
@@ -425,6 +414,10 @@ fn scalar_literal_kind(value: &ScalarValue) -> &'static str {
         ScalarValue::Int64(_) => "integer",
         ScalarValue::Float64(_) => "float",
         ScalarValue::Boolean(_) => "boolean",
+        ScalarValue::TimestampSecond(_, _)
+        | ScalarValue::TimestampMillisecond(_, _)
+        | ScalarValue::TimestampMicrosecond(_, _)
+        | ScalarValue::TimestampNanosecond(_, _) => "timestamp",
         _ => "unsupported literal",
     }
 }
@@ -634,7 +627,7 @@ mod tests {
     }
 
     #[test]
-    fn udf_argument_values_formats_native_timestamp_literals() {
+    fn udf_argument_values_preserves_native_timestamp_literals() {
         let mut udf = udf();
         udf.arguments = vec![argument("since", ManifestDataType::Timestamp)];
         let timestamp =
@@ -642,7 +635,10 @@ mod tests {
 
         assert_eq!(
             udf_argument_values(&udf, &[Expr::Literal(timestamp, None)]).unwrap(),
-            params([("since", QueryParameterValue::string("2024-01-01T00:00:00Z"))])
+            params([(
+                "since",
+                QueryParameterValue::timestamp_micros(1_704_067_200_000_000)
+            )])
         );
     }
 
@@ -660,7 +656,10 @@ mod tests {
 
         assert_eq!(
             udf_argument_values(&udf, &[timestamp]).unwrap(),
-            params([("since", QueryParameterValue::string("2024-01-01T00:00:00Z"))])
+            params([(
+                "since",
+                QueryParameterValue::timestamp_micros(1_704_067_200_000_000)
+            )])
         );
     }
 }

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -1,11 +1,29 @@
-//! UDF SQL signature inference orchestration.
+//! UDF SQL signature inference and runtime argument binding helpers.
 
-use crate::runtime::query::QueryRuntimeAdapter;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Field, Schema};
+use coral_spec::ManifestDataType;
+use datafusion::common::ScalarValue;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::logical_expr::Expr;
+
+use crate::runtime::query::{QueryRuntimeAdapter, query_parameter_scalar_value};
+use crate::types::parameter_binding_is_string_shaped;
 use crate::{
-    CoreError, UdfRuntimeArgument, UdfRuntimeResultColumn, UdfRuntimeSignature,
-    UdfRuntimeSqlDefinition,
+    CoreError, QueryParameterValue, QueryParameters, UdfRuntimeArgument, UdfRuntimeDefinition,
+    UdfRuntimeImplementation, UdfRuntimeResultColumn, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
 };
-use arrow::datatypes::Schema;
+
+#[expect(
+    dead_code,
+    reason = "UDF table-function execution consumes registered UDF SQL in the next stack branch."
+)]
+pub(crate) fn udf_sql(udf: &UdfRuntimeDefinition) -> &str {
+    let UdfRuntimeImplementation::CoralSql { query } = &udf.implementation;
+    query
+}
 
 pub(crate) async fn infer_udf_signature(
     query_runtime: &QueryRuntimeAdapter,
@@ -57,4 +75,592 @@ fn result_columns(schema: &Schema) -> Vec<UdfRuntimeResultColumn> {
             nullable: field.is_nullable(),
         })
         .collect()
+}
+
+pub(crate) fn udf_query_parameters(
+    udf: &UdfRuntimeDefinition,
+    arguments: &QueryParameters,
+) -> DataFusionResult<QueryParameters> {
+    UdfArgumentBinding::new(udf, arguments).into_query_params()
+}
+
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "UDF table-function execution consumes literal call binding in the next stack branch."
+    )
+)]
+pub(crate) fn udf_argument_values(
+    udf: &UdfRuntimeDefinition,
+    args: &[Expr],
+) -> DataFusionResult<QueryParameters> {
+    if args.len() > udf.arguments.len() {
+        return Err(DataFusionError::Plan(format!(
+            "udf '{}' expected at most {} arguments, got {}",
+            udf.name,
+            udf.arguments.len(),
+            args.len()
+        )));
+    }
+
+    let mut params = QueryParameters::new();
+    for (index, argument) in udf.arguments.iter().enumerate() {
+        if let Some(expr) = args.get(index) {
+            params.insert(
+                argument.name.clone(),
+                udf_argument_value(udf, argument, expr)?,
+            );
+        }
+    }
+    udf_query_parameters(udf, &params)
+}
+
+fn udf_argument_value(
+    udf: &UdfRuntimeDefinition,
+    argument: &UdfRuntimeArgument,
+    expr: &Expr,
+) -> DataFusionResult<QueryParameterValue> {
+    let Some(value) = literal_scalar_value(expr)? else {
+        return Err(DataFusionError::Plan(format!(
+            "udf '{}' argument '{}' must be a literal after parameter binding",
+            udf.name, argument.name
+        )));
+    };
+    UdfParameterTypeBinding::new(argument.data_type)
+        .literal_value(&value)
+        .ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "udf '{}' argument '{}' expected {}, got {}",
+                udf.name,
+                argument.name,
+                argument.data_type.as_manifest_str(),
+                scalar_literal_kind(&value)
+            ))
+        })
+}
+
+fn literal_scalar_value(expr: &Expr) -> DataFusionResult<Option<ScalarValue>> {
+    match unalias(expr) {
+        Expr::Literal(value, _) => Ok(Some(value.clone())),
+        Expr::Cast(cast) => Ok(literal_scalar_value(&cast.expr)?
+            .map(|value| value.cast_to(&cast.data_type))
+            .transpose()?),
+        Expr::TryCast(cast) => {
+            let Some(value) = literal_scalar_value(&cast.expr)? else {
+                return Ok(None);
+            };
+            Ok(Some(
+                value
+                    .cast_to(&cast.data_type)
+                    .unwrap_or(ScalarValue::try_new_null(&cast.data_type)?),
+            ))
+        }
+        Expr::Negative(expr) => Ok(literal_scalar_value(expr)?
+            .map(|value| value.arithmetic_negate())
+            .transpose()?),
+        _ => Ok(None),
+    }
+}
+
+fn unalias(mut expr: &Expr) -> &Expr {
+    while let Expr::Alias(alias) = expr {
+        expr = &alias.expr;
+    }
+    expr
+}
+
+#[expect(
+    dead_code,
+    reason = "UDF table-function execution consumes bound parameter values in the next stack branch."
+)]
+pub(crate) fn udf_param_values(params: &QueryParameters) -> Vec<(String, ScalarValue)> {
+    params
+        .iter()
+        .map(|(name, value)| (name.clone(), query_parameter_scalar_value(value)))
+        .collect()
+}
+
+#[expect(
+    dead_code,
+    reason = "UDF table-function execution consumes result schemas in the next stack branch."
+)]
+pub(crate) fn udf_arrow_schema(udf: &UdfRuntimeDefinition) -> DataFusionResult<Arc<Schema>> {
+    if udf.result_columns.is_empty() {
+        return Err(DataFusionError::Plan(format!(
+            "published udf '{}' requires declared result columns",
+            udf.name
+        )));
+    }
+
+    let fields = udf
+        .result_columns
+        .iter()
+        .map(udf_result_field)
+        .collect::<Vec<_>>();
+    Ok(Arc::new(Schema::new(fields)))
+}
+
+fn udf_result_field(column: &UdfRuntimeResultColumn) -> Field {
+    Field::new(&column.name, column.data_type.clone(), column.nullable)
+}
+
+struct UdfArgumentBinding<'a> {
+    udf: &'a UdfRuntimeDefinition,
+    arguments: &'a QueryParameters,
+}
+
+impl<'a> UdfArgumentBinding<'a> {
+    fn new(udf: &'a UdfRuntimeDefinition, arguments: &'a QueryParameters) -> Self {
+        Self { udf, arguments }
+    }
+
+    fn into_query_params(self) -> DataFusionResult<QueryParameters> {
+        self.reject_duplicate_argument_definitions()?;
+        self.reject_unknown_arguments()?;
+
+        let mut params = self.arguments.clone();
+        for argument in &self.udf.arguments {
+            self.bind_argument(argument, &mut params)?;
+        }
+        Ok(params)
+    }
+
+    fn reject_duplicate_argument_definitions(&self) -> DataFusionResult<()> {
+        let mut seen = BTreeSet::new();
+        for argument in &self.udf.arguments {
+            if !seen.insert(argument.name.as_str()) {
+                return Err(DataFusionError::Plan(format!(
+                    "udf '{}' argument '{}' is declared more than once",
+                    self.udf.name, argument.name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn reject_unknown_arguments(&self) -> DataFusionResult<()> {
+        if let Some(argument_name) = self.arguments.keys().find(|argument_name| {
+            self.udf
+                .arguments
+                .iter()
+                .all(|argument| argument.name != **argument_name)
+        }) {
+            return Err(DataFusionError::Plan(format!(
+                "udf '{}' received unknown argument '{}'",
+                self.udf.name, argument_name
+            )));
+        }
+        Ok(())
+    }
+
+    fn bind_argument(
+        &self,
+        argument: &UdfRuntimeArgument,
+        params: &mut QueryParameters,
+    ) -> DataFusionResult<()> {
+        let binding = UdfParameterTypeBinding::new(argument.data_type);
+        let Some(value) = params.get(&argument.name) else {
+            return Err(DataFusionError::Plan(format!(
+                "udf '{}' is missing argument '{}'",
+                self.udf.name, argument.name
+            )));
+        };
+        let value_kind = query_parameter_value_kind(value);
+        let Some(value) = binding.coerce_value(value) else {
+            return Err(DataFusionError::Plan(format!(
+                "udf '{}' argument '{}' expected {}, got {}",
+                self.udf.name,
+                argument.name,
+                argument.data_type.as_manifest_str(),
+                value_kind
+            )));
+        };
+        params.insert(argument.name.clone(), value);
+        Ok(())
+    }
+}
+
+struct UdfParameterTypeBinding {
+    data_type: ManifestDataType,
+}
+
+impl UdfParameterTypeBinding {
+    fn new(data_type: ManifestDataType) -> Self {
+        Self { data_type }
+    }
+
+    fn literal_value(&self, value: &ScalarValue) -> Option<QueryParameterValue> {
+        if value.is_null() {
+            return Some(self.typed_null());
+        }
+
+        if self.is_string_shaped()
+            && let Some(value) = string_shaped_literal_value(value, self.data_type)
+        {
+            return Some(QueryParameterValue::string(value));
+        }
+
+        match self.data_type {
+            ManifestDataType::Int64 => {
+                signed_integer_literal(value).map(QueryParameterValue::integer)
+            }
+            ManifestDataType::Float64 => float_literal(value)
+                .map(QueryParameterValue::float)
+                .or_else(|| {
+                    signed_integer_literal(value)
+                        .and_then(|value| float_parameter_from_integer(Some(value)))
+                }),
+            ManifestDataType::Boolean => match value {
+                ScalarValue::Boolean(Some(value)) => Some(QueryParameterValue::boolean(*value)),
+                _ => None,
+            },
+            ManifestDataType::Utf8 | ManifestDataType::Json | ManifestDataType::Timestamp => None,
+        }
+    }
+
+    fn coerce_value(&self, value: &QueryParameterValue) -> Option<QueryParameterValue> {
+        match (self.data_type, value) {
+            (data_type, QueryParameterValue::String(_))
+                if parameter_binding_is_string_shaped(data_type) =>
+            {
+                Some(value.clone())
+            }
+            (ManifestDataType::Int64, QueryParameterValue::Integer(_))
+            | (ManifestDataType::Float64, QueryParameterValue::Float(_))
+            | (ManifestDataType::Boolean, QueryParameterValue::Boolean(_)) => Some(value.clone()),
+            (ManifestDataType::Float64, QueryParameterValue::Integer(value)) => {
+                float_parameter_from_integer(*value)
+            }
+            _ => None,
+        }
+    }
+
+    fn typed_null(&self) -> QueryParameterValue {
+        if self.is_string_shaped() {
+            return QueryParameterValue::null_string();
+        }
+
+        match self.data_type {
+            ManifestDataType::Int64 => QueryParameterValue::null_integer(),
+            ManifestDataType::Float64 => QueryParameterValue::null_float(),
+            ManifestDataType::Boolean => QueryParameterValue::null_boolean(),
+            _ => unreachable!("string-binding manifest types returned above"),
+        }
+    }
+
+    fn is_string_shaped(&self) -> bool {
+        parameter_binding_is_string_shaped(self.data_type)
+    }
+}
+
+fn signed_integer_literal(value: &ScalarValue) -> Option<i64> {
+    match value {
+        ScalarValue::Int8(Some(value)) => Some(i64::from(*value)),
+        ScalarValue::Int16(Some(value)) => Some(i64::from(*value)),
+        ScalarValue::Int32(Some(value)) => Some(i64::from(*value)),
+        ScalarValue::Int64(Some(value)) => Some(*value),
+        _ => None,
+    }
+}
+
+fn float_literal(value: &ScalarValue) -> Option<f64> {
+    match value {
+        ScalarValue::Float32(Some(value)) => Some(f64::from(*value)),
+        ScalarValue::Float64(Some(value)) => Some(*value),
+        _ => None,
+    }
+}
+
+fn float_parameter_from_integer(value: Option<i64>) -> Option<QueryParameterValue> {
+    let Some(value) = value else {
+        return Some(QueryParameterValue::null_float());
+    };
+    let ScalarValue::Float64(Some(value)) = ScalarValue::Int64(Some(value))
+        .cast_to(&DataType::Float64)
+        .ok()?
+    else {
+        return None;
+    };
+    Some(QueryParameterValue::float(value))
+}
+
+fn string_shaped_literal_value(value: &ScalarValue, data_type: ManifestDataType) -> Option<String> {
+    if let Some(value) = value.try_as_str().flatten() {
+        return Some(value.to_string());
+    }
+
+    if data_type == ManifestDataType::Timestamp
+        && matches!(
+            value,
+            ScalarValue::TimestampSecond(_, _)
+                | ScalarValue::TimestampMillisecond(_, _)
+                | ScalarValue::TimestampMicrosecond(_, _)
+                | ScalarValue::TimestampNanosecond(_, _)
+        )
+    {
+        return value
+            .cast_to(&DataType::Utf8)
+            .ok()?
+            .try_as_str()
+            .flatten()
+            .map(str::to_string);
+    }
+
+    None
+}
+
+fn query_parameter_value_kind(value: &QueryParameterValue) -> &'static str {
+    match value {
+        QueryParameterValue::String(_) => "string",
+        QueryParameterValue::Integer(_) => "integer",
+        QueryParameterValue::Float(_) => "float",
+        QueryParameterValue::Boolean(_) => "boolean",
+    }
+}
+
+fn scalar_literal_kind(value: &ScalarValue) -> &'static str {
+    match value {
+        ScalarValue::Utf8(_) | ScalarValue::LargeUtf8(_) | ScalarValue::Utf8View(_) => "string",
+        ScalarValue::Int64(_) => "integer",
+        ScalarValue::Float64(_) => "float",
+        ScalarValue::Boolean(_) => "boolean",
+        _ => "unsupported literal",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::datatypes::TimeUnit;
+    use datafusion::logical_expr::expr::{Cast, TryCast};
+
+    fn argument(name: &str, data_type: ManifestDataType) -> UdfRuntimeArgument {
+        UdfRuntimeArgument {
+            name: name.to_string(),
+            data_type,
+        }
+    }
+
+    fn udf() -> UdfRuntimeDefinition {
+        UdfRuntimeDefinition {
+            name: "open_pull_requests".to_string(),
+            description: String::new(),
+            arguments: vec![argument("author", ManifestDataType::Utf8)],
+            implementation: UdfRuntimeImplementation::CoralSql {
+                query: "select * from github.pull_requests where author = $author".to_string(),
+            },
+            publish: crate::UdfRuntimePublish {
+                table_function: crate::UdfRuntimeTableFunctionPublish {
+                    schema: "udfs".to_string(),
+                    name: "open_pull_requests".to_string(),
+                    description: String::new(),
+                },
+            },
+            result_columns: Vec::new(),
+        }
+    }
+
+    fn params(
+        values: impl IntoIterator<Item = (&'static str, QueryParameterValue)>,
+    ) -> QueryParameters {
+        values
+            .into_iter()
+            .map(|(name, value)| (name.to_string(), value))
+            .collect()
+    }
+
+    #[test]
+    fn udf_query_parameters_accepts_matching_arguments() {
+        let udf = udf();
+        let arguments = params([("author", QueryParameterValue::string("Bradley-Butcher"))]);
+
+        assert_eq!(
+            udf_query_parameters(&udf, &arguments).unwrap(),
+            params([("author", QueryParameterValue::string("Bradley-Butcher"))])
+        );
+    }
+
+    #[test]
+    fn udf_query_parameters_coerces_integer_values_for_float_arguments() {
+        let mut udf = udf();
+        udf.arguments = vec![argument("min_score", ManifestDataType::Float64)];
+
+        assert_eq!(
+            udf_query_parameters(
+                &udf,
+                &params([("min_score", QueryParameterValue::integer(1))])
+            )
+            .unwrap(),
+            params([("min_score", QueryParameterValue::float(1.0))])
+        );
+        assert_eq!(
+            udf_query_parameters(
+                &udf,
+                &params([("min_score", QueryParameterValue::null_integer())])
+            )
+            .unwrap(),
+            params([("min_score", QueryParameterValue::null_float())])
+        );
+    }
+
+    #[test]
+    fn udf_query_parameters_rejects_invalid_arguments() {
+        let udf = udf();
+        let cases = [
+            (
+                params([
+                    ("author", QueryParameterValue::string("Bradley-Butcher")),
+                    ("repository", QueryParameterValue::string("withcoral/coral")),
+                ]),
+                "Error during planning: udf 'open_pull_requests' received unknown argument 'repository'",
+            ),
+            (
+                QueryParameters::new(),
+                "Error during planning: udf 'open_pull_requests' is missing argument 'author'",
+            ),
+            (
+                params([("author", QueryParameterValue::integer(42))]),
+                "Error during planning: udf 'open_pull_requests' argument 'author' expected Utf8, got integer",
+            ),
+        ];
+
+        for (arguments, expected) in cases {
+            assert_eq!(
+                udf_query_parameters(&udf, &arguments)
+                    .unwrap_err()
+                    .strip_backtrace(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn udf_argument_values_binds_supported_literals() {
+        let udf = udf();
+        let exprs = [
+            Expr::Literal(ScalarValue::Utf8(Some("Bradley-Butcher".into())), None),
+            Expr::Literal(ScalarValue::Utf8View(Some("Bradley-Butcher".into())), None),
+            Expr::Literal(ScalarValue::Utf8(Some("Bradley-Butcher".into())), None).alias("author"),
+        ];
+
+        for expr in exprs {
+            assert_eq!(
+                udf_argument_values(&udf, &[expr]).unwrap(),
+                params([("author", QueryParameterValue::string("Bradley-Butcher"))])
+            );
+        }
+    }
+
+    #[test]
+    fn udf_argument_values_coerces_integer_literals_for_float_arguments() {
+        let mut udf = udf();
+        udf.arguments = vec![argument("min_score", ManifestDataType::Float64)];
+
+        assert_eq!(
+            udf_argument_values(&udf, &[Expr::Literal(ScalarValue::Int64(Some(1)), None)]).unwrap(),
+            params([("min_score", QueryParameterValue::float(1.0))])
+        );
+    }
+
+    #[test]
+    fn udf_argument_values_widens_compatible_numeric_casts() {
+        let integer = Expr::Cast(Cast::new(
+            Box::new(Expr::Literal(ScalarValue::Int64(Some(1)), None)),
+            DataType::Int32,
+        ));
+        let mut udf = udf();
+        udf.arguments = vec![argument("value", ManifestDataType::Int64)];
+        assert_eq!(
+            udf_argument_values(&udf, &[integer]).unwrap(),
+            params([("value", QueryParameterValue::integer(1))])
+        );
+
+        let float = Expr::Cast(Cast::new(
+            Box::new(Expr::Literal(ScalarValue::Int64(Some(1)), None)),
+            DataType::Float32,
+        ));
+        udf.arguments = vec![argument("value", ManifestDataType::Float64)];
+        assert_eq!(
+            udf_argument_values(&udf, &[float]).unwrap(),
+            params([("value", QueryParameterValue::float(1.0))])
+        );
+    }
+
+    #[test]
+    fn udf_argument_values_accepts_negative_numeric_literals() {
+        let mut udf = udf();
+        udf.arguments = vec![argument("value", ManifestDataType::Int64)];
+        let integer = Expr::Negative(Box::new(Expr::Literal(ScalarValue::Int64(Some(3)), None)));
+        assert_eq!(
+            udf_argument_values(&udf, &[integer]).unwrap(),
+            params([("value", QueryParameterValue::integer(-3))])
+        );
+
+        udf.arguments = vec![argument("value", ManifestDataType::Float64)];
+        let float = Expr::Negative(Box::new(Expr::Literal(
+            ScalarValue::Float64(Some(1.5)),
+            None,
+        )));
+        assert_eq!(
+            udf_argument_values(&udf, &[float]).unwrap(),
+            params([("value", QueryParameterValue::float(-1.5))])
+        );
+    }
+
+    #[test]
+    fn udf_argument_values_evaluates_try_cast_literals() {
+        let mut udf = udf();
+        udf.arguments = vec![argument("min_score", ManifestDataType::Float64)];
+
+        let try_cast = |value: &str| {
+            Expr::TryCast(TryCast::new(
+                Box::new(Expr::Literal(
+                    ScalarValue::Utf8(Some(value.to_string())),
+                    None,
+                )),
+                DataType::Float64,
+            ))
+        };
+
+        assert_eq!(
+            udf_argument_values(&udf, &[try_cast("1.5")]).unwrap(),
+            params([("min_score", QueryParameterValue::float(1.5))])
+        );
+        assert_eq!(
+            udf_argument_values(&udf, &[try_cast("not-a-number")]).unwrap(),
+            params([("min_score", QueryParameterValue::null_float())])
+        );
+    }
+
+    #[test]
+    fn udf_argument_values_formats_native_timestamp_literals() {
+        let mut udf = udf();
+        udf.arguments = vec![argument("since", ManifestDataType::Timestamp)];
+        let timestamp =
+            ScalarValue::TimestampMicrosecond(Some(1_704_067_200_000_000), Some("+00:00".into()));
+
+        assert_eq!(
+            udf_argument_values(&udf, &[Expr::Literal(timestamp, None)]).unwrap(),
+            params([("since", QueryParameterValue::string("2024-01-01T00:00:00Z"))])
+        );
+    }
+
+    #[test]
+    fn udf_argument_values_evaluates_timestamp_literal_casts() {
+        let mut udf = udf();
+        udf.arguments = vec![argument("since", ManifestDataType::Timestamp)];
+        let timestamp = Expr::Cast(Cast::new(
+            Box::new(Expr::Literal(
+                ScalarValue::Utf8(Some("2024-01-01T00:00:00Z".to_string())),
+                None,
+            )),
+            DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into())),
+        ));
+
+        assert_eq!(
+            udf_argument_values(&udf, &[timestamp]).unwrap(),
+            params([("since", QueryParameterValue::string("2024-01-01T00:00:00Z"))])
+        );
+    }
 }

--- a/crates/coral-engine/src/types.rs
+++ b/crates/coral-engine/src/types.rs
@@ -28,6 +28,12 @@ pub(crate) fn arrow_data_type(data_type: ManifestDataType) -> DataType {
     }
 }
 
+/// Returns whether a manifest type binds through `DataFusion` SQL parameters as
+/// one of the string-shaped Arrow values.
+pub(crate) fn parameter_binding_is_string_shaped(data_type: ManifestDataType) -> bool {
+    matches!(data_type, ManifestDataType::Utf8 | ManifestDataType::Json)
+}
+
 /// Resolves a DataFusion/Arrow inferred parameter type into Coral manifest
 /// spelling when the type can be expressed in function metadata.
 pub(crate) fn manifest_data_type_for_arrow(data_type: &DataType) -> Option<ManifestDataType> {
@@ -107,5 +113,21 @@ mod tests {
             manifest_data_type_for_arrow(&DataType::Utf8View),
             Some(ManifestDataType::Utf8)
         );
+    }
+
+    #[test]
+    fn only_text_manifest_types_use_string_parameter_binding() {
+        assert!(parameter_binding_is_string_shaped(ManifestDataType::Utf8));
+        assert!(parameter_binding_is_string_shaped(ManifestDataType::Json));
+        assert!(!parameter_binding_is_string_shaped(
+            ManifestDataType::Timestamp
+        ));
+        assert!(!parameter_binding_is_string_shaped(ManifestDataType::Int64));
+        assert!(!parameter_binding_is_string_shaped(
+            ManifestDataType::Float64
+        ));
+        assert!(!parameter_binding_is_string_shaped(
+            ManifestDataType::Boolean
+        ));
     }
 }


### PR DESCRIPTION
## Intent

Bind a validated UDF call into typed DataFusion query parameters.

This is the boundary between an outer table-function call and the placeholders in the UDF body. It validates the call once, preserves the declared parameter type, and produces the existing `QueryParameters` shape used by query planning.

## Contract and ownership

- `QueryParameterValue` is Coral's typed value surface between SQL-call arguments and DataFusion placeholders.
- Binding rejects missing, unknown, duplicate, and incompatible arguments before body planning.
- Typed nulls retain the declared UDF argument type.
- `Timestamp` and `Json` remain string-shaped at this boundary; integers may widen to declared floats.

## What changed

- Added typed query-parameter values and SQL-literal conversion.
- Added UDF argument definition validation and exact call-site failure cases.
- Added `udf_query_parameters` for converting a validated call into body parameters.
- Split source-function installation into its relation-planner and analyzer phases.

The source-function split belongs here because execution in the next PR must park UDF calls during relation planning, bind their parameters, then run source-function analysis inside the expanded body. The existing `install()` path still installs both phases together, and the analyzer remains idempotent.

## Invariants

- No UDF is registered as a SQL table function yet.
- Literal arguments are validated eagerly; placeholders are validated after outer query binding.
- Existing source-only query behavior is unchanged.
- Parameter names are normalized once at the binding boundary.

## Review order

1. `contracts/query.rs` — typed query values.
2. `runtime/udfs.rs` — definition and call binding.
3. `runtime/source_functions.rs` — planner/analyzer separation.
4. `query.rs` — the narrow engine entry point.
5. `tests/udf_tests.rs` — type matrix and exact failures.

## Not in this PR

- UDF table-function registration or execution.
- Catalog publication.
- Storage, lifecycle, API, app, or CLI changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p coral-engine --test engine --all-features --locked udf_`
- `cargo clippy -p coral-engine --all-targets --all-features --locked -- -D warnings`
- `make rust-checks` from the top of the restacked series
