### PR TITLE
fix(spec): recursively hydrate external refs in OpenAPI specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,10 +1402,12 @@ name = "coral-spec"
 version = "0.5.1"
 dependencies = [
  "jsonschema",
+ "reqwest 0.13.4",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror",
  "tracing",
  "url",

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -937,7 +937,7 @@ fn read_url_descriptor_on_blocking_thread(url: &str) -> Result<DescriptorRead, A
             response.status()
         )));
     }
-    let effective_base_uri = response.url().to_string();
+    let effective_base_uri = effective_descriptor_base_uri(response.url());
     if let Some(length) = response.content_length()
         && length > MAX_DESCRIPTOR_BYTES
     {
@@ -961,6 +961,13 @@ fn read_url_descriptor_on_blocking_thread(url: &str) -> Result<DescriptorRead, A
         bytes,
         effective_base_uri: Some(effective_base_uri),
     })
+}
+
+fn effective_descriptor_base_uri(url: &reqwest::Url) -> String {
+    let mut url = url.clone();
+    url.set_query(None);
+    url.set_fragment(None);
+    url.to_string()
 }
 
 fn ensure_https_descriptor_url(url: &str) -> Result<(), AppError> {
@@ -1689,6 +1696,17 @@ surfaces:
         assert!(
             error.to_string().contains("must use HTTPS"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn effective_descriptor_base_uri_strips_query_and_fragment() {
+        let url = reqwest::Url::parse("https://example.com/specs/openapi.yaml?download=1#ignored")
+            .expect("url");
+
+        assert_eq!(
+            effective_descriptor_base_uri(&url),
+            "https://example.com/specs/openapi.yaml"
         );
     }
 }

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -11,8 +11,8 @@ use coral_spec::v4::{
     ProjectionCatalog, SURFACE_IMPORTER_VERSION, SemanticIr, SurfaceType,
     V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceManifest,
     generate_projection_catalog, import_mcp_surface, import_openapi_surface,
-    normalize_mcp_tool_catalog, normalize_source_document, openapi_document_metadata,
-    validate_materialized_source, validate_openapi_base_url_template,
+    import_openapi_surface_with_base_uri, normalize_mcp_tool_catalog, normalize_source_document,
+    openapi_document_metadata, validate_materialized_source, validate_openapi_base_url_template,
 };
 use coral_spec::{
     ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestInputKind, ManifestInputSpec,
@@ -666,6 +666,12 @@ struct MaterializedSurfaceBuild {
     semantic_ir: SemanticIr,
 }
 
+#[derive(Debug)]
+struct DescriptorRead {
+    bytes: Vec<u8>,
+    effective_base_uri: Option<String>,
+}
+
 fn materialize_surface(
     manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,
@@ -681,23 +687,40 @@ fn materialize_openapi_surface(
     manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,
 ) -> Result<MaterializedSurfaceBuild, AppError> {
-    let bytes = read_descriptor(surface)?;
-    validate_materialized_surface_base_url(manifest, surface, &bytes)?;
-    let observed_sha256 = sha256_hex(&bytes);
-    let semantic_ir = import_openapi_surface(manifest, surface, &bytes).map_err(|error| {
-        AppError::FailedPrecondition(format!(
-            "failed to import source '{}' surface '{}': {error}",
-            manifest.common.name, surface.id
-        ))
-    })?;
-    let normalized_document = normalize_source_document(&bytes)
+    let descriptor = read_descriptor(surface)?;
+    validate_materialized_surface_base_url(manifest, surface, &descriptor.bytes)?;
+    let observed_sha256 = sha256_hex(&descriptor.bytes);
+    let semantic_ir = import_openapi_surface_with_descriptor(manifest, surface, &descriptor)
+        .map_err(|error| {
+            AppError::FailedPrecondition(format!(
+                "failed to import source '{}' surface '{}': {error}",
+                manifest.common.name, surface.id
+            ))
+        })?;
+    let normalized_document = normalize_source_document(&descriptor.bytes)
         .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
     Ok(MaterializedSurfaceBuild {
-        raw_document: bytes,
+        raw_document: descriptor.bytes,
         normalized_document: normalized_document.into_bytes(),
         observed_sha256,
         semantic_ir,
     })
+}
+
+fn import_openapi_surface_with_descriptor(
+    manifest: &V4SourceManifest,
+    surface: &coral_spec::v4::V4Surface,
+    descriptor: &DescriptorRead,
+) -> coral_spec::Result<SemanticIr> {
+    if let Some(base_uri) = descriptor.effective_base_uri.as_deref() {
+        return import_openapi_surface_with_base_uri(
+            manifest,
+            surface,
+            &descriptor.bytes,
+            base_uri,
+        );
+    }
+    import_openapi_surface(manifest, surface, &descriptor.bytes)
 }
 
 fn materialize_mcp_surface(
@@ -818,7 +841,7 @@ fn validate_materialized_surface_base_url(
     .map_err(|error| AppError::FailedPrecondition(error.to_string()))
 }
 
-fn read_descriptor(surface: &coral_spec::v4::V4Surface) -> Result<Vec<u8>, AppError> {
+fn read_descriptor(surface: &coral_spec::v4::V4Surface) -> Result<DescriptorRead, AppError> {
     match &surface.descriptor {
         coral_spec::v4::SurfaceDescriptor::File { file } => read_file_descriptor(file),
         coral_spec::v4::SurfaceDescriptor::Url { url } => read_url_descriptor(url),
@@ -831,7 +854,7 @@ fn read_descriptor(surface: &coral_spec::v4::V4Surface) -> Result<Vec<u8>, AppEr
     }
 }
 
-fn read_file_descriptor(file: &Path) -> Result<Vec<u8>, AppError> {
+fn read_file_descriptor(file: &Path) -> Result<DescriptorRead, AppError> {
     let canonical = canonicalize_file_descriptor(file)?;
     let metadata = std::fs::metadata(&canonical)?;
     if metadata.len() > MAX_DESCRIPTOR_BYTES {
@@ -841,7 +864,11 @@ fn read_file_descriptor(file: &Path) -> Result<Vec<u8>, AppError> {
             metadata.len()
         )));
     }
-    std::fs::read(canonical).map_err(AppError::from)
+    let bytes = std::fs::read(canonical).map_err(AppError::from)?;
+    Ok(DescriptorRead {
+        bytes,
+        effective_base_uri: None,
+    })
 }
 
 pub(crate) fn canonicalize_file_descriptor(file: &Path) -> Result<PathBuf, AppError> {
@@ -868,7 +895,7 @@ pub(crate) fn canonicalize_file_descriptor(file: &Path) -> Result<PathBuf, AppEr
     Ok(canonical)
 }
 
-fn read_url_descriptor(url: &str) -> Result<Vec<u8>, AppError> {
+fn read_url_descriptor(url: &str) -> Result<DescriptorRead, AppError> {
     let url = url.to_string();
     let panic_url = url.clone();
     std::thread::spawn(move || read_url_descriptor_on_blocking_thread(&url))
@@ -880,7 +907,7 @@ fn read_url_descriptor(url: &str) -> Result<Vec<u8>, AppError> {
         })?
 }
 
-fn read_url_descriptor_on_blocking_thread(url: &str) -> Result<Vec<u8>, AppError> {
+fn read_url_descriptor_on_blocking_thread(url: &str) -> Result<DescriptorRead, AppError> {
     ensure_https_descriptor_url(url)?;
     let client = reqwest::blocking::Client::builder()
         .timeout(DESCRIPTOR_FETCH_TIMEOUT)
@@ -910,6 +937,7 @@ fn read_url_descriptor_on_blocking_thread(url: &str) -> Result<Vec<u8>, AppError
             response.status()
         )));
     }
+    let effective_base_uri = response.url().to_string();
     if let Some(length) = response.content_length()
         && length > MAX_DESCRIPTOR_BYTES
     {
@@ -929,7 +957,10 @@ fn read_url_descriptor_on_blocking_thread(url: &str) -> Result<Vec<u8>, AppError
             "OpenAPI descriptor '{url}' is too large: exceeds {MAX_DESCRIPTOR_BYTES} bytes"
         )));
     }
-    Ok(bytes)
+    Ok(DescriptorRead {
+        bytes,
+        effective_base_uri: Some(effective_base_uri),
+    })
 }
 
 fn ensure_https_descriptor_url(url: &str) -> Result<(), AppError> {

--- a/crates/coral-spec/Cargo.toml
+++ b/crates/coral-spec/Cargo.toml
@@ -15,8 +15,10 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 thiserror.workspace = true
 jsonschema.workspace = true
+reqwest.workspace = true
 schemars.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+tempfile.workspace = true
 tracing.workspace = true

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -52,6 +52,6 @@ pub use projections::{
 pub use schema::generated_v4_source_manifest_schema;
 pub use surfaces::{
     McpToolCatalog, McpToolDescriptor, OpenApiDocumentMetadata, import_mcp_surface,
-    import_openapi_surface, normalize_mcp_tool_catalog, normalize_source_document,
-    openapi_document_metadata,
+    import_openapi_surface, import_openapi_surface_with_base_uri, normalize_mcp_tool_catalog,
+    normalize_source_document, openapi_document_metadata,
 };

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1032,6 +1032,66 @@ paths:
     );
 }
 
+#[test]
+fn importer_resolves_same_document_uri_refs() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let openapi_file = temp.path().join("openapi.yaml");
+    let manifest = parse_source_manifest_yaml(&format!(
+        r"
+name: same_document_uri_refs
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    base_url: https://api.example.com
+",
+        openapi_file.display()
+    ))
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          $ref: openapi.yaml#/components/responses/Items
+components:
+  responses:
+    Items:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: openapi.yaml#/components/schemas/Item
+  schemas:
+    Item:
+      type: object
+      properties:
+        id: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("same-document URI refs should import");
+
+    let operation = ir.operations.first().expect("operation");
+    assert_eq!(operation.output.cardinality, OutputCardinality::List);
+    assert_eq!(operation.output.type_ref, "item");
+    assert!(
+        operation.diagnostics.is_empty(),
+        "{:?}",
+        operation.diagnostics
+    );
+}
+
 fn write_external_ref_fixture(root: &Path) {
     std::fs::create_dir_all(root.join("paths")).expect("paths dir");
     std::fs::create_dir_all(root.join("parameters")).expect("parameters dir");

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1092,6 +1092,58 @@ components:
     );
 }
 
+#[test]
+fn importer_bases_relative_refs_on_supplied_descriptor_uri() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let authored_file = temp.path().join("authored/openapi.yaml");
+    let final_file = temp.path().join("final/openapi.yaml");
+    std::fs::create_dir_all(temp.path().join("final/paths")).expect("paths dir");
+    std::fs::write(
+        temp.path().join("final/paths/items.yaml"),
+        r"
+get:
+  operationId: items/list
+  responses:
+    '204': {}
+",
+    )
+    .expect("final path item");
+    let final_base_uri = url::Url::from_file_path(&final_file)
+        .expect("final descriptor uri")
+        .to_string();
+    let manifest = parse_source_manifest_yaml(&format!(
+        r"
+name: redirected_descriptor_refs
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    base_url: https://api.example.com
+",
+        authored_file.display()
+    ))
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface_with_base_uri(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    $ref: paths/items.yaml
+"
+        .as_bytes(),
+        &final_base_uri,
+    )
+    .expect("relative refs should use supplied descriptor URI");
+
+    assert_eq!(ir.operations.len(), 1);
+    assert_eq!(ir.operations.first().expect("operation").id, "items_list");
+}
+
 fn write_external_ref_fixture(root: &Path) {
     std::fs::create_dir_all(root.join("paths")).expect("paths dir");
     std::fs::create_dir_all(root.join("parameters")).expect("parameters dir");

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -930,6 +930,108 @@ paths:
     );
 }
 
+#[test]
+fn importer_ignores_unused_external_refs_in_root_components() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let openapi_file = temp.path().join("openapi.yaml");
+    let manifest = parse_source_manifest_yaml(&format!(
+        r"
+name: unused_root_refs
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    base_url: https://api.example.com
+",
+        openapi_file.display()
+    ))
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '204': {}
+components:
+  schemas:
+    Unused:
+      $ref: missing.yaml#/Nope
+"
+        .as_bytes(),
+    )
+    .expect("unused external component refs should not fail import");
+
+    assert_eq!(ir.operations.len(), 1);
+    assert_eq!(ir.operations.first().expect("operation").id, "items_list");
+}
+
+#[test]
+fn importer_ignores_unused_external_refs_in_referenced_documents() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let openapi_file = temp.path().join("openapi.yaml");
+    std::fs::create_dir_all(temp.path().join("schemas")).expect("schemas dir");
+    std::fs::write(
+        temp.path().join("schemas/items.yaml"),
+        r"
+Item:
+  type: object
+  properties:
+    id: {type: string}
+Unused:
+  $ref: missing.yaml#/Nope
+",
+    )
+    .expect("external schema");
+    let manifest = parse_source_manifest_yaml(&format!(
+        r"
+name: unused_external_refs
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    base_url: https://api.example.com
+",
+        openapi_file.display()
+    ))
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: schemas/items.yaml#/Item
+"
+        .as_bytes(),
+    )
+    .expect("unused refs in external documents should not fail import");
+
+    assert_eq!(ir.operations.len(), 1);
+    assert_eq!(
+        ir.operations.first().expect("operation").output.type_ref,
+        "item"
+    );
+}
+
 fn write_external_ref_fixture(root: &Path) {
     std::fs::create_dir_all(root.join("paths")).expect("paths dir");
     std::fs::create_dir_all(root.join("parameters")).expect("parameters dir");

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -845,7 +845,6 @@ paths:
     assert_eq!(page.name, "page");
     assert_eq!(page.data_type, IrScalarType::Integer);
     assert_eq!(operation.output.cardinality, OutputCardinality::List);
-    assert_eq!(operation.output.type_ref, "item");
     assert!(
         operation.diagnostics.is_empty(),
         "{:?}",
@@ -855,7 +854,7 @@ paths:
     let item = ir
         .types
         .iter()
-        .find(|ty| ty.id == "item")
+        .find(|ty| ty.id == operation.output.type_ref)
         .expect("item type");
     let IrTypeShape::Object { fields } = &item.shape else {
         panic!("item should import as object: {:?}", item.shape);
@@ -871,6 +870,103 @@ paths:
             .shape,
         IrTypeShape::Scalar(IrScalarType::String)
     ));
+}
+
+#[test]
+fn importer_keeps_external_ref_type_ids_distinct_by_document() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let openapi_file = temp.path().join("openapi.yaml");
+    std::fs::create_dir_all(temp.path().join("schemas")).expect("schemas dir");
+    std::fs::write(
+        temp.path().join("schemas/a.yaml"),
+        r"
+Item:
+  type: object
+  properties:
+    a_id: {type: string}
+",
+    )
+    .expect("a schema");
+    std::fs::write(
+        temp.path().join("schemas/b.yaml"),
+        r"
+Item:
+  type: object
+  properties:
+    b_id: {type: integer}
+",
+    )
+    .expect("b schema");
+    let manifest = parse_source_manifest_yaml(&format!(
+        r"
+name: external_ref_type_collisions
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    base_url: https://api.example.com
+",
+        openapi_file.display()
+    ))
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /a:
+    get:
+      operationId: a/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: schemas/a.yaml#/Item
+  /b:
+    get:
+      operationId: b/get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: schemas/b.yaml#/Item
+"
+        .as_bytes(),
+    )
+    .expect("external refs import");
+    let a = ir
+        .operations
+        .iter()
+        .find(|operation| operation.id == "a_get")
+        .expect("a operation");
+    let b = ir
+        .operations
+        .iter()
+        .find(|operation| operation.id == "b_get")
+        .expect("b operation");
+
+    assert_ne!(a.output.type_ref, b.output.type_ref);
+    assert!(a.output.type_ref.starts_with("item_"));
+    assert!(b.output.type_ref.starts_with("item_"));
+    assert_type_has_field(&ir.types, &a.output.type_ref, "a_id");
+    assert_type_has_field(&ir.types, &b.output.type_ref, "b_id");
+}
+
+fn assert_type_has_field(types: &[IrType], type_ref: &str, field_name: &str) {
+    let ty = types.iter().find(|ty| ty.id == type_ref).expect("type");
+    let IrTypeShape::Object { fields } = &ty.shape else {
+        panic!("type should import as object: {:?}", ty.shape);
+    };
+    assert!(
+        fields.iter().any(|field| field.name == field_name),
+        "type {type_ref} should have field {field_name}: {fields:?}"
+    );
 }
 
 #[test]
@@ -1026,9 +1122,10 @@ paths:
     .expect("unused refs in external documents should not fail import");
 
     assert_eq!(ir.operations.len(), 1);
-    assert_eq!(
-        ir.operations.first().expect("operation").output.type_ref,
-        "item"
+    assert_type_has_field(
+        &ir.types,
+        &ir.operations.first().expect("operation").output.type_ref,
+        "id",
     );
 }
 
@@ -1090,6 +1187,65 @@ components:
         "{:?}",
         operation.diagnostics
     );
+}
+
+#[test]
+fn importer_ignores_descriptor_uri_query_for_same_document_refs() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let openapi_file = temp.path().join("openapi.yaml");
+    let mut descriptor_uri = url::Url::from_file_path(&openapi_file).expect("descriptor uri");
+    descriptor_uri.set_query(Some("download=1"));
+    descriptor_uri.set_fragment(Some("ignored"));
+    let manifest = parse_source_manifest_yaml(&format!(
+        r"
+name: descriptor_query_refs
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    base_url: https://api.example.com
+",
+        openapi_file.display()
+    ))
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface_with_base_uri(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          $ref: openapi.yaml#/components/responses/Items
+components:
+  responses:
+    Items:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: openapi.yaml#/components/schemas/Item
+  schemas:
+    Item:
+      type: object
+      properties:
+        id: {type: string}
+"
+        .as_bytes(),
+        descriptor_uri.as_str(),
+    )
+    .expect("descriptor query should not affect same-document URI refs");
+
+    let operation = ir.operations.first().expect("operation");
+    assert_eq!(operation.output.cardinality, OutputCardinality::List);
+    assert_eq!(operation.output.type_ref, "item");
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -873,6 +873,63 @@ paths:
     ));
 }
 
+#[test]
+fn importer_rejects_file_refs_from_https_documents() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let external_file = temp.path().join("local.yaml");
+    std::fs::write(
+        &external_file,
+        r"
+get:
+  operationId: items/list
+  responses:
+    '204': {}
+",
+    )
+    .expect("external file");
+    let external_uri = url::Url::from_file_path(&external_file)
+        .expect("external file uri")
+        .to_string();
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: remote_file_ref
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let error = import_openapi_surface(
+        v4,
+        surface,
+        format!(
+            r"
+openapi: 3.0.3
+paths:
+  /items:
+    $ref: {external_uri}
+"
+        )
+        .as_bytes(),
+    )
+    .expect_err("remote descriptor must not read local file refs");
+
+    let message = error.to_string();
+    assert!(
+        message.contains("file external reference"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("is not allowed from non-file document"),
+        "unexpected error: {message}"
+    );
+}
+
 fn write_external_ref_fixture(root: &Path) {
     std::fs::create_dir_all(root.join("paths")).expect("paths dir");
     std::fs::create_dir_all(root.join("parameters")).expect("parameters dir");

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use super::*;
 use crate::{SourceTableFunctionKind, parse_source_manifest_yaml};
@@ -788,7 +789,7 @@ paths:
       operationId: external/list
       responses:
         '200':
-          $ref: 'https://example.com/openapi.yaml#/components/responses/Items'
+          $ref: '#/components/responses/MissingExternal'
 "
         .as_bytes(),
     )
@@ -800,13 +801,120 @@ paths:
         .map(|diagnostic| diagnostic.code.as_str())
         .collect::<Vec<_>>();
     assert!(codes.contains(&"OPENAPI_REF_NOT_FOUND"), "{codes:?}");
-    assert!(
-        codes.contains(&"OPENAPI_EXTERNAL_REF_UNSUPPORTED"),
-        "{codes:?}"
-    );
     for operation in &ir.operations {
         assert_eq!(operation.output.cardinality, OutputCardinality::None);
     }
+}
+
+#[test]
+fn importer_hydrates_external_openapi_refs() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_external_ref_fixture(temp.path());
+    let openapi_file = temp.path().join("openapi.yaml");
+    let manifest = parse_source_manifest_yaml(&format!(
+        r"
+name: external_refs
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    base_url: https://api.example.com
+",
+        openapi_file.display()
+    ))
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    $ref: paths/items.yaml
+"
+        .as_bytes(),
+    )
+    .expect("external refs import");
+    let operation = ir.operations.first().expect("operation");
+    assert_eq!(operation.id, "items_list");
+    assert_eq!(operation.inputs.len(), 1);
+    let page = operation.inputs.first().expect("page input");
+    assert_eq!(page.name, "page");
+    assert_eq!(page.data_type, IrScalarType::Integer);
+    assert_eq!(operation.output.cardinality, OutputCardinality::List);
+    assert_eq!(operation.output.type_ref, "item");
+    assert!(
+        operation.diagnostics.is_empty(),
+        "{:?}",
+        operation.diagnostics
+    );
+
+    let item = ir
+        .types
+        .iter()
+        .find(|ty| ty.id == "item")
+        .expect("item type");
+    let IrTypeShape::Object { fields } = &item.shape else {
+        panic!("item should import as object: {:?}", item.shape);
+    };
+    assert_eq!(fields.len(), 1);
+    let id = fields.first().expect("id field");
+    assert_eq!(id.name, "id");
+    assert!(matches!(
+        ir.types
+            .iter()
+            .find(|ty| ty.id == id.type_ref)
+            .expect("id type")
+            .shape,
+        IrTypeShape::Scalar(IrScalarType::String)
+    ));
+}
+
+fn write_external_ref_fixture(root: &Path) {
+    std::fs::create_dir_all(root.join("paths")).expect("paths dir");
+    std::fs::create_dir_all(root.join("parameters")).expect("parameters dir");
+    std::fs::create_dir_all(root.join("schemas")).expect("schemas dir");
+    std::fs::write(
+        root.join("paths/items.yaml"),
+        r"
+get:
+  operationId: items/list
+  parameters:
+    - $ref: ../parameters/page.yaml#/Page
+  responses:
+    '200':
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: ../schemas/item.yaml#/Item
+",
+    )
+    .expect("path ref");
+    std::fs::write(
+        root.join("parameters/page.yaml"),
+        r"
+Page:
+  name: page
+  in: query
+  schema: {type: integer}
+",
+    )
+    .expect("parameter ref");
+    std::fs::write(
+        root.join("schemas/item.yaml"),
+        r"
+Item:
+  type: object
+  properties:
+    id: {type: string}
+",
+    )
+    .expect("schema ref");
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/surfaces/mod.rs
+++ b/crates/coral-spec/src/v4/surfaces/mod.rs
@@ -4,6 +4,6 @@ mod openapi;
 
 pub use mcp::{McpToolCatalog, McpToolDescriptor, import_mcp_surface, normalize_mcp_tool_catalog};
 pub use openapi::{
-    OpenApiDocumentMetadata, import_openapi_surface, normalize_source_document,
-    openapi_document_metadata,
+    OpenApiDocumentMetadata, import_openapi_surface, import_openapi_surface_with_base_uri,
+    normalize_source_document, openapi_document_metadata,
 };

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -3,7 +3,7 @@ use std::io::Read as _;
 use std::path::Path;
 use std::time::Duration;
 
-use serde_json::Value;
+use serde_json::{Map, Value};
 use url::Url;
 
 use crate::v4::diagnostics::Diagnostic;
@@ -73,11 +73,13 @@ fn dereference_openapi_document(surface: &V4Surface, document: &Value) -> Result
             surface.id
         ))
     })?;
+    let reachable_document = reachable_openapi_document(document);
     let mut seen = BTreeSet::new();
     let mut external_documents = BTreeMap::new();
     collect_external_ref_documents(
         &parsed_descriptor_url,
-        document,
+        &reachable_document,
+        &reachable_document,
         &mut seen,
         &mut external_documents,
     )
@@ -110,7 +112,7 @@ fn dereference_openapi_document(surface: &V4Surface, document: &Value) -> Result
     jsonschema::options()
         .with_base_uri(base_uri)
         .with_registry(&registry)
-        .dereference(document)
+        .dereference(&reachable_document)
         .map_err(|error| {
             ManifestError::validation(format!(
                 "failed to dereference OpenAPI document for surface '{}': {error}",
@@ -121,35 +123,35 @@ fn dereference_openapi_document(surface: &V4Surface, document: &Value) -> Result
 
 fn collect_external_ref_documents(
     base_uri: &Url,
+    document: &Value,
     value: &Value,
     seen: &mut BTreeSet<String>,
     external_documents: &mut BTreeMap<String, Value>,
 ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
     match value {
         Value::Object(object) => {
-            if let Some(reference) = object.get("$ref").and_then(Value::as_str)
-                && let Some(document_uri) = external_ref_document_uri(base_uri, reference)?
-            {
-                let document_uri_string = document_uri.to_string();
-                if seen.insert(document_uri_string.clone()) {
-                    let mut document = retrieve_external_ref_document(base_uri, &document_uri)?;
-                    annotate_ref_sites(&mut document);
-                    collect_external_ref_documents(
-                        &document_uri,
-                        &document,
-                        seen,
-                        external_documents,
-                    )?;
-                    external_documents.insert(document_uri_string, document);
-                }
+            if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+                collect_ref_documents(base_uri, document, reference, seen, external_documents)?;
             }
             for value in object.values() {
-                collect_external_ref_documents(base_uri, value, seen, external_documents)?;
+                collect_external_ref_documents(
+                    base_uri,
+                    document,
+                    value,
+                    seen,
+                    external_documents,
+                )?;
             }
         }
         Value::Array(values) => {
             for value in values {
-                collect_external_ref_documents(base_uri, value, seen, external_documents)?;
+                collect_external_ref_documents(
+                    base_uri,
+                    document,
+                    value,
+                    seen,
+                    external_documents,
+                )?;
             }
         }
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
@@ -157,18 +159,172 @@ fn collect_external_ref_documents(
     Ok(())
 }
 
-fn external_ref_document_uri(
+fn collect_ref_documents(
     base_uri: &Url,
+    document: &Value,
     reference: &str,
-) -> std::result::Result<Option<Url>, Box<dyn std::error::Error + Send + Sync>> {
-    if reference.starts_with('#') {
-        return Ok(None);
+    seen: &mut BTreeSet<String>,
+    external_documents: &mut BTreeMap<String, Value>,
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let resolved_ref_uri = base_uri.join(reference)?;
+    let resolved_ref_uri_string = resolved_ref_uri.to_string();
+    if !seen.insert(resolved_ref_uri_string) {
+        return Ok(());
     }
-    let mut resolved = base_uri.join(reference)?;
-    resolved.set_fragment(None);
     let mut base_document_uri = base_uri.clone();
     base_document_uri.set_fragment(None);
-    Ok((resolved != base_document_uri).then_some(resolved))
+    let mut document_uri = resolved_ref_uri.clone();
+    document_uri.set_fragment(None);
+
+    if document_uri == base_document_uri {
+        let Ok(target) = ref_target(document, &resolved_ref_uri) else {
+            return Ok(());
+        };
+        let target = target.clone();
+        return collect_external_ref_documents(
+            base_uri,
+            document,
+            &target,
+            seen,
+            external_documents,
+        );
+    }
+
+    let document_uri_string = document_uri.to_string();
+    if !external_documents.contains_key(&document_uri_string) {
+        let mut document = retrieve_external_ref_document(base_uri, &document_uri)?;
+        annotate_ref_sites(&mut document);
+        external_documents.insert(document_uri_string.clone(), document);
+    }
+    let external_document = external_documents
+        .get(&document_uri_string)
+        .expect("external document was inserted")
+        .clone();
+    let target = ref_target(&external_document, &resolved_ref_uri)?.clone();
+    collect_external_ref_documents(
+        &document_uri,
+        &external_document,
+        &target,
+        seen,
+        external_documents,
+    )
+}
+
+fn ref_target<'a>(
+    document: &'a Value,
+    resolved_ref_uri: &Url,
+) -> std::result::Result<&'a Value, Box<dyn std::error::Error + Send + Sync>> {
+    let Some(fragment) = resolved_ref_uri.fragment() else {
+        return Ok(document);
+    };
+    if fragment.is_empty() {
+        return Ok(document);
+    }
+    if !fragment.starts_with('/') {
+        return Err(std::io::Error::other(format!(
+            "OpenAPI reference '{resolved_ref_uri}' uses unsupported fragment '{fragment}'"
+        ))
+        .into());
+    }
+    document.pointer(fragment).ok_or_else(|| {
+        std::io::Error::other(format!(
+            "OpenAPI reference target '{resolved_ref_uri}' was not found"
+        ))
+        .into()
+    })
+}
+
+fn reachable_openapi_document(document: &Value) -> Value {
+    let mut reachable = Value::Object(Map::new());
+    for key in ["openapi", "paths"] {
+        if let Some(value) = document.get(key) {
+            reachable
+                .as_object_mut()
+                .expect("reachable document is an object")
+                .insert(key.to_string(), value.clone());
+        }
+    }
+
+    let mut seen = BTreeSet::new();
+    let mut pointers = BTreeSet::new();
+    if let Some(paths) = document.get("paths") {
+        collect_reachable_local_ref_pointers(document, paths, &mut seen, &mut pointers);
+    }
+    for pointer in pointers {
+        if let Some(value) = document.pointer(&pointer) {
+            insert_json_pointer(&mut reachable, &pointer, value.clone());
+        }
+    }
+
+    reachable
+}
+
+fn collect_reachable_local_ref_pointers(
+    document: &Value,
+    value: &Value,
+    seen: &mut BTreeSet<String>,
+    pointers: &mut BTreeSet<String>,
+) {
+    match value {
+        Value::Object(object) => {
+            if let Some(reference) = object.get("$ref").and_then(Value::as_str)
+                && let Some(pointer) = reference.strip_prefix('#')
+                && pointer.starts_with('/')
+                && seen.insert(pointer.to_string())
+            {
+                pointers.insert(pointer.to_string());
+                if let Some(target) = document.pointer(pointer) {
+                    collect_reachable_local_ref_pointers(document, target, seen, pointers);
+                }
+            }
+            for value in object.values() {
+                collect_reachable_local_ref_pointers(document, value, seen, pointers);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_reachable_local_ref_pointers(document, value, seen, pointers);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn insert_json_pointer(document: &mut Value, pointer: &str, value: Value) {
+    let Some(pointer) = pointer.strip_prefix('/') else {
+        *document = value;
+        return;
+    };
+    let segments = pointer
+        .split('/')
+        .map(decode_json_pointer_segment)
+        .collect::<Vec<_>>();
+    insert_json_pointer_segments(document, &segments, value);
+}
+
+fn insert_json_pointer_segments(document: &mut Value, segments: &[String], value: Value) {
+    let Some((segment, rest)) = segments.split_first() else {
+        *document = value;
+        return;
+    };
+    if !document.is_object() {
+        *document = Value::Object(Map::new());
+    }
+    let object = document
+        .as_object_mut()
+        .expect("JSON pointer destination is an object");
+    if rest.is_empty() {
+        object.insert(segment.clone(), value);
+        return;
+    }
+    let child = object
+        .entry(segment.clone())
+        .or_insert_with(|| Value::Object(Map::new()));
+    insert_json_pointer_segments(child, rest, value);
+}
+
+fn decode_json_pointer_segment(segment: &str) -> String {
+    segment.replace("~1", "/").replace("~0", "~")
 }
 
 fn openapi_document_base_uri(surface: &V4Surface) -> Result<String> {

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -1,20 +1,29 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::io::Read as _;
+use std::path::Path;
+use std::time::Duration;
 
 use serde_json::Value;
+use url::Url;
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrType, SemanticIr};
-use crate::v4::manifest::{V4SourceManifest, V4Surface};
+use crate::v4::manifest::{SurfaceDescriptor, V4SourceManifest, V4Surface};
 use crate::v4::surfaces::json_schema::{RefError, resolve_local_ref};
 use crate::v4::{OPENAPI_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
 use crate::{ManifestError, Result};
+
+const ORIGINAL_REF_EXTENSION: &str = "x-coral-original-ref";
+const EXTERNAL_REF_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_EXTERNAL_REF_BYTES: u64 = 16 * 1024 * 1024;
+const EXTERNAL_REF_USER_AGENT: &str = "coral-openapi-importer";
 
 pub fn import_openapi_surface(
     manifest: &V4SourceManifest,
     surface: &V4Surface,
     document_bytes: &[u8],
 ) -> Result<SemanticIr> {
-    let document: Value =
+    let mut document: Value =
         serde_yaml::from_slice(document_bytes).map_err(ManifestError::parse_yaml)?;
     let openapi = document
         .get("openapi")
@@ -27,8 +36,290 @@ pub fn import_openapi_surface(
         )));
     }
 
+    annotate_ref_sites(&mut document);
+    let document = dereference_openapi_document(surface, &document)?;
     let mut importer = OpenApiImporter::new(manifest, surface, &document);
     importer.import()
+}
+
+fn annotate_ref_sites(value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            if let Some(reference) = object
+                .get("$ref")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+            {
+                object.insert(ORIGINAL_REF_EXTENSION.to_string(), Value::String(reference));
+            }
+            for value in object.values_mut() {
+                annotate_ref_sites(value);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                annotate_ref_sites(value);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn dereference_openapi_document(surface: &V4Surface, document: &Value) -> Result<Value> {
+    let base_uri = openapi_document_base_uri(surface)?;
+    let parsed_descriptor_url = Url::parse(&base_uri).map_err(|error| {
+        ManifestError::validation(format!(
+            "OpenAPI descriptor base URI '{base_uri}' for surface '{}' is invalid: {error}",
+            surface.id
+        ))
+    })?;
+    let mut seen = BTreeSet::new();
+    let mut external_documents = BTreeMap::new();
+    collect_external_ref_documents(
+        &parsed_descriptor_url,
+        document,
+        &mut seen,
+        &mut external_documents,
+    )
+    .map_err(|error| {
+        ManifestError::validation(format!(
+            "failed to load OpenAPI external references for surface '{}': {error}",
+            surface.id
+        ))
+    })?;
+    if external_documents.is_empty() {
+        return Ok(document.clone());
+    }
+
+    let mut registry = jsonschema::Registry::new();
+    for (uri, document) in external_documents {
+        registry = registry.add(uri, document).map_err(|error| {
+            ManifestError::validation(format!(
+                "failed to register OpenAPI external reference for surface '{}': {error}",
+                surface.id
+            ))
+        })?;
+    }
+    let registry = registry.prepare().map_err(|error| {
+        ManifestError::validation(format!(
+            "failed to prepare OpenAPI external reference registry for surface '{}': {error}",
+            surface.id
+        ))
+    })?;
+
+    jsonschema::options()
+        .with_base_uri(base_uri)
+        .with_registry(&registry)
+        .dereference(document)
+        .map_err(|error| {
+            ManifestError::validation(format!(
+                "failed to dereference OpenAPI document for surface '{}': {error}",
+                surface.id
+            ))
+        })
+}
+
+fn collect_external_ref_documents(
+    base_uri: &Url,
+    value: &Value,
+    seen: &mut BTreeSet<String>,
+    external_documents: &mut BTreeMap<String, Value>,
+) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    match value {
+        Value::Object(object) => {
+            if let Some(reference) = object.get("$ref").and_then(Value::as_str)
+                && let Some(document_uri) = external_ref_document_uri(base_uri, reference)?
+            {
+                let document_uri_string = document_uri.to_string();
+                if seen.insert(document_uri_string.clone()) {
+                    let mut document = retrieve_external_ref_document(&document_uri)?;
+                    annotate_ref_sites(&mut document);
+                    collect_external_ref_documents(
+                        &document_uri,
+                        &document,
+                        seen,
+                        external_documents,
+                    )?;
+                    external_documents.insert(document_uri_string, document);
+                }
+            }
+            for value in object.values() {
+                collect_external_ref_documents(base_uri, value, seen, external_documents)?;
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_external_ref_documents(base_uri, value, seen, external_documents)?;
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+    Ok(())
+}
+
+fn external_ref_document_uri(
+    base_uri: &Url,
+    reference: &str,
+) -> std::result::Result<Option<Url>, Box<dyn std::error::Error + Send + Sync>> {
+    if reference.starts_with('#') {
+        return Ok(None);
+    }
+    let mut resolved = base_uri.join(reference)?;
+    resolved.set_fragment(None);
+    let mut base_document_uri = base_uri.clone();
+    base_document_uri.set_fragment(None);
+    Ok((resolved != base_document_uri).then_some(resolved))
+}
+
+fn openapi_document_base_uri(surface: &V4Surface) -> Result<String> {
+    match &surface.descriptor {
+        SurfaceDescriptor::Url { url } => Ok(url.clone()),
+        SurfaceDescriptor::File { file } => file_descriptor_base_uri(file),
+        SurfaceDescriptor::McpServer { .. } => Err(ManifestError::validation(format!(
+            "DSL v4 MCP surface '{}' does not have an OpenAPI descriptor",
+            surface.id
+        ))),
+    }
+}
+
+fn file_descriptor_base_uri(file: &Path) -> Result<String> {
+    Url::from_file_path(file)
+        .map(|url| url.to_string())
+        .map_err(|()| {
+            ManifestError::validation(format!(
+                "OpenAPI descriptor '{}' could not be converted to a file URI",
+                file.display()
+            ))
+        })
+}
+
+fn retrieve_external_ref_document(
+    uri: &Url,
+) -> std::result::Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+    match uri.scheme() {
+        "https" => retrieve_https_external_ref(uri),
+        "file" => retrieve_file_external_ref(uri),
+        "http" => Err(std::io::Error::other(format!(
+            "OpenAPI external reference '{uri}' must use HTTPS"
+        ))
+        .into()),
+        scheme => Err(std::io::Error::other(format!(
+            "unsupported OpenAPI external reference scheme '{scheme}' for '{uri}'"
+        ))
+        .into()),
+    }
+}
+
+fn retrieve_https_external_ref(
+    uri: &Url,
+) -> std::result::Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+    let uri = uri.to_string();
+    let panic_uri = uri.clone();
+    std::thread::spawn(move || retrieve_https_external_ref_on_blocking_thread(&uri))
+        .join()
+        .map_err(|_panic| {
+            std::io::Error::other(format!(
+                "failed to fetch OpenAPI external reference '{panic_uri}': fetch thread panicked"
+            ))
+        })?
+}
+
+fn retrieve_file_external_ref(
+    uri: &Url,
+) -> std::result::Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+    let path = uri.to_file_path().map_err(|()| {
+        std::io::Error::other(format!(
+            "OpenAPI external reference '{uri}' is not a valid file URI"
+        ))
+    })?;
+    let metadata = std::fs::symlink_metadata(&path)?;
+    if metadata.file_type().is_symlink() {
+        return Err(std::io::Error::other(format!(
+            "OpenAPI external reference '{}' must not be a symlink",
+            path.display()
+        ))
+        .into());
+    }
+    if !metadata.file_type().is_file() {
+        return Err(std::io::Error::other(format!(
+            "OpenAPI external reference '{}' must be a regular file",
+            path.display()
+        ))
+        .into());
+    }
+    if metadata.len() > MAX_EXTERNAL_REF_BYTES {
+        return Err(std::io::Error::other(format!(
+            "OpenAPI external reference '{}' is too large: {} bytes exceeds {MAX_EXTERNAL_REF_BYTES}",
+            path.display(),
+            metadata.len()
+        ))
+        .into());
+    }
+    let bytes = std::fs::read(&path)?;
+    parse_external_ref_document(uri.as_str(), &bytes)
+}
+
+fn retrieve_https_external_ref_on_blocking_thread(
+    uri: &str,
+) -> std::result::Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(EXTERNAL_REF_FETCH_TIMEOUT)
+        .https_only(true)
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .user_agent(EXTERNAL_REF_USER_AGENT)
+        .build()?;
+    let mut response = client.get(uri).send()?;
+    if response.url().scheme() != "https" {
+        return Err(std::io::Error::other(format!(
+            "OpenAPI external reference '{uri}' redirected to non-HTTPS URL '{}'",
+            response.url()
+        ))
+        .into());
+    }
+    if !response.status().is_success() {
+        return Err(std::io::Error::other(format!(
+            "failed to fetch OpenAPI external reference '{uri}': HTTP {}",
+            response.status()
+        ))
+        .into());
+    }
+    if let Some(length) = response.content_length()
+        && length > MAX_EXTERNAL_REF_BYTES
+    {
+        return Err(std::io::Error::other(format!(
+                "OpenAPI external reference '{uri}' is too large: {length} bytes exceeds {MAX_EXTERNAL_REF_BYTES}"
+            ))
+            .into());
+    }
+    let mut bytes = Vec::new();
+    let mut limited = response.by_ref().take(MAX_EXTERNAL_REF_BYTES + 1);
+    limited.read_to_end(&mut bytes)?;
+    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > MAX_EXTERNAL_REF_BYTES {
+        return Err(std::io::Error::other(format!(
+                "OpenAPI external reference '{uri}' is too large: exceeds {MAX_EXTERNAL_REF_BYTES} bytes"
+            ))
+            .into());
+    }
+    parse_external_ref_document(uri, &bytes)
+}
+
+fn parse_external_ref_document(
+    uri: &str,
+    bytes: &[u8],
+) -> std::result::Result<Value, Box<dyn std::error::Error + Send + Sync>> {
+    serde_yaml::from_slice(bytes).map_err(|error| {
+        std::io::Error::other(format!(
+            "failed to parse OpenAPI external reference '{uri}' as YAML/JSON: {error}"
+        ))
+        .into()
+    })
+}
+
+pub(super) fn original_ref(value: &Value) -> Option<&str> {
+    value
+        .get("$ref")
+        .or_else(|| value.get(ORIGINAL_REF_EXTENSION))
+        .and_then(Value::as_str)
 }
 
 pub(super) struct OpenApiImporter<'a> {

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -73,7 +73,9 @@ fn dereference_openapi_document(surface: &V4Surface, document: &Value) -> Result
             surface.id
         ))
     })?;
-    let reachable_document = reachable_openapi_document(document);
+    let mut document = document.clone();
+    normalize_same_document_refs(&parsed_descriptor_url, &mut document);
+    let reachable_document = reachable_openapi_document(&document);
     let mut seen = BTreeSet::new();
     let mut external_documents = BTreeMap::new();
     collect_external_ref_documents(
@@ -90,7 +92,7 @@ fn dereference_openapi_document(surface: &V4Surface, document: &Value) -> Result
         ))
     })?;
     if external_documents.is_empty() {
-        return Ok(document.clone());
+        return Ok(document);
     }
 
     let mut registry = jsonschema::Registry::new();
@@ -194,6 +196,7 @@ fn collect_ref_documents(
     if !external_documents.contains_key(&document_uri_string) {
         let mut document = retrieve_external_ref_document(base_uri, &document_uri)?;
         annotate_ref_sites(&mut document);
+        normalize_same_document_refs(&document_uri, &mut document);
         external_documents.insert(document_uri_string.clone(), document);
     }
     let external_document = external_documents
@@ -325,6 +328,43 @@ fn insert_json_pointer_segments(document: &mut Value, segments: &[String], value
 
 fn decode_json_pointer_segment(segment: &str) -> String {
     segment.replace("~1", "/").replace("~0", "~")
+}
+
+fn normalize_same_document_refs(base_uri: &Url, value: &mut Value) {
+    match value {
+        Value::Object(object) => {
+            if let Some(reference) = object.get("$ref").and_then(Value::as_str)
+                && let Some(local_reference) = same_document_local_ref(base_uri, reference)
+            {
+                object.insert("$ref".to_string(), Value::String(local_reference));
+            }
+            for value in object.values_mut() {
+                normalize_same_document_refs(base_uri, value);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                normalize_same_document_refs(base_uri, value);
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn same_document_local_ref(base_uri: &Url, reference: &str) -> Option<String> {
+    if reference.starts_with('#') {
+        return None;
+    }
+    let resolved_ref_uri = base_uri.join(reference).ok()?;
+    let fragment = resolved_ref_uri.fragment()?.to_string();
+    if !fragment.starts_with('/') {
+        return None;
+    }
+    let mut document_uri = resolved_ref_uri;
+    document_uri.set_fragment(None);
+    let mut base_document_uri = base_uri.clone();
+    base_document_uri.set_fragment(None);
+    (document_uri == base_document_uri).then(|| format!("#{fragment}"))
 }
 
 fn openapi_document_base_uri(surface: &V4Surface) -> Result<String> {

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -23,6 +23,16 @@ pub fn import_openapi_surface(
     surface: &V4Surface,
     document_bytes: &[u8],
 ) -> Result<SemanticIr> {
+    let base_uri = openapi_document_base_uri(surface)?;
+    import_openapi_surface_with_base_uri(manifest, surface, document_bytes, &base_uri)
+}
+
+pub fn import_openapi_surface_with_base_uri(
+    manifest: &V4SourceManifest,
+    surface: &V4Surface,
+    document_bytes: &[u8],
+    descriptor_base_uri: &str,
+) -> Result<SemanticIr> {
     let mut document: Value =
         serde_yaml::from_slice(document_bytes).map_err(ManifestError::parse_yaml)?;
     let openapi = document
@@ -37,7 +47,7 @@ pub fn import_openapi_surface(
     }
 
     annotate_ref_sites(&mut document);
-    let document = dereference_openapi_document(surface, &document)?;
+    let document = dereference_openapi_document(surface, descriptor_base_uri, &document)?;
     let mut importer = OpenApiImporter::new(manifest, surface, &document);
     importer.import()
 }
@@ -65,11 +75,14 @@ fn annotate_ref_sites(value: &mut Value) {
     }
 }
 
-fn dereference_openapi_document(surface: &V4Surface, document: &Value) -> Result<Value> {
-    let base_uri = openapi_document_base_uri(surface)?;
-    let parsed_descriptor_url = Url::parse(&base_uri).map_err(|error| {
+fn dereference_openapi_document(
+    surface: &V4Surface,
+    descriptor_base_uri: &str,
+    document: &Value,
+) -> Result<Value> {
+    let parsed_descriptor_url = Url::parse(descriptor_base_uri).map_err(|error| {
         ManifestError::validation(format!(
-            "OpenAPI descriptor base URI '{base_uri}' for surface '{}' is invalid: {error}",
+            "OpenAPI descriptor base URI '{descriptor_base_uri}' for surface '{}' is invalid: {error}",
             surface.id
         ))
     })?;
@@ -112,7 +125,7 @@ fn dereference_openapi_document(surface: &V4Surface, document: &Value) -> Result
     })?;
 
     jsonschema::options()
-        .with_base_uri(base_uri)
+        .with_base_uri(descriptor_base_uri)
         .with_registry(&registry)
         .dereference(&reachable_document)
         .map_err(|error| {

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -80,12 +80,8 @@ fn dereference_openapi_document(
     descriptor_base_uri: &str,
     document: &Value,
 ) -> Result<Value> {
-    let parsed_descriptor_url = Url::parse(descriptor_base_uri).map_err(|error| {
-        ManifestError::validation(format!(
-            "OpenAPI descriptor base URI '{descriptor_base_uri}' for surface '{}' is invalid: {error}",
-            surface.id
-        ))
-    })?;
+    let parsed_descriptor_url = normalized_descriptor_base_uri(surface, descriptor_base_uri)?;
+    let descriptor_base_uri = parsed_descriptor_url.to_string();
     let mut document = document.clone();
     normalize_same_document_refs(&parsed_descriptor_url, &mut document);
     let reachable_document = reachable_openapi_document(&document);
@@ -125,7 +121,7 @@ fn dereference_openapi_document(
     })?;
 
     jsonschema::options()
-        .with_base_uri(descriptor_base_uri)
+        .with_base_uri(&descriptor_base_uri)
         .with_registry(&registry)
         .dereference(&reachable_document)
         .map_err(|error| {
@@ -134,6 +130,18 @@ fn dereference_openapi_document(
                 surface.id
             ))
         })
+}
+
+fn normalized_descriptor_base_uri(surface: &V4Surface, descriptor_base_uri: &str) -> Result<Url> {
+    let mut url = Url::parse(descriptor_base_uri).map_err(|error| {
+        ManifestError::validation(format!(
+            "OpenAPI descriptor base URI '{descriptor_base_uri}' for surface '{}' is invalid: {error}",
+            surface.id
+        ))
+    })?;
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url)
 }
 
 fn collect_external_ref_documents(

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -132,7 +132,7 @@ fn collect_external_ref_documents(
             {
                 let document_uri_string = document_uri.to_string();
                 if seen.insert(document_uri_string.clone()) {
-                    let mut document = retrieve_external_ref_document(&document_uri)?;
+                    let mut document = retrieve_external_ref_document(base_uri, &document_uri)?;
                     annotate_ref_sites(&mut document);
                     collect_external_ref_documents(
                         &document_uri,
@@ -194,11 +194,16 @@ fn file_descriptor_base_uri(file: &Path) -> Result<String> {
 }
 
 fn retrieve_external_ref_document(
+    referring_document_uri: &Url,
     uri: &Url,
 ) -> std::result::Result<Value, Box<dyn std::error::Error + Send + Sync>> {
     match uri.scheme() {
         "https" => retrieve_https_external_ref(uri),
-        "file" => retrieve_file_external_ref(uri),
+        "file" if referring_document_uri.scheme() == "file" => retrieve_file_external_ref(uri),
+        "file" => Err(std::io::Error::other(format!(
+            "OpenAPI file external reference '{uri}' is not allowed from non-file document '{referring_document_uri}'"
+        ))
+        .into()),
         "http" => Err(std::io::Error::other(format!(
             "OpenAPI external reference '{uri}' must use HTTPS"
         ))

--- a/crates/coral-spec/src/v4/surfaces/openapi/mod.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/mod.rs
@@ -5,4 +5,4 @@ mod responses;
 mod schemas;
 
 pub use document::{OpenApiDocumentMetadata, normalize_source_document, openapi_document_metadata};
-pub use import::import_openapi_surface;
+pub use import::{import_openapi_surface, import_openapi_surface_with_base_uri};

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -6,7 +6,7 @@ use crate::v4::ir::{
     IrEntityCandidate, IrOperationOutput, OutputCardinality, RestResponseAttachment,
 };
 
-use super::import::OpenApiImporter;
+use super::import::{OpenApiImporter, original_ref};
 
 impl OpenApiImporter<'_> {
     pub(super) fn import_response(
@@ -189,9 +189,7 @@ fn classify_response_schema(
             OutputCardinality::List,
             Vec::new(),
             item.clone(),
-            item.get("$ref")
-                .and_then(Value::as_str)
-                .map(entity_name_from_ref),
+            original_ref(&item).map(entity_name_from_ref),
         );
     }
     if schema
@@ -210,18 +208,14 @@ fn classify_response_schema(
                 OutputCardinality::WrappedList,
                 vec![property_name.to_string()],
                 item.clone(),
-                item.get("$ref")
-                    .and_then(Value::as_str)
-                    .map(entity_name_from_ref),
+                original_ref(&item).map(entity_name_from_ref),
             );
         }
         return (
             OutputCardinality::Singleton,
             Vec::new(),
             schema.clone(),
-            schema
-                .get("$ref")
-                .and_then(Value::as_str)
+            original_ref(schema)
                 .map(entity_name_from_ref)
                 .or_else(|| Some(entity_name_from_path(path))),
         );

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{IrField, IrType, IrTypeShape};
-use crate::v4::naming::normalize_identifier;
+use crate::v4::naming::{normalize_identifier, stable_suffix};
 use crate::v4::surfaces::json_schema::{
     JsonSchemaComparisonError, direct_json_object_shape, json_schema_required_fields,
     json_schema_scalar_type, merge_json_schema_properties_exact,
@@ -209,5 +209,16 @@ fn enum_value(value: &Value) -> String {
 }
 
 fn type_id_from_ref(reference: &str) -> String {
+    if !reference.starts_with('#') {
+        return format!(
+            "{}_{}",
+            local_type_id_from_ref(reference),
+            stable_suffix(reference)
+        );
+    }
+    local_type_id_from_ref(reference)
+}
+
+fn local_type_id_from_ref(reference: &str) -> String {
     normalize_identifier(reference.rsplit('/').next().unwrap_or(reference), "type")
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/schemas.rs
@@ -10,7 +10,7 @@ use crate::v4::surfaces::json_schema::{
     json_schema_scalar_type, merge_json_schema_properties_exact,
 };
 
-use super::import::OpenApiImporter;
+use super::import::{OpenApiImporter, original_ref};
 
 impl OpenApiImporter<'_> {
     #[expect(
@@ -25,7 +25,7 @@ impl OpenApiImporter<'_> {
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Option<String> {
         let resolved = self.resolve_ref(schema, operation_id, diagnostics)?;
-        let type_id = schema.get("$ref").and_then(Value::as_str).map_or_else(
+        let type_id = original_ref(schema).map_or_else(
             || normalize_identifier(suggested_id, "type"),
             type_id_from_ref,
         );
@@ -187,7 +187,7 @@ impl OpenApiImporter<'_> {
         if let Some(description) = schema.get("description").and_then(Value::as_str) {
             return description.to_string();
         }
-        let Some(reference) = schema.get("$ref").and_then(Value::as_str) else {
+        let Some(reference) = original_ref(schema) else {
             return String::new();
         };
         let Some(pointer) = reference.strip_prefix('#') else {


### PR DESCRIPTION
## Summary

- Hydrates reachable external OpenAPI `$ref`s before DSL v4 import, including recursive file/HTTPS refs and same-document URI refs.
- Preserves original `$ref` names after dereferencing so response/entity/type names still come from the authored schema references.
- Avoids fetching unused root/component refs, blocks local file refs from remote descriptors, and applies HTTPS, redirect, timeout, and size checks to remote external refs.
- Uses the final descriptor URL after redirects as the base URI for resolving relative refs during materialization.

## Stack

- Targets #1499 / `sw/upgrade-jsonschema-crate`.

## Testing

- `cargo test -p coral-spec v4::openapi_tests`
- `cargo test -p coral-app materialization`

### Testing with the Sentry API

Spec: https://github.com/getsentry/sentry/blob/master/api-docs/openapi.json

```
export SENTRY_TOKEN=xxx
target/debug/coral source add --file ~/misc/sentry_v4/manifest.yaml
target/debug/coral sql "select function_name from coral.table_functions where schema_name = 'sentry_v4'"
+-----------------------------------------------------------------------+
| function_name                                                         |
+-----------------------------------------------------------------------+
| events_list_a_project_s_issues                                        |
| events_list_a_tag_s_values_related_to_an_issue                        |
| integration_list_an_organization_s_integration_platform_installations |
| projects_list_a_project_s_service_hooks                               |
| projects_list_a_project_s_user_feedback                               |
| projects_list_a_tag_s_values                                          |
| projects_retrieve_a_service_hook                                      |
+-----------------------------------------------------------------------+
```

NB: the weird function names are Coral working as expected; the Sentry API uses [verbose operation IDs](https://github.com/getsentry/sentry/blob/3695cb5af603bc8f7198f5808421083c2b47bad6/api-docs/paths/projects/service-hooks.json#L5).