### PR TITLE
feat(engine): execute UDF table functions

### DIFF
--- a/crates/coral-app/src/catalog/service.rs
+++ b/crates/coral-app/src/catalog/service.rs
@@ -44,7 +44,7 @@ impl CatalogServiceApi for CatalogService {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
         let attribution = QueryAttribution::from_extensions(request.extensions());
-        instrument_grpc(span, async move {
+        Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let pagination = pagination_from_proto(request.pagination.unwrap_or_default());
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -74,7 +74,7 @@ impl CatalogServiceApi for CatalogService {
                     table_function_count: catalog_page.counts.table_function_count,
                 }),
             }))
-        })
+        }))
         .await
     }
 
@@ -85,7 +85,7 @@ impl CatalogServiceApi for CatalogService {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
         let attribution = QueryAttribution::from_extensions(request.extensions());
-        instrument_grpc(span, async move {
+        Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let schema_name = optional_trimmed(&request.schema_name);
@@ -121,7 +121,7 @@ impl CatalogServiceApi for CatalogService {
                     .collect(),
                 pagination: Some(pagination),
             }))
-        })
+        }))
         .await
     }
 
@@ -132,7 +132,7 @@ impl CatalogServiceApi for CatalogService {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
         let attribution = QueryAttribution::from_extensions(request.extensions());
-        instrument_grpc(span, async move {
+        Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let schema_name = required_trimmed(&request.schema_name, "schema_name")?;
@@ -149,7 +149,7 @@ impl CatalogServiceApi for CatalogService {
                 &workspace_name,
                 result,
             )))
-        })
+        }))
         .await
     }
 
@@ -160,7 +160,7 @@ impl CatalogServiceApi for CatalogService {
         let span = grpc_span(&request);
         let catalog = self.catalog.clone();
         let attribution = QueryAttribution::from_extensions(request.extensions());
-        instrument_grpc(span, async move {
+        Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let schema_name = required_trimmed(&request.schema_name, "schema_name")?;
@@ -199,7 +199,7 @@ impl CatalogServiceApi for CatalogService {
                     .collect(),
                 pagination: Some(pagination),
             }))
-        })
+        }))
         .await
     }
 }

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -529,6 +529,8 @@ pub struct QueryRuntimeConfig {
     pub memory: QueryMemoryConfig,
     /// Runtime policy for dependent predicate pushdown.
     pub dependent_join: DependentJoinConfig,
+    /// Validated UDFs available in this runtime build.
+    pub udfs: Vec<super::UdfRuntimeDefinition>,
 }
 
 impl QueryRuntimeConfig {
@@ -540,7 +542,15 @@ impl QueryRuntimeConfig {
             extensions,
             memory: QueryMemoryConfig::default(),
             dependent_join: DependentJoinConfig::default(),
+            udfs: Vec::new(),
         }
+    }
+
+    /// Attaches validated UDFs to this runtime config.
+    #[must_use]
+    pub fn with_udfs(mut self, udfs: Vec<super::UdfRuntimeDefinition>) -> Self {
+        self.udfs = udfs;
+        self
     }
 }
 

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -13,4 +13,5 @@ pub(crate) mod registry;
 pub(crate) mod schema_provider;
 pub(crate) mod scoped_table_functions;
 pub(crate) mod source_functions;
+pub(crate) mod udf_calls;
 pub(crate) mod udfs;

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -12,7 +12,8 @@ use datafusion::error::DataFusionError;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::logical_expr::{Expr, LogicalPlan};
-use datafusion::physical_plan::displayable;
+use datafusion::optimizer::Analyzer as DataFusionAnalyzer;
+use datafusion::physical_plan::{collect, displayable};
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
 use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
 use tokio::sync::OnceCell;
@@ -38,7 +39,9 @@ use crate::runtime::scoped_table_functions::ScopedTableFunctionName;
 use crate::runtime::source_functions::{
     SOURCE_FUNCTION_NODE_NAME, SourceFunctionNode, SourceFunctionRegistry,
 };
-use crate::runtime::udf_calls::{UDF_CALL_NODE_NAME, UdfCallNode, UdfCallRegistry};
+use crate::runtime::udf_calls::{
+    UDF_CALL_NODE_NAME, UdfCallAnalyzerRule, UdfCallNode, UdfCallRegistry,
+};
 use crate::{
     CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, MemorySize, QueryExecution,
     QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
@@ -274,9 +277,12 @@ fn build_session_context(
         target: "coral_engine::datafusion",
         options: exec_options
     );
+    let mut analyzer_rules = DataFusionAnalyzer::new().rules;
+    analyzer_rules.insert(0, Arc::new(UdfCallAnalyzerRule));
     let mut builder = SessionStateBuilder::new()
         .with_config(session_config)
         .with_runtime_env(runtime_env)
+        .with_analyzer_rules(analyzer_rules)
         .with_default_features();
     if dependent_join.optimizer_enabled() {
         builder = builder.with_optimizer_rule(Arc::new(optimizer::rule(dependent_join.clone())));
@@ -521,12 +527,16 @@ impl QueryRuntimeAdapter {
             .await
             .map_err(SqlExecutionFailure::Planning)?;
         let df = apply_query_parameters(df, params).map_err(SqlExecutionFailure::Planning)?;
-        let arrow_schema = Arc::new(df.schema().as_arrow().clone());
         let provenance = self
             .query_provenance(sql, df.logical_plan())
             .map_err(SqlExecutionFailure::Planning)?;
-        let batches = df
-            .collect()
+        let task_ctx = Arc::new(df.task_ctx());
+        let physical_plan = df
+            .create_physical_plan()
+            .await
+            .map_err(SqlExecutionFailure::Collection)?;
+        let arrow_schema = physical_plan.schema();
+        let batches = collect(physical_plan, task_ctx)
             .await
             .map_err(SqlExecutionFailure::Collection)?;
         let execution = QueryExecution::new(arrow_schema, batches, provenance);

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -1,6 +1,6 @@
 //! Concrete `DataFusion` runtime assembly for the data plane.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, FieldRef};
@@ -34,15 +34,17 @@ use crate::runtime::query_planner::CoralQueryPlanner;
 use crate::runtime::registry::{
     CompiledQuerySource, SourceRegistrationCandidate, SourceRegistrationFailure, register_sources,
 };
+use crate::runtime::scoped_table_functions::ScopedTableFunctionName;
 use crate::runtime::source_functions::{
     SOURCE_FUNCTION_NODE_NAME, SourceFunctionNode, SourceFunctionRegistry,
 };
+use crate::runtime::udf_calls::{UDF_CALL_NODE_NAME, UdfCallNode, UdfCallRegistry};
 use crate::{
     CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, MemorySize, QueryExecution,
     QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
     QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext,
     QuerySource, QueryTableFunctionUsage, QueryTableUsage, RequestAuthenticator, SourceDecorator,
-    SourceInputResolver, TableFunctionInfo, TableInfo,
+    SourceInputResolver, TableFunctionInfo, TableInfo, UdfRuntimeDefinition,
 };
 
 pub(crate) struct QueryRuntimeAdapter {
@@ -73,6 +75,7 @@ struct FallbackRuntimeConfig {
     runtime_context: QueryRuntimeContext,
     dependent_join: DependentJoinConfig,
     memory: QueryMemoryConfig,
+    udfs: Vec<UdfRuntimeDefinition>,
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
 }
@@ -82,6 +85,17 @@ struct RegisteredRuntime {
     tables: Vec<TableInfo>,
     table_functions: Vec<TableFunctionInfo>,
     failures: Vec<SourceRegistrationFailure>,
+}
+
+struct RuntimeBuildInputs<'a> {
+    sources: &'a [QuerySource],
+    runtime_context: &'a QueryRuntimeContext,
+    request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
+    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    source_decorators: &'a mut [Box<dyn SourceDecorator>],
+    dependent_join: &'a DependentJoinConfig,
+    memory: &'a QueryMemoryConfig,
+    udfs: &'a [UdfRuntimeDefinition],
 }
 
 enum SqlExecutionFailure {
@@ -107,6 +121,7 @@ async fn build_runtime_inner(
         memory,
         dependent_join,
         mut extensions,
+        udfs,
     } = runtime;
     let request_authenticators = extensions.request_authenticators.clone();
     let source_input_resolver = extensions.source_input_resolver.clone();
@@ -123,20 +138,22 @@ async fn build_runtime_inner(
             runtime_context: runtime_context.clone(),
             dependent_join: dependent_join.clone(),
             memory: memory.clone(),
+            udfs: udfs.clone(),
             request_authenticators: request_authenticators.clone(),
             source_input_resolver: source_input_resolver.clone(),
         })
     });
 
-    let primary = build_registered_runtime(
+    let primary = build_registered_runtime(RuntimeBuildInputs {
         sources,
-        &runtime_context,
-        &request_authenticators,
+        runtime_context: &runtime_context,
+        request_authenticators: &request_authenticators,
         source_input_resolver,
-        extensions.source_decorators.as_mut_slice(),
-        &dependent_join,
-        &memory,
-    )
+        source_decorators: extensions.source_decorators.as_mut_slice(),
+        dependent_join: &dependent_join,
+        memory: &memory,
+        udfs: &udfs,
+    })
     .await?;
 
     Ok(QueryRuntimeAdapter {
@@ -152,22 +169,16 @@ async fn build_runtime_inner(
 }
 
 async fn build_registered_runtime(
-    sources: &[QuerySource],
-    runtime_context: &QueryRuntimeContext,
-    request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
-    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    source_decorators: &mut [Box<dyn SourceDecorator>],
-    dependent_join: &DependentJoinConfig,
-    memory: &QueryMemoryConfig,
+    config: RuntimeBuildInputs<'_>,
 ) -> Result<RegisteredRuntime, CoreError> {
-    let ctx = build_session_context(dependent_join, memory)?;
+    let ctx = build_session_context(config.dependent_join, config.memory)?;
     let registration = register_runtime_sources(
         &ctx,
-        sources,
-        runtime_context,
-        request_authenticators,
-        source_input_resolver,
-        source_decorators,
+        config.sources,
+        config.runtime_context,
+        config.request_authenticators,
+        config.source_input_resolver,
+        config.source_decorators,
     )
     .await?;
     catalog::register(&ctx, &registration.active_sources)
@@ -180,11 +191,7 @@ async fn build_registered_runtime(
             .iter()
             .flat_map(|source| source.table_functions.iter()),
     );
-    if !source_functions.is_empty() {
-        source_functions
-            .install(&ctx)
-            .map_err(|err| datafusion_to_core(&err, &tables))?;
-    }
+    install_table_function_call_planners(&ctx, source_functions, config.udfs, &tables).await?;
     for failure in &registration.failures {
         tracing::warn!(
             source = %failure.schema_name,
@@ -199,6 +206,48 @@ async fn build_registered_runtime(
         table_functions,
         failures: registration.failures,
     })
+}
+
+async fn install_table_function_call_planners(
+    ctx: &SessionContext,
+    source_functions: SourceFunctionRegistry,
+    udfs: &[UdfRuntimeDefinition],
+    tables: &[TableInfo],
+) -> Result<(), CoreError> {
+    let source_table_function_names = source_functions.names();
+    match (!source_functions.is_empty(), !udfs.is_empty()) {
+        (false, false) => Ok(()),
+        (true, false) => source_functions
+            .install(ctx)
+            .map_err(|err| datafusion_to_core(&err, tables)),
+        (false, true) => {
+            install_udf_call_planner(ctx, udfs, source_table_function_names, tables).await
+        }
+        (true, true) => {
+            // UDF expansion can reveal source-function calls inside the UDF body.
+            // Install source planning first, then run the source analyzer after UDF expansion.
+            source_functions
+                .install_relation_planner(ctx)
+                .map_err(|err| datafusion_to_core(&err, tables))?;
+            install_udf_call_planner(ctx, udfs, source_table_function_names, tables).await?;
+            SourceFunctionRegistry::install_analyzer(ctx);
+            Ok(())
+        }
+    }
+}
+
+async fn install_udf_call_planner(
+    ctx: &SessionContext,
+    udfs: &[UdfRuntimeDefinition],
+    source_table_function_names: HashSet<ScopedTableFunctionName>,
+    tables: &[TableInfo],
+) -> Result<(), CoreError> {
+    let udf_calls = Box::pin(UdfCallRegistry::new(ctx, udfs, source_table_function_names))
+        .await
+        .map_err(|err| datafusion_to_core(&err, tables))?;
+    udf_calls
+        .install(ctx)
+        .map_err(|err| datafusion_to_core(&err, tables))
 }
 
 fn build_session_context(
@@ -537,31 +586,14 @@ impl QueryRuntimeAdapter {
     ) -> Result<QueryExecutionProvenance, DataFusionError> {
         let mut tables = BTreeSet::new();
         let mut table_functions = BTreeSet::new();
-        plan.apply_with_subqueries(|node| {
-            match node {
-                LogicalPlan::TableScan(scan) => {
-                    self.collect_table_scan_usage(&scan.table_name, &mut tables);
-                }
-                LogicalPlan::Extension(extension) => {
-                    if let Some(function) =
-                        extension.node.as_any().downcast_ref::<SourceFunctionNode>()
-                    {
-                        self.collect_table_function_usage(
-                            function.table_reference(),
-                            &mut table_functions,
-                        );
-                    }
-                }
-                _ => {}
-            }
-            Ok(TreeNodeRecursion::Continue)
-        })?;
+        self.collect_plan_provenance(plan, &mut tables, &mut table_functions)?;
 
         let mut sources = BTreeSet::new();
         sources.extend(tables.iter().map(|usage| usage.source_name().to_string()));
         sources.extend(
             table_functions
                 .iter()
+                .filter(|usage| self.schema_to_source.contains_key(usage.schema_name()))
                 .map(|usage| usage.source_name().to_string()),
         );
 
@@ -571,6 +603,46 @@ impl QueryRuntimeAdapter {
             tables.into_iter().collect(),
             table_functions.into_iter().collect(),
         ))
+    }
+
+    fn collect_plan_provenance(
+        &self,
+        plan: &LogicalPlan,
+        tables: &mut BTreeSet<QueryTableUsage>,
+        table_functions: &mut BTreeSet<QueryTableFunctionUsage>,
+    ) -> Result<(), DataFusionError> {
+        plan.apply_with_subqueries(|node| {
+            match node {
+                LogicalPlan::TableScan(scan) => {
+                    self.collect_table_scan_usage(&scan.table_name, tables);
+                }
+                LogicalPlan::Extension(extension) => {
+                    if let Some(function) =
+                        extension.node.as_any().downcast_ref::<SourceFunctionNode>()
+                    {
+                        self.collect_table_function_usage(
+                            function.table_reference(),
+                            table_functions,
+                        );
+                    } else if let Some(function) =
+                        extension.node.as_any().downcast_ref::<UdfCallNode>()
+                    {
+                        self.record_table_function_usage(
+                            function.table_reference(),
+                            table_functions,
+                        );
+                        self.collect_plan_provenance(
+                            function.body_plan(),
+                            tables,
+                            table_functions,
+                        )?;
+                    }
+                }
+                _ => {}
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })?;
+        Ok(())
     }
 
     fn collect_table_scan_usage(
@@ -605,14 +677,25 @@ impl QueryRuntimeAdapter {
         if self.table_functions.iter().any(|function| {
             function.schema_name == schema_name && function.function_name == function_name
         }) {
-            table_functions.insert(QueryTableFunctionUsage::new(
-                self.source_name_for_schema(schema_name),
-                schema_name,
-                function_name,
-            ));
-            return true;
+            return self.record_table_function_usage(table_reference, table_functions);
         }
         false
+    }
+
+    fn record_table_function_usage(
+        &self,
+        table_reference: &TableReference,
+        table_functions: &mut BTreeSet<QueryTableFunctionUsage>,
+    ) -> bool {
+        let Some((schema_name, function_name)) = relation_parts(table_reference) else {
+            return false;
+        };
+        table_functions.insert(QueryTableFunctionUsage::new(
+            self.source_name_for_schema(schema_name),
+            schema_name,
+            function_name,
+        ));
+        true
     }
 
     fn source_name_for_schema(&self, schema_name: &str) -> String {
@@ -836,7 +919,7 @@ fn reject_unbound_sql_parameters(plan: &LogicalPlan) -> Result<(), DataFusionErr
 fn ordinary_sql_placeholders(plan: &LogicalPlan) -> Result<BTreeSet<String>, DataFusionError> {
     let mut placeholders = BTreeSet::new();
     plan.apply_with_subqueries(|node| {
-        if is_parameterized_source_function_call(node) {
+        if is_parameterized_table_function_call(node) {
             return Ok(TreeNodeRecursion::Jump);
         }
         node.apply_expressions(|expr| {
@@ -852,11 +935,14 @@ fn ordinary_sql_placeholders(plan: &LogicalPlan) -> Result<BTreeSet<String>, Dat
     Ok(placeholders)
 }
 
-fn is_parameterized_source_function_call(plan: &LogicalPlan) -> bool {
+fn is_parameterized_table_function_call(plan: &LogicalPlan) -> bool {
     let LogicalPlan::Extension(extension) = plan else {
         return false;
     };
-    extension.node.name() == SOURCE_FUNCTION_NODE_NAME
+    matches!(
+        extension.node.name(),
+        SOURCE_FUNCTION_NODE_NAME | UDF_CALL_NODE_NAME
+    )
 }
 
 pub(crate) fn query_parameter_scalar_value(value: &QueryParameterValue) -> ScalarValue {
@@ -871,7 +957,7 @@ pub(crate) fn query_parameter_scalar_value(value: &QueryParameterValue) -> Scala
     }
 }
 
-fn reject_unknown_parameters(
+pub(crate) fn reject_unknown_parameters(
     plan: &LogicalPlan,
     params: &QueryParameters,
 ) -> Result<(), DataFusionError> {
@@ -944,15 +1030,17 @@ fn format_memory_limit(limit: MemorySize) -> String {
 impl FallbackRuntimeConfig {
     async fn build_without_dependent_join(&self) -> Result<RegisteredRuntime, CoreError> {
         let mut source_decorators = Vec::new();
-        build_registered_runtime(
-            &self.sources,
-            &self.runtime_context,
-            &self.request_authenticators,
-            self.source_input_resolver.clone(),
-            source_decorators.as_mut_slice(),
-            &self.dependent_join.without_rewrites(),
-            &self.memory,
-        )
+        let dependent_join = self.dependent_join.without_rewrites();
+        build_registered_runtime(RuntimeBuildInputs {
+            sources: &self.sources,
+            runtime_context: &self.runtime_context,
+            request_authenticators: &self.request_authenticators,
+            source_input_resolver: self.source_input_resolver.clone(),
+            source_decorators: source_decorators.as_mut_slice(),
+            dependent_join: &dependent_join,
+            memory: &self.memory,
+            udfs: &self.udfs,
+        })
         .await
     }
 }
@@ -972,7 +1060,7 @@ impl FallbackRuntime {
     }
 }
 
-fn read_only_sql_options() -> SQLOptions {
+pub(crate) fn read_only_sql_options() -> SQLOptions {
     SQLOptions::new()
         .with_allow_ddl(false)
         .with_allow_dml(false)
@@ -1117,6 +1205,7 @@ mod tests {
             memory: QueryMemoryConfig {
                 limit: Some(MemorySize::from_str("1Ki").unwrap()),
             },
+            udfs: Vec::new(),
             request_authenticators: HashMap::new(),
             source_input_resolver: None,
         };

--- a/crates/coral-engine/src/runtime/scoped_table_functions.rs
+++ b/crates/coral-engine/src/runtime/scoped_table_functions.rs
@@ -18,7 +18,16 @@ pub(crate) trait ScopedTableFunctionSignature {
     fn display_name(&self) -> &str;
     fn arg_count(&self) -> usize;
     fn arg_name(&self, index: usize) -> Option<&str>;
-    fn contains(&self, name: &str) -> bool;
+
+    fn canonical_arg_name(&self, name: &str) -> Option<&str> {
+        for index in 0..self.arg_count() {
+            let candidate = self.arg_name(index)?;
+            if candidate == name {
+                return Some(candidate);
+            }
+        }
+        None
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -28,6 +37,13 @@ pub(crate) struct ScopedTableFunctionName {
 }
 
 impl ScopedTableFunctionName {
+    pub(crate) fn from_parts(schema: &str, function: &str) -> Self {
+        Self {
+            schema: normalize_runtime_identifier(schema),
+            function: normalize_runtime_identifier(function),
+        }
+    }
+
     pub(crate) fn from_manifest(function: &RegisteredTableFunction) -> Self {
         Self {
             schema: function.schema_name.clone(),
@@ -41,6 +57,10 @@ impl ScopedTableFunctionName {
             function: context.normalize_ident(function),
         }
     }
+}
+
+fn normalize_runtime_identifier(identifier: &str) -> String {
+    identifier.to_ascii_lowercase()
 }
 
 #[derive(Debug)]
@@ -100,6 +120,38 @@ pub(crate) fn find_placeholder(expr: &Expr) -> Option<String> {
 
 pub(crate) fn qualified_name(schema: &str, function: &str) -> String {
     format!("{schema}.{function}")
+}
+
+pub(crate) fn available_functions_hint<'a>(
+    schema: &str,
+    functions: impl IntoIterator<Item = (&'a ScopedTableFunctionName, &'a str)>,
+) -> String {
+    let mut names: Vec<&str> = functions
+        .into_iter()
+        .filter_map(|(key, display_name)| (key.schema == schema).then_some(display_name))
+        .collect();
+    names.sort_unstable();
+
+    if names.is_empty() {
+        String::new()
+    } else {
+        format!("; available functions: {}", names.join(", "))
+    }
+}
+
+pub(crate) fn reject_unbound_parameters<'a>(
+    display_name: &str,
+    args: impl IntoIterator<Item = (&'a str, &'a Expr)>,
+) -> Result<()> {
+    for (name, arg) in args {
+        if let Some(placeholder) = find_placeholder(arg) {
+            return Err(DataFusionError::Plan(format!(
+                "{display_name} argument '{name}' is bound to parameter {placeholder}, \
+                 but no value was provided for it"
+            )));
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn original_relation(relation: TableFactor) -> RelationPlanning {
@@ -194,9 +246,47 @@ pub(crate) fn lower_named_args_to_positional_exprs(
 ) -> Result<Vec<Expr>> {
     let mut supplied = collect_named_args(function, args, context)?;
 
+    lower_supplied_args_to_positional_exprs(function, &mut supplied, context)
+}
+
+/// Lowers named call arguments when every declared argument must be present.
+/// Explicit NULL values still count as supplied and are interpreted by the
+/// function's type binder.
+pub(crate) fn lower_required_named_args_to_positional_exprs(
+    function: &dyn ScopedTableFunctionSignature,
+    args: &TableFunctionArgs,
+    context: &mut dyn RelationPlannerContext,
+) -> Result<Vec<Expr>> {
+    let mut supplied = collect_named_args(function, args, context)?;
+    reject_missing_args(function, &supplied)?;
+
+    lower_supplied_args_to_positional_exprs(function, &mut supplied, context)
+}
+
+fn lower_supplied_args_to_positional_exprs(
+    function: &dyn ScopedTableFunctionSignature,
+    supplied: &mut HashMap<String, SqlExpr>,
+    context: &mut dyn RelationPlannerContext,
+) -> Result<Vec<Expr>> {
     (0..function.arg_count())
-        .map(|index| lower_positional_arg(function, index, &mut supplied, context))
+        .map(|index| lower_positional_arg(function, index, supplied, context))
         .collect()
+}
+
+fn reject_missing_args(
+    function: &dyn ScopedTableFunctionSignature,
+    supplied: &HashMap<String, SqlExpr>,
+) -> Result<()> {
+    for index in 0..function.arg_count() {
+        let name = declared_arg_name(function, index)?;
+        if !supplied.contains_key(name) {
+            return Err(DataFusionError::Plan(format!(
+                "{} is missing argument '{name}'",
+                function.display_name()
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn lower_positional_arg(
@@ -248,16 +338,17 @@ fn insert_named_arg(
     context: &dyn RelationPlannerContext,
 ) -> Result<()> {
     let lookup_name = context.normalize_ident(name.clone());
-    if !seen.insert(lookup_name.clone()) {
+    let Some(canonical_name) = function.canonical_arg_name(&lookup_name) else {
         return Err(DataFusionError::Plan(format!(
-            "{} duplicate argument '{}'",
+            "{} unknown argument '{}'",
             function.display_name(),
             name.value
         )));
-    }
-    if !function.contains(&lookup_name) {
+    };
+    let canonical_name = canonical_name.to_string();
+    if !seen.insert(canonical_name.clone()) {
         return Err(DataFusionError::Plan(format!(
-            "{} unknown argument '{}'",
+            "{} duplicate argument '{}'",
             function.display_name(),
             name.value
         )));
@@ -269,7 +360,7 @@ fn insert_named_arg(
             name.value
         )));
     };
-    supplied.insert(lookup_name, sql_expr.clone());
+    supplied.insert(canonical_name, sql_expr.clone());
     Ok(())
 }
 

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -35,9 +35,11 @@ use crate::backends::{
     RegisteredTableFunction, RegisteredTableFunctionArgument, SourceFunctionProviderFactory,
 };
 use crate::runtime::scoped_table_functions::{
-    ScopedTableFunctionCall, ScopedTableFunctionName, ScopedTableFunctionSignature, call_parts,
-    find_placeholder, lower_named_args_to_positional_exprs, original_relation, qualified_name,
-    reject_settings, reject_unsupported_modifiers,
+    ScopedTableFunctionCall, ScopedTableFunctionName, ScopedTableFunctionSignature,
+    available_functions_hint, call_parts, find_placeholder, lower_named_args_to_positional_exprs,
+    original_relation, qualified_name, reject_settings,
+    reject_unbound_parameters as reject_unbound_table_function_parameters,
+    reject_unsupported_modifiers,
 };
 use coral_spec::ManifestDataType;
 
@@ -71,6 +73,10 @@ impl SourceFunctionRegistry {
 
     pub(crate) fn is_empty(&self) -> bool {
         self.functions.is_empty()
+    }
+
+    pub(crate) fn names(&self) -> HashSet<ScopedTableFunctionName> {
+        self.functions.keys().cloned().collect()
     }
 
     /// Installs source-function planning and binding for one session.
@@ -118,20 +124,12 @@ impl SourceFunctionRegistry {
     }
 
     fn available_functions_hint(&self, schema: &str) -> String {
-        let mut names: Vec<&str> = self
-            .functions
-            .iter()
-            .filter_map(|(key, function)| {
-                (key.schema == schema).then_some(function.display_name.as_str())
-            })
-            .collect();
-        names.sort_unstable();
-
-        if names.is_empty() {
-            String::new()
-        } else {
-            format!("; available functions: {}", names.join(", "))
-        }
+        available_functions_hint(
+            schema,
+            self.functions
+                .iter()
+                .map(|(key, function)| (key, function.display_name.as_str())),
+        )
     }
 }
 
@@ -202,10 +200,6 @@ impl SourceFunction {
             factory: Arc::clone(&function.factory),
         }
     }
-
-    fn contains(&self, name: &str) -> bool {
-        self.arguments.iter().any(|argument| argument.name == name)
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -236,10 +230,6 @@ impl ScopedTableFunctionSignature for SourceFunction {
         self.arguments
             .get(index)
             .map(|argument| argument.name.as_str())
-    }
-
-    fn contains(&self, name: &str) -> bool {
-        self.contains(name)
     }
 }
 
@@ -298,16 +288,11 @@ impl SourceFunctionNode {
     }
 
     fn reject_unbound_parameters(&self) -> Result<()> {
-        for (declared_arg, call_expr) in self.declared_args_with_call_exprs() {
-            if let Some(placeholder) = find_placeholder(call_expr) {
-                return Err(DataFusionError::Plan(format!(
-                    "{} argument '{}' is bound to parameter {placeholder}, \
-                     but no value was provided for it",
-                    self.display_name, declared_arg.name
-                )));
-            }
-        }
-        Ok(())
+        reject_unbound_table_function_parameters(
+            &self.display_name,
+            self.declared_args_with_call_exprs()
+                .map(|(argument, arg)| (argument.name.as_str(), arg)),
+        )
     }
 
     fn to_provider_scan(&self) -> Result<LogicalPlan> {

--- a/crates/coral-engine/src/runtime/udf_calls.rs
+++ b/crates/coral-engine/src/runtime/udf_calls.rs
@@ -71,13 +71,11 @@ impl UdfCallRegistry {
         Ok(registry)
     }
 
-    /// Installs this relation planner together with the analyzer rule that
-    /// expands the nodes it parks. The two are a pair: any session that can
-    /// plan UDF calls must also be able to expand them.
+    /// Installs the relation planner that parks UDF calls. Runtime bootstrap
+    /// installs the expansion rule before `DataFusion`'s default analyzer rules
+    /// so the expanded body receives normal analysis.
     pub(crate) fn install(self, ctx: &SessionContext) -> Result<()> {
-        ctx.register_relation_planner(Arc::new(self))?;
-        ctx.add_analyzer_rule(Arc::new(UdfCallAnalyzerRule));
-        Ok(())
+        ctx.register_relation_planner(Arc::new(self))
     }
 
     fn insert_function(

--- a/crates/coral-engine/src/runtime/udf_calls.rs
+++ b/crates/coral-engine/src/runtime/udf_calls.rs
@@ -1,0 +1,480 @@
+//! UDF SQL call planning.
+//!
+//! UDFs publish as ordinary scoped SQL table functions, but their body is
+//! Coral SQL. The planner parks a UDF call until query parameters have been
+//! bound, then expands the call into the udf body plan with udf arguments
+//! supplied as `DataFusion` parameter values.
+
+use std::cmp::Ordering;
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Schema};
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::Transformed;
+use datafusion::common::{DFSchema, DFSchemaRef, TableReference};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::planner::{
+    PlannedRelation, RelationPlanner, RelationPlannerContext, RelationPlanning,
+};
+use datafusion::logical_expr::sqlparser::ast::TableFactor;
+use datafusion::logical_expr::{
+    Expr, Extension, LogicalPlan, LogicalPlanBuilder, UserDefinedLogicalNodeCore,
+};
+use datafusion::optimizer::AnalyzerRule;
+use datafusion::prelude::SessionContext;
+
+use crate::runtime::query::{read_only_sql_options, reject_unknown_parameters};
+use crate::runtime::scoped_table_functions::{
+    ScopedTableFunctionCall, ScopedTableFunctionName, ScopedTableFunctionSignature,
+    available_functions_hint, call_parts, find_placeholder,
+    lower_required_named_args_to_positional_exprs, original_relation, qualified_name,
+    reject_settings, reject_unbound_parameters as reject_unbound_table_function_parameters,
+    reject_unsupported_modifiers,
+};
+use crate::runtime::udfs::{udf_argument_values, udf_arrow_schema, udf_param_values, udf_sql};
+use crate::{QueryParameters, UdfRuntimeDefinition};
+
+pub(crate) const UDF_CALL_NODE_NAME: &str = "CoralUdfCall";
+
+#[derive(Debug)]
+pub(crate) struct UdfCallRegistry {
+    functions: HashMap<ScopedTableFunctionName, UdfCallTarget>,
+    udf_schemas: HashSet<String>,
+    source_function_schemas: HashSet<String>,
+}
+
+impl UdfCallRegistry {
+    pub(crate) async fn new(
+        ctx: &SessionContext,
+        udfs: &[UdfRuntimeDefinition],
+        source_functions: HashSet<ScopedTableFunctionName>,
+    ) -> Result<Self> {
+        let source_function_schemas = source_functions
+            .iter()
+            .map(|function| function.schema.clone())
+            .collect();
+        let mut registry = Self {
+            functions: HashMap::new(),
+            udf_schemas: HashSet::new(),
+            source_function_schemas,
+        };
+
+        for udf in udfs {
+            let body_plan = ctx.state().create_logical_plan(udf_sql(udf)).await?;
+            read_only_sql_options().verify_plan(&body_plan)?;
+            registry.insert_function(udf, &body_plan, &source_functions)?;
+        }
+
+        Ok(registry)
+    }
+
+    /// Installs this relation planner together with the analyzer rule that
+    /// expands the nodes it parks. The two are a pair: any session that can
+    /// plan UDF calls must also be able to expand them.
+    pub(crate) fn install(self, ctx: &SessionContext) -> Result<()> {
+        ctx.register_relation_planner(Arc::new(self))?;
+        ctx.add_analyzer_rule(Arc::new(UdfCallAnalyzerRule));
+        Ok(())
+    }
+
+    fn insert_function(
+        &mut self,
+        udf: &UdfRuntimeDefinition,
+        body_plan: &LogicalPlan,
+        source_functions: &HashSet<ScopedTableFunctionName>,
+    ) -> Result<()> {
+        let publish = &udf.publish.table_function;
+        let key = ScopedTableFunctionName::from_parts(&publish.schema, &publish.name);
+        if source_functions.contains(&key) {
+            return Err(DataFusionError::Plan(format!(
+                "udf table function {} conflicts with existing table function",
+                qualified_name(&key.schema, &key.function)
+            )));
+        }
+        if self
+            .functions
+            .insert(
+                key.clone(),
+                UdfCallTarget::new(&key.schema, &key.function, udf, body_plan)?,
+            )
+            .is_some()
+        {
+            return Err(DataFusionError::Plan(format!(
+                "duplicate udf table function {}",
+                qualified_name(&key.schema, &key.function)
+            )));
+        }
+        self.udf_schemas.insert(key.schema);
+        Ok(())
+    }
+
+    fn find(&self, call: &ScopedTableFunctionCall) -> Option<&UdfCallTarget> {
+        self.functions.get(&call.lookup_key)
+    }
+
+    fn owns_udf_only_schema(&self, call: &ScopedTableFunctionCall) -> bool {
+        self.udf_schemas.contains(&call.lookup_key.schema)
+            && !self
+                .source_function_schemas
+                .contains(&call.lookup_key.schema)
+    }
+
+    fn available_functions_hint(&self, schema: &str) -> String {
+        available_functions_hint(
+            schema,
+            self.functions
+                .iter()
+                .map(|(key, function)| (key, function.display_name.as_str())),
+        )
+    }
+}
+
+impl RelationPlanner for UdfCallRegistry {
+    fn plan_relation(
+        &self,
+        relation: TableFactor,
+        context: &mut dyn RelationPlannerContext,
+    ) -> Result<RelationPlanning> {
+        let Some(call) = ScopedTableFunctionCall::parse(&relation, context) else {
+            return Ok(original_relation(relation));
+        };
+
+        let Some(function) = self.find(&call) else {
+            if self.owns_udf_only_schema(&call) {
+                let hint = self.available_functions_hint(&call.lookup_key.schema);
+                return Err(call.unknown_function_error("udf table function", &hint));
+            }
+            return Ok(original_relation(relation));
+        };
+
+        reject_unsupported_modifiers(&call, &relation)?;
+        let (call_args, alias) = call_parts(relation);
+        reject_settings(&call, &call_args)?;
+
+        let args = lower_required_named_args_to_positional_exprs(function, &call_args, context)?;
+        let node = UdfCallNode::new(function, args);
+
+        if !node.has_parameter_placeholders() {
+            node.validate_arguments()?;
+        }
+
+        let plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(node),
+        });
+        Ok(RelationPlanning::Planned(Box::new(PlannedRelation::new(
+            plan, alias,
+        ))))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct UdfCallTarget {
+    display_name: String,
+    table_reference: TableReference,
+    arg_names: Vec<String>,
+    udf: UdfRuntimeDefinition,
+    body_plan: LogicalPlan,
+    schema: DFSchemaRef,
+}
+
+impl UdfCallTarget {
+    fn new(
+        schema: &str,
+        name: &str,
+        udf: &UdfRuntimeDefinition,
+        body_plan: &LogicalPlan,
+    ) -> Result<Self> {
+        validate_argument_definitions(udf)?;
+        let table_reference = TableReference::partial(schema.to_string(), name.to_string());
+        let arg_names = udf
+            .arguments
+            .iter()
+            .map(|argument| argument.name.clone())
+            .collect::<Vec<_>>();
+        let arrow_schema = udf_arrow_schema(udf)?;
+        validate_declared_result_schema(udf, body_plan, &arrow_schema)?;
+        let qualified_schema = Arc::new(DFSchema::try_from_qualified_schema(
+            table_reference.clone(),
+            arrow_schema.as_ref(),
+        )?);
+
+        Ok(Self {
+            display_name: qualified_name(schema, name),
+            table_reference,
+            arg_names,
+            udf: udf.clone(),
+            body_plan: body_plan.clone(),
+            schema: qualified_schema,
+        })
+    }
+}
+
+impl ScopedTableFunctionSignature for UdfCallTarget {
+    fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    fn arg_count(&self) -> usize {
+        self.arg_names.len()
+    }
+
+    fn arg_name(&self, index: usize) -> Option<&str> {
+        self.arg_names.get(index).map(String::as_str)
+    }
+
+    fn canonical_arg_name(&self, name: &str) -> Option<&str> {
+        self.arg_names
+            .iter()
+            .map(String::as_str)
+            .find(|argument| argument.eq_ignore_ascii_case(name))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct UdfCallNode {
+    display_name: String,
+    table_reference: TableReference,
+    arg_names: Vec<String>,
+    args: Vec<Expr>,
+    schema: DFSchemaRef,
+    udf: UdfRuntimeDefinition,
+    body_plan: LogicalPlan,
+}
+
+impl UdfCallNode {
+    fn new(function: &UdfCallTarget, args: Vec<Expr>) -> Self {
+        Self {
+            display_name: function.display_name.clone(),
+            table_reference: function.table_reference.clone(),
+            arg_names: function.arg_names.clone(),
+            args,
+            schema: Arc::clone(&function.schema),
+            udf: function.udf.clone(),
+            body_plan: function.body_plan.clone(),
+        }
+    }
+
+    fn has_parameter_placeholders(&self) -> bool {
+        self.args.iter().any(|arg| find_placeholder(arg).is_some())
+    }
+
+    pub(crate) fn body_plan(&self) -> &LogicalPlan {
+        &self.body_plan
+    }
+
+    pub(crate) fn table_reference(&self) -> &TableReference {
+        &self.table_reference
+    }
+
+    fn reject_unbound_parameters(&self) -> Result<()> {
+        reject_unbound_table_function_parameters(
+            &self.display_name,
+            self.arg_names
+                .iter()
+                .zip(&self.args)
+                .map(|(name, arg)| (name.as_str(), arg)),
+        )
+    }
+
+    fn validate_arguments(&self) -> Result<()> {
+        udf_argument_values(&self.udf, &self.args)?;
+        Ok(())
+    }
+
+    fn to_expanded_plan(&self) -> Result<LogicalPlan> {
+        self.reject_unbound_parameters()?;
+        let params = udf_argument_values(&self.udf, &self.args)?;
+        self.reject_missing_body_parameters(&params)?;
+        reject_unknown_parameters(&self.body_plan, &params)?;
+        let plan = self
+            .body_plan
+            .clone()
+            .with_param_values(udf_param_values(&params))?;
+        LogicalPlanBuilder::from(plan)
+            .alias(self.table_reference.clone())?
+            .build()
+    }
+
+    fn reject_missing_body_parameters(&self, params: &QueryParameters) -> Result<()> {
+        let mut referenced = self
+            .body_plan
+            .get_parameter_names()?
+            .into_iter()
+            .collect::<Vec<_>>();
+        referenced.sort();
+
+        for placeholder in referenced {
+            let name = placeholder.strip_prefix('$').unwrap_or(&placeholder);
+            if params.get(name).is_none() {
+                return Err(DataFusionError::Plan(format!(
+                    "udf '{}' body references parameter '{}' not declared as an argument",
+                    self.display_name, placeholder
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_argument_definitions(udf: &UdfRuntimeDefinition) -> Result<()> {
+    let mut seen = BTreeSet::new();
+    for argument in &udf.arguments {
+        if !seen.insert(argument.name.to_ascii_lowercase()) {
+            return Err(DataFusionError::Plan(format!(
+                "udf '{}' argument '{}' is declared more than once",
+                udf.name, argument.name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_declared_result_schema(
+    udf: &UdfRuntimeDefinition,
+    body_plan: &LogicalPlan,
+    declared_schema: &Schema,
+) -> Result<()> {
+    let declared_fields = declared_schema.fields();
+    let body_fields = body_plan.schema().fields();
+
+    if declared_fields.len() != body_fields.len() {
+        return Err(DataFusionError::Plan(format!(
+            "udf '{}' declares {} result columns but its SQL body produces {}",
+            udf.name,
+            declared_fields.len(),
+            body_fields.len()
+        )));
+    }
+
+    for (index, (declared, actual)) in declared_fields.iter().zip(body_fields.iter()).enumerate() {
+        let column_position = index + 1;
+        if declared.name() != actual.name() {
+            return Err(DataFusionError::Plan(format!(
+                "udf '{}' declared column {column_position} as '{}' but its SQL body produces '{}'",
+                udf.name,
+                declared.name(),
+                actual.name()
+            )));
+        }
+        if !result_data_types_match(declared.data_type(), actual.data_type()) {
+            return Err(DataFusionError::Plan(format!(
+                "udf '{}' declared column '{}' as {} but its SQL body produces {}",
+                udf.name,
+                declared.name(),
+                declared.data_type(),
+                actual.data_type()
+            )));
+        }
+        if !declared.is_nullable() && actual.is_nullable() {
+            return Err(DataFusionError::Plan(format!(
+                "udf '{}' declared column '{}' as non-nullable but its SQL body produces nullable values",
+                udf.name,
+                declared.name()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn result_data_types_match(left: &DataType, right: &DataType) -> bool {
+    left == right || (crate::types::is_string_family(left) && crate::types::is_string_family(right))
+}
+
+// Node identity is the published function name plus its argument expressions and
+// result schema. The remaining fields are derived from the same registered UDF
+// definition, so they are deliberately excluded from equality and hashing.
+impl PartialEq for UdfCallNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.display_name == other.display_name
+            && self.args == other.args
+            && self.schema == other.schema
+    }
+}
+
+impl Eq for UdfCallNode {}
+
+impl Hash for UdfCallNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.display_name.hash(state);
+        self.args.hash(state);
+        self.schema.hash(state);
+    }
+}
+
+impl PartialOrd for UdfCallNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if self == other {
+            return Some(Ordering::Equal);
+        }
+        Some(format!("{self:?}").cmp(&format!("{other:?}")))
+    }
+}
+
+impl UserDefinedLogicalNodeCore for UdfCallNode {
+    fn name(&self) -> &'static str {
+        UDF_CALL_NODE_NAME
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        Vec::new()
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        self.args.clone()
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "UdfCall: {}", self.display_name)
+    }
+
+    fn with_exprs_and_inputs(&self, exprs: Vec<Expr>, inputs: Vec<LogicalPlan>) -> Result<Self> {
+        if !inputs.is_empty() {
+            return Err(DataFusionError::Plan(format!(
+                "UDF {} takes no plan inputs",
+                self.display_name
+            )));
+        }
+        if exprs.len() != self.args.len() {
+            return Err(DataFusionError::Plan(format!(
+                "UDF {} expected {} argument expressions, got {}",
+                self.display_name,
+                self.args.len(),
+                exprs.len()
+            )));
+        }
+        Ok(Self {
+            args: exprs.into_iter().map(Expr::unalias).collect(),
+            ..self.clone()
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct UdfCallAnalyzerRule;
+
+impl AnalyzerRule for UdfCallAnalyzerRule {
+    fn analyze(&self, plan: LogicalPlan, _config: &ConfigOptions) -> Result<LogicalPlan> {
+        plan.transform_up_with_subqueries(|plan| {
+            let LogicalPlan::Extension(extension) = &plan else {
+                return Ok(Transformed::no(plan));
+            };
+            let Some(node) = extension.node.as_any().downcast_ref::<UdfCallNode>() else {
+                return Ok(Transformed::no(plan));
+            };
+            Ok(Transformed::yes(node.to_expanded_plan()?))
+        })
+        .map(|transformed| transformed.data)
+    }
+
+    fn name(&self) -> &'static str {
+        "coral_udf_calls"
+    }
+}

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -1,6 +1,5 @@
 //! UDF SQL signature inference and runtime argument binding helpers.
 
-use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, Schema};
@@ -16,10 +15,6 @@ use crate::{
     UdfRuntimeImplementation, UdfRuntimeResultColumn, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
 };
 
-#[expect(
-    dead_code,
-    reason = "UDF table-function execution consumes registered UDF SQL in the next stack branch."
-)]
 pub(crate) fn udf_sql(udf: &UdfRuntimeDefinition) -> &str {
     let UdfRuntimeImplementation::CoralSql { query } = &udf.implementation;
     query
@@ -84,13 +79,6 @@ pub(crate) fn udf_query_parameters(
     UdfArgumentBinding::new(udf, arguments).into_query_params()
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "UDF table-function execution consumes literal call binding in the next stack branch."
-    )
-)]
 pub(crate) fn udf_argument_values(
     udf: &UdfRuntimeDefinition,
     args: &[Expr],
@@ -170,10 +158,6 @@ fn unalias(mut expr: &Expr) -> &Expr {
     expr
 }
 
-#[expect(
-    dead_code,
-    reason = "UDF table-function execution consumes bound parameter values in the next stack branch."
-)]
 pub(crate) fn udf_param_values(params: &QueryParameters) -> Vec<(String, ScalarValue)> {
     params
         .iter()
@@ -181,10 +165,6 @@ pub(crate) fn udf_param_values(params: &QueryParameters) -> Vec<(String, ScalarV
         .collect()
 }
 
-#[expect(
-    dead_code,
-    reason = "UDF table-function execution consumes result schemas in the next stack branch."
-)]
 pub(crate) fn udf_arrow_schema(udf: &UdfRuntimeDefinition) -> DataFusionResult<Arc<Schema>> {
     if udf.result_columns.is_empty() {
         return Err(DataFusionError::Plan(format!(
@@ -216,7 +196,6 @@ impl<'a> UdfArgumentBinding<'a> {
     }
 
     fn into_query_params(self) -> DataFusionResult<QueryParameters> {
-        self.reject_duplicate_argument_definitions()?;
         self.reject_unknown_arguments()?;
 
         let mut params = self.arguments.clone();
@@ -224,19 +203,6 @@ impl<'a> UdfArgumentBinding<'a> {
             self.bind_argument(argument, &mut params)?;
         }
         Ok(params)
-    }
-
-    fn reject_duplicate_argument_definitions(&self) -> DataFusionResult<()> {
-        let mut seen = BTreeSet::new();
-        for argument in &self.udf.arguments {
-            if !seen.insert(argument.name.as_str()) {
-                return Err(DataFusionError::Plan(format!(
-                    "udf '{}' argument '{}' is declared more than once",
-                    self.udf.name, argument.name
-                )));
-            }
-        }
-        Ok(())
     }
 
     fn reject_unknown_arguments(&self) -> DataFusionResult<()> {

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -475,12 +475,15 @@ async fn infer_udf_signature_uses_explicit_cast_for_argument_type() {
 
 #[tokio::test]
 async fn infer_udf_signature_accepts_timestamp_source_argument_and_cast() {
-    let source = build_source(search_function_manifest("mixed_timestamp_search"));
+    let source = build_source(search_function_manifest(
+        "mixed_timestamp_search",
+        "https://example.test",
+    ));
 
     let signature = CoralQuery::infer_udf_signature(
         &[source],
         test_runtime(),
-        udf(
+        udf_sql(
             "mixed_timestamp",
             "select cast($since as TIMESTAMP) as since \
              from mixed_timestamp_search.search_issues(q => 'open', since => $since)",

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -613,6 +613,39 @@ async fn published_udf_table_function_executes_udf_sql() {
 }
 
 #[tokio::test]
+async fn published_udf_table_function_coerces_arguments_in_the_expanded_body() {
+    let udf = UdfRuntimeDefinition {
+        name: "format_id".to_string(),
+        description: "Formats an id".to_string(),
+        arguments: vec![udf_argument("id", ManifestDataType::Int64)],
+        implementation: UdfRuntimeImplementation::CoralSql {
+            query: "select concat($id, '-x') as formatted_id".to_string(),
+        },
+        publish: udf_publish("format_id"),
+        result_columns: vec![udf_result_column("formatted_id", DataType::Utf8View)],
+    };
+    let runtime = test_runtime().with_udfs(vec![udf]);
+
+    let execution = CoralQuery::execute_sql(
+        &[],
+        runtime,
+        "select formatted_id from udfs.format_id(id => 42)",
+    )
+    .await
+    .expect("expanded UDF body should receive normal DataFusion type coercion");
+
+    let batch = execution
+        .batches()
+        .first()
+        .expect("format UDF should produce one batch");
+    assert_eq!(execution.arrow_schema().as_ref(), batch.schema().as_ref());
+    assert_eq!(
+        execution_to_rows(&execution),
+        vec![json!({"formatted_id": "42-x"})]
+    );
+}
+
+#[tokio::test]
 async fn published_udf_table_function_normalizes_publish_identifiers() {
     let (_temp, source) = events_source("mixed_case_published_udf_events");
     let runtime = test_runtime().with_udfs(vec![mixed_case_published_min_id_udf(

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -5,14 +5,21 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use coral_engine::{
-    CoralQuery, EngineExtensions, QueryExecutionProvenance, QueryResultObserver,
-    QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext, StatusCode,
-    UdfRuntimeImplementation, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
+    CoralQuery, CoreError, EngineExtensions, QueryExecutionProvenance, QueryParameterValue,
+    QueryParameters, QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig,
+    QueryRuntimeContext, StatusCode, UdfRuntimeArgument, UdfRuntimeDefinition,
+    UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn, UdfRuntimeSignature,
+    UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
 };
 use coral_spec::ManifestDataType;
 use serde_json::{Value, json};
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use crate::harness::{build_source, dir_url, test_runtime, write_jsonl_file};
+use crate::harness::{build_source, dir_url, execution_to_rows, test_runtime, write_jsonl_file};
+
+const EVENTS_CALL: &str = "select * from udfs.min_id_events(min_id => 1)";
+const REVIEW_QUERY: &str = "repo:withcoral/coral review";
 
 #[derive(Debug, Default)]
 struct RowCountObserver {
@@ -63,13 +70,13 @@ fn events_manifest(name: &str, dir: &Path) -> Value {
     })
 }
 
-fn search_function_manifest(name: &str) -> Value {
+fn search_function_manifest(name: &str, base_url: &str) -> Value {
     json!({
         "name": name,
         "version": "0.1.0",
         "dsl_version": 3,
         "backend": "http",
-        "base_url": "https://example.test",
+        "base_url": base_url,
         "functions": [{
             "name": "search_issues",
             "description": "Search issues",
@@ -78,6 +85,11 @@ fn search_function_manifest(name: &str) -> Value {
                     "name": "q",
                     "required": true,
                     "bind": { "arg": "q" }
+                },
+                {
+                    "name": "mode",
+                    "values": ["lexical", "semantic", "hybrid"],
+                    "bind": { "arg": "search_type" }
                 },
                 {
                     "name": "min_score",
@@ -105,6 +117,7 @@ fn search_function_manifest(name: &str) -> Value {
                 "path": "/api/search/issues",
                 "query": [
                     { "name": "q", "from": "arg", "key": "q" },
+                    { "name": "search_type", "from": "arg", "key": "search_type" },
                     { "name": "min_score", "from": "arg", "key": "min_score" },
                     { "name": "max_items", "from": "arg", "key": "max_items" },
                     { "name": "payload", "from": "arg", "key": "payload" },
@@ -122,7 +135,43 @@ fn search_function_manifest(name: &str) -> Value {
     })
 }
 
-fn udf(name: &str, query: impl Into<String>) -> UdfRuntimeSqlDefinition {
+async fn search_source_with_response(
+    server: &MockServer,
+    source_name: &str,
+    mode: &str,
+    title: &str,
+    score: f64,
+) -> coral_engine::QuerySource {
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", REVIEW_QUERY))
+        .and(query_param("search_type", mode))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{ "title": title, "score": score }]
+        })))
+        .expect(1)
+        .mount(server)
+        .await;
+
+    build_source(search_function_manifest(source_name, &server.uri()))
+}
+
+fn search_source(server: &MockServer, source_name: &str) -> coral_engine::QuerySource {
+    build_source(search_function_manifest(source_name, &server.uri()))
+}
+
+fn events_source(source_name: &str) -> (tempfile::TempDir, coral_engine::QuerySource) {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "events.jsonl",
+        &[json!({"id": 1}), json!({"id": 2})],
+    );
+    let source = build_source(events_manifest(source_name, temp.path()));
+    (temp, source)
+}
+
+fn udf_sql(name: &str, query: impl Into<String>) -> UdfRuntimeSqlDefinition {
     UdfRuntimeSqlDefinition {
         name: name.to_string(),
         implementation: UdfRuntimeImplementation::CoralSql {
@@ -131,20 +180,126 @@ fn udf(name: &str, query: impl Into<String>) -> UdfRuntimeSqlDefinition {
     }
 }
 
-fn min_id_udf(source_name: &str) -> UdfRuntimeSqlDefinition {
-    udf(
+fn min_id_sql_udf(source_name: &str) -> UdfRuntimeSqlDefinition {
+    udf_sql(
         "min_id_events",
         format!("select id from {source_name}.events where id >= $min_id order by id"),
     )
 }
 
-fn review_queue_udf(source_name: &str) -> UdfRuntimeSqlDefinition {
-    udf(
+fn review_queue_sql_udf(source_name: &str) -> UdfRuntimeSqlDefinition {
+    udf_sql(
         "review_queue",
         format!(
             "select title, score from {source_name}.search_issues(q => $query, min_score => $min_score, payload => $payload, since => $since)"
         ),
     )
+}
+
+fn udf_publish(name: &str) -> UdfRuntimePublish {
+    UdfRuntimePublish {
+        table_function: UdfRuntimeTableFunctionPublish {
+            schema: "udfs".to_string(),
+            name: name.to_string(),
+            description: String::new(),
+        },
+    }
+}
+
+fn udf_argument(name: &str, data_type: ManifestDataType) -> UdfRuntimeArgument {
+    UdfRuntimeArgument {
+        name: name.to_string(),
+        data_type,
+    }
+}
+
+fn udf_result_column(name: &str, data_type: DataType) -> UdfRuntimeResultColumn {
+    udf_result_column_with_nullability(name, data_type, true)
+}
+
+fn udf_result_column_with_nullability(
+    name: &str,
+    data_type: DataType,
+    nullable: bool,
+) -> UdfRuntimeResultColumn {
+    UdfRuntimeResultColumn {
+        name: name.to_string(),
+        data_type,
+        nullable,
+    }
+}
+
+fn min_id_udf(source_name: &str) -> UdfRuntimeDefinition {
+    UdfRuntimeDefinition {
+        name: "min_id_events".to_string(),
+        description: "Events above an id".to_string(),
+        arguments: vec![udf_argument("min_id", ManifestDataType::Int64)],
+        implementation: UdfRuntimeImplementation::CoralSql {
+            query: format!("select id from {source_name}.events where id >= $min_id order by id"),
+        },
+        publish: udf_publish("min_id_events"),
+        result_columns: vec![udf_result_column("id", DataType::Int64)],
+    }
+}
+
+fn min_id_udf_without_columns(source_name: &str) -> UdfRuntimeDefinition {
+    let mut udf = min_id_udf(source_name);
+    udf.result_columns.clear();
+    udf
+}
+
+fn min_id_udf_with_result_column(
+    source_name: &str,
+    column_name: &str,
+    data_type: DataType,
+) -> UdfRuntimeDefinition {
+    let mut udf = min_id_udf(source_name);
+    udf.result_columns = vec![udf_result_column(column_name, data_type)];
+    udf
+}
+
+fn min_id_udf_with_body(source_name: &str, body: impl Into<String>) -> UdfRuntimeDefinition {
+    let mut udf = min_id_udf(source_name);
+    udf.implementation = UdfRuntimeImplementation::CoralSql { query: body.into() };
+    udf
+}
+
+fn min_id_udf_with_non_nullable_result(
+    source_name: &str,
+    body: impl Into<String>,
+) -> UdfRuntimeDefinition {
+    let mut udf = min_id_udf_with_body(source_name, body);
+    udf.result_columns = vec![udf_result_column_with_nullability(
+        "id",
+        DataType::Int64,
+        false,
+    )];
+    udf
+}
+
+fn mixed_case_published_min_id_udf(source_name: &str) -> UdfRuntimeDefinition {
+    let mut udf = min_id_udf(source_name);
+    udf.publish = UdfRuntimePublish {
+        table_function: UdfRuntimeTableFunctionPublish {
+            schema: "Udfs".to_string(),
+            name: "Min_Id_Events".to_string(),
+            description: String::new(),
+        },
+    };
+    udf
+}
+
+fn published_limited_events_udf(source_name: &str) -> UdfRuntimeDefinition {
+    UdfRuntimeDefinition {
+        name: "limited_events".to_string(),
+        description: "Limited events".to_string(),
+        arguments: Vec::new(),
+        implementation: UdfRuntimeImplementation::CoralSql {
+            query: format!("select id from {source_name}.events limit 1"),
+        },
+        publish: udf_publish("limited_events"),
+        result_columns: vec![udf_result_column("id", DataType::Int64)],
+    }
 }
 
 fn argument_types(signature: &UdfRuntimeSignature) -> Vec<(&str, ManifestDataType)> {
@@ -163,20 +318,116 @@ fn column_types(signature: &UdfRuntimeSignature) -> Vec<(&str, &DataType)> {
         .collect()
 }
 
+fn review_queue_udf(source_name: &str) -> UdfRuntimeDefinition {
+    UdfRuntimeDefinition {
+        name: "review_queue".to_string(),
+        description: "Review queue".to_string(),
+        arguments: vec![
+            udf_argument("min_score", ManifestDataType::Float64),
+            udf_argument("mode", ManifestDataType::Utf8),
+            udf_argument("payload", ManifestDataType::Json),
+            udf_argument("query", ManifestDataType::Utf8),
+            udf_argument("since", ManifestDataType::Timestamp),
+        ],
+        implementation: UdfRuntimeImplementation::CoralSql {
+            query: format!(
+                "select title, score from {source_name}.search_issues(q => $query, mode => $mode, min_score => $min_score, payload => $payload, since => $since)"
+            ),
+        },
+        publish: udf_publish("review_queue"),
+        result_columns: Vec::new(),
+    }
+}
+
+fn published_review_queue_udf(source_name: &str) -> UdfRuntimeDefinition {
+    let mut udf = review_queue_udf(source_name);
+    udf.result_columns = vec![
+        udf_result_column("title", DataType::Utf8),
+        udf_result_column("score", DataType::Float64),
+    ];
+    udf
+}
+
+fn review_queue_udf_published_as(source_name: &str, schema: &str) -> UdfRuntimeDefinition {
+    review_queue_udf_published_at(source_name, schema, "review_queue")
+}
+
+fn review_queue_udf_published_at(
+    source_name: &str,
+    schema: &str,
+    name: &str,
+) -> UdfRuntimeDefinition {
+    let mut udf = published_review_queue_udf(source_name);
+    udf.publish = UdfRuntimePublish {
+        table_function: UdfRuntimeTableFunctionPublish {
+            schema: schema.to_string(),
+            name: name.to_string(),
+            description: String::new(),
+        },
+    };
+    udf
+}
+
 fn runtime_with_observer(observer: Arc<dyn QueryResultObserver>) -> QueryRuntimeConfig {
     let mut extensions = EngineExtensions::default();
     extensions.query_result_observers.push(observer);
     QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions)
 }
 
+fn assert_invalid_input_contains(error: CoreError, expected: &str) {
+    let CoreError::InvalidInput(detail) = error else {
+        panic!("expected CoreError::InvalidInput, got {error:?}");
+    };
+    assert!(
+        detail.contains(expected),
+        "expected error detail to contain {expected:?}, got {detail:?}"
+    );
+}
+
+async fn assert_udf_sql_error(
+    source_name: &str,
+    udfs: Vec<UdfRuntimeDefinition>,
+    sql: &str,
+    expected: &str,
+) {
+    let (_temp, source) = events_source(source_name);
+    let runtime = test_runtime().with_udfs(udfs);
+
+    let error = CoralQuery::execute_sql(&[source], runtime, sql)
+        .await
+        .expect_err("udf SQL should fail");
+
+    assert_invalid_input_contains(error, expected);
+}
+
+async fn assert_source_udf_sql_error(
+    source_name: &str,
+    udfs: Vec<UdfRuntimeDefinition>,
+    sql: &str,
+    expected: &str,
+) {
+    let server = MockServer::start().await;
+    let source = search_source(&server, source_name);
+    let runtime = test_runtime().with_udfs(udfs);
+
+    let error = CoralQuery::execute_sql(&[source], runtime, sql)
+        .await
+        .expect_err("udf SQL should fail");
+
+    assert_invalid_input_contains(error, expected);
+}
+
 #[tokio::test]
 async fn infer_udf_signature_uses_source_function_schema_with_parameters() {
-    let source = build_source(search_function_manifest("signature_param_search"));
+    let source = build_source(search_function_manifest(
+        "signature_param_search",
+        "https://example.test",
+    ));
 
     let signature = CoralQuery::infer_udf_signature(
         &[source],
         test_runtime(),
-        review_queue_udf("signature_param_search"),
+        review_queue_sql_udf("signature_param_search"),
     )
     .await
     .expect("udf signature inference should use source function schema without binding params");
@@ -206,7 +457,7 @@ async fn infer_udf_signature_uses_explicit_cast_for_argument_type() {
     let signature = CoralQuery::infer_udf_signature(
         &[],
         test_runtime(),
-        udf("cast_label", "select cast($label as VARCHAR) as label"),
+        udf_sql("cast_label", "select cast($label as VARCHAR) as label"),
     )
     .await
     .expect("udf schema inference should use cast type");
@@ -246,19 +497,13 @@ async fn infer_udf_signature_accepts_timestamp_source_argument_and_cast() {
 
 #[tokio::test]
 async fn infer_udf_signature_uses_column_comparison_for_argument_type() {
-    let temp = tempfile::tempdir().expect("temp dir");
-    write_jsonl_file(
-        temp.path(),
-        "events.jsonl",
-        &[json!({"id": 1}), json!({"id": 2})],
-    );
-    let source = build_source(events_manifest("schema_udf_events", temp.path()));
+    let (_temp, source) = events_source("schema_udf_events");
     let observer = Arc::new(RowCountObserver::default());
 
     let signature = CoralQuery::infer_udf_signature(
         &[source],
         runtime_with_observer(observer.clone()),
-        min_id_udf("schema_udf_events"),
+        min_id_sql_udf("schema_udf_events"),
     )
     .await
     .expect("udf signature inference should plan without collection");
@@ -279,7 +524,7 @@ async fn infer_udf_signature_rejects_ambiguous_argument_type() {
     let error = CoralQuery::infer_udf_signature(
         &[],
         test_runtime(),
-        udf("ambiguous_value", "select $value as value"),
+        udf_sql("ambiguous_value", "select $value as value"),
     )
     .await
     .expect_err("ambiguous udf argument should fail");
@@ -303,11 +548,14 @@ async fn infer_udf_signature_rejects_ambiguous_argument_type() {
 
 #[tokio::test]
 async fn infer_udf_signature_rejects_conflicting_argument_types() {
-    let source = build_source(search_function_manifest("conflicting_param_search"));
+    let source = build_source(search_function_manifest(
+        "conflicting_param_search",
+        "https://example.test",
+    ));
     let error = CoralQuery::infer_udf_signature(
         &[source],
         test_runtime(),
-        udf(
+        udf_sql(
             "conflicting_param",
             "select title from conflicting_param_search.search_issues(q => $value, min_score => $value)",
         ),
@@ -326,4 +574,347 @@ async fn infer_udf_signature_rejects_conflicting_argument_types() {
         error.to_string().contains("use explicit casts"),
         "unexpected error: {error}"
     );
+}
+
+#[tokio::test]
+async fn published_udf_table_function_executes_udf_sql() {
+    let (_temp, source) = events_source("published_udf_events");
+    let runtime = test_runtime().with_udfs(vec![min_id_udf("published_udf_events")]);
+
+    let execution = CoralQuery::execute_sql(
+        &[source],
+        runtime,
+        "select id from udfs.min_id_events(min_id => 2)",
+    )
+    .await
+    .expect("published udf table function should execute");
+
+    assert_eq!(execution_to_rows(&execution), vec![json!({"id": 2})]);
+    assert_eq!(execution.provenance().sources(), ["published_udf_events"]);
+    let table = execution
+        .provenance()
+        .tables()
+        .first()
+        .expect("UDF body table provenance");
+    assert_eq!(table.source_name(), "published_udf_events");
+    assert_eq!(table.schema_name(), "published_udf_events");
+    assert_eq!(table.table_name(), "events");
+    let function = execution
+        .provenance()
+        .table_functions()
+        .first()
+        .expect("invoked UDF provenance");
+    assert_eq!(function.source_name(), "udfs");
+    assert_eq!(function.schema_name(), "udfs");
+    assert_eq!(function.function_name(), "min_id_events");
+}
+
+#[tokio::test]
+async fn published_udf_table_function_normalizes_publish_identifiers() {
+    let (_temp, source) = events_source("mixed_case_published_udf_events");
+    let runtime = test_runtime().with_udfs(vec![mixed_case_published_min_id_udf(
+        "mixed_case_published_udf_events",
+    )]);
+
+    let execution = CoralQuery::execute_sql(
+        &[source],
+        runtime,
+        "select id from udfs.min_id_events(min_id => 2)",
+    )
+    .await
+    .expect("published udf table function should use normalized identifiers");
+
+    assert_eq!(execution_to_rows(&execution), vec![json!({"id": 2})]);
+}
+
+#[tokio::test]
+async fn published_udf_table_function_normalizes_argument_identifiers() {
+    let (_temp, source) = events_source("mixed_case_arg_udf_events");
+    let mut udf = min_id_udf("mixed_case_arg_udf_events");
+    udf.arguments
+        .first_mut()
+        .expect("test UDF should have one argument")
+        .name = "minId".to_string();
+    udf.implementation = UdfRuntimeImplementation::CoralSql {
+        query: "select id from mixed_case_arg_udf_events.events where id >= $minId order by id"
+            .to_string(),
+    };
+    let runtime = test_runtime().with_udfs(vec![udf]);
+
+    let execution = CoralQuery::execute_sql(
+        &[source],
+        runtime,
+        "select id from udfs.min_id_events(minId => 2)",
+    )
+    .await
+    .expect("published UDF argument lookup should normalize SQL identifiers");
+
+    assert_eq!(execution_to_rows(&execution), vec![json!({"id": 2})]);
+}
+
+#[tokio::test]
+async fn published_udf_table_function_accepts_query_params() {
+    let (_temp, source) = events_source("published_param_udf_events");
+    let runtime = test_runtime().with_udfs(vec![min_id_udf("published_param_udf_events")]);
+
+    let execution = CoralQuery::execute_sql_with_params(
+        &[source],
+        runtime,
+        "select id from udfs.min_id_events(min_id => $min_id)",
+        QueryParameters::from([("min_id".to_string(), QueryParameterValue::integer(2))]),
+    )
+    .await
+    .expect("published udf table function should accept params");
+
+    assert_eq!(execution_to_rows(&execution), vec![json!({"id": 2})]);
+}
+
+#[tokio::test]
+async fn published_udf_table_function_requires_every_argument() {
+    assert_udf_sql_error(
+        "missing_arg_udf_events",
+        vec![min_id_udf("missing_arg_udf_events")],
+        "select id from udfs.min_id_events()",
+        "udfs.min_id_events is missing argument 'min_id'",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn published_udf_table_function_rejects_unbound_query_params() {
+    assert_udf_sql_error(
+        "unbound_param_udf_events",
+        vec![min_id_udf("unbound_param_udf_events")],
+        "select id from udfs.min_id_events(min_id => $min_id)",
+        "udfs.min_id_events argument 'min_id' is bound to parameter $min_id, but no value was provided for it",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn duplicate_udf_table_function_publish_fails() {
+    let mut duplicate = min_id_udf("duplicate_udf_events");
+    duplicate.name = "duplicate_min_id_events".to_string();
+
+    assert_udf_sql_error(
+        "duplicate_udf_events",
+        vec![min_id_udf("duplicate_udf_events"), duplicate],
+        EVENTS_CALL,
+        "duplicate udf table function udfs.min_id_events",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn udf_table_function_rejects_duplicate_argument_definition() {
+    let mut udf = min_id_udf("duplicate_arg_udf_events");
+    udf.arguments
+        .push(udf_argument("MIN_ID", ManifestDataType::Int64));
+
+    assert_udf_sql_error(
+        "duplicate_arg_udf_events",
+        vec![udf],
+        EVENTS_CALL,
+        "udf 'min_id_events' argument 'MIN_ID' is declared more than once",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn udf_table_function_requires_result_columns() {
+    assert_udf_sql_error(
+        "missing_columns_udf_events",
+        vec![min_id_udf_without_columns("missing_columns_udf_events")],
+        EVENTS_CALL,
+        "published udf 'min_id_events' requires declared result columns",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn udf_table_function_rejects_mismatched_declared_result_name() {
+    assert_udf_sql_error(
+        "mismatched_column_name_udf_events",
+        vec![min_id_udf_with_result_column(
+            "mismatched_column_name_udf_events",
+            "event_id",
+            DataType::Int64,
+        )],
+        EVENTS_CALL,
+        "udf 'min_id_events' declared column 1 as 'event_id' but its SQL body produces 'id'",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn udf_table_function_rejects_mismatched_declared_result_type() {
+    assert_udf_sql_error(
+        "mismatched_column_type_udf_events",
+        vec![min_id_udf_with_result_column(
+            "mismatched_column_type_udf_events",
+            "id",
+            DataType::Utf8,
+        )],
+        EVENTS_CALL,
+        "udf 'min_id_events' declared column 'id' as Utf8 but its SQL body produces Int64",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn udf_table_function_rejects_overstated_non_nullable_result() {
+    assert_udf_sql_error(
+        "mismatched_column_nullability_udf_events",
+        vec![min_id_udf_with_non_nullable_result(
+            "mismatched_column_nullability_udf_events",
+            "select cast(null as bigint) as id",
+        )],
+        EVENTS_CALL,
+        "udf 'min_id_events' declared column 'id' as non-nullable but its SQL body produces nullable values",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn udf_table_function_rejects_undeclared_body_parameter() {
+    assert_udf_sql_error(
+        "undeclared_body_param_udf_events",
+        vec![min_id_udf_with_body(
+            "undeclared_body_param_udf_events",
+            "select id from undeclared_body_param_udf_events.events where id >= $min_id and $status is not null order by id",
+        )],
+        EVENTS_CALL,
+        "udf 'udfs.min_id_events' body references parameter '$status' not declared as an argument",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn udf_table_function_rejects_unknown_function_in_udf_schema() {
+    assert_udf_sql_error(
+        "unknown_udf_events",
+        vec![min_id_udf("unknown_udf_events")],
+        "select * from udfs.nope()",
+        "unknown udf table function udfs.nope; available functions: udfs.min_id_events",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn udf_table_function_rejects_unsupported_modifiers_with_neutral_error() {
+    assert_udf_sql_error(
+        "modifier_udf_events",
+        vec![min_id_udf("modifier_udf_events")],
+        "select * from udfs.min_id_events(min_id => 1) WITH ORDINALITY",
+        "table function udfs.min_id_events does not support WITH ORDINALITY",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn published_udf_table_function_preserves_inner_limit() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    write_jsonl_file(temp.path(), "first/events.jsonl", &[json!({"id": 1})]);
+    write_jsonl_file(temp.path(), "second/events.jsonl", &[json!({"id": 2})]);
+
+    let source = build_source(events_manifest("limited_udf_events", temp.path()));
+    let runtime =
+        test_runtime().with_udfs(vec![published_limited_events_udf("limited_udf_events")]);
+
+    let execution = CoralQuery::execute_sql(
+        &[source],
+        runtime,
+        "select count(*) as count from udfs.limited_events()",
+    )
+    .await
+    .expect("published udf table function should preserve inner limit");
+
+    assert_eq!(execution_to_rows(&execution), vec![json!({"count": 1})]);
+}
+
+#[tokio::test]
+async fn udf_can_share_source_schema_and_call_source_function_with_params() {
+    let server = MockServer::start().await;
+    let source = search_source_with_response(
+        &server,
+        "shared_udf_schema",
+        "semantic",
+        "Schema-shared udf",
+        3.0,
+    )
+    .await;
+    let runtime = test_runtime().with_udfs(vec![review_queue_udf_published_as(
+        "shared_udf_schema",
+        "shared_udf_schema",
+    )]);
+
+    let execution = CoralQuery::execute_sql_with_params(
+        &[source],
+        runtime,
+        "select title, score from shared_udf_schema.review_queue(\
+             query => $query, \
+             mode => $mode, \
+             min_score => 1, \
+             payload => NULL, \
+             since => TIMESTAMP '2024-01-01T00:00:00Z'\
+         )",
+        QueryParameters::from([
+            (
+                "query".to_string(),
+                QueryParameterValue::string(REVIEW_QUERY),
+            ),
+            ("mode".to_string(), QueryParameterValue::string("semantic")),
+        ]),
+    )
+    .await
+    .expect("schema-shared udf should call source function with params");
+
+    assert_eq!(
+        execution_to_rows(&execution),
+        vec![json!({"title": "Schema-shared udf", "score": 3.0})]
+    );
+    assert_eq!(execution.provenance().sources(), ["shared_udf_schema"]);
+    let published_function = execution
+        .provenance()
+        .table_functions()
+        .iter()
+        .find(|function| function.function_name() == "review_queue")
+        .expect("invoked UDF provenance");
+    assert_eq!(published_function.source_name(), "shared_udf_schema");
+    let body_function = execution
+        .provenance()
+        .table_functions()
+        .iter()
+        .find(|function| function.function_name() == "search_issues")
+        .expect("UDF body table-function provenance");
+    assert_eq!(body_function.source_name(), "shared_udf_schema");
+}
+
+#[tokio::test]
+async fn unknown_function_in_shared_source_schema_keeps_source_diagnostic() {
+    assert_source_udf_sql_error(
+        "shared_udf_schema",
+        vec![review_queue_udf_published_as(
+            "shared_udf_schema",
+            "shared_udf_schema",
+        )],
+        "select * from shared_udf_schema.nope()",
+        "unknown source table function shared_udf_schema.nope; available functions: shared_udf_schema.search_issues",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn udf_table_function_cannot_replace_source_table_function() {
+    assert_source_udf_sql_error(
+        "source_function_collision_search",
+        vec![review_queue_udf_published_at(
+            "source_function_collision_search",
+            "source_function_collision_search",
+            "search_issues",
+        )],
+        "select * from source_function_collision_search.search_issues(query => 'repo:withcoral/coral review', mode => 'hybrid')",
+        "udf table function source_function_collision_search.search_issues conflicts with existing table function",
+    )
+    .await;
 }


### PR DESCRIPTION
## Intent

Execute a validated Coral SQL UDF as a DataFusion table function.

This PR is the execution slice: it takes the inferred and validated definitions from the preceding PRs and installs them into one query runtime. Catalog discovery remains in #1530.

## Execution lifecycle

1. `QueryRuntimeConfig` receives validated UDF definitions.
2. Runtime setup normalizes published names, rejects duplicates and source-function collisions, validates declared results, and plans each body.
3. A relation planner parks UDF calls as extension nodes.
4. DataFusion binds outer query parameters.
5. An analyzer validates call arguments and expands each parked node into the planned UDF body.
6. The existing source-function analyzer resolves source calls inside that expanded body.

This ordering is the core invariant: body parameters are never substituted as SQL text, and source functions inside a UDF use the same planner/analyzer path as ordinary queries.

## What changed

- Added `QueryRuntimeConfig::with_udfs` and runtime UDF registration.
- Added the UDF relation planner and expansion analyzer.
- Added canonical identifier handling, duplicate/collision checks, and result-schema validation.
- Added scenario tests for execution, query parameters, normalization, limits, unsupported modifiers, collisions, and declared result mismatches.
- Kept the catalog-app adjustment at the gRPC service boundary: the larger runtime makes four catalog futures exceed the workspace `large_futures` lint threshold, so only those service calls are boxed. Catalog behavior is unchanged.

## Boundaries

- `coral-engine` owns compilation and execution of generic runtime definitions.
- This PR supports table-function publication only.
- UDF bodies are Coral SQL and may call installed source functions.
- No UDF definitions means the existing source-only runtime path is unchanged.

## Review-size note

Most of the diff is one cohesive planner/analyzer module plus scenario coverage: `runtime/udf_calls.rs` is about 480 lines and the engine test additions are about 630 lines. There is no smaller independently useful execution slice between “park the call” and “expand a typed body.”

## Review order

1. `contracts/query.rs` — runtime config input.
2. `runtime/udf_calls.rs` — park, bind, and expand.
3. `runtime/query.rs` — registration and analyzer order.
4. `runtime/scoped_table_functions.rs` and `runtime/source_functions.rs` — shared name and source seams.
5. `coral-app/src/catalog/service.rs` — boundary-only future boxing.
6. `tests/udf_tests.rs` — execution and failure cases.

## Not in this PR

- Catalog discovery; that is #1530.
- Storage, lifecycle, API, app loading, or CLI commands.
- Nested UDF calls.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p coral-engine --test engine --all-features --locked udf_`
- `cargo clippy -p coral-engine -p coral-app --all-targets --all-features --locked -- -D warnings`
- `make rust-checks` from the top of the restacked series
