### PR TITLE
fix(engine): scope runtime inputs to source components

### DIFF
--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -161,7 +161,7 @@ fn http_manifest_for_surface(
         rate_limit: openapi_runtime.rate_limit.clone(),
         tables,
         functions,
-        declared_inputs: manifest.declared_inputs.clone(),
+        declared_inputs: surface.inputs.clone(),
     })
 }
 
@@ -255,7 +255,7 @@ fn mcp_manifest_for_surface(
         server: mcp_runtime.server.clone(),
         functions,
         tables,
-        declared_inputs: manifest.declared_inputs.clone(),
+        declared_inputs: surface.inputs.clone(),
     })
 }
 
@@ -408,7 +408,10 @@ mod tests {
         SurfaceRuntimeConfig, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource,
         V4SourceCommon, V4SourceManifest, V4Surface,
     };
-    use coral_spec::{PageSizeSpec, PaginationMode, PaginationSpec, ResponseSpec};
+    use coral_spec::{
+        ManifestInputKind, ManifestInputSpec, PageSizeSpec, PaginationMode, PaginationSpec,
+        ResponseSpec,
+    };
 
     use super::{runtime_components_for_v4_source, surface_base_url};
 
@@ -622,6 +625,17 @@ mod tests {
         }
     }
 
+    fn secret_input(key: &str) -> ManifestInputSpec {
+        ManifestInputSpec {
+            key: key.to_string(),
+            kind: ManifestInputKind::Secret,
+            required: true,
+            default_value: String::new(),
+            hint: None,
+            credential: None,
+        }
+    }
+
     #[test]
     fn multi_surface_runtime_components_use_surface_relation_namespaces() {
         let manifest = V4SourceManifest {
@@ -671,6 +685,83 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(schema_names, ["github_v4_rest", "github_v4_mcp"]);
+    }
+
+    #[test]
+    fn multi_surface_runtime_components_use_surface_declared_inputs() {
+        let rest_input = secret_input("rest_token");
+        let mcp_input = secret_input("mcp_token");
+        let mut rest_surface = openapi_surface("rest", "github_v4_rest");
+        rest_surface.inputs = vec![rest_input.clone()];
+        let mut mcp_surface = mcp_surface("mcp", "github_v4_mcp");
+        mcp_surface.inputs = vec![mcp_input.clone()];
+        let manifest = V4SourceManifest {
+            common: V4SourceCommon {
+                dsl_version: 4,
+                name: "github_v4".to_string(),
+                description: String::new(),
+                test_queries: Vec::new(),
+            },
+            declared_inputs: vec![rest_input, mcp_input],
+            surfaces: vec![rest_surface, mcp_surface],
+        };
+        let materialized = V4MaterializedSource {
+            fingerprint: Fingerprint {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "github_v4".to_string(),
+                manifest_sha256: String::new(),
+                surfaces: Vec::new(),
+                importer_version: SURFACE_IMPORTER_VERSION.to_string(),
+                projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+            },
+            surfaces: vec![
+                rest_materialized_surface_with_pagination(
+                    "rest",
+                    "rest_list_issues",
+                    PaginationSpec::default(),
+                ),
+                mcp_materialized_surface("mcp", "mcp_list_issues"),
+            ],
+            projections: ProjectionCatalog {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "github_v4".to_string(),
+                generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
+                projections: vec![
+                    published_projection("rest", "github_v4_rest", "rest_list_issues"),
+                    published_projection("mcp", "github_v4_mcp", "mcp_list_issues"),
+                ],
+                diagnostics: Vec::new(),
+            },
+            diagnostics: Vec::new(),
+        };
+
+        let components =
+            runtime_components_for_v4_source(&manifest, &materialized).expect("runtime components");
+        let coral_engine::RuntimeSourceComponent::Http(http) =
+            components.first().expect("http component")
+        else {
+            panic!("expected HTTP component");
+        };
+        let coral_engine::RuntimeSourceComponent::Mcp(mcp) =
+            components.get(1).expect("mcp component")
+        else {
+            panic!("expected MCP component");
+        };
+
+        assert_eq!(
+            http.declared_inputs
+                .iter()
+                .map(|input| input.key.as_str())
+                .collect::<Vec<_>>(),
+            ["rest_token"]
+        );
+        assert_eq!(
+            mcp.declared_inputs
+                .iter()
+                .map(|input| input.key.as_str())
+                .collect::<Vec<_>>(),
+            ["mcp_token"]
+        );
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -76,7 +76,10 @@ pub(crate) fn compile_manifest(
 ) -> Box<dyn CompiledBackendSource> {
     compile_source(
         manifest.clone(),
-        SourceInputResolutionContext::from_query_source(request.source),
+        SourceInputResolutionContext::from_query_source_for_inputs(
+            request.source,
+            &manifest.declared_inputs,
+        ),
         request.request_authenticators.clone(),
         request.runtime_context.body_capture_max_bytes,
         request.runtime_context.trace_context.clone(),

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -90,7 +90,10 @@ pub(crate) fn compile_manifest(
     manifest: &McpSourceManifest,
     request: &BackendCompileRequest<'_>,
 ) -> Box<dyn CompiledBackendSource> {
-    let source_input_resolution = SourceInputResolutionContext::from_query_source(request.source);
+    let source_input_resolution = SourceInputResolutionContext::from_query_source_for_inputs(
+        request.source,
+        &manifest.declared_inputs,
+    );
     let resolved_inputs = Arc::new(coral_spec::resolve_inputs(
         &manifest.declared_inputs,
         source_input_resolution.secrets(),

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -156,11 +156,41 @@ impl SourceInputResolutionContext {
     #[must_use]
     /// Builds request input-resolution context from one selected query source.
     pub fn from_query_source(source: &QuerySource) -> Self {
+        Self::from_query_source_for_inputs(source, source.declared_inputs())
+    }
+
+    #[must_use]
+    /// Builds request input-resolution context scoped to one runtime component.
+    pub(crate) fn from_query_source_for_inputs(
+        source: &QuerySource,
+        declared_inputs: &[ManifestInputSpec],
+    ) -> Self {
+        let variables = declared_inputs
+            .iter()
+            .filter(|input| input.kind == ManifestInputKind::Variable)
+            .filter_map(|input| {
+                source
+                    .variables()
+                    .get(&input.key)
+                    .map(|value| (input.key.clone(), value.clone()))
+            })
+            .collect();
+        let secrets = declared_inputs
+            .iter()
+            .filter(|input| input.kind == ManifestInputKind::Secret)
+            .filter_map(|input| {
+                source
+                    .secrets()
+                    .get(&input.key)
+                    .map(|value| (input.key.clone(), value.clone()))
+            })
+            .collect();
+
         Self {
             source_name: Arc::from(source.source_name()),
-            declared_inputs: Arc::from(source.declared_inputs().to_vec()),
-            variables: Arc::new(source.variables().clone()),
-            secrets: Arc::new(source.secrets().clone()),
+            declared_inputs: Arc::from(declared_inputs.to_vec()),
+            variables: Arc::new(variables),
+            secrets: Arc::new(secrets),
         }
     }
 

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -1,11 +1,15 @@
 use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
 
-use coral_engine::{CoralQuery, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage};
+use coral_engine::{
+    CoralQuery, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
+    SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError,
+};
 use coral_spec::backends::http::HttpSourceManifest;
 use coral_spec::parse_source_manifest_yaml;
 use coral_spec::{FilterMode, FilterSpec, ManifestDataType};
 use serde_json::json;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::harness::{execution_to_rows, test_runtime};
@@ -62,6 +66,119 @@ async fn multi_component_source_executes_across_component_tables() {
         vec![
             json!({"kind": "issue", "id": 1, "title": "Issue"}),
             json!({"kind": "pull", "id": 2, "title": "Pull"}),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn multi_component_source_scopes_inputs_to_each_component() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/items"))
+        .and(header("authorization", "Bearer fresh-rest-token"))
+        .and(header("x-region", "eu-west-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {"id": 1}
+        ])))
+        .mount(&server)
+        .await;
+
+    let rest = http_component_with_inputs(&server.uri());
+    let mcp = mcp_component_with_inputs();
+    let mut declared_inputs = rest.declared_inputs.clone();
+    declared_inputs.extend(mcp.declared_inputs.clone());
+    let source = QuerySource::from_runtime_components(
+        RuntimeSourcePackage {
+            source_name: "demo".to_string(),
+            authored_version: None,
+            description: "Multi-surface input isolation fixture".to_string(),
+            declared_inputs,
+            test_queries: Vec::new(),
+            components: vec![
+                RuntimeSourceComponent::Http(rest),
+                RuntimeSourceComponent::Mcp(mcp),
+            ],
+        },
+        BTreeMap::from([
+            ("MCP_REGION".to_string(), "us-east-1".to_string()),
+            ("MCP_TOKEN".to_string(), "wrong-kind-variable".to_string()),
+            ("REST_REGION".to_string(), "eu-west-1".to_string()),
+            ("REST_TOKEN".to_string(), "wrong-kind-variable".to_string()),
+        ]),
+        BTreeMap::from([
+            ("MCP_REGION".to_string(), "wrong-kind-secret".to_string()),
+            ("MCP_TOKEN".to_string(), "mcp-token".to_string()),
+            ("REST_REGION".to_string(), "wrong-kind-secret".to_string()),
+            ("REST_TOKEN".to_string(), "stale-rest-token".to_string()),
+        ]),
+    )
+    .expect("runtime package");
+
+    assert_component_input_catalog(&source).await;
+
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let mut runtime = test_runtime();
+    runtime.extensions.source_input_resolver = Some(Arc::new(RecordingInputResolver {
+        calls: Arc::clone(&calls),
+    }));
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(&[source], runtime, "SELECT id FROM demo_rest.items")
+            .await
+            .expect("REST query should execute without resolving MCP inputs"),
+    );
+
+    assert_eq!(rows, vec![json!({"id": 1})]);
+    assert_eq!(
+        *calls.lock().expect("resolver calls"),
+        vec![ResolutionCall {
+            source_name: "demo".to_string(),
+            declared_inputs: vec!["REST_REGION".to_string(), "REST_TOKEN".to_string()],
+            variables: vec!["REST_REGION".to_string()],
+            secrets: vec!["REST_TOKEN".to_string()],
+        }]
+    );
+}
+
+async fn assert_component_input_catalog(source: &QuerySource) {
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            std::slice::from_ref(source),
+            test_runtime(),
+            "SELECT schema_name, key, kind, value, is_set FROM coral.inputs \
+             WHERE schema_name IN ('demo_mcp', 'demo_rest') ORDER BY schema_name, key",
+        )
+        .await
+        .expect("catalog query should succeed"),
+    );
+    assert_eq!(
+        rows,
+        vec![
+            json!({
+                "schema_name": "demo_mcp",
+                "key": "MCP_REGION",
+                "kind": "variable",
+                "value": "us-east-1",
+                "is_set": true,
+            }),
+            json!({
+                "schema_name": "demo_mcp",
+                "key": "MCP_TOKEN",
+                "kind": "secret",
+                "is_set": true,
+            }),
+            json!({
+                "schema_name": "demo_rest",
+                "key": "REST_REGION",
+                "kind": "variable",
+                "value": "eu-west-1",
+                "is_set": true,
+            }),
+            json!({
+                "schema_name": "demo_rest",
+                "key": "REST_TOKEN",
+                "kind": "secret",
+                "is_set": true,
+            }),
         ]
     );
 }
@@ -270,6 +387,113 @@ tables:
     ))
     .expect("manifest");
     manifest.as_http().expect("http manifest").clone()
+}
+
+fn http_component_with_inputs(base_url: &str) -> HttpSourceManifest {
+    let manifest = parse_source_manifest_yaml(&format!(
+        r#"
+name: demo_rest
+version: 1.0.0
+dsl_version: 3
+backend: http
+inputs:
+  REST_REGION:
+    kind: variable
+  REST_TOKEN:
+    kind: secret
+base_url: {base_url}
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{{{input.REST_TOKEN}}}}
+    - name: X-Region
+      from: template
+      template: "{{{{input.REST_REGION}}}}"
+tables:
+  - name: items
+    description: REST items
+    request:
+      method: GET
+      path: /items
+    response: {{}}
+    columns:
+      - name: id
+        type: Int64
+"#
+    ))
+    .expect("REST component manifest");
+    manifest.as_http().expect("HTTP manifest").clone()
+}
+
+fn mcp_component_with_inputs() -> coral_spec::backends::mcp::McpSourceManifest {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: demo_mcp
+version: 1.0.0
+dsl_version: 3
+backend: mcp
+inputs:
+  MCP_REGION:
+    kind: variable
+  MCP_TOKEN:
+    kind: secret
+server:
+  transport: stdio
+  command: unused
+tables:
+  - name: items
+    description: MCP items
+    tool: list_items
+    response:
+      rows_path: [items]
+    columns:
+      - name: id
+        type: Int64
+",
+    )
+    .expect("MCP component manifest");
+    manifest.as_mcp().expect("MCP manifest").clone()
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ResolutionCall {
+    source_name: String,
+    declared_inputs: Vec<String>,
+    variables: Vec<String>,
+    secrets: Vec<String>,
+}
+
+#[derive(Debug)]
+struct RecordingInputResolver {
+    calls: Arc<Mutex<Vec<ResolutionCall>>>,
+}
+
+#[async_trait::async_trait]
+impl SourceInputResolver for RecordingInputResolver {
+    async fn resolve_inputs(
+        &self,
+        source: &SourceInputResolutionContext,
+    ) -> Result<BTreeMap<String, String>, SourceInputResolverError> {
+        self.calls
+            .lock()
+            .expect("resolver calls")
+            .push(ResolutionCall {
+                source_name: source.source_name().to_string(),
+                declared_inputs: source
+                    .declared_inputs()
+                    .iter()
+                    .map(|input| input.key.clone())
+                    .collect(),
+                variables: source.variables().keys().cloned().collect(),
+                secrets: source.secrets().keys().cloned().collect(),
+            });
+        let mut resolved = source.variables().clone();
+        resolved.extend(source.secrets().clone());
+        resolved.insert("REST_TOKEN".to_string(), "fresh-rest-token".to_string());
+        Ok(resolved)
+    }
 }
 
 fn file_component_with_lookup_key_filter() -> coral_spec::backends::file::FileSourceManifest {


### PR DESCRIPTION
## Intent

DSL v4 package assembly keeps a source-wide union of declared inputs while each generated runtime component owns only its surface declarations. The component manifests were narrowed, but HTTP and MCP compilation rebuilt request-time resolver contexts from the package union, so a query could refresh unrelated credentials and `coral.inputs` duplicated unrelated input metadata across schemas.

This change scopes HTTP and MCP resolution contexts, variables, and secrets to each component declaration while preserving the logical installed source name used by app-managed credential snapshots.

## What it enables

Multi-surface sources isolate request-time input refresh and catalog exposure by component. An expired OAuth credential on one surface can no longer be considered while another surface issues a request, and each component schema reports only the inputs it owns.

## Usage examples

For a source with a REST component declaring `REST_REGION` and `REST_TOKEN` plus an MCP component declaring `MCP_REGION` and `MCP_TOKEN`:

- a query against the REST component resolves only `REST_REGION` and `REST_TOKEN`
- the resolver still receives the logical source name rather than the component schema name
- `coral.inputs` lists REST keys under the REST schema and MCP keys under the MCP schema

The regression also injects wrong-kind material to prove variable and secret maps are filtered by both key and declared kind.

## Validation

- `cargo test --locked -p coral-engine --all-features --test engine multi_component_source_scopes_inputs_to_each_component -- --nocapture`
- `cargo test --locked -p coral-engine --all-features --test engine composite_tests:: -- --nocapture`
- `make rust-checks` — Clippy, 1,579 tests, and rustdoc passed
- fresh structured autoreview: clean, confidence 0.94