### PR TITLE
feat(api): add identity service contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,6 +1336,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
+ "tokio-stream",
  "tonic",
  "tonic-types",
  "tracing",

--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -1,6 +1,25 @@
 //! Build script for the generated `coral-api` `protobuf` and `tonic` bindings.
 
+const PROTOS: &[&str] = &[
+    "proto/coral/v1/catalog.proto",
+    "proto/coral/v1/resources.proto",
+    "proto/coral/v1/workspaces.proto",
+    "proto/coral/v1/task.proto",
+    "proto/coral/v1/feedback.proto",
+    "proto/coral/v1/sources.proto",
+    "proto/coral/v1/identities.proto",
+    "proto/coral/v1/identity_specs.proto",
+    "proto/coral/v1/query.proto",
+    "proto/coral/v1/search.proto",
+    "proto/coral/v1/traces.proto",
+];
+
 fn main() {
+    for proto in PROTOS {
+        println!("cargo:rerun-if-changed={proto}");
+    }
+    println!("cargo:rerun-if-changed=proto");
+
     let protoc = protoc_bin_vendored::protoc_bin_path().expect("vendored protoc");
     let mut config = tonic_prost_build::Config::new();
     config.protoc_executable(protoc);
@@ -15,20 +34,6 @@ fn main() {
     tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
-        .compile_with_config(
-            config,
-            &[
-                "proto/coral/v1/catalog.proto",
-                "proto/coral/v1/resources.proto",
-                "proto/coral/v1/workspaces.proto",
-                "proto/coral/v1/task.proto",
-                "proto/coral/v1/feedback.proto",
-                "proto/coral/v1/sources.proto",
-                "proto/coral/v1/query.proto",
-                "proto/coral/v1/search.proto",
-                "proto/coral/v1/traces.proto",
-            ],
-            &["proto"],
-        )
+        .compile_with_config(config, PROTOS, &["proto"])
         .expect("compile coral v1 protobuf");
 }

--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -1,0 +1,131 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/resources.proto";
+
+// Scope that owns stored provider-facing identity material.
+enum IdentityOwner {
+  // Identity owner was not specified.
+  IDENTITY_OWNER_UNSPECIFIED = 0;
+  // Identity material is owned by the current Coral user principal.
+  IDENTITY_OWNER_USER = 1;
+  // Identity material is owned by a workspace and independent of a user principal.
+  IDENTITY_OWNER_WORKSPACE = 2;
+}
+
+// Stored provider-facing identity instance backed by an installed identity spec.
+message Identity {
+  // Stable identity name used by source identity bindings.
+  string name = 1;
+  // Identity spec name used to instantiate this identity. User-owned identities
+  // reference global specs; workspace-owned identities resolve their workspace
+  // spec with global fallback.
+  string identity_spec = 2;
+  // Provider or issuer name copied from the identity spec.
+  string issuer = 3;
+  // Identity type, such as `oauth` or `fixed_token`.
+  string identity_type = 4;
+  // Stored identity owner.
+  IdentityOwner owner = 5;
+  // Safe provider metadata, never token material.
+  repeated CredentialMetadata metadata = 6;
+}
+
+// Creates or replaces one identity owned by the request Coral user principal.
+message CreateUserOwnedIdentityRequest {
+  // Stable identity name used by source identity bindings.
+  string name = 1;
+  // Globally installed identity spec name. User-owned identities never resolve
+  // workspace-scoped specs.
+  string identity_spec = 2;
+
+  // Type-specific setup material. OAuth identity specs do not need per-identity
+  // setup material because their setup inputs belong to the installed identity
+  // spec.
+  oneof setup {
+    // Fixed-token identity setup input.
+    FixedTokenUserOwnedIdentitySetup fixed_token = 3;
+  }
+}
+
+// Setup payload for a fixed-token identity.
+message FixedTokenUserOwnedIdentitySetup {
+  // Bearer token to store for this identity.
+  string token = 1;
+}
+
+// OAuth authorization details emitted while creating an identity.
+message IdentityOAuthAuthorization {
+  // Provider authorization URL the user must visit.
+  string authorization_url = 1;
+  // Seconds until the OAuth retrieval expires.
+  uint64 expires_in_seconds = 2;
+  // Device-flow user code the user must enter at the provider URL.
+  string user_code = 3;
+  // Device-flow provider verification URL.
+  string verification_uri = 4;
+  // Device-flow provider verification URL with the user code embedded, when provided.
+  string verification_uri_complete = 5;
+}
+
+// Safe completion details emitted after creating an OAuth identity.
+message IdentityOAuthCompleted {
+  // Safe provider metadata, never token material.
+  repeated CredentialMetadata metadata = 1;
+}
+
+// Streaming event emitted while creating a user-owned identity.
+message CreateUserOwnedIdentityResponse {
+  // Creation progress or completion event.
+  oneof event {
+    // Identity creation completed.
+    Identity identity = 1;
+    // OAuth authorization URL is ready.
+    IdentityOAuthAuthorization oauth_authorization = 2;
+    // OAuth credential retrieval completed.
+    IdentityOAuthCompleted oauth_completed = 3;
+  }
+}
+
+// Lists user-owned identities for the request Coral user principal.
+message ListUserOwnedIdentitiesRequest {}
+
+// Returns user-owned identities sorted by name.
+message ListUserOwnedIdentitiesResponse {
+  // Stored user-owned identities.
+  repeated Identity identities = 1;
+}
+
+// Fetches one user-owned identity for the request Coral user principal.
+message GetUserOwnedIdentityRequest {
+  // Stored identity name.
+  string name = 1;
+}
+
+// Returns one user-owned identity.
+message GetUserOwnedIdentityResponse {
+  // Stored identity.
+  Identity identity = 1;
+}
+
+// Deletes one user-owned identity for the request Coral user principal.
+message DeleteUserOwnedIdentityRequest {
+  // Stored identity name.
+  string name = 1;
+}
+
+// Confirms user-owned identity deletion.
+message DeleteUserOwnedIdentityResponse {}
+
+// Stored identity APIs.
+service IdentityService {
+  // Creates or replaces one identity owned by the request Coral user principal.
+  rpc CreateUserOwnedIdentity(CreateUserOwnedIdentityRequest) returns (stream CreateUserOwnedIdentityResponse);
+  // Lists user-owned identities.
+  rpc ListUserOwnedIdentities(ListUserOwnedIdentitiesRequest) returns (ListUserOwnedIdentitiesResponse);
+  // Fetches one user-owned identity.
+  rpc GetUserOwnedIdentity(GetUserOwnedIdentityRequest) returns (GetUserOwnedIdentityResponse);
+  // Deletes one user-owned identity.
+  rpc DeleteUserOwnedIdentity(DeleteUserOwnedIdentityRequest) returns (DeleteUserOwnedIdentityResponse);
+}

--- a/crates/coral-api/proto/coral/v1/identity_specs.proto
+++ b/crates/coral-api/proto/coral/v1/identity_specs.proto
@@ -1,0 +1,120 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/resources.proto";
+
+// An identity spec installed in either the global scope or one workspace scope.
+message IdentitySpec {
+  // Stable identity spec name.
+  string name = 1;
+  // Authored identity spec version string.
+  string version = 2;
+  // Human-readable description.
+  string description = 3;
+  // Provider or issuer name, such as `github`.
+  string issuer = 4;
+  // Identity type, such as `oauth` or `fixed_token`.
+  string identity_type = 5;
+  // Canonical identity spec manifest YAML.
+  string manifest_yaml = 6;
+  // Scope where this identity spec is installed. If absent, the spec is global.
+  Workspace workspace = 7;
+}
+
+// Installs one identity spec in the requested scope, or replaces an unused
+// existing spec in that same scope. Existing specs referenced by stored
+// identities may only be re-added with an equivalent manifest.
+message AddIdentitySpecRequest {
+  // Raw identity spec manifest YAML to validate and install.
+  string manifest_yaml = 1;
+  // Setup input values owned by the installed identity spec. The server parses
+  // `manifest_yaml`, matches values by key to declared identity spec inputs,
+  // and uses the manifest-declared input kind to decide whether each value is
+  // secret material.
+  repeated IdentitySpecInputValue input_values = 2;
+  // Target scope. If absent, installs globally; if present, installs in that
+  // workspace's identity-spec scope.
+  Workspace workspace = 3;
+}
+
+// One setup input value for an installed identity spec.
+message IdentitySpecInputValue {
+  // Declared identity spec input key from AddIdentitySpecRequest.manifest_yaml.
+  string key = 1;
+  // Input value. Callers do not classify values here; the identity spec
+  // manifest determines whether this value is stored as secret material.
+  string value = 2;
+}
+
+// Returns the installed identity spec.
+message AddIdentitySpecResponse {
+  // The installed identity spec, including the scope where it was installed.
+  IdentitySpec identity_spec = 1;
+  // Whether an existing spec with the same name in the same scope was replaced.
+  bool replaced = 2;
+}
+
+// Lists installed identity specs in one requested scope.
+message ListIdentitySpecsRequest {
+  // Requested identity-spec scope. If absent, list global specs. If present,
+  // list specs installed in that workspace's scope.
+  Workspace workspace = 1;
+  // When workspace is present, include global specs alongside workspace-scoped
+  // specs. When workspace is absent, the requested scope is already global, so
+  // this flag has no additional effect.
+  bool include_global = 2;
+}
+
+// Returns identity specs for the requested scope.
+message ListIdentitySpecsResponse {
+  // Installed identity specs sorted by scope and name. Each item includes its
+  // own scope; absent workspace means the item is global.
+  repeated IdentitySpec identity_specs = 1;
+}
+
+// Fetches one installed identity spec in one requested scope.
+message GetIdentitySpecRequest {
+  // Identity spec name.
+  string name = 1;
+  // Requested identity-spec scope. If absent, fetches the global spec. If
+  // present, fetches the spec in that workspace's scope.
+  Workspace workspace = 2;
+}
+
+// Returns one installed identity spec.
+message GetIdentitySpecResponse {
+  // The installed identity spec, including the scope where it was installed.
+  IdentitySpec identity_spec = 1;
+}
+
+// Deletes one installed identity spec in one requested scope.
+message DeleteIdentitySpecRequest {
+  // Identity spec name.
+  string name = 1;
+  // Requested identity-spec scope. If absent, deletes the global spec. If
+  // present, deletes the spec in that workspace's scope.
+  Workspace workspace = 2;
+  // Required when deleting the spec would orphan stored identity instances of
+  // any owner or identity type.
+  bool force = 3;
+}
+
+// Confirms identity spec deletion.
+message DeleteIdentitySpecResponse {
+  // Number of stored identities orphaned by deletion, across identity owners
+  // and identity types visible to the app.
+  uint32 orphaned_identities = 1;
+}
+
+// Identity spec APIs.
+service IdentitySpecService {
+  // Installs one identity spec in the requested scope.
+  rpc AddIdentitySpec(AddIdentitySpecRequest) returns (AddIdentitySpecResponse);
+  // Lists identity specs in the requested scope.
+  rpc ListIdentitySpecs(ListIdentitySpecsRequest) returns (ListIdentitySpecsResponse);
+  // Fetches one identity spec in the requested scope.
+  rpc GetIdentitySpec(GetIdentitySpecRequest) returns (GetIdentitySpecResponse);
+  // Deletes one identity spec in the requested scope.
+  rpc DeleteIdentitySpec(DeleteIdentitySpecRequest) returns (DeleteIdentitySpecResponse);
+}

--- a/crates/coral-api/proto/coral/v1/resources.proto
+++ b/crates/coral-api/proto/coral/v1/resources.proto
@@ -7,3 +7,11 @@ message Workspace {
   // Bare workspace name, such as `default`.
   string name = 1;
 }
+
+// Safe metadata returned after credential retrieval completes.
+message CredentialMetadata {
+  // Metadata key.
+  string key = 1;
+  // Metadata value.
+  string value = 2;
+}

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -380,14 +380,6 @@ message ImportSourceResponse {
   }
 }
 
-// Safe metadata returned after OAuth retrieval completes.
-message CredentialMetadata {
-  // Metadata key.
-  string key = 1;
-  // Metadata value.
-  string value = 2;
-}
-
 // OAuth method input used during credential retrieval. These values are not
 // stored as source-visible configuration; Coral may store sensitive values as
 // internal credential metadata when needed to preserve the OAuth lifecycle.

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -61,6 +61,13 @@ pub const CATALOG_RESPONSE_MAX_MESSAGE_SIZE: usize = QUERY_RESPONSE_MAX_MESSAGE_
 /// DSL v4 sources from large `OpenAPI` documents can exceed tonic's 4 MB default.
 pub const SOURCE_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE_SIZE;
 
+/// Maximum gRPC message size for `IdentitySpecService` *responses*, in bytes.
+///
+/// Identity-spec listing returns an unpaginated aggregate in which every item
+/// includes its canonical manifest YAML, so valid responses can exceed tonic's
+/// 4 MB default.
+pub const IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE_SIZE;
+
 /// Maximum gRPC message size for `SearchService` *responses*, in bytes.
 ///
 /// Universal Search returns bounded metadata hints, but it may include table,

--- a/crates/coral-client/Cargo.toml
+++ b/crates/coral-client/Cargo.toml
@@ -29,4 +29,6 @@ coral-telemetry.workspace = true
 
 [dev-dependencies]
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
+tokio.workspace = true
+tokio-stream = { workspace = true, features = ["net"] }
 tracing-subscriber.workspace = true

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -3,12 +3,15 @@
 use coral_api::v1::Workspace;
 use coral_api::v1::catalog_service_client::CatalogServiceClient;
 use coral_api::v1::feedback_service_client::FeedbackServiceClient;
+use coral_api::v1::identity_service_client::IdentityServiceClient;
+use coral_api::v1::identity_spec_service_client::IdentitySpecServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::search_service_client::SearchServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
 use coral_api::v1::workspace_service_client::WorkspaceServiceClient;
 use coral_api::{
-    CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
+    CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE,
+    IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
     SEARCH_RESPONSE_MAX_MESSAGE_SIZE, SOURCE_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tonic::service::interceptor::InterceptedService;
@@ -44,6 +47,12 @@ pub type SourceClient = SourceServiceClient<GrpcService>;
 /// Public workspace-management gRPC client.
 pub type WorkspaceClient = WorkspaceServiceClient<GrpcService>;
 
+/// Public identity-spec gRPC client.
+pub type IdentitySpecClient = IdentitySpecServiceClient<GrpcService>;
+
+/// Public stored-identity gRPC client.
+pub type IdentityClient = IdentityServiceClient<GrpcService>;
+
 /// Public catalog-discovery gRPC client.
 pub type CatalogClient = CatalogServiceClient<GrpcService>;
 
@@ -63,6 +72,8 @@ pub type FeedbackClient = FeedbackServiceClient<GrpcService>;
 pub struct AppClient {
     source: SourceClient,
     workspace: WorkspaceClient,
+    identity_spec: IdentitySpecClient,
+    identity: IdentityClient,
     catalog: CatalogClient,
     query: QueryClient,
     search: SearchClient,
@@ -86,6 +97,10 @@ impl AppClient {
         let source_client = SourceClient::new(grpc_service(channel.clone(), &grpc_endpoint))
             .max_decoding_message_size(SOURCE_RESPONSE_MAX_MESSAGE_SIZE);
         let workspace_client = WorkspaceClient::new(grpc_service(channel.clone(), &grpc_endpoint));
+        let identity_spec_client =
+            IdentitySpecClient::new(grpc_service(channel.clone(), &grpc_endpoint))
+                .max_decoding_message_size(IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE);
+        let identity_client = IdentityClient::new(grpc_service(channel.clone(), &grpc_endpoint));
         let catalog_client = CatalogClient::new(grpc_service(channel.clone(), &grpc_endpoint))
             .max_decoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE);
         let query_client = QueryClient::new(grpc_service(channel.clone(), &grpc_endpoint))
@@ -96,6 +111,8 @@ impl AppClient {
         Ok(Self {
             source: source_client,
             workspace: workspace_client,
+            identity_spec: identity_spec_client,
+            identity: identity_client,
             catalog: catalog_client,
             query: query_client,
             search: search_client,
@@ -113,6 +130,18 @@ impl AppClient {
     /// Returns a cloned workspace-management client.
     pub fn workspace_client(&self) -> WorkspaceClient {
         self.workspace.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned identity-spec client.
+    pub fn identity_spec_client(&self) -> IdentitySpecClient {
+        self.identity_spec.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned stored-identity client.
+    pub fn identity_client(&self) -> IdentityClient {
+        self.identity.clone()
     }
 
     #[must_use]
@@ -145,4 +174,111 @@ fn grpc_service(channel: Channel, endpoint: &GrpcClientEndpoint) -> GrpcService 
         InterceptedService::new(channel, RequestContextInterceptor),
         endpoint.clone(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use coral_api::IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE;
+    use coral_api::v1::identity_spec_service_server::{
+        IdentitySpecService, IdentitySpecServiceServer,
+    };
+    use coral_api::v1::{
+        AddIdentitySpecRequest, AddIdentitySpecResponse, DeleteIdentitySpecRequest,
+        DeleteIdentitySpecResponse, GetIdentitySpecRequest, GetIdentitySpecResponse, IdentitySpec,
+        ListIdentitySpecsRequest, ListIdentitySpecsResponse,
+    };
+    use tokio::net::TcpListener;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tonic::transport::Server;
+    use tonic::{Request, Response, Status};
+
+    use super::AppClient;
+
+    const TONIC_DEFAULT_MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
+    const MANIFEST_SIZE: usize = 1024 * 1024;
+    const SPEC_COUNT: usize = 5;
+
+    #[derive(Debug)]
+    struct LargeIdentitySpecFixture;
+
+    #[tonic::async_trait]
+    impl IdentitySpecService for LargeIdentitySpecFixture {
+        async fn add_identity_spec(
+            &self,
+            _request: Request<AddIdentitySpecRequest>,
+        ) -> Result<Response<AddIdentitySpecResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+
+        async fn list_identity_specs(
+            &self,
+            _request: Request<ListIdentitySpecsRequest>,
+        ) -> Result<Response<ListIdentitySpecsResponse>, Status> {
+            let identity_specs = (0..SPEC_COUNT)
+                .map(|index| IdentitySpec {
+                    name: format!("large-{index}"),
+                    manifest_yaml: "x".repeat(MANIFEST_SIZE),
+                    ..IdentitySpec::default()
+                })
+                .collect();
+            Ok(Response::new(ListIdentitySpecsResponse { identity_specs }))
+        }
+
+        async fn get_identity_spec(
+            &self,
+            _request: Request<GetIdentitySpecRequest>,
+        ) -> Result<Response<GetIdentitySpecResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+
+        async fn delete_identity_spec(
+            &self,
+            _request: Request<DeleteIdentitySpecRequest>,
+        ) -> Result<Response<DeleteIdentitySpecResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+    }
+
+    #[tokio::test]
+    async fn app_client_decodes_identity_spec_aggregate_above_tonic_default() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind identity-spec fixture");
+        let address = listener.local_addr().expect("read fixture address");
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .add_service(
+                    IdentitySpecServiceServer::new(LargeIdentitySpecFixture)
+                        .max_encoding_message_size(IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE),
+                )
+                .serve_with_incoming(TcpListenerStream::new(listener))
+                .await
+        });
+
+        let app_client = AppClient::connect(&format!("http://{address}"))
+            .await
+            .expect("connect AppClient to identity-spec fixture");
+        let response = app_client
+            .identity_spec_client()
+            .list_identity_specs(ListIdentitySpecsRequest::default())
+            .await
+            .expect("decode identity-spec response through AppClient")
+            .into_inner();
+
+        assert_eq!(response.identity_specs.len(), SPEC_COUNT);
+        assert!(
+            response
+                .identity_specs
+                .iter()
+                .all(|spec| spec.manifest_yaml.len() < TONIC_DEFAULT_MAX_MESSAGE_SIZE)
+        );
+        let manifest_bytes = response
+            .identity_specs
+            .iter()
+            .map(|spec| spec.manifest_yaml.len())
+            .sum::<usize>();
+        assert!(manifest_bytes > TONIC_DEFAULT_MAX_MESSAGE_SIZE);
+
+        server.abort();
+    }
 }

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -41,8 +41,9 @@ use coral_api::v1::ExecuteSqlResponse;
 use serde_json::Value;
 
 pub use client::{
-    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, QueryClient, SearchClient,
-    SourceClient, WorkspaceClient, default_workspace, workspace,
+    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, IdentityClient,
+    IdentitySpecClient, QueryClient, SearchClient, SourceClient, WorkspaceClient,
+    default_workspace, workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use search::{


### PR DESCRIPTION
## Intent
Land the first API surface of the `dsl-v4-identity-v3` stack: protobuf contracts for identity specs and stored identities, plus thin `coral-client` accessors. This is contracts and clients only; service implementations land in later stack units.

## What it enables
Later units can implement the identity spec manager, identity manager, and OAuth runtime on a DB-backed store while generated clients already compile against the gRPC surface. The API supports global and workspace-scoped identity specs and user-owned identity credential objects.

## Usage examples
- Use `AppClient::connect(endpoint).await?.identity_spec_client()` for `AddIdentitySpec`, `ListIdentitySpecs`, `GetIdentitySpec`, and `DeleteIdentitySpec`.
- Use `AppClient::connect(endpoint).await?.identity_client()` for `CreateUserOwnedIdentity`, `ListUserOwnedIdentities`, `GetUserOwnedIdentity`, and `DeleteUserOwnedIdentity`.
- For identity specs, omit `workspace` for global scope; set `workspace` for a workspace scope; set `include_global` on list requests only when workspace-scoped results should include global specs too.