### PR TITLE
feat(app): add request principal boundary

### DIFF
--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -15,6 +15,9 @@ use crate::state::db::DbError;
 /// Errors surfaced by the local application layer.
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
+    /// The request did not present valid authentication.
+    #[error("unauthenticated: {0}")]
+    Unauthenticated(String),
     /// A requested source was not found in config.
     #[error("source '{0}' not found")]
     SourceNotFound(String),
@@ -153,6 +156,10 @@ fn truncate_status_detail(detail: String) -> String {
     format!("{truncated}{MARKER}")
 }
 
+pub(crate) fn status_with_bounded_detail(code: Code, detail: impl Into<String>) -> Status {
+    Status::new(code, truncate_status_detail(detail.into()))
+}
+
 #[expect(
     clippy::needless_pass_by_value,
     reason = "used directly as a map_err adapter across tonic service handlers"
@@ -177,7 +184,7 @@ pub(crate) fn app_status(error: AppError) -> Status {
             details,
         );
     }
-    Status::new(app_code(&error), truncate_status_detail(error.to_string()))
+    status_with_bounded_detail(app_code(&error), error.to_string())
 }
 
 pub(crate) fn core_status(error: CoreError) -> Status {
@@ -245,6 +252,7 @@ fn grpc_code(status: StatusCode) -> Code {
 
 fn app_code(error: &AppError) -> Code {
     match error {
+        AppError::Unauthenticated(_) => Code::Unauthenticated,
         AppError::SourceNotFound(_) | AppError::WorkspaceNotFound(_) => Code::NotFound,
         AppError::WorkspaceAlreadyExists(_) => Code::AlreadyExists,
         AppError::InvalidInput(_) => Code::InvalidArgument,
@@ -305,6 +313,15 @@ mod tests {
                 .contains("cannot resolve source identities")
         );
         assert!(!status.message().contains("Re-add"));
+    }
+
+    #[test]
+    fn app_status_maps_unauthenticated_and_truncates_detail() {
+        let status = app_status(AppError::Unauthenticated("x".repeat(20 * 1024)));
+
+        assert_eq!(status.code(), Code::Unauthenticated);
+        assert!(status.message().len() <= MAX_STATUS_DETAIL_BYTES);
+        assert!(status.message().ends_with("… (truncated)"));
     }
 
     #[test]

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -15,7 +15,7 @@ use crate::workspaces::WorkspaceName;
 
 #[cfg(test)]
 pub(crate) use error::MAX_STATUS_DETAIL_BYTES;
-pub(crate) use error::{app_status, core_status};
+pub(crate) use error::{app_status, core_status, status_with_bounded_detail};
 
 pub use error::AppError;
 pub use server::{RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider};

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -1,6 +1,170 @@
 //! Shared validation helpers for app-owned identifiers.
 
+use std::fmt;
+
 use crate::bootstrap::AppError;
+
+/// Stable local user used by single-user local mode.
+pub(crate) const LOCAL_MEMBER_ID: &str = "local";
+
+/// Request-scoped user principal selected by the app transport layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserPrincipal {
+    user_id: String,
+}
+
+impl UserPrincipal {
+    /// Builds the default single-user local principal.
+    #[must_use]
+    pub fn local() -> Self {
+        Self {
+            user_id: LOCAL_MEMBER_ID.to_string(),
+        }
+    }
+
+    /// Builds a principal for a validated user id.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the user id is empty, contains whitespace,
+    /// contains path separators, or aliases the reserved local single-user
+    /// sentinel.
+    pub fn for_user(user_id: &str) -> Result<Self, AppError> {
+        if user_id.chars().any(char::is_whitespace) {
+            return Err(AppError::InvalidInput(
+                "user id must not contain whitespace".to_string(),
+            ));
+        }
+        let user_id = parse_path_segment("user", user_id)?;
+        if user_id == LOCAL_MEMBER_ID {
+            return Err(AppError::InvalidInput(format!(
+                "user id '{LOCAL_MEMBER_ID}' is reserved for single-user local mode"
+            )));
+        }
+        Ok(Self { user_id })
+    }
+
+    /// Returns the validated user id.
+    #[must_use]
+    pub fn user_id(&self) -> &str {
+        &self.user_id
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UserPrincipalProviderErrorKind {
+    Unauthenticated,
+    Unavailable,
+    Internal,
+}
+
+/// Client-safe failure reported by a request principal provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserPrincipalProviderError {
+    kind: UserPrincipalProviderErrorKind,
+    client_message: String,
+}
+
+impl UserPrincipalProviderError {
+    fn new(
+        kind: UserPrincipalProviderErrorKind,
+        client_message: impl Into<String>,
+        default_message: &str,
+    ) -> Self {
+        let client_message = client_message.into();
+        let client_message = if client_message.trim().is_empty() {
+            default_message.to_string()
+        } else {
+            client_message
+        };
+        Self {
+            kind,
+            client_message,
+        }
+    }
+
+    /// Builds a provider error with a client-safe message.
+    #[must_use]
+    pub fn unauthenticated(client_message: impl Into<String>) -> Self {
+        Self::new(
+            UserPrincipalProviderErrorKind::Unauthenticated,
+            client_message,
+            "unauthenticated request",
+        )
+    }
+
+    /// Builds a transient provider failure with a client-safe message.
+    #[must_use]
+    pub fn unavailable(client_message: impl Into<String>) -> Self {
+        Self::new(
+            UserPrincipalProviderErrorKind::Unavailable,
+            client_message,
+            "user principal provider unavailable",
+        )
+    }
+
+    /// Builds an unexpected provider failure with a client-safe message.
+    #[must_use]
+    pub fn internal(client_message: impl Into<String>) -> Self {
+        Self::new(
+            UserPrincipalProviderErrorKind::Internal,
+            client_message,
+            "user principal provider failed",
+        )
+    }
+
+    pub(crate) fn kind(&self) -> UserPrincipalProviderErrorKind {
+        self.kind
+    }
+
+    /// Returns the client-safe failure message.
+    #[must_use]
+    pub fn client_message(&self) -> &str {
+        &self.client_message
+    }
+}
+
+impl fmt::Display for UserPrincipalProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.client_message)
+    }
+}
+
+impl std::error::Error for UserPrincipalProviderError {}
+
+/// Server-side provider for request user principals.
+///
+/// The OSS provider always returns [`UserPrincipal::local`]. Product runtimes
+/// can install a provider that authenticates inbound metadata and returns the
+/// corresponding user principal.
+#[tonic::async_trait]
+pub trait UserPrincipalProvider: Send + Sync + std::fmt::Debug {
+    /// Returns the user principal for one inbound gRPC request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UserPrincipalProviderError`] when transport metadata is
+    /// malformed, the provider cannot authenticate the request, or principal
+    /// selection fails.
+    async fn principal_for_metadata(
+        &self,
+        metadata: &tonic::metadata::MetadataMap,
+    ) -> Result<UserPrincipal, UserPrincipalProviderError>;
+}
+
+/// Default OSS principal provider for single-user local mode.
+#[derive(Debug, Default)]
+pub struct SingleUserPrincipalProvider;
+
+#[tonic::async_trait]
+impl UserPrincipalProvider for SingleUserPrincipalProvider {
+    async fn principal_for_metadata(
+        &self,
+        _metadata: &tonic::metadata::MetadataMap,
+    ) -> Result<UserPrincipal, UserPrincipalProviderError> {
+        Ok(UserPrincipal::local())
+    }
+}
 
 pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppError> {
     let trimmed = value.trim();
@@ -22,7 +186,9 @@ pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppE
 
 #[cfg(test)]
 mod tests {
-    use super::parse_path_segment;
+    use super::{
+        SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider, parse_path_segment,
+    };
 
     #[test]
     fn rejects_empty_names() {
@@ -48,5 +214,42 @@ mod tests {
                 .to_string()
                 .contains("source name must not be '.' or '..'")
         );
+    }
+
+    #[test]
+    fn user_principal_rejects_whitespace_anywhere() {
+        for invalid in [" saul", "saul ", "alice bob", "alice\tbob", "alice\nbob"] {
+            let error = UserPrincipal::for_user(invalid).expect_err("whitespace should fail");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("user id must not contain whitespace")
+            );
+        }
+    }
+
+    #[test]
+    fn user_principal_rejects_path_segments_and_reserved_local_id() {
+        for invalid in ["team/saul", r"team\saul", ".", "..", "local"] {
+            UserPrincipal::for_user(invalid).expect_err("invalid user id should fail");
+        }
+    }
+
+    #[test]
+    fn user_principal_preserves_valid_id() {
+        let principal = UserPrincipal::for_user("saul").expect("valid user");
+
+        assert_eq!(principal.user_id(), "saul");
+    }
+
+    #[tokio::test]
+    async fn single_user_provider_returns_local_principal() {
+        let principal = SingleUserPrincipalProvider
+            .principal_for_metadata(&tonic::metadata::MetadataMap::new())
+            .await
+            .expect("local principal");
+
+        assert_eq!(principal, UserPrincipal::local());
     }
 }

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -49,6 +49,7 @@ pub mod features;
 mod feedback;
 mod identity;
 mod query;
+mod request_context;
 mod search;
 mod sources;
 mod state;
@@ -62,6 +63,9 @@ pub use bootstrap::{
     AppError, RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider,
 };
 pub use coral_engine::{EngineExtensions, QuerySource};
+pub use identity::{
+    SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider, UserPrincipalProviderError,
+};
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -703,6 +703,7 @@ fn query_error_message(error: &QueryManagerError) -> String {
 
 fn app_error_type(error: &AppError) -> &'static str {
     match error {
+        AppError::Unauthenticated(_) => "UNAUTHENTICATED",
         AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
         AppError::WorkspaceNotFound(_) => "WORKSPACE_NOT_FOUND",
         AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",

--- a/crates/coral-app/src/request_context.rs
+++ b/crates/coral-app/src/request_context.rs
@@ -1,0 +1,72 @@
+//! Request-scoped app context selected at the transport boundary.
+
+use tonic::{Request, Status};
+
+use crate::bootstrap::{AppError, app_status};
+use crate::identity::UserPrincipal;
+
+/// Request-scoped data that domain services may need after authentication.
+///
+/// This intentionally starts narrow. Query attribution still flows through its
+/// existing path today, but can move here later without widening every
+/// principal-aware call signature again.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RequestContext {
+    principal: UserPrincipal,
+}
+
+impl RequestContext {
+    pub(crate) fn new(principal: UserPrincipal) -> Self {
+        Self { principal }
+    }
+
+    // Installed server-wide by the immediate P1a child and consumed at service
+    // boundaries by P1b.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "installed server-wide by P1a and consumed at service boundaries by P1b"
+        )
+    )]
+    pub(crate) fn from_request<T>(request: &Request<T>) -> Result<Self, Status> {
+        request.extensions().get::<Self>().cloned().ok_or_else(|| {
+            app_status(AppError::Unauthenticated(
+                "missing request principal".to_string(),
+            ))
+        })
+    }
+
+    // Consumed by the QueryContext introduced in the immediate P1b child.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by the QueryContext introduced in the P1b child"
+        )
+    )]
+    pub(crate) fn principal(&self) -> &UserPrincipal {
+        &self.principal
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exposes_request_principal() {
+        let principal = UserPrincipal::for_user("saul").expect("valid user");
+        let context = RequestContext::new(principal.clone());
+
+        assert_eq!(context.principal(), &principal);
+    }
+
+    #[test]
+    fn rejects_requests_without_a_principal() {
+        let status = RequestContext::from_request(&Request::new(()))
+            .expect_err("missing context should fail closed");
+
+        assert_eq!(status.code(), tonic::Code::Unauthenticated);
+    }
+}

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -1,6 +1,9 @@
 //! Shared gRPC transport helpers for app-owned services.
 
 use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
 
 use coral_api::{
     CORAL_ERROR_DOMAIN, grpc_response_status_code,
@@ -17,20 +20,32 @@ use coral_spec::{SearchLimitsSpec, SourceTableFunctionKind};
 use opentelemetry::propagation::Extractor;
 use opentelemetry::trace::Status as OtelStatus;
 use tonic::codegen::{Service, http};
+use tonic::metadata::MetadataMap;
 use tonic::{Code, Request, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
+use tower::Layer;
 use tracing::{Instrument as _, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
-use crate::bootstrap::{AppError, app_status, core_status};
+use crate::bootstrap::{AppError, app_status, core_status, status_with_bounded_detail};
 use crate::catalog::discovery::{
     CatalogItem, CatalogMetadataField, CatalogSearchResult, ColumnMetadataField,
     ColumnSearchResult, DescribeTableResult,
 };
+use crate::identity::{
+    SingleUserPrincipalProvider, UserPrincipalProvider, UserPrincipalProviderError,
+    UserPrincipalProviderErrorKind,
+};
 use crate::query::manager::QueryManagerError;
+use crate::request_context::RequestContext;
 use crate::workspaces::WorkspaceName;
 
 struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
+
+const USER_PRINCIPAL_PROVIDER_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Clone)]
+struct GrpcServerSpan(tracing::Span);
 
 impl Extractor for MetadataExtractor<'_> {
     fn get(&self, key: &str) -> Option<&str> {
@@ -49,31 +64,33 @@ impl Extractor for MetadataExtractor<'_> {
     }
 }
 
-/// Wraps a generated tonic service and stores inbound request context on the request.
-///
-/// Tonic preserves `http::Request` extensions when it decodes the protobuf
-/// message into a `tonic::Request`, but generated server wrappers do not insert
-/// `tonic::GrpcMethod` the way generated clients do. This keeps the method
-/// data and Coral request metadata at the transport boundary and lets handlers
-/// read typed context from the request.
+/// Compatibility wrapper used until the next stack unit installs one layer
+/// around the complete route tree.
 #[derive(Clone)]
 pub(crate) struct GrpcMethodAnnotatedService<S> {
-    inner: S,
+    inner: GrpcRequestContextService<S>,
 }
 
 impl<S> GrpcMethodAnnotatedService<S> {
     pub(crate) fn new(inner: S) -> Self {
-        Self { inner }
+        let layer = GrpcRequestContextLayer::new(Arc::new(SingleUserPrincipalProvider));
+        Self {
+            inner: layer.layer(inner),
+        }
     }
 }
 
-impl<S, B> Service<http::Request<B>> for GrpcMethodAnnotatedService<S>
+impl<S, B, ResBody> Service<http::Request<B>> for GrpcMethodAnnotatedService<S>
 where
-    S: Service<http::Request<B>>,
+    S: Service<http::Request<B>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    B: Send + 'static,
+    ResBody: Default + Send + 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = S::Future;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(
         &mut self,
@@ -82,8 +99,7 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut request: http::Request<B>) -> Self::Future {
-        annotate_request_context(&mut request);
+    fn call(&mut self, request: http::Request<B>) -> Self::Future {
         self.inner.call(request)
     }
 }
@@ -95,9 +111,155 @@ where
     const NAME: &'static str = S::NAME;
 }
 
+/// Tower layer that installs Coral request context for gRPC route trees.
+///
+/// Tonic preserves `http::Request` extensions when it decodes the protobuf
+/// message into a `tonic::Request`, but generated server wrappers do not insert
+/// `tonic::GrpcMethod` the way generated clients do. This keeps the method
+/// data and Coral request metadata at the transport boundary and lets handlers
+/// read typed context from the request.
+///
+/// The wrapper also authenticates the inbound metadata once before dispatching
+/// to a service handler, so every registered gRPC route is covered by the same
+/// principal-selection path.
+#[derive(Clone)]
+pub(crate) struct GrpcRequestContextLayer {
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+}
+
+impl GrpcRequestContextLayer {
+    pub(crate) fn new(user_principal_provider: Arc<dyn UserPrincipalProvider>) -> Self {
+        Self {
+            user_principal_provider,
+        }
+    }
+}
+
+impl<S> Layer<S> for GrpcRequestContextLayer {
+    type Service = GrpcRequestContextService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        GrpcRequestContextService {
+            inner,
+            user_principal_provider: Arc::clone(&self.user_principal_provider),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct GrpcRequestContextService<S> {
+    inner: S,
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+}
+
+impl<S, B, ResBody> Service<http::Request<B>> for GrpcRequestContextService<S>
+where
+    S: Service<http::Request<B>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    B: Send + 'static,
+    ResBody: Default + Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: http::Request<B>) -> Self::Future {
+        annotate_request_context(&mut request);
+        let method_metadata = request.extensions().get::<GrpcServerMethod>().map_or_else(
+            || GrpcMethodMetadata::new("coral.v1.UnknownService", "Unknown"),
+            |method| GrpcMethodMetadata::new(method.service.as_str(), method.method.as_str()),
+        );
+        let request_metadata = MetadataMap::from_headers(request.headers().clone());
+        let user_principal_provider = Arc::clone(&self.user_principal_provider);
+        let span = grpc_span_for_metadata(&method_metadata, &request_metadata);
+        request
+            .extensions_mut()
+            .insert(GrpcServerSpan(span.clone()));
+
+        let mut inner = self.inner.clone();
+        std::mem::swap(&mut self.inner, &mut inner);
+
+        let instrumented_span = span.clone();
+        Box::pin(
+            async move {
+                match principal_for_request(
+                    user_principal_provider.as_ref(),
+                    &request_metadata,
+                    USER_PRINCIPAL_PROVIDER_TIMEOUT,
+                )
+                .await
+                {
+                    Ok(principal) => {
+                        request
+                            .extensions_mut()
+                            .insert(RequestContext::new(principal));
+                        inner.call(request).await
+                    }
+                    Err(error) => {
+                        let status = user_principal_provider_status(&error);
+                        record_grpc_status(&span, status.code(), Some(&status));
+                        Ok(status.into_http())
+                    }
+                }
+            }
+            .instrument(instrumented_span),
+        )
+    }
+}
+
+async fn principal_for_request(
+    provider: &dyn UserPrincipalProvider,
+    metadata: &MetadataMap,
+    timeout: Duration,
+) -> Result<crate::identity::UserPrincipal, UserPrincipalProviderError> {
+    tokio::time::timeout(timeout, provider.principal_for_metadata(metadata))
+        .await
+        .unwrap_or_else(|_| {
+            Err(UserPrincipalProviderError::unavailable(
+                "user principal provider timed out",
+            ))
+        })
+}
+
+fn user_principal_provider_status(error: &UserPrincipalProviderError) -> Status {
+    let (code, prefix) = match error.kind() {
+        UserPrincipalProviderErrorKind::Unauthenticated => {
+            (Code::Unauthenticated, "unauthenticated")
+        }
+        UserPrincipalProviderErrorKind::Unavailable => (Code::Unavailable, "unavailable"),
+        UserPrincipalProviderErrorKind::Internal => (Code::Internal, "internal"),
+    };
+    status_with_bounded_detail(code, format!("{prefix}: {}", error.client_message()))
+}
+
+impl<S> tonic::server::NamedService for GrpcRequestContextService<S>
+where
+    S: tonic::server::NamedService,
+{
+    const NAME: &'static str = S::NAME;
+}
+
 /// Creates a span parented to the trace context extracted from a gRPC request.
 pub(crate) fn grpc_span<T>(request: &Request<T>) -> tracing::Span {
+    if let Some(span) = request.extensions().get::<GrpcServerSpan>() {
+        return span.0.clone();
+    }
     let metadata = grpc_method(request);
+    grpc_span_for_metadata(&metadata, request.metadata())
+}
+
+fn grpc_span_for_metadata(
+    metadata: &GrpcMethodMetadata,
+    request_metadata: &MetadataMap,
+) -> tracing::Span {
     let span_name = format!("{}/{}", metadata.service, metadata.method);
     let span = tracing::info_span!(
         "grpc",
@@ -115,7 +277,7 @@ pub(crate) fn grpc_span<T>(request: &Request<T>) -> tracing::Span {
         grpc.code = tracing::field::Empty,
         status = tracing::field::Empty,
     );
-    coral_telemetry::set_parent_from_extractor(&span, &MetadataExtractor(request.metadata()));
+    coral_telemetry::set_parent_from_extractor(&span, &MetadataExtractor(request_metadata));
     span
 }
 
@@ -491,12 +653,18 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        GrpcMethodMetadata, GrpcServerMethod, grpc_method, query_status,
+        GrpcMethodMetadata, GrpcRequestContextLayer, GrpcServerMethod, grpc_method, query_status,
         query_test_result_to_proto, table_function_to_proto, table_summary_to_proto,
-        table_to_proto, workspace_name_from_proto, workspace_to_proto,
+        table_to_proto, user_principal_provider_status, workspace_name_from_proto,
+        workspace_to_proto,
     };
     use crate::bootstrap::AppError;
+    use crate::identity::{
+        SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider,
+        UserPrincipalProviderError,
+    };
     use crate::query::manager::QueryManagerError;
+    use crate::request_context::RequestContext;
     use crate::workspaces::WorkspaceName;
     use coral_engine::{
         ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableFunctionInfo,
@@ -535,6 +703,32 @@ mod tests {
     }
 
     #[test]
+    fn user_principal_provider_status_preserves_failure_class() {
+        let cases = [
+            (
+                UserPrincipalProviderError::unauthenticated("bad token"),
+                Code::Unauthenticated,
+                "unauthenticated: bad token",
+            ),
+            (
+                UserPrincipalProviderError::unavailable("key service offline"),
+                Code::Unavailable,
+                "unavailable: key service offline",
+            ),
+            (
+                UserPrincipalProviderError::internal("invalid principal selection"),
+                Code::Internal,
+                "internal: invalid principal selection",
+            ),
+        ];
+        for (error, code, message) in cases {
+            let status = user_principal_provider_status(&error);
+            assert_eq!(status.code(), code);
+            assert_eq!(status.message(), message);
+        }
+    }
+
+    #[test]
     fn grpc_server_method_derives_from_uri_path() {
         assert_eq!(
             GrpcServerMethod::from_path("/coral.v1.QueryService/ExecuteSql"),
@@ -561,6 +755,74 @@ mod tests {
             grpc_method(&request),
             GrpcMethodMetadata::new("coral.v1.QueryService", "ExecuteSql")
         );
+    }
+
+    #[derive(Debug)]
+    struct FixedUserPrincipalProvider {
+        principal: UserPrincipal,
+    }
+
+    #[tonic::async_trait]
+    impl UserPrincipalProvider for FixedUserPrincipalProvider {
+        async fn principal_for_metadata(
+            &self,
+            _metadata: &tonic::metadata::MetadataMap,
+        ) -> Result<UserPrincipal, UserPrincipalProviderError> {
+            Ok(self.principal.clone())
+        }
+    }
+
+    async fn principal_inserted_by(
+        provider: std::sync::Arc<dyn UserPrincipalProvider>,
+    ) -> UserPrincipal {
+        use std::sync::{Arc, Mutex};
+        use tonic::codegen::http;
+        use tower::{Layer as _, Service as _};
+
+        let observed_context = Arc::new(Mutex::new(None));
+        let observed_context_for_service = Arc::clone(&observed_context);
+        let service = tower::service_fn(move |request: http::Request<()>| {
+            let observed_context = Arc::clone(&observed_context_for_service);
+            async move {
+                *observed_context.lock().expect("observed context lock") =
+                    request.extensions().get::<RequestContext>().cloned();
+                Ok::<_, std::convert::Infallible>(http::Response::new(()))
+            }
+        });
+        let mut service = GrpcRequestContextLayer::new(provider).layer(service);
+        let request = http::Request::builder()
+            .uri("/coral.v1.QueryService/ExecuteSql")
+            .body(())
+            .expect("http request");
+
+        service.call(request).await.expect("service response");
+
+        observed_context
+            .lock()
+            .expect("observed context lock")
+            .clone()
+            .expect("request context")
+            .principal()
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn request_context_layer_inserts_local_principal() {
+        let principal =
+            principal_inserted_by(std::sync::Arc::new(SingleUserPrincipalProvider)).await;
+
+        assert_eq!(principal, UserPrincipal::local());
+    }
+
+    #[tokio::test]
+    async fn request_context_layer_honors_injected_provider() {
+        let expected_principal = UserPrincipal::for_user("saul").expect("valid user");
+        let principal = principal_inserted_by(std::sync::Arc::new(FixedUserPrincipalProvider {
+            principal: expected_principal.clone(),
+        }))
+        .await;
+
+        assert_eq!(principal, expected_principal);
     }
 
     #[test]


### PR DESCRIPTION
## Intent

Establish the app-owned request-principal boundary needed for multi-user identity without changing client transport behavior or choosing a hosted authentication policy.

## What it enables

- A validated `UserPrincipal` model and provider abstraction.
- Fail-closed `Unauthenticated` error mapping at the app boundary.
- A request context layer that makes the selected principal available to domain services.
- A compatible local single-user default while later stack units add centralized server authentication.

## Usage examples

Existing local-server callers need no changes. The default provider selects the reserved local principal, and the transport boundary installs it into `RequestContext` before dispatching a request.

