### PR TITLE
fix(spec): allow projection overrides without generator version

### DIFF
--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -39,6 +39,18 @@ pub enum AppError {
         /// Specific materialization mismatch or missing-artifact detail.
         detail: String,
     },
+    /// A user-maintained DSL v4 projection override is malformed or stale.
+    #[error(
+        "failed precondition: source '{source_name}' has invalid DSL v4 projection override '{override_path}': {detail}. Edit or remove the override file."
+    )]
+    InvalidV4ProjectionOverride {
+        /// Source name whose override failed validation.
+        source_name: String,
+        /// Projection override path that failed validation.
+        override_path: String,
+        /// Specific override mismatch or malformed-artifact detail.
+        detail: String,
+    },
     /// Provider-managed credential refresh failed during active source use.
     #[error("credential refresh failed: {0}")]
     CredentialRefresh(String),
@@ -206,6 +218,7 @@ fn app_code(error: &AppError) -> Code {
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
         | AppError::MissingOrIncompatibleV4Materialization { .. }
+        | AppError::InvalidV4ProjectionOverride { .. }
         | AppError::CredentialRefresh(_)
         | AppError::MissingConfigDir
         | AppError::Credentials(CredentialsError::Parse(_) | CredentialsError::Unavailable(_)) => {

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -314,7 +314,8 @@ impl QueryManager {
                 Ok((loaded_source, _version)) => loaded_sources.push(loaded_source),
                 Err(
                     error @ (AppError::Credentials(CredentialsError::Unavailable(_))
-                    | AppError::MissingOrIncompatibleV4Materialization { .. }),
+                    | AppError::MissingOrIncompatibleV4Materialization { .. }
+                    | AppError::InvalidV4ProjectionOverride { .. }),
                 ) => {
                     return Err(error);
                 }
@@ -668,6 +669,7 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::MissingOrIncompatibleV4Materialization { .. } => {
             "MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION"
         }
+        AppError::InvalidV4ProjectionOverride { .. } => "INVALID_V4_PROJECTION_OVERRIDE",
         AppError::CredentialRefresh(_) => "CREDENTIAL_REFRESH",
         AppError::Unavailable(_) => "UNAVAILABLE",
         AppError::Io(_) => "IO",

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
-use crate::state::AppStateLayout;
+use crate::state::{AppStateLayout, V4ProjectionCatalogFile, V4ProjectionCatalogOrigin};
 use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
 
@@ -157,11 +157,9 @@ pub(crate) fn load_v4_materialization(
     manifest: &V4SourceManifest,
 ) -> Result<V4MaterializedSource, AppError> {
     let fingerprint_path = layout.v4_fingerprint_file(workspace_name, source_name);
-    let projections_path = layout.v4_projections_file(workspace_name, source_name);
-    let projections_override_path =
-        layout.v4_projections_override_file(workspace_name, source_name);
+    let projections_file = layout.v4_projection_catalog_file(workspace_name, source_name);
     let diagnostics_path = layout.v4_diagnostics_file(workspace_name, source_name);
-    if !fingerprint_path.exists() || !projections_path.exists() || !diagnostics_path.exists() {
+    if !fingerprint_path.exists() || !projections_file.path.exists() || !diagnostics_path.exists() {
         return Err(incompatible_materialization_error(
             source_name,
             "required artifact is missing",
@@ -177,9 +175,15 @@ pub(crate) fn load_v4_materialization(
         ));
     }
     let fingerprint_surfaces = validate_fingerprint_surfaces(source_name, manifest, &fingerprint)?;
-    let mut projections: ProjectionCatalog =
-        read_artifact_yaml(source_name, "projection catalog", &projections_path)?;
-    validate_projection_catalog_header(source_name, manifest, &projections)?;
+    let mut projections: ProjectionCatalog = match projections_file.origin {
+        V4ProjectionCatalogOrigin::Materialized => {
+            read_artifact_yaml(source_name, "projection catalog", &projections_file.path)?
+        }
+        V4ProjectionCatalogOrigin::Override => {
+            read_projection_override_yaml(source_name, &projections_file.path)?
+        }
+    };
+    validate_projection_catalog_header(source_name, manifest, &projections, &projections_file)?;
     let diagnostics: Vec<Diagnostic> =
         read_artifact_yaml(source_name, "diagnostics", &diagnostics_path)?;
     let mut surfaces = Vec::new();
@@ -219,10 +223,13 @@ pub(crate) fn load_v4_materialization(
             raw_source_document_path,
         });
     }
-    let projection_sync_mode = if projections_override_path.exists() {
-        ProjectionPaginationInputSyncMode::PreserveExistingExposure
-    } else {
-        ProjectionPaginationInputSyncMode::RecomputeRestInputExposure
+    let projection_sync_mode = match projections_file.origin {
+        V4ProjectionCatalogOrigin::Materialized => {
+            ProjectionPaginationInputSyncMode::RecomputeRestInputExposure
+        }
+        V4ProjectionCatalogOrigin::Override => {
+            ProjectionPaginationInputSyncMode::PreserveExistingExposure
+        }
     };
     sync_projection_pagination_inputs(
         surfaces.iter().map(|surface| &surface.semantic_ir),
@@ -344,26 +351,62 @@ fn validate_projection_catalog_header(
     source_name: &SourceName,
     manifest: &V4SourceManifest,
     projections: &ProjectionCatalog,
+    projections_file: &V4ProjectionCatalogFile,
 ) -> Result<(), AppError> {
     if projections.artifact_schema_version != V4_ARTIFACT_SCHEMA_VERSION {
-        return Err(incompatible_materialization_error(
+        return Err(projection_catalog_error(
             source_name,
+            projections_file,
             "projection catalog artifact schema version mismatch",
         ));
     }
     if projections.source_name != manifest.common.name {
-        return Err(incompatible_materialization_error(
+        return Err(projection_catalog_error(
             source_name,
+            projections_file,
             "projection catalog source name does not match installed manifest",
         ));
     }
-    if projections.generator_version != PROJECTION_GENERATOR_VERSION {
-        return Err(incompatible_materialization_error(
-            source_name,
-            "projection catalog generator version mismatch",
-        ));
+    match projections_file.origin {
+        V4ProjectionCatalogOrigin::Materialized => {
+            if projections.generator_version.as_deref() != Some(PROJECTION_GENERATOR_VERSION) {
+                return Err(projection_catalog_error(
+                    source_name,
+                    projections_file,
+                    "projection catalog generator version mismatch",
+                ));
+            }
+        }
+        V4ProjectionCatalogOrigin::Override => {
+            if let Some(generator_version) = projections.generator_version.as_deref()
+                && generator_version != PROJECTION_GENERATOR_VERSION
+            {
+                return Err(projection_catalog_error(
+                    source_name,
+                    projections_file,
+                    format!(
+                        "projection override was copied from generator version '{generator_version}', but this Coral build expects '{PROJECTION_GENERATOR_VERSION}'; remove generator_version after reviewing the override or recreate it from the current generated catalog"
+                    ),
+                ));
+            }
+        }
     }
     Ok(())
+}
+
+fn projection_catalog_error(
+    source_name: &SourceName,
+    projections_file: &V4ProjectionCatalogFile,
+    detail: impl AsRef<str>,
+) -> AppError {
+    match projections_file.origin {
+        V4ProjectionCatalogOrigin::Materialized => {
+            incompatible_materialization_error(source_name, detail)
+        }
+        V4ProjectionCatalogOrigin::Override => {
+            invalid_projection_override_error(source_name, &projections_file.path, detail)
+        }
+    }
 }
 
 fn require_file(source_name: &SourceName, path: &Path) -> Result<(), AppError> {
@@ -1141,6 +1184,31 @@ fn read_artifact_yaml<T: serde::de::DeserializeOwned>(
     })
 }
 
+fn read_projection_override_yaml(
+    source_name: &SourceName,
+    path: &Path,
+) -> Result<ProjectionCatalog, AppError> {
+    read_yaml(path).map_err(|error| {
+        invalid_projection_override_error(
+            source_name,
+            path,
+            format!("failed to read projection override artifact: {error}"),
+        )
+    })
+}
+
+fn invalid_projection_override_error(
+    source_name: &SourceName,
+    path: &Path,
+    detail: impl AsRef<str>,
+) -> AppError {
+    AppError::InvalidV4ProjectionOverride {
+        source_name: source_name.to_string(),
+        override_path: path.display().to_string(),
+        detail: detail.as_ref().to_string(),
+    }
+}
+
 fn write_yaml<T: serde::Serialize>(path: &Path, value: &T) -> Result<(), AppError> {
     if let Some(parent) = path.parent() {
         fs::ensure_private_dir(parent)?;
@@ -1333,6 +1401,47 @@ surfaces:
         replace_v4_materialization(&layout, &workspace_name(), &source_name(), &build.temp_dir)
             .expect("install materialization");
         (state_temp, descriptor_temp, layout, manifest_yaml, manifest)
+    }
+
+    fn installed_projection_catalog_value(layout: &AppStateLayout) -> serde_yaml::Value {
+        let path = layout
+            .v4_materialized_dir(&workspace_name(), &source_name())
+            .join(PROJECTIONS_FILENAME);
+        serde_yaml::from_slice(&std::fs::read(path).expect("read generated projections"))
+            .expect("parse generated projections")
+    }
+
+    fn remove_generator_version(catalog: &mut serde_yaml::Value) {
+        let key = serde_yaml::Value::String("generator_version".to_string());
+        catalog
+            .as_mapping_mut()
+            .expect("projection catalog mapping")
+            .remove(&key);
+    }
+
+    fn set_generator_version(catalog: &mut serde_yaml::Value, generator_version: &str) {
+        let key = serde_yaml::Value::String("generator_version".to_string());
+        catalog
+            .as_mapping_mut()
+            .expect("projection catalog mapping")
+            .insert(
+                key,
+                serde_yaml::Value::String(generator_version.to_string()),
+            );
+    }
+
+    fn write_projection_override(layout: &AppStateLayout, catalog: &serde_yaml::Value) -> PathBuf {
+        let path = layout
+            .v4_override_dir(&workspace_name(), &source_name())
+            .join(PROJECTIONS_FILENAME);
+        std::fs::create_dir_all(path.parent().expect("override parent"))
+            .expect("create override dir");
+        std::fs::write(
+            &path,
+            serde_yaml::to_string(catalog).expect("encode projection override"),
+        )
+        .expect("write projection override");
+        path
     }
 
     #[tokio::test]
@@ -1561,6 +1670,150 @@ surfaces:
                 .to_string()
                 .contains("manifest fingerprint does not match installed manifest"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn load_v4_materialization_rejects_generated_projection_catalog_without_generator_version() {
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        let projection_path = layout
+            .v4_materialized_dir(&workspace_name(), &source_name())
+            .join(PROJECTIONS_FILENAME);
+        let mut catalog = installed_projection_catalog_value(&layout);
+        remove_generator_version(&mut catalog);
+        std::fs::write(
+            &projection_path,
+            serde_yaml::to_string(&catalog).expect("encode projections"),
+        )
+        .expect("write generated projections");
+
+        let error = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect_err("generated projection catalog without generator version should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("projection catalog generator version mismatch"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn load_v4_materialization_accepts_projection_override_without_generator_version() {
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        let mut catalog = installed_projection_catalog_value(&layout);
+        remove_generator_version(&mut catalog);
+        write_projection_override(&layout, &catalog);
+
+        let materialized = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect("projection override without generator version should load");
+
+        assert_eq!(materialized.projections.generator_version, None);
+    }
+
+    #[test]
+    fn load_v4_materialization_accepts_projection_override_with_current_generator_version() {
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        let catalog = installed_projection_catalog_value(&layout);
+        write_projection_override(&layout, &catalog);
+
+        let materialized = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect("projection override with current generator version should load");
+
+        assert_eq!(
+            materialized.projections.generator_version.as_deref(),
+            Some(PROJECTION_GENERATOR_VERSION)
+        );
+    }
+
+    #[test]
+    fn load_v4_materialization_rejects_stale_projection_override_generator_version() {
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        let mut catalog = installed_projection_catalog_value(&layout);
+        set_generator_version(&mut catalog, "derive-read-v0");
+        let override_path = write_projection_override(&layout, &catalog);
+
+        let error = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect_err("stale projection override generator version should fail");
+        let message = error.to_string();
+
+        assert!(
+            matches!(error, AppError::InvalidV4ProjectionOverride { .. }),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            message.contains(&override_path.display().to_string()),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("Edit or remove the override file"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            !message.contains("Re-add the source"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn load_v4_materialization_rejects_corrupted_projection_override_with_override_guidance() {
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        let override_path = layout
+            .v4_override_dir(&workspace_name(), &source_name())
+            .join(PROJECTIONS_FILENAME);
+        std::fs::create_dir_all(override_path.parent().expect("override parent"))
+            .expect("create override dir");
+        std::fs::write(&override_path, b": not yaml").expect("write corrupt projection override");
+
+        let error = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect_err("corrupt projection override should fail");
+        let message = error.to_string();
+
+        assert!(
+            matches!(error, AppError::InvalidV4ProjectionOverride { .. }),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            message.contains("failed to read projection override artifact"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            message.contains("Edit or remove the override file"),
+            "unexpected error: {message}"
+        );
+        assert!(
+            !message.contains("Re-add the source"),
+            "unexpected error: {message}"
         );
     }
 

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -653,7 +653,7 @@ mod tests {
             projections: ProjectionCatalog {
                 artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
                 source_name: "github_v4".to_string(),
-                generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+                generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
                 projections: vec![
                     published_projection("rest", "github_v4_rest", "rest_list_issues"),
                     published_projection("mcp", "github_v4_mcp", "mcp_list_issues"),
@@ -716,7 +716,7 @@ mod tests {
             projections: ProjectionCatalog {
                 artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
                 source_name: "github_v4".to_string(),
-                generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+                generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
                 projections: vec![published_projection(
                     "rest",
                     "github_v4_rest",
@@ -784,7 +784,7 @@ mod tests {
             projections: ProjectionCatalog {
                 artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
                 source_name: "github_v4".to_string(),
-                generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+                generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
                 projections: vec![published_projection(
                     "mcp",
                     "github_v4_mcp",
@@ -848,7 +848,7 @@ mod tests {
             projections: ProjectionCatalog {
                 artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
                 source_name: "github_v4".to_string(),
-                generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+                generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
                 projections: vec![published_projection(
                     "mcp",
                     "github_v4_mcp",

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -16,6 +16,18 @@ use crate::workspaces::{WorkspaceName, WorkspacePaths};
 pub(crate) const INSTALLED_MANIFEST_FILE_NAME: &str = "manifest.yaml";
 pub(crate) const INSTALLED_SECRETS_FILE_NAME: &str = "secrets.env";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum V4ProjectionCatalogOrigin {
+    Materialized,
+    Override,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct V4ProjectionCatalogFile {
+    pub(crate) path: PathBuf,
+    pub(crate) origin: V4ProjectionCatalogOrigin,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct AppStateLayout {
     config_dir: PathBuf,
@@ -176,36 +188,27 @@ impl AppStateLayout {
             .join(FINGERPRINT_FILENAME)
     }
 
-    fn v4_overridden_or_materialized(
+    pub(crate) fn v4_projection_catalog_file(
         &self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
-        path: &str,
-    ) -> PathBuf {
-        let override_file = self.v4_override_dir(workspace_name, source_name).join(path);
+    ) -> V4ProjectionCatalogFile {
+        let override_file = self
+            .v4_override_dir(workspace_name, source_name)
+            .join(PROJECTIONS_FILENAME);
         if override_file.exists() {
-            override_file
+            V4ProjectionCatalogFile {
+                path: override_file,
+                origin: V4ProjectionCatalogOrigin::Override,
+            }
         } else {
-            self.v4_materialized_dir(workspace_name, source_name)
-                .join(path)
+            V4ProjectionCatalogFile {
+                path: self
+                    .v4_materialized_dir(workspace_name, source_name)
+                    .join(PROJECTIONS_FILENAME),
+                origin: V4ProjectionCatalogOrigin::Materialized,
+            }
         }
-    }
-
-    pub(crate) fn v4_projections_file(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> PathBuf {
-        self.v4_overridden_or_materialized(workspace_name, source_name, PROJECTIONS_FILENAME)
-    }
-
-    pub(crate) fn v4_projections_override_file(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> PathBuf {
-        self.v4_override_dir(workspace_name, source_name)
-            .join(PROJECTIONS_FILENAME)
     }
 
     pub(crate) fn v4_diagnostics_file(
@@ -307,16 +310,21 @@ mod tests {
     }
 
     #[test]
-    fn v4_projections_file_returns_override_if_present() {
+    fn v4_projection_catalog_file_returns_override_if_present() {
         let temp = tempdir().expect("tempdir");
         let config_dir = temp.path().join("coral-config");
         let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
         let workspace_name = WorkspaceName::parse("default").expect("workspace");
         let source_name = SourceName::parse("github").expect("source");
 
+        let generated = layout.v4_projection_catalog_file(&workspace_name, &source_name);
         assert_eq!(
-            layout.v4_projections_file(&workspace_name, &source_name),
+            generated.path,
             config_dir.join("workspaces/default/sources/github/materialized/v4/projections.yaml")
+        );
+        assert_eq!(
+            generated.origin,
+            super::V4ProjectionCatalogOrigin::Materialized
         );
 
         let override_dir = config_dir.join("workspaces/default/sources/github/overrides");
@@ -324,13 +332,11 @@ mod tests {
         let override_file = override_dir.join(PROJECTIONS_FILENAME);
         fs::write(&override_file, "{}").expect("write to override file");
 
+        let overridden = layout.v4_projection_catalog_file(&workspace_name, &source_name);
+        assert_eq!(overridden.path, override_file);
         assert_eq!(
-            layout.v4_projections_file(&workspace_name, &source_name),
-            override_file
-        );
-        assert_eq!(
-            layout.v4_projections_override_file(&workspace_name, &source_name),
-            override_file
+            overridden.origin,
+            super::V4ProjectionCatalogOrigin::Override
         );
         assert_eq!(
             layout.v4_parameter_metadata_override_file(&workspace_name, &source_name, "rest"),

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -8,4 +8,4 @@ pub(crate) use config::{
     RawFeatureContainerState, RawFeatureOverrides, RawFeatureValue, load_raw_feature_overrides,
     set_raw_feature_override,
 };
-pub(crate) use layout::AppStateLayout;
+pub(crate) use layout::{AppStateLayout, V4ProjectionCatalogFile, V4ProjectionCatalogOrigin};

--- a/crates/coral-spec/src/v4/artifacts.rs
+++ b/crates/coral-spec/src/v4/artifacts.rs
@@ -185,7 +185,7 @@ surfaces:
             projections: ProjectionCatalog {
                 artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
                 source_name: "demo".to_string(),
-                generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+                generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
                 projections: Vec::new(),
                 diagnostics: Vec::new(),
             },

--- a/crates/coral-spec/src/v4/parameter_metadata.rs
+++ b/crates/coral-spec/src/v4/parameter_metadata.rs
@@ -891,7 +891,7 @@ operation_overrides:
         ProjectionCatalog {
             artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
             source_name: "demo".to_string(),
-            generator_version: "test".to_string(),
+            generator_version: Some("test".to_string()),
             projections: vec![Projection {
                 name: "widgets".to_string(),
                 namespace: "demo".to_string(),

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -53,7 +53,7 @@ pub fn generate_projection_catalog(
     Ok(ProjectionCatalog {
         artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
         source_name: manifest.common.name.clone(),
-        generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+        generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
         projections,
         diagnostics,
     })

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -8,7 +8,8 @@ use crate::{DetailHintSpec, ManifestDataType, SearchLimitsSpec, SourceTableFunct
 pub struct ProjectionCatalog {
     pub artifact_schema_version: u32,
     pub source_name: String,
-    pub generator_version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generator_version: Option<String>,
     pub projections: Vec<Projection>,
     pub diagnostics: Vec<Diagnostic>,
 }
@@ -89,7 +90,7 @@ mod tests {
         let catalog = ProjectionCatalog {
             artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
             source_name: "demo".to_string(),
-            generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
+            generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
             projections: vec![Projection {
                 name: "search_issues".to_string(),
                 namespace: "demo".to_string(),
@@ -169,6 +170,23 @@ diagnostics: []
             catalog.projections.first().expect("projection").namespace,
             ""
         );
+    }
+
+    #[test]
+    fn projection_catalog_deserializes_without_generator_version() {
+        let raw = format!(
+            r"
+artifact_schema_version: {V4_ARTIFACT_SCHEMA_VERSION}
+source_name: demo
+projections: []
+diagnostics: []
+"
+        );
+
+        let catalog: ProjectionCatalog =
+            serde_yaml::from_str(&raw).expect("projection override catalog should deserialize");
+
+        assert_eq!(catalog.generator_version, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Make `ProjectionCatalog.generator_version` optional so projection override catalogs can omit generated provenance.
- Keep generated projection catalogs versioned and continue rejecting missing or stale generated catalog versions.
- Track whether `projections.yaml` came from materialized artifacts or `overrides/` and surface override-specific guidance for stale or malformed override files.

## Why

Projection overrides may start as copied generated catalogs, but they are user-maintained files once placed under `overrides/`. Requiring `generator_version` for those files conflated generated-artifact freshness with manual override provenance.

## Validation

- `cargo test -p coral-app load_v4_materialization_`
- `make rust-checks`