### PR TITLE
feat(spec): add v4 surface identity requirements

### DIFF
--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -585,6 +585,7 @@ mod tests {
                 description: String::new(),
                 test_queries: Vec::new(),
             },
+            identity_requirements: None,
             declared_inputs: Vec::new(),
             surface,
         }
@@ -781,6 +782,7 @@ mod tests {
                 description: String::new(),
                 test_queries: Vec::new(),
             },
+            identity_requirements: None,
             declared_inputs: Vec::new(),
             surface,
         };
@@ -845,6 +847,7 @@ mod tests {
                 description: String::new(),
                 test_queries: Vec::new(),
             },
+            identity_requirements: None,
             declared_inputs: Vec::new(),
             surface,
         };
@@ -892,6 +895,7 @@ mod tests {
                 description: String::new(),
                 test_queries: Vec::new(),
             },
+            identity_requirements: None,
             declared_inputs: Vec::new(),
             surface,
         };
@@ -947,6 +951,7 @@ mod tests {
                 description: String::new(),
                 test_queries: Vec::new(),
             },
+            identity_requirements: None,
             declared_inputs: Vec::new(),
             surface,
         };

--- a/crates/coral-spec/src/schema/source_manifest_v4.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest_v4.schema.json
@@ -33,6 +33,22 @@
         "minLength": 1
       }
     },
+    "identity_requirements": {
+      "type": "object",
+      "properties": {
+        "accepts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AcceptedIdentityRequirementSchema"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "accepts"
+      ]
+    },
     "surface": {
       "$ref": "#/$defs/V4SurfaceSchema"
     }
@@ -700,6 +716,35 @@
         {
           "$ref": "#/$defs/V4OAuthPublicDynamicClientSchema"
         }
+      ]
+    },
+    "AcceptedIdentityRequirementSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "[^\t-\r    -     　]"
+        },
+        "identity_specs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[\t-\r    -     　]*[A-Za-z_][A-Za-z0-9_]*[\t-\r    -     　]*$"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "audience": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "identity_specs"
       ]
     },
     "V4SurfaceSchema": {

--- a/crates/coral-spec/src/v4/manifest.rs
+++ b/crates/coral-spec/src/v4/manifest.rs
@@ -190,13 +190,7 @@ impl V4SourceManifest {
             surface,
             ..
         } = raw;
-        if dsl_version != 4 {
-            return Err(ManifestError::validation(format!(
-                "source '{name}' declares dsl_version {dsl_version}; expected 4"
-            )));
-        }
-        validate_v4_source_name(&name)?;
-        validate_test_queries(&name, &test_queries)?;
+        validate_manifest_header(&name, dsl_version, &test_queries)?;
         let common = V4SourceCommon {
             dsl_version,
             name: name.clone(),
@@ -224,6 +218,20 @@ impl V4SourceManifest {
             declared_inputs,
         })
     }
+}
+
+fn validate_manifest_header(
+    source_name: &str,
+    dsl_version: u32,
+    test_queries: &[String],
+) -> Result<()> {
+    if dsl_version != 4 {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' declares dsl_version {dsl_version}; expected 4"
+        )));
+    }
+    validate_v4_source_name(source_name)?;
+    validate_test_queries(source_name, test_queries)
 }
 
 fn parse_surface(

--- a/crates/coral-spec/src/v4/manifest.rs
+++ b/crates/coral-spec/src/v4/manifest.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -10,13 +11,15 @@ use crate::inputs::{
     validate_oauth_endpoint_templates_with_scope,
 };
 use crate::{
-    HeaderSpec, ManifestError, ManifestInputSpec, ParsedTemplate, Result, TemplateNamespace,
-    validate_source_name, validate_test_queries,
+    HeaderSpec, ManifestError, ManifestInputKind, ManifestInputSpec, ParsedTemplate, Result,
+    TemplateNamespace, validate_identifier, validate_source_name, validate_test_queries,
 };
 
 #[derive(Debug, Clone)]
 pub struct V4SourceManifest {
     pub common: V4SourceCommon,
+    /// Identity requirements that gate this source at runtime.
+    pub identity_requirements: Option<IdentityRequirements>,
     pub surface: V4Surface,
     pub declared_inputs: Vec<ManifestInputSpec>,
 }
@@ -87,6 +90,29 @@ pub struct McpRuntimeConfig {
     pub server: McpServerSpec,
 }
 
+/// Identity authentication contract declared by a DSL v4 source.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct IdentityRequirements {
+    /// Accepted identity alternatives. A source may be authenticated by any
+    /// one entry in this list.
+    pub accepts: Vec<AcceptedIdentityRequirement>,
+}
+
+/// One acceptable identity shape for a source identity requirement.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct AcceptedIdentityRequirement {
+    /// Stable author-chosen requirement identifier, scoped to the source.
+    pub id: String,
+    /// Identity spec ids that may satisfy this requirement.
+    pub identity_specs: Vec<String>,
+    /// Provider-specific audience constraints matched during identity
+    /// binding and runtime resolution.
+    #[serde(default)]
+    pub audience: BTreeMap<String, Value>,
+}
+
 impl V4Surface {
     pub fn openapi_runtime(&self) -> Option<&OpenApiRuntimeConfig> {
         match &self.runtime {
@@ -116,6 +142,8 @@ struct RawV4SourceManifest {
     description: String,
     #[serde(default)]
     test_queries: Vec<String>,
+    #[serde(default)]
+    identity_requirements: Option<IdentityRequirements>,
     surface: RawV4Surface,
 }
 
@@ -158,6 +186,7 @@ impl V4SourceManifest {
             name,
             description,
             test_queries,
+            mut identity_requirements,
             surface,
             ..
         } = raw;
@@ -181,9 +210,16 @@ impl V4SourceManifest {
         validate_input_references(surface_value, &declared_inputs)?;
         validate_oauth_endpoint_templates_with_scope(&declared_inputs, "top-level inputs")?;
         let surface = parse_surface(&name, surface, surface_value, &declared_inputs)?;
+        normalize_and_validate_source_identity_requirements(
+            &name,
+            identity_requirements.as_mut(),
+            &surface,
+            &declared_inputs,
+        )?;
 
         Ok(Self {
             common,
+            identity_requirements,
             surface,
             declared_inputs,
         })
@@ -273,6 +309,112 @@ fn validate_v4_source_name(name: &str) -> Result<()> {
         )));
     }
     validate_source_name(name)
+}
+
+fn validate_identity_source_inputs(source_name: &str, inputs: &[ManifestInputSpec]) -> Result<()> {
+    for input in inputs {
+        if input.kind == ManifestInputKind::Secret {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' input '{}' must not use kind: secret in DSL v4; use identity_requirements and identity specs for credentials",
+                input.key
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn normalize_identity_requirements(requirements: &mut IdentityRequirements) {
+    for accepted in &mut requirements.accepts {
+        trim_in_place(&mut accepted.id);
+        for identity_spec in &mut accepted.identity_specs {
+            trim_in_place(identity_spec);
+        }
+    }
+}
+
+fn trim_in_place(value: &mut String) {
+    if value.trim().len() != value.len() {
+        *value = value.trim().to_string();
+    }
+}
+
+fn normalize_and_validate_source_identity_requirements(
+    source_name: &str,
+    requirements: Option<&mut IdentityRequirements>,
+    surface: &V4Surface,
+    inputs: &[ManifestInputSpec],
+) -> Result<()> {
+    let Some(requirements) = requirements else {
+        return Ok(());
+    };
+    if surface.surface_type != SurfaceType::OpenApi {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' identity_requirements are only supported for OpenAPI sources"
+        )));
+    }
+    validate_identity_source_inputs(source_name, inputs)?;
+    normalize_identity_requirements(requirements);
+    validate_identity_requirements(source_name, requirements)
+}
+
+fn validate_identity_requirements(
+    source_name: &str,
+    requirements: &IdentityRequirements,
+) -> Result<()> {
+    if requirements.accepts.is_empty() {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' identity_requirements.accepts must contain at least one accepted identity"
+        )));
+    }
+
+    let mut seen_accept_ids = HashSet::new();
+    for accepted in &requirements.accepts {
+        if accepted.id.trim().is_empty() {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' identity requirement id must be non-empty"
+            )));
+        }
+        if !seen_accept_ids.insert(accepted.id.clone()) {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' has duplicate identity requirement id '{}'",
+                accepted.id
+            )));
+        }
+        validate_accepted_identity_specs(source_name, accepted)?;
+    }
+
+    Ok(())
+}
+
+fn validate_accepted_identity_specs(
+    source_name: &str,
+    accepted: &AcceptedIdentityRequirement,
+) -> Result<()> {
+    if accepted.identity_specs.is_empty() {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' identity requirement '{}' identity_specs must contain at least one identity spec id",
+            accepted.id
+        )));
+    }
+
+    let mut seen_identity_specs = HashSet::new();
+    for identity_spec_id in &accepted.identity_specs {
+        validate_identifier(
+            identity_spec_id,
+            &format!(
+                "source '{source_name}' identity requirement '{}' identity spec id",
+                accepted.id
+            ),
+        )?;
+        if !seen_identity_specs.insert(identity_spec_id) {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' identity requirement '{}' has duplicate identity spec id '{}'",
+                accepted.id, identity_spec_id
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 fn mcp_server_location(server: &McpServerSpec) -> String {

--- a/crates/coral-spec/src/v4/manifest_tests.rs
+++ b/crates/coral-spec/src/v4/manifest_tests.rs
@@ -466,3 +466,125 @@ surface:
         ManifestOAuthScopeDelimiter::Comma
     );
 }
+
+#[test]
+fn parses_and_normalizes_v4_identity_requirements() {
+    let manifest = parse_source_manifest_yaml(
+        r#"
+name: github
+dsl_version: 4
+identity_requirements:
+  accepts:
+    - id: " github_rest_read "
+      identity_specs: [" github_oauth ", github_pat]
+      audience: {host: github.com, port: 443}
+surface:
+  type: openapi
+  file: /tmp/github-openapi.yaml
+"#,
+    )
+    .expect("v4 manifest");
+    let accepted = manifest
+        .as_v4()
+        .and_then(|v4| v4.identity_requirements.as_ref())
+        .and_then(|requirements| requirements.accepts.first())
+        .expect("accepted identity requirement");
+
+    assert_eq!(accepted.id, "github_rest_read");
+    assert_eq!(accepted.identity_specs, ["github_oauth", "github_pat"]);
+    assert_eq!(
+        accepted.audience.get("host"),
+        Some(&serde_json::json!("github.com"))
+    );
+    assert_eq!(accepted.audience.get("port"), Some(&serde_json::json!(443)));
+}
+
+#[test]
+fn rejects_invalid_v4_identity_requirement_entries() {
+    let invalid = [
+        (
+            "  accepts:\n    - {id: github_rest_read, identity_specs: [github_oauth]}\n    - {id: \" github_rest_read \", identity_specs: [github_pat]}\n",
+            "duplicate identity requirement id 'github_rest_read'",
+        ),
+        (
+            "  accepts:\n    - {id: github_rest_read, identity_specs: [github_oauth, \" github_oauth \"]}\n",
+            "duplicate identity spec id 'github_oauth'",
+        ),
+    ];
+
+    for (requirements, expected) in invalid {
+        let raw = format!(
+            "name: github\ndsl_version: 4\nidentity_requirements:\n{requirements}surface:\n  type: openapi\n  file: /tmp/github-openapi.yaml\n"
+        );
+        let error = parse_source_manifest_yaml(&raw).expect_err("duplicates should fail");
+        assert!(
+            error.to_string().contains(expected),
+            "unexpected error: {error}"
+        );
+    }
+}
+
+#[test]
+fn rejects_secret_inputs_only_on_identity_gated_sources() {
+    let error = parse_source_manifest_yaml(
+        r"
+name: github
+dsl_version: 4
+inputs:
+  TOKEN: {kind: secret}
+identity_requirements:
+  accepts:
+    - {id: github_rest_read, identity_specs: [github_oauth]}
+surface:
+  type: openapi
+  file: /tmp/github-openapi.yaml
+",
+    )
+    .expect_err("gated source should reject legacy secrets");
+
+    assert!(
+        error.to_string().contains(
+            "input 'TOKEN' must not use kind: secret in DSL v4; use identity_requirements and identity specs for credentials"
+        ),
+        "unexpected error: {error}"
+    );
+
+    parse_source_manifest_yaml(
+        r"
+name: github
+dsl_version: 4
+inputs:
+  TOKEN: {kind: secret}
+surface:
+  type: openapi
+  file: /tmp/github-openapi.yaml
+",
+    )
+    .expect("ungated source retains legacy secret inputs");
+}
+
+#[test]
+fn rejects_identity_requirements_on_mcp_sources() {
+    let error = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+identity_requirements:
+  accepts:
+    - {id: demo, identity_specs: [demo_oauth]}
+surface:
+  type: mcp
+  server:
+    transport: stdio
+    command: demo-mcp-server
+",
+    )
+    .expect_err("identity requirements are OpenAPI-only");
+
+    assert!(
+        error
+            .to_string()
+            .contains("identity_requirements are only supported for OpenAPI sources"),
+        "unexpected error: {error}"
+    );
+}

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -41,8 +41,9 @@ pub use ir::{
     RestRequestBody, RestResponseAttachment, SemanticIr,
 };
 pub use manifest::{
-    McpRuntimeConfig, OpenApiRuntimeConfig, SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType,
-    V4SourceCommon, V4SourceManifest, V4Surface, validate_openapi_base_url_template,
+    AcceptedIdentityRequirement, IdentityRequirements, McpRuntimeConfig, OpenApiRuntimeConfig,
+    SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType, V4SourceCommon, V4SourceManifest,
+    V4Surface, validate_openapi_base_url_template,
 };
 pub use naming::normalize_identifier;
 pub use parameter_metadata::{

--- a/crates/coral-spec/src/v4/schema.rs
+++ b/crates/coral-spec/src/v4/schema.rs
@@ -14,6 +14,9 @@ use crate::{
     ManifestOAuthRedirectUriPortMode, ManifestOAuthScopesSpec,
 };
 
+const NON_WHITESPACE_PATTERN: &str = "[^\u{0009}-\u{000d}\u{0020}\u{0085}\u{00a0}\u{1680}\u{2000}-\u{200a}\u{2028}\u{2029}\u{202f}\u{205f}\u{3000}]";
+const TRIMMED_IDENTIFIER_PATTERN: &str = "^[\u{0009}-\u{000d}\u{0020}\u{0085}\u{00a0}\u{1680}\u{2000}-\u{200a}\u{2028}\u{2029}\u{202f}\u{205f}\u{3000}]*[A-Za-z_][A-Za-z0-9_]*[\u{0009}-\u{000d}\u{0020}\u{0085}\u{00a0}\u{1680}\u{2000}-\u{200a}\u{2028}\u{2029}\u{202f}\u{205f}\u{3000}]*$";
+
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[schemars(title = "Coral DSL v4 Source Manifest")]
@@ -31,6 +34,9 @@ struct V4SourceManifestSchema {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[schemars(inner(length(min = 1)))]
     test_queries: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(required)]
+    identity_requirements: Option<IdentityRequirementsSchema>,
     surface: V4SurfaceSchema,
 }
 
@@ -66,6 +72,31 @@ struct V4OpenApiSurfaceSchema {
 #[serde(deny_unknown_fields)]
 struct V4McpSurfaceSchema {
     server: McpServerSpec,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct IdentityRequirementsSchema {
+    #[schemars(length(min = 1))]
+    accepts: Vec<AcceptedIdentityRequirementSchema>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct AcceptedIdentityRequirementSchema {
+    #[schemars(length(min = 1), pattern(NON_WHITESPACE_PATTERN))]
+    id: String,
+    #[schemars(
+        length(min = 1),
+        inner(
+            length(min = 1),
+            pattern(TRIMMED_IDENTIFIER_PATTERN)
+        ),
+        extend("uniqueItems" = true)
+    )]
+    identity_specs: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    audience: BTreeMap<String, Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -509,6 +540,80 @@ surface:
             "generated schema should accept flattened MCP value sources: {errors:?}"
         );
         parse_source_manifest_yaml(raw).expect("parser accepts flattened MCP value sources");
+    }
+
+    #[test]
+    fn generated_schema_accepts_identity_requirements_and_parser_agrees() {
+        let raw = r"
+name: demo
+dsl_version: 4
+identity_requirements:
+  accepts:
+    - id: github_rest_read
+      identity_specs: [github_oauth, github_pat]
+      audience: {host: github.com, port: 443}
+surface:
+  type: openapi
+  url: https://example.com/openapi.yaml
+";
+
+        let validator = validator();
+        let errors = validation_errors(&validator, &manifest_json(raw));
+        assert!(
+            errors.is_empty(),
+            "generated schema should accept identity requirements: {errors:?}"
+        );
+        parse_source_manifest_yaml(raw).expect("parser accepts identity requirements");
+    }
+
+    #[test]
+    fn generated_schema_rejects_invalid_identity_requirement_shapes() {
+        let invalid_fields = [
+            "identity_requirements: null\n",
+            "identity_requirements: {accepts: []}\n",
+            "identity_requirements:\n  accepts:\n    - id: \"\"\n      identity_specs: [github_oauth]\n",
+            "identity_requirements:\n  accepts:\n    - id: \"   \"\n      identity_specs: [github_oauth]\n",
+            "identity_requirements:\n  accepts:\n    - id: github_rest_read\n      identity_specs: []\n",
+            "identity_requirements:\n  accepts:\n    - id: github_rest_read\n      identity_specs: [\"\"]\n",
+            "identity_requirements:\n  accepts:\n    - id: github_rest_read\n      identity_specs: [\"   \"]\n",
+            "identity_requirements:\n  accepts:\n    - id: github_rest_read\n      identity_specs: [github-oauth]\n",
+            "identity_requirements:\n  accepts:\n    - id: github_rest_read\n      identity_specs: [github_oauth, github_oauth]\n",
+            "identity_requirements:\n  accepts:\n    - id: github_rest_read\n      identity_specs: [github_oauth]\n      issuer: github\n",
+        ];
+
+        let validator = validator();
+        for manifest_fields in invalid_fields {
+            let raw = format!(
+                "name: demo\ndsl_version: 4\n{manifest_fields}surface:\n  type: openapi\n  url: https://example.com/openapi.yaml\n"
+            );
+            assert!(
+                !validator.is_valid(&manifest_json(&raw)),
+                "generated schema should reject: {manifest_fields}"
+            );
+            parse_source_manifest_yaml(&raw)
+                .expect_err("parser should reject invalid identity requirements");
+        }
+    }
+
+    #[test]
+    fn generated_schema_rejects_surface_scoped_identity_requirements() {
+        let raw = r"
+name: demo
+dsl_version: 4
+surface:
+  type: openapi
+  url: https://example.com/openapi.yaml
+  identity_requirements:
+    accepts:
+      - {id: github_rest_read, identity_specs: [github_oauth]}
+";
+
+        assert!(
+            !validator().is_valid(&manifest_json(raw)),
+            "generated schema should reject surface-scoped identity requirements"
+        );
+        parse_source_manifest_yaml(raw)
+            .expect_err("parser should reject surface-scoped identity requirements");
     }
 
     #[test]


### PR DESCRIPTION
## Intent

Add the DSL v4 OpenAPI `identity_requirements.accepts` contract. Identity-gated surfaces reject legacy `kind: secret` inputs on that same surface, while ungated v4 surfaces retain their existing secret-input path.

This PR owns only the authored spec, validation, and generated schema contract. The fail-closed runtime guard is intentionally layered in #1512.

## What it enables

Later identity binding and resolution units can match a surface requirement by requirement id, accepted identity spec ids, and audience metadata. The generated schema accepts the frozen shape `{id, identity_specs, audience}` and rejects empty, duplicate, malformed, or unknown fields.

## Usage examples

```yaml
surfaces:
  - id: rest
    type: openapi
    file: /tmp/github-openapi.yaml
    identity_requirements:
      accepts:
        - id: github_rest_read
          identity_specs: [github_oauth, github_pat]
          audience:
            host: github.com
```

MCP surfaces reject `identity_requirements`. A secret input on one ungated surface does not invalidate a different gated surface.

## Validation

- `make rust-checks`
- `make schema-check`
- `make docs-check`
- `cargo test --locked -p coral-spec --all-features`
- focused `coral-app` runtime-package tests