### PR TITLE
feat(spec): parse manifest bundles

### DIFF
--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -44,6 +44,14 @@ pub enum AppError {
         /// Human-readable description of the missing input or inputs.
         detail: String,
     },
+    /// This build cannot resolve a DSL v4 source's declared identities.
+    #[error(
+        "failed precondition: source '{source_name}' declares DSL v4 identity_requirements, but this Coral build cannot resolve source identities. Use a Coral build with identity runtime support before querying this source."
+    )]
+    UnsupportedV4IdentityRequirements {
+        /// Source containing unsupported identity requirements.
+        source_name: String,
+    },
     /// A DSL v4 source has missing or stale generated runtime artifacts.
     #[error(
         "failed precondition: source '{source_name}' has missing or incompatible DSL v4 materialized artifacts: {detail}. Re-add the source to regenerate them."
@@ -290,6 +298,7 @@ fn app_code(error: &AppError) -> Code {
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
         | AppError::MissingSourceInputs { .. }
+        | AppError::UnsupportedV4IdentityRequirements { .. }
         | AppError::MissingOrIncompatibleV4Materialization { .. }
         | AppError::IncompatibleInstalledV4Manifest { .. }
         | AppError::InvalidV4ProjectionOverride { .. }
@@ -341,6 +350,26 @@ mod tests {
         assert_eq!(status.code(), Code::Unauthenticated);
         assert!(status.message().len() <= MAX_STATUS_DETAIL_BYTES);
         assert!(status.message().ends_with("… (truncated)"));
+    }
+
+    #[test]
+    fn app_status_explains_unsupported_v4_identity_requirements_without_readd_guidance() {
+        let status = app_status(AppError::UnsupportedV4IdentityRequirements {
+            source_name: "demo".to_string(),
+        });
+
+        assert_eq!(status.code(), Code::FailedPrecondition);
+        assert!(
+            status
+                .message()
+                .contains("source 'demo' declares DSL v4 identity_requirements")
+        );
+        assert!(
+            status
+                .message()
+                .contains("cannot resolve source identities")
+        );
+        assert!(!status.message().contains("Re-add"));
     }
 
     #[test]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -993,6 +993,9 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::InvalidInput(_) => "INVALID_INPUT",
         AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
         AppError::MissingSourceInputs { .. } => "MISSING_SOURCE_INPUTS",
+        AppError::UnsupportedV4IdentityRequirements { .. } => {
+            "UNSUPPORTED_V4_IDENTITY_REQUIREMENTS"
+        }
         AppError::MissingOrIncompatibleV4Materialization { .. } => {
             "MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION"
         }
@@ -1814,6 +1817,77 @@ surface:
             execution_to_rows(&execution),
             vec![json!({"id": 1, "title": "Generated runtime package"})]
         );
+    }
+
+    #[tokio::test]
+    async fn load_query_source_preserves_unsupported_v4_identity_requirements_error() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let source_manager = SourceManager::new_for_tests(
+            fixture.manager.config_store.clone(),
+            fixture.manager.credential_manager.clone(),
+            fixture.manager.layout.clone(),
+        );
+        let workspace_name = WorkspaceName::default();
+        let descriptor_temp = tempfile::tempdir().expect("descriptor temp dir");
+        let openapi_file = descriptor_temp.path().join("identity-guard-openapi.yaml");
+        std::fs::write(
+            &openapi_file,
+            r"
+openapi: 3.0.3
+info: {title: Identity Guard}
+paths:
+  /items:
+    get:
+      operationId: items/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: integer}
+",
+        )
+        .expect("write OpenAPI fixture");
+        let source = source_manager
+            .import_source(
+                &workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: format!(
+                        r"
+name: github_v4_identity_guard
+dsl_version: 4
+identity_requirements:
+  accepts:
+    - id: github_api
+      identity_specs: [github_oauth]
+surface:
+  type: openapi
+  file: {}
+",
+                        openapi_file.display()
+                    ),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect("import identity-gated v4 source");
+        std::fs::remove_file(&openapi_file).expect("remove authored descriptor after import");
+
+        let error = fixture
+            .manager
+            .load_query_source(&workspace_name, &source)
+            .expect_err("identity-gated source must fail closed");
+
+        assert!(matches!(
+            &error,
+            AppError::UnsupportedV4IdentityRequirements { source_name }
+                if source_name == "github_v4_identity_guard"
+        ));
+        assert!(!error.to_string().contains("Re-add"));
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/search/catalog/local_snapshot.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot.rs
@@ -115,7 +115,8 @@ impl CatalogSnapshotLoader {
                         .extend(source_catalog.table_functions);
                 }
                 Err(
-                    error @ (AppError::MissingOrIncompatibleV4Materialization { .. }
+                    error @ (AppError::UnsupportedV4IdentityRequirements { .. }
+                    | AppError::MissingOrIncompatibleV4Materialization { .. }
                     | AppError::IncompatibleInstalledV4Manifest { .. }
                     | AppError::InvalidV4ProjectionOverride { .. }
                     | AppError::InvalidV4ParameterMetadataOverride { .. }),
@@ -174,11 +175,12 @@ impl CatalogSnapshotLoader {
             )?;
             runtime_component_for_v4_source(v4, &materialized)
                 .map(|component| component.into_iter().collect())
-                .map_err(|error| {
-                    incompatible_materialization_error(
+                .map_err(|error| match error {
+                    error @ AppError::UnsupportedV4IdentityRequirements { .. } => error,
+                    error => incompatible_materialization_error(
                         &source.name,
                         format!("failed to assemble runtime package: {error}"),
-                    )
+                    ),
                 })
         } else {
             Ok(runtime_components_from_manifest(&source_spec))

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -129,12 +129,14 @@ pub(crate) fn query_source_from_installed_manifest(
             v4,
             diagnostic_reporter,
         )?;
-        let component = runtime_component_for_v4_source(v4, &materialized).map_err(|error| {
-            incompatible_materialization_error(
-                &source.name,
-                format!("failed to assemble runtime package: {error}"),
-            )
-        })?;
+        let component =
+            runtime_component_for_v4_source(v4, &materialized).map_err(|error| match error {
+                error @ AppError::UnsupportedV4IdentityRequirements { .. } => error,
+                error => incompatible_materialization_error(
+                    &source.name,
+                    format!("failed to assemble runtime package: {error}"),
+                ),
+            })?;
         let query_source = QuerySource::from_runtime_components(
             RuntimeSourcePackage {
                 source_name: source_spec.schema_name().to_string(),
@@ -170,6 +172,11 @@ pub(crate) fn runtime_component_for_v4_source(
     manifest: &V4SourceManifest,
     materialized: &V4MaterializedSource,
 ) -> Result<Option<RuntimeSourceComponent>, AppError> {
+    if manifest.identity_requirements.is_some() {
+        return Err(AppError::UnsupportedV4IdentityRequirements {
+            source_name: manifest.common.name.clone(),
+        });
+    }
     if !has_published_projection(materialized) {
         return Ok(None);
     }
@@ -494,16 +501,18 @@ mod tests {
     use coral_spec::backends::http::{AuthSpec, RateLimitSpec};
     use coral_spec::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec, McpServerSpec};
     use coral_spec::v4::{
-        Fingerprint, FingerprintSurface, HttpMethod, IrExecutionAttachment, IrOperation,
-        IrOperationOutput, MCP_IMPORTER_VERSION, MaterializedSurface, McpExecutionAttachment,
-        McpRuntimeConfig, OPENAPI_IMPORTER_VERSION, OpenApiRuntimeConfig,
-        PROJECTION_GENERATOR_VERSION, Projection, ProjectionCatalog, ProjectionKind,
-        ProjectionVisibility, RestExecutionAttachment, RestResponseAttachment,
-        SURFACE_IMPORTER_VERSION, SemanticIr, SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType,
-        V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceCommon, V4SourceManifest,
-        V4Surface,
+        AcceptedIdentityRequirement, Fingerprint, FingerprintSurface, HttpMethod,
+        IdentityRequirements, IrExecutionAttachment, IrOperation, IrOperationOutput,
+        MCP_IMPORTER_VERSION, MaterializedSurface, McpExecutionAttachment, McpRuntimeConfig,
+        OPENAPI_IMPORTER_VERSION, OpenApiRuntimeConfig, PROJECTION_GENERATOR_VERSION, Projection,
+        ProjectionCatalog, ProjectionKind, ProjectionVisibility, RestExecutionAttachment,
+        RestResponseAttachment, SURFACE_IMPORTER_VERSION, SemanticIr, SurfaceDescriptor,
+        SurfaceRuntimeConfig, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource,
+        V4SourceCommon, V4SourceManifest, V4Surface,
     };
     use coral_spec::{PageSizeSpec, PaginationMode, PaginationSpec, ResponseSpec};
+
+    use crate::bootstrap::AppError;
 
     use super::{runtime_component_for_v4_source, runtime_contract_fingerprint, surface_base_url};
 
@@ -975,6 +984,45 @@ mod tests {
             .expect("runtime component assembly");
 
         assert!(component.is_none());
+    }
+
+    #[test]
+    fn runtime_component_fails_closed_for_identity_gated_source_without_projections() {
+        let mut manifest = manifest_with_surface(surface_without_authored_base_url());
+        manifest.identity_requirements = Some(IdentityRequirements {
+            accepts: vec![AcceptedIdentityRequirement {
+                id: "github".to_string(),
+                identity_specs: vec!["github_oauth".to_string()],
+                audience: BTreeMap::new(),
+            }],
+        });
+        let materialized = V4MaterializedSource {
+            fingerprint: None,
+            surface: materialized_surface(PathBuf::from("/tmp/openapi.yaml")),
+            projections: ProjectionCatalog {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "demo".to_string(),
+                generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
+                projections: Vec::new(),
+                diagnostics: Vec::new(),
+            },
+            diagnostics: Vec::new(),
+        };
+
+        let error = runtime_component_for_v4_source(&manifest, &materialized)
+            .expect_err("identity-gated source must fail before projection filtering");
+
+        assert!(matches!(
+            &error,
+            AppError::UnsupportedV4IdentityRequirements { source_name }
+                if source_name == "demo"
+        ));
+        assert!(
+            error
+                .to_string()
+                .contains("cannot resolve source identities")
+        );
+        assert!(!error.to_string().contains("Re-add"));
     }
 
     #[test]

--- a/crates/coral-spec/src/bundle.rs
+++ b/crates/coral-spec/src/bundle.rs
@@ -1,0 +1,286 @@
+//! Multi-document manifest bundle parsing.
+
+use std::collections::HashSet;
+
+use serde::Deserialize as _;
+use serde_json::Value;
+
+use crate::{
+    IdentityManifest, ManifestError, Result, ValidatedSourceManifest,
+    parse_identity_manifest_value, parse_source_manifest_value,
+};
+
+/// One identity spec document parsed from a manifest bundle.
+#[derive(Debug, Clone)]
+pub struct IdentityManifestDocument {
+    /// Canonical YAML for this identity spec document.
+    pub manifest_yaml: String,
+    /// Validated identity spec.
+    pub manifest: IdentityManifest,
+}
+
+/// A source manifest plus any identity specs authored in the same YAML bundle.
+#[derive(Debug, Clone)]
+pub struct ManifestBundle {
+    /// Canonical YAML for the source document only.
+    pub source_manifest_yaml: String,
+    /// Validated source manifest.
+    pub source_manifest: ValidatedSourceManifest,
+    /// Validated identity spec documents from the bundle.
+    pub identity_manifests: Vec<IdentityManifestDocument>,
+}
+
+/// Parses a YAML file that may contain one source manifest and zero or more
+/// identity specs separated by `---`.
+///
+/// Single-document source manifests keep the same acceptance behavior as
+/// [`crate::parse_source_manifest_yaml`]. Multi-document files must contain
+/// exactly one source manifest document. Identity spec documents are selected
+/// with `kind: identity`; any other explicit `kind` fails closed.
+pub fn parse_manifest_bundle_yaml(raw: &str) -> Result<ManifestBundle> {
+    let mut source = None;
+    let mut identities = Vec::new();
+    let mut identity_names = HashSet::new();
+
+    for (index, document) in serde_yaml::Deserializer::from_str(raw).enumerate() {
+        let value = Value::deserialize(document).map_err(ManifestError::parse_yaml)?;
+        if value.is_null() {
+            continue;
+        }
+        let document_number = index + 1;
+        match manifest_document_kind(&value, document_number)? {
+            ManifestDocumentKind::Source => {
+                if source.is_some() {
+                    return Err(ManifestError::validation(
+                        "manifest bundle must contain exactly one source manifest document",
+                    ));
+                }
+                let manifest = parse_source_manifest_value(value.clone())?;
+                source = Some((serialize_document_yaml(&value)?, manifest));
+            }
+            ManifestDocumentKind::Identity => {
+                let manifest = parse_identity_manifest_value(value.clone())?;
+                if !identity_names.insert(manifest.name.clone()) {
+                    return Err(ManifestError::validation(format!(
+                        "manifest bundle declares identity spec '{}' more than once",
+                        manifest.name
+                    )));
+                }
+                identities.push(IdentityManifestDocument {
+                    manifest_yaml: serialize_document_yaml(&value)?,
+                    manifest,
+                });
+            }
+        }
+    }
+
+    let Some((source_manifest_yaml, source_manifest)) = source else {
+        return Err(ManifestError::validation(
+            "manifest bundle must contain exactly one source manifest document",
+        ));
+    };
+
+    Ok(ManifestBundle {
+        source_manifest_yaml,
+        source_manifest,
+        identity_manifests: identities,
+    })
+}
+
+enum ManifestDocumentKind {
+    Source,
+    Identity,
+}
+
+fn manifest_document_kind(value: &Value, document_number: usize) -> Result<ManifestDocumentKind> {
+    let Some(kind) = value.get("kind") else {
+        return Ok(ManifestDocumentKind::Source);
+    };
+    match kind.as_str() {
+        Some("identity") => Ok(ManifestDocumentKind::Identity),
+        Some(other) => Err(ManifestError::validation(format!(
+            "manifest bundle document {document_number} has unsupported kind '{other}'"
+        ))),
+        None => Err(ManifestError::validation(format!(
+            "manifest bundle document {document_number} kind must be a string"
+        ))),
+    }
+}
+
+fn serialize_document_yaml(value: &Value) -> Result<String> {
+    serde_yaml::to_string(value).map_err(ManifestError::parse_yaml)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{parse_identity_manifest_yaml, parse_source_manifest_yaml};
+
+    use super::parse_manifest_bundle_yaml;
+
+    fn identity_yaml(name: &str) -> String {
+        format!(
+            "kind: identity\nspec_version: 1\nname: {name}\nversion: 0.1.0\nissuer: github\ntype: fixed_token\naudience: {{host: api.github.com}}\n"
+        )
+    }
+
+    fn source_yaml(name: &str) -> String {
+        format!(
+            "name: {name}\ndsl_version: 4\nidentity_requirements:\n  accepts:\n    - id: github_api\n      identity_specs: [github_oauth, github_pat]\n      audience: {{host: api.github.com}}\nsurface:\n  type: openapi\n  file: /tmp/github-openapi.yaml\n"
+        )
+    }
+
+    #[test]
+    fn parses_single_document_source_manifest_as_bundle() {
+        let bundle = parse_manifest_bundle_yaml(&source_yaml("demo")).expect("bundle");
+
+        assert_eq!(bundle.source_manifest.schema_name(), "demo");
+        assert!(
+            bundle
+                .source_manifest
+                .as_v4()
+                .and_then(|manifest| manifest.identity_requirements.as_ref())
+                .is_some(),
+            "identity requirements do not require bundled specs at parse time"
+        );
+        assert!(bundle.identity_manifests.is_empty());
+        assert!(bundle.source_manifest_yaml.contains("name: demo"));
+    }
+
+    #[test]
+    fn parses_v4_source_with_multiple_identity_specs_and_canonicalizes_documents() {
+        let raw = format!(
+            "---\n\n---\n{}---\n{}---\nnull\n---\n{}",
+            identity_yaml("github_oauth"),
+            source_yaml("demo"),
+            identity_yaml("github_pat")
+        );
+
+        let bundle = parse_manifest_bundle_yaml(&raw).expect("bundle");
+
+        assert_eq!(bundle.source_manifest.schema_name(), "demo");
+        assert_eq!(
+            bundle
+                .identity_manifests
+                .iter()
+                .map(|document| document.manifest.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["github_oauth", "github_pat"]
+        );
+        assert!(
+            bundle
+                .identity_manifests
+                .iter()
+                .all(|document| document.manifest_yaml.contains("kind: identity"))
+        );
+
+        let reparsed_source = parse_source_manifest_yaml(&bundle.source_manifest_yaml)
+            .expect("canonical source document reparses");
+        assert_eq!(reparsed_source.schema_name(), "demo");
+        for document in &bundle.identity_manifests {
+            assert_eq!(
+                parse_identity_manifest_yaml(&document.manifest_yaml)
+                    .expect("canonical identity document reparses"),
+                document.manifest
+            );
+        }
+
+        let canonical_bundle = std::iter::once(bundle.source_manifest_yaml.as_str())
+            .chain(
+                bundle
+                    .identity_manifests
+                    .iter()
+                    .map(|document| document.manifest_yaml.as_str()),
+            )
+            .collect::<Vec<_>>()
+            .join("---\n");
+        let canonical_reparse = parse_manifest_bundle_yaml(&canonical_bundle)
+            .expect("canonical bundle reparses idempotently");
+        assert_eq!(
+            canonical_reparse.source_manifest_yaml,
+            bundle.source_manifest_yaml
+        );
+        assert_eq!(
+            canonical_reparse
+                .identity_manifests
+                .iter()
+                .map(|document| document.manifest_yaml.as_str())
+                .collect::<Vec<_>>(),
+            bundle
+                .identity_manifests
+                .iter()
+                .map(|document| document.manifest_yaml.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn rejects_bundle_without_source_manifest() {
+        let error = parse_manifest_bundle_yaml(&identity_yaml("github_oauth"))
+            .expect_err("source document required");
+
+        assert!(
+            error
+                .to_string()
+                .contains("manifest bundle must contain exactly one source manifest document"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_source_manifest() {
+        let raw = format!("---\n{}---\n{}", source_yaml("demo"), source_yaml("other"));
+        let error = parse_manifest_bundle_yaml(&raw).expect_err("one source document allowed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("manifest bundle must contain exactly one source manifest document"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_identity_spec_name() {
+        let raw = format!(
+            "---\n{}---\n{}---\n{}",
+            source_yaml("demo"),
+            identity_yaml("github_oauth"),
+            identity_yaml("github_oauth")
+        );
+        let error = parse_manifest_bundle_yaml(&raw).expect_err("identity names must be unique");
+
+        assert!(
+            error
+                .to_string()
+                .contains("declares identity spec 'github_oauth' more than once"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_or_non_string_explicit_kind() {
+        for (raw, expected) in [
+            ("kind: source\nname: demo", "unsupported kind 'source'"),
+            ("kind: 1\nname: demo", "kind must be a string"),
+            ("kind: null\nname: demo", "kind must be a string"),
+        ] {
+            let error = parse_manifest_bundle_yaml(raw).expect_err("kind should fail closed");
+            assert!(
+                error.to_string().contains(expected),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn delegates_document_validation_to_normal_manifest_parsers() {
+        let invalid_source = "name: demo\ndsl_version: 4\nsurface: []\n";
+        parse_manifest_bundle_yaml(invalid_source).expect_err("invalid source must fail");
+
+        let invalid_identity = format!(
+            "{}---\nkind: identity\nspec_version: 1\nname: broken\nversion: 0.1.0\nissuer: github\n",
+            source_yaml("demo")
+        );
+        parse_manifest_bundle_yaml(&invalid_identity).expect_err("invalid identity must fail");
+    }
+}

--- a/crates/coral-spec/src/bundle.rs
+++ b/crates/coral-spec/src/bundle.rs
@@ -108,7 +108,7 @@ fn manifest_document_kind(value: &Value, document_number: usize) -> Result<Manif
 }
 
 fn serialize_document_yaml(value: &Value) -> Result<String> {
-    serde_yaml::to_string(value).map_err(ManifestError::parse_yaml)
+    serde_yaml::to_string(value).map_err(ManifestError::serialize_yaml)
 }
 
 #[cfg(test)]

--- a/crates/coral-spec/src/error.rs
+++ b/crates/coral-spec/src/error.rs
@@ -13,6 +13,13 @@ pub enum ManifestError {
         #[source]
         source: serde_yaml::Error,
     },
+    /// The source-spec YAML could not be serialized.
+    #[error("failed to serialize manifest yaml: {source}")]
+    SerializeYaml {
+        /// The underlying YAML serialization error.
+        #[source]
+        source: serde_yaml::Error,
+    },
     /// A structured source-spec value could not be deserialized.
     #[error("failed to deserialize manifest: {source}")]
     Deserialize {
@@ -28,6 +35,10 @@ pub enum ManifestError {
 impl ManifestError {
     pub(crate) fn parse_yaml(source: serde_yaml::Error) -> Self {
         Self::ParseYaml { source }
+    }
+
+    pub(crate) fn serialize_yaml(source: serde_yaml::Error) -> Self {
+        Self::SerializeYaml { source }
     }
 
     pub(crate) fn deserialize(source: serde_json::Error) -> Self {

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -80,6 +80,7 @@
     reason = "These manifest builders and accessors are internal crate APIs, not end-user APIs."
 )]
 pub mod backends;
+mod bundle;
 mod common;
 mod error;
 mod identities;
@@ -97,6 +98,7 @@ pub use backends::mcp::{
     McpEnvSpec, McpHttpAuthSpec, McpLimitBinding, McpServerSpec, McpSourceManifest,
     McpTableFilterBinding, McpTableFilterSpec, McpTableFunctionSpec, McpTableSpec,
 };
+pub use bundle::{IdentityManifestDocument, ManifestBundle, parse_manifest_bundle_yaml};
 pub use common::{
     BodyFieldSpec, BodySpec, ColumnSpec, DO_NOT_INDEX_COLUMN_METADATA_KEY, DetailHintSpec,
     ExprSpec, FilterMode, FilterSpec, FunctionArgBinding, HeaderSpec, HttpMethod, ManifestDataType,

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -16,7 +16,7 @@ pub fn normalize_mcp_tool_catalog(catalog: &McpToolCatalog) -> Result<Vec<u8>> {
         .sort_by(|left, right| left.name.cmp(&right.name));
     serde_yaml::to_string(&normalized)
         .map(String::into_bytes)
-        .map_err(ManifestError::parse_yaml)
+        .map_err(ManifestError::serialize_yaml)
 }
 
 pub fn import_mcp_surface(

--- a/crates/coral-spec/src/v4/surfaces/openapi/document.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/document.rs
@@ -4,7 +4,7 @@ use crate::{ManifestError, Result};
 
 pub fn normalize_source_document(bytes: &[u8]) -> Result<String> {
     let value: Value = serde_yaml::from_slice(bytes).map_err(ManifestError::parse_yaml)?;
-    serde_yaml::to_string(&value).map_err(ManifestError::parse_yaml)
+    serde_yaml::to_string(&value).map_err(ManifestError::serialize_yaml)
 }
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
## Intent

Add canonical multi-document manifest bundle parsing to `coral-spec`: exactly one source manifest plus zero or more explicit `kind: identity` documents. Also add the typed, fail-closed app guard that prevents identity-gated DSL v4 OpenAPI surfaces from entering runtime before identity resolution lands.

The parser ignores blank documents, validates every nonblank document through the normal source or identity parser, rejects unsupported explicit kinds and duplicates, preserves identity document order, and returns canonical YAML.

## What it enables

Sources can ship the authored source manifest and required identity specs in one artifact without adding premature cross-document completeness or residency rules. Runtime loading now preserves `UnsupportedV4IdentityRequirements` through direct, query, telemetry, and gRPC paths instead of exposing an unresolved gated surface or wrapping the error as stale materialization.

## Usage examples

```rust
let bundle = coral_spec::parse_manifest_bundle_yaml(raw_yaml)?;
let source = bundle.source_manifest;
let identities = bundle.identity_manifests;
```

A v4 source document may declare `identity_requirements`, followed by identity documents such as:

```yaml
---
kind: identity
spec_version: 1
name: github_oauth
version: 0.1.0
issuer: github
type: fixed_token
inputs: {}
```

Until binding and resolution are implemented, loading the gated source returns a typed failed-precondition error naming the source and surface.

## Validation

- `make rust-checks`
- `make schema-check`
- `make docs-check`
- `cargo test --locked -p coral-spec --all-features`
- `cargo test --locked -p coral-app --all-features`
- focused bundle, runtime-package, bootstrap, transport, and query-loading tests