### PR TITLE
feat(spec): pin v4 manifest artifacts

### DIFF
--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -163,6 +163,26 @@ mod tests {
     }
 
     #[test]
+    fn describe_v4_manifest_exposes_authored_version() {
+        let source = describe_manifest(
+            r"
+name: demo_v4
+dsl_version: 4
+version: 1.2.3
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+",
+            SourceOrigin::Imported,
+            false,
+        )
+        .expect("describe v4 manifest");
+
+        assert_eq!(source.version.as_deref(), Some("1.2.3"));
+    }
+
+    #[test]
     fn describe_manifest_extracts_declared_inputs() {
         let source = describe_manifest(
             r#"

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -1584,7 +1584,7 @@ fn durable_import_manifest_yaml(
     };
     let mut replacement_files = BTreeMap::new();
     for surface in &v4.surfaces {
-        let SurfaceDescriptor::File { file } = &surface.descriptor else {
+        let SurfaceDescriptor::File { file, .. } = &surface.descriptor else {
             continue;
         };
         let canonical = canonicalize_file_descriptor(file)?;

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1063,24 +1063,17 @@ fn write_materialization(
     for surface in &manifest.surfaces {
         let materialized_surface = match materialize_surface(manifest, surface, inputs) {
             Ok(materialized_surface) => materialized_surface,
-            Err(error) => {
-                let message = format!(
-                    "failed to materialize source '{}' surface '{}': {error}",
-                    manifest.common.name, surface.id
+            Err(SurfaceMaterializationError::Recoverable(error)) => {
+                record_surface_materialization_failure(
+                    manifest,
+                    surface,
+                    &error,
+                    &mut diagnostics,
+                    &mut first_surface_error,
                 );
-                if first_surface_error.is_none() {
-                    first_surface_error = Some(message.clone());
-                }
-                diagnostics.push(Diagnostic {
-                    code: "SURFACE_MATERIALIZATION_FAILED".to_string(),
-                    severity: DiagnosticSeverity::Warning,
-                    message,
-                    surface_id: Some(surface.id.clone()),
-                    operation_id: None,
-                    projection_name: None,
-                });
                 continue;
             }
+            Err(SurfaceMaterializationError::Fatal(error)) => return Err(error),
         };
         let surface_dir = temp_dir.join("surfaces").join(&surface.id);
         write_surface_artifacts(&surface_dir, &materialized_surface)?;
@@ -1144,6 +1137,30 @@ fn write_materialization(
     Ok(())
 }
 
+fn record_surface_materialization_failure(
+    manifest: &V4SourceManifest,
+    surface: &coral_spec::v4::V4Surface,
+    error: &AppError,
+    diagnostics: &mut Vec<Diagnostic>,
+    first_surface_error: &mut Option<String>,
+) {
+    let message = format!(
+        "failed to materialize source '{}' surface '{}': {error}",
+        manifest.common.name, surface.id
+    );
+    if first_surface_error.is_none() {
+        *first_surface_error = Some(message.clone());
+    }
+    diagnostics.push(Diagnostic {
+        code: "SURFACE_MATERIALIZATION_FAILED".to_string(),
+        severity: DiagnosticSeverity::Warning,
+        message,
+        surface_id: Some(surface.id.clone()),
+        operation_id: None,
+        projection_name: None,
+    });
+}
+
 struct MaterializedSurfaceBuild {
     raw_document: Vec<u8>,
     normalized_document: Vec<u8>,
@@ -1173,24 +1190,36 @@ fn write_surface_artifacts(
     Ok(())
 }
 
+enum SurfaceMaterializationError {
+    Recoverable(AppError),
+    Fatal(AppError),
+}
+
+impl From<AppError> for SurfaceMaterializationError {
+    fn from(error: AppError) -> Self {
+        Self::Recoverable(error)
+    }
+}
+
 fn materialize_surface(
     manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,
     inputs: &MaterializationInputs,
-) -> Result<MaterializedSurfaceBuild, AppError> {
+) -> Result<MaterializedSurfaceBuild, SurfaceMaterializationError> {
     match surface.surface_type {
         SurfaceType::OpenApi => materialize_openapi_surface(manifest, surface),
-        SurfaceType::Mcp => materialize_mcp_surface(manifest, surface, inputs),
+        SurfaceType::Mcp => materialize_mcp_surface(manifest, surface, inputs).map_err(Into::into),
     }
 }
 
 fn materialize_openapi_surface(
     manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,
-) -> Result<MaterializedSurfaceBuild, AppError> {
+) -> Result<MaterializedSurfaceBuild, SurfaceMaterializationError> {
     let bytes = read_descriptor(surface)?;
-    validate_materialized_surface_base_url(manifest, surface, &bytes)?;
     let observed_sha256 = sha256_hex(&bytes);
+    validate_descriptor_sha256(surface, &observed_sha256)?;
+    validate_materialized_surface_base_url(manifest, surface, &bytes)?;
     let semantic_ir = import_openapi_surface(manifest, surface, &bytes).map_err(|error| {
         AppError::FailedPrecondition(format!(
             "failed to import source '{}' surface '{}': {error}",
@@ -1325,10 +1354,28 @@ fn validate_materialized_surface_base_url(
     .map_err(|error| AppError::FailedPrecondition(error.to_string()))
 }
 
+fn validate_descriptor_sha256(
+    surface: &coral_spec::v4::V4Surface,
+    observed_sha256: &str,
+) -> Result<(), SurfaceMaterializationError> {
+    let Some(expected_sha256) = surface.descriptor.sha256() else {
+        return Ok(());
+    };
+    if expected_sha256 != observed_sha256 {
+        return Err(SurfaceMaterializationError::Fatal(
+            AppError::FailedPrecondition(format!(
+                "DSL v4 surface '{}' descriptor sha256 mismatch: expected {}, observed {}",
+                surface.id, expected_sha256, observed_sha256
+            )),
+        ));
+    }
+    Ok(())
+}
+
 fn read_descriptor(surface: &coral_spec::v4::V4Surface) -> Result<Vec<u8>, AppError> {
     match &surface.descriptor {
-        coral_spec::v4::SurfaceDescriptor::File { file } => read_file_descriptor(file),
-        coral_spec::v4::SurfaceDescriptor::Url { url } => read_url_descriptor(url),
+        coral_spec::v4::SurfaceDescriptor::File { file, .. } => read_file_descriptor(file),
+        coral_spec::v4::SurfaceDescriptor::Url { url, .. } => read_url_descriptor(url),
         coral_spec::v4::SurfaceDescriptor::McpServer { .. } => {
             Err(AppError::FailedPrecondition(format!(
                 "DSL v4 MCP surface '{}' does not have an OpenAPI descriptor",
@@ -2227,6 +2274,173 @@ surfaces:
                 .contains("dereferenced or bundled OpenAPI documents"),
             "{}",
             diagnostic.message
+        );
+    }
+
+    #[test]
+    fn build_v4_materialization_accepts_matching_descriptor_sha256() {
+        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+        let openapi_file = descriptor_temp.path().join("openapi.yaml");
+        std::fs::write(&openapi_file, openapi_fixture()).expect("write descriptor");
+        let descriptor_sha256 = sha256_hex(openapi_fixture().as_bytes());
+        let state_temp = TempDir::new().expect("state temp dir");
+        let layout =
+            AppStateLayout::discover(Some(state_temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let manifest_yaml = format!(
+            r"
+name: sha_match_materialization_test
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    sha256: {descriptor_sha256}
+    base_url: https://api.example.com
+",
+            openapi_file.display()
+        );
+        let manifest = parse_source_manifest_yaml(&manifest_yaml)
+            .expect("parse v4 manifest")
+            .as_v4()
+            .expect("v4")
+            .clone();
+
+        let build = build_v4_materialization_tmp(
+            &layout,
+            &workspace_name(),
+            &SourceName::parse("sha_match_materialization_test").expect("source"),
+            &manifest_yaml,
+            &manifest,
+            &MaterializationInputs::default(),
+            "test",
+        )
+        .expect("matching descriptor sha should materialize");
+        let fingerprint: Fingerprint =
+            read_yaml(&build.temp_dir.join(FINGERPRINT_FILENAME)).expect("read fingerprint");
+        assert_eq!(
+            fingerprint
+                .surfaces
+                .first()
+                .expect("fingerprint surface")
+                .descriptor_sha256,
+            descriptor_sha256
+        );
+    }
+
+    #[test]
+    fn build_v4_materialization_rejects_descriptor_sha256_mismatch() {
+        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+        let openapi_file = descriptor_temp.path().join("openapi.yaml");
+        std::fs::write(&openapi_file, openapi_fixture()).expect("write descriptor");
+        let state_temp = TempDir::new().expect("state temp dir");
+        let layout =
+            AppStateLayout::discover(Some(state_temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let manifest_yaml = format!(
+            r"
+name: sha_mismatch_materialization_test
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    base_url: https://api.example.com
+",
+            openapi_file.display()
+        );
+        let manifest = parse_source_manifest_yaml(&manifest_yaml)
+            .expect("parse v4 manifest")
+            .as_v4()
+            .expect("v4")
+            .clone();
+
+        let error = build_v4_materialization_tmp(
+            &layout,
+            &workspace_name(),
+            &SourceName::parse("sha_mismatch_materialization_test").expect("source"),
+            &manifest_yaml,
+            &manifest,
+            &MaterializationInputs::default(),
+            "test",
+        )
+        .expect_err("descriptor sha mismatch should fail");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("surface 'rest'") && message.contains("descriptor sha256 mismatch"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn build_v4_materialization_aborts_all_surfaces_on_descriptor_sha256_mismatch() {
+        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+        let openapi_file = descriptor_temp.path().join("openapi.yaml");
+        std::fs::write(&openapi_file, openapi_fixture()).expect("write descriptor");
+        let state_temp = TempDir::new().expect("state temp dir");
+        let layout =
+            AppStateLayout::discover(Some(state_temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let source_name =
+            SourceName::parse("sha_mismatch_multi_materialization_test").expect("source");
+        let manifest_yaml = format!(
+            r"
+name: sha_mismatch_multi_materialization_test
+dsl_version: 4
+surfaces:
+  - id: good
+    namespace_suffix: good
+    type: openapi
+    file: {}
+    base_url: https://api.example.com
+  - id: bad
+    namespace_suffix: bad
+    type: openapi
+    file: {}
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    base_url: https://api.example.com
+",
+            openapi_file.display(),
+            openapi_file.display()
+        );
+        let manifest = parse_source_manifest_yaml(&manifest_yaml)
+            .expect("parse v4 manifest")
+            .as_v4()
+            .expect("v4")
+            .clone();
+        let temp_dir = layout.v4_materialized_tmp_dir(&workspace_name(), &source_name, "test");
+        let target_dir = layout.v4_materialized_dir(&workspace_name(), &source_name);
+
+        let error = build_v4_materialization_tmp(
+            &layout,
+            &workspace_name(),
+            &source_name,
+            &manifest_yaml,
+            &manifest,
+            &MaterializationInputs::default(),
+            "test",
+        )
+        .expect_err("pin mismatch should abort the whole materialization");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("surface 'bad'")
+                && message.contains("descriptor sha256 mismatch")
+                && message.contains(
+                    "expected 0000000000000000000000000000000000000000000000000000000000000000"
+                )
+                && message.contains("observed "),
+            "unexpected error: {message}"
+        );
+        assert!(
+            !temp_dir.exists(),
+            "failed materialization should clean temporary artifacts"
+        );
+        assert!(
+            !target_dir.exists(),
+            "failed materialization should not install a partial package"
         );
     }
 

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -673,6 +673,7 @@ mod tests {
             surface_type: SurfaceType::OpenApi,
             descriptor: SurfaceDescriptor::File {
                 file: PathBuf::from("/tmp/openapi.yaml"),
+                sha256: None,
             },
             inputs: Vec::new(),
             runtime: SurfaceRuntimeConfig::OpenApi(OpenApiRuntimeConfig {
@@ -739,6 +740,7 @@ mod tests {
             common: V4SourceCommon {
                 dsl_version: 4,
                 name: "demo".to_string(),
+                version: None,
                 description: String::new(),
                 test_queries: Vec::new(),
             },
@@ -997,6 +999,7 @@ mod tests {
             common: V4SourceCommon {
                 dsl_version: 4,
                 name: "github_v4".to_string(),
+                version: None,
                 description: String::new(),
                 test_queries: Vec::new(),
             },
@@ -1049,6 +1052,7 @@ mod tests {
             common: V4SourceCommon {
                 dsl_version: 4,
                 name: "github_v4".to_string(),
+                version: None,
                 description: String::new(),
                 test_queries: Vec::new(),
             },
@@ -1093,6 +1097,7 @@ mod tests {
             common: V4SourceCommon {
                 dsl_version: 4,
                 name: "github_v4".to_string(),
+                version: None,
                 description: String::new(),
                 test_queries: Vec::new(),
             },
@@ -1147,6 +1152,7 @@ mod tests {
             common: V4SourceCommon {
                 dsl_version: 4,
                 name: "github_v4".to_string(),
+                version: None,
                 description: String::new(),
                 test_queries: Vec::new(),
             },
@@ -1224,6 +1230,7 @@ mod tests {
             common: V4SourceCommon {
                 dsl_version: 4,
                 name: "github_v4".to_string(),
+                version: None,
                 description: String::new(),
                 test_queries: Vec::new(),
             },
@@ -1285,6 +1292,7 @@ mod tests {
             common: V4SourceCommon {
                 dsl_version: 4,
                 name: "github_v4".to_string(),
+                version: None,
                 description: String::new(),
                 test_queries: Vec::new(),
             },

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -475,7 +475,7 @@ fn durable_manifest_file_yaml(
     };
     let mut replacement_files = BTreeMap::new();
     for surface in &v4.surfaces {
-        let SurfaceDescriptor::File { file } = &surface.descriptor else {
+        let SurfaceDescriptor::File { file, .. } = &surface.descriptor else {
             continue;
         };
         let canonical = canonicalize_manifest_descriptor(file, manifest_dir)?;

--- a/crates/coral-spec/src/bundle.rs
+++ b/crates/coral-spec/src/bundle.rs
@@ -125,7 +125,7 @@ mod tests {
 
     fn source_yaml(name: &str) -> String {
         format!(
-            "name: {name}\ndsl_version: 4\nidentity_requirements:\n  accepts:\n    - id: github_api\n      identity_specs: [github_oauth, github_pat]\n      audience: {{host: api.github.com}}\nsurfaces:\n  - id: rest\n    type: openapi\n    file: /tmp/github-openapi.yaml\n"
+            "name: {name}\ndsl_version: 4\nversion: 1.2.3\nidentity_requirements:\n  accepts:\n    - id: github_api\n      identity_specs: [github_oauth, github_pat]\n      audience: {{host: api.github.com}}\nsurfaces:\n  - id: rest\n    type: openapi\n    file: /tmp/github-openapi.yaml\n    sha256: 0000000000000000000000000000000000000000000000000000000000000000\n"
         )
     }
 
@@ -176,6 +176,14 @@ mod tests {
         let reparsed_source = parse_source_manifest_yaml(&bundle.source_manifest_yaml)
             .expect("canonical source document reparses");
         assert_eq!(reparsed_source.schema_name(), "demo");
+        assert_eq!(reparsed_source.source_version(), Some("1.2.3"));
+        assert_eq!(
+            reparsed_source
+                .as_v4()
+                .and_then(|manifest| manifest.surfaces.first())
+                .and_then(|surface| surface.descriptor.sha256()),
+            Some("0000000000000000000000000000000000000000000000000000000000000000")
+        );
         for document in &bundle.identity_manifests {
             assert_eq!(
                 parse_identity_manifest_yaml(&document.manifest_yaml)

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -77,7 +77,7 @@ impl ValidatedSourceManifest {
             ValidatedManifestKind::Http(manifest) => Some(&manifest.common.version),
             ValidatedManifestKind::File(manifest) => Some(&manifest.common.version),
             ValidatedManifestKind::Mcp(manifest) => Some(&manifest.common.version),
-            ValidatedManifestKind::V4(_) => None,
+            ValidatedManifestKind::V4(manifest) => manifest.common.version.as_deref(),
         }
     }
 

--- a/crates/coral-spec/src/schema/source_manifest_v4.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest_v4.schema.json
@@ -13,6 +13,10 @@
       "type": "string",
       "minLength": 1
     },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
     "description": {
       "type": "string"
     },
@@ -105,6 +109,10 @@
             "file": {
               "type": "string",
               "minLength": 1
+            },
+            "sha256": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$"
             },
             "inputs": {
               "type": "object",

--- a/crates/coral-spec/src/v4/manifest.rs
+++ b/crates/coral-spec/src/v4/manifest.rs
@@ -29,6 +29,8 @@ pub struct V4SourceManifest {
 pub struct V4SourceCommon {
     pub dsl_version: u32,
     pub name: String,
+    /// Optional authored source-spec version metadata.
+    pub version: Option<String>,
     pub description: String,
     pub test_queries: Vec<String>,
 }
@@ -53,9 +55,19 @@ pub enum SurfaceType {
 
 #[derive(Debug, Clone)]
 pub enum SurfaceDescriptor {
-    Url { url: String },
-    File { file: PathBuf },
-    McpServer { location: String },
+    Url {
+        url: String,
+        /// Expected SHA-256 digest of the fetched descriptor bytes.
+        sha256: Option<String>,
+    },
+    File {
+        file: PathBuf,
+        /// Expected SHA-256 digest of the file descriptor bytes.
+        sha256: Option<String>,
+    },
+    McpServer {
+        location: String,
+    },
 }
 
 impl SurfaceDescriptor {
@@ -72,6 +84,14 @@ impl SurfaceDescriptor {
             Self::Url { url, .. } => url.clone(),
             Self::File { file, .. } => file.display().to_string(),
             Self::McpServer { location } => location.clone(),
+        }
+    }
+
+    /// Returns the expected descriptor SHA-256 digest, when the manifest pins one.
+    pub fn sha256(&self) -> Option<&str> {
+        match self {
+            Self::Url { sha256, .. } | Self::File { sha256, .. } => sha256.as_deref(),
+            Self::McpServer { .. } => None,
         }
     }
 }
@@ -140,6 +160,8 @@ struct RawV4SourceManifest {
     dsl_version: u32,
     name: String,
     #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
     description: String,
     #[serde(default)]
     test_queries: Vec<String>,
@@ -160,6 +182,8 @@ struct RawV4Surface {
     url: Option<String>,
     #[serde(default)]
     file: Option<PathBuf>,
+    #[serde(default)]
+    sha256: Option<String>,
     #[serde(default, rename = "inputs")]
     _inputs: Option<Value>,
     #[serde(default)]
@@ -190,6 +214,7 @@ impl V4SourceManifest {
         let RawV4SourceManifest {
             dsl_version,
             name,
+            version,
             description,
             test_queries,
             mut identity_requirements,
@@ -199,6 +224,7 @@ impl V4SourceManifest {
         let common = V4SourceCommon {
             dsl_version,
             name: name.clone(),
+            version,
             description,
             test_queries,
         };
@@ -382,7 +408,13 @@ fn parse_mcp_surface(
             raw_surface.id
         )));
     }
-    for field in ["base_url", "auth", "request_headers", "rate_limit"] {
+    for field in [
+        "base_url",
+        "auth",
+        "request_headers",
+        "rate_limit",
+        "sha256",
+    ] {
         if surface_value.get(field).is_some() {
             return Err(ManifestError::validation(format!(
                 "source '{source_name}' MCP surface '{}' must not declare OpenAPI field '{field}'",
@@ -595,6 +627,9 @@ fn parse_openapi_descriptor(
     source_name: &str,
     surface: &RawV4Surface,
 ) -> Result<SurfaceDescriptor> {
+    if let Some(sha256) = surface.sha256.as_deref() {
+        validate_descriptor_sha256(source_name, &surface.id, sha256)?;
+    }
     match (&surface.url, &surface.file) {
         (Some(url), None) => {
             if !url.starts_with("https://") {
@@ -603,13 +638,33 @@ fn parse_openapi_descriptor(
                     surface.id
                 )));
             }
-            Ok(SurfaceDescriptor::Url { url: url.clone() })
+            Ok(SurfaceDescriptor::Url {
+                url: url.clone(),
+                sha256: surface.sha256.clone(),
+            })
         }
-        (None, Some(file)) => Ok(SurfaceDescriptor::File { file: file.clone() }),
+        (None, Some(file)) => Ok(SurfaceDescriptor::File {
+            file: file.clone(),
+            sha256: surface.sha256.clone(),
+        }),
         (Some(_), Some(_)) | (None, None) => Err(ManifestError::validation(format!(
             "source '{source_name}' surface '{}' must declare exactly one of url or file",
             surface.id
         ))),
+    }
+}
+
+fn validate_descriptor_sha256(source_name: &str, surface_id: &str, sha256: &str) -> Result<()> {
+    let valid = sha256.len() == 64
+        && sha256
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || matches!(ch, 'a'..='f'));
+    if valid {
+        Ok(())
+    } else {
+        Err(ManifestError::validation(format!(
+            "source '{source_name}' surface '{surface_id}' sha256 must be a 64-character lowercase hexadecimal digest"
+        )))
     }
 }
 

--- a/crates/coral-spec/src/v4/manifest_tests.rs
+++ b/crates/coral-spec/src/v4/manifest_tests.rs
@@ -42,6 +42,99 @@ surfaces:
 }
 
 #[test]
+fn parses_v4_manifest_version_and_descriptor_sha256() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+version: 1.2.3
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+",
+    )
+    .expect("v4 manifest");
+    assert_eq!(manifest.source_version(), Some("1.2.3"));
+    let v4 = manifest.as_v4().expect("v4");
+    assert_eq!(v4.common.version.as_deref(), Some("1.2.3"));
+    assert_eq!(
+        v4.surfaces.first().expect("surface").descriptor.sha256(),
+        Some("0000000000000000000000000000000000000000000000000000000000000000")
+    );
+}
+
+#[test]
+fn rejects_empty_v4_manifest_version() {
+    let error = parse_source_manifest_yaml(
+        r#"
+name: demo
+dsl_version: 4
+version: ""
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+"#,
+    )
+    .expect_err("empty version should fail");
+
+    assert!(
+        error.to_string().contains("/version"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn rejects_invalid_v4_descriptor_sha256() {
+    for sha256 in [
+        "abc",
+        "000000000000000000000000000000000000000000000000000000000000000G",
+    ] {
+        let raw = format!(
+            r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    sha256: {sha256}
+"
+        );
+        let error = parse_source_manifest_yaml(&raw).expect_err("invalid sha256 should fail");
+        assert!(
+            error.to_string().contains("sha256"),
+            "unexpected error for {sha256}: {error}"
+        );
+    }
+}
+
+#[test]
+fn rejects_v4_mcp_descriptor_sha256() {
+    let error = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: mcp
+    type: mcp
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
+    server:
+      transport: stdio
+      command: demo-mcp-server
+",
+    )
+    .expect_err("mcp sha256 should fail");
+
+    assert!(
+        error.to_string().contains("sha256"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn parses_v4_openapi_surface_without_base_url() {
     let manifest = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -18,6 +18,7 @@ surfaces:
   - id: rest
     type: openapi
     file: /tmp/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
     inputs:
       GITHUB_API_BASE:
         kind: variable
@@ -171,6 +172,7 @@ surfaces:
   - id: rest
     type: openapi
     file: /tmp/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
     base_url: https://api.example.com
 ",
     )
@@ -251,6 +253,7 @@ surfaces:
   - id: rest
     type: openapi
     file: /tmp/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
     base_url: https://api.github.com
 ",
     )
@@ -426,6 +429,7 @@ surfaces:
   - id: rest
     type: openapi
     file: /tmp/openapi.yaml
+    sha256: 0000000000000000000000000000000000000000000000000000000000000000
     base_url: https://api.github.com
 ",
     )

--- a/crates/coral-spec/src/v4/schema.rs
+++ b/crates/coral-spec/src/v4/schema.rs
@@ -26,6 +26,9 @@ struct V4SourceManifestSchema {
     #[schemars(length(min = 1))]
     name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(required, length(min = 1))]
+    version: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(required)]
     description: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -41,7 +44,7 @@ struct V4SourceManifestSchema {
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum V4SurfaceSchema {
-    Openapi(V4OpenApiSurfaceSchema),
+    Openapi(Box<V4OpenApiSurfaceSchema>),
     Mcp(V4McpSurfaceSchema),
 }
 
@@ -65,6 +68,9 @@ struct V4OpenApiSurfaceSchema {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(required, length(min = 1))]
     file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(required, pattern(r"^[0-9a-f]{64}$"))]
+    sha256: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(required, extend("propertyNames" = { "minLength": 1 }))]
     inputs: Option<BTreeMap<String, V4InputSpecSchema>>,
@@ -812,7 +818,6 @@ surfaces:
     #[test]
     fn generated_schema_rejects_v3_only_fields_and_removed_snapshot_fields() {
         let invalid = [
-            "version: 1.0.0\n",
             "backend: http\n",
             "tables: []\n",
             "auth: {type: HeaderAuth}\n",
@@ -827,12 +832,50 @@ surfaces:
                 "field should be rejected: {field}"
             );
         }
+    }
 
+    #[test]
+    fn generated_schema_validates_v4_version_and_parser_agrees() {
+        let raw = "name: demo\ndsl_version: 4\nversion: 1.0.0\nsurfaces:\n  - id: rest\n    type: openapi\n    url: https://example.com/openapi.yaml\n";
+        assert!(
+            validator().is_valid(&manifest_json(raw)),
+            "source version should be accepted"
+        );
+        assert_eq!(
+            parse_source_manifest_yaml(raw)
+                .expect("parser accepts source version")
+                .source_version(),
+            Some("1.0.0")
+        );
+
+        for version in ["\"\"", "null"] {
+            let raw = format!(
+                "name: demo\ndsl_version: 4\nversion: {version}\nsurfaces:\n  - id: rest\n    type: openapi\n    url: https://example.com/openapi.yaml\n"
+            );
+            assert!(
+                !validator().is_valid(&manifest_json(&raw)),
+                "invalid source version should be rejected: {version}"
+            );
+            parse_source_manifest_yaml(&raw)
+                .expect_err("parser should reject invalid source version");
+        }
+    }
+
+    #[test]
+    fn generated_schema_validates_surface_sha256() {
         let raw = "name: demo\ndsl_version: 4\nsurfaces:\n  - id: rest\n    type: openapi\n    url: https://example.com/openapi.yaml\n    sha256: 0000000000000000000000000000000000000000000000000000000000000000\n";
         assert!(
-            !validator().is_valid(&manifest_json(raw)),
-            "surface sha256 should be rejected"
+            validator().is_valid(&manifest_json(raw)),
+            "valid surface sha256 should be accepted"
         );
+        parse_source_manifest_yaml(raw).expect("parser accepts surface sha256");
+
+        let raw = "name: demo\ndsl_version: 4\nsurfaces:\n  - id: rest\n    type: openapi\n    url: https://example.com/openapi.yaml\n    sha256: nope\n";
+        assert!(
+            !validator().is_valid(&manifest_json(raw)),
+            "invalid surface sha256 should be rejected"
+        );
+        parse_source_manifest_yaml(raw).expect_err("parser rejects invalid surface sha256");
     }
 
     #[test]
@@ -841,6 +884,7 @@ surfaces:
             "    url: null\n",
             "    file: null\n",
             "    url: https://example.com/openapi.yaml\n    base_url: null\n",
+            "    url: https://example.com/openapi.yaml\n    sha256: null\n",
             "    url: https://example.com/openapi.yaml\n    auth: null\n",
             "    url: https://example.com/openapi.yaml\n    rate_limit: null\n",
         ];


### PR DESCRIPTION
## Intent

Add optional authored `version` metadata to DSL v4 source manifests and optional lowercase SHA-256 pins to OpenAPI URL/file descriptors. Materialization verifies the exact fetched or file bytes before base-URL derivation, import, normalization, or projection generation.

## What it enables

Canonical manifest bundles can carry source version and descriptor-integrity metadata alongside identity specs. Catalog/query consumers receive the authored version, while registry and import layers can rely on an exact descriptor artifact.

A pin mismatch is fatal for the whole source: Coral names the surface plus expected and observed digests, cleans temporary artifacts, and installs no partial package. Unpinned descriptors and non-integrity surface failures retain their existing behavior. MCP descriptors cannot declare `sha256`.

## Usage examples

```yaml
name: github_v4
dsl_version: 4
version: 0.1.0
surfaces:
  - id: rest
    type: openapi
    file: /abs/path/openapi.yaml
    sha256: 0000000000000000000000000000000000000000000000000000000000000000
```

`version` is nonempty authored metadata; Coral does not impose semantic-version parsing. The pin is exactly 64 lowercase hexadecimal characters and covers raw descriptor bytes.

## Validation

- `make rust-checks` — Clippy and rustdoc clean; 1,615 nextest tests passed, 2 skipped
- `make perf-check` — `coral.tables` mean 204 ms (750 ms threshold)
- `make schema-check`
- `make lint-sources`
- `make docs-check`
- full `coral-spec` — 385 tests plus 1 doctest
- `coral-app` `sources::` — 69 tests
- focused schema, bundle, catalog, and materialization regressions