### PR TITLE
feat(engine): compose request identity selection

### DIFF
--- a/crates/coral-app/src/functions/runtime.rs
+++ b/crates/coral-app/src/functions/runtime.rs
@@ -29,10 +29,15 @@ pub(crate) async fn infer_runtime_functions(
         .iter()
         .map(runtime_sql_definition)
         .collect();
-    let signatures =
-        CoralQuery::infer_udf_signatures(selected_sources, runtime_config, sql_definitions)
-            .await
-            .map_err(|error| runtime_validation_error(&error))?;
+    // Runtime construction is state-heavy; box the engine future so it does
+    // not inflate every caller's future.
+    let signatures = Box::pin(CoralQuery::infer_udf_signatures(
+        selected_sources,
+        runtime_config,
+        sql_definitions,
+    ))
+    .await
+    .map_err(|error| runtime_validation_error(&error))?;
 
     Ok(apply_signatures(runtime_functions, signatures))
 }

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -4,8 +4,8 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, OnceLock};
 
 use crate::{
-    QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceInputResolver,
-    SourceObservationPublisher,
+    BoundRequestIdentityHttpAuthenticator, QueryRuntimeContext, QuerySource, RequestAuthenticator,
+    SourceInputResolver, SourceObservationPublisher,
 };
 use async_trait::async_trait;
 use coral_spec::{
@@ -132,6 +132,8 @@ pub(crate) struct BackendCompileRequest<'a> {
     pub(crate) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
     pub(crate) source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
     pub(crate) source_observation_publishers: &'a [Arc<dyn SourceObservationPublisher>],
+    pub(crate) request_identity_http_authenticators:
+        &'a HashMap<String, BoundRequestIdentityHttpAuthenticator>,
 }
 
 /// Shared resources available while registering one batch of compiled sources.

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -15,8 +15,8 @@ use crate::backends::http::registration_checks::validate_source_scoped_http_conf
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::http::trace::HttpBodyCapture;
 use crate::{
-    RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver,
-    SourceInputResolverError,
+    BoundRequestIdentityHttpAuthenticator, RequestAuthenticator, SourceInputResolutionContext,
+    SourceInputResolver, SourceInputResolverError,
 };
 use coral_spec::backends::http::{HttpSourceManifest, RateLimitSpec};
 use coral_spec::{AuthSpec, HeaderSpec, ParsedTemplate, RequestSpec as ManifestRequestSpec};
@@ -35,6 +35,11 @@ pub(crate) struct HttpSourceClient {
     pub(super) request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolution_context: Option<SourceInputResolutionContext>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    #[expect(
+        dead_code,
+        reason = "bound identity authenticators are injected into requests by a later stack unit"
+    )]
+    pub(super) request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
     pub(super) rate_limit: RateLimitSpec,
     pub(super) resolved_inputs: Arc<BTreeMap<String, String>>,
     pub(super) body_capture: HttpBodyCapture,
@@ -44,6 +49,7 @@ pub(crate) struct HttpSourceClient {
 pub(crate) struct HttpSourceClientRuntime {
     source_input_resolution_context: Option<SourceInputResolutionContext>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<OtelContext>,
     http: reqwest::Client,
@@ -53,6 +59,7 @@ impl HttpSourceClientRuntime {
     pub(crate) fn new(
         source_input_resolution_context: SourceInputResolutionContext,
         source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+        request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
         body_capture_max_bytes: Option<usize>,
         trace_context: Option<OtelContext>,
         http: reqwest::Client,
@@ -60,6 +67,7 @@ impl HttpSourceClientRuntime {
         Self {
             source_input_resolution_context: Some(source_input_resolution_context),
             source_input_resolver,
+            request_identity_http_authenticator,
             body_capture_max_bytes,
             trace_context,
             http,
@@ -71,6 +79,7 @@ impl HttpSourceClientRuntime {
         Self {
             source_input_resolution_context: None,
             source_input_resolver: None,
+            request_identity_http_authenticator: None,
             body_capture_max_bytes,
             trace_context: None,
             http,
@@ -182,6 +191,7 @@ impl HttpSourceClient {
             request_authenticators: request_authenticators.clone(),
             source_input_resolution_context: runtime.source_input_resolution_context,
             source_input_resolver: runtime.source_input_resolver,
+            request_identity_http_authenticator: runtime.request_identity_http_authenticator,
             rate_limit: manifest.rate_limit.clone(),
             resolved_inputs: Arc::new(resolved_inputs),
             body_capture: HttpBodyCapture::new(runtime.body_capture_max_bytes),

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -19,7 +19,10 @@ use crate::backends::{
     build_registered_table_function, registered_columns_from_specs, required_filter_names,
     validate_lookup_key_filter_backend_support,
 };
-use crate::{RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver};
+use crate::{
+    BoundRequestIdentityHttpAuthenticator, RequestAuthenticator, SourceInputResolutionContext,
+    SourceInputResolver,
+};
 use coral_spec::SourceBackend;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod auth;
@@ -54,41 +57,26 @@ struct HttpCompiledSource {
     trace_context: Option<opentelemetry::Context>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
     source_observation_publishers: SourceObservationPublishers,
-}
-
-pub(crate) fn compile_source(
-    manifest: HttpSourceManifest,
-    source_input_resolution: SourceInputResolutionContext,
-    request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
-    body_capture_max_bytes: Option<usize>,
-    trace_context: Option<opentelemetry::Context>,
-    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    source_observation_publishers: SourceObservationPublishers,
-) -> Box<dyn CompiledBackendSource> {
-    Box::new(HttpCompiledSource {
-        manifest,
-        source_input_resolution,
-        request_authenticators,
-        body_capture_max_bytes,
-        trace_context,
-        source_input_resolver,
-        source_observation_publishers,
-    })
+    request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
 }
 
 pub(crate) fn compile_manifest(
     manifest: &HttpSourceManifest,
     request: &BackendCompileRequest<'_>,
+    request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
 ) -> Box<dyn CompiledBackendSource> {
-    compile_source(
-        manifest.clone(),
-        SourceInputResolutionContext::from_query_source(request.source),
-        request.request_authenticators.clone(),
-        request.runtime_context.body_capture_max_bytes,
-        request.runtime_context.trace_context.clone(),
-        request.source_input_resolver.clone(),
-        source_observation_publishers(request.source_observation_publishers),
-    )
+    Box::new(HttpCompiledSource {
+        manifest: manifest.clone(),
+        source_input_resolution: SourceInputResolutionContext::from_query_source(request.source),
+        request_authenticators: request.request_authenticators.clone(),
+        body_capture_max_bytes: request.runtime_context.body_capture_max_bytes,
+        trace_context: request.runtime_context.trace_context.clone(),
+        source_input_resolver: request.source_input_resolver.clone(),
+        source_observation_publishers: source_observation_publishers(
+            request.source_observation_publishers,
+        ),
+        request_identity_http_authenticator,
+    })
 }
 
 #[async_trait]
@@ -122,6 +110,7 @@ impl CompiledBackendSource for HttpCompiledSource {
         let runtime = HttpSourceClientRuntime::new(
             self.source_input_resolution.clone(),
             self.source_input_resolver.clone(),
+            self.request_identity_http_authenticator.clone(),
             self.body_capture_max_bytes,
             self.trace_context.clone(),
             http,

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -71,8 +71,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::{
-    CoreError, QuerySource, RequestAuthenticator, RuntimeSourceComponent, SourceInputResolver,
-    SourceObservationPublisher,
+    BoundRequestIdentityHttpAuthenticator, CoreError, QuerySource, RequestAuthenticator,
+    RuntimeSourceComponent, SourceInputResolver, SourceObservationPublisher,
 };
 #[cfg(test)]
 use coral_spec::ValidatedSourceManifest;
@@ -99,6 +99,7 @@ pub(crate) fn compile_query_source(
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
     source_observation_publishers: &[Arc<dyn SourceObservationPublisher>],
+    request_identity_http_authenticators: &HashMap<String, BoundRequestIdentityHttpAuthenticator>,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     if source.components().is_empty() {
         return Err(CoreError::FailedPrecondition(format!(
@@ -114,12 +115,13 @@ pub(crate) fn compile_query_source(
         request_authenticators,
         source_input_resolver,
         source_observation_publishers,
+        request_identity_http_authenticators,
     };
     let compiled_components = source
         .components()
         .iter()
         .map(|component| compile_component(component, &request))
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
     Ok(composite::compile_source(
         source.source_name().to_string(),
         compiled_components,
@@ -129,11 +131,33 @@ pub(crate) fn compile_query_source(
 fn compile_component(
     component: &RuntimeSourceComponent,
     request: &BackendCompileRequest<'_>,
-) -> Box<dyn CompiledBackendSource> {
+) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     match component {
-        RuntimeSourceComponent::Http(manifest) => http::compile_manifest(manifest, request),
-        RuntimeSourceComponent::File(manifest) => file::compile_manifest(manifest, request),
-        RuntimeSourceComponent::Mcp(manifest) => mcp::compile_manifest(manifest, request),
+        RuntimeSourceComponent::Http(manifest) => {
+            let request_identity_http_authenticator = request
+                .source
+                .identity_requirements()
+                .map(|_| {
+                    request
+                        .request_identity_http_authenticators
+                        .get(request.source.source_name())
+                        .cloned()
+                        .ok_or_else(|| {
+                            CoreError::FailedPrecondition(format!(
+                                "source '{}' declares identity_requirements but no bound request identity HTTP authenticator is installed",
+                                request.source.source_name()
+                            ))
+                        })
+                })
+                .transpose()?;
+            Ok(http::compile_manifest(
+                manifest,
+                request,
+                request_identity_http_authenticator,
+            ))
+        }
+        RuntimeSourceComponent::File(manifest) => Ok(file::compile_manifest(manifest, request)),
+        RuntimeSourceComponent::Mcp(manifest) => Ok(mcp::compile_manifest(manifest, request)),
     }
 }
 
@@ -160,6 +184,7 @@ pub(crate) fn compile_source_manifest(
             request_authenticators: &request_authenticators,
             source_input_resolver: None,
             source_observation_publishers: &[],
+            request_identity_http_authenticators: &HashMap::new(),
         },
     )
 }
@@ -170,7 +195,7 @@ pub(crate) fn compile_validated_manifest(
     request: &BackendCompileRequest<'_>,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     if let Some(http_manifest) = manifest.as_http() {
-        return Ok(http::compile_manifest(http_manifest, request));
+        return Ok(http::compile_manifest(http_manifest, request, None));
     }
     if let Some(file_manifest) = manifest.as_file() {
         return Ok(file::compile_manifest(file_manifest, request));

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -44,11 +44,14 @@ use crate::runtime::udf_calls::{
 };
 use crate::runtime::udfs::published_table_functions;
 use crate::{
-    CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, MemorySize, QueryExecution,
-    QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
-    QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext,
-    QuerySource, QueryTableFunctionUsage, QueryTableUsage, RequestAuthenticator, SourceDecorator,
-    SourceInputResolver, SourceObservationPublisher, TableFunctionInfo, TableInfo,
+    BoundRequestIdentityHttpAuthenticator, CatalogInfo, CoreError, DependentJoinConfig,
+    DescribeTableInfo, MemorySize, QueryExecution, QueryExecutionProvenance, QueryMemoryConfig,
+    QueryParameterValue, QueryParameters, QueryPlan, QueryResultObserver, QueryResultObserverError,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage,
+    RequestAuthenticator, RequestIdentityHttpAuthenticatorError,
+    RequestIdentityHttpAuthenticatorFactory, RequestIdentitySelectionContext,
+    RequestIdentitySelectionError, RequestIdentitySelector, SelectedRequestIdentity,
+    SourceDecorator, SourceInputResolver, SourceObservationPublisher, TableFunctionInfo, TableInfo,
     UdfRuntimeDefinition,
 };
 
@@ -72,6 +75,9 @@ pub(crate) struct InferredSqlSignature {
     pub(crate) planned_schema: Arc<arrow::datatypes::Schema>,
 }
 
+type BoundRequestIdentityHttpAuthenticators =
+    HashMap<String, BoundRequestIdentityHttpAuthenticator>;
+
 struct FallbackRuntime {
     config: FallbackRuntimeConfig,
     runtime: OnceCell<RegisteredRuntime>,
@@ -92,6 +98,7 @@ struct FallbackRuntimeConfig {
     memory: QueryMemoryConfig,
     udfs: Vec<UdfRuntimeDefinition>,
     extension_hooks: RuntimeExtensionHooks,
+    request_identity_http_authenticators: BoundRequestIdentityHttpAuthenticators,
 }
 
 struct RegisteredRuntime {
@@ -107,6 +114,7 @@ struct RuntimeBuildInputs<'a> {
     sources: &'a [QuerySource],
     runtime_context: &'a QueryRuntimeContext,
     extension_hooks: &'a RuntimeExtensionHooks,
+    request_identity_http_authenticators: &'a BoundRequestIdentityHttpAuthenticators,
     source_decorators: &'a mut [Box<dyn SourceDecorator>],
     dependent_join: &'a DependentJoinConfig,
     memory: &'a QueryMemoryConfig,
@@ -137,8 +145,8 @@ async fn build_runtime_inner(
         dependent_join,
         mut extensions,
         udfs,
-        request_identity_selector: _,
-        request_identity_http_authenticator_factory: _,
+        request_identity_selector,
+        request_identity_http_authenticator_factory,
     } = runtime;
     let extension_hooks = RuntimeExtensionHooks {
         request_authenticators: extensions.request_authenticators.clone(),
@@ -146,6 +154,12 @@ async fn build_runtime_inner(
         source_observation_publishers: extensions.source_observation_publishers.clone(),
     };
     let udfs_installed = !udfs.is_empty();
+    let request_identity_http_authenticators = bind_request_identity_http_authenticators(
+        sources,
+        request_identity_selector,
+        request_identity_http_authenticator_factory,
+    )
+    .await?;
     // Resolver-row overflow can retry without the dependent-join optimizer only
     // when runtime registration is replayable. Source decorators are mutable
     // one-shot registration hooks today, so decorated runtimes keep resolver-row
@@ -161,6 +175,7 @@ async fn build_runtime_inner(
             memory: memory.clone(),
             udfs: udfs.clone(),
             extension_hooks: extension_hooks.clone(),
+            request_identity_http_authenticators: request_identity_http_authenticators.clone(),
         })
     });
 
@@ -168,6 +183,7 @@ async fn build_runtime_inner(
         sources,
         runtime_context: &runtime_context,
         extension_hooks: &extension_hooks,
+        request_identity_http_authenticators: &request_identity_http_authenticators,
         source_decorators: extensions.source_decorators.as_mut_slice(),
         dependent_join: &dependent_join,
         memory: &memory,
@@ -190,6 +206,104 @@ async fn build_runtime_inner(
     })
 }
 
+async fn bind_request_identity_http_authenticators(
+    sources: &[QuerySource],
+    request_identity_selector: Option<Arc<dyn RequestIdentitySelector>>,
+    request_identity_http_authenticator_factory: Option<RequestIdentityHttpAuthenticatorFactory>,
+) -> Result<BoundRequestIdentityHttpAuthenticators, CoreError> {
+    let mut identity_contexts = Vec::new();
+    let mut seen_source_names = HashSet::new();
+    for source in sources {
+        let Some(context) = source.identity_selection_context() else {
+            continue;
+        };
+        let source_name = context.source_name().to_string();
+        if !seen_source_names.insert(source_name.clone()) {
+            return Err(CoreError::FailedPrecondition(format!(
+                "source '{source_name}' appears more than once with identity_requirements"
+            )));
+        }
+        identity_contexts.push((source_name, context));
+    }
+
+    let mut authenticators = HashMap::with_capacity(identity_contexts.len());
+    for (source_name, context) in identity_contexts {
+        let selector = request_identity_selector.as_ref().ok_or_else(|| {
+            CoreError::FailedPrecondition(format!(
+                "source '{}' declares identity_requirements but no request identity selector is installed",
+                context.source_name()
+            ))
+        })?;
+        let factory = request_identity_http_authenticator_factory
+            .as_ref()
+            .ok_or_else(|| {
+                CoreError::FailedPrecondition(format!(
+                    "source '{}' declares identity_requirements but no request identity HTTP authenticator factory is installed",
+                    context.source_name()
+                ))
+            })?;
+        let selected = selector
+            .select_identity(&context)
+            .await
+            .map_err(|error| request_identity_selection_error(&context, &error))?;
+        validate_selected_identity(&context, &selected)?;
+        let authenticator = factory(selected.clone()).map_err(|error| {
+            request_identity_http_authenticator_factory_error(&context, &selected, &error)
+        })?;
+        authenticators.insert(source_name, authenticator);
+    }
+    Ok(authenticators)
+}
+
+fn validate_selected_identity(
+    context: &RequestIdentitySelectionContext,
+    selected: &SelectedRequestIdentity,
+) -> Result<(), CoreError> {
+    if context.accepts_identity(selected.identity_spec_id(), selected.audience()) {
+        return Ok(());
+    }
+    Err(CoreError::FailedPrecondition(format!(
+        "request identity selector selected identity '{}' with spec '{}' that does not satisfy identity_requirements for source '{}'",
+        selected.identity_id(),
+        selected.identity_spec_id(),
+        context.source_name()
+    )))
+}
+
+fn request_identity_selection_error(
+    context: &RequestIdentitySelectionContext,
+    error: &RequestIdentitySelectionError,
+) -> CoreError {
+    let detail = format!(
+        "request identity selector failed for source '{}': {error}",
+        context.source_name()
+    );
+    match error {
+        RequestIdentitySelectionError::InvalidInput(_) => CoreError::InvalidInput(detail),
+        RequestIdentitySelectionError::FailedPrecondition(_) => {
+            CoreError::FailedPrecondition(detail)
+        }
+    }
+}
+
+fn request_identity_http_authenticator_factory_error(
+    context: &RequestIdentitySelectionContext,
+    selected: &SelectedRequestIdentity,
+    error: &RequestIdentityHttpAuthenticatorError,
+) -> CoreError {
+    let detail = format!(
+        "request identity HTTP authenticator factory failed for selected identity '{}' on source '{}': {error}",
+        selected.identity_id(),
+        context.source_name()
+    );
+    match error {
+        RequestIdentityHttpAuthenticatorError::InvalidInput(_) => CoreError::InvalidInput(detail),
+        RequestIdentityHttpAuthenticatorError::FailedPrecondition(_) => {
+            CoreError::FailedPrecondition(detail)
+        }
+    }
+}
+
 async fn build_registered_runtime(
     config: RuntimeBuildInputs<'_>,
 ) -> Result<RegisteredRuntime, CoreError> {
@@ -199,6 +313,7 @@ async fn build_registered_runtime(
         config.sources,
         config.runtime_context,
         config.extension_hooks,
+        config.request_identity_http_authenticators,
         config.source_decorators,
     )
     .await?;
@@ -340,6 +455,7 @@ async fn register_runtime_sources(
     sources: &[QuerySource],
     runtime_context: &QueryRuntimeContext,
     extension_hooks: &RuntimeExtensionHooks,
+    request_identity_http_authenticators: &BoundRequestIdentityHttpAuthenticators,
     source_decorators: &mut [Box<dyn SourceDecorator>],
 ) -> Result<crate::runtime::registry::SourceRegistrationResult, CoreError> {
     let mut source_candidates = Vec::new();
@@ -350,6 +466,7 @@ async fn register_runtime_sources(
             &extension_hooks.request_authenticators,
             extension_hooks.source_input_resolver.clone(),
             &extension_hooks.source_observation_publishers,
+            request_identity_http_authenticators,
         ) {
             Ok(compiled) => {
                 source_candidates.push(SourceRegistrationCandidate::Compiled(
@@ -1123,6 +1240,7 @@ impl FallbackRuntimeConfig {
             sources: &self.sources,
             runtime_context: &self.runtime_context,
             extension_hooks: &self.extension_hooks,
+            request_identity_http_authenticators: &self.request_identity_http_authenticators,
             source_decorators: source_decorators.as_mut_slice(),
             dependent_join: &dependent_join,
             memory: &self.memory,
@@ -1201,9 +1319,10 @@ fn query_result_observer_error(name: &str, error: &QueryResultObserverError) -> 
 }
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::str::FromStr as _;
 
+    use coral_spec::v4::IdentityRequirements;
     use datafusion::execution::memory_pool::MemoryConsumer;
 
     use super::*;
@@ -1268,6 +1387,48 @@ mod tests {
     }
 
     #[test]
+    fn request_identity_extension_errors_preserve_status_class() {
+        let context = RequestIdentitySelectionContext::new(
+            "github_v4",
+            IdentityRequirements {
+                accepts: Vec::new(),
+            },
+        );
+        let selected = SelectedRequestIdentity::new("identity-1", "github_oauth", BTreeMap::new());
+
+        assert!(matches!(
+            request_identity_selection_error(
+                &context,
+                &RequestIdentitySelectionError::invalid_input("selector failure")
+            ),
+            CoreError::InvalidInput(detail) if detail.contains("source 'github_v4': selector failure")
+        ));
+        assert!(matches!(
+            request_identity_selection_error(
+                &context,
+                &RequestIdentitySelectionError::failed_precondition("selector failure")
+            ),
+            CoreError::FailedPrecondition(detail) if detail.contains("source 'github_v4': selector failure")
+        ));
+        assert!(matches!(
+            request_identity_http_authenticator_factory_error(
+                &context,
+                &selected,
+                &RequestIdentityHttpAuthenticatorError::invalid_input("factory failure")
+            ),
+            CoreError::InvalidInput(detail) if detail.contains("selected identity 'identity-1'")
+        ));
+        assert!(matches!(
+            request_identity_http_authenticator_factory_error(
+                &context,
+                &selected,
+                &RequestIdentityHttpAuthenticatorError::failed_precondition("factory failure")
+            ),
+            CoreError::FailedPrecondition(detail) if detail.contains("selected identity 'identity-1'")
+        ));
+    }
+
+    #[test]
     fn build_session_context_applies_memory_limit() {
         let ctx = build_session_context(
             &DependentJoinConfig::default(),
@@ -1307,6 +1468,7 @@ mod tests {
                 source_input_resolver: None,
                 source_observation_publishers: Vec::new(),
             },
+            request_identity_http_authenticators: HashMap::new(),
         };
 
         let runtime = fallback

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -1,8 +1,18 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-use coral_engine::{CoralQuery, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage};
+use async_trait::async_trait;
+use coral_engine::{
+    BoundRequestIdentityHttpAuthenticator, CoralQuery, QueryRuntimeConfig, QuerySource,
+    RequestIdentityHttpAuthenticatorError, RequestIdentityHttpAuthenticatorFactory,
+    RequestIdentitySelectionContext, RequestIdentitySelectionError, RequestIdentitySelector,
+    RuntimeSourceComponent, RuntimeSourcePackage, SelectedRequestIdentity,
+};
 use coral_spec::parse_source_manifest_yaml;
+use coral_spec::v4::{AcceptedIdentityRequirement, IdentityRequirements};
 use coral_spec::{FilterMode, FilterSpec, ManifestDataType};
+use reqwest::header::{HeaderName, HeaderValue};
 use serde_json::json;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -246,6 +256,137 @@ async fn validate_source_reports_only_component_schemas_for_multi_schema_source(
     assert!(report.table_functions.is_empty());
 }
 
+#[tokio::test]
+async fn identity_gated_source_requires_request_identity_selector() {
+    let source = identity_runtime_source(identity_http_component());
+
+    let error = CoralQuery::list_catalog(&[source], test_runtime(), None)
+        .await
+        .expect_err("identity-gated source should require a selector");
+
+    assert!(
+        error.to_string().contains(
+            "source 'github_v4' declares identity_requirements but no request identity selector is installed"
+        ),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn identity_gated_source_requires_request_identity_authenticator_factory() {
+    let source = identity_runtime_source(identity_http_component());
+    let runtime =
+        test_runtime().with_request_identity_selector(Some(Arc::new(UnexpectedIdentitySelector)));
+
+    let error = CoralQuery::list_catalog(&[source], runtime, None)
+        .await
+        .expect_err("identity-gated source should require an authenticator factory");
+
+    assert!(
+        error.to_string().contains(
+            "source 'github_v4' declares identity_requirements but no request identity HTTP authenticator factory is installed"
+        ),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn identity_gated_source_binds_identity_once_for_all_http_components() {
+    let first = identity_http_component();
+    let mut second = identity_http_component();
+    second.common.name = "github_v4_graphql".to_string();
+    let source = identity_runtime_source_with_components(vec![first, second]);
+    let factory_called = Arc::new(AtomicBool::new(false));
+    let runtime = identity_runtime(
+        SelectedRequestIdentity::new(
+            "identity-1",
+            "github_oauth",
+            BTreeMap::from([
+                ("host".to_string(), json!("api.github.com")),
+                ("port".to_string(), json!(443)),
+            ]),
+        ),
+        Arc::clone(&factory_called),
+    );
+
+    let catalog = CoralQuery::list_catalog(&[source], runtime, None)
+        .await
+        .expect("one source identity should authenticate every HTTP component");
+
+    assert!(
+        catalog
+            .tables
+            .iter()
+            .any(|table| table.schema_name == "github_v4_rest")
+    );
+    assert!(
+        catalog
+            .tables
+            .iter()
+            .any(|table| table.schema_name == "github_v4_graphql")
+    );
+    assert!(factory_called.load(Ordering::Relaxed));
+}
+
+#[tokio::test]
+async fn identity_gated_source_rejects_selected_identity_type_mismatch() {
+    let source = identity_runtime_source(identity_http_component());
+    let factory_called = Arc::new(AtomicBool::new(false));
+    let runtime = identity_runtime(
+        SelectedRequestIdentity::new(
+            "identity-1",
+            "github_oauth",
+            BTreeMap::from([
+                ("host".to_string(), json!("api.github.com")),
+                ("port".to_string(), json!(443.0)),
+            ]),
+        ),
+        Arc::clone(&factory_called),
+    );
+
+    let error = CoralQuery::list_catalog(&[source], runtime, None)
+        .await
+        .expect_err("JSON type mismatch should reject selected identity");
+
+    assert!(
+        error.to_string().contains(
+            "selected identity 'identity-1' with spec 'github_oauth' that does not satisfy identity_requirements"
+        ),
+        "{error}"
+    );
+    assert!(!factory_called.load(Ordering::Relaxed));
+}
+
+#[tokio::test]
+async fn identity_gated_source_accepts_spec_id_and_audience_subset() {
+    let source = identity_runtime_source(identity_http_component());
+    let factory_called = Arc::new(AtomicBool::new(false));
+    let runtime = identity_runtime(
+        SelectedRequestIdentity::new(
+            "identity-1",
+            "github_oauth",
+            BTreeMap::from([
+                ("host".to_string(), json!("api.github.com")),
+                ("port".to_string(), json!(443)),
+                ("tenant".to_string(), json!("acme")),
+            ]),
+        ),
+        Arc::clone(&factory_called),
+    );
+
+    let catalog = CoralQuery::list_catalog(&[source], runtime, None)
+        .await
+        .expect("matching identity should build runtime");
+
+    assert!(
+        catalog
+            .tables
+            .iter()
+            .any(|table| { table.schema_name == "github_v4_rest" && table.table_name == "issues" })
+    );
+    assert!(factory_called.load(Ordering::Relaxed));
+}
+
 fn http_component(
     base_url: &str,
     schema_name: &str,
@@ -275,6 +416,113 @@ tables:
     ))
     .expect("manifest");
     manifest.as_http().expect("http manifest").clone()
+}
+
+fn identity_http_component() -> coral_spec::backends::http::HttpSourceManifest {
+    let mut manifest = http_component(
+        "https://api.example.com",
+        "github_v4_rest",
+        "issues",
+        "/issues",
+    );
+    manifest.common.dsl_version = 4;
+    manifest
+}
+
+fn identity_runtime_source(
+    component: coral_spec::backends::http::HttpSourceManifest,
+) -> QuerySource {
+    identity_runtime_source_with_components(vec![component])
+}
+
+fn identity_runtime_source_with_components(
+    components: Vec<coral_spec::backends::http::HttpSourceManifest>,
+) -> QuerySource {
+    QuerySource::from_runtime_components(
+        RuntimeSourcePackage {
+            source_name: "github_v4".to_string(),
+            authored_version: None,
+            description: "GitHub v4 runtime package".to_string(),
+            declared_inputs: Vec::new(),
+            test_queries: Vec::new(),
+            identity_requirements: Some(identity_requirements()),
+            components: components
+                .into_iter()
+                .map(RuntimeSourceComponent::Http)
+                .collect(),
+        },
+        BTreeMap::new(),
+        BTreeMap::new(),
+    )
+    .expect("identity runtime package")
+}
+
+fn identity_requirements() -> IdentityRequirements {
+    IdentityRequirements {
+        accepts: vec![AcceptedIdentityRequirement {
+            id: "github_rest_read".to_string(),
+            identity_specs: vec!["github_oauth".to_string()],
+            audience: BTreeMap::from([
+                ("host".to_string(), json!("api.github.com")),
+                ("port".to_string(), json!(443)),
+            ]),
+        }],
+    }
+}
+
+fn identity_runtime(
+    identity: SelectedRequestIdentity,
+    factory_called: Arc<AtomicBool>,
+) -> QueryRuntimeConfig {
+    QueryRuntimeConfig::default()
+        .with_request_identity_selector(Some(Arc::new(FixedIdentitySelector { identity })))
+        .with_request_identity_http_authenticator_factory(Some(identity_factory(factory_called)))
+}
+
+fn identity_factory(factory_called: Arc<AtomicBool>) -> RequestIdentityHttpAuthenticatorFactory {
+    Arc::new(move |_identity| {
+        assert!(
+            !factory_called.swap(true, Ordering::Relaxed),
+            "identity authenticator factory should run once per source"
+        );
+        Ok(empty_identity_authenticator())
+    })
+}
+
+fn empty_identity_authenticator() -> BoundRequestIdentityHttpAuthenticator {
+    Arc::new(|_request, _resolved_inputs| {
+        Box::pin(async {
+            Ok::<Vec<(HeaderName, HeaderValue)>, RequestIdentityHttpAuthenticatorError>(Vec::new())
+        })
+    })
+}
+
+#[derive(Debug)]
+struct FixedIdentitySelector {
+    identity: SelectedRequestIdentity,
+}
+
+#[async_trait]
+impl RequestIdentitySelector for FixedIdentitySelector {
+    async fn select_identity(
+        &self,
+        _identity: &RequestIdentitySelectionContext,
+    ) -> Result<SelectedRequestIdentity, RequestIdentitySelectionError> {
+        Ok(self.identity.clone())
+    }
+}
+
+#[derive(Debug)]
+struct UnexpectedIdentitySelector;
+
+#[async_trait]
+impl RequestIdentitySelector for UnexpectedIdentitySelector {
+    async fn select_identity(
+        &self,
+        _identity: &RequestIdentitySelectionContext,
+    ) -> Result<SelectedRequestIdentity, RequestIdentitySelectionError> {
+        panic!("identity selection should not run")
+    }
 }
 
 fn file_component_with_lookup_key_filter() -> coral_spec::backends::file::FileSourceManifest {

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -291,6 +291,32 @@ async fn identity_gated_source_requires_request_identity_authenticator_factory()
 }
 
 #[tokio::test]
+async fn identity_gated_sources_reject_duplicate_source_names_before_binding() {
+    let sources = [
+        identity_runtime_source(identity_http_component()),
+        identity_runtime_source(identity_http_component()),
+    ];
+    let factory_called = Arc::new(AtomicBool::new(false));
+    let runtime = test_runtime()
+        .with_request_identity_selector(Some(Arc::new(UnexpectedIdentitySelector)))
+        .with_request_identity_http_authenticator_factory(Some(identity_factory(Arc::clone(
+            &factory_called,
+        ))));
+
+    let error = CoralQuery::list_catalog(&sources, runtime, None)
+        .await
+        .expect_err("duplicate gated source names should fail before identity binding");
+
+    assert!(
+        error
+            .to_string()
+            .contains("source 'github_v4' appears more than once with identity_requirements"),
+        "{error}"
+    );
+    assert!(!factory_called.load(Ordering::Relaxed));
+}
+
+#[tokio::test]
 async fn identity_gated_source_binds_identity_once_for_all_http_components() {
     let first = identity_http_component();
     let mut second = identity_http_component();


### PR DESCRIPTION
## Intent

Compose source-level DSL v4 identity requirements into engine runtime construction so identity-gated HTTP sources fail closed before registration when selection or binding material is missing or invalid.

## What it enables

- Runtime construction invokes the app-provided `RequestIdentitySelector` once for each identity-gated source.
- Selected identities are validated against accepted identity spec ids and audience subset rules with exact JSON type equality.
- One HTTP identity authenticator is bound per source and shared by every HTTP component in that source, including dependent-join fallback runtime construction.
- Duplicate gated source names fail before identity selection or authenticator binding.
- Bound authenticators are threaded through backend compilation for the later request-time injection unit.

## Usage examples

- Configure `QueryRuntimeConfig` with a request identity selector and HTTP authenticator factory before building a runtime that contains identity-gated DSL v4 sources.
- Return `SelectedRequestIdentity::new(identity_id, identity_spec_id, audience)` from the selector.
- Let runtime construction reject missing extension points, duplicate gated source names, and selected identities that do not satisfy the source requirements.

## Validation

- `make rust-checks`
- `make perf-check`
