### PR TITLE
feat(desktop): publish mac app with updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,9 +318,92 @@ jobs:
             coral-${{ matrix.target }}.zip
             coral-${{ matrix.target }}.tar.gz
 
+  build-desktop-macos:
+    needs:
+      - validate-release-ref
+    environment: release
+    runs-on: macos-latest
+    env:
+      TAG_NAME: ${{ needs.validate-release-ref.outputs.tag-name }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-release-ref.outputs.commit-sha }}
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: apps/desktop/.node-version
+          package-manager-cache: false
+
+      - name: Install desktop dependencies
+        run: npm ci --prefix apps/desktop
+
+      - name: Build, sign, and notarize desktop app
+        shell: bash
+        env:
+          CORAL_DESKTOP_RELEASE: "1"
+          CSC_LINK: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          CSC_NAME: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
+          APPLE_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APPLE_TEAM_ID:-}" ] && [[ "${CSC_NAME:-}" =~ \(([A-Z0-9]{10})\) ]]; then
+            export APPLE_TEAM_ID="${BASH_REMATCH[1]}"
+          fi
+          if [ -z "${APPLE_TEAM_ID:-}" ]; then
+            echo "APPLE_TEAM_ID must be set as a release environment variable or be present in APPLE_CODESIGN_IDENTITY." >&2
+            exit 1
+          fi
+
+          npm run package:mac --prefix apps/desktop
+
+      - name: Verify desktop app signature and notarization
+        shell: bash
+        run: |
+          set -euo pipefail
+          app_bundle="$(find apps/desktop/dist -name 'Coral.app' -type d -prune | head -n 1)"
+          if [ -z "$app_bundle" ]; then
+            echo "Could not find packaged Coral.app under apps/desktop/dist." >&2
+            exit 1
+          fi
+          codesign --verify --deep --strict --verbose=2 "$app_bundle"
+          xcrun stapler validate "$app_bundle"
+          test -s apps/desktop/dist/latest-mac.yml
+
+          shopt -s nullglob
+          dmg_artifacts=(apps/desktop/dist/coral-desktop-*.dmg)
+          zip_artifacts=(apps/desktop/dist/coral-desktop-*.zip)
+          if [ "${#dmg_artifacts[@]}" -ne 1 ] || [ "${#zip_artifacts[@]}" -ne 1 ]; then
+            echo "Expected exactly one desktop DMG and one desktop ZIP artifact." >&2
+            printf 'DMGs: %s\n' "${dmg_artifacts[*]:-<none>}" >&2
+            printf 'ZIPs: %s\n' "${zip_artifacts[*]:-<none>}" >&2
+            exit 1
+          fi
+
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: coral-desktop-macos
+          if-no-files-found: error
+          path: |
+            apps/desktop/dist/coral-desktop-*.dmg
+            apps/desktop/dist/coral-desktop-*.zip
+            apps/desktop/dist/coral-desktop-*.blockmap
+            apps/desktop/dist/latest-mac.yml
+
   checksums:
     needs:
       - build
+      - build-desktop-macos
       - sign-notarize-macos
     runs-on: ubuntu-latest
     steps:
@@ -332,9 +415,15 @@ jobs:
           merge-multiple: true
       - name: Generate checksums
         run: |
+          set -euo pipefail
+          shopt -s nullglob
           cd artifacts
-          sha256sum coral-*.tar.gz > checksums.sha256
-          sha256sum coral-*.zip >> checksums.sha256
+          artifacts=(coral-*.tar.gz coral-*.zip coral-*.dmg)
+          if [ "${#artifacts[@]}" -eq 0 ]; then
+            echo "No Coral release archives found" >&2
+            exit 1
+          fi
+          sha256sum "${artifacts[@]}" > checksums.sha256
           test -s checksums.sha256
       - name: Upload checksums
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -377,7 +466,14 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          artifacts=(artifacts/coral-*.tar.gz artifacts/coral-*.zip artifacts/checksums.sha256)
+          artifacts=(
+            artifacts/coral-*.tar.gz
+            artifacts/coral-*.zip
+            artifacts/coral-*.dmg
+            artifacts/coral-*.blockmap
+            artifacts/latest-mac.yml
+            artifacts/checksums.sha256
+          )
           if [ "${#artifacts[@]}" -lt 2 ]; then
             echo "No Coral release archives found" >&2
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,7 +350,7 @@ jobs:
           CSC_LINK: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
           CSC_NAME: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
-          APPLE_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8_BASE64 }}
+          APP_STORE_CONNECT_API_KEY_P8_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8_BASE64 }}
           APPLE_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
@@ -363,6 +363,14 @@ jobs:
             echo "APPLE_TEAM_ID must be set as a release environment variable or be present in APPLE_CODESIGN_IDENTITY." >&2
             exit 1
           fi
+
+          # electron-builder's notarization (@electron/notarize) expects
+          # APPLE_API_KEY to be a *path* to the App Store Connect .p8 key, not
+          # its contents — decode the base64 secret to a file first.
+          APPLE_API_KEY="$RUNNER_TEMP/app-store-connect-api-key.p8"
+          printf '%s' "$APP_STORE_CONNECT_API_KEY_P8_BASE64" | base64 --decode > "$APPLE_API_KEY"
+          test -s "$APPLE_API_KEY"
+          export APPLE_API_KEY
 
           npm run package:mac --prefix apps/desktop
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,6 +40,7 @@ jobs:
       ui-tests: ${{ steps.filter.outputs.ui-tests }}
       reef-checks: ${{ steps.filter.outputs.reef-checks }}
       desktop-checks: ${{ steps.filter.outputs.desktop-checks }}
+      desktop-package-macos: ${{ steps.filter.outputs.desktop-package-macos }}
       proto-lint: ${{ steps.filter.outputs.proto-lint }}
       source-lint: ${{ steps.filter.outputs.source-lint }}
       docs-freshness: ${{ steps.filter.outputs.docs-freshness }}
@@ -96,6 +97,15 @@ jobs:
             desktop-checks:
               - '.github/workflows/validate.yml'
               - 'apps/desktop/**'
+            desktop-package-macos:
+              - '.github/workflows/validate.yml'
+              - '.github/workflows/release.yml'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/**'
+              - 'apps/desktop/**'
+              - 'apps/reef/**'
+              - 'apps/ui/**'
             proto-lint:
               - '.github/workflows/validate.yml'
               - 'Makefile'
@@ -507,6 +517,64 @@ jobs:
       - name: Type-check desktop
         run: npm run check --prefix apps/desktop
 
+  desktop-package-macos:
+    name: Desktop macOS package
+    runs-on: macos-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.desktop-package-macos == 'true' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Set up Node
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: apps/desktop/.node-version
+          package-manager-cache: false
+
+      - name: Set up Node with trusted npm cache
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: apps/desktop/.node-version
+          cache: npm
+          cache-dependency-path: apps/desktop/package-lock.json
+
+      - name: Install desktop dependencies
+        run: npm ci --prefix apps/desktop
+
+      - name: Package desktop app
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: npm run package:mac --prefix apps/desktop
+
+      - name: Verify desktop package artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -s apps/desktop/dist/latest-mac.yml
+
+          shopt -s nullglob
+          dmg_artifacts=(apps/desktop/dist/coral-desktop-*.dmg)
+          zip_artifacts=(apps/desktop/dist/coral-desktop-*.zip)
+          blockmap_artifacts=(apps/desktop/dist/coral-desktop-*.blockmap)
+          if [ "${#dmg_artifacts[@]}" -ne 1 ] || [ "${#zip_artifacts[@]}" -ne 1 ]; then
+            echo "Expected exactly one desktop DMG and one desktop ZIP artifact." >&2
+            printf 'DMGs: %s\n' "${dmg_artifacts[*]:-<none>}" >&2
+            printf 'ZIPs: %s\n' "${zip_artifacts[*]:-<none>}" >&2
+            exit 1
+          fi
+          if [ "${#blockmap_artifacts[@]}" -eq 0 ]; then
+            echo "Expected at least one desktop blockmap artifact." >&2
+            exit 1
+          fi
+          grep -q "$(basename "${zip_artifacts[0]}")" apps/desktop/dist/latest-mac.yml
+
   proto-lint:
     name: Lint protobuf API
     runs-on: ubuntu-latest
@@ -732,6 +800,7 @@ jobs:
         ui-tests,
         reef-checks,
         desktop-checks,
+        desktop-package-macos,
         proto-lint,
         gha-security-audit-pr,
         gha-security-audit-sarif,
@@ -755,6 +824,7 @@ jobs:
           UI_TESTS_RESULT: ${{ needs.ui-tests.result }}
           REEF_CHECKS_RESULT: ${{ needs.reef-checks.result }}
           DESKTOP_CHECKS_RESULT: ${{ needs.desktop-checks.result }}
+          DESKTOP_PACKAGE_MACOS_RESULT: ${{ needs.desktop-package-macos.result }}
           PROTO_LINT_RESULT: ${{ needs.proto-lint.result }}
           GHA_SECURITY_AUDIT_PR_RESULT: ${{ needs.gha-security-audit-pr.result }}
           GHA_SECURITY_AUDIT_SARIF_RESULT: ${{ needs.gha-security-audit-sarif.result }}
@@ -773,6 +843,7 @@ jobs:
             "ui-tests:$UI_TESTS_RESULT"
             "reef-checks:$REEF_CHECKS_RESULT"
             "desktop-checks:$DESKTOP_CHECKS_RESULT"
+            "desktop-package-macos:$DESKTOP_PACKAGE_MACOS_RESULT"
             "proto-lint:$PROTO_LINT_RESULT"
             "gha-security-audit-pr:$GHA_SECURITY_AUDIT_PR_RESULT"
             "gha-security-audit-sarif:$GHA_SECURITY_AUDIT_SARIF_RESULT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,10 @@
   latency. CI installs the bundled `github` source with fake credentials and
   fails when release `coral sql "select * from coral.tables"` has a hyperfine
   mean above 750 ms.
+- Desktop distribution changes must exercise the release-shaped macOS package
+  path, not only the desktop type-check. The Validate workflow runs the
+  `Desktop macOS package` job for desktop, Reef, UI, Rust, and release-workflow
+  inputs so PRs catch missing DMG/ZIP/update metadata before the release job.
 - The `Validate` workflow intentionally skips draft pull request runs, starts
   again on `ready_for_review`, and still triggers on `converted_to_draft` so the
   replacement skipped run cancels any in-progress validation for the PR branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,11 @@
   `xtask/src/sources.rs`, performance checks live in `xtask/src/perf.rs`, and
   skill export lives in `xtask/src/skills.rs`. Release signing and
   notarization automation lives in `xtask/src/release.rs`.
+- The Electron desktop app version is tied to the CLI release version through
+  release-please. The release workflow builds the macOS desktop app from
+  `apps/desktop`, uploads its DMG/ZIP/update metadata to the same GitHub
+  Release as the CLI artifacts, and the website should link to the
+  `releases/latest/download` DMG rather than storing desktop binaries itself.
 - `make docs-check` intentionally skips the aggregate community source catalog.
   Any PR may leave that generated page stale so unrelated changes do not fail
   on aggregate community catalog drift; keep docs freshness strict for bundled

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -27,7 +27,8 @@ app lifecycle, window and menu, and MCP client configuration.
   Windows target)
 - Coral MCP configuration for Codex and Claude Code — from the Settings page and
   the app menu — via `add-mcp`
-- macOS DMG packaging via `electron-builder`
+- signed, notarized macOS DMG and ZIP packaging via `electron-builder`
+- GitHub Releases update metadata for packaged desktop auto-updates
 - macOS system theme support
 
 ## Development
@@ -70,6 +71,11 @@ npm run package:dir --prefix apps/desktop
 ```
 
 Use `npm run package:dmg --prefix apps/desktop` for the macOS drag-and-drop DMG.
+Use `npm run package:mac --prefix apps/desktop` to build the release-shaped
+universal macOS DMG and ZIP with updater metadata.
+
+Release builds set `CORAL_DESKTOP_RELEASE=1`, which requires Apple signing and
+notarization credentials and fails if the app cannot be signed.
 
 > Run the `--prefix apps/desktop` commands from the repo root. If you are already in
 > `apps/desktop/`, drop the flag (e.g. `npm run package:dir`).

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -1,9 +1,18 @@
 import type { Configuration } from 'electron-builder'
 
+const releaseBuild = process.env.CORAL_DESKTOP_RELEASE === '1'
+
 const config: Configuration = {
   appId: 'com.withcoral.desktop',
   productName: 'Coral',
-  artifactName: 'coral-desktop-${os}-${arch}.${ext}',
+  forceCodeSigning: releaseBuild,
+  publish: [
+    {
+      provider: 'github',
+      owner: 'withcoral',
+      repo: 'coral',
+    },
+  ],
   directories: {
     output: 'dist',
     buildResources: 'resources',
@@ -37,9 +46,14 @@ const config: Configuration = {
     },
   ],
   mac: {
+    artifactName: 'coral-desktop-mac-${arch}.${ext}',
     category: 'public.app-category.developer-tools',
+    entitlements: 'resources/entitlements.mac.plist',
+    entitlementsInherit: 'resources/entitlements.mac.inherit.plist',
+    hardenedRuntime: true,
     icon: 'resources/icons/icon.icns',
-    target: ['dmg'],
+    notarize: releaseBuild,
+    target: ['dmg', 'zip'],
   },
 }
 

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@withcoral/desktop",
-  "version": "0.4.4",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@withcoral/desktop",
-      "version": "0.4.4",
+      "version": "0.5.2",
       "dependencies": {
         "@base-ui/react": "1.5.0",
         "@bufbuild/protobuf": "2.12.1",
@@ -17,6 +17,7 @@
         "@vanilla-extract/recipes": "0.5.7",
         "add-mcp": "^1.11.0",
         "classnames": "2.5.1",
+        "electron-updater": "^6.8.9",
         "isbot": "5.1.43",
         "jotai": "2.20.1",
         "lucide-react": "1.18.0",
@@ -69,6 +70,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -291,6 +293,7 @@
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/parser": "^7.29.7",
@@ -397,7 +400,8 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
       "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@clack/core": {
       "version": "0.4.1",
@@ -425,6 +429,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
       "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -711,7 +716,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -733,7 +737,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -747,8 +750,7 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
       "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -2002,7 +2004,6 @@
       "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.21.1.tgz",
       "integrity": "sha512-T6z6oeT+o0OwqukE6kLs9w5ooB75b8NPRadyU9pPTml83l40TPN+mscPt2OQ9P9cYfwEBMfsfivwiJujs2mzmg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.9",
@@ -2021,15 +2022,13 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/@vanilla-extract/private": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@vanilla-extract/private/-/private-1.0.9.tgz",
       "integrity": "sha512-gT2jbfZuaaCLrAxwXbRgIhGhcXbRZCG3v4TTUnjw0EJ7ArdBRxkq4msNJkbuRkCgfIK5ATmprB5t9ljvLeFDEA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@vanilla-extract/recipes": {
       "version": "0.5.7",
@@ -2494,6 +2493,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2545,7 +2545,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -2891,8 +2890,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2937,7 +2935,6 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
       "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">= 6"
       },
@@ -2949,8 +2946,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3016,7 +3012,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
       "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
       },
@@ -3030,15 +3025,13 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.9.tgz",
       "integrity": "sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3179,6 +3172,7 @@
       "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -3339,6 +3333,34 @@
       "devOptional": true,
       "license": "ISC"
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-vite": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/electron-vite/-/electron-vite-5.0.0.tgz",
@@ -3376,7 +3398,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -3397,7 +3418,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3413,7 +3433,6 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3424,7 +3443,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -3732,7 +3750,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -3983,7 +4000,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -4458,7 +4474,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -4481,7 +4496,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash": {
@@ -4489,6 +4503,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -4722,7 +4749,6 @@
       "resolved": "https://registry.npmjs.org/media-query-parser/-/media-query-parser-2.0.2.tgz",
       "integrity": "sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       }
@@ -5270,7 +5296,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -5282,8 +5307,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/modern-ahocorasick/-/modern-ahocorasick-1.1.0.tgz",
       "integrity": "sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -5569,6 +5593,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5658,7 +5683,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -5676,7 +5700,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -5793,6 +5816,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5841,6 +5865,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5880,6 +5905,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
       "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -6070,7 +6096,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -6163,7 +6188,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -6456,7 +6480,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -6495,6 +6518,12 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -6598,6 +6627,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6715,7 +6745,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -6838,6 +6867,7 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,8 @@
     "package:dir": "electron-builder --dir --config electron-builder.config.ts",
     "prepackage:dmg": "npm run build",
     "package:dmg": "electron-builder --mac dmg --config electron-builder.config.ts",
+    "prepackage:mac": "CORAL_DESKTOP_UNIVERSAL=1 npm run build",
+    "package:mac": "electron-builder --mac --universal --publish never --config electron-builder.config.ts",
     "stage:coral": "node ./scripts/stage-coral.mjs"
   },
   "dependencies": {
@@ -32,6 +34,7 @@
     "@vanilla-extract/recipes": "0.5.7",
     "add-mcp": "^1.11.0",
     "classnames": "2.5.1",
+    "electron-updater": "^6.8.9",
     "isbot": "5.1.43",
     "jotai": "2.20.1",
     "lucide-react": "1.18.0",

--- a/apps/desktop/resources/entitlements.mac.inherit.plist
+++ b/apps/desktop/resources/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/desktop/resources/entitlements.mac.plist
+++ b/apps/desktop/resources/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/desktop/scripts/stage-coral.mjs
+++ b/apps/desktop/scripts/stage-coral.mjs
@@ -7,6 +7,9 @@ const repoRoot = resolve(desktopRoot, '..', '..')
 const outputDir = resolve(desktopRoot, 'resources', 'coral')
 const binaryName = process.platform === 'win32' ? 'coral.exe' : 'coral'
 const targetBinary = resolve(repoRoot, 'target', 'release', binaryName)
+const universalMacBinary = resolve(repoRoot, 'target', 'release', 'coral-universal')
+const universalMac = process.env.CORAL_DESKTOP_UNIVERSAL === '1'
+const macTargets = ['x86_64-apple-darwin', 'aarch64-apple-darwin']
 
 function run(command, args, options = {}) {
   return new Promise((resolveRun, rejectRun) => {
@@ -37,14 +40,38 @@ await run('npm', ['run', 'build', '--prefix', 'apps/reef'], {
     VITE_CORAL_DESKTOP_APP: '1',
   },
 })
-await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release'])
+
+async function buildCoralCli() {
+  if (!universalMac) {
+    await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release'])
+    return targetBinary
+  }
+
+  if (process.platform !== 'darwin') {
+    throw new Error('CORAL_DESKTOP_UNIVERSAL=1 is only supported on macOS.')
+  }
+
+  await run('rustup', ['target', 'add', ...macTargets])
+  for (const target of macTargets) {
+    await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release', '--target', target])
+  }
+  await run('lipo', [
+    '-create',
+    ...macTargets.map((target) => resolve(repoRoot, 'target', target, 'release', binaryName)),
+    '-output',
+    universalMacBinary,
+  ])
+  return universalMacBinary
+}
+
+const builtBinary = await buildCoralCli()
 
 await rm(outputDir, { recursive: true, force: true })
 await mkdir(outputDir, { recursive: true })
-await copyFile(targetBinary, join(outputDir, binaryName))
+await copyFile(builtBinary, join(outputDir, binaryName))
 
 if (process.platform !== 'win32') {
   await chmod(join(outputDir, binaryName), 0o755)
 }
 
-console.log(`[stage-coral] staged ${targetBinary} -> ${join(outputDir, binaryName)}`)
+console.log(`[stage-coral] staged ${builtBinary} -> ${join(outputDir, binaryName)}`)

--- a/apps/desktop/src/main/auto-update.ts
+++ b/apps/desktop/src/main/auto-update.ts
@@ -1,0 +1,100 @@
+import { dialog, app } from 'electron'
+import { createRequire } from 'node:module'
+import type { AppUpdater, UpdateCheckResult } from 'electron-updater'
+
+const require = createRequire(import.meta.url)
+const { autoUpdater } = require('electron-updater') as { autoUpdater: AppUpdater }
+
+const STARTUP_UPDATE_CHECK_DELAY_MS = 5000
+
+let installed = false
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+function logUpdateError(context: string, error: unknown): void {
+  console.error(`[coral-updater] ${context}: ${errorMessage(error)}`)
+}
+
+function installUpdateLogging(): void {
+  autoUpdater.on('checking-for-update', () => {
+    console.info('[coral-updater] checking for updates')
+  })
+  autoUpdater.on('update-available', (info) => {
+    console.info(`[coral-updater] update available: ${info.version}`)
+  })
+  autoUpdater.on('update-not-available', (info) => {
+    console.info(`[coral-updater] no update available; latest is ${info.version}`)
+  })
+  autoUpdater.on('download-progress', (progress) => {
+    console.info(`[coral-updater] download ${progress.percent.toFixed(1)}%`)
+  })
+  autoUpdater.on('update-downloaded', (info) => {
+    console.info(`[coral-updater] update downloaded: ${info.version}`)
+  })
+  autoUpdater.on('error', (error) => {
+    logUpdateError('update check failed', error)
+  })
+}
+
+async function showManualResult(result: UpdateCheckResult | null): Promise<void> {
+  if (!result) {
+    await dialog.showMessageBox({
+      type: 'info',
+      message: 'Update checks are unavailable for this build',
+      detail: 'Coral can check for desktop updates only from a packaged release build.',
+    })
+    return
+  }
+
+  if (!result.isUpdateAvailable) {
+    await dialog.showMessageBox({
+      type: 'info',
+      message: 'Coral is up to date',
+      detail: `You are running Coral ${app.getVersion()}.`,
+    })
+    return
+  }
+
+  await dialog.showMessageBox({
+    type: 'info',
+    message: `Coral ${result.updateInfo.version} is downloading`,
+    detail: 'You will be notified when the update is ready. It will install after Coral quits.',
+  })
+}
+
+export function installAutoUpdater(): void {
+  if (!app.isPackaged || installed) return
+
+  installed = true
+  autoUpdater.autoDownload = true
+  autoUpdater.autoInstallOnAppQuit = true
+  installUpdateLogging()
+
+  setTimeout(() => {
+    void checkForDesktopUpdates({ interactive: false })
+  }, STARTUP_UPDATE_CHECK_DELAY_MS)
+}
+
+export async function checkForDesktopUpdates({ interactive }: { interactive: boolean }): Promise<void> {
+  if (!app.isPackaged) {
+    if (interactive) await showManualResult(null)
+    return
+  }
+
+  try {
+    const result = await autoUpdater.checkForUpdatesAndNotify()
+    if (interactive) await showManualResult(result)
+  } catch (error) {
+    logUpdateError('manual update check failed', error)
+    if (interactive) {
+      await dialog.showMessageBox({
+        type: 'error',
+        message: 'Update check failed',
+        detail: errorMessage(error),
+      })
+    }
+  }
+}

--- a/apps/desktop/src/main/auto-update.ts
+++ b/apps/desktop/src/main/auto-update.ts
@@ -6,6 +6,10 @@ const require = createRequire(import.meta.url)
 const { autoUpdater } = require('electron-updater') as { autoUpdater: AppUpdater }
 
 const STARTUP_UPDATE_CHECK_DELAY_MS = 5000
+// Long-running desktop sessions would otherwise only see new releases after a
+// restart; re-check periodically so a release ships to open apps too. The
+// downloaded update still installs on quit.
+const PERIODIC_UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000
 
 let installed = false
 
@@ -76,6 +80,10 @@ export function installAutoUpdater(): void {
   setTimeout(() => {
     void checkForDesktopUpdates({ interactive: false })
   }, STARTUP_UPDATE_CHECK_DELAY_MS)
+  // electron-updater dedupes overlapping checks, so a plain interval is safe.
+  setInterval(() => {
+    void checkForDesktopUpdates({ interactive: false })
+  }, PERIODIC_UPDATE_CHECK_INTERVAL_MS)
 }
 
 export async function checkForDesktopUpdates({ interactive }: { interactive: boolean }): Promise<void> {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -12,6 +12,7 @@ import {
   registerAppSchemePrivileges,
 } from './app-renderer'
 import { killAllTrackedChildren, startCoralSidecar, type CoralSidecar } from './sidecar'
+import { checkForDesktopUpdates, installAutoUpdater } from './auto-update'
 
 const SHUTDOWN_TIMEOUT_MS = 6000
 
@@ -286,6 +287,16 @@ function installMenu() {
           label: 'Configure MCP',
           submenu: mcpSubmenu,
         },
+        ...(app.isPackaged
+          ? ([
+              {
+                label: 'Check for Updates...',
+                click: () => {
+                  void checkForDesktopUpdates({ interactive: true })
+                },
+              },
+            ] satisfies Electron.MenuItemConstructorOptions[])
+          : []),
         { type: 'separator' },
         { role: 'quit' },
       ],
@@ -340,6 +351,7 @@ app.whenReady().then(() => {
   nativeTheme.on('updated', updatePlatformIcon)
   registerIpcHandlers()
   installMenu()
+  installAutoUpdater()
   registerAppProtocol(() => ensureSidecar().then((started) => started.url))
   void ensureSidecar().catch((error: unknown) => {
     const message = error instanceof Error ? error.message : String(error)

--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -1,30 +1,19 @@
 ---
 title: "Installation"
-description: "Install Coral"
+description: "Install the Coral CLI"
 ---
 
-Coral ships as a macOS desktop app and a single local CLI. The CLI binary is
-used for source management, SQL queries, and the MCP stdio server; Coral
-Desktop bundles that CLI as its local sidecar.
+Coral ships as a single local CLI. Once installed, the same binary is used for source management, SQL queries, and the MCP stdio server.
 
 <Note>
-  Coral publishes a macOS desktop app plus macOS, Linux, and x86_64 Windows CLI
-  artifacts. Windows CLI support currently targets native Windows 10/11 on
-  `x86_64-pc-windows-msvc`; ARM64 Windows is not released.
+  Coral publishes macOS, Linux, and x86_64 Windows artifacts. Windows support
+  currently targets native Windows 10/11 on `x86_64-pc-windows-msvc`; ARM64
+  Windows is not released.
 </Note>
 
 ## Install Coral
 
 <Tabs>
-  <Tab title="Desktop app">
-    Download the signed macOS desktop app:
-
-    [Download Coral Desktop for macOS](https://github.com/withcoral/coral/releases/latest/download/coral-desktop-mac-universal.dmg)
-
-    Coral Desktop bundles the matching Coral CLI sidecar for that release and
-    checks for desktop updates automatically.
-  </Tab>
-
   <Tab title="Homebrew">
     ```shellscript
     brew install withcoral/tap/coral
@@ -145,15 +134,6 @@ Desktop bundles that CLI as its local sidecar.
 ## Upgrade
 
 <Tabs>
-  <Tab title="Desktop app">
-    Coral Desktop checks for updates at startup. To check manually, open
-    **Coral > Check for Updates...** from the app menu.
-
-    You can also download and install the latest DMG again:
-
-    [Download Coral Desktop for macOS](https://github.com/withcoral/coral/releases/latest/download/coral-desktop-mac-universal.dmg)
-  </Tab>
-
   <Tab title="Homebrew">
     ```shellscript
     brew upgrade withcoral/tap/coral
@@ -185,14 +165,6 @@ Desktop bundles that CLI as its local sidecar.
 ## Uninstall
 
 <Tabs>
-  <Tab title="Desktop app">
-    Move Coral from `/Applications` to the Trash. To remove local Coral state:
-
-    ```shellscript
-    rm -rf ~/.config/coral
-    ```
-  </Tab>
-
   <Tab title="Homebrew">
     ```shellscript
     brew uninstall withcoral/tap/coral

--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -1,19 +1,30 @@
 ---
 title: "Installation"
-description: "Install the Coral CLI"
+description: "Install Coral"
 ---
 
-Coral ships as a single local CLI. Once installed, the same binary is used for source management, SQL queries, and the MCP stdio server.
+Coral ships as a macOS desktop app and a single local CLI. The CLI binary is
+used for source management, SQL queries, and the MCP stdio server; Coral
+Desktop bundles that CLI as its local sidecar.
 
 <Note>
-  Coral publishes macOS, Linux, and x86_64 Windows artifacts. Windows support
-  currently targets native Windows 10/11 on `x86_64-pc-windows-msvc`; ARM64
-  Windows is not released.
+  Coral publishes a macOS desktop app plus macOS, Linux, and x86_64 Windows CLI
+  artifacts. Windows CLI support currently targets native Windows 10/11 on
+  `x86_64-pc-windows-msvc`; ARM64 Windows is not released.
 </Note>
 
 ## Install Coral
 
 <Tabs>
+  <Tab title="Desktop app">
+    Download the signed macOS desktop app:
+
+    [Download Coral Desktop for macOS](https://github.com/withcoral/coral/releases/latest/download/coral-desktop-mac-universal.dmg)
+
+    Coral Desktop bundles the matching Coral CLI sidecar for that release and
+    checks for desktop updates automatically.
+  </Tab>
+
   <Tab title="Homebrew">
     ```shellscript
     brew install withcoral/tap/coral
@@ -134,6 +145,15 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
 ## Upgrade
 
 <Tabs>
+  <Tab title="Desktop app">
+    Coral Desktop checks for updates at startup. To check manually, open
+    **Coral > Check for Updates...** from the app menu.
+
+    You can also download and install the latest DMG again:
+
+    [Download Coral Desktop for macOS](https://github.com/withcoral/coral/releases/latest/download/coral-desktop-mac-universal.dmg)
+  </Tab>
+
   <Tab title="Homebrew">
     ```shellscript
     brew upgrade withcoral/tap/coral
@@ -165,6 +185,14 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
 ## Uninstall
 
 <Tabs>
+  <Tab title="Desktop app">
+    Move Coral from `/Applications` to the Trash. To remove local Coral state:
+
+    ```shellscript
+    rm -rf ~/.config/coral
+    ```
+  </Tab>
+
   <Tab title="Homebrew">
     ```shellscript
     brew uninstall withcoral/tap/coral

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,9 @@
       "package-name": "coral",
       "extra-files": [
         "Cargo.toml",
-        { "type": "json", "path": "apps/desktop/package.json", "jsonpath": "$.version" }
+        { "type": "json", "path": "apps/desktop/package.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "apps/desktop/package-lock.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "apps/desktop/package-lock.json", "jsonpath": "$.packages[\"\"].version" }
       ],
       "exclude-paths": ["sources/community", "sources/core-v4"]
     }


### PR DESCRIPTION
Ships the macOS desktop app lifecycle: a downloadable installer on every release, and automatic update -> download -> install for running apps.

## Download (installer on the internet)
- Every release builds a **signed + notarized universal** (arm64 + x86_64) macOS app — sidecar lipo'd from both targets — and uploads `coral-desktop-mac-universal.dmg` + `.zip` (+ blockmaps, `latest-mac.yml`) to the same GitHub Release as the CLI, included in `checksums.sha256`.
- The artifact name is version-less, so the stable link always serves the newest release:
  `https://github.com/withcoral/coral/releases/latest/download/coral-desktop-mac-universal.dmg` (documented in installation.mdx).
- CI verifies `codesign`/`stapler`, `latest-mac.yml` presence, and exact artifact counts before upload; a failed desktop build fails the whole release, so update metadata can never silently go missing.

## Update flow (new release -> download -> install)
- `electron-updater` (GitHub provider): checks 5s after startup **and every 4h thereafter** (long-running sessions pick up releases without a restart), auto-downloads, notifies, installs on quit. Manual **Coral -> Check for Updates...** menu item with result dialogs.
- `release-please` keeps the desktop version (package.json + lockfile) in lockstep with the release tag, so version comparison is exact and each release carries the matching sidecar.

## Verified locally
- Unsigned zip+dmg build produces correct `latest-mac.yml` (zip-first + sha512) and embedded `app-update.yml` (github/withcoral/coral).
- Launched the packaged build: updater fires, resolves the latest GitHub release (`v0.5.1`), requests `latest-mac.yml` — 404 as expected since no release ships desktop artifacts yet. The first release off this PR closes that loop.
- Repo tags (`vX.Y.Z`) match what electron-updater's GitHub provider parses; Apple secrets already exist under the names the CLI notarize job uses.

## Fixed during review
- `@electron/notarize` expects `APPLE_API_KEY` to be a **path** to the .p8 key, not base64 contents — the workflow now decodes the secret to `RUNNER_TEMP` first. This would have failed the first real release run.
- Validate now has a `Desktop macOS package` job for desktop, Reef, UI, Rust, and release-workflow inputs. It runs the release-shaped unsigned macOS package path and asserts the DMG, ZIP, blockmaps, and `latest-mac.yml`; `AGENTS.md` now tells contributors and agents to use that package path for desktop distribution changes instead of relying only on type-checks.

## Not verifiable before a real release
Signing + notarization themselves (secrets live in the `release` environment). Prerequisite: `APPLE_TEAM_ID` set as a release environment variable, or present in `APPLE_CODESIGN_IDENTITY` (workflow handles both, fails loudly otherwise).

https://claude.ai/code/session_01LHpYSWV9NFgBWsgRfF3nkA
