### PR TITLE
feat(ui): add DSL v4 source creator

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { Shell } from '@/components/shell'
 import { useRouter } from '@/lib/router'
 import { TracesPage } from '@/views/TracesPage'
+import { SourceCreate } from '@/views/sources/source-create'
 import { SourcesIndex } from '@/views/sources/sources-index'
 import { ToastContainer } from '@/wax/components/toast'
 import { useThemeClassOnBody } from '@/wax/theme/theme-provider'
@@ -12,7 +13,13 @@ export function App() {
 
   return (
     <Shell>
-      {location.route.kind === 'sources' ? <SourcesIndex /> : <TracesPage />}
+      {location.route.kind === 'source-create' ? (
+        <SourceCreate />
+      ) : location.route.kind === 'sources' ? (
+        <SourcesIndex />
+      ) : (
+        <TracesPage />
+      )}
       <ToastContainer />
     </Shell>
   )

--- a/apps/ui/src/components/navbar/navbar.tsx
+++ b/apps/ui/src/components/navbar/navbar.tsx
@@ -21,6 +21,12 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { icon: 'Activity', label: 'Traces', target: { kind: 'traces' }, matches: ['traces'] },
   { icon: 'Plug', label: 'Sources', target: { kind: 'sources' }, matches: ['sources'] },
+  {
+    icon: 'Plus',
+    label: 'Create source',
+    target: { kind: 'source-create' },
+    matches: ['source-create'],
+  },
 ]
 
 const QUERY_STREAM_LABEL = 'Query stream'

--- a/apps/ui/src/lib/router.ts
+++ b/apps/ui/src/lib/router.ts
@@ -1,6 +1,6 @@
 import { useCallback, useSyncExternalStore } from 'react'
 
-export type Route = { kind: 'traces' } | { kind: 'sources' }
+export type Route = { kind: 'traces' } | { kind: 'sources' } | { kind: 'source-create' }
 
 export interface ParsedLocation {
   route: Route
@@ -9,6 +9,10 @@ export interface ParsedLocation {
 function parseHash(): ParsedLocation {
   const raw = window.location.hash.replace(/^#\/?/, '')
   const segments = raw.split('?')[0].split('/').filter(Boolean)
+
+  if (segments[0] === 'sources' && segments[1] === 'create') {
+    return { route: { kind: 'source-create' } }
+  }
 
   if (segments[0] === 'sources') {
     return { route: { kind: 'sources' } }
@@ -23,6 +27,7 @@ function parseHash(): ParsedLocation {
 
 function serialise(parsed: ParsedLocation): string {
   if (parsed.route.kind === 'traces') return '#/traces'
+  if (parsed.route.kind === 'source-create') return '#/sources/create'
   return '#/sources'
 }
 

--- a/apps/ui/src/lib/sources.ts
+++ b/apps/ui/src/lib/sources.ts
@@ -7,10 +7,13 @@ import {
   DiscoverSourcesRequestSchema,
   GetSourceInfoRequestSchema,
   GetSourceRequestSchema,
+  ImportSourceRequestSchema,
   SourceOrigin,
+  ValidateSourceRequestSchema,
   type OAuthCredentialRetrieval,
   type Source,
   type SourceInfo,
+  type ValidateSourceResponse,
 } from '@/generated/coral/v1/sources_pb'
 
 import { sourceClient, WORKSPACE } from './coral-clients'
@@ -153,4 +156,29 @@ export async function createBundledSourceWithOAuth(
     }
   }
   throw new Error(`install stream ended without a source event`)
+}
+
+export async function importSource(manifestYaml: string, inputs: InstallInput[]): Promise<Source> {
+  const { variables, secrets } = splitBindings(inputs)
+  const stream = sourceClient.importSource(
+    create(ImportSourceRequestSchema, {
+      workspace: WORKSPACE,
+      manifestYaml,
+      variables,
+      secrets,
+    }),
+  )
+
+  for await (const response of stream) {
+    const event = response.event
+    if (event.case === 'source') return event.value
+  }
+
+  throw new Error(`import stream ended without a source event`)
+}
+
+export async function validateSource(name: string): Promise<ValidateSourceResponse> {
+  return sourceClient.validateSource(
+    create(ValidateSourceRequestSchema, { workspace: WORKSPACE, name }),
+  )
 }

--- a/apps/ui/src/views/sources/source-create.css.ts
+++ b/apps/ui/src/views/sources/source-create.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css'
+import { recipe } from '@vanilla-extract/recipes'
 
 import { breakpoints } from '@/styles/theme'
 import { fontFamily } from '@/wax/theme/font.css'
@@ -18,7 +19,7 @@ export const container = style({
   flexDirection: 'column',
   gap: 24,
   marginInline: 'auto',
-  maxWidth: 1280,
+  maxWidth: 1180,
   width: '100%',
 })
 
@@ -41,18 +42,11 @@ export const headerText = style({
   minWidth: 0,
 })
 
-export const headerActions = style({
-  display: 'flex',
-  flexWrap: 'wrap',
-  gap: 8,
-  justifyContent: 'flex-end',
-})
-
 export const layout = style({
-  alignItems: 'flex-start',
+  alignItems: 'start',
   display: 'grid',
   gap: 24,
-  gridTemplateColumns: 'minmax(0, 1fr) minmax(360px, 440px)',
+  gridTemplateColumns: 'minmax(0, 1fr) minmax(360px, 460px)',
   '@media': {
     [`screen and (max-width: ${breakpoints.sidebarCollapse})`]: {
       gridTemplateColumns: '1fr',
@@ -65,7 +59,6 @@ export const formColumn = style({
   flexDirection: 'column',
   gap: 16,
   minWidth: 0,
-  width: '100%',
 })
 
 export const previewColumn = style({
@@ -75,7 +68,6 @@ export const previewColumn = style({
   minWidth: 0,
   position: 'sticky',
   top: 0,
-  width: '100%',
   '@media': {
     [`screen and (max-width: ${breakpoints.sidebarCollapse})`]: {
       position: 'static',
@@ -94,10 +86,58 @@ export const panel = style({
 })
 
 export const panelHead = style({
-  alignItems: 'center',
+  alignItems: 'flex-start',
   display: 'flex',
   gap: 12,
   justifyContent: 'space-between',
+})
+
+export const choiceGrid = style({
+  display: 'grid',
+  gap: 12,
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      gridTemplateColumns: '1fr',
+    },
+  },
+})
+
+export const choiceButton = recipe({
+  base: {
+    alignItems: 'center',
+    background: theme.surface.onMainContent,
+    border: `1px solid ${theme.stroke.secondary}`,
+    borderRadius: 8,
+    color: theme.content.primary,
+    cursor: 'pointer',
+    display: 'flex',
+    gap: 12,
+    minHeight: 68,
+    padding: 14,
+    textAlign: 'left',
+    transition: 'border-color 120ms ease, background-color 120ms ease',
+    width: '100%',
+    ':hover': {
+      borderColor: theme.stroke.primary,
+    },
+  },
+  variants: {
+    active: {
+      true: {
+        background: theme.surface.mainContent,
+        borderColor: theme.content.primary,
+      },
+      false: {},
+    },
+  },
+})
+
+export const choiceText = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
+  minWidth: 0,
 })
 
 export const fieldGrid = style({
@@ -116,6 +156,18 @@ export const field = style({
   flexDirection: 'column',
   gap: 6,
   minWidth: 0,
+})
+
+export const stack = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+})
+
+export const stackSmall = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
 })
 
 export const select = style({
@@ -160,101 +212,29 @@ export const manifestTextarea = style([
     fontFamily: fontFamily.dmMono,
     fontSize: 12,
     lineHeight: '18px',
-    minHeight: 520,
+    minHeight: 620,
     whiteSpace: 'pre',
   },
 ])
 
-export const stack = style({
+export const generateRow = style({
+  alignItems: 'center',
   display: 'flex',
-  flexDirection: 'column',
-  gap: 12,
-})
-
-export const stackSmall = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 8,
-})
-
-export const itemPanel = style({
-  background: theme.surface.onMainContent,
-  border: `1px solid ${theme.stroke.secondary}`,
-  borderRadius: 8,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 14,
-  padding: 14,
-})
-
-export const itemHeader = style({
-  alignItems: 'flex-start',
-  display: 'flex',
-  gap: 12,
+  gap: 16,
   justifyContent: 'space-between',
-})
-
-export const checkRow = style({
-  alignItems: 'center',
-  display: 'flex',
-  gap: 8,
-  minHeight: 34,
-})
-
-export const segmented = style({
-  background: theme.surface.onMainContent,
-  border: `1px solid ${theme.stroke.secondary}`,
-  borderRadius: 8,
-  display: 'inline-flex',
-  padding: 3,
-  width: 'fit-content',
-})
-
-export const segment = style({
-  background: 'transparent',
-  border: 'none',
-  borderRadius: 6,
-  color: theme.content.secondary,
-  cursor: 'pointer',
-  fontSize: 12,
-  fontWeight: 600,
-  minHeight: 26,
-  paddingBlock: 4,
-  paddingInline: 10,
-  selectors: {
-    '&[data-active="true"]': {
-      background: theme.surface.card,
-      color: theme.content.primary,
-    },
-  },
-})
-
-export const subsectionHead = style({
-  alignItems: 'center',
-  display: 'flex',
-  gap: 12,
-  justifyContent: 'space-between',
-})
-
-export const headerRow = style({
-  alignItems: 'center',
-  display: 'grid',
-  gap: 8,
-  gridTemplateColumns: 'minmax(120px, 1fr) 128px minmax(160px, 1.2fr) auto',
   '@media': {
     [`screen and (max-width: ${breakpoints.mobile})`]: {
       alignItems: 'stretch',
-      gridTemplateColumns: '1fr',
+      flexDirection: 'column',
     },
   },
 })
 
 export const issueBox = style({
   alignItems: 'flex-start',
-  background: theme.pill.amber.background,
-  border: `1px solid ${theme.pill.amber.stroke}`,
+  background: theme.surface.card,
+  border: `1px solid ${theme.stroke.secondary}`,
   borderRadius: 8,
-  color: theme.pill.amber.color,
   display: 'flex',
   gap: 10,
   padding: 12,
@@ -263,8 +243,8 @@ export const issueBox = style({
 export const issueList = style({
   display: 'flex',
   flexDirection: 'column',
-  gap: 2,
-  margin: 0,
+  gap: 4,
+  marginBlock: 4,
   paddingInlineStart: 18,
 })
 
@@ -284,7 +264,12 @@ export const resultSection = style({
 export const resultGrid = style({
   display: 'grid',
   gap: 8,
-  gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      gridTemplateColumns: '1fr',
+    },
+  },
 })
 
 export const resultCard = style({
@@ -299,12 +284,17 @@ export const resultCard = style({
 })
 
 export const queryResult = style({
+  alignItems: 'flex-start',
   background: theme.surface.onMainContent,
   border: `1px solid ${theme.stroke.secondary}`,
   borderRadius: 8,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 6,
-  minWidth: 0,
+  display: 'grid',
+  gap: 8,
+  gridTemplateColumns: 'minmax(0, 1fr) auto',
   padding: 10,
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      gridTemplateColumns: '1fr',
+    },
+  },
 })

--- a/apps/ui/src/views/sources/source-create.css.ts
+++ b/apps/ui/src/views/sources/source-create.css.ts
@@ -1,0 +1,310 @@
+import { style } from '@vanilla-extract/css'
+
+import { breakpoints } from '@/styles/theme'
+import { fontFamily } from '@/wax/theme/font.css'
+import { theme } from '@/wax/theme/theme.css'
+
+export const root = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  overflow: 'auto',
+  paddingBlock: 32,
+  paddingInline: 24,
+})
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
+  marginInline: 'auto',
+  maxWidth: 1280,
+  width: '100%',
+})
+
+export const header = style({
+  alignItems: 'flex-start',
+  display: 'flex',
+  gap: 16,
+  justifyContent: 'space-between',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      flexDirection: 'column',
+    },
+  },
+})
+
+export const headerText = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  minWidth: 0,
+})
+
+export const headerActions = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 8,
+  justifyContent: 'flex-end',
+})
+
+export const layout = style({
+  alignItems: 'flex-start',
+  display: 'grid',
+  gap: 24,
+  gridTemplateColumns: 'minmax(0, 1fr) minmax(360px, 440px)',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.sidebarCollapse})`]: {
+      gridTemplateColumns: '1fr',
+    },
+  },
+})
+
+export const formColumn = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  minWidth: 0,
+  width: '100%',
+})
+
+export const previewColumn = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  minWidth: 0,
+  position: 'sticky',
+  top: 0,
+  width: '100%',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.sidebarCollapse})`]: {
+      position: 'static',
+    },
+  },
+})
+
+export const panel = style({
+  background: theme.surface.card,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 8,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+  padding: 16,
+})
+
+export const panelHead = style({
+  alignItems: 'center',
+  display: 'flex',
+  gap: 12,
+  justifyContent: 'space-between',
+})
+
+export const fieldGrid = style({
+  display: 'grid',
+  gap: 12,
+  gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      gridTemplateColumns: '1fr',
+    },
+  },
+})
+
+export const field = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  minWidth: 0,
+})
+
+export const select = style({
+  background: theme.surface.mainContent,
+  border: `1px solid ${theme.input.stroke.default}`,
+  borderRadius: 8,
+  color: theme.content.primary,
+  fontFamily: 'inherit',
+  fontSize: 13,
+  height: 34,
+  minWidth: 0,
+  outline: 'none',
+  paddingBlock: 0,
+  paddingInline: 10,
+  width: '100%',
+  ':focus': {
+    borderColor: theme.input.stroke.focus,
+  },
+})
+
+export const textarea = style({
+  background: theme.surface.mainContent,
+  border: `1px solid ${theme.input.stroke.default}`,
+  borderRadius: 8,
+  color: theme.content.primary,
+  fontFamily: 'inherit',
+  fontSize: 13,
+  lineHeight: '20px',
+  minHeight: 96,
+  outline: 'none',
+  padding: 10,
+  resize: 'vertical',
+  width: '100%',
+  ':focus': {
+    borderColor: theme.input.stroke.focus,
+  },
+})
+
+export const manifestTextarea = style([
+  textarea,
+  {
+    fontFamily: fontFamily.dmMono,
+    fontSize: 12,
+    lineHeight: '18px',
+    minHeight: 520,
+    whiteSpace: 'pre',
+  },
+])
+
+export const stack = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+})
+
+export const stackSmall = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+})
+
+export const itemPanel = style({
+  background: theme.surface.onMainContent,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 8,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 14,
+  padding: 14,
+})
+
+export const itemHeader = style({
+  alignItems: 'flex-start',
+  display: 'flex',
+  gap: 12,
+  justifyContent: 'space-between',
+})
+
+export const checkRow = style({
+  alignItems: 'center',
+  display: 'flex',
+  gap: 8,
+  minHeight: 34,
+})
+
+export const segmented = style({
+  background: theme.surface.onMainContent,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 8,
+  display: 'inline-flex',
+  padding: 3,
+  width: 'fit-content',
+})
+
+export const segment = style({
+  background: 'transparent',
+  border: 'none',
+  borderRadius: 6,
+  color: theme.content.secondary,
+  cursor: 'pointer',
+  fontSize: 12,
+  fontWeight: 600,
+  minHeight: 26,
+  paddingBlock: 4,
+  paddingInline: 10,
+  selectors: {
+    '&[data-active="true"]': {
+      background: theme.surface.card,
+      color: theme.content.primary,
+    },
+  },
+})
+
+export const subsectionHead = style({
+  alignItems: 'center',
+  display: 'flex',
+  gap: 12,
+  justifyContent: 'space-between',
+})
+
+export const headerRow = style({
+  alignItems: 'center',
+  display: 'grid',
+  gap: 8,
+  gridTemplateColumns: 'minmax(120px, 1fr) 128px minmax(160px, 1.2fr) auto',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      alignItems: 'stretch',
+      gridTemplateColumns: '1fr',
+    },
+  },
+})
+
+export const issueBox = style({
+  alignItems: 'flex-start',
+  background: theme.pill.amber.background,
+  border: `1px solid ${theme.pill.amber.stroke}`,
+  borderRadius: 8,
+  color: theme.pill.amber.color,
+  display: 'flex',
+  gap: 10,
+  padding: 12,
+})
+
+export const issueList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 2,
+  margin: 0,
+  paddingInlineStart: 18,
+})
+
+export const resultHeader = style({
+  alignItems: 'flex-start',
+  display: 'flex',
+  gap: 12,
+  justifyContent: 'space-between',
+})
+
+export const resultSection = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+})
+
+export const resultGrid = style({
+  display: 'grid',
+  gap: 8,
+  gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+})
+
+export const resultCard = style({
+  background: theme.surface.onMainContent,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 8,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  minWidth: 0,
+  padding: 10,
+})
+
+export const queryResult = style({
+  background: theme.surface.onMainContent,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 8,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  minWidth: 0,
+  padding: 10,
+})

--- a/apps/ui/src/views/sources/source-create.tsx
+++ b/apps/ui/src/views/sources/source-create.tsx
@@ -1,0 +1,1405 @@
+import { useMemo, useState } from 'react'
+import type React from 'react'
+
+import { Container as ButtonContainer } from '@/wax/components/button/container'
+import { Icon as ButtonIcon } from '@/wax/components/button/icon'
+import { Text as ButtonText } from '@/wax/components/button/text'
+import { Icon } from '@/wax/components/icon'
+import { TextInput } from '@/wax/components/inputs/text'
+import { addToast } from '@/wax/components/toast'
+import { Typography } from '@/wax/components/typography'
+
+import { ErrorBanner } from '@/components/error-banner'
+import { importSource, validateSource, type InstallInput } from '@/lib/sources'
+
+import * as styles from './source-create.css'
+
+type SourceInputKind = 'variable' | 'secret'
+type SurfaceType = 'openapi' | 'mcp'
+type OpenApiDescriptorKind = 'url' | 'file'
+type OpenApiAuthMode = 'none' | 'bearer' | 'header'
+type HeaderValueMode = 'literal' | 'input' | 'template'
+type McpTransport = 'streamable_http' | 'stdio'
+
+interface SourceInputDraft {
+  id: string
+  key: string
+  kind: SourceInputKind
+  required: boolean
+  defaultValue: string
+  hint: string
+}
+
+interface RequestHeaderDraft {
+  id: string
+  name: string
+  mode: HeaderValueMode
+  value: string
+}
+
+interface SurfaceDraft {
+  id: string
+  surfaceId: string
+  namespaceSuffix: string
+  type: SurfaceType
+  openapiDescriptorKind: OpenApiDescriptorKind
+  openapiDescriptor: string
+  openapiBaseUrl: string
+  openapiAuthMode: OpenApiAuthMode
+  authInputKey: string
+  authHeaderName: string
+  requestHeaders: RequestHeaderDraft[]
+  mcpTransport: McpTransport
+  mcpUrl: string
+  mcpCommand: string
+  mcpArgs: string
+  mcpBearerInputKey: string
+}
+
+interface SourceDraft {
+  name: string
+  description: string
+  inputs: SourceInputDraft[]
+  surfaces: SurfaceDraft[]
+  testQueries: string
+}
+
+type ImportState =
+  | { kind: 'idle' }
+  | { kind: 'importing' }
+  | { kind: 'validating'; sourceName: string }
+  | { kind: 'imported'; sourceName: string }
+  | { kind: 'validated'; sourceName: string; response: Awaited<ReturnType<typeof validateSource>> }
+
+let draftId = 0
+
+function nextDraftId(prefix: string): string {
+  draftId += 1
+  return `${prefix}-${draftId}`
+}
+
+function defaultSurface(): SurfaceDraft {
+  return {
+    id: nextDraftId('surface'),
+    surfaceId: 'rest',
+    namespaceSuffix: '',
+    type: 'openapi',
+    openapiDescriptorKind: 'url',
+    openapiDescriptor:
+      'https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.yaml',
+    openapiBaseUrl: 'https://api.github.com',
+    openapiAuthMode: 'none',
+    authInputKey: '',
+    authHeaderName: 'Authorization',
+    requestHeaders: [
+      {
+        id: nextDraftId('header'),
+        name: 'User-Agent',
+        mode: 'literal',
+        value: 'coral-dsl-v4',
+      },
+    ],
+    mcpTransport: 'streamable_http',
+    mcpUrl: 'https://api.githubcopilot.com/mcp/x/all/readonly',
+    mcpCommand: '',
+    mcpArgs: '',
+    mcpBearerInputKey: '',
+  }
+}
+
+function defaultDraft(): SourceDraft {
+  return {
+    name: 'github_openapi_v4',
+    description: 'Query a generated OpenAPI surface through Coral DSL v4.',
+    inputs: [],
+    surfaces: [defaultSurface()],
+    testQueries: '',
+  }
+}
+
+export function SourceCreate() {
+  const [draft, setDraft] = useState<SourceDraft>(() => defaultDraft())
+  const generatedManifest = useMemo(() => buildManifestYaml(draft), [draft])
+  const [editedManifest, setEditedManifest] = useState<string | null>(null)
+  const [inputValues, setInputValues] = useState<Record<string, string>>({})
+  const [importState, setImportState] = useState<ImportState>({ kind: 'idle' })
+  const [error, setError] = useState<string | null>(null)
+
+  const manifestYaml = editedManifest ?? generatedManifest
+  const validationErrors = useMemo(() => validateDraft(draft), [draft])
+  const installErrors = useMemo(
+    () => validateInstallInputs(draft.inputs, inputValues),
+    [draft.inputs, inputValues],
+  )
+  const canImport =
+    validationErrors.length === 0 &&
+    installErrors.length === 0 &&
+    manifestYaml.trim().length > 0 &&
+    (importState.kind === 'idle' ||
+      importState.kind === 'imported' ||
+      importState.kind === 'validated')
+
+  async function submit(validateAfterImport: boolean) {
+    if (!canImport) return
+
+    setError(null)
+    setImportState({ kind: 'importing' })
+
+    try {
+      const source = await importSource(manifestYaml, installInputs(draft.inputs, inputValues))
+      addToast('neutral', {
+        title: `Imported ${source.name}`,
+        description: 'The DSL v4 source manifest was materialized and installed.',
+      })
+
+      if (!validateAfterImport) {
+        setImportState({ kind: 'imported', sourceName: source.name })
+        return
+      }
+
+      setImportState({ kind: 'validating', sourceName: source.name })
+      const response = await validateSource(source.name)
+      setImportState({ kind: 'validated', sourceName: source.name, response })
+      addToast('neutral', {
+        title: `Validated ${source.name}`,
+        description: validationSummary(response),
+      })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+      setImportState({ kind: 'idle' })
+    }
+  }
+
+  function updateDraft(update: (previous: SourceDraft) => SourceDraft) {
+    setDraft(update)
+    if (editedManifest === null) return
+    setEditedManifest(null)
+  }
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.container}>
+        <div className={styles.header}>
+          <div className={styles.headerText}>
+            <Typography.HeadingLarge as="h1">Create DSL v4 Source</Typography.HeadingLarge>
+            <Typography.Body variant="secondary">
+              Compose an imported source manifest from OpenAPI and MCP surfaces.
+            </Typography.Body>
+          </div>
+          <div className={styles.headerActions}>
+            <ButtonContainer
+              onClick={() => {
+                setDraft(defaultDraft())
+                setEditedManifest(null)
+                setInputValues({})
+                setImportState({ kind: 'idle' })
+                setError(null)
+              }}
+              size="32"
+              variant="secondary"
+            >
+              <ButtonIcon name="RefreshCw" />
+              <ButtonText>Reset</ButtonText>
+            </ButtonContainer>
+            <ButtonContainer
+              disabled={!canImport}
+              onClick={() => void submit(false)}
+              size="32"
+              variant="secondary"
+            >
+              <ButtonIcon name={importState.kind === 'importing' ? 'Loader' : 'Check'} />
+              <ButtonText>{importState.kind === 'importing' ? 'Importing…' : 'Import'}</ButtonText>
+            </ButtonContainer>
+            <ButtonContainer
+              disabled={!canImport}
+              onClick={() => void submit(true)}
+              size="32"
+              variant="primary"
+            >
+              <ButtonIcon
+                name={
+                  importState.kind === 'importing' || importState.kind === 'validating'
+                    ? 'Loader'
+                    : 'Check'
+                }
+              />
+              <ButtonText>{primaryActionLabel(importState)}</ButtonText>
+            </ButtonContainer>
+          </div>
+        </div>
+
+        {validationErrors.length > 0 ? (
+          <InlineIssue title="Manifest fields need attention" messages={validationErrors} />
+        ) : installErrors.length > 0 ? (
+          <InlineIssue title="Installation values need attention" messages={installErrors} />
+        ) : null}
+
+        {error ? <ErrorBanner title="Source import failed" message={error} /> : null}
+
+        <div className={styles.layout}>
+          <div className={styles.formColumn}>
+            <SourceSection draft={draft} updateDraft={updateDraft} />
+            <InputsSection
+              inputs={draft.inputs}
+              updateDraft={updateDraft}
+              inputValues={inputValues}
+              setInputValues={setInputValues}
+            />
+            <SurfacesSection draft={draft} updateDraft={updateDraft} />
+            <TestQueriesSection draft={draft} updateDraft={updateDraft} />
+          </div>
+
+          <aside className={styles.previewColumn}>
+            <div className={styles.panel}>
+              <div className={styles.panelHead}>
+                <div>
+                  <Typography.HeadingSmall as="h2">Manifest</Typography.HeadingSmall>
+                  {editedManifest ? (
+                    <Typography.BodySmall variant="tertiary">
+                      Edited YAML is being imported.
+                    </Typography.BodySmall>
+                  ) : null}
+                </div>
+                {editedManifest ? (
+                  <ButtonContainer onClick={() => setEditedManifest(null)} size="22" variant="bare">
+                    <ButtonText>Reset YAML</ButtonText>
+                  </ButtonContainer>
+                ) : null}
+              </div>
+              <textarea
+                aria-label="Manifest YAML"
+                className={styles.manifestTextarea}
+                spellCheck={false}
+                value={manifestYaml}
+                onChange={(event) => setEditedManifest(event.target.value)}
+              />
+            </div>
+
+            <InstallValuesSection
+              inputs={draft.inputs}
+              inputValues={inputValues}
+              setInputValues={setInputValues}
+            />
+          </aside>
+        </div>
+
+        {importState.kind === 'imported' ? (
+          <ResultPanel
+            title={`Imported ${importState.sourceName}`}
+            body="Run validation to inspect the tables and functions exposed by this source."
+            action={
+              <ButtonContainer
+                onClick={async () => {
+                  setError(null)
+                  setImportState({ kind: 'validating', sourceName: importState.sourceName })
+                  try {
+                    const response = await validateSource(importState.sourceName)
+                    setImportState({
+                      kind: 'validated',
+                      sourceName: importState.sourceName,
+                      response,
+                    })
+                  } catch (e) {
+                    setError(e instanceof Error ? e.message : String(e))
+                    setImportState({ kind: 'imported', sourceName: importState.sourceName })
+                  }
+                }}
+                size="32"
+                variant="secondary"
+              >
+                <ButtonIcon name="Check" />
+                <ButtonText>Validate</ButtonText>
+              </ButtonContainer>
+            }
+          />
+        ) : null}
+
+        {importState.kind === 'validated' ? <ValidationResult state={importState} /> : null}
+      </div>
+    </div>
+  )
+}
+
+function SourceSection({
+  draft,
+  updateDraft,
+}: {
+  draft: SourceDraft
+  updateDraft: (update: (previous: SourceDraft) => SourceDraft) => void
+}) {
+  return (
+    <section className={styles.panel}>
+      <Typography.HeadingSmall as="h2">Source</Typography.HeadingSmall>
+      <div className={styles.fieldGrid}>
+        <Field label="Name">
+          <TextInput
+            value={draft.name}
+            onChange={(name) => updateDraft((previous) => ({ ...previous, name }))}
+            placeholder="github_v4"
+          />
+        </Field>
+        <Field label="Description">
+          <TextInput
+            value={draft.description}
+            onChange={(description) => updateDraft((previous) => ({ ...previous, description }))}
+            placeholder="Query data from a provider API"
+          />
+        </Field>
+      </div>
+    </section>
+  )
+}
+
+function InputsSection({
+  inputs,
+  updateDraft,
+  inputValues,
+  setInputValues,
+}: {
+  inputs: SourceInputDraft[]
+  updateDraft: (update: (previous: SourceDraft) => SourceDraft) => void
+  inputValues: Record<string, string>
+  setInputValues: React.Dispatch<React.SetStateAction<Record<string, string>>>
+}) {
+  return (
+    <section className={styles.panel}>
+      <div className={styles.panelHead}>
+        <Typography.HeadingSmall as="h2">Inputs</Typography.HeadingSmall>
+        <ButtonContainer
+          onClick={() =>
+            updateDraft((previous) => ({
+              ...previous,
+              inputs: [
+                ...previous.inputs,
+                {
+                  id: nextDraftId('input'),
+                  key: `API_TOKEN_${previous.inputs.length + 1}`,
+                  kind: 'secret',
+                  required: true,
+                  defaultValue: '',
+                  hint: '',
+                },
+              ],
+            }))
+          }
+          size="32"
+          variant="secondary"
+        >
+          <ButtonIcon name="Plus" />
+          <ButtonText>Add input</ButtonText>
+        </ButtonContainer>
+      </div>
+
+      {inputs.length === 0 ? (
+        <Typography.BodySmall variant="tertiary">
+          No source inputs. Add one for API tokens, tenants, base URLs, or MCP auth.
+        </Typography.BodySmall>
+      ) : (
+        <div className={styles.stack}>
+          {inputs.map((input) => (
+            <InputEditor
+              key={input.id}
+              input={input}
+              inputValue={inputValues[input.id] ?? ''}
+              onInputValueChange={(value) =>
+                setInputValues((previous) => ({ ...previous, [input.id]: value }))
+              }
+              updateDraft={updateDraft}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function InputEditor({
+  input,
+  inputValue,
+  onInputValueChange,
+  updateDraft,
+}: {
+  input: SourceInputDraft
+  inputValue: string
+  onInputValueChange: (value: string) => void
+  updateDraft: (update: (previous: SourceDraft) => SourceDraft) => void
+}) {
+  const updateInput = (patch: Partial<SourceInputDraft>) => {
+    updateDraft((previous) => ({
+      ...previous,
+      inputs: previous.inputs.map((item) => (item.id === input.id ? { ...item, ...patch } : item)),
+    }))
+  }
+
+  return (
+    <div className={styles.itemPanel}>
+      <div className={styles.itemHeader}>
+        <Typography.BodyLargeStrong>{input.key || 'New input'}</Typography.BodyLargeStrong>
+        <ButtonContainer
+          onClick={() =>
+            updateDraft((previous) => ({
+              ...previous,
+              inputs: previous.inputs.filter((item) => item.id !== input.id),
+              surfaces: previous.surfaces.map((surface) => ({
+                ...surface,
+                authInputKey: surface.authInputKey === input.key ? '' : surface.authInputKey,
+                mcpBearerInputKey:
+                  surface.mcpBearerInputKey === input.key ? '' : surface.mcpBearerInputKey,
+              })),
+            }))
+          }
+          size="22"
+          variant="bare"
+        >
+          <ButtonIcon name="X" />
+          <ButtonText>Remove</ButtonText>
+        </ButtonContainer>
+      </div>
+      <div className={styles.fieldGrid}>
+        <Field label="Key">
+          <TextInput value={input.key} onChange={(key) => updateInput({ key })} />
+        </Field>
+        <Field label="Kind">
+          <select
+            className={styles.select}
+            value={input.kind}
+            onChange={(event) =>
+              updateInput({
+                kind: event.target.value as SourceInputKind,
+                defaultValue: event.target.value === 'secret' ? '' : input.defaultValue,
+              })
+            }
+          >
+            <option value="secret">Secret</option>
+            <option value="variable">Variable</option>
+          </select>
+        </Field>
+        <Field label="Install value">
+          <TextInput
+            type={input.kind === 'secret' ? 'password' : 'text'}
+            value={inputValue}
+            onChange={onInputValueChange}
+            placeholder={input.defaultValue || input.key}
+          />
+        </Field>
+        {input.kind === 'variable' ? (
+          <Field label="Default">
+            <TextInput
+              value={input.defaultValue}
+              onChange={(defaultValue) => updateInput({ defaultValue })}
+              placeholder="https://api.example.com"
+            />
+          </Field>
+        ) : null}
+      </div>
+      <div className={styles.fieldGrid}>
+        <label className={styles.checkRow}>
+          <input
+            type="checkbox"
+            checked={input.required}
+            onChange={(event) => updateInput({ required: event.target.checked })}
+          />
+          <Typography.BodySmall>Required</Typography.BodySmall>
+        </label>
+        <Field label="Hint">
+          <TextInput
+            value={input.hint}
+            onChange={(hint) => updateInput({ hint })}
+            placeholder="Where to find this value"
+          />
+        </Field>
+      </div>
+    </div>
+  )
+}
+
+function SurfacesSection({
+  draft,
+  updateDraft,
+}: {
+  draft: SourceDraft
+  updateDraft: (update: (previous: SourceDraft) => SourceDraft) => void
+}) {
+  return (
+    <section className={styles.panel}>
+      <div className={styles.panelHead}>
+        <Typography.HeadingSmall as="h2">Surfaces</Typography.HeadingSmall>
+        <ButtonContainer
+          onClick={() =>
+            updateDraft((previous) => {
+              const surface = defaultSurface()
+              surface.surfaceId = previous.surfaces.some((item) => item.surfaceId === 'mcp')
+                ? `surface_${previous.surfaces.length + 1}`
+                : 'mcp'
+              surface.namespaceSuffix = surface.surfaceId
+              surface.type = 'mcp'
+              return { ...previous, surfaces: [...previous.surfaces, surface] }
+            })
+          }
+          size="32"
+          variant="secondary"
+        >
+          <ButtonIcon name="Plus" />
+          <ButtonText>Add surface</ButtonText>
+        </ButtonContainer>
+      </div>
+      <div className={styles.stack}>
+        {draft.surfaces.map((surface) => (
+          <SurfaceEditor
+            key={surface.id}
+            draft={draft}
+            surface={surface}
+            updateDraft={updateDraft}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function SurfaceEditor({
+  draft,
+  surface,
+  updateDraft,
+}: {
+  draft: SourceDraft
+  surface: SurfaceDraft
+  updateDraft: (update: (previous: SourceDraft) => SourceDraft) => void
+}) {
+  const secretInputs = draft.inputs.filter((input) => input.kind === 'secret')
+  const updateSurface = (patch: Partial<SurfaceDraft>) => {
+    updateDraft((previous) => ({
+      ...previous,
+      surfaces: previous.surfaces.map((item) =>
+        item.id === surface.id ? { ...item, ...patch } : item,
+      ),
+    }))
+  }
+
+  return (
+    <div className={styles.itemPanel}>
+      <div className={styles.itemHeader}>
+        <div>
+          <Typography.BodyLargeStrong>
+            {surface.surfaceId || 'New surface'}
+          </Typography.BodyLargeStrong>
+          <Typography.BodySmall variant="tertiary">
+            {relationName(draft.name, surface)}
+          </Typography.BodySmall>
+        </div>
+        <ButtonContainer
+          disabled={draft.surfaces.length === 1}
+          onClick={() =>
+            updateDraft((previous) => ({
+              ...previous,
+              surfaces: previous.surfaces.filter((item) => item.id !== surface.id),
+            }))
+          }
+          size="22"
+          variant="bare"
+        >
+          <ButtonIcon name="X" />
+          <ButtonText>Remove</ButtonText>
+        </ButtonContainer>
+      </div>
+
+      <div className={styles.fieldGrid}>
+        <Field label="Surface ID">
+          <TextInput
+            value={surface.surfaceId}
+            onChange={(surfaceId) => updateSurface({ surfaceId })}
+          />
+        </Field>
+        <Field label="Namespace suffix">
+          <TextInput
+            value={surface.namespaceSuffix}
+            onChange={(namespaceSuffix) => updateSurface({ namespaceSuffix })}
+            placeholder="default namespace"
+          />
+        </Field>
+        <Field label="Type">
+          <div className={styles.segmented}>
+            <button
+              type="button"
+              className={styles.segment}
+              data-active={surface.type === 'openapi' ? 'true' : 'false'}
+              onClick={() => updateSurface({ type: 'openapi' })}
+            >
+              OpenAPI
+            </button>
+            <button
+              type="button"
+              className={styles.segment}
+              data-active={surface.type === 'mcp' ? 'true' : 'false'}
+              onClick={() => updateSurface({ type: 'mcp' })}
+            >
+              MCP
+            </button>
+          </div>
+        </Field>
+      </div>
+
+      {surface.type === 'openapi' ? (
+        <OpenApiSurfaceEditor
+          inputs={draft.inputs}
+          surface={surface}
+          secretInputs={secretInputs}
+          updateSurface={updateSurface}
+        />
+      ) : (
+        <McpSurfaceEditor
+          surface={surface}
+          secretInputs={secretInputs}
+          updateSurface={updateSurface}
+        />
+      )}
+    </div>
+  )
+}
+
+function OpenApiSurfaceEditor({
+  inputs,
+  surface,
+  secretInputs,
+  updateSurface,
+}: {
+  inputs: SourceInputDraft[]
+  surface: SurfaceDraft
+  secretInputs: SourceInputDraft[]
+  updateSurface: (patch: Partial<SurfaceDraft>) => void
+}) {
+  return (
+    <>
+      <div className={styles.fieldGrid}>
+        <Field label="Descriptor">
+          <select
+            className={styles.select}
+            value={surface.openapiDescriptorKind}
+            onChange={(event) =>
+              updateSurface({ openapiDescriptorKind: event.target.value as OpenApiDescriptorKind })
+            }
+          >
+            <option value="url">HTTPS URL</option>
+            <option value="file">Absolute file path</option>
+          </select>
+        </Field>
+        <Field label={surface.openapiDescriptorKind === 'url' ? 'OpenAPI URL' : 'OpenAPI file'}>
+          <TextInput
+            type={surface.openapiDescriptorKind === 'url' ? 'url' : 'text'}
+            value={surface.openapiDescriptor}
+            onChange={(openapiDescriptor) => updateSurface({ openapiDescriptor })}
+            placeholder={
+              surface.openapiDescriptorKind === 'url'
+                ? 'https://example.com/openapi.yaml'
+                : '/absolute/path/openapi.yaml'
+            }
+          />
+        </Field>
+        <Field label="Base URL">
+          <TextInput
+            value={surface.openapiBaseUrl}
+            onChange={(openapiBaseUrl) => updateSurface({ openapiBaseUrl })}
+            placeholder="https://api.example.com"
+          />
+        </Field>
+      </div>
+
+      <div className={styles.fieldGrid}>
+        <Field label="Auth">
+          <select
+            className={styles.select}
+            value={surface.openapiAuthMode}
+            onChange={(event) =>
+              updateSurface({ openapiAuthMode: event.target.value as OpenApiAuthMode })
+            }
+          >
+            <option value="none">None</option>
+            <option value="bearer">Bearer token</option>
+            <option value="header">Header from secret</option>
+          </select>
+        </Field>
+        {surface.openapiAuthMode !== 'none' ? (
+          <Field label="Secret input">
+            <InputKeySelect
+              inputs={secretInputs}
+              value={surface.authInputKey}
+              onChange={(authInputKey) => updateSurface({ authInputKey })}
+            />
+          </Field>
+        ) : null}
+        {surface.openapiAuthMode === 'header' ? (
+          <Field label="Header name">
+            <TextInput
+              value={surface.authHeaderName}
+              onChange={(authHeaderName) => updateSurface({ authHeaderName })}
+              placeholder="X-API-Key"
+            />
+          </Field>
+        ) : null}
+      </div>
+
+      <div className={styles.subsectionHead}>
+        <Typography.BodyStrong>Request headers</Typography.BodyStrong>
+        <ButtonContainer
+          onClick={() =>
+            updateSurface({
+              requestHeaders: [
+                ...surface.requestHeaders,
+                { id: nextDraftId('header'), name: '', mode: 'literal', value: '' },
+              ],
+            })
+          }
+          size="22"
+          variant="bare"
+        >
+          <ButtonIcon name="Plus" />
+          <ButtonText>Add header</ButtonText>
+        </ButtonContainer>
+      </div>
+      {surface.requestHeaders.length > 0 ? (
+        <div className={styles.stackSmall}>
+          {surface.requestHeaders.map((header) => (
+            <RequestHeaderEditor
+              key={header.id}
+              header={header}
+              inputs={inputs}
+              updateHeader={(patch) =>
+                updateSurface({
+                  requestHeaders: surface.requestHeaders.map((item) =>
+                    item.id === header.id ? { ...item, ...patch } : item,
+                  ),
+                })
+              }
+              removeHeader={() =>
+                updateSurface({
+                  requestHeaders: surface.requestHeaders.filter((item) => item.id !== header.id),
+                })
+              }
+            />
+          ))}
+        </div>
+      ) : null}
+    </>
+  )
+}
+
+function McpSurfaceEditor({
+  surface,
+  secretInputs,
+  updateSurface,
+}: {
+  surface: SurfaceDraft
+  secretInputs: SourceInputDraft[]
+  updateSurface: (patch: Partial<SurfaceDraft>) => void
+}) {
+  return (
+    <>
+      <div className={styles.fieldGrid}>
+        <Field label="Transport">
+          <select
+            className={styles.select}
+            value={surface.mcpTransport}
+            onChange={(event) =>
+              updateSurface({ mcpTransport: event.target.value as McpTransport })
+            }
+          >
+            <option value="streamable_http">Streamable HTTP</option>
+            <option value="stdio">Stdio</option>
+          </select>
+        </Field>
+        {surface.mcpTransport === 'streamable_http' ? (
+          <Field label="MCP URL">
+            <TextInput
+              type="url"
+              value={surface.mcpUrl}
+              onChange={(mcpUrl) => updateSurface({ mcpUrl })}
+              placeholder="https://example.com/mcp"
+            />
+          </Field>
+        ) : (
+          <Field label="Command">
+            <TextInput
+              value={surface.mcpCommand}
+              onChange={(mcpCommand) => updateSurface({ mcpCommand })}
+              placeholder="npx"
+            />
+          </Field>
+        )}
+        {surface.mcpTransport === 'stdio' ? (
+          <Field label="Arguments">
+            <TextInput
+              value={surface.mcpArgs}
+              onChange={(mcpArgs) => updateSurface({ mcpArgs })}
+              placeholder="-y @modelcontextprotocol/server-example"
+            />
+          </Field>
+        ) : null}
+      </div>
+      {surface.mcpTransport === 'streamable_http' ? (
+        <div className={styles.fieldGrid}>
+          <Field label="Bearer input">
+            <InputKeySelect
+              allowEmpty
+              inputs={secretInputs}
+              value={surface.mcpBearerInputKey}
+              onChange={(mcpBearerInputKey) => updateSurface({ mcpBearerInputKey })}
+            />
+          </Field>
+        </div>
+      ) : null}
+    </>
+  )
+}
+
+function RequestHeaderEditor({
+  header,
+  inputs,
+  updateHeader,
+  removeHeader,
+}: {
+  header: RequestHeaderDraft
+  inputs: SourceInputDraft[]
+  updateHeader: (patch: Partial<RequestHeaderDraft>) => void
+  removeHeader: () => void
+}) {
+  return (
+    <div className={styles.headerRow}>
+      <TextInput
+        value={header.name}
+        onChange={(name) => updateHeader({ name })}
+        placeholder="Header"
+      />
+      <select
+        className={styles.select}
+        value={header.mode}
+        onChange={(event) => updateHeader({ mode: event.target.value as HeaderValueMode })}
+      >
+        <option value="literal">Literal</option>
+        <option value="input">Input</option>
+        <option value="template">Template</option>
+      </select>
+      {header.mode === 'input' ? (
+        <InputKeySelect
+          inputs={inputs}
+          value={header.value}
+          onChange={(value) => updateHeader({ value })}
+        />
+      ) : (
+        <TextInput value={header.value} onChange={(value) => updateHeader({ value })} />
+      )}
+      <ButtonContainer ariaLabel="Remove header" onClick={removeHeader} size="32" variant="bare">
+        <ButtonIcon name="X" />
+      </ButtonContainer>
+    </div>
+  )
+}
+
+function TestQueriesSection({
+  draft,
+  updateDraft,
+}: {
+  draft: SourceDraft
+  updateDraft: (update: (previous: SourceDraft) => SourceDraft) => void
+}) {
+  return (
+    <section className={styles.panel}>
+      <Typography.HeadingSmall as="h2">Test Queries</Typography.HeadingSmall>
+      <textarea
+        aria-label="Test queries"
+        className={styles.textarea}
+        value={draft.testQueries}
+        onChange={(event) =>
+          updateDraft((previous) => ({ ...previous, testQueries: event.target.value }))
+        }
+        placeholder="SELECT * FROM github_openapi_v4.search_issues_and_pull_requests(q => 'repo:octocat/Hello-World is:issue') LIMIT 5"
+      />
+    </section>
+  )
+}
+
+function InstallValuesSection({
+  inputs,
+  inputValues,
+  setInputValues,
+}: {
+  inputs: SourceInputDraft[]
+  inputValues: Record<string, string>
+  setInputValues: React.Dispatch<React.SetStateAction<Record<string, string>>>
+}) {
+  return (
+    <div className={styles.panel}>
+      <Typography.HeadingSmall as="h2">Install Values</Typography.HeadingSmall>
+      {inputs.length === 0 ? (
+        <Typography.BodySmall variant="tertiary">
+          No values needed for this manifest.
+        </Typography.BodySmall>
+      ) : (
+        <div className={styles.stackSmall}>
+          {inputs.map((input) => (
+            <Field key={input.id} label={input.key || 'Input'}>
+              <TextInput
+                type={input.kind === 'secret' ? 'password' : 'text'}
+                value={inputValues[input.id] ?? ''}
+                onChange={(value) =>
+                  setInputValues((previous) => ({ ...previous, [input.id]: value }))
+                }
+                placeholder={input.defaultValue || input.key}
+              />
+            </Field>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ValidationResult({ state }: { state: Extract<ImportState, { kind: 'validated' }> }) {
+  const { response } = state
+  return (
+    <section className={styles.panel}>
+      <div className={styles.resultHeader}>
+        <div>
+          <Typography.HeadingSmall as="h2">Validated {state.sourceName}</Typography.HeadingSmall>
+          <Typography.BodySmall variant="tertiary">
+            {validationSummary(response)}
+          </Typography.BodySmall>
+        </div>
+        <Icon name="CircleCheck" size="24" color="success" />
+      </div>
+
+      {response.tables.length > 0 ? (
+        <div className={styles.resultSection}>
+          <Typography.BodyStrong>Tables</Typography.BodyStrong>
+          <div className={styles.resultGrid}>
+            {response.tables.slice(0, 8).map((table) => (
+              <div className={styles.resultCard} key={`${table.schemaName}.${table.name}`}>
+                <Typography.BodySmallStrong>
+                  {table.schemaName}.{table.name}
+                </Typography.BodySmallStrong>
+                <Typography.BodySmall variant="tertiary">
+                  {table.columns.length} columns
+                  {table.requiredFilters.length
+                    ? `, ${table.requiredFilters.length} required filters`
+                    : ''}
+                </Typography.BodySmall>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {response.tableFunctions.length > 0 ? (
+        <div className={styles.resultSection}>
+          <Typography.BodyStrong>Table Functions</Typography.BodyStrong>
+          <div className={styles.resultGrid}>
+            {response.tableFunctions.slice(0, 8).map((fn) => (
+              <div className={styles.resultCard} key={`${fn.schemaName}.${fn.name}`}>
+                <Typography.BodySmallStrong>
+                  {fn.schemaName}.{fn.name}
+                </Typography.BodySmallStrong>
+                <Typography.BodySmall variant="tertiary">
+                  {fn.arguments.length} args, {fn.resultColumns.length} columns
+                </Typography.BodySmall>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {response.queryTests.length > 0 ? (
+        <div className={styles.resultSection}>
+          <Typography.BodyStrong>Query Tests</Typography.BodyStrong>
+          <div className={styles.stackSmall}>
+            {response.queryTests.map((test) => (
+              <div className={styles.queryResult} key={test.sql}>
+                <Typography.CodeSmallInline>{test.sql}</Typography.CodeSmallInline>
+                <Typography.BodySmall
+                  variant={test.outcome.case === 'failure' ? 'tertiary' : 'secondary'}
+                >
+                  {test.outcome.case === 'success'
+                    ? `${test.outcome.value.rowCount.toString()} rows`
+                    : test.outcome.case === 'failure'
+                      ? test.outcome.value.errorMessage
+                      : 'No result'}
+                </Typography.BodySmall>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+function ResultPanel({
+  title,
+  body,
+  action,
+}: {
+  title: string
+  body: string
+  action: React.ReactNode
+}) {
+  return (
+    <section className={styles.panel}>
+      <div className={styles.resultHeader}>
+        <div>
+          <Typography.HeadingSmall as="h2">{title}</Typography.HeadingSmall>
+          <Typography.BodySmall variant="tertiary">{body}</Typography.BodySmall>
+        </div>
+        {action}
+      </div>
+    </section>
+  )
+}
+
+function InlineIssue({ title, messages }: { title: string; messages: string[] }) {
+  return (
+    <div className={styles.issueBox}>
+      <Icon name="CircleAlert" size="16" color="warning" />
+      <div>
+        <Typography.BodySmallStrong>{title}</Typography.BodySmallStrong>
+        <ul className={styles.issueList}>
+          {messages.slice(0, 4).map((message) => (
+            <li key={message}>
+              <Typography.BodySmall variant="secondary">{message}</Typography.BodySmall>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className={styles.field}>
+      <Typography.BodySmallStrong>{label}</Typography.BodySmallStrong>
+      {children}
+    </label>
+  )
+}
+
+function InputKeySelect({
+  inputs,
+  value,
+  onChange,
+  allowEmpty,
+}: {
+  inputs: SourceInputDraft[]
+  value: string
+  onChange: (value: string) => void
+  allowEmpty?: boolean
+}) {
+  return (
+    <select
+      className={styles.select}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {allowEmpty ? <option value="">None</option> : null}
+      {!allowEmpty && value === '' ? <option value="">Select input</option> : null}
+      {inputs.map((input) => (
+        <option key={input.id} value={input.key}>
+          {input.key}
+        </option>
+      ))}
+    </select>
+  )
+}
+
+function buildManifestYaml(draft: SourceDraft): string {
+  const lines: string[] = []
+  lines.push(`name: ${yamlScalar(draft.name)}`)
+  lines.push('dsl_version: 4')
+  if (draft.description.trim()) emitStringField(lines, 0, 'description', draft.description.trim())
+  lines.push('surfaces:')
+
+  for (const surface of draft.surfaces) {
+    lines.push(`  - id: ${yamlScalar(surface.surfaceId)}`)
+    if (surface.namespaceSuffix.trim()) {
+      lines.push(`    namespace_suffix: ${yamlScalar(surface.namespaceSuffix.trim())}`)
+    }
+    lines.push(`    type: ${surface.type}`)
+
+    if (surface.type === 'openapi') {
+      const descriptorKey = surface.openapiDescriptorKind === 'url' ? 'url' : 'file'
+      lines.push(`    ${descriptorKey}: ${yamlScalar(surface.openapiDescriptor.trim())}`)
+      emitInputs(lines, 4, draft.inputs)
+      if (surface.openapiBaseUrl.trim()) {
+        lines.push(`    base_url: ${yamlScalar(surface.openapiBaseUrl.trim())}`)
+      }
+      emitOpenApiAuth(lines, surface)
+      emitRequestHeaders(lines, surface.requestHeaders)
+    } else {
+      emitInputs(lines, 4, draft.inputs)
+      lines.push('    server:')
+      if (surface.mcpTransport === 'streamable_http') {
+        lines.push('      transport: streamable_http')
+        lines.push(`      url: ${yamlScalar(surface.mcpUrl.trim())}`)
+        if (surface.mcpBearerInputKey) {
+          lines.push('      auth:')
+          lines.push('        type: bearer')
+          lines.push('        from: input')
+          lines.push(`        key: ${yamlScalar(surface.mcpBearerInputKey)}`)
+        }
+      } else {
+        lines.push('      transport: stdio')
+        lines.push(`      command: ${yamlScalar(surface.mcpCommand.trim())}`)
+        const args = splitArgs(surface.mcpArgs)
+        if (args.length > 0) {
+          lines.push('      args:')
+          for (const arg of args) lines.push(`        - ${yamlScalar(arg)}`)
+        }
+      }
+    }
+  }
+
+  const queries = draft.testQueries
+    .split('\n')
+    .map((query) => query.trim())
+    .filter(Boolean)
+  if (queries.length > 0) {
+    lines.push('test_queries:')
+    for (const query of queries) lines.push(`  - ${yamlScalar(query)}`)
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+function emitInputs(lines: string[], indent: number, inputs: SourceInputDraft[]) {
+  if (inputs.length === 0) return
+  const pad = ' '.repeat(indent)
+  lines.push(`${pad}inputs:`)
+  for (const input of inputs) {
+    lines.push(`${pad}  ${input.key || 'INPUT'}:`)
+    lines.push(`${pad}    kind: ${input.kind}`)
+    if (input.kind === 'variable' && input.defaultValue.trim()) {
+      lines.push(`${pad}    default: ${yamlScalar(input.defaultValue.trim())}`)
+    }
+    const requiredDefault = input.kind === 'variable' && input.defaultValue.trim().length > 0
+    if (input.required === false || requiredDefault) {
+      lines.push(`${pad}    required: ${input.required ? 'true' : 'false'}`)
+    }
+    if (input.hint.trim()) emitStringField(lines, indent + 4, 'hint', input.hint.trim())
+  }
+}
+
+function emitOpenApiAuth(lines: string[], surface: SurfaceDraft) {
+  if (surface.openapiAuthMode === 'none') return
+  lines.push('    auth:')
+  lines.push('      type: HeaderAuth')
+  lines.push('      headers:')
+  if (surface.openapiAuthMode === 'bearer') {
+    lines.push('        - name: Authorization')
+    lines.push('          from: template')
+    lines.push(`          template: ${yamlScalar(`Bearer {{input.${surface.authInputKey}}}`)}`)
+    return
+  }
+  lines.push(`        - name: ${yamlScalar(surface.authHeaderName.trim())}`)
+  lines.push('          from: input')
+  lines.push(`          key: ${yamlScalar(surface.authInputKey)}`)
+}
+
+function emitRequestHeaders(lines: string[], headers: RequestHeaderDraft[]) {
+  const active = headers.filter((header) => header.name.trim() && header.value.trim())
+  if (active.length === 0) return
+  lines.push('    request_headers:')
+  for (const header of active) {
+    lines.push(`      - name: ${yamlScalar(header.name.trim())}`)
+    if (header.mode === 'input') {
+      lines.push('        from: input')
+      lines.push(`        key: ${yamlScalar(header.value.trim())}`)
+    } else if (header.mode === 'template') {
+      lines.push('        from: template')
+      lines.push(`        template: ${yamlScalar(header.value.trim())}`)
+    } else {
+      lines.push('        from: literal')
+      lines.push(`        value: ${yamlScalar(header.value.trim())}`)
+    }
+  }
+}
+
+function emitStringField(lines: string[], indent: number, key: string, value: string) {
+  const pad = ' '.repeat(indent)
+  if (value.includes('\n')) {
+    lines.push(`${pad}${key}: |`)
+    for (const line of value.split('\n')) lines.push(`${pad}  ${line}`)
+  } else {
+    lines.push(`${pad}${key}: ${yamlScalar(value)}`)
+  }
+}
+
+function yamlScalar(value: string): string {
+  return JSON.stringify(value)
+}
+
+function splitArgs(raw: string): string[] {
+  return raw
+    .split(/\s+/)
+    .map((arg) => arg.trim())
+    .filter(Boolean)
+}
+
+function validateDraft(draft: SourceDraft): string[] {
+  const errors: string[] = []
+  if (!/^[a-z][a-z0-9_]*$/.test(draft.name)) {
+    errors.push('Source name must match [a-z][a-z0-9_]*.')
+  }
+  if (['coral', 'coral_admin', 'public'].includes(draft.name)) {
+    errors.push(`Source name '${draft.name}' is reserved.`)
+  }
+  validateInputs(draft.inputs, errors)
+  validateSurfaces(draft, errors)
+  return errors
+}
+
+function validateInputs(inputs: SourceInputDraft[], errors: string[]) {
+  const seen = new Set<string>()
+  for (const input of inputs) {
+    if (!input.key.trim()) errors.push('Input keys must not be empty.')
+    if (/[=/\\\n\r]/.test(input.key) || input.key.startsWith('#')) {
+      errors.push(`Input '${input.key}' contains characters the source spec rejects.`)
+    }
+    if (seen.has(input.key)) errors.push(`Input '${input.key}' is declared more than once.`)
+    seen.add(input.key)
+    if (input.kind === 'secret' && input.defaultValue) {
+      errors.push(`Secret input '${input.key}' cannot declare a default.`)
+    }
+    if (input.kind === 'variable' && credentialLike(input.key)) {
+      errors.push(`Credential-looking input '${input.key}' must be a secret.`)
+    }
+  }
+}
+
+function validateSurfaces(draft: SourceDraft, errors: string[]) {
+  const surfaceIds = new Set<string>()
+  const namespaces = new Set<string>()
+  let defaultNamespaceSurface: string | null = null
+  const inputKeys = new Set(draft.inputs.map((input) => input.key))
+  const secretKeys = new Set(
+    draft.inputs.filter((input) => input.kind === 'secret').map((input) => input.key),
+  )
+
+  for (const surface of draft.surfaces) {
+    if (!/^[a-z][a-z0-9_]*$/.test(surface.surfaceId)) {
+      errors.push(`Surface '${surface.surfaceId}' must match [a-z][a-z0-9_]*.`)
+    }
+    if (surfaceIds.has(surface.surfaceId)) {
+      errors.push(`Surface '${surface.surfaceId}' is declared more than once.`)
+    }
+    surfaceIds.add(surface.surfaceId)
+
+    if (surface.namespaceSuffix.trim()) {
+      if (!/^[a-z][a-z0-9_]*$/.test(surface.namespaceSuffix)) {
+        errors.push(`Surface '${surface.surfaceId}' namespace suffix must match [a-z][a-z0-9_]*.`)
+      }
+    } else if (draft.surfaces.length > 1) {
+      if (defaultNamespaceSurface) {
+        errors.push(
+          `Surfaces '${defaultNamespaceSurface}' and '${surface.surfaceId}' both use the default namespace.`,
+        )
+      }
+      defaultNamespaceSurface = surface.surfaceId
+    }
+
+    const namespace = relationName(draft.name, surface)
+    if (namespaces.has(namespace)) errors.push(`Relation namespace '${namespace}' is duplicated.`)
+    namespaces.add(namespace)
+
+    if (surface.type === 'openapi') {
+      if (!surface.openapiDescriptor.trim()) {
+        errors.push(`Surface '${surface.surfaceId}' needs a descriptor.`)
+      }
+      if (
+        surface.openapiDescriptorKind === 'url' &&
+        !surface.openapiDescriptor.trim().startsWith('https://')
+      ) {
+        errors.push(`Surface '${surface.surfaceId}' OpenAPI URL must use https.`)
+      }
+      if (
+        surface.openapiDescriptorKind === 'file' &&
+        !surface.openapiDescriptor.trim().startsWith('/')
+      ) {
+        errors.push(`Surface '${surface.surfaceId}' file descriptor must be absolute.`)
+      }
+      if (surface.openapiAuthMode !== 'none' && !secretKeys.has(surface.authInputKey)) {
+        errors.push(`Surface '${surface.surfaceId}' auth must reference a secret input.`)
+      }
+      if (surface.openapiAuthMode === 'header' && !surface.authHeaderName.trim()) {
+        errors.push(`Surface '${surface.surfaceId}' auth header name is required.`)
+      }
+      for (const header of surface.requestHeaders) {
+        if (
+          (header.name.trim() && !header.value.trim()) ||
+          (!header.name.trim() && header.value.trim())
+        ) {
+          errors.push(`Surface '${surface.surfaceId}' has an incomplete request header.`)
+        }
+        if (header.mode === 'input' && header.value.trim() && !inputKeys.has(header.value)) {
+          errors.push(`Surface '${surface.surfaceId}' request header references an unknown input.`)
+        }
+      }
+    } else if (surface.mcpTransport === 'streamable_http') {
+      if (!surface.mcpUrl.trim()) {
+        errors.push(`Surface '${surface.surfaceId}' needs an MCP URL.`)
+      }
+      if (surface.mcpBearerInputKey && !secretKeys.has(surface.mcpBearerInputKey)) {
+        errors.push(`Surface '${surface.surfaceId}' MCP auth must reference a secret input.`)
+      }
+    } else if (!surface.mcpCommand.trim()) {
+      errors.push(`Surface '${surface.surfaceId}' needs a stdio command.`)
+    }
+  }
+}
+
+function credentialLike(key: string): boolean {
+  return [
+    'API_KEY',
+    'APPLICATION_KEY',
+    'ACCESS_KEY',
+    'ACCESS_TOKEN',
+    'ADMIN_KEY',
+    'AUTHORIZATION',
+    'BEARER_TOKEN',
+    'CLIENT_SECRET',
+    'PASSWORD',
+    'PRIVATE_KEY',
+    'READ_KEY',
+    'SECRET',
+    'TOKEN',
+  ].some((marker) => key.toUpperCase().includes(marker))
+}
+
+function validateInstallInputs(
+  inputs: SourceInputDraft[],
+  inputValues: Record<string, string>,
+): string[] {
+  return inputs
+    .filter((input) => input.required)
+    .filter((input) => !(inputValues[input.id] ?? '').trim())
+    .map((input) => `Required input '${input.key}' needs an install value.`)
+}
+
+function installInputs(inputs: SourceInputDraft[], values: Record<string, string>): InstallInput[] {
+  return inputs.flatMap((input) => {
+    const value = (values[input.id] ?? '').trim()
+    if (!value) return []
+    return [{ key: input.key, value, secret: input.kind === 'secret' }]
+  })
+}
+
+function relationName(sourceName: string, surface: SurfaceDraft): string {
+  const suffix = surface.namespaceSuffix.trim()
+  return suffix ? `${sourceName}_${suffix}` : sourceName
+}
+
+function primaryActionLabel(state: ImportState): string {
+  if (state.kind === 'importing') return 'Importing…'
+  if (state.kind === 'validating') return 'Validating…'
+  return 'Import & validate'
+}
+
+function validationSummary(response: Awaited<ReturnType<typeof validateSource>>): string {
+  return `${response.tables.length} tables, ${response.tableFunctions.length} table functions, ${response.queryTests.length} query tests.`
+}

--- a/apps/ui/src/views/sources/source-create.tsx
+++ b/apps/ui/src/views/sources/source-create.tsx
@@ -14,148 +14,97 @@ import { importSource, validateSource, type InstallInput } from '@/lib/sources'
 
 import * as styles from './source-create.css'
 
-type SourceInputKind = 'variable' | 'secret'
-type SurfaceType = 'openapi' | 'mcp'
-type OpenApiDescriptorKind = 'url' | 'file'
-type OpenApiAuthMode = 'none' | 'bearer' | 'header'
-type HeaderValueMode = 'literal' | 'input' | 'template'
+type SourceKind = 'openapi' | 'mcp'
+type AuthMode = 'none' | 'bearer' | 'header'
 type McpTransport = 'streamable_http' | 'stdio'
 
-interface SourceInputDraft {
-  id: string
-  key: string
-  kind: SourceInputKind
-  required: boolean
-  defaultValue: string
-  hint: string
-}
-
-interface RequestHeaderDraft {
-  id: string
+interface SourceDraft {
+  kind: SourceKind
   name: string
-  mode: HeaderValueMode
-  value: string
-}
-
-interface SurfaceDraft {
-  id: string
-  surfaceId: string
-  namespaceSuffix: string
-  type: SurfaceType
-  openapiDescriptorKind: OpenApiDescriptorKind
-  openapiDescriptor: string
+  description: string
+  openapiUrl: string
   openapiBaseUrl: string
-  openapiAuthMode: OpenApiAuthMode
-  authInputKey: string
-  authHeaderName: string
-  requestHeaders: RequestHeaderDraft[]
   mcpTransport: McpTransport
   mcpUrl: string
   mcpCommand: string
   mcpArgs: string
-  mcpBearerInputKey: string
-}
-
-interface SourceDraft {
-  name: string
-  description: string
-  inputs: SourceInputDraft[]
-  surfaces: SurfaceDraft[]
-  testQueries: string
+  authMode: AuthMode
+  headerName: string
+  tokenKey: string
+  tokenValue: string
 }
 
 type ImportState =
   | { kind: 'idle' }
   | { kind: 'importing' }
   | { kind: 'validating'; sourceName: string }
-  | { kind: 'imported'; sourceName: string }
   | { kind: 'validated'; sourceName: string; response: Awaited<ReturnType<typeof validateSource>> }
 
-let draftId = 0
+const DEFAULT_OPENAPI_URL =
+  'https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.yaml'
+const DEFAULT_MCP_URL = 'https://api.githubcopilot.com/mcp/x/all/readonly'
 
-function nextDraftId(prefix: string): string {
-  draftId += 1
-  return `${prefix}-${draftId}`
-}
-
-function defaultSurface(): SurfaceDraft {
+function defaultDraft(kind: SourceKind = 'openapi'): SourceDraft {
   return {
-    id: nextDraftId('surface'),
-    surfaceId: 'rest',
-    namespaceSuffix: '',
-    type: 'openapi',
-    openapiDescriptorKind: 'url',
-    openapiDescriptor:
-      'https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.yaml',
-    openapiBaseUrl: 'https://api.github.com',
-    openapiAuthMode: 'none',
-    authInputKey: '',
-    authHeaderName: 'Authorization',
-    requestHeaders: [
-      {
-        id: nextDraftId('header'),
-        name: 'User-Agent',
-        mode: 'literal',
-        value: 'coral-dsl-v4',
-      },
-    ],
+    kind,
+    name: defaultName(kind),
+    description: defaultDescription(kind),
+    openapiUrl: DEFAULT_OPENAPI_URL,
+    openapiBaseUrl: '',
     mcpTransport: 'streamable_http',
-    mcpUrl: 'https://api.githubcopilot.com/mcp/x/all/readonly',
+    mcpUrl: DEFAULT_MCP_URL,
     mcpCommand: '',
     mcpArgs: '',
-    mcpBearerInputKey: '',
+    authMode: 'bearer',
+    headerName: 'Authorization',
+    tokenKey: 'GITHUB_TOKEN',
+    tokenValue: '',
   }
 }
 
-function defaultDraft(): SourceDraft {
-  return {
-    name: 'github_openapi_v4',
-    description: 'Query a generated OpenAPI surface through Coral DSL v4.',
-    inputs: [],
-    surfaces: [defaultSurface()],
-    testQueries: '',
-  }
+function defaultName(kind: SourceKind): string {
+  return kind === 'openapi' ? 'github_openapi_v4' : 'github_mcp_v4'
+}
+
+function defaultDescription(kind: SourceKind): string {
+  return kind === 'openapi'
+    ? 'Generated from a remote OpenAPI descriptor.'
+    : 'Generated from an MCP server tool catalog.'
 }
 
 export function SourceCreate() {
   const [draft, setDraft] = useState<SourceDraft>(() => defaultDraft())
   const generatedManifest = useMemo(() => buildManifestYaml(draft), [draft])
   const [editedManifest, setEditedManifest] = useState<string | null>(null)
-  const [inputValues, setInputValues] = useState<Record<string, string>>({})
   const [importState, setImportState] = useState<ImportState>({ kind: 'idle' })
   const [error, setError] = useState<string | null>(null)
 
   const manifestYaml = editedManifest ?? generatedManifest
   const validationErrors = useMemo(() => validateDraft(draft), [draft])
-  const installErrors = useMemo(
-    () => validateInstallInputs(draft.inputs, inputValues),
-    [draft.inputs, inputValues],
-  )
   const canImport =
     validationErrors.length === 0 &&
-    installErrors.length === 0 &&
     manifestYaml.trim().length > 0 &&
-    (importState.kind === 'idle' ||
-      importState.kind === 'imported' ||
-      importState.kind === 'validated')
+    (importState.kind === 'idle' || importState.kind === 'validated')
 
-  async function submit(validateAfterImport: boolean) {
+  function updateDraft(update: (previous: SourceDraft) => SourceDraft) {
+    setDraft(update)
+    setEditedManifest(null)
+    setImportState((previous) => (previous.kind === 'validated' ? { kind: 'idle' } : previous))
+    setError(null)
+  }
+
+  async function submit() {
     if (!canImport) return
 
     setError(null)
     setImportState({ kind: 'importing' })
 
     try {
-      const source = await importSource(manifestYaml, installInputs(draft.inputs, inputValues))
+      const source = await importSource(manifestYaml, installInputs(draft))
       addToast('neutral', {
         title: `Imported ${source.name}`,
-        description: 'The DSL v4 source manifest was materialized and installed.',
+        description: 'Coral materialized the DSL v4 source and generated projections.',
       })
-
-      if (!validateAfterImport) {
-        setImportState({ kind: 'imported', sourceName: source.name })
-        return
-      }
 
       setImportState({ kind: 'validating', sourceName: source.name })
       const response = await validateSource(source.name)
@@ -170,12 +119,6 @@ export function SourceCreate() {
     }
   }
 
-  function updateDraft(update: (previous: SourceDraft) => SourceDraft) {
-    setDraft(update)
-    if (editedManifest === null) return
-    setEditedManifest(null)
-  }
-
   return (
     <div className={styles.root}>
       <div className={styles.container}>
@@ -183,144 +126,130 @@ export function SourceCreate() {
           <div className={styles.headerText}>
             <Typography.HeadingLarge as="h1">Create DSL v4 Source</Typography.HeadingLarge>
             <Typography.Body variant="secondary">
-              Compose an imported source manifest from OpenAPI and MCP surfaces.
+              Create one generated OpenAPI or MCP source.
             </Typography.Body>
           </div>
-          <div className={styles.headerActions}>
-            <ButtonContainer
-              onClick={() => {
-                setDraft(defaultDraft())
-                setEditedManifest(null)
-                setInputValues({})
-                setImportState({ kind: 'idle' })
-                setError(null)
-              }}
-              size="32"
-              variant="secondary"
-            >
-              <ButtonIcon name="RefreshCw" />
-              <ButtonText>Reset</ButtonText>
-            </ButtonContainer>
-            <ButtonContainer
-              disabled={!canImport}
-              onClick={() => void submit(false)}
-              size="32"
-              variant="secondary"
-            >
-              <ButtonIcon name={importState.kind === 'importing' ? 'Loader' : 'Check'} />
-              <ButtonText>{importState.kind === 'importing' ? 'Importing…' : 'Import'}</ButtonText>
-            </ButtonContainer>
-            <ButtonContainer
-              disabled={!canImport}
-              onClick={() => void submit(true)}
-              size="32"
-              variant="primary"
-            >
-              <ButtonIcon
-                name={
-                  importState.kind === 'importing' || importState.kind === 'validating'
-                    ? 'Loader'
-                    : 'Check'
-                }
-              />
-              <ButtonText>{primaryActionLabel(importState)}</ButtonText>
-            </ButtonContainer>
-          </div>
+          <ButtonContainer
+            onClick={() => {
+              setDraft(defaultDraft())
+              setEditedManifest(null)
+              setImportState({ kind: 'idle' })
+              setError(null)
+            }}
+            size="32"
+            variant="secondary"
+          >
+            <ButtonIcon name="RefreshCw" />
+            <ButtonText>Reset</ButtonText>
+          </ButtonContainer>
         </div>
-
-        {validationErrors.length > 0 ? (
-          <InlineIssue title="Manifest fields need attention" messages={validationErrors} />
-        ) : installErrors.length > 0 ? (
-          <InlineIssue title="Installation values need attention" messages={installErrors} />
-        ) : null}
-
-        {error ? <ErrorBanner title="Source import failed" message={error} /> : null}
 
         <div className={styles.layout}>
           <div className={styles.formColumn}>
-            <SourceSection draft={draft} updateDraft={updateDraft} />
-            <InputsSection
-              inputs={draft.inputs}
-              updateDraft={updateDraft}
-              inputValues={inputValues}
-              setInputValues={setInputValues}
-            />
-            <SurfacesSection draft={draft} updateDraft={updateDraft} />
-            <TestQueriesSection draft={draft} updateDraft={updateDraft} />
+            {error ? <ErrorBanner message={error} /> : null}
+
+            <KindSection draft={draft} updateDraft={updateDraft} />
+            <ConnectionSection draft={draft} updateDraft={updateDraft} />
+            <AuthSection draft={draft} updateDraft={updateDraft} />
+
+            {validationErrors.length > 0 ? (
+              <InlineIssue title="Complete the source setup" messages={validationErrors} />
+            ) : null}
+
+            <GenerateSection canImport={canImport} importState={importState} submit={submit} />
+
+            {importState.kind === 'validated' ? <ValidationResult state={importState} /> : null}
           </div>
 
           <aside className={styles.previewColumn}>
-            <div className={styles.panel}>
+            <section className={styles.panel}>
               <div className={styles.panelHead}>
                 <div>
-                  <Typography.HeadingSmall as="h2">Manifest</Typography.HeadingSmall>
-                  {editedManifest ? (
-                    <Typography.BodySmall variant="tertiary">
-                      Edited YAML is being imported.
-                    </Typography.BodySmall>
-                  ) : null}
+                  <Typography.HeadingSmall as="h2">Manifest YAML</Typography.HeadingSmall>
+                  <Typography.BodySmall variant="tertiary">
+                    Review or edit the manifest sent to ImportSource.
+                  </Typography.BodySmall>
                 </div>
-                {editedManifest ? (
-                  <ButtonContainer onClick={() => setEditedManifest(null)} size="22" variant="bare">
-                    <ButtonText>Reset YAML</ButtonText>
+                {editedManifest !== null ? (
+                  <ButtonContainer
+                    onClick={() => setEditedManifest(null)}
+                    size="32"
+                    variant="secondary"
+                  >
+                    <ButtonIcon name="RefreshCw" />
+                    <ButtonText>Regenerate</ButtonText>
                   </ButtonContainer>
                 ) : null}
               </div>
               <textarea
                 aria-label="Manifest YAML"
                 className={styles.manifestTextarea}
-                spellCheck={false}
                 value={manifestYaml}
                 onChange={(event) => setEditedManifest(event.target.value)}
+                spellCheck={false}
               />
-            </div>
-
-            <InstallValuesSection
-              inputs={draft.inputs}
-              inputValues={inputValues}
-              setInputValues={setInputValues}
-            />
+            </section>
           </aside>
         </div>
-
-        {importState.kind === 'imported' ? (
-          <ResultPanel
-            title={`Imported ${importState.sourceName}`}
-            body="Run validation to inspect the tables and functions exposed by this source."
-            action={
-              <ButtonContainer
-                onClick={async () => {
-                  setError(null)
-                  setImportState({ kind: 'validating', sourceName: importState.sourceName })
-                  try {
-                    const response = await validateSource(importState.sourceName)
-                    setImportState({
-                      kind: 'validated',
-                      sourceName: importState.sourceName,
-                      response,
-                    })
-                  } catch (e) {
-                    setError(e instanceof Error ? e.message : String(e))
-                    setImportState({ kind: 'imported', sourceName: importState.sourceName })
-                  }
-                }}
-                size="32"
-                variant="secondary"
-              >
-                <ButtonIcon name="Check" />
-                <ButtonText>Validate</ButtonText>
-              </ButtonContainer>
-            }
-          />
-        ) : null}
-
-        {importState.kind === 'validated' ? <ValidationResult state={importState} /> : null}
       </div>
     </div>
   )
 }
 
-function SourceSection({
+function KindSection({
+  draft,
+  updateDraft,
+}: {
+  draft: SourceDraft
+  updateDraft: (update: (previous: SourceDraft) => SourceDraft) => void
+}) {
+  function setKind(kind: SourceKind) {
+    updateDraft((previous) => {
+      const previousDefaultName = defaultName(previous.kind)
+      const previousDefaultDescription = defaultDescription(previous.kind)
+
+      return {
+        ...previous,
+        kind,
+        name: previous.name === previousDefaultName ? defaultName(kind) : previous.name,
+        description:
+          previous.description === previousDefaultDescription
+            ? defaultDescription(kind)
+            : previous.description,
+        authMode:
+          kind === 'mcp' && previous.authMode === 'header'
+            ? 'bearer'
+            : previous.mcpTransport === 'stdio'
+              ? 'none'
+              : previous.authMode,
+      }
+    })
+  }
+
+  return (
+    <section className={styles.panel}>
+      <Typography.HeadingSmall as="h2">1. Source type</Typography.HeadingSmall>
+      <div className={styles.choiceGrid}>
+        <ChoiceButton
+          active={draft.kind === 'openapi'}
+          icon="Activity"
+          label="OpenAPI spec"
+          meta="Remote HTTPS descriptor"
+          onClick={() => setKind('openapi')}
+        />
+        <ChoiceButton
+          active={draft.kind === 'mcp'}
+          icon="Plug"
+          label="MCP server"
+          meta="Streamable HTTP or stdio"
+          onClick={() => setKind('mcp')}
+        />
+      </div>
+    </section>
+  )
+}
+
+function ConnectionSection({
   draft,
   updateDraft,
 }: {
@@ -329,9 +258,9 @@ function SourceSection({
 }) {
   return (
     <section className={styles.panel}>
-      <Typography.HeadingSmall as="h2">Source</Typography.HeadingSmall>
+      <Typography.HeadingSmall as="h2">2. Connection</Typography.HeadingSmall>
       <div className={styles.fieldGrid}>
-        <Field label="Name">
+        <Field label="Source name">
           <TextInput
             value={draft.name}
             onChange={(name) => updateDraft((previous) => ({ ...previous, name }))}
@@ -342,614 +271,215 @@ function SourceSection({
           <TextInput
             value={draft.description}
             onChange={(description) => updateDraft((previous) => ({ ...previous, description }))}
-            placeholder="Query data from a provider API"
+            placeholder="Generated source"
           />
         </Field>
       </div>
-    </section>
-  )
-}
 
-function InputsSection({
-  inputs,
-  updateDraft,
-  inputValues,
-  setInputValues,
-}: {
-  inputs: SourceInputDraft[]
-  updateDraft: (update: (previous: SourceDraft) => SourceDraft) => void
-  inputValues: Record<string, string>
-  setInputValues: React.Dispatch<React.SetStateAction<Record<string, string>>>
-}) {
-  return (
-    <section className={styles.panel}>
-      <div className={styles.panelHead}>
-        <Typography.HeadingSmall as="h2">Inputs</Typography.HeadingSmall>
-        <ButtonContainer
-          onClick={() =>
-            updateDraft((previous) => ({
-              ...previous,
-              inputs: [
-                ...previous.inputs,
-                {
-                  id: nextDraftId('input'),
-                  key: `API_TOKEN_${previous.inputs.length + 1}`,
-                  kind: 'secret',
-                  required: true,
-                  defaultValue: '',
-                  hint: '',
-                },
-              ],
-            }))
-          }
-          size="32"
-          variant="secondary"
-        >
-          <ButtonIcon name="Plus" />
-          <ButtonText>Add input</ButtonText>
-        </ButtonContainer>
-      </div>
-
-      {inputs.length === 0 ? (
-        <Typography.BodySmall variant="tertiary">
-          No source inputs. Add one for API tokens, tenants, base URLs, or MCP auth.
-        </Typography.BodySmall>
-      ) : (
+      {draft.kind === 'openapi' ? (
         <div className={styles.stack}>
-          {inputs.map((input) => (
-            <InputEditor
-              key={input.id}
-              input={input}
-              inputValue={inputValues[input.id] ?? ''}
-              onInputValueChange={(value) =>
-                setInputValues((previous) => ({ ...previous, [input.id]: value }))
-              }
-              updateDraft={updateDraft}
-            />
-          ))}
-        </div>
-      )}
-    </section>
-  )
-}
-
-function InputEditor({
-  input,
-  inputValue,
-  onInputValueChange,
-  updateDraft,
-}: {
-  input: SourceInputDraft
-  inputValue: string
-  onInputValueChange: (value: string) => void
-  updateDraft: (update: (previous: SourceDraft) => SourceDraft) => void
-}) {
-  const updateInput = (patch: Partial<SourceInputDraft>) => {
-    updateDraft((previous) => ({
-      ...previous,
-      inputs: previous.inputs.map((item) => (item.id === input.id ? { ...item, ...patch } : item)),
-    }))
-  }
-
-  return (
-    <div className={styles.itemPanel}>
-      <div className={styles.itemHeader}>
-        <Typography.BodyLargeStrong>{input.key || 'New input'}</Typography.BodyLargeStrong>
-        <ButtonContainer
-          onClick={() =>
-            updateDraft((previous) => ({
-              ...previous,
-              inputs: previous.inputs.filter((item) => item.id !== input.id),
-              surfaces: previous.surfaces.map((surface) => ({
-                ...surface,
-                authInputKey: surface.authInputKey === input.key ? '' : surface.authInputKey,
-                mcpBearerInputKey:
-                  surface.mcpBearerInputKey === input.key ? '' : surface.mcpBearerInputKey,
-              })),
-            }))
-          }
-          size="22"
-          variant="bare"
-        >
-          <ButtonIcon name="X" />
-          <ButtonText>Remove</ButtonText>
-        </ButtonContainer>
-      </div>
-      <div className={styles.fieldGrid}>
-        <Field label="Key">
-          <TextInput value={input.key} onChange={(key) => updateInput({ key })} />
-        </Field>
-        <Field label="Kind">
-          <select
-            className={styles.select}
-            value={input.kind}
-            onChange={(event) =>
-              updateInput({
-                kind: event.target.value as SourceInputKind,
-                defaultValue: event.target.value === 'secret' ? '' : input.defaultValue,
-              })
-            }
-          >
-            <option value="secret">Secret</option>
-            <option value="variable">Variable</option>
-          </select>
-        </Field>
-        <Field label="Install value">
-          <TextInput
-            type={input.kind === 'secret' ? 'password' : 'text'}
-            value={inputValue}
-            onChange={onInputValueChange}
-            placeholder={input.defaultValue || input.key}
-          />
-        </Field>
-        {input.kind === 'variable' ? (
-          <Field label="Default">
-            <TextInput
-              value={input.defaultValue}
-              onChange={(defaultValue) => updateInput({ defaultValue })}
-              placeholder="https://api.example.com"
-            />
-          </Field>
-        ) : null}
-      </div>
-      <div className={styles.fieldGrid}>
-        <label className={styles.checkRow}>
-          <input
-            type="checkbox"
-            checked={input.required}
-            onChange={(event) => updateInput({ required: event.target.checked })}
-          />
-          <Typography.BodySmall>Required</Typography.BodySmall>
-        </label>
-        <Field label="Hint">
-          <TextInput
-            value={input.hint}
-            onChange={(hint) => updateInput({ hint })}
-            placeholder="Where to find this value"
-          />
-        </Field>
-      </div>
-    </div>
-  )
-}
-
-function SurfacesSection({
-  draft,
-  updateDraft,
-}: {
-  draft: SourceDraft
-  updateDraft: (update: (previous: SourceDraft) => SourceDraft) => void
-}) {
-  return (
-    <section className={styles.panel}>
-      <div className={styles.panelHead}>
-        <Typography.HeadingSmall as="h2">Surfaces</Typography.HeadingSmall>
-        <ButtonContainer
-          onClick={() =>
-            updateDraft((previous) => {
-              const surface = defaultSurface()
-              surface.surfaceId = previous.surfaces.some((item) => item.surfaceId === 'mcp')
-                ? `surface_${previous.surfaces.length + 1}`
-                : 'mcp'
-              surface.namespaceSuffix = surface.surfaceId
-              surface.type = 'mcp'
-              return { ...previous, surfaces: [...previous.surfaces, surface] }
-            })
-          }
-          size="32"
-          variant="secondary"
-        >
-          <ButtonIcon name="Plus" />
-          <ButtonText>Add surface</ButtonText>
-        </ButtonContainer>
-      </div>
-      <div className={styles.stack}>
-        {draft.surfaces.map((surface) => (
-          <SurfaceEditor
-            key={surface.id}
-            draft={draft}
-            surface={surface}
-            updateDraft={updateDraft}
-          />
-        ))}
-      </div>
-    </section>
-  )
-}
-
-function SurfaceEditor({
-  draft,
-  surface,
-  updateDraft,
-}: {
-  draft: SourceDraft
-  surface: SurfaceDraft
-  updateDraft: (update: (previous: SourceDraft) => SourceDraft) => void
-}) {
-  const secretInputs = draft.inputs.filter((input) => input.kind === 'secret')
-  const updateSurface = (patch: Partial<SurfaceDraft>) => {
-    updateDraft((previous) => ({
-      ...previous,
-      surfaces: previous.surfaces.map((item) =>
-        item.id === surface.id ? { ...item, ...patch } : item,
-      ),
-    }))
-  }
-
-  return (
-    <div className={styles.itemPanel}>
-      <div className={styles.itemHeader}>
-        <div>
-          <Typography.BodyLargeStrong>
-            {surface.surfaceId || 'New surface'}
-          </Typography.BodyLargeStrong>
-          <Typography.BodySmall variant="tertiary">
-            {relationName(draft.name, surface)}
-          </Typography.BodySmall>
-        </div>
-        <ButtonContainer
-          disabled={draft.surfaces.length === 1}
-          onClick={() =>
-            updateDraft((previous) => ({
-              ...previous,
-              surfaces: previous.surfaces.filter((item) => item.id !== surface.id),
-            }))
-          }
-          size="22"
-          variant="bare"
-        >
-          <ButtonIcon name="X" />
-          <ButtonText>Remove</ButtonText>
-        </ButtonContainer>
-      </div>
-
-      <div className={styles.fieldGrid}>
-        <Field label="Surface ID">
-          <TextInput
-            value={surface.surfaceId}
-            onChange={(surfaceId) => updateSurface({ surfaceId })}
-          />
-        </Field>
-        <Field label="Namespace suffix">
-          <TextInput
-            value={surface.namespaceSuffix}
-            onChange={(namespaceSuffix) => updateSurface({ namespaceSuffix })}
-            placeholder="default namespace"
-          />
-        </Field>
-        <Field label="Type">
-          <div className={styles.segmented}>
-            <button
-              type="button"
-              className={styles.segment}
-              data-active={surface.type === 'openapi' ? 'true' : 'false'}
-              onClick={() => updateSurface({ type: 'openapi' })}
-            >
-              OpenAPI
-            </button>
-            <button
-              type="button"
-              className={styles.segment}
-              data-active={surface.type === 'mcp' ? 'true' : 'false'}
-              onClick={() => updateSurface({ type: 'mcp' })}
-            >
-              MCP
-            </button>
-          </div>
-        </Field>
-      </div>
-
-      {surface.type === 'openapi' ? (
-        <OpenApiSurfaceEditor
-          inputs={draft.inputs}
-          surface={surface}
-          secretInputs={secretInputs}
-          updateSurface={updateSurface}
-        />
-      ) : (
-        <McpSurfaceEditor
-          surface={surface}
-          secretInputs={secretInputs}
-          updateSurface={updateSurface}
-        />
-      )}
-    </div>
-  )
-}
-
-function OpenApiSurfaceEditor({
-  inputs,
-  surface,
-  secretInputs,
-  updateSurface,
-}: {
-  inputs: SourceInputDraft[]
-  surface: SurfaceDraft
-  secretInputs: SourceInputDraft[]
-  updateSurface: (patch: Partial<SurfaceDraft>) => void
-}) {
-  return (
-    <>
-      <div className={styles.fieldGrid}>
-        <Field label="Descriptor">
-          <select
-            className={styles.select}
-            value={surface.openapiDescriptorKind}
-            onChange={(event) =>
-              updateSurface({ openapiDescriptorKind: event.target.value as OpenApiDescriptorKind })
-            }
-          >
-            <option value="url">HTTPS URL</option>
-            <option value="file">Absolute file path</option>
-          </select>
-        </Field>
-        <Field label={surface.openapiDescriptorKind === 'url' ? 'OpenAPI URL' : 'OpenAPI file'}>
-          <TextInput
-            type={surface.openapiDescriptorKind === 'url' ? 'url' : 'text'}
-            value={surface.openapiDescriptor}
-            onChange={(openapiDescriptor) => updateSurface({ openapiDescriptor })}
-            placeholder={
-              surface.openapiDescriptorKind === 'url'
-                ? 'https://example.com/openapi.yaml'
-                : '/absolute/path/openapi.yaml'
-            }
-          />
-        </Field>
-        <Field label="Base URL">
-          <TextInput
-            value={surface.openapiBaseUrl}
-            onChange={(openapiBaseUrl) => updateSurface({ openapiBaseUrl })}
-            placeholder="https://api.example.com"
-          />
-        </Field>
-      </div>
-
-      <div className={styles.fieldGrid}>
-        <Field label="Auth">
-          <select
-            className={styles.select}
-            value={surface.openapiAuthMode}
-            onChange={(event) =>
-              updateSurface({ openapiAuthMode: event.target.value as OpenApiAuthMode })
-            }
-          >
-            <option value="none">None</option>
-            <option value="bearer">Bearer token</option>
-            <option value="header">Header from secret</option>
-          </select>
-        </Field>
-        {surface.openapiAuthMode !== 'none' ? (
-          <Field label="Secret input">
-            <InputKeySelect
-              inputs={secretInputs}
-              value={surface.authInputKey}
-              onChange={(authInputKey) => updateSurface({ authInputKey })}
-            />
-          </Field>
-        ) : null}
-        {surface.openapiAuthMode === 'header' ? (
-          <Field label="Header name">
-            <TextInput
-              value={surface.authHeaderName}
-              onChange={(authHeaderName) => updateSurface({ authHeaderName })}
-              placeholder="X-API-Key"
-            />
-          </Field>
-        ) : null}
-      </div>
-
-      <div className={styles.subsectionHead}>
-        <Typography.BodyStrong>Request headers</Typography.BodyStrong>
-        <ButtonContainer
-          onClick={() =>
-            updateSurface({
-              requestHeaders: [
-                ...surface.requestHeaders,
-                { id: nextDraftId('header'), name: '', mode: 'literal', value: '' },
-              ],
-            })
-          }
-          size="22"
-          variant="bare"
-        >
-          <ButtonIcon name="Plus" />
-          <ButtonText>Add header</ButtonText>
-        </ButtonContainer>
-      </div>
-      {surface.requestHeaders.length > 0 ? (
-        <div className={styles.stackSmall}>
-          {surface.requestHeaders.map((header) => (
-            <RequestHeaderEditor
-              key={header.id}
-              header={header}
-              inputs={inputs}
-              updateHeader={(patch) =>
-                updateSurface({
-                  requestHeaders: surface.requestHeaders.map((item) =>
-                    item.id === header.id ? { ...item, ...patch } : item,
-                  ),
-                })
-              }
-              removeHeader={() =>
-                updateSurface({
-                  requestHeaders: surface.requestHeaders.filter((item) => item.id !== header.id),
-                })
-              }
-            />
-          ))}
-        </div>
-      ) : null}
-    </>
-  )
-}
-
-function McpSurfaceEditor({
-  surface,
-  secretInputs,
-  updateSurface,
-}: {
-  surface: SurfaceDraft
-  secretInputs: SourceInputDraft[]
-  updateSurface: (patch: Partial<SurfaceDraft>) => void
-}) {
-  return (
-    <>
-      <div className={styles.fieldGrid}>
-        <Field label="Transport">
-          <select
-            className={styles.select}
-            value={surface.mcpTransport}
-            onChange={(event) =>
-              updateSurface({ mcpTransport: event.target.value as McpTransport })
-            }
-          >
-            <option value="streamable_http">Streamable HTTP</option>
-            <option value="stdio">Stdio</option>
-          </select>
-        </Field>
-        {surface.mcpTransport === 'streamable_http' ? (
-          <Field label="MCP URL">
+          <Field label="OpenAPI spec URL">
             <TextInput
               type="url"
-              value={surface.mcpUrl}
-              onChange={(mcpUrl) => updateSurface({ mcpUrl })}
-              placeholder="https://example.com/mcp"
+              value={draft.openapiUrl}
+              onChange={(openapiUrl) => updateDraft((previous) => ({ ...previous, openapiUrl }))}
+              placeholder="https://example.com/openapi.yaml"
             />
           </Field>
-        ) : (
-          <Field label="Command">
+          <Field label="Base URL override">
             <TextInput
-              value={surface.mcpCommand}
-              onChange={(mcpCommand) => updateSurface({ mcpCommand })}
-              placeholder="npx"
-            />
-          </Field>
-        )}
-        {surface.mcpTransport === 'stdio' ? (
-          <Field label="Arguments">
-            <TextInput
-              value={surface.mcpArgs}
-              onChange={(mcpArgs) => updateSurface({ mcpArgs })}
-              placeholder="-y @modelcontextprotocol/server-example"
-            />
-          </Field>
-        ) : null}
-      </div>
-      {surface.mcpTransport === 'streamable_http' ? (
-        <div className={styles.fieldGrid}>
-          <Field label="Bearer input">
-            <InputKeySelect
-              allowEmpty
-              inputs={secretInputs}
-              value={surface.mcpBearerInputKey}
-              onChange={(mcpBearerInputKey) => updateSurface({ mcpBearerInputKey })}
+              type="url"
+              value={draft.openapiBaseUrl}
+              onChange={(openapiBaseUrl) =>
+                updateDraft((previous) => ({ ...previous, openapiBaseUrl }))
+              }
+              placeholder="Use OpenAPI servers entry"
             />
           </Field>
         </div>
-      ) : null}
-    </>
-  )
-}
-
-function RequestHeaderEditor({
-  header,
-  inputs,
-  updateHeader,
-  removeHeader,
-}: {
-  header: RequestHeaderDraft
-  inputs: SourceInputDraft[]
-  updateHeader: (patch: Partial<RequestHeaderDraft>) => void
-  removeHeader: () => void
-}) {
-  return (
-    <div className={styles.headerRow}>
-      <TextInput
-        value={header.name}
-        onChange={(name) => updateHeader({ name })}
-        placeholder="Header"
-      />
-      <select
-        className={styles.select}
-        value={header.mode}
-        onChange={(event) => updateHeader({ mode: event.target.value as HeaderValueMode })}
-      >
-        <option value="literal">Literal</option>
-        <option value="input">Input</option>
-        <option value="template">Template</option>
-      </select>
-      {header.mode === 'input' ? (
-        <InputKeySelect
-          inputs={inputs}
-          value={header.value}
-          onChange={(value) => updateHeader({ value })}
-        />
       ) : (
-        <TextInput value={header.value} onChange={(value) => updateHeader({ value })} />
+        <div className={styles.stack}>
+          <Field label="Transport">
+            <select
+              className={styles.select}
+              value={draft.mcpTransport}
+              onChange={(event) => {
+                const mcpTransport = event.target.value as McpTransport
+                updateDraft((previous) => ({
+                  ...previous,
+                  mcpTransport,
+                  authMode:
+                    mcpTransport === 'stdio'
+                      ? 'none'
+                      : previous.authMode === 'header'
+                        ? 'bearer'
+                        : previous.authMode,
+                }))
+              }}
+            >
+              <option value="streamable_http">Streamable HTTP</option>
+              <option value="stdio">Stdio command</option>
+            </select>
+          </Field>
+
+          {draft.mcpTransport === 'streamable_http' ? (
+            <Field label="MCP server URL">
+              <TextInput
+                type="url"
+                value={draft.mcpUrl}
+                onChange={(mcpUrl) => updateDraft((previous) => ({ ...previous, mcpUrl }))}
+                placeholder="https://example.com/mcp"
+              />
+            </Field>
+          ) : (
+            <div className={styles.fieldGrid}>
+              <Field label="Command">
+                <TextInput
+                  value={draft.mcpCommand}
+                  onChange={(mcpCommand) =>
+                    updateDraft((previous) => ({ ...previous, mcpCommand }))
+                  }
+                  placeholder="demo-mcp-server"
+                />
+              </Field>
+              <Field label="Arguments">
+                <TextInput
+                  value={draft.mcpArgs}
+                  onChange={(mcpArgs) => updateDraft((previous) => ({ ...previous, mcpArgs }))}
+                  placeholder="--readonly"
+                />
+              </Field>
+            </div>
+          )}
+        </div>
       )}
-      <ButtonContainer ariaLabel="Remove header" onClick={removeHeader} size="32" variant="bare">
-        <ButtonIcon name="X" />
-      </ButtonContainer>
-    </div>
+    </section>
   )
 }
 
-function TestQueriesSection({
+function AuthSection({
   draft,
   updateDraft,
 }: {
   draft: SourceDraft
   updateDraft: (update: (previous: SourceDraft) => SourceDraft) => void
 }) {
+  const authModes = allowedAuthModes(draft)
+  const authMode = authModes.includes(draft.authMode) ? draft.authMode : 'none'
+
   return (
     <section className={styles.panel}>
-      <Typography.HeadingSmall as="h2">Test Queries</Typography.HeadingSmall>
-      <textarea
-        aria-label="Test queries"
-        className={styles.textarea}
-        value={draft.testQueries}
-        onChange={(event) =>
-          updateDraft((previous) => ({ ...previous, testQueries: event.target.value }))
-        }
-        placeholder="SELECT * FROM github_openapi_v4.search_issues_and_pull_requests(q => 'repo:octocat/Hello-World is:issue') LIMIT 5"
-      />
+      <Typography.HeadingSmall as="h2">3. Auth</Typography.HeadingSmall>
+      <div className={styles.fieldGrid}>
+        <Field label="Auth mode">
+          <select
+            className={styles.select}
+            value={authMode}
+            onChange={(event) => {
+              const nextAuthMode = event.target.value as AuthMode
+              updateDraft((previous) => ({ ...previous, authMode: nextAuthMode }))
+            }}
+          >
+            <option value="none">None</option>
+            {authModes.includes('bearer') ? <option value="bearer">Bearer token</option> : null}
+            {authModes.includes('header') ? <option value="header">Header token</option> : null}
+          </select>
+        </Field>
+        {draft.kind === 'openapi' && authMode === 'header' ? (
+          <Field label="Header name">
+            <TextInput
+              value={draft.headerName}
+              onChange={(headerName) => updateDraft((previous) => ({ ...previous, headerName }))}
+              placeholder="Authorization"
+            />
+          </Field>
+        ) : null}
+      </div>
+
+      {needsSecret(draft) ? (
+        <div className={styles.fieldGrid}>
+          <Field label="Secret input key">
+            <TextInput
+              value={draft.tokenKey}
+              onChange={(tokenKey) => updateDraft((previous) => ({ ...previous, tokenKey }))}
+              placeholder="API_TOKEN"
+            />
+          </Field>
+          <Field label="Token">
+            <TextInput
+              type="password"
+              value={draft.tokenValue}
+              onChange={(tokenValue) => updateDraft((previous) => ({ ...previous, tokenValue }))}
+              placeholder="Paste token"
+            />
+          </Field>
+        </div>
+      ) : null}
     </section>
   )
 }
 
-function InstallValuesSection({
-  inputs,
-  inputValues,
-  setInputValues,
+function GenerateSection({
+  canImport,
+  importState,
+  submit,
 }: {
-  inputs: SourceInputDraft[]
-  inputValues: Record<string, string>
-  setInputValues: React.Dispatch<React.SetStateAction<Record<string, string>>>
+  canImport: boolean
+  importState: ImportState
+  submit: () => Promise<void>
+}) {
+  const busy = importState.kind === 'importing' || importState.kind === 'validating'
+  const buttonText =
+    importState.kind === 'importing'
+      ? 'Importing...'
+      : importState.kind === 'validating'
+        ? 'Validating...'
+        : 'Import and generate projections'
+
+  return (
+    <section className={styles.panel}>
+      <div className={styles.generateRow}>
+        <div>
+          <Typography.HeadingSmall as="h2">4. Generate</Typography.HeadingSmall>
+          <Typography.BodySmall variant="tertiary">
+            ImportSource materializes the source, then validation lists generated projections.
+          </Typography.BodySmall>
+        </div>
+        <ButtonContainer disabled={!canImport || busy} onClick={() => void submit()} size="32">
+          <ButtonIcon name={busy ? 'Loader' : 'Check'} />
+          <ButtonText>{buttonText}</ButtonText>
+        </ButtonContainer>
+      </div>
+    </section>
+  )
+}
+
+function ChoiceButton({
+  active,
+  icon,
+  label,
+  meta,
+  onClick,
+}: {
+  active: boolean
+  icon: 'Activity' | 'Plug'
+  label: string
+  meta: string
+  onClick: () => void
 }) {
   return (
-    <div className={styles.panel}>
-      <Typography.HeadingSmall as="h2">Install Values</Typography.HeadingSmall>
-      {inputs.length === 0 ? (
-        <Typography.BodySmall variant="tertiary">
-          No values needed for this manifest.
-        </Typography.BodySmall>
-      ) : (
-        <div className={styles.stackSmall}>
-          {inputs.map((input) => (
-            <Field key={input.id} label={input.key || 'Input'}>
-              <TextInput
-                type={input.kind === 'secret' ? 'password' : 'text'}
-                value={inputValues[input.id] ?? ''}
-                onChange={(value) =>
-                  setInputValues((previous) => ({ ...previous, [input.id]: value }))
-                }
-                placeholder={input.defaultValue || input.key}
-              />
-            </Field>
-          ))}
-        </div>
-      )}
-    </div>
+    <button
+      aria-pressed={active}
+      className={styles.choiceButton({ active })}
+      onClick={onClick}
+      type="button"
+    >
+      <Icon name={icon} size="20" color={active ? 'primary' : 'secondary'} />
+      <span className={styles.choiceText}>
+        <Typography.BodySmallStrong>{label}</Typography.BodySmallStrong>
+        <Typography.BodySmall variant="tertiary">{meta}</Typography.BodySmall>
+      </span>
+    </button>
   )
 }
 
@@ -1031,28 +561,6 @@ function ValidationResult({ state }: { state: Extract<ImportState, { kind: 'vali
   )
 }
 
-function ResultPanel({
-  title,
-  body,
-  action,
-}: {
-  title: string
-  body: string
-  action: React.ReactNode
-}) {
-  return (
-    <section className={styles.panel}>
-      <div className={styles.resultHeader}>
-        <div>
-          <Typography.HeadingSmall as="h2">{title}</Typography.HeadingSmall>
-          <Typography.BodySmall variant="tertiary">{body}</Typography.BodySmall>
-        </div>
-        {action}
-      </div>
-    </section>
-  )
-}
-
 function InlineIssue({ title, messages }: { title: string; messages: string[] }) {
   return (
     <div className={styles.issueBox}>
@@ -1060,7 +568,7 @@ function InlineIssue({ title, messages }: { title: string; messages: string[] })
       <div>
         <Typography.BodySmallStrong>{title}</Typography.BodySmallStrong>
         <ul className={styles.issueList}>
-          {messages.slice(0, 4).map((message) => (
+          {messages.slice(0, 5).map((message) => (
             <li key={message}>
               <Typography.BodySmall variant="secondary">{message}</Typography.BodySmall>
             </li>
@@ -1080,324 +588,166 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   )
 }
 
-function InputKeySelect({
-  inputs,
-  value,
-  onChange,
-  allowEmpty,
-}: {
-  inputs: SourceInputDraft[]
-  value: string
-  onChange: (value: string) => void
-  allowEmpty?: boolean
-}) {
-  return (
-    <select
-      className={styles.select}
-      value={value}
-      onChange={(event) => onChange(event.target.value)}
-    >
-      {allowEmpty ? <option value="">None</option> : null}
-      {!allowEmpty && value === '' ? <option value="">Select input</option> : null}
-      {inputs.map((input) => (
-        <option key={input.id} value={input.key}>
-          {input.key}
-        </option>
-      ))}
-    </select>
-  )
+function allowedAuthModes(draft: SourceDraft): AuthMode[] {
+  if (draft.kind === 'openapi') return ['none', 'bearer', 'header']
+  if (draft.mcpTransport === 'streamable_http') return ['none', 'bearer']
+  return ['none']
+}
+
+function needsSecret(draft: SourceDraft): boolean {
+  if (draft.kind === 'openapi') return draft.authMode === 'bearer' || draft.authMode === 'header'
+  return draft.mcpTransport === 'streamable_http' && draft.authMode === 'bearer'
+}
+
+function installInputs(draft: SourceDraft): InstallInput[] {
+  if (!needsSecret(draft)) return []
+  return [{ key: draft.tokenKey.trim(), value: draft.tokenValue, secret: true }]
 }
 
 function buildManifestYaml(draft: SourceDraft): string {
-  const lines: string[] = []
-  lines.push(`name: ${yamlScalar(draft.name)}`)
-  lines.push('dsl_version: 4')
-  if (draft.description.trim()) emitStringField(lines, 0, 'description', draft.description.trim())
+  const lines = [`name: ${yamlString(draft.name.trim())}`, 'dsl_version: 4']
+  if (draft.description.trim()) lines.push(`description: ${yamlString(draft.description.trim())}`)
   lines.push('surfaces:')
 
-  for (const surface of draft.surfaces) {
-    lines.push(`  - id: ${yamlScalar(surface.surfaceId)}`)
-    if (surface.namespaceSuffix.trim()) {
-      lines.push(`    namespace_suffix: ${yamlScalar(surface.namespaceSuffix.trim())}`)
+  if (draft.kind === 'openapi') {
+    lines.push('  - id: rest')
+    lines.push('    type: openapi')
+    lines.push(`    url: ${yamlString(draft.openapiUrl.trim())}`)
+    if (needsSecret(draft)) pushSecretInput(lines, '    ', draft.tokenKey.trim())
+    if (draft.openapiBaseUrl.trim()) {
+      lines.push(`    base_url: ${yamlString(draft.openapiBaseUrl.trim())}`)
     }
-    lines.push(`    type: ${surface.type}`)
-
-    if (surface.type === 'openapi') {
-      const descriptorKey = surface.openapiDescriptorKind === 'url' ? 'url' : 'file'
-      lines.push(`    ${descriptorKey}: ${yamlScalar(surface.openapiDescriptor.trim())}`)
-      emitInputs(lines, 4, draft.inputs)
-      if (surface.openapiBaseUrl.trim()) {
-        lines.push(`    base_url: ${yamlScalar(surface.openapiBaseUrl.trim())}`)
+    if (draft.authMode === 'bearer') {
+      lines.push('    auth:')
+      lines.push('      type: HeaderAuth')
+      lines.push('      headers:')
+      lines.push(`        - name: ${yamlString(draft.headerName.trim() || 'Authorization')}`)
+      lines.push('          from: template')
+      lines.push(`          template: ${yamlString(`Bearer {{input.${draft.tokenKey.trim()}}}`)}`)
+    } else if (draft.authMode === 'header') {
+      lines.push('    auth:')
+      lines.push('      type: HeaderAuth')
+      lines.push('      headers:')
+      lines.push(`        - name: ${yamlString(draft.headerName.trim())}`)
+      lines.push('          from: template')
+      lines.push(`          template: ${yamlString(`{{input.${draft.tokenKey.trim()}}}`)}`)
+    }
+    lines.push('    request_headers:')
+    lines.push('      - name: User-Agent')
+    lines.push('        from: literal')
+    lines.push('        value: coral-dsl-v4')
+  } else {
+    lines.push('  - id: mcp')
+    lines.push('    type: mcp')
+    if (needsSecret(draft)) pushSecretInput(lines, '    ', draft.tokenKey.trim())
+    lines.push('    server:')
+    if (draft.mcpTransport === 'streamable_http') {
+      lines.push('      transport: streamable_http')
+      lines.push(`      url: ${yamlString(draft.mcpUrl.trim())}`)
+      if (draft.authMode === 'bearer') {
+        lines.push('      auth:')
+        lines.push('        type: bearer')
+        lines.push('        from: input')
+        lines.push(`        key: ${draft.tokenKey.trim()}`)
       }
-      emitOpenApiAuth(lines, surface)
-      emitRequestHeaders(lines, surface.requestHeaders)
     } else {
-      emitInputs(lines, 4, draft.inputs)
-      lines.push('    server:')
-      if (surface.mcpTransport === 'streamable_http') {
-        lines.push('      transport: streamable_http')
-        lines.push(`      url: ${yamlScalar(surface.mcpUrl.trim())}`)
-        if (surface.mcpBearerInputKey) {
-          lines.push('      auth:')
-          lines.push('        type: bearer')
-          lines.push('        from: input')
-          lines.push(`        key: ${yamlScalar(surface.mcpBearerInputKey)}`)
-        }
-      } else {
-        lines.push('      transport: stdio')
-        lines.push(`      command: ${yamlScalar(surface.mcpCommand.trim())}`)
-        const args = splitArgs(surface.mcpArgs)
-        if (args.length > 0) {
-          lines.push('      args:')
-          for (const arg of args) lines.push(`        - ${yamlScalar(arg)}`)
-        }
+      lines.push('      transport: stdio')
+      lines.push(`      command: ${yamlString(draft.mcpCommand.trim())}`)
+      const args = splitArgs(draft.mcpArgs)
+      if (args.length > 0) {
+        lines.push('      args:')
+        for (const arg of args) lines.push(`        - ${yamlString(arg)}`)
       }
     }
-  }
-
-  const queries = draft.testQueries
-    .split('\n')
-    .map((query) => query.trim())
-    .filter(Boolean)
-  if (queries.length > 0) {
-    lines.push('test_queries:')
-    for (const query of queries) lines.push(`  - ${yamlScalar(query)}`)
   }
 
   return `${lines.join('\n')}\n`
 }
 
-function emitInputs(lines: string[], indent: number, inputs: SourceInputDraft[]) {
-  if (inputs.length === 0) return
-  const pad = ' '.repeat(indent)
-  lines.push(`${pad}inputs:`)
-  for (const input of inputs) {
-    lines.push(`${pad}  ${input.key || 'INPUT'}:`)
-    lines.push(`${pad}    kind: ${input.kind}`)
-    if (input.kind === 'variable' && input.defaultValue.trim()) {
-      lines.push(`${pad}    default: ${yamlScalar(input.defaultValue.trim())}`)
-    }
-    const requiredDefault = input.kind === 'variable' && input.defaultValue.trim().length > 0
-    if (input.required === false || requiredDefault) {
-      lines.push(`${pad}    required: ${input.required ? 'true' : 'false'}`)
-    }
-    if (input.hint.trim()) emitStringField(lines, indent + 4, 'hint', input.hint.trim())
-  }
-}
-
-function emitOpenApiAuth(lines: string[], surface: SurfaceDraft) {
-  if (surface.openapiAuthMode === 'none') return
-  lines.push('    auth:')
-  lines.push('      type: HeaderAuth')
-  lines.push('      headers:')
-  if (surface.openapiAuthMode === 'bearer') {
-    lines.push('        - name: Authorization')
-    lines.push('          from: template')
-    lines.push(`          template: ${yamlScalar(`Bearer {{input.${surface.authInputKey}}}`)}`)
-    return
-  }
-  lines.push(`        - name: ${yamlScalar(surface.authHeaderName.trim())}`)
-  lines.push('          from: input')
-  lines.push(`          key: ${yamlScalar(surface.authInputKey)}`)
-}
-
-function emitRequestHeaders(lines: string[], headers: RequestHeaderDraft[]) {
-  const active = headers.filter((header) => header.name.trim() && header.value.trim())
-  if (active.length === 0) return
-  lines.push('    request_headers:')
-  for (const header of active) {
-    lines.push(`      - name: ${yamlScalar(header.name.trim())}`)
-    if (header.mode === 'input') {
-      lines.push('        from: input')
-      lines.push(`        key: ${yamlScalar(header.value.trim())}`)
-    } else if (header.mode === 'template') {
-      lines.push('        from: template')
-      lines.push(`        template: ${yamlScalar(header.value.trim())}`)
-    } else {
-      lines.push('        from: literal')
-      lines.push(`        value: ${yamlScalar(header.value.trim())}`)
-    }
-  }
-}
-
-function emitStringField(lines: string[], indent: number, key: string, value: string) {
-  const pad = ' '.repeat(indent)
-  if (value.includes('\n')) {
-    lines.push(`${pad}${key}: |`)
-    for (const line of value.split('\n')) lines.push(`${pad}  ${line}`)
-  } else {
-    lines.push(`${pad}${key}: ${yamlScalar(value)}`)
-  }
-}
-
-function yamlScalar(value: string): string {
-  return JSON.stringify(value)
-}
-
-function splitArgs(raw: string): string[] {
-  return raw
-    .split(/\s+/)
-    .map((arg) => arg.trim())
-    .filter(Boolean)
+function pushSecretInput(lines: string[], indent: string, key: string) {
+  lines.push(`${indent}inputs:`)
+  lines.push(`${indent}  ${key}:`)
+  lines.push(`${indent}    kind: secret`)
 }
 
 function validateDraft(draft: SourceDraft): string[] {
   const errors: string[] = []
-  if (!/^[a-z][a-z0-9_]*$/.test(draft.name)) {
-    errors.push('Source name must match [a-z][a-z0-9_]*.')
+  const name = draft.name.trim()
+  if (!name) {
+    errors.push('Source name is required.')
+  } else if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    errors.push(
+      'Source name must start with a letter or underscore and use only letters, numbers, and underscores.',
+    )
   }
-  if (['coral', 'coral_admin', 'public'].includes(draft.name)) {
-    errors.push(`Source name '${draft.name}' is reserved.`)
+
+  if (draft.kind === 'openapi') {
+    if (!isHttpsUrl(draft.openapiUrl.trim())) {
+      errors.push('OpenAPI spec URL must be HTTPS.')
+    }
+    if (draft.openapiBaseUrl.trim() && !isHttpUrl(draft.openapiBaseUrl.trim())) {
+      errors.push('Base URL override must be a valid HTTP or HTTPS URL.')
+    }
+    if ((draft.authMode === 'bearer' || draft.authMode === 'header') && !draft.headerName.trim()) {
+      errors.push('Header name is required for OpenAPI auth.')
+    }
+  } else if (draft.mcpTransport === 'streamable_http') {
+    if (!isAllowedMcpHttpUrl(draft.mcpUrl.trim())) {
+      errors.push('MCP Streamable HTTP URL must be HTTPS, or HTTP on localhost.')
+    }
+  } else if (!draft.mcpCommand.trim()) {
+    errors.push('MCP stdio command is required.')
   }
-  validateInputs(draft.inputs, errors)
-  validateSurfaces(draft, errors)
+
+  if (needsSecret(draft)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(draft.tokenKey.trim())) {
+      errors.push('Secret input key must use letters, numbers, and underscores.')
+    }
+    if (!draft.tokenValue.trim()) {
+      errors.push(
+        'Token is required before import because Coral validates declared required secrets before materialization.',
+      )
+    }
+  }
+
   return errors
 }
 
-function validateInputs(inputs: SourceInputDraft[], errors: string[]) {
-  const seen = new Set<string>()
-  for (const input of inputs) {
-    if (!input.key.trim()) errors.push('Input keys must not be empty.')
-    if (/[=/\\\n\r]/.test(input.key) || input.key.startsWith('#')) {
-      errors.push(`Input '${input.key}' contains characters the source spec rejects.`)
-    }
-    if (seen.has(input.key)) errors.push(`Input '${input.key}' is declared more than once.`)
-    seen.add(input.key)
-    if (input.kind === 'secret' && input.defaultValue) {
-      errors.push(`Secret input '${input.key}' cannot declare a default.`)
-    }
-    if (input.kind === 'variable' && credentialLike(input.key)) {
-      errors.push(`Credential-looking input '${input.key}' must be a secret.`)
-    }
+function yamlString(value: string): string {
+  return JSON.stringify(value)
+}
+
+function splitArgs(value: string): string[] {
+  const matches = value.matchAll(/"([^"]*)"|'([^']*)'|[^\s]+/g)
+  return Array.from(matches, (match) => match[1] ?? match[2] ?? match[0]).filter(Boolean)
+}
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === 'https:'
+  } catch {
+    return false
   }
 }
 
-function validateSurfaces(draft: SourceDraft, errors: string[]) {
-  const surfaceIds = new Set<string>()
-  const namespaces = new Set<string>()
-  let defaultNamespaceSurface: string | null = null
-  const inputKeys = new Set(draft.inputs.map((input) => input.key))
-  const secretKeys = new Set(
-    draft.inputs.filter((input) => input.kind === 'secret').map((input) => input.key),
-  )
-
-  for (const surface of draft.surfaces) {
-    if (!/^[a-z][a-z0-9_]*$/.test(surface.surfaceId)) {
-      errors.push(`Surface '${surface.surfaceId}' must match [a-z][a-z0-9_]*.`)
-    }
-    if (surfaceIds.has(surface.surfaceId)) {
-      errors.push(`Surface '${surface.surfaceId}' is declared more than once.`)
-    }
-    surfaceIds.add(surface.surfaceId)
-
-    if (surface.namespaceSuffix.trim()) {
-      if (!/^[a-z][a-z0-9_]*$/.test(surface.namespaceSuffix)) {
-        errors.push(`Surface '${surface.surfaceId}' namespace suffix must match [a-z][a-z0-9_]*.`)
-      }
-    } else if (draft.surfaces.length > 1) {
-      if (defaultNamespaceSurface) {
-        errors.push(
-          `Surfaces '${defaultNamespaceSurface}' and '${surface.surfaceId}' both use the default namespace.`,
-        )
-      }
-      defaultNamespaceSurface = surface.surfaceId
-    }
-
-    const namespace = relationName(draft.name, surface)
-    if (namespaces.has(namespace)) errors.push(`Relation namespace '${namespace}' is duplicated.`)
-    namespaces.add(namespace)
-
-    if (surface.type === 'openapi') {
-      if (!surface.openapiDescriptor.trim()) {
-        errors.push(`Surface '${surface.surfaceId}' needs a descriptor.`)
-      }
-      if (
-        surface.openapiDescriptorKind === 'url' &&
-        !surface.openapiDescriptor.trim().startsWith('https://')
-      ) {
-        errors.push(`Surface '${surface.surfaceId}' OpenAPI URL must use https.`)
-      }
-      if (
-        surface.openapiDescriptorKind === 'file' &&
-        !surface.openapiDescriptor.trim().startsWith('/')
-      ) {
-        errors.push(`Surface '${surface.surfaceId}' file descriptor must be absolute.`)
-      }
-      if (surface.openapiAuthMode !== 'none' && !secretKeys.has(surface.authInputKey)) {
-        errors.push(`Surface '${surface.surfaceId}' auth must reference a secret input.`)
-      }
-      if (surface.openapiAuthMode === 'header' && !surface.authHeaderName.trim()) {
-        errors.push(`Surface '${surface.surfaceId}' auth header name is required.`)
-      }
-      for (const header of surface.requestHeaders) {
-        if (
-          (header.name.trim() && !header.value.trim()) ||
-          (!header.name.trim() && header.value.trim())
-        ) {
-          errors.push(`Surface '${surface.surfaceId}' has an incomplete request header.`)
-        }
-        if (header.mode === 'input' && header.value.trim() && !inputKeys.has(header.value)) {
-          errors.push(`Surface '${surface.surfaceId}' request header references an unknown input.`)
-        }
-      }
-    } else if (surface.mcpTransport === 'streamable_http') {
-      if (!surface.mcpUrl.trim()) {
-        errors.push(`Surface '${surface.surfaceId}' needs an MCP URL.`)
-      }
-      if (surface.mcpBearerInputKey && !secretKeys.has(surface.mcpBearerInputKey)) {
-        errors.push(`Surface '${surface.surfaceId}' MCP auth must reference a secret input.`)
-      }
-    } else if (!surface.mcpCommand.trim()) {
-      errors.push(`Surface '${surface.surfaceId}' needs a stdio command.`)
-    }
+function isHttpUrl(value: string): boolean {
+  try {
+    const protocol = new URL(value).protocol
+    return protocol === 'http:' || protocol === 'https:'
+  } catch {
+    return false
   }
 }
 
-function credentialLike(key: string): boolean {
-  return [
-    'API_KEY',
-    'APPLICATION_KEY',
-    'ACCESS_KEY',
-    'ACCESS_TOKEN',
-    'ADMIN_KEY',
-    'AUTHORIZATION',
-    'BEARER_TOKEN',
-    'CLIENT_SECRET',
-    'PASSWORD',
-    'PRIVATE_KEY',
-    'READ_KEY',
-    'SECRET',
-    'TOKEN',
-  ].some((marker) => key.toUpperCase().includes(marker))
-}
-
-function validateInstallInputs(
-  inputs: SourceInputDraft[],
-  inputValues: Record<string, string>,
-): string[] {
-  return inputs
-    .filter((input) => input.required)
-    .filter((input) => !(inputValues[input.id] ?? '').trim())
-    .map((input) => `Required input '${input.key}' needs an install value.`)
-}
-
-function installInputs(inputs: SourceInputDraft[], values: Record<string, string>): InstallInput[] {
-  return inputs.flatMap((input) => {
-    const value = (values[input.id] ?? '').trim()
-    if (!value) return []
-    return [{ key: input.key, value, secret: input.kind === 'secret' }]
-  })
-}
-
-function relationName(sourceName: string, surface: SurfaceDraft): string {
-  const suffix = surface.namespaceSuffix.trim()
-  return suffix ? `${sourceName}_${suffix}` : sourceName
-}
-
-function primaryActionLabel(state: ImportState): string {
-  if (state.kind === 'importing') return 'Importing…'
-  if (state.kind === 'validating') return 'Validating…'
-  return 'Import & validate'
+function isAllowedMcpHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    if (url.protocol === 'https:') return true
+    if (url.protocol !== 'http:') return false
+    return ['localhost', '127.0.0.1', '::1'].includes(url.hostname)
+  } catch {
+    return false
+  }
 }
 
 function validationSummary(response: Awaited<ReturnType<typeof validateSource>>): string {

--- a/apps/ui/src/views/sources/sources-index.css.ts
+++ b/apps/ui/src/views/sources/sources-index.css.ts
@@ -30,9 +30,17 @@ export const container = style({
 })
 
 export const header = style({
+  alignItems: 'flex-start',
+  display: 'flex',
+  gap: 16,
+  justifyContent: 'space-between',
+})
+
+export const headerText = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 4,
+  minWidth: 0,
 })
 
 export const loadingState = style({

--- a/apps/ui/src/views/sources/sources-index.tsx
+++ b/apps/ui/src/views/sources/sources-index.tsx
@@ -3,9 +3,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Icon } from '@/wax/components/icon'
 import { TextInput } from '@/wax/components/inputs/text'
 import { Typography } from '@/wax/components/typography'
+import { Container as ButtonContainer } from '@/wax/components/button/container'
+import { Icon as ButtonIcon } from '@/wax/components/button/icon'
+import { Text as ButtonText } from '@/wax/components/button/text'
 
 import { ErrorBanner } from '@/components/error-banner'
 import { providerIcon } from '@/lib/provider-icons'
+import { useRouter } from '@/lib/router'
 import { SOURCE_CATEGORY_ORDER, getCategoryForSource } from '@/lib/source-categories'
 import { discoverBundled, type CatalogEntry } from '@/lib/sources'
 
@@ -22,6 +26,7 @@ export function SourcesIndex() {
   const [installingName, setInstallingName] = useState<string | null>(null)
   const [detailName, setDetailName] = useState<string | null>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
+  const { navigate } = useRouter()
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
@@ -112,11 +117,21 @@ export function SourcesIndex() {
     <div className={styles.root}>
       <div className={styles.container}>
         <div className={styles.header}>
-          <Typography.HeadingLarge as="h1">Sources</Typography.HeadingLarge>
-          <Typography.Body variant="secondary">
-            Connect external systems to query their data from Coral. Click a source to install or
-            inspect it.
-          </Typography.Body>
+          <div className={styles.headerText}>
+            <Typography.HeadingLarge as="h1">Sources</Typography.HeadingLarge>
+            <Typography.Body variant="secondary">
+              Connect external systems to query their data from Coral. Click a source to install or
+              inspect it.
+            </Typography.Body>
+          </div>
+          <ButtonContainer
+            onClick={() => navigate({ route: { kind: 'source-create' } })}
+            size="32"
+            variant="secondary"
+          >
+            <ButtonIcon name="Plus" />
+            <ButtonText>Create DSL v4 source</ButtonText>
+          </ButtonContainer>
         </div>
 
         <div className={styles.searchBar}>

--- a/apps/ui/tests/ui/sources.spec.ts
+++ b/apps/ui/tests/ui/sources.spec.ts
@@ -256,10 +256,11 @@ test('creates and validates a DSL v4 source', async ({ network, page, review }) 
   await review.pause()
 
   await review.chapter(
-    'Import and validate',
+    'Import and generate projections',
     'Submit the generated manifest and show validation results',
   )
-  await page.getByRole('button', { name: 'Import & validate' }).click()
+  await page.getByPlaceholder('Paste token').fill('ghp_test_token')
+  await page.getByRole('button', { name: 'Import and generate projections' }).click()
 
   await expect(page.getByRole('heading', { name: 'Validated github_openapi_v4' })).toBeVisible()
   await expect(page.getByText('github_openapi_v4.search_issues_and_pull_requests')).toBeVisible()

--- a/apps/ui/tests/ui/sources.spec.ts
+++ b/apps/ui/tests/ui/sources.spec.ts
@@ -1,4 +1,8 @@
-import { sourceLifecycleHandlers, sourceOAuthInstallHandlers } from './support/source-handlers'
+import {
+  sourceCreateHandlers,
+  sourceLifecycleHandlers,
+  sourceOAuthInstallHandlers,
+} from './support/source-handlers'
 import { expect, test } from './playwright.setup'
 
 test('lists core sources by category, searches, and shows configured status', async ({
@@ -236,5 +240,29 @@ test('cmd-F focuses the search input', async ({ network, page, review }) => {
   await page.keyboard.press('ControlOrMeta+f')
 
   await expect(page.getByPlaceholder('Search sources…')).toBeFocused()
+  await review.pause()
+})
+
+test('creates and validates a DSL v4 source', async ({ network, page, review }) => {
+  network.use(...sourceCreateHandlers())
+
+  await review.chapter('Open the v4 source creator', 'Render the source manifest builder page')
+  await page.goto('/#/sources/create')
+
+  await expect(page.getByRole('heading', { name: 'Create DSL v4 Source', level: 1 })).toBeVisible()
+  const manifest = page.getByLabel('Manifest YAML')
+  await expect(manifest).toHaveValue(/dsl_version: 4/)
+  await expect(manifest).toHaveValue(/type: openapi/)
+  await review.pause()
+
+  await review.chapter(
+    'Import and validate',
+    'Submit the generated manifest and show validation results',
+  )
+  await page.getByRole('button', { name: 'Import & validate' }).click()
+
+  await expect(page.getByRole('heading', { name: 'Validated github_openapi_v4' })).toBeVisible()
+  await expect(page.getByText('github_openapi_v4.search_issues_and_pull_requests')).toBeVisible()
+  await expect(page.getByText('github_openapi_v4.issues_get')).toBeVisible()
   await review.pause()
 })

--- a/apps/ui/tests/ui/support/source-fixtures.ts
+++ b/apps/ui/tests/ui/support/source-fixtures.ts
@@ -1,12 +1,19 @@
 import { create } from '@bufbuild/protobuf'
 
 import {
+  ColumnSchema,
+  TableFunctionResultColumnSchema,
+  TableFunctionSchema,
+  TableSchema,
+} from '../../../src/generated/coral/v1/catalog_pb'
+import {
   CreateBundledSourceResponseSchema,
   CreateBundledSourceWithOAuthResponseSchema,
   DeleteSourceResponseSchema,
   DiscoverSourcesResponseSchema,
   GetSourceInfoResponseSchema,
   GetSourceResponseSchema,
+  ImportSourceResponseSchema,
   ListSourcesResponseSchema,
   OAuthCredentialClientIdSchema,
   OAuthCredentialClientSchema,
@@ -27,6 +34,7 @@ import {
   SourceSecretSchema,
   SourceVariableInputSchema,
   SourceVariableSchema,
+  ValidateSourceResponseSchema,
   type Source,
   type SourceInfo,
 } from '../../../src/generated/coral/v1/sources_pb'
@@ -241,6 +249,14 @@ const installedLinear: Source = create(SourceSchema, {
   secrets: [create(SourceSecretSchema, { key: 'LINEAR_API_TOKEN', value: '' })],
 })
 
+const installedDslV4Source: Source = create(SourceSchema, {
+  name: 'github_openapi_v4',
+  origin: SourceOrigin.IMPORTED,
+  credentialStorage: SourceCredentialStorage.FILE,
+  variables: [],
+  secrets: [],
+})
+
 export const initialInstalledSources: Source[] = [installedCloudwatchLogs, installedGithub]
 
 export const discoverInitialResponse = create(DiscoverSourcesResponseSchema, {
@@ -330,5 +346,55 @@ export const createGithubOauthResponses = [
     },
   }),
 ]
+
+export const importDslV4Responses = [
+  create(ImportSourceResponseSchema, {
+    event: {
+      case: 'source',
+      value: installedDslV4Source,
+    },
+  }),
+]
+
+export const validateDslV4Response = create(ValidateSourceResponseSchema, {
+  source: installedDslV4Source,
+  tables: [
+    create(TableSchema, {
+      workspace: { name: 'default' },
+      schemaName: 'github_openapi_v4',
+      name: 'search_issues_and_pull_requests',
+      description: 'Search issues and pull requests.',
+      columns: [
+        create(ColumnSchema, {
+          name: 'id',
+          dataType: 'Int64',
+          nullable: false,
+          ordinalPosition: 0,
+        }),
+        create(ColumnSchema, {
+          name: 'title',
+          dataType: 'Utf8',
+          nullable: true,
+          ordinalPosition: 1,
+        }),
+      ],
+    }),
+  ],
+  tableFunctions: [
+    create(TableFunctionSchema, {
+      workspace: { name: 'default' },
+      schemaName: 'github_openapi_v4',
+      name: 'issues_get',
+      description: 'Get an issue by owner, repo, and issue number.',
+      resultColumns: [
+        create(TableFunctionResultColumnSchema, {
+          name: 'result_json',
+          dataType: 'Json',
+          nullable: true,
+        }),
+      ],
+    }),
+  ],
+})
 
 export const deleteSourceResponse = create(DeleteSourceResponseSchema, {})

--- a/apps/ui/tests/ui/support/source-handlers.ts
+++ b/apps/ui/tests/ui/support/source-handlers.ts
@@ -184,6 +184,10 @@ export function sourceCreateHandlers() {
       if (!message.manifestYaml.includes('github_openapi_v4')) {
         throw new Error('expected ImportSource manifest to include the source name')
       }
+      const token = message.secrets.find((secret) => secret.key === 'GITHUB_TOKEN')?.value
+      if (token !== 'ghp_test_token') {
+        throw new Error(`expected ImportSource to send GITHUB_TOKEN=ghp_test_token, got ${token}`)
+      }
       return grpcWebStreamResponse(ImportSourceResponseSchema, importDslV4Responses)
     }),
     http.post(validateUrl, async ({ request }) => {

--- a/apps/ui/tests/ui/support/source-handlers.ts
+++ b/apps/ui/tests/ui/support/source-handlers.ts
@@ -12,7 +12,11 @@ import {
   GetSourceInfoResponseSchema,
   GetSourceRequestSchema,
   GetSourceResponseSchema,
+  ImportSourceRequestSchema,
+  ImportSourceResponseSchema,
   ListSourcesResponseSchema,
+  ValidateSourceRequestSchema,
+  ValidateSourceResponseSchema,
 } from '../../../src/generated/coral/v1/sources_pb'
 import { grpcWebError, grpcWebRequest, grpcWebResponse, grpcWebStreamResponse } from './grpc-web'
 import {
@@ -30,11 +34,13 @@ import {
   getInstalledCloudwatchLogsResponse,
   getInstalledGithubResponse,
   getInstalledLinearResponse,
+  importDslV4Responses,
   listAfterGithubOauthResponse,
   listAfterLinearInstallResponse,
   listAfterLinearRemovedResponse,
   listEmptyResponse,
   listInitialResponse,
+  validateDslV4Response,
 } from './source-fixtures'
 
 const discoverUrl = '*/coral.v1.SourceService/DiscoverSources'
@@ -43,6 +49,8 @@ const getUrl = '*/coral.v1.SourceService/GetSource'
 const getInfoUrl = '*/coral.v1.SourceService/GetSourceInfo'
 const createBundledUrl = '*/coral.v1.SourceService/CreateBundledSource'
 const createBundledWithOAuthUrl = '*/coral.v1.SourceService/CreateBundledSourceWithOAuth'
+const importUrl = '*/coral.v1.SourceService/ImportSource'
+const validateUrl = '*/coral.v1.SourceService/ValidateSource'
 const deleteUrl = '*/coral.v1.SourceService/DeleteSource'
 
 function sourceInfoResponse(name: string) {
@@ -159,6 +167,31 @@ export function sourceOAuthInstallHandlers() {
         createGithubOauthResponses,
         { delayMs: 1500 },
       )
+    }),
+  ]
+}
+
+export function sourceCreateHandlers() {
+  return [
+    http.post(importUrl, async ({ request }) => {
+      const message = await grpcWebRequest(ImportSourceRequestSchema, request)
+      if (!message.manifestYaml.includes('dsl_version: 4')) {
+        throw new Error('expected ImportSource manifest to use DSL v4')
+      }
+      if (!message.manifestYaml.includes('type: openapi')) {
+        throw new Error('expected ImportSource manifest to include an OpenAPI surface')
+      }
+      if (!message.manifestYaml.includes('github_openapi_v4')) {
+        throw new Error('expected ImportSource manifest to include the source name')
+      }
+      return grpcWebStreamResponse(ImportSourceResponseSchema, importDslV4Responses)
+    }),
+    http.post(validateUrl, async ({ request }) => {
+      const message = await grpcWebRequest(ValidateSourceRequestSchema, request)
+      if (message.name !== 'github_openapi_v4') {
+        throw new Error(`expected ValidateSource for github_openapi_v4, got ${message.name}`)
+      }
+      return grpcWebResponse(ValidateSourceResponseSchema, validateDslV4Response)
     }),
   ]
 }


### PR DESCRIPTION
## Summary

- Add a new `#/sources/create` page for the current DSL v4 source creation flow.
- Simplify creation to one generated surface at a time: choose OpenAPI spec or MCP server, enter connection details, provide auth, then import/materialize and validate.
- Add UI source-service helpers for `ImportSource` and `ValidateSource`, plus navigation and focused Playwright coverage.

## Verified DSL v4 behavior

- `ImportSource` is the public API that installs the manifest and runs DSL v4 materialization; there is no current UI-facing projection-preview endpoint before persistence.
- OpenAPI v4 materialization fetches an HTTPS descriptor and generates projections from the semantic IR.
- MCP v4 materialization discovers the MCP tool catalog at import time. The manifest supports Streamable HTTP server URLs and stdio commands.
- Required secrets are validated before materialization, so GitHub-style required tokens must be collected before import.
- Checked-in preview v4 examples are `github_v4` and `stripe_v4`; Slack remains a DSL v3 source in this repo.

## Validation

- `npm run check --prefix apps/ui`
- `npm run type-check --prefix apps/ui`
- `npm run test:ui --prefix apps/ui -- sources.spec.ts`