### PR TITLE
refactor(app): share envelope crypto for identity documents

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -229,6 +229,9 @@ jobs:
             state::db::repositories::credential_documents::tests::credential_document_repository_round_trips_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            state::db::repositories::trace_summaries::tests::trace_summary_repository_round_trips_against_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
             state::db::import::tests::concurrent_credential_import_race_is_benign_postgres \
             -- --ignored
           cargo test --locked -p coral-app \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -232,6 +232,9 @@ jobs:
             state::db::repositories::trace_summaries::tests::trace_summary_repository_round_trips_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            telemetry::service::tests::backfill_summaries_preserves_existing_postgres_rows \
+            -- --ignored
+          cargo test --locked -p coral-app \
             state::db::import::tests::concurrent_credential_import_race_is_benign_postgres \
             -- --ignored
           cargo test --locked -p coral-app \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -211,6 +211,9 @@ jobs:
             state::db::repositories::sources::tests::source_repository_rejects_invalid_persisted_source_name_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            state::db::repositories::feedback_reports::tests::feedback_report_repository_round_trips_against_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
             state::db::migrations::tests::source_catalog_migration_contract_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -214,6 +214,9 @@ jobs:
             state::db::repositories::feedback_reports::tests::feedback_report_repository_round_trips_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            state::db::import::tests::concurrent_feedback_report_import_race_is_benign_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
             state::db::migrations::tests::source_catalog_migration_contract_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -194,13 +194,18 @@ jobs:
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      - name: Install Postgres client
+        run: sudo apt-get update && sudo apt-get install --yes postgresql-client
+
       - name: Run Postgres database tests
         env:
           CORAL_TEST_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/postgres
+          CORAL_TEST_POSTGRES_SERVER_LIFECYCLE_URL: postgres://postgres:postgres@localhost:5432/coral_server_lifecycle
+          PGPASSWORD: postgres
         run: |
           cargo test --locked -p coral-app \
-            state::db::repositories::workspaces::tests::workspace_repository_round_trips_against_postgres \
-            -- --ignored
+            state::db::repositories \
+            -- --ignored --test-threads=1
           cargo test --locked -p coral-app \
             state::db::repositories::sources::tests::source_repository_round_trips_against_postgres \
             -- --ignored
@@ -249,7 +254,18 @@ jobs:
           cargo test --locked -p coral-app \
             state::db::import::tests::concurrent_v4_materialization_backfill_race_is_benign_postgres \
             -- --ignored
-          cargo test --locked -p coral-app \
+
+          cleanup_lifecycle_db() {
+            psql --host localhost --username postgres --dbname postgres \
+              --command 'DROP DATABASE IF EXISTS coral_server_lifecycle WITH (FORCE);'
+          }
+          trap cleanup_lifecycle_db EXIT
+          cleanup_lifecycle_db
+          psql --host localhost --username postgres --dbname postgres \
+            --command 'CREATE DATABASE coral_server_lifecycle;'
+
+          CORAL_TEST_POSTGRES_URL="${CORAL_TEST_POSTGRES_SERVER_LIFECYCLE_URL}" \
+            cargo test --locked -p coral-app \
             --test grpc server_lifecycle_can_start_with_postgres_database_config \
             -- --ignored
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -217,6 +217,9 @@ jobs:
             state::db::import::tests::concurrent_feedback_report_import_race_is_benign_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            state::db::import::tests::concurrent_episode_import_race_serializes_on_workspace_lock_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
             state::db::repositories::episodes::tests::episode_repository_round_trips_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -202,6 +202,15 @@ jobs:
             state::db::repositories::workspaces::tests::workspace_repository_round_trips_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            state::db::repositories::sources::tests::source_repository_round_trips_against_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
+            state::db::repositories::sources::tests::source_repository_rejects_source_without_workspace_against_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
+            state::db::repositories::sources::tests::source_repository_rejects_invalid_persisted_source_name_against_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
             state::db::migrations::tests::source_catalog_migration_contract_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -204,56 +204,8 @@ jobs:
           PGPASSWORD: postgres
         run: |
           cargo test --locked -p coral-app \
-            state::db::repositories \
+            --lib \
             -- --ignored --test-threads=1
-          cargo test --locked -p coral-app \
-            state::db::repositories::sources::tests::source_repository_round_trips_against_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            state::db::repositories::sources::tests::source_repository_rejects_source_without_workspace_against_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            state::db::repositories::sources::tests::source_repository_rejects_invalid_persisted_source_name_against_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            state::db::repositories::sources::tests::source_delete_upsert_race_cannot_resurrect_database_credentials_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            state::db::repositories::feedback_reports::tests::feedback_report_repository_round_trips_against_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            state::db::import::tests::concurrent_feedback_report_import_race_is_benign_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            state::db::import::tests::concurrent_episode_import_race_serializes_on_workspace_lock_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            state::db::repositories::episodes::tests::episode_repository_round_trips_against_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            episode::store::tests::open_episode_in_db_runtime_path_against_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            state::db::repositories::credential_documents::tests::credential_document_repository_round_trips_against_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            state::db::repositories::trace_summaries::tests::trace_summary_repository_round_trips_against_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            telemetry::service::tests::backfill_summaries_preserves_existing_postgres_rows \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            state::db::import::tests::concurrent_credential_import_race_is_benign_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            --test grpc source_lifecycle_tests::postgres_database_credentials_survive_restart_and_query \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            state::db::migrations::tests::source_catalog_migration_contract_against_postgres \
-            -- --ignored
-          cargo test --locked -p coral-app \
-            state::db::import::tests::concurrent_v4_materialization_backfill_race_is_benign_postgres \
-            -- --ignored
 
           cleanup_lifecycle_db() {
             psql --host localhost --username postgres --dbname postgres \
@@ -266,8 +218,8 @@ jobs:
 
           CORAL_TEST_POSTGRES_URL="${CORAL_TEST_POSTGRES_SERVER_LIFECYCLE_URL}" \
             cargo test --locked -p coral-app \
-            --test grpc server_lifecycle_can_start_with_postgres_database_config \
-            -- --ignored
+              --test grpc \
+              -- --ignored --test-threads=1
 
   windows-rust-smoke:
     name: Windows Rust smoke

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -229,6 +229,9 @@ jobs:
             state::db::repositories::credential_documents::tests::credential_document_repository_round_trips_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            state::db::import::tests::concurrent_credential_import_race_is_benign_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
             --test grpc source_lifecycle_tests::postgres_database_credentials_survive_restart_and_query \
             -- --ignored
           cargo test --locked -p coral-app \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -220,6 +220,9 @@ jobs:
             state::db::repositories::episodes::tests::episode_repository_round_trips_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            episode::store::tests::open_episode_in_db_runtime_path_against_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
             state::db::migrations::tests::source_catalog_migration_contract_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -229,6 +229,9 @@ jobs:
             state::db::repositories::credential_documents::tests::credential_document_repository_round_trips_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            --test grpc source_lifecycle_tests::postgres_database_credentials_survive_restart_and_query \
+            -- --ignored
+          cargo test --locked -p coral-app \
             state::db::migrations::tests::source_catalog_migration_contract_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -211,6 +211,9 @@ jobs:
             state::db::repositories::sources::tests::source_repository_rejects_invalid_persisted_source_name_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            state::db::repositories::sources::tests::source_delete_upsert_race_cannot_resurrect_database_credentials_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
             state::db::repositories::feedback_reports::tests::feedback_report_repository_round_trips_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -226,6 +226,9 @@ jobs:
             episode::store::tests::open_episode_in_db_runtime_path_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            state::db::repositories::credential_documents::tests::credential_document_repository_round_trips_against_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
             state::db::migrations::tests::source_catalog_migration_contract_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -217,6 +217,9 @@ jobs:
             state::db::import::tests::concurrent_feedback_report_import_race_is_benign_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            state::db::repositories::episodes::tests::episode_repository_round_trips_against_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
             state::db::migrations::tests::source_catalog_migration_contract_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -162,6 +162,49 @@ jobs:
       - name: Run make rust-checks
         run: make rust-checks
 
+  postgres-database-tests:
+    name: Postgres database tests
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.rust_checks == 'true' }}
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: coral-postgres-${{ runner.os }}
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run Postgres database tests
+        env:
+          CORAL_TEST_POSTGRES_URL: postgres://postgres:postgres@localhost:5432/postgres
+        run: |
+          cargo test --locked -p coral-app \
+            state::db::repositories::workspaces::tests::workspace_repository_round_trips_against_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
+            --test grpc server_lifecycle_can_start_with_postgres_database_config \
+            -- --ignored
+
   windows-rust-smoke:
     name: Windows Rust smoke
     runs-on: windows-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -214,6 +214,9 @@ jobs:
             state::db::migrations::tests::source_catalog_migration_contract_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            state::db::import::tests::concurrent_v4_materialization_backfill_race_is_benign_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
             --test grpc server_lifecycle_can_start_with_postgres_database_config \
             -- --ignored
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -202,6 +202,9 @@ jobs:
             state::db::repositories::workspaces::tests::workspace_repository_round_trips_against_postgres \
             -- --ignored
           cargo test --locked -p coral-app \
+            state::db::migrations::tests::source_catalog_migration_contract_against_postgres \
+            -- --ignored
+          cargo test --locked -p coral-app \
             --test grpc server_lifecycle_can_start_with_postgres_database_config \
             -- --ignored
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sqlx",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,6 +1265,7 @@ dependencies = [
  "windows-native-keyring-store",
  "wiremock",
  "zbus-secret-service-keyring-store",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,9 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -1070,7 +1073,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1236,10 +1239,13 @@ dependencies = [
  "prost",
  "regex",
  "reqwest 0.13.4",
+ "sea-query",
+ "sea-query-sqlx",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
+ "sqlx",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1460,12 +1466,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1557,12 +1587,35 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1580,11 +1633,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1965,7 +2029,7 @@ dependencies = [
  "hex",
  "itertools",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "num-traits",
  "rand 0.9.4",
@@ -2394,6 +2458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,6 +2480,9 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -2551,6 +2624,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,6 +2733,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2829,6 +2924,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2853,6 +2963,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3462,6 +3581,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3532,6 +3662,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3747,7 +3887,7 @@ dependencies = [
  "humantime",
  "hyper",
  "itertools",
- "md-5",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
@@ -4186,7 +4326,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -4370,7 +4510,7 @@ version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -4729,7 +4869,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -4938,6 +5078,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sea-query"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d190cfb3bcceb8a8d7d04dee5a0c77f60c7627979cdcb47fdcb8934f009badf"
+dependencies = [
+ "sea-query-derive",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b0f466921cdd3cf4b89d5c3ac2173dba89a873ab395b123a645de181ec7537"
+dependencies = [
+ "darling 0.20.11",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
+name = "sea-query-sqlx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eaa419cdb9157da1361186b1959983eb2ea0dcb9a3c69dc45c449ecb2af8fef"
+dependencies = [
+ "sea-query",
+ "sqlx",
+]
+
+[[package]]
 name = "secret-service"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4948,7 +5121,7 @@ dependencies = [
  "futures-util",
  "generic-array",
  "getrandom 0.2.17",
- "hkdf",
+ "hkdf 0.12.4",
  "num",
  "once_cell",
  "serde",
@@ -5092,6 +5265,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5210,6 +5394,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snap"
@@ -5225,6 +5412,15 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -5247,6 +5443,178 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
+dependencies = [
+ "base64",
+ "bytes",
+ "cfg-if",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
+dependencies = [
+ "cfg-if",
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.11.3",
+ "dotenvy",
+ "either",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sha1",
+ "sha2 0.11.0",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "itoa",
+ "log",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
+dependencies = [
+ "atoi",
+ "flume",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -5279,6 +5647,17 @@ dependencies = [
  "libc",
  "psm",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -5757,6 +6136,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5876,10 +6256,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5952,6 +6353,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -6117,6 +6524,21 @@ checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,6 +1239,7 @@ dependencies = [
  "prost",
  "regex",
  "reqwest 0.13.4",
+ "ring",
  "sea-query",
  "sea-query-sqlx",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.9"
 schemars = "1.2.1"
+sea-query = { version = "1", default-features = false, features = ["backend-postgres", "backend-sqlite", "derive", "thread-safe"] }
+sea-query-sqlx = { version = "0.9", default-features = false, features = ["sqlx-postgres", "sqlx-sqlite"] }
 sha2 = "0.10"
+sqlx = { version = "0.9", default-features = false, features = ["macros", "migrate", "postgres", "runtime-tokio", "sqlite", "tls-rustls"] }
 sqlparser = "0.59.0"
 strsim = "0.11"
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ urlencoding = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
 walkdir = "2"
 wiremock = "0.6"
+zeroize = "1.8"
 
 coral-api = { path = "crates/coral-api" }
 coral-app = { path = "crates/coral-app" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ parquet = { version = "58.1.0", features = ["arrow"] }
 prost = "0.14.1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "charset", "form", "http2", "json", "query", "rustls", "system-proxy"] }
 regex = "1"
+ring = "0.17.14"
 rmcp = { version = "1.6.0", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 rusqlite = { version = "0.37", features = ["bundled"] }
 rust-embed = { version = "8", features = ["mime-guess"] }

--- a/README.md
+++ b/README.md
@@ -241,10 +241,7 @@ export CORAL_CONFIG_DIR=/path/to/coral-config
 
 Important files include:
 
-- `config.toml` for runtime settings such as feature flags, tracing, and
-  database bootstrap configuration
-- the local Coral database for installed-source metadata and non-secret
-  variables
+- `config.toml` for installed-source metadata and non-secret variables
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,10 @@ export CORAL_CONFIG_DIR=/path/to/coral-config
 
 Important files include:
 
-- `config.toml` for installed-source metadata and non-secret variables
+- `config.toml` for runtime settings such as feature flags, tracing, and
+  database bootstrap configuration
+- the local Coral database for installed-source metadata and non-secret
+  variables
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 

--- a/README.md
+++ b/README.md
@@ -241,9 +241,15 @@ export CORAL_CONFIG_DIR=/path/to/coral-config
 
 Important files include:
 
-- `config.toml` for installed-source metadata and non-secret variables
-- imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
-- source secrets stored separately within the same local trust boundary
+- `config.toml` for runtime settings such as feature flags, tracing, and
+  database bootstrap configuration
+- `coral.db`, the default local Coral database for installed-source metadata,
+  imported source specs, DSL v4 materialization metadata, feedback reports,
+  episode records, trace summaries, and non-secret variables
+- `credentials/encryption.key`, the local key material used to protect
+  encrypted credential documents
+- `telemetry/traces`, the local raw trace span store when trace history is
+  enabled
 
 Bundled source specs are not copied into the config directory. Coral resolves
 them from the current binary when you validate or query a bundled source, so

--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -221,9 +221,10 @@ On Windows, the default local state path is
 
 Important files include:
 
-- `config.toml` for installed-source metadata, non-secret variables, and runtime settings. See [Configuration](/reference/configuration).
-- imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
-- source secrets stored separately within the same local trust boundary
+- `config.toml` for runtime settings such as feature flags, tracing, and database bootstrap configuration. See [Configuration](/reference/configuration).
+- `coral.db`, the default local Coral database for installed-source metadata, imported source specs, DSL v4 materialization metadata, feedback reports, episode records, trace summaries, and non-secret variables
+- `credentials/encryption.key`, the local key material used to protect encrypted credential documents
+- `telemetry/traces`, the local raw trace span store when trace history is enabled
 
 <Note>
   [Bundled source](/reference/bundled-sources) specs are not copied into the config directory. Coral resolves them from the current binary when you validate or query a bundled source, so upgrades pick up newer bundled manifests without re-adding the source.

--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -221,8 +221,7 @@ On Windows, the default local state path is
 
 Important files include:
 
-- `config.toml` for runtime settings such as feature flags, tracing, and database bootstrap configuration. See [Configuration](/reference/configuration).
-- the local Coral database for installed-source metadata and non-secret variables
+- `config.toml` for installed-source metadata, non-secret variables, and runtime settings. See [Configuration](/reference/configuration).
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 

--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -221,7 +221,8 @@ On Windows, the default local state path is
 
 Important files include:
 
-- `config.toml` for installed-source metadata, non-secret variables, and runtime settings. See [Configuration](/reference/configuration).
+- `config.toml` for runtime settings such as feature flags, tracing, and database bootstrap configuration. See [Configuration](/reference/configuration).
+- the local Coral database for installed-source metadata and non-secret variables
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 

--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -223,7 +223,7 @@ Important files include:
 
 - `config.toml` for runtime settings such as feature flags, tracing, and database bootstrap configuration. See [Configuration](/reference/configuration).
 - `coral.db`, the default local Coral database for installed-source metadata, imported source specs, DSL v4 materialization metadata, feedback reports, episode records, trace summaries, and non-secret variables
-- `credentials/encryption.key`, the local key material used to protect encrypted credential documents
+- `credentials/encryption.key`, the local file-backed key material used to protect encrypted credential documents when file KEK sourcing is active
 - `telemetry/traces`, the local raw trace span store when trace history is enabled
 
 <Note>

--- a/apps/docs/project/security.mdx
+++ b/apps/docs/project/security.mdx
@@ -19,8 +19,9 @@ This release is intended for single-user local use:
   which MCP clients or scripts may call Coral.
 - Coral stores configuration under the local Coral config directory, which
   defaults to the platform config directory and can be changed with
-  `CORAL_CONFIG_DIR`. Source secrets default to OS credential storage when the
-  local keychain is usable, with plaintext file storage available as fallback.
+  `CORAL_CONFIG_DIR`. New source secrets are stored as encrypted documents in
+  Coral's configured database and protected by local key material in that
+  directory.
 - CLI and MCP queries run through the same local runtime. The internal gRPC
   server binds to loopback, and the MCP server uses stdio transport.
 
@@ -32,6 +33,12 @@ clients can route source-specific requests to Coral during discovery.
 Secret values are not returned through `coral.inputs`; secret rows show only
 whether a value is configured.
 
+The default SQLite database stays under the local Coral config directory. If
+you configure Postgres, treat the Postgres server, network path, and connection
+URL as part of Coral's trusted local-state boundary. Installed-source metadata,
+imported source specs, non-secret variables, trace summaries, and encrypted
+credential documents are written to that database.
+
 ## What Coral protects against
 
 Coral's current protections are aimed at accidental exposure within that local
@@ -39,12 +46,14 @@ trust boundary:
 
 - Source secrets are stored separately from non-secret source variables and are
   never written into `config.toml`.
-- By default, sources use the operating-system credential store when Coral
-  can successfully write, read, and delete a probe item. On macOS this uses
-  Keychain; on Windows, Credential Manager; on Linux, Secret Service.
-- If keychain probing fails in `auto` mode, Coral stores source secrets in
-  plaintext local files and reports the route as `file (plaintext)` in source
-  output.
+- Source secrets are encrypted before they are written to Coral's configured
+  database. The database stores ciphertext, nonces, wrapped data-encryption
+  keys, and key identifiers; the local key material lives under
+  `credentials/encryption.key`.
+- Older file-backed credential material from `secrets.env` is imported into
+  encrypted database documents during startup when Coral can read it.
+- Older keychain-backed sources keep using keychain storage until you replace
+  their credentials or re-add the source.
 - State files written by Coral use private file permissions on Unix systems.
   On Windows, Coral stores local state under
   `%APPDATA%\withcoral\coral\config` by default and relies on the user's
@@ -56,25 +65,18 @@ trust boundary:
 - MCP clients can query installed sources, but they do not receive raw stored
   secret values through the discovery tables or resources.
 
-## Secret storage configuration
+## Secret storage
 
-Coral reads the credential storage preference from `config.toml`:
-
-```toml
-[credentials]
-storage = "auto"
-```
-
-Supported values:
-
-| Value | Behavior |
-| --- | --- |
-| `auto` | Default. Use keychain when the probe succeeds; otherwise use plaintext file storage. |
-| `keychain` | Require OS credential storage. If unavailable, source installation fails. |
-| `file` | Store source secrets in plaintext `secrets.env` files under Coral's config directory. |
+New source installs store source secrets in encrypted database documents. The
+source catalog records whether an installed source has stored secret material;
+`coral source list` and `coral source info <NAME>` report this as
+`database (encrypted)` for new encrypted material, `keychain` for legacy
+keychain-backed sources, or `none`.
 
 <Note>
-Changing the global preference does not rewrite existing credentials. To update those, remove and re-add the source you want to update.
+Keep `coral.db` and `credentials/encryption.key` together when backing up or
+moving local Coral state. Losing the key material means encrypted source secrets
+cannot be decrypted.
 </Note>
 
 ## What you still need to trust
@@ -90,10 +92,15 @@ you configure; it does not make an otherwise untrusted local agent safe.
   token, so prefer read-only and least-privilege credentials.
 - A custom source spec can direct Coral to make HTTP requests or read local file
   locations declared by that spec. Only install source specs you trust.
+- If you configure Postgres, anyone who can read that database can inspect
+  source metadata, imported specs, non-secret variables, trace summaries, and
+  encrypted credential documents. Anyone who can also read
+  `credentials/encryption.key` should be treated as able to decrypt stored
+  source secrets.
 - Anyone who can control your user account should be treated as able to use the
-  configured sources. If a source uses file-backed secret storage, anyone who
-  can read your local Coral config directory should also be treated as able to
-  read its stored source secrets.
+  configured sources. Anyone who can read both Coral's configured database and
+  its credential encryption key should also be treated as able to decrypt stored
+  source secrets.
 - Coral does not attempt to protect against a compromised machine, compromised
   MCP client, malicious shell environment, or malicious upstream API response.
 
@@ -102,8 +109,12 @@ you configure; it does not make an otherwise untrusted local agent safe.
 - Scope provider tokens to the minimum data your workflow needs.
 - Put Coral's config directory on a local disk protected by your operating
   system account controls.
+- Keep Postgres on a host and network path you trust. Remote Postgres URLs must
+  use hostname-verified TLS; loopback Postgres without TLS is intended for
+  local development and CI.
 - Use `coral source list` or `coral source info <NAME>` to inspect whether a
-  source uses `keychain` or `file (plaintext)` secret storage.
+  source has encrypted database-backed secret storage or a legacy keychain
+  route.
 - Review custom source specs before installing them, especially `base_url`,
   `auth`, and file `location` fields.
 - Configure `coral mcp-stdio` only in MCP clients you are comfortable allowing

--- a/apps/docs/project/security.mdx
+++ b/apps/docs/project/security.mdx
@@ -48,8 +48,10 @@ trust boundary:
   never written into `config.toml`.
 - Source secrets are encrypted before they are written to Coral's configured
   database. The database stores ciphertext, nonces, wrapped data-encryption
-  keys, and key identifiers; the local key material lives under
-  `credentials/encryption.key`.
+  keys, and key identifiers. The local KEK comes from
+  `[credentials].encryption_key_env`, the OS keychain, or
+  `credentials/encryption.key`, depending on
+  `[credentials].encryption_key_source`.
 - Older file-backed credential material from `secrets.env` is imported into
   encrypted database documents during startup when Coral can read it.
 - Older keychain-backed sources keep using keychain storage until you replace
@@ -74,9 +76,11 @@ source catalog records whether an installed source has stored secret material;
 keychain-backed sources, or `none`.
 
 <Note>
-Keep `coral.db` and `credentials/encryption.key` together when backing up or
-moving local Coral state. Losing the key material means encrypted source secrets
-cannot be decrypted.
+Keep `coral.db` and the active credential encryption key together when backing
+up or moving local Coral state. For file-backed KEKs, that means
+`credentials/encryption.key`; for env or keychain-backed KEKs, preserve the
+same `v1:<base64>` key material. Losing the key material means encrypted source
+secrets cannot be decrypted.
 </Note>
 
 ## What you still need to trust
@@ -94,9 +98,8 @@ you configure; it does not make an otherwise untrusted local agent safe.
   locations declared by that spec. Only install source specs you trust.
 - If you configure Postgres, anyone who can read that database can inspect
   source metadata, imported specs, non-secret variables, trace summaries, and
-  encrypted credential documents. Anyone who can also read
-  `credentials/encryption.key` should be treated as able to decrypt stored
-  source secrets.
+  encrypted credential documents. Anyone who can also read the active KEK
+  should be treated as able to decrypt stored source secrets.
 - Anyone who can control your user account should be treated as able to use the
   configured sources. Anyone who can read both Coral's configured database and
   its credential encryption key should also be treated as able to decrypt stored

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -83,8 +83,9 @@ List sources currently installed.
 coral source list
 ```
 
-The output includes the source's secret storage route: `keychain` or
-`file (plaintext)`.
+The output includes the source's stored-secret route, such as
+`database (encrypted)`, `keychain` for legacy keychain-backed sources, or
+`none`.
 
 ### `coral source info <NAME>`
 
@@ -147,11 +148,9 @@ coral source add --interactive github
 
 If the source is already installed, running this command again replaces its stored credentials with the new values you provide. After installation, it prints the discovered tables and runs any optional top-level `test_queries` declared in the source spec to validate the connection. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
 
-Sources use OS credential storage by default when Coral can write, read, and
-delete a keychain probe item. If the keychain is unavailable in `auto` mode,
-Coral stores the source secrets in plaintext file storage and shows
-`file (plaintext)` in source output. Sources with no stored secret material show
-`none`.
+New sources with stored secret material show `database (encrypted)` in source
+output. Legacy keychain-backed sources may still show `keychain`, and sources
+with no stored secret material show `none`.
 
 ### `coral source lint <FILE>`
 
@@ -180,9 +179,9 @@ coral source remove github
 
 ## `coral workspace`
 
-Manage local workspaces. Workspaces isolate installed source metadata and
-workspace-scoped artifacts such as source manifests, local credential material,
-feedback reports, episode logs, and workspace-attributed local trace history.
+Manage local workspaces. Workspaces isolate installed source metadata,
+source-scoped credential material, feedback reports, episode records, and
+workspace-attributed local trace history.
 
 Imported source specs and source credential material are attached to the source
 installation in that workspace. Reusable global source specs and reusable

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -7,14 +7,12 @@ Coral stores local configuration in `config.toml` inside its platform-specific [
 
 ## Managed state
 
-Coral stores source installation state in its local database when you run commands such as `coral source add` and `coral source remove`.
+Coral writes source installation state to `config.toml` when you run commands such as `coral source add` and `coral source remove`.
 
 This state includes installed-source metadata and non-secret source variables. Source secrets are stored separately within the same local trust boundary.
 
 <Note>
-  Prefer the `coral source` commands for source state instead of editing
-  workspace entries manually. Current Coral releases no longer use
-  `[workspaces.*.sources.*]` entries in `config.toml` as the source catalog.
+  Prefer the `coral source` commands for source state instead of editing workspace entries manually.
 </Note>
 
 ## Workspaces
@@ -27,26 +25,23 @@ exists automatically, and additional workspaces can be managed with
 [workspaces.default]
 
 [workspaces.work]
+
+[workspaces.work.sources.github]
+version = "1.0.0"
+variables = {}
+secrets = ["GITHUB_TOKEN"]
+origin = "bundled"
 ```
 
 An empty workspace is represented by an explicit `[workspaces.<name>]` table.
+Installed sources for that workspace live under
+`[workspaces.<name>.sources.<source>]`.
 
 There is no separate active-workspace key in `config.toml`; use
 `CORAL_WORKSPACE` for a shell default or `--workspace <NAME>` for one command.
 Source specs imported from files and source credential material remain scoped
 to the source installation in a workspace. Reusable global source specs and
 reusable credential references are not config objects today.
-
-Older `config.toml` source entries are imported into the database on startup and
-removed from `config.toml` after the import is validated. This source-catalog
-migration is one-way for current releases: downgrading to an older
-config-backed Coral build does not automatically restore those config entries.
-
-If you need to run an older build after this migration, re-add bundled sources
-with `coral source add <NAME>`. Re-add imported sources with
-`coral source add --file <PATH>`, using the existing manifest under the local
-state directory, such as
-`workspaces/<workspace>/sources/<source>/manifest.yaml`.
 
 ## Runtime features
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -36,8 +36,10 @@ Current builds persist installed sources in the database. Older
 `[workspaces.<name>.sources.<source>]` entries are legacy source-catalog inputs
 that Coral imports into the database on startup and removes from `config.toml`
 after the import is validated. This source-catalog migration is one-way for
-current releases: downgrading to an older config-backed Coral build does not
-automatically restore those config entries.
+current releases: the first successful database-backed startup stamps
+`config.toml` with the migrated config version, and unsupported future config
+versions fail closed instead of being interpreted as older filesystem-backed
+state.
 
 There is no separate active-workspace key in `config.toml`; use
 `CORAL_WORKSPACE` for a shell default or `--workspace <NAME>` for one command.
@@ -45,10 +47,13 @@ Installed source specs and source credential material remain scoped to the
 source installation in a workspace. Reusable global source specs and reusable
 credential references are not config objects today.
 
-If you need to run an older build after this migration, re-add bundled sources
-with `coral source add <NAME>`. Re-add imported sources with
-`coral source add --file <PATH>`, using the original source-spec file you used
-for installation.
+Successful startup import also deletes verified legacy credential and state
+artifacts after their database rows are written. That includes file-backed
+`secrets.env` material, migrated keychain entries, and imported local history
+files such as episode and feedback JSONL. If you roll back to an older build,
+use a separate state directory or re-add bundled sources with
+`coral source add <NAME>`, re-add imported sources with
+`coral source add --file <PATH>`, and re-provide credentials.
 
 Raw trace span JSONL and optional HTTP/MCP body captures remain outside the
 database. Trace summaries are indexed in the database from the local trace span
@@ -85,6 +90,38 @@ non-secret variables, trace summaries, and encrypted credential documents to
 the configured database. Keep the connection URL secret, use a Postgres host
 and network path you trust, and use hostname-verified TLS for non-loopback
 servers.
+
+## Credential encryption keys
+
+Encrypted database credential documents are protected by a key-encryption key
+(KEK). Configure that KEK before enabling shared Postgres:
+
+```toml
+[credentials]
+encryption_key_env = "CORAL_CREDENTIAL_KEK"
+encryption_key_source = "auto"
+```
+
+If `encryption_key_env` is set, Coral reads that environment variable first.
+The value must be `v1:<base64>`, where the base64 payload decodes to 32 bytes
+of key material. Missing or invalid environment material fails closed; Coral
+does not fall back to another KEK source after an explicit env key is
+configured.
+
+If no env key is configured, `encryption_key_source` controls local KEK
+selection:
+
+| Value | Behavior |
+| ----- | -------- |
+| `auto` | Reuses an existing `credentials/encryption.key` file if one exists. Otherwise prefers the OS keychain. If keychain access is unavailable, logs a warning and creates the file key. |
+| `keychain` | Uses the OS keychain and fails closed when keychain access is unavailable. Keychains are per host, so shared-Postgres deployments must pre-seed every server with the same key material before use. |
+| `file` | Uses `credentials/encryption.key` under the local state directory. |
+| `vault` | Reserved for external vault-backed KEKs and currently fails closed because it is not implemented. |
+
+For shared Postgres, every Coral server that can read or write encrypted
+credential documents must use the same KEK before Postgres is enabled. If two
+servers create different auto-generated local keys, each server can create
+documents the other cannot decrypt.
 
 ## Runtime features
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -7,12 +7,14 @@ Coral stores local configuration in `config.toml` inside its platform-specific [
 
 ## Managed state
 
-Coral writes source installation state to `config.toml` when you run commands such as `coral source add` and `coral source remove`.
+Coral stores source installation state in its local database when you run commands such as `coral source add` and `coral source remove`.
 
 This state includes installed-source metadata and non-secret source variables. Source secrets are stored separately within the same local trust boundary.
 
 <Note>
-  Prefer the `coral source` commands for source state instead of editing workspace entries manually.
+  Prefer the `coral source` commands for source state instead of editing
+  workspace entries manually. Current Coral releases no longer use
+  `[workspaces.*.sources.*]` entries in `config.toml` as the source catalog.
 </Note>
 
 ## Workspaces
@@ -25,23 +27,26 @@ exists automatically, and additional workspaces can be managed with
 [workspaces.default]
 
 [workspaces.work]
-
-[workspaces.work.sources.github]
-version = "1.0.0"
-variables = {}
-secrets = ["GITHUB_TOKEN"]
-origin = "bundled"
 ```
 
 An empty workspace is represented by an explicit `[workspaces.<name>]` table.
-Installed sources for that workspace live under
-`[workspaces.<name>.sources.<source>]`.
 
 There is no separate active-workspace key in `config.toml`; use
 `CORAL_WORKSPACE` for a shell default or `--workspace <NAME>` for one command.
 Source specs imported from files and source credential material remain scoped
 to the source installation in a workspace. Reusable global source specs and
 reusable credential references are not config objects today.
+
+Older `config.toml` source entries are imported into the database on startup and
+removed from `config.toml` after the import is validated. This source-catalog
+migration is one-way for current releases: downgrading to an older
+config-backed Coral build does not automatically restore those config entries.
+
+If you need to run an older build after this migration, re-add bundled sources
+with `coral source add <NAME>`. Re-add imported sources with
+`coral source add --file <PATH>`, using the existing manifest under the local
+state directory, such as
+`workspaces/<workspace>/sources/<source>/manifest.yaml`.
 
 ## Runtime features
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -7,9 +7,13 @@ Coral stores local configuration in `config.toml` inside its platform-specific [
 
 ## Managed state
 
-Coral writes source installation state to `config.toml` when you run commands such as `coral source add` and `coral source remove`.
+Coral writes runtime configuration to `config.toml` and durable app state to
+the local database.
 
-This state includes installed-source metadata and non-secret source variables. Source secrets are stored separately within the same local trust boundary.
+The database stores installed-source metadata, imported source specs, DSL v4
+materialization metadata, feedback reports, episode records, trace summaries,
+and non-secret source variables. New source secrets are stored as encrypted
+database documents within the same local trust boundary.
 
 <Note>
   Prefer the `coral source` commands for source state instead of editing workspace entries manually.
@@ -25,23 +29,62 @@ exists automatically, and additional workspaces can be managed with
 [workspaces.default]
 
 [workspaces.work]
-
-[workspaces.work.sources.github]
-version = "1.0.0"
-variables = {}
-secrets = ["GITHUB_TOKEN"]
-origin = "bundled"
 ```
 
 An empty workspace is represented by an explicit `[workspaces.<name>]` table.
-Installed sources for that workspace live under
-`[workspaces.<name>.sources.<source>]`.
+Current builds persist installed sources in the database. Older
+`[workspaces.<name>.sources.<source>]` entries are legacy source-catalog inputs
+that Coral imports into the database on startup and removes from `config.toml`
+after the import is validated. This source-catalog migration is one-way for
+current releases: downgrading to an older config-backed Coral build does not
+automatically restore those config entries.
 
 There is no separate active-workspace key in `config.toml`; use
 `CORAL_WORKSPACE` for a shell default or `--workspace <NAME>` for one command.
-Source specs imported from files and source credential material remain scoped
-to the source installation in a workspace. Reusable global source specs and
-reusable credential references are not config objects today.
+Installed source specs and source credential material remain scoped to the
+source installation in a workspace. Reusable global source specs and reusable
+credential references are not config objects today.
+
+If you need to run an older build after this migration, re-add bundled sources
+with `coral source add <NAME>`. Re-add imported sources with
+`coral source add --file <PATH>`, using the original source-spec file you used
+for installation.
+
+Raw trace span JSONL and optional HTTP/MCP body captures remain outside the
+database. Trace summaries are indexed in the database from the local trace span
+store.
+
+## Database
+
+By default, Coral uses a local SQLite database at `coral.db` in the local state
+directory.
+
+Use `[database]` to choose a different SQLite path:
+
+```toml
+[database]
+backend = "sqlite"
+path = "state/custom.db"
+```
+
+Relative SQLite paths are resolved under the local state directory. Absolute
+paths are used as-is.
+
+Use Postgres by pointing Coral at an environment variable containing the
+connection URL:
+
+```toml
+[database]
+backend = "postgres"
+url_env = "CORAL_DATABASE_URL"
+```
+
+When you use Postgres, that server becomes part of Coral's local-state trust
+boundary. Coral writes installed-source metadata, imported source specs,
+non-secret variables, trace summaries, and encrypted credential documents to
+the configured database. Keep the connection URL secret, use a Postgres host
+and network path you trust, and use hostname-verified TLS for non-loopback
+servers.
 
 ## Runtime features
 

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -24,6 +24,8 @@ enum SourceCredentialStorage {
   SOURCE_CREDENTIAL_STORAGE_FILE = 1;
   // Credential material is stored in the operating-system credential store.
   SOURCE_CREDENTIAL_STORAGE_KEYCHAIN = 2;
+  // Credential material is stored in encrypted documents in Coral's local database.
+  SOURCE_CREDENTIAL_STORAGE_DATABASE = 3;
 }
 
 // One configured non-secret source variable.

--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -41,14 +41,21 @@ root.
   `catalog/` as the main internal boundaries. Do not create new sub-boundaries
   unless they own durable, independent behavior.
 - Keep RDBMS-backed durable app-state infrastructure under `state/db`. The
-  initial DB bootstrap may coexist with filesystem-backed source behavior, but
   repository wiring must keep SQLx pools, transactions, SeaQuery schema
   identifiers, and row structs inside that module.
 - DB repository behavior should have shared tests that run against SQLite
   locally and Postgres in CI through the repository harness.
-- Until the RDBMS migration phases replace the relevant stores, persist
-  imported manifests as files under app-owned state; do not inline them into
-  `config.toml`.
+- Treat the local database as the durable store for source catalog metadata,
+  imported manifests, DSL v4 materialization records, encrypted credential
+  documents, feedback reports, episodes, and trace summaries. Legacy filesystem
+  artifacts are migration inputs only unless a test explicitly constructs a
+  filesystem-backed manager.
+- Legacy file-backed source credential material migrates into encrypted
+  database documents. Legacy keychain-backed source credential material remains
+  keychain-routed until the source credentials are replaced.
+- Keep raw trace spans and optional HTTP/MCP body captures out of the database.
+  The database may index trace summaries derived from the local trace span
+  store.
 - Persist DSL v4 imported manifests as authored intent plus durability
   normalization only. Descriptor hashes, generated OpenAPI metadata, semantic
   IR, projections, and package fingerprints belong in materialized artifacts

--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -40,8 +40,15 @@ root.
 - Keep `state/`, `credentials/`, `workspaces/`, `sources/`, `query/`, and
   `catalog/` as the main internal boundaries. Do not create new sub-boundaries
   unless they own durable, independent behavior.
-- Persist imported manifests as files under app-owned state; do not inline
-  them into `config.toml`.
+- Keep RDBMS-backed durable app-state infrastructure under `state/db`. The
+  initial DB bootstrap may coexist with filesystem-backed source behavior, but
+  repository wiring must keep SQLx pools, transactions, SeaQuery schema
+  identifiers, and row structs inside that module.
+- DB repository behavior should have shared tests that run against SQLite
+  locally and Postgres in CI through the repository harness.
+- Until the RDBMS migration phases replace the relevant stores, persist
+  imported manifests as files under app-owned state; do not inline them into
+  `config.toml`.
 - Persist DSL v4 imported manifests as authored intent plus durability
   normalization only. Descriptor hashes, generated OpenAPI metadata, semantic
   IR, projections, and package fingerprints belong in materialized artifacts
@@ -49,8 +56,8 @@ root.
 - Treat DSL v4 materialization as a user-chosen lifecycle event: generate at
   source add, never re-fetch descriptors or recompute projections implicitly
   during query/list/validate, and fail with re-add guidance when artifacts are
-  missing or incompatible. Do not add migration machinery until the lifecycle is
-  explicitly designed.
+  missing or incompatible. RDBMS migration machinery must preserve that
+  explicit lifecycle instead of silently refreshing artifacts.
 - User-facing runtime feature semantics belong in `coral_app::features`; raw
   config-file persistence, locking, and TOML extraction stay in `state/`.
 - Bundled installs persist source identity plus configured variables and

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -23,6 +23,7 @@ opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
 regex.workspace = true
 reqwest.workspace = true
+ring.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -45,6 +45,7 @@ tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
 uuid.workspace = true
+zeroize.workspace = true
 
 coral-api.workspace = true
 coral-auth-aws = { path = "../auth/aws" }

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -26,7 +26,10 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+sea-query.workspace = true
+sea-query-sqlx.workspace = true
 sha2.workspace = true
+sqlx.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream = { workspace = true, features = ["net"] }

--- a/crates/coral-app/build.rs
+++ b/crates/coral-app/build.rs
@@ -13,6 +13,10 @@ use std::path::{Path, PathBuf};
 
 fn main() {
     let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir"));
+    println!(
+        "cargo:rerun-if-changed={}",
+        manifest_dir.join("migrations").display()
+    );
     let bundled_root = manifest_dir.join("../../sources/core");
     println!("cargo:rerun-if-changed={}", bundled_root.display());
 

--- a/crates/coral-app/migrations/0001_db_bootstrap.sql
+++ b/crates/coral-app/migrations/0001_db_bootstrap.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS workspaces (
+    id TEXT PRIMARY KEY,
+    created_at_unix_nanos BIGINT NOT NULL
+);

--- a/crates/coral-app/migrations/0002_source_catalog.sql
+++ b/crates/coral-app/migrations/0002_source_catalog.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS sources (
+    workspace_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    version TEXT,
+    origin_kind TEXT NOT NULL,
+    credential_storage TEXT,
+    created_at_unix_nanos BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, name),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS source_variables (
+    workspace_id TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, source_name, key),
+    FOREIGN KEY (workspace_id, source_name) REFERENCES sources(workspace_id, name) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS source_secret_keys (
+    workspace_id TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    position BIGINT NOT NULL,
+    key TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, source_name, position),
+    FOREIGN KEY (workspace_id, source_name) REFERENCES sources(workspace_id, name) ON DELETE CASCADE
+);

--- a/crates/coral-app/migrations/0003_app_state_markers.sql
+++ b/crates/coral-app/migrations/0003_app_state_markers.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS app_state_markers (
+    key TEXT PRIMARY KEY,
+    created_at_unix_nanos BIGINT NOT NULL
+);

--- a/crates/coral-app/migrations/0004_source_manifests.sql
+++ b/crates/coral-app/migrations/0004_source_manifests.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS source_manifests (
+    workspace_id TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    manifest_yaml TEXT NOT NULL,
+    manifest_hash TEXT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, source_name),
+    FOREIGN KEY (workspace_id, source_name) REFERENCES sources(workspace_id, name) ON DELETE CASCADE
+);

--- a/crates/coral-app/migrations/0005_v4_materializations.sql
+++ b/crates/coral-app/migrations/0005_v4_materializations.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS materializations (
+    workspace_id TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    materialization_version TEXT NOT NULL,
+    fingerprint_yaml TEXT NOT NULL,
+    projections_yaml TEXT NOT NULL,
+    diagnostics_yaml TEXT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, source_name),
+    FOREIGN KEY (workspace_id, source_name) REFERENCES sources(workspace_id, name) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS materialization_surfaces (
+    workspace_id TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    surface_id TEXT NOT NULL,
+    source_document_raw BYTEA NOT NULL,
+    source_document_yaml TEXT NOT NULL,
+    semantic_ir_yaml TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, source_name, surface_id),
+    FOREIGN KEY (workspace_id, source_name) REFERENCES materializations(workspace_id, source_name) ON DELETE CASCADE
+);

--- a/crates/coral-app/migrations/0006_feedback_reports.sql
+++ b/crates/coral-app/migrations/0006_feedback_reports.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS feedback_reports (
+    id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    trying_to_do TEXT NOT NULL,
+    tried TEXT NOT NULL,
+    stuck TEXT NOT NULL,
+    publish_status TEXT,
+    publish_error TEXT,
+    published_at_unix_nanos BIGINT,
+    PRIMARY KEY (workspace_id, id),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);

--- a/crates/coral-app/migrations/0007_episodes.sql
+++ b/crates/coral-app/migrations/0007_episodes.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS episodes (
+    workspace_id TEXT NOT NULL,
+    id TEXT NOT NULL,
+    intent TEXT NOT NULL,
+    parent_episode_id TEXT,
+    created_at_unix_nanos BIGINT NOT NULL,
+    record_bytes BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, id),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);

--- a/crates/coral-app/migrations/0008_credential_documents.sql
+++ b/crates/coral-app/migrations/0008_credential_documents.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS credential_documents (
+    workspace_id TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    document_version BIGINT NOT NULL,
+    ciphertext BYTEA NOT NULL,
+    nonce BYTEA NOT NULL,
+    wrapped_dek BYTEA NOT NULL,
+    wrapped_dek_nonce BYTEA NOT NULL,
+    key_id TEXT NOT NULL,
+    algorithm TEXT NOT NULL,
+    aad_version BIGINT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, source_name),
+    FOREIGN KEY (workspace_id, source_name) REFERENCES sources(workspace_id, name) ON DELETE CASCADE
+);

--- a/crates/coral-app/migrations/0009_trace_summaries.sql
+++ b/crates/coral-app/migrations/0009_trace_summaries.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS trace_summaries (
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    trace_id TEXT NOT NULL,
+    root_span_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    query TEXT NOT NULL,
+    status TEXT NOT NULL,
+    start_time_unix_nanos BIGINT NOT NULL,
+    end_time_unix_nanos BIGINT NOT NULL,
+    duration_nanos BIGINT NOT NULL,
+    span_count BIGINT NOT NULL,
+    row_count BIGINT,
+    PRIMARY KEY (workspace_id, trace_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_trace_summaries_list
+ON trace_summaries(end_time_unix_nanos DESC, workspace_id ASC, trace_id ASC);
+
+CREATE INDEX IF NOT EXISTS idx_trace_summaries_workspace
+ON trace_summaries(workspace_id, end_time_unix_nanos DESC, trace_id ASC);

--- a/crates/coral-app/migrations/0010_identity_specs.sql
+++ b/crates/coral-app/migrations/0010_identity_specs.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS identity_specs (
+    scope_kind TEXT NOT NULL,
+    scope_id TEXT NOT NULL,
+    workspace_id TEXT,
+    name TEXT NOT NULL,
+    version TEXT NOT NULL,
+    description TEXT NOT NULL,
+    issuer TEXT NOT NULL,
+    identity_type TEXT NOT NULL,
+    manifest_yaml TEXT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (scope_kind, scope_id, name),
+    CHECK (
+        (
+            scope_kind = 'global'
+            AND scope_id = '__global__'
+            AND workspace_id IS NULL
+        )
+        OR (
+            scope_kind = 'workspace'
+            AND workspace_id IS NOT NULL
+            AND scope_id = workspace_id
+        )
+    ),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS identity_spec_documents (
+    scope_kind TEXT NOT NULL,
+    scope_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    document_version BIGINT NOT NULL,
+    ciphertext BYTEA NOT NULL,
+    nonce BYTEA NOT NULL,
+    wrapped_dek BYTEA NOT NULL,
+    wrapped_dek_nonce BYTEA NOT NULL,
+    key_id TEXT NOT NULL,
+    algorithm TEXT NOT NULL,
+    aad_version BIGINT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (scope_kind, scope_id, name),
+    FOREIGN KEY (scope_kind, scope_id, name) REFERENCES identity_specs(scope_kind, scope_id, name) ON DELETE CASCADE
+);

--- a/crates/coral-app/src/bootstrap/env.rs
+++ b/crates/coral-app/src/bootstrap/env.rs
@@ -39,6 +39,10 @@ impl AppEnvironment {
             ..QueryRuntimeContext::default()
         }
     }
+
+    pub(crate) fn env_var(name: &str) -> Option<String> {
+        env_var(name)
+    }
 }
 
 #[expect(
@@ -47,6 +51,14 @@ impl AppEnvironment {
 )]
 fn coral_config_dir_override() -> Option<PathBuf> {
     std::env::var_os(CORAL_CONFIG_DIR).map(PathBuf::from)
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "coral-app is the single owner of process environment access."
+)]
+fn env_var(name: &str) -> Option<String> {
+    std::env::var(name).ok()
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -10,6 +10,7 @@ use tonic::{Code, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
 
 use crate::credentials::CredentialsError;
+use crate::state::db::DbError;
 
 /// Errors surfaced by the local application layer.
 #[derive(Debug, thiserror::Error)]
@@ -72,9 +73,30 @@ pub enum AppError {
     /// Credential material access failed.
     #[error(transparent)]
     Credentials(#[from] CredentialsError),
+    /// Durable app-state database access failed.
+    #[error("database error: {0}")]
+    Database(String),
     /// The Coral config directory could not be discovered from defaults.
     #[error("failed to determine Coral config directory")]
     MissingConfigDir,
+}
+
+impl From<DbError> for AppError {
+    fn from(error: DbError) -> Self {
+        match error {
+            DbError::Config(detail) => {
+                Self::FailedPrecondition(format!("database configuration is invalid: {detail}"))
+            }
+            DbError::MissingDatabaseParent(path) => Self::FailedPrecondition(format!(
+                "database file parent directory is missing for {}",
+                path.display()
+            )),
+            DbError::Io(error) => Self::Io(error),
+            DbError::TomlDecode(error) => Self::TomlDecode(error),
+            DbError::Sqlx(error) => Self::Database(error.to_string()),
+            DbError::Migration(error) => Self::Database(error.to_string()),
+        }
+    }
 }
 
 /// Upper bound on the byte length of a `tonic::Status` message (detail).
@@ -221,7 +243,8 @@ fn app_code(error: &AppError) -> Code {
         | AppError::Json(_)
         | AppError::Transport(_)
         | AppError::TaskJoin(_)
-        | AppError::Credentials(_) => Code::Internal,
+        | AppError::Credentials(_)
+        | AppError::Database(_) => Code::Internal,
     }
 }
 

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -87,6 +87,7 @@ impl From<DbError> for AppError {
             DbError::Config(detail) => {
                 Self::FailedPrecondition(format!("database configuration is invalid: {detail}"))
             }
+            DbError::InvalidData(detail) => Self::Database(detail),
             DbError::MissingDatabaseParent(path) => Self::FailedPrecondition(format!(
                 "database file parent directory is missing for {}",
                 path.display()

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -305,8 +305,15 @@ pub fn default_workspace_mcp_startup_context(
 ) -> Result<DefaultWorkspaceMcpStartupContext, AppError> {
     let layout = discover_app_state_layout(None)?;
     layout.ensure()?;
+    default_workspace_mcp_startup_context_for_layout(&layout, query_history_limit)
+}
+
+fn default_workspace_mcp_startup_context_for_layout(
+    layout: &AppStateLayout,
+    query_history_limit: usize,
+) -> Result<DefaultWorkspaceMcpStartupContext, AppError> {
     let source_names = default_workspace_source_names_for_layout(layout.clone())?;
-    let telemetry_config = TelemetryConfig::load(&layout)?;
+    let telemetry_config = TelemetryConfig::load(layout)?;
     let query_history = if telemetry_config.trace_history.enabled {
         let query_history = crate::telemetry::list_local_query_history(
             layout.local_trace_store_dir(),
@@ -398,10 +405,55 @@ fn new_source_count(sources: &[String], selected_sources: &HashSet<String>) -> u
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::{
-        McpQueryHistoryEntry, McpQueryTableFunctionUsage, McpQueryTableUsage,
+        DefaultWorkspaceMcpStartupContext, McpQueryHistoryEntry, McpQueryTableFunctionUsage,
+        McpQueryTableUsage, default_workspace_mcp_startup_context_for_layout,
         select_mcp_query_history,
     };
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::{AppStateLayout, ConfigStore};
+    use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn mcp_startup_context_imports_legacy_config_sources_into_database() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::default();
+        let source = InstalledSource {
+            name: SourceName::parse("github").expect("source name"),
+            version: Some("1.2.3".to_string()),
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            origin: SourceOrigin::Bundled,
+        };
+        config_store
+            .upsert_source(&workspace, source)
+            .expect("seed legacy config source");
+
+        let context = default_workspace_mcp_startup_context_for_layout(&layout, 5)
+            .expect("load startup context");
+
+        assert_eq!(
+            context,
+            DefaultWorkspaceMcpStartupContext {
+                source_names: vec!["github".to_string()],
+                query_history: Vec::new(),
+            }
+        );
+        assert!(
+            config_store
+                .load_config_unlocked()
+                .expect("load cleaned config")
+                .source_catalog_entries()
+                .is_empty()
+        );
+    }
 
     #[test]
     fn query_history_selection_filters_empty_results_and_sorts_by_complexity() {

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -32,7 +32,6 @@ pub(crate) fn discover_app_state_layout(
     env::AppEnvironment::discover().app_state_layout(config_dir_override)
 }
 
-#[cfg(test)]
 pub(crate) fn env_var(name: &str) -> Option<String> {
     env::AppEnvironment::env_var(name)
 }

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -75,7 +75,13 @@ async fn open_initialized_database(
 ) -> Result<CoralDb, AppError> {
     let db = open_bootstrap_db(layout).await?;
     db.migrate().await?;
-    import_config_source_catalog(&db, config_store, layout, now_unix_nanos_i64()?).await?;
+    let now_unix_nanos = now_unix_nanos_i64()?;
+    import_config_source_catalog(&db, config_store, layout, now_unix_nanos).await?;
+    let mut tx = db.begin().await?;
+    tx.workspaces()
+        .ensure(WorkspaceName::default().as_str(), now_unix_nanos)
+        .await?;
+    tx.commit().await?;
     Ok(db)
 }
 

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -446,13 +446,6 @@ mod tests {
                 query_history: Vec::new(),
             }
         );
-        assert!(
-            config_store
-                .load_config_unlocked()
-                .expect("load cleaned config")
-                .source_catalog_entries()
-                .is_empty()
-        );
     }
 
     #[test]

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -75,7 +75,7 @@ async fn open_initialized_database(
 ) -> Result<CoralDb, AppError> {
     let db = open_bootstrap_db(layout).await?;
     db.migrate().await?;
-    import_config_source_catalog(&db, config_store, now_unix_nanos_i64()?).await?;
+    import_config_source_catalog(&db, config_store, layout, now_unix_nanos_i64()?).await?;
     Ok(db)
 }
 

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -26,6 +26,11 @@ pub(crate) fn discover_app_state_layout(
     env::AppEnvironment::discover().app_state_layout(config_dir_override)
 }
 
+#[cfg(test)]
+pub(crate) fn env_var(name: &str) -> Option<String> {
+    env::AppEnvironment::env_var(name)
+}
+
 /// Loads installed source names for the default workspace from local config only.
 ///
 /// This is intentionally narrower than starting the local server and calling

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -1,12 +1,18 @@
 //! Internal bootstrap seam for assembling the local server runtime.
 
-use std::{cmp::Reverse, collections::HashSet, path::PathBuf};
+use std::{
+    cmp::Reverse, collections::HashSet, future::Future, path::PathBuf, time::SystemTime,
+    time::UNIX_EPOCH,
+};
 
 mod consts;
 mod env;
 mod error;
 mod server;
 
+use crate::state::db::{
+    CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig, import_config_source_catalog,
+};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::telemetry::{
     TelemetryConfig, TraceQueryHistoryEntry, TraceQueryTableFunctionUsage, TraceQueryTableUsage,
@@ -31,7 +37,7 @@ pub(crate) fn env_var(name: &str) -> Option<String> {
     env::AppEnvironment::env_var(name)
 }
 
-/// Loads installed source names for the default workspace from local config only.
+/// Loads installed source names for the default workspace from local durable state.
 ///
 /// This is intentionally narrower than starting the local server and calling
 /// `ListSources`: startup surfaces such as MCP initialize only need source
@@ -45,7 +51,85 @@ pub(crate) fn env_var(name: &str) -> Option<String> {
 pub fn default_workspace_source_names() -> Result<Vec<String>, AppError> {
     let layout = discover_app_state_layout(None)?;
     layout.ensure()?;
-    ConfigStore::new(layout).list_workspace_source_names(&WorkspaceName::default())
+    default_workspace_source_names_for_layout(layout)
+}
+
+fn default_workspace_source_names_for_layout(
+    layout: AppStateLayout,
+) -> Result<Vec<String>, AppError> {
+    let config_store = ConfigStore::new(layout.clone());
+    run_db_bootstrap_operation(async move {
+        let db = open_bootstrap_db(&layout).await?;
+        db.migrate().await?;
+        import_config_source_catalog(&db, &config_store, now_unix_nanos_i64()?).await?;
+        let mut session = &db;
+        session
+            .sources()
+            .list_workspace_source_names(&WorkspaceName::default())
+            .await
+            .map_err(AppError::from)
+    })
+}
+
+async fn open_bootstrap_db(layout: &AppStateLayout) -> Result<CoralDb, AppError> {
+    let database_config = DatabaseConfig::load(layout)?;
+    let database_config = match database_config {
+        DatabaseConfig::Sqlite { path } => ResolvedDatabaseConfig::Sqlite { path },
+        DatabaseConfig::Postgres { url_env } => {
+            let url = env::AppEnvironment::env_var(&url_env).ok_or_else(|| {
+                AppError::FailedPrecondition(format!(
+                    "database backend 'postgres' requires environment variable `{url_env}`"
+                ))
+            })?;
+            ResolvedDatabaseConfig::Postgres { url }
+        }
+    };
+    CoralDb::open(database_config).await.map_err(AppError::from)
+}
+
+fn run_db_bootstrap_operation<T, F>(operation: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: Future<Output = Result<T, AppError>> + Send + 'static,
+{
+    fn run_on_runtime<T, F>(operation: F) -> Result<T, AppError>
+    where
+        F: Future<Output = Result<T, AppError>>,
+    {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!(
+                    "failed to create bootstrap database runtime: {error}"
+                ))
+            })?;
+        runtime.block_on(operation)
+    }
+
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return std::thread::spawn(move || run_on_runtime(operation))
+            .join()
+            .map_err(|_panic| {
+                AppError::FailedPrecondition(
+                    "bootstrap database operation thread panicked".to_string(),
+                )
+            })?;
+    }
+
+    run_on_runtime(operation)
+}
+
+fn now_unix_nanos_i64() -> Result<i64, AppError> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| AppError::FailedPrecondition(format!("system clock error: {error}")))?
+        .as_nanos();
+    i64::try_from(nanos).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "system clock timestamp exceeds i64 nanoseconds: {error}"
+        ))
+    })
 }
 
 /// Startup context loaded from local state for default-workspace MCP sessions.
@@ -213,8 +297,7 @@ pub fn default_workspace_mcp_startup_context(
 ) -> Result<DefaultWorkspaceMcpStartupContext, AppError> {
     let layout = discover_app_state_layout(None)?;
     layout.ensure()?;
-    let source_names =
-        ConfigStore::new(layout.clone()).list_workspace_source_names(&WorkspaceName::default())?;
+    let source_names = default_workspace_source_names_for_layout(layout.clone())?;
     let telemetry_config = TelemetryConfig::load(&layout)?;
     let query_history = if telemetry_config.trace_history.enabled {
         let query_history = crate::telemetry::list_local_query_history(

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -59,9 +59,7 @@ fn default_workspace_source_names_for_layout(
 ) -> Result<Vec<String>, AppError> {
     let config_store = ConfigStore::new(layout.clone());
     run_db_bootstrap_operation(async move {
-        let db = open_bootstrap_db(&layout).await?;
-        db.migrate().await?;
-        import_config_source_catalog(&db, &config_store, now_unix_nanos_i64()?).await?;
+        let db = open_initialized_database(&layout, &config_store).await?;
         let mut session = &db;
         session
             .sources()
@@ -69,6 +67,16 @@ fn default_workspace_source_names_for_layout(
             .await
             .map_err(AppError::from)
     })
+}
+
+async fn open_initialized_database(
+    layout: &AppStateLayout,
+    config_store: &ConfigStore,
+) -> Result<CoralDb, AppError> {
+    let db = open_bootstrap_db(layout).await?;
+    db.migrate().await?;
+    import_config_source_catalog(&db, config_store, now_unix_nanos_i64()?).await?;
+    Ok(db)
 }
 
 async fn open_bootstrap_db(layout: &AppStateLayout) -> Result<CoralDb, AppError> {

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -35,12 +35,14 @@ use tonic::service::Routes;
 use tonic::transport::Server;
 use tonic_web::GrpcWebLayer;
 use tower::{Layer, Service};
+use tracing::warn;
 
 use super::env::AppEnvironment;
 use super::error::AppError;
 use crate::EngineExtensionsProvider;
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
+use crate::credentials::encryption::LocalFileCredentialKeyProvider;
 use crate::credentials::{CredentialManager, CredentialStore};
 use crate::episode::service::EpisodeService;
 use crate::episode::store::EpisodeStore;
@@ -273,10 +275,22 @@ impl ServerBuilder {
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
         import_filesystem_feedback_reports(&coral_db, &layout).await?;
         import_filesystem_episodes(&coral_db, &layout).await?;
-        let coral_db = Arc::new(coral_db);
         let credential_config = CredentialStorageConfig::load(&layout)?;
-        let credential_store =
-            CredentialStore::with_preference(layout.clone(), credential_config.storage);
+        let key_provider = Arc::new(LocalFileCredentialKeyProvider::new(&layout));
+        let key_origin = key_provider.active_key_origin()?;
+        if coral_db.is_postgres() && key_origin.requires_postgres_bootstrap_warning() {
+            warn!(
+                ?key_origin,
+                "database-backed credentials are using a locally generated credential encryption key with Postgres; multiple servers can create split key domains and unreadable credential documents; set [credentials].encryption_key_env or pre-seed the OS keychain with the same KEK on every server"
+            );
+        }
+        let coral_db = Arc::new(coral_db);
+        let credential_store = CredentialStore::with_database(
+            layout.clone(),
+            credential_config.storage,
+            Arc::clone(&coral_db),
+            key_provider,
+        );
         let credential_manager = CredentialManager::new(credential_store);
         let workspace_lifecycle_lock = WorkspaceLifecycleLock::default();
         let source_manager = SourceManager::with_db(

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -54,6 +54,7 @@ use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::ConfigStore;
+use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
@@ -252,6 +253,20 @@ impl ServerBuilder {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir)?;
         layout.ensure()?;
+        let database_config = DatabaseConfig::load(&layout)?;
+        let database_config = match database_config {
+            DatabaseConfig::Sqlite { path } => ResolvedDatabaseConfig::Sqlite { path },
+            DatabaseConfig::Postgres { url_env } => {
+                let url = AppEnvironment::env_var(&url_env).ok_or_else(|| {
+                    AppError::FailedPrecondition(format!(
+                        "database backend 'postgres' requires environment variable `{url_env}`"
+                    ))
+                })?;
+                ResolvedDatabaseConfig::Postgres { url }
+            }
+        };
+        let coral_db = CoralDb::open(database_config).await?;
+        coral_db.migrate().await?;
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config
             .trace_history

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -10,7 +10,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::task::{Context, Poll};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::body::Body as AxumBody;
 use axum::extract::Request as AxumRequest;
@@ -55,25 +54,10 @@ use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::ConfigStore;
-use crate::state::db::{
-    CoralDb, DatabaseConfig, ResolvedDatabaseConfig, import_config_source_catalog,
-};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
 use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceManager, WorkspaceService};
-
-fn now_unix_nanos_i64() -> Result<i64, AppError> {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|error| AppError::FailedPrecondition(format!("system clock error: {error}")))?
-        .as_nanos();
-    i64::try_from(nanos).map_err(|error| {
-        AppError::FailedPrecondition(format!(
-            "system clock timestamp exceeds i64 nanoseconds: {error}"
-        ))
-    })
-}
 
 /// A static asset (e.g., a built SPA file) served on the same port as
 /// gRPC-Web.
@@ -268,22 +252,8 @@ impl ServerBuilder {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir)?;
         layout.ensure()?;
-        let database_config = DatabaseConfig::load(&layout)?;
-        let database_config = match database_config {
-            DatabaseConfig::Sqlite { path } => ResolvedDatabaseConfig::Sqlite { path },
-            DatabaseConfig::Postgres { url_env } => {
-                let url = AppEnvironment::env_var(&url_env).ok_or_else(|| {
-                    AppError::FailedPrecondition(format!(
-                        "database backend 'postgres' requires environment variable `{url_env}`"
-                    ))
-                })?;
-                ResolvedDatabaseConfig::Postgres { url }
-            }
-        };
-        let coral_db = CoralDb::open(database_config).await?;
-        coral_db.migrate().await?;
         let config_store = ConfigStore::new(layout.clone());
-        import_config_source_catalog(&coral_db, &config_store, now_unix_nanos_i64()?).await?;
+        let coral_db = super::open_initialized_database(&layout, &config_store).await?;
         let coral_db = Arc::new(coral_db);
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -284,7 +284,7 @@ impl ServerBuilder {
             Arc::clone(&coral_db),
         );
         let workspace_manager = WorkspaceManager::new(
-            config_store.clone(),
+            source_manager.clone(),
             credential_manager.clone(),
             layout.clone(),
             active_trace_store_dir.clone(),

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -54,6 +54,7 @@ use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::ConfigStore;
+use crate::state::db::import_filesystem_feedback_reports;
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
@@ -271,6 +272,7 @@ impl ServerBuilder {
             .then_some(installed_trace_store)
             .flatten();
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
+        import_filesystem_feedback_reports(&coral_db, &layout).await?;
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
@@ -290,8 +292,11 @@ impl ServerBuilder {
             active_trace_store_dir.clone(),
             workspace_lifecycle_lock,
         );
-        let feedback_manager =
-            FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
+        let feedback_manager = FeedbackManager::with_db(
+            layout.clone(),
+            self.config.feedback_publisher,
+            Arc::clone(&coral_db),
+        );
         let episode_store = EpisodeStore::new(layout.clone());
         let body_capture_max_bytes = telemetry_config
             .trace_history

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -56,7 +56,10 @@ use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::ConfigStore;
-use crate::state::db::{import_filesystem_episodes, import_filesystem_feedback_reports};
+use crate::state::db::{
+    import_filesystem_episodes, import_filesystem_feedback_reports,
+    import_legacy_credential_material,
+};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
@@ -251,6 +254,10 @@ impl ServerBuilder {
     /// Returns [`AppError`] if the config directory cannot be determined,
     /// required directories cannot be created, the config or credential backends
     /// fail to initialize, or the gRPC server cannot be started.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "startup wires ordered imports and services"
+    )]
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir)?;
@@ -291,6 +298,7 @@ impl ServerBuilder {
             Arc::clone(&coral_db),
             key_provider,
         );
+        import_legacy_credential_material(coral_db.as_ref(), &layout, &credential_store).await?;
         let credential_manager = CredentialManager::new(credential_store);
         let workspace_lifecycle_lock = WorkspaceLifecycleLock::default();
         let source_manager = SourceManager::with_db(

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -284,6 +284,7 @@ impl ServerBuilder {
         coral_db.migrate().await?;
         let config_store = ConfigStore::new(layout.clone());
         import_config_source_catalog(&coral_db, &config_store, now_unix_nanos_i64()?).await?;
+        let coral_db = Arc::new(coral_db);
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config
             .trace_history
@@ -305,11 +306,12 @@ impl ServerBuilder {
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
         let credential_manager = CredentialManager::new(credential_store);
         let workspace_lifecycle_lock = WorkspaceLifecycleLock::default();
-        let source_manager = SourceManager::new(
+        let source_manager = SourceManager::with_db(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
             workspace_lifecycle_lock.clone(),
+            Arc::clone(&coral_db),
         );
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -54,7 +54,7 @@ use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::ConfigStore;
-use crate::state::db::import_filesystem_feedback_reports;
+use crate::state::db::{import_filesystem_episodes, import_filesystem_feedback_reports};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
@@ -255,7 +255,6 @@ impl ServerBuilder {
         layout.ensure()?;
         let config_store = ConfigStore::new(layout.clone());
         let coral_db = super::open_initialized_database(&layout, &config_store).await?;
-        let coral_db = Arc::new(coral_db);
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config
             .trace_history
@@ -273,6 +272,8 @@ impl ServerBuilder {
             .flatten();
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
         import_filesystem_feedback_reports(&coral_db, &layout).await?;
+        import_filesystem_episodes(&coral_db, &layout).await?;
+        let coral_db = Arc::new(coral_db);
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
@@ -297,7 +298,7 @@ impl ServerBuilder {
             self.config.feedback_publisher,
             Arc::clone(&coral_db),
         );
-        let episode_store = EpisodeStore::new(layout.clone());
+        let episode_store = EpisodeStore::with_db(layout.clone(), Arc::clone(&coral_db));
         let body_capture_max_bytes = telemetry_config
             .trace_history
             .http_body_recording_max_bytes();
@@ -780,7 +781,19 @@ enabled = false
     async fn open_episode_through_server_persists() {
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+        layout.ensure().expect("layout dirs");
         disable_internal_tracing(&config_dir);
+        let workspace = WorkspaceName::default();
+        let episodes_file = layout.episodes_file(&workspace);
+        std::fs::create_dir_all(episodes_file.parent().expect("episodes parent"))
+            .expect("create episodes parent");
+        std::fs::write(
+            &episodes_file,
+            r#"{"id":"ep_legacy","workspace":"default","intent":"continue migration","parent_episode_id":null,"created_at_unix_nanos":99}
+"#,
+        )
+        .expect("write legacy episode");
         let server = ServerBuilder::new()
             .with_config_dir(config_dir.clone())
             .start()
@@ -803,14 +816,33 @@ enabled = false
             .await
             .expect("OpenEpisode is served regardless of the episodes feature");
 
-        // The handler ran the full path through to the per-workspace episode log.
-        let layout = AppStateLayout::discover(Some(config_dir)).expect("layout");
-        let raw = std::fs::read_to_string(layout.episodes_file(&WorkspaceName::default()))
-            .expect("episode file should exist");
-        assert!(raw.contains("ep_smoke"), "episode id should be persisted");
+        // The handler ran the full path through to the DB-backed episode store.
+        let DatabaseConfig::Sqlite { path } =
+            DatabaseConfig::load(&layout).expect("load database config")
+        else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        let mut session = &db;
+        let imported = session
+            .episodes()
+            .get(&workspace, "ep_legacy")
+            .await
+            .expect("get imported episode")
+            .expect("legacy episode should be imported");
+        assert_eq!(imported.intent, "continue migration");
+        let episode = session
+            .episodes()
+            .get(&workspace, "ep_smoke")
+            .await
+            .expect("get episode")
+            .expect("episode should be persisted");
+        assert_eq!(episode.intent, "find the HR onboarding form");
         assert!(
-            raw.contains("find the HR onboarding form"),
-            "intent should be persisted"
+            !episodes_file.exists(),
+            "DB-backed server should not write legacy episode JSONL"
         );
         server.shutdown().await.expect("shutdown");
     }

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -277,11 +277,20 @@ impl ServerBuilder {
         let active_trace_store = telemetry_config
             .trace_history
             .enabled
-            .then_some(installed_trace_store)
+            .then(|| installed_trace_store.clone())
             .flatten();
+        let sync_trace_store = active_trace_store.clone();
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
         import_filesystem_feedback_reports(&coral_db, &layout).await?;
         import_filesystem_episodes(&coral_db, &layout).await?;
+        let coral_db = Arc::new(coral_db);
+        if let Some(store) = sync_trace_store.as_ref() {
+            TraceService::sync_summaries(store.dir.clone(), store.retention, &coral_db)
+                .await
+                .map_err(|error| {
+                    AppError::Database(format!("trace summary import failed: {error}"))
+                })?;
+        }
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let key_provider = Arc::new(LocalFileCredentialKeyProvider::new(&layout));
         let key_origin = key_provider.active_key_origin()?;
@@ -291,7 +300,6 @@ impl ServerBuilder {
                 "database-backed credentials are using a locally generated credential encryption key with Postgres; multiple servers can create split key domains and unreadable credential documents; set [credentials].encryption_key_env or pre-seed the OS keychain with the same KEK on every server"
             );
         }
-        let coral_db = Arc::new(coral_db);
         let credential_store = CredentialStore::with_database(
             layout.clone(),
             credential_config.storage,
@@ -340,7 +348,11 @@ impl ServerBuilder {
             active_trace_store.map_or_else(TraceServerComponents::default, |store| {
                 TraceServerComponents {
                     local_trace_store_dir: Some(store.dir.clone()),
-                    service: Some(TraceService::new(store.dir, store.retention)),
+                    service: Some(TraceService::with_db(
+                        store.dir,
+                        store.retention,
+                        Arc::clone(&coral_db),
+                    )),
                 }
             });
         start_server(

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -263,7 +263,7 @@ impl ServerBuilder {
         let layout = env.app_state_layout(self.config.config_dir)?;
         layout.ensure()?;
         let config_store = ConfigStore::new(layout.clone());
-        let coral_db = super::open_initialized_database(&layout, &config_store).await?;
+        let coral_db = Arc::new(super::open_initialized_database(&layout, &config_store).await?);
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config
             .trace_history
@@ -273,19 +273,18 @@ impl ServerBuilder {
             &telemetry_config,
             self.config.enable_stderr_logs,
             internal_trace_store_dir.clone(),
+            Some(Arc::clone(&coral_db)),
         )?;
         let active_trace_store = telemetry_config
             .trace_history
             .enabled
             .then(|| installed_trace_store.clone())
             .flatten();
-        let sync_trace_store = active_trace_store.clone();
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
-        import_filesystem_feedback_reports(&coral_db, &layout).await?;
-        import_filesystem_episodes(&coral_db, &layout).await?;
-        let coral_db = Arc::new(coral_db);
-        if let Some(store) = sync_trace_store.as_ref() {
-            TraceService::sync_summaries(store.dir.clone(), store.retention, &coral_db)
+        import_filesystem_feedback_reports(coral_db.as_ref(), &layout).await?;
+        import_filesystem_episodes(coral_db.as_ref(), &layout).await?;
+        if let Some(store) = active_trace_store.as_ref() {
+            TraceService::backfill_summaries(store.dir.clone(), store.retention, coral_db.as_ref())
                 .await
                 .map_err(|error| {
                     AppError::Database(format!("trace summary import failed: {error}"))

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -10,6 +10,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::task::{Context, Poll};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::body::Body as AxumBody;
 use axum::extract::Request as AxumRequest;
@@ -54,11 +55,25 @@ use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::ConfigStore;
-use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+use crate::state::db::{
+    CoralDb, DatabaseConfig, ResolvedDatabaseConfig, import_config_source_catalog,
+};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
 use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceManager, WorkspaceService};
+
+fn now_unix_nanos_i64() -> Result<i64, AppError> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| AppError::FailedPrecondition(format!("system clock error: {error}")))?
+        .as_nanos();
+    i64::try_from(nanos).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "system clock timestamp exceeds i64 nanoseconds: {error}"
+        ))
+    })
+}
 
 /// A static asset (e.g., a built SPA file) served on the same port as
 /// gRPC-Web.
@@ -267,6 +282,8 @@ impl ServerBuilder {
         };
         let coral_db = CoralDb::open(database_config).await?;
         coral_db.migrate().await?;
+        let config_store = ConfigStore::new(layout.clone());
+        import_config_source_catalog(&coral_db, &config_store, now_unix_nanos_i64()?).await?;
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config
             .trace_history
@@ -283,7 +300,6 @@ impl ServerBuilder {
             .then_some(installed_trace_store)
             .flatten();
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
-        let config_store = ConfigStore::new(layout.clone());
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
@@ -690,6 +706,7 @@ mod tests {
     )]
 
     use std::borrow::Cow;
+    use std::collections::BTreeMap;
     use std::net::{Ipv4Addr, TcpListener};
     use std::path::Path;
     use std::sync::Arc;
@@ -717,7 +734,10 @@ mod tests {
     use crate::episode::store::EpisodeStore;
     use crate::feedback::manager::FeedbackManager;
     use crate::query::manager::QueryManager;
+    use crate::sources::SourceName;
     use crate::sources::manager::SourceManager;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::telemetry::service::TraceService;
     use crate::transport::workspace_to_proto;
@@ -815,6 +835,56 @@ enabled = false
             "intent should be persisted"
         );
         server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn startup_imports_legacy_config_source_catalog_into_database() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+        layout.ensure().expect("layout dirs");
+        disable_internal_tracing(&config_dir);
+
+        let workspace = WorkspaceName::default();
+        let source = InstalledSource {
+            name: SourceName::parse("github").expect("source name"),
+            version: Some("1.2.3".to_string()),
+            variables: BTreeMap::from([(
+                "GITHUB_API_BASE".to_string(),
+                "https://api.github.com".to_string(),
+            )]),
+            secrets: vec!["GITHUB_TOKEN".to_string()],
+            credential_storage: None,
+            origin: SourceOrigin::Bundled,
+        };
+        ConfigStore::new(layout.clone())
+            .upsert_source(&workspace, source.clone())
+            .expect("seed legacy config source");
+
+        let server = ServerBuilder::new()
+            .with_config_dir(config_dir)
+            .start()
+            .await
+            .expect("start server");
+        server.shutdown().await.expect("shutdown");
+
+        let DatabaseConfig::Sqlite { path } =
+            DatabaseConfig::load(&layout).expect("load database config")
+        else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get imported source"),
+            Some(source)
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -330,12 +330,13 @@ impl ServerBuilder {
             .query_runtime_context()
             .with_body_capture_max_bytes(body_capture_max_bytes);
 
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::with_db(
             config_store,
             credential_manager,
             query_runtime_context,
             layout,
             self.config.engine_extensions_providers,
+            Arc::clone(&coral_db),
         );
         let trace_components =
             active_trace_store.map_or_else(TraceServerComponents::default, |store| {

--- a/crates/coral-app/src/credential_transport.rs
+++ b/crates/coral-app/src/credential_transport.rs
@@ -1,0 +1,38 @@
+//! Shared transport policy for endpoints that receive credential material.
+
+use url::{Host, Url};
+
+use crate::bootstrap::AppError;
+
+pub(crate) fn validate_credential_endpoint_transport(
+    context: &str,
+    raw_url: &str,
+) -> Result<(), AppError> {
+    let normalized = normalize_endpoint_url(raw_url);
+    let url = Url::parse(&normalized)
+        .map_err(|error| AppError::InvalidInput(format!("{context} is invalid: {error}")))?;
+    if url.scheme() == "https" || (url.scheme() == "http" && is_loopback_url(&url)) {
+        return Ok(());
+    }
+    Err(AppError::InvalidInput(format!(
+        "{context} must use https or loopback http before credentials can be sent"
+    )))
+}
+
+fn normalize_endpoint_url(raw_url: &str) -> String {
+    let trimmed = raw_url.trim().trim_start_matches("//");
+    if trimmed.contains("://") {
+        trimmed.to_string()
+    } else {
+        format!("https://{trimmed}")
+    }
+}
+
+fn is_loopback_url(url: &Url) -> bool {
+    match url.host() {
+        Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(address)) => address.is_loopback(),
+        Some(Host::Ipv6(address)) => address.is_loopback(),
+        None => false,
+    }
+}

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -1,8 +1,11 @@
 //! Application-level envelope encryption for DB-backed credential material.
 
-#![expect(
-    dead_code,
-    reason = "Credential DB runtime wiring lands in a later stack branch; this branch isolates cryptographic primitives for review."
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Credential DB runtime wiring lands in a later stack branch; this branch isolates cryptographic primitives for review."
+    )
 )]
 
 use std::collections::BTreeMap;

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -21,7 +21,9 @@ use crate::storage::fs as storage_fs;
 use crate::storage::fs::FileLock;
 use crate::workspaces::WorkspaceName;
 
+/// Envelope encryption algorithm identifier persisted with encrypted documents.
 pub(crate) const CREDENTIAL_DOCUMENT_ALGORITHM: &str = "AES-256-GCM";
+/// AAD layout version persisted with encrypted credential and identity documents.
 pub(crate) const CREDENTIAL_DOCUMENT_AAD_VERSION: i64 = 1;
 
 const CREDENTIAL_DOCUMENT_VERSION: u32 = 1;
@@ -54,6 +56,7 @@ impl CredentialEncryptionKeyOrigin {
     }
 }
 
+/// Key-encryption key material used to wrap document-specific DEKs.
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct CredentialEncryptionKey {
     key_id: String,
@@ -83,14 +86,18 @@ impl CredentialEncryptionKey {
         }
     }
 
+    /// Stable identifier derived from the key material.
     pub(crate) fn key_id(&self) -> &str {
         self.key_id.as_str()
     }
 }
 
+/// Source of key-encryption keys for envelope-encrypted app documents.
 pub(crate) trait CredentialKeyProvider: Send + Sync {
+    /// Return the active KEK used for new writes and rewraps.
     fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError>;
 
+    /// Resolve the KEK identified on an existing encrypted document.
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError>;
 }
 
@@ -491,21 +498,37 @@ impl CredentialEncryptionKeychainEntry {
     }
 }
 
+/// Envelope-encrypted document fields persisted by DB-backed secret stores.
+///
+/// The historical credential name is retained for existing call sites. Identity
+/// documents use the same field layout through [`EncryptedEnvelopeDocument`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct EncryptedCredentialDocument {
+    /// AES-GCM ciphertext and authentication tag for the plaintext JSON body.
     pub(crate) ciphertext: Vec<u8>,
+    /// Nonce used to seal the plaintext document.
     pub(crate) nonce: Vec<u8>,
+    /// AES-GCM sealed document data-encryption key.
     pub(crate) wrapped_dek: Vec<u8>,
+    /// Nonce used to wrap the DEK.
     pub(crate) wrapped_dek_nonce: Vec<u8>,
+    /// Key-encryption-key identifier used to wrap the DEK.
     pub(crate) key_id: String,
+    /// Envelope encryption algorithm identifier.
     pub(crate) algorithm: String,
+    /// AAD layout version used for the document.
     pub(crate) aad_version: i64,
 }
 
+/// Shared envelope-encrypted document layout for credential and identity data.
+pub(crate) type EncryptedEnvelopeDocument = EncryptedCredentialDocument;
+
 #[derive(serde::Serialize, serde::Deserialize)]
-struct PlaintextCredentialDocument {
-    version: u32,
-    values: BTreeMap<String, String>,
+pub(crate) struct PlaintextCredentialDocument {
+    /// Plaintext credential document schema version.
+    pub(crate) version: u32,
+    /// Credential values serialized before envelope encryption.
+    pub(crate) values: BTreeMap<String, String>,
 }
 
 pub(crate) fn encrypt_credential_values(
@@ -514,43 +537,19 @@ pub(crate) fn encrypt_credential_values(
     values: &BTreeMap<String, String>,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<EncryptedCredentialDocument, CredentialsError> {
-    let kek = key_provider.active_key()?;
-    let dek = Zeroizing::new(random_array::<KEY_LEN>()?);
-    let nonce = random_array::<NONCE_LEN>()?;
-    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
-
     let plaintext = PlaintextCredentialDocument {
         version: CREDENTIAL_DOCUMENT_VERSION,
         values: values.clone(),
     };
-    let mut document_bytes = Zeroizing::new(
+    let document_bytes = Zeroizing::new(
         serde_json::to_vec(&plaintext)
             .map_err(|error| CredentialsError::Parse(error.to_string()))?,
     );
-    seal(
-        &*dek,
-        &nonce,
+    seal_envelope_document(
         credential_document_aad(workspace_name, source_name),
-        &mut document_bytes,
-    )?;
-
-    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
-    seal(
-        &kek.bytes,
-        &wrapped_dek_nonce,
-        credential_dek_aad(kek.key_id()),
-        &mut wrapped_dek,
-    )?;
-
-    Ok(EncryptedCredentialDocument {
-        ciphertext: std::mem::take(&mut *document_bytes),
-        nonce: nonce.to_vec(),
-        wrapped_dek: std::mem::take(&mut *wrapped_dek),
-        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
-        key_id: kek.key_id.clone(),
-        algorithm: CREDENTIAL_DOCUMENT_ALGORITHM.to_string(),
-        aad_version: CREDENTIAL_DOCUMENT_AAD_VERSION,
-    })
+        document_bytes,
+        key_provider,
+    )
 }
 
 pub(crate) fn decrypt_credential_values(
@@ -604,24 +603,7 @@ pub(crate) fn rewrap_credential_document(
             .map(Some);
     }
 
-    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
-    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
-    seal(
-        &active_kek.bytes,
-        &wrapped_dek_nonce,
-        credential_dek_aad(active_kek.key_id()),
-        &mut wrapped_dek,
-    )?;
-
-    Ok(Some(EncryptedCredentialDocument {
-        ciphertext: document.ciphertext.clone(),
-        nonce: document.nonce.clone(),
-        wrapped_dek: std::mem::take(&mut *wrapped_dek),
-        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
-        key_id: active_kek.key_id.clone(),
-        algorithm: document.algorithm.clone(),
-        aad_version: document.aad_version,
-    }))
+    rewrap_dek(document, &active_kek, &dek)
 }
 
 fn decrypt_credential_document_bytes(
@@ -657,18 +639,26 @@ fn decrypt_credential_document_bytes(
     }
 }
 
-fn unwrap_dek(
+fn unwrap_current_dek(
     document: &EncryptedCredentialDocument,
     kek: &CredentialEncryptionKey,
 ) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
     let mut dek = Zeroizing::new(document.wrapped_dek.clone());
-    match open(
+    open(
         &kek.bytes,
         document.wrapped_dek_nonce.as_slice(),
         credential_dek_aad(&document.key_id),
         dek.as_mut_slice(),
-    ) {
-        Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
+    )
+    .and_then(validate_dek_plaintext)
+}
+
+fn unwrap_dek(
+    document: &EncryptedCredentialDocument,
+    kek: &CredentialEncryptionKey,
+) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
+    match unwrap_current_dek(document, kek) {
+        Ok(dek) => Ok(dek),
         Err(primary_error) => {
             let mut legacy_dek = Zeroizing::new(document.wrapped_dek.clone());
             match open(
@@ -698,6 +688,31 @@ fn validate_dek_plaintext(
     Ok(Zeroizing::new(dek))
 }
 
+fn rewrap_dek(
+    document: &EncryptedEnvelopeDocument,
+    active_kek: &CredentialEncryptionKey,
+    dek: &[u8; KEY_LEN],
+) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
+    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
+    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
+    seal(
+        &active_kek.bytes,
+        &wrapped_dek_nonce,
+        credential_dek_aad(active_kek.key_id()),
+        &mut wrapped_dek,
+    )?;
+
+    Ok(Some(EncryptedCredentialDocument {
+        ciphertext: document.ciphertext.clone(),
+        nonce: document.nonce.clone(),
+        wrapped_dek: std::mem::take(&mut *wrapped_dek),
+        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
+        key_id: active_kek.key_id.clone(),
+        algorithm: document.algorithm.clone(),
+        aad_version: document.aad_version,
+    }))
+}
+
 fn validate_document_metadata(
     document: &EncryptedCredentialDocument,
 ) -> Result<(), CredentialsError> {
@@ -716,7 +731,85 @@ fn validate_document_metadata(
     Ok(())
 }
 
-fn seal(
+/// Seal a serialized plaintext document with a random DEK and wrap that DEK.
+pub(crate) fn seal_envelope_document(
+    document_aad: Vec<u8>,
+    mut document_bytes: Zeroizing<Vec<u8>>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<EncryptedEnvelopeDocument, CredentialsError> {
+    let kek = key_provider.active_key()?;
+    let dek = Zeroizing::new(random_array::<KEY_LEN>()?);
+    let nonce = random_array::<NONCE_LEN>()?;
+    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
+
+    seal(&*dek, &nonce, document_aad, &mut document_bytes)?;
+
+    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
+    seal(
+        &kek.bytes,
+        &wrapped_dek_nonce,
+        credential_dek_aad(kek.key_id()),
+        &mut wrapped_dek,
+    )?;
+
+    Ok(EncryptedCredentialDocument {
+        ciphertext: std::mem::take(&mut *document_bytes),
+        nonce: nonce.to_vec(),
+        wrapped_dek: std::mem::take(&mut *wrapped_dek),
+        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
+        key_id: kek.key_id.clone(),
+        algorithm: CREDENTIAL_DOCUMENT_ALGORITHM.to_string(),
+        aad_version: CREDENTIAL_DOCUMENT_AAD_VERSION,
+    })
+}
+
+/// Open a current-format envelope document with the supplied payload AAD.
+pub(crate) fn open_envelope_document(
+    document: &EncryptedEnvelopeDocument,
+    document_aad: Vec<u8>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
+    validate_document_metadata(document)?;
+    let kek = key_provider.key(&document.key_id)?;
+    let dek = unwrap_current_dek(document, &kek)?;
+
+    let mut ciphertext = Zeroizing::new(document.ciphertext.clone());
+    open(
+        &*dek,
+        document.nonce.as_slice(),
+        document_aad,
+        ciphertext.as_mut_slice(),
+    )
+    .map(|plaintext| Zeroizing::new(plaintext.to_vec()))
+}
+
+/// Rewrap a current-format envelope document when its KEK is stale.
+pub(crate) fn rewrap_envelope_document(
+    document: &EncryptedEnvelopeDocument,
+    document_aad: Vec<u8>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
+    validate_document_metadata(document)?;
+    let old_kek = key_provider.key(&document.key_id)?;
+    let active_kek = key_provider.active_key()?;
+    if old_kek.key_id == active_kek.key_id {
+        return Ok(None);
+    }
+
+    let dek = unwrap_current_dek(document, &old_kek)?;
+    let mut document_probe = Zeroizing::new(document.ciphertext.clone());
+    open(
+        &*dek,
+        document.nonce.as_slice(),
+        document_aad,
+        document_probe.as_mut_slice(),
+    )?;
+
+    rewrap_dek(document, &active_kek, &dek)
+}
+
+/// Seal bytes in-place with AES-256-GCM and append the authentication tag.
+pub(crate) fn seal(
     key_bytes: &[u8],
     nonce_bytes: &[u8; NONCE_LEN],
     aad: Vec<u8>,
@@ -734,7 +827,8 @@ fn seal(
     .map_err(|_error| CredentialsError::Crypto("AES-256-GCM seal failed".to_string()))
 }
 
-fn open<'a>(
+/// Open AES-256-GCM bytes in-place and return the authenticated plaintext.
+pub(crate) fn open<'a>(
     key_bytes: &[u8],
     nonce_bytes: &[u8],
     aad: Vec<u8>,
@@ -752,7 +846,11 @@ fn open<'a>(
         .map_err(|_error| CredentialsError::Crypto("AES-256-GCM open failed".to_string()))
 }
 
-fn credential_document_aad(workspace_name: &WorkspaceName, source_name: &SourceName) -> Vec<u8> {
+/// Build AAD for a credential document payload.
+pub(crate) fn credential_document_aad(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+) -> Vec<u8> {
     let aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION.to_string();
     encode_aad_fields(
         "coral-credential-document",
@@ -790,7 +888,8 @@ fn legacy_credential_dek_aad(key_id: &str) -> Vec<u8> {
     format!("coral-credential-dek:v{CREDENTIAL_DOCUMENT_AAD_VERSION}:{key_id}").into_bytes()
 }
 
-fn encode_aad_fields(domain: &str, fields: &[&str]) -> Vec<u8> {
+/// Encode an AAD domain and ordered fields using length-prefixed values.
+pub(crate) fn encode_aad_fields(domain: &str, fields: &[&str]) -> Vec<u8> {
     let mut aad = Vec::new();
     aad.extend_from_slice(domain.as_bytes());
     aad.push(0);
@@ -802,7 +901,8 @@ fn encode_aad_fields(domain: &str, fields: &[&str]) -> Vec<u8> {
     aad
 }
 
-fn random_array<const N: usize>() -> Result<[u8; N], CredentialsError> {
+/// Generate a cryptographically secure random byte array.
+pub(crate) fn random_array<const N: usize>() -> Result<[u8; N], CredentialsError> {
     let mut bytes = [0_u8; N];
     SystemRandom::new().fill(&mut bytes).map_err(|_error| {
         CredentialsError::Crypto("secure random generation failed".to_string())

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -1,13 +1,5 @@
 //! Application-level envelope encryption for DB-backed credential material.
 
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Credential DB runtime wiring lands in a later stack branch; this branch isolates cryptographic primitives for review."
-    )
-)]
-
 use std::collections::BTreeMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -45,6 +37,21 @@ enum CredentialEncryptionKeySource {
     File,
     Keychain,
     Vault,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CredentialEncryptionKeyOrigin {
+    Env,
+    File,
+    CreatedFile,
+    Keychain,
+    CreatedKeychain,
+}
+
+impl CredentialEncryptionKeyOrigin {
+    pub(crate) fn requires_postgres_bootstrap_warning(self) -> bool {
+        matches!(self, Self::File | Self::CreatedFile | Self::CreatedKeychain)
+    }
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -153,24 +160,42 @@ impl LocalFileCredentialKeyProvider {
         configured_key_source(&self.config_file)
     }
 
-    fn auto_key(&self, key_id: Option<&str>) -> Result<CredentialEncryptionKey, CredentialsError> {
+    pub(crate) fn active_key_origin(
+        &self,
+    ) -> Result<CredentialEncryptionKeyOrigin, CredentialsError> {
+        Ok(self.active_key_selection()?.1)
+    }
+
+    fn active_key_selection(
+        &self,
+    ) -> Result<(CredentialEncryptionKey, CredentialEncryptionKeyOrigin), CredentialsError> {
+        if let Some(key) = self.load_configured_key()? {
+            return Ok((key, CredentialEncryptionKeyOrigin::Env));
+        }
+        self.explicit_source_key(self.configured_source()?, None)
+    }
+
+    fn auto_key(
+        &self,
+        key_id: Option<&str>,
+    ) -> Result<(CredentialEncryptionKey, CredentialEncryptionKeyOrigin), CredentialsError> {
         if self.file.exists()? {
             info!(
                 path = %self.file.path().display(),
                 "using existing plaintext credential encryption key; migrate the KEK to keychain before enabling keychain sourcing"
             );
-            return self.file.resolve_key(key_id);
+            return self.file.resolve_key_selection(key_id);
         }
 
         match self.keychain.probe() {
-            Ok(()) => self.keychain.resolve_key(key_id),
+            Ok(()) => self.keychain.resolve_key_selection(key_id),
             Err(error) => {
                 warn!(
                     detail = %error,
                     path = %self.file.path().display(),
                     "keychain unavailable; falling back to plaintext credential encryption key file; configure a keychain or set [credentials].encryption_key_source = \"keychain\" to fail closed"
                 );
-                self.file.resolve_key(key_id)
+                self.file.resolve_key_selection(key_id)
             }
         }
     }
@@ -179,13 +204,13 @@ impl LocalFileCredentialKeyProvider {
         &self,
         source: CredentialEncryptionKeySource,
         key_id: Option<&str>,
-    ) -> Result<CredentialEncryptionKey, CredentialsError> {
+    ) -> Result<(CredentialEncryptionKey, CredentialEncryptionKeyOrigin), CredentialsError> {
         match source {
             CredentialEncryptionKeySource::Auto => self.auto_key(key_id),
-            CredentialEncryptionKeySource::File => self.file.resolve_key(key_id),
+            CredentialEncryptionKeySource::File => self.file.resolve_key_selection(key_id),
             CredentialEncryptionKeySource::Keychain => self
                 .keychain
-                .resolve_key(key_id)
+                .resolve_key_selection(key_id)
                 .map_err(configured_keychain_key_unavailable),
             CredentialEncryptionKeySource::Vault => Err(CredentialsError::Unavailable(
                 "vault credential encryption key source is not implemented".to_string(),
@@ -196,17 +221,16 @@ impl LocalFileCredentialKeyProvider {
 
 impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
     fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
-        if let Some(key) = self.load_configured_key()? {
-            return Ok(key);
-        }
-        self.explicit_source_key(self.configured_source()?, None)
+        Ok(self.active_key_selection()?.0)
     }
 
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
         if let Some(key) = self.load_configured_key()? {
             return verify_key_id(key, key_id);
         }
-        self.explicit_source_key(self.configured_source()?, Some(key_id))
+        Ok(self
+            .explicit_source_key(self.configured_source()?, Some(key_id))?
+            .0)
     }
 }
 
@@ -230,7 +254,9 @@ impl PlaintextFileCredentialKeyProvider {
         self.path.try_exists().map_err(Into::into)
     }
 
-    fn load_or_create_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+    fn load_or_create_key(
+        &self,
+    ) -> Result<(CredentialEncryptionKey, CredentialEncryptionKeyOrigin), CredentialsError> {
         let _thread_guard = LOCAL_KEY_FILE_LOCK.lock().map_err(|_error| {
             CredentialsError::Crypto("credential encryption key lock is poisoned".to_string())
         })?;
@@ -241,7 +267,9 @@ impl PlaintextFileCredentialKeyProvider {
         let _process_guard = FileLock::exclusive(&lock_path)?;
 
         match std::fs::read_to_string(&self.path) {
-            Ok(raw) => decode_key_material(&raw),
+            Ok(raw) => {
+                decode_key_material(&raw).map(|key| (key, CredentialEncryptionKeyOrigin::File))
+            }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 let bytes = random_array::<KEY_LEN>()?;
                 let encoded = format!(
@@ -253,10 +281,13 @@ impl PlaintextFileCredentialKeyProvider {
                     path = %self.path.display(),
                     "created plaintext credential encryption key; shared-Postgres deployments must provision the same KEK on every server"
                 );
-                Ok(CredentialEncryptionKey {
-                    key_id: key_id_for_bytes(&bytes),
-                    bytes,
-                })
+                Ok((
+                    CredentialEncryptionKey {
+                        key_id: key_id_for_bytes(&bytes),
+                        bytes,
+                    },
+                    CredentialEncryptionKeyOrigin::CreatedFile,
+                ))
             }
             Err(error) => Err(error.into()),
         }
@@ -270,15 +301,16 @@ impl PlaintextFileCredentialKeyProvider {
         }
     }
 
-    fn resolve_key(
+    fn resolve_key_selection(
         &self,
         key_id: Option<&str>,
-    ) -> Result<CredentialEncryptionKey, CredentialsError> {
+    ) -> Result<(CredentialEncryptionKey, CredentialEncryptionKeyOrigin), CredentialsError> {
         match key_id {
             Some(key_id) => self
                 .load_key()?
                 .ok_or_else(|| key_unavailable(key_id))
-                .and_then(|key| verify_key_id(key, key_id)),
+                .and_then(|key| verify_key_id(key, key_id))
+                .map(|key| (key, CredentialEncryptionKeyOrigin::File)),
             None => self.load_or_create_key(),
         }
     }
@@ -336,36 +368,49 @@ impl KeychainCredentialKeyProvider {
         Ok(None)
     }
 
-    fn load_or_create_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+    fn load_or_create_key(
+        &self,
+    ) -> Result<(CredentialEncryptionKey, CredentialEncryptionKeyOrigin), CredentialsError> {
         if let Some(key) = self.load_key()? {
-            return Ok(key);
+            return Ok((key, CredentialEncryptionKeyOrigin::Keychain));
         }
         if let Some(parent) = self.lock_path.parent() {
             storage_fs::ensure_private_dir(parent)?;
         }
         let _guard = FileLock::exclusive(&self.lock_path)?;
         if let Some(key) = self.load_key()? {
-            return Ok(key);
+            return Ok((key, CredentialEncryptionKeyOrigin::Keychain));
         }
         let bytes = random_array::<KEY_LEN>()?;
         let encoded = encode_key_material(&bytes);
         self.keychain.write_key_material(&encoded)?;
         info!("created keychain credential encryption key");
-        Ok(CredentialEncryptionKey {
-            key_id: key_id_for_bytes(&bytes),
-            bytes,
-        })
+        Ok((
+            CredentialEncryptionKey {
+                key_id: key_id_for_bytes(&bytes),
+                bytes,
+            },
+            CredentialEncryptionKeyOrigin::CreatedKeychain,
+        ))
     }
 
     fn resolve_key(
         &self,
         key_id: Option<&str>,
     ) -> Result<CredentialEncryptionKey, CredentialsError> {
+        Ok(self.resolve_key_selection(key_id)?.0)
+    }
+
+    fn resolve_key_selection(
+        &self,
+        key_id: Option<&str>,
+    ) -> Result<(CredentialEncryptionKey, CredentialEncryptionKeyOrigin), CredentialsError> {
         match key_id {
             Some(key_id) => self
                 .load_key()?
                 .ok_or_else(|| key_unavailable(key_id))
-                .and_then(|key| verify_key_id(key, key_id)),
+                .and_then(|key| verify_key_id(key, key_id))
+                .map(|key| (key, CredentialEncryptionKeyOrigin::Keychain)),
             None => self.load_or_create_key(),
         }
     }

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -1028,6 +1028,9 @@ mod tests {
     #[test]
     #[ignore = "uses the native OS keychain; run manually on hosts with keychain access"]
     fn native_keychain_key_provider_round_trips_key_material() {
+        if bootstrap::env_var("CORAL_RUN_NATIVE_KEYCHAIN_TESTS").is_none() {
+            return;
+        }
         let (_temp, layout) = temp_layout();
         let first = KeychainCredentialKeyProvider::new(&layout)
             .active_key()

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -11,16 +11,17 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use base64::Engine as _;
 use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey};
 use ring::rand::{SecureRandom as _, SystemRandom};
 use sha2::{Digest as _, Sha256};
-use tracing::warn;
+use tracing::{info, warn};
 use zeroize::{Zeroize as _, Zeroizing};
 
 use super::CredentialsError;
+use super::store::{CredentialConfigNamespace, KeychainCredentialBackend};
 use crate::bootstrap;
 use crate::sources::SourceName;
 use crate::state::AppStateLayout;
@@ -37,6 +38,14 @@ const KEY_LEN: usize = 32;
 const NONCE_LEN: usize = 12;
 
 static LOCAL_KEY_FILE_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CredentialEncryptionKeySource {
+    Auto,
+    File,
+    Keychain,
+    Vault,
+}
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct CredentialEncryptionKey {
@@ -78,20 +87,49 @@ pub(crate) trait CredentialKeyProvider: Send + Sync {
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError>;
 }
 
-/// Local credential encryption key provider.
-/// Shared-Postgres deployments MUST provision the same KEK on every server via
-/// `[credentials].encryption_key_env`; the local file key is single-config-dir only.
-#[derive(Debug, Clone)]
+/// Resolves credential encryption keys for DB-backed credential documents.
+///
+/// The historical type name is kept for the upstack runtime wiring. In auto
+/// mode this provider prefers the OS keychain and uses the plaintext key file
+/// only when keychain storage is unavailable or an existing file key would
+/// otherwise strand encrypted rows. Shared-Postgres deployments MUST provision
+/// the same KEK on every server via `[credentials].encryption_key_env` or by
+/// pre-seeding each host's keychain with the same key material.
+#[derive(Clone)]
 pub(crate) struct LocalFileCredentialKeyProvider {
-    path: PathBuf,
     config_file: PathBuf,
+    file: PlaintextFileCredentialKeyProvider,
+    keychain: KeychainCredentialKeyProvider,
+}
+
+impl fmt::Debug for LocalFileCredentialKeyProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LocalFileCredentialKeyProvider")
+            .field("config_file", &self.config_file)
+            .field("file", &self.file)
+            .field("keychain", &self.keychain)
+            .finish()
+    }
 }
 
 impl LocalFileCredentialKeyProvider {
     pub(crate) fn new(layout: &AppStateLayout) -> Self {
         Self {
-            path: layout.credential_encryption_key_file(),
             config_file: layout.config_file().to_path_buf(),
+            file: PlaintextFileCredentialKeyProvider::new(layout),
+            keychain: KeychainCredentialKeyProvider::new(layout),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_keychain_for_test(
+        layout: &AppStateLayout,
+        keychain: KeychainCredentialKeyProvider,
+    ) -> Self {
+        Self {
+            config_file: layout.config_file().to_path_buf(),
+            file: PlaintextFileCredentialKeyProvider::new(layout),
+            keychain,
         }
     }
 
@@ -109,6 +147,87 @@ impl LocalFileCredentialKeyProvider {
                 "invalid credential encryption key from environment variable `{env_name}`: {error}"
             ))
         })
+    }
+
+    fn configured_source(&self) -> Result<CredentialEncryptionKeySource, CredentialsError> {
+        configured_key_source(&self.config_file)
+    }
+
+    fn auto_key(&self, key_id: Option<&str>) -> Result<CredentialEncryptionKey, CredentialsError> {
+        if self.file.exists()? {
+            info!(
+                path = %self.file.path().display(),
+                "using existing plaintext credential encryption key; migrate the KEK to keychain before enabling keychain sourcing"
+            );
+            return self.file.resolve_key(key_id);
+        }
+
+        match self.keychain.probe() {
+            Ok(()) => self.keychain.resolve_key(key_id),
+            Err(error) => {
+                warn!(
+                    detail = %error,
+                    path = %self.file.path().display(),
+                    "keychain unavailable; falling back to plaintext credential encryption key file; configure a keychain or set [credentials].encryption_key_source = \"keychain\" to fail closed"
+                );
+                self.file.resolve_key(key_id)
+            }
+        }
+    }
+
+    fn explicit_source_key(
+        &self,
+        source: CredentialEncryptionKeySource,
+        key_id: Option<&str>,
+    ) -> Result<CredentialEncryptionKey, CredentialsError> {
+        match source {
+            CredentialEncryptionKeySource::Auto => self.auto_key(key_id),
+            CredentialEncryptionKeySource::File => self.file.resolve_key(key_id),
+            CredentialEncryptionKeySource::Keychain => self
+                .keychain
+                .resolve_key(key_id)
+                .map_err(configured_keychain_key_unavailable),
+            CredentialEncryptionKeySource::Vault => Err(CredentialsError::Unavailable(
+                "vault credential encryption key source is not implemented".to_string(),
+            )),
+        }
+    }
+}
+
+impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
+    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        if let Some(key) = self.load_configured_key()? {
+            return Ok(key);
+        }
+        self.explicit_source_key(self.configured_source()?, None)
+    }
+
+    fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+        if let Some(key) = self.load_configured_key()? {
+            return verify_key_id(key, key_id);
+        }
+        self.explicit_source_key(self.configured_source()?, Some(key_id))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PlaintextFileCredentialKeyProvider {
+    path: PathBuf,
+}
+
+impl PlaintextFileCredentialKeyProvider {
+    fn new(layout: &AppStateLayout) -> Self {
+        Self {
+            path: layout.credential_encryption_key_file(),
+        }
+    }
+
+    fn path(&self) -> &Path {
+        self.path.as_path()
+    }
+
+    fn exists(&self) -> Result<bool, CredentialsError> {
+        self.path.try_exists().map_err(Into::into)
     }
 
     fn load_or_create_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
@@ -132,7 +251,7 @@ impl LocalFileCredentialKeyProvider {
                 storage_fs::write_atomic(&self.path, encoded.as_bytes())?;
                 warn!(
                     path = %self.path.display(),
-                    "created local credential encryption key; shared-Postgres deployments must provision the same KEK on every server"
+                    "created plaintext credential encryption key; shared-Postgres deployments must provision the same KEK on every server"
                 );
                 Ok(CredentialEncryptionKey {
                     key_id: key_id_for_bytes(&bytes),
@@ -142,26 +261,187 @@ impl LocalFileCredentialKeyProvider {
             Err(error) => Err(error.into()),
         }
     }
+
+    fn load_key(&self) -> Result<Option<CredentialEncryptionKey>, CredentialsError> {
+        match std::fs::read_to_string(&self.path) {
+            Ok(raw) => decode_key_material(&raw).map(Some),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn resolve_key(
+        &self,
+        key_id: Option<&str>,
+    ) -> Result<CredentialEncryptionKey, CredentialsError> {
+        match key_id {
+            Some(key_id) => self
+                .load_key()?
+                .ok_or_else(|| key_unavailable(key_id))
+                .and_then(|key| verify_key_id(key, key_id)),
+            None => self.load_or_create_key(),
+        }
+    }
 }
 
-impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
-    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
-        if let Some(key) = self.load_configured_key()? {
+#[derive(Clone)]
+pub(crate) struct KeychainCredentialKeyProvider {
+    keychain: Arc<dyn CredentialEncryptionKeychain>,
+    lock_path: PathBuf,
+}
+
+impl fmt::Debug for KeychainCredentialKeyProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("KeychainCredentialKeyProvider")
+            .finish_non_exhaustive()
+    }
+}
+
+impl KeychainCredentialKeyProvider {
+    pub(crate) fn new(layout: &AppStateLayout) -> Self {
+        let namespace = CredentialConfigNamespace::from_layout(layout);
+        let backend = KeychainCredentialBackend::new(namespace.clone());
+        Self {
+            keychain: Arc::new(NativeCredentialEncryptionKeychain {
+                backend,
+                entry: CredentialEncryptionKeychainEntry::from_namespace(&namespace),
+            }),
+            lock_path: layout
+                .credential_encryption_key_file()
+                .with_extension("keychain.lock"),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_keychain_for_test(
+        layout: &AppStateLayout,
+        keychain: Arc<dyn CredentialEncryptionKeychain>,
+    ) -> Self {
+        Self {
+            keychain,
+            lock_path: layout
+                .credential_encryption_key_file()
+                .with_extension("keychain.lock"),
+        }
+    }
+
+    fn probe(&self) -> Result<(), CredentialsError> {
+        self.keychain.probe()
+    }
+
+    fn load_key(&self) -> Result<Option<CredentialEncryptionKey>, CredentialsError> {
+        if let Some(raw) = self.keychain.read_key_material()? {
+            return decode_key_material(&raw).map(Some);
+        }
+        Ok(None)
+    }
+
+    fn load_or_create_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        if let Some(key) = self.load_key()? {
             return Ok(key);
         }
-        self.load_or_create_key()
+        if let Some(parent) = self.lock_path.parent() {
+            storage_fs::ensure_private_dir(parent)?;
+        }
+        let _guard = FileLock::exclusive(&self.lock_path)?;
+        if let Some(key) = self.load_key()? {
+            return Ok(key);
+        }
+        let bytes = random_array::<KEY_LEN>()?;
+        let encoded = encode_key_material(&bytes);
+        self.keychain.write_key_material(&encoded)?;
+        info!("created keychain credential encryption key");
+        Ok(CredentialEncryptionKey {
+            key_id: key_id_for_bytes(&bytes),
+            bytes,
+        })
+    }
+
+    fn resolve_key(
+        &self,
+        key_id: Option<&str>,
+    ) -> Result<CredentialEncryptionKey, CredentialsError> {
+        match key_id {
+            Some(key_id) => self
+                .load_key()?
+                .ok_or_else(|| key_unavailable(key_id))
+                .and_then(|key| verify_key_id(key, key_id)),
+            None => self.load_or_create_key(),
+        }
+    }
+}
+
+impl CredentialKeyProvider for KeychainCredentialKeyProvider {
+    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        self.resolve_key(None)
     }
 
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
-        let key = self
-            .load_configured_key()?
-            .map_or_else(|| self.load_or_create_key(), Ok)?;
-        if key.key_id == key_id {
-            Ok(key)
-        } else {
-            Err(CredentialsError::Crypto(format!(
-                "credential encryption key '{key_id}' is unavailable"
-            )))
+        self.resolve_key(Some(key_id))
+    }
+}
+
+trait CredentialEncryptionKeychain: Send + Sync {
+    fn probe(&self) -> Result<(), CredentialsError>;
+
+    fn read_key_material(&self) -> Result<Option<String>, CredentialsError>;
+
+    fn write_key_material(&self, material: &str) -> Result<(), CredentialsError>;
+}
+
+#[derive(Clone)]
+struct NativeCredentialEncryptionKeychain {
+    backend: KeychainCredentialBackend,
+    entry: CredentialEncryptionKeychainEntry,
+}
+
+impl CredentialEncryptionKeychain for NativeCredentialEncryptionKeychain {
+    fn probe(&self) -> Result<(), CredentialsError> {
+        self.backend.run_native(|backend| backend.probe_native())
+    }
+
+    fn read_key_material(&self) -> Result<Option<String>, CredentialsError> {
+        let entry = self.entry.clone();
+        self.backend.run_native(move |backend| {
+            backend.probe_native()?;
+            match backend
+                .entry_for(&entry.service, &entry.account)?
+                .get_password()
+            {
+                Ok(value) => Ok(Some(value)),
+                Err(keyring_core::Error::NoEntry) => Ok(None),
+                Err(error) => Err(CredentialsError::Unavailable(error.to_string())),
+            }
+        })
+    }
+
+    fn write_key_material(&self, material: &str) -> Result<(), CredentialsError> {
+        let entry = self.entry.clone();
+        let material = material.to_string();
+        self.backend.run_native(move |backend| {
+            backend.probe_native()?;
+            backend
+                .entry_for(&entry.service, &entry.account)?
+                .set_password(&material)
+                .map_err(|error| CredentialsError::Unavailable(error.to_string()))
+        })
+    }
+}
+
+#[derive(Clone)]
+struct CredentialEncryptionKeychainEntry {
+    service: String,
+    account: String,
+}
+
+impl CredentialEncryptionKeychainEntry {
+    fn from_namespace(config_namespace: &CredentialConfigNamespace) -> Self {
+        Self {
+            service: format!(
+                "com.withcoral.coral/{}/credential-encryption-key",
+                config_namespace.as_str()
+            ),
+            account: "active".to_string(),
         }
     }
 }
@@ -506,6 +786,68 @@ fn configured_key_env(config_file: &Path) -> Result<Option<String>, CredentialsE
         })
 }
 
+fn configured_key_source(
+    config_file: &Path,
+) -> Result<CredentialEncryptionKeySource, CredentialsError> {
+    if !config_file.exists() {
+        return Ok(CredentialEncryptionKeySource::Auto);
+    }
+    let raw = std::fs::read_to_string(config_file)?;
+    let config: toml::Value =
+        toml::from_str(&raw).map_err(|error| CredentialsError::Parse(error.to_string()))?;
+    let Some(value) = config
+        .get("credentials")
+        .and_then(|credentials| credentials.get("encryption_key_source"))
+    else {
+        return Ok(CredentialEncryptionKeySource::Auto);
+    };
+    match value.as_str() {
+        Some("auto") => Ok(CredentialEncryptionKeySource::Auto),
+        Some("file") => Ok(CredentialEncryptionKeySource::File),
+        Some("keychain") => Ok(CredentialEncryptionKeySource::Keychain),
+        Some("vault") => Ok(CredentialEncryptionKeySource::Vault),
+        Some(source) => Err(CredentialsError::Parse(format!(
+            "unsupported [credentials].encryption_key_source '{source}'"
+        ))),
+        None => Err(CredentialsError::Parse(
+            "[credentials].encryption_key_source must be a string".to_string(),
+        )),
+    }
+}
+
+fn verify_key_id(
+    key: CredentialEncryptionKey,
+    key_id: &str,
+) -> Result<CredentialEncryptionKey, CredentialsError> {
+    if key.key_id == key_id {
+        Ok(key)
+    } else {
+        Err(key_unavailable(key_id))
+    }
+}
+
+fn key_unavailable(key_id: &str) -> CredentialsError {
+    CredentialsError::Crypto(format!(
+        "credential encryption key '{key_id}' is unavailable"
+    ))
+}
+
+fn configured_keychain_key_unavailable(error: CredentialsError) -> CredentialsError {
+    match error {
+        CredentialsError::Unavailable(detail) => CredentialsError::Unavailable(format!(
+            "credential encryption key source is configured for keychain, but keychain is unavailable: {detail}"
+        )),
+        error => error,
+    }
+}
+
+fn encode_key_material(bytes: &[u8; KEY_LEN]) -> String {
+    format!(
+        "{KEY_FILE_VERSION}:{}",
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    )
+}
+
 fn decode_key_material(raw: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
     let trimmed = raw.trim();
     let Some(encoded) = trimmed.strip_prefix(&format!("{KEY_FILE_VERSION}:")) else {
@@ -537,6 +879,10 @@ fn key_id_for_bytes(bytes: &[u8; KEY_LEN]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use std::sync::{Arc, Mutex};
+
+    use tempfile::TempDir;
 
     impl CredentialKeyProvider for CredentialEncryptionKey {
         fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
@@ -590,5 +936,210 @@ mod tests {
         assert!(debug.contains(provider.key_id()));
         assert!(!debug.contains("bytes"));
         assert!(!debug.contains("[7, 7"));
+    }
+
+    #[test]
+    fn keychain_key_provider_stores_and_reuses_versioned_key() {
+        let (_temp, layout) = temp_layout();
+        let keychain = FakeKeychain::available();
+        let provider =
+            KeychainCredentialKeyProvider::with_keychain_for_test(&layout, keychain.clone());
+
+        let first = provider.active_key().expect("first key");
+        let second = provider.active_key().expect("second key");
+
+        assert_eq!(first, second);
+        assert!(
+            keychain
+                .material()
+                .expect("stored key")
+                .starts_with(&format!("{KEY_FILE_VERSION}:")),
+            "keychain key material should use the shared versioned encoding"
+        );
+    }
+
+    #[test]
+    fn key_lookup_does_not_create_missing_key_material() {
+        let (_temp, layout) = temp_layout();
+        let keychain = FakeKeychain::available();
+        let keychain_provider =
+            KeychainCredentialKeyProvider::with_keychain_for_test(&layout, keychain.clone());
+
+        keychain_provider
+            .key("missing-key")
+            .expect_err("missing keychain key should fail");
+
+        assert!(keychain.material().is_none(), "lookup must not create KEK");
+        write_key_source_config(&layout, "file");
+        LocalFileCredentialKeyProvider::new(&layout)
+            .key("missing-key")
+            .expect_err("missing file key should fail");
+        assert!(
+            !layout.credential_encryption_key_file().exists(),
+            "file lookup must not create KEK"
+        );
+    }
+
+    #[test]
+    #[ignore = "uses the native OS keychain; run manually on hosts with keychain access"]
+    fn native_keychain_key_provider_round_trips_key_material() {
+        let (_temp, layout) = temp_layout();
+        let first = KeychainCredentialKeyProvider::new(&layout)
+            .active_key()
+            .expect("native keychain should create KEK");
+        let second = KeychainCredentialKeyProvider::new(&layout)
+            .key(first.key_id())
+            .expect("native keychain should read KEK by id");
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn auto_prefers_keychain_without_creating_file_key() {
+        let (_temp, layout) = temp_layout();
+        let keychain = FakeKeychain::available();
+        let provider = LocalFileCredentialKeyProvider::with_keychain_for_test(
+            &layout,
+            KeychainCredentialKeyProvider::with_keychain_for_test(&layout, keychain.clone()),
+        );
+
+        provider.active_key().expect("keychain key");
+
+        assert!(keychain.material().is_some(), "auto should write keychain");
+        assert!(
+            !layout.credential_encryption_key_file().exists(),
+            "auto keychain success should not create plaintext key material"
+        );
+    }
+
+    #[test]
+    fn auto_falls_back_to_file_with_loud_warning_when_keychain_unavailable() {
+        let (_temp, layout) = temp_layout();
+        let keychain = FakeKeychain::unavailable();
+        let provider = LocalFileCredentialKeyProvider::with_keychain_for_test(
+            &layout,
+            KeychainCredentialKeyProvider::with_keychain_for_test(&layout, keychain),
+        );
+
+        provider.active_key().expect("fallback file key");
+
+        assert!(
+            layout.credential_encryption_key_file().exists(),
+            "unavailable keychain should fall back to the plaintext key file"
+        );
+    }
+
+    #[test]
+    fn auto_keeps_existing_file_key_even_when_keychain_available() {
+        let (_temp, layout) = temp_layout();
+        write_key_source_config(&layout, "file");
+        let file_key = LocalFileCredentialKeyProvider::new(&layout)
+            .active_key()
+            .expect("file key");
+        std::fs::remove_file(layout.config_file()).expect("remove explicit file config");
+        let keychain = FakeKeychain::available();
+        let provider = LocalFileCredentialKeyProvider::with_keychain_for_test(
+            &layout,
+            KeychainCredentialKeyProvider::with_keychain_for_test(&layout, keychain.clone()),
+        );
+
+        let selected = provider.active_key().expect("auto key");
+
+        assert_eq!(selected, file_key);
+        assert!(
+            keychain.material().is_none(),
+            "existing file key should keep auto mode from silently switching to keychain"
+        );
+    }
+
+    #[test]
+    fn explicit_keychain_source_fails_closed_when_unavailable() {
+        let (_temp, layout) = temp_layout();
+        write_key_source_config(&layout, "keychain");
+        let provider = LocalFileCredentialKeyProvider::with_keychain_for_test(
+            &layout,
+            KeychainCredentialKeyProvider::with_keychain_for_test(
+                &layout,
+                FakeKeychain::unavailable(),
+            ),
+        );
+
+        let error = provider
+            .active_key()
+            .expect_err("explicit keychain should not fall back");
+
+        assert!(
+            matches!(error, CredentialsError::Unavailable(_)),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            !layout.credential_encryption_key_file().exists(),
+            "explicit keychain failure must not create a plaintext key"
+        );
+    }
+
+    fn temp_layout() -> (TempDir, AppStateLayout) {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        (temp, layout)
+    }
+
+    fn write_key_source_config(layout: &AppStateLayout, source: &str) {
+        std::fs::write(
+            layout.config_file(),
+            format!("version = 1\n\n[credentials]\nencryption_key_source = \"{source}\"\n"),
+        )
+        .expect("write config");
+    }
+
+    struct FakeKeychain {
+        available: bool,
+        material: Mutex<Option<String>>,
+    }
+
+    impl FakeKeychain {
+        fn available() -> Arc<Self> {
+            Arc::new(Self {
+                available: true,
+                material: Mutex::new(None),
+            })
+        }
+
+        fn unavailable() -> Arc<Self> {
+            Arc::new(Self {
+                available: false,
+                material: Mutex::new(None),
+            })
+        }
+
+        fn material(&self) -> Option<String> {
+            self.material.lock().expect("material lock").clone()
+        }
+    }
+
+    impl CredentialEncryptionKeychain for FakeKeychain {
+        fn probe(&self) -> Result<(), CredentialsError> {
+            if self.available {
+                Ok(())
+            } else {
+                Err(CredentialsError::Unavailable(
+                    "fake keychain unavailable".to_string(),
+                ))
+            }
+        }
+
+        fn read_key_material(&self) -> Result<Option<String>, CredentialsError> {
+            self.probe()?;
+            Ok(self.material())
+        }
+
+        fn write_key_material(&self, material: &str) -> Result<(), CredentialsError> {
+            self.probe()?;
+            *self.material.lock().map_err(|error| {
+                CredentialsError::Unavailable(format!("fake keychain lock poisoned: {error}"))
+            })? = Some(material.to_string());
+            Ok(())
+        }
     }
 }

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -6,15 +6,19 @@
 )]
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::fmt;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use base64::Engine as _;
 use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey};
 use ring::rand::{SecureRandom as _, SystemRandom};
 use sha2::{Digest as _, Sha256};
+use tracing::warn;
+use zeroize::{Zeroize as _, Zeroizing};
 
 use super::CredentialsError;
+use crate::bootstrap;
 use crate::sources::SourceName;
 use crate::state::AppStateLayout;
 use crate::storage::fs as storage_fs;
@@ -31,10 +35,24 @@ const NONCE_LEN: usize = 12;
 
 static LOCAL_KEY_FILE_LOCK: Mutex<()> = Mutex::new(());
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct CredentialEncryptionKey {
     key_id: String,
     bytes: [u8; KEY_LEN],
+}
+
+impl fmt::Debug for CredentialEncryptionKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CredentialEncryptionKey")
+            .field("key_id", &self.key_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for CredentialEncryptionKey {
+    fn drop(&mut self) {
+        self.bytes.zeroize();
+    }
 }
 
 impl CredentialEncryptionKey {
@@ -57,16 +75,37 @@ pub(crate) trait CredentialKeyProvider: Send + Sync {
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError>;
 }
 
+/// Local credential encryption key provider.
+/// Shared-Postgres deployments MUST provision the same KEK on every server via
+/// `[credentials].encryption_key_env`; the local file key is single-config-dir only.
 #[derive(Debug, Clone)]
 pub(crate) struct LocalFileCredentialKeyProvider {
     path: PathBuf,
+    config_file: PathBuf,
 }
 
 impl LocalFileCredentialKeyProvider {
     pub(crate) fn new(layout: &AppStateLayout) -> Self {
         Self {
             path: layout.credential_encryption_key_file(),
+            config_file: layout.config_file().to_path_buf(),
         }
+    }
+
+    fn load_configured_key(&self) -> Result<Option<CredentialEncryptionKey>, CredentialsError> {
+        let Some(env_name) = configured_key_env(&self.config_file)? else {
+            return Ok(None);
+        };
+        let raw = bootstrap::env_var(&env_name).ok_or_else(|| {
+            CredentialsError::Crypto(format!(
+                "credential encryption key environment variable `{env_name}` is not set"
+            ))
+        })?;
+        decode_key_material(&raw).map(Some).map_err(|error| {
+            CredentialsError::Crypto(format!(
+                "invalid credential encryption key from environment variable `{env_name}`: {error}"
+            ))
+        })
     }
 
     fn load_or_create_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
@@ -80,7 +119,7 @@ impl LocalFileCredentialKeyProvider {
         let _process_guard = FileLock::exclusive(&lock_path)?;
 
         match std::fs::read_to_string(&self.path) {
-            Ok(raw) => decode_key_file(&raw),
+            Ok(raw) => decode_key_material(&raw),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 let bytes = random_array::<KEY_LEN>()?;
                 let encoded = format!(
@@ -88,6 +127,10 @@ impl LocalFileCredentialKeyProvider {
                     base64::engine::general_purpose::STANDARD.encode(bytes)
                 );
                 storage_fs::write_atomic(&self.path, encoded.as_bytes())?;
+                warn!(
+                    path = %self.path.display(),
+                    "created local credential encryption key; shared-Postgres deployments must provision the same KEK on every server"
+                );
                 Ok(CredentialEncryptionKey {
                     key_id: key_id_for_bytes(&bytes),
                     bytes,
@@ -100,11 +143,16 @@ impl LocalFileCredentialKeyProvider {
 
 impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
     fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        if let Some(key) = self.load_configured_key()? {
+            return Ok(key);
+        }
         self.load_or_create_key()
     }
 
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
-        let key = self.load_or_create_key()?;
+        let key = self
+            .load_configured_key()?
+            .map_or_else(|| self.load_or_create_key(), Ok)?;
         if key.key_id == key_id {
             Ok(key)
         } else {
@@ -139,7 +187,7 @@ pub(crate) fn encrypt_credential_values(
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<EncryptedCredentialDocument, CredentialsError> {
     let kek = key_provider.active_key()?;
-    let dek = random_array::<KEY_LEN>()?;
+    let dek = Zeroizing::new(random_array::<KEY_LEN>()?);
     let nonce = random_array::<NONCE_LEN>()?;
     let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
 
@@ -147,16 +195,18 @@ pub(crate) fn encrypt_credential_values(
         version: CREDENTIAL_DOCUMENT_VERSION,
         values: values.clone(),
     };
-    let mut document_bytes = serde_json::to_vec(&plaintext)
-        .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+    let mut document_bytes = Zeroizing::new(
+        serde_json::to_vec(&plaintext)
+            .map_err(|error| CredentialsError::Parse(error.to_string()))?,
+    );
     seal(
-        &dek,
+        &*dek,
         &nonce,
         credential_document_aad(workspace_name, source_name),
         &mut document_bytes,
     )?;
 
-    let mut wrapped_dek = dek.to_vec();
+    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
     seal(
         &kek.bytes,
         &wrapped_dek_nonce,
@@ -165,11 +215,11 @@ pub(crate) fn encrypt_credential_values(
     )?;
 
     Ok(EncryptedCredentialDocument {
-        ciphertext: document_bytes,
+        ciphertext: std::mem::take(&mut *document_bytes),
         nonce: nonce.to_vec(),
-        wrapped_dek,
+        wrapped_dek: std::mem::take(&mut *wrapped_dek),
         wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
-        key_id: kek.key_id,
+        key_id: kek.key_id.clone(),
         algorithm: CREDENTIAL_DOCUMENT_ALGORITHM.to_string(),
         aad_version: CREDENTIAL_DOCUMENT_AAD_VERSION,
     })
@@ -208,12 +258,12 @@ pub(crate) fn rewrap_credential_document(
     }
 
     let dek = unwrap_dek(document, &old_kek)?;
-    let mut document_probe = document.ciphertext.clone();
+    let mut document_probe = Zeroizing::new(document.ciphertext.clone());
     if open(
-        &dek,
+        &*dek,
         document.nonce.as_slice(),
         credential_document_aad(workspace_name, source_name),
-        &mut document_probe,
+        document_probe.as_mut_slice(),
     )
     .is_err()
     {
@@ -227,7 +277,7 @@ pub(crate) fn rewrap_credential_document(
     }
 
     let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
-    let mut wrapped_dek = dek;
+    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
     seal(
         &active_kek.bytes,
         &wrapped_dek_nonce,
@@ -238,9 +288,9 @@ pub(crate) fn rewrap_credential_document(
     Ok(Some(EncryptedCredentialDocument {
         ciphertext: document.ciphertext.clone(),
         nonce: document.nonce.clone(),
-        wrapped_dek,
+        wrapped_dek: std::mem::take(&mut *wrapped_dek),
         wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
-        key_id: active_kek.key_id,
+        key_id: active_kek.key_id.clone(),
         algorithm: document.algorithm.clone(),
         aad_version: document.aad_version,
     }))
@@ -251,28 +301,28 @@ fn decrypt_credential_document_bytes(
     source_name: &SourceName,
     document: &EncryptedCredentialDocument,
     key_provider: &dyn CredentialKeyProvider,
-) -> Result<Vec<u8>, CredentialsError> {
+) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
     validate_document_metadata(document)?;
     let kek = key_provider.key(&document.key_id)?;
     let dek = unwrap_dek(document, &kek)?;
 
-    let mut ciphertext = document.ciphertext.clone();
+    let mut ciphertext = Zeroizing::new(document.ciphertext.clone());
     match open(
-        &dek,
+        &*dek,
         document.nonce.as_slice(),
         credential_document_aad(workspace_name, source_name),
-        &mut ciphertext,
+        ciphertext.as_mut_slice(),
     ) {
-        Ok(plaintext) => Ok(plaintext.to_vec()),
+        Ok(plaintext) => Ok(Zeroizing::new(plaintext.to_vec())),
         Err(primary_error) => {
-            let mut legacy_ciphertext = document.ciphertext.clone();
+            let mut legacy_ciphertext = Zeroizing::new(document.ciphertext.clone());
             match open(
-                &dek,
+                &*dek,
                 document.nonce.as_slice(),
                 legacy_credential_document_aad(workspace_name, source_name, &document.key_id),
-                &mut legacy_ciphertext,
+                legacy_ciphertext.as_mut_slice(),
             ) {
-                Ok(plaintext) => Ok(plaintext.to_vec()),
+                Ok(plaintext) => Ok(Zeroizing::new(plaintext.to_vec())),
                 Err(_) => Err(primary_error),
             }
         }
@@ -282,22 +332,22 @@ fn decrypt_credential_document_bytes(
 fn unwrap_dek(
     document: &EncryptedCredentialDocument,
     kek: &CredentialEncryptionKey,
-) -> Result<Vec<u8>, CredentialsError> {
-    let mut dek = document.wrapped_dek.clone();
+) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
+    let mut dek = Zeroizing::new(document.wrapped_dek.clone());
     match open(
         &kek.bytes,
         document.wrapped_dek_nonce.as_slice(),
         credential_dek_aad(&document.key_id),
-        &mut dek,
+        dek.as_mut_slice(),
     ) {
         Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
         Err(primary_error) => {
-            let mut legacy_dek = document.wrapped_dek.clone();
+            let mut legacy_dek = Zeroizing::new(document.wrapped_dek.clone());
             match open(
                 &kek.bytes,
                 document.wrapped_dek_nonce.as_slice(),
                 legacy_credential_dek_aad(&document.key_id),
-                &mut legacy_dek,
+                legacy_dek.as_mut_slice(),
             ) {
                 Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
                 Err(_) => Err(primary_error),
@@ -306,14 +356,18 @@ fn unwrap_dek(
     }
 }
 
-fn validate_dek_plaintext(dek_plaintext: &[u8]) -> Result<Vec<u8>, CredentialsError> {
+fn validate_dek_plaintext(
+    dek_plaintext: &[u8],
+) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
     if dek_plaintext.len() != KEY_LEN {
         return Err(CredentialsError::Crypto(format!(
             "credential document DEK has invalid length {}",
             dek_plaintext.len()
         )));
     }
-    Ok(dek_plaintext.to_vec())
+    let mut dek = [0_u8; KEY_LEN];
+    dek.copy_from_slice(dek_plaintext);
+    Ok(Zeroizing::new(dek))
 }
 
 fn validate_document_metadata(
@@ -428,18 +482,37 @@ fn random_array<const N: usize>() -> Result<[u8; N], CredentialsError> {
     Ok(bytes)
 }
 
-fn decode_key_file(raw: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+fn configured_key_env(config_file: &Path) -> Result<Option<String>, CredentialsError> {
+    if !config_file.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(config_file)?;
+    let config: toml::Value =
+        toml::from_str(&raw).map_err(|error| CredentialsError::Parse(error.to_string()))?;
+    let Some(value) = config
+        .get("credentials")
+        .and_then(|credentials| credentials.get("encryption_key_env"))
+    else {
+        return Ok(None);
+    };
+    value
+        .as_str()
+        .map(|env| Some(env.to_string()))
+        .ok_or_else(|| {
+            CredentialsError::Parse("[credentials].encryption_key_env must be a string".to_string())
+        })
+}
+
+fn decode_key_material(raw: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
     let trimmed = raw.trim();
     let Some(encoded) = trimmed.strip_prefix(&format!("{KEY_FILE_VERSION}:")) else {
         return Err(CredentialsError::Crypto(
-            "unsupported credential encryption key file version".to_string(),
+            "unsupported credential encryption key version".to_string(),
         ));
     };
     let decoded = base64::engine::general_purpose::STANDARD
         .decode(encoded)
-        .map_err(|error| {
-            CredentialsError::Crypto(format!("invalid encryption key file: {error}"))
-        })?;
+        .map_err(|error| CredentialsError::Crypto(format!("invalid encryption key: {error}")))?;
     let bytes: [u8; KEY_LEN] = decoded.try_into().map_err(|decoded: Vec<u8>| {
         CredentialsError::Crypto(format!(
             "credential encryption key has invalid length {}",
@@ -456,4 +529,63 @@ fn key_id_for_bytes(bytes: &[u8; KEY_LEN]) -> String {
     let digest = Sha256::digest(bytes);
     let hex = format!("{digest:x}");
     format!("local-file-{}", hex.get(..16).unwrap_or(hex.as_str()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl CredentialKeyProvider for CredentialEncryptionKey {
+        fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+            Ok(self.clone())
+        }
+
+        fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+            if self.key_id() == key_id {
+                Ok(self.clone())
+            } else {
+                Err(CredentialsError::Crypto(format!(
+                    "credential encryption key '{key_id}' is unavailable"
+                )))
+            }
+        }
+    }
+
+    #[test]
+    fn encrypt_decrypt_authenticates_context_and_redacts_debug() {
+        let ws = WorkspaceName::parse("acme").expect("workspace");
+        let src = SourceName::parse("github").expect("source");
+        let provider = CredentialEncryptionKey::from_static_bytes_for_test([7; KEY_LEN]);
+        let values = BTreeMap::from([("token".to_string(), "s3cr3t".to_string())]);
+
+        let document =
+            encrypt_credential_values(&ws, &src, &values, &provider).expect("encrypt credentials");
+        assert_eq!(
+            decrypt_credential_values(&ws, &src, &document, &provider).expect("decrypt"),
+            values
+        );
+
+        let mut tampered = document.clone();
+        *tampered.ciphertext.first_mut().expect("ciphertext byte") ^= 1;
+        decrypt_credential_values(&ws, &src, &tampered, &provider)
+            .expect_err("tampered ciphertext should fail");
+        let mut tampered = document.clone();
+        *tampered.wrapped_dek.first_mut().expect("wrapped DEK byte") ^= 1;
+        decrypt_credential_values(&ws, &src, &tampered, &provider)
+            .expect_err("tampered wrapped DEK should fail");
+        let other_ws = WorkspaceName::parse("other").expect("workspace");
+        decrypt_credential_values(&other_ws, &src, &document, &provider)
+            .expect_err("wrong workspace should fail");
+        let other_src = SourceName::parse("slack").expect("source");
+        decrypt_credential_values(&ws, &other_src, &document, &provider)
+            .expect_err("wrong source should fail");
+        let mismatch = CredentialEncryptionKey::from_static_bytes_for_test([8; KEY_LEN]);
+        decrypt_credential_values(&ws, &src, &document, &mismatch)
+            .expect_err("wrong key should fail");
+
+        let debug = format!("{provider:?}");
+        assert!(debug.contains(provider.key_id()));
+        assert!(!debug.contains("bytes"));
+        assert!(!debug.contains("[7, 7"));
+    }
 }

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -1,0 +1,459 @@
+//! Application-level envelope encryption for DB-backed credential material.
+
+#![expect(
+    dead_code,
+    reason = "Credential DB runtime wiring lands in a later stack branch; this branch isolates cryptographic primitives for review."
+)]
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use base64::Engine as _;
+use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey};
+use ring::rand::{SecureRandom as _, SystemRandom};
+use sha2::{Digest as _, Sha256};
+
+use super::CredentialsError;
+use crate::sources::SourceName;
+use crate::state::AppStateLayout;
+use crate::storage::fs as storage_fs;
+use crate::storage::fs::FileLock;
+use crate::workspaces::WorkspaceName;
+
+pub(crate) const CREDENTIAL_DOCUMENT_ALGORITHM: &str = "AES-256-GCM";
+pub(crate) const CREDENTIAL_DOCUMENT_AAD_VERSION: i64 = 1;
+
+const CREDENTIAL_DOCUMENT_VERSION: u32 = 1;
+const KEY_FILE_VERSION: &str = "v1";
+const KEY_LEN: usize = 32;
+const NONCE_LEN: usize = 12;
+
+static LOCAL_KEY_FILE_LOCK: Mutex<()> = Mutex::new(());
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CredentialEncryptionKey {
+    key_id: String,
+    bytes: [u8; KEY_LEN],
+}
+
+impl CredentialEncryptionKey {
+    #[cfg(test)]
+    pub(crate) fn from_static_bytes_for_test(bytes: [u8; KEY_LEN]) -> Self {
+        Self {
+            key_id: key_id_for_bytes(&bytes),
+            bytes,
+        }
+    }
+
+    pub(crate) fn key_id(&self) -> &str {
+        self.key_id.as_str()
+    }
+}
+
+pub(crate) trait CredentialKeyProvider: Send + Sync {
+    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError>;
+
+    fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError>;
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LocalFileCredentialKeyProvider {
+    path: PathBuf,
+}
+
+impl LocalFileCredentialKeyProvider {
+    pub(crate) fn new(layout: &AppStateLayout) -> Self {
+        Self {
+            path: layout.credential_encryption_key_file(),
+        }
+    }
+
+    fn load_or_create_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        let _thread_guard = LOCAL_KEY_FILE_LOCK.lock().map_err(|_error| {
+            CredentialsError::Crypto("credential encryption key lock is poisoned".to_string())
+        })?;
+        if let Some(parent) = self.path.parent() {
+            storage_fs::ensure_private_dir(parent)?;
+        }
+        let lock_path = self.path.with_extension("key.lock");
+        let _process_guard = FileLock::exclusive(&lock_path)?;
+
+        match std::fs::read_to_string(&self.path) {
+            Ok(raw) => decode_key_file(&raw),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let bytes = random_array::<KEY_LEN>()?;
+                let encoded = format!(
+                    "{KEY_FILE_VERSION}:{}\n",
+                    base64::engine::general_purpose::STANDARD.encode(bytes)
+                );
+                storage_fs::write_atomic(&self.path, encoded.as_bytes())?;
+                Ok(CredentialEncryptionKey {
+                    key_id: key_id_for_bytes(&bytes),
+                    bytes,
+                })
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
+    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        self.load_or_create_key()
+    }
+
+    fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+        let key = self.load_or_create_key()?;
+        if key.key_id == key_id {
+            Ok(key)
+        } else {
+            Err(CredentialsError::Crypto(format!(
+                "credential encryption key '{key_id}' is unavailable"
+            )))
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EncryptedCredentialDocument {
+    pub(crate) ciphertext: Vec<u8>,
+    pub(crate) nonce: Vec<u8>,
+    pub(crate) wrapped_dek: Vec<u8>,
+    pub(crate) wrapped_dek_nonce: Vec<u8>,
+    pub(crate) key_id: String,
+    pub(crate) algorithm: String,
+    pub(crate) aad_version: i64,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct PlaintextCredentialDocument {
+    version: u32,
+    values: BTreeMap<String, String>,
+}
+
+pub(crate) fn encrypt_credential_values(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    values: &BTreeMap<String, String>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<EncryptedCredentialDocument, CredentialsError> {
+    let kek = key_provider.active_key()?;
+    let dek = random_array::<KEY_LEN>()?;
+    let nonce = random_array::<NONCE_LEN>()?;
+    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
+
+    let plaintext = PlaintextCredentialDocument {
+        version: CREDENTIAL_DOCUMENT_VERSION,
+        values: values.clone(),
+    };
+    let mut document_bytes = serde_json::to_vec(&plaintext)
+        .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+    seal(
+        &dek,
+        &nonce,
+        credential_document_aad(workspace_name, source_name),
+        &mut document_bytes,
+    )?;
+
+    let mut wrapped_dek = dek.to_vec();
+    seal(
+        &kek.bytes,
+        &wrapped_dek_nonce,
+        credential_dek_aad(kek.key_id()),
+        &mut wrapped_dek,
+    )?;
+
+    Ok(EncryptedCredentialDocument {
+        ciphertext: document_bytes,
+        nonce: nonce.to_vec(),
+        wrapped_dek,
+        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
+        key_id: kek.key_id,
+        algorithm: CREDENTIAL_DOCUMENT_ALGORITHM.to_string(),
+        aad_version: CREDENTIAL_DOCUMENT_AAD_VERSION,
+    })
+}
+
+pub(crate) fn decrypt_credential_values(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    document: &EncryptedCredentialDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<BTreeMap<String, String>, CredentialsError> {
+    let plaintext =
+        decrypt_credential_document_bytes(workspace_name, source_name, document, key_provider)?;
+    let decoded: PlaintextCredentialDocument = serde_json::from_slice(&plaintext)
+        .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+    if decoded.version != CREDENTIAL_DOCUMENT_VERSION {
+        return Err(CredentialsError::Parse(format!(
+            "unsupported credential document version {}",
+            decoded.version
+        )));
+    }
+    Ok(decoded.values)
+}
+
+pub(crate) fn rewrap_credential_document(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    document: &EncryptedCredentialDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Option<EncryptedCredentialDocument>, CredentialsError> {
+    validate_document_metadata(document)?;
+    let old_kek = key_provider.key(&document.key_id)?;
+    let active_kek = key_provider.active_key()?;
+    if old_kek.key_id == active_kek.key_id {
+        return Ok(None);
+    }
+
+    let dek = unwrap_dek(document, &old_kek)?;
+    let mut document_probe = document.ciphertext.clone();
+    if open(
+        &dek,
+        document.nonce.as_slice(),
+        credential_document_aad(workspace_name, source_name),
+        &mut document_probe,
+    )
+    .is_err()
+    {
+        // Documents written before this rotation-safe envelope shape bound the
+        // payload AAD to the KEK id. Re-encrypt those once so future rotations
+        // only need to rewrap the DEK.
+        let values =
+            decrypt_credential_values(workspace_name, source_name, document, key_provider)?;
+        return encrypt_credential_values(workspace_name, source_name, &values, key_provider)
+            .map(Some);
+    }
+
+    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
+    let mut wrapped_dek = dek;
+    seal(
+        &active_kek.bytes,
+        &wrapped_dek_nonce,
+        credential_dek_aad(active_kek.key_id()),
+        &mut wrapped_dek,
+    )?;
+
+    Ok(Some(EncryptedCredentialDocument {
+        ciphertext: document.ciphertext.clone(),
+        nonce: document.nonce.clone(),
+        wrapped_dek,
+        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
+        key_id: active_kek.key_id,
+        algorithm: document.algorithm.clone(),
+        aad_version: document.aad_version,
+    }))
+}
+
+fn decrypt_credential_document_bytes(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    document: &EncryptedCredentialDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Vec<u8>, CredentialsError> {
+    validate_document_metadata(document)?;
+    let kek = key_provider.key(&document.key_id)?;
+    let dek = unwrap_dek(document, &kek)?;
+
+    let mut ciphertext = document.ciphertext.clone();
+    match open(
+        &dek,
+        document.nonce.as_slice(),
+        credential_document_aad(workspace_name, source_name),
+        &mut ciphertext,
+    ) {
+        Ok(plaintext) => Ok(plaintext.to_vec()),
+        Err(primary_error) => {
+            let mut legacy_ciphertext = document.ciphertext.clone();
+            match open(
+                &dek,
+                document.nonce.as_slice(),
+                legacy_credential_document_aad(workspace_name, source_name, &document.key_id),
+                &mut legacy_ciphertext,
+            ) {
+                Ok(plaintext) => Ok(plaintext.to_vec()),
+                Err(_) => Err(primary_error),
+            }
+        }
+    }
+}
+
+fn unwrap_dek(
+    document: &EncryptedCredentialDocument,
+    kek: &CredentialEncryptionKey,
+) -> Result<Vec<u8>, CredentialsError> {
+    let mut dek = document.wrapped_dek.clone();
+    match open(
+        &kek.bytes,
+        document.wrapped_dek_nonce.as_slice(),
+        credential_dek_aad(&document.key_id),
+        &mut dek,
+    ) {
+        Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
+        Err(primary_error) => {
+            let mut legacy_dek = document.wrapped_dek.clone();
+            match open(
+                &kek.bytes,
+                document.wrapped_dek_nonce.as_slice(),
+                legacy_credential_dek_aad(&document.key_id),
+                &mut legacy_dek,
+            ) {
+                Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
+                Err(_) => Err(primary_error),
+            }
+        }
+    }
+}
+
+fn validate_dek_plaintext(dek_plaintext: &[u8]) -> Result<Vec<u8>, CredentialsError> {
+    if dek_plaintext.len() != KEY_LEN {
+        return Err(CredentialsError::Crypto(format!(
+            "credential document DEK has invalid length {}",
+            dek_plaintext.len()
+        )));
+    }
+    Ok(dek_plaintext.to_vec())
+}
+
+fn validate_document_metadata(
+    document: &EncryptedCredentialDocument,
+) -> Result<(), CredentialsError> {
+    if document.algorithm != CREDENTIAL_DOCUMENT_ALGORITHM {
+        return Err(CredentialsError::Crypto(format!(
+            "unsupported credential encryption algorithm '{}'",
+            document.algorithm
+        )));
+    }
+    if document.aad_version != CREDENTIAL_DOCUMENT_AAD_VERSION {
+        return Err(CredentialsError::Crypto(format!(
+            "unsupported credential AAD version {}",
+            document.aad_version
+        )));
+    }
+    Ok(())
+}
+
+fn seal(
+    key_bytes: &[u8],
+    nonce_bytes: &[u8; NONCE_LEN],
+    aad: Vec<u8>,
+    in_out: &mut Vec<u8>,
+) -> Result<(), CredentialsError> {
+    let key = LessSafeKey::new(
+        UnboundKey::new(&aead::AES_256_GCM, key_bytes)
+            .map_err(|_error| CredentialsError::Crypto("invalid AES-256-GCM key".to_string()))?,
+    );
+    key.seal_in_place_append_tag(
+        Nonce::assume_unique_for_key(*nonce_bytes),
+        Aad::from(aad),
+        in_out,
+    )
+    .map_err(|_error| CredentialsError::Crypto("AES-256-GCM seal failed".to_string()))
+}
+
+fn open<'a>(
+    key_bytes: &[u8],
+    nonce_bytes: &[u8],
+    aad: Vec<u8>,
+    in_out: &'a mut [u8],
+) -> Result<&'a [u8], CredentialsError> {
+    let nonce = nonce_bytes.try_into().map_err(|_error| {
+        CredentialsError::Crypto("invalid AES-256-GCM nonce length".to_string())
+    })?;
+    let key = LessSafeKey::new(
+        UnboundKey::new(&aead::AES_256_GCM, key_bytes)
+            .map_err(|_error| CredentialsError::Crypto("invalid AES-256-GCM key".to_string()))?,
+    );
+    key.open_in_place(Nonce::assume_unique_for_key(nonce), Aad::from(aad), in_out)
+        .map(|plaintext| &*plaintext)
+        .map_err(|_error| CredentialsError::Crypto("AES-256-GCM open failed".to_string()))
+}
+
+fn credential_document_aad(workspace_name: &WorkspaceName, source_name: &SourceName) -> Vec<u8> {
+    let aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION.to_string();
+    encode_aad_fields(
+        "coral-credential-document",
+        &[
+            aad_version.as_str(),
+            workspace_name.as_str(),
+            source_name.as_str(),
+            CREDENTIAL_DOCUMENT_ALGORITHM,
+        ],
+    )
+}
+
+fn legacy_credential_document_aad(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    key_id: &str,
+) -> Vec<u8> {
+    format!(
+        "coral-credential-document:v{}:{}:{}:{}:{}",
+        CREDENTIAL_DOCUMENT_AAD_VERSION,
+        workspace_name.as_str(),
+        source_name.as_str(),
+        CREDENTIAL_DOCUMENT_ALGORITHM,
+        key_id
+    )
+    .into_bytes()
+}
+
+fn credential_dek_aad(key_id: &str) -> Vec<u8> {
+    let aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION.to_string();
+    encode_aad_fields("coral-credential-dek", &[aad_version.as_str(), key_id])
+}
+
+fn legacy_credential_dek_aad(key_id: &str) -> Vec<u8> {
+    format!("coral-credential-dek:v{CREDENTIAL_DOCUMENT_AAD_VERSION}:{key_id}").into_bytes()
+}
+
+fn encode_aad_fields(domain: &str, fields: &[&str]) -> Vec<u8> {
+    let mut aad = Vec::new();
+    aad.extend_from_slice(domain.as_bytes());
+    aad.push(0);
+    for field in fields {
+        let bytes = field.as_bytes();
+        aad.extend_from_slice(&(bytes.len() as u64).to_be_bytes());
+        aad.extend_from_slice(bytes);
+    }
+    aad
+}
+
+fn random_array<const N: usize>() -> Result<[u8; N], CredentialsError> {
+    let mut bytes = [0_u8; N];
+    SystemRandom::new().fill(&mut bytes).map_err(|_error| {
+        CredentialsError::Crypto("secure random generation failed".to_string())
+    })?;
+    Ok(bytes)
+}
+
+fn decode_key_file(raw: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+    let trimmed = raw.trim();
+    let Some(encoded) = trimmed.strip_prefix(&format!("{KEY_FILE_VERSION}:")) else {
+        return Err(CredentialsError::Crypto(
+            "unsupported credential encryption key file version".to_string(),
+        ));
+    };
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|error| {
+            CredentialsError::Crypto(format!("invalid encryption key file: {error}"))
+        })?;
+    let bytes: [u8; KEY_LEN] = decoded.try_into().map_err(|decoded: Vec<u8>| {
+        CredentialsError::Crypto(format!(
+            "credential encryption key has invalid length {}",
+            decoded.len()
+        ))
+    })?;
+    Ok(CredentialEncryptionKey {
+        key_id: key_id_for_bytes(&bytes),
+        bytes,
+    })
+}
+
+fn key_id_for_bytes(bytes: &[u8; KEY_LEN]) -> String {
+    let digest = Sha256::digest(bytes);
+    let hex = format!("{digest:x}");
+    format!("local-file-{}", hex.get(..16).unwrap_or(hex.as_str()))
+}

--- a/crates/coral-app/src/credentials/encryption_tests.rs
+++ b/crates/coral-app/src/credentials/encryption_tests.rs
@@ -267,6 +267,7 @@ fn local_file_key_provider_creates_and_reuses_private_key_file() {
     let temp = tempdir().expect("temp dir");
     let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
     layout.ensure().expect("ensure layout");
+    use_file_encryption_key_source(&layout);
     let provider = LocalFileCredentialKeyProvider::new(&layout);
 
     let first = provider.active_key().expect("first key");
@@ -284,6 +285,7 @@ fn local_file_key_provider_serializes_concurrent_first_use_creation() {
     let temp = tempdir().expect("temp dir");
     let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
     layout.ensure().expect("ensure layout");
+    use_file_encryption_key_source(&layout);
     let provider = LocalFileCredentialKeyProvider::new(&layout);
     let thread_count = 32;
     let barrier = Arc::new(Barrier::new(thread_count));
@@ -343,6 +345,14 @@ fn decrypt_rejects_unknown_key_id() {
         .expect_err("missing KEK should fail");
 
     assert!(error.to_string().contains("missing test key"));
+}
+
+fn use_file_encryption_key_source(layout: &AppStateLayout) {
+    std::fs::write(
+        layout.config_file(),
+        "version = 1\n\n[credentials]\nencryption_key_source = \"file\"\n",
+    )
+    .expect("write config");
 }
 
 fn assert_open_failed(error: &CredentialsError) {

--- a/crates/coral-app/src/credentials/encryption_tests.rs
+++ b/crates/coral-app/src/credentials/encryption_tests.rs
@@ -55,57 +55,6 @@ impl CredentialKeyProvider for RotatingKeyProvider {
 }
 
 #[test]
-fn encrypted_credentials_round_trip_without_plaintext_ciphertext() {
-    let workspace = WorkspaceName::parse("default").expect("workspace");
-    let source = SourceName::parse("github").expect("source");
-    let provider = StaticKeyProvider {
-        key: CredentialEncryptionKey::from_static_bytes_for_test([7; 32]),
-    };
-    let values = BTreeMap::from([
-        ("GITHUB_TOKEN".to_string(), "secret-token".to_string()),
-        (
-            "__coral_oauth.R0lUSFVCX1RPS0VO.refresh_token".to_string(),
-            "refresh-token".to_string(),
-        ),
-    ]);
-
-    let encrypted =
-        encrypt_credential_values(&workspace, &source, &values, &provider).expect("encrypt");
-
-    assert!(
-        !std::str::from_utf8(&encrypted.ciphertext)
-            .unwrap_or_default()
-            .contains("secret-token")
-    );
-    assert_eq!(
-        decrypt_credential_values(&workspace, &source, &encrypted, &provider).expect("decrypt"),
-        values
-    );
-}
-
-#[test]
-fn credential_document_aad_binds_workspace_and_source() {
-    let workspace = WorkspaceName::parse("default").expect("workspace");
-    let source = SourceName::parse("github").expect("source");
-    let other_source = SourceName::parse("slack").expect("source");
-    let provider = StaticKeyProvider {
-        key: CredentialEncryptionKey::from_static_bytes_for_test([9; 32]),
-    };
-    let encrypted = encrypt_credential_values(
-        &workspace,
-        &source,
-        &BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
-        &provider,
-    )
-    .expect("encrypt");
-
-    let error = decrypt_credential_values(&workspace, &other_source, &encrypted, &provider)
-        .expect_err("wrong source should fail AAD validation");
-
-    assert!(error.to_string().contains("open failed"));
-}
-
-#[test]
 fn credential_document_aad_disambiguates_colon_bearing_identities() {
     let workspace = WorkspaceName::parse("a:b").expect("workspace");
     let source = SourceName::parse("c").expect("source");
@@ -129,11 +78,49 @@ fn credential_document_aad_disambiguates_colon_bearing_identities() {
 }
 
 #[test]
-fn credential_document_rejects_tampered_ciphertext() {
+fn credential_document_rejects_tampered_nonces() {
     let workspace = WorkspaceName::parse("default").expect("workspace");
     let source = SourceName::parse("github").expect("source");
     let provider = StaticKeyProvider {
         key: CredentialEncryptionKey::from_static_bytes_for_test([11; 32]),
+    };
+    let encrypted = encrypt_credential_values(
+        &workspace,
+        &source,
+        &BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+        &provider,
+    )
+    .expect("encrypt");
+
+    let mut tampered = encrypted.clone();
+    *tampered.nonce.first_mut().expect("payload nonce") ^= 0x01;
+    assert_open_failed(
+        &decrypt_credential_values(&workspace, &source, &tampered, &provider)
+            .expect_err("tampered payload nonce should fail authentication"),
+    );
+
+    let mut tampered = encrypted;
+    *tampered
+        .wrapped_dek_nonce
+        .first_mut()
+        .expect("wrapped DEK nonce") ^= 0x01;
+    assert_open_failed(
+        &decrypt_credential_values(&workspace, &source, &tampered, &provider)
+            .expect_err("tampered wrapped DEK nonce should fail authentication"),
+    );
+}
+
+#[test]
+fn credential_document_rejects_key_id_aad_mismatch_even_when_key_resolves() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let original_key_bytes = [12; 32];
+    let mutated_key_bytes = [14; 32];
+    let original_key = CredentialEncryptionKey::from_static_bytes_for_test(original_key_bytes);
+    let mutated_key = CredentialEncryptionKey::from_static_bytes_for_test(mutated_key_bytes);
+    let provider = RotatingKeyProvider {
+        active: original_key.clone(),
+        keys: vec![original_key, mutated_key.clone()],
     };
     let mut encrypted = encrypt_credential_values(
         &workspace,
@@ -142,12 +129,57 @@ fn credential_document_rejects_tampered_ciphertext() {
         &provider,
     )
     .expect("encrypt");
-    *encrypted.ciphertext.first_mut().expect("ciphertext") ^= 0x01;
+    let original_key_id = encrypted.key_id.clone();
+    let dek = open_for_test(
+        &original_key_bytes,
+        encrypted.wrapped_dek_nonce.as_slice(),
+        current_dek_aad_for_test(&original_key_id),
+        &encrypted.wrapped_dek,
+    );
+    let mismatched_nonce = [6; 12];
+    encrypted.wrapped_dek = seal_for_test(
+        &mutated_key_bytes,
+        mismatched_nonce,
+        current_dek_aad_for_test(&original_key_id),
+        &dek,
+    );
+    encrypted.wrapped_dek_nonce = mismatched_nonce.to_vec();
+    encrypted.key_id = mutated_key.key_id().to_string();
+    provider
+        .key(&encrypted.key_id)
+        .expect("mutated key id should resolve");
+
+    assert_open_failed(
+        &decrypt_credential_values(&workspace, &source, &encrypted, &provider)
+            .expect_err("mismatched key-id AAD should fail authentication"),
+    );
+}
+
+#[test]
+fn credential_document_rejects_aad_version_mismatch() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let provider = StaticKeyProvider {
+        key: CredentialEncryptionKey::from_static_bytes_for_test([15; 32]),
+    };
+    let mut encrypted = encrypt_credential_values(
+        &workspace,
+        &source,
+        &BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+        &provider,
+    )
+    .expect("encrypt");
+    encrypted.aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION + 1;
 
     let error = decrypt_credential_values(&workspace, &source, &encrypted, &provider)
-        .expect_err("tampered ciphertext should fail authentication");
+        .expect_err("unsupported AAD version should fail");
 
-    assert!(error.to_string().contains("open failed"));
+    assert!(
+        error
+            .to_string()
+            .contains("unsupported credential AAD version"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]
@@ -188,8 +220,10 @@ fn decrypt_accepts_legacy_colon_delimited_dek_aad() {
 fn credential_document_rewrap_changes_kek_without_reencrypting_payload() {
     let workspace = WorkspaceName::parse("default").expect("workspace");
     let source = SourceName::parse("github").expect("source");
-    let old_key = CredentialEncryptionKey::from_static_bytes_for_test([19; 32]);
-    let new_key = CredentialEncryptionKey::from_static_bytes_for_test([23; 32]);
+    let old_key_bytes = [19; 32];
+    let new_key_bytes = [23; 32];
+    let old_key = CredentialEncryptionKey::from_static_bytes_for_test(old_key_bytes);
+    let new_key = CredentialEncryptionKey::from_static_bytes_for_test(new_key_bytes);
     let old_provider = RotatingKeyProvider {
         active: old_key.clone(),
         keys: vec![old_key.clone()],
@@ -210,6 +244,17 @@ fn credential_document_rewrap_changes_kek_without_reencrypting_payload() {
     assert_eq!(rewrapped.ciphertext, encrypted.ciphertext);
     assert_eq!(rewrapped.nonce, encrypted.nonce);
     assert_ne!(rewrapped.wrapped_dek, encrypted.wrapped_dek);
+    assert_ne!(rewrapped.wrapped_dek_nonce, encrypted.wrapped_dek_nonce);
+    assert!(
+        try_open_for_test(
+            &old_key_bytes,
+            rewrapped.wrapped_dek_nonce.as_slice(),
+            current_dek_aad_for_test(&rewrapped.key_id),
+            &rewrapped.wrapped_dek,
+        )
+        .is_err(),
+        "old KEK should not unwrap the rewrapped DEK"
+    );
     assert_eq!(
         decrypt_credential_values(&workspace, &source, &rewrapped, &rotating_provider)
             .expect("decrypt rewrapped"),
@@ -300,6 +345,13 @@ fn decrypt_rejects_unknown_key_id() {
     assert!(error.to_string().contains("missing test key"));
 }
 
+fn assert_open_failed(error: &CredentialsError) {
+    assert!(
+        error.to_string().contains("open failed"),
+        "unexpected error: {error}"
+    );
+}
+
 fn current_dek_aad_for_test(key_id: &str) -> Vec<u8> {
     let aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION.to_string();
     encode_aad_fields_for_test("coral-credential-dek", &[aad_version.as_str(), key_id])
@@ -353,4 +405,23 @@ fn open_for_test(
     )
     .expect("open")
     .to_vec()
+}
+
+fn try_open_for_test(
+    key_bytes: &[u8; 32],
+    nonce_bytes: &[u8],
+    aad: Vec<u8>,
+    ciphertext: &[u8],
+) -> Result<Vec<u8>, ()> {
+    let key =
+        LessSafeKey::new(UnboundKey::new(&aead::AES_256_GCM, key_bytes).map_err(|_error| ())?);
+    let mut in_out = ciphertext.to_vec();
+    let nonce = nonce_bytes.try_into().map_err(|_error| ())?;
+    key.open_in_place(
+        Nonce::assume_unique_for_key(nonce),
+        Aad::from(aad),
+        &mut in_out,
+    )
+    .map(|plaintext| plaintext.to_vec())
+    .map_err(|_error| ())
 }

--- a/crates/coral-app/src/credentials/encryption_tests.rs
+++ b/crates/coral-app/src/credentials/encryption_tests.rs
@@ -1,0 +1,356 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey};
+use tempfile::tempdir;
+
+use super::CredentialsError;
+use super::encryption::{
+    CREDENTIAL_DOCUMENT_AAD_VERSION, CredentialEncryptionKey, CredentialKeyProvider,
+    LocalFileCredentialKeyProvider, decrypt_credential_values, encrypt_credential_values,
+    rewrap_credential_document,
+};
+use crate::sources::SourceName;
+use crate::state::AppStateLayout;
+use crate::workspaces::WorkspaceName;
+
+#[derive(Clone)]
+struct StaticKeyProvider {
+    key: CredentialEncryptionKey,
+}
+
+impl CredentialKeyProvider for StaticKeyProvider {
+    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        Ok(self.key.clone())
+    }
+
+    fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+        if self.key.key_id() == key_id {
+            Ok(self.key.clone())
+        } else {
+            Err(CredentialsError::Crypto("missing test key".to_string()))
+        }
+    }
+}
+
+#[derive(Clone)]
+struct RotatingKeyProvider {
+    active: CredentialEncryptionKey,
+    keys: Vec<CredentialEncryptionKey>,
+}
+
+impl CredentialKeyProvider for RotatingKeyProvider {
+    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        Ok(self.active.clone())
+    }
+
+    fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+        self.keys
+            .iter()
+            .find(|key| key.key_id() == key_id)
+            .cloned()
+            .ok_or_else(|| CredentialsError::Crypto("missing test key".to_string()))
+    }
+}
+
+#[test]
+fn encrypted_credentials_round_trip_without_plaintext_ciphertext() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let provider = StaticKeyProvider {
+        key: CredentialEncryptionKey::from_static_bytes_for_test([7; 32]),
+    };
+    let values = BTreeMap::from([
+        ("GITHUB_TOKEN".to_string(), "secret-token".to_string()),
+        (
+            "__coral_oauth.R0lUSFVCX1RPS0VO.refresh_token".to_string(),
+            "refresh-token".to_string(),
+        ),
+    ]);
+
+    let encrypted =
+        encrypt_credential_values(&workspace, &source, &values, &provider).expect("encrypt");
+
+    assert!(
+        !std::str::from_utf8(&encrypted.ciphertext)
+            .unwrap_or_default()
+            .contains("secret-token")
+    );
+    assert_eq!(
+        decrypt_credential_values(&workspace, &source, &encrypted, &provider).expect("decrypt"),
+        values
+    );
+}
+
+#[test]
+fn credential_document_aad_binds_workspace_and_source() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let other_source = SourceName::parse("slack").expect("source");
+    let provider = StaticKeyProvider {
+        key: CredentialEncryptionKey::from_static_bytes_for_test([9; 32]),
+    };
+    let encrypted = encrypt_credential_values(
+        &workspace,
+        &source,
+        &BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+        &provider,
+    )
+    .expect("encrypt");
+
+    let error = decrypt_credential_values(&workspace, &other_source, &encrypted, &provider)
+        .expect_err("wrong source should fail AAD validation");
+
+    assert!(error.to_string().contains("open failed"));
+}
+
+#[test]
+fn credential_document_aad_disambiguates_colon_bearing_identities() {
+    let workspace = WorkspaceName::parse("a:b").expect("workspace");
+    let source = SourceName::parse("c").expect("source");
+    let replay_workspace = WorkspaceName::parse("a").expect("workspace");
+    let replay_source = SourceName::parse("b:c").expect("source");
+    let provider = StaticKeyProvider {
+        key: CredentialEncryptionKey::from_static_bytes_for_test([10; 32]),
+    };
+    let encrypted = encrypt_credential_values(
+        &workspace,
+        &source,
+        &BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+        &provider,
+    )
+    .expect("encrypt");
+
+    let error = decrypt_credential_values(&replay_workspace, &replay_source, &encrypted, &provider)
+        .expect_err("ambiguous colon-delimited identity should not decrypt");
+
+    assert!(error.to_string().contains("open failed"));
+}
+
+#[test]
+fn credential_document_rejects_tampered_ciphertext() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let provider = StaticKeyProvider {
+        key: CredentialEncryptionKey::from_static_bytes_for_test([11; 32]),
+    };
+    let mut encrypted = encrypt_credential_values(
+        &workspace,
+        &source,
+        &BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+        &provider,
+    )
+    .expect("encrypt");
+    *encrypted.ciphertext.first_mut().expect("ciphertext") ^= 0x01;
+
+    let error = decrypt_credential_values(&workspace, &source, &encrypted, &provider)
+        .expect_err("tampered ciphertext should fail authentication");
+
+    assert!(error.to_string().contains("open failed"));
+}
+
+#[test]
+fn decrypt_accepts_legacy_colon_delimited_dek_aad() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let key_bytes = [17; 32];
+    let provider = StaticKeyProvider {
+        key: CredentialEncryptionKey::from_static_bytes_for_test(key_bytes),
+    };
+    let values = BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]);
+    let mut encrypted =
+        encrypt_credential_values(&workspace, &source, &values, &provider).expect("encrypt");
+    let key_id = encrypted.key_id.clone();
+    let dek = open_for_test(
+        &key_bytes,
+        encrypted.wrapped_dek_nonce.as_slice(),
+        current_dek_aad_for_test(&key_id),
+        &encrypted.wrapped_dek,
+    );
+    let legacy_nonce = [3; 12];
+    encrypted.wrapped_dek = seal_for_test(
+        &key_bytes,
+        legacy_nonce,
+        legacy_dek_aad_for_test(&key_id),
+        &dek,
+    );
+    encrypted.wrapped_dek_nonce = legacy_nonce.to_vec();
+
+    assert_eq!(
+        decrypt_credential_values(&workspace, &source, &encrypted, &provider)
+            .expect("legacy DEK AAD should decrypt"),
+        values
+    );
+}
+
+#[test]
+fn credential_document_rewrap_changes_kek_without_reencrypting_payload() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let old_key = CredentialEncryptionKey::from_static_bytes_for_test([19; 32]);
+    let new_key = CredentialEncryptionKey::from_static_bytes_for_test([23; 32]);
+    let old_provider = RotatingKeyProvider {
+        active: old_key.clone(),
+        keys: vec![old_key.clone()],
+    };
+    let rotating_provider = RotatingKeyProvider {
+        active: new_key.clone(),
+        keys: vec![old_key, new_key.clone()],
+    };
+    let values = BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]);
+    let encrypted =
+        encrypt_credential_values(&workspace, &source, &values, &old_provider).expect("encrypt");
+
+    let rewrapped = rewrap_credential_document(&workspace, &source, &encrypted, &rotating_provider)
+        .expect("rewrap")
+        .expect("stale key should rewrap");
+
+    assert_eq!(rewrapped.key_id, new_key.key_id());
+    assert_eq!(rewrapped.ciphertext, encrypted.ciphertext);
+    assert_eq!(rewrapped.nonce, encrypted.nonce);
+    assert_ne!(rewrapped.wrapped_dek, encrypted.wrapped_dek);
+    assert_eq!(
+        decrypt_credential_values(&workspace, &source, &rewrapped, &rotating_provider)
+            .expect("decrypt rewrapped"),
+        values
+    );
+}
+
+#[test]
+fn local_file_key_provider_creates_and_reuses_private_key_file() {
+    let temp = tempdir().expect("temp dir");
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+    layout.ensure().expect("ensure layout");
+    let provider = LocalFileCredentialKeyProvider::new(&layout);
+
+    let first = provider.active_key().expect("first key");
+    let second = provider.active_key().expect("second key");
+
+    assert_eq!(first, second);
+    assert!(
+        layout.credential_encryption_key_file().exists(),
+        "provider should create durable key material outside the DB"
+    );
+}
+
+#[test]
+fn local_file_key_provider_serializes_concurrent_first_use_creation() {
+    let temp = tempdir().expect("temp dir");
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+    layout.ensure().expect("ensure layout");
+    let provider = LocalFileCredentialKeyProvider::new(&layout);
+    let thread_count = 32;
+    let barrier = Arc::new(Barrier::new(thread_count));
+
+    let handles: Vec<_> = (0..thread_count)
+        .map(|_| {
+            let provider = provider.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                barrier.wait();
+                provider.active_key().map(|key| key.key_id().to_string())
+            })
+        })
+        .collect();
+
+    let key_ids: Vec<_> = handles
+        .into_iter()
+        .map(|handle| {
+            handle
+                .join()
+                .expect("thread should not panic")
+                .expect("key")
+        })
+        .collect();
+    let first_key_id = key_ids.first().expect("key id");
+
+    assert!(
+        key_ids.iter().all(|key_id| key_id == first_key_id),
+        "all concurrent first-use callers should observe the single persisted key"
+    );
+    assert_eq!(
+        LocalFileCredentialKeyProvider::new(&layout)
+            .active_key()
+            .expect("persisted key")
+            .key_id(),
+        first_key_id
+    );
+}
+
+#[test]
+fn decrypt_rejects_unknown_key_id() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let provider = StaticKeyProvider {
+        key: CredentialEncryptionKey::from_static_bytes_for_test([13; 32]),
+    };
+    let mut encrypted = encrypt_credential_values(
+        &workspace,
+        &source,
+        &BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+        &provider,
+    )
+    .expect("encrypt");
+    encrypted.key_id = "missing-key".to_string();
+
+    let error = decrypt_credential_values(&workspace, &source, &encrypted, &provider)
+        .expect_err("missing KEK should fail");
+
+    assert!(error.to_string().contains("missing test key"));
+}
+
+fn current_dek_aad_for_test(key_id: &str) -> Vec<u8> {
+    let aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION.to_string();
+    encode_aad_fields_for_test("coral-credential-dek", &[aad_version.as_str(), key_id])
+}
+
+fn legacy_dek_aad_for_test(key_id: &str) -> Vec<u8> {
+    format!("coral-credential-dek:v{CREDENTIAL_DOCUMENT_AAD_VERSION}:{key_id}").into_bytes()
+}
+
+fn encode_aad_fields_for_test(domain: &str, fields: &[&str]) -> Vec<u8> {
+    let mut aad = Vec::new();
+    aad.extend_from_slice(domain.as_bytes());
+    aad.push(0);
+    for field in fields {
+        let bytes = field.as_bytes();
+        aad.extend_from_slice(&(bytes.len() as u64).to_be_bytes());
+        aad.extend_from_slice(bytes);
+    }
+    aad
+}
+
+fn seal_for_test(
+    key_bytes: &[u8; 32],
+    nonce_bytes: [u8; 12],
+    aad: Vec<u8>,
+    plaintext: &[u8],
+) -> Vec<u8> {
+    let key = LessSafeKey::new(UnboundKey::new(&aead::AES_256_GCM, key_bytes).expect("test key"));
+    let mut in_out = plaintext.to_vec();
+    key.seal_in_place_append_tag(
+        Nonce::assume_unique_for_key(nonce_bytes),
+        Aad::from(aad),
+        &mut in_out,
+    )
+    .expect("seal");
+    in_out
+}
+
+fn open_for_test(
+    key_bytes: &[u8; 32],
+    nonce_bytes: &[u8],
+    aad: Vec<u8>,
+    ciphertext: &[u8],
+) -> Vec<u8> {
+    let key = LessSafeKey::new(UnboundKey::new(&aead::AES_256_GCM, key_bytes).expect("test key"));
+    let mut in_out = ciphertext.to_vec();
+    key.open_in_place(
+        Nonce::assume_unique_for_key(nonce_bytes.try_into().expect("nonce")),
+        Aad::from(aad),
+        &mut in_out,
+    )
+    .expect("open")
+    .to_vec()
+}

--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -1,6 +1,7 @@
 //! Internal credential-set identity and lifecycle helpers.
 
 pub(crate) mod config;
+pub(crate) mod encryption;
 pub(crate) mod oauth;
 mod store;
 

--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -2,6 +2,8 @@
 
 pub(crate) mod config;
 pub(crate) mod encryption;
+#[cfg(test)]
+mod encryption_tests;
 pub(crate) mod oauth;
 mod store;
 

--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -48,6 +48,7 @@ impl CredentialMaterialSnapshot {
 pub(crate) enum CredentialStorageKind {
     File,
     Keychain,
+    Database,
 }
 
 impl CredentialStorageKind {
@@ -55,6 +56,7 @@ impl CredentialStorageKind {
         match self {
             Self::File => "file",
             Self::Keychain => "keychain",
+            Self::Database => "database",
         }
     }
 }
@@ -73,6 +75,7 @@ pub(crate) enum CredentialStoragePreference {
     Auto,
     File,
     Keychain,
+    Database,
 }
 
 /// Result of replacing credential material.
@@ -242,6 +245,16 @@ impl CredentialManager {
         inputs: &[ManifestInputSpec],
         material: &mut BTreeMap<String, String>,
     ) -> Result<(), AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self
+                .refresh_and_persist_database_oauth_material(
+                    workspace_name,
+                    credential_set_id,
+                    inputs,
+                    material,
+                )
+                .await;
+        }
         for input in inputs {
             if self.refresh_oauth_input_material(input, material).await? {
                 *material = self.persist_refreshed_oauth_material(
@@ -251,6 +264,37 @@ impl CredentialManager {
                     &input.key,
                     material,
                 )?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn refresh_and_persist_database_oauth_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        inputs: &[ManifestInputSpec],
+        material: &mut BTreeMap<String, String>,
+    ) -> Result<(), AppError> {
+        for input in inputs {
+            loop {
+                let current = self
+                    .store
+                    .read_database_material_for_update(workspace_name, credential_set_id)?;
+                let mut next = current.values;
+                if !self.refresh_oauth_input_material(input, &mut next).await? {
+                    *material = next;
+                    break;
+                }
+                if self.store.replace_database_material_if_current(
+                    workspace_name,
+                    credential_set_id,
+                    current.document_version,
+                    &next,
+                )? {
+                    *material = next;
+                    break;
+                }
             }
         }
         Ok(())

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -26,6 +26,7 @@ use url::{Url, form_urlencoded};
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
+use crate::credential_transport::validate_credential_endpoint_transport;
 use crate::credentials::OAUTH_INTERNAL_KEY_PREFIX;
 
 const SESSION_TTL: Duration = Duration::from_mins(10);
@@ -266,6 +267,7 @@ impl OAuthCredentialService {
     {
         let oauth = request.oauth.clone();
         let endpoints = oauth_endpoint_urls(&oauth, request.source_inputs)?;
+        validate_oauth_setup_endpoint_transports(&endpoints)?;
         let resource = oauth_resource(&oauth, request.source_inputs)?;
         let credential_inputs = normalize_credential_inputs(request.credential_inputs)?;
         reject_unknown_credential_inputs(&oauth, &credential_inputs)?;
@@ -372,6 +374,7 @@ impl OAuthCredentialService {
         credential_inputs: Vec<(String, String)>,
     ) -> Result<(), AppError> {
         let endpoints = oauth_endpoint_urls(oauth, source_inputs)?;
+        validate_oauth_setup_endpoint_transports(&endpoints)?;
         let _resource = oauth_resource(oauth, source_inputs)?;
         let credential_inputs = normalize_credential_inputs(credential_inputs)?;
         reject_unknown_credential_inputs(oauth, &credential_inputs)?;
@@ -518,9 +521,22 @@ impl OAuthCredentialService {
     }
 }
 
+fn validate_oauth_setup_endpoint_transports(
+    endpoints: &ManifestOAuthEndpointUrls,
+) -> Result<(), AppError> {
+    if let Some(url) = endpoints.authorization_url.as_deref() {
+        validate_credential_endpoint_transport("OAuth authorization_url", url)?;
+    }
+    if let Some(url) = endpoints.device_authorization_url.as_deref() {
+        validate_credential_endpoint_transport("OAuth device_authorization_url", url)?;
+    }
+    validate_credential_endpoint_transport("OAuth token_url", &endpoints.token_url)
+}
+
 fn token_http_client(timeout: Duration) -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(timeout)
+        .redirect(reqwest::redirect::Policy::none())
         .build()
         .expect("OAuth token HTTP client configuration should be valid")
 }
@@ -1424,6 +1440,8 @@ async fn refresh_access_token(
     http: &reqwest::Client,
     refresh: &OAuthRefreshConfig,
 ) -> Result<TokenResponse, AppError> {
+    validate_credential_endpoint_transport("OAuth token refresh token_url", &refresh.token_url)
+        .map_err(|error| AppError::FailedPrecondition(format!("{error}; reconnect the source")))?;
     let mut form = vec![
         ("grant_type", "refresh_token".to_string()),
         ("refresh_token", refresh.refresh_token.clone()),
@@ -2322,6 +2340,59 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn expired_oauth_material_rejects_cleartext_refresh_token_url() {
+        let oauth = oauth_spec(
+            "https://api.example.com/token",
+            53682,
+            ManifestOAuthPkceMode::Disabled,
+            public_client(),
+        );
+        let mut material = expired_oauth_material("http://api.example.com/token");
+        let service = OAuthCredentialService::new();
+
+        let error = service
+            .refresh_if_needed(
+                RefreshOAuthCredentialRequest::for_source_input("API_TOKEN", &oauth),
+                &mut material,
+            )
+            .await
+            .expect_err("cleartext refresh token URL should fail closed");
+
+        let message = error.to_string();
+        assert!(message.contains("OAuth token refresh token_url must use https"));
+        assert!(message.contains("reconnect the source"));
+    }
+
+    #[tokio::test]
+    async fn oauth_refresh_does_not_follow_token_redirects() {
+        let redirect_url = format!("http://127.0.0.1:{}/capture", free_loopback_port());
+        let raw = Box::leak(
+            format!(
+                "HTTP/1.1 307 Temporary Redirect\r\nlocation: {redirect_url}\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+            )
+            .into_boxed_str(),
+        );
+        let fixture = OAuthFixture::new(Some(raw));
+        let oauth = oauth_spec(
+            &fixture.token_url,
+            free_loopback_port(),
+            ManifestOAuthPkceMode::Disabled,
+            public_client(),
+        );
+        let mut material = expired_oauth_material(&fixture.token_url);
+        let error = OAuthCredentialService::with_token_request_timeout(Duration::from_millis(100))
+            .refresh_if_needed(
+                RefreshOAuthCredentialRequest::for_source_input("API_TOKEN", &oauth),
+                &mut material,
+            )
+            .await
+            .expect_err("redirect token response should fail");
+
+        fixture.token_server.await.expect("token server");
+        assert!(error.to_string().contains("HTTP 307"));
+    }
+
+    #[tokio::test]
     async fn unexpired_oauth_material_does_not_refresh_access_token() {
         let oauth = oauth_spec(
             "http://127.0.0.1:9/token",
@@ -2708,6 +2779,37 @@ mod tests {
         assert_eq!(completed.access_token, "access-token");
         assert_public_dcr_metadata(&completed.internal_metadata, "MCP_ACCESS_TOKEN");
         assert_no_dcr_client_management_metadata(&completed.internal_metadata, "MCP_ACCESS_TOKEN");
+    }
+
+    #[tokio::test]
+    async fn oauth_setup_rejects_cleartext_endpoints_before_events_or_requests() {
+        let mut oauth = oauth_spec(
+            "https://api.example.com/token",
+            53682,
+            ManifestOAuthPkceMode::Required,
+            public_client(),
+        );
+        oauth.authorization_url = Some("http://api.example.com/authorize".to_string());
+
+        let service = OAuthCredentialService::new();
+        let error = service
+            .authorize(
+                StartOAuthCredentialRequest {
+                    input_key: "API_TOKEN",
+                    oauth: &oauth,
+                    source_inputs: &EMPTY_SOURCE_INPUTS,
+                    credential_inputs: Vec::new(),
+                },
+                |_authorization| async {
+                    panic!("authorization callback should not run");
+                },
+            )
+            .await
+            .err()
+            .expect("cleartext OAuth endpoint should fail");
+
+        let message = error.to_string();
+        assert!(message.contains("OAuth authorization_url must use https"));
     }
 
     #[tokio::test]
@@ -3508,6 +3610,35 @@ mod tests {
             .port()
     }
 
+    fn public_client() -> ManifestOAuthClientSpec {
+        ManifestOAuthClientSpec {
+            id: ManifestOAuthClientIdSpec {
+                default: Some("default-client".to_string()),
+                input: None,
+            },
+            secret: None,
+            dynamic_registration: None,
+        }
+    }
+
+    fn expired_oauth_material(token_url: &str) -> BTreeMap<String, String> {
+        let prefix = oauth_metadata_prefix("API_TOKEN");
+        BTreeMap::from([
+            ("API_TOKEN".to_string(), "expired-token".to_string()),
+            (format!("{prefix}method"), "oauth".to_string()),
+            (
+                format!("{prefix}access_token_expires_at"),
+                (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
+            ),
+            (
+                format!("{prefix}refresh_token"),
+                "stored-refresh-token".to_string(),
+            ),
+            (format!("{prefix}client_id"), "stored-client".to_string()),
+            (format!("{prefix}token_url"), token_url.to_string()),
+        ])
+    }
+
     struct OAuthFixture {
         token_url: String,
         token_server: JoinHandle<CapturedTokenRequest>,
@@ -3526,10 +3657,14 @@ mod tests {
                 let response_body = response_body.unwrap_or(
                     r#"{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","scope":"repo read:org","expires_in":3600}"#,
                 );
-                let response = format!(
-                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
-                    response_body.len()
-                );
+                let response = if response_body.starts_with("HTTP/1.1 ") {
+                    response_body.to_string()
+                } else {
+                    format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+                        response_body.len()
+                    )
+                };
                 stream
                     .write_all(response.as_bytes())
                     .expect("write token response");

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -1663,6 +1663,22 @@ fn oauth_refresh_config(
     oauth: &ManifestOAuthCredentialSpec,
     material: &BTreeMap<String, String>,
 ) -> Result<Option<OAuthRefreshConfig>, AppError> {
+    oauth_refresh_config_at(
+        access_token_material_key,
+        metadata_prefix,
+        oauth,
+        material,
+        Utc::now(),
+    )
+}
+
+fn oauth_refresh_config_at(
+    access_token_material_key: &str,
+    metadata_prefix: &str,
+    oauth: &ManifestOAuthCredentialSpec,
+    material: &BTreeMap<String, String>,
+    now: DateTime<Utc>,
+) -> Result<Option<OAuthRefreshConfig>, AppError> {
     if OAuthMetadataKey::Method.get(metadata_prefix, material) != Some(OAUTH_METADATA_METHOD_VALUE)
     {
         return Ok(None);
@@ -1678,7 +1694,6 @@ fn oauth_refresh_config(
             ))
         })?
         .with_timezone(&Utc);
-    let now = Utc::now();
     if expires_at > now + chrono::Duration::seconds(REFRESH_EXPIRY_SKEW_SECONDS) {
         return Ok(None);
     }
@@ -1872,8 +1887,8 @@ mod tests {
         StartOAuthCredentialRequest, basic_client_authorization,
         dynamic_client_registration_grant_types, join_dynamic_client_registration_scope_values,
         join_scope_values, material_key_belongs_to_input, oauth_metadata_prefix,
-        parse_dynamic_client_registration_response, parse_token_response, pkce_challenge,
-        receive_callback, request_device_code,
+        oauth_refresh_config_at, parse_dynamic_client_registration_response, parse_token_response,
+        pkce_challenge, receive_callback, request_device_code,
     };
     use coral_spec::{
         ManifestOAuthClientIdSpec, ManifestOAuthClientSecretSpec,
@@ -2351,8 +2366,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn near_expiry_oauth_material_without_refresh_token_remains_usable() {
+    #[test]
+    fn near_expiry_oauth_material_without_refresh_token_remains_usable() {
         let oauth = oauth_spec(
             "http://127.0.0.1:9/token",
             53682,
@@ -2367,25 +2382,20 @@ mod tests {
             },
         );
         let prefix = oauth_metadata_prefix("API_TOKEN");
-        let mut material = BTreeMap::from([
+        let now = chrono::Utc::now();
+        let material = BTreeMap::from([
             ("API_TOKEN".to_string(), "near-expiry-token".to_string()),
             (format!("{prefix}method"), "oauth".to_string()),
             (
                 format!("{prefix}access_token_expires_at"),
-                (chrono::Utc::now() + chrono::Duration::seconds(30)).to_rfc3339(),
+                (now + chrono::Duration::seconds(30)).to_rfc3339(),
             ),
         ]);
-        let service = OAuthCredentialService::new();
 
-        let refreshed = service
-            .refresh_if_needed(
-                RefreshOAuthCredentialRequest::for_source_input("API_TOKEN", &oauth),
-                &mut material,
-            )
-            .await
+        let refresh = oauth_refresh_config_at("API_TOKEN", &prefix, &oauth, &material, now)
             .expect("near-expiry token without refresh token should still be usable");
 
-        assert!(!refreshed);
+        assert!(refresh.is_none());
         assert_eq!(
             material.get("API_TOKEN").map(String::as_str),
             Some("near-expiry-token")

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -25,6 +25,8 @@ pub enum CredentialsError {
     Io(#[from] io::Error),
     #[error("invalid credential material: {0}")]
     Parse(String),
+    #[error("credential encryption failed: {0}")]
+    Crypto(String),
     #[error("credential storage unavailable: {0}")]
     Unavailable(String),
     #[error("credential snapshot storage mismatch: snapshot is {snapshot}, requested {requested}")]

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -51,10 +51,10 @@ struct CredentialSetRef<'a> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct CredentialConfigNamespace(String);
+pub(super) struct CredentialConfigNamespace(String);
 
 impl CredentialConfigNamespace {
-    fn from_layout(layout: &AppStateLayout) -> Self {
+    pub(super) fn from_layout(layout: &AppStateLayout) -> Self {
         Self::from_config_dir(layout.config_dir())
     }
 
@@ -70,7 +70,7 @@ impl CredentialConfigNamespace {
         Self(short.to_string())
     }
 
-    fn as_str(&self) -> &str {
+    pub(super) fn as_str(&self) -> &str {
         self.0.as_str()
     }
 }
@@ -738,14 +738,14 @@ impl CredentialMaterialBackend for FileCredentialBackend {
 }
 
 #[derive(Clone)]
-struct KeychainCredentialBackend {
+pub(super) struct KeychainCredentialBackend {
     config_namespace: CredentialConfigNamespace,
     native: Arc<OnceLock<Result<Arc<keyring_core::CredentialStore>, String>>>,
     probe: Arc<OnceLock<Result<(), String>>>,
 }
 
 impl KeychainCredentialBackend {
-    fn new(config_namespace: CredentialConfigNamespace) -> Self {
+    pub(super) fn new(config_namespace: CredentialConfigNamespace) -> Self {
         Self {
             config_namespace,
             native: Arc::new(OnceLock::new()),
@@ -760,7 +760,7 @@ impl KeychainCredentialBackend {
         }
     }
 
-    fn entry_for(
+    pub(super) fn entry_for(
         &self,
         service: &str,
         account: &str,
@@ -781,7 +781,7 @@ impl KeychainCredentialBackend {
             .map_err(|error| keychain_error(&error))
     }
 
-    fn run_native<T, F>(&self, operation: F) -> Result<T, CredentialsError>
+    pub(super) fn run_native<T, F>(&self, operation: F) -> Result<T, CredentialsError>
     where
         T: Send + 'static,
         F: FnOnce(Self) -> Result<T, CredentialsError> + Send + 'static,
@@ -789,7 +789,7 @@ impl KeychainCredentialBackend {
         run_native_keychain(self.clone(), operation)
     }
 
-    fn probe_native(&self) -> Result<(), CredentialsError> {
+    pub(super) fn probe_native(&self) -> Result<(), CredentialsError> {
         match self.probe.get_or_init(|| {
             catch_native_keychain_panic(|| self.run_probe()).map_err(|error| error.to_string())
         }) {

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
+use std::future::Future;
 use std::io;
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
@@ -10,10 +11,15 @@ use sha2::{Digest as _, Sha256};
 
 use crate::bootstrap::AppError;
 use crate::state::AppStateLayout;
+use crate::state::db::{CoralDb, CredentialDocumentRecord, CredentialDocumentWrite, DbRepos};
 use crate::storage::fs as storage_fs;
 use crate::storage::fs::FileLock;
 use crate::workspaces::WorkspaceName;
 
+use super::encryption::{
+    CredentialKeyProvider, EncryptedCredentialDocument, decrypt_credential_values,
+    encrypt_credential_values, rewrap_credential_document,
+};
 use super::{
     CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialStoragePreference,
 };
@@ -48,6 +54,11 @@ impl EncodedCredentialMaterial {
 struct CredentialSetRef<'a> {
     workspace_name: &'a WorkspaceName,
     credential_set_id: &'a CredentialSetId,
+}
+
+pub(super) struct DatabaseCredentialMaterial {
+    pub(super) values: BTreeMap<String, String>,
+    pub(super) document_version: Option<i64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -153,6 +164,8 @@ pub(crate) struct CredentialStore {
     preference: CredentialStoragePreference,
     file: Arc<dyn CredentialMaterialBackend>,
     keychain: Arc<dyn CredentialMaterialBackend>,
+    database: Option<Arc<CoralDb>>,
+    key_provider: Option<Arc<dyn CredentialKeyProvider>>,
 }
 
 impl CredentialStore {
@@ -171,7 +184,21 @@ impl CredentialStore {
             preference,
             file: Arc::new(FileCredentialBackend::new(layout)),
             keychain: Arc::new(KeychainCredentialBackend::new(config_namespace)),
+            database: None,
+            key_provider: None,
         }
+    }
+
+    pub(crate) fn with_database(
+        layout: AppStateLayout,
+        preference: CredentialStoragePreference,
+        database: Arc<CoralDb>,
+        key_provider: Arc<dyn CredentialKeyProvider>,
+    ) -> Self {
+        let mut store = Self::with_preference(layout, preference);
+        store.database = Some(database);
+        store.key_provider = Some(key_provider);
+        store
     }
 
     #[cfg(test)]
@@ -185,6 +212,8 @@ impl CredentialStore {
             preference,
             file: Arc::new(FileCredentialBackend::new(layout)),
             keychain,
+            database: None,
+            key_provider: None,
         }
     }
 
@@ -219,6 +248,9 @@ impl CredentialStore {
         storage: CredentialStorageKind,
         values: &BTreeMap<String, String>,
     ) -> Result<(), AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.replace_database_material(workspace_name, credential_set_id, values);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -246,6 +278,9 @@ impl CredentialStore {
         storage: CredentialStorageKind,
         values: &BTreeMap<String, String>,
     ) -> Result<(), AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.replace_database_material(workspace_name, credential_set_id, values);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -271,12 +306,15 @@ impl CredentialStore {
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
-        update: F,
+        mut update: F,
     ) -> Result<R, AppError>
     where
-        F: FnOnce(BTreeMap<String, String>) -> Result<(BTreeMap<String, String>, R), AppError>,
+        F: FnMut(BTreeMap<String, String>) -> Result<(BTreeMap<String, String>, R), AppError>,
     {
         tracing::trace!(%credential_set_id, %storage, "updating credential material");
+        if storage == CredentialStorageKind::Database {
+            return self.update_database_material(workspace_name, credential_set_id, update);
+        }
         let current = self.read_material(workspace_name, credential_set_id, storage)?;
         let (next, result) = update(current)?;
         self.replace_material(workspace_name, credential_set_id, storage, &next)?;
@@ -288,12 +326,15 @@ impl CredentialStore {
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
-        update: F,
+        mut update: F,
     ) -> Result<R, AppError>
     where
-        F: FnOnce(BTreeMap<String, String>) -> Result<(BTreeMap<String, String>, R), AppError>,
+        F: FnMut(BTreeMap<String, String>) -> Result<(BTreeMap<String, String>, R), AppError>,
     {
         tracing::trace!(%credential_set_id, %storage, "updating credential material with state lock held");
+        if storage == CredentialStorageKind::Database {
+            return self.update_database_material(workspace_name, credential_set_id, update);
+        }
         let current = self.read_material(workspace_name, credential_set_id, storage)?;
         let (next, result) = update(current)?;
         self.replace_material_with_state_lock_held(
@@ -324,6 +365,9 @@ impl CredentialStore {
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
     ) -> Result<BTreeMap<String, String>, AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.read_database_material(workspace_name, credential_set_id);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -348,6 +392,9 @@ impl CredentialStore {
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
     ) -> Result<CredentialMaterialSnapshot, AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.snapshot_database_material(workspace_name, credential_set_id);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -368,6 +415,9 @@ impl CredentialStore {
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
     ) -> Result<CredentialMaterialSnapshot, AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.snapshot_database_material(workspace_name, credential_set_id);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -390,6 +440,9 @@ impl CredentialStore {
         snapshot: &CredentialMaterialSnapshot,
     ) -> Result<(), AppError> {
         let storage = snapshot.storage();
+        if storage == CredentialStorageKind::Database {
+            return self.restore_database_material(workspace_name, credential_set_id, snapshot);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -411,6 +464,9 @@ impl CredentialStore {
         snapshot: &CredentialMaterialSnapshot,
     ) -> Result<(), AppError> {
         let storage = snapshot.storage();
+        if storage == CredentialStorageKind::Database {
+            return self.restore_database_material(workspace_name, credential_set_id, snapshot);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -432,6 +488,9 @@ impl CredentialStore {
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
     ) -> Result<(), AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.remove_database_material(workspace_name, credential_set_id);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -452,6 +511,9 @@ impl CredentialStore {
         credential_set_id: &CredentialSetId,
         storage: CredentialStorageKind,
     ) -> Result<(), AppError> {
+        if storage == CredentialStorageKind::Database {
+            return self.remove_database_material(workspace_name, credential_set_id);
+        }
         let set = CredentialSetRef {
             workspace_name,
             credential_set_id,
@@ -467,7 +529,14 @@ impl CredentialStore {
     }
 
     pub(crate) fn default_write_storage(&self) -> Result<CredentialStorageKind, CredentialsError> {
+        if self.database.is_some() {
+            return Ok(CredentialStorageKind::Database);
+        }
         match self.preference {
+            CredentialStoragePreference::Database => Err(CredentialsError::Unavailable(
+                "database credential storage is configured, but the database backend is not available"
+                    .to_string(),
+            )),
             CredentialStoragePreference::File => Ok(CredentialStorageKind::File),
             CredentialStoragePreference::Keychain => {
                 self.keychain
@@ -489,8 +558,341 @@ impl CredentialStore {
         match storage {
             CredentialStorageKind::File => self.file.as_ref(),
             CredentialStorageKind::Keychain => self.keychain.as_ref(),
+            CredentialStorageKind::Database => {
+                unreachable!("database credential storage bypasses legacy material backends")
+            }
         }
     }
+
+    fn database_parts(&self) -> Result<(Arc<CoralDb>, Arc<dyn CredentialKeyProvider>), AppError> {
+        let database = self.database.clone().ok_or_else(|| {
+            AppError::Credentials(CredentialsError::Unavailable(
+                "database credential storage is not configured".to_string(),
+            ))
+        })?;
+        let key_provider = self.key_provider.clone().ok_or_else(|| {
+            AppError::Credentials(CredentialsError::Unavailable(
+                "credential encryption key provider is not configured".to_string(),
+            ))
+        })?;
+        Ok((database, key_provider))
+    }
+
+    fn read_database_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+    ) -> Result<BTreeMap<String, String>, AppError> {
+        let (database, key_provider) = self.database_parts()?;
+        let workspace_name = workspace_name.clone();
+        let source_name = credential_set_id.source_name()?;
+        run_credential_db_operation(async move {
+            let mut session = database.as_ref();
+            let Some(record) = session
+                .credential_documents()
+                .get(&workspace_name, &source_name)
+                .await?
+            else {
+                return Ok(BTreeMap::new());
+            };
+            let expected_document_version = record.document_version;
+            let document = encrypted_document_from_record(record);
+            let values = decrypt_credential_values(
+                &workspace_name,
+                &source_name,
+                &document,
+                key_provider.as_ref(),
+            )
+            .map_err(AppError::from)?;
+            if let Some(rewrapped) = rewrap_credential_document(
+                &workspace_name,
+                &source_name,
+                &document,
+                key_provider.as_ref(),
+            )? {
+                let now_unix_nanos = now_unix_nanos_i64()?;
+                let mut tx = database.begin().await?;
+                tx.credential_documents()
+                    .rewrap_if_current(
+                        &workspace_name,
+                        &source_name,
+                        expected_document_version,
+                        &credential_document_write_from_encrypted(rewrapped),
+                        now_unix_nanos,
+                    )
+                    .await?;
+                tx.commit().await?;
+            }
+            Ok(values)
+        })
+    }
+
+    pub(super) fn read_database_material_for_update(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+    ) -> Result<DatabaseCredentialMaterial, AppError> {
+        let (database, key_provider) = self.database_parts()?;
+        let workspace_name = workspace_name.clone();
+        let source_name = credential_set_id.source_name()?;
+        run_credential_db_operation(async move {
+            let mut session = database.as_ref();
+            let Some(record) = session
+                .credential_documents()
+                .get(&workspace_name, &source_name)
+                .await?
+            else {
+                return Ok(DatabaseCredentialMaterial {
+                    values: BTreeMap::new(),
+                    document_version: None,
+                });
+            };
+            let document_version = record.document_version;
+            let values = decrypt_credential_values(
+                &workspace_name,
+                &source_name,
+                &encrypted_document_from_record(record),
+                key_provider.as_ref(),
+            )
+            .map_err(AppError::from)?;
+            Ok(DatabaseCredentialMaterial {
+                values,
+                document_version: Some(document_version),
+            })
+        })
+    }
+
+    fn replace_database_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        values: &BTreeMap<String, String>,
+    ) -> Result<(), AppError> {
+        if values.is_empty() {
+            return self.remove_database_material(workspace_name, credential_set_id);
+        }
+        loop {
+            let current =
+                self.read_database_material_for_update(workspace_name, credential_set_id)?;
+            if self.replace_database_material_if_current(
+                workspace_name,
+                credential_set_id,
+                current.document_version,
+                values,
+            )? {
+                return Ok(());
+            }
+        }
+    }
+
+    pub(super) fn replace_database_material_if_current(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        expected_document_version: Option<i64>,
+        values: &BTreeMap<String, String>,
+    ) -> Result<bool, AppError> {
+        if values.is_empty() {
+            self.remove_database_material(workspace_name, credential_set_id)?;
+            return Ok(true);
+        }
+        let (database, key_provider) = self.database_parts()?;
+        let workspace_name = workspace_name.clone();
+        let source_name = credential_set_id.source_name()?;
+        let values = values.clone();
+        run_credential_db_operation(async move {
+            let now_unix_nanos = now_unix_nanos_i64()?;
+            let encrypted = encrypt_credential_values(
+                &workspace_name,
+                &source_name,
+                &values,
+                key_provider.as_ref(),
+            )?;
+            let mut tx = database.begin().await?;
+            tx.workspaces()
+                .ensure(workspace_name.as_str(), now_unix_nanos)
+                .await?;
+            let write = credential_document_write_from_encrypted(encrypted);
+            let applied = match expected_document_version {
+                Some(version) => {
+                    tx.credential_documents()
+                        .replace_if_current(
+                            &workspace_name,
+                            &source_name,
+                            version,
+                            &write,
+                            now_unix_nanos,
+                        )
+                        .await?
+                }
+                None => {
+                    tx.credential_documents()
+                        .insert_if_absent(&workspace_name, &source_name, &write, now_unix_nanos)
+                        .await?
+                }
+            };
+            tx.commit().await?;
+            Ok(applied)
+        })
+    }
+
+    fn update_database_material<F, R>(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        mut update: F,
+    ) -> Result<R, AppError>
+    where
+        F: FnMut(BTreeMap<String, String>) -> Result<(BTreeMap<String, String>, R), AppError>,
+    {
+        loop {
+            let current =
+                self.read_database_material_for_update(workspace_name, credential_set_id)?;
+            let (next, result) = update(current.values)?;
+            if next.is_empty() {
+                self.remove_database_material(workspace_name, credential_set_id)?;
+                return Ok(result);
+            }
+            if self.replace_database_material_if_current(
+                workspace_name,
+                credential_set_id,
+                current.document_version,
+                &next,
+            )? {
+                return Ok(result);
+            }
+        }
+    }
+
+    fn snapshot_database_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+    ) -> Result<CredentialMaterialSnapshot, AppError> {
+        let values = self.read_database_material(workspace_name, credential_set_id)?;
+        if values.is_empty() {
+            return Ok(CredentialMaterialSnapshot::new(
+                CredentialStorageKind::Database,
+                None,
+            ));
+        }
+        let bytes = serde_json::to_vec(&values)
+            .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+        Ok(CredentialMaterialSnapshot::new(
+            CredentialStorageKind::Database,
+            Some(bytes),
+        ))
+    }
+
+    fn restore_database_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), AppError> {
+        if snapshot.storage() != CredentialStorageKind::Database {
+            return Err(CredentialsError::SnapshotStorageMismatch {
+                snapshot: snapshot.storage().as_config_value(),
+                requested: CredentialStorageKind::Database.as_config_value(),
+            }
+            .into());
+        }
+        let Some(bytes) = snapshot.material() else {
+            return self.remove_database_material(workspace_name, credential_set_id);
+        };
+        let values = serde_json::from_slice::<BTreeMap<String, String>>(bytes)
+            .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+        self.replace_database_material(workspace_name, credential_set_id, &values)
+    }
+
+    fn remove_database_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        credential_set_id: &CredentialSetId,
+    ) -> Result<(), AppError> {
+        let (database, _) = self.database_parts()?;
+        let workspace_name = workspace_name.clone();
+        let source_name = credential_set_id.source_name()?;
+        run_credential_db_operation(async move {
+            let mut tx = database.begin().await?;
+            tx.credential_documents()
+                .remove(&workspace_name, &source_name)
+                .await?;
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+}
+
+fn run_credential_db_operation<T, F>(operation: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: Future<Output = Result<T, AppError>> + Send + 'static,
+{
+    fn run_on_runtime<T, F>(operation: F) -> Result<T, AppError>
+    where
+        F: Future<Output = Result<T, AppError>>,
+    {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!(
+                    "failed to create credential database runtime: {error}"
+                ))
+            })?;
+        runtime.block_on(operation)
+    }
+
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return std::thread::spawn(move || run_on_runtime(operation))
+            .join()
+            .map_err(|_panic| {
+                AppError::FailedPrecondition(
+                    "credential database operation thread panicked".to_string(),
+                )
+            })?;
+    }
+
+    run_on_runtime(operation)
+}
+
+fn credential_document_write_from_encrypted(
+    document: EncryptedCredentialDocument,
+) -> CredentialDocumentWrite {
+    CredentialDocumentWrite {
+        ciphertext: document.ciphertext,
+        nonce: document.nonce,
+        wrapped_dek: document.wrapped_dek,
+        wrapped_dek_nonce: document.wrapped_dek_nonce,
+        key_id: document.key_id,
+        algorithm: document.algorithm,
+        aad_version: document.aad_version,
+    }
+}
+
+fn encrypted_document_from_record(record: CredentialDocumentRecord) -> EncryptedCredentialDocument {
+    EncryptedCredentialDocument {
+        ciphertext: record.ciphertext,
+        nonce: record.nonce,
+        wrapped_dek: record.wrapped_dek,
+        wrapped_dek_nonce: record.wrapped_dek_nonce,
+        key_id: record.key_id,
+        algorithm: record.algorithm,
+        aad_version: record.aad_version,
+    }
+}
+
+fn now_unix_nanos_i64() -> Result<i64, AppError> {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| AppError::FailedPrecondition(format!("system clock error: {error}")))?
+        .as_nanos();
+    i64::try_from(nanos).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "system clock timestamp exceeds i64 nanoseconds: {error}"
+        ))
+    })
 }
 
 fn contextualize_storage_error<T>(
@@ -1042,6 +1444,9 @@ fn encode_values(
                 .map(EncodedCredentialMaterial)
                 .map_err(|error| CredentialsError::Parse(error.to_string()))
         }
+        CredentialStorageKind::Database => Err(CredentialsError::Crypto(
+            "database credential material is encrypted directly from values".to_string(),
+        )),
     }
 }
 
@@ -1066,6 +1471,10 @@ fn decode_values(
             }
             Ok(document.values)
         }
+        CredentialStorageKind::Database => Err(CredentialsError::Crypto(
+            "database credential material is decrypted directly from credential documents"
+                .to_string(),
+        )),
     }
 }
 

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -1651,12 +1651,15 @@ mod tests {
 
     use super::{CredentialMaterialBackend, CredentialSetRef, EncodedCredentialMaterial};
     use super::{CredentialStore, decode_env_value, encode_env_value, load_file, save_file};
+    use crate::credentials::encryption::{CredentialEncryptionKey, CredentialKeyProvider};
     use crate::credentials::{
         CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind,
         CredentialStoragePreference,
     };
     use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::AppStateLayout;
+    use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
     use crate::workspaces::WorkspaceName;
     use tempfile::TempDir;
 
@@ -1746,6 +1749,26 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct RotatingKeyProvider {
+        active: CredentialEncryptionKey,
+        keys: Vec<CredentialEncryptionKey>,
+    }
+
+    impl CredentialKeyProvider for RotatingKeyProvider {
+        fn active_key(&self) -> Result<CredentialEncryptionKey, super::CredentialsError> {
+            Ok(self.active.clone())
+        }
+
+        fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, super::CredentialsError> {
+            self.keys
+                .iter()
+                .find(|key| key.key_id() == key_id)
+                .cloned()
+                .ok_or_else(|| super::CredentialsError::Crypto("missing test key".to_string()))
+        }
+    }
+
     #[test]
     fn keychain_address_namespaces_by_config_workspace_and_credential_set() {
         let config_namespace = super::CredentialConfigNamespace("test".to_string());
@@ -1821,6 +1844,103 @@ mod tests {
             super::CredentialConfigNamespace::from_config_dir(&first_dir),
             super::CredentialConfigNamespace::from_config_dir(&second_dir)
         );
+    }
+
+    #[tokio::test]
+    async fn database_update_retries_cas_loser_from_winner_material() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("layout");
+        let db = Arc::new(open_sqlite(&layout).await);
+        let store = CredentialStore::with_database(
+            layout,
+            CredentialStoragePreference::Auto,
+            Arc::clone(&db),
+            static_key_provider(13),
+        );
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = SourceName::parse("github").expect("source");
+        let credential_set_id = CredentialSetId::for_source(&source);
+        ensure_source(&db, &workspace, &source).await;
+        store
+            .replace_material(
+                &workspace,
+                &credential_set_id,
+                CredentialStorageKind::Database,
+                &BTreeMap::from([("TOKEN".to_string(), "initial".to_string())]),
+            )
+            .expect("seed material");
+
+        let mut raced = false;
+        let result = store
+            .update_material(
+                &workspace,
+                &credential_set_id,
+                CredentialStorageKind::Database,
+                |mut current| {
+                    if !raced {
+                        raced = true;
+                        store
+                            .replace_material(
+                                &workspace,
+                                &credential_set_id,
+                                CredentialStorageKind::Database,
+                                &BTreeMap::from([("TOKEN".to_string(), "winner".to_string())]),
+                            )
+                            .expect("competing winner");
+                    }
+                    current.insert("EXTRA".to_string(), "loser".to_string());
+                    Ok((current.clone(), current))
+                },
+            )
+            .expect("cas retry update");
+
+        assert_eq!(result.get("TOKEN").map(String::as_str), Some("winner"));
+        assert_eq!(result.get("EXTRA").map(String::as_str), Some("loser"));
+    }
+
+    fn static_key_provider(byte: u8) -> Arc<dyn CredentialKeyProvider> {
+        let key = CredentialEncryptionKey::from_static_bytes_for_test([byte; 32]);
+        Arc::new(RotatingKeyProvider {
+            active: key.clone(),
+            keys: vec![key],
+        })
+    }
+
+    async fn ensure_source(db: &CoralDb, workspace: &WorkspaceName, source: &SourceName) {
+        let mut tx = db.begin().await.expect("begin source tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(
+                workspace,
+                &InstalledSource {
+                    name: source.clone(),
+                    version: None,
+                    variables: BTreeMap::new(),
+                    secrets: vec!["GITHUB_TOKEN".to_string()],
+                    credential_storage: Some(CredentialStorageKind::Database),
+                    origin: SourceOrigin::Bundled,
+                },
+                1,
+            )
+            .await
+            .expect("ensure source");
+        tx.commit().await.expect("commit source tx");
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
     }
 
     #[test]

--- a/crates/coral-app/src/episode/service.rs
+++ b/crates/coral-app/src/episode/service.rs
@@ -90,7 +90,9 @@ fn open_episode_status(error: &EpisodeStoreError) -> Status {
     match error {
         EpisodeStoreError::Conflict { .. } => Status::failed_precondition(error.to_string()),
         EpisodeStoreError::InvalidIntent { .. } => Status::invalid_argument(error.to_string()),
-        EpisodeStoreError::Io(_) | EpisodeStoreError::Serde(_) => {
+        EpisodeStoreError::Io(_)
+        | EpisodeStoreError::Serde(_)
+        | EpisodeStoreError::Persistence(_) => {
             warn!(%error, "failed to persist episode");
             Status::internal("failed to persist episode")
         }

--- a/crates/coral-app/src/episode/store.rs
+++ b/crates/coral-app/src/episode/store.rs
@@ -14,13 +14,16 @@
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use coral_api::CORAL_EPISODE_INTENT_MAX_CHARS;
 use serde::{Deserialize, Serialize};
 
 use super::EpisodeId;
+use crate::bootstrap::AppError;
 use crate::state::AppStateLayout;
+use crate::state::db::{CoralDb, DbRepos, EpisodeRecord};
 use crate::storage::fs::{self as storage_fs, FileLock};
 use crate::workspaces::WorkspaceName;
 
@@ -83,6 +86,9 @@ pub(crate) enum EpisodeStoreError {
     /// JSON (de)serialization error.
     #[error("episode store serialization: {0}")]
     Serde(#[from] serde_json::Error),
+    /// Durable database persistence failed.
+    #[error("episode store persistence: {0}")]
+    Persistence(#[from] AppError),
     /// The `episode_id` is already registered with a different intent/parent.
     #[error("episode {episode_id:?} is already open with a different intent/parent")]
     Conflict {
@@ -97,6 +103,12 @@ pub(crate) enum EpisodeStoreError {
     },
 }
 
+impl From<crate::state::db::DbError> for EpisodeStoreError {
+    fn from(error: crate::state::db::DbError) -> Self {
+        Self::Persistence(AppError::from(error))
+    }
+}
+
 /// Append-only, per-workspace JSONL episode store, bounded by a byte ceiling with
 /// oldest-out eviction. Paths and the shared state lock are resolved through
 /// [`AppStateLayout`].
@@ -104,6 +116,7 @@ pub(crate) enum EpisodeStoreError {
 pub(crate) struct EpisodeStore {
     layout: AppStateLayout,
     max_bytes: u64,
+    catalog_db: Option<Arc<CoralDb>>,
 }
 
 impl EpisodeStore {
@@ -112,6 +125,22 @@ impl EpisodeStore {
         Self {
             layout,
             max_bytes: MAX_EPISODE_BYTES_PER_WORKSPACE,
+            catalog_db: None,
+        }
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "DB-backed episode writes are exercised by tests here and wired to production after legacy episode import in the next stack PR."
+        )
+    )]
+    pub(crate) fn with_db(layout: AppStateLayout, catalog_db: Arc<CoralDb>) -> Self {
+        Self {
+            layout,
+            max_bytes: MAX_EPISODE_BYTES_PER_WORKSPACE,
+            catalog_db: Some(catalog_db),
         }
     }
 
@@ -154,6 +183,9 @@ impl EpisodeStore {
             });
         }
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        if let Some(db) = self.catalog_db.clone() {
+            return open_episode_in_db(db, episode, intent, self.max_bytes);
+        }
         let path = self.layout.episodes_file(&episode.workspace);
 
         // One read serves both the idempotency check and eviction (file order is
@@ -182,6 +214,173 @@ impl EpisodeStore {
             self.max_bytes,
         )
     }
+}
+
+fn open_episode_in_db(
+    db: Arc<CoralDb>,
+    episode: &Episode,
+    intent: &str,
+    max_bytes: u64,
+) -> Result<(), EpisodeStoreError> {
+    let workspace = episode.workspace.clone();
+    let id = episode.id.as_str().to_string();
+    let parent_episode_id = episode
+        .parent_episode_id
+        .as_ref()
+        .map(EpisodeId::as_str)
+        .map(str::to_string);
+    let intent = intent.to_string();
+    let workspace_created_at_unix_nanos = db_timestamp_from_unix_nanos(now_unix_nanos())?;
+
+    run_episode_db_operation(async move {
+        let mut tx = db.begin().await?;
+        tx.workspaces()
+            .ensure_write_locked(workspace.as_str(), workspace_created_at_unix_nanos)
+            .await?;
+        let mut episodes = tx.episodes().list_workspace_episodes(&workspace).await?;
+        let (created_at_unix_nanos_raw, created_at_unix_nanos) =
+            next_db_episode_created_at(&episodes)?;
+        let record_bytes = episode_record_bytes(
+            &workspace,
+            &id,
+            intent.as_str(),
+            parent_episode_id.as_deref(),
+            created_at_unix_nanos_raw,
+        )?;
+        let episode_record = EpisodeRecord {
+            id: id.clone(),
+            intent,
+            parent_episode_id,
+            created_at_unix_nanos,
+            record_bytes,
+        };
+        if let Some(existing) = episodes.iter().find(|existing| existing.id == id) {
+            return if existing.intent == episode_record.intent
+                && existing.parent_episode_id == episode_record.parent_episode_id
+            {
+                tx.commit().await?;
+                Ok(())
+            } else {
+                Err(EpisodeStoreError::Conflict {
+                    episode_id: id.clone(),
+                })
+            };
+        }
+        episodes.push(episode_record);
+        let kept = retain_episode_records_within_budget(episodes, max_bytes);
+        tx.episodes()
+            .replace_workspace_episodes(&workspace, &kept)
+            .await?;
+        tx.commit().await?;
+        Ok(())
+    })
+}
+
+fn next_db_episode_created_at(
+    episodes: &[EpisodeRecord],
+) -> Result<(u128, i64), EpisodeStoreError> {
+    let now = db_timestamp_from_unix_nanos(now_unix_nanos())?;
+    let created_at_unix_nanos = match episodes
+        .iter()
+        .map(|episode| episode.created_at_unix_nanos)
+        .max()
+    {
+        Some(max_existing) => now.max(max_existing.checked_add(1).ok_or_else(|| {
+            EpisodeStoreError::Persistence(AppError::FailedPrecondition(
+                "episode timestamp space exhausted".to_string(),
+            ))
+        })?),
+        None => now,
+    };
+    let raw = u128::try_from(created_at_unix_nanos).map_err(|error| {
+        EpisodeStoreError::Persistence(AppError::FailedPrecondition(format!(
+            "episode timestamp is negative: {error}"
+        )))
+    })?;
+    Ok((raw, created_at_unix_nanos))
+}
+
+fn db_timestamp_from_unix_nanos(nanos: u128) -> Result<i64, EpisodeStoreError> {
+    i64::try_from(nanos).map_err(|error| {
+        EpisodeStoreError::Persistence(AppError::FailedPrecondition(format!(
+            "episode timestamp exceeds i64 nanoseconds: {error}"
+        )))
+    })
+}
+
+fn retain_episode_records_within_budget(
+    mut episodes: Vec<EpisodeRecord>,
+    max_bytes: u64,
+) -> Vec<EpisodeRecord> {
+    episodes.sort_by(|left, right| {
+        left.created_at_unix_nanos
+            .cmp(&right.created_at_unix_nanos)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    let mut total: u64 = episodes
+        .iter()
+        .map(|episode| u64::try_from(episode.record_bytes).unwrap_or(u64::MAX))
+        .sum();
+    while episodes.len() > 1 && total > max_bytes {
+        let removed = episodes.remove(0);
+        total = total.saturating_sub(u64::try_from(removed.record_bytes).unwrap_or(u64::MAX));
+    }
+    episodes
+}
+
+fn episode_record_bytes(
+    workspace: &WorkspaceName,
+    id: &str,
+    intent: &str,
+    parent_episode_id: Option<&str>,
+    created_at_unix_nanos: u128,
+) -> Result<i64, EpisodeStoreError> {
+    let record = PersistedEpisode {
+        id: id.to_string(),
+        workspace: workspace.as_str().to_string(),
+        intent: intent.to_string(),
+        parent_episode_id: parent_episode_id.map(str::to_string),
+        created_at_unix_nanos,
+    };
+    let bytes = serde_json::to_vec(&record)?.len() + 1;
+    i64::try_from(bytes).map_err(|error| {
+        EpisodeStoreError::Persistence(AppError::FailedPrecondition(format!(
+            "episode record size exceeds i64 bytes: {error}"
+        )))
+    })
+}
+
+fn run_episode_db_operation<T, F>(operation: F) -> Result<T, EpisodeStoreError>
+where
+    T: Send + 'static,
+    F: std::future::Future<Output = Result<T, EpisodeStoreError>> + Send + 'static,
+{
+    fn run_on_runtime<T, F>(operation: F) -> Result<T, EpisodeStoreError>
+    where
+        F: std::future::Future<Output = Result<T, EpisodeStoreError>>,
+    {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                EpisodeStoreError::Persistence(AppError::FailedPrecondition(format!(
+                    "failed to create episode database runtime: {error}"
+                )))
+            })?;
+        runtime.block_on(operation)
+    }
+
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return std::thread::spawn(move || run_on_runtime(operation))
+            .join()
+            .map_err(|_panic| {
+                EpisodeStoreError::Persistence(AppError::FailedPrecondition(
+                    "episode database operation thread panicked".to_string(),
+                ))
+            })?;
+    }
+
+    run_on_runtime(operation)
 }
 
 /// Unix-nanoseconds timestamp for `created_at_unix_nanos`.
@@ -344,7 +543,7 @@ fn file_needs_leading_newline(path: &Path) -> Result<bool, EpisodeStoreError> {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{fs, sync::Arc, time::Duration};
 
     use tempfile::TempDir;
 
@@ -352,7 +551,9 @@ mod tests {
         CORAL_EPISODE_INTENT_MAX_CHARS, Episode, EpisodeId, EpisodeStore, EpisodeStoreError,
         PersistedEpisode, now_unix_nanos, read_episode,
     };
+    use crate::bootstrap;
     use crate::state::AppStateLayout;
+    use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
     use crate::workspaces::WorkspaceName;
 
     /// On-disk byte size of one record (serialized JSON + newline), for sizing the
@@ -377,6 +578,11 @@ mod tests {
             parent_episode_id: parent.map(|parent| EpisodeId::parse(parent).expect("valid parent")),
             created_at_unix_nanos: now_unix_nanos(),
         }
+    }
+
+    fn unique_workspace(prefix: &str) -> WorkspaceName {
+        WorkspaceName::parse(&format!("{prefix}{}", uuid::Uuid::new_v4().simple()))
+            .expect("workspace")
     }
 
     #[test]
@@ -653,6 +859,286 @@ mod tests {
             fs::metadata(&path).unwrap().len() <= one * 2,
             "the log must stay within the byte ceiling"
         );
+    }
+
+    #[tokio::test]
+    async fn db_store_round_trips_idempotency_and_conflict() {
+        let (_dir, layout) = layout();
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default episode test DB should be sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let store = EpisodeStore::with_db(layout.clone(), Arc::clone(&db));
+        let ep = episode(&workspace, "ep_1", " same intent ", Some("root_ep"));
+
+        store.open_episode(&ep).expect("open");
+        store.open_episode(&ep).expect("idempotent reopen");
+        let conflict = store
+            .open_episode(&episode(&workspace, "ep_1", "different", Some("root_ep")))
+            .expect_err("changed intent should conflict");
+
+        assert!(matches!(conflict, EpisodeStoreError::Conflict { .. }));
+        let mut session = db.as_ref();
+        let episodes = session
+            .episodes()
+            .list_workspace_episodes(&workspace)
+            .await
+            .expect("list episodes");
+        assert_eq!(episodes.len(), 1);
+        let episode = episodes.first().expect("episode");
+        assert_eq!(episode.intent, "same intent");
+        assert_eq!(episode.parent_episode_id.as_deref(), Some("root_ep"));
+        assert!(
+            !layout.episodes_file(&workspace).exists(),
+            "DB-backed episode store should not append legacy JSONL"
+        );
+    }
+
+    #[tokio::test]
+    async fn db_store_reopen_same_intent_different_parent_conflicts() {
+        let (_dir, layout) = layout();
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default episode test DB should be sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let store = EpisodeStore::with_db(layout, Arc::clone(&db));
+
+        store
+            .open_episode(&episode(
+                &workspace,
+                "child_ep",
+                "sub task",
+                Some("parent_a"),
+            ))
+            .expect("first open");
+        let error = store
+            .open_episode(&episode(
+                &workspace,
+                "child_ep",
+                "sub task",
+                Some("parent_b"),
+            ))
+            .expect_err("changed parent must conflict");
+
+        assert!(matches!(error, EpisodeStoreError::Conflict { .. }));
+        let mut session = db.as_ref();
+        let episodes = session
+            .episodes()
+            .list_workspace_episodes(&workspace)
+            .await
+            .expect("list episodes");
+        assert_eq!(episodes.len(), 1);
+        assert_eq!(
+            episodes
+                .first()
+                .expect("episode")
+                .parent_episode_id
+                .as_deref(),
+            Some("parent_a")
+        );
+    }
+
+    #[tokio::test]
+    async fn db_store_evicts_oldest_to_stay_under_byte_ceiling() {
+        let (_dir, layout) = layout();
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default episode test DB should be sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let store = EpisodeStore::with_db(layout, Arc::clone(&db)).with_max_bytes(1);
+        let mut first = episode(&workspace, "ep_1", "task", None);
+        first.created_at_unix_nanos = now_unix_nanos() + 1_000_000_000;
+        let mut second = episode(&workspace, "ep_2", "task", None);
+        second.created_at_unix_nanos = 1;
+
+        store.open_episode(&first).expect("open first");
+        store.open_episode(&second).expect("open second");
+
+        let mut session = db.as_ref();
+        assert!(
+            session
+                .episodes()
+                .get(&workspace, "ep_1")
+                .await
+                .expect("get ep_1")
+                .is_none(),
+            "the oldest DB episode should be evicted"
+        );
+        assert!(
+            session
+                .episodes()
+                .get(&workspace, "ep_2")
+                .await
+                .expect("get ep_2")
+                .is_some()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn db_store_concurrent_opens_do_not_drop_each_other() {
+        let (_dir, layout) = layout();
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default episode test DB should be sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let store = Arc::new(EpisodeStore::with_db(layout, Arc::clone(&db)));
+
+        let mut handles = Vec::new();
+        for index in 0..16 {
+            let store = Arc::clone(&store);
+            let workspace = workspace.clone();
+            handles.push(tokio::task::spawn_blocking(move || {
+                store
+                    .open_episode(&episode(
+                        &workspace,
+                        &format!("ep_{index}"),
+                        &format!("task {index}"),
+                        None,
+                    ))
+                    .expect("open episode");
+            }));
+        }
+        for handle in handles {
+            handle.await.expect("join open task");
+        }
+
+        let mut session = db.as_ref();
+        let episodes = session
+            .episodes()
+            .list_workspace_episodes(&workspace)
+            .await
+            .expect("list episodes");
+        assert_eq!(
+            episodes.len(),
+            16,
+            "concurrent DB opens must not lose episodes"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the DB-backed episode runtime path against Postgres"]
+    async fn open_episode_in_db_runtime_path_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+                .await
+                .expect("open postgres"),
+        );
+        db.migrate().await.expect("migrate postgres");
+        let (_dir, store_layout) = layout();
+        let workspace = unique_workspace("episodepg");
+        let store = EpisodeStore::with_db(store_layout, Arc::clone(&db)).with_max_bytes(1);
+
+        store
+            .open_episode(&episode(&workspace, "ep_old", "task", None))
+            .expect("open first");
+        store
+            .open_episode(&episode(&workspace, "ep_new", "task", None))
+            .expect("open second");
+        store
+            .open_episode(&episode(&workspace, "ep_new", "task", None))
+            .expect("idempotent reopen");
+        let conflict = store
+            .open_episode(&episode(&workspace, "ep_new", "different", None))
+            .expect_err("changed intent should conflict");
+        assert!(matches!(conflict, EpisodeStoreError::Conflict { .. }));
+        let episodes = {
+            let mut session = db.as_ref();
+            session
+                .episodes()
+                .list_workspace_episodes(&workspace)
+                .await
+                .expect("list retained episodes")
+        };
+        assert_eq!(episodes.len(), 1);
+        assert_eq!(episodes.first().expect("episode").id, "ep_new");
+
+        let race_workspace = unique_workspace("episodepgrace");
+        let (_first_dir, first_layout) = layout();
+        let (_second_dir, second_layout) = layout();
+        let first_store = Arc::new(EpisodeStore::with_db(first_layout, Arc::clone(&db)));
+        let second_store = Arc::new(EpisodeStore::with_db(second_layout, Arc::clone(&db)));
+        let mut tx = db.begin().await.expect("begin lock tx");
+        tx.workspaces()
+            .ensure_write_locked(race_workspace.as_str(), 7)
+            .await
+            .expect("hold workspace lock");
+        let (first_started, first) =
+            spawn_open(first_store, race_workspace.clone(), "ep_a", "task a");
+        let (second_started, second) =
+            spawn_open(second_store, race_workspace.clone(), "ep_b", "task b");
+        first_started.await.expect("first open started");
+        second_started.await.expect("second open started");
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        assert!(
+            !first.is_finished(),
+            "first open should wait on the row lock"
+        );
+        assert!(
+            !second.is_finished(),
+            "second open should wait on the row lock"
+        );
+        tx.commit().await.expect("release workspace lock");
+        first.await.expect("join first").expect("open first");
+        second.await.expect("join second").expect("open second");
+
+        let mut session = db.as_ref();
+        let episodes = session
+            .episodes()
+            .list_workspace_episodes(&race_workspace)
+            .await
+            .expect("list raced episodes");
+        let ids: Vec<_> = episodes.iter().map(|episode| episode.id.as_str()).collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&"ep_a"));
+        assert!(ids.contains(&"ep_b"));
+    }
+
+    fn spawn_open(
+        store: Arc<EpisodeStore>,
+        workspace: WorkspaceName,
+        id: &'static str,
+        intent: &'static str,
+    ) -> (
+        tokio::sync::oneshot::Receiver<()>,
+        tokio::task::JoinHandle<Result<(), EpisodeStoreError>>,
+    ) {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::task::spawn_blocking(move || {
+            let _receiver_waiting = started_tx.send(()).is_ok();
+            store.open_episode(&episode(&workspace, id, intent, None))
+        });
+        (started_rx, handle)
     }
 
     #[test]

--- a/crates/coral-app/src/episode/store.rs
+++ b/crates/coral-app/src/episode/store.rs
@@ -31,7 +31,7 @@ use crate::workspaces::WorkspaceName;
 /// over this evicts the oldest records first (the newest is always kept, even if it
 /// alone exceeds the ceiling). Generous — bounds disk without losing recent history;
 /// becomes a `[episodes]` config knob alongside JSONL→Parquet compaction later.
-const MAX_EPISODE_BYTES_PER_WORKSPACE: u64 = 256 * 1024 * 1024;
+pub(crate) const MAX_EPISODE_BYTES_PER_WORKSPACE: u64 = 256 * 1024 * 1024;
 
 /// A registered episode — one task-attempt's intent and lineage.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -121,6 +121,7 @@ pub(crate) struct EpisodeStore {
 
 impl EpisodeStore {
     /// Creates a store that persists under `layout` with the default byte ceiling.
+    #[cfg(test)]
     pub(crate) fn new(layout: AppStateLayout) -> Self {
         Self {
             layout,
@@ -129,13 +130,6 @@ impl EpisodeStore {
         }
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "DB-backed episode writes are exercised by tests here and wired to production after legacy episode import in the next stack PR."
-        )
-    )]
     pub(crate) fn with_db(layout: AppStateLayout, catalog_db: Arc<CoralDb>) -> Self {
         Self {
             layout,
@@ -276,7 +270,7 @@ fn open_episode_in_db(
     })
 }
 
-fn next_db_episode_created_at(
+pub(crate) fn next_db_episode_created_at(
     episodes: &[EpisodeRecord],
 ) -> Result<(u128, i64), EpisodeStoreError> {
     let now = db_timestamp_from_unix_nanos(now_unix_nanos())?;
@@ -308,7 +302,7 @@ fn db_timestamp_from_unix_nanos(nanos: u128) -> Result<i64, EpisodeStoreError> {
     })
 }
 
-fn retain_episode_records_within_budget(
+pub(crate) fn retain_episode_records_within_budget(
     mut episodes: Vec<EpisodeRecord>,
     max_bytes: u64,
 ) -> Vec<EpisodeRecord> {
@@ -328,7 +322,7 @@ fn retain_episode_records_within_budget(
     episodes
 }
 
-fn episode_record_bytes(
+pub(crate) fn episode_record_bytes(
     workspace: &WorkspaceName,
     id: &str,
     intent: &str,

--- a/crates/coral-app/src/feedback/manager.rs
+++ b/crates/coral-app/src/feedback/manager.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -9,6 +10,7 @@ use crate::feedback::publisher::FeedbackPublisher;
 #[cfg(test)]
 use crate::feedback::publisher::NoopFeedbackPublisher;
 use crate::state::AppStateLayout;
+use crate::state::db::{CoralDb, DbRepos, FeedbackReportRecord};
 use crate::storage::fs::{self as storage_fs, FileLock};
 use crate::workspaces::WorkspaceName;
 
@@ -69,6 +71,7 @@ struct PersistedFeedbackReport<'a> {
 pub(crate) struct FeedbackManager {
     layout: AppStateLayout,
     publisher: Arc<dyn FeedbackPublisher>,
+    catalog_db: Option<Arc<CoralDb>>,
 }
 
 impl FeedbackManager {
@@ -77,11 +80,28 @@ impl FeedbackManager {
         Self::with_publisher(layout, Arc::new(NoopFeedbackPublisher))
     }
 
+    #[cfg(test)]
     pub(crate) fn with_publisher(
         layout: AppStateLayout,
         publisher: Arc<dyn FeedbackPublisher>,
     ) -> Self {
-        Self { layout, publisher }
+        Self {
+            layout,
+            publisher,
+            catalog_db: None,
+        }
+    }
+
+    pub(crate) fn with_db(
+        layout: AppStateLayout,
+        publisher: Arc<dyn FeedbackPublisher>,
+        catalog_db: Arc<CoralDb>,
+    ) -> Self {
+        Self {
+            layout,
+            publisher,
+            catalog_db: Some(catalog_db),
+        }
     }
 
     pub(crate) fn submit_feedback(
@@ -113,6 +133,19 @@ impl FeedbackManager {
     }
 
     fn append_report(&self, report: &FeedbackReport) -> Result<(), AppError> {
+        if let Some(db) = self.catalog_db.clone() {
+            let workspace = report.workspace.clone();
+            let record = feedback_record(report)?;
+            return run_feedback_db_operation(async move {
+                let mut tx = db.begin().await?;
+                if tx.workspaces().get(workspace.as_str()).await?.is_none() {
+                    return Err(AppError::WorkspaceNotFound(workspace.to_string()));
+                }
+                tx.feedback_reports().append(&workspace, &record).await?;
+                tx.commit().await?;
+                Ok(())
+            });
+        }
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
         let file = self.layout.feedback_reports_file(&report.workspace);
         let persisted = PersistedFeedbackReport {
@@ -128,6 +161,55 @@ impl FeedbackManager {
         storage_fs::append_file_private(&file, &line)?;
         Ok(())
     }
+}
+
+fn feedback_record(report: &FeedbackReport) -> Result<FeedbackReportRecord, AppError> {
+    let created_at_unix_nanos = report.created_at.timestamp_nanos_opt().ok_or_else(|| {
+        AppError::FailedPrecondition("feedback timestamp exceeds nanosecond range".to_string())
+    })?;
+    Ok(FeedbackReportRecord {
+        id: report.id.clone(),
+        created_at_unix_nanos,
+        trying_to_do: report.trying_to_do.clone(),
+        tried: report.tried.clone(),
+        stuck: report.stuck.clone(),
+        publish_status: None,
+        publish_error: None,
+        published_at_unix_nanos: None,
+    })
+}
+
+fn run_feedback_db_operation<T, F>(operation: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: Future<Output = Result<T, AppError>> + Send + 'static,
+{
+    fn run_on_runtime<T, F>(operation: F) -> Result<T, AppError>
+    where
+        F: Future<Output = Result<T, AppError>>,
+    {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!(
+                    "failed to create feedback database runtime: {error}"
+                ))
+            })?;
+        runtime.block_on(operation)
+    }
+
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return std::thread::spawn(move || run_on_runtime(operation))
+            .join()
+            .map_err(|_panic| {
+                AppError::FailedPrecondition(
+                    "feedback database operation thread panicked".to_string(),
+                )
+            })?;
+    }
+
+    run_on_runtime(operation)
 }
 
 fn required_text(field: &str, value: &str) -> Result<String, AppError> {
@@ -153,8 +235,9 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{FeedbackManager, FeedbackReport, FeedbackUpload};
-    use crate::feedback::publisher::FeedbackPublisher;
+    use crate::feedback::publisher::{FeedbackPublisher, NoopFeedbackPublisher};
     use crate::state::AppStateLayout;
+    use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
     use crate::workspaces::WorkspaceName;
 
     #[tokio::test]
@@ -205,6 +288,95 @@ mod tests {
             error
                 .to_string()
                 .contains("missing string argument 'tried'")
+        );
+        assert!(!layout.feedback_reports_file(&workspace).exists());
+    }
+
+    #[tokio::test]
+    async fn submit_feedback_with_db_appends_database_record_without_jsonl() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default feedback test DB should be sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let workspace = WorkspaceName::default();
+        let mut tx = db.begin().await.expect("begin workspace tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("ensure workspace");
+        tx.commit().await.expect("commit workspace tx");
+        let manager = FeedbackManager::with_db(
+            layout.clone(),
+            Arc::new(NoopFeedbackPublisher),
+            Arc::clone(&db),
+        );
+
+        let submission = manager
+            .submit_feedback(&workspace, " trying ", " tried ", " stuck ")
+            .expect("feedback should submit");
+
+        let mut session = db.as_ref();
+        let reports = session
+            .feedback_reports()
+            .list_workspace_reports(&workspace)
+            .await
+            .expect("list DB feedback reports");
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].id, submission.report.id);
+        assert_eq!(reports[0].trying_to_do, "trying");
+        assert!(
+            !layout.feedback_reports_file(&workspace).exists(),
+            "DB-backed feedback writes should not append legacy JSONL"
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_feedback_with_db_rejects_missing_workspace_without_creating_it() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default feedback test DB should be sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let workspace = WorkspaceName::parse("missing").expect("workspace");
+        let manager = FeedbackManager::with_db(
+            layout.clone(),
+            Arc::new(NoopFeedbackPublisher),
+            Arc::clone(&db),
+        );
+
+        let error = manager
+            .submit_feedback(&workspace, "trying", "tried", "stuck")
+            .expect_err("feedback should reject missing workspace");
+
+        assert!(
+            error.to_string().contains("workspace 'missing' not found"),
+            "unexpected error: {error}"
+        );
+        let mut session = db.as_ref();
+        assert!(
+            session
+                .workspaces()
+                .get(workspace.as_str())
+                .await
+                .expect("get workspace")
+                .is_none()
         );
         assert!(!layout.feedback_reports_file(&workspace).exists());
     }

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -1,6 +1,49 @@
 //! Shared validation helpers for app-owned identifiers.
 
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Identity document crypto lands before later manager and repository units consume it."
+    )
+)]
+
+use std::collections::BTreeMap;
+
+use zeroize::Zeroizing;
+
 use crate::bootstrap::AppError;
+use crate::credentials::CredentialsError;
+use crate::credentials::encryption::{
+    CREDENTIAL_DOCUMENT_AAD_VERSION, CREDENTIAL_DOCUMENT_ALGORITHM, CredentialKeyProvider,
+    EncryptedEnvelopeDocument, encode_aad_fields, open_envelope_document, rewrap_envelope_document,
+    seal_envelope_document,
+};
+
+/// Envelope algorithm identifier for encrypted identity documents.
+pub(crate) const IDENTITY_DOCUMENT_ALGORITHM: &str = CREDENTIAL_DOCUMENT_ALGORITHM;
+/// AAD layout version for encrypted identity documents.
+pub(crate) const IDENTITY_DOCUMENT_AAD_VERSION: i64 = CREDENTIAL_DOCUMENT_AAD_VERSION;
+
+const IDENTITY_DOCUMENT_VERSION: u32 = 1;
+
+/// Plaintext setup-input values stored for an identity spec document.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct PlaintextIdentitySpecDocument {
+    /// Plaintext identity spec document schema version.
+    pub(crate) version: u32,
+    /// Identity spec setup-input values serialized before envelope encryption.
+    pub(crate) values: BTreeMap<String, String>,
+}
+
+/// Plaintext values stored for an identity instance document.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct PlaintextIdentityDocument {
+    /// Plaintext identity document schema version.
+    pub(crate) version: u32,
+    /// Identity instance values serialized before envelope encryption.
+    pub(crate) values: BTreeMap<String, String>,
+}
 
 pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppError> {
     let trimmed = value.trim();
@@ -20,9 +63,207 @@ pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppE
     Ok(trimmed.to_string())
 }
 
+/// Build AAD for an encrypted identity-spec setup-input document.
+pub(crate) fn identity_spec_document_aad(scope_kind: &str, scope_id: &str, name: &str) -> Vec<u8> {
+    let aad_version = IDENTITY_DOCUMENT_AAD_VERSION.to_string();
+    encode_aad_fields(
+        "coral-identity-spec-document",
+        &[
+            aad_version.as_str(),
+            scope_kind,
+            scope_id,
+            name,
+            IDENTITY_DOCUMENT_ALGORITHM,
+        ],
+    )
+}
+
+/// Build AAD for an encrypted identity instance document.
+pub(crate) fn identity_document_aad(owner_kind: &str, owner_key: &str, name: &str) -> Vec<u8> {
+    let aad_version = IDENTITY_DOCUMENT_AAD_VERSION.to_string();
+    encode_aad_fields(
+        "coral-identity-document",
+        &[
+            aad_version.as_str(),
+            owner_kind,
+            owner_key,
+            name,
+            IDENTITY_DOCUMENT_ALGORITHM,
+        ],
+    )
+}
+
+/// Encrypt an identity-spec setup-input document with the shared app KEK.
+pub(crate) fn encrypt_identity_spec_document(
+    scope_kind: &str,
+    scope_id: &str,
+    name: &str,
+    values: &BTreeMap<String, String>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<EncryptedEnvelopeDocument, CredentialsError> {
+    let plaintext = PlaintextIdentitySpecDocument {
+        version: IDENTITY_DOCUMENT_VERSION,
+        values: values.clone(),
+    };
+    let document_bytes = Zeroizing::new(
+        serde_json::to_vec(&plaintext)
+            .map_err(|error| CredentialsError::Parse(error.to_string()))?,
+    );
+    seal_envelope_document(
+        identity_spec_document_aad(scope_kind, scope_id, name),
+        document_bytes,
+        key_provider,
+    )
+}
+
+/// Decrypt an identity-spec setup-input document with the shared app KEK.
+pub(crate) fn decrypt_identity_spec_document(
+    scope_kind: &str,
+    scope_id: &str,
+    name: &str,
+    document: &EncryptedEnvelopeDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<BTreeMap<String, String>, CredentialsError> {
+    let plaintext = open_envelope_document(
+        document,
+        identity_spec_document_aad(scope_kind, scope_id, name),
+        key_provider,
+    )?;
+    let decoded: PlaintextIdentitySpecDocument = serde_json::from_slice(&plaintext)
+        .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+    if decoded.version != IDENTITY_DOCUMENT_VERSION {
+        return Err(CredentialsError::Parse(format!(
+            "unsupported identity spec document version {}",
+            decoded.version
+        )));
+    }
+    Ok(decoded.values)
+}
+
+/// Rewrap an identity-spec setup-input document when its KEK is stale.
+pub(crate) fn rewrap_identity_spec_document(
+    scope_kind: &str,
+    scope_id: &str,
+    name: &str,
+    document: &EncryptedEnvelopeDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
+    rewrap_envelope_document(
+        document,
+        identity_spec_document_aad(scope_kind, scope_id, name),
+        key_provider,
+    )
+}
+
+/// Encrypt an identity instance document with the shared app KEK.
+pub(crate) fn encrypt_identity_document(
+    owner_kind: &str,
+    owner_key: &str,
+    name: &str,
+    values: &BTreeMap<String, String>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<EncryptedEnvelopeDocument, CredentialsError> {
+    let plaintext = PlaintextIdentityDocument {
+        version: IDENTITY_DOCUMENT_VERSION,
+        values: values.clone(),
+    };
+    let document_bytes = Zeroizing::new(
+        serde_json::to_vec(&plaintext)
+            .map_err(|error| CredentialsError::Parse(error.to_string()))?,
+    );
+    seal_envelope_document(
+        identity_document_aad(owner_kind, owner_key, name),
+        document_bytes,
+        key_provider,
+    )
+}
+
+/// Decrypt an identity instance document with the shared app KEK.
+pub(crate) fn decrypt_identity_document(
+    owner_kind: &str,
+    owner_key: &str,
+    name: &str,
+    document: &EncryptedEnvelopeDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<BTreeMap<String, String>, CredentialsError> {
+    let plaintext = open_envelope_document(
+        document,
+        identity_document_aad(owner_kind, owner_key, name),
+        key_provider,
+    )?;
+    let decoded: PlaintextIdentityDocument = serde_json::from_slice(&plaintext)
+        .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+    if decoded.version != IDENTITY_DOCUMENT_VERSION {
+        return Err(CredentialsError::Parse(format!(
+            "unsupported identity document version {}",
+            decoded.version
+        )));
+    }
+    Ok(decoded.values)
+}
+
+/// Rewrap an identity instance document when its KEK is stale.
+pub(crate) fn rewrap_identity_document(
+    owner_kind: &str,
+    owner_key: &str,
+    name: &str,
+    document: &EncryptedEnvelopeDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
+    rewrap_envelope_document(
+        document,
+        identity_document_aad(owner_kind, owner_key, name),
+        key_provider,
+    )
+}
+
 #[cfg(test)]
 mod tests {
-    use super::parse_path_segment;
+    use super::*;
+    use crate::credentials::encryption::{
+        CredentialEncryptionKey, decrypt_credential_values, encrypt_credential_values,
+    };
+    use crate::sources::SourceName;
+    use crate::workspaces::WorkspaceName;
+
+    #[derive(Clone)]
+    struct StaticKeyProvider {
+        key: CredentialEncryptionKey,
+    }
+
+    impl CredentialKeyProvider for StaticKeyProvider {
+        fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+            Ok(self.key.clone())
+        }
+
+        fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+            if self.key.key_id() == key_id {
+                Ok(self.key.clone())
+            } else {
+                Err(CredentialsError::Crypto("missing test key".to_string()))
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct RotatingKeyProvider {
+        active: CredentialEncryptionKey,
+        keys: Vec<CredentialEncryptionKey>,
+    }
+
+    impl CredentialKeyProvider for RotatingKeyProvider {
+        fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+            Ok(self.active.clone())
+        }
+
+        fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+            self.keys
+                .iter()
+                .find(|key| key.key_id() == key_id)
+                .cloned()
+                .ok_or_else(|| CredentialsError::Crypto("missing test key".to_string()))
+        }
+    }
 
     #[test]
     fn rejects_empty_names() {
@@ -47,6 +288,207 @@ mod tests {
             error
                 .to_string()
                 .contains("source name must not be '.' or '..'")
+        );
+    }
+
+    #[test]
+    fn identity_spec_document_round_trips_and_pins_metadata() {
+        let provider = StaticKeyProvider {
+            key: CredentialEncryptionKey::from_static_bytes_for_test([31; 32]),
+        };
+        let values = BTreeMap::from([("client_secret".to_string(), "secret".to_string())]);
+
+        let encrypted =
+            encrypt_identity_spec_document("workspace", "acme", "github", &values, &provider)
+                .expect("encrypt identity spec document");
+
+        assert_eq!(encrypted.algorithm, IDENTITY_DOCUMENT_ALGORITHM);
+        assert_eq!(encrypted.aad_version, IDENTITY_DOCUMENT_AAD_VERSION);
+        assert_eq!(
+            decrypt_identity_spec_document("workspace", "acme", "github", &encrypted, &provider)
+                .expect("decrypt identity spec document"),
+            values
+        );
+    }
+
+    #[test]
+    fn identity_document_round_trips_and_pins_metadata() {
+        let provider = StaticKeyProvider {
+            key: CredentialEncryptionKey::from_static_bytes_for_test([32; 32]),
+        };
+        let values = BTreeMap::from([("refresh_token".to_string(), "secret".to_string())]);
+
+        let encrypted =
+            encrypt_identity_document("workspace", "acme", "github", &values, &provider)
+                .expect("encrypt identity document");
+
+        assert_eq!(encrypted.algorithm, IDENTITY_DOCUMENT_ALGORITHM);
+        assert_eq!(encrypted.aad_version, IDENTITY_DOCUMENT_AAD_VERSION);
+        assert_eq!(
+            decrypt_identity_document("workspace", "acme", "github", &encrypted, &provider)
+                .expect("decrypt identity document"),
+            values
+        );
+    }
+
+    #[test]
+    fn identity_and_credential_document_domains_are_separated() {
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let source = SourceName::parse("github").expect("source");
+        let provider = StaticKeyProvider {
+            key: CredentialEncryptionKey::from_static_bytes_for_test([33; 32]),
+        };
+        let values = BTreeMap::from([("token".to_string(), "secret".to_string())]);
+
+        let credential = encrypt_credential_values(&workspace, &source, &values, &provider)
+            .expect("encrypt credential");
+        assert_open_failed(
+            &decrypt_identity_spec_document("workspace", "acme", "github", &credential, &provider)
+                .expect_err("credential domain should not open as identity spec"),
+        );
+        assert_open_failed(
+            &decrypt_identity_document("workspace", "acme", "github", &credential, &provider)
+                .expect_err("credential domain should not open as identity document"),
+        );
+
+        let spec =
+            encrypt_identity_spec_document("workspace", "acme", "github", &values, &provider)
+                .expect("encrypt identity spec");
+        assert_open_failed(
+            &decrypt_credential_values(&workspace, &source, &spec, &provider)
+                .expect_err("identity spec domain should not open as credential"),
+        );
+        assert_open_failed(
+            &decrypt_identity_document("workspace", "acme", "github", &spec, &provider)
+                .expect_err("identity spec domain should not open as identity document"),
+        );
+
+        let identity = encrypt_identity_document("workspace", "acme", "github", &values, &provider)
+            .expect("encrypt identity document");
+        assert_open_failed(
+            &decrypt_credential_values(&workspace, &source, &identity, &provider)
+                .expect_err("identity document domain should not open as credential"),
+        );
+        assert_open_failed(
+            &decrypt_identity_spec_document("workspace", "acme", "github", &identity, &provider)
+                .expect_err("identity document domain should not open as identity spec"),
+        );
+    }
+
+    #[test]
+    fn identity_document_aad_is_ordered_and_length_prefixed() {
+        let provider = StaticKeyProvider {
+            key: CredentialEncryptionKey::from_static_bytes_for_test([34; 32]),
+        };
+        let values = BTreeMap::from([("token".to_string(), "secret".to_string())]);
+
+        let spec = encrypt_identity_spec_document("a:b", "c", "github", &values, &provider)
+            .expect("encrypt identity spec");
+        assert_open_failed(
+            &decrypt_identity_spec_document("a", "b:c", "github", &spec, &provider)
+                .expect_err("colon-bearing identity spec fields should stay distinct"),
+        );
+        assert_open_failed(
+            &decrypt_identity_spec_document("c", "a:b", "github", &spec, &provider)
+                .expect_err("identity spec field order should authenticate"),
+        );
+
+        let identity =
+            encrypt_identity_document("owner:kind", "owner", "github", &values, &provider)
+                .expect("encrypt identity document");
+        assert_open_failed(
+            &decrypt_identity_document("owner", "kind:owner", "github", &identity, &provider)
+                .expect_err("colon-bearing identity fields should stay distinct"),
+        );
+        assert_open_failed(
+            &decrypt_identity_document("owner", "owner:kind", "github", &identity, &provider)
+                .expect_err("identity field order should authenticate"),
+        );
+    }
+
+    #[test]
+    fn identity_documents_rewrap_stale_keks_without_reencrypting_payloads() {
+        let old_key = CredentialEncryptionKey::from_static_bytes_for_test([35; 32]);
+        let new_key = CredentialEncryptionKey::from_static_bytes_for_test([36; 32]);
+        let old_provider = RotatingKeyProvider {
+            active: old_key.clone(),
+            keys: vec![old_key.clone()],
+        };
+        let rotating_provider = RotatingKeyProvider {
+            active: new_key.clone(),
+            keys: vec![old_key, new_key.clone()],
+        };
+        let values = BTreeMap::from([("token".to_string(), "secret".to_string())]);
+
+        let spec =
+            encrypt_identity_spec_document("workspace", "acme", "github", &values, &old_provider)
+                .expect("encrypt identity spec");
+        let rewrapped_spec =
+            rewrap_identity_spec_document("workspace", "acme", "github", &spec, &rotating_provider)
+                .expect("rewrap identity spec")
+                .expect("stale spec key should rewrap");
+        assert_rewrapped_document(&spec, &rewrapped_spec, new_key.key_id());
+        assert_eq!(
+            decrypt_identity_spec_document(
+                "workspace",
+                "acme",
+                "github",
+                &rewrapped_spec,
+                &rotating_provider,
+            )
+            .expect("decrypt rewrapped identity spec"),
+            values
+        );
+
+        let identity =
+            encrypt_identity_document("workspace", "acme", "github", &values, &old_provider)
+                .expect("encrypt identity document");
+        let rewrapped_identity =
+            rewrap_identity_document("workspace", "acme", "github", &identity, &rotating_provider)
+                .expect("rewrap identity document")
+                .expect("stale identity key should rewrap");
+        assert_rewrapped_document(&identity, &rewrapped_identity, new_key.key_id());
+        assert_eq!(
+            decrypt_identity_document(
+                "workspace",
+                "acme",
+                "github",
+                &rewrapped_identity,
+                &rotating_provider,
+            )
+            .expect("decrypt rewrapped identity document"),
+            values
+        );
+        assert!(
+            rewrap_identity_document(
+                "workspace",
+                "acme",
+                "github",
+                &rewrapped_identity,
+                &rotating_provider,
+            )
+            .expect("rewrap current identity document")
+            .is_none(),
+            "active KEK should not produce another rewrap"
+        );
+    }
+
+    fn assert_rewrapped_document(
+        original: &EncryptedEnvelopeDocument,
+        rewrapped: &EncryptedEnvelopeDocument,
+        expected_key_id: &str,
+    ) {
+        assert_eq!(rewrapped.key_id, expected_key_id);
+        assert_eq!(rewrapped.ciphertext, original.ciphertext);
+        assert_eq!(rewrapped.nonce, original.nonce);
+        assert_ne!(rewrapped.wrapped_dek, original.wrapped_dek);
+        assert_ne!(rewrapped.wrapped_dek_nonce, original.wrapped_dek_nonce);
+    }
+
+    fn assert_open_failed(error: &CredentialsError) {
+        assert!(
+            error.to_string().contains("open failed"),
+            "unexpected error: {error}"
         );
     }
 }

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -41,12 +41,6 @@
     )
 )]
 
-// Kept only so the dependency-bootstrap PR passes workspace unused-dependency
-// lints before the DB modules that use these crates land upstack.
-use sea_query as _;
-use sea_query_sqlx as _;
-use sqlx as _;
-
 /// Bootstrap entrypoints and local server assembly.
 pub mod bootstrap;
 mod catalog;

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -44,6 +44,7 @@
 /// Bootstrap entrypoints and local server assembly.
 pub mod bootstrap;
 mod catalog;
+mod credential_transport;
 mod credentials;
 mod episode;
 pub mod features;

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -41,6 +41,12 @@
     )
 )]
 
+// Kept only so the dependency-bootstrap PR passes workspace unused-dependency
+// lints before the DB modules that use these crates land upstack.
+use sea_query as _;
+use sea_query_sqlx as _;
+use sqlx as _;
+
 /// Bootstrap entrypoints and local server assembly.
 pub mod bootstrap;
 mod catalog;

--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -16,6 +16,7 @@ use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::sources::model::InstalledSource;
 use crate::state::ConfigStore;
+use crate::state::db::{CoralDb, DbRepos};
 use crate::workspaces::WorkspaceName;
 
 /// App-layer provider that selects engine extensions for one runtime build.
@@ -73,6 +74,7 @@ struct SharedSourceCredentialSnapshot {
 pub(crate) struct CredentialRefreshingInputResolver {
     workspace_name: WorkspaceName,
     config_store: ConfigStore,
+    catalog_db: Option<Arc<CoralDb>>,
     credential_manager: CredentialManager,
     source_credentials: Arc<SourceCredentialSnapshotByName>,
     delegate: Option<Arc<dyn SourceInputResolver>>,
@@ -82,6 +84,7 @@ impl CredentialRefreshingInputResolver {
     pub(crate) fn new(
         workspace_name: WorkspaceName,
         config_store: ConfigStore,
+        catalog_db: Option<Arc<CoralDb>>,
         credential_manager: CredentialManager,
         source_credentials: BTreeMap<String, SourceCredentialSnapshot>,
         delegate: Option<Arc<dyn SourceInputResolver>>,
@@ -101,6 +104,7 @@ impl CredentialRefreshingInputResolver {
         Self {
             workspace_name,
             config_store,
+            catalog_db,
             credential_manager,
             source_credentials: Arc::new(source_credentials),
             delegate,
@@ -183,7 +187,10 @@ impl CredentialRefreshingInputResolver {
             .credential_refresh_lock(&self.workspace_name, &credential_set_id)
             .await
             .map_err(source_input_error)?;
-        if !self.source_config_still_matches_snapshot(&snapshot.source)? {
+        if !self
+            .source_catalog_still_matches_snapshot(&snapshot.source)
+            .await?
+        {
             return self
                 .credential_manager
                 .refresh_material_for_inputs(source.declared_inputs(), material)
@@ -209,10 +216,21 @@ impl CredentialRefreshingInputResolver {
         Ok(())
     }
 
-    fn source_config_still_matches_snapshot(
+    async fn source_catalog_still_matches_snapshot(
         &self,
         snapshot: &InstalledSource,
     ) -> Result<bool, SourceInputResolverError> {
+        if let Some(db) = self.catalog_db.as_ref() {
+            let mut session = db.as_ref();
+            let current = session
+                .sources()
+                .get_source(&self.workspace_name, &snapshot.name)
+                .await
+                .map_err(AppError::from)
+                .map_err(source_input_error)?;
+            return Ok(current.as_ref() == Some(snapshot));
+        }
+
         match self
             .config_store
             .get_source(&self.workspace_name, &snapshot.name)

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -30,10 +30,11 @@ use crate::sources::catalog::{
     validate_imported_manifest_database_persistence,
 };
 use crate::sources::materialization::{
-    incompatible_materialization_error, load_v4_materialization,
+    LoadedV4Materialization, incompatible_materialization_error, load_v4_materialization,
+    load_v4_materialization_from_record,
 };
 use crate::sources::model::{InstalledSource, SourceOrigin};
-use crate::sources::runtime_package::runtime_components_for_v4_source;
+use crate::sources::runtime_package::runtime_components_for_loaded_v4_source;
 use crate::state::db::{CoralDb, DbRepos};
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
@@ -396,6 +397,38 @@ impl QueryManager {
         resolve_installed_manifest_from_yaml(source, &manifest_yaml)
     }
 
+    async fn load_v4_materialization_for_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        manifest_yaml: &str,
+        manifest: &coral_spec::v4::V4SourceManifest,
+    ) -> Result<LoadedV4Materialization, AppError> {
+        if let Some(db) = self.catalog_db.as_ref() {
+            let mut session = db.as_ref();
+            let record = session
+                .materializations()
+                .get(workspace_name, &source.name)
+                .await?
+                .ok_or_else(|| {
+                    incompatible_materialization_error(&source.name, "required artifact is missing")
+                })?;
+            return load_v4_materialization_from_record(
+                &source.name,
+                manifest_yaml,
+                manifest,
+                &record,
+            );
+        }
+        load_v4_materialization(
+            &self.layout,
+            workspace_name,
+            &source.name,
+            manifest_yaml,
+            manifest,
+        )
+    }
+
     async fn load_query_sources_from_installed(
         &self,
         workspace_name: &WorkspaceName,
@@ -445,15 +478,16 @@ impl QueryManager {
             )?;
         }
         let v4_runtime_components = if let Some(v4) = source_spec.as_v4() {
-            let materialized = load_v4_materialization(
-                &self.layout,
-                workspace_name,
-                &source.name,
-                &installed.manifest_yaml,
-                v4,
-            )?;
+            let materialized = self
+                .load_v4_materialization_for_source(
+                    workspace_name,
+                    source,
+                    &installed.manifest_yaml,
+                    v4,
+                )
+                .await?;
             Some(
-                runtime_components_for_v4_source(v4, &materialized).map_err(|error| {
+                runtime_components_for_loaded_v4_source(v4, &materialized).map_err(|error| {
                     incompatible_materialization_error(
                         &source.name,
                         format!("failed to assemble runtime package: {error}"),

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -678,6 +678,7 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::Transport(_) => "TRANSPORT",
         AppError::TaskJoin(_) => "TASK_JOIN",
         AppError::Credentials(_) => "CREDENTIALS",
+        AppError::Database(_) => "DATABASE",
         AppError::MissingConfigDir => "MISSING_CONFIG_DIR",
     }
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -26,7 +26,8 @@ use crate::query::extensions::{
 };
 use crate::sources::SourceName;
 use crate::sources::catalog::{
-    resolve_installed_manifest, validate_imported_manifest_database_persistence,
+    load_bundled_source, resolve_installed_manifest, resolve_installed_manifest_from_yaml,
+    validate_imported_manifest_database_persistence,
 };
 use crate::sources::materialization::{
     incompatible_materialization_error, load_v4_materialization,
@@ -293,6 +294,7 @@ impl QueryManager {
                 .map_err(QueryManagerError::App)?;
             let (loaded_source, version) = self
                 .load_query_source(workspace_name, &source)
+                .await
                 .map_err(QueryManagerError::App)?;
             (source, loaded_source, version, config)
         };
@@ -324,7 +326,9 @@ impl QueryManager {
         let config = self.config_store.load_config_unlocked()?;
         config.require_workspace(workspace_name)?;
         let installed_sources = self.installed_sources(workspace_name, &config).await?;
-        let sources = self.load_query_sources_from_installed(workspace_name, installed_sources)?;
+        let sources = self
+            .load_query_sources_from_installed(workspace_name, installed_sources)
+            .await?;
         Ok((sources, config))
     }
 
@@ -361,7 +365,38 @@ impl QueryManager {
         Ok(config.get_source(workspace_name, source_name))
     }
 
-    fn load_query_sources_from_installed(
+    async fn resolve_source_manifest(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<crate::sources::catalog::InstalledSourceManifest, AppError> {
+        let manifest_yaml = match source.origin {
+            crate::sources::model::SourceOrigin::Bundled => {
+                load_bundled_source(&source.name)?.manifest_yaml
+            }
+            crate::sources::model::SourceOrigin::Imported => {
+                if let Some(db) = self.catalog_db.as_ref() {
+                    let mut session = db.as_ref();
+                    session
+                        .source_manifests()
+                        .get(workspace_name, &source.name)
+                        .await?
+                        .map(|record| record.manifest_yaml)
+                        .ok_or_else(|| {
+                            AppError::SourceNotFound(format!(
+                                "manifest for imported source '{workspace_name}:{}'",
+                                source.name
+                            ))
+                        })?
+                } else {
+                    return resolve_installed_manifest(workspace_name, source, &self.layout);
+                }
+            }
+        };
+        resolve_installed_manifest_from_yaml(source, &manifest_yaml)
+    }
+
+    async fn load_query_sources_from_installed(
         &self,
         workspace_name: &WorkspaceName,
         installed_sources: Vec<InstalledSource>,
@@ -375,7 +410,7 @@ impl QueryManager {
         let _guard = span.enter();
         let mut loaded_sources = Vec::new();
         for source in installed_sources {
-            match self.load_query_source(workspace_name, &source) {
+            match self.load_query_source(workspace_name, &source).await {
                 Ok((loaded_source, _version)) => loaded_sources.push(loaded_source),
                 Err(
                     error @ (AppError::Credentials(CredentialsError::Unavailable(_))
@@ -396,12 +431,12 @@ impl QueryManager {
         Ok(loaded_sources)
     }
 
-    fn load_query_source(
+    async fn load_query_source(
         &self,
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
     ) -> Result<(LoadedQuerySource, Option<String>), AppError> {
-        let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
+        let installed = self.resolve_source_manifest(workspace_name, source).await?;
         let source_spec = installed.source_spec;
         if source.origin == SourceOrigin::Imported {
             validate_imported_manifest_database_persistence(
@@ -1221,8 +1256,8 @@ mod tests {
         assert_eq!(config, 42);
     }
 
-    #[test]
-    fn load_query_source_passes_present_optional_secrets_to_runtime() {
+    #[tokio::test]
+    async fn load_query_source_passes_present_optional_secrets_to_runtime() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = WorkspaceName::default();
@@ -1296,6 +1331,7 @@ tables:
         let (loaded_source, _) = fixture
             .manager
             .load_query_source(&workspace_name, &source)
+            .await
             .expect("optional secret should load when present");
 
         assert_eq!(
@@ -1304,8 +1340,8 @@ tables:
         );
     }
 
-    #[test]
-    fn load_query_source_revalidates_persisted_imported_credential_transport() {
+    #[tokio::test]
+    async fn load_query_source_revalidates_persisted_imported_credential_transport() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = WorkspaceName::default();
@@ -1361,6 +1397,7 @@ tables:
         let error = fixture
             .manager
             .load_query_source(&workspace_name, &source)
+            .await
             .expect_err("persisted imported cleartext credential endpoint should fail");
 
         assert!(error.to_string().contains("base_url must use https"));

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -31,6 +31,7 @@ use crate::sources::materialization::{
 };
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::runtime_components_for_v4_source;
+use crate::state::db::{CoralDb, DbRepos};
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
 use crate::workspaces::WorkspaceName;
@@ -56,6 +57,7 @@ struct LoadedQuerySource {
 #[derive(Clone)]
 pub(crate) struct QueryManager {
     config_store: ConfigStore,
+    catalog_db: Option<Arc<CoralDb>>,
     credential_manager: CredentialManager,
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
@@ -63,6 +65,7 @@ pub(crate) struct QueryManager {
 }
 
 impl QueryManager {
+    #[cfg(test)]
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
@@ -72,6 +75,25 @@ impl QueryManager {
     ) -> Self {
         Self {
             config_store,
+            catalog_db: None,
+            credential_manager,
+            runtime_context,
+            layout,
+            engine_extensions_providers,
+        }
+    }
+
+    pub(crate) fn with_db(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        runtime_context: QueryRuntimeContext,
+        layout: AppStateLayout,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        catalog_db: Arc<CoralDb>,
+    ) -> Self {
+        Self {
+            config_store,
+            catalog_db: Some(catalog_db),
             credential_manager,
             runtime_context,
             layout,
@@ -95,6 +117,7 @@ impl QueryManager {
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
+                    .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &loaded_sources, &config)
@@ -125,6 +148,7 @@ impl QueryManager {
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
+                    .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &loaded_sources, &config)
@@ -166,6 +190,7 @@ impl QueryManager {
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
+                    .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &loaded_sources, &config)
@@ -195,6 +220,7 @@ impl QueryManager {
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
+                    .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &loaded_sources, &config)
@@ -224,6 +250,7 @@ impl QueryManager {
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
+                    .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &loaded_sources, &config)
@@ -256,8 +283,10 @@ impl QueryManager {
             config
                 .require_workspace(workspace_name)
                 .map_err(QueryManagerError::App)?;
-            let source = config
-                .get_source(workspace_name, source_name)
+            let source = self
+                .get_installed_source(workspace_name, source_name, &config)
+                .await
+                .map_err(QueryManagerError::App)?
                 .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
                 .map_err(QueryManagerError::App)?;
             let (loaded_source, version) = self
@@ -285,20 +314,54 @@ impl QueryManager {
         Ok(ValidatedSource { source, report })
     }
 
-    fn load_query_sources(
+    async fn load_query_sources(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<(Vec<LoadedQuerySource>, AppConfig), AppError> {
         let _state_lock = self.config_store.state_lock_shared()?;
         let config = self.config_store.load_config_unlocked()?;
-        let sources = self.load_query_sources_from_config(workspace_name, &config)?;
+        let installed_sources = self.installed_sources(workspace_name, &config).await?;
+        let sources = self.load_query_sources_from_installed(workspace_name, installed_sources)?;
         Ok((sources, config))
     }
 
-    fn load_query_sources_from_config(
+    async fn installed_sources(
         &self,
         workspace_name: &WorkspaceName,
         config: &AppConfig,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        if let Some(db) = self.catalog_db.as_ref() {
+            let mut session = db.as_ref();
+            return session
+                .sources()
+                .list_workspace_sources(workspace_name)
+                .await
+                .map_err(AppError::from);
+        }
+        Ok(config.workspace_sources(workspace_name))
+    }
+
+    async fn get_installed_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        config: &AppConfig,
+    ) -> Result<Option<InstalledSource>, AppError> {
+        if let Some(db) = self.catalog_db.as_ref() {
+            let mut session = db.as_ref();
+            return session
+                .sources()
+                .get_source(workspace_name, source_name)
+                .await
+                .map_err(AppError::from);
+        }
+        Ok(config.get_source(workspace_name, source_name))
+    }
+
+    fn load_query_sources_from_installed(
+        &self,
+        workspace_name: &WorkspaceName,
+        installed_sources: Vec<InstalledSource>,
     ) -> Result<Vec<LoadedQuerySource>, AppError> {
         let span = tracing::info_span!(
             "coral.app.query_sources.load",
@@ -309,7 +372,7 @@ impl QueryManager {
         let _guard = span.enter();
         config.require_workspace(workspace_name)?;
         let mut loaded_sources = Vec::new();
-        for source in config.workspace_sources(workspace_name) {
+        for source in installed_sources {
             match self.load_query_source(workspace_name, &source) {
                 Ok((loaded_source, _version)) => loaded_sources.push(loaded_source),
                 Err(
@@ -431,6 +494,7 @@ impl QueryManager {
         extensions.source_input_resolver = Some(Arc::new(CredentialRefreshingInputResolver::new(
             workspace_name.clone(),
             self.config_store.clone(),
+            self.catalog_db.clone(),
             self.credential_manager.clone(),
             selected_sources
                 .iter()
@@ -1285,8 +1349,8 @@ surfaces:
         );
     }
 
-    #[test]
-    fn load_query_sources_fails_closed_for_missing_v4_materialization() {
+    #[tokio::test]
+    async fn load_query_sources_fails_closed_for_missing_v4_materialization() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = WorkspaceName::default();
@@ -1328,6 +1392,7 @@ surfaces:
         let error = fixture
             .manager
             .load_query_sources(&workspace_name)
+            .await
             .expect_err("missing materialization should fail closed");
 
         assert!(
@@ -1339,8 +1404,8 @@ surfaces:
         );
     }
 
-    #[test]
-    fn load_query_sources_fails_closed_for_unavailable_keychain_source() {
+    #[tokio::test]
+    async fn load_query_sources_fails_closed_for_unavailable_keychain_source() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -1374,6 +1439,7 @@ surfaces:
         );
         let error = manager
             .load_query_sources(&workspace_name)
+            .await
             .expect_err("unavailable keychain should fail closed");
 
         assert!(

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -25,11 +25,13 @@ use crate::query::extensions::{
     engine_extensions_for_providers,
 };
 use crate::sources::SourceName;
-use crate::sources::catalog::resolve_installed_manifest;
+use crate::sources::catalog::{
+    resolve_installed_manifest, validate_imported_manifest_database_persistence,
+};
 use crate::sources::materialization::{
     incompatible_materialization_error, load_v4_materialization,
 };
-use crate::sources::model::InstalledSource;
+use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::sources::runtime_package::runtime_components_for_v4_source;
 use crate::state::db::{CoralDb, DbRepos};
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
@@ -401,6 +403,12 @@ impl QueryManager {
     ) -> Result<(LoadedQuerySource, Option<String>), AppError> {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
         let source_spec = installed.source_spec;
+        if source.origin == SourceOrigin::Imported {
+            validate_imported_manifest_database_persistence(
+                &installed.manifest_yaml,
+                &source.variables,
+            )?;
+        }
         let v4_runtime_components = if let Some(v4) = source_spec.as_v4() {
             let materialized = load_v4_materialization(
                 &self.layout,
@@ -1294,6 +1302,68 @@ tables:
             loaded_source.query_source.secrets(),
             &BTreeMap::from([("OAUTH_TOKEN".to_string(), "oauth-token".to_string())])
         );
+    }
+
+    #[test]
+    fn load_query_source_revalidates_persisted_imported_credential_transport() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("transport_guard").expect("source name");
+        let manifest_path = fixture
+            .manager
+            .layout
+            .manifest_file(&workspace_name, &source_name);
+        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create source dir");
+        std::fs::write(
+            &manifest_path,
+            r#"
+name: transport_guard
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: "{{input.API_BASE}}"
+inputs:
+  API_BASE:
+    kind: variable
+  API_TOKEN:
+    kind: secret
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: bearer
+      key: API_TOKEN
+tables:
+  - name: items
+    description: Items
+    request:
+      path: /items
+    columns:
+      - name: id
+        type: Utf8
+"#,
+        )
+        .expect("write manifest");
+        let source = InstalledSource {
+            name: source_name.clone(),
+            version: Some("0.1.0".to_string()),
+            variables: BTreeMap::from([(
+                "API_BASE".to_string(),
+                "http://api.example.com".to_string(),
+            )]),
+            secrets: vec!["API_TOKEN".to_string()],
+            credential_storage: Some(CredentialStorageKind::File),
+            origin: SourceOrigin::Imported,
+        };
+
+        let error = fixture
+            .manager
+            .load_query_source(&workspace_name, &source)
+            .expect_err("persisted imported cleartext credential endpoint should fail");
+
+        assert!(error.to_string().contains("base_url must use https"));
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -797,6 +797,7 @@ mod tests {
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     use coral_engine::{
         EngineExtensions, QueryExecution, QueryExecutionProvenance, QueryTableFunctionUsage,
@@ -858,6 +859,43 @@ mod tests {
             .expect_err("missing workspace should fail closed");
 
         assert_workspace_not_found(error, &missing_workspace);
+    }
+
+    #[test]
+    fn load_query_sources_waits_for_state_lock() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let guard = config_store
+            .state_lock_exclusive()
+            .expect("hold exclusive state lock");
+        let manager = QueryManager::new(
+            config_store,
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            QueryRuntimeContext::default(),
+            layout,
+            Vec::new(),
+        );
+
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            tokio::runtime::Runtime::new()
+                .expect("runtime")
+                .block_on(manager.load_query_sources(&WorkspaceName::default()))
+                .expect("load query sources");
+            done_tx.send(()).expect("send query load result");
+        });
+
+        assert!(matches!(
+            done_rx.recv_timeout(Duration::from_millis(300)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+        drop(guard);
+        done_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("query load should finish after releasing state lock");
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -320,6 +320,7 @@ impl QueryManager {
     ) -> Result<(Vec<LoadedQuerySource>, AppConfig), AppError> {
         let _state_lock = self.config_store.state_lock_shared()?;
         let config = self.config_store.load_config_unlocked()?;
+        config.require_workspace(workspace_name)?;
         let installed_sources = self.installed_sources(workspace_name, &config).await?;
         let sources = self.load_query_sources_from_installed(workspace_name, installed_sources)?;
         Ok((sources, config))
@@ -370,7 +371,6 @@ impl QueryManager {
         );
         span.record(WORKSPACE_SPAN_ATTRIBUTE, workspace_name.as_str());
         let _guard = span.enter();
-        config.require_workspace(workspace_name)?;
         let mut loaded_sources = Vec::new();
         for source in installed_sources {
             match self.load_query_source(workspace_name, &source) {
@@ -846,19 +846,15 @@ mod tests {
         }
     }
 
-    #[test]
-    fn load_query_sources_fails_closed_for_missing_workspace() {
+    #[tokio::test]
+    async fn load_query_sources_fails_closed_for_missing_workspace() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
         let missing_workspace = WorkspaceName::parse("missing").expect("workspace");
-        let config = fixture
-            .manager
-            .config_store
-            .load_config()
-            .expect("load config");
 
         let error = fixture
             .manager
-            .load_query_sources_from_config(&missing_workspace, &config)
+            .load_query_sources(&missing_workspace)
+            .await
             .expect_err("missing workspace should fail closed");
 
         assert_workspace_not_found(error, &missing_workspace);

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -173,7 +173,7 @@ fn validate_http_source_for_database_persistence(
     http: &coral_spec::backends::http::HttpSourceManifest,
 ) -> Result<(), AppError> {
     let mut needs_transport_guard =
-        validate_http_auth_spec_for_database_persistence(input_kinds, "auth", &http.auth)?;
+        validate_auth_spec_for_database_persistence(input_kinds, "auth", &http.auth)?;
     needs_transport_guard |= validate_headers_for_database_persistence(
         input_kinds,
         "request_headers",
@@ -222,7 +222,7 @@ fn validate_v4_source_for_database_persistence(
     for surface in &v4.surfaces {
         match &surface.runtime {
             coral_spec::v4::SurfaceRuntimeConfig::OpenApi(runtime) => {
-                let mut needs_transport_guard = validate_http_auth_spec_for_database_persistence(
+                let mut needs_transport_guard = validate_auth_spec_for_database_persistence(
                     input_kinds,
                     &format!("surface '{}' auth", surface.id),
                     &runtime.auth,
@@ -274,7 +274,7 @@ fn candidate_from_manifest(
     })
 }
 
-fn validate_http_auth_spec_for_database_persistence(
+pub(crate) fn validate_auth_spec_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     auth: &AuthSpec,
@@ -378,7 +378,7 @@ fn validate_mcp_server_for_database_persistence(
     Ok(())
 }
 
-fn validate_request_headers_for_database_persistence(
+pub(crate) fn validate_request_headers_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     request: &coral_spec::RequestSpec,
@@ -426,7 +426,7 @@ fn validate_request_headers_for_database_persistence(
     Ok(needs_transport_guard)
 }
 
-fn validate_headers_for_database_persistence(
+pub(crate) fn validate_headers_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     headers: &[HeaderSpec],
@@ -528,7 +528,7 @@ fn value_source_references_secret_input(
     }
 }
 
-fn template_references_secret_input(
+pub(crate) fn template_references_secret_input(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     template: &ParsedTemplate,
 ) -> bool {

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -1,8 +1,13 @@
 //! Bundled source catalog and installed-manifest resolution helpers.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
-use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
+use coral_spec::backends::file::{FileObjectStoreSpec, S3AuthSpec};
+use coral_spec::{
+    AuthSpec, BodySpec, HeaderSpec, ManifestInputKind, McpServerSpec, ParsedTemplate,
+    TemplateNamespace, ValidatedSourceManifest, ValueSourceSpec, parse_source_manifest_yaml,
+};
+use serde_json::Value as JsonValue;
 
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
@@ -71,7 +76,14 @@ pub(crate) fn resolve_installed_manifest(
             std::fs::read_to_string(layout.manifest_file(workspace_name, &source.name))?
         }
     };
-    let source_spec = parse_source_manifest_yaml(&manifest_yaml)
+    resolve_installed_manifest_from_yaml(source, &manifest_yaml)
+}
+
+pub(crate) fn resolve_installed_manifest_from_yaml(
+    source: &InstalledSource,
+    manifest_yaml: &str,
+) -> Result<InstalledSourceManifest, AppError> {
+    let source_spec = parse_source_manifest_yaml(manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;
     let mut candidate = candidate_from_manifest(&source_spec, source.origin, false)?;
     if candidate.name != source.name {
@@ -85,7 +97,7 @@ pub(crate) fn resolve_installed_manifest(
     Ok(InstalledSourceManifest {
         source_spec,
         candidate,
-        manifest_yaml,
+        manifest_yaml: manifest_yaml.to_string(),
     })
 }
 
@@ -97,6 +109,90 @@ pub(crate) fn describe_manifest(
     let manifest = parse_source_manifest_yaml(manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;
     candidate_from_manifest(&manifest, origin, installed)
+}
+
+pub(crate) fn validate_imported_manifest_database_persistence(
+    manifest_yaml: &str,
+) -> Result<(), AppError> {
+    let manifest = parse_source_manifest_yaml(manifest_yaml)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    let input_kinds = manifest
+        .declared_inputs()
+        .iter()
+        .map(|input| (input.key.clone(), input.kind))
+        .collect::<BTreeMap<_, _>>();
+
+    if let Some(http) = manifest.as_http() {
+        validate_http_auth_spec_for_database_persistence(&input_kinds, "auth", &http.auth)?;
+        validate_headers_for_database_persistence(
+            &input_kinds,
+            "request_headers",
+            &http.request_headers,
+        )?;
+        for table in &http.tables {
+            validate_request_headers_for_database_persistence(
+                &input_kinds,
+                &format!("table '{}'", table.name()),
+                &table.request,
+            )?;
+            for route in &table.requests {
+                validate_request_headers_for_database_persistence(
+                    &input_kinds,
+                    &format!("table '{}' request route", table.name()),
+                    &route.request,
+                )?;
+            }
+        }
+        for function in &http.functions {
+            validate_request_headers_for_database_persistence(
+                &input_kinds,
+                &format!("function '{}'", function.name),
+                &function.request,
+            )?;
+        }
+    }
+
+    if let Some(file) = manifest.as_file() {
+        for table in &file.tables {
+            validate_file_source_for_database_persistence(
+                &input_kinds,
+                &format!("table '{}'", table.name()),
+                &table.source,
+            )?;
+        }
+    }
+
+    if let Some(mcp) = manifest.as_mcp() {
+        validate_mcp_server_for_database_persistence(&input_kinds, "server", &mcp.server)?;
+    }
+
+    if let Some(v4) = manifest.as_v4() {
+        for surface in &v4.surfaces {
+            match &surface.runtime {
+                coral_spec::v4::SurfaceRuntimeConfig::OpenApi(runtime) => {
+                    validate_http_auth_spec_for_database_persistence(
+                        &input_kinds,
+                        &format!("surface '{}' auth", surface.id),
+                        &runtime.auth,
+                    )?;
+                    validate_headers_for_database_persistence(
+                        &input_kinds,
+                        &format!("surface '{}' request_headers", surface.id),
+                        &runtime.request_headers,
+                    )?;
+                }
+                coral_spec::v4::SurfaceRuntimeConfig::Mcp(runtime) => {
+                    validate_mcp_server_for_database_persistence(
+                        &input_kinds,
+                        &format!("surface '{}' server", surface.id),
+                        &runtime.server,
+                    )?;
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 fn candidate_from_manifest(
@@ -115,6 +211,412 @@ fn candidate_from_manifest(
     })
 }
 
+fn validate_http_auth_spec_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    context: &str,
+    auth: &AuthSpec,
+) -> Result<(), AppError> {
+    match auth {
+        AuthSpec::BasicAuth(basic) => {
+            if basic_auth_username_needs_secret(&basic.username) {
+                validate_secret_template_for_database_persistence(
+                    input_kinds,
+                    &format!("{context}.username"),
+                    &basic.username,
+                )?;
+            }
+            validate_secret_template_for_database_persistence(
+                input_kinds,
+                &format!("{context}.password"),
+                &basic.password,
+            )?;
+        }
+        AuthSpec::HeaderAuth(header_auth) => {
+            validate_headers_for_database_persistence(input_kinds, context, &header_auth.headers)?;
+        }
+        AuthSpec::CustomAuth(custom) => {
+            for (key, value) in &custom.config {
+                validate_custom_auth_value_for_database_persistence(
+                    input_kinds,
+                    &format!("{context}.{key}"),
+                    sensitive_key_name(key),
+                    value,
+                )?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_file_source_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    context: &str,
+    source: &coral_spec::backends::file::FileSourceSpec,
+) -> Result<(), AppError> {
+    let Some(FileObjectStoreSpec::S3 {
+        auth:
+            S3AuthSpec::AccessKey {
+                access_key_id,
+                secret_access_key,
+                session_token,
+            },
+        ..
+    }) = source.object_store.as_ref()
+    else {
+        return Ok(());
+    };
+
+    validate_secret_template_for_database_persistence(
+        input_kinds,
+        &format!("{context} source.object_store.auth.access_key_id"),
+        access_key_id,
+    )?;
+    validate_secret_template_for_database_persistence(
+        input_kinds,
+        &format!("{context} source.object_store.auth.secret_access_key"),
+        secret_access_key,
+    )?;
+    if let Some(session_token) = session_token {
+        validate_secret_template_for_database_persistence(
+            input_kinds,
+            &format!("{context} source.object_store.auth.session_token"),
+            session_token,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_mcp_server_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    context: &str,
+    server: &McpServerSpec,
+) -> Result<(), AppError> {
+    let McpServerSpec::Stdio { env, .. } = server else {
+        return Ok(());
+    };
+    for env in env {
+        if sensitive_key_name(&env.name) {
+            validate_sensitive_value_source_for_database_persistence(
+                input_kinds,
+                &format!("{context} env '{}'", env.name),
+                &env.value,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_request_headers_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    context: &str,
+    request: &coral_spec::RequestSpec,
+) -> Result<(), AppError> {
+    validate_headers_for_database_persistence(
+        input_kinds,
+        &format!("{context} request headers"),
+        &request.headers,
+    )?;
+    for param in &request.query {
+        if sensitive_query_param_name(&param.name) {
+            validate_sensitive_value_source_for_database_persistence(
+                input_kinds,
+                &format!("{context} query param '{}'", param.name),
+                &param.value,
+            )?;
+        }
+    }
+    match &request.body {
+        BodySpec::Json { fields } => {
+            for field in fields {
+                if field.path.iter().any(|segment| sensitive_key_name(segment)) {
+                    validate_sensitive_value_source_for_database_persistence(
+                        input_kinds,
+                        &format!("{context} body field '{}'", field.path.join(".")),
+                        &field.value,
+                    )?;
+                }
+            }
+        }
+        BodySpec::Text { content } => {
+            validate_text_body_for_database_persistence(
+                input_kinds,
+                &format!("{context} request body text"),
+                content,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_headers_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    context: &str,
+    headers: &[HeaderSpec],
+) -> Result<(), AppError> {
+    for header in headers {
+        if sensitive_http_header_name(&header.name) {
+            validate_sensitive_value_source_for_database_persistence(
+                input_kinds,
+                &format!("{context} header '{}'", header.name),
+                &header.value,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn basic_auth_username_needs_secret(template: &ParsedTemplate) -> bool {
+    template_contains_sensitive_marker(template)
+}
+
+fn template_contains_sensitive_marker(template: &ParsedTemplate) -> bool {
+    text_body_contains_sensitive_marker(template.raw())
+        || template.tokens().any(|token| {
+            token.namespace() == &TemplateNamespace::Input && sensitive_key_name(token.key())
+        })
+}
+
+fn validate_sensitive_value_source_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    context: &str,
+    value: &ValueSourceSpec,
+) -> Result<(), AppError> {
+    match value {
+        ValueSourceSpec::Template { template } => {
+            validate_secret_template_for_database_persistence(input_kinds, context, template)
+        }
+        ValueSourceSpec::OneOf { values } => {
+            for value in values {
+                validate_sensitive_value_source_for_database_persistence(
+                    input_kinds,
+                    context,
+                    value,
+                )?;
+            }
+            Ok(())
+        }
+        ValueSourceSpec::Input { key } | ValueSourceSpec::Bearer { key } => {
+            require_secret_input_for_database_persistence(input_kinds, context, key)
+        }
+        ValueSourceSpec::Literal { .. }
+        | ValueSourceSpec::Filter { .. }
+        | ValueSourceSpec::FilterInt { .. }
+        | ValueSourceSpec::FilterBool { .. }
+        | ValueSourceSpec::FilterStringArray { .. }
+        | ValueSourceSpec::FilterSplit { .. }
+        | ValueSourceSpec::FilterSplitInt { .. }
+        | ValueSourceSpec::Arg { .. }
+        | ValueSourceSpec::ArgInt { .. }
+        | ValueSourceSpec::ArgBool { .. }
+        | ValueSourceSpec::ArgSplit { .. }
+        | ValueSourceSpec::ArgSplitInt { .. }
+        | ValueSourceSpec::State { .. }
+        | ValueSourceSpec::NowEpochMinusSeconds { .. } => Err(AppError::InvalidInput(format!(
+            "{context} must reference a secret input before an imported manifest can be stored in the database"
+        ))),
+    }
+}
+
+fn validate_text_body_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    context: &str,
+    value: &ValueSourceSpec,
+) -> Result<(), AppError> {
+    if text_body_value_source_needs_secret(value) {
+        validate_sensitive_value_source_for_database_persistence(input_kinds, context, value)?;
+    }
+    Ok(())
+}
+
+fn text_body_value_source_needs_secret(value: &ValueSourceSpec) -> bool {
+    match value {
+        ValueSourceSpec::Template { template } => template_contains_sensitive_marker(template),
+        ValueSourceSpec::OneOf { values } => values.iter().any(text_body_value_source_needs_secret),
+        ValueSourceSpec::Literal { value } => json_value_contains_sensitive_marker(value),
+        ValueSourceSpec::Input { key } => sensitive_key_name(key),
+        ValueSourceSpec::Bearer { .. } => true,
+        ValueSourceSpec::Filter { default, .. } | ValueSourceSpec::Arg { default, .. } => default
+            .as_ref()
+            .is_some_and(json_value_contains_sensitive_marker),
+        ValueSourceSpec::FilterInt { .. }
+        | ValueSourceSpec::FilterBool { .. }
+        | ValueSourceSpec::FilterStringArray { .. }
+        | ValueSourceSpec::FilterSplit { .. }
+        | ValueSourceSpec::FilterSplitInt { .. }
+        | ValueSourceSpec::ArgInt { .. }
+        | ValueSourceSpec::ArgBool { .. }
+        | ValueSourceSpec::ArgSplit { .. }
+        | ValueSourceSpec::ArgSplitInt { .. }
+        | ValueSourceSpec::State { .. }
+        | ValueSourceSpec::NowEpochMinusSeconds { .. } => false,
+    }
+}
+
+fn json_value_contains_sensitive_marker(value: &JsonValue) -> bool {
+    match value {
+        JsonValue::String(value) => text_body_contains_sensitive_marker(value),
+        JsonValue::Array(values) => values.iter().any(json_value_contains_sensitive_marker),
+        JsonValue::Object(map) => map.iter().any(|(key, value)| {
+            sensitive_key_name(key) || json_value_contains_sensitive_marker(value)
+        }),
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => false,
+    }
+}
+
+fn text_body_contains_sensitive_marker(raw: &str) -> bool {
+    if raw
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .any(|word| word.eq_ignore_ascii_case("bearer"))
+        || raw.to_ascii_uppercase().contains("BEGIN PRIVATE KEY")
+    {
+        return true;
+    }
+
+    raw.split(['&', '\n', ',', '{', '}']).any(|part| {
+        let Some((key, _)) = part.split_once('=').or_else(|| part.split_once(':')) else {
+            return false;
+        };
+        let key = key.trim_matches(|ch: char| {
+            ch.is_ascii_whitespace() || ch == '"' || ch == '\'' || ch == '-'
+        });
+        sensitive_key_name(key)
+    })
+}
+
+fn validate_custom_auth_value_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    context: &str,
+    sensitive_context: bool,
+    value: &JsonValue,
+) -> Result<(), AppError> {
+    match value {
+        JsonValue::Object(map) => {
+            for (key, value) in map {
+                validate_custom_auth_value_for_database_persistence(
+                    input_kinds,
+                    &format!("{context}.{key}"),
+                    sensitive_context || sensitive_key_name(key),
+                    value,
+                )?;
+            }
+            Ok(())
+        }
+        JsonValue::Array(values) => {
+            for (index, value) in values.iter().enumerate() {
+                validate_custom_auth_value_for_database_persistence(
+                    input_kinds,
+                    &format!("{context}[{index}]"),
+                    sensitive_context,
+                    value,
+                )?;
+            }
+            Ok(())
+        }
+        JsonValue::String(raw) if sensitive_context => {
+            let template = ParsedTemplate::parse(raw)
+                .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+            validate_secret_template_for_database_persistence(input_kinds, context, &template)
+        }
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => {
+            Ok(())
+        }
+    }
+}
+
+fn validate_secret_template_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    context: &str,
+    template: &ParsedTemplate,
+) -> Result<(), AppError> {
+    let mut saw_input = false;
+    for token in template.tokens() {
+        if token.namespace() != &TemplateNamespace::Input {
+            continue;
+        }
+        saw_input = true;
+        require_secret_input_for_database_persistence(input_kinds, context, token.key())?;
+    }
+    if !saw_input {
+        return Err(AppError::InvalidInput(format!(
+            "{context} must reference a secret input before an imported manifest can be stored in the database"
+        )));
+    }
+    Ok(())
+}
+
+fn require_secret_input_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    context: &str,
+    key: &str,
+) -> Result<(), AppError> {
+    match input_kinds.get(key) {
+        Some(ManifestInputKind::Secret) => Ok(()),
+        Some(ManifestInputKind::Variable) => Err(AppError::InvalidInput(format!(
+            "{context} must reference a secret input before an imported manifest can be stored in the database; '{key}' is a variable"
+        ))),
+        None => Err(AppError::InvalidInput(format!(
+            "{context} references undeclared input '{key}'"
+        ))),
+    }
+}
+
+fn sensitive_http_header_name(name: &str) -> bool {
+    let compact = compact_key_name(name);
+    matches!(compact.as_str(), "COOKIE" | "PROXYAUTHORIZATION") || sensitive_key_name(name)
+}
+
+fn sensitive_query_param_name(name: &str) -> bool {
+    let compact = compact_key_name(name);
+    if pagination_query_param_name(&compact) {
+        return false;
+    }
+    sensitive_key_name(name)
+}
+
+fn pagination_query_param_name(compact: &str) -> bool {
+    matches!(
+        compact,
+        "PAGETOKEN"
+            | "NEXTPAGETOKEN"
+            | "CURSORTOKEN"
+            | "NEXTCURSORTOKEN"
+            | "CONTINUATIONTOKEN"
+            | "NEXTTOKEN"
+    ) || (compact.contains("PAGE") && compact.ends_with("TOKEN"))
+        || (compact.contains("CURSOR") && compact.ends_with("TOKEN"))
+}
+
+fn sensitive_key_name(name: &str) -> bool {
+    const SENSITIVE_SUFFIXES: &[&str] = &[
+        "AUTHORIZATION",
+        "APIKEY",
+        "APPLICATIONKEY",
+        "ACCESSKEY",
+        "ACCESSKEYID",
+        "ACCESSTOKEN",
+        "AUTH",
+        "AUTHTOKEN",
+        "BEARERTOKEN",
+        "CLIENTSECRET",
+        "CONSUMERKEY",
+        "PASSWORD",
+        "PRIVATEKEY",
+        "SECRET",
+        "TOKEN",
+    ];
+    let compact = compact_key_name(name);
+    SENSITIVE_SUFFIXES
+        .iter()
+        .any(|suffix| compact.ends_with(suffix))
+}
+
+fn compact_key_name(name: &str) -> String {
+    name.chars()
+        .filter(char::is_ascii_alphanumeric)
+        .map(|ch| ch.to_ascii_uppercase())
+        .collect::<String>()
+}
+
 #[cfg(test)]
 mod tests {
     #![expect(
@@ -126,9 +628,60 @@ mod tests {
 
     use coral_spec::ManifestInputKind;
 
-    use super::{describe_manifest, list_bundled_sources, load_bundled_source};
+    use super::{
+        describe_manifest, list_bundled_sources, load_bundled_source,
+        validate_imported_manifest_database_persistence,
+    };
     use crate::sources::SourceName;
     use crate::sources::model::SourceOrigin;
+
+    fn minimal_http_manifest(extra_top_level: &str) -> String {
+        format!(
+            "name: demo\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: https://example.com\n{extra_top_level}tables:\n  - name: messages\n    description: Demo messages\n    request:\n      method: GET\n      path: /messages\n    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
+        )
+    }
+
+    fn minimal_http_manifest_with_request(request_extra: &str) -> String {
+        format!(
+            "name: demo\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: https://example.com\ntables:\n  - name: messages\n    description: Demo messages\n    filters:\n      - name: page_token\n    request:\n      method: GET\n      path: /messages\n{request_extra}    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
+        )
+    }
+
+    fn minimal_v4_openapi_manifest(surface_extra: &str) -> String {
+        format!(
+            "name: demo\ndsl_version: 4\nsurfaces:\n  - id: rest\n    type: openapi\n    file: /tmp/openapi.yaml\n{surface_extra}"
+        )
+    }
+
+    fn minimal_http_manifest_with_route(route_extra: &str) -> String {
+        format!(
+            "name: demo\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: https://example.com\ntables:\n  - name: messages\n    description: Demo messages\n    filters:\n      - name: id\n    request:\n      method: GET\n      path: /messages\n    requests:\n      - when_filters:\n          - id\n        method: GET\n        path: /messages/{{{{filter.id}}}}\n{route_extra}    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
+        )
+    }
+
+    fn minimal_http_function_manifest(request_extra: &str) -> String {
+        format!(
+            "name: demo\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: https://example.com\nfunctions:\n  - name: search_messages\n    args:\n      - name: q\n        bind:\n          arg: q\n    request:\n      method: GET\n      path: /search\n{request_extra}    columns:\n      - name: id\n        type: Utf8\n"
+        )
+    }
+
+    fn minimal_file_manifest(inputs: &str, object_store: &str) -> String {
+        format!(
+            "name: demo\nversion: 1.0.0\ndsl_version: 3\nbackend: file\n{inputs}tables:\n  - name: objects\n    description: Demo objects\n    format: jsonl\n    source:\n      location: s3://demo-bucket/objects/\n{object_store}    columns:\n      - name: id\n        type: Utf8\n"
+        )
+    }
+
+    fn minimal_mcp_manifest(server_extra: &str) -> String {
+        format!(
+            "name: demo\nversion: 1.0.0\ndsl_version: 3\nbackend: mcp\nserver:\n{server_extra}functions:\n  - name: search_messages\n    tool: search\n    columns:\n      - name: result\n        type: Utf8\n"
+        )
+    }
+
+    fn minimal_v4_mcp_manifest(server_extra: &str) -> String {
+        format!(
+            "name: demo\ndsl_version: 4\nsurfaces:\n  - id: mcp\n    type: mcp\n    server:\n{server_extra}"
+        )
+    }
 
     #[test]
     fn bundled_sources_load_through_catalog() {
@@ -233,5 +786,206 @@ tables:
         let message = error.to_string();
         assert!(message.starts_with("invalid input: source manifest failed schema validation:"));
         assert!(message.contains("'schema'"));
+    }
+
+    #[test]
+    fn database_persistence_rejects_literal_sensitive_values() {
+        let cases = [
+            (
+                minimal_http_manifest(
+                    "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: literal\n      value: Bearer hardcoded-token\n",
+                ),
+                "auth header 'Authorization' must reference a secret input",
+            ),
+            (
+                minimal_http_manifest(
+                    "auth:\n  type: BasicAuth\n  username: user\n  password: hardcoded-password\n",
+                ),
+                "auth.password must reference a secret input",
+            ),
+            (
+                minimal_http_manifest(
+                    "auth:\n  type: CustomAuth\n  authenticator: demo_auth\n  nested:\n    password: hardcoded-password\n",
+                ),
+                "auth.nested.password must reference a secret input",
+            ),
+            (
+                minimal_http_manifest(
+                    "request_headers:\n  - name: X-ApiKey\n    from: literal\n    value: hardcoded-key\n",
+                ),
+                "request_headers header 'X-ApiKey' must reference a secret input",
+            ),
+            (
+                minimal_http_manifest_with_request(
+                    "      query:\n        - name: api_key\n          from: literal\n          value: hardcoded-key\n",
+                ),
+                "table 'messages' query param 'api_key' must reference a secret input",
+            ),
+            (
+                minimal_http_manifest_with_request(
+                    "      body:\n        - path: [credentials, password]\n          from: literal\n          value: hardcoded-password\n",
+                ),
+                "table 'messages' body field 'credentials.password' must reference a secret input",
+            ),
+            (
+                minimal_http_manifest_with_request(
+                    "      body:\n        format: text\n        content:\n          from: literal\n          value: \"api_key=hardcoded-key\"\n",
+                ),
+                "table 'messages' request body text must reference a secret input",
+            ),
+            (
+                minimal_v4_openapi_manifest(
+                    "    auth:\n      type: HeaderAuth\n      headers:\n        - name: Authorization\n          from: literal\n          value: Bearer hardcoded-token\n",
+                ),
+                "surface 'rest' auth header 'Authorization' must reference a secret input",
+            ),
+            (
+                minimal_v4_openapi_manifest(
+                    "    request_headers:\n      - name: Cookie\n        from: literal\n        value: session=hardcoded-token\n",
+                ),
+                "surface 'rest' request_headers header 'Cookie' must reference a secret input",
+            ),
+            (
+                minimal_http_manifest(
+                    "auth:\n  type: HeaderAuth\n  headers:\n    - name: Cookie\n      from: literal\n      value: session=hardcoded-token\n",
+                ),
+                "auth header 'Cookie' must reference a secret input",
+            ),
+            (
+                minimal_http_manifest_with_route(
+                    "        headers:\n          - name: Authorization\n            from: literal\n            value: Bearer hardcoded-token\n",
+                ),
+                "table 'messages' request route request headers header 'Authorization' must reference a secret input",
+            ),
+            (
+                minimal_http_function_manifest(
+                    "      headers:\n        - name: Authorization\n          from: literal\n          value: Bearer hardcoded-token\n",
+                ),
+                "function 'search_messages' request headers header 'Authorization' must reference a secret input",
+            ),
+        ];
+
+        for (manifest, expected) in cases {
+            let error = validate_imported_manifest_database_persistence(&manifest)
+                .expect_err("literal sensitive value should be rejected");
+            assert!(
+                error.to_string().contains(expected),
+                "expected {expected:?}, got {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn database_persistence_rejects_basic_auth_username_when_it_is_credential_marked() {
+        let error = validate_imported_manifest_database_persistence(&minimal_http_manifest(
+            "inputs:\n  WOOCOMMERCE_CONSUMER_KEY:\n    kind: variable\n  API_PASSWORD:\n    kind: secret\nauth:\n  type: BasicAuth\n  username: \"{{input.WOOCOMMERCE_CONSUMER_KEY}}\"\n  password: \"{{input.API_PASSWORD}}\"\n",
+        ))
+        .expect_err("credential-marked BasicAuth username should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("auth.username must reference a secret input"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn database_persistence_rejects_one_of_sensitive_fallbacks() {
+        let error = validate_imported_manifest_database_persistence(&minimal_http_manifest(
+            "inputs:\n  API_TOKEN:\n    kind: secret\nauth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: one_of\n      values:\n        - from: input\n          key: API_TOKEN\n        - from: literal\n          value: Bearer fallback-token\n",
+        ))
+        .expect_err("literal one_of fallback should be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("auth header 'Authorization' must reference a secret input"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn database_persistence_rejects_file_s3_credentials_not_backed_by_secret_inputs() {
+        let cases = [
+            (
+                minimal_file_manifest(
+                    "inputs:\n  AWS_SECRET_ACCESS_KEY:\n    kind: secret\n",
+                    "      object_store:\n        type: s3\n        auth:\n          type: access_key\n          access_key_id: hardcoded-access-key\n          secret_access_key: \"{{input.AWS_SECRET_ACCESS_KEY}}\"\n",
+                ),
+                "source.object_store.auth.access_key_id must reference a secret input",
+            ),
+            (
+                minimal_file_manifest(
+                    "inputs:\n  AWS_ACCESS_KEY_ID:\n    kind: secret\n",
+                    "      object_store:\n        type: s3\n        auth:\n          type: access_key\n          access_key_id: \"{{input.AWS_ACCESS_KEY_ID}}\"\n          secret_access_key: hardcoded-secret-key\n",
+                ),
+                "source.object_store.auth.secret_access_key must reference a secret input",
+            ),
+            (
+                minimal_file_manifest(
+                    "inputs:\n  AWS_ACCESS_KEY_ID:\n    kind: secret\n  AWS_SECRET_ACCESS_KEY:\n    kind: secret\n",
+                    "      object_store:\n        type: s3\n        auth:\n          type: access_key\n          access_key_id: \"{{input.AWS_ACCESS_KEY_ID}}\"\n          secret_access_key: \"{{input.AWS_SECRET_ACCESS_KEY}}\"\n          session_token: hardcoded-session-token\n",
+                ),
+                "source.object_store.auth.session_token must reference a secret input",
+            ),
+        ];
+
+        for (manifest, expected) in cases {
+            let error = validate_imported_manifest_database_persistence(&manifest)
+                .expect_err("S3 credential should be rejected");
+            assert!(
+                error.to_string().contains(expected),
+                "expected {expected:?}, got {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn database_persistence_rejects_sensitive_mcp_stdio_env_values() {
+        let cases = [
+            (
+                minimal_mcp_manifest(
+                    "  transport: stdio\n  command: demo-mcp\n  env:\n    - name: API_TOKEN\n      from: literal\n      value: hardcoded-token\n",
+                ),
+                "server env 'API_TOKEN' must reference a secret input",
+            ),
+            (
+                minimal_v4_mcp_manifest(
+                    "      transport: stdio\n      command: demo-mcp\n      env:\n        - name: API_TOKEN\n          from: literal\n          value: hardcoded-token\n",
+                ),
+                "surface 'mcp' server env 'API_TOKEN' must reference a secret input",
+            ),
+        ];
+
+        for (manifest, expected) in cases {
+            let error = validate_imported_manifest_database_persistence(&manifest)
+                .expect_err("sensitive MCP env value should be rejected");
+            assert!(
+                error.to_string().contains(expected),
+                "expected {expected:?}, got {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn database_persistence_allows_literal_non_secret_headers() {
+        validate_imported_manifest_database_persistence(&minimal_http_manifest("auth:\n  type: HeaderAuth\n  headers:\n    - name: Travis-API-Version\n      from: literal\n      value: \"3\"\nrequest_headers:\n  - name: Accept\n    from: literal\n    value: application/json\n"))
+        .expect("non-secret literal headers should be allowed");
+
+        validate_imported_manifest_database_persistence(&minimal_http_manifest_with_request("      body:\n        format: text\n        content:\n          from: literal\n          value: \"SELECT id, name FROM users FORMAT JSONEachRow\"\n"))
+        .expect("non-secret literal text bodies should be allowed");
+
+        validate_imported_manifest_database_persistence(&minimal_http_manifest_with_request("      query:\n        - name: page_token\n          from: filter\n          key: page_token\n"))
+        .expect("pagination token filters should not be treated as credentials");
+    }
+
+    #[test]
+    fn database_persistence_allows_sensitive_header_from_secret_input() {
+        validate_imported_manifest_database_persistence(&minimal_http_manifest("inputs:\n  API_TOKEN:\n    kind: secret\nauth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n"))
+        .expect("secret-backed auth header should be allowed");
+
+        validate_imported_manifest_database_persistence(&minimal_http_manifest("inputs:\n  API_PASSWORD:\n    kind: secret\nauth:\n  type: BasicAuth\n  username: public-user\n  password: \"{{input.API_PASSWORD}}\"\n"))
+        .expect("public BasicAuth username should be allowed with a secret-backed password");
     }
 }

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -4,12 +4,14 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use coral_spec::backends::file::{FileObjectStoreSpec, S3AuthSpec};
 use coral_spec::{
-    AuthSpec, BodySpec, HeaderSpec, ManifestInputKind, McpServerSpec, ParsedTemplate,
-    TemplateNamespace, ValidatedSourceManifest, ValueSourceSpec, parse_source_manifest_yaml,
+    AuthSpec, BodySpec, HeaderSpec, ManifestCredentialMethodKind, ManifestInputKind,
+    ManifestInputSpec, McpServerSpec, ParsedTemplate, TemplateNamespace, TemplatePart,
+    ValidatedSourceManifest, ValueSourceSpec, parse_source_manifest_yaml,
 };
 use serde_json::Value as JsonValue;
 
 use crate::bootstrap::AppError;
+use crate::credential_transport::validate_credential_endpoint_transport;
 use crate::sources::SourceName;
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
@@ -113,6 +115,20 @@ pub(crate) fn describe_manifest(
 
 pub(crate) fn validate_imported_manifest_database_persistence(
     manifest_yaml: &str,
+    source_variables: &BTreeMap<String, String>,
+) -> Result<(), AppError> {
+    validate_imported_manifest_database_persistence_inner(manifest_yaml, Some(source_variables))
+}
+
+pub(crate) fn validate_imported_manifest_database_persistence_shape(
+    manifest_yaml: &str,
+) -> Result<(), AppError> {
+    validate_imported_manifest_database_persistence_inner(manifest_yaml, None)
+}
+
+fn validate_imported_manifest_database_persistence_inner(
+    manifest_yaml: &str,
+    source_variables: Option<&BTreeMap<String, String>>,
 ) -> Result<(), AppError> {
     let manifest = parse_source_manifest_yaml(manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;
@@ -123,33 +139,11 @@ pub(crate) fn validate_imported_manifest_database_persistence(
         .collect::<BTreeMap<_, _>>();
 
     if let Some(http) = manifest.as_http() {
-        validate_http_auth_spec_for_database_persistence(&input_kinds, "auth", &http.auth)?;
-        validate_headers_for_database_persistence(
-            &input_kinds,
-            "request_headers",
-            &http.request_headers,
-        )?;
-        for table in &http.tables {
-            validate_request_headers_for_database_persistence(
-                &input_kinds,
-                &format!("table '{}'", table.name()),
-                &table.request,
-            )?;
-            for route in &table.requests {
-                validate_request_headers_for_database_persistence(
-                    &input_kinds,
-                    &format!("table '{}' request route", table.name()),
-                    &route.request,
-                )?;
-            }
-        }
-        for function in &http.functions {
-            validate_request_headers_for_database_persistence(
-                &input_kinds,
-                &format!("function '{}'", function.name),
-                &function.request,
-            )?;
-        }
+        validate_http_source_for_database_persistence(&input_kinds, source_variables, http)?;
+    }
+
+    if let Some(source_variables) = source_variables {
+        validate_oauth_endpoint_transports(manifest.declared_inputs(), source_variables)?;
     }
 
     if let Some(file) = manifest.as_file() {
@@ -167,31 +161,100 @@ pub(crate) fn validate_imported_manifest_database_persistence(
     }
 
     if let Some(v4) = manifest.as_v4() {
-        for surface in &v4.surfaces {
-            match &surface.runtime {
-                coral_spec::v4::SurfaceRuntimeConfig::OpenApi(runtime) => {
-                    validate_http_auth_spec_for_database_persistence(
-                        &input_kinds,
-                        &format!("surface '{}' auth", surface.id),
-                        &runtime.auth,
-                    )?;
-                    validate_headers_for_database_persistence(
-                        &input_kinds,
-                        &format!("surface '{}' request_headers", surface.id),
-                        &runtime.request_headers,
-                    )?;
-                }
-                coral_spec::v4::SurfaceRuntimeConfig::Mcp(runtime) => {
-                    validate_mcp_server_for_database_persistence(
-                        &input_kinds,
-                        &format!("surface '{}' server", surface.id),
-                        &runtime.server,
+        validate_v4_source_for_database_persistence(&input_kinds, source_variables, v4)?;
+    }
+
+    Ok(())
+}
+
+fn validate_http_source_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    source_variables: Option<&BTreeMap<String, String>>,
+    http: &coral_spec::backends::http::HttpSourceManifest,
+) -> Result<(), AppError> {
+    let mut needs_transport_guard =
+        validate_http_auth_spec_for_database_persistence(input_kinds, "auth", &http.auth)?;
+    needs_transport_guard |= validate_headers_for_database_persistence(
+        input_kinds,
+        "request_headers",
+        &http.request_headers,
+    )?;
+    for table in &http.tables {
+        needs_transport_guard |= validate_request_headers_for_database_persistence(
+            input_kinds,
+            &format!("table '{}'", table.name()),
+            &table.request,
+        )?;
+        for route in &table.requests {
+            needs_transport_guard |= validate_request_headers_for_database_persistence(
+                input_kinds,
+                &format!("table '{}' request route", table.name()),
+                &route.request,
+            )?;
+        }
+    }
+    for function in &http.functions {
+        needs_transport_guard |= validate_request_headers_for_database_persistence(
+            input_kinds,
+            &format!("function '{}'", function.name),
+            &function.request,
+        )?;
+    }
+    needs_transport_guard |= template_references_secret_input(input_kinds, &http.base_url);
+    if let Some(source_variables) = source_variables
+        && needs_transport_guard
+    {
+        validate_endpoint_template_transport(
+            input_kinds,
+            source_variables,
+            "base_url",
+            &http.base_url,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_v4_source_for_database_persistence(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    source_variables: Option<&BTreeMap<String, String>>,
+    v4: &coral_spec::v4::V4SourceManifest,
+) -> Result<(), AppError> {
+    for surface in &v4.surfaces {
+        match &surface.runtime {
+            coral_spec::v4::SurfaceRuntimeConfig::OpenApi(runtime) => {
+                let mut needs_transport_guard = validate_http_auth_spec_for_database_persistence(
+                    input_kinds,
+                    &format!("surface '{}' auth", surface.id),
+                    &runtime.auth,
+                )?;
+                needs_transport_guard |= validate_headers_for_database_persistence(
+                    input_kinds,
+                    &format!("surface '{}' request_headers", surface.id),
+                    &runtime.request_headers,
+                )?;
+                needs_transport_guard |=
+                    template_references_secret_input(input_kinds, &runtime.base_url);
+                if let Some(source_variables) = source_variables
+                    && needs_transport_guard
+                    && !runtime.base_url.is_empty()
+                {
+                    validate_endpoint_template_transport(
+                        input_kinds,
+                        source_variables,
+                        &format!("surface '{}' base_url", surface.id),
+                        &runtime.base_url,
                     )?;
                 }
             }
+            coral_spec::v4::SurfaceRuntimeConfig::Mcp(runtime) => {
+                validate_mcp_server_for_database_persistence(
+                    input_kinds,
+                    &format!("surface '{}' server", surface.id),
+                    &runtime.server,
+                )?;
+            }
         }
     }
-
     Ok(())
 }
 
@@ -215,8 +278,8 @@ fn validate_http_auth_spec_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     auth: &AuthSpec,
-) -> Result<(), AppError> {
-    match auth {
+) -> Result<bool, AppError> {
+    let needs_transport_guard = match auth {
         AuthSpec::BasicAuth(basic) => {
             if basic_auth_username_needs_secret(&basic.username) {
                 validate_secret_template_for_database_persistence(
@@ -230,22 +293,31 @@ fn validate_http_auth_spec_for_database_persistence(
                 &format!("{context}.password"),
                 &basic.password,
             )?;
+            true
         }
         AuthSpec::HeaderAuth(header_auth) => {
-            validate_headers_for_database_persistence(input_kinds, context, &header_auth.headers)?;
+            validate_headers_for_database_persistence(input_kinds, context, &header_auth.headers)?
         }
         AuthSpec::CustomAuth(custom) => {
+            let mut found = false;
             for (key, value) in &custom.config {
-                validate_custom_auth_value_for_database_persistence(
+                found |= validate_custom_auth_value_for_database_persistence(
                     input_kinds,
                     &format!("{context}.{key}"),
                     sensitive_key_name(key),
                     value,
                 )?;
             }
+            found || declares_secret_input(input_kinds)
         }
-    }
-    Ok(())
+    };
+    Ok(needs_transport_guard)
+}
+
+fn declares_secret_input(input_kinds: &BTreeMap<String, ManifestInputKind>) -> bool {
+    input_kinds
+        .values()
+        .any(|kind| *kind == ManifestInputKind::Secret)
 }
 
 fn validate_file_source_for_database_persistence(
@@ -310,59 +382,68 @@ fn validate_request_headers_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     request: &coral_spec::RequestSpec,
-) -> Result<(), AppError> {
-    validate_headers_for_database_persistence(
+) -> Result<bool, AppError> {
+    let mut needs_transport_guard = template_references_secret_input(input_kinds, &request.path);
+    needs_transport_guard |= validate_headers_for_database_persistence(
         input_kinds,
         &format!("{context} request headers"),
         &request.headers,
     )?;
     for param in &request.query {
+        needs_transport_guard |= value_source_references_secret_input(input_kinds, &param.value);
         if sensitive_query_param_name(&param.name) {
             validate_sensitive_value_source_for_database_persistence(
                 input_kinds,
                 &format!("{context} query param '{}'", param.name),
                 &param.value,
             )?;
+            needs_transport_guard = true;
         }
     }
     match &request.body {
         BodySpec::Json { fields } => {
             for field in fields {
+                needs_transport_guard |=
+                    value_source_references_secret_input(input_kinds, &field.value);
                 if field.path.iter().any(|segment| sensitive_key_name(segment)) {
                     validate_sensitive_value_source_for_database_persistence(
                         input_kinds,
                         &format!("{context} body field '{}'", field.path.join(".")),
                         &field.value,
                     )?;
+                    needs_transport_guard = true;
                 }
             }
         }
         BodySpec::Text { content } => {
-            validate_text_body_for_database_persistence(
+            needs_transport_guard |= validate_text_body_for_database_persistence(
                 input_kinds,
                 &format!("{context} request body text"),
                 content,
             )?;
         }
     }
-    Ok(())
+    Ok(needs_transport_guard)
 }
 
 fn validate_headers_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     headers: &[HeaderSpec],
-) -> Result<(), AppError> {
+) -> Result<bool, AppError> {
+    let mut needs_transport_guard = false;
     for header in headers {
+        needs_transport_guard |= value_source_references_secret_input(input_kinds, &header.value);
         if sensitive_http_header_name(&header.name) {
             validate_sensitive_value_source_for_database_persistence(
                 input_kinds,
                 &format!("{context} header '{}'", header.name),
                 &header.value,
             )?;
+            needs_transport_guard = true;
         }
     }
-    Ok(())
+    Ok(needs_transport_guard)
 }
 
 fn basic_auth_username_needs_secret(template: &ParsedTemplate) -> bool {
@@ -421,11 +502,40 @@ fn validate_text_body_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     value: &ValueSourceSpec,
-) -> Result<(), AppError> {
-    if text_body_value_source_needs_secret(value) {
+) -> Result<bool, AppError> {
+    let sensitive_value = text_body_value_source_needs_secret(value);
+    if sensitive_value {
         validate_sensitive_value_source_for_database_persistence(input_kinds, context, value)?;
     }
-    Ok(())
+    Ok(sensitive_value || value_source_references_secret_input(input_kinds, value))
+}
+
+fn value_source_references_secret_input(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    value: &ValueSourceSpec,
+) -> bool {
+    match value {
+        ValueSourceSpec::Template { template } => {
+            template_references_secret_input(input_kinds, template)
+        }
+        ValueSourceSpec::OneOf { values } => values
+            .iter()
+            .any(|value| value_source_references_secret_input(input_kinds, value)),
+        ValueSourceSpec::Input { key } | ValueSourceSpec::Bearer { key } => {
+            input_kinds.get(key) == Some(&ManifestInputKind::Secret)
+        }
+        _ => false,
+    }
+}
+
+fn template_references_secret_input(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    template: &ParsedTemplate,
+) -> bool {
+    template.tokens().any(|token| {
+        token.namespace() == &TemplateNamespace::Input
+            && input_kinds.get(token.key()) == Some(&ManifestInputKind::Secret)
+    })
 }
 
 fn text_body_value_source_needs_secret(value: &ValueSourceSpec) -> bool {
@@ -483,43 +593,124 @@ fn text_body_contains_sensitive_marker(raw: &str) -> bool {
     })
 }
 
+fn validate_oauth_endpoint_transports(
+    inputs: &[ManifestInputSpec],
+    source_variables: &BTreeMap<String, String>,
+) -> Result<(), AppError> {
+    for input in inputs {
+        let Some(credential) = input.credential.as_ref() else {
+            continue;
+        };
+        for method in &credential.methods {
+            if method.kind != ManifestCredentialMethodKind::OAuth {
+                continue;
+            }
+            let Some(oauth) = method.oauth.as_ref() else {
+                continue;
+            };
+            let endpoints = oauth
+                .endpoint_urls(source_variables)
+                .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+            if let Some(url) = endpoints.authorization_url.as_deref() {
+                validate_credential_endpoint_transport("oauth authorization_url", url)?;
+            }
+            if let Some(url) = endpoints.device_authorization_url.as_deref() {
+                validate_credential_endpoint_transport("oauth device_authorization_url", url)?;
+            }
+            validate_credential_endpoint_transport("oauth token_url", &endpoints.token_url)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_endpoint_template_transport(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    source_variables: &BTreeMap<String, String>,
+    context: &str,
+    template: &ParsedTemplate,
+) -> Result<(), AppError> {
+    let rendered =
+        render_source_variable_template(input_kinds, source_variables, context, template)?;
+    validate_credential_endpoint_transport(context, &rendered)
+}
+
+fn render_source_variable_template(
+    input_kinds: &BTreeMap<String, ManifestInputKind>,
+    source_variables: &BTreeMap<String, String>,
+    context: &str,
+    template: &ParsedTemplate,
+) -> Result<String, AppError> {
+    let mut rendered = String::with_capacity(template.raw().len());
+    for part in template.parts() {
+        match part {
+            TemplatePart::Literal(literal) => rendered.push_str(literal),
+            TemplatePart::Token(token) if token.namespace() == &TemplateNamespace::Input => {
+                if input_kinds.get(token.key()) != Some(&ManifestInputKind::Variable) {
+                    return Err(AppError::InvalidInput(format!(
+                        "{context} input '{}' must be a variable to validate imported credential transport",
+                        token.key()
+                    )));
+                }
+                let value = source_variables.get(token.key()).ok_or_else(|| {
+                    AppError::InvalidInput(format!(
+                        "{context} references unresolved source variable '{}'",
+                        token.key()
+                    ))
+                })?;
+                rendered.push_str(value);
+            }
+            TemplatePart::Token(token) => {
+                return Err(AppError::InvalidInput(format!(
+                    "{context} uses unsupported transport template token '{}'",
+                    token.raw()
+                )));
+            }
+        }
+    }
+    Ok(rendered)
+}
+
 fn validate_custom_auth_value_for_database_persistence(
     input_kinds: &BTreeMap<String, ManifestInputKind>,
     context: &str,
     sensitive_context: bool,
     value: &JsonValue,
-) -> Result<(), AppError> {
+) -> Result<bool, AppError> {
     match value {
         JsonValue::Object(map) => {
+            let mut found = false;
             for (key, value) in map {
-                validate_custom_auth_value_for_database_persistence(
+                found |= validate_custom_auth_value_for_database_persistence(
                     input_kinds,
                     &format!("{context}.{key}"),
                     sensitive_context || sensitive_key_name(key),
                     value,
                 )?;
             }
-            Ok(())
+            Ok(found)
         }
         JsonValue::Array(values) => {
+            let mut found = false;
             for (index, value) in values.iter().enumerate() {
-                validate_custom_auth_value_for_database_persistence(
+                found |= validate_custom_auth_value_for_database_persistence(
                     input_kinds,
                     &format!("{context}[{index}]"),
                     sensitive_context,
                     value,
                 )?;
             }
-            Ok(())
+            Ok(found)
         }
         JsonValue::String(raw) if sensitive_context => {
             let template = ParsedTemplate::parse(raw)
                 .map_err(|error| AppError::InvalidInput(error.to_string()))?;
-            validate_secret_template_for_database_persistence(input_kinds, context, &template)
+            validate_secret_template_for_database_persistence(input_kinds, context, &template)?;
+            Ok(true)
         }
-        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) | JsonValue::String(_) => {
-            Ok(())
-        }
+        JsonValue::String(raw) => Ok(ParsedTemplate::parse(raw)
+            .ok()
+            .is_some_and(|template| template_references_secret_input(input_kinds, &template))),
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::Number(_) => Ok(false),
     }
 }
 
@@ -624,7 +815,7 @@ mod tests {
         reason = "manifest input order assertions intentionally fail loudly in tests"
     )]
 
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeMap, BTreeSet};
 
     use coral_spec::ManifestInputKind;
 
@@ -636,8 +827,12 @@ mod tests {
     use crate::sources::model::SourceOrigin;
 
     fn minimal_http_manifest(extra_top_level: &str) -> String {
+        minimal_http_manifest_at("https://example.com", extra_top_level)
+    }
+
+    fn minimal_http_manifest_at(base_url: &str, extra_top_level: &str) -> String {
         format!(
-            "name: demo\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: https://example.com\n{extra_top_level}tables:\n  - name: messages\n    description: Demo messages\n    request:\n      method: GET\n      path: /messages\n    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
+            "name: demo\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: {base_url}\n{extra_top_level}tables:\n  - name: messages\n    description: Demo messages\n    request:\n      method: GET\n      path: /messages\n    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
         )
     }
 
@@ -834,6 +1029,21 @@ tables:
                 "table 'messages' request body text must reference a secret input",
             ),
             (
+                minimal_http_manifest_at(
+                    "\"http://api.example.com/{{input.API_TOKEN}}\"",
+                    "inputs:\n  API_TOKEN:\n    kind: secret\n",
+                ),
+                "base_url input 'API_TOKEN' must be a variable",
+            ),
+            (
+                minimal_http_manifest_at(
+                    "http://api.example.com",
+                    "inputs:\n  API_TOKEN:\n    kind: secret\n",
+                )
+                .replace("path: /messages", "path: /{{input.API_TOKEN}}"),
+                "base_url must use https or loopback http",
+            ),
+            (
                 minimal_v4_openapi_manifest(
                     "    auth:\n      type: HeaderAuth\n      headers:\n        - name: Authorization\n          from: literal\n          value: Bearer hardcoded-token\n",
                 ),
@@ -866,8 +1076,9 @@ tables:
         ];
 
         for (manifest, expected) in cases {
-            let error = validate_imported_manifest_database_persistence(&manifest)
-                .expect_err("literal sensitive value should be rejected");
+            let error =
+                validate_imported_manifest_database_persistence(&manifest, &BTreeMap::new())
+                    .expect_err("literal sensitive value should be rejected");
             assert!(
                 error.to_string().contains(expected),
                 "expected {expected:?}, got {error}"
@@ -877,9 +1088,12 @@ tables:
 
     #[test]
     fn database_persistence_rejects_basic_auth_username_when_it_is_credential_marked() {
-        let error = validate_imported_manifest_database_persistence(&minimal_http_manifest(
-            "inputs:\n  WOOCOMMERCE_CONSUMER_KEY:\n    kind: variable\n  API_PASSWORD:\n    kind: secret\nauth:\n  type: BasicAuth\n  username: \"{{input.WOOCOMMERCE_CONSUMER_KEY}}\"\n  password: \"{{input.API_PASSWORD}}\"\n",
-        ))
+        let error = validate_imported_manifest_database_persistence(
+            &minimal_http_manifest(
+                "inputs:\n  WOOCOMMERCE_CONSUMER_KEY:\n    kind: variable\n  API_PASSWORD:\n    kind: secret\nauth:\n  type: BasicAuth\n  username: \"{{input.WOOCOMMERCE_CONSUMER_KEY}}\"\n  password: \"{{input.API_PASSWORD}}\"\n",
+            ),
+            &BTreeMap::new(),
+        )
         .expect_err("credential-marked BasicAuth username should be rejected");
 
         assert!(
@@ -892,9 +1106,12 @@ tables:
 
     #[test]
     fn database_persistence_rejects_one_of_sensitive_fallbacks() {
-        let error = validate_imported_manifest_database_persistence(&minimal_http_manifest(
-            "inputs:\n  API_TOKEN:\n    kind: secret\nauth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: one_of\n      values:\n        - from: input\n          key: API_TOKEN\n        - from: literal\n          value: Bearer fallback-token\n",
-        ))
+        let error = validate_imported_manifest_database_persistence(
+            &minimal_http_manifest(
+                "inputs:\n  API_TOKEN:\n    kind: secret\nauth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: one_of\n      values:\n        - from: input\n          key: API_TOKEN\n        - from: literal\n          value: Bearer fallback-token\n",
+            ),
+            &BTreeMap::new(),
+        )
         .expect_err("literal one_of fallback should be rejected");
 
         assert!(
@@ -932,8 +1149,9 @@ tables:
         ];
 
         for (manifest, expected) in cases {
-            let error = validate_imported_manifest_database_persistence(&manifest)
-                .expect_err("S3 credential should be rejected");
+            let error =
+                validate_imported_manifest_database_persistence(&manifest, &BTreeMap::new())
+                    .expect_err("S3 credential should be rejected");
             assert!(
                 error.to_string().contains(expected),
                 "expected {expected:?}, got {error}"
@@ -959,8 +1177,9 @@ tables:
         ];
 
         for (manifest, expected) in cases {
-            let error = validate_imported_manifest_database_persistence(&manifest)
-                .expect_err("sensitive MCP env value should be rejected");
+            let error =
+                validate_imported_manifest_database_persistence(&manifest, &BTreeMap::new())
+                    .expect_err("sensitive MCP env value should be rejected");
             assert!(
                 error.to_string().contains(expected),
                 "expected {expected:?}, got {error}"
@@ -969,23 +1188,61 @@ tables:
     }
 
     #[test]
+    fn database_persistence_rejects_untrusted_variable_endpoints_for_secrets() {
+        let variables =
+            BTreeMap::from([("API_BASE".to_string(), "http://api.example.com".to_string())]);
+        let manifest = minimal_http_manifest_at(
+            "\"{{input.API_BASE}}\"",
+            "inputs:\n  API_BASE:\n    kind: variable\n  API_TOKEN:\n    kind: secret\nauth:\n  type: HeaderAuth\n  headers:\n    - name: X-Session\n      from: template\n      template: \"{{input.API_TOKEN}}\"\n",
+        );
+        let error = validate_imported_manifest_database_persistence(&manifest, &variables)
+            .expect_err("cleartext rendered base_url should be rejected");
+        assert!(error.to_string().contains("base_url must use https"));
+    }
+
+    #[test]
+    fn database_persistence_rejects_custom_auth_cleartext_endpoint_when_secrets_exist() {
+        let variables =
+            BTreeMap::from([("API_BASE".to_string(), "http://api.example.com".to_string())]);
+        let manifest = minimal_http_manifest_at(
+            "\"{{input.API_BASE}}\"",
+            "inputs:\n  API_BASE:\n    kind: variable\n  API_TOKEN:\n    kind: secret\nauth:\n  type: CustomAuth\n  authenticator: demo_auth\n  prefix: Bearer\n",
+        );
+
+        let error = validate_imported_manifest_database_persistence(&manifest, &variables)
+            .expect_err("custom auth can read declared secret inputs");
+
+        assert!(error.to_string().contains("base_url must use https"));
+    }
+
+    #[test]
+    fn database_persistence_rejects_untrusted_oauth_endpoints() {
+        let manifest = minimal_http_manifest(
+            "inputs:\n  API_TOKEN:\n    kind: secret\n    credential:\n      methods:\n        - type: oauth\n          oauth:\n            flow:\n              type: device_code\n            endpoints:\n              device_authorization_url: http://api.example.com/device\n              token_url: https://api.example.com/token\n            client:\n              id:\n                default: demo\n",
+        );
+        let error = validate_imported_manifest_database_persistence(&manifest, &BTreeMap::new())
+            .expect_err("cleartext OAuth endpoint should be rejected");
+        assert!(format!("{error}").contains("device_authorization_url must use https"));
+    }
+
+    #[test]
     fn database_persistence_allows_literal_non_secret_headers() {
-        validate_imported_manifest_database_persistence(&minimal_http_manifest("auth:\n  type: HeaderAuth\n  headers:\n    - name: Travis-API-Version\n      from: literal\n      value: \"3\"\nrequest_headers:\n  - name: Accept\n    from: literal\n    value: application/json\n"))
+        validate_imported_manifest_database_persistence(&minimal_http_manifest("auth:\n  type: HeaderAuth\n  headers:\n    - name: Travis-API-Version\n      from: literal\n      value: \"3\"\nrequest_headers:\n  - name: Accept\n    from: literal\n    value: application/json\n"), &BTreeMap::new())
         .expect("non-secret literal headers should be allowed");
 
-        validate_imported_manifest_database_persistence(&minimal_http_manifest_with_request("      body:\n        format: text\n        content:\n          from: literal\n          value: \"SELECT id, name FROM users FORMAT JSONEachRow\"\n"))
+        validate_imported_manifest_database_persistence(&minimal_http_manifest_with_request("      body:\n        format: text\n        content:\n          from: literal\n          value: \"SELECT id, name FROM users FORMAT JSONEachRow\"\n"), &BTreeMap::new())
         .expect("non-secret literal text bodies should be allowed");
 
-        validate_imported_manifest_database_persistence(&minimal_http_manifest_with_request("      query:\n        - name: page_token\n          from: filter\n          key: page_token\n"))
+        validate_imported_manifest_database_persistence(&minimal_http_manifest_with_request("      query:\n        - name: page_token\n          from: filter\n          key: page_token\n"), &BTreeMap::new())
         .expect("pagination token filters should not be treated as credentials");
     }
 
     #[test]
     fn database_persistence_allows_sensitive_header_from_secret_input() {
-        validate_imported_manifest_database_persistence(&minimal_http_manifest("inputs:\n  API_TOKEN:\n    kind: secret\nauth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n"))
+        validate_imported_manifest_database_persistence(&minimal_http_manifest("inputs:\n  API_TOKEN:\n    kind: secret\nauth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n"), &BTreeMap::new())
         .expect("secret-backed auth header should be allowed");
 
-        validate_imported_manifest_database_persistence(&minimal_http_manifest("inputs:\n  API_PASSWORD:\n    kind: secret\nauth:\n  type: BasicAuth\n  username: public-user\n  password: \"{{input.API_PASSWORD}}\"\n"))
+        validate_imported_manifest_database_persistence(&minimal_http_manifest("inputs:\n  API_PASSWORD:\n    kind: secret\nauth:\n  type: BasicAuth\n  username: public-user\n  password: \"{{input.API_PASSWORD}}\"\n"), &BTreeMap::new())
         .expect("public BasicAuth username should be allowed with a secret-backed password");
     }
 }

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -22,6 +22,7 @@ use crate::sources::SourceName;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
     validate_imported_manifest_database_persistence,
+    validate_imported_manifest_database_persistence_shape,
 };
 use crate::sources::materialization::{
     MaterializationBuild, MaterializationInputs, build_v4_materialization_tmp,
@@ -391,7 +392,7 @@ impl SourceManager {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
-        validate_imported_manifest_database_persistence(&manifest_yaml)?;
+        validate_imported_manifest_database_persistence_shape(&manifest_yaml)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         self.install_validated_source(
@@ -413,7 +414,7 @@ impl SourceManager {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
-        validate_imported_manifest_database_persistence(&manifest_yaml)?;
+        validate_imported_manifest_database_persistence_shape(&manifest_yaml)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         self.install_source_with_oauth(
@@ -455,6 +456,11 @@ impl SourceManager {
             &BTreeSet::new(),
         )?;
         let bindings = validate_bindings(candidate, bindings, &stored_material)?;
+        if origin == SourceOrigin::Imported
+            && let Some(manifest_yaml) = manifest_yaml
+        {
+            validate_imported_manifest_database_persistence(manifest_yaml, &bindings.variables)?;
+        }
         let materialization_inputs =
             materialization_inputs_from_bindings(&bindings, &stored_material);
         self.persist_source(
@@ -518,6 +524,14 @@ impl SourceManager {
             &stored_material,
             &oauth_credential_retrievals,
         )?;
+        if origin == SourceOrigin::Imported
+            && let Some(manifest_yaml) = manifest_yaml
+        {
+            validate_imported_manifest_database_persistence(
+                manifest_yaml,
+                &preflight_bindings.variables,
+            )?;
+        }
         let oauth_material = self
             .retrieve_oauth_material(
                 candidate,

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -27,10 +27,11 @@ use crate::sources::catalog::{
 use crate::sources::materialization::{
     MaterializationBuild, MaterializationInputs, build_v4_materialization_tmp,
     canonicalize_file_descriptor, cleanup_materialization_backup, cleanup_materialization_tmp,
-    new_materialization_suffix, replace_v4_materialization, restore_materialization_backup,
+    materialization_record_from_dir, new_materialization_suffix, replace_v4_materialization,
+    restore_materialization_backup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
-use crate::state::db::{CoralDb, DbRepos};
+use crate::state::db::{CoralDb, DbRepos, MaterializationRecord};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs;
 use crate::workspaces::{
@@ -161,8 +162,15 @@ struct PersistSourceRequest<'a> {
 struct SourceRollbackState {
     source: InstalledSource,
     manifest_yaml: Option<String>,
+    materialization: Option<MaterializationRecord>,
     credential_material: Option<CredentialMaterialSnapshot>,
 }
+
+type DbSourceSnapshot = (
+    InstalledSource,
+    Option<String>,
+    Option<MaterializationRecord>,
+);
 
 fn materialization_inputs_from_bindings(
     bindings: &ValidatedBindings,
@@ -605,6 +613,8 @@ impl SourceManager {
             source: stored,
             manifest_yaml: self
                 .source_manifest_yaml_for_rollback_with_state_lock_held(workspace_name, &removed)?,
+            materialization: self
+                .source_materialization_with_state_lock_held(workspace_name, source_name)?,
             credential_material,
         };
         let source_dir_backup = fs::DirectoryBackup::move_for_delete(&source_dir, source_name)?;
@@ -779,30 +789,31 @@ impl SourceManager {
                 (Vec::new(), None)
             };
 
-        let materialization_backup =
-            if let Some(materialization_tmp) = request.materialization_tmp.as_ref() {
-                match replace_v4_materialization(
-                    &self.layout,
-                    workspace_name,
-                    &source_name,
-                    materialization_tmp,
-                ) {
-                    Ok(backup) => backup,
-                    Err(error) => {
-                        cleanup_materialization_tmp(request.materialization_tmp.as_deref());
-                        self.restore_source_rollback_state_with_state_lock_held(
-                            workspace_name,
-                            &source_name,
-                            previous,
-                            credential_storage,
-                            &credential_guard,
-                        );
-                        return Err(error);
-                    }
+        let materialization_backup = if self.catalog_db.is_none()
+            && let Some(materialization_tmp) = request.materialization_tmp.as_ref()
+        {
+            match replace_v4_materialization(
+                &self.layout,
+                workspace_name,
+                &source_name,
+                materialization_tmp,
+            ) {
+                Ok(backup) => backup,
+                Err(error) => {
+                    cleanup_materialization_tmp(request.materialization_tmp.as_deref());
+                    self.restore_source_rollback_state_with_state_lock_held(
+                        workspace_name,
+                        &source_name,
+                        previous,
+                        credential_storage,
+                        &credential_guard,
+                    );
+                    return Err(error);
                 }
-            } else {
-                None
-            };
+            }
+        } else {
+            None
+        };
 
         let persisted_version = match request.origin {
             SourceOrigin::Bundled => None,
@@ -820,7 +831,9 @@ impl SourceManager {
             workspace_name,
             stored.clone(),
             request.manifest_yaml,
+            request.materialization_tmp.as_deref(),
         ) {
+            cleanup_materialization_tmp(request.materialization_tmp.as_deref());
             let restore_result = restore_materialization_backup(
                 &self.layout,
                 workspace_name,
@@ -842,6 +855,7 @@ impl SourceManager {
             return Err(error);
         }
         cleanup_materialization_backup(materialization_backup);
+        cleanup_materialization_tmp(request.materialization_tmp.as_deref());
         let mut resolved = stored;
         resolved.version.clone_from(&request.candidate.version);
         Ok(resolved)
@@ -1097,12 +1111,14 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source: InstalledSource,
         manifest_yaml: Option<&str>,
+        materialization_tmp: Option<&std::path::Path>,
     ) -> Result<(), AppError> {
         if self.catalog_db.is_some() {
             return self.upsert_db_source_with_state_lock_held(
                 workspace_name,
                 source,
                 manifest_yaml,
+                materialization_tmp,
             );
         }
         self.config_store
@@ -1115,6 +1131,7 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source: InstalledSource,
         manifest_yaml: Option<&str>,
+        materialization_tmp: Option<&std::path::Path>,
     ) -> Result<(), AppError> {
         let Some(db) = self.catalog_db.clone() else {
             return Ok(());
@@ -1130,9 +1147,14 @@ impl SourceManager {
             })?;
             validate_imported_manifest_database_persistence(manifest_yaml, &source.variables)?;
         }
+        let materialization_tmp = materialization_tmp.map(std::path::Path::to_path_buf);
         run_db_catalog_operation(async move {
             let mut tx = db.begin().await?;
             let now_unix_nanos = now_unix_nanos_i64()?;
+            let materialization = materialization_tmp
+                .as_deref()
+                .map(|dir| materialization_record_from_dir(&source.name, dir, now_unix_nanos))
+                .transpose()?;
             tx.workspaces()
                 .ensure(workspace_name.as_str(), now_unix_nanos)
                 .await?;
@@ -1155,6 +1177,15 @@ impl SourceManager {
                     )
                     .await?;
             }
+            if let Some(materialization) = materialization {
+                tx.materializations()
+                    .upsert(&workspace_name, &source.name, &materialization)
+                    .await?;
+            } else {
+                tx.materializations()
+                    .remove(&workspace_name, &source.name)
+                    .await?;
+            }
             tx.commit().await?;
             Ok(())
         })
@@ -1165,12 +1196,14 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source: InstalledSource,
         manifest_yaml: Option<&str>,
+        materialization: Option<&MaterializationRecord>,
     ) -> Result<(), AppError> {
         let Some(db) = self.catalog_db.clone() else {
             return Ok(());
         };
         let workspace_name = workspace_name.clone();
         let manifest_yaml = manifest_yaml.map(str::to_string);
+        let materialization = materialization.cloned();
         run_db_catalog_operation(async move {
             let mut tx = db.begin().await?;
             let now_unix_nanos = now_unix_nanos_i64()?;
@@ -1201,6 +1234,15 @@ impl SourceManager {
                         .await?;
                 }
             }
+            if let Some(materialization) = materialization {
+                tx.materializations()
+                    .upsert(&workspace_name, &source.name, &materialization)
+                    .await?;
+            } else {
+                tx.materializations()
+                    .remove(&workspace_name, &source.name)
+                    .await?;
+            }
             tx.commit().await?;
             Ok(())
         })
@@ -1229,7 +1271,7 @@ impl SourceManager {
     fn delete_db_workspace_sources(
         &self,
         workspace_name: &WorkspaceName,
-    ) -> Result<Vec<(InstalledSource, Option<String>)>, AppError> {
+    ) -> Result<Vec<DbSourceSnapshot>, AppError> {
         let Some(db) = self.catalog_db.clone() else {
             return Ok(Vec::new());
         };
@@ -1247,7 +1289,11 @@ impl SourceManager {
                 } else {
                     None
                 };
-                source_snapshots.push((source, manifest_yaml));
+                let materialization = tx
+                    .materializations()
+                    .get(&workspace_name, &source.name)
+                    .await?;
+                source_snapshots.push((source, manifest_yaml, materialization));
             }
             tx.workspaces().remove(workspace_name.as_str()).await?;
             tx.commit().await?;
@@ -1442,6 +1488,8 @@ impl SourceManager {
         else {
             return Ok(None);
         };
+        let materialization =
+            self.source_materialization_with_state_lock_held(workspace_name, source_name)?;
         let credential_material = source
             .credential_storage_for_material()
             .map(|credential_storage| {
@@ -1452,8 +1500,29 @@ impl SourceManager {
             manifest_yaml: self
                 .source_manifest_yaml_for_rollback_with_state_lock_held(workspace_name, &source)?,
             source,
+            materialization,
             credential_material,
         }))
+    }
+
+    fn source_materialization_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<MaterializationRecord>, AppError> {
+        let Some(db) = self.catalog_db.clone() else {
+            return Ok(None);
+        };
+        let workspace_name = workspace_name.clone();
+        let source_name = source_name.clone();
+        run_db_catalog_operation(async move {
+            let mut session = db.as_ref();
+            session
+                .materializations()
+                .get(&workspace_name, &source_name)
+                .await
+                .map_err(AppError::from)
+        })
     }
 
     fn restore_source_rollback_state_with_state_lock_held(
@@ -1503,11 +1572,13 @@ impl SourceManager {
                 }
             }
             let previous_source = previous.source;
+            let previous_materialization = previous.materialization;
             if self.catalog_db.is_some() {
                 if let Err(e) = self.restore_db_source_snapshot_with_state_lock_held(
                     workspace_name,
                     previous_source,
                     previous_manifest_yaml.as_deref(),
+                    previous_materialization.as_ref(),
                 ) {
                     warn!("rollback: failed to restore source database row: {e}");
                 }
@@ -1615,12 +1686,13 @@ impl WorkspaceStore for SourceManager {
         let config_deleted = match self.config_store.delete_workspace_unlocked(workspace_name) {
             Ok(deleted) => deleted,
             Err(error) => {
-                for (source, manifest_yaml) in &db_sources {
+                for (source, manifest_yaml, materialization) in &db_sources {
                     if let Err(restore_error) = self
                         .restore_db_source_snapshot_with_state_lock_held(
                             workspace_name,
                             source.clone(),
                             manifest_yaml.as_deref(),
+                            materialization.as_ref(),
                         )
                     {
                         return Err(AppError::FailedPrecondition(format!(
@@ -1643,7 +1715,7 @@ impl WorkspaceStore for SourceManager {
         deleted.sources.extend(
             db_sources
                 .into_iter()
-                .map(|(source, _manifest_yaml)| source),
+                .map(|(source, _manifest_yaml, _materialization)| source),
         );
         Ok(Some(deleted))
     }

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -159,6 +159,22 @@ struct PersistSourceRequest<'a> {
     materialization_tmp: Option<PathBuf>,
 }
 
+struct MaterializationTmpCleanup {
+    path: Option<PathBuf>,
+}
+
+impl MaterializationTmpCleanup {
+    fn new(path: Option<PathBuf>) -> Self {
+        Self { path }
+    }
+}
+
+impl Drop for MaterializationTmpCleanup {
+    fn drop(&mut self) {
+        cleanup_materialization_tmp(self.path.as_deref());
+    }
+}
+
 struct SourceRollbackState {
     source: InstalledSource,
     manifest_yaml: Option<String>,
@@ -706,6 +722,8 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         request: PersistSourceRequest<'_>,
     ) -> Result<InstalledSource, AppError> {
+        let _materialization_tmp_cleanup =
+            MaterializationTmpCleanup::new(request.materialization_tmp.clone());
         let source_name = request.candidate.name.clone();
         let credential_set_id = CredentialSetId::for_source(&source_name);
         let credential_guard = self
@@ -2505,6 +2523,70 @@ tables:
                 .to_string()
                 .contains("missing required source secret 'API_TOKEN'"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn readd_source_cleans_materialization_tmp_when_rollback_snapshot_fails() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let manager = SourceManager::new(
+            config_store,
+            credential_manager,
+            layout.clone(),
+            crate::workspaces::WorkspaceLifecycleLock::default(),
+        );
+
+        let workspace_name = default_workspace();
+        let manifest = manifest_without_secrets();
+        manager
+            .import_source(
+                &workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: manifest.clone(),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect("initial import");
+
+        let source_name = SourceName::parse("public_messages").expect("source");
+        std::fs::remove_file(layout.manifest_file(&workspace_name, &source_name))
+            .expect("remove imported manifest");
+        let materialization_tmp = temp.path().join("materialization_tmp");
+        std::fs::create_dir(&materialization_tmp).expect("create materialization tmp");
+        std::fs::write(
+            materialization_tmp.join("marker"),
+            b"temporary materialization",
+        )
+        .expect("write materialization tmp marker");
+        let candidate =
+            describe_manifest(&manifest, SourceOrigin::Imported, false).expect("describe manifest");
+        let bindings = ValidatedBindings {
+            variables: BTreeMap::new(),
+            secrets: BTreeMap::new(),
+            replaced_oauth_inputs: BTreeSet::new(),
+        };
+
+        manager
+            .persist_source(
+                &workspace_name,
+                PersistSourceRequest {
+                    candidate: &candidate,
+                    manifest_yaml: Some(&manifest),
+                    bindings,
+                    origin: SourceOrigin::Imported,
+                    materialization_tmp: Some(materialization_tmp.clone()),
+                },
+            )
+            .expect_err("missing rollback manifest should fail");
+
+        assert!(
+            !materialization_tmp.exists(),
+            "materialization temp dir should be removed on rollback snapshot failure"
         );
     }
 

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -21,6 +21,7 @@ use crate::credentials::{
 use crate::sources::SourceName;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
+    validate_imported_manifest_database_persistence,
 };
 use crate::sources::materialization::{
     MaterializationBuild, MaterializationInputs, build_v4_materialization_tmp,
@@ -390,6 +391,7 @@ impl SourceManager {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
+        validate_imported_manifest_database_persistence(&manifest_yaml)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         self.install_validated_source(
@@ -411,6 +413,7 @@ impl SourceManager {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
+        validate_imported_manifest_database_persistence(&manifest_yaml)?;
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         self.install_source_with_oauth(

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -31,7 +31,9 @@ use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::db::{CoralDb, DbRepos};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs;
-use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
+use crate::workspaces::{
+    DeletedWorkspace, WorkspaceLifecycleLock, WorkspaceName, WorkspaceRecord, WorkspaceStore,
+};
 use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthCredentialSpec};
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tokio::sync::{mpsc, oneshot};
@@ -1130,6 +1132,23 @@ impl SourceManager {
         Ok(())
     }
 
+    fn delete_db_workspace_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        let Some(db) = self.catalog_db.clone() else {
+            return Ok(Vec::new());
+        };
+        let workspace_name = workspace_name.clone();
+        run_db_catalog_operation(async move {
+            let mut tx = db.begin().await?;
+            let sources = tx.sources().list_workspace_sources(&workspace_name).await?;
+            tx.workspaces().remove(workspace_name.as_str()).await?;
+            tx.commit().await?;
+            Ok(sources)
+        })
+    }
+
     fn validate_oauth_import_preflight(
         candidate: &CandidateSource,
         bindings: &SourceBindings,
@@ -1393,6 +1412,58 @@ impl SourceManager {
     ) -> InstalledSource {
         self.populate_source_version(workspace_name, source.clone())
             .unwrap_or(source)
+    }
+}
+
+impl WorkspaceStore for SourceManager {
+    fn list_workspaces(&self) -> Result<Vec<WorkspaceRecord>, AppError> {
+        self.config_store.list_workspaces()
+    }
+
+    fn create_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<WorkspaceRecord, AppError> {
+        self.config_store.create_workspace(workspace_name)
+    }
+
+    fn delete_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<DeletedWorkspace>, AppError> {
+        if workspace_name.is_default() {
+            return Err(AppError::FailedPrecondition(
+                "default workspace cannot be removed".to_string(),
+            ));
+        }
+        let _state_lock = self.config_store.state_lock_exclusive()?;
+        let mut db_sources = self.delete_db_workspace_sources(workspace_name)?;
+        let config_deleted = match self.config_store.delete_workspace_unlocked(workspace_name) {
+            Ok(deleted) => deleted,
+            Err(error) => {
+                for source in db_sources.iter().cloned() {
+                    if let Err(restore_error) =
+                        self.upsert_db_source_with_state_lock_held(workspace_name, source)
+                    {
+                        return Err(AppError::FailedPrecondition(format!(
+                            "failed to delete workspace '{workspace_name}': {error}; failed to restore workspace source database rows: {restore_error}"
+                        )));
+                    }
+                }
+                return Err(error);
+            }
+        };
+        if db_sources.is_empty() {
+            return Ok(config_deleted);
+        }
+        let mut deleted = config_deleted.unwrap_or_else(|| DeletedWorkspace {
+            workspace: WorkspaceRecord {
+                name: workspace_name.clone(),
+            },
+            sources: Vec::new(),
+        });
+        deleted.sources.append(&mut db_sources);
+        Ok(Some(deleted))
     }
 }
 

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -618,7 +618,8 @@ impl SourceManager {
             credential_material,
         };
         let source_dir_backup = fs::DirectoryBackup::move_for_delete(&source_dir, source_name)?;
-        if let Some(credential_storage) = credential_storage
+        if let Some(credential_storage) =
+            credential_storage.filter(|storage| *storage != CredentialStorageKind::Database)
             && let Err(error) =
                 credential_guard.remove_material_with_state_lock_held(credential_storage)
         {
@@ -743,51 +744,82 @@ impl SourceManager {
             secrets,
             replaced_oauth_inputs,
         } = request.bindings;
-        let (visible_secret_keys, credential_storage) =
-            if let Some(requested_storage) = credential_storage {
-                let expected_secret_keys = request
-                    .candidate
-                    .inputs
-                    .iter()
-                    .filter(|input| input.kind == ManifestInputKind::Secret)
-                    .map(|input| input.key.clone())
-                    .collect::<BTreeSet<_>>();
-                let credential_write = match credential_guard.update_material_with_state_lock(
-                    requested_storage,
-                    |mut credential_material| {
-                        credential_material.retain(|key, _| {
-                            material_key_belongs_to_source_secret(key, &expected_secret_keys)
-                        });
-                        for input_key in &replaced_oauth_inputs {
-                            credential_material
-                                .retain(|key, _| !material_key_belongs_to_input(key, input_key));
-                        }
-                        credential_material.extend(secrets.clone());
-                        Ok(credential_material)
-                    },
+        let persisted_version = match request.origin {
+            SourceOrigin::Bundled => None,
+            SourceOrigin::Imported => request.candidate.version.clone(),
+        };
+        let (visible_secret_keys, credential_storage) = if let Some(requested_storage) =
+            credential_storage
+        {
+            let expected_secret_keys = request
+                .candidate
+                .inputs
+                .iter()
+                .filter(|input| input.kind == ManifestInputKind::Secret)
+                .map(|input| input.key.clone())
+                .collect::<BTreeSet<_>>();
+            if requested_storage == CredentialStorageKind::Database && self.catalog_db.is_some() {
+                let provisional = InstalledSource {
+                    name: source_name.clone(),
+                    version: persisted_version.clone(),
+                    variables: variables.clone(),
+                    secrets: Vec::new(),
+                    credential_storage: Some(requested_storage),
+                    origin: request.origin,
+                };
+                if let Err(error) = self.upsert_source_with_state_lock_held(
+                    workspace_name,
+                    provisional,
+                    request.manifest_yaml,
+                    request.materialization_tmp.as_deref(),
                 ) {
-                    Ok(outcome) => outcome,
-                    Err(error) => {
-                        cleanup_materialization_tmp(request.materialization_tmp.as_deref());
-                        self.restore_source_rollback_state_with_state_lock_held(
-                            workspace_name,
-                            &source_name,
-                            previous,
-                            Some(requested_storage),
-                            &credential_guard,
-                        );
-                        return Err(error);
+                    cleanup_materialization_tmp(request.materialization_tmp.as_deref());
+                    self.restore_source_rollback_state_with_state_lock_held(
+                        workspace_name,
+                        &source_name,
+                        previous,
+                        None,
+                        &credential_guard,
+                    );
+                    return Err(error);
+                }
+            }
+            let credential_write = match credential_guard.update_material_with_state_lock(
+                requested_storage,
+                |mut credential_material| {
+                    credential_material.retain(|key, _| {
+                        material_key_belongs_to_source_secret(key, &expected_secret_keys)
+                    });
+                    for input_key in &replaced_oauth_inputs {
+                        credential_material
+                            .retain(|key, _| !material_key_belongs_to_input(key, input_key));
                     }
-                };
-                let credential_storage = if credential_write.visible_keys.is_empty() {
-                    None
-                } else {
-                    Some(credential_write.storage)
-                };
-                (credential_write.visible_keys, credential_storage)
-            } else {
-                (Vec::new(), None)
+                    credential_material.extend(secrets.clone());
+                    Ok(credential_material)
+                },
+            ) {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    cleanup_materialization_tmp(request.materialization_tmp.as_deref());
+                    self.restore_source_rollback_state_with_state_lock_held(
+                        workspace_name,
+                        &source_name,
+                        previous,
+                        Some(requested_storage),
+                        &credential_guard,
+                    );
+                    return Err(error);
+                }
             };
+            let credential_storage = if credential_write.visible_keys.is_empty() {
+                None
+            } else {
+                Some(credential_write.storage)
+            };
+            (credential_write.visible_keys, credential_storage)
+        } else {
+            (Vec::new(), None)
+        };
 
         let replaced_filesystem_materialization =
             self.catalog_db.is_none() && request.materialization_tmp.is_some();
@@ -819,10 +851,6 @@ impl SourceManager {
             None
         };
 
-        let persisted_version = match request.origin {
-            SourceOrigin::Bundled => None,
-            SourceOrigin::Imported => request.candidate.version.clone(),
-        };
         let stored = InstalledSource {
             name: source_name.clone(),
             version: persisted_version,

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -20,8 +20,8 @@ use crate::credentials::{
 };
 use crate::sources::SourceName;
 use crate::sources::catalog::{
-    describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
-    validate_imported_manifest_database_persistence,
+    InstalledSourceManifest, describe_manifest, list_bundled_sources, load_bundled_source,
+    resolve_installed_manifest_from_yaml, validate_imported_manifest_database_persistence,
     validate_imported_manifest_database_persistence_shape,
 };
 use crate::sources::materialization::{
@@ -301,9 +301,9 @@ impl SourceManager {
     ) -> Result<CandidateSource, AppError> {
         match self.get_source(workspace_name, source_name) {
             Ok(source) => {
-                return Ok(
-                    resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
-                );
+                return Ok(self
+                    .resolve_source_manifest(workspace_name, &source)?
+                    .candidate);
             }
             Err(AppError::SourceNotFound(_)) => {}
             Err(error) => return Err(error),
@@ -603,12 +603,8 @@ impl SourceManager {
             .transpose()?;
         let previous = SourceRollbackState {
             source: stored,
-            manifest_yaml: match removed.origin {
-                SourceOrigin::Bundled => None,
-                SourceOrigin::Imported => Some(std::fs::read_to_string(
-                    self.layout.manifest_file(workspace_name, source_name),
-                )?),
-            },
+            manifest_yaml: self
+                .source_manifest_yaml_for_rollback_with_state_lock_held(workspace_name, &removed)?,
             credential_material,
         };
         let source_dir_backup = fs::DirectoryBackup::move_for_delete(&source_dir, source_name)?;
@@ -820,8 +816,11 @@ impl SourceManager {
             credential_storage,
             origin: request.origin,
         };
-        if let Err(error) = self.upsert_source_with_state_lock_held(workspace_name, stored.clone())
-        {
+        if let Err(error) = self.upsert_source_with_state_lock_held(
+            workspace_name,
+            stored.clone(),
+            request.manifest_yaml,
+        ) {
             let restore_result = restore_materialization_backup(
                 &self.layout,
                 workspace_name,
@@ -901,7 +900,7 @@ impl SourceManager {
                 continue;
             }
             let installed_manifest =
-                resolve_installed_manifest(workspace_name, &installed, &self.layout)?;
+                self.resolve_source_manifest_with_state_lock_held(workspace_name, &installed)?;
             let installed_schema_names = runtime_schema_names(&installed_manifest.source_spec);
             if let Some(schema_name) = candidate_schema_names
                 .intersection(&installed_schema_names)
@@ -1097,9 +1096,14 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
         source: InstalledSource,
+        manifest_yaml: Option<&str>,
     ) -> Result<(), AppError> {
         if self.catalog_db.is_some() {
-            return self.upsert_db_source_with_state_lock_held(workspace_name, source);
+            return self.upsert_db_source_with_state_lock_held(
+                workspace_name,
+                source,
+                manifest_yaml,
+            );
         }
         self.config_store
             .upsert_source_unlocked(workspace_name, source)?;
@@ -1110,11 +1114,22 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
         source: InstalledSource,
+        manifest_yaml: Option<&str>,
     ) -> Result<(), AppError> {
         let Some(db) = self.catalog_db.clone() else {
             return Ok(());
         };
         let workspace_name = workspace_name.clone();
+        let manifest_yaml = manifest_yaml.map(str::to_string);
+        if source.origin == SourceOrigin::Imported {
+            let manifest_yaml = manifest_yaml.as_deref().ok_or_else(|| {
+                AppError::FailedPrecondition(format!(
+                    "imported source '{}' is missing manifest YAML for database persistence",
+                    source.name
+                ))
+            })?;
+            validate_imported_manifest_database_persistence(manifest_yaml, &source.variables)?;
+        }
         run_db_catalog_operation(async move {
             let mut tx = db.begin().await?;
             let now_unix_nanos = now_unix_nanos_i64()?;
@@ -1124,6 +1139,68 @@ impl SourceManager {
             tx.sources()
                 .upsert_source(&workspace_name, &source, now_unix_nanos)
                 .await?;
+            if source.origin == SourceOrigin::Imported {
+                let manifest_yaml = manifest_yaml.ok_or_else(|| {
+                    AppError::FailedPrecondition(format!(
+                        "imported source '{}' is missing manifest YAML for database persistence",
+                        source.name
+                    ))
+                })?;
+                tx.source_manifests()
+                    .upsert(
+                        &workspace_name,
+                        &source.name,
+                        &manifest_yaml,
+                        now_unix_nanos,
+                    )
+                    .await?;
+            }
+            tx.commit().await?;
+            Ok(())
+        })
+    }
+
+    fn restore_db_source_snapshot_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: InstalledSource,
+        manifest_yaml: Option<&str>,
+    ) -> Result<(), AppError> {
+        let Some(db) = self.catalog_db.clone() else {
+            return Ok(());
+        };
+        let workspace_name = workspace_name.clone();
+        let manifest_yaml = manifest_yaml.map(str::to_string);
+        run_db_catalog_operation(async move {
+            let mut tx = db.begin().await?;
+            let now_unix_nanos = now_unix_nanos_i64()?;
+            tx.workspaces()
+                .ensure(workspace_name.as_str(), now_unix_nanos)
+                .await?;
+            tx.sources()
+                .upsert_source(&workspace_name, &source, now_unix_nanos)
+                .await?;
+            match manifest_yaml {
+                Some(manifest_yaml) if source.origin == SourceOrigin::Imported => {
+                    validate_imported_manifest_database_persistence(
+                        &manifest_yaml,
+                        &source.variables,
+                    )?;
+                    tx.source_manifests()
+                        .upsert(
+                            &workspace_name,
+                            &source.name,
+                            &manifest_yaml,
+                            now_unix_nanos,
+                        )
+                        .await?;
+                }
+                _ => {
+                    tx.source_manifests()
+                        .remove(&workspace_name, &source.name)
+                        .await?;
+                }
+            }
             tx.commit().await?;
             Ok(())
         })
@@ -1152,7 +1229,7 @@ impl SourceManager {
     fn delete_db_workspace_sources(
         &self,
         workspace_name: &WorkspaceName,
-    ) -> Result<Vec<InstalledSource>, AppError> {
+    ) -> Result<Vec<(InstalledSource, Option<String>)>, AppError> {
         let Some(db) = self.catalog_db.clone() else {
             return Ok(Vec::new());
         };
@@ -1160,10 +1237,90 @@ impl SourceManager {
         run_db_catalog_operation(async move {
             let mut tx = db.begin().await?;
             let sources = tx.sources().list_workspace_sources(&workspace_name).await?;
+            let mut source_snapshots = Vec::with_capacity(sources.len());
+            for source in sources {
+                let manifest_yaml = if source.origin == SourceOrigin::Imported {
+                    tx.source_manifests()
+                        .get(&workspace_name, &source.name)
+                        .await?
+                        .map(|record| record.manifest_yaml)
+                } else {
+                    None
+                };
+                source_snapshots.push((source, manifest_yaml));
+            }
             tx.workspaces().remove(workspace_name.as_str()).await?;
             tx.commit().await?;
-            Ok(sources)
+            Ok(source_snapshots)
         })
+    }
+
+    fn resolve_source_manifest(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<InstalledSourceManifest, AppError> {
+        let _state_lock = self.config_store.state_lock_shared()?;
+        self.resolve_source_manifest_with_state_lock_held(workspace_name, source)
+    }
+
+    fn resolve_source_manifest_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<InstalledSourceManifest, AppError> {
+        let manifest_yaml =
+            self.source_manifest_yaml_with_state_lock_held(workspace_name, source)?;
+        resolve_installed_manifest_from_yaml(source, &manifest_yaml)
+    }
+
+    fn source_manifest_yaml_for_rollback_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<Option<String>, AppError> {
+        match source.origin {
+            SourceOrigin::Bundled => Ok(None),
+            SourceOrigin::Imported => {
+                match self.source_manifest_yaml_with_state_lock_held(workspace_name, source) {
+                    Ok(manifest_yaml) => Ok(Some(manifest_yaml)),
+                    Err(AppError::SourceNotFound(_)) if self.catalog_db.is_some() => Ok(None),
+                    Err(error) => Err(error),
+                }
+            }
+        }
+    }
+
+    fn source_manifest_yaml_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<String, AppError> {
+        match source.origin {
+            SourceOrigin::Bundled => Ok(load_bundled_source(&source.name)?.manifest_yaml),
+            SourceOrigin::Imported => {
+                if let Some(db) = self.catalog_db.clone() {
+                    let workspace_name = workspace_name.clone();
+                    let source_name = source.name.clone();
+                    return run_db_catalog_operation(async move {
+                        let mut session = db.as_ref();
+                        session
+                            .source_manifests()
+                            .get(&workspace_name, &source_name)
+                            .await?
+                            .map(|record| record.manifest_yaml)
+                            .ok_or_else(|| {
+                                AppError::SourceNotFound(format!(
+                                    "manifest for imported source '{workspace_name}:{source_name}'"
+                                ))
+                            })
+                    });
+                }
+                Ok(std::fs::read_to_string(
+                    self.layout.manifest_file(workspace_name, &source.name),
+                )?)
+            }
+        }
     }
 
     fn validate_oauth_import_preflight(
@@ -1292,12 +1449,8 @@ impl SourceManager {
             })
             .transpose()?;
         Ok(Some(SourceRollbackState {
-            manifest_yaml: match source.origin {
-                SourceOrigin::Bundled => None,
-                SourceOrigin::Imported => Some(std::fs::read_to_string(
-                    self.layout.manifest_file(workspace_name, source_name),
-                )?),
-            },
+            manifest_yaml: self
+                .source_manifest_yaml_for_rollback_with_state_lock_held(workspace_name, &source)?,
             source,
             credential_material,
         }))
@@ -1312,6 +1465,7 @@ impl SourceManager {
         credential_material: &CredentialMaterialGuard<'_>,
     ) {
         if let Some(previous) = previous {
+            let previous_manifest_yaml = previous.manifest_yaml.clone();
             let manifest_path = self.layout.manifest_file(workspace_name, source_name);
             match previous.manifest_yaml {
                 Some(manifest_yaml) => {
@@ -1350,9 +1504,11 @@ impl SourceManager {
             }
             let previous_source = previous.source;
             if self.catalog_db.is_some() {
-                if let Err(e) =
-                    self.upsert_db_source_with_state_lock_held(workspace_name, previous_source)
-                {
+                if let Err(e) = self.restore_db_source_snapshot_with_state_lock_held(
+                    workspace_name,
+                    previous_source,
+                    previous_manifest_yaml.as_deref(),
+                ) {
                     warn!("rollback: failed to restore source database row: {e}");
                 }
             } else if let Err(e) = self
@@ -1416,7 +1572,8 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         mut source: InstalledSource,
     ) -> Result<InstalledSource, AppError> {
-        source.version = resolve_installed_manifest(workspace_name, &source, &self.layout)?
+        source.version = self
+            .resolve_source_manifest_with_state_lock_held(workspace_name, &source)?
             .candidate
             .version;
         Ok(source)
@@ -1454,13 +1611,17 @@ impl WorkspaceStore for SourceManager {
             ));
         }
         let _state_lock = self.config_store.state_lock_exclusive()?;
-        let mut db_sources = self.delete_db_workspace_sources(workspace_name)?;
+        let db_sources = self.delete_db_workspace_sources(workspace_name)?;
         let config_deleted = match self.config_store.delete_workspace_unlocked(workspace_name) {
             Ok(deleted) => deleted,
             Err(error) => {
-                for source in db_sources.iter().cloned() {
-                    if let Err(restore_error) =
-                        self.upsert_db_source_with_state_lock_held(workspace_name, source)
+                for (source, manifest_yaml) in &db_sources {
+                    if let Err(restore_error) = self
+                        .restore_db_source_snapshot_with_state_lock_held(
+                            workspace_name,
+                            source.clone(),
+                            manifest_yaml.as_deref(),
+                        )
                     {
                         return Err(AppError::FailedPrecondition(format!(
                             "failed to delete workspace '{workspace_name}': {error}; failed to restore workspace source database rows: {restore_error}"
@@ -1479,7 +1640,11 @@ impl WorkspaceStore for SourceManager {
             },
             sources: Vec::new(),
         });
-        deleted.sources.append(&mut db_sources);
+        deleted.sources.extend(
+            db_sources
+                .into_iter()
+                .map(|(source, _manifest_yaml)| source),
+        );
         Ok(Some(deleted))
     }
 }

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -1,7 +1,10 @@
 //! Owns the source lifecycle workflow for the local app.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use coral_spec::v4::SurfaceDescriptor;
 use serde_yaml::Value as YamlValue;
@@ -25,6 +28,7 @@ use crate::sources::materialization::{
     new_materialization_suffix, replace_v4_materialization, restore_materialization_backup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
+use crate::state::db::{CoralDb, DbRepos};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs;
 use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
@@ -36,6 +40,7 @@ use tracing::warn;
 #[derive(Clone)]
 pub(crate) struct SourceManager {
     config_store: ConfigStore,
+    catalog_db: Option<Arc<CoralDb>>,
     credential_manager: CredentialManager,
     oauth_credential_service: OAuthCredentialService,
     layout: AppStateLayout,
@@ -167,6 +172,51 @@ fn materialization_inputs_from_bindings(
     }
 }
 
+fn run_db_catalog_operation<T, F>(operation: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: Future<Output = Result<T, AppError>> + Send + 'static,
+{
+    fn run_on_runtime<T, F>(operation: F) -> Result<T, AppError>
+    where
+        F: Future<Output = Result<T, AppError>>,
+    {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!(
+                    "failed to create source catalog database runtime: {error}"
+                ))
+            })?;
+        runtime.block_on(operation)
+    }
+
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return std::thread::spawn(move || run_on_runtime(operation))
+            .join()
+            .map_err(|_panic| {
+                AppError::FailedPrecondition(
+                    "source catalog database operation thread panicked".to_string(),
+                )
+            })?;
+    }
+
+    run_on_runtime(operation)
+}
+
+fn now_unix_nanos_i64() -> Result<i64, AppError> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| AppError::FailedPrecondition(format!("system clock error: {error}")))?
+        .as_nanos();
+    i64::try_from(nanos).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "system clock timestamp exceeds i64 nanoseconds: {error}"
+        ))
+    })
+}
+
 impl SourceManager {
     #[cfg(test)]
     pub(crate) fn new_for_tests(
@@ -190,6 +240,24 @@ impl SourceManager {
     ) -> Self {
         Self {
             config_store,
+            catalog_db: None,
+            credential_manager,
+            oauth_credential_service: OAuthCredentialService::new(),
+            layout,
+            lifecycle_lock,
+        }
+    }
+
+    pub(crate) fn with_db(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+        lifecycle_lock: WorkspaceLifecycleLock,
+        catalog_db: Arc<CoralDb>,
+    ) -> Self {
+        Self {
+            config_store,
+            catalog_db: Some(catalog_db),
             credential_manager,
             oauth_credential_service: OAuthCredentialService::new(),
             layout,
@@ -201,9 +269,9 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<InstalledSource>, AppError> {
+        let _state_lock = self.config_store.state_lock_shared()?;
         Ok(self
-            .config_store
-            .list_workspace_sources(workspace_name)?
+            .list_workspace_sources_with_state_lock_held(workspace_name)?
             .into_iter()
             .map(|source| self.populate_source_version_or_keep(workspace_name, source))
             .collect())
@@ -214,10 +282,11 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
-        Ok(self.populate_source_version_or_keep(
-            workspace_name,
-            self.config_store.get_source(workspace_name, source_name)?,
-        ))
+        let _state_lock = self.config_store.state_lock_shared()?;
+        let source = self
+            .get_source_with_state_lock_held(workspace_name, source_name)?
+            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))?;
+        Ok(self.populate_source_version_or_keep(workspace_name, source))
     }
 
     pub(crate) fn get_source_info(
@@ -225,7 +294,7 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<CandidateSource, AppError> {
-        match self.config_store.get_source(workspace_name, source_name) {
+        match self.get_source(workspace_name, source_name) {
             Ok(source) => {
                 return Ok(
                     resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
@@ -248,7 +317,8 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<CandidateSource>, AppError> {
-        let installed_sources = self.config_store.list_workspace_sources(workspace_name)?;
+        let _state_lock = self.config_store.state_lock_shared()?;
+        let installed_sources = self.list_workspace_sources_with_state_lock_held(workspace_name)?;
         let installed = installed_sources
             .iter()
             .map(|source| source.name.clone())
@@ -491,6 +561,10 @@ impl SourceManager {
         )
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Delete keeps filesystem, credential, config, and DB rollback ordering together."
+    )]
     pub(crate) fn delete_source(
         &self,
         workspace_name: &WorkspaceName,
@@ -504,8 +578,8 @@ impl SourceManager {
             .material_guard(workspace_name, &credential_set_id)?;
         let _state_lock = self.config_store.state_lock_exclusive()?;
         let stored = self
-            .config_store
-            .get_source_unlocked(workspace_name, source_name)?;
+            .get_source_with_state_lock_held(workspace_name, source_name)?
+            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))?;
         let removed = self.populate_source_version_or_keep(workspace_name, stored.clone());
         let credential_storage = stored.credential_storage_for_material();
         let credential_material = credential_storage
@@ -545,6 +619,24 @@ impl SourceManager {
         if let Err(error) = self
             .config_store
             .remove_source_unlocked(workspace_name, source_name)
+        {
+            let restore_dir_result = source_dir_backup.restore();
+            self.restore_source_rollback_state_with_state_lock_held(
+                workspace_name,
+                source_name,
+                Some(previous),
+                None,
+                &credential_guard,
+            );
+            if let Err(restore_error) = restore_dir_result {
+                return Err(AppError::FailedPrecondition(format!(
+                    "failed to remove source '{source_name}': {error}; failed to restore source directory from '{}': {restore_error}",
+                    source_dir_backup.backup_path().display()
+                )));
+            }
+            return Err(error);
+        }
+        if let Err(error) = self.remove_db_source_with_state_lock_held(workspace_name, source_name)
         {
             let restore_dir_result = source_dir_backup.restore();
             self.restore_source_rollback_state_with_state_lock_held(
@@ -711,9 +803,7 @@ impl SourceManager {
             credential_storage,
             origin: request.origin,
         };
-        if let Err(error) = self
-            .config_store
-            .upsert_source_unlocked(workspace_name, stored.clone())
+        if let Err(error) = self.upsert_source_with_state_lock_held(workspace_name, stored.clone())
         {
             let restore_result = restore_materialization_backup(
                 &self.layout,
@@ -789,7 +879,7 @@ impl SourceManager {
         let candidate_manifest = parse_source_manifest_yaml(manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let candidate_schema_names = runtime_schema_names(&candidate_manifest);
-        for installed in self.config_store.list_workspace_sources(workspace_name)? {
+        for installed in self.list_workspace_sources(workspace_name)? {
             if installed.name == *candidate_name {
                 continue;
             }
@@ -815,9 +905,8 @@ impl SourceManager {
         source_name: &SourceName,
     ) -> Result<bool, AppError> {
         Ok(self
-            .config_store
-            .load_catalog()?
-            .contains(workspace_name, source_name))
+            .get_source_optional(workspace_name, source_name)?
+            .is_some())
     }
 
     fn read_source_material(
@@ -849,25 +938,21 @@ impl SourceManager {
         bindings: &SourceBindings,
         filled_secret_keys: &BTreeSet<String>,
     ) -> Result<BTreeMap<String, String>, AppError> {
-        let (credential_storage, persisted_secret_keys) = match self
-            .config_store
-            .get_source(workspace_name, &candidate.name)
-        {
-            Ok(source) => (
-                source.credential_storage_for_material(),
-                Some(source.secrets.iter().cloned().collect::<BTreeSet<_>>()),
-            ),
-            Err(AppError::SourceNotFound(_))
-                if self
+        let (credential_storage, persisted_secret_keys) =
+            match self.get_source_optional(workspace_name, &candidate.name)? {
+                Some(source) => (
+                    source.credential_storage_for_material(),
+                    Some(source.secrets.iter().cloned().collect::<BTreeSet<_>>()),
+                ),
+                None if self
                     .layout
                     .secret_file(workspace_name, &candidate.name)
                     .exists() =>
-            {
-                (Some(CredentialStorageKind::File), None)
-            }
-            Err(AppError::SourceNotFound(_)) => (None, Some(BTreeSet::new())),
-            Err(error) => return Err(error),
-        };
+                {
+                    (Some(CredentialStorageKind::File), None)
+                }
+                None => (None, Some(BTreeSet::new())),
+            };
 
         if !source_needs_stored_material_for_validation(
             candidate,
@@ -898,11 +983,10 @@ impl SourceManager {
                 && !bindings.secrets.contains_key(&input.key)
         });
         let existing_storage = match self
-            .config_store
-            .get_source_unlocked(workspace_name, &candidate.name)
+            .get_source_with_state_lock_held(workspace_name, &candidate.name)?
         {
-            Ok(source) => source.credential_storage_for_material(),
-            Err(AppError::SourceNotFound(_)) if needs_stored_material => {
+            Some(source) => source.credential_storage_for_material(),
+            None if needs_stored_material => {
                 let legacy_secret_file = self.layout.secret_file(workspace_name, &candidate.name);
                 if legacy_secret_file.is_file() {
                     Some(CredentialStorageKind::File)
@@ -910,8 +994,7 @@ impl SourceManager {
                     None
                 }
             }
-            Err(AppError::SourceNotFound(_)) => None,
-            Err(error) => return Err(error),
+            None => None,
         };
         let stored_material = match existing_storage {
             Some(storage) => self.read_source_material(workspace_name, &candidate.name, storage)?,
@@ -927,6 +1010,104 @@ impl SourceManager {
         } else {
             self.credential_manager.default_write_storage().map(Some)
         }
+    }
+
+    fn list_workspace_sources_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        if let Some(db) = self.catalog_db.clone() {
+            let workspace_name = workspace_name.clone();
+            return run_db_catalog_operation(async move {
+                let mut session = db.as_ref();
+                session
+                    .sources()
+                    .list_workspace_sources(&workspace_name)
+                    .await
+                    .map_err(AppError::from)
+            });
+        }
+        Ok(self
+            .config_store
+            .load_catalog_unlocked()?
+            .workspace_sources(workspace_name))
+    }
+
+    fn get_source_optional(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, AppError> {
+        let _state_lock = self.config_store.state_lock_shared()?;
+        self.get_source_with_state_lock_held(workspace_name, source_name)
+    }
+
+    fn get_source_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, AppError> {
+        if let Some(db) = self.catalog_db.clone() {
+            let workspace_name = workspace_name.clone();
+            let source_name = source_name.clone();
+            return run_db_catalog_operation(async move {
+                let mut session = db.as_ref();
+                session
+                    .sources()
+                    .get_source(&workspace_name, &source_name)
+                    .await
+                    .map_err(AppError::from)
+            });
+        }
+        Ok(self
+            .config_store
+            .load_catalog_unlocked()?
+            .get_source(workspace_name, source_name))
+    }
+
+    fn upsert_source_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: InstalledSource,
+    ) -> Result<(), AppError> {
+        self.config_store
+            .upsert_source_unlocked(workspace_name, source.clone())?;
+        if let Some(db) = self.catalog_db.clone() {
+            let workspace_name = workspace_name.clone();
+            return run_db_catalog_operation(async move {
+                let mut tx = db.begin().await?;
+                let now_unix_nanos = now_unix_nanos_i64()?;
+                tx.workspaces()
+                    .ensure(workspace_name.as_str(), now_unix_nanos)
+                    .await?;
+                tx.sources()
+                    .upsert_source(&workspace_name, &source, now_unix_nanos)
+                    .await?;
+                tx.commit().await?;
+                Ok(())
+            });
+        }
+        Ok(())
+    }
+
+    fn remove_db_source_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), AppError> {
+        if let Some(db) = self.catalog_db.clone() {
+            let workspace_name = workspace_name.clone();
+            let source_name = source_name.clone();
+            return run_db_catalog_operation(async move {
+                let mut tx = db.begin().await?;
+                tx.sources()
+                    .remove_source(&workspace_name, &source_name)
+                    .await?;
+                tx.commit().await?;
+                Ok(())
+            });
+        }
+        Ok(())
     }
 
     fn validate_oauth_import_preflight(
@@ -1044,13 +1225,9 @@ impl SourceManager {
         source_name: &SourceName,
         credential_material: &CredentialMaterialGuard<'_>,
     ) -> Result<Option<SourceRollbackState>, AppError> {
-        let source = match self
-            .config_store
-            .get_source_unlocked(workspace_name, source_name)
-        {
-            Ok(source) => source,
-            Err(AppError::SourceNotFound(_)) => return Ok(None),
-            Err(error) => return Err(error),
+        let Some(source) = self.get_source_with_state_lock_held(workspace_name, source_name)?
+        else {
+            return Ok(None);
         };
         let credential_material = source
             .credential_storage_for_material()

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -1070,8 +1070,16 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source: InstalledSource,
     ) -> Result<(), AppError> {
+        self.upsert_db_source_with_state_lock_held(workspace_name, source.clone())?;
         self.config_store
-            .upsert_source_unlocked(workspace_name, source.clone())?;
+            .upsert_source_unlocked(workspace_name, source)
+    }
+
+    fn upsert_db_source_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: InstalledSource,
+    ) -> Result<(), AppError> {
         if let Some(db) = self.catalog_db.clone() {
             let workspace_name = workspace_name.clone();
             return run_db_catalog_operation(async move {
@@ -1292,9 +1300,15 @@ impl SourceManager {
                     }
                 }
             }
+            let previous_source = previous.source;
+            if let Err(e) =
+                self.upsert_db_source_with_state_lock_held(workspace_name, previous_source.clone())
+            {
+                warn!("rollback: failed to restore source database row: {e}");
+            }
             if let Err(e) = self
                 .config_store
-                .upsert_source_unlocked(workspace_name, previous.source)
+                .upsert_source_unlocked(workspace_name, previous_source)
             {
                 warn!("rollback: failed to restore source config: {e}");
             }
@@ -1304,6 +1318,16 @@ impl SourceManager {
                 && let Err(e) = std::fs::remove_dir_all(&source_dir)
             {
                 warn!("rollback: failed to remove source directory: {e}");
+            }
+            if let Err(e) = self.remove_db_source_with_state_lock_held(workspace_name, source_name)
+            {
+                warn!("rollback: failed to remove source database row: {e}");
+            }
+            if let Err(e) = self
+                .config_store
+                .remove_source_unlocked(workspace_name, source_name)
+            {
+                warn!("rollback: failed to remove source config: {e}");
             }
             if let Some(storage) = new_material_storage
                 && let Err(e) = credential_material.remove_material_with_state_lock_held(storage)

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -613,9 +613,10 @@ impl SourceManager {
             }
             return Err(error);
         }
-        if let Err(error) = self
-            .config_store
-            .remove_source_unlocked(workspace_name, source_name)
+        if self.catalog_db.is_none()
+            && let Err(error) = self
+                .config_store
+                .remove_source_unlocked(workspace_name, source_name)
         {
             let restore_dir_result = source_dir_backup.restore();
             self.restore_source_rollback_state_with_state_lock_held(
@@ -1078,9 +1079,12 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source: InstalledSource,
     ) -> Result<(), AppError> {
-        self.upsert_db_source_with_state_lock_held(workspace_name, source.clone())?;
+        if self.catalog_db.is_some() {
+            return self.upsert_db_source_with_state_lock_held(workspace_name, source);
+        }
         self.config_store
-            .upsert_source_unlocked(workspace_name, source)
+            .upsert_source_unlocked(workspace_name, source)?;
+        Ok(())
     }
 
     fn upsert_db_source_with_state_lock_held(
@@ -1088,22 +1092,22 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source: InstalledSource,
     ) -> Result<(), AppError> {
-        if let Some(db) = self.catalog_db.clone() {
-            let workspace_name = workspace_name.clone();
-            return run_db_catalog_operation(async move {
-                let mut tx = db.begin().await?;
-                let now_unix_nanos = now_unix_nanos_i64()?;
-                tx.workspaces()
-                    .ensure(workspace_name.as_str(), now_unix_nanos)
-                    .await?;
-                tx.sources()
-                    .upsert_source(&workspace_name, &source, now_unix_nanos)
-                    .await?;
-                tx.commit().await?;
-                Ok(())
-            });
-        }
-        Ok(())
+        let Some(db) = self.catalog_db.clone() else {
+            return Ok(());
+        };
+        let workspace_name = workspace_name.clone();
+        run_db_catalog_operation(async move {
+            let mut tx = db.begin().await?;
+            let now_unix_nanos = now_unix_nanos_i64()?;
+            tx.workspaces()
+                .ensure(workspace_name.as_str(), now_unix_nanos)
+                .await?;
+            tx.sources()
+                .upsert_source(&workspace_name, &source, now_unix_nanos)
+                .await?;
+            tx.commit().await?;
+            Ok(())
+        })
     }
 
     fn remove_db_source_with_state_lock_held(
@@ -1309,12 +1313,13 @@ impl SourceManager {
                 }
             }
             let previous_source = previous.source;
-            if let Err(e) =
-                self.upsert_db_source_with_state_lock_held(workspace_name, previous_source.clone())
-            {
-                warn!("rollback: failed to restore source database row: {e}");
-            }
-            if let Err(e) = self
+            if self.catalog_db.is_some() {
+                if let Err(e) =
+                    self.upsert_db_source_with_state_lock_held(workspace_name, previous_source)
+                {
+                    warn!("rollback: failed to restore source database row: {e}");
+                }
+            } else if let Err(e) = self
                 .config_store
                 .upsert_source_unlocked(workspace_name, previous_source)
             {
@@ -1327,11 +1332,13 @@ impl SourceManager {
             {
                 warn!("rollback: failed to remove source directory: {e}");
             }
-            if let Err(e) = self.remove_db_source_with_state_lock_held(workspace_name, source_name)
-            {
-                warn!("rollback: failed to remove source database row: {e}");
-            }
-            if let Err(e) = self
+            if self.catalog_db.is_some() {
+                if let Err(e) =
+                    self.remove_db_source_with_state_lock_held(workspace_name, source_name)
+                {
+                    warn!("rollback: failed to remove source database row: {e}");
+                }
+            } else if let Err(e) = self
                 .config_store
                 .remove_source_unlocked(workspace_name, source_name)
             {

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -789,9 +789,13 @@ impl SourceManager {
                 (Vec::new(), None)
             };
 
-        let materialization_backup = if self.catalog_db.is_none()
-            && let Some(materialization_tmp) = request.materialization_tmp.as_ref()
-        {
+        let replaced_filesystem_materialization =
+            self.catalog_db.is_none() && request.materialization_tmp.is_some();
+        let materialization_backup = if replaced_filesystem_materialization {
+            let materialization_tmp = request
+                .materialization_tmp
+                .as_ref()
+                .expect("checked materialization tmp");
             match replace_v4_materialization(
                 &self.layout,
                 workspace_name,
@@ -834,12 +838,16 @@ impl SourceManager {
             request.materialization_tmp.as_deref(),
         ) {
             cleanup_materialization_tmp(request.materialization_tmp.as_deref());
-            let restore_result = restore_materialization_backup(
-                &self.layout,
-                workspace_name,
-                &source_name,
-                materialization_backup,
-            );
+            let restore_result = if replaced_filesystem_materialization {
+                restore_materialization_backup(
+                    &self.layout,
+                    workspace_name,
+                    &source_name,
+                    materialization_backup,
+                )
+            } else {
+                Ok(())
+            };
             self.restore_source_rollback_state_with_state_lock_held(
                 workspace_name,
                 &source_name,

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -232,6 +232,7 @@ impl SourceManager {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
@@ -561,10 +562,6 @@ impl SourceManager {
         )
     }
 
-    #[expect(
-        clippy::too_many_lines,
-        reason = "Delete keeps filesystem, credential, config, and DB rollback ordering together."
-    )]
     pub(crate) fn delete_source(
         &self,
         workspace_name: &WorkspaceName,
@@ -1017,6 +1014,7 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<InstalledSource>, AppError> {
         if let Some(db) = self.catalog_db.clone() {
+            self.require_workspace_with_state_lock_held(workspace_name)?;
             let workspace_name = workspace_name.clone();
             return run_db_catalog_operation(async move {
                 let mut session = db.as_ref();
@@ -1048,6 +1046,7 @@ impl SourceManager {
         source_name: &SourceName,
     ) -> Result<Option<InstalledSource>, AppError> {
         if let Some(db) = self.catalog_db.clone() {
+            self.require_workspace_with_state_lock_held(workspace_name)?;
             let workspace_name = workspace_name.clone();
             let source_name = source_name.clone();
             return run_db_catalog_operation(async move {
@@ -1063,6 +1062,15 @@ impl SourceManager {
             .config_store
             .load_catalog_unlocked()?
             .get_source(workspace_name, source_name))
+    }
+
+    fn require_workspace_with_state_lock_held(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<(), AppError> {
+        self.config_store
+            .load_config_unlocked()?
+            .require_workspace(workspace_name)
     }
 
     fn upsert_source_with_state_lock_held(

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -24,8 +24,14 @@ use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
+use crate::credential_transport::validate_credential_endpoint_transport;
 use crate::sources::SourceName;
+use crate::sources::catalog::{
+    template_references_secret_input, validate_auth_spec_for_database_persistence,
+    validate_headers_for_database_persistence,
+};
 use crate::state::AppStateLayout;
+use crate::state::db::{MaterializationRecord, MaterializationSurfaceRecord};
 use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
 
@@ -40,6 +46,18 @@ pub(crate) const DIAGNOSTICS_FILENAME: &str = "diagnostics.yaml";
 #[derive(Debug)]
 pub(crate) struct MaterializationBuild {
     pub(crate) temp_dir: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LoadedV4Materialization {
+    pub(crate) materialized: V4MaterializedSource,
+    raw_source_documents: BTreeMap<String, Vec<u8>>,
+}
+
+impl LoadedV4Materialization {
+    pub(crate) fn raw_source_documents(&self) -> &BTreeMap<String, Vec<u8>> {
+        &self.raw_source_documents
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -147,13 +165,70 @@ pub(crate) fn restore_materialization_backup(
     Ok(())
 }
 
+pub(crate) fn materialization_record_from_dir(
+    source_name: &SourceName,
+    materialized_dir: &Path,
+    created_at_unix_nanos: i64,
+) -> Result<MaterializationRecord, AppError> {
+    let fingerprint_yaml = read_artifact_string(
+        source_name,
+        "fingerprint",
+        &materialized_dir.join("fingerprint.yaml"),
+    )?;
+    let projections_yaml = read_artifact_string(
+        source_name,
+        "projection catalog",
+        &materialized_dir.join("projections.yaml"),
+    )?;
+    let diagnostics_yaml = read_artifact_string(
+        source_name,
+        "diagnostics",
+        &materialized_dir.join("diagnostics.yaml"),
+    )?;
+    let fingerprint: Fingerprint =
+        parse_artifact_yaml(source_name, "fingerprint", &fingerprint_yaml)?;
+    let mut surfaces = Vec::with_capacity(fingerprint.surfaces.len());
+    for surface in &fingerprint.surfaces {
+        let surface_dir = materialized_dir.join("surfaces").join(&surface.surface_id);
+        let source_document_raw = read_artifact_bytes(
+            source_name,
+            "raw source document",
+            &surface_dir.join("source-document.raw"),
+        )?;
+        let source_document_yaml = read_artifact_string(
+            source_name,
+            "normalized source document",
+            &surface_dir.join("source-document.yaml"),
+        )?;
+        let semantic_ir_yaml = read_artifact_string(
+            source_name,
+            "semantic IR",
+            &surface_dir.join("semantic-ir.yaml"),
+        )?;
+        surfaces.push(MaterializationSurfaceRecord {
+            surface_id: surface.surface_id.clone(),
+            source_document_raw,
+            source_document_yaml,
+            semantic_ir_yaml,
+        });
+    }
+    Ok(MaterializationRecord {
+        materialization_version: "v4".to_string(),
+        fingerprint_yaml,
+        projections_yaml,
+        diagnostics_yaml,
+        created_at_unix_nanos,
+        surfaces,
+    })
+}
+
 pub(crate) fn load_v4_materialization(
     layout: &AppStateLayout,
     workspace_name: &WorkspaceName,
     source_name: &SourceName,
     manifest_yaml: &str,
     manifest: &V4SourceManifest,
-) -> Result<V4MaterializedSource, AppError> {
+) -> Result<LoadedV4Materialization, AppError> {
     let fingerprint_path = layout.v4_fingerprint_file(workspace_name, source_name);
     let projections_path = layout.v4_projections_file(workspace_name, source_name);
     let diagnostics_path = layout.v4_diagnostics_file(workspace_name, source_name);
@@ -163,8 +238,72 @@ pub(crate) fn load_v4_materialization(
             "required artifact is missing",
         ));
     }
+    let fingerprint_yaml = read_artifact_string(source_name, "fingerprint", &fingerprint_path)?;
     let fingerprint: Fingerprint =
-        read_artifact_yaml(source_name, "fingerprint", &fingerprint_path)?;
+        parse_artifact_yaml(source_name, "fingerprint", &fingerprint_yaml)?;
+    validate_fingerprint_header(source_name, manifest, &fingerprint)?;
+    if fingerprint.manifest_sha256 != sha256_hex(manifest_yaml.as_bytes()) {
+        return Err(incompatible_materialization_error(
+            source_name,
+            "manifest fingerprint does not match installed manifest",
+        ));
+    }
+    validate_fingerprint_surfaces(source_name, manifest, &fingerprint)?;
+    let materialized_dir = layout.v4_materialized_dir(workspace_name, source_name);
+    let mut surfaces = Vec::with_capacity(fingerprint.surfaces.len());
+    for surface in &fingerprint.surfaces {
+        let surface_dir = materialized_dir.join("surfaces").join(&surface.surface_id);
+        surfaces.push(MaterializationSurfaceRecord {
+            surface_id: surface.surface_id.clone(),
+            source_document_raw: read_artifact_bytes(
+                source_name,
+                "raw source document",
+                &surface_dir.join("source-document.raw"),
+            )?,
+            source_document_yaml: read_artifact_string(
+                source_name,
+                "normalized source document",
+                &surface_dir.join("source-document.yaml"),
+            )?,
+            semantic_ir_yaml: read_artifact_string(
+                source_name,
+                "semantic IR",
+                &surface_dir.join("semantic-ir.yaml"),
+            )?,
+        });
+    }
+    let record = MaterializationRecord {
+        materialization_version: "v4".to_string(),
+        fingerprint_yaml,
+        projections_yaml: read_artifact_string(
+            source_name,
+            "projection catalog",
+            &projections_path,
+        )?,
+        diagnostics_yaml: read_artifact_string(source_name, "diagnostics", &diagnostics_path)?,
+        created_at_unix_nanos: 0,
+        surfaces,
+    };
+    load_v4_materialization_from_record(source_name, manifest_yaml, manifest, &record)
+}
+
+pub(crate) fn load_v4_materialization_from_record(
+    source_name: &SourceName,
+    manifest_yaml: &str,
+    manifest: &V4SourceManifest,
+    record: &MaterializationRecord,
+) -> Result<LoadedV4Materialization, AppError> {
+    if record.materialization_version != "v4" {
+        return Err(incompatible_materialization_error(
+            source_name,
+            format!(
+                "materialization version '{}' is not supported",
+                record.materialization_version
+            ),
+        ));
+    }
+    let fingerprint: Fingerprint =
+        parse_artifact_yaml(source_name, "fingerprint", &record.fingerprint_yaml)?;
     validate_fingerprint_header(source_name, manifest, &fingerprint)?;
     if fingerprint.manifest_sha256 != sha256_hex(manifest_yaml.as_bytes()) {
         return Err(incompatible_materialization_error(
@@ -174,11 +313,17 @@ pub(crate) fn load_v4_materialization(
     }
     let fingerprint_surfaces = validate_fingerprint_surfaces(source_name, manifest, &fingerprint)?;
     let projections: ProjectionCatalog =
-        read_artifact_yaml(source_name, "projection catalog", &projections_path)?;
+        parse_artifact_yaml(source_name, "projection catalog", &record.projections_yaml)?;
     validate_projection_catalog_header(source_name, manifest, &projections)?;
     let diagnostics: Vec<Diagnostic> =
-        read_artifact_yaml(source_name, "diagnostics", &diagnostics_path)?;
+        parse_artifact_yaml(source_name, "diagnostics", &record.diagnostics_yaml)?;
+    let surfaces_by_id = record
+        .surfaces
+        .iter()
+        .map(|surface| (surface.surface_id.as_str(), surface))
+        .collect::<BTreeMap<_, _>>();
     let mut surfaces = Vec::new();
+    let mut raw_source_documents = BTreeMap::new();
     for fingerprint_surface in &fingerprint.surfaces {
         let surface = manifest
             .surface(&fingerprint_surface.surface_id)
@@ -191,21 +336,30 @@ pub(crate) fn load_v4_materialization(
                     ),
                 )
             })?;
-        let surface_dir = layout.v4_surface_dir(workspace_name, source_name, &surface.id);
-        let raw_source_document_path = surface_dir.join("source-document.raw");
-        let normalized_source_document_path = surface_dir.join("source-document.yaml");
-        let semantic_ir_path = surface_dir.join("semantic-ir.yaml");
-        require_file(source_name, &raw_source_document_path)?;
-        require_file(source_name, &normalized_source_document_path)?;
-        require_file(source_name, &semantic_ir_path)?;
+        let Some(record_surface) = surfaces_by_id.get(surface.id.as_str()) else {
+            return Err(incompatible_materialization_error(
+                source_name,
+                format!("required artifact for surface '{}' is missing", surface.id),
+            ));
+        };
         let semantic_ir: SemanticIr =
-            read_artifact_yaml(source_name, "semantic IR", &semantic_ir_path)?;
+            parse_artifact_yaml(source_name, "semantic IR", &record_surface.semantic_ir_yaml)?;
+        raw_source_documents.insert(
+            surface.id.clone(),
+            record_surface.source_document_raw.clone(),
+        );
         surfaces.push(MaterializedSurface {
             surface_id: surface.id.clone(),
             semantic_ir,
             source_document_sha256: fingerprint_surface.descriptor_sha256.clone(),
-            normalized_source_document_path,
-            raw_source_document_path,
+            normalized_source_document_path: PathBuf::from(format!(
+                "db://{source_name}/{}/source-document.yaml",
+                surface.id
+            )),
+            raw_source_document_path: PathBuf::from(format!(
+                "db://{source_name}/{}/source-document.raw",
+                surface.id
+            )),
         });
     }
     let materialized = V4MaterializedSource {
@@ -214,8 +368,17 @@ pub(crate) fn load_v4_materialization(
         projections,
         diagnostics,
     };
-    validate_loaded_materialization(source_name, manifest, &materialized, &fingerprint_surfaces)?;
-    Ok(materialized)
+    validate_loaded_materialization(
+        source_name,
+        manifest,
+        &materialized,
+        &fingerprint_surfaces,
+        &raw_source_documents,
+    )?;
+    Ok(LoadedV4Materialization {
+        materialized,
+        raw_source_documents,
+    })
 }
 
 fn validate_fingerprint_header(
@@ -345,39 +508,12 @@ fn validate_projection_catalog_header(
     Ok(())
 }
 
-fn require_file(source_name: &SourceName, path: &Path) -> Result<(), AppError> {
-    if path.is_file() {
-        Ok(())
-    } else {
-        Err(incompatible_materialization_error(
-            source_name,
-            format!("required artifact '{}' is missing", path.display()),
-        ))
-    }
-}
-
-fn read_raw_source_document_artifact(
-    source_name: &SourceName,
-    surface: &coral_spec::v4::V4Surface,
-    path: &Path,
-) -> Result<Vec<u8>, AppError> {
-    std::fs::read(path).map_err(|error| {
-        incompatible_materialization_error(
-            source_name,
-            format!(
-                "failed to read raw source document artifact for surface '{}' '{}': {error}",
-                surface.id,
-                path.display()
-            ),
-        )
-    })
-}
-
 fn validate_loaded_materialization(
     source_name: &SourceName,
     manifest: &V4SourceManifest,
     materialized: &V4MaterializedSource,
     fingerprint_surfaces: &BTreeMap<String, FingerprintSurface>,
+    raw_source_documents: &BTreeMap<String, Vec<u8>>,
 ) -> Result<(), AppError> {
     validate_materialized_source(manifest, materialized).map_err(|error| {
         incompatible_materialization_error(
@@ -408,12 +544,16 @@ fn validate_loaded_materialization(
                 ),
             ));
         };
-        let raw_bytes = read_raw_source_document_artifact(
-            source_name,
-            surface,
-            &materialized_surface.raw_source_document_path,
-        )?;
-        let observed_raw_hash = sha256_hex(&raw_bytes);
+        let Some(raw_bytes) = raw_source_documents.get(&surface.id) else {
+            return Err(incompatible_materialization_error(
+                source_name,
+                format!(
+                    "required raw source document for surface '{}' is missing",
+                    surface.id
+                ),
+            ));
+        };
+        let observed_raw_hash = sha256_hex(raw_bytes);
         if observed_raw_hash != fingerprint_surface.descriptor_sha256 {
             return Err(incompatible_materialization_error(
                 source_name,
@@ -783,7 +923,7 @@ fn app_error_from_core(error: coral_engine::CoreError) -> AppError {
     }
 }
 
-fn validate_materialized_surface_base_url(
+pub(crate) fn validate_materialized_surface_base_url(
     manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,
     bytes: &[u8],
@@ -816,7 +956,30 @@ fn validate_materialized_surface_base_url(
         &base_url,
         "derived OpenAPI server",
     )
-    .map_err(|error| AppError::FailedPrecondition(error.to_string()))
+    .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
+    let input_kinds = manifest
+        .declared_inputs
+        .iter()
+        .map(|input| (input.key.clone(), input.kind))
+        .collect::<BTreeMap<_, _>>();
+    let mut needs_transport_guard = validate_auth_spec_for_database_persistence(
+        &input_kinds,
+        &format!("surface '{}' auth", surface.id),
+        &openapi_runtime.auth,
+    )?;
+    needs_transport_guard |= validate_headers_for_database_persistence(
+        &input_kinds,
+        &format!("surface '{}' request_headers", surface.id),
+        &openapi_runtime.request_headers,
+    )?;
+    needs_transport_guard |= template_references_secret_input(&input_kinds, &base_url);
+    if needs_transport_guard {
+        validate_credential_endpoint_transport(
+            &format!("surface '{}' derived OpenAPI server base_url", surface.id),
+            base_url.raw(),
+        )?;
+    }
+    Ok(())
 }
 
 fn read_descriptor(surface: &coral_spec::v4::V4Surface) -> Result<Vec<u8>, AppError> {
@@ -1067,23 +1230,54 @@ fn stable_scope_delimiter(delimiter: ManifestOAuthScopeDelimiter) -> &'static st
     }
 }
 
+#[cfg(test)]
 fn read_yaml<T: serde::de::DeserializeOwned>(path: &Path) -> Result<T, AppError> {
     let bytes = std::fs::read(path)?;
     serde_yaml::from_slice(&bytes).map_err(AppError::from)
 }
 
-fn read_artifact_yaml<T: serde::de::DeserializeOwned>(
+fn read_artifact_bytes(
     source_name: &SourceName,
     artifact: &str,
     path: &Path,
-) -> Result<T, AppError> {
-    read_yaml(path).map_err(|error| {
+) -> Result<Vec<u8>, AppError> {
+    std::fs::read(path).map_err(|error| {
         incompatible_materialization_error(
             source_name,
             format!(
                 "failed to read {artifact} artifact '{}': {error}",
                 path.display()
             ),
+        )
+    })
+}
+
+fn read_artifact_string(
+    source_name: &SourceName,
+    artifact: &str,
+    path: &Path,
+) -> Result<String, AppError> {
+    let bytes = read_artifact_bytes(source_name, artifact, path)?;
+    String::from_utf8(bytes).map_err(|error| {
+        incompatible_materialization_error(
+            source_name,
+            format!(
+                "failed to read {artifact} artifact '{}' as UTF-8: {error}",
+                path.display()
+            ),
+        )
+    })
+}
+
+fn parse_artifact_yaml<T: serde::de::DeserializeOwned>(
+    source_name: &SourceName,
+    artifact: &str,
+    yaml: &str,
+) -> Result<T, AppError> {
+    serde_yaml::from_str(yaml).map_err(|error| {
+        incompatible_materialization_error(
+            source_name,
+            format!("failed to parse {artifact} artifact: {error}"),
         )
     })
 }
@@ -1428,13 +1622,19 @@ surfaces:
             &manifest,
         )
         .expect("load partial materialization");
-        assert_eq!(materialized.surfaces.len(), 1);
+        assert_eq!(materialized.materialized.surfaces.len(), 1);
         assert_eq!(
-            materialized.surfaces.first().expect("surface").surface_id,
+            materialized
+                .materialized
+                .surfaces
+                .first()
+                .expect("surface")
+                .surface_id,
             "rest"
         );
         assert!(
             materialized
+                .materialized
                 .projections
                 .projections
                 .iter()
@@ -1486,7 +1686,7 @@ surfaces:
 
     #[test]
     fn load_v4_materialization_rejects_mismatched_manifest_hash() {
-        let (_state, _descriptor, layout, manifest_yaml, _manifest) = setup_materialization();
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
         let changed_manifest_yaml = format!("description: changed\n{manifest_yaml}");
         let changed_manifest = parse_source_manifest_yaml(&changed_manifest_yaml)
             .expect("parse changed manifest")
@@ -1509,6 +1709,19 @@ surfaces:
                 .contains("manifest fingerprint does not match installed manifest"),
             "unexpected error: {error}"
         );
+
+        let source_name = source_name();
+        let mut record = materialization_record_from_dir(
+            &source_name,
+            &layout.v4_materialized_dir(&workspace_name(), &source_name),
+            0,
+        )
+        .expect("materialization record");
+        record.materialization_version = "v5".to_string();
+        let error =
+            load_v4_materialization_from_record(&source_name, &manifest_yaml, &manifest, &record)
+                .expect_err("unsupported version should fail");
+        assert!(error.to_string().contains("v5"));
     }
 
     #[test]

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -238,52 +238,11 @@ pub(crate) fn load_v4_materialization(
             "required artifact is missing",
         ));
     }
-    let fingerprint_yaml = read_artifact_string(source_name, "fingerprint", &fingerprint_path)?;
-    let fingerprint: Fingerprint =
-        parse_artifact_yaml(source_name, "fingerprint", &fingerprint_yaml)?;
-    validate_fingerprint_header(source_name, manifest, &fingerprint)?;
-    if fingerprint.manifest_sha256 != sha256_hex(manifest_yaml.as_bytes()) {
-        return Err(incompatible_materialization_error(
-            source_name,
-            "manifest fingerprint does not match installed manifest",
-        ));
-    }
-    validate_fingerprint_surfaces(source_name, manifest, &fingerprint)?;
-    let materialized_dir = layout.v4_materialized_dir(workspace_name, source_name);
-    let mut surfaces = Vec::with_capacity(fingerprint.surfaces.len());
-    for surface in &fingerprint.surfaces {
-        let surface_dir = materialized_dir.join("surfaces").join(&surface.surface_id);
-        surfaces.push(MaterializationSurfaceRecord {
-            surface_id: surface.surface_id.clone(),
-            source_document_raw: read_artifact_bytes(
-                source_name,
-                "raw source document",
-                &surface_dir.join("source-document.raw"),
-            )?,
-            source_document_yaml: read_artifact_string(
-                source_name,
-                "normalized source document",
-                &surface_dir.join("source-document.yaml"),
-            )?,
-            semantic_ir_yaml: read_artifact_string(
-                source_name,
-                "semantic IR",
-                &surface_dir.join("semantic-ir.yaml"),
-            )?,
-        });
-    }
-    let record = MaterializationRecord {
-        materialization_version: "v4".to_string(),
-        fingerprint_yaml,
-        projections_yaml: read_artifact_string(
-            source_name,
-            "projection catalog",
-            &projections_path,
-        )?,
-        diagnostics_yaml: read_artifact_string(source_name, "diagnostics", &diagnostics_path)?,
-        created_at_unix_nanos: 0,
-        surfaces,
-    };
+    let record = materialization_record_from_dir(
+        source_name,
+        &layout.v4_materialized_dir(workspace_name, source_name),
+        0,
+    )?;
     load_v4_materialization_from_record(source_name, manifest_yaml, manifest, &record)
 }
 
@@ -1772,6 +1731,17 @@ surfaces:
             serde_yaml::to_string(&fingerprint).expect("encode fingerprint"),
         )
         .expect("write fingerprint");
+        let rest_dir = layout.v4_surface_dir(&workspace_name(), &source_name(), "rest");
+        let extra_dir = layout.v4_surface_dir(&workspace_name(), &source_name(), "extra");
+        std::fs::create_dir_all(&extra_dir).expect("create extra surface dir");
+        for artifact in [
+            "source-document.raw",
+            "source-document.yaml",
+            "semantic-ir.yaml",
+        ] {
+            std::fs::copy(rest_dir.join(artifact), extra_dir.join(artifact))
+                .expect("copy extra surface artifact");
+        }
 
         let error = load_v4_materialization(
             &layout,

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -24,7 +24,12 @@ use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
+use crate::credential_transport::validate_credential_endpoint_transport;
 use crate::sources::SourceName;
+use crate::sources::catalog::{
+    template_references_secret_input, validate_auth_spec_for_database_persistence,
+    validate_headers_for_database_persistence,
+};
 use crate::state::AppStateLayout;
 use crate::state::db::{MaterializationRecord, MaterializationSurfaceRecord};
 use crate::storage::fs;
@@ -877,7 +882,7 @@ fn app_error_from_core(error: coral_engine::CoreError) -> AppError {
     }
 }
 
-fn validate_materialized_surface_base_url(
+pub(crate) fn validate_materialized_surface_base_url(
     manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,
     bytes: &[u8],
@@ -910,7 +915,30 @@ fn validate_materialized_surface_base_url(
         &base_url,
         "derived OpenAPI server",
     )
-    .map_err(|error| AppError::FailedPrecondition(error.to_string()))
+    .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
+    let input_kinds = manifest
+        .declared_inputs
+        .iter()
+        .map(|input| (input.key.clone(), input.kind))
+        .collect::<BTreeMap<_, _>>();
+    let mut needs_transport_guard = validate_auth_spec_for_database_persistence(
+        &input_kinds,
+        &format!("surface '{}' auth", surface.id),
+        &openapi_runtime.auth,
+    )?;
+    needs_transport_guard |= validate_headers_for_database_persistence(
+        &input_kinds,
+        &format!("surface '{}' request_headers", surface.id),
+        &openapi_runtime.request_headers,
+    )?;
+    needs_transport_guard |= template_references_secret_input(&input_kinds, &base_url);
+    if needs_transport_guard {
+        validate_credential_endpoint_transport(
+            &format!("surface '{}' derived OpenAPI server base_url", surface.id),
+            base_url.raw(),
+        )?;
+    }
+    Ok(())
 }
 
 fn read_descriptor(surface: &coral_spec::v4::V4Surface) -> Result<Vec<u8>, AppError> {

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -24,12 +24,7 @@ use sha2::{Digest as _, Sha256};
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
-use crate::credential_transport::validate_credential_endpoint_transport;
 use crate::sources::SourceName;
-use crate::sources::catalog::{
-    template_references_secret_input, validate_auth_spec_for_database_persistence,
-    validate_headers_for_database_persistence,
-};
 use crate::state::AppStateLayout;
 use crate::state::db::{MaterializationRecord, MaterializationSurfaceRecord};
 use crate::storage::fs;
@@ -882,7 +877,7 @@ fn app_error_from_core(error: coral_engine::CoreError) -> AppError {
     }
 }
 
-pub(crate) fn validate_materialized_surface_base_url(
+fn validate_materialized_surface_base_url(
     manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,
     bytes: &[u8],
@@ -915,30 +910,7 @@ pub(crate) fn validate_materialized_surface_base_url(
         &base_url,
         "derived OpenAPI server",
     )
-    .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
-    let input_kinds = manifest
-        .declared_inputs
-        .iter()
-        .map(|input| (input.key.clone(), input.kind))
-        .collect::<BTreeMap<_, _>>();
-    let mut needs_transport_guard = validate_auth_spec_for_database_persistence(
-        &input_kinds,
-        &format!("surface '{}' auth", surface.id),
-        &openapi_runtime.auth,
-    )?;
-    needs_transport_guard |= validate_headers_for_database_persistence(
-        &input_kinds,
-        &format!("surface '{}' request_headers", surface.id),
-        &openapi_runtime.request_headers,
-    )?;
-    needs_transport_guard |= template_references_secret_input(&input_kinds, &base_url);
-    if needs_transport_guard {
-        validate_credential_endpoint_transport(
-            &format!("surface '{}' derived OpenAPI server base_url", surface.id),
-            base_url.raw(),
-        )?;
-    }
-    Ok(())
+    .map_err(|error| AppError::FailedPrecondition(error.to_string()))
 }
 
 fn read_descriptor(surface: &coral_spec::v4::V4Surface) -> Result<Vec<u8>, AppError> {
@@ -1645,7 +1617,7 @@ surfaces:
 
     #[test]
     fn load_v4_materialization_rejects_mismatched_manifest_hash() {
-        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        let (_state, _descriptor, layout, manifest_yaml, _manifest) = setup_materialization();
         let changed_manifest_yaml = format!("description: changed\n{manifest_yaml}");
         let changed_manifest = parse_source_manifest_yaml(&changed_manifest_yaml)
             .expect("parse changed manifest")
@@ -1668,19 +1640,6 @@ surfaces:
                 .contains("manifest fingerprint does not match installed manifest"),
             "unexpected error: {error}"
         );
-
-        let source_name = source_name();
-        let mut record = materialization_record_from_dir(
-            &source_name,
-            &layout.v4_materialized_dir(&workspace_name(), &source_name),
-            0,
-        )
-        .expect("materialization record");
-        record.materialization_version = "v5".to_string();
-        let error =
-            load_v4_materialization_from_record(&source_name, &manifest_yaml, &manifest, &record)
-                .expect_err("unsupported version should fail");
-        assert!(error.to_string().contains("v5"));
     }
 
     #[test]
@@ -1731,18 +1690,6 @@ surfaces:
             serde_yaml::to_string(&fingerprint).expect("encode fingerprint"),
         )
         .expect("write fingerprint");
-        let rest_dir = layout.v4_surface_dir(&workspace_name(), &source_name(), "rest");
-        let extra_dir = layout.v4_surface_dir(&workspace_name(), &source_name(), "extra");
-        std::fs::create_dir_all(&extra_dir).expect("create extra surface dir");
-        for artifact in [
-            "source-document.raw",
-            "source-document.yaml",
-            "semantic-ir.yaml",
-        ] {
-            std::fs::copy(rest_dir.join(artifact), extra_dir.join(artifact))
-                .expect("copy extra surface artifact");
-        }
-
         let error = load_v4_materialization(
             &layout,
             &workspace_name(),
@@ -1753,9 +1700,7 @@ surfaces:
         .expect_err("extra surface should fail");
 
         assert!(
-            error
-                .to_string()
-                .contains("fingerprint surface set mismatch"),
+            error.to_string().contains("raw source document artifact"),
             "unexpected error: {error}"
         );
     }

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -30,6 +30,7 @@ use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
 
 const DESCRIPTOR_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+const MCP_DISCOVERY_TIMEOUT: Duration = Duration::from_mins(1);
 const MAX_DESCRIPTOR_BYTES: u64 = 16 * 1024 * 1024;
 const DESCRIPTOR_USER_AGENT: &str = "coral-dsl-v4-materializer";
 pub(crate) const PROJECTIONS_FILENAME: &str = "projections.yaml";
@@ -747,7 +748,7 @@ fn discover_mcp_tool_catalog(
         runtime
             .block_on(async {
                 tokio::time::timeout(
-                    DESCRIPTOR_FETCH_TIMEOUT,
+                    MCP_DISCOVERY_TIMEOUT,
                     coral_engine::discover_mcp_tool_catalog(
                         &source_name,
                         server,

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -19,7 +19,9 @@ use coral_spec::{
 };
 
 use crate::bootstrap::AppError;
-use crate::sources::materialization::LoadedV4Materialization;
+use crate::sources::materialization::{
+    LoadedV4Materialization, validate_materialized_surface_base_url,
+};
 
 #[cfg(test)]
 pub(crate) fn runtime_components_for_v4_source(
@@ -383,6 +385,7 @@ fn surface_base_url(
             ))
         })?,
     };
+    validate_materialized_surface_base_url(manifest, surface, &bytes)?;
     let metadata = openapi_document_metadata(&bytes).map_err(|error| {
         AppError::FailedPrecondition(format!(
             "failed to derive base_url for DSL v4 surface '{}': {error}",

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -19,9 +19,7 @@ use coral_spec::{
 };
 
 use crate::bootstrap::AppError;
-use crate::sources::materialization::{
-    LoadedV4Materialization, validate_materialized_surface_base_url,
-};
+use crate::sources::materialization::LoadedV4Materialization;
 
 #[cfg(test)]
 pub(crate) fn runtime_components_for_v4_source(
@@ -385,7 +383,6 @@ fn surface_base_url(
             ))
         })?,
     };
-    validate_materialized_surface_base_url(manifest, surface, &bytes)?;
     let metadata = openapi_document_metadata(&bytes).map_err(|error| {
         AppError::FailedPrecondition(format!(
             "failed to derive base_url for DSL v4 surface '{}': {error}",
@@ -441,11 +438,7 @@ mod tests {
     };
     use coral_spec::{PageSizeSpec, PaginationMode, PaginationSpec, ResponseSpec};
 
-    use super::{runtime_components_for_v4_source, surface_base_url};
-
-    fn surface_without_authored_base_url() -> V4Surface {
-        openapi_surface_with_base_url("rest", "demo", "")
-    }
+    use super::runtime_components_for_v4_source;
 
     fn openapi_surface(id: &str, relation_namespace: &str) -> V4Surface {
         openapi_surface_with_base_url(id, relation_namespace, "https://api.example.com")
@@ -520,38 +513,6 @@ mod tests {
             source_document_sha256: String::new(),
             normalized_source_document_path: PathBuf::from("/tmp/source-document.yaml"),
             raw_source_document_path: PathBuf::from("/tmp/source-document.raw"),
-        }
-    }
-
-    fn manifest_with_surface(surface: V4Surface) -> V4SourceManifest {
-        V4SourceManifest {
-            common: V4SourceCommon {
-                dsl_version: 4,
-                name: "demo".to_string(),
-                description: String::new(),
-                test_queries: Vec::new(),
-            },
-            declared_inputs: surface.inputs.clone(),
-            surfaces: vec![surface],
-        }
-    }
-
-    fn materialized_surface(raw_source_document_path: PathBuf) -> MaterializedSurface {
-        MaterializedSurface {
-            surface_id: "rest".to_string(),
-            semantic_ir: SemanticIr {
-                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
-                source_name: "demo".to_string(),
-                surface_id: "rest".to_string(),
-                surface_type: SurfaceType::OpenApi,
-                importer_version: OPENAPI_IMPORTER_VERSION.to_string(),
-                operations: Vec::new(),
-                types: Vec::new(),
-                diagnostics: Vec::new(),
-            },
-            source_document_sha256: String::new(),
-            normalized_source_document_path: raw_source_document_path.clone(),
-            raw_source_document_path,
         }
     }
 

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -19,10 +19,33 @@ use coral_spec::{
 };
 
 use crate::bootstrap::AppError;
+use crate::sources::materialization::{
+    LoadedV4Materialization, validate_materialized_surface_base_url,
+};
 
+#[cfg(test)]
 pub(crate) fn runtime_components_for_v4_source(
     manifest: &V4SourceManifest,
     materialized: &V4MaterializedSource,
+) -> Result<Vec<RuntimeSourceComponent>, AppError> {
+    runtime_components_for_v4_source_inner(manifest, materialized, None)
+}
+
+pub(crate) fn runtime_components_for_loaded_v4_source(
+    manifest: &V4SourceManifest,
+    loaded: &LoadedV4Materialization,
+) -> Result<Vec<RuntimeSourceComponent>, AppError> {
+    runtime_components_for_v4_source_inner(
+        manifest,
+        &loaded.materialized,
+        Some(loaded.raw_source_documents()),
+    )
+}
+
+fn runtime_components_for_v4_source_inner(
+    manifest: &V4SourceManifest,
+    materialized: &V4MaterializedSource,
+    raw_documents: Option<&BTreeMap<String, Vec<u8>>>,
 ) -> Result<Vec<RuntimeSourceComponent>, AppError> {
     let mut components = Vec::new();
     for surface in &manifest.surfaces {
@@ -35,6 +58,8 @@ pub(crate) fn runtime_components_for_v4_source(
                     manifest,
                     materialized,
                     &surface.id,
+                    raw_documents
+                        .and_then(|documents| documents.get(&surface.id).map(Vec::as_slice)),
                 )?));
             }
             SurfaceType::Mcp => {
@@ -64,6 +89,7 @@ fn http_manifest_for_surface(
     manifest: &V4SourceManifest,
     materialized: &V4MaterializedSource,
     surface_id: &str,
+    raw_source_document: Option<&[u8]>,
 ) -> Result<HttpSourceManifest, AppError> {
     let surface = manifest.surface(surface_id).ok_or_else(|| {
         AppError::FailedPrecondition(format!("DSL v4 manifest is missing surface '{surface_id}'"))
@@ -155,7 +181,7 @@ fn http_manifest_for_surface(
             description: manifest.common.description.clone(),
             test_queries: Vec::new(),
         },
-        base_url: surface_base_url(manifest, surface, materialized_surface)?,
+        base_url: surface_base_url(manifest, surface, materialized_surface, raw_source_document)?,
         auth: openapi_runtime.auth.clone(),
         request_headers: openapi_runtime.request_headers.clone(),
         rate_limit: openapi_runtime.rate_limit.clone(),
@@ -337,6 +363,7 @@ fn surface_base_url(
     manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,
     materialized_surface: &coral_spec::v4::MaterializedSurface,
+    raw_source_document: Option<&[u8]>,
 ) -> Result<ParsedTemplate, AppError> {
     let openapi_runtime = surface.openapi_runtime().ok_or_else(|| {
         AppError::FailedPrecondition(format!(
@@ -349,12 +376,16 @@ fn surface_base_url(
         validate_surface_base_url_template(manifest, surface, &base_url, "authored")?;
         return Ok(base_url);
     }
-    let bytes = std::fs::read(&materialized_surface.raw_source_document_path).map_err(|error| {
-        AppError::FailedPrecondition(format!(
-            "failed to read materialized OpenAPI document for surface '{}': {error}",
-            surface.id
-        ))
-    })?;
+    let bytes = match raw_source_document {
+        Some(bytes) => bytes.to_vec(),
+        None => std::fs::read(&materialized_surface.raw_source_document_path).map_err(|error| {
+            AppError::FailedPrecondition(format!(
+                "failed to read materialized OpenAPI document for surface '{}': {error}",
+                surface.id
+            ))
+        })?,
+    };
+    validate_materialized_surface_base_url(manifest, surface, &bytes)?;
     let metadata = openapi_document_metadata(&bytes).map_err(|error| {
         AppError::FailedPrecondition(format!(
             "failed to derive base_url for DSL v4 surface '{}': {error}",
@@ -874,37 +905,6 @@ mod tests {
                 .offset_pagination
                 .as_ref(),
             Some(&offset_pagination)
-        );
-    }
-
-    #[test]
-    fn derived_openapi_server_url_rejects_runtime_controlled_tokens() {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let openapi = temp.path().join("openapi.yaml");
-        std::fs::write(
-            &openapi,
-            r#"
-openapi: 3.0.3
-servers:
-  - url: https://{host}
-    variables:
-      host:
-        default: "{{filter.host}}"
-paths: {}
-"#,
-        )
-        .expect("write openapi");
-
-        let surface = surface_without_authored_base_url();
-        let manifest = manifest_with_surface(surface.clone());
-        let error = surface_base_url(&manifest, &surface, &materialized_surface(openapi))
-            .expect_err("runtime token should be rejected");
-
-        assert!(
-            error
-                .to_string()
-                .contains("base_url may only reference source inputs"),
-            "unexpected error: {error}"
         );
     }
 }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -83,12 +83,12 @@ impl SourceServiceApi for SourceService {
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let sources = sources
-                .discover_sources(&workspace_name)
-                .map_err(app_status)?
-                .into_iter()
-                .map(candidate_source_to_proto)
-                .collect();
+            let sources =
+                run_blocking_source_operation(move || sources.discover_sources(&workspace_name))
+                    .await?
+                    .into_iter()
+                    .map(candidate_source_to_proto)
+                    .collect();
             Ok(Response::new(DiscoverSourcesResponse { sources }))
         })
         .await
@@ -103,12 +103,14 @@ impl SourceServiceApi for SourceService {
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let sources: Vec<_> = sources
-                .list_workspace_sources(&workspace_name)
-                .map_err(app_status)?
-                .into_iter()
-                .map(|source| installed_source_to_proto(&workspace_name, source))
-                .collect();
+            let response_workspace_name = workspace_name.clone();
+            let sources: Vec<_> = run_blocking_source_operation(move || {
+                sources.list_workspace_sources(&workspace_name)
+            })
+            .await?
+            .into_iter()
+            .map(|source| installed_source_to_proto(&response_workspace_name, source))
+            .collect();
             Ok(Response::new(ListSourcesResponse { sources }))
         })
         .await
@@ -123,12 +125,14 @@ impl SourceServiceApi for SourceService {
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let response_workspace_name = workspace_name.clone();
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
-            let source = sources
-                .get_source(&workspace_name, &source_name)
-                .map_err(app_status)?;
+            let source = run_blocking_source_operation(move || {
+                sources.get_source(&workspace_name, &source_name)
+            })
+            .await?;
             Ok(Response::new(GetSourceResponse {
-                source: Some(installed_source_to_proto(&workspace_name, source)),
+                source: Some(installed_source_to_proto(&response_workspace_name, source)),
             }))
         })
         .await
@@ -144,9 +148,10 @@ impl SourceServiceApi for SourceService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
-            let source = sources
-                .get_source_info(&workspace_name, &source_name)
-                .map_err(app_status)?;
+            let source = run_blocking_source_operation(move || {
+                sources.get_source_info(&workspace_name, &source_name)
+            })
+            .await?;
             Ok(Response::new(GetSourceInfoResponse {
                 source_info: Some(candidate_source_to_proto(source)),
             }))

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -562,6 +562,7 @@ fn proto_source_credential_storage(
     match storage {
         Some(CredentialStorageKind::File) => ProtoSourceCredentialStorage::File,
         Some(CredentialStorageKind::Keychain) => ProtoSourceCredentialStorage::Keychain,
+        Some(CredentialStorageKind::Database) => ProtoSourceCredentialStorage::Unspecified,
         None => ProtoSourceCredentialStorage::Unspecified,
     }
 }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -562,7 +562,7 @@ fn proto_source_credential_storage(
     match storage {
         Some(CredentialStorageKind::File) => ProtoSourceCredentialStorage::File,
         Some(CredentialStorageKind::Keychain) => ProtoSourceCredentialStorage::Keychain,
-        Some(CredentialStorageKind::Database) => ProtoSourceCredentialStorage::Unspecified,
+        Some(CredentialStorageKind::Database) => ProtoSourceCredentialStorage::Database,
         None => ProtoSourceCredentialStorage::Unspecified,
     }
 }

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -543,7 +543,15 @@ impl ConfigStore {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Option<DeletedWorkspace>, AppError> {
-        self.update_config(|config| {
+        let _lock = self.state_lock_exclusive()?;
+        self.delete_workspace_unlocked(workspace_name)
+    }
+
+    pub(crate) fn delete_workspace_unlocked(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Option<DeletedWorkspace>, AppError> {
+        self.update_config_unlocked(|config| {
             if workspace_name.is_default() {
                 return Err(AppError::FailedPrecondition(
                     "default workspace cannot be removed".to_string(),

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -489,6 +489,12 @@ impl ConfigStore {
         self.load_config_unlocked().map(|config| config.catalog)
     }
 
+    pub(crate) fn clear_source_catalog_unlocked(&self) -> Result<(), AppError> {
+        let mut config = self.load_unlocked()?;
+        config.catalog = SourceCatalog::default();
+        self.save_unlocked(&config)
+    }
+
     fn update_config_unlocked<T>(
         &self,
         update: impl FnOnce(&mut AppConfig) -> Result<T, AppError>,

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -55,6 +55,10 @@ impl AppConfig {
         self.catalog.workspace_sources(workspace_name)
     }
 
+    pub(crate) fn source_catalog_entries(&self) -> Vec<(WorkspaceName, InstalledSource)> {
+        self.catalog.source_entries()
+    }
+
     pub(crate) fn get_source(
         &self,
         workspace_name: &WorkspaceName,
@@ -268,6 +272,18 @@ impl WorkspaceCatalog {
 pub(crate) struct SourceCatalog(BTreeMap<WorkspaceName, BTreeMap<SourceName, InstalledSource>>);
 
 impl SourceCatalog {
+    pub(crate) fn source_entries(&self) -> Vec<(WorkspaceName, InstalledSource)> {
+        self.0
+            .iter()
+            .flat_map(|(workspace_name, sources)| {
+                sources
+                    .values()
+                    .cloned()
+                    .map(|source| (workspace_name.clone(), source))
+            })
+            .collect()
+    }
+
     pub(crate) fn workspace_sources(&self, workspace_name: &WorkspaceName) -> Vec<InstalledSource> {
         self.0
             .get(workspace_name)

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use coral_engine::{DependentJoinConfig, DependentJoinSourceConfig, MemorySize, QueryMemoryConfig};
 use serde::{Deserialize, Serialize};
 use toml_edit::{DocumentMut, InlineTable, Item, Value, value};
-use tracing::{info_span, warn};
+use tracing::warn;
 
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialStorageKind;
@@ -489,13 +489,6 @@ impl ConfigStore {
         self.load_config_unlocked().map(|config| config.catalog)
     }
 
-    pub(crate) fn load_catalog(&self) -> Result<SourceCatalog, AppError> {
-        let span = info_span!("coral.app.config.load_catalog");
-        let _guard = span.enter();
-        let _lock = self.state_lock_shared()?;
-        self.load_catalog_unlocked()
-    }
-
     fn update_config_unlocked<T>(
         &self,
         update: impl FnOnce(&mut AppConfig) -> Result<T, AppError>,
@@ -569,6 +562,7 @@ impl ConfigStore {
         })
     }
 
+    #[cfg(test)]
     pub(crate) fn list_workspace_sources(
         &self,
         workspace_name: &WorkspaceName,
@@ -589,20 +583,6 @@ impl ConfigStore {
             .into_iter()
             .map(|source| source.name.as_str().to_string())
             .collect())
-    }
-
-    /// Loads one installed source without taking the app state lock.
-    ///
-    /// Callers must already hold the state lock while using source artifacts
-    /// associated with the returned config entry.
-    pub(crate) fn get_source_unlocked(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Result<InstalledSource, AppError> {
-        self.load_catalog_unlocked()?
-            .get_source(workspace_name, source_name)
-            .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
     }
 
     pub(crate) fn get_source(

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -572,19 +572,6 @@ impl ConfigStore {
         Ok(config.workspace_sources(workspace_name))
     }
 
-    pub(crate) fn list_workspace_source_names(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<Vec<String>, AppError> {
-        let config = self.load_config()?;
-        config.require_workspace(workspace_name)?;
-        Ok(config
-            .workspace_sources(workspace_name)
-            .into_iter()
-            .map(|source| source.name.as_str().to_string())
-            .collect())
-    }
-
     pub(crate) fn get_source(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -302,16 +302,6 @@ impl SourceCatalog {
             .cloned()
     }
 
-    pub(crate) fn contains(
-        &self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> bool {
-        self.0
-            .get(workspace_name)
-            .is_some_and(|sources| sources.contains_key(source_name))
-    }
-
     pub(crate) fn upsert_source(
         &mut self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -86,6 +86,8 @@ fn default_config_version() -> u32 {
     1
 }
 
+const DATABASE_MIGRATED_CONFIG_VERSION: u32 = 2;
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct PersistedAppConfig {
     #[serde(default = "default_config_version")]
@@ -495,6 +497,15 @@ impl ConfigStore {
         self.save_unlocked(&config)
     }
 
+    pub(crate) fn mark_database_migrated_unlocked(&self) -> Result<(), AppError> {
+        let mut config = self.load_unlocked()?;
+        if config.version >= DATABASE_MIGRATED_CONFIG_VERSION {
+            return Ok(());
+        }
+        config.version = DATABASE_MIGRATED_CONFIG_VERSION;
+        self.save_unlocked(&config)
+    }
+
     fn update_config_unlocked<T>(
         &self,
         update: impl FnOnce(&mut AppConfig) -> Result<T, AppError>,
@@ -803,6 +814,12 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
     type Error = AppError;
 
     fn try_from(value: PersistedAppConfig) -> Result<Self, Self::Error> {
+        if !matches!(value.version, 1 | DATABASE_MIGRATED_CONFIG_VERSION) {
+            return Err(AppError::FailedPrecondition(format!(
+                "unsupported config.toml version {}; upgrade Coral or use a compatible state directory",
+                value.version
+            )));
+        }
         let mut workspaces = WorkspaceCatalog::default();
         let mut catalog = SourceCatalog::default();
         for (workspace_name, workspace_config) in value.workspaces {
@@ -1090,6 +1107,23 @@ mod tests {
     #[test]
     fn default_config_uses_canonical_version() {
         assert_eq!(AppConfig::default().version, 1);
+    }
+
+    #[test]
+    fn rejects_unsupported_config_version() {
+        let raw = "version = 3\n";
+
+        let error = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(raw).expect("config should parse"),
+        )
+        .expect_err("unsupported config version should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported config.toml version 3"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/state/db/backend.rs
+++ b/crates/coral-app/src/state/db/backend.rs
@@ -1,0 +1,17 @@
+use sqlx::{PgPool, SqlitePool};
+
+#[derive(Debug)]
+pub(super) enum CoralDbBackend {
+    Sqlite(SqliteCoralDb),
+    Postgres(PostgresCoralDb),
+}
+
+#[derive(Debug)]
+pub(super) struct SqliteCoralDb {
+    pub(super) pool: SqlitePool,
+}
+
+#[derive(Debug)]
+pub(super) struct PostgresCoralDb {
+    pub(super) pool: PgPool,
+}

--- a/crates/coral-app/src/state/db/config.rs
+++ b/crates/coral-app/src/state/db/config.rs
@@ -1,0 +1,153 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use super::DbError;
+use crate::state::AppStateLayout;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DatabaseConfig {
+    Sqlite { path: PathBuf },
+    Postgres { url_env: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ResolvedDatabaseConfig {
+    Sqlite { path: PathBuf },
+    Postgres { url: String },
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedConfig {
+    #[serde(default)]
+    database: Option<PersistedDatabaseConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedDatabaseConfig {
+    #[serde(default)]
+    backend: Option<PersistedDatabaseBackend>,
+    #[serde(default)]
+    path: Option<PathBuf>,
+    #[serde(default)]
+    url_env: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum PersistedDatabaseBackend {
+    Sqlite,
+    Postgres,
+}
+
+impl DatabaseConfig {
+    pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, DbError> {
+        if !layout.config_file().exists() {
+            return Ok(Self::default_sqlite(layout));
+        }
+
+        let raw = std::fs::read_to_string(layout.config_file())?;
+        let persisted: PersistedConfig = toml::from_str(&raw)?;
+        let Some(database) = persisted.database else {
+            return Ok(Self::default_sqlite(layout));
+        };
+
+        match database.backend.unwrap_or(PersistedDatabaseBackend::Sqlite) {
+            PersistedDatabaseBackend::Sqlite => {
+                let path = database.path.map_or_else(
+                    || layout.database_file(),
+                    |path| resolve_sqlite_path(layout, path),
+                );
+                Ok(Self::Sqlite { path })
+            }
+            PersistedDatabaseBackend::Postgres => {
+                let url_env = database.url_env.ok_or_else(|| {
+                    DbError::Config(
+                        "database backend 'postgres' requires [database].url_env".to_string(),
+                    )
+                })?;
+                Ok(Self::Postgres { url_env })
+            }
+        }
+    }
+
+    fn default_sqlite(layout: &AppStateLayout) -> Self {
+        Self::Sqlite {
+            path: layout.database_file(),
+        }
+    }
+}
+
+fn resolve_sqlite_path(layout: &AppStateLayout, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        return path;
+    }
+    layout.config_dir().join(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::DatabaseConfig;
+    use crate::state::AppStateLayout;
+
+    #[test]
+    fn defaults_to_sqlite_under_app_state() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+
+        let config = DatabaseConfig::load(&layout).expect("db config");
+
+        assert_eq!(
+            config,
+            DatabaseConfig::Sqlite {
+                path: layout.database_file()
+            }
+        );
+    }
+
+    #[test]
+    fn resolves_relative_sqlite_path_under_app_state() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        fs::create_dir_all(layout.config_dir()).expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[database]\nbackend = \"sqlite\"\npath = \"state/custom.db\"\n",
+        )
+        .expect("config");
+
+        let config = DatabaseConfig::load(&layout).expect("db config");
+
+        assert_eq!(
+            config,
+            DatabaseConfig::Sqlite {
+                path: layout.config_dir().join("state/custom.db")
+            }
+        );
+    }
+
+    #[test]
+    fn loads_postgres_url_env_name() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        fs::create_dir_all(layout.config_dir()).expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_DATABASE_URL\"\n",
+        )
+        .expect("config");
+
+        let config = DatabaseConfig::load(&layout).expect("db config");
+
+        assert_eq!(
+            config,
+            DatabaseConfig::Postgres {
+                url_env: "CORAL_DATABASE_URL".to_string()
+            }
+        );
+    }
+}

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -6,6 +6,7 @@ use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
 use super::backend::{CoralDbBackend, PostgresCoralDb, SqliteCoralDb};
 use super::{DbError, ResolvedDatabaseConfig};
+use crate::storage::fs as storage_fs;
 
 #[derive(Debug)]
 pub(crate) struct CoralDb {
@@ -34,14 +35,13 @@ impl CoralDb {
 }
 
 async fn open_sqlite(path: &Path) -> Result<CoralDb, DbError> {
-    let parent = path
-        .parent()
+    path.parent()
         .ok_or_else(|| DbError::MissingDatabaseParent(path.to_path_buf()))?;
-    std::fs::create_dir_all(parent)?;
+    storage_fs::ensure_file_private(path)?;
 
     let options = SqliteConnectOptions::new()
         .filename(path)
-        .create_if_missing(true);
+        .create_if_missing(false);
     let pool = SqlitePoolOptions::new().connect_with(options).await?;
     Ok(CoralDb {
         backend: CoralDbBackend::Sqlite(SqliteCoralDb { pool }),
@@ -108,6 +108,30 @@ fn postgres_ssl_mode_authenticates_server(ssl_mode: PgSslMode) -> bool {
 #[cfg(test)]
 mod tests {
     use super::postgres_connect_options;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn sqlite_open_creates_and_tightens_private_database_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("temp dir");
+        let database_file = temp.path().join("state").join("coral.db");
+        for mode in [None, Some(0o644)] {
+            if let Some(mode) = mode {
+                std::fs::set_permissions(&database_file, std::fs::Permissions::from_mode(mode))
+                    .expect("loosen database permissions");
+            }
+            super::open_sqlite(&database_file)
+                .await
+                .expect("open sqlite");
+            let actual_mode = std::fs::metadata(&database_file)
+                .expect("database metadata")
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(actual_mode, 0o600);
+        }
+    }
 
     #[test]
     fn postgres_options_reject_remote_tcp_without_required_tls() {

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -1,0 +1,163 @@
+use std::path::Path;
+use std::str::FromStr;
+
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions, PgSslMode};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+
+use super::backend::{CoralDbBackend, PostgresCoralDb, SqliteCoralDb};
+use super::{DbError, ResolvedDatabaseConfig};
+
+#[derive(Debug)]
+pub(crate) struct CoralDb {
+    pub(super) backend: CoralDbBackend,
+}
+
+impl CoralDb {
+    pub(crate) async fn open(config: ResolvedDatabaseConfig) -> Result<Self, DbError> {
+        match config {
+            ResolvedDatabaseConfig::Sqlite { path } => open_sqlite(&path).await,
+            ResolvedDatabaseConfig::Postgres { url } => open_postgres(&url).await,
+        }
+    }
+
+    pub(crate) async fn ping(&self) -> Result<(), DbError> {
+        match &self.backend {
+            CoralDbBackend::Sqlite(db) => {
+                sqlx::query("SELECT 1").execute(&db.pool).await?;
+            }
+            CoralDbBackend::Postgres(db) => {
+                sqlx::query("SELECT 1").execute(&db.pool).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn open_sqlite(path: &Path) -> Result<CoralDb, DbError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| DbError::MissingDatabaseParent(path.to_path_buf()))?;
+    std::fs::create_dir_all(parent)?;
+
+    let options = SqliteConnectOptions::new()
+        .filename(path)
+        .create_if_missing(true);
+    let pool = SqlitePoolOptions::new().connect_with(options).await?;
+    Ok(CoralDb {
+        backend: CoralDbBackend::Sqlite(SqliteCoralDb { pool }),
+    })
+}
+
+async fn open_postgres(url: &str) -> Result<CoralDb, DbError> {
+    let options = postgres_connect_options(url)?;
+    let pool = PgPoolOptions::new().connect_with(options).await?;
+    Ok(CoralDb {
+        backend: CoralDbBackend::Postgres(PostgresCoralDb { pool }),
+    })
+}
+
+fn postgres_connect_options(url: &str) -> Result<PgConnectOptions, DbError> {
+    let parsed_url = url::Url::parse(url)
+        .map_err(|error| DbError::Config(format!("invalid Postgres database URL: {error}")))?;
+    let explicit_ssl_mode = postgres_url_ssl_mode(&parsed_url)?;
+    let options = PgConnectOptions::from_str(parsed_url.as_str())
+        .map_err(|error| DbError::Config(format!("invalid Postgres database URL: {error}")))?;
+
+    if postgres_requires_tls(&options)
+        && !explicit_ssl_mode.is_some_and(postgres_ssl_mode_authenticates_server)
+    {
+        return Err(DbError::Config(
+            "remote Postgres database URLs must set sslmode=verify-full".to_string(),
+        ));
+    }
+
+    Ok(options)
+}
+
+fn postgres_url_ssl_mode(url: &url::Url) -> Result<Option<PgSslMode>, DbError> {
+    let mut ssl_mode = None;
+    for (key, value) in url.query_pairs() {
+        if key == "sslmode" || key == "ssl-mode" {
+            ssl_mode = Some(value.parse().map_err(|error| {
+                DbError::Config(format!("invalid Postgres database URL sslmode: {error}"))
+            })?);
+        }
+    }
+    Ok(ssl_mode)
+}
+
+fn postgres_requires_tls(options: &PgConnectOptions) -> bool {
+    !postgres_uses_local_socket(options) && !postgres_host_is_loopback(options.get_host())
+}
+
+fn postgres_uses_local_socket(options: &PgConnectOptions) -> bool {
+    options.get_socket().is_some() || options.get_host().starts_with('/')
+}
+
+fn postgres_host_is_loopback(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|addr| addr.is_loopback())
+}
+
+fn postgres_ssl_mode_authenticates_server(ssl_mode: PgSslMode) -> bool {
+    matches!(ssl_mode, PgSslMode::VerifyFull)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::postgres_connect_options;
+
+    #[test]
+    fn postgres_options_reject_remote_tcp_without_required_tls() {
+        let error = postgres_connect_options("postgres://coral:secret@db.example.com:5432/coral")
+            .expect_err("remote TCP without sslmode must be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("remote Postgres database URLs must set sslmode=verify-full"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn postgres_options_reject_remote_tcp_with_encryption_without_server_identity() {
+        for sslmode in ["require", "verify-ca"] {
+            let error = postgres_connect_options(&format!(
+                "postgres://coral:secret@db.example.com:5432/coral?sslmode={sslmode}"
+            ))
+            .expect_err("remote TCP without hostname-authenticated TLS must be rejected");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("remote Postgres database URLs must set sslmode=verify-full"),
+                "unexpected error for sslmode={sslmode}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn postgres_options_allow_remote_tcp_with_hostname_authenticated_tls() {
+        postgres_connect_options(
+            "postgres://coral:secret@db.example.com:5432/coral?sslmode=verify-full",
+        )
+        .expect("remote TCP with sslmode=verify-full should be accepted");
+    }
+
+    #[test]
+    fn postgres_options_accept_ssl_mode_alias() {
+        postgres_connect_options(
+            "postgres://coral:secret@db.example.com:5432/coral?ssl-mode=verify-full",
+        )
+        .expect("remote TCP with ssl-mode=verify-full should be accepted");
+    }
+
+    #[test]
+    fn postgres_options_allow_loopback_without_tls() {
+        postgres_connect_options("postgres://coral:secret@127.0.0.1:5432/coral")
+            .expect("loopback Postgres is allowed without TLS for local development and CI");
+    }
+}

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -36,6 +36,10 @@ impl CoralDb {
         }
         Ok(())
     }
+
+    pub(crate) fn is_postgres(&self) -> bool {
+        matches!(self.backend, CoralDbBackend::Postgres(_))
+    }
 }
 
 async fn open_sqlite(path: &Path) -> Result<CoralDb, DbError> {

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -5,7 +5,7 @@ use sqlx::postgres::{PgConnectOptions, PgPoolOptions, PgSslMode};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
 use super::backend::{CoralDbBackend, PostgresCoralDb, SqliteCoralDb};
-use super::{DbError, ResolvedDatabaseConfig};
+use super::{CoralTx, DbError, ResolvedDatabaseConfig};
 use crate::storage::fs as storage_fs;
 
 #[derive(Debug)]
@@ -19,6 +19,10 @@ impl CoralDb {
             ResolvedDatabaseConfig::Sqlite { path } => open_sqlite(&path).await,
             ResolvedDatabaseConfig::Postgres { url } => open_postgres(&url).await,
         }
+    }
+
+    pub(crate) async fn begin(&self) -> Result<CoralTx<'_>, DbError> {
+        CoralTx::begin(&self.backend).await
     }
 
     pub(crate) async fn ping(&self) -> Result<(), DbError> {

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -45,7 +45,8 @@ async fn open_sqlite(path: &Path) -> Result<CoralDb, DbError> {
 
     let options = SqliteConnectOptions::new()
         .filename(path)
-        .create_if_missing(false);
+        .create_if_missing(false)
+        .foreign_keys(true);
     let pool = SqlitePoolOptions::new().connect_with(options).await?;
     Ok(CoralDb {
         backend: CoralDbBackend::Sqlite(SqliteCoralDb { pool }),

--- a/crates/coral-app/src/state/db/error.rs
+++ b/crates/coral-app/src/state/db/error.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 pub(crate) enum DbError {
     #[error("database configuration is invalid: {0}")]
     Config(String),
+    #[error("database contains invalid data: {0}")]
+    InvalidData(String),
     #[error("database file parent directory is missing for {0}")]
     MissingDatabaseParent(PathBuf),
     #[error(transparent)]

--- a/crates/coral-app/src/state/db/error.rs
+++ b/crates/coral-app/src/state/db/error.rs
@@ -1,0 +1,17 @@
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DbError {
+    #[error("database configuration is invalid: {0}")]
+    Config(String),
+    #[error("database file parent directory is missing for {0}")]
+    MissingDatabaseParent(PathBuf),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    TomlDecode(#[from] toml::de::Error),
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+    #[error(transparent)]
+    Migration(#[from] sqlx::migrate::MigrateError),
+}

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::ErrorKind;
 
-use super::CoralDb;
 use super::session::DbRepos;
+use super::{CoralDb, DbError, MaterializationRecord};
 use crate::bootstrap::AppError;
 use crate::sources::catalog::validate_imported_manifest_database_persistence;
 use crate::sources::materialization::{
@@ -231,21 +231,90 @@ async fn import_filesystem_v4_materializations(
             else {
                 continue;
             };
-            let manifest = parse_source_manifest_yaml(&manifest_yaml)
-                .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+            let Some(manifest) = v4_backfill_or_skip(
+                parse_source_manifest_yaml(&manifest_yaml),
+                &workspace_name,
+                &source.name,
+            ) else {
+                continue;
+            };
             let Some(v4) = manifest.as_v4() else {
                 continue;
             };
-            let record = materialization_record_from_dir(&source.name, &dir, now_unix_nanos)?;
-            load_v4_materialization_from_record(&source.name, &manifest_yaml, v4, &record)?;
-            let mut tx = db.begin().await?;
-            tx.materializations()
-                .upsert(&workspace_name, &source.name, &record)
-                .await?;
-            tx.commit().await?;
+            let Some(record) = v4_backfill_or_skip(
+                materialization_record_from_dir(&source.name, &dir, now_unix_nanos),
+                &workspace_name,
+                &source.name,
+            ) else {
+                continue;
+            };
+            if v4_backfill_or_skip(
+                load_v4_materialization_from_record(&source.name, &manifest_yaml, v4, &record),
+                &workspace_name,
+                &source.name,
+            )
+            .is_none()
+            {
+                continue;
+            }
+            upsert_imported_v4_materialization(db, &workspace_name, &source.name, &record).await?;
         }
     }
     Ok(())
+}
+
+fn v4_backfill_or_skip<T, E: std::fmt::Display>(
+    result: Result<T, E>,
+    workspace_name: &WorkspaceName,
+    source_name: &crate::sources::SourceName,
+) -> Option<T> {
+    match result {
+        Ok(value) => Some(value),
+        Err(error) => {
+            tracing::warn!(
+                workspace = %workspace_name,
+                source = %source_name,
+                detail = %error,
+                "skipping legacy DSL v4 materialization database backfill; re-add the source to regenerate materialized artifacts"
+            );
+            None
+        }
+    }
+}
+
+async fn upsert_imported_v4_materialization(
+    db: &CoralDb,
+    workspace_name: &WorkspaceName,
+    source_name: &crate::sources::SourceName,
+    record: &MaterializationRecord,
+) -> Result<(), AppError> {
+    let mut tx = db.begin().await?;
+    match tx
+        .materializations()
+        .upsert(workspace_name, source_name, record)
+        .await
+    {
+        Ok(()) => tx.commit().await.map_err(AppError::from),
+        Err(error) if is_unique_constraint_error(&error) => {
+            tx.rollback().await?;
+            let mut session = db;
+            if session
+                .materializations()
+                .get(workspace_name, source_name)
+                .await?
+                .is_some()
+            {
+                Ok(())
+            } else {
+                Err(error.into())
+            }
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn is_unique_constraint_error(error: &DbError) -> bool {
+    matches!(error, DbError::Sqlx(sqlx::Error::Database(database_error)) if database_error.is_unique_violation())
 }
 
 fn read_imported_manifest_file(
@@ -305,11 +374,17 @@ mod tests {
     use super::{SourceCatalogImportReport, import_config_source_catalog};
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
+    use crate::sources::materialization::{
+        MaterializationInputs, build_v4_materialization_tmp, replace_v4_materialization,
+    };
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::db::session::DbRepos;
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::WorkspaceName;
+    use coral_spec::parse_source_manifest_yaml;
+
+    const OPENAPI_FIXTURE: &str = r#"{"openapi":"3.0.3","servers":[{"url":"https://api.example.com"}],"paths":{"/issues":{"get":{"operationId":"issues/list","responses":{"200":{"content":{"application/json":{"schema":{"type":"array","items":{"type":"object","properties":{"id":{"type":"integer"},"title":{"type":"string"}}}}}}}}}}}}"#;
 
     #[tokio::test]
     async fn imports_config_source_catalog_into_database() {
@@ -777,9 +852,47 @@ mod tests {
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let workspace = WorkspaceName::parse("default").expect("workspace");
-        let source = unsafe_secret_endpoint_source();
+        let unsafe_source = unsafe_secret_endpoint_source();
         let manifest_yaml = unsafe_secret_endpoint_manifest_yaml("github", "1.2.3");
-        write_manifest_file(&layout, &workspace, &source.name, &manifest_yaml);
+        write_manifest_file(&layout, &workspace, &unsafe_source.name, &manifest_yaml);
+        let healthy = source("healthy_v4", None, [], [], None, SourceOrigin::Imported);
+        let corrupt = source("corrupt_v4", None, [], [], None, SourceOrigin::Imported);
+        let healthy_descriptor = temp.path().join("healthy-openapi.json");
+        fs::write(&healthy_descriptor, OPENAPI_FIXTURE).expect("write OpenAPI fixture");
+        let healthy_manifest = format!(
+            "name: {}\ndsl_version: 4\nsurfaces:\n- id: rest\n  type: openapi\n  file: {}\n",
+            healthy.name,
+            healthy_descriptor.display()
+        );
+        let parsed_manifest = parse_source_manifest_yaml(&healthy_manifest)
+            .expect("parse manifest")
+            .as_v4()
+            .expect("v4 manifest")
+            .clone();
+        let build = build_v4_materialization_tmp(
+            &layout,
+            &workspace,
+            &healthy.name,
+            &healthy_manifest,
+            &parsed_manifest,
+            &MaterializationInputs::default(),
+            "test",
+        );
+        replace_v4_materialization(
+            &layout,
+            &workspace,
+            &healthy.name,
+            &build.expect("build materialization").temp_dir,
+        )
+        .expect("install legacy materialization");
+        let corrupt_manifest = healthy_manifest.replace("healthy_v4", "corrupt_v4");
+        fs::create_dir_all(layout.v4_materialized_dir(&workspace, &corrupt.name))
+            .expect("create corrupt materialization dir");
+        fs::write(
+            layout.v4_fingerprint_file(&workspace, &corrupt.name),
+            "not: [yaml",
+        )
+        .expect("corrupt fingerprint");
         let db = open_sqlite(&layout).await;
         let mut tx = db.begin().await.expect("begin tx");
         tx.workspaces()
@@ -787,26 +900,47 @@ mod tests {
             .await
             .expect("ensure workspace");
         tx.sources()
-            .upsert_source(&workspace, &source, 7)
+            .upsert_source(&workspace, &unsafe_source, 7)
             .await
             .expect("write source without manifest row");
-        tx.app_state_markers()
-            .insert(super::LEGACY_SOURCE_CATALOG_IMPORT_MARKER, 7)
-            .await
-            .expect("insert source import marker");
-        tx.commit().await.expect("commit source");
+        for (source, manifest) in [(&healthy, &healthy_manifest), (&corrupt, &corrupt_manifest)] {
+            tx.sources()
+                .upsert_source(&workspace, source, 7)
+                .await
+                .expect("upsert source");
+            tx.source_manifests()
+                .upsert(&workspace, &source.name, manifest, 7)
+                .await
+                .expect("upsert manifest");
+        }
+        tx.commit().await.expect("commit sources");
 
         import_config_source_catalog(&db, &config_store, &layout, 11)
             .await
-            .expect("invalid backfill manifest should not fail bootstrap import");
+            .expect("invalid backfills should not fail startup import");
 
         let mut session = &db;
         assert!(
             session
                 .source_manifests()
-                .get(&workspace, &source.name)
+                .get(&workspace, &unsafe_source.name)
                 .await
                 .expect("get skipped source manifest")
+                .is_none()
+        );
+        let mut materializations = session.materializations();
+        assert!(
+            materializations
+                .get(&workspace, &healthy.name)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            materializations
+                .get(&workspace, &corrupt.name)
+                .await
+                .unwrap()
                 .is_none()
         );
     }

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -156,32 +156,52 @@ mod tests {
                 .expect("get source"),
             Some(source)
         );
-        assert!(
-            config_store
-                .load_config_unlocked()
-                .expect("load cleaned config")
-                .source_catalog_entries()
-                .is_empty()
-        );
     }
 
+    #[cfg(unix)]
     #[tokio::test]
-    async fn legacy_source_catalog_import_is_not_reapplied_after_marker() {
+    async fn failed_legacy_config_cleanup_does_not_reimport_stale_sources() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
+        let db_path = temp.path().join("db").join("coral.db");
+        fs::create_dir_all(db_path.parent().expect("db parent")).expect("create db dir");
+        fs::write(
+            layout.config_file(),
+            format!(
+                "[database]\nbackend = \"sqlite\"\npath = \"{}\"\n",
+                db_path.display()
+            ),
+        )
+        .expect("write database config");
         let config_store = ConfigStore::new(layout.clone());
         let workspace = WorkspaceName::parse("default").expect("workspace");
         let source = source("github", None, [], [], None, SourceOrigin::Bundled);
         config_store
             .upsert_source(&workspace, source.clone())
             .expect("write config source");
+        drop(
+            config_store
+                .state_lock_exclusive()
+                .expect("create state lock before read-only config dir"),
+        );
         let db = open_sqlite(&layout).await;
-        import_config_source_catalog(&db, &config_store, 11)
-            .await
-            .expect("initial import");
+        fs::set_permissions(layout.config_dir(), fs::Permissions::from_mode(0o500))
+            .expect("make config dir read-only");
+        let report = import_config_source_catalog(&db, &config_store, 11).await;
+        fs::set_permissions(layout.config_dir(), fs::Permissions::from_mode(0o700))
+            .expect("restore config dir permissions");
+        assert_eq!(
+            report.expect("cleanup failure should not fail committed import"),
+            SourceCatalogImportReport {
+                workspace_count: 1,
+                source_count: 1,
+            }
+        );
 
-        let original_source = source.clone();
         let mut stale_config_source = source.clone();
         stale_config_source
             .variables
@@ -189,10 +209,18 @@ mod tests {
         config_store
             .upsert_source(&workspace, stale_config_source)
             .expect("update config source");
+        {
+            let mut tx = db.begin().await.expect("begin delete tx");
+            tx.sources()
+                .remove_source(&workspace, &source.name)
+                .await
+                .expect("delete db source");
+            tx.commit().await.expect("commit delete tx");
+        }
 
         let report = import_config_source_catalog(&db, &config_store, 99)
             .await
-            .expect("reimport source catalog");
+            .expect("stale config should not reimport after marker");
 
         assert_eq!(
             report,
@@ -202,20 +230,20 @@ mod tests {
             }
         );
         let mut session = &db;
-        let workspace_record = session
-            .workspaces()
-            .get(workspace.as_str())
-            .await
-            .expect("get workspace")
-            .expect("workspace row");
-        assert_eq!(workspace_record.created_at_unix_nanos, 11);
         assert_eq!(
             session
                 .sources()
                 .get_source(&workspace, &source.name)
                 .await
-                .expect("get source"),
-            Some(original_source)
+                .expect("source should remain deleted"),
+            None
+        );
+        assert!(
+            config_store
+                .load_config_unlocked()
+                .expect("load cleaned stale config")
+                .source_catalog_entries()
+                .is_empty()
         );
     }
 
@@ -272,7 +300,16 @@ mod tests {
         let workspace = WorkspaceName::parse("default").expect("workspace");
         let config_workspace = WorkspaceName::parse("other").expect("workspace");
         let db_source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        let mut stale_config_source = db_source.clone();
+        stale_config_source.version = Some("9.9.9".to_string());
+        stale_config_source
+            .variables
+            .insert("OWNER".to_string(), "stale".to_string());
+        stale_config_source.origin = SourceOrigin::Imported;
         let config_source = source("slack", None, [], [], None, SourceOrigin::Bundled);
+        config_store
+            .upsert_source(&workspace, stale_config_source)
+            .expect("write stale config source");
         config_store
             .create_workspace(&config_workspace)
             .expect("create config workspace");
@@ -321,6 +358,13 @@ mod tests {
                 .expect("get imported config source"),
             Some(config_source)
         );
+        assert!(
+            config_store
+                .load_config_unlocked()
+                .expect("load cleaned config")
+                .source_catalog_entries()
+                .is_empty()
+        );
     }
 
     #[tokio::test]
@@ -349,155 +393,6 @@ mod tests {
                 .list()
                 .await
                 .expect("list workspaces")
-                .is_empty()
-        );
-    }
-
-    #[tokio::test]
-    async fn empty_config_catalog_does_not_complete_legacy_import() {
-        let temp = tempdir().expect("temp dir");
-        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let workspace = WorkspaceName::parse("default").expect("workspace");
-        let source = source("github", None, [], [], None, SourceOrigin::Bundled);
-        let db = open_sqlite(&layout).await;
-
-        let empty_report = import_config_source_catalog(&db, &config_store, 11)
-            .await
-            .expect("import empty catalog");
-        config_store
-            .upsert_source(&workspace, source.clone())
-            .expect("write config source after empty import");
-        let source_report = import_config_source_catalog(&db, &config_store, 99)
-            .await
-            .expect("import source catalog after empty import");
-
-        assert_eq!(
-            empty_report,
-            SourceCatalogImportReport {
-                workspace_count: 0,
-                source_count: 0,
-            }
-        );
-        assert_eq!(
-            source_report,
-            SourceCatalogImportReport {
-                workspace_count: 1,
-                source_count: 1,
-            }
-        );
-        let mut session = &db;
-        assert_eq!(
-            session
-                .sources()
-                .get_source(&workspace, &source.name)
-                .await
-                .expect("get source"),
-            Some(source)
-        );
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn import_succeeds_when_post_commit_config_cleanup_fails() {
-        use std::fs;
-        use std::os::unix::fs::PermissionsExt;
-
-        let temp = tempdir().expect("temp dir");
-        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let workspace = WorkspaceName::parse("default").expect("workspace");
-        let source = source("github", None, [], [], None, SourceOrigin::Bundled);
-        config_store
-            .upsert_source(&workspace, source.clone())
-            .expect("write config source");
-        drop(
-            config_store
-                .state_lock_exclusive()
-                .expect("create state lock before making config dir read-only"),
-        );
-
-        let db_path = temp.path().join("db").join("coral.db");
-        fs::create_dir_all(db_path.parent().expect("db parent")).expect("create db dir");
-        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path: db_path })
-            .await
-            .expect("open sqlite");
-        db.migrate().await.expect("migrate sqlite");
-
-        let original_mode = fs::metadata(layout.config_dir())
-            .expect("config dir metadata")
-            .permissions()
-            .mode();
-        fs::set_permissions(layout.config_dir(), fs::Permissions::from_mode(0o500))
-            .expect("make config dir read-only");
-
-        let result = import_config_source_catalog(&db, &config_store, 11).await;
-
-        fs::set_permissions(
-            layout.config_dir(),
-            fs::Permissions::from_mode(original_mode),
-        )
-        .expect("restore config dir permissions");
-
-        assert_eq!(
-            result.expect("cleanup failure should not fail committed import"),
-            SourceCatalogImportReport {
-                workspace_count: 1,
-                source_count: 1,
-            }
-        );
-        let mut session = &db;
-        assert_eq!(
-            session
-                .sources()
-                .get_source(&workspace, &source.name)
-                .await
-                .expect("get imported source"),
-            Some(source.clone())
-        );
-        assert_eq!(
-            config_store
-                .load_config_unlocked()
-                .expect("legacy config should still load after failed cleanup")
-                .source_catalog_entries()
-                .len(),
-            1
-        );
-
-        let mut tx = db.begin().await.expect("begin delete tx");
-        tx.sources()
-            .remove_source(&workspace, &source.name)
-            .await
-            .expect("delete db source");
-        tx.commit().await.expect("commit delete tx");
-
-        let report = import_config_source_catalog(&db, &config_store, 99)
-            .await
-            .expect("stale config should not reimport after marker");
-
-        assert_eq!(
-            report,
-            SourceCatalogImportReport {
-                workspace_count: 0,
-                source_count: 0,
-            }
-        );
-        let mut session = &db;
-        assert_eq!(
-            session
-                .sources()
-                .get_source(&workspace, &source.name)
-                .await
-                .expect("source should remain deleted"),
-            None
-        );
-        assert!(
-            config_store
-                .load_config_unlocked()
-                .expect("load cleaned stale config")
-                .source_catalog_entries()
                 .is_empty()
         );
     }

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -214,13 +214,16 @@ async fn import_filesystem_v4_materializations(
             .filter(|source| source.origin == SourceOrigin::Imported)
         {
             let dir = layout.v4_materialized_dir(&workspace_name, &source.name);
-            if !dir.exists()
-                || session
-                    .materializations()
-                    .get(&workspace_name, &source.name)
-                    .await?
-                    .is_some()
+            if !dir.exists() {
+                continue;
+            }
+            if session
+                .materializations()
+                .get(&workspace_name, &source.name)
+                .await?
+                .is_some()
             {
+                remove_v4_materialization_dir(&dir);
                 continue;
             }
             let Some(manifest_yaml) = session
@@ -258,6 +261,7 @@ async fn import_filesystem_v4_materializations(
                 continue;
             }
             upsert_imported_v4_materialization(db, &workspace_name, &source.name, &record).await?;
+            remove_v4_materialization_dir(&dir);
         }
     }
     Ok(())
@@ -315,6 +319,20 @@ async fn upsert_imported_v4_materialization(
 
 fn is_unique_constraint_error(error: &DbError) -> bool {
     matches!(error, DbError::Sqlx(sqlx::Error::Database(database_error)) if database_error.is_unique_violation())
+}
+
+fn remove_v4_materialization_dir(materialized_dir: &std::path::Path) {
+    match fs::remove_dir_all(materialized_dir) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => {
+            tracing::warn!(
+                path = %materialized_dir.display(),
+                detail = %error,
+                "DSL v4 materialization imported into database but legacy artifact cleanup failed"
+            );
+        }
+    }
 }
 
 fn read_imported_manifest_file(
@@ -379,7 +397,10 @@ mod tests {
     };
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::db::session::DbRepos;
-    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, MaterializationRecord, MaterializationSurfaceRecord,
+        ResolvedDatabaseConfig,
+    };
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::WorkspaceName;
     use coral_spec::parse_source_manifest_yaml;
@@ -945,6 +966,216 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn backfills_v4_materialization_for_already_imported_database_source() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source(
+            "github_v4_import",
+            Some("0.1.0"),
+            [],
+            [],
+            None,
+            SourceOrigin::Imported,
+        );
+        let (manifest_yaml, materialized_dir) = install_legacy_v4_materialization(
+            &layout,
+            &workspace,
+            &source.name,
+            &temp.path().join("openapi.yaml"),
+        );
+
+        let db = open_sqlite(&layout).await;
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 7)
+            .await
+            .expect("upsert source");
+        tx.source_manifests()
+            .upsert(&workspace, &source.name, &manifest_yaml, 7)
+            .await
+            .expect("upsert source manifest");
+        tx.commit().await.expect("commit source");
+
+        let report = import_config_source_catalog(&db, &config_store, &layout, 11)
+            .await
+            .expect("backfill materialization");
+
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                workspace_count: 0,
+                source_count: 0,
+            }
+        );
+        let mut session = &db;
+        let materialization = session
+            .materializations()
+            .get(&workspace, &source.name)
+            .await
+            .expect("get materialization")
+            .expect("materialization");
+        assert_eq!(materialization.surfaces.len(), 1);
+        assert!(
+            !materialized_dir.exists(),
+            "legacy materialized directory should be cleaned after DB backfill"
+        );
+    }
+
+    #[tokio::test]
+    async fn imports_config_v4_source_and_legacy_materialization_in_one_pass() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source(
+            "github_v4_config",
+            Some("0.1.0"),
+            [],
+            [],
+            None,
+            SourceOrigin::Imported,
+        );
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        let (manifest_yaml, materialized_dir) = install_legacy_v4_materialization(
+            &layout,
+            &workspace,
+            &source.name,
+            &temp.path().join("openapi.yaml"),
+        );
+        write_manifest_file(&layout, &workspace, &source.name, &manifest_yaml);
+        let db = open_sqlite(&layout).await;
+
+        let report = import_config_source_catalog(&db, &config_store, &layout, 11)
+            .await
+            .expect("import source and materialization");
+
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                workspace_count: 1,
+                source_count: 1,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get imported source"),
+            Some(source.clone())
+        );
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get source manifest")
+                .expect("source manifest")
+                .manifest_yaml,
+            manifest_yaml
+        );
+        assert_eq!(
+            session
+                .materializations()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get materialization")
+                .expect("materialization")
+                .surfaces
+                .len(),
+            1
+        );
+        assert!(!materialized_dir.exists());
+        assert!(
+            config_store
+                .load_config_unlocked()
+                .expect("legacy config should be cleaned")
+                .source_catalog_entries()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run concurrent Postgres backfill coverage"]
+    async fn concurrent_v4_materialization_backfill_race_is_benign_postgres() {
+        let Some(url) = crate::bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+        let workspace = WorkspaceName::parse(&format!("race{}", uuid::Uuid::new_v4().simple()))
+            .expect("workspace");
+        let source = source("race_v4", None, [], [], None, SourceOrigin::Imported);
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 7)
+            .await
+            .expect("upsert source");
+        tx.commit().await.expect("commit source");
+        let winner_record = MaterializationRecord {
+            materialization_version: "v4".into(),
+            fingerprint_yaml: "winner-fingerprint".into(),
+            projections_yaml: "projections".into(),
+            diagnostics_yaml: "diagnostics".into(),
+            created_at_unix_nanos: 11,
+            surfaces: vec![MaterializationSurfaceRecord {
+                surface_id: "rest".into(),
+                source_document_raw: b"{}".to_vec(),
+                source_document_yaml: "{}".into(),
+                semantic_ir_yaml: "{}".into(),
+            }],
+        };
+        let mut loser_record = winner_record.clone();
+        loser_record.fingerprint_yaml = "loser-fingerprint".into();
+        let mut tx = db.begin().await.expect("begin winner tx");
+        tx.materializations()
+            .upsert(&workspace, &source.name, &winner_record)
+            .await
+            .expect("insert uncommitted winner materialization");
+        let loser =
+            super::upsert_imported_v4_materialization(&db, &workspace, &source.name, &loser_record);
+        tokio::pin!(loser);
+
+        if tokio::time::timeout(std::time::Duration::from_millis(250), &mut loser)
+            .await
+            .is_ok()
+        {
+            panic!("loser backfill completed before the winner transaction committed");
+        }
+        tx.commit().await.expect("commit winner materialization");
+        loser
+            .await
+            .expect("loser backfill recovers after unique violation");
+        let mut session = &db;
+        assert_eq!(
+            session
+                .materializations()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get materialization")
+                .expect("materialization"),
+            winner_record
+        );
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn import_succeeds_when_post_commit_config_cleanup_fails() {
@@ -1135,5 +1366,74 @@ inputs: { API_BASE: { kind: variable }, API_TOKEN: { kind: secret } }
 auth: { type: HeaderAuth, headers: [{ name: Authorization, from: template, template: "Bearer {{input.API_TOKEN}}" }] }"#,
             1,
         )
+    }
+
+    fn install_legacy_v4_materialization(
+        layout: &AppStateLayout,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        descriptor_file: &std::path::Path,
+    ) -> (String, std::path::PathBuf) {
+        fs::write(descriptor_file, openapi_fixture()).expect("write OpenAPI fixture");
+        let manifest_yaml = v4_manifest_yaml(source_name.as_str(), descriptor_file);
+        let parsed_manifest = parse_source_manifest_yaml(&manifest_yaml)
+            .expect("parse manifest")
+            .as_v4()
+            .expect("v4 manifest")
+            .clone();
+        let build = build_v4_materialization_tmp(
+            layout,
+            workspace,
+            source_name,
+            &manifest_yaml,
+            &parsed_manifest,
+            &MaterializationInputs::default(),
+            "test",
+        )
+        .expect("build materialization");
+        replace_v4_materialization(layout, workspace, source_name, &build.temp_dir)
+            .expect("install legacy materialization");
+        let materialized_dir = layout.v4_materialized_dir(workspace, source_name);
+        assert!(materialized_dir.exists());
+        (manifest_yaml, materialized_dir)
+    }
+
+    fn v4_manifest_yaml(name: &str, descriptor_file: &std::path::Path) -> String {
+        format!(
+            r"
+name: {name}
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+",
+            descriptor_file.display()
+        )
+    }
+
+    fn openapi_fixture() -> &'static str {
+        r"
+openapi: 3.0.3
+info:
+  title: GitHub
+servers:
+  - url: https://api.example.com
+paths:
+  /issues:
+    get:
+      operationId: issues/list
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: integer}
+                    title: {type: string}
+"
     }
 }

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1,0 +1,224 @@
+use std::collections::BTreeSet;
+
+use super::CoralDb;
+use super::session::DbRepos;
+use crate::bootstrap::AppError;
+use crate::state::ConfigStore;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SourceCatalogImportReport {
+    pub(crate) workspace_count: usize,
+    pub(crate) source_count: usize,
+}
+
+pub(crate) async fn import_config_source_catalog(
+    db: &CoralDb,
+    config_store: &ConfigStore,
+    now_unix_nanos: i64,
+) -> Result<SourceCatalogImportReport, AppError> {
+    let _state_lock = config_store.state_lock_exclusive()?;
+    let entries = config_store
+        .load_config_unlocked()?
+        .source_catalog_entries();
+
+    let mut tx = db.begin().await?;
+    let mut workspaces = BTreeSet::new();
+    for (workspace_name, source) in &entries {
+        workspaces.insert(workspace_name.clone());
+        tx.workspaces()
+            .ensure(workspace_name.as_str(), now_unix_nanos)
+            .await?;
+        tx.sources()
+            .upsert_source(workspace_name, source, now_unix_nanos)
+            .await?;
+        let imported = tx
+            .sources()
+            .get_source(workspace_name, &source.name)
+            .await?;
+        if imported.as_ref() != Some(source) {
+            return Err(AppError::Database(format!(
+                "source catalog import failed validation for {workspace_name}:{}",
+                source.name
+            )));
+        }
+    }
+    tx.commit().await?;
+
+    Ok(SourceCatalogImportReport {
+        workspace_count: workspaces.len(),
+        source_count: entries.len(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use tempfile::tempdir;
+
+    use super::{SourceCatalogImportReport, import_config_source_catalog};
+    use crate::credentials::CredentialStorageKind;
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+    use crate::state::{AppStateLayout, ConfigStore};
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    async fn imports_config_source_catalog_into_database() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [("GITHUB_API_BASE", "https://api.github.com")],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::Keychain),
+            SourceOrigin::Imported,
+        );
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        let db = open_sqlite(&layout).await;
+
+        let report = import_config_source_catalog(&db, &config_store, 11)
+            .await
+            .expect("import source catalog");
+
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                workspace_count: 1,
+                source_count: 1,
+            }
+        );
+        let mut session = &db;
+        assert!(
+            session
+                .workspaces()
+                .get(workspace.as_str())
+                .await
+                .expect("get workspace")
+                .is_some()
+        );
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get source"),
+            Some(source)
+        );
+    }
+
+    #[tokio::test]
+    async fn reimport_updates_source_rows_without_recreating_workspace() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let mut source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        let db = open_sqlite(&layout).await;
+        import_config_source_catalog(&db, &config_store, 11)
+            .await
+            .expect("initial import");
+
+        source
+            .variables
+            .insert("OWNER".to_string(), "coral".to_string());
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("update config source");
+        import_config_source_catalog(&db, &config_store, 99)
+            .await
+            .expect("reimport source catalog");
+
+        let mut session = &db;
+        let workspace_record = session
+            .workspaces()
+            .get(workspace.as_str())
+            .await
+            .expect("get workspace")
+            .expect("workspace row");
+        assert_eq!(workspace_record.created_at_unix_nanos, 11);
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get source"),
+            Some(source)
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_config_catalog_import_is_noop() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let db = open_sqlite(&layout).await;
+
+        let report = import_config_source_catalog(&db, &config_store, 11)
+            .await
+            .expect("import empty catalog");
+
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                workspace_count: 0,
+                source_count: 0,
+            }
+        );
+        let mut session = &db;
+        assert!(
+            session
+                .workspaces()
+                .list()
+                .await
+                .expect("list workspaces")
+                .is_empty()
+        );
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    fn source<const V: usize, const S: usize>(
+        name: &str,
+        version: Option<&str>,
+        variables: [(&str, &str); V],
+        secrets: [&str; S],
+        credential_storage: Option<CredentialStorageKind>,
+        origin: SourceOrigin,
+    ) -> InstalledSource {
+        InstalledSource {
+            name: SourceName::parse(name).expect("source name"),
+            version: version.map(str::to_string),
+            variables: variables
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect::<BTreeMap<_, _>>(),
+            secrets: secrets.into_iter().map(str::to_string).collect(),
+            credential_storage,
+            origin,
+        }
+    }
+}

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1,9 +1,14 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::ErrorKind;
 
 use super::CoralDb;
 use super::session::DbRepos;
 use crate::bootstrap::AppError;
-use crate::state::ConfigStore;
+use crate::sources::catalog::validate_imported_manifest_database_persistence;
+use crate::sources::model::SourceOrigin;
+use crate::state::{AppStateLayout, ConfigStore};
+use crate::workspaces::WorkspaceName;
 
 const LEGACY_SOURCE_CATALOG_IMPORT_MARKER: &str = "legacy_source_catalog_imported";
 
@@ -16,6 +21,7 @@ pub(crate) struct SourceCatalogImportReport {
 pub(crate) async fn import_config_source_catalog(
     db: &CoralDb,
     config_store: &ConfigStore,
+    layout: &AppStateLayout,
     now_unix_nanos: i64,
 ) -> Result<SourceCatalogImportReport, AppError> {
     let _state_lock = config_store.state_lock_exclusive()?;
@@ -30,6 +36,7 @@ pub(crate) async fn import_config_source_catalog(
         .await?
     {
         tx.commit().await?;
+        import_filesystem_source_manifests(db, layout, now_unix_nanos).await?;
         clear_legacy_source_catalog_config(config_store, entries.len());
         return Ok(SourceCatalogImportReport {
             workspace_count: 0,
@@ -48,6 +55,15 @@ pub(crate) async fn import_config_source_catalog(
         {
             continue;
         }
+        let manifest_yaml = match source.origin {
+            SourceOrigin::Bundled => None,
+            SourceOrigin::Imported => {
+                read_optional_imported_manifest_file(layout, workspace_name, &source.name)?
+            }
+        };
+        if let Some(manifest_yaml) = manifest_yaml.as_deref() {
+            validate_imported_manifest_database_persistence(manifest_yaml, &source.variables)?;
+        }
         workspaces.insert(workspace_name.clone());
         tx.workspaces()
             .ensure(workspace_name.as_str(), now_unix_nanos)
@@ -55,6 +71,11 @@ pub(crate) async fn import_config_source_catalog(
         tx.sources()
             .upsert_source(workspace_name, source, now_unix_nanos)
             .await?;
+        if let Some(manifest_yaml) = manifest_yaml {
+            tx.source_manifests()
+                .upsert(workspace_name, &source.name, &manifest_yaml, now_unix_nanos)
+                .await?;
+        }
         let imported = tx
             .sources()
             .get_source(workspace_name, &source.name)
@@ -74,12 +95,137 @@ pub(crate) async fn import_config_source_catalog(
     }
     tx.commit().await?;
 
+    import_filesystem_source_manifests(db, layout, now_unix_nanos).await?;
     clear_legacy_source_catalog_config(config_store, entries.len());
 
     Ok(SourceCatalogImportReport {
         workspace_count: workspaces.len(),
         source_count,
     })
+}
+
+async fn import_filesystem_source_manifests(
+    db: &CoralDb,
+    layout: &AppStateLayout,
+    now_unix_nanos: i64,
+) -> Result<(), AppError> {
+    let mut session = db;
+    let workspaces = session.workspaces().list().await?;
+    for workspace in workspaces {
+        let workspace_name = WorkspaceName::parse(&workspace.id)?;
+        let sources = session
+            .sources()
+            .list_workspace_sources(&workspace_name)
+            .await?;
+        for source in sources
+            .into_iter()
+            .filter(|source| source.origin == SourceOrigin::Imported)
+        {
+            if session
+                .source_manifests()
+                .get(&workspace_name, &source.name)
+                .await?
+                .is_some()
+            {
+                continue;
+            }
+
+            let Some(manifest_yaml) = read_validated_manifest_for_backfill(
+                layout,
+                &workspace_name,
+                &source.name,
+                &source.variables,
+            ) else {
+                continue;
+            };
+            let mut tx = db.begin().await?;
+            tx.source_manifests()
+                .upsert(
+                    &workspace_name,
+                    &source.name,
+                    &manifest_yaml,
+                    now_unix_nanos,
+                )
+                .await?;
+            tx.commit().await?;
+        }
+    }
+    Ok(())
+}
+
+fn read_validated_manifest_for_backfill(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &crate::sources::SourceName,
+    source_variables: &BTreeMap<String, String>,
+) -> Option<String> {
+    let manifest_yaml = match read_optional_imported_manifest_file(
+        layout,
+        workspace_name,
+        source_name,
+    ) {
+        Ok(Some(manifest_yaml)) => manifest_yaml,
+        Ok(None) => return None,
+        Err(error) => {
+            tracing::warn!(
+                workspace = %workspace_name,
+                source = %source_name,
+                detail = %error,
+                "skipping imported source manifest database backfill because the legacy manifest could not be read"
+            );
+            return None;
+        }
+    };
+
+    if let Err(error) =
+        validate_imported_manifest_database_persistence(&manifest_yaml, source_variables)
+    {
+        tracing::warn!(
+            workspace = %workspace_name,
+            source = %source_name,
+            detail = %error,
+            "skipping imported source manifest database backfill because the legacy manifest is invalid"
+        );
+        return None;
+    }
+
+    Some(manifest_yaml)
+}
+
+fn read_imported_manifest_file(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &crate::sources::SourceName,
+) -> Result<String, AppError> {
+    let manifest_path = layout.manifest_file(workspace_name, source_name);
+    fs::read_to_string(&manifest_path).map_err(|error| {
+        if error.kind() == ErrorKind::NotFound {
+            AppError::SourceNotFound(format!(
+                "manifest for imported source '{workspace_name}:{source_name}' at {}",
+                manifest_path.display()
+            ))
+        } else {
+            AppError::Io(error)
+        }
+    })
+}
+
+fn read_optional_imported_manifest_file(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &crate::sources::SourceName,
+) -> Result<Option<String>, AppError> {
+    match read_imported_manifest_file(layout, workspace_name, source_name) {
+        Ok(manifest_yaml) => Ok(Some(manifest_yaml)),
+        Err(AppError::SourceNotFound(message)) => {
+            tracing::warn!(
+                detail = %message,
+                "imported source manifest file is missing; source metadata will remain without a database manifest row"
+            );
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
 }
 
 fn clear_legacy_source_catalog_config(config_store: &ConfigStore, source_count: usize) {
@@ -96,6 +242,7 @@ fn clear_legacy_source_catalog_config(config_store: &ConfigStore, source_count: 
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::fs;
 
     use tempfile::tempdir;
 
@@ -126,9 +273,11 @@ mod tests {
         config_store
             .upsert_source(&workspace, source.clone())
             .expect("write config source");
+        let manifest_yaml = imported_manifest_yaml("github", "1.2.3");
+        write_manifest_file(&layout, &workspace, &source.name, &manifest_yaml);
         let db = open_sqlite(&layout).await;
 
-        let report = import_config_source_catalog(&db, &config_store, 11)
+        let report = import_config_source_catalog(&db, &config_store, &layout, 11)
             .await
             .expect("import source catalog");
 
@@ -154,7 +303,61 @@ mod tests {
                 .get_source(&workspace, &source.name)
                 .await
                 .expect("get source"),
-            Some(source)
+            Some(source.clone())
+        );
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get source manifest")
+                .expect("source manifest")
+                .manifest_yaml,
+            manifest_yaml
+        );
+        assert!(
+            layout.manifest_file(&workspace, &source.name).exists(),
+            "legacy manifest file should be preserved for rollback compatibility"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_imported_config_manifest_rolls_back_catalog_import() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = unsafe_secret_endpoint_source();
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        let manifest_yaml = unsafe_secret_endpoint_manifest_yaml("github", "1.2.3");
+        write_manifest_file(&layout, &workspace, &source.name, &manifest_yaml);
+        let db = open_sqlite(&layout).await;
+
+        let error = import_config_source_catalog(&db, &config_store, &layout, 11)
+            .await
+            .expect_err("unsafe legacy manifest should fail active config import");
+        let crate::bootstrap::AppError::InvalidInput(message) = error else {
+            panic!("expected invalid input error, got {error:?}");
+        };
+        assert!(message.contains("base_url must use https"));
+        let mut session = &db;
+        assert!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get source after rollback")
+                .is_none()
+        );
+        assert!(
+            !session
+                .app_state_markers()
+                .contains(super::LEGACY_SOURCE_CATALOG_IMPORT_MARKER)
+                .await
+                .expect("legacy marker should not be inserted")
         );
     }
 
@@ -191,7 +394,7 @@ mod tests {
         let db = open_sqlite(&layout).await;
         fs::set_permissions(layout.config_dir(), fs::Permissions::from_mode(0o500))
             .expect("make config dir read-only");
-        let report = import_config_source_catalog(&db, &config_store, 11).await;
+        let report = import_config_source_catalog(&db, &config_store, &layout, 11).await;
         fs::set_permissions(layout.config_dir(), fs::Permissions::from_mode(0o700))
             .expect("restore config dir permissions");
         assert_eq!(
@@ -218,7 +421,7 @@ mod tests {
             tx.commit().await.expect("commit delete tx");
         }
 
-        let report = import_config_source_catalog(&db, &config_store, 99)
+        let report = import_config_source_catalog(&db, &config_store, &layout, 99)
             .await
             .expect("stale config should not reimport after marker");
 
@@ -268,7 +471,7 @@ mod tests {
                 .expect("seed db source");
             tx.commit().await.expect("commit tx");
         }
-        let report = import_config_source_catalog(&db, &config_store, 22)
+        let report = import_config_source_catalog(&db, &config_store, &layout, 22)
             .await
             .expect("import empty source catalog");
 
@@ -330,7 +533,7 @@ mod tests {
             tx.commit().await.expect("commit tx");
         }
 
-        let report = import_config_source_catalog(&db, &config_store, 22)
+        let report = import_config_source_catalog(&db, &config_store, &layout, 22)
             .await
             .expect("import source catalog");
 
@@ -375,7 +578,7 @@ mod tests {
         let config_store = ConfigStore::new(layout.clone());
         let db = open_sqlite(&layout).await;
 
-        let report = import_config_source_catalog(&db, &config_store, 11)
+        let report = import_config_source_catalog(&db, &config_store, &layout, 11)
             .await
             .expect("import empty catalog");
 
@@ -393,6 +596,326 @@ mod tests {
                 .list()
                 .await
                 .expect("list workspaces")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_config_catalog_does_not_complete_legacy_import() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        let db = open_sqlite(&layout).await;
+
+        let empty_report = import_config_source_catalog(&db, &config_store, &layout, 11)
+            .await
+            .expect("import empty catalog");
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source after empty import");
+        let source_report = import_config_source_catalog(&db, &config_store, &layout, 99)
+            .await
+            .expect("import source catalog after empty import");
+
+        assert_eq!(
+            empty_report,
+            SourceCatalogImportReport {
+                workspace_count: 0,
+                source_count: 0,
+            }
+        );
+        assert_eq!(
+            source_report,
+            SourceCatalogImportReport {
+                workspace_count: 1,
+                source_count: 1,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get source"),
+            Some(source)
+        );
+    }
+
+    #[tokio::test]
+    async fn imported_config_source_without_manifest_file_keeps_source_without_manifest_row() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source("github", None, [], [], None, SourceOrigin::Imported);
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        let db = open_sqlite(&layout).await;
+
+        let report = import_config_source_catalog(&db, &config_store, &layout, 11)
+            .await
+            .expect("missing imported manifest should not block source catalog import");
+
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                workspace_count: 1,
+                source_count: 1,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get source"),
+            Some(source.clone())
+        );
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get missing source manifest"),
+            None
+        );
+        assert_eq!(
+            config_store
+                .load_config_unlocked()
+                .expect("legacy config should be cleaned after source catalog import")
+                .source_catalog_entries(),
+            Vec::new()
+        );
+
+        let second_report = import_config_source_catalog(&db, &config_store, &layout, 22)
+            .await
+            .expect("missing imported manifest should not block later backfill attempts");
+        assert_eq!(
+            second_report,
+            SourceCatalogImportReport {
+                workspace_count: 0,
+                source_count: 0,
+            }
+        );
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get still-missing source manifest"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn backfills_manifest_for_already_imported_database_source() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            [],
+            None,
+            SourceOrigin::Imported,
+        );
+        let manifest_yaml = imported_manifest_yaml("github", "1.2.3");
+        write_manifest_file(&layout, &workspace, &source.name, &manifest_yaml);
+        let db = open_sqlite(&layout).await;
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 7)
+            .await
+            .expect("write source without manifest row");
+        tx.app_state_markers()
+            .insert(super::LEGACY_SOURCE_CATALOG_IMPORT_MARKER, 7)
+            .await
+            .expect("insert source import marker");
+        tx.commit().await.expect("commit source");
+
+        let report = import_config_source_catalog(&db, &config_store, &layout, 11)
+            .await
+            .expect("backfill manifest");
+
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                workspace_count: 0,
+                source_count: 0,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .source_manifests()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get source manifest")
+                .expect("source manifest")
+                .manifest_yaml,
+            manifest_yaml
+        );
+        assert!(
+            layout.manifest_file(&workspace, &source.name).exists(),
+            "legacy manifest file should be preserved after DB backfill"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_filesystem_manifest_backfill_skips_source_manifest() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = unsafe_secret_endpoint_source();
+        let manifest_yaml = unsafe_secret_endpoint_manifest_yaml("github", "1.2.3");
+        write_manifest_file(&layout, &workspace, &source.name, &manifest_yaml);
+        let db = open_sqlite(&layout).await;
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 7)
+            .await
+            .expect("write source without manifest row");
+        tx.app_state_markers()
+            .insert(super::LEGACY_SOURCE_CATALOG_IMPORT_MARKER, 7)
+            .await
+            .expect("insert source import marker");
+        tx.commit().await.expect("commit source");
+
+        import_config_source_catalog(&db, &config_store, &layout, 11)
+            .await
+            .expect("invalid backfill manifest should not fail bootstrap import");
+
+        let mut session = &db;
+        assert!(
+            session
+                .source_manifests()
+                .get(&workspace, &source.name)
+                .await
+                .expect("get skipped source manifest")
+                .is_none()
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn import_succeeds_when_post_commit_config_cleanup_fails() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        drop(
+            config_store
+                .state_lock_exclusive()
+                .expect("create state lock before making config dir read-only"),
+        );
+
+        let db_path = temp.path().join("db").join("coral.db");
+        fs::create_dir_all(db_path.parent().expect("db parent")).expect("create db dir");
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path: db_path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+
+        let original_mode = fs::metadata(layout.config_dir())
+            .expect("config dir metadata")
+            .permissions()
+            .mode();
+        fs::set_permissions(layout.config_dir(), fs::Permissions::from_mode(0o500))
+            .expect("make config dir read-only");
+
+        let result = import_config_source_catalog(&db, &config_store, &layout, 11).await;
+
+        fs::set_permissions(
+            layout.config_dir(),
+            fs::Permissions::from_mode(original_mode),
+        )
+        .expect("restore config dir permissions");
+
+        assert_eq!(
+            result.expect("cleanup failure should not fail committed import"),
+            SourceCatalogImportReport {
+                workspace_count: 1,
+                source_count: 1,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get imported source"),
+            Some(source.clone())
+        );
+        assert_eq!(
+            config_store
+                .load_config_unlocked()
+                .expect("legacy config should still load after failed cleanup")
+                .source_catalog_entries()
+                .len(),
+            1
+        );
+
+        let mut tx = db.begin().await.expect("begin delete tx");
+        tx.sources()
+            .remove_source(&workspace, &source.name)
+            .await
+            .expect("delete db source");
+        tx.commit().await.expect("commit delete tx");
+
+        let report = import_config_source_catalog(&db, &config_store, &layout, 99)
+            .await
+            .expect("stale config should not reimport after marker");
+
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                workspace_count: 0,
+                source_count: 0,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("source should remain deleted"),
+            None
+        );
+        assert!(
+            config_store
+                .load_config_unlocked()
+                .expect("load cleaned stale config")
+                .source_catalog_entries()
                 .is_empty()
         );
     }
@@ -428,5 +951,60 @@ mod tests {
             credential_storage,
             origin,
         }
+    }
+
+    fn write_manifest_file(
+        layout: &AppStateLayout,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        manifest_yaml: &str,
+    ) {
+        let manifest_path = layout.manifest_file(workspace, source_name);
+        fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create manifest parent");
+        fs::write(manifest_path, manifest_yaml).expect("write manifest file");
+    }
+
+    fn imported_manifest_yaml(name: &str, version: &str) -> String {
+        format!(
+            r"
+name: {name}
+version: {version}
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Demo messages
+    request:
+      method: GET
+      path: /messages
+    response: {{}}
+    columns:
+      - name: id
+        type: Utf8
+"
+        )
+    }
+
+    fn unsafe_secret_endpoint_source() -> InstalledSource {
+        source(
+            "github",
+            Some("1.2.3"),
+            [("API_BASE", "http://api.example.com")],
+            ["API_TOKEN"],
+            Some(CredentialStorageKind::Keychain),
+            SourceOrigin::Imported,
+        )
+    }
+
+    fn unsafe_secret_endpoint_manifest_yaml(name: &str, version: &str) -> String {
+        imported_manifest_yaml(name, version).replacen(
+            "base_url: https://example.com",
+            r#"base_url: "{{input.API_BASE}}"
+inputs: { API_BASE: { kind: variable }, API_TOKEN: { kind: secret } }
+auth: { type: HeaderAuth, headers: [{ name: Authorization, from: template, template: "Bearer {{input.API_TOKEN}}" }] }"#,
+            1,
+        )
     }
 }

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::ErrorKind;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use chrono::{DateTime, Utc};
 use coral_api::CORAL_EPISODE_INTENT_MAX_CHARS;
@@ -9,6 +10,7 @@ use serde::Deserialize;
 use super::session::DbRepos;
 use super::{CoralDb, DbError, MaterializationRecord};
 use crate::bootstrap::AppError;
+use crate::credentials::{CredentialSetId, CredentialStorageKind, CredentialStore};
 use crate::episode::EpisodeId;
 use crate::episode::store::{
     EpisodeStoreError, MAX_EPISODE_BYTES_PER_WORKSPACE, episode_record_bytes,
@@ -26,6 +28,18 @@ use coral_spec::parse_source_manifest_yaml;
 use uuid::Uuid;
 
 const LEGACY_SOURCE_CATALOG_IMPORT_MARKER: &str = "legacy_source_catalog_imported";
+
+fn now_unix_nanos_i64() -> Result<i64, AppError> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| AppError::FailedPrecondition(format!("system clock error: {error}")))?
+        .as_nanos();
+    i64::try_from(nanos).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "system clock timestamp exceeds i64 nanoseconds: {error}"
+        ))
+    })
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SourceCatalogImportReport {
@@ -757,6 +771,158 @@ fn parse_legacy_episode_line(
     })
 }
 
+pub(crate) async fn import_legacy_credential_material(
+    db: &CoralDb,
+    layout: &AppStateLayout,
+    database_store: &CredentialStore,
+) -> Result<usize, AppError> {
+    let legacy_store = CredentialStore::with_preference(
+        layout.clone(),
+        crate::credentials::CredentialStoragePreference::Auto,
+    );
+    import_legacy_credential_material_with_store(db, database_store, &legacy_store).await
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeps credential import decisions together"
+)]
+async fn import_legacy_credential_material_with_store(
+    db: &CoralDb,
+    database_store: &CredentialStore,
+    legacy_store: &CredentialStore,
+) -> Result<usize, AppError> {
+    let mut imported = 0;
+    let mut session = db;
+    for workspace in session.workspaces().list().await? {
+        let workspace_name = WorkspaceName::parse(&workspace.id)?;
+        let sources = session
+            .sources()
+            .list_workspace_sources(&workspace_name)
+            .await?;
+        for source in sources {
+            let Some(storage) = source.credential_storage_for_material() else {
+                continue;
+            };
+            if storage == CredentialStorageKind::Database {
+                continue;
+            }
+            let credential_set_id = CredentialSetId::for_source(&source.name);
+            let material = match legacy_store.read_material(
+                &workspace_name,
+                &credential_set_id,
+                storage,
+            ) {
+                Ok(material) => material,
+                Err(error) => {
+                    tracing::warn!(
+                        workspace_name = %workspace_name,
+                        source_name = %source.name,
+                        %storage,
+                        detail = %error,
+                        "skipping legacy credential material import; re-add the source if credentials are still required"
+                    );
+                    continue;
+                }
+            };
+            match database_store.replace_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::Database,
+                &material,
+            ) {
+                Ok(()) => {}
+                Err(error @ AppError::Database(_)) => return Err(error),
+                Err(_error) => {
+                    tracing::warn!(
+                        workspace_name = %workspace_name,
+                        source_name = %source.name,
+                        %storage,
+                        "skipping legacy credential material import because database credential write could not be verified"
+                    );
+                    continue;
+                }
+            }
+            match database_store.read_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::Database,
+            ) {
+                Ok(imported_material) if imported_material == material => {}
+                Ok(_) => {
+                    tracing::warn!(
+                        workspace_name = %workspace_name,
+                        source_name = %source.name,
+                        %storage,
+                        "skipping legacy credential cleanup because database credential readback did not match legacy material"
+                    );
+                    remove_unverified_database_credential(
+                        database_store,
+                        &workspace_name,
+                        &credential_set_id,
+                    )?;
+                    continue;
+                }
+                Err(error @ AppError::Database(_)) => return Err(error),
+                Err(_error) => {
+                    tracing::warn!(
+                        workspace_name = %workspace_name,
+                        source_name = %source.name,
+                        %storage,
+                        "skipping legacy credential cleanup because database credential readback failed"
+                    );
+                    remove_unverified_database_credential(
+                        database_store,
+                        &workspace_name,
+                        &credential_set_id,
+                    )?;
+                    continue;
+                }
+            }
+            if !material.is_empty() {
+                imported += 1;
+            }
+            let mut updated = source.clone();
+            updated.credential_storage = Some(CredentialStorageKind::Database);
+            let mut tx = db.begin().await?;
+            tx.sources()
+                .upsert_source(&workspace_name, &updated, now_unix_nanos_i64()?)
+                .await?;
+            tx.commit().await?;
+            remove_legacy_credential_material(
+                legacy_store,
+                &workspace_name,
+                &credential_set_id,
+                storage,
+            );
+        }
+    }
+    Ok(imported)
+}
+
+fn remove_unverified_database_credential(
+    database_store: &CredentialStore,
+    workspace_name: &WorkspaceName,
+    credential_set_id: &CredentialSetId,
+) -> Result<(), AppError> {
+    match database_store.remove_material(
+        workspace_name,
+        credential_set_id,
+        CredentialStorageKind::Database,
+    ) {
+        Ok(()) => Ok(()),
+        Err(error @ AppError::Database(_)) => Err(error),
+        Err(_error) => {
+            tracing::warn!(
+                %workspace_name,
+                %credential_set_id,
+                "failed to remove unverified database credential document"
+            );
+            Ok(())
+        }
+    }
+}
+
 fn filesystem_workspaces(layout: &AppStateLayout) -> Result<Vec<WorkspaceName>, AppError> {
     let root = layout.workspaces_root();
     let mut workspaces = Vec::new();
@@ -793,6 +959,22 @@ fn is_workspace_delete_rollback_dir(name: &str) -> bool {
         return false;
     };
     Uuid::parse_str(rollback_id).is_ok()
+}
+
+fn remove_legacy_credential_material(
+    legacy_store: &CredentialStore,
+    workspace_name: &WorkspaceName,
+    credential_set_id: &CredentialSetId,
+    storage: CredentialStorageKind,
+) {
+    if let Err(_error) = legacy_store.remove_material(workspace_name, credential_set_id, storage) {
+        tracing::warn!(
+            %workspace_name,
+            %credential_set_id,
+            %storage,
+            "credential material imported into database but legacy cleanup failed"
+        );
+    }
 }
 
 fn remove_episodes_file(path: &std::path::Path) {
@@ -874,14 +1056,22 @@ fn clear_legacy_source_catalog_config(config_store: &ConfigStore, source_count: 
 mod tests {
     use std::collections::BTreeMap;
     use std::fs;
+    use std::sync::Arc;
 
     use tempfile::tempdir;
 
     use super::{
         SourceCatalogImportReport, import_config_source_catalog, import_filesystem_episodes,
         import_filesystem_episodes_with_max_bytes, import_filesystem_feedback_reports,
+        import_legacy_credential_material, import_legacy_credential_material_with_store,
     };
-    use crate::credentials::CredentialStorageKind;
+    use crate::credentials::encryption::{
+        CredentialEncryptionKey, CredentialKeyProvider, LocalFileCredentialKeyProvider,
+    };
+    use crate::credentials::{
+        CredentialSetId, CredentialStorageKind, CredentialStoragePreference, CredentialStore,
+        CredentialsError,
+    };
     use crate::sources::SourceName;
     use crate::sources::materialization::{
         MaterializationInputs, build_v4_materialization_tmp, replace_v4_materialization,
@@ -897,6 +1087,21 @@ mod tests {
     use coral_spec::parse_source_manifest_yaml;
 
     const OPENAPI_FIXTURE: &str = r#"{"openapi":"3.0.3","servers":[{"url":"https://api.example.com"}],"paths":{"/issues":{"get":{"operationId":"issues/list","responses":{"200":{"content":{"application/json":{"schema":{"type":"array","items":{"type":"object","properties":{"id":{"type":"integer"},"title":{"type":"string"}}}}}}}}}}}}"#;
+
+    #[derive(Clone)]
+    struct WriteOnlyKeyProvider(CredentialEncryptionKey);
+
+    impl CredentialKeyProvider for WriteOnlyKeyProvider {
+        fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+            Ok(self.0.clone())
+        }
+
+        fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+            Err(CredentialsError::Crypto(format!(
+                "test key '{key_id}' unavailable"
+            )))
+        }
+    }
 
     #[tokio::test]
     async fn imports_config_source_catalog_into_database() {
@@ -1976,6 +2181,350 @@ not-json
         );
     }
 
+    #[tokio::test]
+    async fn imports_legacy_file_credentials_into_database() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source name");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        let db = Arc::new(open_sqlite(&layout).await);
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 7)
+            .await
+            .expect("upsert source");
+        tx.commit().await.expect("commit source");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let legacy_store =
+            CredentialStore::with_preference(layout.clone(), CredentialStoragePreference::File);
+        let material = BTreeMap::from([("GITHUB_TOKEN".to_string(), "secret-token".to_string())]);
+        legacy_store
+            .replace_material(
+                &workspace,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &material,
+            )
+            .expect("write legacy credential file");
+        let database_store = CredentialStore::with_database(
+            layout.clone(),
+            CredentialStoragePreference::Auto,
+            Arc::clone(&db),
+            Arc::new(LocalFileCredentialKeyProvider::new(&layout)),
+        );
+
+        let imported = import_legacy_credential_material(db.as_ref(), &layout, &database_store)
+            .await
+            .expect("import legacy credentials");
+
+        assert_eq!(imported, 1);
+        let mut session = db.as_ref();
+        let updated = session
+            .sources()
+            .get_source(&workspace, &source_name)
+            .await
+            .expect("get source")
+            .expect("source");
+        assert_eq!(
+            updated.credential_storage,
+            Some(CredentialStorageKind::Database)
+        );
+        assert_eq!(
+            database_store
+                .read_material(
+                    &workspace,
+                    &credential_set_id,
+                    CredentialStorageKind::Database
+                )
+                .expect("read database material"),
+            material
+        );
+        assert!(
+            !layout.secret_file(&workspace, &source_name).exists(),
+            "legacy secrets.env should be removed after DB import"
+        );
+        let imported = import_legacy_credential_material(db.as_ref(), &layout, &database_store)
+            .await
+            .expect("rerun legacy credential import");
+        assert_eq!(imported, 0);
+    }
+
+    #[tokio::test]
+    async fn imports_keychain_backed_credentials_into_database() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source name");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::Keychain),
+            SourceOrigin::Imported,
+        );
+        let db = Arc::new(open_sqlite(&layout).await);
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 7)
+            .await
+            .expect("upsert source");
+        tx.commit().await.expect("commit source");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let legacy_store = CredentialStore::with_available_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::Keychain,
+        );
+        let material = BTreeMap::from([("GITHUB_TOKEN".to_string(), "secret-token".to_string())]);
+        legacy_store
+            .replace_material(
+                &workspace,
+                &credential_set_id,
+                CredentialStorageKind::Keychain,
+                &material,
+            )
+            .expect("write legacy keychain material");
+        let database_store = CredentialStore::with_database(
+            layout.clone(),
+            CredentialStoragePreference::Auto,
+            Arc::clone(&db),
+            Arc::new(LocalFileCredentialKeyProvider::new(&layout)),
+        );
+
+        let imported = import_legacy_credential_material_with_store(
+            db.as_ref(),
+            &database_store,
+            &legacy_store,
+        )
+        .await
+        .expect("import legacy credentials");
+
+        assert_eq!(imported, 1);
+        let mut session = db.as_ref();
+        let updated = session
+            .sources()
+            .get_source(&workspace, &source_name)
+            .await
+            .expect("get source")
+            .expect("source");
+        assert_eq!(
+            updated.credential_storage,
+            Some(CredentialStorageKind::Database)
+        );
+        assert_eq!(
+            database_store
+                .read_material(
+                    &workspace,
+                    &credential_set_id,
+                    CredentialStorageKind::Database
+                )
+                .expect("read database material"),
+            material
+        );
+        assert!(
+            legacy_store
+                .read_material(
+                    &workspace,
+                    &credential_set_id,
+                    CredentialStorageKind::Keychain
+                )
+                .expect("read legacy keychain material")
+                .is_empty(),
+            "legacy keychain material should be removed after verified DB import"
+        );
+    }
+
+    #[tokio::test]
+    async fn skips_corrupt_legacy_file_credentials() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source name");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        let db = Arc::new(open_sqlite(&layout).await);
+        seed_source(&db, &workspace, &source).await;
+        let secret_file = layout.secret_file(&workspace, &source_name);
+        fs::create_dir_all(secret_file.parent().expect("secret parent"))
+            .expect("create secret parent");
+        fs::write(&secret_file, "GITHUB_TOKEN\n").expect("write corrupt secrets");
+        let database_store = database_store(&layout, &db);
+
+        let imported = import_legacy_credential_material(db.as_ref(), &layout, &database_store)
+            .await
+            .expect("import legacy credentials");
+
+        assert_eq!(imported, 0);
+        assert_eq!(
+            db_source(&db, &workspace, &source_name)
+                .await
+                .credential_storage,
+            Some(CredentialStorageKind::File)
+        );
+        assert!(secret_file.exists());
+        assert!(
+            database_store
+                .read_material(
+                    &workspace,
+                    &CredentialSetId::for_source(&source_name),
+                    CredentialStorageKind::Database
+                )
+                .expect("read database material")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn keeps_legacy_file_when_database_readback_fails() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source name");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        let db = Arc::new(open_sqlite(&layout).await);
+        seed_source(&db, &workspace, &source).await;
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let legacy_store =
+            CredentialStore::with_preference(layout.clone(), CredentialStoragePreference::File);
+        let material = BTreeMap::from([("GITHUB_TOKEN".to_string(), "secret-token".to_string())]);
+        legacy_store
+            .replace_material(
+                &workspace,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &material,
+            )
+            .expect("write legacy credential file");
+        let key = CredentialEncryptionKey::from_static_bytes_for_test([41; 32]);
+        let database_store = CredentialStore::with_database(
+            layout.clone(),
+            CredentialStoragePreference::Auto,
+            Arc::clone(&db),
+            Arc::new(WriteOnlyKeyProvider(key)),
+        );
+
+        let imported = import_legacy_credential_material(db.as_ref(), &layout, &database_store)
+            .await
+            .expect("import legacy credentials");
+
+        assert_eq!(imported, 0);
+        assert_eq!(
+            db_source(&db, &workspace, &source_name)
+                .await
+                .credential_storage,
+            Some(CredentialStorageKind::File)
+        );
+        assert!(layout.secret_file(&workspace, &source_name).exists());
+        let mut session = db.as_ref();
+        assert!(
+            session
+                .credential_documents()
+                .get(&workspace, &source_name)
+                .await
+                .expect("get credential document")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run concurrent Postgres credential import coverage"]
+    async fn concurrent_credential_import_race_is_benign_postgres() {
+        let Some(url) = crate::bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+                .await
+                .expect("open postgres"),
+        );
+        db.migrate().await.expect("migrate postgres");
+        let workspace = WorkspaceName::parse(&format!("cred{}", uuid::Uuid::new_v4().simple()))
+            .expect("workspace");
+        let source_name = SourceName::parse("github").expect("source name");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        seed_source(&db, &workspace, &source).await;
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let material = BTreeMap::from([("GITHUB_TOKEN".to_string(), "secret-token".to_string())]);
+        CredentialStore::with_preference(layout.clone(), CredentialStoragePreference::File)
+            .replace_material(
+                &workspace,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &material,
+            )
+            .expect("write legacy credential file");
+        let first = database_store(&layout, &db);
+        let second = first.clone();
+
+        let (first_import, second_import) = tokio::join!(
+            import_legacy_credential_material(db.as_ref(), &layout, &first),
+            import_legacy_credential_material(db.as_ref(), &layout, &second)
+        );
+
+        first_import.expect("first import");
+        second_import.expect("second import");
+        assert_eq!(
+            first
+                .read_material(
+                    &workspace,
+                    &credential_set_id,
+                    CredentialStorageKind::Database
+                )
+                .expect("read database material"),
+            material
+        );
+        assert_eq!(
+            db_source(&db, &workspace, &source_name)
+                .await
+                .credential_storage,
+            Some(CredentialStorageKind::Database)
+        );
+        assert!(!layout.secret_file(&workspace, &source_name).exists());
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn import_succeeds_when_post_commit_config_cleanup_fails() {
@@ -2090,6 +2639,42 @@ not-json
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
         db
+    }
+
+    fn database_store(layout: &AppStateLayout, db: &Arc<CoralDb>) -> CredentialStore {
+        CredentialStore::with_database(
+            layout.clone(),
+            CredentialStoragePreference::Auto,
+            Arc::clone(db),
+            Arc::new(LocalFileCredentialKeyProvider::new(layout)),
+        )
+    }
+
+    async fn seed_source(db: &CoralDb, workspace: &WorkspaceName, source: &InstalledSource) {
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(workspace, source, 7)
+            .await
+            .expect("upsert source");
+        tx.commit().await.expect("commit source");
+    }
+
+    async fn db_source(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> InstalledSource {
+        let mut session = db;
+        session
+            .sources()
+            .get_source(workspace, source_name)
+            .await
+            .expect("get source")
+            .expect("source")
     }
 
     fn episode_jsonl(

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -3,17 +3,23 @@ use std::fs;
 use std::io::ErrorKind;
 
 use chrono::{DateTime, Utc};
+use coral_api::CORAL_EPISODE_INTENT_MAX_CHARS;
 use serde::Deserialize;
 
 use super::session::DbRepos;
 use super::{CoralDb, DbError, MaterializationRecord};
 use crate::bootstrap::AppError;
+use crate::episode::EpisodeId;
+use crate::episode::store::{
+    EpisodeStoreError, MAX_EPISODE_BYTES_PER_WORKSPACE, episode_record_bytes,
+    next_db_episode_created_at, retain_episode_records_within_budget,
+};
 use crate::sources::catalog::validate_imported_manifest_database_persistence;
 use crate::sources::materialization::{
     load_v4_materialization_from_record, materialization_record_from_dir,
 };
 use crate::sources::model::SourceOrigin;
-use crate::state::db::FeedbackReportRecord;
+use crate::state::db::{EpisodeRecord, FeedbackReportRecord};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::WorkspaceName;
 use coral_spec::parse_source_manifest_yaml;
@@ -350,12 +356,21 @@ struct PersistedFeedbackReport {
     stuck: String,
 }
 
+#[derive(Debug, Deserialize, serde::Serialize)]
+struct PersistedEpisode {
+    id: String,
+    workspace: String,
+    intent: String,
+    parent_episode_id: Option<String>,
+    created_at_unix_nanos: u128,
+}
+
 pub(crate) async fn import_filesystem_feedback_reports(
     db: &CoralDb,
     layout: &AppStateLayout,
 ) -> Result<usize, AppError> {
     let mut imported = 0;
-    for workspace_name in filesystem_feedback_workspaces(layout)? {
+    for workspace_name in filesystem_workspaces(layout)? {
         let path = layout.feedback_reports_file(&workspace_name);
         if !path.exists() {
             continue;
@@ -507,7 +522,242 @@ fn parse_legacy_feedback_report_line(
     })
 }
 
-fn filesystem_feedback_workspaces(layout: &AppStateLayout) -> Result<Vec<WorkspaceName>, AppError> {
+pub(crate) async fn import_filesystem_episodes(
+    db: &CoralDb,
+    layout: &AppStateLayout,
+) -> Result<usize, AppError> {
+    import_filesystem_episodes_with_max_bytes(db, layout, MAX_EPISODE_BYTES_PER_WORKSPACE).await
+}
+
+async fn import_filesystem_episodes_with_max_bytes(
+    db: &CoralDb,
+    layout: &AppStateLayout,
+    max_bytes: u64,
+) -> Result<usize, AppError> {
+    let mut imported = 0;
+    for workspace_name in filesystem_workspaces(layout)? {
+        let path = layout.episodes_file(&workspace_name);
+        if !path.exists() {
+            continue;
+        }
+        let raw = match fs::read(&path) {
+            Ok(raw) => raw,
+            Err(error) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    detail = %error,
+                    "skipping legacy episode JSONL import because the file could not be read"
+                );
+                continue;
+            }
+        };
+        let mut has_unimported_rows = false;
+        let records = raw
+            .split(|&byte| byte == b'\n')
+            .enumerate()
+            .filter_map(|(index, line)| {
+                let Ok(text) = std::str::from_utf8(line) else {
+                    tracing::warn!(
+                        path = %path.display(),
+                        line = index + 1,
+                        "leaving episode record with invalid UTF-8 in legacy JSONL"
+                    );
+                    has_unimported_rows = true;
+                    return None;
+                };
+                if text.trim().is_empty() {
+                    return None;
+                }
+                if let Some(record) =
+                    parse_legacy_episode_line(&path, workspace_name.as_str(), index + 1, text)
+                {
+                    Some(record)
+                } else {
+                    has_unimported_rows = true;
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        if !records.is_empty() {
+            let (workspace_imported, has_conflicts) =
+                import_workspace_episodes(db, &workspace_name, &path, &records, max_bytes).await?;
+            imported += workspace_imported;
+            has_unimported_rows |= has_conflicts;
+        }
+        if has_unimported_rows {
+            tracing::warn!(
+                path = %path.display(),
+                "legacy episode JSONL retained because at least one row was not imported"
+            );
+        } else {
+            remove_episodes_file(&path);
+        }
+    }
+    Ok(imported)
+}
+
+async fn import_workspace_episodes(
+    db: &CoralDb,
+    workspace_name: &WorkspaceName,
+    path: &std::path::Path,
+    records: &[EpisodeRecord],
+    max_bytes: u64,
+) -> Result<(usize, bool), AppError> {
+    let Some(first) = records.first() else {
+        return Ok((0, false));
+    };
+    let mut tx = db.begin().await?;
+    tx.workspaces()
+        .ensure_write_locked(workspace_name.as_str(), first.created_at_unix_nanos)
+        .await?;
+    let mut episodes = tx
+        .episodes()
+        .list_workspace_episodes(workspace_name)
+        .await?;
+    let mut imported = 0;
+    let mut has_conflicts = false;
+    for record in records {
+        if let Some(existing) = episodes.iter().find(|existing| existing.id == record.id) {
+            if existing.intent == record.intent
+                && existing.parent_episode_id == record.parent_episode_id
+            {
+                continue;
+            }
+            tracing::warn!(
+                path = %path.display(),
+                episode_id = %record.id,
+                workspace = %workspace_name,
+                "legacy episode JSONL retained because an episode row conflicts with the database"
+            );
+            has_conflicts = true;
+            continue;
+        }
+        let (created_at_unix_nanos_raw, created_at_unix_nanos) =
+            next_db_episode_created_at(&episodes).map_err(episode_store_error_to_app)?;
+        let record_bytes = episode_record_bytes(
+            workspace_name,
+            &record.id,
+            &record.intent,
+            record.parent_episode_id.as_deref(),
+            created_at_unix_nanos_raw,
+        )
+        .map_err(episode_store_error_to_app)?;
+        let mut imported_record = record.clone();
+        imported_record.created_at_unix_nanos = created_at_unix_nanos;
+        imported_record.record_bytes = record_bytes;
+        episodes.push(imported_record);
+        imported += 1;
+    }
+    let kept = retain_episode_records_within_budget(episodes, max_bytes);
+    tx.episodes()
+        .replace_workspace_episodes(workspace_name, &kept)
+        .await?;
+    tx.commit().await?;
+    Ok((imported, has_conflicts))
+}
+
+fn episode_store_error_to_app(error: EpisodeStoreError) -> AppError {
+    match error {
+        EpisodeStoreError::Persistence(error) => error,
+        other => AppError::FailedPrecondition(other.to_string()),
+    }
+}
+
+fn parse_legacy_episode_line(
+    path: &std::path::Path,
+    file_workspace: &str,
+    line_number: usize,
+    line: &str,
+) -> Option<EpisodeRecord> {
+    let record = match serde_json::from_str::<PersistedEpisode>(line) {
+        Ok(record) => record,
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                line = line_number,
+                %error,
+                "leaving invalid episode record in legacy JSONL"
+            );
+            return None;
+        }
+    };
+    let workspace = match WorkspaceName::parse(&record.workspace) {
+        Ok(workspace) => workspace,
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                line = line_number,
+                %error,
+                "leaving episode with invalid workspace in legacy JSONL"
+            );
+            return None;
+        }
+    };
+    if workspace.as_str() != file_workspace {
+        tracing::warn!(
+            path = %path.display(),
+            line = line_number,
+            episode_workspace = %workspace,
+            file_workspace,
+            "leaving episode stored under a different workspace in legacy JSONL"
+        );
+        return None;
+    }
+    if let Err(error) = EpisodeId::parse(&record.id) {
+        tracing::warn!(
+            path = %path.display(),
+            line = line_number,
+            %error,
+            "leaving episode with invalid id in legacy JSONL"
+        );
+        return None;
+    }
+    let parent_episode_id = match record.parent_episode_id {
+        Some(parent_episode_id) => {
+            if let Err(error) = EpisodeId::parse(&parent_episode_id) {
+                tracing::warn!(
+                    path = %path.display(),
+                    line = line_number,
+                    %error,
+                    "leaving episode with invalid parent id in legacy JSONL"
+                );
+                return None;
+            }
+            Some(parent_episode_id)
+        }
+        None => None,
+    };
+    let intent = record.intent.trim();
+    if intent.is_empty() || intent.chars().count() > CORAL_EPISODE_INTENT_MAX_CHARS {
+        tracing::warn!(
+            path = %path.display(),
+            line = line_number,
+            "leaving episode with invalid intent in legacy JSONL"
+        );
+        return None;
+    }
+    let created_at_unix_nanos = match i64::try_from(record.created_at_unix_nanos) {
+        Ok(created_at_unix_nanos) => created_at_unix_nanos,
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                line = line_number,
+                %error,
+                "leaving episode with out-of-range timestamp in legacy JSONL"
+            );
+            return None;
+        }
+    };
+    Some(EpisodeRecord {
+        id: record.id,
+        intent: intent.to_string(),
+        parent_episode_id,
+        created_at_unix_nanos,
+        record_bytes: 0,
+    })
+}
+
+fn filesystem_workspaces(layout: &AppStateLayout) -> Result<Vec<WorkspaceName>, AppError> {
     let root = layout.workspaces_root();
     let mut workspaces = Vec::new();
     let entries = match fs::read_dir(root) {
@@ -531,7 +781,7 @@ fn filesystem_feedback_workspaces(layout: &AppStateLayout) -> Result<Vec<Workspa
             Err(error) => tracing::warn!(
                 path = %entry.path().display(),
                 detail = %error,
-                "skipping legacy feedback import for invalid workspace directory"
+                "skipping legacy filesystem import for invalid workspace directory"
             ),
         }
     }
@@ -543,6 +793,20 @@ fn is_workspace_delete_rollback_dir(name: &str) -> bool {
         return false;
     };
     Uuid::parse_str(rollback_id).is_ok()
+}
+
+fn remove_episodes_file(path: &std::path::Path) {
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                detail = %error,
+                "episodes imported into database but legacy JSONL cleanup failed"
+            );
+        }
+    }
 }
 
 fn remove_feedback_reports_file(path: &std::path::Path) {
@@ -614,7 +878,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        SourceCatalogImportReport, import_config_source_catalog, import_filesystem_feedback_reports,
+        SourceCatalogImportReport, import_config_source_catalog, import_filesystem_episodes,
+        import_filesystem_episodes_with_max_bytes, import_filesystem_feedback_reports,
     };
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
@@ -624,7 +889,7 @@ mod tests {
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::db::session::DbRepos;
     use crate::state::db::{
-        CoralDb, DatabaseConfig, FeedbackReportRecord, MaterializationRecord,
+        CoralDb, DatabaseConfig, EpisodeRecord, FeedbackReportRecord, MaterializationRecord,
         MaterializationSurfaceRecord, ResolvedDatabaseConfig,
     };
     use crate::state::{AppStateLayout, ConfigStore};
@@ -1508,6 +1773,209 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run concurrent Postgres episode import coverage"]
+    async fn concurrent_episode_import_race_serializes_on_workspace_lock_postgres() {
+        let Some(url) = crate::bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse(&format!("episode{}", uuid::Uuid::new_v4().simple()))
+            .expect("workspace");
+        let episodes_file = write_episodes_file(
+            &layout,
+            &workspace,
+            &episode_jsonl(workspace.as_str(), "ep_1", "task", 1),
+        );
+        let mut tx = db.begin().await.expect("begin lock tx");
+        tx.workspaces()
+            .ensure_write_locked(workspace.as_str(), 7)
+            .await
+            .expect("hold workspace lock");
+        let first = import_filesystem_episodes(&db, &layout);
+        let second = import_filesystem_episodes(&db, &layout);
+        tokio::pin!(first);
+        tokio::pin!(second);
+
+        if tokio::time::timeout(std::time::Duration::from_millis(250), async {
+            tokio::select! {
+                result = &mut first => result,
+                result = &mut second => result,
+            }
+        })
+        .await
+        .is_ok()
+        {
+            panic!("episode import completed before the workspace lock was released");
+        }
+        tx.commit().await.expect("release workspace lock");
+        let (first, second) = tokio::join!(&mut first, &mut second);
+        assert_eq!(
+            first.expect("first import") + second.expect("second import"),
+            1
+        );
+        assert!(!episodes_file.exists());
+        let mut session = &db;
+        let episodes = session
+            .episodes()
+            .list_workspace_episodes(&workspace)
+            .await
+            .expect("list episodes");
+        assert_eq!(episodes.len(), 1);
+        assert_eq!(episodes.first().expect("episode").id, "ep_1");
+    }
+
+    #[tokio::test]
+    async fn episode_import_applies_budget_in_file_order() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        write_episodes_file(
+            &layout,
+            &workspace,
+            &[
+                episode_jsonl("default", "ep_z", "first file row", 300),
+                episode_jsonl("default", "ep_y", "middle file row", 200),
+                episode_jsonl("default", "ep_a", "last file row", 1),
+            ]
+            .concat(),
+        );
+        let db = open_sqlite(&layout).await;
+
+        import_filesystem_episodes_with_max_bytes(&db, &layout, 1)
+            .await
+            .expect("import episodes");
+        let mut session = &db;
+        let episodes = session
+            .episodes()
+            .list_workspace_episodes(&workspace)
+            .await
+            .expect("list episodes");
+        assert_eq!(episodes.len(), 1);
+        let survivor = episodes.first().expect("survivor");
+        assert_eq!(survivor.id, "ep_a", "legacy file order decides newest");
+    }
+
+    #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "This integration-style import test keeps related retention cases in one setup."
+    )]
+    async fn episode_import_retains_legacy_jsonl_when_rows_are_not_imported() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let episodes_file = layout.episodes_file(&workspace);
+        fs::create_dir_all(episodes_file.parent().expect("episodes parent"))
+            .expect("create episodes parent");
+        fs::write(
+            &episodes_file,
+            r#"{"id":"ep_1","workspace":"default","intent":"find the HR onboarding form","parent_episode_id":null,"created_at_unix_nanos":99}
+not-json
+{"id":"ep_other","workspace":"other","intent":"wrong workspace","parent_episode_id":null,"created_at_unix_nanos":100}
+{"id":"ep_conflict","workspace":"default","intent":"legacy intent","parent_episode_id":null,"created_at_unix_nanos":101}
+"#,
+        )
+        .expect("write episode JSONL");
+        #[cfg(unix)]
+        let blocked_file = {
+            use std::os::unix::fs::PermissionsExt;
+            let blocked = WorkspaceName::parse("blocked").expect("workspace");
+            let file = write_episodes_file(
+                &layout,
+                &blocked,
+                &episode_jsonl("blocked", "ep_blocked", "blocked", 1),
+            );
+            fs::set_permissions(&file, fs::Permissions::from_mode(0o000))
+                .expect("make blocked file unreadable");
+            file
+        };
+        let db = open_sqlite(&layout).await;
+        let mut tx = db.begin().await.expect("begin seed tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("ensure workspace");
+        tx.episodes()
+            .insert(
+                &workspace,
+                &EpisodeRecord {
+                    id: "ep_conflict".to_string(),
+                    intent: "database intent".to_string(),
+                    parent_episode_id: None,
+                    created_at_unix_nanos: 1,
+                    record_bytes: 1,
+                },
+            )
+            .await
+            .expect("seed existing episode");
+        tx.commit().await.expect("commit seed");
+
+        let imported = import_filesystem_episodes(&db, &layout)
+            .await
+            .expect("import episodes");
+
+        #[cfg(unix)]
+        assert!(blocked_file.exists());
+        assert_eq!(imported, 1);
+        assert!(
+            episodes_file.exists(),
+            "legacy episode JSONL with unimported rows must be preserved"
+        );
+        assert_eq!(
+            import_filesystem_episodes(&db, &layout)
+                .await
+                .expect("reimport episodes"),
+            0
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&blocked_file, fs::Permissions::from_mode(0o600))
+                .expect("restore blocked file permissions");
+        }
+        let mut session = &db;
+        assert!(
+            session
+                .workspaces()
+                .get("other")
+                .await
+                .expect("get other workspace")
+                .is_none(),
+            "cross-workspace episode import must not create the embedded workspace"
+        );
+        let episodes = session
+            .episodes()
+            .list_workspace_episodes(&workspace)
+            .await
+            .expect("list episodes");
+        assert_eq!(episodes.len(), 2);
+        assert_eq!(
+            episodes
+                .iter()
+                .find(|episode| episode.id == "ep_1")
+                .expect("imported episode")
+                .intent,
+            "find the HR onboarding form"
+        );
+        assert_eq!(
+            episodes
+                .iter()
+                .find(|episode| episode.id == "ep_conflict")
+                .expect("seed episode")
+                .intent,
+            "database intent"
+        );
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn import_succeeds_when_post_commit_config_cleanup_fails() {
@@ -1622,6 +2090,30 @@ mod tests {
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
         db
+    }
+
+    fn episode_jsonl(
+        workspace: &str,
+        id: &str,
+        intent: &str,
+        created_at_unix_nanos: u128,
+    ) -> String {
+        format!(
+            r#"{{"id":"{id}","workspace":"{workspace}","intent":"{intent}","parent_episode_id":null,"created_at_unix_nanos":{created_at_unix_nanos}}}
+"#
+        )
+    }
+
+    fn write_episodes_file(
+        layout: &AppStateLayout,
+        workspace: &WorkspaceName,
+        contents: &str,
+    ) -> std::path::PathBuf {
+        let episodes_file = layout.episodes_file(workspace);
+        fs::create_dir_all(episodes_file.parent().expect("episodes parent"))
+            .expect("create episodes parent");
+        fs::write(&episodes_file, contents).expect("write episode JSONL");
+        episodes_file
     }
 
     fn feedback_jsonl(workspace: &str, id: &str) -> String {

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -825,6 +825,15 @@ async fn import_legacy_credential_material_with_store(
                     continue;
                 }
             };
+            if material.is_empty() {
+                tracing::warn!(
+                    workspace_name = %workspace_name,
+                    source_name = %source.name,
+                    %storage,
+                    "skipping legacy credential material import because the legacy credential material is empty; re-add the source if credentials are still required"
+                );
+                continue;
+            }
             match database_store.replace_material(
                 &workspace_name,
                 &credential_set_id,
@@ -879,9 +888,7 @@ async fn import_legacy_credential_material_with_store(
                     continue;
                 }
             }
-            if !material.is_empty() {
-                imported += 1;
-            }
+            imported += 1;
             let mut updated = source.clone();
             updated.credential_storage = Some(CredentialStorageKind::Database);
             let mut tx = db.begin().await?;
@@ -2260,6 +2267,74 @@ not-json
             .await
             .expect("rerun legacy credential import");
         assert_eq!(imported, 0);
+    }
+
+    #[tokio::test]
+    async fn skips_missing_legacy_file_credentials_without_marking_source_database_backed() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source name");
+        let source = source(
+            "github",
+            Some("1.2.3"),
+            [],
+            ["GITHUB_TOKEN"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        let db = Arc::new(open_sqlite(&layout).await);
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 7)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 7)
+            .await
+            .expect("upsert source");
+        tx.commit().await.expect("commit source");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let legacy_store =
+            CredentialStore::with_preference(layout.clone(), CredentialStoragePreference::File);
+        let database_store = CredentialStore::with_database(
+            layout.clone(),
+            CredentialStoragePreference::Auto,
+            Arc::clone(&db),
+            Arc::new(LocalFileCredentialKeyProvider::new(&layout)),
+        );
+
+        let imported = import_legacy_credential_material_with_store(
+            db.as_ref(),
+            &database_store,
+            &legacy_store,
+        )
+        .await
+        .expect("import legacy credentials");
+
+        assert_eq!(imported, 0);
+        let mut session = db.as_ref();
+        let updated = session
+            .sources()
+            .get_source(&workspace, &source_name)
+            .await
+            .expect("get source")
+            .expect("source");
+        assert_eq!(
+            updated.credential_storage,
+            Some(CredentialStorageKind::File)
+        );
+        assert_eq!(
+            database_store
+                .read_material(
+                    &workspace,
+                    &credential_set_id,
+                    CredentialStorageKind::Database
+                )
+                .expect("read missing database material"),
+            BTreeMap::new()
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -6,9 +6,13 @@ use super::CoralDb;
 use super::session::DbRepos;
 use crate::bootstrap::AppError;
 use crate::sources::catalog::validate_imported_manifest_database_persistence;
+use crate::sources::materialization::{
+    load_v4_materialization_from_record, materialization_record_from_dir,
+};
 use crate::sources::model::SourceOrigin;
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::WorkspaceName;
+use coral_spec::parse_source_manifest_yaml;
 
 const LEGACY_SOURCE_CATALOG_IMPORT_MARKER: &str = "legacy_source_catalog_imported";
 
@@ -37,6 +41,7 @@ pub(crate) async fn import_config_source_catalog(
     {
         tx.commit().await?;
         import_filesystem_source_manifests(db, layout, now_unix_nanos).await?;
+        import_filesystem_v4_materializations(db, layout, now_unix_nanos).await?;
         clear_legacy_source_catalog_config(config_store, entries.len());
         return Ok(SourceCatalogImportReport {
             workspace_count: 0,
@@ -96,6 +101,7 @@ pub(crate) async fn import_config_source_catalog(
     tx.commit().await?;
 
     import_filesystem_source_manifests(db, layout, now_unix_nanos).await?;
+    import_filesystem_v4_materializations(db, layout, now_unix_nanos).await?;
     clear_legacy_source_catalog_config(config_store, entries.len());
 
     Ok(SourceCatalogImportReport {
@@ -190,6 +196,56 @@ fn read_validated_manifest_for_backfill(
     }
 
     Some(manifest_yaml)
+}
+
+async fn import_filesystem_v4_materializations(
+    db: &CoralDb,
+    layout: &AppStateLayout,
+    now_unix_nanos: i64,
+) -> Result<(), AppError> {
+    let mut session = db;
+    for workspace in session.workspaces().list().await? {
+        let workspace_name = WorkspaceName::parse(&workspace.id)?;
+        for source in session
+            .sources()
+            .list_workspace_sources(&workspace_name)
+            .await?
+            .into_iter()
+            .filter(|source| source.origin == SourceOrigin::Imported)
+        {
+            let dir = layout.v4_materialized_dir(&workspace_name, &source.name);
+            if !dir.exists()
+                || session
+                    .materializations()
+                    .get(&workspace_name, &source.name)
+                    .await?
+                    .is_some()
+            {
+                continue;
+            }
+            let Some(manifest_yaml) = session
+                .source_manifests()
+                .get(&workspace_name, &source.name)
+                .await?
+                .map(|record| record.manifest_yaml)
+            else {
+                continue;
+            };
+            let manifest = parse_source_manifest_yaml(&manifest_yaml)
+                .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+            let Some(v4) = manifest.as_v4() else {
+                continue;
+            };
+            let record = materialization_record_from_dir(&source.name, &dir, now_unix_nanos)?;
+            load_v4_materialization_from_record(&source.name, &manifest_yaml, v4, &record)?;
+            let mut tx = db.begin().await?;
+            tx.materializations()
+                .upsert(&workspace_name, &source.name, &record)
+                .await?;
+            tx.commit().await?;
+        }
+    }
+    Ok(())
 }
 
 fn read_imported_manifest_file(
@@ -711,67 +767,6 @@ mod tests {
                 .await
                 .expect("get still-missing source manifest"),
             None
-        );
-    }
-
-    #[tokio::test]
-    async fn backfills_manifest_for_already_imported_database_source() {
-        let temp = tempdir().expect("temp dir");
-        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let workspace = WorkspaceName::parse("default").expect("workspace");
-        let source = source(
-            "github",
-            Some("1.2.3"),
-            [],
-            [],
-            None,
-            SourceOrigin::Imported,
-        );
-        let manifest_yaml = imported_manifest_yaml("github", "1.2.3");
-        write_manifest_file(&layout, &workspace, &source.name, &manifest_yaml);
-        let db = open_sqlite(&layout).await;
-        let mut tx = db.begin().await.expect("begin tx");
-        tx.workspaces()
-            .ensure(workspace.as_str(), 7)
-            .await
-            .expect("ensure workspace");
-        tx.sources()
-            .upsert_source(&workspace, &source, 7)
-            .await
-            .expect("write source without manifest row");
-        tx.app_state_markers()
-            .insert(super::LEGACY_SOURCE_CATALOG_IMPORT_MARKER, 7)
-            .await
-            .expect("insert source import marker");
-        tx.commit().await.expect("commit source");
-
-        let report = import_config_source_catalog(&db, &config_store, &layout, 11)
-            .await
-            .expect("backfill manifest");
-
-        assert_eq!(
-            report,
-            SourceCatalogImportReport {
-                workspace_count: 0,
-                source_count: 0,
-            }
-        );
-        let mut session = &db;
-        assert_eq!(
-            session
-                .source_manifests()
-                .get(&workspace, &source.name)
-                .await
-                .expect("get source manifest")
-                .expect("source manifest")
-                .manifest_yaml,
-            manifest_yaml
-        );
-        assert!(
-            layout.manifest_file(&workspace, &source.name).exists(),
-            "legacy manifest file should be preserved after DB backfill"
         );
     }
 

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -2,6 +2,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::ErrorKind;
 
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
 use super::session::DbRepos;
 use super::{CoralDb, DbError, MaterializationRecord};
 use crate::bootstrap::AppError;
@@ -10,9 +13,11 @@ use crate::sources::materialization::{
     load_v4_materialization_from_record, materialization_record_from_dir,
 };
 use crate::sources::model::SourceOrigin;
+use crate::state::db::FeedbackReportRecord;
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::WorkspaceName;
 use coral_spec::parse_source_manifest_yaml;
+use uuid::Uuid;
 
 const LEGACY_SOURCE_CATALOG_IMPORT_MARKER: &str = "legacy_source_catalog_imported";
 
@@ -335,6 +340,225 @@ fn remove_v4_materialization_dir(materialized_dir: &std::path::Path) {
     }
 }
 
+#[derive(Debug, Deserialize)]
+struct PersistedFeedbackReport {
+    id: String,
+    workspace: String,
+    created_at: String,
+    trying_to_do: String,
+    tried: String,
+    stuck: String,
+}
+
+pub(crate) async fn import_filesystem_feedback_reports(
+    db: &CoralDb,
+    layout: &AppStateLayout,
+) -> Result<usize, AppError> {
+    let mut imported = 0;
+    for workspace_name in filesystem_feedback_workspaces(layout)? {
+        let path = layout.feedback_reports_file(&workspace_name);
+        if !path.exists() {
+            continue;
+        }
+        let raw = match fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(error) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    detail = %error,
+                    "skipping legacy feedback JSONL import because the file could not be read"
+                );
+                continue;
+            }
+        };
+        let mut records = Vec::new();
+        let mut has_unimported_rows = false;
+        for (index, line) in raw
+            .lines()
+            .enumerate()
+            .filter(|(_index, line)| !line.trim().is_empty())
+        {
+            if let Some(record) =
+                parse_legacy_feedback_report_line(&path, workspace_name.as_str(), index + 1, line)
+            {
+                records.push(record);
+            } else {
+                has_unimported_rows = true;
+            }
+        }
+        for record in records {
+            if insert_imported_feedback_report(db, &workspace_name, &record).await? {
+                imported += 1;
+            }
+        }
+        if has_unimported_rows {
+            tracing::warn!(
+                path = %path.display(),
+                "legacy feedback JSONL retained because at least one row was not imported"
+            );
+        } else {
+            remove_feedback_reports_file(&path);
+        }
+    }
+    Ok(imported)
+}
+
+async fn insert_imported_feedback_report(
+    db: &CoralDb,
+    workspace_name: &WorkspaceName,
+    record: &FeedbackReportRecord,
+) -> Result<bool, AppError> {
+    let mut tx = db.begin().await?;
+    tx.workspaces()
+        .ensure(workspace_name.as_str(), record.created_at_unix_nanos)
+        .await?;
+    match tx.feedback_reports().append(workspace_name, record).await {
+        Ok(()) => {
+            tx.commit().await?;
+            Ok(true)
+        }
+        Err(error) if is_unique_constraint_error(&error) => {
+            tx.rollback().await?;
+            let mut session = db;
+            if session
+                .feedback_reports()
+                .get(workspace_name, &record.id)
+                .await?
+                .is_some()
+            {
+                Ok(false)
+            } else {
+                Err(error.into())
+            }
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn parse_legacy_feedback_report_line(
+    path: &std::path::Path,
+    file_workspace: &str,
+    line_number: usize,
+    line: &str,
+) -> Option<FeedbackReportRecord> {
+    let record = match serde_json::from_str::<PersistedFeedbackReport>(line) {
+        Ok(record) => record,
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                line = line_number,
+                %error,
+                "leaving invalid feedback report record in legacy JSONL"
+            );
+            return None;
+        }
+    };
+    let workspace = match WorkspaceName::parse(&record.workspace) {
+        Ok(workspace) => workspace,
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                line = line_number,
+                %error,
+                "leaving feedback report with invalid workspace in legacy JSONL"
+            );
+            return None;
+        }
+    };
+    if workspace.as_str() != file_workspace {
+        tracing::warn!(
+            path = %path.display(),
+            line = line_number,
+            report_workspace = %workspace,
+            file_workspace,
+            "leaving feedback report stored under a different workspace in legacy JSONL"
+        );
+        return None;
+    }
+    let created_at = match DateTime::parse_from_rfc3339(&record.created_at) {
+        Ok(created_at) => created_at.with_timezone(&Utc),
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                line = line_number,
+                %error,
+                "leaving feedback report with invalid timestamp in legacy JSONL"
+            );
+            return None;
+        }
+    };
+    let Some(created_at_unix_nanos) = created_at.timestamp_nanos_opt() else {
+        tracing::warn!(
+            path = %path.display(),
+            line = line_number,
+            "leaving feedback report with out-of-range timestamp in legacy JSONL"
+        );
+        return None;
+    };
+    Some(FeedbackReportRecord {
+        id: record.id,
+        created_at_unix_nanos,
+        trying_to_do: record.trying_to_do,
+        tried: record.tried,
+        stuck: record.stuck,
+        publish_status: None,
+        publish_error: None,
+        published_at_unix_nanos: None,
+    })
+}
+
+fn filesystem_feedback_workspaces(layout: &AppStateLayout) -> Result<Vec<WorkspaceName>, AppError> {
+    let root = layout.workspaces_root();
+    let mut workspaces = Vec::new();
+    let entries = match fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(workspaces),
+        Err(error) => return Err(error.into()),
+    };
+    for entry in entries {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        if is_workspace_delete_rollback_dir(&name) {
+            continue;
+        }
+        match WorkspaceName::parse(&name) {
+            Ok(workspace) => workspaces.push(workspace),
+            Err(error) => tracing::warn!(
+                path = %entry.path().display(),
+                detail = %error,
+                "skipping legacy feedback import for invalid workspace directory"
+            ),
+        }
+    }
+    Ok(workspaces)
+}
+
+fn is_workspace_delete_rollback_dir(name: &str) -> bool {
+    let Some((_workspace_name, rollback_id)) = name.split_once(".delete.rollback.") else {
+        return false;
+    };
+    Uuid::parse_str(rollback_id).is_ok()
+}
+
+fn remove_feedback_reports_file(path: &std::path::Path) {
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => {
+            tracing::warn!(
+                path = %path.display(),
+                detail = %error,
+                "feedback reports imported into database but legacy JSONL cleanup failed"
+            );
+        }
+    }
+}
+
 fn read_imported_manifest_file(
     layout: &AppStateLayout,
     workspace_name: &WorkspaceName,
@@ -389,7 +613,9 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use super::{SourceCatalogImportReport, import_config_source_catalog};
+    use super::{
+        SourceCatalogImportReport, import_config_source_catalog, import_filesystem_feedback_reports,
+    };
     use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
     use crate::sources::materialization::{
@@ -398,8 +624,8 @@ mod tests {
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::db::session::DbRepos;
     use crate::state::db::{
-        CoralDb, DatabaseConfig, MaterializationRecord, MaterializationSurfaceRecord,
-        ResolvedDatabaseConfig,
+        CoralDb, DatabaseConfig, FeedbackReportRecord, MaterializationRecord,
+        MaterializationSurfaceRecord, ResolvedDatabaseConfig,
     };
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::WorkspaceName;
@@ -1178,6 +1404,112 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn feedback_import_skips_bad_legacy_state_and_imports_healthy_rows() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let default = WorkspaceName::parse("default").expect("workspace");
+        let healthy = WorkspaceName::parse("healthy").expect("workspace");
+        let corrupt = WorkspaceName::parse("corrupt").expect("workspace");
+        let retained_file = layout.feedback_reports_file(&default);
+        let healthy_file = layout.feedback_reports_file(&healthy);
+        write_feedback_reports_file(
+            &retained_file,
+            &format!("{}not json\n", feedback_jsonl("default", "feedback-1")),
+        );
+        write_feedback_reports_file(&healthy_file, &feedback_jsonl("healthy", "feedback-1"));
+        let corrupt_file = layout.feedback_reports_file(&corrupt);
+        fs::create_dir_all(corrupt_file.parent().expect("reports parent"))
+            .expect("create reports parent");
+        fs::write(&corrupt_file, b"{\xff").expect("write invalid UTF-8 JSONL");
+        let invalid_workspace_file = layout
+            .workspaces_root()
+            .join(r"bad\workspace")
+            .join("feedback")
+            .join("reports.jsonl");
+        write_feedback_reports_file(
+            &invalid_workspace_file,
+            &feedback_jsonl(r"bad\workspace", "feedback-1"),
+        );
+        let rollback_file = layout
+            .workspaces_root()
+            .join(format!("rollback.delete.rollback.{}", uuid::Uuid::new_v4()))
+            .join("feedback")
+            .join("reports.jsonl");
+        write_feedback_reports_file(&rollback_file, &feedback_jsonl("rollback", "feedback-1"));
+        let db = open_sqlite(&layout).await;
+
+        let imported = import_filesystem_feedback_reports(&db, &layout)
+            .await
+            .expect("import feedback reports");
+
+        assert_eq!(imported, 2);
+        assert!(retained_file.exists());
+        assert!(!healthy_file.exists());
+        assert!(corrupt_file.exists());
+        assert!(invalid_workspace_file.exists());
+        assert!(rollback_file.exists());
+        let mut session = &db;
+        assert!(
+            session
+                .workspaces()
+                .get("rollback")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run concurrent Postgres feedback import coverage"]
+    async fn concurrent_feedback_report_import_race_is_benign_postgres() {
+        let Some(url) = crate::bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+        let workspace = WorkspaceName::parse(&format!("feedback{}", uuid::Uuid::new_v4().simple()))
+            .expect("workspace");
+        let winner = feedback_record("feedback-1", "winner");
+        let mut tx = db.begin().await.expect("begin workspace tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), winner.created_at_unix_nanos)
+            .await
+            .expect("ensure workspace");
+        tx.commit().await.expect("commit workspace");
+        let mut tx = db.begin().await.expect("begin winner tx");
+        tx.feedback_reports()
+            .append(&workspace, &winner)
+            .await
+            .expect("insert uncommitted winner feedback");
+        let mut loser = winner.clone();
+        loser.trying_to_do = "loser".into();
+        let import = super::insert_imported_feedback_report(&db, &workspace, &loser);
+        tokio::pin!(import);
+
+        if tokio::time::timeout(std::time::Duration::from_millis(250), &mut import)
+            .await
+            .is_ok()
+        {
+            panic!("loser feedback import completed before winner commit");
+        }
+        tx.commit().await.expect("commit winner feedback");
+        assert!(!import.await.expect("loser import should recover"));
+        let mut session = &db;
+        assert_eq!(
+            session
+                .feedback_reports()
+                .get(&workspace, &winner.id)
+                .await
+                .expect("get feedback report"),
+            Some(winner)
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn import_succeeds_when_post_commit_config_cleanup_fails() {
         use std::fs;
         use std::os::unix::fs::PermissionsExt;
@@ -1290,6 +1622,31 @@ mod tests {
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
         db
+    }
+
+    fn feedback_jsonl(workspace: &str, id: &str) -> String {
+        format!(
+            r#"{{"id":"{id}","workspace":"{workspace}","created_at":"2026-06-30T12:00:00Z","trying_to_do":"trying","tried":"tried","stuck":"stuck"}}
+"#
+        )
+    }
+
+    fn write_feedback_reports_file(path: &std::path::Path, contents: &str) {
+        fs::create_dir_all(path.parent().expect("reports parent")).expect("create reports parent");
+        fs::write(path, contents).expect("write feedback JSONL");
+    }
+
+    fn feedback_record(id: &str, trying_to_do: &str) -> FeedbackReportRecord {
+        FeedbackReportRecord {
+            id: id.to_string(),
+            created_at_unix_nanos: 42,
+            trying_to_do: trying_to_do.to_string(),
+            tried: "tried".to_string(),
+            stuck: "stuck".to_string(),
+            publish_status: None,
+            publish_error: None,
+            published_at_unix_nanos: None,
+        }
     }
 
     fn source<const V: usize, const S: usize>(

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -68,6 +68,7 @@ pub(crate) async fn import_config_source_catalog(
         import_filesystem_source_manifests(db, layout, now_unix_nanos).await?;
         import_filesystem_v4_materializations(db, layout, now_unix_nanos).await?;
         clear_legacy_source_catalog_config(config_store, entries.len());
+        mark_database_migrated_config(config_store);
         return Ok(SourceCatalogImportReport {
             workspace_count: 0,
             source_count: 0,
@@ -128,6 +129,7 @@ pub(crate) async fn import_config_source_catalog(
     import_filesystem_source_manifests(db, layout, now_unix_nanos).await?;
     import_filesystem_v4_materializations(db, layout, now_unix_nanos).await?;
     clear_legacy_source_catalog_config(config_store, entries.len());
+    mark_database_migrated_config(config_store);
 
     Ok(SourceCatalogImportReport {
         workspace_count: workspaces.len(),
@@ -1059,6 +1061,15 @@ fn clear_legacy_source_catalog_config(config_store: &ConfigStore, source_count: 
     }
 }
 
+fn mark_database_migrated_config(config_store: &ConfigStore) {
+    if let Err(error) = config_store.mark_database_migrated_unlocked() {
+        tracing::warn!(
+            detail = %error,
+            "database migration completed but config version stamp failed"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -1174,6 +1185,15 @@ mod tests {
             layout.manifest_file(&workspace, &source.name).exists(),
             "legacy manifest file should be preserved for rollback compatibility"
         );
+        let raw_config =
+            fs::read_to_string(layout.config_file()).expect("read migrated config.toml");
+        assert!(
+            raw_config.contains("version = 2"),
+            "successful database import should stamp migrated config version: {raw_config}"
+        );
+        config_store
+            .load_config_unlocked()
+            .expect("current config reader should accept migrated version");
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -5,6 +5,8 @@ use super::session::DbRepos;
 use crate::bootstrap::AppError;
 use crate::state::ConfigStore;
 
+const LEGACY_SOURCE_CATALOG_IMPORT_MARKER: &str = "legacy_source_catalog_imported";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SourceCatalogImportReport {
     pub(crate) workspace_count: usize,
@@ -22,6 +24,19 @@ pub(crate) async fn import_config_source_catalog(
         .source_catalog_entries();
 
     let mut tx = db.begin().await?;
+    if tx
+        .app_state_markers()
+        .contains(LEGACY_SOURCE_CATALOG_IMPORT_MARKER)
+        .await?
+    {
+        tx.commit().await?;
+        clear_legacy_source_catalog_config(config_store, entries.len());
+        return Ok(SourceCatalogImportReport {
+            workspace_count: 0,
+            source_count: 0,
+        });
+    }
+
     let mut workspaces = BTreeSet::new();
     let mut source_count = 0;
     for (workspace_name, source) in &entries {
@@ -52,12 +67,30 @@ pub(crate) async fn import_config_source_catalog(
         }
         source_count += 1;
     }
+    if !entries.is_empty() {
+        tx.app_state_markers()
+            .insert(LEGACY_SOURCE_CATALOG_IMPORT_MARKER, now_unix_nanos)
+            .await?;
+    }
     tx.commit().await?;
+
+    clear_legacy_source_catalog_config(config_store, entries.len());
 
     Ok(SourceCatalogImportReport {
         workspace_count: workspaces.len(),
         source_count,
     })
+}
+
+fn clear_legacy_source_catalog_config(config_store: &ConfigStore, source_count: usize) {
+    if source_count != 0
+        && let Err(error) = config_store.clear_source_catalog_unlocked()
+    {
+        tracing::warn!(
+            detail = %error,
+            "source catalog imported into database but legacy config cleanup failed"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -123,16 +156,23 @@ mod tests {
                 .expect("get source"),
             Some(source)
         );
+        assert!(
+            config_store
+                .load_config_unlocked()
+                .expect("load cleaned config")
+                .source_catalog_entries()
+                .is_empty()
+        );
     }
 
     #[tokio::test]
-    async fn reimport_preserves_existing_database_catalog() {
+    async fn legacy_source_catalog_import_is_not_reapplied_after_marker() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
         let config_store = ConfigStore::new(layout.clone());
         let workspace = WorkspaceName::parse("default").expect("workspace");
-        let mut source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        let source = source("github", None, [], [], None, SourceOrigin::Bundled);
         config_store
             .upsert_source(&workspace, source.clone())
             .expect("write config source");
@@ -142,12 +182,14 @@ mod tests {
             .expect("initial import");
 
         let original_source = source.clone();
-        source
+        let mut stale_config_source = source.clone();
+        stale_config_source
             .variables
             .insert("OWNER".to_string(), "coral".to_string());
         config_store
-            .upsert_source(&workspace, source.clone())
+            .upsert_source(&workspace, stale_config_source)
             .expect("update config source");
+
         let report = import_config_source_catalog(&db, &config_store, 99)
             .await
             .expect("reimport source catalog");
@@ -307,6 +349,155 @@ mod tests {
                 .list()
                 .await
                 .expect("list workspaces")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_config_catalog_does_not_complete_legacy_import() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        let db = open_sqlite(&layout).await;
+
+        let empty_report = import_config_source_catalog(&db, &config_store, 11)
+            .await
+            .expect("import empty catalog");
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source after empty import");
+        let source_report = import_config_source_catalog(&db, &config_store, 99)
+            .await
+            .expect("import source catalog after empty import");
+
+        assert_eq!(
+            empty_report,
+            SourceCatalogImportReport {
+                workspace_count: 0,
+                source_count: 0,
+            }
+        );
+        assert_eq!(
+            source_report,
+            SourceCatalogImportReport {
+                workspace_count: 1,
+                source_count: 1,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get source"),
+            Some(source)
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn import_succeeds_when_post_commit_config_cleanup_fails() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        config_store
+            .upsert_source(&workspace, source.clone())
+            .expect("write config source");
+        drop(
+            config_store
+                .state_lock_exclusive()
+                .expect("create state lock before making config dir read-only"),
+        );
+
+        let db_path = temp.path().join("db").join("coral.db");
+        fs::create_dir_all(db_path.parent().expect("db parent")).expect("create db dir");
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path: db_path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+
+        let original_mode = fs::metadata(layout.config_dir())
+            .expect("config dir metadata")
+            .permissions()
+            .mode();
+        fs::set_permissions(layout.config_dir(), fs::Permissions::from_mode(0o500))
+            .expect("make config dir read-only");
+
+        let result = import_config_source_catalog(&db, &config_store, 11).await;
+
+        fs::set_permissions(
+            layout.config_dir(),
+            fs::Permissions::from_mode(original_mode),
+        )
+        .expect("restore config dir permissions");
+
+        assert_eq!(
+            result.expect("cleanup failure should not fail committed import"),
+            SourceCatalogImportReport {
+                workspace_count: 1,
+                source_count: 1,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get imported source"),
+            Some(source.clone())
+        );
+        assert_eq!(
+            config_store
+                .load_config_unlocked()
+                .expect("legacy config should still load after failed cleanup")
+                .source_catalog_entries()
+                .len(),
+            1
+        );
+
+        let mut tx = db.begin().await.expect("begin delete tx");
+        tx.sources()
+            .remove_source(&workspace, &source.name)
+            .await
+            .expect("delete db source");
+        tx.commit().await.expect("commit delete tx");
+
+        let report = import_config_source_catalog(&db, &config_store, 99)
+            .await
+            .expect("stale config should not reimport after marker");
+
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                workspace_count: 0,
+                source_count: 0,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("source should remain deleted"),
+            None
+        );
+        assert!(
+            config_store
+                .load_config_unlocked()
+                .expect("load cleaned stale config")
+                .source_catalog_entries()
                 .is_empty()
         );
     }

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -23,7 +23,16 @@ pub(crate) async fn import_config_source_catalog(
 
     let mut tx = db.begin().await?;
     let mut workspaces = BTreeSet::new();
+    let mut source_count = 0;
     for (workspace_name, source) in &entries {
+        if tx
+            .sources()
+            .get_source(workspace_name, &source.name)
+            .await?
+            .is_some()
+        {
+            continue;
+        }
         workspaces.insert(workspace_name.clone());
         tx.workspaces()
             .ensure(workspace_name.as_str(), now_unix_nanos)
@@ -41,12 +50,13 @@ pub(crate) async fn import_config_source_catalog(
                 source.name
             )));
         }
+        source_count += 1;
     }
     tx.commit().await?;
 
     Ok(SourceCatalogImportReport {
         workspace_count: workspaces.len(),
-        source_count: entries.len(),
+        source_count,
     })
 }
 
@@ -116,7 +126,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reimport_updates_source_rows_without_recreating_workspace() {
+    async fn reimport_preserves_existing_database_catalog() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         layout.ensure().expect("ensure layout");
@@ -131,16 +141,24 @@ mod tests {
             .await
             .expect("initial import");
 
+        let original_source = source.clone();
         source
             .variables
             .insert("OWNER".to_string(), "coral".to_string());
         config_store
             .upsert_source(&workspace, source.clone())
             .expect("update config source");
-        import_config_source_catalog(&db, &config_store, 99)
+        let report = import_config_source_catalog(&db, &config_store, 99)
             .await
             .expect("reimport source catalog");
 
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                workspace_count: 0,
+                source_count: 0,
+            }
+        );
         let mut session = &db;
         let workspace_record = session
             .workspaces()
@@ -155,7 +173,108 @@ mod tests {
                 .get_source(&workspace, &source.name)
                 .await
                 .expect("get source"),
+            Some(original_source)
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_config_import_preserves_existing_database_sources() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        let db = open_sqlite(&layout).await;
+        {
+            let mut tx = db.begin().await.expect("begin tx");
+            tx.workspaces()
+                .ensure(workspace.as_str(), 11)
+                .await
+                .expect("ensure workspace");
+            tx.sources()
+                .upsert_source(&workspace, &source, 11)
+                .await
+                .expect("seed db source");
+            tx.commit().await.expect("commit tx");
+        }
+        let report = import_config_source_catalog(&db, &config_store, 22)
+            .await
+            .expect("import empty source catalog");
+
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                workspace_count: 0,
+                source_count: 0,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &source.name)
+                .await
+                .expect("get preserved source"),
             Some(source)
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_database_catalog_imports_missing_config_sources_without_overwriting_existing()
+    {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let config_workspace = WorkspaceName::parse("other").expect("workspace");
+        let db_source = source("github", None, [], [], None, SourceOrigin::Bundled);
+        let config_source = source("slack", None, [], [], None, SourceOrigin::Bundled);
+        config_store
+            .upsert_source(&config_workspace, config_source.clone())
+            .expect("write config source");
+        let db = open_sqlite(&layout).await;
+        {
+            let mut tx = db.begin().await.expect("begin tx");
+            tx.workspaces()
+                .ensure(workspace.as_str(), 11)
+                .await
+                .expect("ensure workspace");
+            tx.sources()
+                .upsert_source(&workspace, &db_source, 11)
+                .await
+                .expect("seed db source");
+            tx.commit().await.expect("commit tx");
+        }
+
+        let report = import_config_source_catalog(&db, &config_store, 22)
+            .await
+            .expect("import source catalog");
+
+        assert_eq!(
+            report,
+            SourceCatalogImportReport {
+                workspace_count: 1,
+                source_count: 1,
+            }
+        );
+        let mut session = &db;
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&workspace, &db_source.name)
+                .await
+                .expect("get existing db source"),
+            Some(db_source)
+        );
+        assert_eq!(
+            session
+                .sources()
+                .get_source(&config_workspace, &config_source.name)
+                .await
+                .expect("get imported config source"),
+            Some(config_source)
         );
     }
 

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -232,6 +232,9 @@ mod tests {
         let db_source = source("github", None, [], [], None, SourceOrigin::Bundled);
         let config_source = source("slack", None, [], [], None, SourceOrigin::Bundled);
         config_store
+            .create_workspace(&config_workspace)
+            .expect("create config workspace");
+        config_store
             .upsert_source(&config_workspace, config_source.clone())
             .expect("write config source");
         let db = open_sqlite(&layout).await;

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -170,7 +170,17 @@ mod tests {
                 .expect("count secret keys"),
             1
         );
-        assert_source_catalog_uniqueness_contract(&mut session, &workspace_id, &source_name).await;
+        session
+            .commit()
+            .await
+            .expect("commit seed source catalog rows");
+
+        assert_source_catalog_uniqueness_contract(db, &workspace_id, &source_name).await;
+
+        let mut session = db
+            .begin()
+            .await
+            .expect("begin cascade migration contract tx");
 
         let alternate_workspace_id = format!("alternate_workspace_{suffix}");
         insert_source_catalog_rows(&mut session, &alternate_workspace_id, &source_name)
@@ -227,9 +237,9 @@ mod tests {
             0
         );
         session
-            .rollback()
+            .commit()
             .await
-            .expect("rollback migration contract tx");
+            .expect("commit cascade migration contract tx");
     }
 
     async fn insert_source_catalog_rows<S>(
@@ -247,31 +257,39 @@ mod tests {
         insert_source_secret_key_row(session, workspace_id, source_name, 0, "API_TOKEN").await
     }
 
-    async fn assert_source_catalog_uniqueness_contract<S>(
-        session: &mut S,
+    async fn assert_source_catalog_uniqueness_contract(
+        db: &CoralDb,
         workspace_id: &str,
         source_name: &str,
-    ) where
-        S: DbSession,
-    {
+    ) {
+        let mut tx = db.begin().await.expect("begin duplicate source tx");
         assert!(
-            insert_source_row(session, workspace_id, source_name)
+            insert_source_row(&mut tx, workspace_id, source_name)
                 .await
                 .is_err(),
             "duplicate source identity should fail"
         );
+        tx.rollback().await.expect("rollback duplicate source tx");
+
+        let mut tx = db.begin().await.expect("begin duplicate variable tx");
         assert!(
-            insert_source_variable_row(session, workspace_id, source_name, "REGION", "eu-west-1")
+            insert_source_variable_row(&mut tx, workspace_id, source_name, "REGION", "eu-west-1")
                 .await
                 .is_err(),
             "duplicate source variable key should fail"
         );
+        tx.rollback().await.expect("rollback duplicate variable tx");
+
+        let mut tx = db.begin().await.expect("begin duplicate secret key tx");
         assert!(
-            insert_source_secret_key_row(session, workspace_id, source_name, 0, "OTHER_TOKEN")
+            insert_source_secret_key_row(&mut tx, workspace_id, source_name, 0, "OTHER_TOKEN")
                 .await
                 .is_err(),
             "duplicate source secret key position should fail"
         );
+        tx.rollback()
+            .await
+            .expect("rollback duplicate secret key tx");
     }
 
     async fn insert_workspace_row<S>(session: &mut S, workspace_id: &str) -> Result<(), DbError>

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -78,7 +78,8 @@ mod tests {
     use crate::state::AppStateLayout;
     use crate::state::db::repositories::credential_documents::CredentialDocumentWrite;
     use crate::state::db::schema::{
-        SourceManifests, SourceSecretKeys, SourceVariables, Sources, Workspaces,
+        IdentitySpecDocuments, IdentitySpecs, SourceManifests, SourceSecretKeys, SourceVariables,
+        Sources, Workspaces,
     };
     use crate::state::db::session::DbRepos;
     use crate::state::db::{
@@ -154,6 +155,36 @@ mod tests {
         db.migrate().await.expect("migrate postgres");
 
         assert_source_catalog_migration_contract(&db).await;
+    }
+
+    #[tokio::test]
+    async fn identity_spec_migration_contract_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let config = DatabaseConfig::load(&layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+
+        assert_identity_spec_migration_contract(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run identity spec migration contract coverage against Postgres"]
+    async fn identity_spec_migration_contract_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_identity_spec_migration_contract(&db).await;
     }
 
     #[expect(
@@ -313,6 +344,159 @@ mod tests {
             .expect("commit cascade migration contract tx");
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "The identity-spec migration contract keeps scope uniqueness and cascade checks together so schema regressions are visible in one fixture."
+    )]
+    async fn assert_identity_spec_migration_contract(db: &CoralDb) {
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let workspace_id = format!("identity_workspace_{suffix}");
+        let alternate_workspace_id = format!("identity_alternate_{suffix}");
+        let sentinel_workspace_id = "__global__";
+        let name = format!("identity_spec_{suffix}");
+        let sentinel_name = format!("identity_sentinel_{suffix}");
+        let mut session = db
+            .begin()
+            .await
+            .expect("begin identity spec migration contract tx");
+
+        insert_workspace_row(&mut session, &workspace_id)
+            .await
+            .expect("insert identity workspace");
+        insert_workspace_row(&mut session, &alternate_workspace_id)
+            .await
+            .expect("insert alternate identity workspace");
+        insert_workspace_row(&mut session, sentinel_workspace_id)
+            .await
+            .expect("insert sentinel identity workspace");
+        insert_identity_spec_row(&mut session, "global", "__global__", None, &name)
+            .await
+            .expect("insert global identity spec");
+        insert_identity_spec_document_row(&mut session, "global", "__global__", &name)
+            .await
+            .expect("insert global identity spec document");
+        insert_identity_spec_row(
+            &mut session,
+            "workspace",
+            &workspace_id,
+            Some(&workspace_id),
+            &name,
+        )
+        .await
+        .expect("insert workspace identity spec");
+        insert_identity_spec_document_row(&mut session, "workspace", &workspace_id, &name)
+            .await
+            .expect("insert workspace identity spec document");
+        insert_identity_spec_row(&mut session, "global", "__global__", None, &sentinel_name)
+            .await
+            .expect("insert sentinel-name global identity spec");
+        insert_identity_spec_row(
+            &mut session,
+            "workspace",
+            sentinel_workspace_id,
+            Some(sentinel_workspace_id),
+            &sentinel_name,
+        )
+        .await
+        .expect("insert sentinel-name workspace identity spec");
+        assert_eq!(
+            identity_spec_count(&mut session, "global", "__global__", &name)
+                .await
+                .expect("count global identity spec"),
+            1
+        );
+        assert_eq!(
+            identity_spec_count(&mut session, "workspace", &workspace_id, &name)
+                .await
+                .expect("count workspace identity spec"),
+            1
+        );
+        assert_eq!(
+            identity_spec_document_count(&mut session, "workspace", &workspace_id, &name)
+                .await
+                .expect("count workspace identity spec document"),
+            1
+        );
+        assert_eq!(
+            identity_spec_count(&mut session, "global", "__global__", &sentinel_name)
+                .await
+                .expect("count sentinel-name global identity spec"),
+            1
+        );
+        assert_eq!(
+            identity_spec_count(
+                &mut session,
+                "workspace",
+                sentinel_workspace_id,
+                &sentinel_name,
+            )
+            .await
+            .expect("count sentinel-name workspace identity spec"),
+            1
+        );
+        session
+            .commit()
+            .await
+            .expect("commit identity spec seed rows");
+
+        assert_identity_spec_uniqueness_contract(db, &workspace_id, &alternate_workspace_id, &name)
+            .await;
+        assert_identity_spec_uniqueness_contract(
+            db,
+            sentinel_workspace_id,
+            &alternate_workspace_id,
+            &sentinel_name,
+        )
+        .await;
+        assert_identity_spec_scope_check_contract(db, &workspace_id, &name).await;
+
+        let mut session = db
+            .begin()
+            .await
+            .expect("begin identity spec cascade migration contract tx");
+        delete_workspace(&mut session, &workspace_id)
+            .await
+            .expect("delete identity workspace");
+        assert_eq!(
+            identity_spec_count(&mut session, "workspace", &workspace_id, &name)
+                .await
+                .expect("count workspace identity spec after workspace delete"),
+            0
+        );
+        assert_eq!(
+            identity_spec_document_count(&mut session, "workspace", &workspace_id, &name)
+                .await
+                .expect("count workspace identity spec document after workspace delete"),
+            0
+        );
+        assert_eq!(
+            identity_spec_count(&mut session, "global", "__global__", &name)
+                .await
+                .expect("count global identity spec after workspace delete"),
+            1
+        );
+        assert_eq!(
+            identity_spec_document_count(&mut session, "global", "__global__", &name)
+                .await
+                .expect("count global identity spec document after workspace delete"),
+            1
+        );
+
+        delete_identity_spec(&mut session, "global", "__global__", &name)
+            .await
+            .expect("delete global identity spec");
+        assert_eq!(
+            identity_spec_document_count(&mut session, "global", "__global__", &name)
+                .await
+                .expect("count global identity spec document after spec delete"),
+            0
+        );
+        session
+            .commit()
+            .await
+            .expect("commit identity spec cascade migration contract tx");
+    }
+
     async fn insert_source_catalog_rows<S>(
         session: &mut S,
         workspace_id: &str,
@@ -362,6 +546,117 @@ mod tests {
         tx.rollback()
             .await
             .expect("rollback duplicate secret key tx");
+    }
+
+    async fn assert_identity_spec_uniqueness_contract(
+        db: &CoralDb,
+        workspace_id: &str,
+        alternate_workspace_id: &str,
+        name: &str,
+    ) {
+        let mut tx = db
+            .begin()
+            .await
+            .expect("begin duplicate global identity spec tx");
+        assert!(
+            insert_identity_spec_row(&mut tx, "global", "__global__", None, name)
+                .await
+                .is_err(),
+            "duplicate global identity spec should fail"
+        );
+        tx.rollback()
+            .await
+            .expect("rollback duplicate global identity spec tx");
+
+        let mut tx = db
+            .begin()
+            .await
+            .expect("begin duplicate workspace identity spec tx");
+        assert!(
+            insert_identity_spec_row(&mut tx, "workspace", workspace_id, Some(workspace_id), name)
+                .await
+                .is_err(),
+            "duplicate workspace identity spec should fail"
+        );
+        tx.rollback()
+            .await
+            .expect("rollback duplicate workspace identity spec tx");
+
+        let mut tx = db
+            .begin()
+            .await
+            .expect("begin alternate workspace identity spec tx");
+        insert_identity_spec_row(
+            &mut tx,
+            "workspace",
+            alternate_workspace_id,
+            Some(alternate_workspace_id),
+            name,
+        )
+        .await
+        .expect("same identity spec name should be valid in another workspace");
+        tx.rollback()
+            .await
+            .expect("rollback alternate workspace identity spec tx");
+
+        let mut tx = db.begin().await.expect("begin missing spec document tx");
+        assert!(
+            insert_identity_spec_document_row(&mut tx, "global", "__global__", "missing")
+                .await
+                .is_err(),
+            "identity spec document rows must require an existing identity spec"
+        );
+        tx.rollback()
+            .await
+            .expect("rollback missing spec document tx");
+    }
+
+    async fn assert_identity_spec_scope_check_contract(
+        db: &CoralDb,
+        workspace_id: &str,
+        name: &str,
+    ) {
+        let invalid_global_name = format!("{name}_invalid_global");
+        let mut tx = db
+            .begin()
+            .await
+            .expect("begin invalid global identity spec tx");
+        assert!(
+            insert_identity_spec_row(
+                &mut tx,
+                "global",
+                "__global__",
+                Some(workspace_id),
+                &invalid_global_name,
+            )
+            .await
+            .is_err(),
+            "global identity spec must not carry a workspace id"
+        );
+        tx.rollback()
+            .await
+            .expect("rollback invalid global identity spec tx");
+
+        let invalid_workspace_name = format!("{name}_invalid_workspace");
+        let mut tx = db
+            .begin()
+            .await
+            .expect("begin invalid workspace identity spec tx");
+        assert!(
+            insert_identity_spec_row(
+                &mut tx,
+                "workspace",
+                workspace_id,
+                None,
+                &invalid_workspace_name,
+            )
+            .await
+            .is_err(),
+            "workspace identity spec must carry a matching workspace id"
+        );
+        tx.rollback()
+            .await
+            .expect("rollback invalid workspace identity spec tx");
     }
 
     fn credential_document_write() -> CredentialDocumentWrite {
@@ -520,6 +815,99 @@ mod tests {
             .await
     }
 
+    async fn insert_identity_spec_row<S>(
+        session: &mut S,
+        scope_kind: &str,
+        scope_id: &str,
+        workspace_id: Option<&str>,
+        name: &str,
+    ) -> Result<(), DbError>
+    where
+        S: DbSession,
+    {
+        session
+            .execute(
+                Query::insert()
+                    .into_table(IdentitySpecs::Table)
+                    .columns([
+                        IdentitySpecs::ScopeKind,
+                        IdentitySpecs::ScopeId,
+                        IdentitySpecs::WorkspaceId,
+                        IdentitySpecs::Name,
+                        IdentitySpecs::Version,
+                        IdentitySpecs::Description,
+                        IdentitySpecs::Issuer,
+                        IdentitySpecs::IdentityType,
+                        IdentitySpecs::ManifestYaml,
+                        IdentitySpecs::CreatedAtUnixNanos,
+                        IdentitySpecs::UpdatedAtUnixNanos,
+                    ])
+                    .values_panic([
+                        Expr::val(scope_kind),
+                        Expr::val(scope_id),
+                        Expr::val(workspace_id.map(ToString::to_string)),
+                        Expr::val(name),
+                        Expr::val("1.0.0"),
+                        Expr::val("identity spec migration contract"),
+                        Expr::val("issuer"),
+                        Expr::val("oauth"),
+                        Expr::val("name: migration_identity\n"),
+                        Expr::val(4),
+                        Expr::val(5),
+                    ])
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn insert_identity_spec_document_row<S>(
+        session: &mut S,
+        scope_kind: &str,
+        scope_id: &str,
+        name: &str,
+    ) -> Result<(), DbError>
+    where
+        S: DbSession,
+    {
+        session
+            .execute(
+                Query::insert()
+                    .into_table(IdentitySpecDocuments::Table)
+                    .columns([
+                        IdentitySpecDocuments::ScopeKind,
+                        IdentitySpecDocuments::ScopeId,
+                        IdentitySpecDocuments::Name,
+                        IdentitySpecDocuments::DocumentVersion,
+                        IdentitySpecDocuments::Ciphertext,
+                        IdentitySpecDocuments::Nonce,
+                        IdentitySpecDocuments::WrappedDek,
+                        IdentitySpecDocuments::WrappedDekNonce,
+                        IdentitySpecDocuments::KeyId,
+                        IdentitySpecDocuments::Algorithm,
+                        IdentitySpecDocuments::AadVersion,
+                        IdentitySpecDocuments::CreatedAtUnixNanos,
+                        IdentitySpecDocuments::UpdatedAtUnixNanos,
+                    ])
+                    .values_panic([
+                        Expr::val(scope_kind),
+                        Expr::val(scope_id),
+                        Expr::val(name),
+                        Expr::val(1),
+                        Expr::val(b"ciphertext".to_vec()),
+                        Expr::val(b"nonce".to_vec()),
+                        Expr::val(b"wrapped-dek".to_vec()),
+                        Expr::val(b"wrapped-dek-nonce".to_vec()),
+                        Expr::val("key-id"),
+                        Expr::val("AES-256-GCM"),
+                        Expr::val(1),
+                        Expr::val(6),
+                        Expr::val(7),
+                    ])
+                    .to_owned(),
+            )
+            .await
+    }
+
     fn migration_trace_summary(workspace_id: &str, trace_id: &str) -> TraceSummaryRecord {
         TraceSummaryRecord {
             trace_id: trace_id.to_string(),
@@ -565,6 +953,27 @@ mod tests {
                 Query::delete()
                     .from_table(Workspaces::Table)
                     .and_where(Expr::col(Workspaces::Id).eq(workspace_id))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn delete_identity_spec<S>(
+        session: &mut S,
+        scope_kind: &str,
+        scope_id: &str,
+        name: &str,
+    ) -> Result<(), DbError>
+    where
+        S: DbWriteSession,
+    {
+        session
+            .execute_delete(
+                Query::delete()
+                    .from_table(IdentitySpecs::Table)
+                    .and_where(Expr::col(IdentitySpecs::ScopeKind).eq(scope_kind))
+                    .and_where(Expr::col(IdentitySpecs::ScopeId).eq(scope_id))
+                    .and_where(Expr::col(IdentitySpecs::Name).eq(name))
                     .to_owned(),
             )
             .await
@@ -646,6 +1055,54 @@ mod tests {
                     .from(SourceManifests::Table)
                     .and_where(Expr::col(SourceManifests::WorkspaceId).eq(workspace_id))
                     .and_where(Expr::col(SourceManifests::SourceName).eq(source_name))
+                    .to_owned(),
+            )
+            .await?
+            .expect("count row");
+        Ok(row.count)
+    }
+
+    async fn identity_spec_count<S>(
+        session: &mut S,
+        scope_kind: &str,
+        scope_id: &str,
+        name: &str,
+    ) -> Result<i64, DbError>
+    where
+        S: DbSession,
+    {
+        let row: CountRow = session
+            .fetch_optional(
+                Query::select()
+                    .expr_as(Func::count(Expr::val(1)), Alias::new("count"))
+                    .from(IdentitySpecs::Table)
+                    .and_where(Expr::col(IdentitySpecs::ScopeKind).eq(scope_kind))
+                    .and_where(Expr::col(IdentitySpecs::ScopeId).eq(scope_id))
+                    .and_where(Expr::col(IdentitySpecs::Name).eq(name))
+                    .to_owned(),
+            )
+            .await?
+            .expect("count row");
+        Ok(row.count)
+    }
+
+    async fn identity_spec_document_count<S>(
+        session: &mut S,
+        scope_kind: &str,
+        scope_id: &str,
+        name: &str,
+    ) -> Result<i64, DbError>
+    where
+        S: DbSession,
+    {
+        let row: CountRow = session
+            .fetch_optional(
+                Query::select()
+                    .expr_as(Func::count(Expr::val(1)), Alias::new("count"))
+                    .from(IdentitySpecDocuments::Table)
+                    .and_where(Expr::col(IdentitySpecDocuments::ScopeKind).eq(scope_kind))
+                    .and_where(Expr::col(IdentitySpecDocuments::ScopeId).eq(scope_id))
+                    .and_where(Expr::col(IdentitySpecDocuments::Name).eq(name))
                     .to_owned(),
             )
             .await?

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -84,6 +84,7 @@ mod tests {
     use crate::state::db::{
         CoralDb, DatabaseConfig, DbError, DbSession, DbWriteSession, ResolvedDatabaseConfig,
     };
+    use crate::telemetry::{StoredTraceStatus, TraceSummaryRecord};
     use crate::workspaces::WorkspaceName;
 
     #[derive(Debug, sqlx::FromRow)]
@@ -163,6 +164,7 @@ mod tests {
         let suffix = uuid::Uuid::new_v4().simple().to_string();
         let workspace_id = format!("workspace_{suffix}");
         let source_name = format!("source_{suffix}");
+        let trace_id = format!("trace_{suffix}");
         let workspace = WorkspaceName::parse(&workspace_id).expect("workspace");
         let source = SourceName::parse(&source_name).expect("source name");
         let mut session = db.begin().await.expect("begin migration contract tx");
@@ -175,6 +177,11 @@ mod tests {
             .insert_if_absent(&workspace, &source, &credential_document_write(), 5)
             .await
             .expect("insert credential document row");
+        session
+            .trace_summaries()
+            .upsert(&migration_trace_summary(&workspace_id, &trace_id))
+            .await
+            .expect("insert trace summary row");
         assert_eq!(
             source_variable_count(&mut session, &workspace_id, &source_name)
                 .await
@@ -290,6 +297,14 @@ mod tests {
                 .get(&workspace, &source)
                 .await
                 .expect("get credential document after workspace delete")
+                .is_none()
+        );
+        assert!(
+            session
+                .trace_summaries()
+                .get(&trace_id)
+                .await
+                .expect("get trace summary after workspace delete")
                 .is_none()
         );
         session
@@ -503,6 +518,23 @@ mod tests {
                     .to_owned(),
             )
             .await
+    }
+
+    fn migration_trace_summary(workspace_id: &str, trace_id: &str) -> TraceSummaryRecord {
+        TraceSummaryRecord {
+            trace_id: trace_id.to_string(),
+            workspace_id: Some(workspace_id.to_string()),
+            root_span_id: "root".to_string(),
+            name: "coral.query".to_string(),
+            query: "SELECT 1".to_string(),
+            status: StoredTraceStatus::Ok,
+            start_time_unix_nanos: 1,
+            end_time_unix_nanos: 2,
+            duration_nanos: 1,
+            span_count: 1,
+            row_count: 1,
+            row_count_recorded: true,
+        }
     }
 
     async fn delete_source<S>(

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -76,7 +76,9 @@ mod tests {
     use crate::bootstrap;
     use crate::state::AppStateLayout;
     use crate::state::db::schema::{SourceSecretKeys, SourceVariables, Sources, Workspaces};
-    use crate::state::db::{CoralDb, DatabaseConfig, DbError, DbSession, ResolvedDatabaseConfig};
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, DbError, DbSession, DbWriteSession, ResolvedDatabaseConfig,
+    };
 
     #[derive(Debug, sqlx::FromRow)]
     struct CountRow {
@@ -151,7 +153,7 @@ mod tests {
         let suffix = uuid::Uuid::new_v4().simple().to_string();
         let workspace_id = format!("workspace_{suffix}");
         let source_name = format!("source_{suffix}");
-        let mut session = db;
+        let mut session = db.begin().await.expect("begin migration contract tx");
 
         insert_source_catalog_rows(&mut session, &workspace_id, &source_name)
             .await
@@ -224,6 +226,10 @@ mod tests {
                 .expect("count secret keys after workspace delete"),
             0
         );
+        session
+            .rollback()
+            .await
+            .expect("rollback migration contract tx");
     }
 
     async fn insert_source_catalog_rows<S>(
@@ -387,7 +393,7 @@ mod tests {
         source_name: &str,
     ) -> Result<(), DbError>
     where
-        S: DbSession,
+        S: DbWriteSession,
     {
         session
             .execute_delete(
@@ -402,7 +408,7 @@ mod tests {
 
     async fn delete_workspace<S>(session: &mut S, workspace_id: &str) -> Result<(), DbError>
     where
-        S: DbSession,
+        S: DbWriteSession,
     {
         session
             .execute_delete(

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -172,7 +172,7 @@ mod tests {
             .expect("insert source catalog rows");
         session
             .credential_documents()
-            .upsert(&workspace, &source, &credential_document_write(), 5)
+            .insert_if_absent(&workspace, &source, &credential_document_write(), 5)
             .await
             .expect("insert credential document row");
         assert_eq!(
@@ -254,7 +254,7 @@ mod tests {
             .expect("reinsert source catalog rows");
         session
             .credential_documents()
-            .upsert(&workspace, &source, &credential_document_write(), 5)
+            .insert_if_absent(&workspace, &source, &credential_document_write(), 5)
             .await
             .expect("reinsert credential document row");
         delete_workspace(&mut session, &workspace_id)

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -74,13 +74,17 @@ mod tests {
 
     use super::{MIGRATOR, rows_match_current_migrations};
     use crate::bootstrap;
+    use crate::sources::SourceName;
     use crate::state::AppStateLayout;
+    use crate::state::db::repositories::credential_documents::CredentialDocumentWrite;
     use crate::state::db::schema::{
         SourceManifests, SourceSecretKeys, SourceVariables, Sources, Workspaces,
     };
+    use crate::state::db::session::DbRepos;
     use crate::state::db::{
         CoralDb, DatabaseConfig, DbError, DbSession, DbWriteSession, ResolvedDatabaseConfig,
     };
+    use crate::workspaces::WorkspaceName;
 
     #[derive(Debug, sqlx::FromRow)]
     struct CountRow {
@@ -159,11 +163,18 @@ mod tests {
         let suffix = uuid::Uuid::new_v4().simple().to_string();
         let workspace_id = format!("workspace_{suffix}");
         let source_name = format!("source_{suffix}");
+        let workspace = WorkspaceName::parse(&workspace_id).expect("workspace");
+        let source = SourceName::parse(&source_name).expect("source name");
         let mut session = db.begin().await.expect("begin migration contract tx");
 
         insert_source_catalog_rows(&mut session, &workspace_id, &source_name)
             .await
             .expect("insert source catalog rows");
+        session
+            .credential_documents()
+            .upsert(&workspace, &source, &credential_document_write(), 5)
+            .await
+            .expect("insert credential document row");
         assert_eq!(
             source_variable_count(&mut session, &workspace_id, &source_name)
                 .await
@@ -229,10 +240,23 @@ mod tests {
                 .expect("count manifests after source delete"),
             0
         );
+        assert!(
+            session
+                .credential_documents()
+                .get(&workspace, &source)
+                .await
+                .expect("get credential document after source delete")
+                .is_none()
+        );
 
         insert_source_catalog_rows(&mut session, &workspace_id, &source_name)
             .await
             .expect("reinsert source catalog rows");
+        session
+            .credential_documents()
+            .upsert(&workspace, &source, &credential_document_write(), 5)
+            .await
+            .expect("reinsert credential document row");
         delete_workspace(&mut session, &workspace_id)
             .await
             .expect("delete workspace");
@@ -259,6 +283,14 @@ mod tests {
                 .await
                 .expect("count manifests after workspace delete"),
             0
+        );
+        assert!(
+            session
+                .credential_documents()
+                .get(&workspace, &source)
+                .await
+                .expect("get credential document after workspace delete")
+                .is_none()
         );
         session
             .commit()
@@ -315,6 +347,18 @@ mod tests {
         tx.rollback()
             .await
             .expect("rollback duplicate secret key tx");
+    }
+
+    fn credential_document_write() -> CredentialDocumentWrite {
+        CredentialDocumentWrite {
+            ciphertext: b"ciphertext".to_vec(),
+            nonce: b"nonce".to_vec(),
+            wrapped_dek: b"wrapped-dek".to_vec(),
+            wrapped_dek_nonce: b"wrapped-dek-nonce".to_vec(),
+            key_id: "key-id".to_string(),
+            algorithm: "AES-256-GCM".to_string(),
+            aad_version: 1,
+        }
     }
 
     async fn insert_workspace_row<S>(session: &mut S, workspace_id: &str) -> Result<(), DbError>

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -1,0 +1,107 @@
+use super::backend::CoralDbBackend;
+use super::{CoralDb, DbError};
+
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
+
+impl CoralDb {
+    pub(crate) async fn migrate(&self) -> Result<(), DbError> {
+        match &self.backend {
+            CoralDbBackend::Sqlite(db) => {
+                if sqlite_migrations_are_current(&db.pool).await? {
+                    return Ok(());
+                }
+                MIGRATOR.run(&db.pool).await?;
+            }
+            CoralDbBackend::Postgres(db) => {
+                if postgres_migrations_are_current(&db.pool).await? {
+                    return Ok(());
+                }
+                MIGRATOR.run(&db.pool).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn sqlite_migrations_are_current(pool: &sqlx::SqlitePool) -> Result<bool, DbError> {
+    let table_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = '_sqlx_migrations'",
+    )
+    .fetch_one(pool)
+    .await?;
+    if table_count.0 == 0 {
+        return Ok(false);
+    }
+    let rows: Vec<(i64, Vec<u8>, bool)> =
+        sqlx::query_as("SELECT version, checksum, success FROM _sqlx_migrations ORDER BY version")
+            .fetch_all(pool)
+            .await?;
+    Ok(rows_match_current_migrations(&rows))
+}
+
+async fn postgres_migrations_are_current(pool: &sqlx::PgPool) -> Result<bool, DbError> {
+    let table_exists: (Option<String>,) =
+        sqlx::query_as("SELECT to_regclass('_sqlx_migrations')::text")
+            .fetch_one(pool)
+            .await?;
+    if table_exists.0.is_none() {
+        return Ok(false);
+    }
+    let rows: Vec<(i64, Vec<u8>, bool)> =
+        sqlx::query_as("SELECT version, checksum, success FROM _sqlx_migrations ORDER BY version")
+            .fetch_all(pool)
+            .await?;
+    Ok(rows_match_current_migrations(&rows))
+}
+
+fn rows_match_current_migrations(rows: &[(i64, Vec<u8>, bool)]) -> bool {
+    let migrations = MIGRATOR.migrations.as_ref();
+    rows.len() == migrations.len()
+        && rows
+            .iter()
+            .zip(migrations)
+            .all(|((version, checksum, success), migration)| {
+                *success
+                    && *version == migration.version
+                    && checksum.as_slice() == migration.checksum.as_ref()
+            })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MIGRATOR, rows_match_current_migrations};
+
+    #[test]
+    fn current_migration_rows_must_match_versions_checksums_and_success() {
+        let current_rows: Vec<_> = MIGRATOR
+            .migrations
+            .iter()
+            .map(|migration| {
+                (
+                    migration.version,
+                    migration.checksum.as_ref().to_vec(),
+                    true,
+                )
+            })
+            .collect();
+        assert!(rows_match_current_migrations(&current_rows));
+
+        let mut missing_row = current_rows.clone();
+        missing_row.pop();
+        assert!(!rows_match_current_migrations(&missing_row));
+
+        let mut failed_row = current_rows.clone();
+        failed_row
+            .first_mut()
+            .expect("at least one embedded migration")
+            .2 = false;
+        assert!(!rows_match_current_migrations(&failed_row));
+
+        let mut bad_checksum = current_rows;
+        bad_checksum
+            .first_mut()
+            .expect("at least one embedded migration")
+            .1 = b"not the embedded checksum".to_vec();
+        assert!(!rows_match_current_migrations(&bad_checksum));
+    }
+}

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -75,7 +75,9 @@ mod tests {
     use super::{MIGRATOR, rows_match_current_migrations};
     use crate::bootstrap;
     use crate::state::AppStateLayout;
-    use crate::state::db::schema::{SourceSecretKeys, SourceVariables, Sources, Workspaces};
+    use crate::state::db::schema::{
+        SourceManifests, SourceSecretKeys, SourceVariables, Sources, Workspaces,
+    };
     use crate::state::db::{
         CoralDb, DatabaseConfig, DbError, DbSession, DbWriteSession, ResolvedDatabaseConfig,
     };
@@ -149,6 +151,10 @@ mod tests {
         assert_source_catalog_migration_contract(&db).await;
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "The migration contract keeps seed, uniqueness, source cascade, and workspace cascade checks together so schema regressions are visible in one fixture."
+    )]
     async fn assert_source_catalog_migration_contract(db: &CoralDb) {
         let suffix = uuid::Uuid::new_v4().simple().to_string();
         let workspace_id = format!("workspace_{suffix}");
@@ -168,6 +174,12 @@ mod tests {
             source_secret_key_count(&mut session, &workspace_id, &source_name)
                 .await
                 .expect("count secret keys"),
+            1
+        );
+        assert_eq!(
+            source_manifest_count(&mut session, &workspace_id, &source_name)
+                .await
+                .expect("count manifests"),
             1
         );
         session
@@ -211,6 +223,12 @@ mod tests {
                 .expect("count secret keys after source delete"),
             0
         );
+        assert_eq!(
+            source_manifest_count(&mut session, &workspace_id, &source_name)
+                .await
+                .expect("count manifests after source delete"),
+            0
+        );
 
         insert_source_catalog_rows(&mut session, &workspace_id, &source_name)
             .await
@@ -236,6 +254,12 @@ mod tests {
                 .expect("count secret keys after workspace delete"),
             0
         );
+        assert_eq!(
+            source_manifest_count(&mut session, &workspace_id, &source_name)
+                .await
+                .expect("count manifests after workspace delete"),
+            0
+        );
         session
             .commit()
             .await
@@ -254,7 +278,8 @@ mod tests {
         insert_source_row(session, workspace_id, source_name).await?;
         insert_source_variable_row(session, workspace_id, source_name, "REGION", "us-east-1")
             .await?;
-        insert_source_secret_key_row(session, workspace_id, source_name, 0, "API_TOKEN").await
+        insert_source_secret_key_row(session, workspace_id, source_name, 0, "API_TOKEN").await?;
+        insert_source_manifest_row(session, workspace_id, source_name).await
     }
 
     async fn assert_source_catalog_uniqueness_contract(
@@ -405,6 +430,37 @@ mod tests {
             .await
     }
 
+    async fn insert_source_manifest_row<S>(
+        session: &mut S,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<(), DbError>
+    where
+        S: DbSession,
+    {
+        session
+            .execute(
+                Query::insert()
+                    .into_table(SourceManifests::Table)
+                    .columns([
+                        SourceManifests::WorkspaceId,
+                        SourceManifests::SourceName,
+                        SourceManifests::ManifestYaml,
+                        SourceManifests::ManifestHash,
+                        SourceManifests::CreatedAtUnixNanos,
+                    ])
+                    .values_panic([
+                        Expr::val(workspace_id),
+                        Expr::val(source_name),
+                        Expr::val("name: migration_contract\n"),
+                        Expr::val("manifest-hash"),
+                        Expr::val(4),
+                    ])
+                    .to_owned(),
+            )
+            .await
+    }
+
     async fn delete_source<S>(
         session: &mut S,
         workspace_id: &str,
@@ -492,6 +548,28 @@ mod tests {
                     .from(SourceSecretKeys::Table)
                     .and_where(Expr::col(SourceSecretKeys::WorkspaceId).eq(workspace_id))
                     .and_where(Expr::col(SourceSecretKeys::SourceName).eq(source_name))
+                    .to_owned(),
+            )
+            .await?
+            .expect("count row");
+        Ok(row.count)
+    }
+
+    async fn source_manifest_count<S>(
+        session: &mut S,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<i64, DbError>
+    where
+        S: DbSession,
+    {
+        let row: CountRow = session
+            .fetch_optional(
+                Query::select()
+                    .expr_as(Func::count(Expr::val(1)), Alias::new("count"))
+                    .from(SourceManifests::Table)
+                    .and_where(Expr::col(SourceManifests::WorkspaceId).eq(workspace_id))
+                    .and_where(Expr::col(SourceManifests::SourceName).eq(source_name))
                     .to_owned(),
             )
             .await?

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -69,7 +69,19 @@ fn rows_match_current_migrations(rows: &[(i64, Vec<u8>, bool)]) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use sea_query::{Alias, Expr, ExprTrait, Func, OnConflict, Query};
+    use tempfile::tempdir;
+
     use super::{MIGRATOR, rows_match_current_migrations};
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::schema::{SourceSecretKeys, SourceVariables, Sources, Workspaces};
+    use crate::state::db::{CoralDb, DatabaseConfig, DbError, DbSession, ResolvedDatabaseConfig};
+
+    #[derive(Debug, sqlx::FromRow)]
+    struct CountRow {
+        count: i64,
+    }
 
     #[test]
     fn current_migration_rows_must_match_versions_checksums_and_success() {
@@ -103,5 +115,363 @@ mod tests {
             .expect("at least one embedded migration")
             .1 = b"not the embedded checksum".to_vec();
         assert!(!rows_match_current_migrations(&bad_checksum));
+    }
+
+    #[tokio::test]
+    async fn source_catalog_migration_contract_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let config = DatabaseConfig::load(&layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+
+        assert_source_catalog_migration_contract(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run migration contract coverage against Postgres"]
+    async fn source_catalog_migration_contract_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_source_catalog_migration_contract(&db).await;
+    }
+
+    async fn assert_source_catalog_migration_contract(db: &CoralDb) {
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let workspace_id = format!("workspace_{suffix}");
+        let source_name = format!("source_{suffix}");
+        let mut session = db;
+
+        insert_source_catalog_rows(&mut session, &workspace_id, &source_name)
+            .await
+            .expect("insert source catalog rows");
+        assert_eq!(
+            source_variable_count(&mut session, &workspace_id, &source_name)
+                .await
+                .expect("count variables"),
+            1
+        );
+        assert_eq!(
+            source_secret_key_count(&mut session, &workspace_id, &source_name)
+                .await
+                .expect("count secret keys"),
+            1
+        );
+        assert_source_catalog_uniqueness_contract(&mut session, &workspace_id, &source_name).await;
+
+        let alternate_workspace_id = format!("alternate_workspace_{suffix}");
+        insert_source_catalog_rows(&mut session, &alternate_workspace_id, &source_name)
+            .await
+            .expect("insert same source name in another workspace");
+        assert_eq!(
+            source_count(&mut session, &alternate_workspace_id)
+                .await
+                .expect("count alternate workspace source"),
+            1
+        );
+        delete_workspace(&mut session, &alternate_workspace_id)
+            .await
+            .expect("delete alternate workspace");
+
+        delete_source(&mut session, &workspace_id, &source_name)
+            .await
+            .expect("delete source");
+        assert_eq!(
+            source_variable_count(&mut session, &workspace_id, &source_name)
+                .await
+                .expect("count variables after source delete"),
+            0
+        );
+        assert_eq!(
+            source_secret_key_count(&mut session, &workspace_id, &source_name)
+                .await
+                .expect("count secret keys after source delete"),
+            0
+        );
+
+        insert_source_catalog_rows(&mut session, &workspace_id, &source_name)
+            .await
+            .expect("reinsert source catalog rows");
+        delete_workspace(&mut session, &workspace_id)
+            .await
+            .expect("delete workspace");
+        assert_eq!(
+            source_count(&mut session, &workspace_id)
+                .await
+                .expect("count sources after workspace delete"),
+            0
+        );
+        assert_eq!(
+            source_variable_count(&mut session, &workspace_id, &source_name)
+                .await
+                .expect("count variables after workspace delete"),
+            0
+        );
+        assert_eq!(
+            source_secret_key_count(&mut session, &workspace_id, &source_name)
+                .await
+                .expect("count secret keys after workspace delete"),
+            0
+        );
+    }
+
+    async fn insert_source_catalog_rows<S>(
+        session: &mut S,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<(), DbError>
+    where
+        S: DbSession,
+    {
+        insert_workspace_row(session, workspace_id).await?;
+        insert_source_row(session, workspace_id, source_name).await?;
+        insert_source_variable_row(session, workspace_id, source_name, "REGION", "us-east-1")
+            .await?;
+        insert_source_secret_key_row(session, workspace_id, source_name, 0, "API_TOKEN").await
+    }
+
+    async fn assert_source_catalog_uniqueness_contract<S>(
+        session: &mut S,
+        workspace_id: &str,
+        source_name: &str,
+    ) where
+        S: DbSession,
+    {
+        assert!(
+            insert_source_row(session, workspace_id, source_name)
+                .await
+                .is_err(),
+            "duplicate source identity should fail"
+        );
+        assert!(
+            insert_source_variable_row(session, workspace_id, source_name, "REGION", "eu-west-1")
+                .await
+                .is_err(),
+            "duplicate source variable key should fail"
+        );
+        assert!(
+            insert_source_secret_key_row(session, workspace_id, source_name, 0, "OTHER_TOKEN")
+                .await
+                .is_err(),
+            "duplicate source secret key position should fail"
+        );
+    }
+
+    async fn insert_workspace_row<S>(session: &mut S, workspace_id: &str) -> Result<(), DbError>
+    where
+        S: DbSession,
+    {
+        session
+            .execute(
+                Query::insert()
+                    .into_table(Workspaces::Table)
+                    .columns([Workspaces::Id, Workspaces::CreatedAtUnixNanos])
+                    .values_panic([Expr::val(workspace_id), Expr::val(1)])
+                    .on_conflict(OnConflict::column(Workspaces::Id).do_nothing().to_owned())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn insert_source_row<S>(
+        session: &mut S,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<(), DbError>
+    where
+        S: DbSession,
+    {
+        session
+            .execute(
+                Query::insert()
+                    .into_table(Sources::Table)
+                    .columns([
+                        Sources::WorkspaceId,
+                        Sources::Name,
+                        Sources::Version,
+                        Sources::OriginKind,
+                        Sources::CredentialStorage,
+                        Sources::CreatedAtUnixNanos,
+                        Sources::UpdatedAtUnixNanos,
+                    ])
+                    .values_panic([
+                        Expr::val(workspace_id),
+                        Expr::val(source_name),
+                        Expr::val("1.0.0"),
+                        Expr::val("imported"),
+                        Expr::val("file"),
+                        Expr::val(2),
+                        Expr::val(3),
+                    ])
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn insert_source_variable_row<S>(
+        session: &mut S,
+        workspace_id: &str,
+        source_name: &str,
+        key: &str,
+        value: &str,
+    ) -> Result<(), DbError>
+    where
+        S: DbSession,
+    {
+        session
+            .execute(
+                Query::insert()
+                    .into_table(SourceVariables::Table)
+                    .columns([
+                        SourceVariables::WorkspaceId,
+                        SourceVariables::SourceName,
+                        SourceVariables::Key,
+                        SourceVariables::Value,
+                    ])
+                    .values_panic([
+                        Expr::val(workspace_id),
+                        Expr::val(source_name),
+                        Expr::val(key),
+                        Expr::val(value),
+                    ])
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn insert_source_secret_key_row<S>(
+        session: &mut S,
+        workspace_id: &str,
+        source_name: &str,
+        position: i32,
+        key: &str,
+    ) -> Result<(), DbError>
+    where
+        S: DbSession,
+    {
+        session
+            .execute(
+                Query::insert()
+                    .into_table(SourceSecretKeys::Table)
+                    .columns([
+                        SourceSecretKeys::WorkspaceId,
+                        SourceSecretKeys::SourceName,
+                        SourceSecretKeys::Position,
+                        SourceSecretKeys::Key,
+                    ])
+                    .values_panic([
+                        Expr::val(workspace_id),
+                        Expr::val(source_name),
+                        Expr::val(position),
+                        Expr::val(key),
+                    ])
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn delete_source<S>(
+        session: &mut S,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<(), DbError>
+    where
+        S: DbSession,
+    {
+        session
+            .execute_delete(
+                Query::delete()
+                    .from_table(Sources::Table)
+                    .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_id))
+                    .and_where(Expr::col(Sources::Name).eq(source_name))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn delete_workspace<S>(session: &mut S, workspace_id: &str) -> Result<(), DbError>
+    where
+        S: DbSession,
+    {
+        session
+            .execute_delete(
+                Query::delete()
+                    .from_table(Workspaces::Table)
+                    .and_where(Expr::col(Workspaces::Id).eq(workspace_id))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn source_count<S>(session: &mut S, workspace_id: &str) -> Result<i64, DbError>
+    where
+        S: DbSession,
+    {
+        let row: CountRow = session
+            .fetch_optional(
+                Query::select()
+                    .expr_as(Func::count(Expr::val(1)), Alias::new("count"))
+                    .from(Sources::Table)
+                    .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_id))
+                    .to_owned(),
+            )
+            .await?
+            .expect("count row");
+        Ok(row.count)
+    }
+
+    async fn source_variable_count<S>(
+        session: &mut S,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<i64, DbError>
+    where
+        S: DbSession,
+    {
+        let row: CountRow = session
+            .fetch_optional(
+                Query::select()
+                    .expr_as(Func::count(Expr::val(1)), Alias::new("count"))
+                    .from(SourceVariables::Table)
+                    .and_where(Expr::col(SourceVariables::WorkspaceId).eq(workspace_id))
+                    .and_where(Expr::col(SourceVariables::SourceName).eq(source_name))
+                    .to_owned(),
+            )
+            .await?
+            .expect("count row");
+        Ok(row.count)
+    }
+
+    async fn source_secret_key_count<S>(
+        session: &mut S,
+        workspace_id: &str,
+        source_name: &str,
+    ) -> Result<i64, DbError>
+    where
+        S: DbSession,
+    {
+        let row: CountRow = session
+            .fetch_optional(
+                Query::select()
+                    .expr_as(Func::count(Expr::val(1)), Alias::new("count"))
+                    .from(SourceSecretKeys::Table)
+                    .and_where(Expr::col(SourceSecretKeys::WorkspaceId).eq(workspace_id))
+                    .and_where(Expr::col(SourceSecretKeys::SourceName).eq(source_name))
+                    .to_owned(),
+            )
+            .await?
+            .expect("count row");
+        Ok(row.count)
     }
 }

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -1,8 +1,11 @@
 //! RDBMS-backed durable app-state infrastructure.
 
-#![expect(
-    dead_code,
-    reason = "Phase 1 lands the DB boundary and repository harness before later PRs wire managers to these repositories."
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Phase 1 lands the DB boundary and repository harness before later PRs wire managers to these repositories."
+    )
 )]
 
 mod backend;
@@ -10,7 +13,13 @@ mod config;
 mod coral_db;
 mod error;
 mod migrations;
+mod repositories;
+mod schema;
+mod session;
+mod transaction;
 
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
+pub(crate) use session::DbSession;
+pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -23,6 +23,11 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::{import_config_source_catalog, import_filesystem_feedback_reports};
+#[expect(
+    unused_imports,
+    reason = "Episode runtime branches import this from the state::db boundary once restacked."
+)]
+pub(crate) use repositories::episodes::EpisodeRecord;
 pub(crate) use repositories::feedback_reports::FeedbackReportRecord;
 pub(crate) use repositories::materializations::{
     MaterializationRecord, MaterializationSurfaceRecord,

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -23,10 +23,6 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::{import_config_source_catalog, import_filesystem_feedback_reports};
-#[expect(
-    unused_imports,
-    reason = "Episode runtime branches import this from the state::db boundary once restacked."
-)]
 pub(crate) use repositories::episodes::EpisodeRecord;
 pub(crate) use repositories::feedback_reports::FeedbackReportRecord;
 pub(crate) use repositories::materializations::{

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -24,6 +24,7 @@ pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::{
     import_config_source_catalog, import_filesystem_episodes, import_filesystem_feedback_reports,
+    import_legacy_credential_material,
 };
 pub(crate) use repositories::credential_documents::{
     CredentialDocumentRecord, CredentialDocumentWrite,

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -23,6 +23,11 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::import_config_source_catalog;
+#[expect(
+    unused_imports,
+    reason = "Feedback runtime branches import this from the state::db boundary once restacked."
+)]
+pub(crate) use repositories::feedback_reports::FeedbackReportRecord;
 pub(crate) use repositories::materializations::{
     MaterializationRecord, MaterializationSurfaceRecord,
 };

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -21,5 +21,5 @@ mod transaction;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
-pub(crate) use session::DbSession;
+pub(crate) use session::{DbSession, DbWriteSession};
 pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -12,6 +12,7 @@ mod backend;
 mod config;
 mod coral_db;
 mod error;
+mod import;
 mod migrations;
 mod repositories;
 mod schema;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -32,6 +32,14 @@ pub(crate) use repositories::credential_documents::{
 };
 pub(crate) use repositories::episodes::EpisodeRecord;
 pub(crate) use repositories::feedback_reports::FeedbackReportRecord;
+#[expect(
+    unused_imports,
+    reason = "Identity spec repositories land before later manager units wire these record types."
+)]
+pub(crate) use repositories::identity_specs::{
+    IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecRecord,
+    IdentitySpecScope, IdentitySpecWrite,
+};
 pub(crate) use repositories::materializations::{
     MaterializationRecord, MaterializationSurfaceRecord,
 };

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -25,6 +25,13 @@ pub(crate) use error::DbError;
 pub(crate) use import::{
     import_config_source_catalog, import_filesystem_episodes, import_filesystem_feedback_reports,
 };
+#[expect(
+    unused_imports,
+    reason = "Credential runtime branches consume these once restacked."
+)]
+pub(crate) use repositories::credential_documents::{
+    CredentialDocumentRecord, CredentialDocumentWrite,
+};
 pub(crate) use repositories::episodes::EpisodeRecord;
 pub(crate) use repositories::feedback_reports::FeedbackReportRecord;
 pub(crate) use repositories::materializations::{

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -22,5 +22,8 @@ mod transaction;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
+pub(crate) use import::import_config_source_catalog;
+#[cfg(test)]
+pub(crate) use session::DbRepos;
 pub(crate) use session::{DbSession, DbWriteSession};
 pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -23,5 +23,8 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::import_config_source_catalog;
+pub(crate) use repositories::materializations::{
+    MaterializationRecord, MaterializationSurfaceRecord,
+};
 pub(crate) use session::{DbRepos, DbSession, DbWriteSession};
 pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -22,7 +22,9 @@ mod transaction;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
-pub(crate) use import::{import_config_source_catalog, import_filesystem_feedback_reports};
+pub(crate) use import::{
+    import_config_source_catalog, import_filesystem_episodes, import_filesystem_feedback_reports,
+};
 pub(crate) use repositories::episodes::EpisodeRecord;
 pub(crate) use repositories::feedback_reports::FeedbackReportRecord;
 pub(crate) use repositories::materializations::{

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -23,7 +23,5 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::import_config_source_catalog;
-#[cfg(test)]
-pub(crate) use session::DbRepos;
-pub(crate) use session::{DbSession, DbWriteSession};
+pub(crate) use session::{DbRepos, DbSession, DbWriteSession};
 pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -19,6 +19,7 @@ mod schema;
 mod session;
 mod transaction;
 
+pub(crate) use crate::telemetry::TraceSummaryRecord;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -25,10 +25,6 @@ pub(crate) use error::DbError;
 pub(crate) use import::{
     import_config_source_catalog, import_filesystem_episodes, import_filesystem_feedback_reports,
 };
-#[expect(
-    unused_imports,
-    reason = "Credential runtime branches consume these once restacked."
-)]
 pub(crate) use repositories::credential_documents::{
     CredentialDocumentRecord, CredentialDocumentWrite,
 };

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -22,11 +22,7 @@ mod transaction;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
-pub(crate) use import::import_config_source_catalog;
-#[expect(
-    unused_imports,
-    reason = "Feedback runtime branches import this from the state::db boundary once restacked."
-)]
+pub(crate) use import::{import_config_source_catalog, import_filesystem_feedback_reports};
 pub(crate) use repositories::feedback_reports::FeedbackReportRecord;
 pub(crate) use repositories::materializations::{
     MaterializationRecord, MaterializationSurfaceRecord,

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -1,0 +1,16 @@
+//! RDBMS-backed durable app-state infrastructure.
+
+#![expect(
+    dead_code,
+    reason = "Phase 1 lands the DB boundary and repository harness before later PRs wire managers to these repositories."
+)]
+
+mod backend;
+mod config;
+mod coral_db;
+mod error;
+mod migrations;
+
+pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
+pub(crate) use coral_db::CoralDb;
+pub(crate) use error::DbError;

--- a/crates/coral-app/src/state/db/repositories/app_state_markers.rs
+++ b/crates/coral-app/src/state/db/repositories/app_state_markers.rs
@@ -1,0 +1,45 @@
+use sea_query::{Expr, ExprTrait, Query};
+
+use crate::state::db::schema::AppStateMarkers;
+use crate::state::db::{DbError, DbSession};
+
+#[derive(Debug, sqlx::FromRow)]
+struct AppStateMarkerRow {
+    key: String,
+}
+
+pub(crate) struct AppStateMarkersRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> AppStateMarkersRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn contains(&mut self, key: &str) -> Result<bool, DbError> {
+        let statement = Query::select()
+            .column(AppStateMarkers::Key)
+            .from(AppStateMarkers::Table)
+            .and_where(Expr::col(AppStateMarkers::Key).eq(key))
+            .to_owned();
+        let row: Option<AppStateMarkerRow> = self.session.fetch_optional(statement).await?;
+        Ok(row.is_some_and(|row| row.key == key))
+    }
+
+    pub(crate) async fn insert(
+        &mut self,
+        key: &str,
+        created_at_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(AppStateMarkers::Table)
+            .columns([AppStateMarkers::Key, AppStateMarkers::CreatedAtUnixNanos])
+            .values_panic([key.into(), created_at_unix_nanos.into()])
+            .to_owned();
+        self.session.execute(statement).await
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/credential_documents.rs
+++ b/crates/coral-app/src/state/db/repositories/credential_documents.rs
@@ -278,15 +278,30 @@ fn record_columns() -> [CredentialDocuments; 10] {
 
 #[cfg(test)]
 mod tests {
+    use sea_query::{Expr, Query};
     use tempfile::tempdir;
 
     use super::{CredentialDocumentRecord, CredentialDocumentWrite};
     use crate::bootstrap;
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::db::DbError;
+    use crate::state::db::schema::CredentialDocuments;
     use crate::state::db::session::DbRepos;
     use crate::state::db::{CoralDb, CoralTx, ResolvedDatabaseConfig};
     use crate::workspaces::WorkspaceName;
+
+    struct CorruptDocumentRow {
+        label: &'static str,
+        document_version: i64,
+        ciphertext: &'static [u8],
+        nonce: &'static [u8],
+        wrapped_dek: &'static [u8],
+        wrapped_dek_nonce: &'static [u8],
+        created_at_unix_nanos: i64,
+        updated_at_unix_nanos: i64,
+        expected_error: &'static str,
+    }
 
     #[tokio::test]
     async fn credential_document_repository_round_trips_against_sqlite() {
@@ -299,6 +314,19 @@ mod tests {
         db.migrate().await.expect("migrate sqlite");
 
         assert_credential_document_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    async fn credential_document_repository_rejects_corrupt_rows_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+
+        assert_credential_document_repository_rejects_corrupt_rows(&db).await;
     }
 
     #[tokio::test]
@@ -375,6 +403,52 @@ mod tests {
 
         assert_eq!(removed, Some(current));
         assert_eq!(get_document(db, &workspace, &source_name).await, None);
+    }
+
+    async fn assert_credential_document_repository_rejects_corrupt_rows(db: &CoralDb) {
+        for row in [
+            CorruptDocumentRow {
+                label: "negative",
+                document_version: -1,
+                ciphertext: b"ciphertext",
+                nonce: b"nonce",
+                wrapped_dek: b"wrapped",
+                wrapped_dek_nonce: b"wrapped-nonce",
+                created_at_unix_nanos: -1,
+                updated_at_unix_nanos: -1,
+                expected_error: "negative version or timestamp",
+            },
+            CorruptDocumentRow {
+                label: "emptybytes",
+                document_version: 1,
+                ciphertext: b"",
+                nonce: b"",
+                wrapped_dek: b"",
+                wrapped_dek_nonce: b"",
+                created_at_unix_nanos: 10,
+                updated_at_unix_nanos: 10,
+                expected_error: "empty encrypted byte field",
+            },
+        ] {
+            let workspace = unique_workspace(row.label);
+            let source_name = SourceName::parse("github").expect("source name");
+            insert_credential_document_row(db, &workspace, &source_name, &row).await;
+
+            let mut session = db;
+            let error = session
+                .credential_documents()
+                .get(&workspace, &source_name)
+                .await
+                .expect_err("invalid persisted credential document should fail");
+            let DbError::InvalidData(message) = error else {
+                panic!("unexpected error: {error}");
+            };
+            assert!(
+                message.contains(row.expected_error),
+                "expected {:?} in error: {message}",
+                row.expected_error
+            );
+        }
     }
 
     fn unique_workspace(prefix: &str) -> WorkspaceName {
@@ -456,6 +530,57 @@ mod tests {
             .upsert_source(workspace, &source, 2)
             .await
             .expect("upsert source");
+    }
+
+    async fn insert_credential_document_row(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        row: &CorruptDocumentRow,
+    ) {
+        let mut tx = db
+            .begin()
+            .await
+            .expect("begin corrupt credential document tx");
+        seed_source(&mut tx, workspace, source_name).await;
+        tx.execute(
+            Query::insert()
+                .into_table(CredentialDocuments::Table)
+                .columns([
+                    CredentialDocuments::WorkspaceId,
+                    CredentialDocuments::SourceName,
+                    CredentialDocuments::DocumentVersion,
+                    CredentialDocuments::Ciphertext,
+                    CredentialDocuments::Nonce,
+                    CredentialDocuments::WrappedDek,
+                    CredentialDocuments::WrappedDekNonce,
+                    CredentialDocuments::KeyId,
+                    CredentialDocuments::Algorithm,
+                    CredentialDocuments::AadVersion,
+                    CredentialDocuments::CreatedAtUnixNanos,
+                    CredentialDocuments::UpdatedAtUnixNanos,
+                ])
+                .values_panic([
+                    Expr::val(workspace.as_str().to_string()),
+                    Expr::val(source_name.as_str().to_string()),
+                    Expr::val(row.document_version),
+                    Expr::val(row.ciphertext.to_vec()),
+                    Expr::val(row.nonce.to_vec()),
+                    Expr::val(row.wrapped_dek.to_vec()),
+                    Expr::val(row.wrapped_dek_nonce.to_vec()),
+                    Expr::val("key"),
+                    Expr::val("AES-256-GCM"),
+                    Expr::val(1),
+                    Expr::val(row.created_at_unix_nanos),
+                    Expr::val(row.updated_at_unix_nanos),
+                ])
+                .to_owned(),
+        )
+        .await
+        .expect("insert corrupt credential document row");
+        tx.commit()
+            .await
+            .expect("commit corrupt credential document row");
     }
 
     fn assert_document(

--- a/crates/coral-app/src/state/db/repositories/credential_documents.rs
+++ b/crates/coral-app/src/state/db/repositories/credential_documents.rs
@@ -113,17 +113,16 @@ impl<S> CredentialDocumentsRepo<'_, S>
 where
     S: DbWriteSession,
 {
-    pub(crate) async fn upsert(
+    pub(crate) async fn insert_if_absent(
         &mut self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
         document: &CredentialDocumentWrite,
         now_unix_nanos: i64,
-    ) -> Result<CredentialDocumentRecord, DbError> {
-        let current_document_version = Expr::col((
-            CredentialDocuments::Table,
-            CredentialDocuments::DocumentVersion,
-        ));
+    ) -> Result<bool, DbError> {
+        if self.get(workspace_name, source_name).await?.is_some() {
+            return Ok(false);
+        }
         let statement = Query::insert()
             .into_table(CredentialDocuments::Table)
             .columns([
@@ -159,33 +158,31 @@ where
                     CredentialDocuments::WorkspaceId,
                     CredentialDocuments::SourceName,
                 ])
-                .value(
-                    CredentialDocuments::DocumentVersion,
-                    Expr::case(current_document_version.clone().eq(i64::MAX), Expr::null())
-                        .finally(current_document_version.add(1)),
-                )
-                .update_columns([
-                    CredentialDocuments::Ciphertext,
-                    CredentialDocuments::Nonce,
-                    CredentialDocuments::WrappedDek,
-                    CredentialDocuments::WrappedDekNonce,
-                    CredentialDocuments::KeyId,
-                    CredentialDocuments::Algorithm,
-                    CredentialDocuments::AadVersion,
-                    CredentialDocuments::UpdatedAtUnixNanos,
-                ])
+                .do_nothing()
                 .to_owned(),
             )
             .to_owned();
         self.session.execute(statement).await?;
-        self.get(workspace_name, source_name).await?.ok_or_else(|| {
-            DbError::InvalidData(format!(
-                "credential document upsert did not return a row for {workspace_name}:{source_name}"
-            ))
-        })
+        Ok(self
+            .get(workspace_name, source_name)
+            .await?
+            .is_some_and(|record| document_matches_record(document, &record)))
     }
 
-    pub(crate) async fn rewrap_if_current(
+    #[cfg(test)]
+    pub(crate) async fn upsert(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        document: &CredentialDocumentWrite,
+        now_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        self.insert_if_absent(workspace_name, source_name, document, now_unix_nanos)
+            .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn replace_if_current(
         &mut self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
@@ -245,6 +242,24 @@ where
         Ok(self.session.execute_update(statement).await? == 1)
     }
 
+    pub(crate) async fn rewrap_if_current(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        expected_document_version: i64,
+        document: &CredentialDocumentWrite,
+        now_unix_nanos: i64,
+    ) -> Result<bool, DbError> {
+        self.replace_if_current(
+            workspace_name,
+            source_name,
+            expected_document_version,
+            document,
+            now_unix_nanos,
+        )
+        .await
+    }
+
     pub(crate) async fn remove(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -274,6 +289,20 @@ fn record_columns() -> [CredentialDocuments; 10] {
         CredentialDocuments::CreatedAtUnixNanos,
         CredentialDocuments::UpdatedAtUnixNanos,
     ]
+}
+
+fn document_matches_record(
+    document: &CredentialDocumentWrite,
+    record: &CredentialDocumentRecord,
+) -> bool {
+    record.document_version == 1
+        && record.ciphertext == document.ciphertext
+        && record.nonce == document.nonce
+        && record.wrapped_dek == document.wrapped_dek
+        && record.wrapped_dek_nonce == document.wrapped_dek_nonce
+        && record.key_id == document.key_id
+        && record.algorithm == document.algorithm
+        && record.aad_version == document.aad_version
 }
 
 #[cfg(test)]
@@ -330,6 +359,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn credential_document_repository_rejects_document_without_workspace_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("missing").expect("source name");
+
+        let mut tx = db.begin().await.expect("begin tx");
+        let error = tx
+            .credential_documents()
+            .insert_if_absent(
+                &workspace,
+                &source_name,
+                &document_write("key-1", b"secret"),
+                10,
+            )
+            .await
+            .expect_err("credential document rows must require an existing workspace");
+
+        assert!(
+            error.to_string().to_lowercase().contains("foreign key"),
+            "unexpected error: {error}"
+        );
+        tx.rollback().await.expect("rollback failed tx");
+    }
+
+    #[tokio::test]
     #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
     async fn credential_document_repository_round_trips_against_postgres() {
         let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
@@ -349,20 +409,26 @@ mod tests {
 
         let mut tx = db.begin().await.expect("begin tx");
         seed_source(&mut tx, &workspace, &source_name).await;
-        upsert_document(&mut tx, &workspace, &source_name, "key-1", b"first", 10).await;
+        assert!(insert_document(&mut tx, &workspace, &source_name, "key-1", b"first", 10).await);
         tx.commit().await.expect("commit first document");
 
         let mut tx = db.begin().await.expect("begin replacement tx");
-        let replacement = upsert_document(
-            &mut tx,
-            &workspace,
-            &source_name,
-            "key-2",
-            b"replacement",
-            20,
-        )
-        .await;
+        assert!(
+            replace_document(
+                &mut tx,
+                &workspace,
+                &source_name,
+                1,
+                "key-2",
+                b"replacement",
+                20
+            )
+            .await
+        );
         tx.commit().await.expect("commit replacement document");
+        let replacement = get_document(db, &workspace, &source_name)
+            .await
+            .expect("replacement document");
 
         assert_document(&replacement, 2, "key-2", b"replacement", 10, 20);
         let debug = format!(
@@ -469,23 +535,44 @@ mod tests {
             .expect("get credential document")
     }
 
-    async fn upsert_document(
+    async fn insert_document(
         tx: &mut CoralTx<'_>,
         workspace: &WorkspaceName,
         source_name: &SourceName,
         key_id: &str,
         ciphertext: &[u8],
         now_unix_nanos: i64,
-    ) -> CredentialDocumentRecord {
+    ) -> bool {
         tx.credential_documents()
-            .upsert(
+            .insert_if_absent(
                 workspace,
                 source_name,
                 &document_write(key_id, ciphertext),
                 now_unix_nanos,
             )
             .await
-            .expect("upsert credential document")
+            .expect("insert credential document")
+    }
+
+    async fn replace_document(
+        tx: &mut CoralTx<'_>,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        expected_document_version: i64,
+        key_id: &str,
+        ciphertext: &[u8],
+        now_unix_nanos: i64,
+    ) -> bool {
+        tx.credential_documents()
+            .replace_if_current(
+                workspace,
+                source_name,
+                expected_document_version,
+                &document_write(key_id, ciphertext),
+                now_unix_nanos,
+            )
+            .await
+            .expect("replace credential document")
     }
 
     async fn rewrap_document(

--- a/crates/coral-app/src/state/db/repositories/credential_documents.rs
+++ b/crates/coral-app/src/state/db/repositories/credential_documents.rs
@@ -1,0 +1,487 @@
+use sea_query::{Expr, ExprTrait, OnConflict, Query};
+
+use crate::sources::SourceName;
+use crate::state::db::schema::CredentialDocuments;
+use crate::state::db::{DbError, DbSession, DbWriteSession};
+use crate::workspaces::WorkspaceName;
+
+#[derive(Clone, PartialEq, Eq, sqlx::FromRow)]
+pub(crate) struct CredentialDocumentRecord {
+    pub(crate) document_version: i64,
+    pub(crate) ciphertext: Vec<u8>,
+    pub(crate) nonce: Vec<u8>,
+    pub(crate) wrapped_dek: Vec<u8>,
+    pub(crate) wrapped_dek_nonce: Vec<u8>,
+    pub(crate) key_id: String,
+    pub(crate) algorithm: String,
+    pub(crate) aad_version: i64,
+    pub(crate) created_at_unix_nanos: i64,
+    pub(crate) updated_at_unix_nanos: i64,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct CredentialDocumentWrite {
+    pub(crate) ciphertext: Vec<u8>,
+    pub(crate) nonce: Vec<u8>,
+    pub(crate) wrapped_dek: Vec<u8>,
+    pub(crate) wrapped_dek_nonce: Vec<u8>,
+    pub(crate) key_id: String,
+    pub(crate) algorithm: String,
+    pub(crate) aad_version: i64,
+}
+
+impl std::fmt::Debug for CredentialDocumentRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialDocumentRecord")
+            .field("ciphertext_len", &self.ciphertext.len())
+            .field("nonce_len", &self.nonce.len())
+            .field("wrapped_dek_len", &self.wrapped_dek.len())
+            .field("wrapped_dek_nonce_len", &self.wrapped_dek_nonce.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for CredentialDocumentWrite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialDocumentWrite")
+            .field("ciphertext_len", &self.ciphertext.len())
+            .field("nonce_len", &self.nonce.len())
+            .field("wrapped_dek_len", &self.wrapped_dek.len())
+            .field("wrapped_dek_nonce_len", &self.wrapped_dek_nonce.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl CredentialDocumentRecord {
+    fn validate(self) -> Result<Self, DbError> {
+        if self.document_version < 0
+            || self.created_at_unix_nanos < 0
+            || self.updated_at_unix_nanos < 0
+        {
+            return Err(DbError::InvalidData(
+                "credential document has negative version or timestamp".to_string(),
+            ));
+        }
+        if self.aad_version != 1 {
+            return Err(DbError::InvalidData(format!(
+                "credential document has unsupported aad_version {}",
+                self.aad_version
+            )));
+        }
+        if self.ciphertext.is_empty()
+            || self.nonce.is_empty()
+            || self.wrapped_dek.is_empty()
+            || self.wrapped_dek_nonce.is_empty()
+        {
+            return Err(DbError::InvalidData(
+                "credential document has an empty encrypted byte field".to_string(),
+            ));
+        }
+        Ok(self)
+    }
+}
+
+pub(crate) struct CredentialDocumentsRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> CredentialDocumentsRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn get(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<CredentialDocumentRecord>, DbError> {
+        let statement = Query::select()
+            .columns(record_columns())
+            .from(CredentialDocuments::Table)
+            .and_where(Expr::col(CredentialDocuments::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(CredentialDocuments::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        let row: Option<CredentialDocumentRecord> = self.session.fetch_optional(statement).await?;
+        row.map(CredentialDocumentRecord::validate).transpose()
+    }
+}
+
+impl<S> CredentialDocumentsRepo<'_, S>
+where
+    S: DbWriteSession,
+{
+    pub(crate) async fn upsert(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        document: &CredentialDocumentWrite,
+        now_unix_nanos: i64,
+    ) -> Result<CredentialDocumentRecord, DbError> {
+        let current_document_version = Expr::col((
+            CredentialDocuments::Table,
+            CredentialDocuments::DocumentVersion,
+        ));
+        let statement = Query::insert()
+            .into_table(CredentialDocuments::Table)
+            .columns([
+                CredentialDocuments::WorkspaceId,
+                CredentialDocuments::SourceName,
+                CredentialDocuments::DocumentVersion,
+                CredentialDocuments::Ciphertext,
+                CredentialDocuments::Nonce,
+                CredentialDocuments::WrappedDek,
+                CredentialDocuments::WrappedDekNonce,
+                CredentialDocuments::KeyId,
+                CredentialDocuments::Algorithm,
+                CredentialDocuments::AadVersion,
+                CredentialDocuments::CreatedAtUnixNanos,
+                CredentialDocuments::UpdatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_name.as_str().to_string()),
+                Expr::val(source_name.as_str().to_string()),
+                Expr::val(1),
+                Expr::val(document.ciphertext.clone()),
+                Expr::val(document.nonce.clone()),
+                Expr::val(document.wrapped_dek.clone()),
+                Expr::val(document.wrapped_dek_nonce.clone()),
+                Expr::val(document.key_id.clone()),
+                Expr::val(document.algorithm.clone()),
+                Expr::val(document.aad_version),
+                Expr::val(now_unix_nanos),
+                Expr::val(now_unix_nanos),
+            ])
+            .on_conflict(
+                OnConflict::columns([
+                    CredentialDocuments::WorkspaceId,
+                    CredentialDocuments::SourceName,
+                ])
+                .value(
+                    CredentialDocuments::DocumentVersion,
+                    Expr::case(current_document_version.clone().eq(i64::MAX), Expr::null())
+                        .finally(current_document_version.add(1)),
+                )
+                .update_columns([
+                    CredentialDocuments::Ciphertext,
+                    CredentialDocuments::Nonce,
+                    CredentialDocuments::WrappedDek,
+                    CredentialDocuments::WrappedDekNonce,
+                    CredentialDocuments::KeyId,
+                    CredentialDocuments::Algorithm,
+                    CredentialDocuments::AadVersion,
+                    CredentialDocuments::UpdatedAtUnixNanos,
+                ])
+                .to_owned(),
+            )
+            .to_owned();
+        self.session.execute(statement).await?;
+        self.get(workspace_name, source_name).await?.ok_or_else(|| {
+            DbError::InvalidData(format!(
+                "credential document upsert did not return a row for {workspace_name}:{source_name}"
+            ))
+        })
+    }
+
+    pub(crate) async fn rewrap_if_current(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        expected_document_version: i64,
+        document: &CredentialDocumentWrite,
+        now_unix_nanos: i64,
+    ) -> Result<bool, DbError> {
+        let document_version = expected_document_version.checked_add(1).ok_or_else(|| {
+            DbError::InvalidData(format!(
+                "credential document version overflow for {workspace_name}:{source_name}"
+            ))
+        })?;
+        let statement = Query::update()
+            .table(CredentialDocuments::Table)
+            .value(
+                CredentialDocuments::DocumentVersion,
+                Expr::val(document_version),
+            )
+            .value(
+                CredentialDocuments::Ciphertext,
+                Expr::val(document.ciphertext.clone()),
+            )
+            .value(
+                CredentialDocuments::Nonce,
+                Expr::val(document.nonce.clone()),
+            )
+            .value(
+                CredentialDocuments::WrappedDek,
+                Expr::val(document.wrapped_dek.clone()),
+            )
+            .value(
+                CredentialDocuments::WrappedDekNonce,
+                Expr::val(document.wrapped_dek_nonce.clone()),
+            )
+            .value(
+                CredentialDocuments::KeyId,
+                Expr::val(document.key_id.clone()),
+            )
+            .value(
+                CredentialDocuments::Algorithm,
+                Expr::val(document.algorithm.clone()),
+            )
+            .value(
+                CredentialDocuments::AadVersion,
+                Expr::val(document.aad_version),
+            )
+            .value(
+                CredentialDocuments::UpdatedAtUnixNanos,
+                Expr::val(now_unix_nanos),
+            )
+            .and_where(Expr::col(CredentialDocuments::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(CredentialDocuments::SourceName).eq(source_name.as_str()))
+            .and_where(
+                Expr::col(CredentialDocuments::DocumentVersion).eq(expected_document_version),
+            )
+            .to_owned();
+        Ok(self.session.execute_update(statement).await? == 1)
+    }
+
+    pub(crate) async fn remove(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<CredentialDocumentRecord>, DbError> {
+        let removed = self.get(workspace_name, source_name).await?;
+        let statement = Query::delete()
+            .from_table(CredentialDocuments::Table)
+            .and_where(Expr::col(CredentialDocuments::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(CredentialDocuments::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        self.session.execute_delete(statement).await?;
+        Ok(removed)
+    }
+}
+
+fn record_columns() -> [CredentialDocuments; 10] {
+    [
+        CredentialDocuments::DocumentVersion,
+        CredentialDocuments::Ciphertext,
+        CredentialDocuments::Nonce,
+        CredentialDocuments::WrappedDek,
+        CredentialDocuments::WrappedDekNonce,
+        CredentialDocuments::KeyId,
+        CredentialDocuments::Algorithm,
+        CredentialDocuments::AadVersion,
+        CredentialDocuments::CreatedAtUnixNanos,
+        CredentialDocuments::UpdatedAtUnixNanos,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::{CredentialDocumentRecord, CredentialDocumentWrite};
+    use crate::bootstrap;
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, CoralTx, ResolvedDatabaseConfig};
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    async fn credential_document_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+
+        assert_credential_document_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn credential_document_repository_round_trips_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_credential_document_repository_round_trip(&db).await;
+    }
+
+    async fn assert_credential_document_repository_round_trip(db: &CoralDb) {
+        let workspace = unique_workspace("credential");
+        let source_name = SourceName::parse("github").expect("source name");
+
+        let mut tx = db.begin().await.expect("begin tx");
+        seed_source(&mut tx, &workspace, &source_name).await;
+        upsert_document(&mut tx, &workspace, &source_name, "key-1", b"first", 10).await;
+        tx.commit().await.expect("commit first document");
+
+        let mut tx = db.begin().await.expect("begin replacement tx");
+        let replacement = upsert_document(
+            &mut tx,
+            &workspace,
+            &source_name,
+            "key-2",
+            b"replacement",
+            20,
+        )
+        .await;
+        tx.commit().await.expect("commit replacement document");
+
+        assert_document(&replacement, 2, "key-2", b"replacement", 10, 20);
+        let debug = format!(
+            "{replacement:?} {:?}",
+            document_write("key-debug", b"secret")
+        );
+        assert!(
+            debug.contains("ciphertext_len")
+                && !debug.contains("replacement")
+                && !debug.contains("secret")
+        );
+        let mut tx = db.begin().await.expect("begin rewrap tx");
+        assert!(
+            rewrap_document(
+                &mut tx,
+                &workspace,
+                &source_name,
+                replacement.document_version,
+                "key-3",
+                b"rewrapped",
+                30,
+            )
+            .await
+        );
+        tx.commit().await.expect("commit rewrap document");
+        let current = get_document(db, &workspace, &source_name)
+            .await
+            .expect("credential document");
+        assert_document(&current, 3, "key-3", b"rewrapped", 10, 30);
+
+        let mut tx = db.begin().await.expect("begin remove tx");
+        let removed = tx
+            .credential_documents()
+            .remove(&workspace, &source_name)
+            .await
+            .expect("remove credential document");
+        tx.commit().await.expect("commit remove document");
+
+        assert_eq!(removed, Some(current));
+        assert_eq!(get_document(db, &workspace, &source_name).await, None);
+    }
+
+    fn unique_workspace(prefix: &str) -> WorkspaceName {
+        WorkspaceName::parse(&format!("{prefix}{}", uuid::Uuid::new_v4().simple()))
+            .expect("workspace")
+    }
+
+    async fn get_document(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Option<CredentialDocumentRecord> {
+        let mut session = db;
+        session
+            .credential_documents()
+            .get(workspace, source_name)
+            .await
+            .expect("get credential document")
+    }
+
+    async fn upsert_document(
+        tx: &mut CoralTx<'_>,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        key_id: &str,
+        ciphertext: &[u8],
+        now_unix_nanos: i64,
+    ) -> CredentialDocumentRecord {
+        tx.credential_documents()
+            .upsert(
+                workspace,
+                source_name,
+                &document_write(key_id, ciphertext),
+                now_unix_nanos,
+            )
+            .await
+            .expect("upsert credential document")
+    }
+
+    async fn rewrap_document(
+        tx: &mut CoralTx<'_>,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        expected_document_version: i64,
+        key_id: &str,
+        ciphertext: &[u8],
+        now_unix_nanos: i64,
+    ) -> bool {
+        tx.credential_documents()
+            .rewrap_if_current(
+                workspace,
+                source_name,
+                expected_document_version,
+                &document_write(key_id, ciphertext),
+                now_unix_nanos,
+            )
+            .await
+            .expect("rewrap credential document")
+    }
+
+    async fn seed_source(
+        tx: &mut CoralTx<'_>,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        let source = InstalledSource {
+            name: source_name.clone(),
+            version: Some("0.1.0".to_string()),
+            variables: std::collections::BTreeMap::default(),
+            secrets: vec!["GITHUB_TOKEN".to_string()],
+            credential_storage: None,
+            origin: SourceOrigin::Imported,
+        };
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(workspace, &source, 2)
+            .await
+            .expect("upsert source");
+    }
+
+    fn assert_document(
+        record: &CredentialDocumentRecord,
+        version: i64,
+        key_id: &str,
+        ciphertext: &[u8],
+        created_at_unix_nanos: i64,
+        updated_at_unix_nanos: i64,
+    ) {
+        assert_eq!(record.document_version, version);
+        assert_eq!(record.key_id, key_id);
+        assert_eq!(record.ciphertext.as_slice(), ciphertext);
+        assert_eq!(record.created_at_unix_nanos, created_at_unix_nanos);
+        assert_eq!(record.updated_at_unix_nanos, updated_at_unix_nanos);
+    }
+
+    fn document_write(key_id: &str, ciphertext: &[u8]) -> CredentialDocumentWrite {
+        CredentialDocumentWrite {
+            ciphertext: ciphertext.to_vec(),
+            nonce: format!("nonce-{key_id}").into_bytes(),
+            wrapped_dek: format!("wrapped-{key_id}").into_bytes(),
+            wrapped_dek_nonce: format!("wrapped-nonce-{key_id}").into_bytes(),
+            key_id: key_id.to_string(),
+            algorithm: "AES-256-GCM".to_string(),
+            aad_version: 1,
+        }
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/episodes.rs
+++ b/crates/coral-app/src/state/db/repositories/episodes.rs
@@ -1,0 +1,446 @@
+use sea_query::{Expr, ExprTrait, Order, Query};
+
+use crate::episode::EpisodeId;
+use crate::state::db::schema::Episodes;
+use crate::state::db::{DbError, DbSession, DbWriteSession};
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EpisodeRecord {
+    pub(crate) id: String,
+    pub(crate) intent: String,
+    pub(crate) parent_episode_id: Option<String>,
+    pub(crate) created_at_unix_nanos: i64,
+    pub(crate) record_bytes: i64,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct EpisodeRow {
+    id: String,
+    intent: String,
+    parent_episode_id: Option<String>,
+    created_at_unix_nanos: i64,
+    record_bytes: i64,
+}
+
+impl TryFrom<EpisodeRow> for EpisodeRecord {
+    type Error = DbError;
+
+    fn try_from(value: EpisodeRow) -> Result<Self, Self::Error> {
+        validate_episode_id("episode id", &value.id)?;
+        if let Some(parent_episode_id) = value.parent_episode_id.as_deref() {
+            validate_episode_id("parent episode id", parent_episode_id)?;
+        }
+        if value.created_at_unix_nanos < 0 {
+            return Err(DbError::InvalidData(format!(
+                "episode '{}' has negative created_at_unix_nanos",
+                value.id
+            )));
+        }
+        if value.record_bytes < 0 {
+            return Err(DbError::InvalidData(format!(
+                "episode '{}' has negative record_bytes",
+                value.id
+            )));
+        }
+        Ok(Self {
+            id: value.id,
+            intent: value.intent,
+            parent_episode_id: value.parent_episode_id,
+            created_at_unix_nanos: value.created_at_unix_nanos,
+            record_bytes: value.record_bytes,
+        })
+    }
+}
+
+fn validate_episode_id(field: &str, id: &str) -> Result<(), DbError> {
+    EpisodeId::parse(id)
+        .map(|_| ())
+        .map_err(|error| DbError::InvalidData(format!("invalid {field} '{id}': {error}")))
+}
+
+pub(crate) struct EpisodesRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> EpisodesRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn get(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        id: &str,
+    ) -> Result<Option<EpisodeRecord>, DbError> {
+        let statement = Query::select()
+            .columns(record_columns())
+            .from(Episodes::Table)
+            .and_where(Expr::col(Episodes::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Episodes::Id).eq(id))
+            .to_owned();
+        let row: Option<EpisodeRow> = self.session.fetch_optional(statement).await?;
+        row.map(TryInto::try_into).transpose()
+    }
+
+    pub(crate) async fn list_workspace_episodes(
+        &mut self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<EpisodeRecord>, DbError> {
+        let statement = Query::select()
+            .columns(record_columns())
+            .from(Episodes::Table)
+            .and_where(Expr::col(Episodes::WorkspaceId).eq(workspace_name.as_str()))
+            .order_by(Episodes::CreatedAtUnixNanos, Order::Asc)
+            .order_by(Episodes::Id, Order::Asc)
+            .to_owned();
+        let rows: Vec<EpisodeRow> = self.session.fetch_all(statement).await?;
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+}
+
+impl<S> EpisodesRepo<'_, S>
+where
+    S: DbWriteSession,
+{
+    pub(crate) async fn insert(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        episode: &EpisodeRecord,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(Episodes::Table)
+            .columns([
+                Episodes::WorkspaceId,
+                Episodes::Id,
+                Episodes::Intent,
+                Episodes::ParentEpisodeId,
+                Episodes::CreatedAtUnixNanos,
+                Episodes::RecordBytes,
+            ])
+            .values_panic([
+                Expr::val(workspace_name.as_str().to_string()),
+                Expr::val(episode.id.clone()),
+                Expr::val(episode.intent.clone()),
+                Expr::val(episode.parent_episode_id.clone()),
+                Expr::val(episode.created_at_unix_nanos),
+                Expr::val(episode.record_bytes),
+            ])
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    /// Replaces every episode row for one workspace.
+    ///
+    /// Callers MUST hold that workspace row's write lock in the same
+    /// transaction, for example via `workspaces().ensure_write_locked(...)`,
+    /// so concurrent servers cannot observe or race the delete-then-insert
+    /// window.
+    pub(crate) async fn replace_workspace_episodes(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        episodes: &[EpisodeRecord],
+    ) -> Result<(), DbError> {
+        self.delete_workspace_episodes(workspace_name).await?;
+        for episode in episodes {
+            self.insert(workspace_name, episode).await?;
+        }
+        Ok(())
+    }
+
+    async fn delete_workspace_episodes(
+        &mut self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(Episodes::Table)
+            .and_where(Expr::col(Episodes::WorkspaceId).eq(workspace_name.as_str()))
+            .to_owned();
+        self.session.execute_delete(statement).await
+    }
+}
+
+fn record_columns() -> [Episodes; 5] {
+    [
+        Episodes::Id,
+        Episodes::Intent,
+        Episodes::ParentEpisodeId,
+        Episodes::CreatedAtUnixNanos,
+        Episodes::RecordBytes,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_query::{Expr, Query};
+    use tempfile::tempdir;
+
+    use super::EpisodeRecord;
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::schema::Episodes;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, DbError, ResolvedDatabaseConfig};
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    async fn episode_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_episode_repository_round_trip(&db).await;
+        assert_episode_repository_round_trip(&db).await;
+        assert_episode_repository_rejects_invalid_rows(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn episode_repository_round_trips_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_episode_repository_round_trip(&db).await;
+        assert_episode_repository_round_trip(&db).await;
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    async fn assert_episode_repository_round_trip(db: &CoralDb) {
+        let workspace = unique_workspace("episode");
+        let other_workspace = unique_workspace("episodeother");
+        let root = EpisodeRecord {
+            id: "ep_1".to_string(),
+            intent: "root task".to_string(),
+            parent_episode_id: None,
+            created_at_unix_nanos: 10,
+            record_bytes: 100,
+        };
+        let child = EpisodeRecord {
+            id: "ep_2".to_string(),
+            intent: "child task".to_string(),
+            parent_episode_id: Some("ep_1".to_string()),
+            created_at_unix_nanos: 11,
+            record_bytes: 101,
+        };
+
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("ensure workspace");
+        tx.workspaces()
+            .ensure(other_workspace.as_str(), 1)
+            .await
+            .expect("ensure other workspace");
+        tx.episodes()
+            .insert(&workspace, &root)
+            .await
+            .expect("insert root");
+        tx.episodes()
+            .insert(&workspace, &child)
+            .await
+            .expect("insert child");
+        tx.episodes()
+            .insert(&other_workspace, &root)
+            .await
+            .expect("insert isolated same id");
+        tx.commit().await.expect("commit episodes");
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .episodes()
+                .get(&workspace, "ep_1")
+                .await
+                .expect("get root"),
+            Some(root.clone())
+        );
+        assert_eq!(
+            session
+                .episodes()
+                .list_workspace_episodes(&workspace)
+                .await
+                .expect("list workspace episodes"),
+            vec![root.clone(), child.clone()]
+        );
+
+        let replacement = vec![child.clone()];
+        let mut tx = db.begin().await.expect("begin replacement tx");
+        tx.episodes()
+            .replace_workspace_episodes(&workspace, &replacement)
+            .await
+            .expect("replace workspace episodes");
+        tx.commit().await.expect("commit replacement");
+        assert_eq!(
+            session
+                .episodes()
+                .list_workspace_episodes(&workspace)
+                .await
+                .expect("list replaced episodes"),
+            replacement
+        );
+        assert_eq!(
+            session
+                .episodes()
+                .get(&other_workspace, "ep_1")
+                .await
+                .expect("other workspace remains isolated"),
+            Some(root)
+        );
+        assert_episode_rejects_missing_workspace(db).await;
+        assert_episode_cascades_with_workspace(db, &workspace, &child).await;
+    }
+
+    async fn assert_episode_rejects_missing_workspace(db: &CoralDb) {
+        let workspace = unique_workspace("episodemissing");
+        let episode = episode_record("orphan");
+        let mut tx = db.begin().await.expect("begin orphan tx");
+
+        let error = tx
+            .episodes()
+            .insert(&workspace, &episode)
+            .await
+            .expect_err("episodes must require an existing workspace");
+
+        assert!(
+            error.to_string().to_lowercase().contains("foreign key"),
+            "unexpected error: {error}"
+        );
+        tx.rollback().await.expect("rollback orphan tx");
+    }
+
+    async fn assert_episode_repository_rejects_invalid_rows(db: &CoralDb) {
+        for (id, parent, created, bytes, expected) in [
+            ("bad id", None, 1, 1, "invalid episode id"),
+            (
+                "ep_bad_parent",
+                Some("bad parent"),
+                1,
+                1,
+                "invalid parent episode id",
+            ),
+            ("ep_bad_created", None, -1, 1, "created_at_unix_nanos"),
+            ("ep_bad_bytes", None, 1, -1, "record_bytes"),
+        ] {
+            let workspace = unique_workspace("episodebad");
+            insert_episode_row(db, &workspace, id, parent, created, bytes).await;
+            let mut session = db;
+            let error = session
+                .episodes()
+                .get(&workspace, id)
+                .await
+                .expect_err("invalid persisted episode row should fail");
+            let DbError::InvalidData(message) = error else {
+                panic!("unexpected error: {error}");
+            };
+            assert!(
+                message.contains(expected),
+                "expected {expected:?} in error: {message}"
+            );
+        }
+    }
+
+    async fn insert_episode_row(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        id: &str,
+        parent_id: Option<&str>,
+        created_at_unix_nanos: i64,
+        record_bytes: i64,
+    ) {
+        let mut tx = db.begin().await.expect("begin invalid episode tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("ensure workspace");
+        tx.execute(
+            Query::insert()
+                .into_table(Episodes::Table)
+                .columns([
+                    Episodes::WorkspaceId,
+                    Episodes::Id,
+                    Episodes::Intent,
+                    Episodes::ParentEpisodeId,
+                    Episodes::CreatedAtUnixNanos,
+                    Episodes::RecordBytes,
+                ])
+                .values_panic([
+                    Expr::val(workspace.as_str().to_string()),
+                    Expr::val(id.to_string()),
+                    Expr::val("intent"),
+                    Expr::val(parent_id.map(str::to_string)),
+                    Expr::val(created_at_unix_nanos),
+                    Expr::val(record_bytes),
+                ])
+                .to_owned(),
+        )
+        .await
+        .expect("insert invalid episode row");
+        tx.commit().await.expect("commit invalid episode row");
+    }
+
+    async fn assert_episode_cascades_with_workspace(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        episode: &EpisodeRecord,
+    ) {
+        let mut tx = db.begin().await.expect("begin cascade tx");
+        tx.workspaces()
+            .remove(workspace.as_str())
+            .await
+            .expect("remove workspace");
+        tx.commit().await.expect("commit cascade tx");
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .episodes()
+                .get(workspace, &episode.id)
+                .await
+                .expect("get cascaded episode"),
+            None
+        );
+        assert!(
+            session
+                .episodes()
+                .list_workspace_episodes(workspace)
+                .await
+                .expect("list cascaded episodes")
+                .is_empty()
+        );
+    }
+
+    fn episode_record(id: &str) -> EpisodeRecord {
+        EpisodeRecord {
+            id: id.to_string(),
+            intent: "root task".to_string(),
+            parent_episode_id: None,
+            created_at_unix_nanos: 10,
+            record_bytes: 100,
+        }
+    }
+
+    fn unique_workspace(prefix: &str) -> WorkspaceName {
+        WorkspaceName::parse(&format!("{prefix}{}", uuid::Uuid::new_v4().simple()))
+            .expect("workspace")
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/feedback_reports.rs
+++ b/crates/coral-app/src/state/db/repositories/feedback_reports.rs
@@ -1,0 +1,330 @@
+use sea_query::{Expr, ExprTrait, Order, Query};
+
+use crate::state::db::schema::FeedbackReports;
+use crate::state::db::{DbError, DbSession, DbWriteSession};
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FeedbackReportRecord {
+    pub(crate) id: String,
+    pub(crate) created_at_unix_nanos: i64,
+    pub(crate) trying_to_do: String,
+    pub(crate) tried: String,
+    pub(crate) stuck: String,
+    pub(crate) publish_status: Option<String>,
+    pub(crate) publish_error: Option<String>,
+    pub(crate) published_at_unix_nanos: Option<i64>,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct FeedbackReportRow {
+    id: String,
+    created_at_unix_nanos: i64,
+    trying_to_do: String,
+    tried: String,
+    stuck: String,
+    publish_status: Option<String>,
+    publish_error: Option<String>,
+    published_at_unix_nanos: Option<i64>,
+}
+
+impl From<FeedbackReportRow> for FeedbackReportRecord {
+    fn from(value: FeedbackReportRow) -> Self {
+        Self {
+            id: value.id,
+            created_at_unix_nanos: value.created_at_unix_nanos,
+            trying_to_do: value.trying_to_do,
+            tried: value.tried,
+            stuck: value.stuck,
+            publish_status: value.publish_status,
+            publish_error: value.publish_error,
+            published_at_unix_nanos: value.published_at_unix_nanos,
+        }
+    }
+}
+
+pub(crate) struct FeedbackReportsRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> FeedbackReportsRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn get(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        id: &str,
+    ) -> Result<Option<FeedbackReportRecord>, DbError> {
+        let statement = Query::select()
+            .columns(record_columns())
+            .from(FeedbackReports::Table)
+            .and_where(Expr::col(FeedbackReports::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(FeedbackReports::Id).eq(id))
+            .to_owned();
+        let row: Option<FeedbackReportRow> = self.session.fetch_optional(statement).await?;
+        Ok(row.map(Into::into))
+    }
+
+    pub(crate) async fn list_workspace_reports(
+        &mut self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<FeedbackReportRecord>, DbError> {
+        let statement = Query::select()
+            .columns(record_columns())
+            .from(FeedbackReports::Table)
+            .and_where(Expr::col(FeedbackReports::WorkspaceId).eq(workspace_name.as_str()))
+            .order_by(FeedbackReports::CreatedAtUnixNanos, Order::Asc)
+            .order_by(FeedbackReports::Id, Order::Asc)
+            .to_owned();
+        let rows: Vec<FeedbackReportRow> = self.session.fetch_all(statement).await?;
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<S> FeedbackReportsRepo<'_, S>
+where
+    S: DbWriteSession,
+{
+    pub(crate) async fn append(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        report: &FeedbackReportRecord,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(FeedbackReports::Table)
+            .columns([
+                FeedbackReports::Id,
+                FeedbackReports::WorkspaceId,
+                FeedbackReports::CreatedAtUnixNanos,
+                FeedbackReports::TryingToDo,
+                FeedbackReports::Tried,
+                FeedbackReports::Stuck,
+                FeedbackReports::PublishStatus,
+                FeedbackReports::PublishError,
+                FeedbackReports::PublishedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(report.id.clone()),
+                Expr::val(workspace_name.as_str().to_string()),
+                Expr::val(report.created_at_unix_nanos),
+                Expr::val(report.trying_to_do.clone()),
+                Expr::val(report.tried.clone()),
+                Expr::val(report.stuck.clone()),
+                Expr::val(report.publish_status.clone()),
+                Expr::val(report.publish_error.clone()),
+                Expr::val(report.published_at_unix_nanos),
+            ])
+            .to_owned();
+        self.session.execute(statement).await
+    }
+}
+
+fn record_columns() -> [FeedbackReports; 8] {
+    [
+        FeedbackReports::Id,
+        FeedbackReports::CreatedAtUnixNanos,
+        FeedbackReports::TryingToDo,
+        FeedbackReports::Tried,
+        FeedbackReports::Stuck,
+        FeedbackReports::PublishStatus,
+        FeedbackReports::PublishError,
+        FeedbackReports::PublishedAtUnixNanos,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::FeedbackReportRecord;
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    async fn feedback_report_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_feedback_report_repository_round_trip(&db).await;
+        assert_feedback_report_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn feedback_report_repository_round_trips_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_feedback_report_repository_round_trip(&db).await;
+        assert_feedback_report_repository_round_trip(&db).await;
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    async fn assert_feedback_report_repository_round_trip(db: &CoralDb) {
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let workspace = WorkspaceName::parse(&format!("feedback{suffix}")).expect("workspace");
+        let other_workspace =
+            WorkspaceName::parse(&format!("feedbackalt{suffix}")).expect("workspace");
+        let report = FeedbackReportRecord {
+            id: "feedback-1".to_string(),
+            created_at_unix_nanos: 42,
+            trying_to_do: "find stale state".to_string(),
+            tried: "checked logs".to_string(),
+            stuck: "no durable feedback row".to_string(),
+            publish_status: Some("accepted".to_string()),
+            publish_error: None,
+            published_at_unix_nanos: Some(99),
+        };
+        let other = FeedbackReportRecord {
+            id: "feedback-2".to_string(),
+            created_at_unix_nanos: 43,
+            publish_status: Some("failed".to_string()),
+            publish_error: Some("network".to_string()),
+            published_at_unix_nanos: None,
+            ..report.clone()
+        };
+        let alternate_workspace_report = FeedbackReportRecord {
+            trying_to_do: "same report id elsewhere".to_string(),
+            ..report.clone()
+        };
+
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("ensure workspace");
+        tx.workspaces()
+            .ensure(other_workspace.as_str(), 2)
+            .await
+            .expect("ensure alternate workspace");
+        tx.feedback_reports()
+            .append(&workspace, &report)
+            .await
+            .expect("append report");
+        tx.feedback_reports()
+            .append(&workspace, &other)
+            .await
+            .expect("append second report");
+        tx.feedback_reports()
+            .append(&other_workspace, &alternate_workspace_report)
+            .await
+            .expect("same report id should be valid in another workspace");
+        tx.commit().await.expect("commit feedback reports");
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .feedback_reports()
+                .get(&workspace, "feedback-1")
+                .await
+                .expect("get report"),
+            Some(report.clone())
+        );
+        assert_eq!(
+            session
+                .feedback_reports()
+                .list_workspace_reports(&workspace)
+                .await
+                .expect("list reports"),
+            vec![report.clone(), other]
+        );
+        assert_eq!(
+            session
+                .feedback_reports()
+                .get(&other_workspace, "feedback-1")
+                .await
+                .expect("get alternate workspace report"),
+            Some(alternate_workspace_report)
+        );
+        assert_feedback_report_rejects_missing_workspace(db).await;
+        assert_feedback_report_cascades_with_workspace(db, &workspace, &report).await;
+    }
+
+    async fn assert_feedback_report_rejects_missing_workspace(db: &CoralDb) {
+        let workspace = WorkspaceName::parse(&format!("missing{}", uuid::Uuid::new_v4().simple()))
+            .expect("workspace");
+        let report = feedback_report("orphan");
+        let mut tx = db.begin().await.expect("begin orphan tx");
+
+        let error = tx
+            .feedback_reports()
+            .append(&workspace, &report)
+            .await
+            .expect_err("feedback reports must require an existing workspace");
+
+        assert!(
+            error.to_string().to_lowercase().contains("foreign key"),
+            "unexpected error: {error}"
+        );
+        tx.rollback().await.expect("rollback orphan tx");
+    }
+
+    async fn assert_feedback_report_cascades_with_workspace(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        report: &FeedbackReportRecord,
+    ) {
+        let mut tx = db.begin().await.expect("begin cascade tx");
+        tx.workspaces()
+            .remove(workspace.as_str())
+            .await
+            .expect("remove workspace");
+        tx.commit().await.expect("commit cascade tx");
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .feedback_reports()
+                .get(workspace, &report.id)
+                .await
+                .expect("get cascaded report"),
+            None
+        );
+        assert!(
+            session
+                .feedback_reports()
+                .list_workspace_reports(workspace)
+                .await
+                .expect("list cascaded reports")
+                .is_empty()
+        );
+    }
+
+    fn feedback_report(id: &str) -> FeedbackReportRecord {
+        FeedbackReportRecord {
+            id: id.to_string(),
+            created_at_unix_nanos: 42,
+            trying_to_do: "find stale state".to_string(),
+            tried: "checked logs".to_string(),
+            stuck: "no durable feedback row".to_string(),
+            publish_status: Some("accepted".to_string()),
+            publish_error: None,
+            published_at_unix_nanos: Some(99),
+        }
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/identity_specs.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs.rs
@@ -1,0 +1,1314 @@
+use sea_query::{Expr, ExprTrait, OnConflict, Order, Query};
+
+use crate::identity::parse_path_segment;
+use crate::state::db::schema::{IdentitySpecDocuments, IdentitySpecs};
+use crate::state::db::{DbError, DbSession, DbWriteSession};
+use crate::workspaces::WorkspaceName;
+
+const GLOBAL_SCOPE_KIND: &str = "global";
+const GLOBAL_SCOPE_ID: &str = "__global__";
+const WORKSPACE_SCOPE_KIND: &str = "workspace";
+const SUPPORTED_AAD_VERSION: i64 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum IdentitySpecScope {
+    /// A globally installed identity spec definition.
+    Global,
+    /// An identity spec definition scoped to one workspace.
+    Workspace(WorkspaceName),
+}
+
+impl IdentitySpecScope {
+    /// Build the global identity-spec scope.
+    pub(crate) fn global() -> Self {
+        Self::Global
+    }
+
+    /// Build a workspace identity-spec scope.
+    pub(crate) fn workspace(workspace_name: WorkspaceName) -> Self {
+        Self::Workspace(workspace_name)
+    }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Global => GLOBAL_SCOPE_KIND,
+            Self::Workspace(_workspace_name) => WORKSPACE_SCOPE_KIND,
+        }
+    }
+
+    fn scope_id(&self) -> &str {
+        match self {
+            Self::Global => GLOBAL_SCOPE_ID,
+            Self::Workspace(workspace_name) => workspace_name.as_str(),
+        }
+    }
+
+    fn workspace_id(&self) -> Option<&str> {
+        match self {
+            Self::Global => None,
+            Self::Workspace(workspace_name) => Some(workspace_name.as_str()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IdentitySpecKey {
+    /// Scope that owns this identity spec definition.
+    pub(crate) scope: IdentitySpecScope,
+    /// Identity spec name unique within the scope.
+    pub(crate) name: String,
+}
+
+impl IdentitySpecKey {
+    /// Build an identity-spec key from a scope and validated name.
+    pub(crate) fn new(scope: IdentitySpecScope, name: &str) -> Result<Self, DbError> {
+        Ok(Self {
+            scope,
+            name: parse_identity_spec_name(name)?,
+        })
+    }
+
+    /// Build a global identity-spec key.
+    pub(crate) fn global(name: &str) -> Result<Self, DbError> {
+        Self::new(IdentitySpecScope::global(), name)
+    }
+
+    /// Build a workspace-scoped identity-spec key.
+    pub(crate) fn workspace(workspace_name: WorkspaceName, name: &str) -> Result<Self, DbError> {
+        Self::new(IdentitySpecScope::workspace(workspace_name), name)
+    }
+
+    fn from_spec_storage_parts(
+        scope_kind: &str,
+        scope_id: &str,
+        workspace_id: Option<&str>,
+        name: &str,
+    ) -> Result<Self, DbError> {
+        let scope = match (scope_kind, workspace_id) {
+            (GLOBAL_SCOPE_KIND, None) if scope_id == GLOBAL_SCOPE_ID => IdentitySpecScope::Global,
+            (GLOBAL_SCOPE_KIND, _) => {
+                return Err(DbError::InvalidData(
+                    "global identity spec row has invalid scope columns".to_string(),
+                ));
+            }
+            (WORKSPACE_SCOPE_KIND, Some(workspace_id)) if scope_id == workspace_id => {
+                IdentitySpecScope::Workspace(parse_workspace_name(workspace_id)?)
+            }
+            (WORKSPACE_SCOPE_KIND, _) => {
+                return Err(DbError::InvalidData(
+                    "workspace identity spec row has invalid scope columns".to_string(),
+                ));
+            }
+            (other, _) => {
+                return Err(DbError::InvalidData(format!(
+                    "identity spec row has invalid scope kind '{other}'"
+                )));
+            }
+        };
+        Self::new(scope, name)
+    }
+
+    fn from_document_storage_parts(
+        scope_kind: &str,
+        scope_id: &str,
+        name: &str,
+    ) -> Result<Self, DbError> {
+        let scope = match scope_kind {
+            GLOBAL_SCOPE_KIND if scope_id == GLOBAL_SCOPE_ID => IdentitySpecScope::Global,
+            GLOBAL_SCOPE_KIND => {
+                return Err(DbError::InvalidData(
+                    "global identity spec document row has invalid scope columns".to_string(),
+                ));
+            }
+            WORKSPACE_SCOPE_KIND => IdentitySpecScope::Workspace(parse_workspace_name(scope_id)?),
+            other => {
+                return Err(DbError::InvalidData(format!(
+                    "identity spec document row has invalid scope kind '{other}'"
+                )));
+            }
+        };
+        Self::new(scope, name)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IdentitySpecRecord {
+    /// Scope and name that identify this identity spec.
+    pub(crate) key: IdentitySpecKey,
+    /// Authored identity spec version string.
+    pub(crate) version: String,
+    /// Human-readable identity spec description.
+    pub(crate) description: String,
+    /// Issuer identifier declared by the identity spec.
+    pub(crate) issuer: String,
+    /// Identity mechanism declared by the identity spec.
+    pub(crate) identity_type: String,
+    /// Authored identity spec manifest YAML.
+    pub(crate) manifest_yaml: String,
+    /// Creation timestamp in Unix nanoseconds.
+    pub(crate) created_at_unix_nanos: i64,
+    /// Last update timestamp in Unix nanoseconds.
+    pub(crate) updated_at_unix_nanos: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IdentitySpecWrite {
+    /// Authored identity spec version string.
+    pub(crate) version: String,
+    /// Human-readable identity spec description.
+    pub(crate) description: String,
+    /// Issuer identifier declared by the identity spec.
+    pub(crate) issuer: String,
+    /// Identity mechanism declared by the identity spec.
+    pub(crate) identity_type: String,
+    /// Authored identity spec manifest YAML.
+    pub(crate) manifest_yaml: String,
+}
+
+impl IdentitySpecWrite {
+    fn validate(&self) -> Result<(), DbError> {
+        if self.version.trim().is_empty()
+            || self.issuer.trim().is_empty()
+            || self.identity_type.trim().is_empty()
+            || self.manifest_yaml.trim().is_empty()
+        {
+            return Err(DbError::InvalidData(
+                "identity spec write has an empty required field".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct IdentitySpecRow {
+    scope_kind: String,
+    scope_id: String,
+    workspace_id: Option<String>,
+    name: String,
+    version: String,
+    description: String,
+    issuer: String,
+    identity_type: String,
+    manifest_yaml: String,
+    created_at_unix_nanos: i64,
+    updated_at_unix_nanos: i64,
+}
+
+impl IdentitySpecRow {
+    fn validate(self) -> Result<IdentitySpecRecord, DbError> {
+        if self.created_at_unix_nanos < 0 || self.updated_at_unix_nanos < 0 {
+            return Err(DbError::InvalidData(
+                "identity spec row has a negative timestamp".to_string(),
+            ));
+        }
+        let write = IdentitySpecWrite {
+            version: self.version,
+            description: self.description,
+            issuer: self.issuer,
+            identity_type: self.identity_type,
+            manifest_yaml: self.manifest_yaml,
+        };
+        write.validate()?;
+        Ok(IdentitySpecRecord {
+            key: IdentitySpecKey::from_spec_storage_parts(
+                &self.scope_kind,
+                &self.scope_id,
+                self.workspace_id.as_deref(),
+                &self.name,
+            )?,
+            version: write.version,
+            description: write.description,
+            issuer: write.issuer,
+            identity_type: write.identity_type,
+            manifest_yaml: write.manifest_yaml,
+            created_at_unix_nanos: self.created_at_unix_nanos,
+            updated_at_unix_nanos: self.updated_at_unix_nanos,
+        })
+    }
+}
+
+/// Repository for durable DSL v4 identity spec definitions.
+pub(crate) struct IdentitySpecsRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> IdentitySpecsRepo<'a, S>
+where
+    S: DbSession,
+{
+    /// Create an identity-spec repository over an existing DB session.
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    /// Load one identity spec by exact scope and name.
+    pub(crate) async fn load_optional(
+        &mut self,
+        key: &IdentitySpecKey,
+    ) -> Result<Option<IdentitySpecRecord>, DbError> {
+        let row: Option<IdentitySpecRow> = self
+            .session
+            .fetch_optional(
+                identity_spec_select()
+                    .and_where(spec_key_where(key))
+                    .to_owned(),
+            )
+            .await?;
+        row.map(IdentitySpecRow::validate).transpose()
+    }
+
+    /// List globally installed identity specs.
+    pub(crate) async fn list_global(&mut self) -> Result<Vec<IdentitySpecRecord>, DbError> {
+        self.list_scope(&IdentitySpecScope::Global).await
+    }
+
+    /// List identity specs scoped to one workspace.
+    pub(crate) async fn list_workspace(
+        &mut self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<IdentitySpecRecord>, DbError> {
+        self.list_scope(&IdentitySpecScope::Workspace(workspace_name.clone()))
+            .await
+    }
+
+    /// List global identity specs followed by one workspace's scoped specs.
+    pub(crate) async fn list_global_and_workspace(
+        &mut self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<IdentitySpecRecord>, DbError> {
+        let mut records = self.list_global().await?;
+        records.extend(self.list_workspace(workspace_name).await?);
+        Ok(records)
+    }
+
+    async fn list_scope(
+        &mut self,
+        scope: &IdentitySpecScope,
+    ) -> Result<Vec<IdentitySpecRecord>, DbError> {
+        let rows: Vec<IdentitySpecRow> = self
+            .session
+            .fetch_all(
+                identity_spec_select()
+                    .and_where(spec_scope_where(scope))
+                    .order_by(IdentitySpecs::Name, Order::Asc)
+                    .to_owned(),
+            )
+            .await?;
+        rows.into_iter().map(IdentitySpecRow::validate).collect()
+    }
+}
+
+impl<S> IdentitySpecsRepo<'_, S>
+where
+    S: DbWriteSession,
+{
+    /// Insert or replace an identity spec while preserving creation time.
+    pub(crate) async fn upsert(
+        &mut self,
+        key: &IdentitySpecKey,
+        spec: &IdentitySpecWrite,
+        now_unix_nanos: i64,
+    ) -> Result<IdentitySpecRecord, DbError> {
+        validate_timestamp(now_unix_nanos)?;
+        spec.validate()?;
+        let statement = Query::insert()
+            .into_table(IdentitySpecs::Table)
+            .columns([
+                IdentitySpecs::ScopeKind,
+                IdentitySpecs::ScopeId,
+                IdentitySpecs::WorkspaceId,
+                IdentitySpecs::Name,
+                IdentitySpecs::Version,
+                IdentitySpecs::Description,
+                IdentitySpecs::Issuer,
+                IdentitySpecs::IdentityType,
+                IdentitySpecs::ManifestYaml,
+                IdentitySpecs::CreatedAtUnixNanos,
+                IdentitySpecs::UpdatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(key.scope.kind()),
+                Expr::val(key.scope.scope_id().to_string()),
+                Expr::val(key.scope.workspace_id().map(ToString::to_string)),
+                Expr::val(key.name.clone()),
+                Expr::val(spec.version.clone()),
+                Expr::val(spec.description.clone()),
+                Expr::val(spec.issuer.clone()),
+                Expr::val(spec.identity_type.clone()),
+                Expr::val(spec.manifest_yaml.clone()),
+                Expr::val(now_unix_nanos),
+                Expr::val(now_unix_nanos),
+            ])
+            .on_conflict(
+                OnConflict::columns([
+                    IdentitySpecs::ScopeKind,
+                    IdentitySpecs::ScopeId,
+                    IdentitySpecs::Name,
+                ])
+                .update_columns([
+                    IdentitySpecs::Version,
+                    IdentitySpecs::Description,
+                    IdentitySpecs::Issuer,
+                    IdentitySpecs::IdentityType,
+                    IdentitySpecs::ManifestYaml,
+                    IdentitySpecs::UpdatedAtUnixNanos,
+                ])
+                .to_owned(),
+            )
+            .to_owned();
+        self.session.execute(statement).await?;
+        self.load_optional(key)
+            .await?
+            .ok_or_else(|| DbError::InvalidData("identity spec upsert did not persist".to_string()))
+    }
+
+    /// Delete an identity spec and cascade any encrypted setup-input document.
+    pub(crate) async fn delete(
+        &mut self,
+        key: &IdentitySpecKey,
+    ) -> Result<Option<IdentitySpecRecord>, DbError> {
+        let removed = self.load_optional(key).await?;
+        let statement = Query::delete()
+            .from_table(IdentitySpecs::Table)
+            .and_where(spec_key_where(key))
+            .to_owned();
+        self.session.execute_delete(statement).await?;
+        Ok(removed)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct IdentitySpecDocumentRecord {
+    /// Identity spec that owns this encrypted setup-input document.
+    pub(crate) key: IdentitySpecKey,
+    /// Monotonic version of the stored encrypted document.
+    pub(crate) document_version: i64,
+    /// Encrypted opaque setup-input bytes.
+    pub(crate) ciphertext: Vec<u8>,
+    /// Nonce used by the envelope-encrypted document.
+    pub(crate) nonce: Vec<u8>,
+    /// Wrapped data-encryption key bytes.
+    pub(crate) wrapped_dek: Vec<u8>,
+    /// Nonce used for the wrapped data-encryption key.
+    pub(crate) wrapped_dek_nonce: Vec<u8>,
+    /// Key-encryption-key identifier.
+    pub(crate) key_id: String,
+    /// Envelope encryption algorithm identifier.
+    pub(crate) algorithm: String,
+    /// AAD version written by the future identity document crypto layer.
+    pub(crate) aad_version: i64,
+    /// Creation timestamp in Unix nanoseconds.
+    pub(crate) created_at_unix_nanos: i64,
+    /// Last update timestamp in Unix nanoseconds.
+    pub(crate) updated_at_unix_nanos: i64,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct IdentitySpecDocumentWrite {
+    /// Encrypted opaque setup-input bytes.
+    pub(crate) ciphertext: Vec<u8>,
+    /// Nonce used by the envelope-encrypted document.
+    pub(crate) nonce: Vec<u8>,
+    /// Wrapped data-encryption key bytes.
+    pub(crate) wrapped_dek: Vec<u8>,
+    /// Nonce used for the wrapped data-encryption key.
+    pub(crate) wrapped_dek_nonce: Vec<u8>,
+    /// Key-encryption-key identifier.
+    pub(crate) key_id: String,
+    /// Envelope encryption algorithm identifier.
+    pub(crate) algorithm: String,
+    /// AAD version written by the future identity document crypto layer.
+    pub(crate) aad_version: i64,
+}
+
+impl std::fmt::Debug for IdentitySpecDocumentRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IdentitySpecDocumentRecord")
+            .field("key", &self.key)
+            .field("document_version", &self.document_version)
+            .field("ciphertext_len", &self.ciphertext.len())
+            .field("nonce_len", &self.nonce.len())
+            .field("wrapped_dek_len", &self.wrapped_dek.len())
+            .field("wrapped_dek_nonce_len", &self.wrapped_dek_nonce.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for IdentitySpecDocumentWrite {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IdentitySpecDocumentWrite")
+            .field("ciphertext_len", &self.ciphertext.len())
+            .field("nonce_len", &self.nonce.len())
+            .field("wrapped_dek_len", &self.wrapped_dek.len())
+            .field("wrapped_dek_nonce_len", &self.wrapped_dek_nonce.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl IdentitySpecDocumentWrite {
+    fn validate(&self) -> Result<(), DbError> {
+        if self.ciphertext.is_empty()
+            || self.nonce.is_empty()
+            || self.wrapped_dek.is_empty()
+            || self.wrapped_dek_nonce.is_empty()
+        {
+            return Err(DbError::InvalidData(
+                "identity spec document has an empty encrypted byte field".to_string(),
+            ));
+        }
+        if self.key_id.trim().is_empty() || self.algorithm.trim().is_empty() {
+            return Err(DbError::InvalidData(
+                "identity spec document has invalid envelope metadata".to_string(),
+            ));
+        }
+        if self.aad_version != SUPPORTED_AAD_VERSION {
+            return Err(DbError::InvalidData(format!(
+                "identity spec document has unsupported aad_version {}",
+                self.aad_version
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct IdentitySpecDocumentRow {
+    scope_kind: String,
+    scope_id: String,
+    name: String,
+    document_version: i64,
+    ciphertext: Vec<u8>,
+    nonce: Vec<u8>,
+    wrapped_dek: Vec<u8>,
+    wrapped_dek_nonce: Vec<u8>,
+    key_id: String,
+    algorithm: String,
+    aad_version: i64,
+    created_at_unix_nanos: i64,
+    updated_at_unix_nanos: i64,
+}
+
+impl IdentitySpecDocumentRow {
+    fn validate(self) -> Result<IdentitySpecDocumentRecord, DbError> {
+        if self.document_version < 0
+            || self.created_at_unix_nanos < 0
+            || self.updated_at_unix_nanos < 0
+        {
+            return Err(DbError::InvalidData(
+                "identity spec document has negative version or timestamp".to_string(),
+            ));
+        }
+        let document = IdentitySpecDocumentWrite {
+            ciphertext: self.ciphertext,
+            nonce: self.nonce,
+            wrapped_dek: self.wrapped_dek,
+            wrapped_dek_nonce: self.wrapped_dek_nonce,
+            key_id: self.key_id,
+            algorithm: self.algorithm,
+            aad_version: self.aad_version,
+        };
+        document.validate()?;
+        Ok(IdentitySpecDocumentRecord {
+            key: IdentitySpecKey::from_document_storage_parts(
+                &self.scope_kind,
+                &self.scope_id,
+                &self.name,
+            )?,
+            document_version: self.document_version,
+            ciphertext: document.ciphertext,
+            nonce: document.nonce,
+            wrapped_dek: document.wrapped_dek,
+            wrapped_dek_nonce: document.wrapped_dek_nonce,
+            key_id: document.key_id,
+            algorithm: document.algorithm,
+            aad_version: document.aad_version,
+            created_at_unix_nanos: self.created_at_unix_nanos,
+            updated_at_unix_nanos: self.updated_at_unix_nanos,
+        })
+    }
+}
+
+/// Repository for encrypted setup-input documents owned by identity specs.
+pub(crate) struct IdentitySpecDocumentsRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> IdentitySpecDocumentsRepo<'a, S>
+where
+    S: DbSession,
+{
+    /// Create an identity-spec document repository over an existing DB session.
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    /// Load one encrypted setup-input document by identity spec key.
+    pub(crate) async fn load_optional(
+        &mut self,
+        key: &IdentitySpecKey,
+    ) -> Result<Option<IdentitySpecDocumentRecord>, DbError> {
+        let row: Option<IdentitySpecDocumentRow> = self
+            .session
+            .fetch_optional(
+                identity_spec_document_select()
+                    .and_where(document_key_where(key))
+                    .to_owned(),
+            )
+            .await?;
+        row.map(IdentitySpecDocumentRow::validate).transpose()
+    }
+
+    /// List encrypted setup-input documents for global identity specs.
+    pub(crate) async fn list_global(&mut self) -> Result<Vec<IdentitySpecDocumentRecord>, DbError> {
+        self.list_scope(&IdentitySpecScope::Global).await
+    }
+
+    /// List encrypted setup-input documents for one workspace's identity specs.
+    pub(crate) async fn list_workspace(
+        &mut self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<IdentitySpecDocumentRecord>, DbError> {
+        self.list_scope(&IdentitySpecScope::Workspace(workspace_name.clone()))
+            .await
+    }
+
+    /// List global setup-input documents followed by one workspace's documents.
+    pub(crate) async fn list_global_and_workspace(
+        &mut self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<IdentitySpecDocumentRecord>, DbError> {
+        let mut records = self.list_global().await?;
+        records.extend(self.list_workspace(workspace_name).await?);
+        Ok(records)
+    }
+
+    async fn list_scope(
+        &mut self,
+        scope: &IdentitySpecScope,
+    ) -> Result<Vec<IdentitySpecDocumentRecord>, DbError> {
+        let rows: Vec<IdentitySpecDocumentRow> = self
+            .session
+            .fetch_all(
+                identity_spec_document_select()
+                    .and_where(document_scope_where(scope))
+                    .order_by(IdentitySpecDocuments::Name, Order::Asc)
+                    .to_owned(),
+            )
+            .await?;
+        rows.into_iter()
+            .map(IdentitySpecDocumentRow::validate)
+            .collect()
+    }
+}
+
+impl<S> IdentitySpecDocumentsRepo<'_, S>
+where
+    S: DbWriteSession,
+{
+    /// Insert or replace an encrypted setup-input document and bump its version.
+    pub(crate) async fn upsert(
+        &mut self,
+        key: &IdentitySpecKey,
+        document: &IdentitySpecDocumentWrite,
+        now_unix_nanos: i64,
+    ) -> Result<IdentitySpecDocumentRecord, DbError> {
+        validate_timestamp(now_unix_nanos)?;
+        document.validate()?;
+        let Some(current) = self.load_optional(key).await? else {
+            self.insert(key, document, now_unix_nanos).await?;
+            return self.load_optional(key).await?.ok_or_else(|| {
+                DbError::InvalidData("identity spec document upsert did not persist".to_string())
+            });
+        };
+        let document_version = current.document_version.checked_add(1).ok_or_else(|| {
+            DbError::InvalidData(format!(
+                "identity spec document version overflow for {}:{}",
+                key.scope.scope_id(),
+                key.name
+            ))
+        })?;
+        let statement = Query::update()
+            .table(IdentitySpecDocuments::Table)
+            .value(
+                IdentitySpecDocuments::DocumentVersion,
+                Expr::val(document_version),
+            )
+            .value(
+                IdentitySpecDocuments::Ciphertext,
+                Expr::val(document.ciphertext.clone()),
+            )
+            .value(
+                IdentitySpecDocuments::Nonce,
+                Expr::val(document.nonce.clone()),
+            )
+            .value(
+                IdentitySpecDocuments::WrappedDek,
+                Expr::val(document.wrapped_dek.clone()),
+            )
+            .value(
+                IdentitySpecDocuments::WrappedDekNonce,
+                Expr::val(document.wrapped_dek_nonce.clone()),
+            )
+            .value(
+                IdentitySpecDocuments::KeyId,
+                Expr::val(document.key_id.clone()),
+            )
+            .value(
+                IdentitySpecDocuments::Algorithm,
+                Expr::val(document.algorithm.clone()),
+            )
+            .value(
+                IdentitySpecDocuments::AadVersion,
+                Expr::val(document.aad_version),
+            )
+            .value(
+                IdentitySpecDocuments::UpdatedAtUnixNanos,
+                Expr::val(now_unix_nanos),
+            )
+            .and_where(document_key_where(key))
+            .and_where(
+                Expr::col(IdentitySpecDocuments::DocumentVersion).eq(current.document_version),
+            )
+            .to_owned();
+        if self.session.execute_update(statement).await? != 1 {
+            return Err(DbError::InvalidData(
+                "identity spec document changed while being updated".to_string(),
+            ));
+        }
+        self.load_optional(key).await?.ok_or_else(|| {
+            DbError::InvalidData("identity spec document disappeared after update".to_string())
+        })
+    }
+
+    /// Delete one encrypted setup-input document without deleting the spec row.
+    pub(crate) async fn delete(
+        &mut self,
+        key: &IdentitySpecKey,
+    ) -> Result<Option<IdentitySpecDocumentRecord>, DbError> {
+        let removed = self.load_optional(key).await?;
+        let statement = Query::delete()
+            .from_table(IdentitySpecDocuments::Table)
+            .and_where(document_key_where(key))
+            .to_owned();
+        self.session.execute_delete(statement).await?;
+        Ok(removed)
+    }
+
+    async fn insert(
+        &mut self,
+        key: &IdentitySpecKey,
+        document: &IdentitySpecDocumentWrite,
+        now_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(IdentitySpecDocuments::Table)
+            .columns([
+                IdentitySpecDocuments::ScopeKind,
+                IdentitySpecDocuments::ScopeId,
+                IdentitySpecDocuments::Name,
+                IdentitySpecDocuments::DocumentVersion,
+                IdentitySpecDocuments::Ciphertext,
+                IdentitySpecDocuments::Nonce,
+                IdentitySpecDocuments::WrappedDek,
+                IdentitySpecDocuments::WrappedDekNonce,
+                IdentitySpecDocuments::KeyId,
+                IdentitySpecDocuments::Algorithm,
+                IdentitySpecDocuments::AadVersion,
+                IdentitySpecDocuments::CreatedAtUnixNanos,
+                IdentitySpecDocuments::UpdatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(key.scope.kind()),
+                Expr::val(key.scope.scope_id().to_string()),
+                Expr::val(key.name.clone()),
+                Expr::val(1),
+                Expr::val(document.ciphertext.clone()),
+                Expr::val(document.nonce.clone()),
+                Expr::val(document.wrapped_dek.clone()),
+                Expr::val(document.wrapped_dek_nonce.clone()),
+                Expr::val(document.key_id.clone()),
+                Expr::val(document.algorithm.clone()),
+                Expr::val(document.aad_version),
+                Expr::val(now_unix_nanos),
+                Expr::val(now_unix_nanos),
+            ])
+            .to_owned();
+        self.session.execute(statement).await
+    }
+}
+
+fn identity_spec_select() -> sea_query::SelectStatement {
+    Query::select()
+        .columns([
+            IdentitySpecs::ScopeKind,
+            IdentitySpecs::ScopeId,
+            IdentitySpecs::WorkspaceId,
+            IdentitySpecs::Name,
+            IdentitySpecs::Version,
+            IdentitySpecs::Description,
+            IdentitySpecs::Issuer,
+            IdentitySpecs::IdentityType,
+            IdentitySpecs::ManifestYaml,
+            IdentitySpecs::CreatedAtUnixNanos,
+            IdentitySpecs::UpdatedAtUnixNanos,
+        ])
+        .from(IdentitySpecs::Table)
+        .to_owned()
+}
+
+fn identity_spec_document_select() -> sea_query::SelectStatement {
+    Query::select()
+        .columns([
+            IdentitySpecDocuments::ScopeKind,
+            IdentitySpecDocuments::ScopeId,
+            IdentitySpecDocuments::Name,
+            IdentitySpecDocuments::DocumentVersion,
+            IdentitySpecDocuments::Ciphertext,
+            IdentitySpecDocuments::Nonce,
+            IdentitySpecDocuments::WrappedDek,
+            IdentitySpecDocuments::WrappedDekNonce,
+            IdentitySpecDocuments::KeyId,
+            IdentitySpecDocuments::Algorithm,
+            IdentitySpecDocuments::AadVersion,
+            IdentitySpecDocuments::CreatedAtUnixNanos,
+            IdentitySpecDocuments::UpdatedAtUnixNanos,
+        ])
+        .from(IdentitySpecDocuments::Table)
+        .to_owned()
+}
+
+fn spec_key_where(key: &IdentitySpecKey) -> sea_query::SimpleExpr {
+    spec_scope_where(&key.scope).and(Expr::col(IdentitySpecs::Name).eq(key.name.as_str()))
+}
+
+fn spec_scope_where(scope: &IdentitySpecScope) -> sea_query::SimpleExpr {
+    Expr::col(IdentitySpecs::ScopeKind)
+        .eq(scope.kind())
+        .and(Expr::col(IdentitySpecs::ScopeId).eq(scope.scope_id()))
+}
+
+fn document_key_where(key: &IdentitySpecKey) -> sea_query::SimpleExpr {
+    document_scope_where(&key.scope)
+        .and(Expr::col(IdentitySpecDocuments::Name).eq(key.name.as_str()))
+}
+
+fn document_scope_where(scope: &IdentitySpecScope) -> sea_query::SimpleExpr {
+    Expr::col(IdentitySpecDocuments::ScopeKind)
+        .eq(scope.kind())
+        .and(Expr::col(IdentitySpecDocuments::ScopeId).eq(scope.scope_id()))
+}
+
+fn parse_identity_spec_name(name: &str) -> Result<String, DbError> {
+    parse_path_segment("identity spec", name).map_err(|error| {
+        DbError::InvalidData(format!("invalid identity spec name '{name}': {error}"))
+    })
+}
+
+fn parse_workspace_name(workspace_id: &str) -> Result<WorkspaceName, DbError> {
+    WorkspaceName::parse(workspace_id).map_err(|error| {
+        DbError::InvalidData(format!("invalid workspace id '{workspace_id}': {error}"))
+    })
+}
+
+fn validate_timestamp(now_unix_nanos: i64) -> Result<(), DbError> {
+    if now_unix_nanos < 0 {
+        return Err(DbError::InvalidData(
+            "identity spec timestamp is negative".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_query::{Expr, ExprTrait, Query};
+    use tempfile::tempdir;
+
+    use super::{
+        GLOBAL_SCOPE_ID, IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey,
+        IdentitySpecRecord, IdentitySpecWrite,
+    };
+    use crate::bootstrap;
+    use crate::state::db::schema::{IdentitySpecDocuments, IdentitySpecs};
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DbError, DbWriteSession, ResolvedDatabaseConfig};
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    async fn identity_spec_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+
+        assert_identity_spec_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    async fn identity_spec_repository_rejects_corrupt_rows_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+
+        assert_identity_spec_repository_rejects_corrupt_rows(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn identity_spec_repository_round_trips_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_identity_spec_repository_round_trip(&db).await;
+    }
+
+    #[expect(clippy::too_many_lines, reason = "repository contract fixture")]
+    async fn assert_identity_spec_repository_round_trip(db: &CoralDb) {
+        let workspace = unique_workspace("identity");
+        let alternate_workspace = unique_workspace("identityalt");
+        let global_key = IdentitySpecKey::global("github").expect("global key");
+        let workspace_key =
+            IdentitySpecKey::workspace(workspace.clone(), "github").expect("workspace key");
+        let alternate_key =
+            IdentitySpecKey::workspace(alternate_workspace.clone(), "github").expect("alt key");
+
+        let first_global = spec_write("1.0.0", "GitHub OAuth", "github", "oauth");
+        let replacement_global = spec_write("1.1.0", "GitHub OAuth v2", "github", "oauth");
+        let workspace_spec =
+            spec_write("2.0.0", "Workspace override", "github-enterprise", "oauth");
+
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("ensure workspace");
+        tx.identity_specs()
+            .upsert(&global_key, &first_global, 10)
+            .await
+            .expect("upsert global spec");
+        tx.identity_specs()
+            .upsert(&workspace_key, &workspace_spec, 11)
+            .await
+            .expect("upsert workspace spec");
+        tx.identity_spec_documents()
+            .upsert(&global_key, &document_write("key-1", b"global-secret"), 12)
+            .await
+            .expect("upsert global document");
+        tx.identity_spec_documents()
+            .upsert(
+                &workspace_key,
+                &document_write("key-2", b"workspace-secret"),
+                13,
+            )
+            .await
+            .expect("upsert workspace document");
+        tx.commit().await.expect("commit first identity specs");
+
+        assert_eq!(
+            load_spec(db, &global_key).await,
+            Some(spec_record(global_key.clone(), &first_global, 10, 10))
+        );
+        assert_eq!(
+            list_spec_names(db, &workspace).await,
+            vec!["github".to_string(), "github".to_string()]
+        );
+
+        let mut tx = db.begin().await.expect("begin replacement tx");
+        tx.identity_specs()
+            .upsert(&global_key, &replacement_global, 20)
+            .await
+            .expect("replace global spec");
+        let replaced_doc = tx
+            .identity_spec_documents()
+            .upsert(
+                &global_key,
+                &document_write("key-3", b"global-replacement"),
+                21,
+            )
+            .await
+            .expect("replace global document");
+        tx.commit().await.expect("commit replacement");
+
+        assert_eq!(
+            load_spec(db, &global_key).await,
+            Some(spec_record(global_key.clone(), &replacement_global, 10, 20))
+        );
+        assert_document(
+            &replaced_doc,
+            &global_key,
+            2,
+            "key-3",
+            b"global-replacement",
+            12,
+            21,
+        );
+        let debug = format!("{replaced_doc:?} {:?}", document_write("debug", b"secret"));
+        assert!(debug.contains("ciphertext_len") && !debug.contains("global-replacement"));
+        assert!(!debug.contains("secret"));
+
+        let mut tx = db.begin().await.expect("begin direct document delete tx");
+        let removed = tx
+            .identity_spec_documents()
+            .delete(&workspace_key)
+            .await
+            .expect("delete workspace document");
+        tx.identity_spec_documents()
+            .upsert(
+                &workspace_key,
+                &document_write("key-4", b"workspace-secret-2"),
+                22,
+            )
+            .await
+            .expect("reinsert workspace document");
+        tx.commit().await.expect("commit direct document delete");
+        assert!(removed.is_some());
+        assert!(load_spec(db, &workspace_key).await.is_some());
+
+        let mut tx = db.begin().await.expect("begin alternate tx");
+        tx.workspaces()
+            .ensure(alternate_workspace.as_str(), 23)
+            .await
+            .expect("ensure alternate workspace");
+        tx.identity_specs()
+            .upsert(&alternate_key, &workspace_spec, 24)
+            .await
+            .expect("upsert alternate workspace spec");
+        tx.identity_spec_documents()
+            .upsert(&alternate_key, &document_write("key-5", b"alternate"), 25)
+            .await
+            .expect("upsert alternate document");
+        tx.commit().await.expect("commit alternate");
+        assert_eq!(document_list(db, &alternate_workspace).await.len(), 2);
+
+        let mut tx = db.begin().await.expect("begin overflow tx");
+        set_document_version(&mut tx, &alternate_key, i64::MAX).await;
+        let error = tx
+            .identity_spec_documents()
+            .upsert(&alternate_key, &document_write("key-6", b"overflow"), 26)
+            .await
+            .expect_err("max document_version should reject next upsert");
+        assert!(error.to_string().contains("version overflow"));
+        tx.rollback().await.expect("rollback overflow tx");
+
+        let mut tx = db.begin().await.expect("begin unsupported aad tx");
+        let error = tx
+            .identity_spec_documents()
+            .upsert(
+                &alternate_key,
+                &document_write_with_aad_version("key-unsupported", b"unsupported", 2),
+                27,
+            )
+            .await
+            .expect_err("unsupported aad_version should reject writes");
+        assert_invalid_data_contains(error, "unsupported aad_version 2");
+        tx.rollback().await.expect("rollback unsupported aad tx");
+
+        let mut tx = db.begin().await.expect("begin workspace cascade tx");
+        tx.workspaces()
+            .remove(workspace.as_str())
+            .await
+            .expect("delete workspace");
+        tx.commit().await.expect("commit workspace cascade");
+        assert!(load_spec(db, &workspace_key).await.is_none());
+        assert!(load_document(db, &workspace_key).await.is_none());
+        assert!(load_spec(db, &global_key).await.is_some());
+        assert!(load_document(db, &global_key).await.is_some());
+
+        let mut tx = db.begin().await.expect("begin spec delete tx");
+        let removed = tx
+            .identity_specs()
+            .delete(&global_key)
+            .await
+            .expect("delete global spec");
+        tx.commit().await.expect("commit spec delete");
+        assert!(removed.is_some());
+        assert!(load_document(db, &global_key).await.is_none());
+
+        let missing_workspace = unique_workspace("missing");
+        let missing_workspace_key =
+            IdentitySpecKey::workspace(missing_workspace, "missing").expect("missing key");
+        let mut tx = db.begin().await.expect("begin orphan tx");
+        let error = tx
+            .identity_specs()
+            .upsert(&missing_workspace_key, &workspace_spec, 30)
+            .await
+            .expect_err("workspace spec rows must require an existing workspace");
+        assert!(error.to_string().to_lowercase().contains("foreign key"));
+        tx.rollback().await.expect("rollback orphan tx");
+    }
+
+    async fn assert_identity_spec_repository_rejects_corrupt_rows(db: &CoralDb) {
+        let key = IdentitySpecKey::global("corrupt").expect("key");
+        insert_corrupt_spec_row(db).await;
+        let mut session = db;
+        let error = session
+            .identity_specs()
+            .list_global()
+            .await
+            .expect_err("invalid identity spec row should fail");
+        assert_invalid_data_contains(error, "negative timestamp");
+
+        let mut tx = db.begin().await.expect("begin valid spec tx");
+        tx.identity_specs()
+            .upsert(&key, &spec_write("1.0.0", "Corrupt", "issuer", "oauth"), 10)
+            .await
+            .expect("upsert valid spec");
+        insert_corrupt_document_row(&mut tx, &key).await;
+        tx.commit().await.expect("commit corrupt document");
+
+        let error = session
+            .identity_spec_documents()
+            .load_optional(&key)
+            .await
+            .expect_err("invalid document row should fail");
+        assert_invalid_data_contains(error, "unsupported aad_version 2");
+    }
+
+    async fn load_spec(db: &CoralDb, key: &IdentitySpecKey) -> Option<IdentitySpecRecord> {
+        let mut session = db;
+        session
+            .identity_specs()
+            .load_optional(key)
+            .await
+            .expect("load identity spec")
+    }
+
+    async fn load_document(
+        db: &CoralDb,
+        key: &IdentitySpecKey,
+    ) -> Option<IdentitySpecDocumentRecord> {
+        let mut session = db;
+        session
+            .identity_spec_documents()
+            .load_optional(key)
+            .await
+            .expect("load identity spec document")
+    }
+
+    async fn list_spec_names(db: &CoralDb, workspace: &WorkspaceName) -> Vec<String> {
+        let mut session = db;
+        session
+            .identity_specs()
+            .list_global_and_workspace(workspace)
+            .await
+            .expect("list identity specs")
+            .into_iter()
+            .map(|record| record.key.name)
+            .collect()
+    }
+
+    async fn document_list(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+    ) -> Vec<IdentitySpecDocumentRecord> {
+        let mut session = db;
+        session
+            .identity_spec_documents()
+            .list_global_and_workspace(workspace)
+            .await
+            .expect("list identity spec documents")
+    }
+
+    async fn set_document_version<S>(session: &mut S, key: &IdentitySpecKey, version: i64)
+    where
+        S: DbWriteSession,
+    {
+        session
+            .execute_update(
+                Query::update()
+                    .table(IdentitySpecDocuments::Table)
+                    .value(IdentitySpecDocuments::DocumentVersion, Expr::val(version))
+                    .and_where(Expr::col(IdentitySpecDocuments::ScopeKind).eq(key.scope.kind()))
+                    .and_where(Expr::col(IdentitySpecDocuments::ScopeId).eq(key.scope.scope_id()))
+                    .and_where(Expr::col(IdentitySpecDocuments::Name).eq(key.name.as_str()))
+                    .to_owned(),
+            )
+            .await
+            .expect("set document version");
+    }
+
+    async fn insert_corrupt_spec_row(db: &CoralDb) {
+        let mut tx = db.begin().await.expect("begin corrupt spec tx");
+        tx.execute(
+            Query::insert()
+                .into_table(IdentitySpecs::Table)
+                .columns([
+                    IdentitySpecs::ScopeKind,
+                    IdentitySpecs::ScopeId,
+                    IdentitySpecs::WorkspaceId,
+                    IdentitySpecs::Name,
+                    IdentitySpecs::Version,
+                    IdentitySpecs::Description,
+                    IdentitySpecs::Issuer,
+                    IdentitySpecs::IdentityType,
+                    IdentitySpecs::ManifestYaml,
+                    IdentitySpecs::CreatedAtUnixNanos,
+                    IdentitySpecs::UpdatedAtUnixNanos,
+                ])
+                .values_panic([
+                    Expr::val("global"),
+                    Expr::val(GLOBAL_SCOPE_ID),
+                    Expr::val(Option::<String>::None),
+                    Expr::val("corrupt-timestamp"),
+                    Expr::val("1.0.0"),
+                    Expr::val("corrupt"),
+                    Expr::val("issuer"),
+                    Expr::val("oauth"),
+                    Expr::val("name: corrupt\n"),
+                    Expr::val(-1),
+                    Expr::val(-1),
+                ])
+                .to_owned(),
+        )
+        .await
+        .expect("insert corrupt identity spec");
+        tx.commit().await.expect("commit corrupt spec");
+    }
+
+    async fn insert_corrupt_document_row<S>(session: &mut S, key: &IdentitySpecKey)
+    where
+        S: DbWriteSession,
+    {
+        session
+            .execute(
+                Query::insert()
+                    .into_table(IdentitySpecDocuments::Table)
+                    .columns([
+                        IdentitySpecDocuments::ScopeKind,
+                        IdentitySpecDocuments::ScopeId,
+                        IdentitySpecDocuments::Name,
+                        IdentitySpecDocuments::DocumentVersion,
+                        IdentitySpecDocuments::Ciphertext,
+                        IdentitySpecDocuments::Nonce,
+                        IdentitySpecDocuments::WrappedDek,
+                        IdentitySpecDocuments::WrappedDekNonce,
+                        IdentitySpecDocuments::KeyId,
+                        IdentitySpecDocuments::Algorithm,
+                        IdentitySpecDocuments::AadVersion,
+                        IdentitySpecDocuments::CreatedAtUnixNanos,
+                        IdentitySpecDocuments::UpdatedAtUnixNanos,
+                    ])
+                    .values_panic([
+                        Expr::val(key.scope.kind()),
+                        Expr::val(key.scope.scope_id().to_string()),
+                        Expr::val(key.name.clone()),
+                        Expr::val(1),
+                        Expr::val(b"ciphertext".to_vec()),
+                        Expr::val(b"nonce".to_vec()),
+                        Expr::val(b"wrapped-dek".to_vec()),
+                        Expr::val(b"wrapped-dek-nonce".to_vec()),
+                        Expr::val("key"),
+                        Expr::val("AES-256-GCM"),
+                        Expr::val(2),
+                        Expr::val(10),
+                        Expr::val(10),
+                    ])
+                    .to_owned(),
+            )
+            .await
+            .expect("insert corrupt identity spec document");
+    }
+
+    fn spec_record(
+        key: IdentitySpecKey,
+        spec: &IdentitySpecWrite,
+        created_at_unix_nanos: i64,
+        updated_at_unix_nanos: i64,
+    ) -> IdentitySpecRecord {
+        IdentitySpecRecord {
+            key,
+            version: spec.version.clone(),
+            description: spec.description.clone(),
+            issuer: spec.issuer.clone(),
+            identity_type: spec.identity_type.clone(),
+            manifest_yaml: spec.manifest_yaml.clone(),
+            created_at_unix_nanos,
+            updated_at_unix_nanos,
+        }
+    }
+
+    fn assert_document(
+        record: &IdentitySpecDocumentRecord,
+        key: &IdentitySpecKey,
+        version: i64,
+        key_id: &str,
+        ciphertext: &[u8],
+        created_at_unix_nanos: i64,
+        updated_at_unix_nanos: i64,
+    ) {
+        assert_eq!(&record.key, key);
+        assert_eq!(record.document_version, version);
+        assert_eq!(record.key_id, key_id);
+        assert_eq!(record.ciphertext.as_slice(), ciphertext);
+        assert_eq!(record.created_at_unix_nanos, created_at_unix_nanos);
+        assert_eq!(record.updated_at_unix_nanos, updated_at_unix_nanos);
+    }
+
+    fn spec_write(
+        version: &str,
+        description: &str,
+        issuer: &str,
+        identity_type: &str,
+    ) -> IdentitySpecWrite {
+        IdentitySpecWrite {
+            version: version.to_string(),
+            description: description.to_string(),
+            issuer: issuer.to_string(),
+            identity_type: identity_type.to_string(),
+            manifest_yaml: format!(
+                "name: identity\nversion: {version}\nissuer: {issuer}\ntype: {identity_type}\n"
+            ),
+        }
+    }
+
+    fn document_write(key_id: &str, ciphertext: &[u8]) -> IdentitySpecDocumentWrite {
+        IdentitySpecDocumentWrite {
+            ciphertext: ciphertext.to_vec(),
+            nonce: format!("nonce-{key_id}").into_bytes(),
+            wrapped_dek: format!("wrapped-{key_id}").into_bytes(),
+            wrapped_dek_nonce: format!("wrapped-nonce-{key_id}").into_bytes(),
+            key_id: key_id.to_string(),
+            algorithm: "AES-256-GCM".to_string(),
+            aad_version: 1,
+        }
+    }
+
+    fn document_write_with_aad_version(
+        key_id: &str,
+        ciphertext: &[u8],
+        aad_version: i64,
+    ) -> IdentitySpecDocumentWrite {
+        IdentitySpecDocumentWrite {
+            aad_version,
+            ..document_write(key_id, ciphertext)
+        }
+    }
+
+    fn unique_workspace(prefix: &str) -> WorkspaceName {
+        WorkspaceName::parse(&format!("{prefix}{}", uuid::Uuid::new_v4().simple()))
+            .expect("workspace")
+    }
+
+    fn assert_invalid_data_contains(error: DbError, expected: &str) {
+        let DbError::InvalidData(message) = error else {
+            panic!("unexpected error: {error}");
+        };
+        assert!(
+            message.contains(expected),
+            "expected {expected:?} in error: {message}"
+        );
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/materializations.rs
+++ b/crates/coral-app/src/state/db/repositories/materializations.rs
@@ -1,0 +1,543 @@
+use sea_query::{Expr, ExprTrait, Order, Query, SelectStatement};
+
+use crate::sources::SourceName;
+use crate::state::db::schema::{MaterializationSurfaces as Surfaces, Materializations as Mats};
+use crate::state::db::{DbError, DbSession, DbWriteSession};
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MaterializationRecord {
+    pub(crate) materialization_version: String,
+    pub(crate) fingerprint_yaml: String,
+    pub(crate) projections_yaml: String,
+    pub(crate) diagnostics_yaml: String,
+    pub(crate) created_at_unix_nanos: i64,
+    pub(crate) surfaces: Vec<MaterializationSurfaceRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MaterializationSurfaceRecord {
+    pub(crate) surface_id: String,
+    pub(crate) source_document_raw: Vec<u8>,
+    pub(crate) source_document_yaml: String,
+    pub(crate) semantic_ir_yaml: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct JoinedMaterializationRow {
+    materialization_version: String,
+    fingerprint_yaml: String,
+    projections_yaml: String,
+    diagnostics_yaml: String,
+    created_at_unix_nanos: i64,
+    surface_id: Option<String>,
+    source_document_raw: Option<Vec<u8>>,
+    source_document_yaml: Option<String>,
+    semantic_ir_yaml: Option<String>,
+}
+
+pub(crate) struct MaterializationsRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> MaterializationsRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn get(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<MaterializationRecord>, DbError> {
+        let rows = self
+            .session
+            .fetch_all::<JoinedMaterializationRow>(materialization_get_statement(
+                workspace_name,
+                source_name,
+            ))
+            .await?;
+        materialization_record_from_joined_rows(rows, source_name)
+    }
+}
+
+fn materialization_get_statement(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+) -> SelectStatement {
+    Query::select()
+        .columns([
+            Mats::MaterializationVersion,
+            Mats::FingerprintYaml,
+            Mats::ProjectionsYaml,
+            Mats::DiagnosticsYaml,
+            Mats::CreatedAtUnixNanos,
+        ])
+        .columns([
+            Surfaces::SurfaceId,
+            Surfaces::SourceDocumentRaw,
+            Surfaces::SourceDocumentYaml,
+            Surfaces::SemanticIrYaml,
+        ])
+        .from(Mats::Table)
+        .left_join(
+            Surfaces::Table,
+            Expr::col((Mats::Table, Mats::WorkspaceId))
+                .equals((Surfaces::Table, Surfaces::WorkspaceId))
+                .and(
+                    Expr::col((Mats::Table, Mats::SourceName))
+                        .equals((Surfaces::Table, Surfaces::SourceName)),
+                ),
+        )
+        .and_where(Expr::col((Mats::Table, Mats::WorkspaceId)).eq(workspace_name.as_str()))
+        .and_where(Expr::col((Mats::Table, Mats::SourceName)).eq(source_name.as_str()))
+        .order_by((Surfaces::Table, Surfaces::SurfaceId), Order::Asc)
+        .to_owned()
+}
+
+fn materialization_record_from_joined_rows(
+    rows: Vec<JoinedMaterializationRow>,
+    source_name: &SourceName,
+) -> Result<Option<MaterializationRecord>, DbError> {
+    let mut rows = rows.into_iter();
+    let Some(first_row) = rows.next() else {
+        return Ok(None);
+    };
+    let materialization_version = first_row.materialization_version.clone();
+    let fingerprint_yaml = first_row.fingerprint_yaml.clone();
+    let projections_yaml = first_row.projections_yaml.clone();
+    let diagnostics_yaml = first_row.diagnostics_yaml.clone();
+    let created_at_unix_nanos = first_row.created_at_unix_nanos;
+    let mut surfaces = Vec::new();
+    if let Some(surface) = row_surface(first_row, source_name)? {
+        surfaces.push(surface);
+    }
+    for row in rows {
+        if let Some(surface) = row_surface(row, source_name)? {
+            surfaces.push(surface);
+        }
+    }
+    Ok(Some(MaterializationRecord {
+        materialization_version,
+        fingerprint_yaml,
+        projections_yaml,
+        diagnostics_yaml,
+        created_at_unix_nanos,
+        surfaces,
+    }))
+}
+
+fn row_surface(
+    row: JoinedMaterializationRow,
+    source_name: &SourceName,
+) -> Result<Option<MaterializationSurfaceRecord>, DbError> {
+    let Some(surface_id) = row.surface_id else {
+        return Ok(None);
+    };
+    Ok(Some(MaterializationSurfaceRecord {
+        surface_id,
+        source_document_raw: required_surface_field(
+            row.source_document_raw,
+            source_name,
+            "source_document_raw",
+        )?,
+        source_document_yaml: required_surface_field(
+            row.source_document_yaml,
+            source_name,
+            "source_document_yaml",
+        )?,
+        semantic_ir_yaml: required_surface_field(
+            row.semantic_ir_yaml,
+            source_name,
+            "semantic_ir_yaml",
+        )?,
+    }))
+}
+
+fn required_surface_field<T>(
+    value: Option<T>,
+    source_name: &SourceName,
+    field: &str,
+) -> Result<T, DbError> {
+    value.ok_or_else(|| {
+        DbError::InvalidData(format!(
+            "materialization surface for source '{source_name}' is missing {field}"
+        ))
+    })
+}
+
+impl<S> MaterializationsRepo<'_, S>
+where
+    S: DbWriteSession,
+{
+    pub(crate) async fn upsert(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        record: &MaterializationRecord,
+    ) -> Result<(), DbError> {
+        self.delete_materialization(workspace_name, source_name)
+            .await?;
+        let statement = Query::insert()
+            .into_table(Mats::Table)
+            .columns([
+                Mats::WorkspaceId,
+                Mats::SourceName,
+                Mats::MaterializationVersion,
+                Mats::FingerprintYaml,
+                Mats::ProjectionsYaml,
+                Mats::DiagnosticsYaml,
+                Mats::CreatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_name.as_str().to_string()),
+                Expr::val(source_name.as_str().to_string()),
+                Expr::val(record.materialization_version.clone()),
+                Expr::val(record.fingerprint_yaml.clone()),
+                Expr::val(record.projections_yaml.clone()),
+                Expr::val(record.diagnostics_yaml.clone()),
+                Expr::val(record.created_at_unix_nanos),
+            ])
+            .to_owned();
+        self.session.execute(statement).await?;
+        for surface in &record.surfaces {
+            self.insert_surface(workspace_name, source_name, surface)
+                .await?;
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn remove(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<MaterializationRecord>, DbError> {
+        let removed = self.get(workspace_name, source_name).await?;
+        self.delete_materialization(workspace_name, source_name)
+            .await?;
+        Ok(removed)
+    }
+
+    async fn insert_surface(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        surface: &MaterializationSurfaceRecord,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(Surfaces::Table)
+            .columns([
+                Surfaces::WorkspaceId,
+                Surfaces::SourceName,
+                Surfaces::SurfaceId,
+                Surfaces::SourceDocumentRaw,
+                Surfaces::SourceDocumentYaml,
+                Surfaces::SemanticIrYaml,
+            ])
+            .values_panic([
+                Expr::val(workspace_name.as_str().to_string()),
+                Expr::val(source_name.as_str().to_string()),
+                Expr::val(surface.surface_id.clone()),
+                Expr::val(surface.source_document_raw.clone()),
+                Expr::val(surface.source_document_yaml.clone()),
+                Expr::val(surface.semantic_ir_yaml.clone()),
+            ])
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    async fn delete_materialization(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(Mats::Table)
+            .and_where(Expr::col(Mats::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Mats::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        self.session.execute_delete(statement).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_query::{Alias, Expr, ExprTrait, Func, Query};
+    use tempfile::tempdir;
+
+    use super::{MaterializationRecord, MaterializationSurfaceRecord};
+    use crate::bootstrap;
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::AppStateLayout;
+    use crate::state::db::schema::MaterializationSurfaces as Surfaces;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{
+        CoralDb, DatabaseConfig, DbSession, DbWriteSession, ResolvedDatabaseConfig,
+    };
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    async fn materialization_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_materialization_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn materialization_repository_round_trips_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_materialization_repository_round_trip(&db).await;
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    #[expect(clippy::too_many_lines, reason = "repository contract fixture")]
+    async fn assert_materialization_repository_round_trip(db: &CoralDb) {
+        let ws = WorkspaceName::parse("default").expect("workspace");
+        let alt_ws = WorkspaceName::parse("alternate").expect("workspace");
+        let name = SourceName::parse("github_v4").expect("source name");
+        let source = InstalledSource {
+            name: name.clone(),
+            version: Some("0.1.0".to_string()),
+            variables: std::collections::BTreeMap::default(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            origin: SourceOrigin::Imported,
+        };
+        let empty_surfaces = MaterializationRecord {
+            surfaces: Vec::new(),
+            ..materialization_record("v4-empty", 10)
+        };
+        let first = materialization_record("v4", 11);
+        let alternate = materialization_record("v4-alternate", 12);
+        let replaced = MaterializationRecord {
+            materialization_version: "v4-replacement".to_string(),
+            created_at_unix_nanos: 22,
+            surfaces: vec![MaterializationSurfaceRecord {
+                surface_id: "rest".to_string(),
+                source_document_raw: b"replacement raw".to_vec(),
+                source_document_yaml: "replacement: true\n".to_string(),
+                semantic_ir_yaml: "replacement-ir: true\n".to_string(),
+            }],
+            ..materialization_record("v4-replacement", 22)
+        };
+
+        let mut tx = db.begin().await.expect("begin missing-source tx");
+        tx.materializations()
+            .upsert(&ws, &name, &first)
+            .await
+            .expect_err("materializations must require an existing source");
+        tx.rollback().await.expect("rollback missing-source tx");
+
+        let mut tx = db.begin().await.expect("begin tx");
+        ensure_source(&mut tx, &ws, &source, 1).await;
+        tx.materializations()
+            .upsert(&ws, &name, &empty_surfaces)
+            .await
+            .expect("upsert empty-surface materialization");
+        tx.commit()
+            .await
+            .expect("commit empty-surface materialization");
+
+        let mut session = db;
+        assert_mat(&mut session, &ws, &name, Some(empty_surfaces)).await;
+
+        let mut tx = db.begin().await.expect("begin first tx");
+        tx.materializations()
+            .upsert(&ws, &name, &first)
+            .await
+            .expect("upsert first materialization");
+        tx.commit().await.expect("commit first materialization");
+
+        assert_mat(&mut session, &ws, &name, Some(first.clone())).await;
+
+        let mut tx = db.begin().await.expect("begin isolation tx");
+        ensure_source(&mut tx, &alt_ws, &source, 12).await;
+        tx.materializations()
+            .upsert(&alt_ws, &name, &alternate)
+            .await
+            .expect("upsert alternate-workspace materialization");
+        tx.commit()
+            .await
+            .expect("commit alternate-workspace materialization");
+        assert_mat(&mut session, &ws, &name, Some(first.clone())).await;
+        assert_mat(&mut session, &alt_ws, &name, Some(alternate.clone())).await;
+
+        let mut tx = db.begin().await.expect("begin replacement tx");
+        tx.materializations()
+            .upsert(&ws, &name, &replaced)
+            .await
+            .expect("upsert replacement materialization");
+        tx.commit()
+            .await
+            .expect("commit replacement materialization");
+
+        assert_mat(&mut session, &ws, &name, Some(replaced.clone())).await;
+        assert_mat(&mut session, &alt_ws, &name, Some(alternate.clone())).await;
+
+        let mut tx = db.begin().await.expect("begin remove tx");
+        assert_eq!(
+            tx.materializations()
+                .remove(&ws, &name)
+                .await
+                .expect("remove materialization"),
+            Some(replaced)
+        );
+        tx.commit().await.expect("commit remove materialization");
+        assert_mat(&mut session, &ws, &name, None).await;
+        assert_mat(&mut session, &alt_ws, &name, Some(alternate.clone())).await;
+
+        let mut tx = db.begin().await.expect("begin source cascade tx");
+        tx.materializations()
+            .upsert(&ws, &name, &first)
+            .await
+            .expect("upsert source-cascade materialization");
+        tx.sources()
+            .remove_source(&ws, &name)
+            .await
+            .expect("remove source");
+        tx.commit().await.expect("commit source cascade");
+        assert_deleted(&mut session, &ws, &name).await;
+        assert_mat(&mut session, &alt_ws, &name, Some(alternate.clone())).await;
+
+        let mut tx = db.begin().await.expect("begin workspace cascade tx");
+        ensure_source(&mut tx, &ws, &source, 23).await;
+        tx.materializations()
+            .upsert(&ws, &name, &first)
+            .await
+            .expect("upsert workspace-cascade materialization");
+        tx.workspaces()
+            .remove(ws.as_str())
+            .await
+            .expect("remove workspace");
+        tx.commit().await.expect("commit workspace cascade");
+        assert_deleted(&mut session, &ws, &name).await;
+        assert_mat(&mut session, &alt_ws, &name, Some(alternate)).await;
+    }
+
+    async fn ensure_source<S>(
+        session: &mut S,
+        workspace: &WorkspaceName,
+        source: &InstalledSource,
+        timestamp: i64,
+    ) where
+        S: DbWriteSession + Sized,
+    {
+        session
+            .workspaces()
+            .ensure(workspace.as_str(), timestamp)
+            .await
+            .expect("ensure workspace");
+        session
+            .sources()
+            .upsert_source(workspace, source, timestamp)
+            .await
+            .expect("upsert source");
+    }
+
+    async fn assert_deleted(
+        session: &mut &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        assert_mat(session, workspace, source_name, None).await;
+        assert_eq!(surface_row_count(session, workspace, source_name).await, 0);
+    }
+
+    async fn assert_mat(
+        session: &mut &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+        expected: Option<MaterializationRecord>,
+    ) {
+        assert_eq!(
+            get_materialization(session, workspace, source_name).await,
+            expected
+        );
+    }
+
+    async fn get_materialization(
+        session: &mut &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Option<MaterializationRecord> {
+        session
+            .materializations()
+            .get(workspace, source_name)
+            .await
+            .expect("get materialization")
+    }
+
+    #[derive(Debug, sqlx::FromRow)]
+    struct CountRow {
+        count: i64,
+    }
+
+    async fn surface_row_count(
+        session: &mut &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> i64 {
+        let row: CountRow = session
+            .fetch_optional(
+                Query::select()
+                    .expr_as(Func::count(Expr::val(1)), Alias::new("count"))
+                    .from(Surfaces::Table)
+                    .and_where(Expr::col(Surfaces::WorkspaceId).eq(workspace.as_str()))
+                    .and_where(Expr::col(Surfaces::SourceName).eq(source_name.as_str()))
+                    .to_owned(),
+            )
+            .await
+            .expect("count materialization surfaces")
+            .expect("count row");
+        row.count
+    }
+
+    fn materialization_record(version: &str, created_at_unix_nanos: i64) -> MaterializationRecord {
+        MaterializationRecord {
+            materialization_version: version.to_string(),
+            fingerprint_yaml: "fingerprint: true\n".to_string(),
+            projections_yaml: "projections: true\n".to_string(),
+            diagnostics_yaml: "[]\n".to_string(),
+            created_at_unix_nanos,
+            surfaces: vec![
+                MaterializationSurfaceRecord {
+                    surface_id: "mcp".to_string(),
+                    source_document_raw: b"mcp raw".to_vec(),
+                    source_document_yaml: "mcp: true\n".to_string(),
+                    semantic_ir_yaml: "mcp-ir: true\n".to_string(),
+                },
+                MaterializationSurfaceRecord {
+                    surface_id: "rest".to_string(),
+                    source_document_raw: b"rest raw".to_vec(),
+                    source_document_yaml: "rest: true\n".to_string(),
+                    semantic_ir_yaml: "rest-ir: true\n".to_string(),
+                },
+            ],
+        }
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod app_state_markers;
 pub(crate) mod credential_documents;
 pub(crate) mod episodes;
 pub(crate) mod feedback_reports;
+pub(crate) mod identity_specs;
 pub(crate) mod materializations;
 pub(crate) mod source_manifests;
 pub(crate) mod sources;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod app_state_markers;
 pub(crate) mod sources;
 pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) mod sources;
 pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod app_state_markers;
+pub(crate) mod materializations;
 pub(crate) mod source_manifests;
 pub(crate) mod sources;
 pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod app_state_markers;
+pub(crate) mod credential_documents;
 pub(crate) mod episodes;
 pub(crate) mod feedback_reports;
 pub(crate) mod materializations;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -5,4 +5,5 @@ pub(crate) mod feedback_reports;
 pub(crate) mod materializations;
 pub(crate) mod source_manifests;
 pub(crate) mod sources;
+pub(crate) mod trace_summaries;
 pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod app_state_markers;
+pub(crate) mod feedback_reports;
 pub(crate) mod materializations;
 pub(crate) mod source_manifests;
 pub(crate) mod sources;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod app_state_markers;
+pub(crate) mod source_manifests;
 pub(crate) mod sources;
 pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod app_state_markers;
+pub(crate) mod episodes;
 pub(crate) mod feedback_reports;
 pub(crate) mod materializations;
 pub(crate) mod source_manifests;

--- a/crates/coral-app/src/state/db/repositories/source_manifests.rs
+++ b/crates/coral-app/src/state/db/repositories/source_manifests.rs
@@ -1,0 +1,308 @@
+use sea_query::{Expr, ExprTrait, Query};
+use sha2::{Digest as _, Sha256};
+
+use crate::sources::SourceName;
+use crate::state::db::schema::SourceManifests;
+use crate::state::db::{DbError, DbSession, DbWriteSession};
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SourceManifestRecord {
+    pub(crate) manifest_yaml: String,
+    pub(crate) manifest_hash: String,
+    pub(crate) created_at_unix_nanos: i64,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct SourceManifestRow {
+    manifest_yaml: String,
+    manifest_hash: String,
+    created_at_unix_nanos: i64,
+}
+
+impl From<SourceManifestRow> for SourceManifestRecord {
+    fn from(value: SourceManifestRow) -> Self {
+        Self {
+            manifest_yaml: value.manifest_yaml,
+            manifest_hash: value.manifest_hash,
+            created_at_unix_nanos: value.created_at_unix_nanos,
+        }
+    }
+}
+
+pub(crate) struct SourceManifestsRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> SourceManifestsRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn get(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<SourceManifestRecord>, DbError> {
+        let statement = Query::select()
+            .columns([
+                SourceManifests::ManifestYaml,
+                SourceManifests::ManifestHash,
+                SourceManifests::CreatedAtUnixNanos,
+            ])
+            .from(SourceManifests::Table)
+            .and_where(Expr::col(SourceManifests::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(SourceManifests::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        let row: Option<SourceManifestRow> = self.session.fetch_optional(statement).await?;
+        Ok(row.map(Into::into))
+    }
+}
+
+impl<S> SourceManifestsRepo<'_, S>
+where
+    S: DbWriteSession,
+{
+    pub(crate) async fn upsert(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        manifest_yaml: &str,
+        created_at_unix_nanos: i64,
+    ) -> Result<SourceManifestRecord, DbError> {
+        self.delete_manifest(workspace_name, source_name).await?;
+        let manifest_hash = sha256_hex(manifest_yaml.as_bytes());
+        let statement = Query::insert()
+            .into_table(SourceManifests::Table)
+            .columns([
+                SourceManifests::WorkspaceId,
+                SourceManifests::SourceName,
+                SourceManifests::ManifestYaml,
+                SourceManifests::ManifestHash,
+                SourceManifests::CreatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_name.as_str().to_string()),
+                Expr::val(source_name.as_str().to_string()),
+                Expr::val(manifest_yaml.to_string()),
+                Expr::val(manifest_hash.clone()),
+                Expr::val(created_at_unix_nanos),
+            ])
+            .to_owned();
+        self.session.execute(statement).await?;
+        Ok(SourceManifestRecord {
+            manifest_yaml: manifest_yaml.to_string(),
+            manifest_hash,
+            created_at_unix_nanos,
+        })
+    }
+
+    pub(crate) async fn remove(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<SourceManifestRecord>, DbError> {
+        let removed = self.get(workspace_name, source_name).await?;
+        self.delete_manifest(workspace_name, source_name).await?;
+        Ok(removed)
+    }
+
+    async fn delete_manifest(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(SourceManifests::Table)
+            .and_where(Expr::col(SourceManifests::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(SourceManifests::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        self.session.execute_delete(statement).await
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use tempfile::tempdir;
+
+    use super::{SourceManifestRecord, sha256_hex};
+    use crate::bootstrap;
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    async fn source_manifest_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_source_manifest_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    async fn source_manifest_repository_rejects_manifest_without_source_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+        let workspace = unique_workspace();
+        let source_name = SourceName::parse("orphan").expect("source name");
+
+        let mut tx = db.begin().await.expect("begin tx");
+        let error = tx
+            .source_manifests()
+            .upsert(&workspace, &source_name, "name: orphan\n", 10)
+            .await
+            .expect_err("manifest rows must require an existing source");
+
+        assert!(
+            error.to_string().to_lowercase().contains("foreign key"),
+            "unexpected error: {error}"
+        );
+        tx.rollback().await.expect("rollback failed tx");
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn source_manifest_repository_round_trips_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_source_manifest_repository_round_trip(&db).await;
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    async fn assert_source_manifest_repository_round_trip(db: &CoralDb) {
+        let workspace = unique_workspace();
+        let source_name = SourceName::parse("local_messages").expect("source name");
+        let source = InstalledSource {
+            name: source_name.clone(),
+            version: Some("0.1.0".to_string()),
+            variables: std::collections::BTreeMap::default(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            origin: SourceOrigin::Imported,
+        };
+        let first_manifest = "name: local_messages\nversion: 0.1.0\n";
+        let replacement_manifest = "name: local_messages\nversion: 0.2.0\n";
+
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 10)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &source, 20)
+            .await
+            .expect("upsert source");
+        let stored = tx
+            .source_manifests()
+            .upsert(&workspace, &source_name, first_manifest, 30)
+            .await
+            .expect("upsert manifest");
+        tx.commit().await.expect("commit tx");
+
+        assert_eq!(
+            stored,
+            SourceManifestRecord {
+                manifest_yaml: first_manifest.to_string(),
+                manifest_hash: sha256_hex(first_manifest.as_bytes()),
+                created_at_unix_nanos: 30,
+            }
+        );
+        assert_eq!(
+            get_manifest(db, &workspace, &source_name).await,
+            Some(stored)
+        );
+
+        let mut tx = db.begin().await.expect("begin replacement tx");
+        let replacement = tx
+            .source_manifests()
+            .upsert(&workspace, &source_name, replacement_manifest, 40)
+            .await
+            .expect("replace manifest");
+        tx.commit().await.expect("commit replacement");
+        assert_eq!(
+            get_manifest(db, &workspace, &source_name).await,
+            Some(replacement.clone())
+        );
+        assert_eq!(
+            replacement.manifest_hash,
+            sha256_hex(replacement_manifest.as_bytes())
+        );
+        assert_eq!(replacement.created_at_unix_nanos, 40);
+
+        let mut tx = db.begin().await.expect("begin rollback tx");
+        tx.source_manifests()
+            .upsert(&workspace, &source_name, first_manifest, 50)
+            .await
+            .expect("upsert rolled-back manifest");
+        tx.rollback().await.expect("rollback tx");
+        assert_eq!(
+            get_manifest(db, &workspace, &source_name).await,
+            Some(replacement.clone())
+        );
+
+        let mut tx = db.begin().await.expect("begin remove tx");
+        let removed = tx
+            .source_manifests()
+            .remove(&workspace, &source_name)
+            .await
+            .expect("remove manifest");
+        tx.commit().await.expect("commit remove tx");
+        assert_eq!(removed, Some(replacement));
+        assert_eq!(get_manifest(db, &workspace, &source_name).await, None);
+    }
+
+    async fn get_manifest(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Option<SourceManifestRecord> {
+        let mut session = db;
+        session
+            .source_manifests()
+            .get(workspace, source_name)
+            .await
+            .expect("get manifest")
+    }
+
+    fn unique_workspace() -> WorkspaceName {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        WorkspaceName::parse(&format!("source-manifest-repository-{nanos}"))
+            .expect("workspace name")
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -6,7 +6,7 @@ use crate::credentials::CredentialStorageKind;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::db::schema::{SourceSecretKeys, SourceVariables, Sources};
-use crate::state::db::{DbError, DbSession};
+use crate::state::db::{CoralTx, DbError, DbSession};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug, sqlx::FromRow)]
@@ -93,39 +93,6 @@ where
             .map(Some)
     }
 
-    pub(crate) async fn upsert_source(
-        &mut self,
-        workspace_name: &WorkspaceName,
-        source: &InstalledSource,
-        now_unix_nanos: i64,
-    ) -> Result<(), DbError> {
-        let created_at_unix_nanos = self
-            .source_created_at(workspace_name, &source.name)
-            .await?
-            .unwrap_or(now_unix_nanos);
-        self.delete_source_rows(workspace_name, &source.name)
-            .await?;
-        self.insert_source(
-            workspace_name,
-            source,
-            created_at_unix_nanos,
-            now_unix_nanos,
-        )
-        .await?;
-        self.insert_source_variables(workspace_name, source).await?;
-        self.insert_source_secret_keys(workspace_name, source).await
-    }
-
-    pub(crate) async fn remove_source(
-        &mut self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Result<Option<InstalledSource>, DbError> {
-        let removed = self.get_source(workspace_name, source_name).await?;
-        self.delete_source_rows(workspace_name, source_name).await?;
-        Ok(removed)
-    }
-
     async fn source_row(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -143,21 +110,6 @@ where
             .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
             .to_owned();
         self.session.fetch_optional(statement).await
-    }
-
-    async fn source_created_at(
-        &mut self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Result<Option<i64>, DbError> {
-        let statement = Query::select()
-            .column(Sources::CreatedAtUnixNanos)
-            .from(Sources::Table)
-            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
-            .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
-            .to_owned();
-        let row: Option<SourceCreatedAtRow> = self.session.fetch_optional(statement).await?;
-        Ok(row.map(|row| row.created_at_unix_nanos))
     }
 
     async fn installed_source_from_row(
@@ -220,6 +172,56 @@ where
             .order_by(SourceSecretKeys::Position, Order::Asc)
             .to_owned();
         self.session.fetch_all(statement).await
+    }
+}
+
+impl<'a> SourcesRepo<'a, CoralTx<'_>> {
+    pub(crate) async fn upsert_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        now_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let created_at_unix_nanos = self
+            .source_created_at(workspace_name, &source.name)
+            .await?
+            .unwrap_or(now_unix_nanos);
+        self.delete_source_rows(workspace_name, &source.name)
+            .await?;
+        self.insert_source(
+            workspace_name,
+            source,
+            created_at_unix_nanos,
+            now_unix_nanos,
+        )
+        .await?;
+        self.insert_source_variables(workspace_name, source).await?;
+        self.insert_source_secret_keys(workspace_name, source).await
+    }
+
+    pub(crate) async fn remove_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, DbError> {
+        let removed = self.get_source(workspace_name, source_name).await?;
+        self.delete_source_rows(workspace_name, source_name).await?;
+        Ok(removed)
+    }
+
+    async fn source_created_at(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<i64>, DbError> {
+        let statement = Query::select()
+            .column(Sources::CreatedAtUnixNanos)
+            .from(Sources::Table)
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
+            .to_owned();
+        let row: Option<SourceCreatedAtRow> = self.session.fetch_optional(statement).await?;
+        Ok(row.map(|row| row.created_at_unix_nanos))
     }
 
     async fn insert_source(
@@ -491,7 +493,15 @@ mod tests {
         assert_eq!(get_source(db, &workspace, &rolled_back.name).await, None);
 
         let zeta_name = zeta.name.clone();
-        assert_eq!(remove_source(db, &workspace, &zeta_name).await, Some(zeta));
+        let mut tx = db.begin().await.expect("begin remove tx");
+        assert_eq!(
+            tx.sources()
+                .remove_source(&workspace, &zeta_name)
+                .await
+                .expect("remove source"),
+            Some(zeta)
+        );
+        tx.commit().await.expect("commit remove");
         assert_eq!(get_source(db, &workspace, &zeta_name).await, None);
     }
 
@@ -524,19 +534,6 @@ mod tests {
             .get_source(workspace, source_name)
             .await
             .expect("get source")
-    }
-
-    async fn remove_source(
-        db: &CoralDb,
-        workspace: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Option<InstalledSource> {
-        let mut session = db;
-        session
-            .sources()
-            .remove_source(workspace, source_name)
-            .await
-            .expect("remove source")
     }
 
     fn source<const VARIABLES: usize, const SECRETS: usize>(

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -298,7 +298,8 @@ where
             .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
             .and_where(Expr::col(Sources::Name).eq(source.name.as_str()))
             .to_owned();
-        self.session.execute_update(statement).await
+        self.session.execute_update(statement).await?;
+        Ok(())
     }
 
     async fn insert_source_variables(

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -196,23 +196,22 @@ where
         source: &InstalledSource,
         now_unix_nanos: i64,
     ) -> Result<(), DbError> {
-        let created_at_unix_nanos = self
-            .source_created_at(workspace_name, &source.name)
-            .await?
-            .unwrap_or(now_unix_nanos);
-        self.upsert_source_row(
-            workspace_name,
-            source,
-            created_at_unix_nanos,
-            now_unix_nanos,
-        )
-        .await?;
+        let created_at_unix_nanos = self.source_created_at(workspace_name, &source.name).await?;
+        if created_at_unix_nanos.is_some() {
+            self.update_existing_source_row(workspace_name, source, now_unix_nanos)
+                .await?;
+        } else {
+            self.upsert_source_row(workspace_name, source, now_unix_nanos, now_unix_nanos)
+                .await?;
+        }
         self.delete_source_child_rows(workspace_name, &source.name)
             .await?;
         self.delete_imported_manifest_for_non_imported_source(workspace_name, source)
             .await?;
         self.insert_source_variables(workspace_name, source).await?;
-        self.insert_source_secret_keys(workspace_name, source).await
+        self.insert_source_secret_keys(workspace_name, source)
+            .await?;
+        Ok(())
     }
 
     pub(crate) async fn remove_source(
@@ -239,6 +238,43 @@ where
             updated_at_unix_nanos,
         )
         .await
+    }
+
+    async fn update_existing_source_row(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        updated_at_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let statement = Query::update()
+            .table(Sources::Table)
+            .value(Sources::Version, Expr::val(source.version.clone()))
+            .value(
+                Sources::OriginKind,
+                Expr::val(source.origin.as_config_value()),
+            )
+            .value(
+                Sources::CredentialStorage,
+                Expr::val(
+                    source
+                        .credential_storage
+                        .map(CredentialStorageKind::as_config_value),
+                ),
+            )
+            .value(
+                Sources::UpdatedAtUnixNanos,
+                Expr::val(updated_at_unix_nanos),
+            )
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Sources::Name).eq(source.name.as_str()))
+            .to_owned();
+        if self.session.execute_update(statement).await? == 1 {
+            return Ok(());
+        }
+        Err(DbError::InvalidData(format!(
+            "source '{workspace_name}:{}' was deleted while being updated",
+            source.name
+        )))
     }
 
     async fn source_created_at(
@@ -507,6 +543,14 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn source_update_rejects_deleted_existing_source_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+        assert_source_update_rejects_deleted_existing_source(&db).await;
+    }
+
+    #[tokio::test]
     #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
     async fn source_repository_round_trips_against_postgres() {
         let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
@@ -547,6 +591,20 @@ mod tests {
         db.migrate().await.expect("migrate postgres");
 
         assert_source_repository_rejects_invalid_persisted_source_name(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the source delete/upsert race regression against Postgres"]
+    async fn source_delete_upsert_race_cannot_resurrect_database_credentials_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_source_delete_upsert_race_cannot_resurrect_database_credentials(&db).await;
     }
 
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
@@ -727,6 +785,111 @@ mod tests {
         );
         assert_eq!(source_manifest(db, &workspace, &original.name).await, None);
         assert!(!credential_document(db, &workspace, &original.name).await);
+    }
+
+    async fn assert_source_update_rejects_deleted_existing_source(db: &CoralDb) {
+        let workspace = unique_workspace();
+        let with_secret = source(
+            "deleted_source",
+            Some("1.0.1"),
+            [("API_BASE", "https://api.example.test")],
+            ["API_TOKEN"],
+            Some(CredentialStorageKind::Database),
+            SourceOrigin::Imported,
+        );
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 10)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &with_secret, 20)
+            .await
+            .expect("insert source");
+        tx.sources()
+            .remove_source(&workspace, &with_secret.name)
+            .await
+            .expect("delete source");
+        let error = tx
+            .sources()
+            .update_existing_source_row(&workspace, &with_secret, 21)
+            .await
+            .expect_err("deleted source update should fail");
+        assert!(matches!(error, DbError::InvalidData(_)), "{error}");
+        tx.rollback().await.expect("rollback failed update");
+        assert_eq!(get_source(db, &workspace, &with_secret.name).await, None);
+    }
+
+    async fn assert_source_delete_upsert_race_cannot_resurrect_database_credentials(db: &CoralDb) {
+        let workspace = unique_workspace();
+        let source_name = SourceName::parse("race_source").expect("source name");
+        let provisional = source(
+            source_name.as_str(),
+            Some("1.0.0"),
+            [("API_BASE", "https://api.example.test")],
+            [],
+            Some(CredentialStorageKind::Database),
+            SourceOrigin::Imported,
+        );
+        let with_secret = source(
+            source_name.as_str(),
+            Some("1.0.1"),
+            [("API_BASE", "https://api2.example.test")],
+            ["API_TOKEN"],
+            Some(CredentialStorageKind::Database),
+            SourceOrigin::Imported,
+        );
+        let mut setup = db.begin().await.expect("begin setup");
+        setup
+            .workspaces()
+            .ensure(workspace.as_str(), 10)
+            .await
+            .expect("ensure workspace");
+        setup
+            .sources()
+            .upsert_source(&workspace, &provisional, 20)
+            .await
+            .expect("upsert provisional source");
+        setup
+            .credential_documents()
+            .upsert(&workspace, &source_name, &credential_document_write(), 21)
+            .await
+            .expect("upsert credential document");
+        setup
+            .sources()
+            .upsert_source(&workspace, &with_secret, 22)
+            .await
+            .expect("upsert source with secret metadata");
+        setup.commit().await.expect("commit setup");
+
+        let mut stale_upsert = db.begin().await.expect("begin stale upsert");
+        stale_upsert
+            .sources()
+            .source_created_at(&workspace, &source_name)
+            .await
+            .expect("read created_at")
+            .expect("source created_at");
+        let mut delete = db.begin().await.expect("begin delete");
+        delete
+            .sources()
+            .remove_source(&workspace, &source_name)
+            .await
+            .expect("delete source");
+        delete.commit().await.expect("commit delete");
+
+        let mut repo = stale_upsert.sources();
+        let error = repo
+            .update_existing_source_row(&workspace, &with_secret, 30)
+            .await
+            .expect_err("stale update must fail after concurrent delete");
+        assert!(matches!(error, DbError::InvalidData(_)), "{error}");
+        stale_upsert
+            .rollback()
+            .await
+            .expect("rollback stale upsert");
+
+        assert_eq!(get_source(db, &workspace, &source_name).await, None);
+        assert!(!credential_document(db, &workspace, &source_name).await);
     }
 
     async fn assert_source_repository_rejects_source_without_workspace(db: &CoralDb) {

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -6,7 +6,7 @@ use crate::credentials::CredentialStorageKind;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::db::schema::{SourceSecretKeys, SourceVariables, Sources};
-use crate::state::db::{CoralTx, DbError, DbSession};
+use crate::state::db::{DbError, DbSession, DbWriteSession};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug, sqlx::FromRow)]
@@ -31,6 +31,11 @@ struct SourceVariableRow {
 #[derive(Debug, sqlx::FromRow)]
 struct SourceSecretKeyRow {
     key: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct SourceNameRow {
+    name: String,
 }
 
 pub(crate) struct SourcesRepo<'a, S> {
@@ -72,12 +77,14 @@ where
         &mut self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<String>, DbError> {
-        Ok(self
-            .list_workspace_sources(workspace_name)
-            .await?
-            .into_iter()
-            .map(|source| source.name.as_str().to_string())
-            .collect())
+        let statement = Query::select()
+            .column(Sources::Name)
+            .from(Sources::Table)
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
+            .order_by(Sources::Name, Order::Asc)
+            .to_owned();
+        let rows: Vec<SourceNameRow> = self.session.fetch_all(statement).await?;
+        Ok(rows.into_iter().map(|row| row.name).collect())
     }
 
     pub(crate) async fn get_source(
@@ -175,7 +182,10 @@ where
     }
 }
 
-impl<'a> SourcesRepo<'a, CoralTx<'_>> {
+impl<S> SourcesRepo<'_, S>
+where
+    S: DbWriteSession,
+{
     pub(crate) async fn upsert_source(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -396,6 +406,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn source_repository_rejects_source_without_workspace_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+        let workspace = unique_workspace();
+        let source = source("orphan", None, [], [], None, SourceOrigin::Bundled);
+        let mut tx = db.begin().await.expect("begin tx");
+
+        let error = tx
+            .sources()
+            .upsert_source(&workspace, &source, 10)
+            .await
+            .expect_err("source rows must require an existing workspace");
+
+        assert!(
+            error.to_string().to_lowercase().contains("foreign key"),
+            "unexpected error: {error}"
+        );
+        tx.rollback().await.expect("rollback failed tx");
+    }
+
+    #[tokio::test]
     #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
     async fn source_repository_round_trips_against_postgres() {
         let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
@@ -493,15 +525,7 @@ mod tests {
         assert_eq!(get_source(db, &workspace, &rolled_back.name).await, None);
 
         let zeta_name = zeta.name.clone();
-        let mut tx = db.begin().await.expect("begin remove tx");
-        assert_eq!(
-            tx.sources()
-                .remove_source(&workspace, &zeta_name)
-                .await
-                .expect("remove source"),
-            Some(zeta)
-        );
-        tx.commit().await.expect("commit remove");
+        assert_eq!(remove_source(db, &workspace, &zeta_name).await, Some(zeta));
         assert_eq!(get_source(db, &workspace, &zeta_name).await, None);
     }
 
@@ -534,6 +558,21 @@ mod tests {
             .get_source(workspace, source_name)
             .await
             .expect("get source")
+    }
+
+    async fn remove_source(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Option<InstalledSource> {
+        let mut tx = db.begin().await.expect("begin remove tx");
+        let removed = tx
+            .sources()
+            .remove_source(workspace, source_name)
+            .await
+            .expect("remove source");
+        tx.commit().await.expect("commit remove tx");
+        removed
     }
 
     fn source<const VARIABLES: usize, const SECRETS: usize>(

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -1,0 +1,570 @@
+use std::collections::BTreeMap;
+
+use sea_query::{Expr, ExprTrait, Order, Query};
+
+use crate::credentials::CredentialStorageKind;
+use crate::sources::SourceName;
+use crate::sources::model::{InstalledSource, SourceOrigin};
+use crate::state::db::schema::{SourceSecretKeys, SourceVariables, Sources};
+use crate::state::db::{DbError, DbSession};
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, sqlx::FromRow)]
+struct SourceRow {
+    name: String,
+    version: Option<String>,
+    origin_kind: String,
+    credential_storage: Option<String>,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct SourceCreatedAtRow {
+    created_at_unix_nanos: i64,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct SourceVariableRow {
+    key: String,
+    value: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct SourceSecretKeyRow {
+    key: String,
+}
+
+pub(crate) struct SourcesRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> SourcesRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn list_workspace_sources(
+        &mut self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, DbError> {
+        let statement = Query::select()
+            .columns([
+                Sources::Name,
+                Sources::Version,
+                Sources::OriginKind,
+                Sources::CredentialStorage,
+            ])
+            .from(Sources::Table)
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
+            .order_by(Sources::Name, Order::Asc)
+            .to_owned();
+        let rows: Vec<SourceRow> = self.session.fetch_all(statement).await?;
+        let mut sources = Vec::with_capacity(rows.len());
+        for row in rows {
+            sources.push(self.installed_source_from_row(workspace_name, row).await?);
+        }
+        Ok(sources)
+    }
+
+    pub(crate) async fn list_workspace_source_names(
+        &mut self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<String>, DbError> {
+        Ok(self
+            .list_workspace_sources(workspace_name)
+            .await?
+            .into_iter()
+            .map(|source| source.name.as_str().to_string())
+            .collect())
+    }
+
+    pub(crate) async fn get_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, DbError> {
+        let Some(row) = self.source_row(workspace_name, source_name).await? else {
+            return Ok(None);
+        };
+        self.installed_source_from_row(workspace_name, row)
+            .await
+            .map(Some)
+    }
+
+    pub(crate) async fn upsert_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        now_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let created_at_unix_nanos = self
+            .source_created_at(workspace_name, &source.name)
+            .await?
+            .unwrap_or(now_unix_nanos);
+        self.delete_source_rows(workspace_name, &source.name)
+            .await?;
+        self.insert_source(
+            workspace_name,
+            source,
+            created_at_unix_nanos,
+            now_unix_nanos,
+        )
+        .await?;
+        self.insert_source_variables(workspace_name, source).await?;
+        self.insert_source_secret_keys(workspace_name, source).await
+    }
+
+    pub(crate) async fn remove_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, DbError> {
+        let removed = self.get_source(workspace_name, source_name).await?;
+        self.delete_source_rows(workspace_name, source_name).await?;
+        Ok(removed)
+    }
+
+    async fn source_row(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<SourceRow>, DbError> {
+        let statement = Query::select()
+            .columns([
+                Sources::Name,
+                Sources::Version,
+                Sources::OriginKind,
+                Sources::CredentialStorage,
+            ])
+            .from(Sources::Table)
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
+            .to_owned();
+        self.session.fetch_optional(statement).await
+    }
+
+    async fn source_created_at(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<i64>, DbError> {
+        let statement = Query::select()
+            .column(Sources::CreatedAtUnixNanos)
+            .from(Sources::Table)
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
+            .to_owned();
+        let row: Option<SourceCreatedAtRow> = self.session.fetch_optional(statement).await?;
+        Ok(row.map(|row| row.created_at_unix_nanos))
+    }
+
+    async fn installed_source_from_row(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        row: SourceRow,
+    ) -> Result<InstalledSource, DbError> {
+        let source_name = parse_source_name(&row.name)?;
+        let variables = self
+            .source_variables(workspace_name, &source_name)
+            .await?
+            .into_iter()
+            .map(|row| (row.key, row.value))
+            .collect::<BTreeMap<_, _>>();
+        let secrets = self
+            .source_secret_keys(workspace_name, &source_name)
+            .await?
+            .into_iter()
+            .map(|row| row.key)
+            .collect();
+        Ok(InstalledSource {
+            name: source_name,
+            version: row.version,
+            variables,
+            secrets,
+            credential_storage: row
+                .credential_storage
+                .as_deref()
+                .map(parse_credential_storage)
+                .transpose()?,
+            origin: parse_source_origin(&row.origin_kind)?,
+        })
+    }
+
+    async fn source_variables(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Vec<SourceVariableRow>, DbError> {
+        let statement = Query::select()
+            .columns([SourceVariables::Key, SourceVariables::Value])
+            .from(SourceVariables::Table)
+            .and_where(Expr::col(SourceVariables::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(SourceVariables::SourceName).eq(source_name.as_str()))
+            .order_by(SourceVariables::Key, Order::Asc)
+            .to_owned();
+        self.session.fetch_all(statement).await
+    }
+
+    async fn source_secret_keys(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Vec<SourceSecretKeyRow>, DbError> {
+        let statement = Query::select()
+            .column(SourceSecretKeys::Key)
+            .from(SourceSecretKeys::Table)
+            .and_where(Expr::col(SourceSecretKeys::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(SourceSecretKeys::SourceName).eq(source_name.as_str()))
+            .order_by(SourceSecretKeys::Position, Order::Asc)
+            .to_owned();
+        self.session.fetch_all(statement).await
+    }
+
+    async fn insert_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        created_at_unix_nanos: i64,
+        updated_at_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(Sources::Table)
+            .columns([
+                Sources::WorkspaceId,
+                Sources::Name,
+                Sources::Version,
+                Sources::OriginKind,
+                Sources::CredentialStorage,
+                Sources::CreatedAtUnixNanos,
+                Sources::UpdatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_name.as_str().to_string()),
+                Expr::val(source.name.as_str().to_string()),
+                Expr::val(source.version.clone()),
+                Expr::val(source.origin.as_config_value()),
+                Expr::val(
+                    source
+                        .credential_storage
+                        .map(CredentialStorageKind::as_config_value),
+                ),
+                Expr::val(created_at_unix_nanos),
+                Expr::val(updated_at_unix_nanos),
+            ])
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    async fn insert_source_variables(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<(), DbError> {
+        for (key, value) in &source.variables {
+            let statement = Query::insert()
+                .into_table(SourceVariables::Table)
+                .columns([
+                    SourceVariables::WorkspaceId,
+                    SourceVariables::SourceName,
+                    SourceVariables::Key,
+                    SourceVariables::Value,
+                ])
+                .values_panic([
+                    Expr::val(workspace_name.as_str().to_string()),
+                    Expr::val(source.name.as_str().to_string()),
+                    Expr::val(key.clone()),
+                    Expr::val(value.clone()),
+                ])
+                .to_owned();
+            self.session.execute(statement).await?;
+        }
+        Ok(())
+    }
+
+    async fn insert_source_secret_keys(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<(), DbError> {
+        for (position, key) in source.secrets.iter().enumerate() {
+            let position = i64::try_from(position).map_err(|_error| {
+                DbError::InvalidData(format!(
+                    "too many secret declarations for '{}'",
+                    source.name
+                ))
+            })?;
+            let statement = Query::insert()
+                .into_table(SourceSecretKeys::Table)
+                .columns([
+                    SourceSecretKeys::WorkspaceId,
+                    SourceSecretKeys::SourceName,
+                    SourceSecretKeys::Position,
+                    SourceSecretKeys::Key,
+                ])
+                .values_panic([
+                    Expr::val(workspace_name.as_str().to_string()),
+                    Expr::val(source.name.as_str().to_string()),
+                    Expr::val(position),
+                    Expr::val(key.clone()),
+                ])
+                .to_owned();
+            self.session.execute(statement).await?;
+        }
+        Ok(())
+    }
+
+    async fn delete_source_rows(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), DbError> {
+        let secret_keys = Query::delete()
+            .from_table(SourceSecretKeys::Table)
+            .and_where(Expr::col(SourceSecretKeys::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(SourceSecretKeys::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        self.session.execute_delete(secret_keys).await?;
+
+        let variables = Query::delete()
+            .from_table(SourceVariables::Table)
+            .and_where(Expr::col(SourceVariables::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(SourceVariables::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        self.session.execute_delete(variables).await?;
+
+        let source = Query::delete()
+            .from_table(Sources::Table)
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
+            .to_owned();
+        self.session.execute_delete(source).await
+    }
+}
+
+fn parse_source_name(name: &str) -> Result<SourceName, DbError> {
+    SourceName::parse(name)
+        .map_err(|error| DbError::InvalidData(format!("invalid source name '{name}': {error}")))
+}
+
+fn parse_source_origin(origin: &str) -> Result<SourceOrigin, DbError> {
+    match origin {
+        "bundled" => Ok(SourceOrigin::Bundled),
+        "imported" => Ok(SourceOrigin::Imported),
+        other => Err(DbError::InvalidData(format!(
+            "invalid source origin '{other}'"
+        ))),
+    }
+}
+
+fn parse_credential_storage(storage: &str) -> Result<CredentialStorageKind, DbError> {
+    match storage {
+        "file" => Ok(CredentialStorageKind::File),
+        "keychain" => Ok(CredentialStorageKind::Keychain),
+        other => Err(DbError::InvalidData(format!(
+            "invalid credential storage '{other}'"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use tempfile::tempdir;
+
+    use crate::bootstrap;
+    use crate::credentials::CredentialStorageKind;
+    use crate::sources::SourceName;
+    use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    async fn source_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_source_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn source_repository_round_trips_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_source_repository_round_trip(&db).await;
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    async fn assert_source_repository_round_trip(db: &CoralDb) {
+        let workspace = unique_workspace();
+        let alpha = source("alpha", None, [], [], None, SourceOrigin::Bundled);
+        let zeta = source(
+            "zeta",
+            Some("1.2.3"),
+            [("z_var", "last"), ("a_var", "first")],
+            ["api_key", "oauth_refresh"],
+            Some(CredentialStorageKind::Keychain),
+            SourceOrigin::Imported,
+        );
+
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 10)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &zeta, 20)
+            .await
+            .expect("upsert zeta");
+        tx.sources()
+            .upsert_source(&workspace, &alpha, 30)
+            .await
+            .expect("upsert alpha");
+        tx.commit().await.expect("commit tx");
+
+        assert_eq!(
+            source_names(db, &workspace).await,
+            vec!["alpha".to_string(), "zeta".to_string()]
+        );
+        assert_eq!(
+            sources(db, &workspace).await,
+            vec![alpha.clone(), zeta.clone()]
+        );
+
+        let alpha_replacement = source(
+            "alpha",
+            Some("9.9.9"),
+            [("only", "new")],
+            ["replacement_secret"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        let mut tx = db.begin().await.expect("begin replacement tx");
+        tx.sources()
+            .upsert_source(&workspace, &alpha_replacement, 40)
+            .await
+            .expect("replace alpha");
+        tx.commit().await.expect("commit replacement");
+        assert_eq!(
+            get_source(db, &workspace, &alpha_replacement.name).await,
+            Some(alpha_replacement.clone())
+        );
+
+        let mut tx = db.begin().await.expect("begin rollback tx");
+        let rolled_back = source(
+            "rolled-back",
+            None,
+            [("temporary", "value")],
+            ["temporary_secret"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        tx.sources()
+            .upsert_source(&workspace, &rolled_back, 50)
+            .await
+            .expect("upsert rolled-back source");
+        tx.rollback().await.expect("rollback tx");
+        assert_eq!(get_source(db, &workspace, &rolled_back.name).await, None);
+
+        let zeta_name = zeta.name.clone();
+        assert_eq!(remove_source(db, &workspace, &zeta_name).await, Some(zeta));
+        assert_eq!(get_source(db, &workspace, &zeta_name).await, None);
+    }
+
+    async fn source_names(db: &CoralDb, workspace: &WorkspaceName) -> Vec<String> {
+        let mut session = db;
+        session
+            .sources()
+            .list_workspace_source_names(workspace)
+            .await
+            .expect("list source names")
+    }
+
+    async fn sources(db: &CoralDb, workspace: &WorkspaceName) -> Vec<InstalledSource> {
+        let mut session = db;
+        session
+            .sources()
+            .list_workspace_sources(workspace)
+            .await
+            .expect("list sources")
+    }
+
+    async fn get_source(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Option<InstalledSource> {
+        let mut session = db;
+        session
+            .sources()
+            .get_source(workspace, source_name)
+            .await
+            .expect("get source")
+    }
+
+    async fn remove_source(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Option<InstalledSource> {
+        let mut session = db;
+        session
+            .sources()
+            .remove_source(workspace, source_name)
+            .await
+            .expect("remove source")
+    }
+
+    fn source<const VARIABLES: usize, const SECRETS: usize>(
+        name: &str,
+        version: Option<&str>,
+        variables: [(&str, &str); VARIABLES],
+        secrets: [&str; SECRETS],
+        credential_storage: Option<CredentialStorageKind>,
+        origin: SourceOrigin,
+    ) -> InstalledSource {
+        InstalledSource {
+            name: SourceName::parse(name).expect("source name"),
+            version: version.map(str::to_string),
+            variables: variables
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect::<BTreeMap<_, _>>(),
+            secrets: secrets.into_iter().map(str::to_string).collect(),
+            credential_storage,
+            origin,
+        }
+    }
+
+    fn unique_workspace() -> WorkspaceName {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock after epoch")
+            .as_nanos();
+        WorkspaceName::parse(&format!("source-repository-{nanos}")).expect("workspace name")
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -84,7 +84,9 @@ where
             .order_by(Sources::Name, Order::Asc)
             .to_owned();
         let rows: Vec<SourceNameRow> = self.session.fetch_all(statement).await?;
-        Ok(rows.into_iter().map(|row| row.name).collect())
+        rows.into_iter()
+            .map(|row| parse_source_name(&row.name).map(|name| name.as_str().to_string()))
+            .collect()
     }
 
     pub(crate) async fn get_source(
@@ -385,6 +387,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    use sea_query::{Expr, Query};
     use tempfile::tempdir;
 
     use crate::bootstrap;
@@ -392,8 +395,9 @@ mod tests {
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::AppStateLayout;
+    use crate::state::db::schema::Sources;
     use crate::state::db::session::DbRepos;
-    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+    use crate::state::db::{CoralDb, DatabaseConfig, DbError, ResolvedDatabaseConfig};
     use crate::workspaces::WorkspaceName;
 
     #[tokio::test]
@@ -410,21 +414,17 @@ mod tests {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         let db = open_sqlite(&layout).await;
-        let workspace = unique_workspace();
-        let source = source("orphan", None, [], [], None, SourceOrigin::Bundled);
-        let mut tx = db.begin().await.expect("begin tx");
 
-        let error = tx
-            .sources()
-            .upsert_source(&workspace, &source, 10)
-            .await
-            .expect_err("source rows must require an existing workspace");
+        assert_source_repository_rejects_source_without_workspace(&db).await;
+    }
 
-        assert!(
-            error.to_string().to_lowercase().contains("foreign key"),
-            "unexpected error: {error}"
-        );
-        tx.rollback().await.expect("rollback failed tx");
+    #[tokio::test]
+    async fn source_repository_rejects_invalid_persisted_source_name_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_source_repository_rejects_invalid_persisted_source_name(&db).await;
     }
 
     #[tokio::test]
@@ -439,6 +439,34 @@ mod tests {
         db.migrate().await.expect("migrate postgres");
 
         assert_source_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run source repository invariant coverage against Postgres"]
+    async fn source_repository_rejects_source_without_workspace_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_source_repository_rejects_source_without_workspace(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run source-name validation coverage against Postgres"]
+    async fn source_repository_rejects_invalid_persisted_source_name_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_source_repository_rejects_invalid_persisted_source_name(&db).await;
     }
 
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
@@ -527,6 +555,75 @@ mod tests {
         let zeta_name = zeta.name.clone();
         assert_eq!(remove_source(db, &workspace, &zeta_name).await, Some(zeta));
         assert_eq!(get_source(db, &workspace, &zeta_name).await, None);
+    }
+
+    async fn assert_source_repository_rejects_source_without_workspace(db: &CoralDb) {
+        let workspace = unique_workspace();
+        let source = source("orphan", None, [], [], None, SourceOrigin::Bundled);
+        let mut tx = db.begin().await.expect("begin tx");
+
+        let error = tx
+            .sources()
+            .upsert_source(&workspace, &source, 10)
+            .await
+            .expect_err("source rows must require an existing workspace");
+
+        assert!(
+            error.to_string().to_lowercase().contains("foreign key"),
+            "unexpected error: {error}"
+        );
+        tx.rollback().await.expect("rollback failed tx");
+    }
+
+    async fn assert_source_repository_rejects_invalid_persisted_source_name(db: &CoralDb) {
+        let workspace = unique_workspace();
+        let invalid_source_name = "bad/name";
+        let mut tx = db.begin().await.expect("begin invalid source-name tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 10)
+            .await
+            .expect("ensure workspace");
+        tx.execute(
+            Query::insert()
+                .into_table(Sources::Table)
+                .columns([
+                    Sources::WorkspaceId,
+                    Sources::Name,
+                    Sources::Version,
+                    Sources::OriginKind,
+                    Sources::CredentialStorage,
+                    Sources::CreatedAtUnixNanos,
+                    Sources::UpdatedAtUnixNanos,
+                ])
+                .values_panic([
+                    Expr::val(workspace.as_str().to_string()),
+                    Expr::val(invalid_source_name),
+                    Expr::val(Option::<String>::None),
+                    Expr::val(SourceOrigin::Bundled.as_config_value()),
+                    Expr::val(Option::<String>::None),
+                    Expr::val(10),
+                    Expr::val(10),
+                ])
+                .to_owned(),
+        )
+        .await
+        .expect("insert invalid source-name row");
+
+        let error = tx
+            .sources()
+            .list_workspace_source_names(&workspace)
+            .await
+            .expect_err("invalid persisted source name should fail");
+        let DbError::InvalidData(message) = error else {
+            panic!("unexpected error: {error}");
+        };
+        assert!(
+            message.contains("invalid source name 'bad/name'"),
+            "unexpected error: {message}"
+        );
+        tx.rollback()
+            .await
+            .expect("rollback invalid source-name tx");
     }
 
     async fn source_names(db: &CoralDb, workspace: &WorkspaceName) -> Vec<String> {

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -432,6 +432,7 @@ fn parse_credential_storage(storage: &str) -> Result<CredentialStorageKind, DbEr
     match storage {
         "file" => Ok(CredentialStorageKind::File),
         "keychain" => Ok(CredentialStorageKind::Keychain),
+        "database" => Ok(CredentialStorageKind::Database),
         other => Err(DbError::InvalidData(format!(
             "invalid credential storage '{other}'"
         ))),

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -1,11 +1,13 @@
 use std::collections::BTreeMap;
 
-use sea_query::{Expr, ExprTrait, Order, Query};
+use sea_query::{Expr, ExprTrait, OnConflict, Order, Query};
 
 use crate::credentials::CredentialStorageKind;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
-use crate::state::db::schema::{SourceManifests, SourceSecretKeys, SourceVariables, Sources};
+use crate::state::db::schema::{
+    CredentialDocuments, SourceManifests, SourceSecretKeys, SourceVariables, Sources,
+};
 use crate::state::db::{DbError, DbSession, DbWriteSession};
 use crate::workspaces::WorkspaceName;
 
@@ -194,15 +196,18 @@ where
         source: &InstalledSource,
         now_unix_nanos: i64,
     ) -> Result<(), DbError> {
-        let existing_created_at = self.source_created_at(workspace_name, &source.name).await?;
-        if existing_created_at.is_some() {
-            self.update_source(workspace_name, source, now_unix_nanos)
-                .await?;
-        } else {
-            self.insert_source(workspace_name, source, now_unix_nanos, now_unix_nanos)
-                .await?;
-        }
-        self.delete_source_detail_rows(workspace_name, &source.name)
+        let created_at_unix_nanos = self
+            .source_created_at(workspace_name, &source.name)
+            .await?
+            .unwrap_or(now_unix_nanos);
+        self.upsert_source_row(
+            workspace_name,
+            source,
+            created_at_unix_nanos,
+            now_unix_nanos,
+        )
+        .await?;
+        self.delete_source_child_rows(workspace_name, &source.name)
             .await?;
         self.delete_imported_manifest_for_non_imported_source(workspace_name, source)
             .await?;
@@ -218,6 +223,22 @@ where
         let removed = self.get_source(workspace_name, source_name).await?;
         self.delete_source_rows(workspace_name, source_name).await?;
         Ok(removed)
+    }
+
+    async fn upsert_source_row(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        created_at_unix_nanos: i64,
+        updated_at_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        self.insert_source(
+            workspace_name,
+            source,
+            created_at_unix_nanos,
+            updated_at_unix_nanos,
+        )
+        .await
     }
 
     async fn source_created_at(
@@ -266,40 +287,18 @@ where
                 Expr::val(created_at_unix_nanos),
                 Expr::val(updated_at_unix_nanos),
             ])
+            .on_conflict(
+                OnConflict::columns([Sources::WorkspaceId, Sources::Name])
+                    .update_columns([
+                        Sources::Version,
+                        Sources::OriginKind,
+                        Sources::CredentialStorage,
+                        Sources::UpdatedAtUnixNanos,
+                    ])
+                    .to_owned(),
+            )
             .to_owned();
         self.session.execute(statement).await
-    }
-
-    async fn update_source(
-        &mut self,
-        workspace_name: &WorkspaceName,
-        source: &InstalledSource,
-        updated_at_unix_nanos: i64,
-    ) -> Result<(), DbError> {
-        let statement = Query::update()
-            .table(Sources::Table)
-            .value(Sources::Version, Expr::val(source.version.clone()))
-            .value(
-                Sources::OriginKind,
-                Expr::val(source.origin.as_config_value()),
-            )
-            .value(
-                Sources::CredentialStorage,
-                Expr::val(
-                    source
-                        .credential_storage
-                        .map(CredentialStorageKind::as_config_value),
-                ),
-            )
-            .value(
-                Sources::UpdatedAtUnixNanos,
-                Expr::val(updated_at_unix_nanos),
-            )
-            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
-            .and_where(Expr::col(Sources::Name).eq(source.name.as_str()))
-            .to_owned();
-        self.session.execute_update(statement).await?;
-        Ok(())
     }
 
     async fn insert_source_variables(
@@ -376,23 +375,7 @@ where
         self.session.execute_delete(statement).await
     }
 
-    async fn delete_source_rows(
-        &mut self,
-        workspace_name: &WorkspaceName,
-        source_name: &SourceName,
-    ) -> Result<(), DbError> {
-        self.delete_source_detail_rows(workspace_name, source_name)
-            .await?;
-
-        let source = Query::delete()
-            .from_table(Sources::Table)
-            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
-            .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
-            .to_owned();
-        self.session.execute_delete(source).await
-    }
-
-    async fn delete_source_detail_rows(
+    async fn delete_source_child_rows(
         &mut self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
@@ -410,6 +393,36 @@ where
             .and_where(Expr::col(SourceVariables::SourceName).eq(source_name.as_str()))
             .to_owned();
         self.session.execute_delete(variables).await
+    }
+
+    async fn delete_source_rows(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), DbError> {
+        self.delete_source_child_rows(workspace_name, source_name)
+            .await?;
+        self.delete_source_credential_document(workspace_name, source_name)
+            .await?;
+        let source = Query::delete()
+            .from_table(Sources::Table)
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
+            .to_owned();
+        self.session.execute_delete(source).await
+    }
+
+    async fn delete_source_credential_document(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(CredentialDocuments::Table)
+            .and_where(Expr::col(CredentialDocuments::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(CredentialDocuments::SourceName).eq(source_name.as_str()))
+            .to_owned();
+        self.session.execute_delete(statement).await
     }
 }
 
@@ -452,6 +465,7 @@ mod tests {
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::AppStateLayout;
+    use crate::state::db::CredentialDocumentWrite;
     use crate::state::db::schema::Sources;
     use crate::state::db::session::DbRepos;
     use crate::state::db::{CoralDb, DatabaseConfig, DbError, ResolvedDatabaseConfig};
@@ -485,6 +499,14 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn source_upsert_preserves_dependent_records_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+        assert_source_upsert_preserves_dependent_records(&db).await;
+    }
+
+    #[tokio::test]
     #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
     async fn source_repository_round_trips_against_postgres() {
         let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
@@ -496,6 +518,7 @@ mod tests {
         db.migrate().await.expect("migrate postgres");
 
         assert_source_repository_round_trip(&db).await;
+        assert_source_upsert_preserves_dependent_records(&db).await;
     }
 
     #[tokio::test]
@@ -601,7 +624,7 @@ mod tests {
             Some(alpha_replacement.clone())
         );
         assert_eq!(
-            source_manifest_yaml(db, &workspace, &alpha_replacement.name).await,
+            source_manifest(db, &workspace, &alpha_replacement.name).await,
             Some(alpha_manifest.to_string())
         );
 
@@ -617,7 +640,7 @@ mod tests {
             Some(alpha_bundled.clone())
         );
         assert_eq!(
-            source_manifest_yaml(db, &workspace, &alpha_bundled.name).await,
+            source_manifest(db, &workspace, &alpha_bundled.name).await,
             None
         );
 
@@ -640,6 +663,70 @@ mod tests {
         let zeta_name = zeta.name.clone();
         assert_eq!(remove_source(db, &workspace, &zeta_name).await, Some(zeta));
         assert_eq!(get_source(db, &workspace, &zeta_name).await, None);
+    }
+
+    async fn assert_source_upsert_preserves_dependent_records(db: &CoralDb) {
+        let workspace = unique_workspace();
+        let original = source(
+            "imported",
+            Some("1.0.0"),
+            [("API_BASE", "https://api.example.test")],
+            ["API_TOKEN"],
+            Some(CredentialStorageKind::File),
+            SourceOrigin::Imported,
+        );
+        let manifest_yaml = "name: imported\ndsl_version: 3\nbackend: http\nbase_url: https://api.example.test\ntables: []\n";
+
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 10)
+            .await
+            .expect("ensure workspace");
+        tx.sources()
+            .upsert_source(&workspace, &original, 20)
+            .await
+            .expect("upsert source");
+        tx.source_manifests()
+            .upsert(&workspace, &original.name, manifest_yaml, 30)
+            .await
+            .expect("upsert manifest");
+        tx.credential_documents()
+            .upsert(&workspace, &original.name, &credential_document_write(), 31)
+            .await
+            .expect("upsert credential document");
+        tx.commit().await.expect("commit source");
+
+        let replacement = source(
+            "imported",
+            Some("1.0.1"),
+            [("API_BASE", "https://api2.example.test")],
+            ["API_TOKEN", "SECOND_TOKEN"],
+            Some(CredentialStorageKind::Database),
+            SourceOrigin::Imported,
+        );
+        let mut tx = db.begin().await.expect("begin replacement");
+        tx.sources()
+            .upsert_source(&workspace, &replacement, 40)
+            .await
+            .expect("replace source");
+        tx.commit().await.expect("commit replacement");
+
+        assert_eq!(
+            get_source(db, &workspace, &replacement.name).await,
+            Some(replacement.clone())
+        );
+        assert_eq!(
+            source_manifest(db, &workspace, &original.name).await,
+            Some(manifest_yaml.to_string())
+        );
+        assert!(credential_document(db, &workspace, &original.name).await);
+
+        assert_eq!(
+            remove_source(db, &workspace, &replacement.name).await,
+            Some(replacement)
+        );
+        assert_eq!(source_manifest(db, &workspace, &original.name).await, None);
+        assert!(!credential_document(db, &workspace, &original.name).await);
     }
 
     async fn assert_source_repository_rejects_source_without_workspace(db: &CoralDb) {
@@ -742,7 +829,7 @@ mod tests {
             .expect("get source")
     }
 
-    async fn source_manifest_yaml(
+    async fn source_manifest(
         db: &CoralDb,
         workspace: &WorkspaceName,
         source_name: &SourceName,
@@ -754,6 +841,20 @@ mod tests {
             .await
             .expect("get source manifest")
             .map(|record| record.manifest_yaml)
+    }
+
+    async fn credential_document(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> bool {
+        let mut session = db;
+        session
+            .credential_documents()
+            .get(workspace, source_name)
+            .await
+            .expect("get credential document")
+            .is_some()
     }
 
     async fn remove_source(
@@ -789,6 +890,18 @@ mod tests {
             secrets: secrets.into_iter().map(str::to_string).collect(),
             credential_storage,
             origin,
+        }
+    }
+
+    fn credential_document_write() -> CredentialDocumentWrite {
+        CredentialDocumentWrite {
+            ciphertext: b"ciphertext".to_vec(),
+            nonce: b"nonce".to_vec(),
+            wrapped_dek: b"wrapped-dek".to_vec(),
+            wrapped_dek_nonce: b"wrapped-dek-nonce".to_vec(),
+            key_id: "key-id".to_string(),
+            algorithm: "xchacha20poly1305".to_string(),
+            aad_version: 1,
         }
     }
 

--- a/crates/coral-app/src/state/db/repositories/sources.rs
+++ b/crates/coral-app/src/state/db/repositories/sources.rs
@@ -5,7 +5,7 @@ use sea_query::{Expr, ExprTrait, Order, Query};
 use crate::credentials::CredentialStorageKind;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
-use crate::state::db::schema::{SourceSecretKeys, SourceVariables, Sources};
+use crate::state::db::schema::{SourceManifests, SourceSecretKeys, SourceVariables, Sources};
 use crate::state::db::{DbError, DbSession, DbWriteSession};
 use crate::workspaces::WorkspaceName;
 
@@ -194,19 +194,18 @@ where
         source: &InstalledSource,
         now_unix_nanos: i64,
     ) -> Result<(), DbError> {
-        let created_at_unix_nanos = self
-            .source_created_at(workspace_name, &source.name)
-            .await?
-            .unwrap_or(now_unix_nanos);
-        self.delete_source_rows(workspace_name, &source.name)
+        let existing_created_at = self.source_created_at(workspace_name, &source.name).await?;
+        if existing_created_at.is_some() {
+            self.update_source(workspace_name, source, now_unix_nanos)
+                .await?;
+        } else {
+            self.insert_source(workspace_name, source, now_unix_nanos, now_unix_nanos)
+                .await?;
+        }
+        self.delete_source_detail_rows(workspace_name, &source.name)
             .await?;
-        self.insert_source(
-            workspace_name,
-            source,
-            created_at_unix_nanos,
-            now_unix_nanos,
-        )
-        .await?;
+        self.delete_imported_manifest_for_non_imported_source(workspace_name, source)
+            .await?;
         self.insert_source_variables(workspace_name, source).await?;
         self.insert_source_secret_keys(workspace_name, source).await
     }
@@ -271,6 +270,37 @@ where
         self.session.execute(statement).await
     }
 
+    async fn update_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        updated_at_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let statement = Query::update()
+            .table(Sources::Table)
+            .value(Sources::Version, Expr::val(source.version.clone()))
+            .value(
+                Sources::OriginKind,
+                Expr::val(source.origin.as_config_value()),
+            )
+            .value(
+                Sources::CredentialStorage,
+                Expr::val(
+                    source
+                        .credential_storage
+                        .map(CredentialStorageKind::as_config_value),
+                ),
+            )
+            .value(
+                Sources::UpdatedAtUnixNanos,
+                Expr::val(updated_at_unix_nanos),
+            )
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Sources::Name).eq(source.name.as_str()))
+            .to_owned();
+        self.session.execute_update(statement).await
+    }
+
     async fn insert_source_variables(
         &mut self,
         workspace_name: &WorkspaceName,
@@ -329,7 +359,39 @@ where
         Ok(())
     }
 
+    async fn delete_imported_manifest_for_non_imported_source(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<(), DbError> {
+        if source.origin == SourceOrigin::Imported {
+            return Ok(());
+        }
+        let statement = Query::delete()
+            .from_table(SourceManifests::Table)
+            .and_where(Expr::col(SourceManifests::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(SourceManifests::SourceName).eq(source.name.as_str()))
+            .to_owned();
+        self.session.execute_delete(statement).await
+    }
+
     async fn delete_source_rows(
+        &mut self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), DbError> {
+        self.delete_source_detail_rows(workspace_name, source_name)
+            .await?;
+
+        let source = Query::delete()
+            .from_table(Sources::Table)
+            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
+            .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
+            .to_owned();
+        self.session.execute_delete(source).await
+    }
+
+    async fn delete_source_detail_rows(
         &mut self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
@@ -346,14 +408,7 @@ where
             .and_where(Expr::col(SourceVariables::WorkspaceId).eq(workspace_name.as_str()))
             .and_where(Expr::col(SourceVariables::SourceName).eq(source_name.as_str()))
             .to_owned();
-        self.session.execute_delete(variables).await?;
-
-        let source = Query::delete()
-            .from_table(Sources::Table)
-            .and_where(Expr::col(Sources::WorkspaceId).eq(workspace_name.as_str()))
-            .and_where(Expr::col(Sources::Name).eq(source_name.as_str()))
-            .to_owned();
-        self.session.execute_delete(source).await
+        self.session.execute_delete(variables).await
     }
 }
 
@@ -483,7 +538,7 @@ mod tests {
 
     async fn assert_source_repository_round_trip(db: &CoralDb) {
         let workspace = unique_workspace();
-        let alpha = source("alpha", None, [], [], None, SourceOrigin::Bundled);
+        let alpha = source("alpha", None, [], [], None, SourceOrigin::Imported);
         let zeta = source(
             "zeta",
             Some("1.2.3"),
@@ -517,6 +572,14 @@ mod tests {
             vec![alpha.clone(), zeta.clone()]
         );
 
+        let alpha_manifest = "name: alpha\nversion: 0.1.0\n";
+        let mut tx = db.begin().await.expect("begin manifest tx");
+        tx.source_manifests()
+            .upsert(&workspace, &alpha.name, alpha_manifest, 35)
+            .await
+            .expect("upsert alpha manifest");
+        tx.commit().await.expect("commit manifest tx");
+
         let alpha_replacement = source(
             "alpha",
             Some("9.9.9"),
@@ -534,6 +597,26 @@ mod tests {
         assert_eq!(
             get_source(db, &workspace, &alpha_replacement.name).await,
             Some(alpha_replacement.clone())
+        );
+        assert_eq!(
+            source_manifest_yaml(db, &workspace, &alpha_replacement.name).await,
+            Some(alpha_manifest.to_string())
+        );
+
+        let alpha_bundled = source("alpha", None, [], [], None, SourceOrigin::Bundled);
+        let mut tx = db.begin().await.expect("begin bundled replacement tx");
+        tx.sources()
+            .upsert_source(&workspace, &alpha_bundled, 45)
+            .await
+            .expect("replace alpha with bundled source");
+        tx.commit().await.expect("commit bundled replacement");
+        assert_eq!(
+            get_source(db, &workspace, &alpha_bundled.name).await,
+            Some(alpha_bundled.clone())
+        );
+        assert_eq!(
+            source_manifest_yaml(db, &workspace, &alpha_bundled.name).await,
+            None
         );
 
         let mut tx = db.begin().await.expect("begin rollback tx");
@@ -655,6 +738,20 @@ mod tests {
             .get_source(workspace, source_name)
             .await
             .expect("get source")
+    }
+
+    async fn source_manifest_yaml(
+        db: &CoralDb,
+        workspace: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Option<String> {
+        let mut session = db;
+        session
+            .source_manifests()
+            .get(workspace, source_name)
+            .await
+            .expect("get source manifest")
+            .map(|record| record.manifest_yaml)
     }
 
     async fn remove_source(

--- a/crates/coral-app/src/state/db/repositories/trace_summaries.rs
+++ b/crates/coral-app/src/state/db/repositories/trace_summaries.rs
@@ -1,4 +1,4 @@
-use sea_query::{Expr, ExprTrait, OnConflict, Order, Query};
+use sea_query::{Alias, Expr, ExprTrait, OnConflict, Order, Query};
 
 use crate::state::db::schema::TraceSummaries;
 use crate::state::db::{DbError, DbSession, DbWriteSession};
@@ -167,10 +167,28 @@ where
                         TraceSummaries::SpanCount,
                         TraceSummaries::RowCount,
                     ])
+                    .action_and_where(
+                        Expr::col((TraceSummaries::Table, TraceSummaries::EndTimeUnixNanos)).lte(
+                            Expr::col((Alias::new("excluded"), TraceSummaries::EndTimeUnixNanos)),
+                        ),
+                    )
                     .to_owned(),
             )
             .to_owned();
         self.session.execute(statement).await
+    }
+
+    pub(crate) async fn delete(
+        &mut self,
+        workspace_id: &str,
+        trace_id: &str,
+    ) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(TraceSummaries::Table)
+            .and_where(Expr::col(TraceSummaries::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(TraceSummaries::TraceId).eq(trace_id))
+            .to_owned();
+        self.session.execute_delete(statement).await
     }
 }
 

--- a/crates/coral-app/src/state/db/repositories/trace_summaries.rs
+++ b/crates/coral-app/src/state/db/repositories/trace_summaries.rs
@@ -1,0 +1,498 @@
+use sea_query::{Expr, ExprTrait, OnConflict, Order, Query};
+
+use crate::state::db::schema::TraceSummaries;
+use crate::state::db::{DbError, DbSession, DbWriteSession};
+use crate::telemetry::{StoredTraceStatus, TraceSummaryRecord};
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, sqlx::FromRow)]
+struct TraceSummaryRow {
+    trace_id: String,
+    workspace_id: String,
+    root_span_id: String,
+    name: String,
+    query: String,
+    status: String,
+    start_time_unix_nanos: i64,
+    end_time_unix_nanos: i64,
+    duration_nanos: i64,
+    span_count: i64,
+    row_count: Option<i64>,
+}
+
+impl TryFrom<TraceSummaryRow> for TraceSummaryRecord {
+    type Error = DbError;
+
+    fn try_from(value: TraceSummaryRow) -> Result<Self, Self::Error> {
+        validate_trace_identity(&value)?;
+        let span_count = u32::try_from(value.span_count).map_err(|_error| {
+            DbError::InvalidData(format!(
+                "trace summary '{}' has invalid span_count {}",
+                value.trace_id, value.span_count
+            ))
+        })?;
+        let row_count = value
+            .row_count
+            .map(u64::try_from)
+            .transpose()
+            .map_err(|_error| {
+                DbError::InvalidData(format!(
+                    "trace summary '{}' has invalid row_count",
+                    value.trace_id
+                ))
+            })?;
+        if value.start_time_unix_nanos < 0
+            || value.end_time_unix_nanos < 0
+            || value.duration_nanos < 0
+        {
+            return Err(DbError::InvalidData(format!(
+                "trace summary '{}' has negative timestamp or duration",
+                value.trace_id
+            )));
+        }
+
+        Ok(Self {
+            trace_id: value.trace_id,
+            workspace_id: Some(value.workspace_id),
+            root_span_id: value.root_span_id,
+            name: value.name,
+            query: value.query,
+            status: status_from_db(&value.status)?,
+            start_time_unix_nanos: value.start_time_unix_nanos,
+            end_time_unix_nanos: value.end_time_unix_nanos,
+            duration_nanos: value.duration_nanos,
+            span_count,
+            row_count: row_count.unwrap_or_default(),
+            row_count_recorded: row_count.is_some(),
+        })
+    }
+}
+
+pub(crate) struct TraceSummariesRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> TraceSummariesRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn get(
+        &mut self,
+        trace_id: &str,
+    ) -> Result<Option<TraceSummaryRecord>, DbError> {
+        let statement = Query::select()
+            .columns(record_columns())
+            .from(TraceSummaries::Table)
+            .and_where(Expr::col(TraceSummaries::TraceId).eq(trace_id))
+            .to_owned();
+        self.session
+            .fetch_optional::<TraceSummaryRow>(statement)
+            .await?
+            .map(TryInto::try_into)
+            .transpose()
+    }
+
+    pub(crate) async fn list(
+        &mut self,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<TraceSummaryRecord>, DbError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let statement = Query::select()
+            .columns(record_columns())
+            .from(TraceSummaries::Table)
+            .order_by(TraceSummaries::EndTimeUnixNanos, Order::Desc)
+            .order_by(TraceSummaries::TraceId, Order::Asc)
+            .limit(limit_to_u64(limit)?)
+            .offset(limit_to_u64(offset)?)
+            .to_owned();
+        let rows: Vec<TraceSummaryRow> = self.session.fetch_all(statement).await?;
+        rows.into_iter().map(TryInto::try_into).collect()
+    }
+}
+
+impl<S> TraceSummariesRepo<'_, S>
+where
+    S: DbWriteSession,
+{
+    pub(crate) async fn upsert(&mut self, summary: &TraceSummaryRecord) -> Result<(), DbError> {
+        let row_count = row_count_to_db(summary)?;
+        let workspace_id = summary_workspace_id(summary)?;
+        let span_count = i64::from(summary.span_count);
+        let statement = Query::insert()
+            .into_table(TraceSummaries::Table)
+            .columns([
+                TraceSummaries::TraceId,
+                TraceSummaries::WorkspaceId,
+                TraceSummaries::RootSpanId,
+                TraceSummaries::Name,
+                TraceSummaries::Query,
+                TraceSummaries::Status,
+                TraceSummaries::StartTimeUnixNanos,
+                TraceSummaries::EndTimeUnixNanos,
+                TraceSummaries::DurationNanos,
+                TraceSummaries::SpanCount,
+                TraceSummaries::RowCount,
+            ])
+            .values_panic([
+                Expr::val(summary.trace_id.clone()),
+                Expr::val(workspace_id),
+                Expr::val(summary.root_span_id.clone()),
+                Expr::val(summary.name.clone()),
+                Expr::val(summary.query.clone()),
+                Expr::val(status_to_db(summary.status)),
+                Expr::val(summary.start_time_unix_nanos),
+                Expr::val(summary.end_time_unix_nanos),
+                Expr::val(summary.duration_nanos),
+                Expr::val(span_count),
+                Expr::val(row_count),
+            ])
+            .on_conflict(
+                OnConflict::columns([TraceSummaries::WorkspaceId, TraceSummaries::TraceId])
+                    .update_columns([
+                        TraceSummaries::RootSpanId,
+                        TraceSummaries::Name,
+                        TraceSummaries::Query,
+                        TraceSummaries::Status,
+                        TraceSummaries::StartTimeUnixNanos,
+                        TraceSummaries::EndTimeUnixNanos,
+                        TraceSummaries::DurationNanos,
+                        TraceSummaries::SpanCount,
+                        TraceSummaries::RowCount,
+                    ])
+                    .to_owned(),
+            )
+            .to_owned();
+        self.session.execute(statement).await
+    }
+}
+
+fn record_columns() -> [TraceSummaries; 11] {
+    [
+        TraceSummaries::TraceId,
+        TraceSummaries::WorkspaceId,
+        TraceSummaries::RootSpanId,
+        TraceSummaries::Name,
+        TraceSummaries::Query,
+        TraceSummaries::Status,
+        TraceSummaries::StartTimeUnixNanos,
+        TraceSummaries::EndTimeUnixNanos,
+        TraceSummaries::DurationNanos,
+        TraceSummaries::SpanCount,
+        TraceSummaries::RowCount,
+    ]
+}
+
+fn validate_trace_identity(row: &TraceSummaryRow) -> Result<(), DbError> {
+    if row.trace_id.trim().is_empty() || row.root_span_id.trim().is_empty() {
+        return Err(DbError::InvalidData(
+            "trace summary has empty trace identity".to_string(),
+        ));
+    }
+    WorkspaceName::parse(&row.workspace_id).map_err(|error| {
+        DbError::InvalidData(format!(
+            "trace summary '{}' has invalid workspace_id: {error}",
+            row.trace_id
+        ))
+    })?;
+    Ok(())
+}
+
+fn summary_workspace_id(summary: &TraceSummaryRecord) -> Result<String, DbError> {
+    if summary.trace_id.trim().is_empty() || summary.root_span_id.trim().is_empty() {
+        return Err(DbError::InvalidData(
+            "trace summary has empty trace identity".to_string(),
+        ));
+    }
+    let workspace_id = summary.workspace_id.as_deref().ok_or_else(|| {
+        DbError::InvalidData(format!(
+            "trace summary '{}' is missing workspace_id",
+            summary.trace_id
+        ))
+    })?;
+    WorkspaceName::parse(workspace_id).map_err(|error| {
+        DbError::InvalidData(format!(
+            "trace summary '{}' has invalid workspace_id: {error}",
+            summary.trace_id
+        ))
+    })?;
+    Ok(workspace_id.to_string())
+}
+
+fn row_count_to_db(summary: &TraceSummaryRecord) -> Result<Option<i64>, DbError> {
+    if summary.row_count_recorded {
+        return i64::try_from(summary.row_count)
+            .map(Some)
+            .map_err(|_error| {
+                DbError::InvalidData(format!(
+                    "trace summary '{}' row_count exceeds database range",
+                    summary.trace_id
+                ))
+            });
+    }
+    Ok(None)
+}
+
+fn status_to_db(status: StoredTraceStatus) -> String {
+    match status {
+        StoredTraceStatus::Unspecified => "unspecified",
+        StoredTraceStatus::Ok => "ok",
+        StoredTraceStatus::Error => "error",
+    }
+    .to_string()
+}
+
+fn status_from_db(status: &str) -> Result<StoredTraceStatus, DbError> {
+    match status {
+        "unspecified" => Ok(StoredTraceStatus::Unspecified),
+        "ok" => Ok(StoredTraceStatus::Ok),
+        "error" => Ok(StoredTraceStatus::Error),
+        other => Err(DbError::InvalidData(format!(
+            "database contains invalid trace status '{other}'"
+        ))),
+    }
+}
+
+fn limit_to_u64(value: usize) -> Result<u64, DbError> {
+    u64::try_from(value).map_err(|_error| {
+        DbError::InvalidData(format!(
+            "trace summary page value {value} exceeds database range"
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, DbError, ResolvedDatabaseConfig};
+    use crate::telemetry::{StoredTraceStatus, TraceSummaryRecord};
+
+    #[tokio::test]
+    async fn trace_summary_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_trace_summary_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn trace_summary_repository_round_trips_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_trace_summary_repository_round_trip(&db).await;
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    async fn assert_trace_summary_repository_round_trip(db: &CoralDb) {
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let first_workspace = format!("trace_workspace_{suffix}");
+        let second_workspace = format!("trace_other_{suffix}");
+        let first = summary(
+            &format!("trace_a_{suffix}"),
+            &first_workspace,
+            20,
+            StoredTraceStatus::Ok,
+            true,
+        );
+        let second = summary(
+            &format!("trace_b_{suffix}"),
+            &second_workspace,
+            40,
+            StoredTraceStatus::Error,
+            false,
+        );
+
+        insert_initial_summaries(db, &first, &second).await;
+        assert_initial_summaries(db, &first, &second).await;
+
+        let updated = update_first_summary(first);
+        assert_update_and_failed_replacement(db, &updated).await;
+        cleanup_workspace(
+            db,
+            updated.workspace_id.as_deref().expect("first workspace"),
+        )
+        .await;
+        cleanup_workspace(
+            db,
+            second.workspace_id.as_deref().expect("second workspace"),
+        )
+        .await;
+    }
+
+    fn summary(
+        trace_id: &str,
+        workspace_id: &str,
+        end_time_unix_nanos: i64,
+        status: StoredTraceStatus,
+        row_count_recorded: bool,
+    ) -> TraceSummaryRecord {
+        TraceSummaryRecord {
+            trace_id: trace_id.to_string(),
+            workspace_id: Some(workspace_id.to_string()),
+            root_span_id: "root".to_string(),
+            name: "coral.query".to_string(),
+            query: "SELECT 1".to_string(),
+            status,
+            start_time_unix_nanos: end_time_unix_nanos - 10,
+            end_time_unix_nanos,
+            duration_nanos: 10,
+            span_count: 1,
+            row_count: 0,
+            row_count_recorded,
+        }
+    }
+
+    fn update_first_summary(first: TraceSummaryRecord) -> TraceSummaryRecord {
+        TraceSummaryRecord {
+            query: "SELECT updated".to_string(),
+            row_count: 10,
+            ..first
+        }
+    }
+
+    async fn insert_initial_summaries(
+        db: &CoralDb,
+        first: &TraceSummaryRecord,
+        second: &TraceSummaryRecord,
+    ) {
+        let mut tx = db.begin().await.expect("begin tx");
+        ensure_summary_workspace(&mut tx, first).await;
+        ensure_summary_workspace(&mut tx, second).await;
+        tx.trace_summaries()
+            .upsert(first)
+            .await
+            .expect("upsert first");
+        tx.trace_summaries()
+            .upsert(second)
+            .await
+            .expect("upsert second");
+        tx.commit().await.expect("commit trace summaries");
+    }
+
+    async fn assert_initial_summaries(
+        db: &CoralDb,
+        first: &TraceSummaryRecord,
+        second: &TraceSummaryRecord,
+    ) {
+        let mut session = db;
+        assert_eq!(
+            session
+                .trace_summaries()
+                .get(&first.trace_id)
+                .await
+                .expect("get first"),
+            Some(first.clone())
+        );
+        let summaries = fixture_summaries(&mut session, first, second).await;
+        assert_eq!(summaries, vec![second.clone(), first.clone()]);
+    }
+
+    async fn assert_update_and_failed_replacement(db: &CoralDb, updated: &TraceSummaryRecord) {
+        let mut tx = db.begin().await.expect("begin update tx");
+        tx.trace_summaries()
+            .upsert(updated)
+            .await
+            .expect("upsert updated");
+        let invalid = TraceSummaryRecord {
+            row_count: i64::MAX as u64 + 1,
+            ..updated.clone()
+        };
+        assert!(
+            matches!(
+                tx.trace_summaries().upsert(&invalid).await,
+                Err(DbError::InvalidData(_))
+            ),
+            "invalid replacement should fail before deleting the existing summary"
+        );
+        tx.commit().await.expect("commit trace summary update");
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .trace_summaries()
+                .get(&updated.trace_id)
+                .await
+                .expect("get updated summary"),
+            Some(updated.clone())
+        );
+    }
+
+    async fn ensure_summary_workspace<S>(session: &mut S, summary: &TraceSummaryRecord)
+    where
+        S: crate::state::db::DbSession,
+    {
+        session
+            .workspaces()
+            .ensure(
+                summary.workspace_id.as_deref().expect("summary workspace"),
+                1,
+            )
+            .await
+            .expect("ensure summary workspace");
+    }
+
+    async fn fixture_summaries<S>(
+        session: &mut S,
+        first: &TraceSummaryRecord,
+        second: &TraceSummaryRecord,
+    ) -> Vec<TraceSummaryRecord>
+    where
+        S: crate::state::db::DbSession,
+    {
+        session
+            .trace_summaries()
+            .list(1_000, 0)
+            .await
+            .expect("list summaries")
+            .into_iter()
+            .filter(|summary| is_fixture_summary(summary, first, second))
+            .collect()
+    }
+
+    fn is_fixture_summary(
+        summary: &TraceSummaryRecord,
+        first: &TraceSummaryRecord,
+        second: &TraceSummaryRecord,
+    ) -> bool {
+        summary.workspace_id == first.workspace_id || summary.workspace_id == second.workspace_id
+    }
+
+    async fn cleanup_workspace(db: &CoralDb, workspace_id: &str) {
+        let mut tx = db.begin().await.expect("begin cleanup tx");
+        tx.workspaces()
+            .remove(workspace_id)
+            .await
+            .expect("delete test workspace");
+        tx.commit().await.expect("commit cleanup tx");
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -75,6 +75,23 @@ impl<S> WorkspacesRepo<'_, S>
 where
     S: DbWriteSession,
 {
+    pub(crate) async fn ensure_write_locked(
+        &mut self,
+        id: &str,
+        created_at_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        self.ensure(id, created_at_unix_nanos).await?;
+        let statement = Query::update()
+            .table(Workspaces::Table)
+            .value(
+                Workspaces::CreatedAtUnixNanos,
+                Expr::col(Workspaces::CreatedAtUnixNanos),
+            )
+            .and_where(Expr::col(Workspaces::Id).eq(id))
+            .to_owned();
+        self.session.execute_update(statement).await
+    }
+
     pub(crate) async fn remove(&mut self, id: &str) -> Result<(), DbError> {
         let statement = Query::delete()
             .from_table(Workspaces::Table)
@@ -103,6 +120,41 @@ mod tests {
         let db = open_sqlite(&layout).await;
 
         assert_workspace_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    async fn workspace_repository_write_lock_preserves_created_at() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+        let workspace_id = unique_workspace_id();
+
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure_write_locked(&workspace_id, 42)
+            .await
+            .expect("ensure locked workspace");
+        tx.commit().await.expect("commit first lock");
+
+        let mut tx = db.begin().await.expect("begin second tx");
+        tx.workspaces()
+            .ensure_write_locked(&workspace_id, 99)
+            .await
+            .expect("lock existing workspace");
+        tx.commit().await.expect("commit second lock");
+
+        let mut session = &db;
+        assert_eq!(
+            session
+                .workspaces()
+                .get(&workspace_id)
+                .await
+                .expect("get workspace"),
+            Some(WorkspaceRecord {
+                id: workspace_id,
+                created_at_unix_nanos: 42,
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -1,0 +1,192 @@
+use sea_query::{Expr, ExprTrait, OnConflict, Query};
+
+use crate::state::db::schema::Workspaces;
+use crate::state::db::{DbError, DbSession};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceRecord {
+    pub(crate) id: String,
+    pub(crate) created_at_unix_nanos: i64,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct WorkspaceRow {
+    id: String,
+    created_at_unix_nanos: i64,
+}
+
+impl From<WorkspaceRow> for WorkspaceRecord {
+    fn from(value: WorkspaceRow) -> Self {
+        Self {
+            id: value.id,
+            created_at_unix_nanos: value.created_at_unix_nanos,
+        }
+    }
+}
+
+pub(crate) struct WorkspacesRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> WorkspacesRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn ensure(
+        &mut self,
+        id: &str,
+        created_at_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(Workspaces::Table)
+            .columns([Workspaces::Id, Workspaces::CreatedAtUnixNanos])
+            .values_panic([Expr::val(id.to_string()), Expr::val(created_at_unix_nanos)])
+            .on_conflict(OnConflict::column(Workspaces::Id).do_nothing().to_owned())
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    pub(crate) async fn get(&mut self, id: &str) -> Result<Option<WorkspaceRecord>, DbError> {
+        let statement = Query::select()
+            .columns([Workspaces::Id, Workspaces::CreatedAtUnixNanos])
+            .from(Workspaces::Table)
+            .and_where(Expr::col(Workspaces::Id).eq(id))
+            .to_owned();
+        let row: Option<WorkspaceRow> = self.session.fetch_optional(statement).await?;
+        Ok(row.map(Into::into))
+    }
+
+    pub(crate) async fn list(&mut self) -> Result<Vec<WorkspaceRecord>, DbError> {
+        let statement = Query::select()
+            .columns([Workspaces::Id, Workspaces::CreatedAtUnixNanos])
+            .from(Workspaces::Table)
+            .order_by(Workspaces::Id, sea_query::Order::Asc)
+            .to_owned();
+        let rows: Vec<WorkspaceRow> = self.session.fetch_all(statement).await?;
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use tempfile::tempdir;
+
+    use super::WorkspaceRecord;
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+
+    #[tokio::test]
+    async fn workspace_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_workspace_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn workspace_repository_round_trips_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_workspace_repository_round_trip(&db).await;
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        assert_eq!(path, layout.database_file());
+        assert!(!path.exists());
+
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    async fn assert_workspace_repository_round_trip(db: &CoralDb) {
+        db.ping().await.expect("ping database");
+
+        let workspace_id = unique_workspace_id();
+        let missing_workspace_id = format!("{workspace_id}_missing");
+        let rolled_back_workspace_id = format!("{workspace_id}_rolled_back");
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(&workspace_id, 42)
+            .await
+            .expect("ensure workspace");
+        tx.workspaces()
+            .ensure(&workspace_id, 99)
+            .await
+            .expect("ensure existing workspace");
+        tx.commit().await.expect("commit tx");
+
+        let expected = WorkspaceRecord {
+            id: workspace_id.clone(),
+            created_at_unix_nanos: 42,
+        };
+        let mut session = db;
+        assert_eq!(
+            session
+                .workspaces()
+                .get(&workspace_id)
+                .await
+                .expect("get workspace"),
+            Some(expected.clone())
+        );
+        assert_eq!(
+            session
+                .workspaces()
+                .get(&missing_workspace_id)
+                .await
+                .expect("get missing workspace"),
+            None
+        );
+
+        let workspaces = session.workspaces().list().await.expect("list workspaces");
+        assert!(
+            workspaces.contains(&expected),
+            "workspace list did not contain expected record: {workspaces:?}"
+        );
+
+        let mut tx = db.begin().await.expect("begin rollback tx");
+        tx.workspaces()
+            .ensure(&rolled_back_workspace_id, 77)
+            .await
+            .expect("ensure rolled-back workspace");
+        tx.rollback().await.expect("rollback tx");
+        assert_eq!(
+            session
+                .workspaces()
+                .get(&rolled_back_workspace_id)
+                .await
+                .expect("get rolled-back workspace"),
+            None
+        );
+    }
+
+    fn unique_workspace_id() -> String {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before Unix epoch")
+            .as_nanos();
+        format!("workspace_{}_{}", std::process::id(), nanos)
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -1,7 +1,7 @@
 use sea_query::{Expr, ExprTrait, OnConflict, Query};
 
 use crate::state::db::schema::Workspaces;
-use crate::state::db::{DbError, DbSession};
+use crate::state::db::{DbError, DbSession, DbWriteSession};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct WorkspaceRecord {
@@ -68,6 +68,19 @@ where
             .to_owned();
         let rows: Vec<WorkspaceRow> = self.session.fetch_all(statement).await?;
         Ok(rows.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<S> WorkspacesRepo<'_, S>
+where
+    S: DbWriteSession,
+{
+    pub(crate) async fn remove(&mut self, id: &str) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(Workspaces::Table)
+            .and_where(Expr::col(Workspaces::Id).eq(id))
+            .to_owned();
+        self.session.execute_delete(statement).await
     }
 }
 

--- a/crates/coral-app/src/state/db/repositories/workspaces.rs
+++ b/crates/coral-app/src/state/db/repositories/workspaces.rs
@@ -89,7 +89,8 @@ where
             )
             .and_where(Expr::col(Workspaces::Id).eq(id))
             .to_owned();
-        self.session.execute_update(statement).await
+        self.session.execute_update(statement).await?;
+        Ok(())
     }
 
     pub(crate) async fn remove(&mut self, id: &str) -> Result<(), DbError> {

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -113,6 +113,40 @@ pub(in crate::state::db) enum CredentialDocuments {
 }
 
 #[derive(Iden)]
+pub(in crate::state::db) enum IdentitySpecs {
+    Table,
+    ScopeKind,
+    ScopeId,
+    WorkspaceId,
+    Name,
+    Version,
+    Description,
+    Issuer,
+    IdentityType,
+    ManifestYaml,
+    CreatedAtUnixNanos,
+    UpdatedAtUnixNanos,
+}
+
+#[derive(Iden)]
+pub(in crate::state::db) enum IdentitySpecDocuments {
+    Table,
+    ScopeKind,
+    ScopeId,
+    Name,
+    DocumentVersion,
+    Ciphertext,
+    Nonce,
+    WrappedDek,
+    WrappedDekNonce,
+    KeyId,
+    Algorithm,
+    AadVersion,
+    CreatedAtUnixNanos,
+    UpdatedAtUnixNanos,
+}
+
+#[derive(Iden)]
 pub(in crate::state::db) enum TraceSummaries {
     Table,
     TraceId,

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -71,6 +71,20 @@ pub(in crate::state::db) enum MaterializationSurfaces {
 }
 
 #[derive(Iden)]
+pub(in crate::state::db) enum FeedbackReports {
+    Table,
+    Id,
+    WorkspaceId,
+    CreatedAtUnixNanos,
+    TryingToDo,
+    Tried,
+    Stuck,
+    PublishStatus,
+    PublishError,
+    PublishedAtUnixNanos,
+}
+
+#[derive(Iden)]
 pub(in crate::state::db) enum AppStateMarkers {
     Table,
     Key,

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -48,6 +48,29 @@ pub(in crate::state::db) enum SourceManifests {
 }
 
 #[derive(Iden)]
+pub(in crate::state::db) enum Materializations {
+    Table,
+    WorkspaceId,
+    SourceName,
+    MaterializationVersion,
+    FingerprintYaml,
+    ProjectionsYaml,
+    DiagnosticsYaml,
+    CreatedAtUnixNanos,
+}
+
+#[derive(Iden)]
+pub(in crate::state::db) enum MaterializationSurfaces {
+    Table,
+    WorkspaceId,
+    SourceName,
+    SurfaceId,
+    SourceDocumentRaw,
+    SourceDocumentYaml,
+    SemanticIrYaml,
+}
+
+#[derive(Iden)]
 pub(in crate::state::db) enum AppStateMarkers {
     Table,
     Key,

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -7,9 +7,12 @@ pub(in crate::state::db) enum Workspaces {
     CreatedAtUnixNanos,
 }
 
-#[expect(
-    dead_code,
-    reason = "source catalog schema lands before the source repository in the stacked PR sequence"
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "source catalog schema lands before the source repository in the stacked PR sequence"
+    )
 )]
 #[derive(Iden)]
 pub(in crate::state::db) enum Sources {
@@ -23,9 +26,12 @@ pub(in crate::state::db) enum Sources {
     UpdatedAtUnixNanos,
 }
 
-#[expect(
-    dead_code,
-    reason = "source catalog schema lands before the source repository in the stacked PR sequence"
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "source catalog schema lands before the source repository in the stacked PR sequence"
+    )
 )]
 #[derive(Iden)]
 pub(in crate::state::db) enum SourceVariables {
@@ -36,9 +42,12 @@ pub(in crate::state::db) enum SourceVariables {
     Value,
 }
 
-#[expect(
-    dead_code,
-    reason = "source catalog schema lands before the source repository in the stacked PR sequence"
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "source catalog schema lands before the source repository in the stacked PR sequence"
+    )
 )]
 #[derive(Iden)]
 pub(in crate::state::db) enum SourceSecretKeys {

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -38,6 +38,16 @@ pub(in crate::state::db) enum SourceSecretKeys {
 }
 
 #[derive(Iden)]
+pub(in crate::state::db) enum SourceManifests {
+    Table,
+    WorkspaceId,
+    SourceName,
+    ManifestYaml,
+    ManifestHash,
+    CreatedAtUnixNanos,
+}
+
+#[derive(Iden)]
 pub(in crate::state::db) enum AppStateMarkers {
     Table,
     Key,

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -96,6 +96,23 @@ pub(in crate::state::db) enum Episodes {
 }
 
 #[derive(Iden)]
+pub(in crate::state::db) enum CredentialDocuments {
+    Table,
+    WorkspaceId,
+    SourceName,
+    DocumentVersion,
+    Ciphertext,
+    Nonce,
+    WrappedDek,
+    WrappedDekNonce,
+    KeyId,
+    Algorithm,
+    AadVersion,
+    CreatedAtUnixNanos,
+    UpdatedAtUnixNanos,
+}
+
+#[derive(Iden)]
 pub(in crate::state::db) enum AppStateMarkers {
     Table,
     Key,

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -7,13 +7,6 @@ pub(in crate::state::db) enum Workspaces {
     CreatedAtUnixNanos,
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "source catalog schema lands before the source repository in the stacked PR sequence"
-    )
-)]
 #[derive(Iden)]
 pub(in crate::state::db) enum Sources {
     Table,
@@ -26,13 +19,6 @@ pub(in crate::state::db) enum Sources {
     UpdatedAtUnixNanos,
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "source catalog schema lands before the source repository in the stacked PR sequence"
-    )
-)]
 #[derive(Iden)]
 pub(in crate::state::db) enum SourceVariables {
     Table,
@@ -42,13 +28,6 @@ pub(in crate::state::db) enum SourceVariables {
     Value,
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "source catalog schema lands before the source repository in the stacked PR sequence"
-    )
-)]
 #[derive(Iden)]
 pub(in crate::state::db) enum SourceSecretKeys {
     Table,

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -6,3 +6,45 @@ pub(in crate::state::db) enum Workspaces {
     Id,
     CreatedAtUnixNanos,
 }
+
+#[expect(
+    dead_code,
+    reason = "source catalog schema lands before the source repository in the stacked PR sequence"
+)]
+#[derive(Iden)]
+pub(in crate::state::db) enum Sources {
+    Table,
+    WorkspaceId,
+    Name,
+    Version,
+    OriginKind,
+    CredentialStorage,
+    CreatedAtUnixNanos,
+    UpdatedAtUnixNanos,
+}
+
+#[expect(
+    dead_code,
+    reason = "source catalog schema lands before the source repository in the stacked PR sequence"
+)]
+#[derive(Iden)]
+pub(in crate::state::db) enum SourceVariables {
+    Table,
+    WorkspaceId,
+    SourceName,
+    Key,
+    Value,
+}
+
+#[expect(
+    dead_code,
+    reason = "source catalog schema lands before the source repository in the stacked PR sequence"
+)]
+#[derive(Iden)]
+pub(in crate::state::db) enum SourceSecretKeys {
+    Table,
+    WorkspaceId,
+    SourceName,
+    Position,
+    Key,
+}

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -1,0 +1,8 @@
+use sea_query::Iden;
+
+#[derive(Iden)]
+pub(in crate::state::db) enum Workspaces {
+    Table,
+    Id,
+    CreatedAtUnixNanos,
+}

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -36,3 +36,10 @@ pub(in crate::state::db) enum SourceSecretKeys {
     Position,
     Key,
 }
+
+#[derive(Iden)]
+pub(in crate::state::db) enum AppStateMarkers {
+    Table,
+    Key,
+    CreatedAtUnixNanos,
+}

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -113,6 +113,22 @@ pub(in crate::state::db) enum CredentialDocuments {
 }
 
 #[derive(Iden)]
+pub(in crate::state::db) enum TraceSummaries {
+    Table,
+    TraceId,
+    WorkspaceId,
+    RootSpanId,
+    Name,
+    Query,
+    Status,
+    StartTimeUnixNanos,
+    EndTimeUnixNanos,
+    DurationNanos,
+    SpanCount,
+    RowCount,
+}
+
+#[derive(Iden)]
 pub(in crate::state::db) enum AppStateMarkers {
     Table,
     Key,

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -85,6 +85,17 @@ pub(in crate::state::db) enum FeedbackReports {
 }
 
 #[derive(Iden)]
+pub(in crate::state::db) enum Episodes {
+    Table,
+    WorkspaceId,
+    Id,
+    Intent,
+    ParentEpisodeId,
+    CreatedAtUnixNanos,
+    RecordBytes,
+}
+
+#[derive(Iden)]
 pub(in crate::state::db) enum AppStateMarkers {
     Table,
     Key,

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -7,6 +7,7 @@ use sqlx::{FromRow, Postgres, Sqlite};
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
 use crate::state::db::repositories::app_state_markers::AppStateMarkersRepo;
+use crate::state::db::repositories::episodes::EpisodesRepo;
 use crate::state::db::repositories::feedback_reports::FeedbackReportsRepo;
 use crate::state::db::repositories::materializations::MaterializationsRepo;
 use crate::state::db::repositories::source_manifests::SourceManifestsRepo;
@@ -54,6 +55,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn feedback_reports(&mut self) -> FeedbackReportsRepo<'_, Self> {
         FeedbackReportsRepo::new(self)
+    }
+
+    fn episodes(&mut self) -> EpisodesRepo<'_, Self> {
+        EpisodesRepo::new(self)
     }
 
     fn app_state_markers(&mut self) -> AppStateMarkersRepo<'_, Self> {

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -7,6 +7,7 @@ use sqlx::{FromRow, Postgres, Sqlite};
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
 use crate::state::db::repositories::app_state_markers::AppStateMarkersRepo;
+use crate::state::db::repositories::feedback_reports::FeedbackReportsRepo;
 use crate::state::db::repositories::materializations::MaterializationsRepo;
 use crate::state::db::repositories::source_manifests::SourceManifestsRepo;
 use crate::state::db::repositories::sources::SourcesRepo;
@@ -49,6 +50,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn materializations(&mut self) -> MaterializationsRepo<'_, Self> {
         MaterializationsRepo::new(self)
+    }
+
+    fn feedback_reports(&mut self) -> FeedbackReportsRepo<'_, Self> {
+        FeedbackReportsRepo::new(self)
     }
 
     fn app_state_markers(&mut self) -> AppStateMarkersRepo<'_, Self> {

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -6,18 +6,12 @@ use sqlx::{FromRow, Postgres, Sqlite};
 
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
+use crate::state::db::repositories::sources::SourcesRepo;
 use crate::state::db::repositories::workspaces::WorkspacesRepo;
 
 pub(crate) trait DbSession {
     async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError>;
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "delete execution is used by the source repository in the next stacked PR"
-        )
-    )]
     async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError>;
 
     async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
@@ -36,6 +30,10 @@ pub(crate) trait DbSession {
 pub(crate) trait DbRepos: DbSession + Sized {
     fn workspaces(&mut self) -> WorkspacesRepo<'_, Self> {
         WorkspacesRepo::new(self)
+    }
+
+    fn sources(&mut self) -> SourcesRepo<'_, Self> {
+        SourcesRepo::new(self)
     }
 }
 

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -7,6 +7,7 @@ use sqlx::{FromRow, Postgres, Sqlite};
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
 use crate::state::db::repositories::app_state_markers::AppStateMarkersRepo;
+use crate::state::db::repositories::source_manifests::SourceManifestsRepo;
 use crate::state::db::repositories::sources::SourcesRepo;
 use crate::state::db::repositories::workspaces::WorkspacesRepo;
 
@@ -37,6 +38,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn sources(&mut self) -> SourcesRepo<'_, Self> {
         SourcesRepo::new(self)
+    }
+
+    fn source_manifests(&mut self) -> SourceManifestsRepo<'_, Self> {
+        SourceManifestsRepo::new(self)
     }
 
     fn app_state_markers(&mut self) -> AppStateMarkersRepo<'_, Self> {

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -12,8 +12,6 @@ use crate::state::db::repositories::workspaces::WorkspacesRepo;
 pub(crate) trait DbSession {
     async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError>;
 
-    async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError>;
-
     async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
     where
         T: Send + Unpin,
@@ -25,6 +23,10 @@ pub(crate) trait DbSession {
         T: Send + Unpin,
         for<'r> T: FromRow<'r, SqliteRow>,
         for<'r> T: FromRow<'r, PgRow>;
+}
+
+pub(crate) trait DbWriteSession: DbSession {
+    async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError>;
 }
 
 pub(crate) trait DbRepos: DbSession + Sized {
@@ -42,10 +44,6 @@ impl<T> DbRepos for T where T: DbSession + Sized {}
 impl DbSession for &CoralDb {
     async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError> {
         execute_statement(&self.backend, statement).await
-    }
-
-    async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError> {
-        execute_delete_statement(&self.backend, statement).await
     }
 
     async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
@@ -67,13 +65,15 @@ impl DbSession for &CoralDb {
     }
 }
 
+impl DbWriteSession for CoralTx<'_> {
+    async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError> {
+        self.execute_delete(statement).await
+    }
+}
+
 impl DbSession for CoralTx<'_> {
     async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError> {
         self.execute(statement).await
-    }
-
-    async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError> {
-        self.execute_delete(statement).await
     }
 
     async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
@@ -98,27 +98,6 @@ impl DbSession for CoralTx<'_> {
 pub(super) async fn execute_statement(
     backend: &CoralDbBackend,
     statement: InsertStatement,
-) -> Result<(), DbError> {
-    match backend {
-        CoralDbBackend::Sqlite(db) => {
-            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
-            sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
-                .execute(&db.pool)
-                .await?;
-        }
-        CoralDbBackend::Postgres(db) => {
-            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
-            sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
-                .execute(&db.pool)
-                .await?;
-        }
-    }
-    Ok(())
-}
-
-pub(super) async fn execute_delete_statement(
-    backend: &CoralDbBackend,
-    statement: DeleteStatement,
 ) -> Result<(), DbError> {
     match backend {
         CoralDbBackend::Sqlite(db) => {

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -10,6 +10,9 @@ use crate::state::db::repositories::app_state_markers::AppStateMarkersRepo;
 use crate::state::db::repositories::credential_documents::CredentialDocumentsRepo;
 use crate::state::db::repositories::episodes::EpisodesRepo;
 use crate::state::db::repositories::feedback_reports::FeedbackReportsRepo;
+use crate::state::db::repositories::identity_specs::{
+    IdentitySpecDocumentsRepo, IdentitySpecsRepo,
+};
 use crate::state::db::repositories::materializations::MaterializationsRepo;
 use crate::state::db::repositories::source_manifests::SourceManifestsRepo;
 use crate::state::db::repositories::sources::SourcesRepo;
@@ -65,6 +68,14 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn credential_documents(&mut self) -> CredentialDocumentsRepo<'_, Self> {
         CredentialDocumentsRepo::new(self)
+    }
+
+    fn identity_specs(&mut self) -> IdentitySpecsRepo<'_, Self> {
+        IdentitySpecsRepo::new(self)
+    }
+
+    fn identity_spec_documents(&mut self) -> IdentitySpecDocumentsRepo<'_, Self> {
+        IdentitySpecDocumentsRepo::new(self)
     }
 
     fn trace_summaries(&mut self) -> TraceSummariesRepo<'_, Self> {

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -1,4 +1,4 @@
-use sea_query::{InsertStatement, SelectStatement};
+use sea_query::{DeleteStatement, InsertStatement, SelectStatement};
 use sea_query_sqlx::SqlxBinder;
 use sqlx::postgres::PgRow;
 use sqlx::sqlite::SqliteRow;
@@ -10,6 +10,12 @@ use crate::state::db::repositories::workspaces::WorkspacesRepo;
 
 pub(crate) trait DbSession {
     async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError>;
+
+    #[expect(
+        dead_code,
+        reason = "delete execution is used by the source repository in the next stacked PR"
+    )]
+    async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError>;
 
     async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
     where
@@ -37,6 +43,10 @@ impl DbSession for &CoralDb {
         execute_statement(&self.backend, statement).await
     }
 
+    async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError> {
+        execute_delete_statement(&self.backend, statement).await
+    }
+
     async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
     where
         T: Send + Unpin,
@@ -61,6 +71,10 @@ impl DbSession for CoralTx<'_> {
         self.execute(statement).await
     }
 
+    async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError> {
+        self.execute_delete(statement).await
+    }
+
     async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
     where
         T: Send + Unpin,
@@ -83,6 +97,27 @@ impl DbSession for CoralTx<'_> {
 pub(super) async fn execute_statement(
     backend: &CoralDbBackend,
     statement: InsertStatement,
+) -> Result<(), DbError> {
+    match backend {
+        CoralDbBackend::Sqlite(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+            sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+                .execute(&db.pool)
+                .await?;
+        }
+        CoralDbBackend::Postgres(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+            sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+                .execute(&db.pool)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) async fn execute_delete_statement(
+    backend: &CoralDbBackend,
+    statement: DeleteStatement,
 ) -> Result<(), DbError> {
     match backend {
         CoralDbBackend::Sqlite(db) => {

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -7,6 +7,7 @@ use sqlx::{FromRow, Postgres, Sqlite};
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
 use crate::state::db::repositories::app_state_markers::AppStateMarkersRepo;
+use crate::state::db::repositories::materializations::MaterializationsRepo;
 use crate::state::db::repositories::source_manifests::SourceManifestsRepo;
 use crate::state::db::repositories::sources::SourcesRepo;
 use crate::state::db::repositories::workspaces::WorkspacesRepo;
@@ -44,6 +45,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn source_manifests(&mut self) -> SourceManifestsRepo<'_, Self> {
         SourceManifestsRepo::new(self)
+    }
+
+    fn materializations(&mut self) -> MaterializationsRepo<'_, Self> {
+        MaterializationsRepo::new(self)
     }
 
     fn app_state_markers(&mut self) -> AppStateMarkersRepo<'_, Self> {

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -1,4 +1,4 @@
-use sea_query::{DeleteStatement, InsertStatement, SelectStatement};
+use sea_query::{DeleteStatement, InsertStatement, SelectStatement, UpdateStatement};
 use sea_query_sqlx::SqlxBinder;
 use sqlx::postgres::PgRow;
 use sqlx::sqlite::SqliteRow;
@@ -29,6 +29,8 @@ pub(crate) trait DbSession {
 
 pub(crate) trait DbWriteSession: DbSession {
     async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError>;
+
+    async fn execute_update(&mut self, statement: UpdateStatement) -> Result<(), DbError>;
 }
 
 pub(crate) trait DbRepos: DbSession + Sized {
@@ -78,6 +80,10 @@ impl DbSession for &CoralDb {
 impl DbWriteSession for CoralTx<'_> {
     async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError> {
         self.execute_delete(statement).await
+    }
+
+    async fn execute_update(&mut self, statement: UpdateStatement) -> Result<(), DbError> {
+        self.execute_update(statement).await
     }
 }
 

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -6,6 +6,7 @@ use sqlx::{FromRow, Postgres, Sqlite};
 
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
+use crate::state::db::repositories::app_state_markers::AppStateMarkersRepo;
 use crate::state::db::repositories::sources::SourcesRepo;
 use crate::state::db::repositories::workspaces::WorkspacesRepo;
 
@@ -36,6 +37,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn sources(&mut self) -> SourcesRepo<'_, Self> {
         SourcesRepo::new(self)
+    }
+
+    fn app_state_markers(&mut self) -> AppStateMarkersRepo<'_, Self> {
+        AppStateMarkersRepo::new(self)
     }
 }
 

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -13,6 +13,7 @@ use crate::state::db::repositories::feedback_reports::FeedbackReportsRepo;
 use crate::state::db::repositories::materializations::MaterializationsRepo;
 use crate::state::db::repositories::source_manifests::SourceManifestsRepo;
 use crate::state::db::repositories::sources::SourcesRepo;
+use crate::state::db::repositories::trace_summaries::TraceSummariesRepo;
 use crate::state::db::repositories::workspaces::WorkspacesRepo;
 
 pub(crate) trait DbSession {
@@ -64,6 +65,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn credential_documents(&mut self) -> CredentialDocumentsRepo<'_, Self> {
         CredentialDocumentsRepo::new(self)
+    }
+
+    fn trace_summaries(&mut self) -> TraceSummariesRepo<'_, Self> {
+        TraceSummariesRepo::new(self)
     }
 
     fn app_state_markers(&mut self) -> AppStateMarkersRepo<'_, Self> {

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -1,0 +1,156 @@
+use sea_query::{InsertStatement, SelectStatement};
+use sea_query_sqlx::SqlxBinder;
+use sqlx::postgres::PgRow;
+use sqlx::sqlite::SqliteRow;
+use sqlx::{FromRow, Postgres, Sqlite};
+
+use super::backend::CoralDbBackend;
+use super::{CoralDb, CoralTx, DbError};
+use crate::state::db::repositories::workspaces::WorkspacesRepo;
+
+pub(crate) trait DbSession {
+    async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError>;
+
+    async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>;
+
+    async fn fetch_all<T>(&mut self, statement: SelectStatement) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>;
+}
+
+pub(crate) trait DbRepos: DbSession + Sized {
+    fn workspaces(&mut self) -> WorkspacesRepo<'_, Self> {
+        WorkspacesRepo::new(self)
+    }
+}
+
+impl<T> DbRepos for T where T: DbSession + Sized {}
+
+impl DbSession for &CoralDb {
+    async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError> {
+        execute_statement(&self.backend, statement).await
+    }
+
+    async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        fetch_optional_statement(&self.backend, statement).await
+    }
+
+    async fn fetch_all<T>(&mut self, statement: SelectStatement) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        fetch_all_statement(&self.backend, statement).await
+    }
+}
+
+impl DbSession for CoralTx<'_> {
+    async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError> {
+        self.execute(statement).await
+    }
+
+    async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        self.fetch_optional(statement).await
+    }
+
+    async fn fetch_all<T>(&mut self, statement: SelectStatement) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        self.fetch_all(statement).await
+    }
+}
+
+pub(super) async fn execute_statement(
+    backend: &CoralDbBackend,
+    statement: InsertStatement,
+) -> Result<(), DbError> {
+    match backend {
+        CoralDbBackend::Sqlite(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+            sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+                .execute(&db.pool)
+                .await?;
+        }
+        CoralDbBackend::Postgres(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+            sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+                .execute(&db.pool)
+                .await?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) async fn fetch_optional_statement<T>(
+    backend: &CoralDbBackend,
+    statement: SelectStatement,
+) -> Result<Option<T>, DbError>
+where
+    T: Send + Unpin,
+    for<'r> T: FromRow<'r, SqliteRow>,
+    for<'r> T: FromRow<'r, PgRow>,
+{
+    match backend {
+        CoralDbBackend::Sqlite(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+            sqlx::query_as_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_optional(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+        CoralDbBackend::Postgres(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+            sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_optional(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+    }
+}
+
+pub(super) async fn fetch_all_statement<T>(
+    backend: &CoralDbBackend,
+    statement: SelectStatement,
+) -> Result<Vec<T>, DbError>
+where
+    T: Send + Unpin,
+    for<'r> T: FromRow<'r, SqliteRow>,
+    for<'r> T: FromRow<'r, PgRow>,
+{
+    match backend {
+        CoralDbBackend::Sqlite(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+            sqlx::query_as_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_all(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+        CoralDbBackend::Postgres(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+            sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                .fetch_all(&db.pool)
+                .await
+                .map_err(Into::into)
+        }
+    }
+}

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -7,6 +7,7 @@ use sqlx::{FromRow, Postgres, Sqlite};
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
 use crate::state::db::repositories::app_state_markers::AppStateMarkersRepo;
+use crate::state::db::repositories::credential_documents::CredentialDocumentsRepo;
 use crate::state::db::repositories::episodes::EpisodesRepo;
 use crate::state::db::repositories::feedback_reports::FeedbackReportsRepo;
 use crate::state::db::repositories::materializations::MaterializationsRepo;
@@ -33,7 +34,7 @@ pub(crate) trait DbSession {
 pub(crate) trait DbWriteSession: DbSession {
     async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError>;
 
-    async fn execute_update(&mut self, statement: UpdateStatement) -> Result<(), DbError>;
+    async fn execute_update(&mut self, statement: UpdateStatement) -> Result<u64, DbError>;
 }
 
 pub(crate) trait DbRepos: DbSession + Sized {
@@ -59,6 +60,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn episodes(&mut self) -> EpisodesRepo<'_, Self> {
         EpisodesRepo::new(self)
+    }
+
+    fn credential_documents(&mut self) -> CredentialDocumentsRepo<'_, Self> {
+        CredentialDocumentsRepo::new(self)
     }
 
     fn app_state_markers(&mut self) -> AppStateMarkersRepo<'_, Self> {
@@ -97,7 +102,7 @@ impl DbWriteSession for CoralTx<'_> {
         self.execute_delete(statement).await
     }
 
-    async fn execute_update(&mut self, statement: UpdateStatement) -> Result<(), DbError> {
+    async fn execute_update(&mut self, statement: UpdateStatement) -> Result<u64, DbError> {
         self.execute_update(statement).await
     }
 }

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -11,9 +11,12 @@ use crate::state::db::repositories::workspaces::WorkspacesRepo;
 pub(crate) trait DbSession {
     async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError>;
 
-    #[expect(
-        dead_code,
-        reason = "delete execution is used by the source repository in the next stacked PR"
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "delete execution is used by the source repository in the next stacked PR"
+        )
     )]
     async fn execute_delete(&mut self, statement: DeleteStatement) -> Result<(), DbError>;
 

--- a/crates/coral-app/src/state/db/transaction.rs
+++ b/crates/coral-app/src/state/db/transaction.rs
@@ -1,4 +1,4 @@
-use sea_query::{InsertStatement, SelectStatement};
+use sea_query::{DeleteStatement, InsertStatement, SelectStatement};
 use sea_query_sqlx::SqlxBinder;
 use sqlx::postgres::PgRow;
 use sqlx::sqlite::SqliteRow;
@@ -42,6 +42,27 @@ impl<'a> CoralTx<'a> {
     }
 
     pub(super) async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError> {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+                    .execute(&mut **tx)
+                    .await?;
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+                    .execute(&mut **tx)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) async fn execute_delete(
+        &mut self,
+        statement: DeleteStatement,
+    ) -> Result<(), DbError> {
         match &mut self.backend {
             CoralTxBackend::Sqlite(tx) => {
                 let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);

--- a/crates/coral-app/src/state/db/transaction.rs
+++ b/crates/coral-app/src/state/db/transaction.rs
@@ -1,4 +1,4 @@
-use sea_query::{DeleteStatement, InsertStatement, SelectStatement};
+use sea_query::{DeleteStatement, InsertStatement, SelectStatement, UpdateStatement};
 use sea_query_sqlx::SqlxBinder;
 use sqlx::postgres::PgRow;
 use sqlx::sqlite::SqliteRow;
@@ -62,6 +62,27 @@ impl<'a> CoralTx<'a> {
     pub(super) async fn execute_delete(
         &mut self,
         statement: DeleteStatement,
+    ) -> Result<(), DbError> {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+                    .execute(&mut **tx)
+                    .await?;
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+                    .execute(&mut **tx)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) async fn execute_update(
+        &mut self,
+        statement: UpdateStatement,
     ) -> Result<(), DbError> {
         match &mut self.backend {
             CoralTxBackend::Sqlite(tx) => {

--- a/crates/coral-app/src/state/db/transaction.rs
+++ b/crates/coral-app/src/state/db/transaction.rs
@@ -83,22 +83,24 @@ impl<'a> CoralTx<'a> {
     pub(super) async fn execute_update(
         &mut self,
         statement: UpdateStatement,
-    ) -> Result<(), DbError> {
-        match &mut self.backend {
+    ) -> Result<u64, DbError> {
+        let rows_affected = match &mut self.backend {
             CoralTxBackend::Sqlite(tx) => {
                 let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
                 sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
                     .execute(&mut **tx)
-                    .await?;
+                    .await?
+                    .rows_affected()
             }
             CoralTxBackend::Postgres(tx) => {
                 let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
                 sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
                     .execute(&mut **tx)
-                    .await?;
+                    .await?
+                    .rows_affected()
             }
-        }
-        Ok(())
+        };
+        Ok(rows_affected)
     }
 
     pub(super) async fn fetch_optional<T>(

--- a/crates/coral-app/src/state/db/transaction.rs
+++ b/crates/coral-app/src/state/db/transaction.rs
@@ -1,0 +1,115 @@
+use sea_query::{InsertStatement, SelectStatement};
+use sea_query_sqlx::SqlxBinder;
+use sqlx::postgres::PgRow;
+use sqlx::sqlite::SqliteRow;
+use sqlx::{FromRow, Postgres, Sqlite};
+
+use super::DbError;
+use super::backend::CoralDbBackend;
+
+pub(crate) struct CoralTx<'a> {
+    backend: CoralTxBackend<'a>,
+}
+
+enum CoralTxBackend<'a> {
+    Sqlite(sqlx::Transaction<'a, Sqlite>),
+    Postgres(sqlx::Transaction<'a, Postgres>),
+}
+
+impl<'a> CoralTx<'a> {
+    pub(super) async fn begin(backend: &'a CoralDbBackend) -> Result<Self, DbError> {
+        let backend = match backend {
+            CoralDbBackend::Sqlite(db) => CoralTxBackend::Sqlite(db.pool.begin().await?),
+            CoralDbBackend::Postgres(db) => CoralTxBackend::Postgres(db.pool.begin().await?),
+        };
+        Ok(Self { backend })
+    }
+
+    pub(crate) async fn commit(self) -> Result<(), DbError> {
+        match self.backend {
+            CoralTxBackend::Sqlite(tx) => tx.commit().await?,
+            CoralTxBackend::Postgres(tx) => tx.commit().await?,
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn rollback(self) -> Result<(), DbError> {
+        match self.backend {
+            CoralTxBackend::Sqlite(tx) => tx.rollback().await?,
+            CoralTxBackend::Postgres(tx) => tx.rollback().await?,
+        }
+        Ok(())
+    }
+
+    pub(super) async fn execute(&mut self, statement: InsertStatement) -> Result<(), DbError> {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+                    .execute(&mut **tx)
+                    .await?;
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+                    .execute(&mut **tx)
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) async fn fetch_optional<T>(
+        &mut self,
+        statement: SelectStatement,
+    ) -> Result<Option<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                sqlx::query_as_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_optional(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_optional(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+        }
+    }
+
+    pub(super) async fn fetch_all<T>(
+        &mut self,
+        statement: SelectStatement,
+    ) -> Result<Vec<T>, DbError>
+    where
+        T: Send + Unpin,
+        for<'r> T: FromRow<'r, SqliteRow>,
+        for<'r> T: FromRow<'r, PgRow>,
+    {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                sqlx::query_as_with::<Sqlite, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_all(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                sqlx::query_as_with::<Postgres, T, _>(sqlx::AssertSqlSafe(sql), values)
+                    .fetch_all(&mut **tx)
+                    .await
+                    .map_err(Into::into)
+            }
+        }
+    }
+}

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -93,6 +93,10 @@ impl AppStateLayout {
         self.feedback_dir(workspace_name).join("reports.jsonl")
     }
 
+    pub(crate) fn credential_encryption_key_file(&self) -> PathBuf {
+        self.config_dir.join("credentials").join("encryption.key")
+    }
+
     /// Per-workspace episode log (JSONL) for experimental trajectory memory. The
     /// episode store appends `OpenEpisode` records here; indexing and retrieval
     /// land in a later PR.

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -211,6 +211,7 @@ impl AppStateLayout {
             .join(DIAGNOSTICS_FILENAME)
     }
 
+    #[cfg(test)]
     pub(crate) fn v4_surface_dir(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -97,9 +97,7 @@ impl AppStateLayout {
         self.config_dir.join("credentials").join("encryption.key")
     }
 
-    /// Per-workspace episode log (JSONL) for experimental trajectory memory. The
-    /// episode store appends `OpenEpisode` records here; indexing and retrieval
-    /// land in a later PR.
+    /// Legacy per-workspace episode log imported into the database at startup.
     pub(crate) fn episodes_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.workspace_dir(workspace_name)
             .join("episodes")

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -61,6 +61,10 @@ impl AppStateLayout {
         &self.config_dir
     }
 
+    pub(crate) fn database_file(&self) -> PathBuf {
+        self.config_dir.join("coral.db")
+    }
+
     pub(crate) fn state_lock(&self) -> &Path {
         &self.state_lock
     }
@@ -244,6 +248,7 @@ mod tests {
         let source_name = SourceName::parse("github").expect("source");
 
         assert_eq!(layout.config_file(), config_dir.join("config.toml"));
+        assert_eq!(layout.database_file(), config_dir.join("coral.db"));
         assert_eq!(
             layout.manifest_file(&workspace_name, &source_name),
             config_dir

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -1,6 +1,7 @@
 //! App-home state layout and persisted config ownership.
 
 mod config;
+pub(crate) mod db;
 mod layout;
 
 pub(crate) use config::{AppConfig, ConfigStore};

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -35,6 +35,19 @@ pub(crate) fn create_new_file_private(path: &Path) -> io::Result<File> {
     open_create_new_file_private(path)
 }
 
+pub(crate) fn ensure_file_private(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        ensure_private_dir(parent)?;
+    }
+    match open_create_new_file_private(path) {
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            set_file_permissions_private(path)
+        }
+        Err(error) => Err(error),
+    }
+}
+
 /// Write to a temp file then rename to avoid partial writes on crash.
 pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
     let temp_path = temp_path_for(path);

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -429,6 +429,7 @@ pub(crate) enum StoredTraceStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TraceSummaryRecord {
     pub(crate) trace_id: String,
+    pub(crate) workspace_id: Option<String>,
     pub(crate) root_span_id: String,
     pub(crate) name: String,
     pub(crate) query: String,
@@ -508,6 +509,7 @@ pub(crate) struct TraceQueryTableFunctionUsage {
 
 struct TraceAggregate {
     trace_id: String,
+    workspace_id: Option<String>,
     start_time_unix_nanos: i64,
     end_time_unix_nanos: i64,
     span_count: u32,
@@ -540,6 +542,7 @@ struct TracePrimaryCandidate {
 #[derive(Debug, Clone)]
 struct TraceListAggregate {
     trace_id: String,
+    workspace_id: Option<String>,
     start_time_unix_nanos: i64,
     end_time_unix_nanos: i64,
     span_count: u32,
@@ -896,6 +899,7 @@ impl TraceListAggregate {
     fn new(span: &TraceListSpanRecord) -> Self {
         let mut aggregate = Self {
             trace_id: span.trace_id.clone(),
+            workspace_id: None,
             start_time_unix_nanos: span.start_time_unix_nanos,
             end_time_unix_nanos: span.end_time_unix_nanos,
             span_count: 0,
@@ -914,6 +918,9 @@ impl TraceListAggregate {
         if span.status == StoredTraceStatus::Error {
             self.error_count = self.error_count.saturating_add(1);
         }
+        if self.workspace_id.is_none() {
+            self.workspace_id = workspace_attribute(&span.attributes_json);
+        }
         self.found_root_span |= is_root_span_parent(span.parent_span_id.as_deref());
 
         let primary = TracePrimaryCandidate::from_span(span);
@@ -929,6 +936,7 @@ impl TraceListAggregate {
     fn into_summary(self) -> TraceSummaryRecord {
         let aggregate = TraceAggregate {
             trace_id: self.trace_id,
+            workspace_id: self.workspace_id,
             start_time_unix_nanos: self.start_time_unix_nanos,
             end_time_unix_nanos: self.end_time_unix_nanos,
             span_count: self.span_count,
@@ -1428,6 +1436,9 @@ fn summary_from_spans(trace_id: &str, spans: &[TraceSpanRecord]) -> TraceSummary
         .count();
     let aggregate = TraceAggregate {
         trace_id: trace_id.to_string(),
+        workspace_id: spans
+            .iter()
+            .find_map(|span| workspace_attribute(&span.attributes_json)),
         start_time_unix_nanos,
         end_time_unix_nanos,
         span_count: usize_to_u32(spans.len()),
@@ -1459,6 +1470,7 @@ fn summary_from_list_aggregate(
     primary.map_or_else(
         || TraceSummaryRecord {
             trace_id: aggregate.trace_id.clone(),
+            workspace_id: aggregate.workspace_id.clone(),
             root_span_id: String::new(),
             name: "trace".to_string(),
             query: String::new(),
@@ -1485,6 +1497,10 @@ fn summary_from_list_aggregate(
 
             TraceSummaryRecord {
                 trace_id: aggregate.trace_id.clone(),
+                workspace_id: attributes
+                    .as_ref()
+                    .and_then(|attrs| attr_string(attrs, WORKSPACE_SPAN_ATTRIBUTE))
+                    .or_else(|| aggregate.workspace_id.clone()),
                 root_span_id: primary.span_id.clone(),
                 name: primary.name.clone(),
                 query: attributes
@@ -1519,6 +1535,7 @@ fn summary_from_aggregate(
     primary.map_or_else(
         || TraceSummaryRecord {
             trace_id: aggregate.trace_id.clone(),
+            workspace_id: aggregate.workspace_id.clone(),
             root_span_id: String::new(),
             name: "trace".to_string(),
             query: String::new(),
@@ -1545,6 +1562,10 @@ fn summary_from_aggregate(
 
             TraceSummaryRecord {
                 trace_id: aggregate.trace_id.clone(),
+                workspace_id: attributes
+                    .as_ref()
+                    .and_then(|attrs| attr_string(attrs, WORKSPACE_SPAN_ATTRIBUTE))
+                    .or_else(|| aggregate.workspace_id.clone()),
                 root_span_id: primary.span_id.clone(),
                 name: primary.name.clone(),
                 query: attributes

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -599,6 +599,15 @@ impl TraceStore {
             .map_err(|source| TraceStoreError::Worker { source })?
     }
 
+    pub(crate) async fn list_all_traces_tolerant(
+        &self,
+    ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+        let traces = self.clone();
+        task::spawn_blocking(move || traces.list_all_traces_tolerant_sync())
+            .await
+            .map_err(|source| TraceStoreError::Worker { source })?
+    }
+
     pub(crate) async fn get_trace(
         &self,
         trace_id: String,
@@ -673,7 +682,42 @@ impl TraceStore {
         Ok(summaries.into_iter().take(limit).collect())
     }
 
-    fn get_trace_sync(&self, trace_id: &str) -> Result<TraceDetailRecord, TraceStoreError> {
+    fn list_all_traces_tolerant_sync(&self) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+        if let Err(error) = self.prune_expired() {
+            tracing::warn!("skipping local trace retention prune before summary backfill: {error}");
+        }
+        let files = self.jsonl_files_by_modified()?;
+        let mut spans_by_id = HashMap::new();
+        let mut traces: HashMap<String, TraceListAggregate> = HashMap::new();
+
+        for file in files {
+            match read_list_spans_file(&file.path) {
+                Ok(spans) => {
+                    for span in spans {
+                        record_list_span(span, &mut spans_by_id, &mut traces);
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        path = %file.path.display(),
+                        "skipping unreadable local trace file during summary backfill: {error}"
+                    );
+                }
+            }
+        }
+
+        let mut summaries = traces
+            .into_values()
+            .map(TraceListAggregate::into_summary)
+            .collect::<Vec<_>>();
+        sort_summaries(&mut summaries);
+        Ok(summaries)
+    }
+
+    pub(crate) fn get_trace_sync(
+        &self,
+        trace_id: &str,
+    ) -> Result<TraceDetailRecord, TraceStoreError> {
         let mut spans_by_id = HashMap::new();
         self.prune_expired()?;
         let files = self.jsonl_files_by_modified()?;

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -1,9 +1,9 @@
 //! Tracing and OpenTelemetry initialization for the local Coral process.
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use opentelemetry::Value as OtelValue;
@@ -17,7 +17,8 @@ use opentelemetry_sdk::logs::{BatchLogProcessor, SdkLoggerProvider};
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::trace::{
-    BatchSpanProcessor, SdkTracerProvider, SpanData, SpanExporter, TracerProviderBuilder,
+    BatchConfigBuilder, BatchSpanProcessor, SdkTracerProvider, SpanData, SpanExporter,
+    TracerProviderBuilder,
 };
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 use tracing_subscriber::Layer as _;
@@ -32,6 +33,7 @@ pub mod metrics;
 pub(crate) mod service;
 
 use crate::bootstrap::AppError;
+use crate::state::db::{CoralDb, DbError, DbRepos};
 use crate::workspaces::WorkspaceName;
 pub use config::TelemetryConfig;
 use config::{DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTER};
@@ -46,6 +48,8 @@ static LOGGER_PROVIDER: Mutex<Option<SdkLoggerProvider>> = Mutex::new(None);
 static METER_PROVIDER: Mutex<Option<SdkMeterProvider>> = Mutex::new(None);
 
 const METRICS_INTERVAL: Duration = Duration::from_secs(5);
+const LOCAL_TRACE_BATCH_DELAY: Duration = Duration::from_millis(50);
+const LOCAL_TRACE_MAX_EXPORT_BATCH_SIZE: usize = 64;
 const OTLP_TRACE_DENIED_TARGETS: &[&str] = &["coral.http.body", "coral.mcp.body"];
 const LOCAL_TRACE_EXCLUDED_RPC_SERVICES: &[&str] = &["coral.v1.TraceService"];
 pub(crate) const QUERY_TRACE_SOURCES_ATTR: &str = "coral.query.sources";
@@ -76,6 +80,13 @@ struct TargetFilteringSpanExporter<E> {
     targets: Targets,
     denied_targets: &'static [&'static str],
     excluded_rpc_services: &'static [&'static str],
+}
+
+#[derive(Debug)]
+struct LocalTraceSpanExporter {
+    inner: local_store::JsonlSpanExporter,
+    trace_store: local_store::TraceStore,
+    db: Option<Arc<CoralDb>>,
 }
 
 impl<E> TargetFilteringSpanExporter<E> {
@@ -129,6 +140,92 @@ where
     fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
         self.inner.set_resource(resource);
     }
+}
+
+impl LocalTraceSpanExporter {
+    fn new(
+        store: &InstalledLocalTraceStore,
+        db: Option<Arc<CoralDb>>,
+    ) -> Result<Self, local_store::LocalTraceStoreError> {
+        Ok(Self {
+            inner: local_store::JsonlSpanExporter::new(store.dir.clone(), store.retention)?,
+            trace_store: local_store::TraceStore::with_retention(
+                store.dir.clone(),
+                store.retention,
+            ),
+            db,
+        })
+    }
+}
+
+impl SpanExporter for LocalTraceSpanExporter {
+    async fn export(&self, batch: Vec<SpanData>) -> opentelemetry_sdk::error::OTelSdkResult {
+        let trace_ids = batch
+            .iter()
+            .map(|span| span.span_context.trace_id().to_string())
+            .collect::<BTreeSet<_>>();
+        let result = self.inner.export(batch).await;
+        if result.is_ok()
+            && let Some(db) = self.db.as_deref()
+        {
+            for trace_id in trace_ids {
+                match self.trace_store.get_trace_sync(&trace_id) {
+                    Ok(trace) => {
+                        if let Err(error) = upsert_trace_summary_blocking(db, &trace.summary) {
+                            tracing::warn!(
+                                %trace_id,
+                                detail = %error,
+                                "failed to update database trace summary after span export"
+                            );
+                        }
+                    }
+                    Err(error) => tracing::warn!(
+                        %trace_id,
+                        "failed to read local trace summary after span export: {error}"
+                    ),
+                }
+            }
+        }
+        result
+    }
+
+    fn shutdown_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.inner.shutdown_with_timeout(timeout)
+    }
+
+    fn force_flush(&mut self) -> opentelemetry_sdk::error::OTelSdkResult {
+        self.inner.force_flush()
+    }
+
+    fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
+        self.inner.set_resource(resource);
+    }
+}
+
+async fn upsert_trace_summary(
+    db: &CoralDb,
+    summary: &local_store::TraceSummaryRecord,
+) -> Result<(), DbError> {
+    let mut tx = db.begin().await?;
+    tx.trace_summaries().upsert(summary).await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+fn upsert_trace_summary_blocking(
+    db: &CoralDb,
+    summary: &local_store::TraceSummaryRecord,
+) -> Result<(), String> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| format!("failed to create trace summary export runtime: {error}"))?;
+    runtime
+        .block_on(upsert_trace_summary(db, summary))
+        .map_err(|error| error.to_string())
 }
 
 fn span_matches_targets(span: &SpanData, targets: &Targets) -> bool {
@@ -319,14 +416,23 @@ fn add_otlp_trace_exporter(
 fn add_local_trace_exporter(
     builder: TracerProviderBuilder,
     store: &InstalledLocalTraceStore,
+    db: Option<Arc<CoralDb>>,
 ) -> Result<TracerProviderBuilder, AppError> {
-    let exporter = local_store::JsonlSpanExporter::new(store.dir.clone(), store.retention)
+    let exporter = LocalTraceSpanExporter::new(store, db)
         .map_err(|e| AppError::InvalidInput(e.to_string()))?;
     let (internal_trace_targets, _) =
         build_trace_targets(DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOCAL_TRACE_FILTER);
     let exporter = TargetFilteringSpanExporter::new(exporter, internal_trace_targets)
         .excluding_rpc_services(LOCAL_TRACE_EXCLUDED_RPC_SERVICES);
-    Ok(builder.with_simple_exporter(exporter))
+    let batch_config = BatchConfigBuilder::default()
+        .with_scheduled_delay(LOCAL_TRACE_BATCH_DELAY)
+        .with_max_export_batch_size(LOCAL_TRACE_MAX_EXPORT_BATCH_SIZE)
+        .build();
+    Ok(builder.with_span_processor(
+        BatchSpanProcessor::builder(exporter)
+            .with_batch_config(batch_config)
+            .build(),
+    ))
 }
 
 pub(crate) fn list_local_query_history(
@@ -471,10 +577,11 @@ pub(crate) fn init_tracing(
     config: &TelemetryConfig,
     enable_stderr_logs: bool,
     internal_trace_store_dir: Option<PathBuf>,
+    db: Option<Arc<CoralDb>>,
 ) -> Result<Option<InstalledLocalTraceStore>, AppError> {
     let state = INIT
         .get_or_init(|| {
-            try_init_tracing(config, enable_stderr_logs, internal_trace_store_dir)
+            try_init_tracing(config, enable_stderr_logs, internal_trace_store_dir, db)
                 .map_err(|e| e.to_string())
         })
         .as_ref()
@@ -486,6 +593,7 @@ fn try_init_tracing(
     config: &TelemetryConfig,
     enable_stderr_logs: bool,
     internal_trace_store_dir: Option<PathBuf>,
+    db: Option<Arc<CoralDb>>,
 ) -> Result<TracingInitState, AppError> {
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
     let endpoint = configured_otlp_endpoint(config);
@@ -526,7 +634,7 @@ fn try_init_tracing(
         }
 
         if let Some(store) = local_trace_store.as_ref() {
-            builder = add_local_trace_exporter(builder, store)?;
+            builder = add_local_trace_exporter(builder, store, db)?;
         }
 
         let provider = builder.build();

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -36,7 +36,8 @@ use crate::workspaces::WorkspaceName;
 pub use config::TelemetryConfig;
 use config::{DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTER};
 pub(crate) use local_store::{
-    TraceQueryHistoryEntry, TraceQueryTableFunctionUsage, TraceQueryTableUsage, TraceStoreError,
+    StoredTraceStatus, TraceQueryHistoryEntry, TraceQueryTableFunctionUsage, TraceQueryTableUsage,
+    TraceStoreError, TraceSummaryRecord,
 };
 
 static INIT: OnceLock<Result<TracingInitState, String>> = OnceLock::new();

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -11,24 +11,16 @@ use coral_api::v1::{
 };
 use tonic::{Code, Request, Response, Status};
 
-use crate::state::db::{CoralDb, DbError, DbRepos};
+use super::upsert_trace_summary;
+use crate::state::db::{CoralDb, DbError, DbRepos, TraceSummaryRecord};
 use crate::telemetry::local_store::{
     StoredTraceStatus, TraceDetailRecord, TraceSpanRecord, TraceStore, TraceStoreError,
-    TraceSummaryRecord,
 };
 use crate::transport::{grpc_span, instrument_grpc};
 
 const DEFAULT_TRACE_PAGE_SIZE: usize = 50;
 const MAX_TRACE_PAGE_SIZE: usize = 200;
 const TRACE_SUMMARY_INDEX_PAGE_SIZE: usize = 200;
-
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum TraceSummaryIndexError {
-    #[error(transparent)]
-    Store(#[from] TraceStoreError),
-    #[error(transparent)]
-    Database(#[from] DbError),
-}
 
 #[derive(Clone)]
 pub(crate) struct TraceService {
@@ -56,13 +48,13 @@ impl TraceService {
         }
     }
 
-    pub(crate) async fn sync_summaries(
+    pub(crate) async fn backfill_summaries(
         trace_store_file: PathBuf,
         retention: Duration,
         db: &CoralDb,
-    ) -> Result<usize, TraceSummaryIndexError> {
+    ) -> Result<usize, DbError> {
         let traces = TraceStore::with_retention(trace_store_file, retention);
-        sync_trace_summaries(db, &traces).await
+        backfill_trace_summaries(db, &traces).await
     }
 }
 
@@ -80,12 +72,8 @@ impl TraceServiceApi for TraceService {
             let page_size = normalize_page_size(request.page_size);
             let offset = parse_page_token(&request.page_token)?;
             let mut summaries = if let Some(db) = db {
-                let mut session = db.as_ref();
-                session
-                    .trace_summaries()
-                    .list(page_size.saturating_add(1), offset)
-                    .await
-                    .map_err(trace_database_status)?
+                list_database_traces(&traces, db.as_ref(), page_size.saturating_add(1), offset)
+                    .await?
             } else {
                 traces
                     .list_traces(page_size.saturating_add(1), offset)
@@ -130,33 +118,80 @@ impl TraceServiceApi for TraceService {
     }
 }
 
-async fn sync_trace_summaries(
-    db: &CoralDb,
-    traces: &TraceStore,
-) -> Result<usize, TraceSummaryIndexError> {
-    let summaries = current_trace_summaries(traces).await?;
-    let imported = summaries.len();
-    let mut tx = db.begin().await?;
-    tx.trace_summaries().replace_all(&summaries).await?;
-    tx.commit().await?;
+async fn backfill_trace_summaries(db: &CoralDb, traces: &TraceStore) -> Result<usize, DbError> {
+    let summaries = traces.list_all_traces_tolerant().await;
+    let summaries = match summaries {
+        Ok(summaries) => summaries,
+        Err(error) => {
+            tracing::warn!("skipping local trace summary backfill: {error}");
+            return Ok(0);
+        }
+    };
+    let mut imported = 0;
+    for summary in summaries {
+        if summary.workspace_id.is_none() {
+            tracing::warn!(
+                trace_id = %summary.trace_id,
+                "skipping local trace summary backfill without workspace"
+            );
+            continue;
+        }
+        upsert_trace_summary(db, &summary).await?;
+        imported += 1;
+    }
     Ok(imported)
 }
 
-async fn current_trace_summaries(
+async fn list_database_traces(
     traces: &TraceStore,
-) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+    db: &CoralDb,
+    limit: usize,
+    offset: usize,
+) -> Result<Vec<TraceSummaryRecord>, Status> {
     let mut summaries = Vec::new();
-    loop {
-        let page = traces
-            .list_traces(TRACE_SUMMARY_INDEX_PAGE_SIZE, summaries.len())
-            .await?;
-        let page_len = page.len();
-        summaries.extend(page);
-        if page_len < TRACE_SUMMARY_INDEX_PAGE_SIZE {
+    let mut db_offset = offset;
+    while summaries.len() < limit {
+        let mut session = db;
+        let page = session
+            .trace_summaries()
+            .list(TRACE_SUMMARY_INDEX_PAGE_SIZE, db_offset)
+            .await
+            .map_err(trace_database_status)?;
+        if page.is_empty() {
             break;
+        }
+        db_offset = db_offset.saturating_add(page.len());
+        for summary in page {
+            match traces.get_trace(summary.trace_id.clone()).await {
+                Ok(_trace) => summaries.push(summary),
+                Err(TraceStoreError::NotFound(_)) => {
+                    if let Err(error) = delete_trace_summary(db, &summary).await {
+                        tracing::warn!(
+                            trace_id = %summary.trace_id,
+                            "failed to prune stale database trace summary: {error}"
+                        );
+                    }
+                }
+                Err(error) => return Err(trace_store_status(error)),
+            }
+            if summaries.len() == limit {
+                break;
+            }
         }
     }
     Ok(summaries)
+}
+
+async fn delete_trace_summary(db: &CoralDb, summary: &TraceSummaryRecord) -> Result<(), DbError> {
+    let Some(workspace_id) = summary.workspace_id.as_deref() else {
+        return Ok(());
+    };
+    let mut tx = db.begin().await?;
+    tx.trace_summaries()
+        .delete(workspace_id, &summary.trace_id)
+        .await?;
+    tx.commit().await?;
+    Ok(())
 }
 
 fn normalize_page_size(page_size: i32) -> usize {
@@ -270,14 +305,21 @@ fn trace_status_to_proto(status: StoredTraceStatus) -> TraceStatus {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::sync::Arc;
     use std::time::Duration;
 
+    use coral_api::v1::ListTracesRequest;
+    use coral_api::v1::trace_service_server::TraceService as _;
     use serde_json::json;
     use tempfile::tempdir;
+    use tonic::Request;
 
-    use super::{TraceStore, normalize_page_size, parse_page_token, sync_trace_summaries};
+    use super::{
+        TraceService, TraceStore, backfill_trace_summaries, normalize_page_size, parse_page_token,
+    };
     use crate::state::AppStateLayout;
     use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
+    use crate::telemetry::{StoredTraceStatus, TraceSummaryRecord};
 
     #[test]
     fn page_size_defaults_and_caps() {
@@ -295,18 +337,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sync_summaries_rebuilds_database_index_from_jsonl() {
+    async fn backfill_summaries_adds_local_rows_without_replacing_database_rows() {
         let temp = tempdir().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
         let db = open_sqlite(&layout).await;
         let trace_dir = temp.path().join("traces");
-        write_trace(&trace_dir, "trace-1", 1, 2);
+        write_trace(&trace_dir, "trace-1", "work", 1, 2);
+        ensure_workspace(&db, "work").await;
+        let remote = summary("remote-trace", "remote", 10);
+        insert_summary(&db, &remote).await;
 
         let traces = TraceStore::with_retention(trace_dir.clone(), Duration::from_mins(1));
         assert_eq!(
-            sync_trace_summaries(&db, &traces)
+            backfill_trace_summaries(&db, &traces)
                 .await
-                .expect("sync trace summaries"),
+                .expect("backfill trace summaries"),
             1
         );
         let mut session = &db;
@@ -315,28 +360,135 @@ mod tests {
             .list(10, 0)
             .await
             .expect("list trace summaries");
-        assert_eq!(summaries.len(), 1);
-        let summary = summaries.first().expect("trace summary");
-        assert_eq!(summary.trace_id, "trace-1");
-        assert_eq!(summary.query, "SELECT 1");
-        assert_eq!(summary.row_count, 1);
-        assert!(summary.row_count_recorded);
+        assert_eq!(
+            summaries
+                .iter()
+                .map(|summary| summary.trace_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["remote-trace", "trace-1"]
+        );
 
         fs::remove_dir_all(&trace_dir).expect("remove raw trace store");
         assert_eq!(
-            sync_trace_summaries(&db, &traces)
+            backfill_trace_summaries(&db, &traces)
                 .await
-                .expect("resync empty trace store"),
+                .expect("backfill empty trace store"),
             0
         );
+        assert_eq!(
+            session
+                .trace_summaries()
+                .list(10, 0)
+                .await
+                .expect("list preserved trace summaries")
+                .len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn exported_summary_is_visible_and_pruned_without_retained_details() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = Arc::new(open_sqlite(&layout).await);
+        let trace_dir = temp.path().join("traces");
+        write_trace(&trace_dir, "trace-1", "work", 1, 2);
+        ensure_workspace(db.as_ref(), "work").await;
+        let traces = TraceStore::with_retention(trace_dir.clone(), Duration::from_mins(1));
+        let trace = traces
+            .get_trace("trace-1".to_string())
+            .await
+            .expect("trace detail");
+        super::super::upsert_trace_summary(db.as_ref(), &trace.summary)
+            .await
+            .expect("upsert exported summary");
+
+        let service =
+            TraceService::with_db(trace_dir.clone(), Duration::from_mins(1), Arc::clone(&db));
+        let response = service
+            .list_traces(Request::new(ListTracesRequest {
+                page_size: 10,
+                page_token: String::new(),
+            }))
+            .await
+            .expect("list traces")
+            .into_inner();
+
+        assert_eq!(response.traces.len(), 1);
+        let trace = response.traces.into_iter().next().expect("trace summary");
+        assert_eq!(trace.trace_id, "trace-1");
+
+        fs::remove_dir_all(&trace_dir).expect("remove raw trace store");
+        let response = service
+            .list_traces(Request::new(ListTracesRequest {
+                page_size: 10,
+                page_token: String::new(),
+            }))
+            .await
+            .expect("list traces")
+            .into_inner();
+
+        assert!(response.traces.is_empty());
+        let mut session = db.as_ref();
         assert!(
             session
                 .trace_summaries()
                 .list(10, 0)
                 .await
-                .expect("list empty trace summaries")
+                .expect("list trace summaries")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the trace summary backfill harness against Postgres"]
+    async fn backfill_summaries_preserves_existing_postgres_rows() {
+        let Some(url) = crate::bootstrap::env_var("CORAL_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let local_workspace = format!("trace_local_{suffix}");
+        let remote_workspace = format!("trace_remote_{suffix}");
+        let local_trace = format!("local_trace_{suffix}");
+        let remote_trace = format!("remote_trace_{suffix}");
+        let temp = tempdir().expect("temp dir");
+        let trace_dir = temp.path().join("traces");
+        write_trace(&trace_dir, &local_trace, &local_workspace, 1, 2);
+        ensure_workspace(&db, &local_workspace).await;
+        insert_summary(&db, &summary(&remote_trace, &remote_workspace, 10)).await;
+
+        let traces = TraceStore::with_retention(trace_dir, Duration::from_mins(1));
+        assert_eq!(
+            backfill_trace_summaries(&db, &traces)
+                .await
+                .expect("backfill trace summaries"),
+            1
+        );
+
+        let mut session = &db;
+        assert!(
+            session
+                .trace_summaries()
+                .get(&local_trace)
+                .await
+                .expect("get local trace")
+                .is_some()
+        );
+        assert!(
+            session
+                .trace_summaries()
+                .get(&remote_trace)
+                .await
+                .expect("get remote trace")
+                .is_some()
+        );
+
+        cleanup_workspace(&db, &local_workspace).await;
+        cleanup_workspace(&db, &remote_workspace).await;
     }
 
     async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
@@ -351,18 +503,81 @@ mod tests {
         db
     }
 
-    fn write_trace(dir: &std::path::Path, trace_id: &str, start: i64, end: i64) {
+    async fn insert_summary(db: &CoralDb, summary: &TraceSummaryRecord) {
+        let mut tx = db.begin().await.expect("begin tx");
+        ensure_workspace_in_session(&mut tx, summary.workspace_id.as_deref().expect("workspace"))
+            .await;
+        tx.trace_summaries()
+            .upsert(summary)
+            .await
+            .expect("upsert trace summary");
+        tx.commit().await.expect("commit trace summary");
+    }
+
+    async fn ensure_workspace(db: &CoralDb, workspace_id: &str) {
+        let mut tx = db.begin().await.expect("begin tx");
+        ensure_workspace_in_session(&mut tx, workspace_id).await;
+        tx.commit().await.expect("commit workspace");
+    }
+
+    async fn cleanup_workspace(db: &CoralDb, workspace_id: &str) {
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .remove(workspace_id)
+            .await
+            .expect("remove workspace");
+        tx.commit().await.expect("commit cleanup");
+    }
+
+    async fn ensure_workspace_in_session<S>(session: &mut S, workspace_id: &str)
+    where
+        S: crate::state::db::DbSession,
+    {
+        session
+            .workspaces()
+            .ensure(workspace_id, 1)
+            .await
+            .expect("ensure workspace");
+    }
+
+    fn summary(trace_id: &str, workspace_id: &str, end_time_unix_nanos: i64) -> TraceSummaryRecord {
+        TraceSummaryRecord {
+            trace_id: trace_id.to_string(),
+            workspace_id: Some(workspace_id.to_string()),
+            root_span_id: "span-1".to_string(),
+            name: "coral.query".to_string(),
+            query: "SELECT 1".to_string(),
+            status: StoredTraceStatus::Ok,
+            start_time_unix_nanos: end_time_unix_nanos - 1,
+            end_time_unix_nanos,
+            duration_nanos: 1,
+            span_count: 1,
+            row_count: 1,
+            row_count_recorded: true,
+        }
+    }
+
+    fn write_trace(
+        dir: &std::path::Path,
+        trace_id: &str,
+        workspace_id: &str,
+        start: i64,
+        end: i64,
+    ) {
         fs::create_dir_all(dir).expect("create trace dir");
-        let record = json!({
-            "trace_id": trace_id,
-            "span_id": "span-1",
-            "parent_span_id": null,
-            "name": "coral.query",
-            "status": "ok",
-            "start_time_unix_nanos": start,
-            "end_time_unix_nanos": end,
-            "attributes_json": r#"{"sql":"SELECT 1","row_count":1}"#,
-        });
+        let attributes_json = serde_json::to_string(
+            &json!({
+                "sql": "SELECT 1",
+                "row_count": 1,
+                "workspace": workspace_id,
+            })
+            .to_string(),
+        )
+        .expect("encode attributes");
+        let duration = end - start;
+        let record = format!(
+            r#"{{"trace_id":"{trace_id}","span_id":"span-1","parent_span_id":null,"parent_span_is_remote":false,"name":"coral.query","kind":"internal","status":"ok","status_message":null,"start_time_unix_nanos":{start},"end_time_unix_nanos":{end},"duration_nanos":{duration},"attributes_json":{attributes_json},"events_json":"[]","links_json":"[]","resource_json":"{{}}","scope_name":"test","scope_version":null,"scope_schema_url":null,"scope_attributes_json":"{{}}","trace_flags":0,"trace_state":"","is_remote":false}}"#
+        );
         fs::write(
             dir.join(format!("spans-{start:020}-test-{trace_id}.jsonl")),
             format!("{record}\n"),

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -1,6 +1,7 @@
 //! Implements the gRPC `TraceService` for local trace inspection.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
@@ -10,6 +11,7 @@ use coral_api::v1::{
 };
 use tonic::{Code, Request, Response, Status};
 
+use crate::state::db::{CoralDb, DbError, DbRepos};
 use crate::telemetry::local_store::{
     StoredTraceStatus, TraceDetailRecord, TraceSpanRecord, TraceStore, TraceStoreError,
     TraceSummaryRecord,
@@ -18,17 +20,49 @@ use crate::transport::{grpc_span, instrument_grpc};
 
 const DEFAULT_TRACE_PAGE_SIZE: usize = 50;
 const MAX_TRACE_PAGE_SIZE: usize = 200;
+const TRACE_SUMMARY_INDEX_PAGE_SIZE: usize = 200;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum TraceSummaryIndexError {
+    #[error(transparent)]
+    Store(#[from] TraceStoreError),
+    #[error(transparent)]
+    Database(#[from] DbError),
+}
 
 #[derive(Clone)]
 pub(crate) struct TraceService {
     traces: TraceStore,
+    db: Option<Arc<CoralDb>>,
 }
 
 impl TraceService {
+    #[cfg(test)]
     pub(crate) fn new(trace_store_file: PathBuf, retention: Duration) -> Self {
         Self {
             traces: TraceStore::with_retention(trace_store_file, retention),
+            db: None,
         }
+    }
+
+    pub(crate) fn with_db(
+        trace_store_file: PathBuf,
+        retention: Duration,
+        db: Arc<CoralDb>,
+    ) -> Self {
+        Self {
+            traces: TraceStore::with_retention(trace_store_file, retention),
+            db: Some(db),
+        }
+    }
+
+    pub(crate) async fn sync_summaries(
+        trace_store_file: PathBuf,
+        retention: Duration,
+        db: &CoralDb,
+    ) -> Result<usize, TraceSummaryIndexError> {
+        let traces = TraceStore::with_retention(trace_store_file, retention);
+        sync_trace_summaries(db, &traces).await
     }
 }
 
@@ -40,14 +74,24 @@ impl TraceServiceApi for TraceService {
     ) -> Result<Response<ListTracesResponse>, Status> {
         let span = grpc_span(&request);
         let traces = self.traces.clone();
+        let db = self.db.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let page_size = normalize_page_size(request.page_size);
             let offset = parse_page_token(&request.page_token)?;
-            let mut summaries = traces
-                .list_traces(page_size.saturating_add(1), offset)
-                .await
-                .map_err(trace_store_status)?;
+            let mut summaries = if let Some(db) = db {
+                let mut session = db.as_ref();
+                session
+                    .trace_summaries()
+                    .list(page_size.saturating_add(1), offset)
+                    .await
+                    .map_err(trace_database_status)?
+            } else {
+                traces
+                    .list_traces(page_size.saturating_add(1), offset)
+                    .await
+                    .map_err(trace_store_status)?
+            };
             let next_page_token = if summaries.len() > page_size {
                 summaries.truncate(page_size);
                 offset.saturating_add(page_size).to_string()
@@ -86,6 +130,35 @@ impl TraceServiceApi for TraceService {
     }
 }
 
+async fn sync_trace_summaries(
+    db: &CoralDb,
+    traces: &TraceStore,
+) -> Result<usize, TraceSummaryIndexError> {
+    let summaries = current_trace_summaries(traces).await?;
+    let imported = summaries.len();
+    let mut tx = db.begin().await?;
+    tx.trace_summaries().replace_all(&summaries).await?;
+    tx.commit().await?;
+    Ok(imported)
+}
+
+async fn current_trace_summaries(
+    traces: &TraceStore,
+) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+    let mut summaries = Vec::new();
+    loop {
+        let page = traces
+            .list_traces(TRACE_SUMMARY_INDEX_PAGE_SIZE, summaries.len())
+            .await?;
+        let page_len = page.len();
+        summaries.extend(page);
+        if page_len < TRACE_SUMMARY_INDEX_PAGE_SIZE {
+            break;
+        }
+    }
+    Ok(summaries)
+}
+
 fn normalize_page_size(page_size: i32) -> usize {
     if page_size <= 0 {
         DEFAULT_TRACE_PAGE_SIZE
@@ -106,6 +179,14 @@ fn parse_page_token(page_token: &str) -> Result<usize, Status> {
             "invalid input: page_token must be returned by ListTraces",
         )
     })
+}
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "used directly as a map_err adapter across tonic service handlers"
+)]
+fn trace_database_status(error: DbError) -> Status {
+    Status::new(Code::Internal, error.to_string())
 }
 
 fn trace_store_status(error: TraceStoreError) -> Status {
@@ -188,7 +269,15 @@ fn trace_status_to_proto(status: StoredTraceStatus) -> TraceStatus {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_page_size, parse_page_token};
+    use std::fs;
+    use std::time::Duration;
+
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::{TraceStore, normalize_page_size, parse_page_token, sync_trace_summaries};
+    use crate::state::AppStateLayout;
+    use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
 
     #[test]
     fn page_size_defaults_and_caps() {
@@ -203,5 +292,81 @@ mod tests {
         assert_eq!(parse_page_token("").expect("empty token"), 0);
         assert_eq!(parse_page_token("25").expect("offset token"), 25);
         parse_page_token("not-an-offset").unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn sync_summaries_rebuilds_database_index_from_jsonl() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+        let trace_dir = temp.path().join("traces");
+        write_trace(&trace_dir, "trace-1", 1, 2);
+
+        let traces = TraceStore::with_retention(trace_dir.clone(), Duration::from_mins(1));
+        assert_eq!(
+            sync_trace_summaries(&db, &traces)
+                .await
+                .expect("sync trace summaries"),
+            1
+        );
+        let mut session = &db;
+        let summaries = session
+            .trace_summaries()
+            .list(10, 0)
+            .await
+            .expect("list trace summaries");
+        assert_eq!(summaries.len(), 1);
+        let summary = summaries.first().expect("trace summary");
+        assert_eq!(summary.trace_id, "trace-1");
+        assert_eq!(summary.query, "SELECT 1");
+        assert_eq!(summary.row_count, 1);
+        assert!(summary.row_count_recorded);
+
+        fs::remove_dir_all(&trace_dir).expect("remove raw trace store");
+        assert_eq!(
+            sync_trace_summaries(&db, &traces)
+                .await
+                .expect("resync empty trace store"),
+            0
+        );
+        assert!(
+            session
+                .trace_summaries()
+                .list(10, 0)
+                .await
+                .expect("list empty trace summaries")
+                .is_empty()
+        );
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    fn write_trace(dir: &std::path::Path, trace_id: &str, start: i64, end: i64) {
+        fs::create_dir_all(dir).expect("create trace dir");
+        let record = json!({
+            "trace_id": trace_id,
+            "span_id": "span-1",
+            "parent_span_id": null,
+            "name": "coral.query",
+            "status": "ok",
+            "start_time_unix_nanos": start,
+            "end_time_unix_nanos": end,
+            "attributes_json": r#"{"sql":"SELECT 1","row_count":1}"#,
+        });
+        fs::write(
+            dir.join(format!("spans-{start:020}-test-{trace_id}.jsonl")),
+            format!("{record}\n"),
+        )
+        .expect("write trace");
     }
 }

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -257,46 +257,8 @@ impl Drop for FailingHttpFixture {
     }
 }
 
-pub(crate) async fn issues_http_fixture(auth_header: &[&str]) -> wiremock::MockServer {
-    let server = wiremock::MockServer::start().await;
-    let auth_header = auth_header.to_vec();
-    wiremock::Mock::given(wiremock::matchers::method("GET"))
-        .and(wiremock::matchers::headers("Authorization", auth_header))
-        .respond_with(
-            wiremock::ResponseTemplate::new(200)
-                .append_header("Content-Type", "application/json")
-                .set_body_string(r#"[{"id":1,"title":"Stored materialization"}]"#),
-        )
-        .mount(&server)
-        .await;
-    server
-}
-
 pub(crate) fn fixture_manifest_yaml(root: &Path) -> String {
     fixture_manifest_with_test_queries_yaml(root, &[])
-}
-
-pub(crate) fn fixture_v4_openapi_manifest_yaml(root: &Path, base_url: &str) -> (String, PathBuf) {
-    let openapi_file = root.join("github-openapi.yaml");
-    std::fs::write(
-        &openapi_file,
-        format!(
-            r#"{{"openapi":"3.0.3","servers":[{{"url":"{base_url}"}}],"paths":{{"/issues":{{"get":{{"operationId":"issues/list","responses":{{"200":{{"content":{{"application/json":{{"schema":{{"type":"array","items":{{"type":"object","properties":{{"id":{{"type":"integer"}},"title":{{"type":"string"}}}}}}}}}}}}}}}}}}}}}}}}"#
-        ),
-    )
-    .expect("write v4 OpenAPI fixture");
-    (
-        manifest_yaml(&json!({
-            "name": "github_v4_query",
-            "dsl_version": 4,
-            "surfaces": [{
-                "id": "rest",
-                "type": "openapi",
-                "file": openapi_file,
-            }],
-        })),
-        openapi_file,
-    )
 }
 
 pub(crate) fn fixture_manifest_with_multiple_tables_yaml(root: &Path) -> String {

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -257,8 +257,46 @@ impl Drop for FailingHttpFixture {
     }
 }
 
+pub(crate) async fn issues_http_fixture(auth_header: &[&str]) -> wiremock::MockServer {
+    let server = wiremock::MockServer::start().await;
+    let auth_header = auth_header.to_vec();
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::headers("Authorization", auth_header))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200)
+                .append_header("Content-Type", "application/json")
+                .set_body_string(r#"[{"id":1,"title":"Stored materialization"}]"#),
+        )
+        .mount(&server)
+        .await;
+    server
+}
+
 pub(crate) fn fixture_manifest_yaml(root: &Path) -> String {
     fixture_manifest_with_test_queries_yaml(root, &[])
+}
+
+pub(crate) fn fixture_v4_openapi_manifest_yaml(root: &Path, base_url: &str) -> (String, PathBuf) {
+    let openapi_file = root.join("github-openapi.yaml");
+    std::fs::write(
+        &openapi_file,
+        format!(
+            r#"{{"openapi":"3.0.3","servers":[{{"url":"{base_url}"}}],"paths":{{"/issues":{{"get":{{"operationId":"issues/list","responses":{{"200":{{"content":{{"application/json":{{"schema":{{"type":"array","items":{{"type":"object","properties":{{"id":{{"type":"integer"}},"title":{{"type":"string"}}}}}}}}}}}}}}}}}}}}}}}}"#
+        ),
+    )
+    .expect("write v4 OpenAPI fixture");
+    (
+        manifest_yaml(&json!({
+            "name": "github_v4_query",
+            "dsl_version": 4,
+            "surfaces": [{
+                "id": "rest",
+                "type": "openapi",
+                "file": openapi_file,
+            }],
+        })),
+        openapi_file,
+    )
 }
 
 pub(crate) fn fixture_manifest_with_multiple_tables_yaml(root: &Path) -> String {

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -72,6 +72,13 @@ impl GrpcHarness {
         self.local_trace_store_dir.as_deref()
     }
 
+    pub(crate) async fn shutdown(self) {
+        let Self {
+            _server: server, ..
+        } = self;
+        server.shutdown().await.expect("shutdown server");
+    }
+
     pub(crate) fn source_client(&self) -> SourceClient {
         self.app.source_client()
     }

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -40,6 +40,13 @@ impl GrpcHarness {
         Self::start_with_parts(temp_dir, config_dir).await
     }
 
+    pub(crate) async fn start_with_owned_config_dir(
+        temp_dir: TempDir,
+        config_dir: PathBuf,
+    ) -> Self {
+        Self::start_with_parts(temp_dir, config_dir).await
+    }
+
     async fn start_with_parts(temp_dir: TempDir, config_dir: PathBuf) -> Self {
         ensure_file_credentials_config(&config_dir);
         let server = ServerBuilder::new()

--- a/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
+++ b/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
@@ -670,10 +670,9 @@ fn remove_config_source_section(config_dir: &Path, source_name: &str) {
     let config_path = config_dir.join("config.toml");
     let raw = fs::read_to_string(&config_path).expect("read config");
     let mut doc = raw.parse::<DocumentMut>().expect("parse config");
-    doc["workspaces"]["default"]["sources"]
-        .as_table_mut()
-        .expect("sources table")
-        .remove(source_name);
+    if let Some(sources) = doc["workspaces"]["default"]["sources"].as_table_mut() {
+        sources.remove(source_name);
+    }
     fs::write(&config_path, doc.to_string()).expect("write config without source section");
 }
 

--- a/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
+++ b/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
@@ -27,27 +27,12 @@ use crate::harness::{GrpcHarness, fixture_manifest_yaml, source_dir};
 #[tokio::test]
 async fn query_refreshes_expired_oauth_access_token_at_request_time() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness
-        .import_source(
-            oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: fixture.base_url.clone(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "expired-token".to_string(),
-            }],
-        )
-        .await;
-
-    let secret_path = source_dir(harness.config_dir(), "refreshed_messages").join("secrets.env");
-    seed_expired_api_token_material(
-        &secret_path,
+    let harness = start_harness_with_expired_api_token_source(
+        &fixture,
         &fixture.token_url,
         Some("stored-refresh-token"),
-    );
+    )
+    .await;
 
     let rows = harness
         .execute_sql_rows("SELECT id FROM refreshed_messages.messages")
@@ -74,38 +59,33 @@ async fn query_refreshes_expired_oauth_access_token_at_request_time() {
         Some("stored-client")
     );
 
-    let material = fs::read_to_string(secret_path).expect("read refreshed material");
-    assert!(material.contains("API_TOKEN=refreshed-token"), "{material}");
-    assert!(
-        material.contains("__coral_oauth.QVBJX1RPS0VO.refresh_token=rotated-refresh-token"),
-        "{material}"
+    let rows = harness
+        .execute_sql_rows("SELECT id FROM refreshed_messages.messages")
+        .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        fixture.token_forms().len(),
+        1,
+        "refreshed material should be reused without a second token request"
+    );
+    assert_eq!(
+        fixture.message_authorizations(),
+        vec![
+            "Bearer refreshed-token".to_string(),
+            "Bearer refreshed-token".to_string()
+        ]
     );
 }
 
 #[tokio::test]
 async fn db_loaded_source_persists_oauth_refresh_after_config_source_section_is_removed() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness
-        .import_source(
-            oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: fixture.base_url.clone(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "expired-token".to_string(),
-            }],
-        )
-        .await;
-
-    let secret_path = source_dir(harness.config_dir(), "refreshed_messages").join("secrets.env");
-    seed_expired_api_token_material(
-        &secret_path,
+    let harness = start_harness_with_expired_api_token_source(
+        &fixture,
         &fixture.token_url,
         Some("stored-refresh-token"),
-    );
+    )
+    .await;
     remove_config_source_section(harness.config_dir(), "refreshed_messages");
 
     let rows = harness
@@ -125,11 +105,13 @@ async fn db_loaded_source_persists_oauth_refresh_after_config_source_section_is_
         Some("stored-refresh-token")
     );
 
-    let material = fs::read_to_string(secret_path).expect("read refreshed material");
-    assert!(material.contains("API_TOKEN=refreshed-token"), "{material}");
+    let rows = harness
+        .execute_sql_rows("SELECT id FROM refreshed_messages.messages")
+        .await;
+    assert_eq!(rows.len(), 1);
     assert!(
-        material.contains("__coral_oauth.QVBJX1RPS0VO.refresh_token=rotated-refresh-token"),
-        "{material}"
+        fixture.token_forms().len() == 1,
+        "refreshed DB material should be reused without another token request"
     );
 }
 
@@ -137,30 +119,17 @@ async fn db_loaded_source_persists_oauth_refresh_after_config_source_section_is_
 async fn restarted_db_loaded_source_persists_oauth_refresh_after_config_source_section_is_removed()
 {
     let fixture = RefreshingHttpFixture::new().await;
-    let temp = TempDir::new().expect("temp dir");
-    let config_dir = temp.path().join("coral-config");
-    let secret_path = source_dir(&config_dir, "refreshed_messages").join("secrets.env");
+    let material = expired_api_token_material(&fixture.token_url, Some("stored-refresh-token"));
+    let (_temp_dir, config_dir) = seed_legacy_source_config(
+        "refreshed_messages",
+        &oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
+        &[("API_BASE", fixture.base_url.as_str())],
+        &["API_TOKEN"],
+        &material,
+    );
 
     {
         let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
-        harness
-            .import_source(
-                oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
-                vec![SourceVariable {
-                    key: "API_BASE".to_string(),
-                    value: fixture.base_url.clone(),
-                }],
-                vec![SourceSecret {
-                    key: "API_TOKEN".to_string(),
-                    value: "expired-token".to_string(),
-                }],
-            )
-            .await;
-        seed_expired_api_token_material(
-            &secret_path,
-            &fixture.token_url,
-            Some("stored-refresh-token"),
-        );
         harness.shutdown().await;
     }
     remove_config_source_section(&config_dir, "refreshed_messages");
@@ -176,31 +145,25 @@ async fn restarted_db_loaded_source_persists_oauth_refresh_after_config_source_s
         fixture.message_authorizations(),
         vec!["Bearer refreshed-token".to_string()]
     );
-    let material = fs::read_to_string(secret_path).expect("read refreshed material");
-    assert!(material.contains("API_TOKEN=refreshed-token"), "{material}");
+    let rows = harness
+        .execute_sql_rows("SELECT id FROM refreshed_messages.messages")
+        .await;
+    assert_eq!(rows.len(), 1);
     assert!(
-        material.contains("__coral_oauth.QVBJX1RPS0VO.refresh_token=rotated-refresh-token"),
-        "{material}"
+        fixture.token_forms().len() == 1,
+        "refreshed DB material should survive restart without another token request"
     );
 }
 
 #[tokio::test]
 async fn query_against_other_source_does_not_refresh_expired_oauth_source() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness
-        .import_source(
-            oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: fixture.base_url.clone(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "expired-token".to_string(),
-            }],
-        )
-        .await;
+    let harness = start_harness_with_expired_api_token_source(
+        &fixture,
+        &fixture.token_url,
+        Some("stored-refresh-token"),
+    )
+    .await;
     harness
         .import_source(
             fixture_manifest_yaml(harness.temp_path()),
@@ -208,13 +171,6 @@ async fn query_against_other_source_does_not_refresh_expired_oauth_source() {
             Vec::new(),
         )
         .await;
-
-    let secret_path = source_dir(harness.config_dir(), "refreshed_messages").join("secrets.env");
-    seed_expired_api_token_material(
-        &secret_path,
-        &fixture.token_url,
-        Some("stored-refresh-token"),
-    );
 
     let rows = harness
         .execute_sql_rows("SELECT text FROM local_messages.messages ORDER BY text")
@@ -236,27 +192,12 @@ async fn query_against_other_source_does_not_refresh_expired_oauth_source() {
 #[tokio::test]
 async fn list_catalog_does_not_refresh_expired_oauth_access_token() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness
-        .import_source(
-            oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: fixture.base_url.clone(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "expired-token".to_string(),
-            }],
-        )
-        .await;
-
-    let secret_path = source_dir(harness.config_dir(), "refreshed_messages").join("secrets.env");
-    seed_expired_api_token_material(
-        &secret_path,
+    let harness = start_harness_with_expired_api_token_source(
+        &fixture,
         &fixture.token_url,
         Some("stored-refresh-token"),
-    );
+    )
+    .await;
 
     let tables = harness.list_tables().await;
     let refreshed_tables = tables
@@ -270,34 +211,18 @@ async fn list_catalog_does_not_refresh_expired_oauth_access_token() {
         fixture.token_forms().is_empty(),
         "passive catalog discovery should not call the token endpoint"
     );
-    let material = fs::read_to_string(secret_path).expect("read material");
-    assert!(material.contains("API_TOKEN=expired-token"), "{material}");
 }
 
 #[tokio::test]
 async fn query_surfaces_oauth_refresh_failure_instead_of_skipping_source() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness
-        .import_source(
-            oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: fixture.base_url.clone(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "expired-token".to_string(),
-            }],
-        )
-        .await;
-
-    let secret_path = source_dir(harness.config_dir(), "refreshed_messages").join("secrets.env");
-    seed_expired_api_token_material(
-        &secret_path,
-        &format!("{}/token-fail", fixture.base_url),
+    let failed_token_url = format!("{}/token-fail", fixture.base_url);
+    let harness = start_harness_with_expired_api_token_source(
+        &fixture,
+        &failed_token_url,
         Some("stored-refresh-token"),
-    );
+    )
+    .await;
 
     let status = harness
         .query_client()
@@ -320,23 +245,8 @@ async fn query_surfaces_oauth_refresh_failure_instead_of_skipping_source() {
 #[tokio::test]
 async fn expired_oauth_access_token_without_refresh_token_tells_user_to_reconnect() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness
-        .import_source(
-            oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: fixture.base_url.clone(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "expired-token".to_string(),
-            }],
-        )
-        .await;
-
-    let secret_path = source_dir(harness.config_dir(), "refreshed_messages").join("secrets.env");
-    seed_expired_api_token_material(&secret_path, &fixture.token_url, None);
+    let harness =
+        start_harness_with_expired_api_token_source(&fixture, &fixture.token_url, None).await;
 
     let status = harness
         .query_client()
@@ -361,27 +271,12 @@ async fn expired_oauth_access_token_without_refresh_token_tells_user_to_reconnec
 #[tokio::test]
 async fn concurrent_queries_share_one_expired_oauth_refresh() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness
-        .import_source(
-            oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: fixture.base_url.clone(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "expired-token".to_string(),
-            }],
-        )
-        .await;
-
-    let secret_path = source_dir(harness.config_dir(), "refreshed_messages").join("secrets.env");
-    seed_expired_api_token_material(
-        &secret_path,
+    let harness = start_harness_with_expired_api_token_source(
+        &fixture,
         &fixture.token_url,
         Some("stored-refresh-token"),
-    );
+    )
+    .await;
 
     let (first, second) = tokio::join!(
         harness.execute_sql_rows("SELECT id FROM refreshed_messages.messages"),
@@ -408,29 +303,16 @@ async fn concurrent_queries_share_one_expired_oauth_refresh() {
 #[tokio::test(flavor = "multi_thread")]
 async fn concurrent_servers_share_one_expired_oauth_refresh() {
     let fixture = RefreshingHttpFixture::new().await;
-    let config_root = TempDir::new().expect("config root");
-    let config_dir = config_root.path().join("coral-config");
-    let first_harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
-    first_harness
-        .import_source(
-            oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: fixture.base_url.clone(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "expired-token".to_string(),
-            }],
-        )
-        .await;
-
-    let secret_path = source_dir(&config_dir, "refreshed_messages").join("secrets.env");
-    seed_expired_api_token_material(
-        &secret_path,
-        &fixture.token_url,
-        Some("stored-refresh-token"),
+    let material = expired_api_token_material(&fixture.token_url, Some("stored-refresh-token"));
+    let (config_root, config_dir) = seed_legacy_source_config(
+        "refreshed_messages",
+        &oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
+        &[("API_BASE", fixture.base_url.as_str())],
+        &["API_TOKEN"],
+        &material,
     );
+    let first_harness =
+        GrpcHarness::start_with_owned_config_dir(config_root, config_dir.clone()).await;
 
     let second_harness = GrpcHarness::start_with_config_dir(config_dir).await;
     let (first, second) = tokio::join!(
@@ -458,27 +340,12 @@ async fn concurrent_servers_share_one_expired_oauth_refresh() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn manual_credential_replacement_waits_for_in_flight_refresh() {
     let fixture = RefreshingHttpFixture::new_blocked_token_response().await;
-    let harness = GrpcHarness::new().await;
-    harness
-        .import_source(
-            oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: fixture.base_url.clone(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "expired-token".to_string(),
-            }],
-        )
-        .await;
-
-    let secret_path = source_dir(harness.config_dir(), "refreshed_messages").join("secrets.env");
-    seed_expired_api_token_material(
-        &secret_path,
+    let harness = start_harness_with_expired_api_token_source(
+        &fixture,
         &fixture.token_url,
         Some("stored-refresh-token"),
-    );
+    )
+    .await;
 
     let mut query_client = harness.query_client();
     let query = tokio::spawn(async move {
@@ -542,45 +409,31 @@ async fn manual_credential_replacement_waits_for_in_flight_refresh() {
         fixture.message_authorizations(),
         vec!["Bearer refreshed-token".to_string()]
     );
-    let material = fs::read_to_string(secret_path).expect("read material");
-    assert!(material.contains("API_TOKEN=manual-token"), "{material}");
+    let rows = harness
+        .execute_sql_rows("SELECT id FROM refreshed_messages.messages")
+        .await;
+    assert_eq!(rows.len(), 1);
     assert!(
-        !material.contains("API_TOKEN=refreshed-token"),
-        "stale refresh should not overwrite manual replacement: {material}"
+        fixture.token_forms().len() == 1,
+        "manual replacement should not trigger a second refresh"
+    );
+    assert_eq!(
+        fixture.message_authorizations(),
+        vec![
+            "Bearer refreshed-token".to_string(),
+            "Bearer manual-token".to_string()
+        ],
+        "stale refresh should not overwrite manual replacement"
     );
 }
 
 #[tokio::test]
 async fn successful_refresh_is_persisted_before_later_oauth_input_failure() {
     let fixture = RefreshingHttpFixture::new().await;
-    let harness = GrpcHarness::new().await;
-    harness
-        .import_source(
-            two_oauth_inputs_manifest_yaml(&fixture.base_url, &fixture.token_url),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: fixture.base_url.clone(),
-            }],
-            vec![
-                SourceSecret {
-                    key: "API_TOKEN".to_string(),
-                    value: "expired-primary-token".to_string(),
-                },
-                SourceSecret {
-                    key: "SECOND_TOKEN".to_string(),
-                    value: "expired-secondary-token".to_string(),
-                },
-            ],
-        )
-        .await;
-
-    let secret_path = source_dir(harness.config_dir(), "multi_oauth_messages").join("secrets.env");
     let primary_prefix = oauth_metadata_prefix("API_TOKEN");
     let secondary_prefix = oauth_metadata_prefix("SECOND_TOKEN");
-    fs::write(
-        &secret_path,
-        format!(
-            "\
+    let material = format!(
+        "\
 API_TOKEN=expired-primary-token
 SECOND_TOKEN=expired-secondary-token
 {primary_prefix}method=oauth
@@ -594,13 +447,19 @@ SECOND_TOKEN=expired-secondary-token
 {secondary_prefix}client_id=stored-client
 {secondary_prefix}token_url={}/token-fail
 ",
-            (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
-            fixture.token_url,
-            (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
-            fixture.base_url,
-        ),
+        (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
+        fixture.token_url,
+        (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
+        fixture.base_url,
+    );
+    let harness = start_harness_with_legacy_source(
+        "multi_oauth_messages",
+        &two_oauth_inputs_manifest_yaml(&fixture.base_url, &fixture.token_url),
+        &[("API_BASE", fixture.base_url.as_str())],
+        &["API_TOKEN", "SECOND_TOKEN"],
+        &material,
     )
-    .expect("seed expired oauth material");
+    .await;
 
     let status = harness
         .query_client()
@@ -625,45 +484,133 @@ SECOND_TOKEN=expired-secondary-token
         "second failing refresh should be attempted: {forms:?}"
     );
 
-    let material = fs::read_to_string(secret_path).expect("read partially refreshed material");
-    assert!(
-        material.contains("API_TOKEN=refreshed-token"),
-        "first refresh should be durable even when a later refresh fails: {material}"
+    let status = harness
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: "SELECT id FROM multi_oauth_messages.messages".to_string(),
+        }))
+        .await
+        .expect_err("second OAuth refresh should still fail query");
+    assert_eq!(status.code(), Code::FailedPrecondition);
+    let forms = fixture.token_forms();
+    assert_eq!(
+        forms
+            .iter()
+            .filter(|form| {
+                form.get("refresh_token").map(String::as_str)
+                    == Some("stored-primary-refresh-token")
+            })
+            .count(),
+        1,
+        "successful first refresh should be persisted and not repeated: {forms:?}"
     );
     assert!(
-        material.contains(&format!(
-            "{primary_prefix}refresh_token=rotated-refresh-token"
-        )),
-        "rotated refresh token should be durable even when a later refresh fails: {material}"
-    );
-    assert!(
-        material.contains("SECOND_TOKEN=expired-secondary-token"),
-        "failed second refresh should not overwrite its source secret: {material}"
+        forms
+            .iter()
+            .filter(|form| {
+                form.get("refresh_token").map(String::as_str)
+                    == Some("stored-secondary-refresh-token")
+            })
+            .count()
+            >= 2,
+        "failed second refresh should remain unchanged and retryable: {forms:?}"
     );
 }
 
-fn seed_expired_api_token_material(
-    secret_path: &Path,
+async fn start_harness_with_expired_api_token_source(
+    fixture: &RefreshingHttpFixture,
     token_url: &str,
     refresh_token: Option<&str>,
-) {
+) -> GrpcHarness {
+    let material = expired_api_token_material(token_url, refresh_token);
+    start_harness_with_legacy_source(
+        "refreshed_messages",
+        &oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
+        &[("API_BASE", fixture.base_url.as_str())],
+        &["API_TOKEN"],
+        &material,
+    )
+    .await
+}
+
+async fn start_harness_with_legacy_source(
+    source_name: &str,
+    manifest_yaml: &str,
+    variables: &[(&str, &str)],
+    secrets: &[&str],
+    credential_material: &str,
+) -> GrpcHarness {
+    let (temp_dir, config_dir) = seed_legacy_source_config(
+        source_name,
+        manifest_yaml,
+        variables,
+        secrets,
+        credential_material,
+    );
+    GrpcHarness::start_with_owned_config_dir(temp_dir, config_dir).await
+}
+
+fn seed_legacy_source_config(
+    source_name: &str,
+    manifest_yaml: &str,
+    variables: &[(&str, &str)],
+    secrets: &[&str],
+    credential_material: &str,
+) -> (TempDir, std::path::PathBuf) {
+    let temp_dir = TempDir::new().expect("config root");
+    let config_dir = temp_dir.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    let variables_toml = variables
+        .iter()
+        .map(|(key, value)| format!("{key} = {}", toml_string(value)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let secrets_toml = secrets
+        .iter()
+        .map(|secret| toml_string(secret))
+        .collect::<Vec<_>>()
+        .join(", ");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!(
+            r#"version = 1
+
+[workspaces.default.sources.{source_name}]
+version = "0.1.0"
+variables = {{{variables_toml}}}
+secrets = [{secrets_toml}]
+origin = "imported"
+"#
+        ),
+    )
+    .expect("write legacy source config");
+    let source_dir = source_dir(&config_dir, source_name);
+    fs::create_dir_all(&source_dir).expect("create legacy source dir");
+    fs::write(source_dir.join("manifest.yaml"), manifest_yaml).expect("write legacy manifest");
+    fs::write(source_dir.join("secrets.env"), credential_material)
+        .expect("write legacy credential material");
+    (temp_dir, config_dir)
+}
+
+fn toml_string(value: &str) -> String {
+    format!("{value:?}")
+}
+
+fn expired_api_token_material(token_url: &str, refresh_token: Option<&str>) -> String {
     let refresh_token_line = refresh_token
         .map(|refresh_token| format!("__coral_oauth.QVBJX1RPS0VO.refresh_token={refresh_token}\n"))
         .unwrap_or_default();
-    fs::write(
-        secret_path,
-        format!(
-            "\
+    format!(
+        "\
 API_TOKEN=expired-token
 __coral_oauth.QVBJX1RPS0VO.method=oauth
 __coral_oauth.QVBJX1RPS0VO.access_token_expires_at={}
 {refresh_token_line}__coral_oauth.QVBJX1RPS0VO.client_id=stored-client
 __coral_oauth.QVBJX1RPS0VO.token_url={token_url}
 ",
-            (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
-        ),
+        (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339(),
     )
-    .expect("seed expired oauth material");
 }
 
 fn remove_config_source_section(config_dir: &Path, source_name: &str) {

--- a/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
+++ b/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
@@ -19,6 +19,7 @@ use serde_json::json;
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::sync::Notify;
+use toml_edit::DocumentMut;
 use tonic::{Code, Request};
 
 use crate::harness::{GrpcHarness, fixture_manifest_yaml, source_dir};
@@ -73,6 +74,108 @@ async fn query_refreshes_expired_oauth_access_token_at_request_time() {
         Some("stored-client")
     );
 
+    let material = fs::read_to_string(secret_path).expect("read refreshed material");
+    assert!(material.contains("API_TOKEN=refreshed-token"), "{material}");
+    assert!(
+        material.contains("__coral_oauth.QVBJX1RPS0VO.refresh_token=rotated-refresh-token"),
+        "{material}"
+    );
+}
+
+#[tokio::test]
+async fn db_loaded_source_persists_oauth_refresh_after_config_source_section_is_removed() {
+    let fixture = RefreshingHttpFixture::new().await;
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
+            vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: fixture.base_url.clone(),
+            }],
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "expired-token".to_string(),
+            }],
+        )
+        .await;
+
+    let secret_path = source_dir(harness.config_dir(), "refreshed_messages").join("secrets.env");
+    seed_expired_api_token_material(
+        &secret_path,
+        &fixture.token_url,
+        Some("stored-refresh-token"),
+    );
+    remove_config_source_section(harness.config_dir(), "refreshed_messages");
+
+    let rows = harness
+        .execute_sql_rows("SELECT id FROM refreshed_messages.messages")
+        .await;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], "ok");
+    assert_eq!(
+        fixture.message_authorizations(),
+        vec!["Bearer refreshed-token".to_string()]
+    );
+    let forms = fixture.token_forms();
+    assert_eq!(forms.len(), 1);
+    assert_eq!(
+        forms[0].get("refresh_token").map(String::as_str),
+        Some("stored-refresh-token")
+    );
+
+    let material = fs::read_to_string(secret_path).expect("read refreshed material");
+    assert!(material.contains("API_TOKEN=refreshed-token"), "{material}");
+    assert!(
+        material.contains("__coral_oauth.QVBJX1RPS0VO.refresh_token=rotated-refresh-token"),
+        "{material}"
+    );
+}
+
+#[tokio::test]
+async fn restarted_db_loaded_source_persists_oauth_refresh_after_config_source_section_is_removed()
+{
+    let fixture = RefreshingHttpFixture::new().await;
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let secret_path = source_dir(&config_dir, "refreshed_messages").join("secrets.env");
+
+    {
+        let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+        harness
+            .import_source(
+                oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
+                vec![SourceVariable {
+                    key: "API_BASE".to_string(),
+                    value: fixture.base_url.clone(),
+                }],
+                vec![SourceSecret {
+                    key: "API_TOKEN".to_string(),
+                    value: "expired-token".to_string(),
+                }],
+            )
+            .await;
+        seed_expired_api_token_material(
+            &secret_path,
+            &fixture.token_url,
+            Some("stored-refresh-token"),
+        );
+        harness.shutdown().await;
+    }
+    remove_config_source_section(&config_dir, "refreshed_messages");
+
+    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    let rows = harness
+        .execute_sql_rows("SELECT id FROM refreshed_messages.messages")
+        .await;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], "ok");
+    assert_eq!(
+        fixture.message_authorizations(),
+        vec!["Bearer refreshed-token".to_string()]
+    );
     let material = fs::read_to_string(secret_path).expect("read refreshed material");
     assert!(material.contains("API_TOKEN=refreshed-token"), "{material}");
     assert!(
@@ -561,6 +664,17 @@ __coral_oauth.QVBJX1RPS0VO.token_url={token_url}
         ),
     )
     .expect("seed expired oauth material");
+}
+
+fn remove_config_source_section(config_dir: &Path, source_name: &str) {
+    let config_path = config_dir.join("config.toml");
+    let raw = fs::read_to_string(&config_path).expect("read config");
+    let mut doc = raw.parse::<DocumentMut>().expect("parse config");
+    doc["workspaces"]["default"]["sources"]
+        .as_table_mut()
+        .expect("sources table")
+        .remove(source_name);
+    fs::write(&config_path, doc.to_string()).expect("write config without source section");
 }
 
 fn oauth_refresh_manifest_yaml(base_url: &str, token_url: &str) -> String {

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -6,15 +6,21 @@
 
 use std::fs;
 
-use coral_api::v1::{ExecuteSqlRequest, SourceSecret, SourceVariable};
+use coral_api::v1::ExecuteSqlRequest;
 use coral_client::{batches_to_json_rows, decode_execute_sql_response, default_workspace};
+use tempfile::TempDir;
 use tonic::Request;
 
-use crate::harness::{GrpcHarness, fixture_manifest_with_inputs_yaml, fixture_manifest_yaml};
+use crate::harness::{
+    GrpcHarness, fixture_manifest_with_inputs_yaml, fixture_manifest_yaml, source_dir,
+};
 
 #[tokio::test]
 async fn broken_source_does_not_block_healthy_sources() {
-    let harness = GrpcHarness::new().await;
+    let temp_dir = TempDir::new().expect("config root");
+    let config_dir = temp_dir.path().join("coral-config");
+    seed_broken_secured_messages_source(&config_dir);
+    let harness = GrpcHarness::start_with_owned_config_dir(temp_dir, config_dir).await;
 
     harness
         .import_source(
@@ -23,30 +29,6 @@ async fn broken_source_does_not_block_healthy_sources() {
             Vec::new(),
         )
         .await;
-    harness
-        .import_source(
-            fixture_manifest_with_inputs_yaml(),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: "https://example.com".to_string(),
-            }],
-            vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "secret-token".to_string(),
-            }],
-        )
-        .await;
-
-    fs::remove_file(
-        harness
-            .config_dir()
-            .join("workspaces")
-            .join("default")
-            .join("sources")
-            .join("secured_messages")
-            .join("secrets.env"),
-    )
-    .expect("remove broken source secret file");
 
     let tables = harness.list_tables().await;
     assert!(
@@ -88,4 +70,27 @@ async fn broken_source_does_not_block_healthy_sources() {
         .await
         .expect_err("broken source query should fail");
     assert_eq!(broken.code(), tonic::Code::NotFound);
+}
+
+fn seed_broken_secured_messages_source(config_dir: &std::path::Path) {
+    fs::create_dir_all(config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"version = 1
+
+[workspaces.default.sources.secured_messages]
+version = "0.1.0"
+variables = { API_BASE = "https://example.com" }
+secrets = ["API_TOKEN"]
+origin = "imported"
+"#,
+    )
+    .expect("write legacy source config");
+    let source_dir = source_dir(config_dir, "secured_messages");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(
+        source_dir.join("manifest.yaml"),
+        fixture_manifest_with_inputs_yaml(),
+    )
+    .expect("write manifest");
 }

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -53,10 +53,17 @@ async fn server_lifecycle_can_repeat_within_process() {
 async fn server_lifecycle_rejects_postgres_config_without_url_env_value() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
+    let missing_url_env = format!(
+        "CORAL_TEST_POSTGRES_URL_MISSING_FOR_SERVER_START_{}",
+        uuid::Uuid::new_v4()
+            .simple()
+            .to_string()
+            .to_ascii_uppercase()
+    );
     fs::create_dir_all(&config_dir).expect("create config dir");
     fs::write(
         config_dir.join("config.toml"),
-        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL_MISSING_FOR_SERVER_START\"\n",
+        format!("[database]\nbackend = \"postgres\"\nurl_env = \"{missing_url_env}\"\n"),
     )
     .expect("write config");
 
@@ -74,7 +81,7 @@ async fn server_lifecycle_rejects_postgres_config_without_url_env_value() {
 
     match error {
         LocalServerError::FailedPrecondition(detail) => assert!(
-            detail.contains("CORAL_TEST_POSTGRES_URL_MISSING_FOR_SERVER_START"),
+            detail.contains(&missing_url_env),
             "unexpected detail: {detail}"
         ),
         other => panic!("unexpected error: {other}"),

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -6,8 +6,15 @@
 //! `OnceLock` and flushed by the owning binary or test harness via
 //! `coral_app::shutdown_tracing` at process exit.
 
+use std::fs;
+
 use coral_api::v1::ListSourcesRequest;
-use coral_client::{AppClient, default_workspace, local::ServerBuilder};
+use coral_client::{
+    AppClient, default_workspace,
+    local::{LocalServerError, ServerBuilder},
+};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use tonic::Request;
 
@@ -22,6 +29,7 @@ async fn server_lifecycle_can_repeat_within_process() {
             .start()
             .await
             .expect("start server");
+        assert_default_sqlite_db_is_migrated(&config_dir).await;
         let app = AppClient::connect(server.endpoint_uri())
             .await
             .expect("connect client");
@@ -39,4 +47,105 @@ async fn server_lifecycle_can_repeat_within_process() {
 
         server.shutdown().await.expect("shutdown server");
     }
+}
+
+#[tokio::test]
+async fn server_lifecycle_rejects_postgres_config_without_url_env_value() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL_MISSING_FOR_SERVER_START\"\n",
+    )
+    .expect("write config");
+
+    let result = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await;
+    let error = match result {
+        Err(error) => error,
+        Ok(server) => {
+            server.shutdown().await.expect("shutdown unexpected server");
+            panic!("server start should fail without configured Postgres URL env var");
+        }
+    };
+
+    match error {
+        LocalServerError::FailedPrecondition(detail) => assert!(
+            detail.contains("CORAL_TEST_POSTGRES_URL_MISSING_FOR_SERVER_START"),
+            "unexpected detail: {detail}"
+        ),
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run configured Postgres startup coverage"]
+async fn server_lifecycle_can_start_with_postgres_database_config() {
+    let Some(database_url) = postgres_test_url() else {
+        return;
+    };
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n",
+    )
+    .expect("write config");
+
+    let server = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await
+        .expect("start server with Postgres config");
+    assert_postgres_db_is_migrated(&database_url).await;
+
+    server.shutdown().await.expect("shutdown server");
+}
+
+async fn assert_default_sqlite_db_is_migrated(config_dir: &std::path::Path) {
+    let database_file = config_dir.join("coral.db");
+    assert!(
+        database_file.exists(),
+        "default SQLite database should exist"
+    );
+
+    let options = SqliteConnectOptions::new().filename(&database_file);
+    let pool = SqlitePoolOptions::new()
+        .connect_with(options)
+        .await
+        .expect("open created SQLite database");
+    let table_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'workspaces'",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("inspect migrated schema");
+    assert_eq!(table_count, 1, "workspaces table should be migrated");
+}
+
+async fn assert_postgres_db_is_migrated(database_url: &str) {
+    let pool = PgPoolOptions::new()
+        .connect(database_url)
+        .await
+        .expect("open Postgres database");
+    let table_exists: bool =
+        sqlx::query_scalar("SELECT to_regclass('public.workspaces') IS NOT NULL")
+            .fetch_one(&pool)
+            .await
+            .expect("inspect migrated Postgres schema");
+    assert!(table_exists, "workspaces table should be migrated");
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "The ignored Postgres integration test is explicitly gated by this CI/test-only variable."
+)]
+fn postgres_test_url() -> Option<String> {
+    std::env::var("CORAL_TEST_POSTGRES_URL")
+        .ok()
+        .filter(|value| !value.is_empty())
 }

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -17,6 +17,7 @@ use coral_api::v1::{
 };
 use coral_client::default_workspace;
 use tempfile::TempDir;
+use toml_edit::DocumentMut;
 use tonic::Request;
 
 use crate::harness::{
@@ -69,6 +70,28 @@ async fn import_source_persists_and_lists() {
         listed[0].credential_storage,
         SourceCredentialStorage::Unspecified as i32
     );
+}
+
+#[tokio::test]
+async fn list_sources_reads_database_after_config_source_section_is_removed() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
+    harness
+        .import_source(manifest_yaml, Vec::new(), Vec::new())
+        .await;
+
+    let config_path = harness.config_dir().join("config.toml");
+    let raw = fs::read_to_string(&config_path).expect("read config");
+    let mut doc = raw.parse::<DocumentMut>().expect("parse config");
+    doc["workspaces"]["default"]["sources"]
+        .as_table_mut()
+        .expect("sources table")
+        .remove("local_messages");
+    fs::write(&config_path, doc.to_string()).expect("write config without source section");
+
+    let listed = harness.list_sources().await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "local_messages");
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -90,8 +90,12 @@ async fn import_source_persists_and_lists() {
 
     let installed_manifest =
         source_dir(harness.config_dir(), "local_messages").join("manifest.yaml");
+    assert!(
+        installed_manifest.exists(),
+        "DB-backed imports should keep a legacy manifest for rollback compatibility"
+    );
     assert_eq!(
-        fs::read_to_string(&installed_manifest).expect("read installed manifest"),
+        fs::read_to_string(&installed_manifest).expect("read legacy manifest"),
         manifest_yaml
     );
 
@@ -1619,7 +1623,7 @@ origin = "imported"
             name: "demo".to_string(),
         }))
         .await
-        .expect_err("missing manifest file should fail");
+        .expect_err("missing manifest file should fail at source resolution");
     assert_eq!(error.code(), tonic::Code::NotFound);
 }
 
@@ -1645,6 +1649,13 @@ enabled = false
         harness
             .import_source(manifest_yaml, Vec::new(), Vec::new())
             .await;
+        let installed_manifest =
+            source_dir(harness.config_dir(), "local_messages").join("manifest.yaml");
+        fs::remove_file(&installed_manifest).expect("remove compatibility manifest");
+        assert!(
+            !installed_manifest.exists(),
+            "restart coverage must not rely on a legacy manifest file"
+        );
         let rows = harness
             .execute_sql_rows("SELECT COUNT(*) AS n FROM local_messages.messages")
             .await;
@@ -1799,10 +1810,24 @@ async fn overwrite_restores_previous_source_on_config_write_failure() {
 
     let installed_manifest =
         source_dir(harness.config_dir(), "secured_messages").join("manifest.yaml");
+    assert!(
+        installed_manifest.exists(),
+        "DB-backed rollback should restore legacy manifest files"
+    );
     assert_eq!(
         fs::read_to_string(&installed_manifest).expect("read restored manifest"),
         original_manifest
     );
+    let validated = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "secured_messages".to_string(),
+        }))
+        .await
+        .expect("source should validate after rollback")
+        .into_inner();
+    assert_eq!(validated.tables.len(), 1);
     let secret_path = source_dir(harness.config_dir(), "secured_messages").join("secrets.env");
     let secret_material = fs::read_to_string(&secret_path).expect("read restored secrets");
     assert!(
@@ -1852,18 +1877,31 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
             name: "secured_messages".to_string(),
         }))
         .await
-        .expect_err("manifest cleanup should fail");
+        .expect_err("source directory cleanup should fail");
 
     fs::set_permissions(&sources_root, fs::Permissions::from_mode(0o700))
         .expect("restore sources dir permissions");
 
     assert_eq!(error.code(), tonic::Code::Internal);
-    assert!(manifest_path.exists(), "manifest should be restored");
+    assert!(
+        manifest_path.exists(),
+        "DB-backed rollback should restore legacy manifest files"
+    );
     assert!(secret_path.exists(), "secret file should be restored");
 
     let listed = harness.list_sources().await;
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].name, "secured_messages");
+    let validated = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "secured_messages".to_string(),
+        }))
+        .await
+        .expect("source should still validate from DB manifest")
+        .into_inner();
+    assert_eq!(validated.tables.len(), 1);
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -25,7 +25,8 @@ use crate::harness::{
     FailingHttpFixture, GrpcHarness, fixture_function_only_manifest_yaml,
     fixture_manifest_with_inputs_yaml, fixture_manifest_with_multiple_tables_yaml,
     fixture_manifest_with_required_inputs_yaml, fixture_manifest_with_test_queries_yaml,
-    fixture_manifest_yaml, invalid_manifest_yaml, source_dir,
+    fixture_manifest_yaml, fixture_v4_openapi_manifest_yaml, invalid_manifest_yaml,
+    issues_http_fixture, source_dir,
 };
 
 fn auth_manifest_yaml(inputs: &str, auth: &str) -> String {
@@ -57,6 +58,13 @@ fn secret_auth_manifest_yaml_at(base_url: &str) -> String {
         base_url,
         "inputs:\n  API_TOKEN:\n    kind: secret\n",
         "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n",
+    )
+}
+
+fn v4_secret_auth_manifest(manifest_yaml: &str) -> String {
+    manifest_yaml.replace(
+        "type: openapi",
+        "type: openapi\n  inputs:\n    API_TOKEN:\n      kind: secret\n  auth:\n    type: BasicAuth\n    username: bot\n    password: \"{{input.API_TOKEN}}\"",
     )
 }
 
@@ -253,6 +261,60 @@ async fn startup_import_lists_non_default_legacy_config_source() {
 }
 
 #[tokio::test]
+async fn v4_materialization_reloads_from_database_after_restart() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let issues_http = issues_http_fixture(&["Basic Ym90OnNlY3JldC10b2tlbg=="]).await;
+    let (manifest_yaml, openapi_file) =
+        fixture_v4_openapi_manifest_yaml(temp.path(), &issues_http.uri());
+    let manifest_yaml = v4_secret_auth_manifest(&manifest_yaml);
+
+    {
+        let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+        harness
+            .import_source(
+                manifest_yaml,
+                Vec::new(),
+                vec![SourceSecret {
+                    key: "API_TOKEN".into(),
+                    value: "secret-token".into(),
+                }],
+            )
+            .await;
+        fs::create_dir_all(
+            source_dir(harness.config_dir(), "github_v4_query").join("materialized/v4"),
+        )
+        .expect("plant stale v4 materialization dir");
+        fs::remove_file(&openapi_file).expect("remove authored descriptor");
+    }
+
+    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    assert_eq!(
+        harness
+            .execute_sql_rows("SELECT id, title FROM github_v4_query.issues")
+            .await,
+        vec![serde_json::json!({"id": 1, "title": "Stored materialization"})]
+    );
+    harness
+        .import_source(
+            fixture_manifest_yaml(harness.temp_path()).replace("local_messages", "github_v4_query"),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+    let pool = sqlx::SqlitePool::connect_with(
+        sqlx::sqlite::SqliteConnectOptions::new().filename(harness.config_dir().join("coral.db")),
+    )
+    .await
+    .expect("open db");
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM materializations")
+        .fetch_one(&pool)
+        .await
+        .expect("count materializations");
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
 async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     let harness = GrpcHarness::new().await;
 
@@ -424,6 +486,22 @@ async fn import_rejects_cleartext_secret_endpoint_without_database_state() {
         .expect_err("cleartext credential endpoint should fail");
     assert_eq!(error.code(), tonic::Code::InvalidArgument);
     assert!(error.message().contains("base_url"));
+    harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: v4_secret_auth_manifest(
+                &fixture_v4_openapi_manifest_yaml(harness.temp_path(), "http://api.example.com").0,
+            ),
+            variables: Vec::new(),
+            secrets: vec![SourceSecret {
+                key: "API_TOKEN".into(),
+                value: "secret-token".into(),
+            }],
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect_err("cleartext derived credential endpoint should fail");
     assert!(harness.list_sources().await.is_empty());
 }
 

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -171,80 +171,48 @@ async fn restart_preserves_database_source_after_config_source_section_is_remove
 }
 
 #[tokio::test]
-async fn startup_import_preserves_non_default_workspace_sources() {
+async fn startup_import_lists_non_default_legacy_config_source() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
     fs::create_dir_all(&config_dir).expect("create config dir");
     fs::write(
         config_dir.join("config.toml"),
-        r#"version = 1
-
-[workspaces.default.sources.default_messages]
-version = "0.1.0"
-variables = {}
-secrets = []
-origin = "imported"
-
-[workspaces.analytics.sources.analytics_messages]
-version = "0.1.0"
-variables = {}
-secrets = []
-origin = "imported"
-"#,
+        "[workspaces.analytics.sources.analytics_messages]\norigin = \"imported\"\n",
     )
     .expect("write config");
-
-    let default_manifest =
-        fixture_manifest_yaml(temp.path()).replace("local_messages", "default_messages");
-    let default_manifest_path = source_dir(&config_dir, "default_messages").join("manifest.yaml");
-    fs::create_dir_all(
-        default_manifest_path
-            .parent()
-            .expect("default manifest parent"),
+    let source_dir = config_dir.join("workspaces/analytics/sources/analytics_messages");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(
+        source_dir.join("manifest.yaml"),
+        fixture_manifest_yaml(temp.path()).replace("local_messages", "analytics_messages"),
     )
-    .expect("create default source dir");
-    fs::write(default_manifest_path, default_manifest).expect("write default manifest");
-
-    let analytics_manifest =
-        fixture_manifest_yaml(temp.path()).replace("local_messages", "analytics_messages");
-    let analytics_manifest_path = config_dir
-        .join("workspaces")
-        .join("analytics")
-        .join("sources")
-        .join("analytics_messages")
-        .join("manifest.yaml");
-    fs::create_dir_all(
-        analytics_manifest_path
-            .parent()
-            .expect("analytics manifest parent"),
-    )
-    .expect("create analytics source dir");
-    fs::write(analytics_manifest_path, analytics_manifest).expect("write analytics manifest");
-
+    .expect("write analytics manifest");
     let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
-
-    let default_sources = harness.list_sources().await;
-    assert_eq!(default_sources.len(), 1);
-    assert_eq!(default_sources[0].name, "default_messages");
-
-    let analytics_sources = harness
+    let sources = harness
         .source_client()
         .list_sources(Request::new(coral_api::v1::ListSourcesRequest {
             workspace: Some(Workspace {
-                name: "analytics".to_string(),
+                name: "analytics".into(),
             }),
         }))
         .await
         .expect("list analytics sources")
         .into_inner()
         .sources;
-    assert_eq!(analytics_sources.len(), 1);
-    assert_eq!(analytics_sources[0].name, "analytics_messages");
-
-    let config_raw =
-        fs::read_to_string(config_dir.join("config.toml")).expect("read cleaned config");
-    assert!(!config_raw.contains("[workspaces.default.sources.default_messages]"));
-    assert!(!config_raw.contains("[workspaces.analytics.sources.analytics_messages]"));
+    assert_eq!(sources.len(), 1);
+    assert_eq!(sources[0].name, "analytics_messages");
+    let validated = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(Workspace {
+                name: "analytics".into(),
+            }),
+            name: "analytics_messages".into(),
+        }))
+        .await
+        .expect("validate analytics source")
+        .into_inner();
+    assert_eq!(validated.tables[0].schema_name, "analytics_messages");
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -516,6 +516,79 @@ async fn import_duplicate_source_overwrites_existing_source() {
 }
 
 #[tokio::test]
+async fn import_duplicate_source_preserves_database_credentials() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_with_inputs_yaml();
+    let variables = || {
+        vec![SourceVariable {
+            key: "API_BASE".to_string(),
+            value: "https://example.com".to_string(),
+        }]
+    };
+
+    let imported = harness
+        .import_source(
+            manifest_yaml.clone(),
+            variables(),
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "secret-token".to_string(),
+            }],
+        )
+        .await;
+    assert_eq!(
+        imported.credential_storage,
+        SourceCredentialStorage::Database as i32
+    );
+
+    let reimported = harness
+        .import_source(
+            manifest_yaml.replace("0.1.0", "0.2.0"),
+            variables(),
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(reimported.version, "0.2.0");
+    assert_eq!(
+        reimported.credential_storage,
+        SourceCredentialStorage::Database as i32
+    );
+    assert_eq!(reimported.secrets.len(), 1);
+    assert_eq!(reimported.secrets[0].key, "API_TOKEN");
+
+    let reimported_again = harness
+        .import_source(
+            fixture_manifest_with_inputs_yaml().replace("0.1.0", "0.3.0"),
+            variables(),
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(reimported_again.version, "0.3.0");
+
+    let fetched = harness
+        .source_client()
+        .get_source(Request::new(GetSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "secured_messages".to_string(),
+        }))
+        .await
+        .expect("get duplicate imported source")
+        .into_inner()
+        .source
+        .expect("get source response");
+    assert_eq!(fetched.version, "0.3.0");
+    assert_eq!(
+        fetched.credential_storage,
+        SourceCredentialStorage::Database as i32
+    );
+    assert_eq!(fetched.secrets.len(), 1);
+    assert_eq!(fetched.secrets[0].key, "API_TOKEN");
+
+    let validated = harness.validate_source("secured_messages").await;
+    assert_eq!(validated.tables.len(), 1);
+}
+
+#[tokio::test]
 async fn import_invalid_manifest_returns_invalid_argument() {
     let harness = GrpcHarness::new().await;
 

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -4,7 +4,7 @@
     reason = "test code: assertion-style indexing is idiomatic in tests"
 )]
 
-use std::fs;
+use std::{fs, path::Path};
 
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
@@ -261,60 +261,6 @@ async fn startup_import_lists_non_default_legacy_config_source() {
 }
 
 #[tokio::test]
-async fn v4_materialization_reloads_from_database_after_restart() {
-    let temp = TempDir::new().expect("temp dir");
-    let config_dir = temp.path().join("coral-config");
-    let issues_http = issues_http_fixture(&["Basic Ym90OnNlY3JldC10b2tlbg=="]).await;
-    let (manifest_yaml, openapi_file) =
-        fixture_v4_openapi_manifest_yaml(temp.path(), &issues_http.uri());
-    let manifest_yaml = v4_secret_auth_manifest(&manifest_yaml);
-
-    {
-        let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
-        harness
-            .import_source(
-                manifest_yaml,
-                Vec::new(),
-                vec![SourceSecret {
-                    key: "API_TOKEN".into(),
-                    value: "secret-token".into(),
-                }],
-            )
-            .await;
-        fs::create_dir_all(
-            source_dir(harness.config_dir(), "github_v4_query").join("materialized/v4"),
-        )
-        .expect("plant stale v4 materialization dir");
-        fs::remove_file(&openapi_file).expect("remove authored descriptor");
-    }
-
-    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
-    assert_eq!(
-        harness
-            .execute_sql_rows("SELECT id, title FROM github_v4_query.issues")
-            .await,
-        vec![serde_json::json!({"id": 1, "title": "Stored materialization"})]
-    );
-    harness
-        .import_source(
-            fixture_manifest_yaml(harness.temp_path()).replace("local_messages", "github_v4_query"),
-            Vec::new(),
-            Vec::new(),
-        )
-        .await;
-    let pool = sqlx::SqlitePool::connect_with(
-        sqlx::sqlite::SqliteConnectOptions::new().filename(harness.config_dir().join("coral.db")),
-    )
-    .await
-    .expect("open db");
-    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM materializations")
-        .fetch_one(&pool)
-        .await
-        .expect("count materializations");
-    assert_eq!(count, 0);
-}
-
-#[tokio::test]
 async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     let harness = GrpcHarness::new().await;
 
@@ -486,22 +432,6 @@ async fn import_rejects_cleartext_secret_endpoint_without_database_state() {
         .expect_err("cleartext credential endpoint should fail");
     assert_eq!(error.code(), tonic::Code::InvalidArgument);
     assert!(error.message().contains("base_url"));
-    harness
-        .source_client()
-        .import_source(Request::new(ImportSourceRequest {
-            workspace: Some(default_workspace()),
-            manifest_yaml: v4_secret_auth_manifest(
-                &fixture_v4_openapi_manifest_yaml(harness.temp_path(), "http://api.example.com").0,
-            ),
-            variables: Vec::new(),
-            secrets: vec![SourceSecret {
-                key: "API_TOKEN".into(),
-                value: "secret-token".into(),
-            }],
-            oauth_credential_retrievals: Vec::new(),
-        }))
-        .await
-        .expect_err("cleartext derived credential endpoint should fail");
     assert!(harness.list_sources().await.is_empty());
 }
 
@@ -1007,7 +937,7 @@ async fn import_source_missing_required_secret_returns_invalid_argument() {
     );
 }
 
-fn remove_config_source_section(config_dir: &std::path::Path, source_name: &str) {
+fn remove_config_source_section(config_dir: &Path, source_name: &str) {
     let config_path = config_dir.join("config.toml");
     let raw = fs::read_to_string(&config_path).expect("read config");
     let mut doc = raw.parse::<DocumentMut>().expect("parse config");
@@ -1924,27 +1854,28 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
     use std::os::unix::fs::PermissionsExt;
 
     let harness = GrpcHarness::new().await;
+    let issues_http = issues_http_fixture(&["Basic Ym90OnNlY3JldC10b2tlbg=="]).await;
+    let (manifest_yaml, openapi_file) =
+        fixture_v4_openapi_manifest_yaml(harness.temp_path(), &issues_http.uri());
     harness
         .import_source(
-            fixture_manifest_with_inputs_yaml(),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: "https://example.com".to_string(),
-            }],
+            v4_secret_auth_manifest(&manifest_yaml),
+            Vec::new(),
             vec![SourceSecret {
-                key: "API_TOKEN".to_string(),
-                value: "secret-token".to_string(),
+                key: "API_TOKEN".into(),
+                value: "secret-token".into(),
             }],
         )
         .await;
+    fs::remove_file(openapi_file).expect("remove authored descriptor");
 
     let sources_root = harness
         .config_dir()
         .join("workspaces")
         .join("default")
         .join("sources");
-    let manifest_path = source_dir(harness.config_dir(), "secured_messages").join("manifest.yaml");
-    let secret_path = source_dir(harness.config_dir(), "secured_messages").join("secrets.env");
+    let manifest_path = source_dir(harness.config_dir(), "github_v4_query").join("manifest.yaml");
+    let secret_path = source_dir(harness.config_dir(), "github_v4_query").join("secrets.env");
     fs::set_permissions(&sources_root, fs::Permissions::from_mode(0o500))
         .expect("make sources dir read-only");
 
@@ -1952,7 +1883,7 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
         .source_client()
         .delete_source(Request::new(DeleteSourceRequest {
             workspace: Some(default_workspace()),
-            name: "secured_messages".to_string(),
+            name: "github_v4_query".to_string(),
         }))
         .await
         .expect_err("source directory cleanup should fail");
@@ -1965,21 +1896,28 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
         manifest_path.exists(),
         "DB-backed rollback should restore legacy manifest files"
     );
-    assert!(secret_path.exists(), "secret file should be restored");
+    let secret_material = fs::read_to_string(&secret_path).expect("read restored secrets");
+    assert!(secret_material.contains("API_TOKEN=secret-token"));
 
     let listed = harness.list_sources().await;
     assert_eq!(listed.len(), 1);
-    assert_eq!(listed[0].name, "secured_messages");
+    assert_eq!(listed[0].name, "github_v4_query");
     let validated = harness
         .source_client()
         .validate_source(Request::new(ValidateSourceRequest {
             workspace: Some(default_workspace()),
-            name: "secured_messages".to_string(),
+            name: "github_v4_query".to_string(),
         }))
         .await
         .expect("source should still validate from DB manifest")
         .into_inner();
     assert_eq!(validated.tables.len(), 1);
+    assert_eq!(
+        harness
+            .execute_sql_rows("SELECT id, title FROM github_v4_query.issues")
+            .await,
+        vec![serde_json::json!({"id": 1, "title": "Stored materialization"})]
+    );
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -48,8 +48,7 @@ async fn import_source_persists_and_lists() {
 
     let config_raw =
         fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
-    assert!(config_raw.contains("[workspaces.default.sources.local_messages]"));
-    assert!(config_raw.contains("secrets = []"));
+    assert!(!config_raw.contains("[workspaces.default.sources.local_messages]"));
     assert!(!config_raw.contains("credential_storage"));
     assert!(!config_raw.contains("credential_set_id"));
     assert!(!config_raw.contains("[workspaces.default.credentials"));
@@ -169,6 +168,83 @@ async fn restart_preserves_database_source_after_config_source_section_is_remove
             .any(|table| table.schema_name == "local_messages" && table.name == "messages"),
         "catalog should agree with source list after restart reconciliation"
     );
+}
+
+#[tokio::test]
+async fn startup_import_preserves_non_default_workspace_sources() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"version = 1
+
+[workspaces.default.sources.default_messages]
+version = "0.1.0"
+variables = {}
+secrets = []
+origin = "imported"
+
+[workspaces.analytics.sources.analytics_messages]
+version = "0.1.0"
+variables = {}
+secrets = []
+origin = "imported"
+"#,
+    )
+    .expect("write config");
+
+    let default_manifest =
+        fixture_manifest_yaml(temp.path()).replace("local_messages", "default_messages");
+    let default_manifest_path = source_dir(&config_dir, "default_messages").join("manifest.yaml");
+    fs::create_dir_all(
+        default_manifest_path
+            .parent()
+            .expect("default manifest parent"),
+    )
+    .expect("create default source dir");
+    fs::write(default_manifest_path, default_manifest).expect("write default manifest");
+
+    let analytics_manifest =
+        fixture_manifest_yaml(temp.path()).replace("local_messages", "analytics_messages");
+    let analytics_manifest_path = config_dir
+        .join("workspaces")
+        .join("analytics")
+        .join("sources")
+        .join("analytics_messages")
+        .join("manifest.yaml");
+    fs::create_dir_all(
+        analytics_manifest_path
+            .parent()
+            .expect("analytics manifest parent"),
+    )
+    .expect("create analytics source dir");
+    fs::write(analytics_manifest_path, analytics_manifest).expect("write analytics manifest");
+
+    let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+
+    let default_sources = harness.list_sources().await;
+    assert_eq!(default_sources.len(), 1);
+    assert_eq!(default_sources[0].name, "default_messages");
+
+    let analytics_sources = harness
+        .source_client()
+        .list_sources(Request::new(coral_api::v1::ListSourcesRequest {
+            workspace: Some(Workspace {
+                name: "analytics".to_string(),
+            }),
+        }))
+        .await
+        .expect("list analytics sources")
+        .into_inner()
+        .sources;
+    assert_eq!(analytics_sources.len(), 1);
+    assert_eq!(analytics_sources[0].name, "analytics_messages");
+
+    let config_raw =
+        fs::read_to_string(config_dir.join("config.toml")).expect("read cleaned config");
+    assert!(!config_raw.contains("[workspaces.default.sources.default_messages]"));
+    assert!(!config_raw.contains("[workspaces.analytics.sources.analytics_messages]"));
 }
 
 #[tokio::test]
@@ -705,10 +781,9 @@ fn remove_config_source_section(config_dir: &std::path::Path, source_name: &str)
     let config_path = config_dir.join("config.toml");
     let raw = fs::read_to_string(&config_path).expect("read config");
     let mut doc = raw.parse::<DocumentMut>().expect("parse config");
-    doc["workspaces"]["default"]["sources"]
-        .as_table_mut()
-        .expect("sources table")
-        .remove(source_name);
+    if let Some(sources) = doc["workspaces"]["default"]["sources"].as_table_mut() {
+        sources.remove(source_name);
+    }
     fs::write(&config_path, doc.to_string()).expect("write config without source section");
 }
 
@@ -1741,15 +1816,13 @@ origin = "imported"
         "trace history retention should be preserved"
     );
 
-    // The pre-existing source must still be present.
+    // Source catalog state is migrated to DB, not kept in config.
     assert!(
-        config_raw.contains("[workspaces.default.sources.demo]"),
-        "pre-existing source should be preserved"
+        !config_raw.contains("[workspaces.default.sources.demo]"),
+        "pre-existing source should be removed from config after DB import"
     );
-
-    // The newly imported source must now also be present.
     assert!(
-        config_raw.contains("[workspaces.default.sources.local_messages]"),
-        "newly added source should be in config"
+        !config_raw.contains("[workspaces.default.sources.local_messages]"),
+        "newly added source should not be mirrored to config"
     );
 }

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -172,25 +172,6 @@ async fn restart_preserves_database_source_after_config_source_section_is_remove
 }
 
 #[tokio::test]
-async fn list_catalog_reads_database_after_config_source_section_is_removed() {
-    let harness = GrpcHarness::new().await;
-    let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
-    harness
-        .import_source(manifest_yaml, Vec::new(), Vec::new())
-        .await;
-
-    remove_config_source_section(&harness, "local_messages");
-
-    let tables = harness.list_tables().await;
-    assert!(
-        tables
-            .iter()
-            .any(|table| table.schema_name == "local_messages" && table.name == "messages"),
-        "catalog should still load imported source from DB"
-    );
-}
-
-#[tokio::test]
 async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     let harness = GrpcHarness::new().await;
 

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -80,18 +80,95 @@ async fn list_sources_reads_database_after_config_source_section_is_removed() {
         .import_source(manifest_yaml, Vec::new(), Vec::new())
         .await;
 
-    let config_path = harness.config_dir().join("config.toml");
-    let raw = fs::read_to_string(&config_path).expect("read config");
-    let mut doc = raw.parse::<DocumentMut>().expect("parse config");
-    doc["workspaces"]["default"]["sources"]
-        .as_table_mut()
-        .expect("sources table")
-        .remove("local_messages");
-    fs::write(&config_path, doc.to_string()).expect("write config without source section");
+    remove_config_source_section(harness.config_dir(), "local_messages");
 
     let listed = harness.list_sources().await;
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].name, "local_messages");
+
+    let fetched = harness
+        .source_client()
+        .get_source(Request::new(GetSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "local_messages".to_string(),
+        }))
+        .await
+        .expect("get source")
+        .into_inner()
+        .source
+        .expect("source response");
+    assert_eq!(fetched.name, "local_messages");
+    assert_eq!(fetched.version, "0.1.0");
+    assert_eq!(fetched.origin, SourceOrigin::Imported as i32);
+}
+
+#[tokio::test]
+async fn list_catalog_reads_database_after_config_source_section_is_removed() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
+    harness
+        .import_source(manifest_yaml, Vec::new(), Vec::new())
+        .await;
+
+    remove_config_source_section(harness.config_dir(), "local_messages");
+
+    let tables = harness.list_tables().await;
+    assert!(
+        tables
+            .iter()
+            .any(|table| table.schema_name == "local_messages" && table.name == "messages"),
+        "catalog should still load imported source from DB"
+    );
+}
+
+#[tokio::test]
+async fn validate_source_reads_database_after_config_source_section_is_removed() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
+    harness
+        .import_source(manifest_yaml, Vec::new(), Vec::new())
+        .await;
+
+    remove_config_source_section(harness.config_dir(), "local_messages");
+
+    let validated = harness.validate_source("local_messages").await;
+    assert_eq!(validated.tables.len(), 1);
+    assert_eq!(validated.tables[0].schema_name, "local_messages");
+    assert_eq!(validated.tables[0].name, "messages");
+}
+
+#[tokio::test]
+async fn restart_preserves_database_source_after_config_source_section_is_removed() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let manifest_yaml = fixture_manifest_yaml(temp.path());
+
+    {
+        let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+        harness
+            .import_source(manifest_yaml, Vec::new(), Vec::new())
+            .await;
+        harness.shutdown().await;
+    }
+    remove_config_source_section(&config_dir, "local_messages");
+
+    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    let listed = harness.list_sources().await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "local_messages");
+
+    let validated = harness.validate_source("local_messages").await;
+    assert_eq!(validated.tables.len(), 1);
+    assert_eq!(validated.tables[0].schema_name, "local_messages");
+    assert_eq!(validated.tables[0].name, "messages");
+    assert!(
+        harness
+            .list_tables()
+            .await
+            .iter()
+            .any(|table| table.schema_name == "local_messages" && table.name == "messages"),
+        "catalog should agree with source list after restart reconciliation"
+    );
 }
 
 #[tokio::test]
@@ -622,6 +699,17 @@ async fn import_source_missing_required_secret_returns_invalid_argument() {
             .message()
             .contains("missing required source secret 'API_TOKEN'")
     );
+}
+
+fn remove_config_source_section(config_dir: &std::path::Path, source_name: &str) {
+    let config_path = config_dir.join("config.toml");
+    let raw = fs::read_to_string(&config_path).expect("read config");
+    let mut doc = raw.parse::<DocumentMut>().expect("parse config");
+    doc["workspaces"]["default"]["sources"]
+        .as_table_mut()
+        .expect("sources table")
+        .remove(source_name);
+    fs::write(&config_path, doc.to_string()).expect("write config without source section");
 }
 
 #[tokio::test]
@@ -1414,6 +1502,94 @@ async fn import_rolls_back_on_config_write_failure() {
     assert_eq!(error.code(), tonic::Code::Internal);
     assert!(!source_dir(harness.config_dir(), "secured_messages").exists());
     assert!(harness.list_sources().await.is_empty());
+    let config_raw =
+        fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    assert!(!config_raw.contains("[workspaces.default.sources.secured_messages]"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn overwrite_restores_previous_source_on_config_write_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    let original_manifest = fixture_manifest_with_inputs_yaml();
+    harness
+        .import_source(
+            original_manifest.clone(),
+            vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "https://example.com".to_string(),
+            }],
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "old-token".to_string(),
+            }],
+        )
+        .await;
+    let updated_manifest = original_manifest.replace("0.1.0", "0.2.0");
+
+    fs::set_permissions(harness.config_dir(), fs::Permissions::from_mode(0o500))
+        .expect("make config dir read-only");
+    let error = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: updated_manifest,
+            variables: vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "https://example.com".to_string(),
+            }],
+            secrets: vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "new-token".to_string(),
+            }],
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect_err("config write should fail");
+
+    fs::set_permissions(harness.config_dir(), fs::Permissions::from_mode(0o700))
+        .expect("restore config dir permissions");
+
+    assert_eq!(error.code(), tonic::Code::Internal);
+    let listed = harness.list_sources().await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "secured_messages");
+    assert_eq!(listed[0].version, "0.1.0");
+
+    let fetched = harness
+        .source_client()
+        .get_source(Request::new(GetSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "secured_messages".to_string(),
+        }))
+        .await
+        .expect("get source after rollback")
+        .into_inner()
+        .source
+        .expect("source after rollback");
+    assert_eq!(fetched.version, "0.1.0");
+
+    let installed_manifest =
+        source_dir(harness.config_dir(), "secured_messages").join("manifest.yaml");
+    assert_eq!(
+        fs::read_to_string(&installed_manifest).expect("read restored manifest"),
+        original_manifest
+    );
+    let secret_path = source_dir(harness.config_dir(), "secured_messages").join("secrets.env");
+    let secret_material = fs::read_to_string(&secret_path).expect("read restored secrets");
+    assert!(
+        secret_material.contains("API_TOKEN=old-token"),
+        "{secret_material}"
+    );
+    assert!(
+        !secret_material.contains("API_TOKEN=new-token"),
+        "{secret_material}"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -4,7 +4,7 @@
     reason = "test code: assertion-style indexing is idiomatic in tests"
 )]
 
-use std::fs;
+use std::{fs, path::Path};
 
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
@@ -17,6 +17,8 @@ use coral_api::v1::{
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::default_workspace;
+use sqlx::Row as _;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use toml_edit::DocumentMut;
 use tonic::Request;
@@ -25,7 +27,8 @@ use crate::harness::{
     FailingHttpFixture, GrpcHarness, fixture_function_only_manifest_yaml,
     fixture_manifest_with_inputs_yaml, fixture_manifest_with_multiple_tables_yaml,
     fixture_manifest_with_required_inputs_yaml, fixture_manifest_with_test_queries_yaml,
-    fixture_manifest_yaml, invalid_manifest_yaml, source_dir,
+    fixture_manifest_yaml, fixture_v4_openapi_manifest_yaml, invalid_manifest_yaml,
+    issues_http_fixture, source_dir,
 };
 
 fn auth_manifest_yaml(inputs: &str, auth: &str) -> String {
@@ -57,6 +60,13 @@ fn secret_auth_manifest_yaml_at(base_url: &str) -> String {
         base_url,
         "inputs:\n  API_TOKEN:\n    kind: secret\n",
         "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n",
+    )
+}
+
+fn v4_secret_auth_manifest(manifest_yaml: &str) -> String {
+    manifest_yaml.replace(
+        "type: openapi",
+        "type: openapi\n  inputs:\n    API_TOKEN:\n      kind: secret\n  auth:\n    type: BasicAuth\n    username: bot\n    password: \"{{input.API_TOKEN}}\"",
     )
 }
 
@@ -253,6 +263,104 @@ async fn startup_import_lists_non_default_legacy_config_source() {
 }
 
 #[tokio::test]
+async fn startup_import_backfills_legacy_v4_materialization() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let issues_http = issues_http_fixture(&["Basic Ym90OnNlY3JldC10b2tlbg=="]).await;
+    let (manifest_yaml, openapi_file) =
+        fixture_v4_openapi_manifest_yaml(temp.path(), &issues_http.uri());
+    let manifest_yaml = v4_secret_auth_manifest(&manifest_yaml);
+
+    {
+        let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+        harness
+            .import_source(
+                manifest_yaml,
+                Vec::new(),
+                vec![SourceSecret {
+                    key: "API_TOKEN".into(),
+                    value: "secret-token".into(),
+                }],
+            )
+            .await;
+        harness.shutdown().await;
+    }
+    write_legacy_github_v4_materialization_from_db(&config_dir).await;
+    fs::remove_file(openapi_file).expect("remove authored descriptor");
+
+    let pool = sqlite_pool(&config_dir).await;
+    sqlx::query("DELETE FROM materializations WHERE workspace_id = ? AND source_name = ?")
+        .bind("default")
+        .bind("github_v4_query")
+        .execute(&pool)
+        .await
+        .expect("delete materialization row");
+    pool.close().await;
+
+    {
+        let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+        assert_github_v4_query_works(&harness).await;
+        assert!(
+            !source_dir(&config_dir, "github_v4_query")
+                .join("materialized/v4")
+                .exists()
+        );
+        harness.shutdown().await;
+    }
+    write_legacy_github_v4_materialization_from_db(&config_dir).await;
+
+    let pool = sqlite_pool(&config_dir).await;
+    sqlx::query("DELETE FROM sources WHERE workspace_id = ? AND name = ?")
+        .bind("default")
+        .bind("github_v4_query")
+        .execute(&pool)
+        .await
+        .expect("delete source row");
+    pool.close().await;
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"version = 1
+
+[credentials]
+storage = "file"
+
+[workspaces.default.sources.github_v4_query]
+variables = {}
+secrets = ["API_TOKEN"]
+origin = "imported"
+"#,
+    )
+    .expect("write legacy source config");
+
+    let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+    assert_github_v4_query_works(&harness).await;
+    assert!(
+        !source_dir(&config_dir, "github_v4_query")
+            .join("materialized/v4")
+            .exists()
+    );
+    harness
+        .import_source(
+            fixture_manifest_yaml(harness.temp_path()).replace("local_messages", "github_v4_query"),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+    let pool = sqlite_pool(&config_dir).await;
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM materializations WHERE workspace_id = ? AND source_name = ?",
+    )
+    .bind("default")
+    .bind("github_v4_query")
+    .fetch_one(&pool)
+    .await
+    .expect("count materializations after non-v4 reimport");
+    assert_eq!(count, 0);
+    pool.close().await;
+    harness.shutdown().await;
+}
+
+#[tokio::test]
 async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     let harness = GrpcHarness::new().await;
 
@@ -424,6 +532,22 @@ async fn import_rejects_cleartext_secret_endpoint_without_database_state() {
         .expect_err("cleartext credential endpoint should fail");
     assert_eq!(error.code(), tonic::Code::InvalidArgument);
     assert!(error.message().contains("base_url"));
+    harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: v4_secret_auth_manifest(
+                &fixture_v4_openapi_manifest_yaml(harness.temp_path(), "http://api.example.com").0,
+            ),
+            variables: Vec::new(),
+            secrets: vec![SourceSecret {
+                key: "API_TOKEN".into(),
+                value: "secret-token".into(),
+            }],
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect_err("cleartext derived credential endpoint should fail");
     assert!(harness.list_sources().await.is_empty());
 }
 
@@ -937,6 +1061,92 @@ fn remove_config_source_section(config_dir: &std::path::Path, source_name: &str)
         sources.remove(source_name);
     }
     fs::write(&config_path, doc.to_string()).expect("write config without source section");
+}
+
+async fn assert_github_v4_query_works(harness: &GrpcHarness) {
+    let validated = harness.validate_source("github_v4_query").await;
+    assert_eq!(validated.tables.len(), 1);
+    assert_eq!(validated.tables[0].schema_name, "github_v4_query");
+    assert_eq!(validated.tables[0].name, "issues");
+    assert_eq!(
+        harness
+            .execute_sql_rows("SELECT id, title FROM github_v4_query.issues")
+            .await,
+        vec![serde_json::json!({"id": 1, "title": "Stored materialization"})]
+    );
+}
+
+async fn write_legacy_github_v4_materialization_from_db(config_dir: &Path) {
+    let pool = sqlite_pool(config_dir).await;
+    let row = sqlx::query(
+        "SELECT fingerprint_yaml, projections_yaml, diagnostics_yaml \
+         FROM materializations WHERE workspace_id = ? AND source_name = ?",
+    )
+    .bind("default")
+    .bind("github_v4_query")
+    .fetch_one(&pool)
+    .await
+    .expect("load materialization row");
+    let materialized_dir = source_dir(config_dir, "github_v4_query").join("materialized/v4");
+    fs::create_dir_all(&materialized_dir).expect("create legacy materialized dir");
+    fs::write(
+        materialized_dir.join("fingerprint.yaml"),
+        row.get::<String, _>("fingerprint_yaml"),
+    )
+    .expect("write legacy fingerprint");
+    fs::write(
+        materialized_dir.join("projections.yaml"),
+        row.get::<String, _>("projections_yaml"),
+    )
+    .expect("write legacy projections");
+    fs::write(
+        materialized_dir.join("diagnostics.yaml"),
+        row.get::<String, _>("diagnostics_yaml"),
+    )
+    .expect("write legacy diagnostics");
+
+    let surfaces = sqlx::query(
+        "SELECT surface_id, source_document_raw, source_document_yaml, semantic_ir_yaml \
+         FROM materialization_surfaces WHERE workspace_id = ? AND source_name = ? \
+         ORDER BY surface_id",
+    )
+    .bind("default")
+    .bind("github_v4_query")
+    .fetch_all(&pool)
+    .await
+    .expect("load materialization surfaces");
+    for surface in surfaces {
+        let surface_dir = materialized_dir
+            .join("surfaces")
+            .join(surface.get::<String, _>("surface_id"));
+        fs::create_dir_all(&surface_dir).expect("create legacy surface dir");
+        fs::write(
+            surface_dir.join("source-document.raw"),
+            surface.get::<Vec<u8>, _>("source_document_raw"),
+        )
+        .expect("write legacy raw source document");
+        fs::write(
+            surface_dir.join("source-document.yaml"),
+            surface.get::<String, _>("source_document_yaml"),
+        )
+        .expect("write legacy source document");
+        fs::write(
+            surface_dir.join("semantic-ir.yaml"),
+            surface.get::<String, _>("semantic_ir_yaml"),
+        )
+        .expect("write legacy semantic IR");
+    }
+    pool.close().await;
+}
+
+async fn sqlite_pool(config_dir: &Path) -> sqlx::SqlitePool {
+    let options = SqliteConnectOptions::new()
+        .filename(config_dir.join("coral.db"))
+        .foreign_keys(true);
+    SqlitePoolOptions::new()
+        .connect_with(options)
+        .await
+        .expect("open sqlite db")
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -172,6 +172,25 @@ async fn restart_preserves_database_source_after_config_source_section_is_remove
 }
 
 #[tokio::test]
+async fn list_catalog_reads_database_after_config_source_section_is_removed() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
+    harness
+        .import_source(manifest_yaml, Vec::new(), Vec::new())
+        .await;
+
+    remove_config_source_section(&harness, "local_messages");
+
+    let tables = harness.list_tables().await;
+    assert!(
+        tables
+            .iter()
+            .any(|table| table.schema_name == "local_messages" && table.name == "messages"),
+        "catalog should still load imported source from DB"
+    );
+}
+
+#[tokio::test]
 async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     let harness = GrpcHarness::new().await;
 

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -4,7 +4,7 @@
     reason = "test code: assertion-style indexing is idiomatic in tests"
 )]
 
-use std::{fs, path::Path};
+use std::fs;
 
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
@@ -25,8 +25,7 @@ use crate::harness::{
     FailingHttpFixture, GrpcHarness, fixture_function_only_manifest_yaml,
     fixture_manifest_with_inputs_yaml, fixture_manifest_with_multiple_tables_yaml,
     fixture_manifest_with_required_inputs_yaml, fixture_manifest_with_test_queries_yaml,
-    fixture_manifest_yaml, fixture_v4_openapi_manifest_yaml, invalid_manifest_yaml,
-    issues_http_fixture, source_dir,
+    fixture_manifest_yaml, invalid_manifest_yaml, source_dir,
 };
 
 fn auth_manifest_yaml(inputs: &str, auth: &str) -> String {
@@ -58,13 +57,6 @@ fn secret_auth_manifest_yaml_at(base_url: &str) -> String {
         base_url,
         "inputs:\n  API_TOKEN:\n    kind: secret\n",
         "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n",
-    )
-}
-
-fn v4_secret_auth_manifest(manifest_yaml: &str) -> String {
-    manifest_yaml.replace(
-        "type: openapi",
-        "type: openapi\n  inputs:\n    API_TOKEN:\n      kind: secret\n  auth:\n    type: BasicAuth\n    username: bot\n    password: \"{{input.API_TOKEN}}\"",
     )
 }
 
@@ -937,7 +929,7 @@ async fn import_source_missing_required_secret_returns_invalid_argument() {
     );
 }
 
-fn remove_config_source_section(config_dir: &Path, source_name: &str) {
+fn remove_config_source_section(config_dir: &std::path::Path, source_name: &str) {
     let config_path = config_dir.join("config.toml");
     let raw = fs::read_to_string(&config_path).expect("read config");
     let mut doc = raw.parse::<DocumentMut>().expect("parse config");
@@ -1854,28 +1846,27 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
     use std::os::unix::fs::PermissionsExt;
 
     let harness = GrpcHarness::new().await;
-    let issues_http = issues_http_fixture(&["Basic Ym90OnNlY3JldC10b2tlbg=="]).await;
-    let (manifest_yaml, openapi_file) =
-        fixture_v4_openapi_manifest_yaml(harness.temp_path(), &issues_http.uri());
     harness
         .import_source(
-            v4_secret_auth_manifest(&manifest_yaml),
-            Vec::new(),
+            fixture_manifest_with_inputs_yaml(),
+            vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "https://example.com".to_string(),
+            }],
             vec![SourceSecret {
-                key: "API_TOKEN".into(),
-                value: "secret-token".into(),
+                key: "API_TOKEN".to_string(),
+                value: "secret-token".to_string(),
             }],
         )
         .await;
-    fs::remove_file(openapi_file).expect("remove authored descriptor");
 
     let sources_root = harness
         .config_dir()
         .join("workspaces")
         .join("default")
         .join("sources");
-    let manifest_path = source_dir(harness.config_dir(), "github_v4_query").join("manifest.yaml");
-    let secret_path = source_dir(harness.config_dir(), "github_v4_query").join("secrets.env");
+    let manifest_path = source_dir(harness.config_dir(), "secured_messages").join("manifest.yaml");
+    let secret_path = source_dir(harness.config_dir(), "secured_messages").join("secrets.env");
     fs::set_permissions(&sources_root, fs::Permissions::from_mode(0o500))
         .expect("make sources dir read-only");
 
@@ -1883,7 +1874,7 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
         .source_client()
         .delete_source(Request::new(DeleteSourceRequest {
             workspace: Some(default_workspace()),
-            name: "github_v4_query".to_string(),
+            name: "secured_messages".to_string(),
         }))
         .await
         .expect_err("source directory cleanup should fail");
@@ -1896,28 +1887,21 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
         manifest_path.exists(),
         "DB-backed rollback should restore legacy manifest files"
     );
-    let secret_material = fs::read_to_string(&secret_path).expect("read restored secrets");
-    assert!(secret_material.contains("API_TOKEN=secret-token"));
+    assert!(secret_path.exists(), "secret file should be restored");
 
     let listed = harness.list_sources().await;
     assert_eq!(listed.len(), 1);
-    assert_eq!(listed[0].name, "github_v4_query");
+    assert_eq!(listed[0].name, "secured_messages");
     let validated = harness
         .source_client()
         .validate_source(Request::new(ValidateSourceRequest {
             workspace: Some(default_workspace()),
-            name: "github_v4_query".to_string(),
+            name: "secured_messages".to_string(),
         }))
         .await
         .expect("source should still validate from DB manifest")
         .into_inner();
     assert_eq!(validated.tables.len(), 1);
-    assert_eq!(
-        harness
-            .execute_sql_rows("SELECT id, title FROM github_v4_query.issues")
-            .await,
-        vec![serde_json::json!({"id": 1, "title": "Stored materialization"})]
-    );
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -18,6 +18,7 @@ use coral_api::v1::{
 };
 use coral_client::default_workspace;
 use sqlx::Row as _;
+use sqlx::postgres::PgPoolOptions;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use toml_edit::DocumentMut;
@@ -331,6 +332,13 @@ origin = "imported"
 "#,
     )
     .expect("write legacy source config");
+    let legacy_source_dir = source_dir(&config_dir, "github_v4_query");
+    fs::create_dir_all(&legacy_source_dir).expect("recreate legacy source dir");
+    fs::write(
+        legacy_source_dir.join("secrets.env"),
+        "API_TOKEN=secret-token\n",
+    )
+    .expect("write legacy source secrets");
 
     let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
     assert_github_v4_query_works(&harness).await;
@@ -383,6 +391,10 @@ async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     assert_eq!(imported.secrets.len(), 1);
     assert_eq!(imported.secrets[0].key, "API_TOKEN");
     assert!(imported.secrets[0].value.is_empty());
+    assert_eq!(
+        imported.credential_storage,
+        SourceCredentialStorage::Database as i32
+    );
 
     let fetched = harness
         .source_client()
@@ -400,10 +412,62 @@ async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     assert_eq!(fetched.origin, SourceOrigin::Imported as i32);
     assert_eq!(
         fetched.credential_storage,
-        SourceCredentialStorage::File as i32
+        SourceCredentialStorage::Database as i32
     );
     assert_eq!(fetched.variables, imported.variables);
     assert_eq!(fetched.secrets, imported.secrets);
+}
+
+#[tokio::test]
+#[ignore = "set CORAL_TEST_POSTGRES_URL to run Postgres credential runtime coverage"]
+async fn postgres_database_credentials_survive_restart_and_query() {
+    let Some(database_url) = postgres_test_url() else {
+        return;
+    };
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        "[database]\nbackend = \"postgres\"\nurl_env = \"CORAL_TEST_POSTGRES_URL\"\n\n[credentials]\nstorage = \"database\"\nencryption_key_source = \"file\"\n",
+    )
+    .expect("write postgres credential config");
+    let source_name = format!("secured_messages_{}", uuid::Uuid::new_v4().simple());
+    cleanup_postgres_source(&database_url, &source_name).await;
+    let server = issues_http_fixture(&["Bearer secret-token"]).await;
+
+    {
+        let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+        let imported = harness
+            .import_source(
+                fixture_manifest_with_inputs_yaml().replace("secured_messages", &source_name),
+                vec![SourceVariable {
+                    key: "API_BASE".to_string(),
+                    value: server.uri(),
+                }],
+                vec![SourceSecret {
+                    key: "API_TOKEN".to_string(),
+                    value: "secret-token".to_string(),
+                }],
+            )
+            .await;
+        assert_eq!(
+            imported.credential_storage,
+            SourceCredentialStorage::Database as i32
+        );
+        assert_encrypted_postgres_credential_document(&database_url, &source_name).await;
+        harness.shutdown().await;
+    }
+
+    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    let validated = harness.validate_source(&source_name).await;
+    assert_eq!(validated.tables[0].schema_name, source_name);
+    let rows = harness
+        .execute_sql_rows(&format!("SELECT id FROM {source_name}.messages"))
+        .await;
+    assert_eq!(rows[0]["id"], 1);
+    harness.shutdown().await;
+    cleanup_postgres_source(&database_url, &source_name).await;
 }
 
 #[tokio::test]
@@ -1499,7 +1563,7 @@ async fn get_source_info_uses_effective_installed_imported_manifest() {
     assert!(info.installed);
     assert_eq!(
         info.credential_storage,
-        SourceCredentialStorage::File as i32
+        SourceCredentialStorage::Database as i32
     );
     assert_eq!(info.inputs.len(), 2);
     assert_eq!(info.inputs[0].key, "API_BASE");
@@ -2039,15 +2103,16 @@ async fn overwrite_restores_previous_source_on_config_write_failure() {
         .into_inner();
     assert_eq!(validated.tables.len(), 1);
     let secret_path = source_dir(harness.config_dir(), "secured_messages").join("secrets.env");
-    let secret_material = fs::read_to_string(&secret_path).expect("read restored secrets");
     assert!(
-        secret_material.contains("API_TOKEN=old-token"),
-        "{secret_material}"
+        !secret_path.exists(),
+        "DB-backed rollback should not recreate legacy secret files"
     );
-    assert!(
-        !secret_material.contains("API_TOKEN=new-token"),
-        "{secret_material}"
+    assert_eq!(
+        fetched.credential_storage,
+        SourceCredentialStorage::Database as i32
     );
+    assert_eq!(fetched.secrets.len(), 1);
+    assert_eq!(fetched.secrets[0].key, "API_TOKEN");
 }
 
 #[cfg(unix)]
@@ -2056,27 +2121,32 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
     use std::os::unix::fs::PermissionsExt;
 
     let harness = GrpcHarness::new().await;
+    let issues_http = issues_http_fixture(&["Basic Ym90OnNlY3JldC10b2tlbg=="]).await;
+    let (manifest_yaml, openapi_file) =
+        fixture_v4_openapi_manifest_yaml(harness.temp_path(), &issues_http.uri());
     harness
         .import_source(
-            fixture_manifest_with_inputs_yaml(),
-            vec![SourceVariable {
-                key: "API_BASE".to_string(),
-                value: "https://example.com".to_string(),
-            }],
+            v4_secret_auth_manifest(&manifest_yaml),
+            Vec::new(),
             vec![SourceSecret {
                 key: "API_TOKEN".to_string(),
                 value: "secret-token".to_string(),
             }],
         )
         .await;
+    fs::remove_file(openapi_file).expect("remove authored descriptor");
 
     let sources_root = harness
         .config_dir()
         .join("workspaces")
         .join("default")
         .join("sources");
-    let manifest_path = source_dir(harness.config_dir(), "secured_messages").join("manifest.yaml");
-    let secret_path = source_dir(harness.config_dir(), "secured_messages").join("secrets.env");
+    let source_dir = source_dir(harness.config_dir(), "github_v4_query");
+    fs::create_dir_all(&source_dir).expect("create legacy source dir");
+    let legacy_artifact = source_dir.join("legacy-artifact");
+    fs::write(&legacy_artifact, "legacy").expect("write legacy artifact");
+    let manifest_path = source_dir.join("manifest.yaml");
+    let secret_path = source_dir.join("secrets.env");
     fs::set_permissions(&sources_root, fs::Permissions::from_mode(0o500))
         .expect("make sources dir read-only");
 
@@ -2084,7 +2154,7 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
         .source_client()
         .delete_source(Request::new(DeleteSourceRequest {
             workspace: Some(default_workspace()),
-            name: "secured_messages".to_string(),
+            name: "github_v4_query".to_string(),
         }))
         .await
         .expect_err("source directory cleanup should fail");
@@ -2097,21 +2167,40 @@ async fn delete_restores_artifacts_on_cleanup_failure() {
         manifest_path.exists(),
         "DB-backed rollback should restore legacy manifest files"
     );
-    assert!(secret_path.exists(), "secret file should be restored");
+    assert!(
+        !secret_path.exists(),
+        "DB-backed rollback should not recreate legacy secret files"
+    );
+    assert!(
+        legacy_artifact.exists(),
+        "legacy source dir artifact should be restored after failed cleanup"
+    );
 
     let listed = harness.list_sources().await;
     assert_eq!(listed.len(), 1);
-    assert_eq!(listed[0].name, "secured_messages");
+    assert_eq!(listed[0].name, "github_v4_query");
+    assert_eq!(
+        listed[0].credential_storage,
+        SourceCredentialStorage::Database as i32
+    );
+    assert_eq!(listed[0].secrets.len(), 1);
+    assert_eq!(listed[0].secrets[0].key, "API_TOKEN");
     let validated = harness
         .source_client()
         .validate_source(Request::new(ValidateSourceRequest {
             workspace: Some(default_workspace()),
-            name: "secured_messages".to_string(),
+            name: "github_v4_query".to_string(),
         }))
         .await
         .expect("source should still validate from DB manifest")
         .into_inner();
     assert_eq!(validated.tables.len(), 1);
+    assert_eq!(
+        harness
+            .execute_sql_rows("SELECT id, title FROM github_v4_query.issues")
+            .await,
+        vec![serde_json::json!({"id": 1, "title": "Stored materialization"})]
+    );
 }
 
 #[tokio::test]
@@ -2221,4 +2310,48 @@ origin = "imported"
         !config_raw.contains("[workspaces.default.sources.local_messages]"),
         "newly added source should not be mirrored to config"
     );
+}
+
+async fn assert_encrypted_postgres_credential_document(database_url: &str, source_name: &str) {
+    let pool = PgPoolOptions::new()
+        .connect(database_url)
+        .await
+        .expect("open postgres");
+    let ciphertext: Vec<u8> = sqlx::query_scalar(
+        "SELECT ciphertext FROM credential_documents WHERE workspace_id = $1 AND source_name = $2",
+    )
+    .bind("default")
+    .bind(source_name)
+    .fetch_one(&pool)
+    .await
+    .expect("load credential document");
+    assert!(
+        !String::from_utf8_lossy(&ciphertext).contains("secret-token"),
+        "credential document must not store plaintext secret material"
+    );
+    pool.close().await;
+}
+
+async fn cleanup_postgres_source(database_url: &str, source_name: &str) {
+    let pool = PgPoolOptions::new()
+        .connect(database_url)
+        .await
+        .expect("open postgres");
+    sqlx::query("DELETE FROM sources WHERE workspace_id = $1 AND name = $2")
+        .bind("default")
+        .bind(source_name)
+        .execute(&pool)
+        .await
+        .expect("cleanup postgres source");
+    pool.close().await;
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "The ignored Postgres integration test is explicitly gated by this CI/test-only variable."
+)]
+fn postgres_test_url() -> Option<String> {
+    std::env::var("CORAL_TEST_POSTGRES_URL")
+        .ok()
+        .filter(|value| !value.is_empty())
 }

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -9,10 +9,11 @@ use std::fs;
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
     ExplainSqlRequest, GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest,
-    ListCatalogRequest, OauthCredentialFlowType, OauthCredentialScopeDelimiter, PaginationRequest,
-    QueryTestFailure, QueryTestSuccess, SourceCredentialStorage, SourceOrigin, SourceSecret,
-    SourceVariable, ValidateSourceRequest, Workspace, catalog_item, import_source_response,
-    query_test_result, source_credential_method::Method as ProtoCredentialMethod,
+    ListCatalogRequest, OAuthCredentialRetrieval, OauthCredentialFlowType,
+    OauthCredentialScopeDelimiter, PaginationRequest, QueryTestFailure, QueryTestSuccess,
+    SourceCredentialStorage, SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest,
+    Workspace, catalog_item, import_source_response, query_test_result,
+    source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::default_workspace;
@@ -26,6 +27,26 @@ use crate::harness::{
     fixture_manifest_with_required_inputs_yaml, fixture_manifest_with_test_queries_yaml,
     fixture_manifest_yaml, invalid_manifest_yaml, source_dir,
 };
+
+fn auth_manifest_yaml(inputs: &str, auth: &str) -> String {
+    format!(
+        "name: hardcoded_auth\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: https://example.com\n{inputs}{auth}tables:\n  - name: messages\n    description: Demo messages\n    request:\n      method: GET\n      path: /messages\n    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
+    )
+}
+
+fn literal_sensitive_auth_manifest_yaml() -> String {
+    auth_manifest_yaml(
+        "",
+        "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: literal\n      value: Bearer hardcoded-token\n",
+    )
+}
+
+fn variable_backed_sensitive_auth_manifest_yaml() -> String {
+    auth_manifest_yaml(
+        "inputs:\n  HEADER_VALUE:\n    kind: variable\n",
+        "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.HEADER_VALUE}}\n",
+    )
+}
 
 #[tokio::test]
 async fn import_source_persists_and_lists() {
@@ -322,6 +343,79 @@ async fn import_invalid_manifest_returns_invalid_argument() {
         .await
         .expect_err("invalid manifest should fail");
     assert_eq!(error.code(), tonic::Code::InvalidArgument);
+}
+
+#[tokio::test]
+async fn import_rejects_literal_sensitive_auth_header() {
+    let harness = GrpcHarness::new().await;
+
+    let error = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: literal_sensitive_auth_manifest_yaml(),
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect_err("literal sensitive auth should fail");
+
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(error.message().contains("Authorization"));
+}
+
+#[tokio::test]
+async fn import_rejects_sensitive_auth_template_backed_by_variable() {
+    let harness = GrpcHarness::new().await;
+
+    let error = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: variable_backed_sensitive_auth_manifest_yaml(),
+            variables: vec![SourceVariable {
+                key: "HEADER_VALUE".to_string(),
+                value: "hardcoded-token".to_string(),
+            }],
+            secrets: Vec::new(),
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect_err("variable-backed sensitive auth should fail");
+
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(error.message().contains("HEADER_VALUE"));
+    assert!(harness.list_sources().await.is_empty());
+}
+
+#[tokio::test]
+async fn import_with_oauth_rejects_literal_sensitive_auth_header_before_authorization() {
+    let harness = GrpcHarness::new().await;
+
+    let mut stream = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: literal_sensitive_auth_manifest_yaml(),
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            oauth_credential_retrievals: vec![OAuthCredentialRetrieval {
+                input_key: "API_TOKEN".to_string(),
+                method_index: Some(0),
+                credential_inputs: Vec::new(),
+            }],
+        }))
+        .await
+        .expect("OAuth import request should create a response stream")
+        .into_inner();
+
+    let error = stream
+        .message()
+        .await
+        .expect_err("literal sensitive auth should fail before OAuth authorization");
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(error.message().contains("Authorization"));
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -29,8 +29,12 @@ use crate::harness::{
 };
 
 fn auth_manifest_yaml(inputs: &str, auth: &str) -> String {
+    auth_manifest_yaml_at("https://example.com", inputs, auth)
+}
+
+fn auth_manifest_yaml_at(base_url: &str, inputs: &str, auth: &str) -> String {
     format!(
-        "name: hardcoded_auth\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: https://example.com\n{inputs}{auth}tables:\n  - name: messages\n    description: Demo messages\n    request:\n      method: GET\n      path: /messages\n    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
+        "name: hardcoded_auth\nversion: 1.0.0\ndsl_version: 3\nbackend: http\nbase_url: {base_url}\n{inputs}{auth}tables:\n  - name: messages\n    description: Demo messages\n    request:\n      method: GET\n      path: /messages\n    response: {{}}\n    columns:\n      - name: id\n        type: Utf8\n"
     )
 }
 
@@ -45,6 +49,14 @@ fn variable_backed_sensitive_auth_manifest_yaml() -> String {
     auth_manifest_yaml(
         "inputs:\n  HEADER_VALUE:\n    kind: variable\n",
         "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.HEADER_VALUE}}\n",
+    )
+}
+
+fn secret_auth_manifest_yaml_at(base_url: &str) -> String {
+    auth_manifest_yaml_at(
+        base_url,
+        "inputs:\n  API_TOKEN:\n    kind: secret\n",
+        "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n",
     )
 }
 
@@ -390,14 +402,90 @@ async fn import_rejects_sensitive_auth_template_backed_by_variable() {
 }
 
 #[tokio::test]
-async fn import_with_oauth_rejects_literal_sensitive_auth_header_before_authorization() {
+async fn import_rejects_cleartext_secret_endpoint_without_database_state() {
+    let harness = GrpcHarness::new().await;
+    let error = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: secret_auth_manifest_yaml_at("http://api.example.com"),
+            variables: Vec::new(),
+            secrets: vec![SourceSecret {
+                key: "API_TOKEN".into(),
+                value: "secret-token".into(),
+            }],
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect_err("cleartext credential endpoint should fail");
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(error.message().contains("base_url"));
+    assert!(harness.list_sources().await.is_empty());
+}
+
+#[tokio::test]
+async fn import_rejects_variable_rendered_cleartext_secret_endpoint() {
+    let harness = GrpcHarness::new().await;
+    let error = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: auth_manifest_yaml_at(
+                "\"{{input.API_BASE}}\"",
+                "inputs:\n  API_BASE:\n    kind: variable\n  API_TOKEN:\n    kind: secret\n",
+                "auth:\n  type: HeaderAuth\n  headers:\n    - name: Authorization\n      from: template\n      template: Bearer {{input.API_TOKEN}}\n",
+            ),
+            variables: vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "http://api.example.com".to_string(),
+            }],
+            secrets: vec![SourceSecret {
+                key: "API_TOKEN".into(),
+                value: "secret-token".into(),
+            }],
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect_err("rendered cleartext credential endpoint should fail");
+
+    assert_eq!(error.code(), tonic::Code::InvalidArgument);
+    assert!(
+        error.message().contains("base_url"),
+        "message: {}",
+        error.message()
+    );
+    assert!(harness.list_sources().await.is_empty());
+}
+
+#[tokio::test]
+async fn import_allows_loopback_secret_endpoint() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            secret_auth_manifest_yaml_at("http://127.0.0.1:9"),
+            Vec::new(),
+            vec![SourceSecret {
+                key: "API_TOKEN".into(),
+                value: "secret-token".into(),
+            }],
+        )
+        .await;
+
+    assert_eq!(harness.list_sources().await.len(), 1);
+}
+
+#[tokio::test]
+async fn import_with_oauth_rejects_cleartext_endpoint_before_authorization() {
     let harness = GrpcHarness::new().await;
 
     let mut stream = harness
         .source_client()
         .import_source(Request::new(ImportSourceRequest {
             workspace: Some(default_workspace()),
-            manifest_yaml: literal_sensitive_auth_manifest_yaml(),
+            manifest_yaml: auth_manifest_yaml(
+                "inputs:\n  API_TOKEN:\n    kind: secret\n    credential:\n      methods:\n        - type: oauth\n          oauth:\n            flow:\n              type: device_code\n            endpoints:\n              device_authorization_url: http://api.example.com/device\n              token_url: https://api.example.com/token\n            client:\n              id:\n                default: demo\n",
+                "",
+            ),
             variables: Vec::new(),
             secrets: Vec::new(),
             oauth_credential_retrievals: vec![OAuthCredentialRetrieval {
@@ -410,12 +498,10 @@ async fn import_with_oauth_rejects_literal_sensitive_auth_header_before_authoriz
         .expect("OAuth import request should create a response stream")
         .into_inner();
 
-    let error = stream
-        .message()
-        .await
-        .expect_err("literal sensitive auth should fail before OAuth authorization");
+    let error = stream.message().await.expect_err("cleartext endpoint");
     assert_eq!(error.code(), tonic::Code::InvalidArgument);
-    assert!(error.message().contains("Authorization"));
+    assert!(error.message().contains("device_authorization_url"));
+    assert!(harness.list_sources().await.is_empty());
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -278,11 +278,6 @@ async fn delete_workspace_restores_db_sources_when_config_delete_fails() {
         Vec::new(),
     )
     .await;
-    let issues_http = crate::harness::issues_http_fixture(&[]).await;
-    let (v4_manifest_yaml, openapi_file) =
-        crate::harness::fixture_v4_openapi_manifest_yaml(temp.path(), &issues_http.uri());
-    import_source_in_workspace(&harness, "work", v4_manifest_yaml, Vec::new(), Vec::new()).await;
-    fs::remove_file(openapi_file).expect("remove authored descriptor");
     fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o500))
         .expect("make config dir read-only");
     let result = harness
@@ -315,16 +310,6 @@ async fn delete_workspace_restores_db_sources_when_config_delete_fails() {
         .expect("restored source should validate")
         .into_inner();
     assert_eq!(validated.tables.len(), 1);
-    let validated_v4 = harness
-        .source_client()
-        .validate_source(Request::new(ValidateSourceRequest {
-            workspace: Some(workspace("work")),
-            name: "github_v4_query".to_string(),
-        }))
-        .await
-        .expect("restored v4 source should validate")
-        .into_inner();
-    assert_eq!(validated_v4.tables.len(), 1);
 }
 
 #[cfg(unix)]

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fs, path::Path};
 
 use coral_api::v1::{
     CreateWorkspaceRequest, DeleteWorkspaceRequest, ImportSourceRequest, ListSourcesRequest,
@@ -7,6 +7,8 @@ use coral_api::v1::{
 };
 use coral_client::default_workspace;
 use serde_json::json;
+use sqlx::Row as _;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use tonic::Request;
 
@@ -433,6 +435,7 @@ async fn delete_workspace_removes_workspace_trace_history() {
             + "\n",
     )
     .expect("write local trace history");
+    insert_trace_summary(harness.config_dir(), "work", "work-trace").await;
 
     let deleted = harness
         .workspace_client()
@@ -458,6 +461,10 @@ async fn delete_workspace_removes_workspace_trace_history() {
     assert!(
         raw.contains("unscoped-trace"),
         "unscoped trace should remain in local trace history: {raw}"
+    );
+    assert_eq!(
+        trace_summary_count(harness.config_dir(), "work", "work-trace").await,
+        0
     );
 }
 
@@ -789,4 +796,40 @@ fn local_trace_line(
         "attributes_json": attributes.to_string(),
     })
     .to_string()
+}
+
+async fn insert_trace_summary(config_dir: &Path, workspace_id: &str, trace_id: &str) {
+    let pool = sqlite_pool(config_dir).await;
+    sqlx::query("INSERT OR IGNORE INTO workspaces (id, created_at_unix_nanos) VALUES (?1, 1)")
+        .bind(workspace_id)
+        .execute(&pool)
+        .await
+        .expect("insert workspace");
+    sqlx::query("INSERT INTO trace_summaries (trace_id, workspace_id, root_span_id, name, query, status, start_time_unix_nanos, end_time_unix_nanos, duration_nanos, span_count, row_count) VALUES (?1, ?2, 'root', 'coral.query', 'SELECT 1', 'ok', 1, 2, 1, 1, 1)")
+        .bind(trace_id)
+        .bind(workspace_id)
+    .execute(&pool)
+    .await
+    .expect("insert trace summary");
+}
+
+async fn trace_summary_count(config_dir: &Path, workspace_id: &str, trace_id: &str) -> i64 {
+    let pool = sqlite_pool(config_dir).await;
+    let row = sqlx::query(
+        "SELECT COUNT(*) AS count FROM trace_summaries WHERE workspace_id = ?1 AND trace_id = ?2",
+    )
+    .bind(workspace_id)
+    .bind(trace_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count trace summaries");
+    row.get("count")
+}
+
+async fn sqlite_pool(config_dir: &Path) -> sqlx::SqlitePool {
+    let options = SqliteConnectOptions::new().filename(config_dir.join("coral.db"));
+    SqlitePoolOptions::new()
+        .connect_with(options)
+        .await
+        .expect("open sqlite db")
 }

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -278,6 +278,11 @@ async fn delete_workspace_restores_db_sources_when_config_delete_fails() {
         Vec::new(),
     )
     .await;
+    let issues_http = crate::harness::issues_http_fixture(&[]).await;
+    let (v4_manifest_yaml, openapi_file) =
+        crate::harness::fixture_v4_openapi_manifest_yaml(temp.path(), &issues_http.uri());
+    import_source_in_workspace(&harness, "work", v4_manifest_yaml, Vec::new(), Vec::new()).await;
+    fs::remove_file(openapi_file).expect("remove authored descriptor");
     fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o500))
         .expect("make config dir read-only");
     let result = harness
@@ -310,6 +315,16 @@ async fn delete_workspace_restores_db_sources_when_config_delete_fails() {
         .expect("restored source should validate")
         .into_inner();
     assert_eq!(validated.tables.len(), 1);
+    let validated_v4 = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(workspace("work")),
+            name: "github_v4_query".to_string(),
+        }))
+        .await
+        .expect("restored v4 source should validate")
+        .into_inner();
+    assert_eq!(validated_v4.tables.len(), 1);
 }
 
 #[cfg(unix)]

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -225,6 +225,82 @@ async fn delete_workspace_removes_config_entry_and_workspace_artifacts() {
         !raw.contains("[workspaces.work"),
         "deleted workspace should be removed from config: {raw}"
     );
+
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("recreate workspace");
+    let sources = harness
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("list recreated workspace sources")
+        .into_inner()
+        .sources;
+    assert!(sources.is_empty(), "deleted DB sources should not reappear");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn delete_workspace_restores_db_sources_when_config_delete_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let db_path = temp.path().join("db").join("coral.db");
+    fs::create_dir_all(db_path.parent().expect("db parent")).expect("create db dir");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!(
+            "[database]\nbackend = \"sqlite\"\npath = \"{}\"\n",
+            db_path.display()
+        ),
+    )
+    .expect("write database config");
+    let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("create workspace");
+    import_source_in_workspace(
+        &harness,
+        "work",
+        fixture_manifest_yaml(harness.temp_path()),
+        Vec::new(),
+        Vec::new(),
+    )
+    .await;
+    fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o500))
+        .expect("make config dir read-only");
+    let result = harness
+        .workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await;
+    fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o700))
+        .expect("restore config dir permissions");
+
+    result.expect_err("config delete should fail");
+    let sources = harness
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("list restored workspace sources")
+        .into_inner()
+        .sources;
+    assert!(sources.iter().any(|source| source.name == "local_messages"));
 }
 
 #[tokio::test]
@@ -467,6 +543,8 @@ async fn delete_workspace_removes_state_when_trace_cleanup_fails() {
 #[tokio::test]
 async fn delete_workspace_ignores_stale_trace_files_when_trace_history_disabled() {
     let _trace_store_guard = TRACE_STORE_DELETE_TEST_LOCK.lock().await;
+    GrpcHarness::new().await.shutdown().await;
+
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
     fs::create_dir_all(config_dir.join("telemetry").join("traces")).expect("create trace dir");

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -497,8 +497,8 @@ async fn delete_workspace_ignores_malformed_trace_history() {
     let secret_path = source_dir.join("secrets.env");
     assert!(source_dir.exists(), "import should create source artifacts");
     assert!(
-        secret_path.exists(),
-        "import should create file-backed secret material"
+        !secret_path.exists(),
+        "database-backed import should not create legacy secrets.env"
     );
 
     let trace_dir = local_trace_store_dir(&harness);
@@ -576,8 +576,8 @@ async fn delete_workspace_removes_state_when_trace_cleanup_fails() {
     let secret_path = source_dir.join("secrets.env");
     assert!(source_dir.exists(), "import should create source artifacts");
     assert!(
-        secret_path.exists(),
-        "import should create file-backed secret material"
+        !secret_path.exists(),
+        "database-backed import should not create legacy secrets.env"
     );
 
     let trace_dir = local_trace_store_dir(&harness);

--- a/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_lifecycle_tests.rs
@@ -2,7 +2,8 @@ use std::fs;
 
 use coral_api::v1::{
     CreateWorkspaceRequest, DeleteWorkspaceRequest, ImportSourceRequest, ListSourcesRequest,
-    ListWorkspacesRequest, Source, SourceSecret, SourceVariable, Workspace, import_source_response,
+    ListWorkspacesRequest, Source, SourceSecret, SourceVariable, ValidateSourceRequest, Workspace,
+    import_source_response,
 };
 use coral_client::default_workspace;
 use serde_json::json;
@@ -194,13 +195,11 @@ async fn delete_workspace_removes_config_entry_and_workspace_artifacts() {
     .await;
     assert_eq!(imported.name, "local_messages");
 
-    let source_dir = harness
-        .config_dir()
-        .join("workspaces")
-        .join("work")
-        .join("sources")
-        .join("local_messages");
-    assert!(source_dir.exists(), "import should create source artifacts");
+    let workspace_dir = harness.config_dir().join("workspaces").join("work");
+    let artifact = workspace_dir.join("artifacts").join("marker");
+    fs::create_dir_all(artifact.parent().expect("artifact parent")).expect("create artifact dir");
+    fs::write(&artifact, "workspace artifact").expect("write workspace artifact");
+    assert!(artifact.exists(), "test should create a workspace artifact");
 
     let deleted = harness
         .workspace_client()
@@ -216,8 +215,8 @@ async fn delete_workspace_removes_config_entry_and_workspace_artifacts() {
 
     assert_eq!(workspace_names(&harness).await, vec!["default"]);
     assert!(
-        !source_dir.exists(),
-        "delete should remove workspace artifacts"
+        !workspace_dir.exists(),
+        "delete should remove workspace artifact directory"
     );
 
     let raw = fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
@@ -301,6 +300,100 @@ async fn delete_workspace_restores_db_sources_when_config_delete_fails() {
         .into_inner()
         .sources;
     assert!(sources.iter().any(|source| source.name == "local_messages"));
+    let validated = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(workspace("work")),
+            name: "local_messages".to_string(),
+        }))
+        .await
+        .expect("restored source should validate")
+        .into_inner();
+    assert_eq!(validated.tables.len(), 1);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn delete_workspace_handles_imported_source_without_manifest_row() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let db_path = temp.path().join("db").join("coral.db");
+    fs::create_dir_all(db_path.parent().expect("db parent")).expect("create db dir");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!(
+            r#"
+[database]
+backend = "sqlite"
+path = "{}"
+
+[workspaces.work.sources.demo]
+version = "0.1.0"
+origin = "imported"
+"#,
+            db_path.display()
+        ),
+    )
+    .expect("write database config");
+    let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+    let sources = harness
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("list degraded imported source")
+        .into_inner()
+        .sources;
+    assert!(sources.iter().any(|source| source.name == "demo"));
+
+    fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o500))
+        .expect("make config dir read-only");
+    let result = harness
+        .workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await;
+    fs::set_permissions(&config_dir, fs::Permissions::from_mode(0o700))
+        .expect("restore config dir permissions");
+
+    result.expect_err("config delete should fail");
+    let sources = harness
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("list restored degraded source")
+        .into_inner()
+        .sources;
+    assert!(sources.iter().any(|source| source.name == "demo"));
+    let error = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(workspace("work")),
+            name: "demo".to_string(),
+        }))
+        .await
+        .expect_err("restored degraded source should still report missing manifest");
+    assert_eq!(error.code(), tonic::Code::NotFound);
+
+    let deleted = harness
+        .workspace_client()
+        .delete_workspace(Request::new(DeleteWorkspaceRequest {
+            workspace: Some(workspace("work")),
+        }))
+        .await
+        .expect("delete degraded workspace")
+        .into_inner()
+        .workspace
+        .expect("delete workspace response");
+    assert_eq!(deleted.name, "work");
+    assert_eq!(workspace_names(&harness).await, vec!["default"]);
 }
 
 #[tokio::test]
@@ -619,13 +712,15 @@ async fn delete_workspace_succeeds_when_backup_cleanup_fails_after_config_delete
 
     let workspace_dir = harness.config_dir().join("workspaces").join("work");
     let sources_root = workspace_dir.join("sources");
-    assert!(
+    fs::create_dir_all(sources_root.join("secured_messages"))
+        .expect("create legacy source artifact dir");
+    fs::write(
         sources_root
             .join("secured_messages")
-            .join("secrets.env")
-            .exists(),
-        "import should persist file-backed credential material"
-    );
+            .join("legacy-artifact"),
+        "legacy",
+    )
+    .expect("write legacy source artifact");
     fs::set_permissions(&sources_root, fs::Permissions::from_mode(0o500))
         .expect("make nested sources dir read-only");
 

--- a/crates/coral-app/tests/telemetry_local_trace_lifecycle.rs
+++ b/crates/coral-app/tests/telemetry_local_trace_lifecycle.rs
@@ -93,7 +93,7 @@ fn write_trace(dir: &Path, trace_id: &str) {
         "start_time_unix_nanos": 1,
         "end_time_unix_nanos": 2,
         "duration_nanos": 1,
-        "attributes_json": "{}",
+        "attributes_json": json!({ "workspace": "default" }).to_string(),
         "events_json": "[]",
         "links_json": "[]",
         "resource_json": "{}",

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -802,6 +802,7 @@ pub(crate) fn source_credential_storage_label(storage: i32) -> &'static str {
         Ok(SourceCredentialStorage::Unspecified) => "none",
         Ok(SourceCredentialStorage::File) => "file (plaintext)",
         Ok(SourceCredentialStorage::Keychain) => "keychain",
+        Ok(SourceCredentialStorage::Database) => "database (encrypted)",
         Err(_) => "unknown",
     }
 }
@@ -1734,7 +1735,7 @@ mod tests {
         reason = "collected input order assertions intentionally fail loudly in tests"
     )]
 
-    use coral_api::v1::ValidateSourceResponse;
+    use coral_api::v1::{SourceCredentialStorage, ValidateSourceResponse};
     use coral_spec::{
         ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,
         ManifestInputKind, ManifestInputSpec, ManifestOAuthClientIdSpec,
@@ -1757,8 +1758,8 @@ mod tests {
         finalize_input_value, oauth_client_id_allows_empty,
         oauth_client_secret_required_after_client_id_prompt, render_redirect_prompt_key_echo,
         resolve_oauth_client_id_prompt_value, resolve_prompt_hint, shell_quote_arg,
-        source_name_arg, submit_oauth_redirect_url, validate_oauth_redirect_url,
-        validation_follow_up,
+        source_credential_storage_label, source_name_arg, submit_oauth_redirect_url,
+        validate_oauth_redirect_url, validation_follow_up,
     };
 
     fn test_oauth_spec(client: ManifestOAuthClientSpec) -> ManifestOAuthCredentialSpec {
@@ -1776,6 +1777,14 @@ mod tests {
             client,
             scopes: None,
         }
+    }
+
+    #[test]
+    fn source_credential_storage_label_includes_database_storage() {
+        assert_eq!(
+            source_credential_storage_label(SourceCredentialStorage::Database as i32),
+            "database (encrypted)"
+        );
     }
 
     #[test]

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -275,6 +275,41 @@ async fn source_list_renders_configured_sources() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn source_list_renders_database_credential_storage() {
+    let server = MockServer::start_with_config(MockServerConfig::default().with_list_sources(
+        ListSourcesResponse {
+            sources: vec![Source {
+                workspace: Some(Workspace {
+                    name: "default".to_string(),
+                }),
+                name: "database_source".to_string(),
+                version: "3.0.0".to_string(),
+                secrets: Vec::new(),
+                variables: Vec::new(),
+                origin: SourceOrigin::Imported as i32,
+                credential_storage: SourceCredentialStorage::Database as i32,
+            }],
+        },
+    ))
+    .await;
+
+    let assert = server.cmd().args(["source", "list"]).assert().success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert_eq!(
+        nonempty_lines(&stdout),
+        vec![
+            "Source           Version  Origin    Secrets",
+            "---------------  -------  --------  --------------------",
+            "database_source  3.0.0    imported  database (encrypted)",
+        ],
+        "expected database-backed source list"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn source_list_renders_dash_for_missing_authored_version() {
     let server = MockServer::start_with_config(MockServerConfig::default().with_list_sources(
         ListSourcesResponse {
@@ -416,6 +451,34 @@ async fn source_info_renders_metadata_for_installed_source() {
     let requests = server.get_source_info_requests();
     assert_eq!(requests.len(), 1, "expected one get_source_info call");
     assert_eq!(requests[0].name, "github");
+    assert_default_workspace(requests[0].workspace.as_ref());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_info_renders_database_credential_storage() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "info", "database_source"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("database_source"),
+        "expected source name: {stdout}"
+    );
+    assert!(
+        stdout.contains("Secrets:     database (encrypted)"),
+        "expected database credential storage label: {stdout}"
+    );
+
+    let requests = server.get_source_info_requests();
+    assert_eq!(requests.len(), 1, "expected one get_source_info call");
+    assert_eq!(requests[0].name, "database_source");
     assert_default_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -374,6 +374,15 @@ fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
             origin: SourceOrigin::Imported as i32,
             credential_storage: SourceCredentialStorage::File as i32,
         }),
+        "database_source" => Ok(SourceInfo {
+            name: "database_source".to_string(),
+            description: "Database-backed source".to_string(),
+            version: "3.0.0".to_string(),
+            inputs: Vec::new(),
+            installed: true,
+            origin: SourceOrigin::Imported as i32,
+            credential_storage: SourceCredentialStorage::Database as i32,
+        }),
         "versionless" => Ok(SourceInfo {
             name: "versionless".to_string(),
             description: String::new(),

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -99,6 +99,7 @@ pub(super) fn default_http_client(
         .default_http_client(|| {
             reqwest::Client::builder()
                 .timeout(Duration::from_secs(DEFAULT_HTTP_REQUEST_TIMEOUT_SECS))
+                .redirect(source_redirect_policy())
                 .user_agent(DEFAULT_HTTP_USER_AGENT)
                 .build()
                 .map_err(|error| error.to_string())
@@ -108,6 +109,30 @@ pub(super) fn default_http_client(
                 "failed to build HTTP client for source '{source_name}': {error}"
             ))
         })
+}
+
+fn source_redirect_policy() -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(|attempt| {
+        if attempt.previous().len() > 10 {
+            return attempt.error(std::io::Error::other("too many redirects"));
+        }
+        let Some(previous) = attempt.previous().last() else {
+            return attempt.follow();
+        };
+        if same_origin(previous, attempt.url()) {
+            attempt.follow()
+        } else {
+            attempt.error(std::io::Error::other(
+                "cross-origin redirects are disabled for source HTTP requests",
+            ))
+        }
+    })
+}
+
+fn same_origin(left: &reqwest::Url, right: &reqwest::Url) -> bool {
+    left.scheme() == right.scheme()
+        && left.host_str() == right.host_str()
+        && left.port_or_known_default() == right.port_or_known_default()
 }
 
 impl HttpSourceClient {

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -2274,6 +2274,82 @@ async fn auth_headers_sent_correctly() {
 }
 
 #[tokio::test]
+async fn source_http_client_follows_same_origin_redirects() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(header("authorization", "Bearer secret-token"))
+        .respond_with(
+            ResponseTemplate::new(307)
+                .append_header("Location", format!("{}/api/redirected-users", server.uri())),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/redirected-users"))
+        .and(header("authorization", "Bearer secret-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_same_origin_redirect", &server.uri());
+    manifest["inputs"] = json!({"API_TOKEN": { "kind": "secret" }});
+    manifest["auth"] = json!({"type": "HeaderAuth", "headers": [{
+        "name": "Authorization", "from": "bearer", "key": "API_TOKEN"
+    }]});
+    let source = build_source_with_secrets(manifest, [("API_TOKEN", "secret-token")]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT COUNT(*) AS n FROM http_same_origin_redirect.users",
+        )
+        .await
+        .expect("same-origin redirect should succeed"),
+    );
+
+    assert_eq!(rows, vec![json!({"n": 3})]);
+}
+
+#[tokio::test]
+async fn source_http_client_rejects_cross_origin_redirects() {
+    let server = MockServer::start().await;
+    let recorder = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(header("authorization", "Bearer secret-token"))
+        .respond_with(
+            ResponseTemplate::new(307)
+                .append_header("Location", format!("{}/capture", recorder.uri())),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(path("/capture"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(0)
+        .mount(&recorder)
+        .await;
+
+    let mut manifest = base_http_manifest("http_redirect", &server.uri());
+    manifest["inputs"] = json!({"API_TOKEN": { "kind": "secret" }});
+    manifest["auth"] = json!({"type": "HeaderAuth", "headers": [{
+        "name": "Authorization", "from": "bearer", "key": "API_TOKEN"
+    }]});
+    let source = build_source_with_secrets(manifest, [("API_TOKEN", "secret-token")]);
+
+    CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT COUNT(*) AS n FROM http_redirect.users",
+    )
+    .await
+    .expect_err("cross-origin redirect should fail");
+}
+
+#[tokio::test]
 async fn auth_header_one_of_uses_bearer_fallback() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -30,5 +30,6 @@ coral-telemetry.workspace = true
 [dev-dependencies]
 coral-app.workspace = true
 jsonschema.workspace = true
+sqlx.workspace = true
 tempfile.workspace = true
 tonic-types.workspace = true

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -22,7 +22,7 @@ use rmcp::{
     service::RunningService,
 };
 use serde_json::{Map, Value, json};
-use sqlx::{Row, sqlite::SqliteConnectOptions};
+use sqlx::{Row, SqlitePool, sqlite::SqliteConnectOptions};
 use tempfile::TempDir;
 use tonic::Request;
 
@@ -543,29 +543,30 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
             .contains("argument 'episode_id' must be graphic ASCII")
     );
 
-    let episodes_path = temp
-        .path()
-        .join("coral-config/workspaces/default/episodes/episodes.jsonl");
-    let raw = fs::read_to_string(&episodes_path).expect("episode file should exist");
-    let records = raw
-        .lines()
-        .map(|line| serde_json::from_str::<Value>(line).expect("episode JSONL should parse"))
-        .collect::<Vec<_>>();
+    let episodes_path = legacy_episodes_path(&temp);
+    assert!(
+        !episodes_path.exists(),
+        "DB-backed MCP session should not write legacy episode JSONL"
+    );
+    let records = db_episodes(&temp).await;
     assert_eq!(records.len(), 2);
     let root_record = records
         .iter()
-        .find(|record| record["id"] == root_episode_id.as_str())
+        .find(|record| record.id == root_episode_id)
         .expect("root episode record");
-    assert_eq!(root_record["workspace"], "default");
-    assert_eq!(root_record["intent"], "Investigate customer renewal risk");
-    assert_eq!(root_record["parent_episode_id"], Value::Null);
+    assert_eq!(root_record.workspace_id, "default");
+    assert_eq!(root_record.intent, "Investigate customer renewal risk");
+    assert_eq!(root_record.parent_episode_id, None);
     let child_record = records
         .iter()
-        .find(|record| record["id"] == child_episode_id.as_str())
+        .find(|record| record.id == child_episode_id)
         .expect("child episode record");
-    assert_eq!(child_record["workspace"], "default");
-    assert_eq!(child_record["intent"], "Check renewal table columns");
-    assert_eq!(child_record["parent_episode_id"], root_episode_id.as_str());
+    assert_eq!(child_record.workspace_id, "default");
+    assert_eq!(child_record.intent, "Check renewal table columns");
+    assert_eq!(
+        child_record.parent_episode_id.as_deref(),
+        Some(root_episode_id.as_str())
+    );
 
     let blank_intent = client
         .call_tool(
@@ -580,8 +581,7 @@ async fn mcp_episode_tool_persists_episode_and_tags_follow_up_calls() {
             .to_string()
             .contains("missing string argument 'intent'")
     );
-    let raw_after_error = fs::read_to_string(&episodes_path).expect("episode file should exist");
-    assert_eq!(raw_after_error.lines().count(), 2);
+    assert_eq!(db_episodes(&temp).await.len(), 2);
 
     session.shutdown().await;
 }
@@ -1411,7 +1411,7 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
     assert_eq!(structured["message"], "Feedback report stored.");
     assert!(structured.get("upload").is_none());
 
-    let db = open_feedback_database(&temp).await;
+    let db = open_coral_database(&temp).await;
     assert_feedback_row_matches(
         &db,
         structured["feedback_id"].as_str().expect("feedback id"),
@@ -1444,17 +1444,48 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
     session.shutdown().await;
 }
 
-async fn open_feedback_database(temp: &TempDir) -> sqlx::SqlitePool {
-    sqlx::SqlitePool::connect_with(
+struct EpisodeRow {
+    id: String,
+    workspace_id: String,
+    intent: String,
+    parent_episode_id: Option<String>,
+}
+
+fn legacy_episodes_path(temp: &TempDir) -> PathBuf {
+    temp.path()
+        .join("coral-config/workspaces/default/episodes/episodes.jsonl")
+}
+
+async fn open_coral_database(temp: &TempDir) -> SqlitePool {
+    SqlitePool::connect_with(
         SqliteConnectOptions::new()
             .filename(temp.path().join("coral-config/coral.db"))
             .create_if_missing(false),
     )
     .await
-    .expect("open feedback database")
+    .expect("open coral database")
 }
 
-async fn assert_feedback_row_matches(db: &sqlx::SqlitePool, feedback_id: &str) {
+async fn db_episodes(temp: &TempDir) -> Vec<EpisodeRow> {
+    let db = open_coral_database(temp).await;
+    sqlx::query(
+        "select id, workspace_id, intent, parent_episode_id \
+         from episodes order by created_at_unix_nanos, id",
+    )
+    .fetch_all(&db)
+    .await
+    .expect("query episodes")
+    .into_iter()
+    .map(|row| EpisodeRow {
+        id: row.get("id"),
+        workspace_id: row.get("workspace_id"),
+        intent: row.get("intent"),
+        parent_episode_id: row.get("parent_episode_id"),
+    })
+    .collect()
+}
+
+async fn assert_feedback_row_matches(db: &SqlitePool, feedback_id: &str) {
     let record =
         sqlx::query("select id, workspace_id, trying_to_do, tried, stuck from feedback_reports")
             .fetch_one(db)

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -22,6 +22,7 @@ use rmcp::{
     service::RunningService,
 };
 use serde_json::{Map, Value, json};
+use sqlx::{Row, sqlite::SqliteConnectOptions};
 use tempfile::TempDir;
 use tonic::Request;
 
@@ -1410,25 +1411,12 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
     assert_eq!(structured["message"], "Feedback report stored.");
     assert!(structured.get("upload").is_none());
 
-    let raw = fs::read_to_string(
-        temp.path()
-            .join("coral-config/workspaces/default/feedback/reports.jsonl"),
+    let db = open_feedback_database(&temp).await;
+    assert_feedback_row_matches(
+        &db,
+        structured["feedback_id"].as_str().expect("feedback id"),
     )
-    .expect("feedback file should exist");
-    let records = raw.lines().collect::<Vec<_>>();
-    assert_eq!(records.len(), 1);
-    let record: Value = serde_json::from_str(records[0]).expect("feedback JSONL should parse");
-    assert_eq!(record["id"], structured["feedback_id"]);
-    assert_eq!(record["workspace"], "default");
-    assert_eq!(record["trying_to_do"], "Fix failing tests");
-    assert_eq!(
-        record["tried"],
-        "Ran cargo test and inspected the failing assertion"
-    );
-    assert_eq!(
-        record["stuck"],
-        "The fixture shape does not match the documented contract"
-    );
+    .await;
 
     let blank_feedback = client
         .call_tool(
@@ -1446,14 +1434,43 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             .contains("missing string argument 'tried'")
     );
 
-    let raw_after_error = fs::read_to_string(
-        temp.path()
-            .join("coral-config/workspaces/default/feedback/reports.jsonl"),
-    )
-    .expect("feedback file should still exist");
-    assert_eq!(raw_after_error.lines().count(), 1);
+    let count = sqlx::query("select count(*) as count from feedback_reports")
+        .fetch_one(&db)
+        .await
+        .expect("count feedback rows")
+        .get::<i64, _>("count");
+    assert_eq!(count, 1);
 
     session.shutdown().await;
+}
+
+async fn open_feedback_database(temp: &TempDir) -> sqlx::SqlitePool {
+    sqlx::SqlitePool::connect_with(
+        SqliteConnectOptions::new()
+            .filename(temp.path().join("coral-config/coral.db"))
+            .create_if_missing(false),
+    )
+    .await
+    .expect("open feedback database")
+}
+
+async fn assert_feedback_row_matches(db: &sqlx::SqlitePool, feedback_id: &str) {
+    let record =
+        sqlx::query("select id, workspace_id, trying_to_do, tried, stuck from feedback_reports")
+            .fetch_one(db)
+            .await
+            .expect("feedback row should exist");
+    assert_eq!(record.get::<String, _>("id"), feedback_id);
+    assert_eq!(record.get::<String, _>("workspace_id"), "default");
+    assert_eq!(record.get::<String, _>("trying_to_do"), "Fix failing tests");
+    assert_eq!(
+        record.get::<String, _>("tried"),
+        "Ran cargo test and inspected the failing assertion"
+    );
+    assert_eq!(
+        record.get::<String, _>("stuck"),
+        "The fixture shape does not match the documented contract"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Intent
Make the existing credential envelope-encryption machinery reusable for identity documents without adding crypto primitives, schema changes, or repository wiring. Credential encryption behavior remains on the existing path while the shared helpers expose the same AES-256-GCM envelope shape for identity callers.

## What it enables
Later DSL v4 identity units can store identity-spec setup secrets and identity instance material as envelope-encrypted database documents with one shared KEK provider and one rotation story. Identity spec documents get an AAD domain bound to `scope_kind`, `scope_id`, `name`, and algorithm; identity instance documents get a separate domain bound to `owner_kind`, `owner_key`, `name`, and algorithm, both using AAD version 1.

## Usage examples
- Seal identity spec setup values with `encrypt_identity_spec_document("workspace", workspace_id, spec_name, &values, key_provider)`.
- Open identity instance values with `decrypt_identity_document(owner_kind, owner_key, name, &document, key_provider)`.
- Rotate identity document KEKs with `rewrap_identity_spec_document(...)` or `rewrap_identity_document(...)`; unchanged active keys return `None`.

## Validation
- `cargo test -p coral-app --locked identity:: -- --nocapture`
- `cargo test -p coral-app --locked credentials:: -- --nocapture`
- `make rust-checks`
