### PR TITLE
fix(desktop): load Sources & Traces from the sidecar in dev

### DIFF
--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -10,6 +10,11 @@ const electronViteBin = resolve(
   process.platform === 'win32' ? 'electron-vite.cmd' : 'electron-vite',
 )
 
+// Shared between the Vite dev server (which proxies `/__coral__` to the sidecar)
+// and the sidecar spawn in the Electron main process. Fixed so Vite's config,
+// loaded before the sidecar exists, has a known proxy target.
+const sidecarPort = process.env.CORAL_DEV_SIDECAR_PORT ?? '8778'
+
 const children = new Set()
 let shuttingDown = false
 
@@ -88,6 +93,7 @@ const appDevServer = spawnChild('npm', ['run', 'dev', '--prefix', 'apps/reef'], 
   env: {
     ...process.env,
     CORAL_DESKTOP_APP: '1',
+    CORAL_DEV_SIDECAR_PORT: sidecarPort,
   },
   stdio: ['ignore', 'pipe', 'pipe'],
 })
@@ -109,6 +115,7 @@ try {
     env: {
       ...process.env,
       ELECTRON_RENDERER_URL: appUrl,
+      CORAL_DEV_SIDECAR_PORT: sidecarPort,
     },
     stdio: 'inherit',
   })

--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -13,7 +13,9 @@ const electronViteBin = resolve(
 // Shared between the Vite dev server (which proxies `/__coral__` to the sidecar)
 // and the sidecar spawn in the Electron main process. Fixed so Vite's config,
 // loaded before the sidecar exists, has a known proxy target.
-const sidecarPort = process.env.CORAL_DEV_SIDECAR_PORT ?? '8778'
+// `||` (not `??`) so an empty CORAL_DEV_SIDECAR_PORT also falls back to the
+// default rather than propagating an empty port to the sidecar and Vite proxy.
+const sidecarPort = process.env.CORAL_DEV_SIDECAR_PORT || '8778'
 
 const children = new Set()
 let shuttingDown = false

--- a/apps/desktop/src/main/app-renderer.ts
+++ b/apps/desktop/src/main/app-renderer.ts
@@ -14,7 +14,9 @@ export const APP_ENTRY_URL = `${APP_ORIGIN}/`
 
 // gRPC-web requests are proxied to the loopback sidecar under this same-origin
 // path, so the strict CSP ('self') covers them and no CORS layer is involved.
-const GRPC_PATH_PREFIX = '/__coral__'
+// In dev the Vite server proxies this same prefix to the sidecar, so the client
+// stays same-origin there too — hence the export.
+export const GRPC_PATH_PREFIX = '/__coral__'
 export const APP_GRPC_BASE = `${APP_ORIGIN}${GRPC_PATH_PREFIX}`
 
 const MIME_TYPES: Record<string, string> = {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import {
   APP_ENTRY_URL,
   APP_GRPC_BASE,
   APP_ORIGIN,
+  GRPC_PATH_PREFIX,
   registerAppProtocol,
   registerAppSchemePrivileges,
 } from './app-renderer'
@@ -238,9 +239,13 @@ function registerIpcHandlers() {
     if (rendererUrl() === null) {
       return { grpcBaseUrl: APP_GRPC_BASE, packaged: app.isPackaged }
     }
-    // Dev (Vite http origin) hits the sidecar directly, so wait for its endpoint.
+    // Dev: the Vite server proxies the same-origin `/__coral__` prefix to the
+    // sidecar (see apps/reef/vite.config.ts), so the renderer stays same-origin
+    // and needs no CORS — mirroring the packaged app:// proxy. Still wait for the
+    // sidecar so the proxy target is live before the UI starts issuing requests.
     const started = await ensureSidecar()
-    return { grpcBaseUrl: started.url, packaged: started.packaged }
+    const devOrigin = new URL(rendererUrl()!).origin
+    return { grpcBaseUrl: `${devOrigin}${GRPC_PATH_PREFIX}`, packaged: started.packaged }
   })
   ipcMain.handle('coral:list-mcp-clients', () => mcpClients())
   ipcMain.handle('coral:configure-mcp', (_event, clientId: McpClientId) => configureMcpClient(clientId))

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -61,6 +61,14 @@ export async function externalCoralPath(): Promise<string> {
   throw new Error('No Coral binary is available yet. Run `npm run stage:coral --prefix apps/desktop` first.')
 }
 
+// Dev binds a known port (default 8778, overridable) so the Vite dev server can
+// proxy the same-origin `/__coral__` prefix to it — the port must be fixed
+// because Vite's config loads before the sidecar exists. Packaged builds keep
+// `--port 0` (dynamic) since they proxy via the app:// scheme, not Vite.
+function devSidecarPort(): string {
+  return process.env.CORAL_DEV_SIDECAR_PORT ?? '8778'
+}
+
 function devSidecarCommand(): { command: string; args: string[]; cwd: string } {
   return {
     command: 'cargo',
@@ -75,7 +83,7 @@ function devSidecarCommand(): { command: string; args: string[]; cwd: string } {
       'ui',
       '--no-open',
       '--port',
-      '0',
+      devSidecarPort(),
     ],
     cwd: repoRoot(),
   }

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -66,7 +66,9 @@ export async function externalCoralPath(): Promise<string> {
 // because Vite's config loads before the sidecar exists. Packaged builds keep
 // `--port 0` (dynamic) since they proxy via the app:// scheme, not Vite.
 function devSidecarPort(): string {
-  return process.env.CORAL_DEV_SIDECAR_PORT ?? '8778'
+  // `||` (not `??`) so an empty CORAL_DEV_SIDECAR_PORT also falls back — an empty
+  // string would otherwise become `--port ""` and the sidecar would fail to start.
+  return process.env.CORAL_DEV_SIDECAR_PORT || '8778'
 }
 
 function devSidecarCommand(): { command: string; args: string[]; cwd: string } {

--- a/apps/reef/app/wax/components/sidebar-button/sidebar-button.tsx
+++ b/apps/reef/app/wax/components/sidebar-button/sidebar-button.tsx
@@ -68,7 +68,7 @@ export function SidebarButton<T extends ElementType = 'button'>(
   return (
     <Component {...componentProps}>
       <Icon className={iconStyles({ variant })} color="inherit" name={icon} size="18" />
-      {children && <span className={textStyles({ variant })}>{children}</span>}
+      {!isMinimized && children && <span className={textStyles({ variant })}>{children}</span>}
     </Component>
   )
 }

--- a/apps/reef/vite.config.ts
+++ b/apps/reef/vite.config.ts
@@ -2,9 +2,28 @@ import { reactRouter } from '@react-router/dev/vite'
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin'
 import { defineConfig } from 'vite'
 
+// Under the desktop dev harness (apps/desktop/scripts/dev.mjs) the sidecar binds
+// this fixed port. Proxying the same-origin `/__coral__` prefix to it keeps the
+// gRPC-web client same-origin in dev — no CORS — mirroring the packaged app://
+// proxy. Must match GRPC_PATH_PREFIX in apps/desktop/src/main/app-renderer.ts.
+// Absent when Reef runs standalone, so no proxy is added there.
+const sidecarPort = process.env.CORAL_DEV_SIDECAR_PORT
+const coralProxy = sidecarPort
+  ? {
+      '/__coral__': {
+        target: `http://127.0.0.1:${sidecarPort}`,
+        changeOrigin: true,
+        rewrite: (path: string) => path.replace(/^\/__coral__/, ''),
+      },
+    }
+  : undefined
+
 export default defineConfig({
   plugins: [vanillaExtractPlugin(), reactRouter()],
   resolve: {
     tsconfigPaths: true,
+  },
+  server: {
+    proxy: coralProxy,
   },
 })


### PR DESCRIPTION
two changes 
- add missing isMinimized prop to sidebar button component 
- routing the app's backend calls through the Vite dev server to the sidecar (same-origin), instead of failing on a blocked cross-origin request. (this was working for me previously because of a local setup override) 