### PR TITLE
refactor(reef): use card list for sources

### DIFF
--- a/apps/reef/app/views/sources/sources-index.css.ts
+++ b/apps/reef/app/views/sources/sources-index.css.ts
@@ -12,10 +12,10 @@ export const spinAnimation = style({
 })
 
 export const root = style({
-  display: 'flex',
-  flexDirection: 'column',
   height: '100%',
-  overflow: 'auto',
+})
+
+export const scrollContent = style({
   paddingBlock: 32,
   paddingInline: 24,
 })

--- a/apps/reef/app/views/sources/sources-index.css.ts
+++ b/apps/reef/app/views/sources/sources-index.css.ts
@@ -85,72 +85,11 @@ export const searchBar = style({
   maxWidth: 360,
 })
 
-export const cardGrid = style({
-  display: 'grid',
-  gap: 16,
-  gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
-})
-
-export const card = style({
-  background: theme.surface.card,
-  border: `1px solid ${theme.stroke.secondary}`,
-  borderRadius: 12,
-  color: 'inherit',
-  cursor: 'pointer',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 8,
-  padding: 16,
-  textAlign: 'left',
-  textDecoration: 'none',
-  transition: 'background 80ms ease, border-color 80ms ease',
-  ':hover': {
-    background: theme.surface.onMainContentHover,
-  },
-})
-
-export const cardHeader = style({
-  alignItems: 'center',
-  display: 'flex',
-  gap: 10,
-})
-
-export const cardLogo = style({
-  alignItems: 'center',
-  background: theme.surface.onMainContent,
-  borderRadius: '50%',
-  display: 'flex',
+export const sourceIcon = style({
+  borderRadius: 999,
+  display: 'block',
   flexShrink: 0,
-  height: 28,
-  justifyContent: 'center',
-  overflow: 'hidden',
-  width: 28,
-})
-
-export const cardLogoImg = style({
-  height: '100%',
-  objectFit: 'cover',
-  width: '100%',
-})
-
-export const cardTitle = style({
-  flexGrow: 1,
-  textTransform: 'capitalize',
-})
-
-export const cardDescription = style({
-  display: '-webkit-box',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  WebkitBoxOrient: 'vertical' as const,
-  WebkitLineClamp: 2,
-})
-
-export const cardFooter = style({
-  alignItems: 'center',
-  color: theme.content.tertiary,
-  display: 'flex',
-  gap: 8,
-  justifyContent: 'flex-end',
-  marginBlockStart: 'auto',
+  height: 20,
+  objectFit: 'contain',
+  width: 20,
 })

--- a/apps/reef/app/views/sources/sources-index.tsx
+++ b/apps/reef/app/views/sources/sources-index.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { CardList, type CardItem } from '@/wax/components/card'
 import { Icon } from '@/wax/components/icon'
 import { TextInput } from '@/wax/components/inputs/text'
-import { Pill } from '@/wax/components/pill'
 import { Typography } from '@/wax/components/typography'
 
 import { ErrorBanner } from '@/components/error-banner'
@@ -156,29 +156,13 @@ export function SourcesIndex() {
 
         {connected.length > 0 ? (
           <Section title="Configured" count={connected.length}>
-            <div className={styles.cardGrid}>
-              {connected.map((entry) => (
-                <SourceCard
-                  key={`${entry.origin}:${entry.name}`}
-                  entry={entry}
-                  onClick={() => onPick(entry)}
-                />
-              ))}
-            </div>
+            <SourceCardList entries={connected} onPick={onPick} />
           </Section>
         ) : null}
 
         {sections.map((section) => (
           <Section key={section.key} title={section.label} count={section.entries.length}>
-            <div className={styles.cardGrid}>
-              {section.entries.map((entry) => (
-                <SourceCard
-                  key={`${entry.origin}:${entry.name}`}
-                  entry={entry}
-                  onClick={() => onPick(entry)}
-                />
-              ))}
-            </div>
+            <SourceCardList entries={section.entries} onPick={onPick} />
           </Section>
         ))}
 
@@ -234,37 +218,52 @@ function Section({
   )
 }
 
-function SourceCard({ entry, onClick }: { entry: IndexEntry; onClick: () => void }) {
-  const icon = providerIcon(entry.name)
+function SourceCardList({
+  entries,
+  onPick,
+}: {
+  entries: IndexEntry[]
+  onPick: (entry: IndexEntry) => void
+}) {
+  const entryById = new Map(entries.map((entry) => [sourceCardId(entry), entry]))
+  const items = entries.map(toCardItem)
+
   return (
-    <button type="button" onClick={onClick} className={styles.card}>
-      <div className={styles.cardHeader}>
-        <div className={styles.cardLogo}>
-          {icon ? (
-            <img alt="" src={icon} className={styles.cardLogoImg} />
-          ) : (
-            <Icon name="Plug" size="18" color="tertiary" />
-          )}
-        </div>
-        <Typography.BodyLargeStrong as="span" className={styles.cardTitle}>
-          {entry.name}
-        </Typography.BodyLargeStrong>
-        {entry.origin === 'imported' ? (
-          <Pill>Imported</Pill>
-        ) : entry.origin === 'bundled' ? (
-          <Pill>Core</Pill>
-        ) : null}
-      </div>
-      {entry.description ? (
-        <Typography.Body variant="tertiary" className={styles.cardDescription}>
-          {entry.description}
-        </Typography.Body>
-      ) : null}
-      {entry.installed ? (
-        <div className={styles.cardFooter}>
-          <Pill>Configured</Pill>
-        </div>
-      ) : null}
-    </button>
+    <CardList
+      items={items}
+      onSelect={(item) => {
+        const entry = entryById.get(item.id)
+        if (entry) onPick(entry)
+      }}
+    />
+  )
+}
+
+function toCardItem(entry: IndexEntry): CardItem {
+  return {
+    description: entry.description,
+    headerPill: sourceOriginPill(entry),
+    icon: sourceIcon(entry.name),
+    id: sourceCardId(entry),
+    title: entry.name,
+  }
+}
+
+function sourceOriginPill(entry: IndexEntry): CardItem['headerPill'] {
+  if (entry.origin === 'bundled') return { label: 'Core' }
+  if (entry.origin === 'imported') return { label: 'Imported' }
+  return undefined
+}
+
+function sourceCardId(entry: IndexEntry) {
+  return `${entry.origin}:${entry.name}`
+}
+
+function sourceIcon(name: string) {
+  const icon = providerIcon(name)
+  return icon ? (
+    <img alt="" className={styles.sourceIcon} src={icon} />
+  ) : (
+    <Icon color="tertiary" name="Plug" size="20" />
   )
 }

--- a/apps/reef/app/views/sources/sources-index.tsx
+++ b/apps/reef/app/views/sources/sources-index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { ScrollArea } from '@/wax/components'
 import { CardList, type CardItem } from '@/wax/components/card'
 import { Icon } from '@/wax/components/icon'
 import { TextInput } from '@/wax/components/inputs/text'
@@ -110,72 +111,76 @@ export function SourcesIndex() {
   }, [refresh])
 
   return (
-    <div className={styles.root}>
-      <div className={styles.container}>
-        <div className={styles.header}>
-          <Typography.HeadingLarge as="h1">Sources</Typography.HeadingLarge>
-          <Typography.Body variant="secondary">
-            Connect external systems to query their data from Coral. Click a source to install or
-            inspect it.
-          </Typography.Body>
-        </div>
+    <>
+      <ScrollArea.Container className={styles.root} constrainWidth>
+        <div className={styles.scrollContent}>
+          <div className={styles.container}>
+            <div className={styles.header}>
+              <Typography.HeadingLarge as="h1">Sources</Typography.HeadingLarge>
+              <Typography.Body variant="secondary">
+                Connect external systems to query their data from Coral. Click a source to install
+                or inspect it.
+              </Typography.Body>
+            </div>
 
-        <div className={styles.searchBar}>
-          <TextInput
-            ref={searchInputRef}
-            value={search}
-            onChange={setSearch}
-            placeholder="Search sources…"
-            icon="Search"
-          />
-        </div>
+            <div className={styles.searchBar}>
+              <TextInput
+                ref={searchInputRef}
+                value={search}
+                onChange={setSearch}
+                placeholder="Search sources…"
+                icon="Search"
+              />
+            </div>
 
-        {error ? (
-          <ErrorBanner
-            title="Couldn't load sources"
-            message={error}
-            onRetry={() => window.location.reload()}
-          />
-        ) : null}
+            {error ? (
+              <ErrorBanner
+                title="Couldn't load sources"
+                message={error}
+                onRetry={() => window.location.reload()}
+              />
+            ) : null}
 
-        {loading ? (
-          <div className={styles.loadingState}>
-            <Icon name="Loader" size="16" color="tertiary" className={styles.spinAnimation} />
-            <Typography.BodySmall variant="tertiary">Loading sources…</Typography.BodySmall>
+            {loading ? (
+              <div className={styles.loadingState}>
+                <Icon name="Loader" size="16" color="tertiary" className={styles.spinAnimation} />
+                <Typography.BodySmall variant="tertiary">Loading sources…</Typography.BodySmall>
+              </div>
+            ) : null}
+
+            {!loading && !error && allEntries.length === 0 ? (
+              <div className={styles.emptyState}>
+                <Icon name="Plug" size="20" color="tertiary" />
+                <Typography.Body variant="secondary">
+                  No sources available. Check the Coral build for a populated catalog.
+                </Typography.Body>
+              </div>
+            ) : null}
+
+            {connected.length > 0 ? (
+              <Section title="Configured" count={connected.length}>
+                <SourceCardList entries={connected} onPick={onPick} />
+              </Section>
+            ) : null}
+
+            {sections.map((section) => (
+              <Section key={section.key} title={section.label} count={section.entries.length}>
+                <SourceCardList entries={section.entries} onPick={onPick} />
+              </Section>
+            ))}
+
+            {connected.length === 0 &&
+            sections.length === 0 &&
+            !loading &&
+            !error &&
+            allEntries.length > 0 ? (
+              <Typography.BodySmall variant="tertiary">
+                No sources match your search.
+              </Typography.BodySmall>
+            ) : null}
           </div>
-        ) : null}
-
-        {!loading && !error && allEntries.length === 0 ? (
-          <div className={styles.emptyState}>
-            <Icon name="Plug" size="20" color="tertiary" />
-            <Typography.Body variant="secondary">
-              No sources available. Check the Coral build for a populated catalog.
-            </Typography.Body>
-          </div>
-        ) : null}
-
-        {connected.length > 0 ? (
-          <Section title="Configured" count={connected.length}>
-            <SourceCardList entries={connected} onPick={onPick} />
-          </Section>
-        ) : null}
-
-        {sections.map((section) => (
-          <Section key={section.key} title={section.label} count={section.entries.length}>
-            <SourceCardList entries={section.entries} onPick={onPick} />
-          </Section>
-        ))}
-
-        {connected.length === 0 &&
-        sections.length === 0 &&
-        !loading &&
-        !error &&
-        allEntries.length > 0 ? (
-          <Typography.BodySmall variant="tertiary">
-            No sources match your search.
-          </Typography.BodySmall>
-        ) : null}
-      </div>
+        </div>
+      </ScrollArea.Container>
 
       <SourceInstallDialog
         name={installingName}
@@ -194,7 +199,7 @@ export function SourcesIndex() {
         }}
         onRemoved={onRemoved}
       />
-    </div>
+    </>
   )
 }
 

--- a/apps/reef/app/views/traces/http-span-detail.tsx
+++ b/apps/reef/app/views/traces/http-span-detail.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useState } from 'react'
 import classNames from 'classnames'
 
+import { ScrollArea } from '@/wax/components'
 import * as Button from '@/wax/components/button'
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
-import * as ScrollArea from '@/wax/components/scroll-area'
 import { Typography } from '@/wax/components/typography'
 import type { TraceSpan } from '@/generated/coral/v1/traces_pb'
 

--- a/apps/reef/app/views/traces/trace-detail.tsx
+++ b/apps/reef/app/views/traces/trace-detail.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import classNames from 'classnames'
 
+import { ScrollArea } from '@/wax/components'
 import * as Button from '@/wax/components/button'
 import { Icon } from '@/wax/components/icon'
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
-import * as ScrollArea from '@/wax/components/scroll-area'
 import { Typography } from '@/wax/components/typography'
 import { getTrace } from '@/lib/coral-traces-client'
 import { TraceStatus, type GetTraceResponse, type TraceSpan } from '@/generated/coral/v1/traces_pb'

--- a/apps/reef/app/wax/components/card/card-list.css.ts
+++ b/apps/reef/app/wax/components/card/card-list.css.ts
@@ -3,7 +3,7 @@ import { style } from '@vanilla-extract/css'
 export const grid = style({
   display: 'grid',
   gap: '16px',
-  gridTemplateColumns: 'repeat(auto-fit, minmax(min(300px, 100%), 1fr))',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(min(300px, 100%), 1fr))',
   listStyle: 'none',
   margin: 0,
   padding: 0,

--- a/apps/reef/app/wax/components/card/card-list.tsx
+++ b/apps/reef/app/wax/components/card/card-list.tsx
@@ -1,10 +1,11 @@
 import { ReactNode } from 'react'
 
-import { Card } from './card'
+import { Card, type CardHeaderPill } from './card'
 import * as styles from './card-list.css'
 
 export interface CardItem {
   description: string
+  headerPill?: CardHeaderPill
   icon?: ReactNode
   id: string
   title: string
@@ -22,6 +23,7 @@ export function CardList({ items, onSelect }: CardListProps) {
         <li className={styles.item} key={item.id}>
           <Card
             description={item.description}
+            headerPill={item.headerPill}
             icon={item.icon}
             onSelect={onSelect ? () => onSelect(item) : undefined}
             title={item.title}

--- a/apps/reef/app/wax/components/card/card.css.ts
+++ b/apps/reef/app/wax/components/card/card.css.ts
@@ -38,7 +38,13 @@ export const header = style({
 })
 
 export const title = style({
+  flexShrink: 1,
   minWidth: 0,
+})
+
+export const headerPill = style({
+  flexShrink: 0,
+  marginLeft: 'auto',
 })
 
 export const description = style({

--- a/apps/reef/app/wax/components/card/card.stories.tsx
+++ b/apps/reef/app/wax/components/card/card.stories.tsx
@@ -38,6 +38,15 @@ export const WithIcon: Story = {
   },
 }
 
+export const WithHeaderPill: Story = {
+  args: {
+    description: 'A source with a compact status pill in the card header.',
+    headerPill: { label: 'Imported' },
+    icon: <Icon name="Plug" size="20" />,
+    title: 'Custom source',
+  },
+}
+
 export const NoIcon: Story = {
   args: {
     description: 'A source rendered without an icon.',

--- a/apps/reef/app/wax/components/card/card.tsx
+++ b/apps/reef/app/wax/components/card/card.tsx
@@ -2,18 +2,24 @@ import classNames from 'classnames'
 import { ReactNode } from 'react'
 
 import { Button } from '@/wax/components'
+import { Pill, type PillProps } from '@/wax/components/pill'
 import { Typography } from '@/wax/components/typography'
 
 import * as styles from './card.css'
 
+export type CardHeaderPill = Omit<PillProps, 'children' | 'size'> & {
+  label: string
+}
+
 export interface CardProps {
   description: string
+  headerPill?: CardHeaderPill
   icon?: ReactNode
   onSelect?: () => void
   title: string
 }
 
-export function Card({ description, icon, onSelect, title }: CardProps) {
+export function Card({ description, headerPill, icon, onSelect, title }: CardProps) {
   const content = (
     <>
       <span className={styles.header}>
@@ -21,6 +27,7 @@ export function Card({ description, icon, onSelect, title }: CardProps) {
         <Typography.BodyLargeStrong className={styles.title} truncate>
           {title}
         </Typography.BodyLargeStrong>
+        {headerPill ? <HeaderPill {...headerPill} /> : null}
       </span>
       <Typography.Body className={styles.description} variant="tertiary">
         {description}
@@ -41,4 +48,12 @@ export function Card({ description, icon, onSelect, title }: CardProps) {
   }
 
   return <div className={styles.card}>{content}</div>
+}
+
+function HeaderPill({ className, label, ...props }: CardHeaderPill) {
+  return (
+    <Pill {...props} className={classNames(styles.headerPill, className)}>
+      {label}
+    </Pill>
+  )
 }

--- a/apps/reef/app/wax/components/card/index.ts
+++ b/apps/reef/app/wax/components/card/index.ts
@@ -1,2 +1,2 @@
-export { Card, type CardProps } from './card'
+export { Card, type CardHeaderPill, type CardProps } from './card'
 export { CardList, type CardItem, type CardListProps } from './card-list'


### PR DESCRIPTION
## Summary

Moving the polished CardList that was living in the other `reef` to this one. We can carefully extend this one if needed.
Dropped the "Configured" at the bottom, as Cards are already grouped at the top in the "Configured" group.

## Test plan

<img width="1083" height="582" alt="image" src="https://github.com/user-attachments/assets/26db0ee7-fb14-4748-8e28-d2e753c7050d" />

Dialog still works

<img width="1346" height="816" alt="image" src="https://github.com/user-attachments/assets/38e4cffc-7e9b-4836-8aeb-c9bf05b32e54" />

