### PR TITLE
feat(engine): catalog UDF table functions

### DIFF
--- a/crates/coral-engine/src/backends/file/tests.rs
+++ b/crates/coral-engine/src/backends/file/tests.rs
@@ -275,7 +275,7 @@ async fn parquet_provider_exposes_inferred_schema_in_coral_columns() {
 
     let active_sources = register_sources_blocking(&ctx, compile_sources(vec![manifest]))
         .expect("file source should register");
-    catalog::register(&ctx, &active_sources.active_sources)
+    catalog::register(&ctx, &active_sources.active_sources, &[])
         .expect("metadata tables should register");
 
     let batches = ctx

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -439,7 +439,7 @@ fn register_test_sources(ctx: &SessionContext, sources: Vec<CompiledQuerySource>
 
 fn register_test_sources_with_catalog(ctx: &SessionContext, sources: Vec<CompiledQuerySource>) {
     let registration = register_sources_blocking(ctx, sources).expect("mcp source should register");
-    catalog::register(ctx, &registration.active_sources).expect("catalog should register");
+    catalog::register(ctx, &registration.active_sources, &[]).expect("catalog should register");
     let source_functions = SourceFunctionRegistry::new(
         registration
             .active_sources

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -56,7 +56,7 @@ pub struct DescribeTableInfo {
     pub missing_context_tables: Vec<TableInfo>,
 }
 
-/// Describes one argument accepted by a source-scoped table function.
+/// Describes one argument accepted by a table function.
 #[derive(Debug, Clone)]
 pub struct TableFunctionArgumentInfo {
     /// Argument name as used in a named SQL function call.
@@ -67,7 +67,7 @@ pub struct TableFunctionArgumentInfo {
     pub values: Vec<String>,
 }
 
-/// Describes one result column returned by a source-scoped table function.
+/// Describes one result column returned by a table function.
 #[derive(Debug, Clone)]
 pub struct TableFunctionResultColumnInfo {
     /// Column name returned by the table function.
@@ -80,7 +80,7 @@ pub struct TableFunctionResultColumnInfo {
     pub description: String,
 }
 
-/// Describes one source-scoped table function.
+/// Describes one table function.
 #[derive(Debug, Clone)]
 pub struct TableFunctionInfo {
     /// `SQL` schema name.

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use coral_spec::{ManifestInputKind, SearchLimitsSpec};
+use coral_spec::{ManifestInputKind, SearchLimitsSpec, SourceTableFunctionKind};
 use datafusion::arrow::array::{ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::datasource::MemTable;
@@ -11,10 +11,7 @@ use datafusion::error::{DataFusionError, Result};
 use datafusion::prelude::SessionContext;
 use serde::Serialize;
 
-use crate::backends::common::{
-    RegisteredTableFunctionArgument, RegisteredTableFunctionResultColumn,
-};
-use crate::backends::{RegisteredSource, RegisteredTableFunction};
+use crate::backends::RegisteredSource;
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
     ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
@@ -24,18 +21,50 @@ use crate::{
 /// Schema name for source metadata tables such as `coral.tables`.
 pub(crate) const SYSTEM_SCHEMA: &str = "coral";
 
+/// Catalog-only metadata for one SQL table-function surface.
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogTableFunction {
+    pub(crate) schema_name: String,
+    pub(crate) function_name: String,
+    pub(crate) description: String,
+    pub(crate) arguments: Vec<CatalogTableFunctionArgument>,
+    pub(crate) result_columns: Vec<CatalogTableFunctionResultColumn>,
+    pub(crate) kind: SourceTableFunctionKind,
+    pub(crate) search_limits: Option<SearchLimitsSpec>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogTableFunctionArgument {
+    pub(crate) name: String,
+    pub(crate) required: bool,
+    pub(crate) values: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogTableFunctionResultColumn {
+    pub(crate) name: String,
+    pub(crate) data_type: String,
+    pub(crate) nullable: bool,
+    pub(crate) description: String,
+}
+
 /// Register `coral.tables` and `coral.columns` for the active source set.
 ///
 /// # Errors
 ///
 /// Returns a `DataFusionError` if the catalog is missing or the metadata
 /// tables cannot be materialized.
-pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]) -> Result<()> {
+pub(crate) fn register(
+    ctx: &SessionContext,
+    active_sources: &[RegisteredSource],
+    catalog_only_table_functions: &[CatalogTableFunction],
+) -> Result<()> {
     let tables_table = build_tables_table(active_sources)?;
     let columns_table = build_columns_table(active_sources)?;
     let filters_table = build_filters_table(active_sources)?;
     let inputs_table = build_inputs_table(active_sources)?;
-    let table_functions_table = build_table_functions_table(active_sources)?;
+    let table_functions_table =
+        build_table_functions_table(active_sources, catalog_only_table_functions)?;
 
     let mut meta_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
         HashMap::new();
@@ -59,7 +88,10 @@ pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]
     Ok(())
 }
 
-fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
+fn build_table_functions_table(
+    active_sources: &[RegisteredSource],
+    catalog_only_table_functions: &[CatalogTableFunction],
+) -> Result<MemTable> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("schema_name", DataType::Utf8, false),
         Field::new("function_name", DataType::Utf8, false),
@@ -70,21 +102,15 @@ fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<Me
         Field::new("search_limits_json", DataType::Utf8, true),
     ]));
 
-    let mut rows = active_sources
-        .iter()
-        .flat_map(|source| source.table_functions.iter())
-        .collect::<Vec<_>>();
-    rows.sort_by(|left, right| {
-        (&left.schema_name, &left.function_name).cmp(&(&right.schema_name, &right.function_name))
-    });
+    let rows = catalog_table_functions(active_sources, catalog_only_table_functions);
 
     let arguments_json = rows
         .iter()
-        .map(|row| table_function_arguments_json(row))
+        .map(table_function_arguments_json)
         .collect::<Result<Vec<_>>>()?;
     let result_columns_json = rows
         .iter()
-        .map(|row| table_function_result_columns_json(row))
+        .map(table_function_result_columns_json)
         .collect::<Result<Vec<_>>>()?;
     let search_limits_json = rows
         .iter()
@@ -108,7 +134,7 @@ fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<Me
     MemTable::try_new(schema, vec![vec![batch]])
 }
 
-fn table_function_arguments_json(row: &RegisteredTableFunction) -> Result<String> {
+fn table_function_arguments_json(row: &CatalogTableFunction) -> Result<String> {
     let arguments = row
         .arguments
         .iter()
@@ -117,7 +143,7 @@ fn table_function_arguments_json(row: &RegisteredTableFunction) -> Result<String
     serde_json::to_string(&arguments).map_err(|error| DataFusionError::External(Box::new(error)))
 }
 
-fn table_function_result_columns_json(row: &RegisteredTableFunction) -> Result<String> {
+fn table_function_result_columns_json(row: &CatalogTableFunction) -> Result<String> {
     let columns = row
         .result_columns
         .iter()
@@ -142,8 +168,8 @@ struct TableFunctionArgumentJson<'a> {
     values: &'a [String],
 }
 
-impl<'a> From<&'a RegisteredTableFunctionArgument> for TableFunctionArgumentJson<'a> {
-    fn from(argument: &'a RegisteredTableFunctionArgument) -> Self {
+impl<'a> From<&'a CatalogTableFunctionArgument> for TableFunctionArgumentJson<'a> {
+    fn from(argument: &'a CatalogTableFunctionArgument) -> Self {
         Self {
             name: &argument.name,
             required: argument.required,
@@ -161,8 +187,8 @@ struct TableFunctionResultColumnJson<'a> {
     description: &'a str,
 }
 
-impl<'a> From<&'a RegisteredTableFunctionResultColumn> for TableFunctionResultColumnJson<'a> {
-    fn from(column: &'a RegisteredTableFunctionResultColumn) -> Self {
+impl<'a> From<&'a CatalogTableFunctionResultColumn> for TableFunctionResultColumnJson<'a> {
+    fn from(column: &'a CatalogTableFunctionResultColumn) -> Self {
         Self {
             name: &column.name,
             data_type: &column.data_type,
@@ -454,7 +480,7 @@ const SYSTEM_TABLE_DEFINITIONS: &[SystemTableDefinition] = &[
     },
     SystemTableDefinition {
         table_name: "table_functions",
-        description: "Metadata for source-scoped Coral table functions.",
+        description: "Metadata for Coral table functions.",
         guide: "Use this table to discover function arguments and result columns before calling a table function in SQL.",
         columns: TABLE_FUNCTIONS_COLUMNS,
     },
@@ -526,25 +552,61 @@ pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableIn
     tables
 }
 
-/// Collect typed source-scoped table function metadata for the active source set.
+/// Collect typed table function metadata for the active runtime.
 #[must_use]
 pub(crate) fn collect_table_functions(
     active_sources: &[RegisteredSource],
+    catalog_only_table_functions: &[CatalogTableFunction],
 ) -> Vec<TableFunctionInfo> {
+    catalog_table_functions(active_sources, catalog_only_table_functions)
+        .into_iter()
+        .map(|function| TableFunctionInfo {
+            schema_name: function.schema_name,
+            function_name: function.function_name,
+            description: function.description,
+            arguments: function
+                .arguments
+                .into_iter()
+                .map(|argument| TableFunctionArgumentInfo {
+                    name: argument.name,
+                    required: argument.required,
+                    values: argument.values,
+                })
+                .collect(),
+            result_columns: function
+                .result_columns
+                .into_iter()
+                .map(|column| TableFunctionResultColumnInfo {
+                    name: column.name,
+                    data_type: column.data_type,
+                    nullable: column.nullable,
+                    description: column.description,
+                })
+                .collect(),
+            kind: function.kind,
+            search_limits: function.search_limits,
+        })
+        .collect()
+}
+
+fn catalog_table_functions(
+    active_sources: &[RegisteredSource],
+    catalog_only_table_functions: &[CatalogTableFunction],
+) -> Vec<CatalogTableFunction> {
     let mut functions = active_sources
         .iter()
         .flat_map(|source| {
             source
                 .table_functions
                 .iter()
-                .map(move |function| TableFunctionInfo {
+                .map(|function| CatalogTableFunction {
                     schema_name: function.schema_name.clone(),
                     function_name: function.function_name.clone(),
                     description: function.description.clone(),
                     arguments: function
                         .arguments
                         .iter()
-                        .map(|argument| TableFunctionArgumentInfo {
+                        .map(|argument| CatalogTableFunctionArgument {
                             name: argument.name.clone(),
                             required: argument.required,
                             values: argument.values.clone(),
@@ -553,7 +615,7 @@ pub(crate) fn collect_table_functions(
                     result_columns: function
                         .result_columns
                         .iter()
-                        .map(|column| TableFunctionResultColumnInfo {
+                        .map(|column| CatalogTableFunctionResultColumn {
                             name: column.name.clone(),
                             data_type: column.data_type.clone(),
                             nullable: column.nullable,
@@ -564,6 +626,7 @@ pub(crate) fn collect_table_functions(
                     search_limits: function.search_limits.clone(),
                 })
         })
+        .chain(catalog_only_table_functions.iter().cloned())
         .collect::<Vec<_>>();
     functions.sort_by(|left, right| {
         (&left.schema_name, &left.function_name).cmp(&(&right.schema_name, &right.function_name))
@@ -969,21 +1032,24 @@ mod tests {
 
     #[test]
     fn collect_table_functions_preserves_registered_function_schema() {
-        let functions = collect_table_functions(&[RegisteredSource {
-            schema_name: "source_schema".to_string(),
-            tables: Vec::new(),
-            table_functions: vec![RegisteredTableFunction {
-                schema_name: "function_schema".to_string(),
-                function_name: "search".to_string(),
-                factory: Arc::new(StubSourceFunctionFactory::default()),
-                kind: coral_spec::SourceTableFunctionKind::Search,
-                description: String::new(),
-                arguments: Vec::new(),
-                result_columns: Vec::new(),
-                search_limits: None,
+        let functions = collect_table_functions(
+            &[RegisteredSource {
+                schema_name: "source_schema".to_string(),
+                tables: Vec::new(),
+                table_functions: vec![RegisteredTableFunction {
+                    schema_name: "function_schema".to_string(),
+                    function_name: "search".to_string(),
+                    factory: Arc::new(StubSourceFunctionFactory::default()),
+                    kind: coral_spec::SourceTableFunctionKind::Search,
+                    description: String::new(),
+                    arguments: Vec::new(),
+                    result_columns: Vec::new(),
+                    search_limits: None,
+                }],
+                inputs: Vec::new(),
             }],
-            inputs: Vec::new(),
-        }]);
+            &[],
+        );
 
         assert_eq!(functions.len(), 1);
         assert_eq!(

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -42,6 +42,7 @@ use crate::runtime::source_functions::{
 use crate::runtime::udf_calls::{
     UDF_CALL_NODE_NAME, UdfCallAnalyzerRule, UdfCallNode, UdfCallRegistry,
 };
+use crate::runtime::udfs::published_table_functions;
 use crate::{
     CatalogInfo, CoreError, DependentJoinConfig, DescribeTableInfo, MemorySize, QueryExecution,
     QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
@@ -184,17 +185,28 @@ async fn build_registered_runtime(
         config.source_decorators,
     )
     .await?;
-    catalog::register(&ctx, &registration.active_sources)
-        .map_err(|err| datafusion_to_core(&err, &[]))?;
-    let tables = catalog::collect_tables(&registration.active_sources);
-    let table_functions = catalog::collect_table_functions(&registration.active_sources);
     let source_functions = SourceFunctionRegistry::new(
         registration
             .active_sources
             .iter()
             .flat_map(|source| source.table_functions.iter()),
     );
-    install_table_function_call_planners(&ctx, source_functions, config.udfs, &tables).await?;
+    let source_function_names = source_functions.names();
+    let udf_table_functions = published_table_functions(config.udfs, &source_function_names)
+        .map_err(|err| datafusion_to_core(&err, &[]))?;
+    catalog::register(&ctx, &registration.active_sources, &udf_table_functions)
+        .map_err(|err| datafusion_to_core(&err, &[]))?;
+    let tables = catalog::collect_tables(&registration.active_sources);
+    let table_functions =
+        catalog::collect_table_functions(&registration.active_sources, &udf_table_functions);
+    install_table_function_call_planners(
+        &ctx,
+        source_functions,
+        source_function_names,
+        config.udfs,
+        &tables,
+    )
+    .await?;
     for failure in &registration.failures {
         tracing::warn!(
             source = %failure.schema_name,
@@ -214,10 +226,10 @@ async fn build_registered_runtime(
 async fn install_table_function_call_planners(
     ctx: &SessionContext,
     source_functions: SourceFunctionRegistry,
+    source_table_function_names: HashSet<ScopedTableFunctionName>,
     udfs: &[UdfRuntimeDefinition],
     tables: &[TableInfo],
 ) -> Result<(), CoreError> {
-    let source_table_function_names = source_functions.names();
     match (!source_functions.is_empty(), !udfs.is_empty()) {
         (false, false) => Ok(()),
         (true, false) => source_functions

--- a/crates/coral-engine/src/runtime/udf_calls.rs
+++ b/crates/coral-engine/src/runtime/udf_calls.rs
@@ -65,7 +65,7 @@ impl UdfCallRegistry {
         for udf in udfs {
             let body_plan = ctx.state().create_logical_plan(udf_sql(udf)).await?;
             read_only_sql_options().verify_plan(&body_plan)?;
-            registry.insert_function(udf, &body_plan, &source_functions)?;
+            registry.insert_function(udf, &body_plan)?;
         }
 
         Ok(registry)
@@ -82,16 +82,9 @@ impl UdfCallRegistry {
         &mut self,
         udf: &UdfRuntimeDefinition,
         body_plan: &LogicalPlan,
-        source_functions: &HashSet<ScopedTableFunctionName>,
     ) -> Result<()> {
         let publish = &udf.publish.table_function;
         let key = ScopedTableFunctionName::from_parts(&publish.schema, &publish.name);
-        if source_functions.contains(&key) {
-            return Err(DataFusionError::Plan(format!(
-                "udf table function {} conflicts with existing table function",
-                qualified_name(&key.schema, &key.function)
-            )));
-        }
         if self
             .functions
             .insert(
@@ -100,8 +93,8 @@ impl UdfCallRegistry {
             )
             .is_some()
         {
-            return Err(DataFusionError::Plan(format!(
-                "duplicate udf table function {}",
+            return Err(DataFusionError::Internal(format!(
+                "validated udf table function {} was registered twice",
                 qualified_name(&key.schema, &key.function)
             )));
         }

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -1,5 +1,6 @@
-//! UDF SQL signature inference and runtime argument binding helpers.
+//! UDF SQL signature inference, runtime argument binding, and catalog helpers.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, Schema};
@@ -8,7 +9,11 @@ use datafusion::common::ScalarValue;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::logical_expr::Expr;
 
+use crate::runtime::catalog::{
+    CatalogTableFunction, CatalogTableFunctionArgument, CatalogTableFunctionResultColumn,
+};
 use crate::runtime::query::{QueryRuntimeAdapter, query_parameter_scalar_value};
+use crate::runtime::scoped_table_functions::{ScopedTableFunctionName, qualified_name};
 use crate::types::parameter_binding_is_string_shaped;
 use crate::{
     CoreError, QueryParameterValue, QueryParameters, UdfRuntimeArgument, UdfRuntimeDefinition,
@@ -77,6 +82,106 @@ pub(crate) fn udf_query_parameters(
     arguments: &QueryParameters,
 ) -> DataFusionResult<QueryParameters> {
     UdfArgumentBinding::new(udf, arguments).into_query_params()
+}
+
+pub(crate) fn published_table_functions(
+    udfs: &[UdfRuntimeDefinition],
+    source_function_names: &HashSet<ScopedTableFunctionName>,
+) -> DataFusionResult<Vec<CatalogTableFunction>> {
+    PublishedTableFunctions::new(source_function_names).build(udfs)
+}
+
+struct PublishedTableFunctions<'a> {
+    source_function_names: &'a HashSet<ScopedTableFunctionName>,
+    seen_udfs: HashSet<ScopedTableFunctionName>,
+    rows: Vec<CatalogTableFunction>,
+}
+
+impl<'a> PublishedTableFunctions<'a> {
+    fn new(source_function_names: &'a HashSet<ScopedTableFunctionName>) -> Self {
+        Self {
+            source_function_names,
+            seen_udfs: HashSet::new(),
+            rows: Vec::new(),
+        }
+    }
+
+    fn build(
+        mut self,
+        udfs: &[UdfRuntimeDefinition],
+    ) -> DataFusionResult<Vec<CatalogTableFunction>> {
+        for udf in udfs {
+            self.push_udf(udf)?;
+        }
+        self.rows.sort_by(|left, right| {
+            (&left.schema_name, &left.function_name)
+                .cmp(&(&right.schema_name, &right.function_name))
+        });
+        Ok(self.rows)
+    }
+
+    fn push_udf(&mut self, udf: &UdfRuntimeDefinition) -> DataFusionResult<()> {
+        let publish = &udf.publish.table_function;
+        let key = ScopedTableFunctionName::from_parts(&publish.schema, &publish.name);
+        self.reject_duplicate_udf(&key)?;
+        self.reject_source_collision(&key)?;
+        udf_arrow_schema(udf)?;
+        self.rows.push(catalog_table_function(udf, &key));
+        Ok(())
+    }
+
+    fn reject_duplicate_udf(&mut self, key: &ScopedTableFunctionName) -> DataFusionResult<()> {
+        if self.seen_udfs.insert(key.clone()) {
+            return Ok(());
+        }
+        let display_name = qualified_name(&key.schema, &key.function);
+        Err(DataFusionError::Plan(format!(
+            "duplicate udf table function {display_name}"
+        )))
+    }
+
+    fn reject_source_collision(&self, key: &ScopedTableFunctionName) -> DataFusionResult<()> {
+        if !self.source_function_names.contains(key) {
+            return Ok(());
+        }
+        let display_name = qualified_name(&key.schema, &key.function);
+        Err(DataFusionError::Plan(format!(
+            "udf table function {display_name} conflicts with existing table function"
+        )))
+    }
+}
+
+fn catalog_table_function(
+    udf: &UdfRuntimeDefinition,
+    key: &ScopedTableFunctionName,
+) -> CatalogTableFunction {
+    let publish = &udf.publish.table_function;
+    CatalogTableFunction {
+        schema_name: key.schema.clone(),
+        function_name: key.function.clone(),
+        kind: coral_spec::SourceTableFunctionKind::Table,
+        description: publish_description(&publish.description, &udf.description),
+        arguments: udf
+            .arguments
+            .iter()
+            .map(|argument| CatalogTableFunctionArgument {
+                name: argument.name.clone(),
+                required: true,
+                values: Vec::new(),
+            })
+            .collect(),
+        result_columns: udf
+            .result_columns
+            .iter()
+            .map(|column| CatalogTableFunctionResultColumn {
+                name: column.name.clone(),
+                data_type: column.data_type.to_string(),
+                nullable: column.nullable,
+                description: String::new(),
+            })
+            .collect(),
+        search_limits: None,
+    }
 }
 
 pub(crate) fn udf_argument_values(
@@ -385,6 +490,14 @@ fn scalar_literal_kind(value: &ScalarValue) -> &'static str {
         | ScalarValue::TimestampMicrosecond(_, _)
         | ScalarValue::TimestampNanosecond(_, _) => "timestamp",
         _ => "unsupported literal",
+    }
+}
+
+fn publish_description(target_description: &str, udf_description: &str) -> String {
+    if target_description.trim().is_empty() {
+        udf_description.to_string()
+    } else {
+        target_description.to_string()
     }
 }
 

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -954,3 +954,51 @@ async fn udf_table_function_cannot_replace_source_table_function() {
     )
     .await;
 }
+#[tokio::test]
+async fn published_udf_table_function_is_cataloged() {
+    let server = MockServer::start().await;
+    let source = search_source(&server, "catalog_udf_search");
+    let runtime = test_runtime().with_udfs(vec![published_review_queue_udf("catalog_udf_search")]);
+
+    let catalog = CoralQuery::list_catalog(&[source], runtime, Some("udfs"))
+        .await
+        .expect("catalog should include udf function");
+
+    assert!(catalog.tables.is_empty());
+    assert_eq!(catalog.table_functions.len(), 1);
+    let function = catalog.table_functions.first().expect("udf table function");
+    assert_eq!(function.schema_name, "udfs");
+    assert_eq!(function.function_name, "review_queue");
+    let [_min_score, _mode, payload, _query, _since] = function.arguments.as_slice() else {
+        panic!("expected five review queue arguments");
+    };
+    assert_eq!(payload.name, "payload");
+    assert!(payload.required);
+    assert_eq!(function.result_columns.len(), 2);
+    assert_eq!(
+        function
+            .result_columns
+            .first()
+            .expect("title result column")
+            .name,
+        "title"
+    );
+}
+
+#[tokio::test]
+async fn published_udf_table_function_catalog_uses_normalized_publish_identifiers() {
+    let (_temp, source) = events_source("catalog_mixed_case_udf_events");
+    let runtime = test_runtime().with_udfs(vec![mixed_case_published_min_id_udf(
+        "catalog_mixed_case_udf_events",
+    )]);
+
+    let catalog = CoralQuery::list_catalog(&[source], runtime, Some("udfs"))
+        .await
+        .expect("catalog should include normalized udf function");
+
+    assert!(catalog.tables.is_empty());
+    assert_eq!(catalog.table_functions.len(), 1);
+    let function = catalog.table_functions.first().expect("udf table function");
+    assert_eq!(function.schema_name, "udfs");
+    assert_eq!(function.function_name, "min_id_events");
+}


### PR DESCRIPTION
## Intent

Make catalog discovery report the same UDF table functions that the runtime can execute.

This is catalog parity, not another execution path. Runtime setup derives catalog rows from the same normalized, validated UDF definitions used for registration, then supplies one snapshot to both `coral.table_functions` and app catalog discovery.

## What changed

- Added catalog-only table-function metadata for published UDFs.
- Merged those rows with existing provider-backed source-function rows.
- Included the merged snapshot in `coral.table_functions` and `collect_table_functions`.
- Reused canonical published names and the same duplicate/source-collision validation as execution.
- Added parity tests for catalog rows, normalization, arguments, result columns, and collisions.

## Invariants

- A UDF cannot be executable but absent from discovery in the same runtime snapshot.
- Name collisions fail before either registration or catalog publication.
- Source table functions remain provider-backed; UDF rows are catalog metadata and do not add a second factory.
- Existing source catalog rows and execution behavior are unchanged.

## Review order

1. `runtime/udfs.rs` — validated UDF-to-catalog mapping.
2. `runtime/catalog.rs` — source and catalog-only row merge.
3. `runtime/query.rs` — creation and reuse of one runtime snapshot.
4. `contracts/catalog.rs` — generic table-function discovery result.
5. `tests/udf_tests.rs` — execution/discovery parity.

## Not in this PR

- UDF execution semantics; those are in #1501.
- Storage, lifecycle, API, app loading, MCP, or CLI changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p coral-engine --test engine --all-features --locked udf_table_function`
- `cargo clippy -p coral-engine --all-targets --all-features --locked -- -D warnings`
- `make rust-checks` from the top of the restacked series
