### PR TITLE
feat(api): add function lifecycle contract

### DIFF
--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -26,6 +26,7 @@ fn main() {
                 "proto/coral/v1/sources.proto",
                 "proto/coral/v1/query.proto",
                 "proto/coral/v1/search.proto",
+                "proto/coral/v1/functions.proto",
                 "proto/coral/v1/traces.proto",
             ],
             &["proto"],

--- a/crates/coral-api/proto/coral/v1/functions.proto
+++ b/crates/coral-api/proto/coral/v1/functions.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package coral.v1;
 
+import "coral/v1/catalog.proto";
 import "coral/v1/resources.proto";
 
 // One scalar function argument.
@@ -13,20 +14,10 @@ message FunctionArgument {
   string data_type = 2;
 }
 
-// One function result column.
-message FunctionResultColumn {
-  // Column name.
-  string name = 1;
-  // Arrow/DataFusion data type rendered as text.
-  string data_type = 2;
-  // Whether the column can contain null values.
-  bool nullable = 3;
-}
-
 // SQL table-function publication target.
 message FunctionTableFunctionPublish {
   // SQL schema.
-  string schema = 1;
+  string schema_name = 1;
   // SQL table-function name.
   string name = 2;
   // User-facing description.
@@ -41,18 +32,18 @@ message FunctionPublish {
 
 // Function definition exposed by function lifecycle APIs.
 message Function {
-  // Workspace whose runtime-ready catalog exposes this function.
-  Workspace workspace = 1;
   // Stable function name.
-  string name = 2;
+  string name = 1;
   // User-facing description.
-  string description = 3;
+  string description = 2;
   // Arguments inferred from the planned function SQL.
-  repeated FunctionArgument arguments = 4;
+  repeated FunctionArgument arguments = 3;
   // Published function surfaces.
-  FunctionPublish publish = 5;
+  FunctionPublish publish = 4;
   // Result columns inferred from the planned function SQL.
-  repeated FunctionResultColumn result_columns = 6;
+  repeated TableFunctionResultColumn result_columns = 5;
+  // Workspace whose runtime-ready catalog exposes this function.
+  Workspace workspace = 6;
 }
 
 // Installs or replaces one user function after validation.
@@ -63,10 +54,10 @@ message AddFunctionRequest {
   string sql = 2;
 }
 
-// Persisted function install response. Function metadata is returned by ListFunctions.
+// Function install response.
 message AddFunctionResponse {
-  // Stable function name.
-  string name = 1;
+  // Installed runtime-ready function.
+  Function function = 1;
 }
 
 // Lists runtime-ready installed functions in one workspace.
@@ -81,16 +72,16 @@ message ListFunctionsResponse {
   repeated Function functions = 1;
 }
 
-// Removes one user function.
-message RemoveFunctionRequest {
+// Deletes one user function.
+message DeleteFunctionRequest {
   // Workspace that owns the function.
   Workspace workspace = 1;
   // Function name.
   string name = 2;
 }
 
-// Empty remove response.
-message RemoveFunctionResponse {}
+// Empty delete response.
+message DeleteFunctionResponse {}
 
 // Function lifecycle APIs.
 service FunctionService {
@@ -98,6 +89,6 @@ service FunctionService {
   rpc AddFunction(AddFunctionRequest) returns (AddFunctionResponse);
   // Lists installed functions that are runtime-ready for the current workspace sources.
   rpc ListFunctions(ListFunctionsRequest) returns (ListFunctionsResponse);
-  // Removes one user function.
-  rpc RemoveFunction(RemoveFunctionRequest) returns (RemoveFunctionResponse);
+  // Deletes one user function.
+  rpc DeleteFunction(DeleteFunctionRequest) returns (DeleteFunctionResponse);
 }

--- a/crates/coral-api/proto/coral/v1/functions.proto
+++ b/crates/coral-api/proto/coral/v1/functions.proto
@@ -24,26 +24,38 @@ message FunctionTableFunctionPublish {
   string description = 3;
 }
 
-// Public surfaces published by a function.
-message FunctionPublish {
+// Runtime metadata for an installed function that currently plans and executes.
+message FunctionRuntimeReady {
+  // User-facing description.
+  string description = 1;
+  // Arguments inferred from the planned function SQL.
+  repeated FunctionArgument arguments = 2;
   // SQL table-function publication.
-  FunctionTableFunctionPublish table_function = 1;
+  FunctionTableFunctionPublish table_function = 3;
+  // Result columns inferred from the planned function SQL.
+  repeated TableFunctionResultColumn result_columns = 4;
 }
 
-// Function definition exposed by function lifecycle APIs.
+// Validation failure for an installed function that is not currently queryable.
+message FunctionRuntimeInvalid {
+  // Actionable reason the function could not be published into the query runtime.
+  string reason = 1;
+}
+
+// Installed function exposed by function lifecycle APIs.
 message Function {
   // Stable function name.
   string name = 1;
-  // User-facing description.
-  string description = 2;
-  // Arguments inferred from the planned function SQL.
-  repeated FunctionArgument arguments = 3;
-  // Published function surfaces.
-  FunctionPublish publish = 4;
-  // Result columns inferred from the planned function SQL.
-  repeated TableFunctionResultColumn result_columns = 5;
-  // Workspace whose runtime-ready catalog exposes this function.
-  Workspace workspace = 6;
+  // Workspace that owns this function.
+  Workspace workspace = 2;
+  // Current runtime state. Installed functions remain listed when invalid so
+  // callers can inspect or remove them.
+  oneof runtime {
+    // The function currently plans and is published into query runtimes.
+    FunctionRuntimeReady ready = 3;
+    // The function is installed but is not currently queryable.
+    FunctionRuntimeInvalid invalid = 4;
+  }
 }
 
 // Installs or replaces one user function after validation.
@@ -60,15 +72,16 @@ message AddFunctionResponse {
   Function function = 1;
 }
 
-// Lists runtime-ready installed functions in one workspace.
+// Lists installed functions and their current runtime status in one workspace.
 message ListFunctionsRequest {
   // Workspace that scopes functions and selected sources.
   Workspace workspace = 1;
 }
 
-// Runtime-ready installed functions.
+// Installed functions and their current runtime status.
 message ListFunctionsResponse {
-  // Functions that planned successfully against the current workspace sources.
+  // Every installed function, including functions that no longer plan against
+  // the current workspace sources.
   repeated Function functions = 1;
 }
 
@@ -87,7 +100,7 @@ message DeleteFunctionResponse {}
 service FunctionService {
   // Installs or replaces one user function.
   rpc AddFunction(AddFunctionRequest) returns (AddFunctionResponse);
-  // Lists installed functions that are runtime-ready for the current workspace sources.
+  // Lists installed functions and their current runtime status.
   rpc ListFunctions(ListFunctionsRequest) returns (ListFunctionsResponse);
   // Deletes one user function.
   rpc DeleteFunction(DeleteFunctionRequest) returns (DeleteFunctionResponse);

--- a/crates/coral-api/proto/coral/v1/functions.proto
+++ b/crates/coral-api/proto/coral/v1/functions.proto
@@ -1,0 +1,108 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/resources.proto";
+
+// One scalar function argument.
+message FunctionArgument {
+  reserved 3;
+  reserved "required";
+
+  // Argument name.
+  string name = 1;
+  // Scalar argument type in ManifestDataType spelling, such as Utf8, Int64,
+  // Float64, Boolean, Timestamp, or Json.
+  string data_type = 2;
+  // User-facing description.
+  string description = 4;
+}
+
+// One function result column.
+message FunctionResultColumn {
+  // Column name.
+  string name = 1;
+  // Arrow/DataFusion data type rendered as text.
+  string data_type = 2;
+  // Whether the column can contain null values.
+  bool nullable = 3;
+  // User-facing description.
+  string description = 4;
+}
+
+// SQL table-function publication target.
+message FunctionTableFunctionPublish {
+  // SQL schema.
+  string schema = 1;
+  // SQL table-function name.
+  string name = 2;
+  // User-facing description.
+  string description = 3;
+}
+
+// Public surfaces published by a function.
+message FunctionPublish {
+  // SQL table-function publication.
+  FunctionTableFunctionPublish table_function = 1;
+}
+
+// Function definition exposed by function lifecycle APIs.
+message Function {
+  // Stable function name.
+  string name = 1;
+  // User-facing description.
+  string description = 2;
+  // Arguments inferred from the planned function SQL.
+  repeated FunctionArgument arguments = 3;
+  // Published function surfaces.
+  FunctionPublish publish = 4;
+  // Result columns inferred from the planned function SQL.
+  repeated FunctionResultColumn result_columns = 5;
+}
+
+// Installs or replaces one user function after validation.
+message AddFunctionRequest {
+  // Workspace that owns the function.
+  Workspace workspace = 1;
+  // Raw function SQL artifact, including SQL comment frontmatter.
+  string sql = 2;
+}
+
+// Persisted function install response. Function metadata is returned by ListFunctions.
+message AddFunctionResponse {
+  // Stable function name.
+  string name = 1;
+}
+
+// Lists runtime-ready installed functions in one workspace.
+message ListFunctionsRequest {
+  // Workspace that scopes functions and selected sources.
+  Workspace workspace = 1;
+}
+
+// Runtime-ready installed functions.
+message ListFunctionsResponse {
+  // Functions that planned successfully against the current workspace sources.
+  repeated Function functions = 1;
+}
+
+// Removes one user function.
+message RemoveFunctionRequest {
+  // Workspace that owns the function.
+  Workspace workspace = 1;
+  // Function name.
+  string name = 2;
+}
+
+// Empty remove response.
+message RemoveFunctionResponse {}
+
+// Function lifecycle APIs.
+service FunctionService {
+  // Installs or replaces one user function.
+  rpc AddFunction(AddFunctionRequest) returns (AddFunctionResponse);
+  // Lists installed functions that are runtime-ready for the current workspace sources.
+  rpc ListFunctions(ListFunctionsRequest) returns (ListFunctionsResponse);
+  // Removes one user function.
+  rpc RemoveFunction(RemoveFunctionRequest) returns (RemoveFunctionResponse);
+}

--- a/crates/coral-api/proto/coral/v1/functions.proto
+++ b/crates/coral-api/proto/coral/v1/functions.proto
@@ -6,16 +6,11 @@ import "coral/v1/resources.proto";
 
 // One scalar function argument.
 message FunctionArgument {
-  reserved 3;
-  reserved "required";
-
   // Argument name.
   string name = 1;
   // Scalar argument type in ManifestDataType spelling, such as Utf8, Int64,
   // Float64, Boolean, Timestamp, or Json.
   string data_type = 2;
-  // User-facing description.
-  string description = 4;
 }
 
 // One function result column.
@@ -26,8 +21,6 @@ message FunctionResultColumn {
   string data_type = 2;
   // Whether the column can contain null values.
   bool nullable = 3;
-  // User-facing description.
-  string description = 4;
 }
 
 // SQL table-function publication target.
@@ -48,16 +41,18 @@ message FunctionPublish {
 
 // Function definition exposed by function lifecycle APIs.
 message Function {
+  // Workspace whose runtime-ready catalog exposes this function.
+  Workspace workspace = 1;
   // Stable function name.
-  string name = 1;
+  string name = 2;
   // User-facing description.
-  string description = 2;
+  string description = 3;
   // Arguments inferred from the planned function SQL.
-  repeated FunctionArgument arguments = 3;
+  repeated FunctionArgument arguments = 4;
   // Published function surfaces.
-  FunctionPublish publish = 4;
+  FunctionPublish publish = 5;
   // Result columns inferred from the planned function SQL.
-  repeated FunctionResultColumn result_columns = 5;
+  repeated FunctionResultColumn result_columns = 6;
 }
 
 // Installs or replaces one user function after validation.

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -104,6 +104,9 @@ pub const CORAL_TASK_INTENT_MAX_CHARS: usize = 4096;
 /// Machine-readable reason for a configured source lookup miss.
 pub const CORAL_ERROR_REASON_SOURCE_NOT_FOUND: &str = "SOURCE_NOT_FOUND";
 
+/// Machine-readable reason for a configured function lookup miss.
+pub const CORAL_ERROR_REASON_FUNCTION_NOT_FOUND: &str = "FUNCTION_NOT_FOUND";
+
 /// Machine-readable reason for a configured workspace lookup miss.
 pub const CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND: &str = "WORKSPACE_NOT_FOUND";
 

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -3,6 +3,7 @@
 use coral_api::v1::Workspace;
 use coral_api::v1::catalog_service_client::CatalogServiceClient;
 use coral_api::v1::feedback_service_client::FeedbackServiceClient;
+use coral_api::v1::function_service_client::FunctionServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::search_service_client::SearchServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
@@ -54,6 +55,9 @@ pub type QueryClient = QueryServiceClient<GrpcService>;
 /// Public Universal Search gRPC client.
 pub type SearchClient = SearchServiceClient<GrpcService>;
 
+/// Public function management gRPC client.
+pub type FunctionClient = FunctionServiceClient<GrpcService>;
+
 /// Public feedback-submission gRPC client.
 pub type FeedbackClient = FeedbackServiceClient<GrpcService>;
 
@@ -70,6 +74,7 @@ pub struct AppClient {
     catalog: CatalogClient,
     query: QueryClient,
     search: SearchClient,
+    function: FunctionClient,
     feedback: FeedbackClient,
     task: TaskClient,
 }
@@ -97,6 +102,8 @@ impl AppClient {
             .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
         let search_client = SearchClient::new(grpc_service(channel.clone(), &grpc_endpoint))
             .max_decoding_message_size(SEARCH_RESPONSE_MAX_MESSAGE_SIZE);
+        let function_client = FunctionClient::new(grpc_service(channel.clone(), &grpc_endpoint))
+            .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
         let feedback_client = FeedbackClient::new(grpc_service(channel.clone(), &grpc_endpoint));
         let task_client = TaskClient::new(grpc_service(channel, &grpc_endpoint));
         Ok(Self {
@@ -105,6 +112,7 @@ impl AppClient {
             catalog: catalog_client,
             query: query_client,
             search: search_client,
+            function: function_client,
             feedback: feedback_client,
             task: task_client,
         })
@@ -138,6 +146,12 @@ impl AppClient {
     /// Returns a cloned Universal Search client.
     pub fn search_client(&self) -> SearchClient {
         self.search.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned function management client.
+    pub fn function_client(&self) -> FunctionClient {
+        self.function.clone()
     }
 
     #[must_use]

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -41,8 +41,8 @@ use coral_api::v1::ExecuteSqlResponse;
 use serde_json::Value;
 
 pub use client::{
-    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, QueryClient, SearchClient,
-    SourceClient, TaskClient, WorkspaceClient, default_workspace, workspace,
+    AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, FunctionClient, QueryClient,
+    SearchClient, SourceClient, TaskClient, WorkspaceClient, default_workspace, workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use propagation::with_task_metadata;


### PR DESCRIPTION
## Why

Define the transport contract for installing and managing user-authored SQL functions. This PR is contract-only: it gives later app and CLI changes a typed lifecycle API without moving storage or planning into `coral-api`.

## Contract

- `AddFunction`, `ListFunctions`, and `DeleteFunction` are explicitly workspace-scoped.
- An installed function has one runtime state: `ready` or `invalid`.
- `ready` carries inferred arguments, result columns, and the single SQL table-function publication target.
- `invalid` carries an actionable reason. Invalid installed functions remain visible so callers can inspect or delete them.

The generated client stays thin; this PR adds only the `FunctionClient` accessor.

## Not in this PR

- Persistence or workspace layout.
- Validation, planning, or execution.
- gRPC service implementation.
- CLI or MCP presentation.

## Validation

- `cargo check -p coral-api -p coral-client --all-features --locked`
- `make rust-checks` on the completed stack
