### PR TITLE
feat(app): load installed functions into query runtime

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -311,7 +311,7 @@ impl ServerBuilder {
             credential_manager.clone(),
             layout.clone(),
             active_trace_store_dir.clone(),
-            workspace_lifecycle_lock,
+            workspace_lifecycle_lock.clone(),
             Arc::clone(&coral_db),
         );
         let feedback_manager =
@@ -330,6 +330,7 @@ impl ServerBuilder {
             credential_manager,
             query_runtime_context,
             layout.clone(),
+            workspace_lifecycle_lock,
             self.config.engine_extensions_providers,
         );
         let search_manager = SearchManager::new(layout, &config_store, workspace_manager.clone());
@@ -977,7 +978,7 @@ backend = "unsupported"
             None,
             Arc::clone(&db),
         );
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::new_for_tests(
             config_store.clone(),
             workspace_manager.clone(),
             credential_manager,
@@ -1416,7 +1417,7 @@ tables:
             None,
             Arc::clone(&db),
         );
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::new_for_tests(
             config_store.clone(),
             workspace_manager.clone(),
             credential_manager,
@@ -1536,7 +1537,7 @@ tables:
             None,
             Arc::clone(&db),
         );
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::new_for_tests(
             config_store.clone(),
             workspace_manager.clone(),
             credential_manager,
@@ -1653,7 +1654,7 @@ tables:
             None,
             Arc::clone(&db),
         );
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::new_for_tests(
             config_store.clone(),
             workspace_manager.clone(),
             credential_manager,

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -4,16 +4,17 @@ use std::collections::{BTreeSet, HashSet};
 use std::fmt;
 use std::sync::Arc;
 
-use coral_engine::{
-    CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, UdfRuntimeDefinition,
-    UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeSqlDefinition,
-    UdfRuntimeTableFunctionPublish,
-};
-use coral_spec::{FunctionImplementationSpec, FunctionSpec, parse_function_sql};
+use coral_engine::{QueryRuntimeConfig, QuerySource, UdfRuntimeDefinition};
+use coral_spec::parse_function_sql;
 
 use crate::bootstrap::AppError;
 use crate::functions::model::{FunctionName, InstalledFunction};
+use crate::functions::runtime::{infer_runtime_function, runtime_function_without_signature};
 use crate::functions::store::{FsFunctionArtifactStore, FunctionArtifactStore};
+use crate::functions::validation::{
+    SqlPublishTargets, initial_sql_publish_targets, record_sql_publish_target,
+    source_sql_publish_targets_for_schemas, unchecked_source_publish_schemas,
+};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
 
@@ -117,11 +118,7 @@ impl FunctionManager {
             AppError::InvalidInput(format!("function validation failed: {error}"))
         })?;
         let function_name = FunctionName::parse(spec.name())?;
-        let mut sql_publish_targets = if needs_source_publish_target_check(&spec) {
-            source_sql_publish_targets(selected_sources)
-        } else {
-            HashSet::new()
-        };
+        let mut sql_publish_targets = initial_sql_publish_targets(&spec, selected_sources);
         self.record_installed_function_sql_publish_targets(
             workspace_name,
             &function_name,
@@ -293,7 +290,7 @@ impl FunctionManager {
         &self,
         workspace_name: &WorkspaceName,
         replacing_function: &FunctionName,
-        publish_targets: &mut HashSet<SqlPublishTarget>,
+        publish_targets: &mut SqlPublishTargets,
     ) -> Result<(), AppError> {
         let mut seen_names = HashSet::new();
         for artifact in self.load_function_artifacts(workspace_name)? {
@@ -325,170 +322,6 @@ fn skip_function(artifact: &FunctionArtifact, detail: fmt::Arguments<'_>) {
         detail = %detail,
         "skipping function during runtime publication"
     );
-}
-
-fn source_sql_publish_targets(selected_sources: &[QuerySource]) -> HashSet<SqlPublishTarget> {
-    let mut targets = HashSet::new();
-    for source in selected_sources {
-        for component in source.components() {
-            record_source_component_sql_targets(component, &mut targets);
-        }
-    }
-    targets
-}
-
-fn record_source_component_sql_targets(
-    component: &RuntimeSourceComponent,
-    targets: &mut HashSet<SqlPublishTarget>,
-) {
-    match component {
-        RuntimeSourceComponent::Http(manifest) => {
-            for table in &manifest.tables {
-                targets.insert(SqlPublishTarget::new(&manifest.common.name, table.name()));
-            }
-            for function in &manifest.functions {
-                targets.insert(SqlPublishTarget::new(&manifest.common.name, &function.name));
-            }
-        }
-        RuntimeSourceComponent::File(manifest) => {
-            for table in &manifest.tables {
-                targets.insert(SqlPublishTarget::new(&manifest.common.name, table.name()));
-            }
-        }
-        RuntimeSourceComponent::Mcp(manifest) => {
-            for table in &manifest.tables {
-                targets.insert(SqlPublishTarget::new(
-                    &manifest.common.name,
-                    &table.common.name,
-                ));
-            }
-            for function in &manifest.functions {
-                targets.insert(SqlPublishTarget::new(
-                    &manifest.common.name,
-                    &function.common.name,
-                ));
-            }
-        }
-    }
-}
-
-fn source_sql_publish_targets_for_schemas(
-    selected_sources: &[QuerySource],
-    schemas: &BTreeSet<String>,
-) -> HashSet<SqlPublishTarget> {
-    let schema_sources = selected_sources
-        .iter()
-        .filter(|source| schemas.contains(source.source_name()))
-        .cloned()
-        .collect::<Vec<_>>();
-    if schema_sources.is_empty() {
-        return HashSet::new();
-    }
-    source_sql_publish_targets(&schema_sources)
-}
-
-fn unchecked_source_publish_schemas(
-    function: &UdfRuntimeDefinition,
-    checked: &BTreeSet<String>,
-) -> BTreeSet<String> {
-    let schema = &function.publish.table_function.schema;
-    if schema != "functions" && !checked.contains(schema) {
-        BTreeSet::from([schema.clone()])
-    } else {
-        BTreeSet::new()
-    }
-}
-
-async fn infer_runtime_function(
-    selected_sources: &[QuerySource],
-    runtime_config: QueryRuntimeConfig,
-    spec: &FunctionSpec,
-) -> Result<UdfRuntimeDefinition, AppError> {
-    let mut runtime_function = runtime_function_without_signature(spec);
-    let sql_definition = runtime_sql_definition(&runtime_function);
-    let signature =
-        CoralQuery::infer_udf_signature(selected_sources, runtime_config, sql_definition)
-            .await
-            .map_err(|error| {
-                AppError::FailedPrecondition(format!("function failed runtime validation: {error}"))
-            })?;
-    runtime_function.arguments = signature.arguments;
-    runtime_function.result_columns = signature.result_columns;
-    Ok(runtime_function)
-}
-
-fn runtime_sql_definition(function: &UdfRuntimeDefinition) -> UdfRuntimeSqlDefinition {
-    UdfRuntimeSqlDefinition {
-        name: function.name.clone(),
-        implementation: function.implementation.clone(),
-    }
-}
-
-fn runtime_function_without_signature(spec: &FunctionSpec) -> UdfRuntimeDefinition {
-    UdfRuntimeDefinition {
-        name: spec.name().to_string(),
-        description: spec.description().to_string(),
-        arguments: Vec::new(),
-        implementation: runtime_implementation(spec.implementation()),
-        publish: runtime_publish(spec),
-        result_columns: Vec::new(),
-    }
-}
-
-fn runtime_implementation(spec: &FunctionImplementationSpec) -> UdfRuntimeImplementation {
-    UdfRuntimeImplementation::CoralSql {
-        query: spec.coral_sql.query.clone(),
-    }
-}
-
-fn runtime_publish(spec: &FunctionSpec) -> UdfRuntimePublish {
-    UdfRuntimePublish {
-        table_function: UdfRuntimeTableFunctionPublish {
-            schema: spec.schema().to_string(),
-            name: spec.name().to_string(),
-            description: String::new(),
-        },
-    }
-}
-
-fn needs_source_publish_target_check(spec: &FunctionSpec) -> bool {
-    spec.schema() != "functions"
-}
-
-fn record_sql_publish_target(
-    function: &UdfRuntimeDefinition,
-    publish_targets: &mut HashSet<SqlPublishTarget>,
-) -> Result<(), AppError> {
-    let target = SqlPublishTarget::new(
-        &function.publish.table_function.schema,
-        &function.publish.table_function.name,
-    );
-    if !publish_targets.insert(target.clone()) {
-        return Err(AppError::FailedPrecondition(format!(
-            "function publish target '{}' is installed more than once",
-            target.display_name()
-        )));
-    }
-    Ok(())
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct SqlPublishTarget {
-    schema: String,
-    name: String,
-}
-
-impl SqlPublishTarget {
-    fn new(schema: &str, name: &str) -> Self {
-        Self {
-            schema: schema.to_ascii_lowercase(),
-            name: name.to_ascii_lowercase(),
-        }
-    }
-
-    fn display_name(&self) -> String {
-        format!("{}.{}", self.schema, self.name)
-    }
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -161,6 +161,24 @@ impl FunctionManager {
             .await
     }
 
+    pub(crate) fn list_functions_with_preparation_failure(
+        &self,
+        workspace_name: &WorkspaceName,
+        preparation_error: &AppError,
+    ) -> Result<Vec<FunctionListing>, AppError> {
+        let preparation_error = format!("function runtime unavailable: {preparation_error}");
+        Ok(self
+            .load_function_artifacts(workspace_name)?
+            .into_iter()
+            .map(|artifact| {
+                let error = parse_function_artifact(&artifact)
+                    .err()
+                    .unwrap_or_else(|| preparation_error.clone());
+                invalid_listing(artifact.name, error)
+            })
+            .collect())
+    }
+
     pub(crate) async fn load_runtime_udfs(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -1,15 +1,16 @@
 //! Owns user-installed function files and workspace inventory.
 
 use std::collections::{BTreeSet, HashSet};
-use std::fmt;
 use std::sync::Arc;
 
 use coral_engine::{QueryRuntimeConfig, QuerySource, UdfRuntimeDefinition};
-use coral_spec::parse_function_sql;
+use coral_spec::{FunctionSpec, parse_function_sql};
 
 use crate::bootstrap::AppError;
 use crate::functions::model::{FunctionName, InstalledFunction};
-use crate::functions::runtime::{infer_runtime_function, runtime_function_without_signature};
+use crate::functions::runtime::{
+    infer_runtime_function, infer_runtime_functions, runtime_function_without_signature,
+};
 use crate::functions::store::{FsFunctionArtifactStore, FunctionArtifactStore};
 use crate::functions::validation::{
     SqlPublishTargets, initial_sql_publish_targets, record_sql_publish_target,
@@ -27,13 +28,30 @@ pub(crate) struct FunctionManager {
 
 struct FunctionArtifact {
     name: FunctionName,
-    raw_sql: String,
+    content: FunctionArtifactContent,
+}
+
+enum FunctionArtifactContent {
+    Sql(String),
+    Unavailable(String),
 }
 
 /// One function as listed by the app inventory surface.
 pub(crate) struct FunctionListing {
-    /// Runtime definition for the function.
-    pub(crate) definition: UdfRuntimeDefinition,
+    /// Stable installed inventory name.
+    pub(crate) name: FunctionName,
+    /// Runtime definition when enough artifact metadata could be read.
+    pub(crate) definition: Option<UdfRuntimeDefinition>,
+    /// Validation failure when the function is not runtime-ready.
+    pub(crate) runtime_error: Option<String>,
+}
+
+enum FunctionCandidate {
+    Listing(FunctionListing),
+    Pending {
+        name: FunctionName,
+        definition: UdfRuntimeDefinition,
+    },
 }
 
 impl FunctionManager {
@@ -136,7 +154,7 @@ impl FunctionManager {
         selected_sources: &[QuerySource],
         runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
     ) -> Result<Vec<FunctionListing>, AppError> {
-        self.list_runtime_function_listings(workspace_name, selected_sources, runtime_config)
+        self.evaluate_function_listings(workspace_name, selected_sources, runtime_config)
             .await
     }
 
@@ -146,15 +164,28 @@ impl FunctionManager {
         selected_sources: &[QuerySource],
         runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
     ) -> Result<Vec<UdfRuntimeDefinition>, AppError> {
-        Ok(self
-            .list_runtime_function_listings(workspace_name, selected_sources, runtime_config)
-            .await?
-            .into_iter()
-            .map(|listing| listing.definition)
-            .collect())
+        let listings = self
+            .evaluate_function_listings(workspace_name, selected_sources, runtime_config)
+            .await?;
+        let mut definitions = Vec::new();
+        for listing in listings {
+            match (listing.definition, listing.runtime_error) {
+                (Some(definition), None) => definitions.push(definition),
+                (_, Some(error)) => tracing::warn!(
+                    function = %listing.name,
+                    detail = %error,
+                    "skipping function during runtime publication"
+                ),
+                (None, None) => tracing::warn!(
+                    function = %listing.name,
+                    "skipping function without a runtime definition"
+                ),
+            }
+        }
+        Ok(definitions)
     }
 
-    async fn list_runtime_function_listings(
+    async fn evaluate_function_listings(
         &self,
         workspace_name: &WorkspaceName,
         selected_sources: &[QuerySource],
@@ -168,30 +199,28 @@ impl FunctionManager {
         let mut seen_names = HashSet::new();
         let mut checked_source_schemas = BTreeSet::new();
         let mut sql_publish_targets = HashSet::new();
-        let mut runtime_functions = Vec::new();
+        let mut candidates = Vec::with_capacity(artifacts.len());
         for artifact in artifacts {
             if !seen_names.insert(artifact.name.clone()) {
-                skip_function(
-                    &artifact,
-                    format_args!("function '{}' is installed more than once", artifact.name),
-                );
+                candidates.push(FunctionCandidate::Listing(invalid_listing(
+                    artifact.name.clone(),
+                    None,
+                    format!("function '{}' is installed more than once", artifact.name),
+                )));
                 continue;
             }
-            let spec = match parse_function_sql(&artifact.raw_sql) {
+            let spec = match parse_function_artifact(&artifact) {
                 Ok(spec) => spec,
                 Err(error) => {
-                    skip_function(&artifact, format_args!("function is invalid: {error}"));
+                    candidates.push(FunctionCandidate::Listing(invalid_listing(
+                        artifact.name,
+                        None,
+                        error,
+                    )));
                     continue;
                 }
             };
-            let runtime_function =
-                match infer_runtime_function(selected_sources, runtime_config()?, &spec).await {
-                    Ok(function) => function,
-                    Err(error) => {
-                        skip_function(&artifact, format_args!("{error}"));
-                        continue;
-                    }
-                };
+            let runtime_function = runtime_function_without_signature(&spec);
             let unchecked_source_schemas =
                 unchecked_source_publish_schemas(&runtime_function, &checked_source_schemas);
             if !unchecked_source_schemas.is_empty() {
@@ -201,17 +230,48 @@ impl FunctionManager {
                 ));
                 checked_source_schemas.extend(unchecked_source_schemas);
             }
-            if let Err(error) =
-                record_sql_publish_target(&runtime_function, &mut sql_publish_targets)
-            {
-                skip_function(&artifact, format_args!("{error}"));
-                continue;
-            }
-            runtime_functions.push(FunctionListing {
+            candidates.push(FunctionCandidate::Pending {
+                name: artifact.name,
                 definition: runtime_function,
             });
         }
-        Ok(runtime_functions)
+
+        let pending = candidates
+            .iter()
+            .filter_map(|candidate| match candidate {
+                FunctionCandidate::Pending { definition, .. } => Some(definition.clone()),
+                FunctionCandidate::Listing(_) => None,
+            })
+            .collect::<Vec<_>>();
+        let inferred = if pending.is_empty() {
+            Vec::new()
+        } else {
+            infer_runtime_functions(selected_sources, runtime_config()?, pending).await?
+        };
+        let mut inferred = inferred.into_iter();
+
+        candidates
+            .into_iter()
+            .map(|candidate| match candidate {
+                FunctionCandidate::Listing(listing) => Ok(listing),
+                FunctionCandidate::Pending { name, definition } => match inferred.next() {
+                    Some(Ok(definition)) => {
+                        match record_sql_publish_target(&definition, &mut sql_publish_targets) {
+                            Ok(()) => Ok(ready_listing(name, definition)),
+                            Err(error) => {
+                                Ok(invalid_listing(name, Some(definition), error.to_string()))
+                            }
+                        }
+                    }
+                    Some(Err(error)) => {
+                        Ok(invalid_listing(name, Some(definition), error.to_string()))
+                    }
+                    None => Err(AppError::FailedPrecondition(
+                        "function runtime validation returned too few results".to_string(),
+                    )),
+                },
+            })
+            .collect()
     }
 
     pub(crate) fn remove_user_function(
@@ -254,31 +314,22 @@ impl FunctionManager {
             .config_store
             .list_workspace_functions_unlocked(workspace_name)?
         {
-            let raw_sql = match self
+            let content = match self
                 .artifacts
                 .read_function_sql(workspace_name, &installed.name)
             {
-                Ok(Some(raw_sql)) => raw_sql,
-                Ok(None) => {
-                    tracing::warn!(
-                        function = %installed.name,
-                        "skipping installed function because its function file is missing"
-                    );
-                    continue;
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        function = %installed.name,
-                        detail = %error,
-                        "skipping installed function because its function file could not be read"
-                    );
-                    continue;
-                }
+                Ok(Some(raw_sql)) => FunctionArtifactContent::Sql(raw_sql),
+                Ok(None) => FunctionArtifactContent::Unavailable(
+                    "installed function file is missing".to_string(),
+                ),
+                Err(error) => FunctionArtifactContent::Unavailable(format!(
+                    "installed function file could not be read: {error}"
+                )),
             };
             let function_name = installed.name;
             artifacts.push(FunctionArtifact {
                 name: function_name,
-                raw_sql,
+                content,
             });
         }
 
@@ -303,9 +354,9 @@ impl FunctionManager {
                     artifact.name
                 )));
             }
-            let spec = parse_function_sql(&artifact.raw_sql).map_err(|error| {
+            let spec = parse_function_artifact(&artifact).map_err(|error| {
                 AppError::FailedPrecondition(format!(
-                    "installed function '{}' is invalid: {error}",
+                    "installed function '{}': {error}",
                     artifact.name
                 ))
             })?;
@@ -316,12 +367,41 @@ impl FunctionManager {
     }
 }
 
-fn skip_function(artifact: &FunctionArtifact, detail: fmt::Arguments<'_>) {
-    tracing::warn!(
-        function = %artifact.name,
-        detail = %detail,
-        "skipping function during runtime publication"
-    );
+fn parse_function_artifact(artifact: &FunctionArtifact) -> Result<FunctionSpec, String> {
+    let raw_sql = match &artifact.content {
+        FunctionArtifactContent::Sql(raw_sql) => raw_sql,
+        FunctionArtifactContent::Unavailable(error) => return Err(error.clone()),
+    };
+    let spec =
+        parse_function_sql(raw_sql).map_err(|error| format!("function is invalid: {error}"))?;
+    let declared_name = FunctionName::parse(spec.name()).map_err(|error| error.to_string())?;
+    if declared_name != artifact.name {
+        return Err(format!(
+            "function file declares name '{declared_name}' but its inventory name is '{}'",
+            artifact.name
+        ));
+    }
+    Ok(spec)
+}
+
+fn ready_listing(name: FunctionName, definition: UdfRuntimeDefinition) -> FunctionListing {
+    FunctionListing {
+        name,
+        definition: Some(definition),
+        runtime_error: None,
+    }
+}
+
+fn invalid_listing(
+    name: FunctionName,
+    definition: Option<UdfRuntimeDefinition>,
+    error: String,
+) -> FunctionListing {
+    FunctionListing {
+        name,
+        definition,
+        runtime_error: Some(error),
+    }
 }
 
 #[cfg(test)]
@@ -464,16 +544,100 @@ select 1 as id
 
         assert_eq!(listed.len(), 1);
         let listed_function = listed.first().expect("one listed function");
-        assert_eq!(listed_function.definition.result_columns.len(), 1);
+        assert!(listed_function.runtime_error.is_none());
+        let definition = listed_function
+            .definition
+            .as_ref()
+            .expect("runtime-ready definition");
+        assert_eq!(definition.result_columns.len(), 1);
         assert_eq!(
-            listed_function
-                .definition
+            definition
                 .result_columns
                 .first()
                 .expect("inferred result column")
                 .name,
             "reviewer"
         );
+    }
+
+    #[tokio::test]
+    async fn list_functions_builds_one_inference_runtime_for_all_functions() {
+        let (_temp, _layout, _config_store, manager) = fixture();
+        let workspace = workspace();
+        install_fixture_function(&manager, &workspace, &function_sql("first"));
+        install_fixture_function(&manager, &workspace, &function_sql("second"));
+        let runtime_builds = std::sync::atomic::AtomicUsize::new(0);
+
+        let listed = manager
+            .list_functions(&workspace, &[], || {
+                runtime_builds.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(QueryRuntimeConfig::default())
+            })
+            .await
+            .expect("list functions");
+
+        assert_eq!(listed.len(), 2);
+        assert_eq!(runtime_builds.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn list_functions_keeps_runtime_invalid_artifacts_visible() {
+        let (_temp, layout, _config_store, manager) = fixture();
+        let workspace = workspace();
+        let raw_sql = function_sql_with_owner_query("review_queue");
+        let installed = install_fixture_function(&manager, &workspace, &raw_sql);
+        std::fs::write(
+            layout.function_file(&workspace, &installed.name),
+            raw_sql.replace(
+                "select cast($owner as VARCHAR) as owner",
+                "select $owner as owner",
+            ),
+        )
+        .expect("rewrite invalid function sql");
+
+        let listed = manager
+            .list_functions(&workspace, &[], || Ok(QueryRuntimeConfig::default()))
+            .await
+            .expect("list functions");
+
+        let listing = listed.first().expect("installed function remains visible");
+        assert_eq!(listing.name, installed.name);
+        assert!(
+            listing
+                .runtime_error
+                .as_deref()
+                .is_some_and(|error| error.contains("has no inferred type"))
+        );
+    }
+
+    #[tokio::test]
+    async fn list_functions_rejects_artifact_name_drift_under_inventory_name() {
+        let (_temp, layout, _config_store, manager) = fixture();
+        let workspace = workspace();
+        let raw_sql = function_sql("review_queue");
+        let installed = install_fixture_function(&manager, &workspace, &raw_sql);
+        std::fs::write(
+            layout.function_file(&workspace, &installed.name),
+            raw_sql.replace("name: review_queue", "name: renamed"),
+        )
+        .expect("rewrite function name");
+
+        let listed = manager
+            .list_functions(&workspace, &[], || Ok(QueryRuntimeConfig::default()))
+            .await
+            .expect("list functions");
+
+        let listing = listed.first().expect("installed function remains visible");
+        assert_eq!(listing.name, installed.name);
+        assert!(
+            listing
+                .runtime_error
+                .as_deref()
+                .is_some_and(|error| error.contains("declares name 'renamed'"))
+        );
+        manager
+            .remove_user_function(&workspace, &installed.name)
+            .expect("inventory name remains removable");
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -1,15 +1,17 @@
 //! Owns user-installed function files and workspace inventory.
 
 use std::collections::BTreeSet;
+use std::future::Future;
 use std::sync::Arc;
 
-use coral_engine::{QueryRuntimeConfig, QuerySource, UdfRuntimeDefinition};
+use coral_engine::{PreparedQueryRuntime, QueryRuntimeConfig, QuerySource, UdfRuntimeDefinition};
 use coral_spec::{FunctionSpec, parse_function_sql};
 
 use crate::bootstrap::AppError;
 use crate::functions::model::{FunctionName, InstalledFunction};
 use crate::functions::runtime::{
-    infer_runtime_function, infer_runtime_functions, runtime_function_without_signature,
+    infer_runtime_function, infer_runtime_functions, infer_runtime_functions_in_prepared_runtime,
+    runtime_function_without_signature,
 };
 use crate::functions::store::{FsFunctionArtifactStore, FunctionArtifactStore};
 use crate::functions::validation::{
@@ -155,10 +157,12 @@ impl FunctionManager {
         &self,
         workspace_name: &WorkspaceName,
         selected_sources: &[QuerySource],
-        runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
+        mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
     ) -> Result<Vec<FunctionListing>, AppError> {
-        self.evaluate_function_listings(workspace_name, selected_sources, runtime_config)
-            .await
+        self.evaluate_function_listings(workspace_name, selected_sources, |pending| async move {
+            infer_runtime_functions(selected_sources, runtime_config()?, pending).await
+        })
+        .await
     }
 
     pub(crate) fn list_functions_with_preparation_failure(
@@ -183,10 +187,12 @@ impl FunctionManager {
         &self,
         workspace_name: &WorkspaceName,
         selected_sources: &[QuerySource],
-        runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
+        runtime: &PreparedQueryRuntime,
     ) -> Result<Vec<UdfRuntimeDefinition>, AppError> {
         let listings = self
-            .evaluate_function_listings(workspace_name, selected_sources, runtime_config)
+            .evaluate_function_listings(workspace_name, selected_sources, |pending| {
+                infer_runtime_functions_in_prepared_runtime(runtime, pending)
+            })
             .await?;
         let mut definitions = Vec::new();
         for listing in listings {
@@ -202,12 +208,16 @@ impl FunctionManager {
         Ok(definitions)
     }
 
-    async fn evaluate_function_listings(
+    async fn evaluate_function_listings<Infer, InferFuture>(
         &self,
         workspace_name: &WorkspaceName,
         selected_sources: &[QuerySource],
-        mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
-    ) -> Result<Vec<FunctionListing>, AppError> {
+        infer: Infer,
+    ) -> Result<Vec<FunctionListing>, AppError>
+    where
+        Infer: FnOnce(Vec<UdfRuntimeDefinition>) -> InferFuture,
+        InferFuture: Future<Output = Result<Vec<Result<UdfRuntimeDefinition, AppError>>, AppError>>,
+    {
         let artifacts = self.load_function_artifacts(workspace_name)?;
         if artifacts.is_empty() {
             return Ok(Vec::new());
@@ -253,7 +263,7 @@ impl FunctionManager {
         let inferred = if pending.is_empty() {
             Vec::new()
         } else {
-            infer_runtime_functions(selected_sources, runtime_config()?, pending).await?
+            infer(pending).await?
         };
         let mut inferred = inferred.into_iter();
 
@@ -657,9 +667,12 @@ select 1 as id
         let workspace = workspace();
         let raw_sql = function_sql("review_queue");
         install_fixture_function(&manager, &workspace, &raw_sql);
+        let runtime = coral_engine::CoralQuery::prepare(&[], QueryRuntimeConfig::default())
+            .await
+            .expect("prepare runtime");
 
         let runtime_functions = manager
-            .load_runtime_udfs(&workspace, &[], || Ok(QueryRuntimeConfig::default()))
+            .load_runtime_udfs(&workspace, &[], &runtime)
             .await
             .expect("load runtime functions");
 

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -405,10 +405,7 @@ async fn infer_runtime_function(
     spec: &FunctionSpec,
 ) -> Result<UdfRuntimeDefinition, AppError> {
     let mut runtime_function = runtime_function_without_signature(spec);
-    let sql_definition = UdfRuntimeSqlDefinition {
-        name: runtime_function.name.clone(),
-        implementation: runtime_function.implementation.clone(),
-    };
+    let sql_definition = runtime_sql_definition(&runtime_function);
     let signature =
         CoralQuery::infer_udf_signature(selected_sources, runtime_config, sql_definition)
             .await
@@ -418,6 +415,13 @@ async fn infer_runtime_function(
     runtime_function.arguments = signature.arguments;
     runtime_function.result_columns = signature.result_columns;
     Ok(runtime_function)
+}
+
+fn runtime_sql_definition(function: &UdfRuntimeDefinition) -> UdfRuntimeSqlDefinition {
+    UdfRuntimeSqlDefinition {
+        name: function.name.clone(),
+        implementation: function.implementation.clone(),
+    }
 }
 
 fn runtime_function_without_signature(spec: &FunctionSpec) -> UdfRuntimeDefinition {

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -1,9 +1,15 @@
 //! Owns user-installed function files and workspace inventory.
 
+use std::collections::{BTreeSet, HashSet};
+use std::fmt;
 use std::sync::Arc;
 
-use coral_engine::UdfRuntimeDefinition;
-use coral_spec::parse_function_sql;
+use coral_engine::{
+    CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, UdfRuntimeDefinition,
+    UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeSqlDefinition,
+    UdfRuntimeTableFunctionPublish,
+};
+use coral_spec::{FunctionImplementationSpec, FunctionSpec, parse_function_sql};
 
 use crate::bootstrap::AppError;
 use crate::functions::model::{FunctionName, InstalledFunction};
@@ -16,6 +22,17 @@ pub(crate) struct FunctionManager {
     config_store: ConfigStore,
     artifacts: Arc<dyn FunctionArtifactStore>,
     lifecycle_lock: WorkspaceLifecycleLock,
+}
+
+struct FunctionArtifact {
+    name: FunctionName,
+    raw_sql: String,
+}
+
+/// One function as listed by the app inventory surface.
+pub(crate) struct FunctionListing {
+    /// Runtime definition for the function.
+    pub(crate) definition: UdfRuntimeDefinition,
 }
 
 impl FunctionManager {
@@ -89,6 +106,117 @@ impl FunctionManager {
         Ok(installed)
     }
 
+    pub(crate) async fn validate_user_function_sql(
+        &self,
+        workspace_name: &WorkspaceName,
+        selected_sources: &[QuerySource],
+        mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
+        raw_sql: &str,
+    ) -> Result<UdfRuntimeDefinition, AppError> {
+        let spec = parse_function_sql(raw_sql).map_err(|error| {
+            AppError::InvalidInput(format!("function validation failed: {error}"))
+        })?;
+        let function_name = FunctionName::parse(spec.name())?;
+        let mut sql_publish_targets = if needs_source_publish_target_check(&spec) {
+            source_sql_publish_targets(selected_sources)
+        } else {
+            HashSet::new()
+        };
+        self.record_installed_function_sql_publish_targets(
+            workspace_name,
+            &function_name,
+            &mut sql_publish_targets,
+        )?;
+        let runtime_function =
+            infer_runtime_function(selected_sources, runtime_config()?, &spec).await?;
+        record_sql_publish_target(&runtime_function, &mut sql_publish_targets)?;
+        Ok(runtime_function)
+    }
+
+    pub(crate) async fn list_functions(
+        &self,
+        workspace_name: &WorkspaceName,
+        selected_sources: &[QuerySource],
+        runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
+    ) -> Result<Vec<FunctionListing>, AppError> {
+        self.list_runtime_function_listings(workspace_name, selected_sources, runtime_config)
+            .await
+    }
+
+    pub(crate) async fn load_runtime_udfs(
+        &self,
+        workspace_name: &WorkspaceName,
+        selected_sources: &[QuerySource],
+        runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
+    ) -> Result<Vec<UdfRuntimeDefinition>, AppError> {
+        Ok(self
+            .list_runtime_function_listings(workspace_name, selected_sources, runtime_config)
+            .await?
+            .into_iter()
+            .map(|listing| listing.definition)
+            .collect())
+    }
+
+    async fn list_runtime_function_listings(
+        &self,
+        workspace_name: &WorkspaceName,
+        selected_sources: &[QuerySource],
+        mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
+    ) -> Result<Vec<FunctionListing>, AppError> {
+        let artifacts = self.load_function_artifacts(workspace_name)?;
+        if artifacts.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut seen_names = HashSet::new();
+        let mut checked_source_schemas = BTreeSet::new();
+        let mut sql_publish_targets = HashSet::new();
+        let mut runtime_functions = Vec::new();
+        for artifact in artifacts {
+            if !seen_names.insert(artifact.name.clone()) {
+                skip_function(
+                    &artifact,
+                    format_args!("function '{}' is installed more than once", artifact.name),
+                );
+                continue;
+            }
+            let spec = match parse_function_sql(&artifact.raw_sql) {
+                Ok(spec) => spec,
+                Err(error) => {
+                    skip_function(&artifact, format_args!("function is invalid: {error}"));
+                    continue;
+                }
+            };
+            let runtime_function =
+                match infer_runtime_function(selected_sources, runtime_config()?, &spec).await {
+                    Ok(function) => function,
+                    Err(error) => {
+                        skip_function(&artifact, format_args!("{error}"));
+                        continue;
+                    }
+                };
+            let unchecked_source_schemas =
+                unchecked_source_publish_schemas(&runtime_function, &checked_source_schemas);
+            if !unchecked_source_schemas.is_empty() {
+                sql_publish_targets.extend(source_sql_publish_targets_for_schemas(
+                    selected_sources,
+                    &unchecked_source_schemas,
+                ));
+                checked_source_schemas.extend(unchecked_source_schemas);
+            }
+            if let Err(error) =
+                record_sql_publish_target(&runtime_function, &mut sql_publish_targets)
+            {
+                skip_function(&artifact, format_args!("{error}"));
+                continue;
+            }
+            runtime_functions.push(FunctionListing {
+                definition: runtime_function,
+            });
+        }
+        Ok(runtime_functions)
+    }
+
     pub(crate) fn remove_user_function(
         &self,
         workspace_name: &WorkspaceName,
@@ -118,6 +246,245 @@ impl FunctionManager {
         }
         Ok(())
     }
+
+    fn load_function_artifacts(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<FunctionArtifact>, AppError> {
+        let _state_lock = self.config_store.state_lock_shared()?;
+        let mut artifacts = Vec::new();
+        for installed in self
+            .config_store
+            .list_workspace_functions_unlocked(workspace_name)?
+        {
+            let raw_sql = match self
+                .artifacts
+                .read_function_sql(workspace_name, &installed.name)
+            {
+                Ok(Some(raw_sql)) => raw_sql,
+                Ok(None) => {
+                    tracing::warn!(
+                        function = %installed.name,
+                        "skipping installed function because its function file is missing"
+                    );
+                    continue;
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        function = %installed.name,
+                        detail = %error,
+                        "skipping installed function because its function file could not be read"
+                    );
+                    continue;
+                }
+            };
+            let function_name = installed.name;
+            artifacts.push(FunctionArtifact {
+                name: function_name,
+                raw_sql,
+            });
+        }
+
+        artifacts.sort_by(|left, right| left.name.as_str().cmp(right.name.as_str()));
+        Ok(artifacts)
+    }
+
+    fn record_installed_function_sql_publish_targets(
+        &self,
+        workspace_name: &WorkspaceName,
+        replacing_function: &FunctionName,
+        publish_targets: &mut HashSet<SqlPublishTarget>,
+    ) -> Result<(), AppError> {
+        let mut seen_names = HashSet::new();
+        for artifact in self.load_function_artifacts(workspace_name)? {
+            if artifact.name == *replacing_function {
+                continue;
+            }
+            if !seen_names.insert(artifact.name.clone()) {
+                return Err(AppError::FailedPrecondition(format!(
+                    "function '{}' is installed more than once",
+                    artifact.name
+                )));
+            }
+            let spec = parse_function_sql(&artifact.raw_sql).map_err(|error| {
+                AppError::FailedPrecondition(format!(
+                    "installed function '{}' is invalid: {error}",
+                    artifact.name
+                ))
+            })?;
+            let runtime_function = runtime_function_without_signature(&spec);
+            record_sql_publish_target(&runtime_function, publish_targets)?;
+        }
+        Ok(())
+    }
+}
+
+fn skip_function(artifact: &FunctionArtifact, detail: fmt::Arguments<'_>) {
+    tracing::warn!(
+        function = %artifact.name,
+        detail = %detail,
+        "skipping function during runtime publication"
+    );
+}
+
+fn source_sql_publish_targets(selected_sources: &[QuerySource]) -> HashSet<SqlPublishTarget> {
+    let mut targets = HashSet::new();
+    for source in selected_sources {
+        for component in source.components() {
+            record_source_component_sql_targets(component, &mut targets);
+        }
+    }
+    targets
+}
+
+fn record_source_component_sql_targets(
+    component: &RuntimeSourceComponent,
+    targets: &mut HashSet<SqlPublishTarget>,
+) {
+    match component {
+        RuntimeSourceComponent::Http(manifest) => {
+            for table in &manifest.tables {
+                targets.insert(SqlPublishTarget::new(&manifest.common.name, table.name()));
+            }
+            for function in &manifest.functions {
+                targets.insert(SqlPublishTarget::new(&manifest.common.name, &function.name));
+            }
+        }
+        RuntimeSourceComponent::File(manifest) => {
+            for table in &manifest.tables {
+                targets.insert(SqlPublishTarget::new(&manifest.common.name, table.name()));
+            }
+        }
+        RuntimeSourceComponent::Mcp(manifest) => {
+            for table in &manifest.tables {
+                targets.insert(SqlPublishTarget::new(
+                    &manifest.common.name,
+                    &table.common.name,
+                ));
+            }
+            for function in &manifest.functions {
+                targets.insert(SqlPublishTarget::new(
+                    &manifest.common.name,
+                    &function.common.name,
+                ));
+            }
+        }
+    }
+}
+
+fn source_sql_publish_targets_for_schemas(
+    selected_sources: &[QuerySource],
+    schemas: &BTreeSet<String>,
+) -> HashSet<SqlPublishTarget> {
+    let schema_sources = selected_sources
+        .iter()
+        .filter(|source| schemas.contains(source.source_name()))
+        .cloned()
+        .collect::<Vec<_>>();
+    if schema_sources.is_empty() {
+        return HashSet::new();
+    }
+    source_sql_publish_targets(&schema_sources)
+}
+
+fn unchecked_source_publish_schemas(
+    function: &UdfRuntimeDefinition,
+    checked: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    let schema = &function.publish.table_function.schema;
+    if schema != "functions" && !checked.contains(schema) {
+        BTreeSet::from([schema.clone()])
+    } else {
+        BTreeSet::new()
+    }
+}
+
+async fn infer_runtime_function(
+    selected_sources: &[QuerySource],
+    runtime_config: QueryRuntimeConfig,
+    spec: &FunctionSpec,
+) -> Result<UdfRuntimeDefinition, AppError> {
+    let mut runtime_function = runtime_function_without_signature(spec);
+    let sql_definition = UdfRuntimeSqlDefinition {
+        name: runtime_function.name.clone(),
+        implementation: runtime_function.implementation.clone(),
+    };
+    let signature =
+        CoralQuery::infer_udf_signature(selected_sources, runtime_config, sql_definition)
+            .await
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!("function failed runtime validation: {error}"))
+            })?;
+    runtime_function.arguments = signature.arguments;
+    runtime_function.result_columns = signature.result_columns;
+    Ok(runtime_function)
+}
+
+fn runtime_function_without_signature(spec: &FunctionSpec) -> UdfRuntimeDefinition {
+    UdfRuntimeDefinition {
+        name: spec.name().to_string(),
+        description: spec.description().to_string(),
+        arguments: Vec::new(),
+        implementation: runtime_implementation(spec.implementation()),
+        publish: runtime_publish(spec),
+        result_columns: Vec::new(),
+    }
+}
+
+fn runtime_implementation(spec: &FunctionImplementationSpec) -> UdfRuntimeImplementation {
+    UdfRuntimeImplementation::CoralSql {
+        query: spec.coral_sql.query.clone(),
+    }
+}
+
+fn runtime_publish(spec: &FunctionSpec) -> UdfRuntimePublish {
+    UdfRuntimePublish {
+        table_function: UdfRuntimeTableFunctionPublish {
+            schema: spec.schema().to_string(),
+            name: spec.name().to_string(),
+            description: String::new(),
+        },
+    }
+}
+
+fn needs_source_publish_target_check(spec: &FunctionSpec) -> bool {
+    spec.schema() != "functions"
+}
+
+fn record_sql_publish_target(
+    function: &UdfRuntimeDefinition,
+    publish_targets: &mut HashSet<SqlPublishTarget>,
+) -> Result<(), AppError> {
+    let target = SqlPublishTarget::new(
+        &function.publish.table_function.schema,
+        &function.publish.table_function.name,
+    );
+    if !publish_targets.insert(target.clone()) {
+        return Err(AppError::FailedPrecondition(format!(
+            "function publish target '{}' is installed more than once",
+            target.display_name()
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SqlPublishTarget {
+    schema: String,
+    name: String,
+}
+
+impl SqlPublishTarget {
+    fn new(schema: &str, name: &str) -> Self {
+        Self {
+            schema: schema.to_ascii_lowercase(),
+            name: name.to_ascii_lowercase(),
+        }
+    }
+
+    fn display_name(&self) -> String {
+        format!("{}.{}", self.schema, self.name)
+    }
 }
 
 #[cfg(test)]
@@ -126,14 +493,10 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
-    use arrow::datatypes::DataType;
-    use coral_engine::{
-        UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn,
-        UdfRuntimeTableFunctionPublish,
-    };
     use tempfile::TempDir;
 
     use super::*;
+    use crate::state::AppStateLayout;
 
     fn fixture() -> (TempDir, AppStateLayout, ConfigStore, FunctionManager) {
         let temp = TempDir::new().expect("temp dir");
@@ -149,10 +512,29 @@ mod tests {
     }
 
     fn function_sql(name: &str) -> String {
+        function_sql_with_publish(name, &format!("functions.{name}"))
+    }
+
+    fn function_sql_with_owner_query(name: &str) -> String {
         format!(
             r"/*
 name: {name}
 schema: functions
+*/
+
+select cast($owner as VARCHAR) as owner
+"
+        )
+    }
+
+    fn function_sql_with_publish(name: &str, publish_target: &str) -> String {
+        let (schema, function) = publish_target
+            .split_once('.')
+            .expect("publish target should be schema.name");
+        format!(
+            r"/*
+name: {function}
+schema: {schema}
 description: Test function {name}
 */
 
@@ -161,27 +543,9 @@ select 1 as id
         )
     }
 
-    fn runtime_function(name: &str) -> UdfRuntimeDefinition {
-        UdfRuntimeDefinition {
-            name: name.to_string(),
-            description: String::new(),
-            arguments: Vec::new(),
-            implementation: UdfRuntimeImplementation::CoralSql {
-                query: "select 1 as id".to_string(),
-            },
-            publish: UdfRuntimePublish {
-                table_function: UdfRuntimeTableFunctionPublish {
-                    schema: "functions".to_string(),
-                    name: name.to_string(),
-                    description: String::new(),
-                },
-            },
-            result_columns: vec![UdfRuntimeResultColumn {
-                name: "id".to_string(),
-                data_type: DataType::Int64,
-                nullable: false,
-            }],
-        }
+    fn validated_function(raw_sql: &str) -> UdfRuntimeDefinition {
+        let spec = parse_function_sql(raw_sql).expect("function spec");
+        runtime_function_without_signature(&spec)
     }
 
     #[derive(Clone)]
@@ -229,33 +593,68 @@ select 1 as id
         }
     }
 
-    #[test]
-    fn install_user_function_writes_inventory_and_artifact() {
-        let (_temp, layout, config_store, manager) = fixture();
+    fn install_fixture_function(
+        manager: &FunctionManager,
+        workspace: &WorkspaceName,
+        raw_sql: &str,
+    ) -> InstalledFunction {
+        let runtime_function = validated_function(raw_sql);
+        manager
+            .install_validated_user_function(workspace, raw_sql, &runtime_function)
+            .expect("install function")
+    }
+
+    #[tokio::test]
+    async fn list_functions_infers_columns_from_sql_body() {
+        let (_temp, layout, _config_store, manager) = fixture();
+        let workspace = workspace();
+        let raw_sql = function_sql_with_owner_query("review_queue");
+        install_fixture_function(&manager, &workspace, &raw_sql);
+        let function_name = FunctionName::parse("review_queue").expect("function name");
+        std::fs::write(
+            layout.function_file(&workspace, &function_name),
+            raw_sql.replace(
+                "select cast($owner as VARCHAR) as owner",
+                "select cast($owner as VARCHAR) as reviewer",
+            ),
+        )
+        .expect("rewrite function sql");
+
+        let listed = manager
+            .list_functions(&workspace, &[], || Ok(QueryRuntimeConfig::default()))
+            .await
+            .expect("list functions");
+
+        assert_eq!(listed.len(), 1);
+        let listed_function = listed.first().expect("one listed function");
+        assert_eq!(listed_function.definition.result_columns.len(), 1);
+        assert_eq!(
+            listed_function
+                .definition
+                .result_columns
+                .first()
+                .expect("inferred result column")
+                .name,
+            "reviewer"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_runtime_udfs_uses_only_runtime_ready_functions() {
+        let (_temp, _layout, _config_store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql("review_queue");
+        install_fixture_function(&manager, &workspace, &raw_sql);
 
-        let installed = manager
-            .install_validated_user_function(
-                &workspace,
-                &raw_sql,
-                &runtime_function("review_queue"),
-            )
-            .expect("install function");
+        let runtime_functions = manager
+            .load_runtime_udfs(&workspace, &[], || Ok(QueryRuntimeConfig::default()))
+            .await
+            .expect("load runtime functions");
 
-        assert_eq!(installed.name.as_str(), "review_queue");
-        assert_eq!(
-            config_store
-                .list_workspace_functions(&workspace)
-                .expect("list function inventory")
-                .len(),
-            1
-        );
-        assert_eq!(
-            std::fs::read_to_string(layout.function_file(&workspace, &installed.name))
-                .expect("read function artifact"),
-            raw_sql
-        );
+        assert_eq!(runtime_functions.len(), 1);
+        let runtime_function = runtime_functions.first().expect("one runtime function");
+        assert_eq!(runtime_function.name, "review_queue");
+        assert_eq!(runtime_function.result_columns.len(), 1);
     }
 
     #[test]
@@ -263,13 +662,7 @@ select 1 as id
         let (_temp, layout, config_store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql("review_queue");
-        let installed = manager
-            .install_validated_user_function(
-                &workspace,
-                &raw_sql,
-                &runtime_function("review_queue"),
-            )
-            .expect("install function");
+        let installed = install_fixture_function(&manager, &workspace, &raw_sql);
 
         manager
             .remove_user_function(&workspace, &installed.name)
@@ -319,12 +712,10 @@ select 1 as id
         let (done_tx, done_rx) = std_mpsc::channel();
         let handle = thread::spawn(move || {
             started_tx.send(()).expect("send started");
+            let raw_sql = function_sql("review_queue");
+            let runtime_function = validated_function(&raw_sql);
             let result = install_manager
-                .install_validated_user_function(
-                    &install_workspace,
-                    &function_sql("review_queue"),
-                    &runtime_function("review_queue"),
-                )
+                .install_validated_user_function(&install_workspace, &raw_sql, &runtime_function)
                 .map(|function| function.name.to_string())
                 .map_err(|error| error.to_string());
             done_tx.send(result).expect("send install result");
@@ -355,13 +746,7 @@ select 1 as id
         let (_temp, layout, config_store, manager) = fixture();
         let workspace = workspace();
         let original_sql = function_sql("review_queue");
-        manager
-            .install_validated_user_function(
-                &workspace,
-                &original_sql,
-                &runtime_function("review_queue"),
-            )
-            .expect("install original function");
+        install_fixture_function(&manager, &workspace, &original_sql);
 
         let function_name = FunctionName::parse("review_queue").expect("function name");
         let replacement_sql = format!("{original_sql}\n");
@@ -375,12 +760,9 @@ select 1 as id
             }),
             lifecycle_lock: WorkspaceLifecycleLock::default(),
         };
+        let runtime_function = validated_function(&replacement_sql);
         let error = manager
-            .install_validated_user_function(
-                &workspace,
-                &replacement_sql,
-                &runtime_function("review_queue"),
-            )
+            .install_validated_user_function(&workspace, &replacement_sql, &runtime_function)
             .expect_err("inventory and restore failures should be reported together");
 
         let AppError::FailedPrecondition(message) = error else {

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -1,6 +1,6 @@
 //! Owns user-installed function files and workspace inventory.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use coral_engine::{QueryRuntimeConfig, QuerySource, UdfRuntimeDefinition};
@@ -40,10 +40,13 @@ enum FunctionArtifactContent {
 pub(crate) struct FunctionListing {
     /// Stable installed inventory name.
     pub(crate) name: FunctionName,
-    /// Runtime definition when enough artifact metadata could be read.
-    pub(crate) definition: Option<UdfRuntimeDefinition>,
-    /// Validation failure when the function is not runtime-ready.
-    pub(crate) runtime_error: Option<String>,
+    /// Current runtime state for this installed function.
+    pub(crate) runtime: FunctionRuntimeStatus,
+}
+
+pub(crate) enum FunctionRuntimeStatus {
+    Ready(UdfRuntimeDefinition),
+    Invalid(String),
 }
 
 enum FunctionCandidate {
@@ -136,7 +139,7 @@ impl FunctionManager {
             AppError::InvalidInput(format!("function validation failed: {error}"))
         })?;
         let function_name = FunctionName::parse(spec.name())?;
-        let mut sql_publish_targets = initial_sql_publish_targets(&spec, selected_sources);
+        let mut sql_publish_targets = initial_sql_publish_targets(selected_sources);
         self.record_installed_function_sql_publish_targets(
             workspace_name,
             &function_name,
@@ -169,16 +172,12 @@ impl FunctionManager {
             .await?;
         let mut definitions = Vec::new();
         for listing in listings {
-            match (listing.definition, listing.runtime_error) {
-                (Some(definition), None) => definitions.push(definition),
-                (_, Some(error)) => tracing::warn!(
+            match listing.runtime {
+                FunctionRuntimeStatus::Ready(definition) => definitions.push(definition),
+                FunctionRuntimeStatus::Invalid(error) => tracing::warn!(
                     function = %listing.name,
                     detail = %error,
                     "skipping function during runtime publication"
-                ),
-                (None, None) => tracing::warn!(
-                    function = %listing.name,
-                    "skipping function without a runtime definition"
                 ),
             }
         }
@@ -196,25 +195,15 @@ impl FunctionManager {
             return Ok(Vec::new());
         }
 
-        let mut seen_names = HashSet::new();
         let mut checked_source_schemas = BTreeSet::new();
-        let mut sql_publish_targets = HashSet::new();
+        let mut sql_publish_targets = SqlPublishTargets::default();
         let mut candidates = Vec::with_capacity(artifacts.len());
         for artifact in artifacts {
-            if !seen_names.insert(artifact.name.clone()) {
-                candidates.push(FunctionCandidate::Listing(invalid_listing(
-                    artifact.name.clone(),
-                    None,
-                    format!("function '{}' is installed more than once", artifact.name),
-                )));
-                continue;
-            }
             let spec = match parse_function_artifact(&artifact) {
                 Ok(spec) => spec,
                 Err(error) => {
                     candidates.push(FunctionCandidate::Listing(invalid_listing(
                         artifact.name,
-                        None,
                         error,
                     )));
                     continue;
@@ -254,18 +243,14 @@ impl FunctionManager {
             .into_iter()
             .map(|candidate| match candidate {
                 FunctionCandidate::Listing(listing) => Ok(listing),
-                FunctionCandidate::Pending { name, definition } => match inferred.next() {
+                FunctionCandidate::Pending { name, .. } => match inferred.next() {
                     Some(Ok(definition)) => {
                         match record_sql_publish_target(&definition, &mut sql_publish_targets) {
                             Ok(()) => Ok(ready_listing(name, definition)),
-                            Err(error) => {
-                                Ok(invalid_listing(name, Some(definition), error.to_string()))
-                            }
+                            Err(error) => Ok(invalid_listing(name, error.to_string())),
                         }
                     }
-                    Some(Err(error)) => {
-                        Ok(invalid_listing(name, Some(definition), error.to_string()))
-                    }
+                    Some(Err(error)) => Ok(invalid_listing(name, error.to_string())),
                     None => Err(AppError::FailedPrecondition(
                         "function runtime validation returned too few results".to_string(),
                     )),
@@ -343,23 +328,21 @@ impl FunctionManager {
         replacing_function: &FunctionName,
         publish_targets: &mut SqlPublishTargets,
     ) -> Result<(), AppError> {
-        let mut seen_names = HashSet::new();
         for artifact in self.load_function_artifacts(workspace_name)? {
             if artifact.name == *replacing_function {
                 continue;
             }
-            if !seen_names.insert(artifact.name.clone()) {
-                return Err(AppError::FailedPrecondition(format!(
-                    "function '{}' is installed more than once",
-                    artifact.name
-                )));
-            }
-            let spec = parse_function_artifact(&artifact).map_err(|error| {
-                AppError::FailedPrecondition(format!(
-                    "installed function '{}': {error}",
-                    artifact.name
-                ))
-            })?;
+            let spec = match parse_function_artifact(&artifact) {
+                Ok(spec) => spec,
+                Err(error) => {
+                    tracing::warn!(
+                        function = %artifact.name,
+                        detail = %error,
+                        "ignoring invalid installed function during publish collision validation"
+                    );
+                    continue;
+                }
+            };
             let runtime_function = runtime_function_without_signature(&spec);
             record_sql_publish_target(&runtime_function, publish_targets)?;
         }
@@ -387,20 +370,14 @@ fn parse_function_artifact(artifact: &FunctionArtifact) -> Result<FunctionSpec, 
 fn ready_listing(name: FunctionName, definition: UdfRuntimeDefinition) -> FunctionListing {
     FunctionListing {
         name,
-        definition: Some(definition),
-        runtime_error: None,
+        runtime: FunctionRuntimeStatus::Ready(definition),
     }
 }
 
-fn invalid_listing(
-    name: FunctionName,
-    definition: Option<UdfRuntimeDefinition>,
-    error: String,
-) -> FunctionListing {
+fn invalid_listing(name: FunctionName, error: String) -> FunctionListing {
     FunctionListing {
         name,
-        definition,
-        runtime_error: Some(error),
+        runtime: FunctionRuntimeStatus::Invalid(error),
     }
 }
 
@@ -544,11 +521,9 @@ select 1 as id
 
         assert_eq!(listed.len(), 1);
         let listed_function = listed.first().expect("one listed function");
-        assert!(listed_function.runtime_error.is_none());
-        let definition = listed_function
-            .definition
-            .as_ref()
-            .expect("runtime-ready definition");
+        let FunctionRuntimeStatus::Ready(definition) = &listed_function.runtime else {
+            panic!("function should be runtime-ready");
+        };
         assert_eq!(definition.result_columns.len(), 1);
         assert_eq!(
             definition
@@ -602,12 +577,10 @@ select 1 as id
 
         let listing = listed.first().expect("installed function remains visible");
         assert_eq!(listing.name, installed.name);
-        assert!(
-            listing
-                .runtime_error
-                .as_deref()
-                .is_some_and(|error| error.contains("has no inferred type"))
-        );
+        let FunctionRuntimeStatus::Invalid(error) = &listing.runtime else {
+            panic!("function should be runtime-invalid");
+        };
+        assert!(error.contains("has no inferred type"));
     }
 
     #[tokio::test]
@@ -629,15 +602,35 @@ select 1 as id
 
         let listing = listed.first().expect("installed function remains visible");
         assert_eq!(listing.name, installed.name);
-        assert!(
-            listing
-                .runtime_error
-                .as_deref()
-                .is_some_and(|error| error.contains("declares name 'renamed'"))
-        );
+        let FunctionRuntimeStatus::Invalid(error) = &listing.runtime else {
+            panic!("function should be runtime-invalid");
+        };
+        assert!(error.contains("declares name 'renamed'"));
         manager
             .remove_user_function(&workspace, &installed.name)
             .expect("inventory name remains removable");
+    }
+
+    #[tokio::test]
+    async fn validate_function_ignores_unrelated_missing_artifact() {
+        let (_temp, layout, _config_store, manager) = fixture();
+        let workspace = workspace();
+        let installed =
+            install_fixture_function(&manager, &workspace, &function_sql("missing_artifact"));
+        std::fs::remove_file(layout.function_file(&workspace, &installed.name))
+            .expect("remove existing artifact");
+
+        let validated = manager
+            .validate_user_function_sql(
+                &workspace,
+                &[],
+                || Ok(QueryRuntimeConfig::default()),
+                &function_sql("new_function"),
+            )
+            .await
+            .expect("unrelated broken artifact should not block validation");
+
+        assert_eq!(validated.name, "new_function");
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/functions/mod.rs
+++ b/crates/coral-app/src/functions/mod.rs
@@ -1,8 +1,4 @@
 //! Function lifecycle and inventory workflow.
-#![expect(
-    dead_code,
-    reason = "function inventory and artifact stores are introduced before runtime and service callers in the split app stack"
-)]
 
 pub(crate) mod manager;
 pub(crate) mod model;

--- a/crates/coral-app/src/functions/mod.rs
+++ b/crates/coral-app/src/functions/mod.rs
@@ -1,7 +1,16 @@
 //! Function lifecycle and inventory workflow.
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "function lifecycle service and CLI callers land upstack in the split stack"
+    )
+)]
 
 pub(crate) mod manager;
 pub(crate) mod model;
+mod runtime;
 mod store;
+mod validation;
 
 pub(crate) use model::FunctionName;

--- a/crates/coral-app/src/functions/runtime.rs
+++ b/crates/coral-app/src/functions/runtime.rs
@@ -1,0 +1,59 @@
+use coral_engine::{
+    CoralQuery, QueryRuntimeConfig, QuerySource, UdfRuntimeDefinition, UdfRuntimeImplementation,
+    UdfRuntimePublish, UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
+};
+use coral_spec::{FunctionImplementationSpec, FunctionSpec};
+
+use crate::bootstrap::AppError;
+
+pub(crate) async fn infer_runtime_function(
+    selected_sources: &[QuerySource],
+    runtime_config: QueryRuntimeConfig,
+    spec: &FunctionSpec,
+) -> Result<UdfRuntimeDefinition, AppError> {
+    let mut runtime_function = runtime_function_without_signature(spec);
+    let sql_definition = runtime_sql_definition(&runtime_function);
+    let signature =
+        CoralQuery::infer_udf_signature(selected_sources, runtime_config, sql_definition)
+            .await
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!("function failed runtime validation: {error}"))
+            })?;
+    runtime_function.arguments = signature.arguments;
+    runtime_function.result_columns = signature.result_columns;
+    Ok(runtime_function)
+}
+
+pub(crate) fn runtime_function_without_signature(spec: &FunctionSpec) -> UdfRuntimeDefinition {
+    UdfRuntimeDefinition {
+        name: spec.name().to_string(),
+        description: spec.description().to_string(),
+        arguments: Vec::new(),
+        implementation: runtime_implementation(spec.implementation()),
+        publish: runtime_publish(spec),
+        result_columns: Vec::new(),
+    }
+}
+
+fn runtime_sql_definition(function: &UdfRuntimeDefinition) -> UdfRuntimeSqlDefinition {
+    UdfRuntimeSqlDefinition {
+        name: function.name.clone(),
+        implementation: function.implementation.clone(),
+    }
+}
+
+fn runtime_implementation(spec: &FunctionImplementationSpec) -> UdfRuntimeImplementation {
+    UdfRuntimeImplementation::CoralSql {
+        query: spec.coral_sql.query.clone(),
+    }
+}
+
+fn runtime_publish(spec: &FunctionSpec) -> UdfRuntimePublish {
+    UdfRuntimePublish {
+        table_function: UdfRuntimeTableFunctionPublish {
+            schema: spec.schema().to_string(),
+            name: spec.name().to_string(),
+            description: String::new(),
+        },
+    }
+}

--- a/crates/coral-app/src/functions/runtime.rs
+++ b/crates/coral-app/src/functions/runtime.rs
@@ -11,17 +11,42 @@ pub(crate) async fn infer_runtime_function(
     runtime_config: QueryRuntimeConfig,
     spec: &FunctionSpec,
 ) -> Result<UdfRuntimeDefinition, AppError> {
-    let mut runtime_function = runtime_function_without_signature(spec);
-    let sql_definition = runtime_sql_definition(&runtime_function);
-    let signature =
-        CoralQuery::infer_udf_signature(selected_sources, runtime_config, sql_definition)
+    let runtime_function = runtime_function_without_signature(spec);
+    let mut results =
+        infer_runtime_functions(selected_sources, runtime_config, vec![runtime_function]).await?;
+    results.pop().ok_or_else(|| {
+        AppError::FailedPrecondition("function runtime validation returned no result".to_string())
+    })?
+}
+
+pub(crate) async fn infer_runtime_functions(
+    selected_sources: &[QuerySource],
+    runtime_config: QueryRuntimeConfig,
+    runtime_functions: Vec<UdfRuntimeDefinition>,
+) -> Result<Vec<Result<UdfRuntimeDefinition, AppError>>, AppError> {
+    let sql_definitions = runtime_functions
+        .iter()
+        .map(runtime_sql_definition)
+        .collect();
+    let signatures =
+        CoralQuery::infer_udf_signatures(selected_sources, runtime_config, sql_definitions)
             .await
-            .map_err(|error| {
-                AppError::FailedPrecondition(format!("function failed runtime validation: {error}"))
-            })?;
-    runtime_function.arguments = signature.arguments;
-    runtime_function.result_columns = signature.result_columns;
-    Ok(runtime_function)
+            .map_err(|error| runtime_validation_error(&error))?;
+
+    Ok(runtime_functions
+        .into_iter()
+        .zip(signatures)
+        .map(|(mut function, signature)| {
+            let signature = signature.map_err(|error| runtime_validation_error(&error))?;
+            function.arguments = signature.arguments;
+            function.result_columns = signature.result_columns;
+            Ok(function)
+        })
+        .collect())
+}
+
+fn runtime_validation_error(error: &coral_engine::CoreError) -> AppError {
+    AppError::FailedPrecondition(format!("function failed runtime validation: {error}"))
 }
 
 pub(crate) fn runtime_function_without_signature(spec: &FunctionSpec) -> UdfRuntimeDefinition {

--- a/crates/coral-app/src/functions/runtime.rs
+++ b/crates/coral-app/src/functions/runtime.rs
@@ -1,6 +1,7 @@
 use coral_engine::{
-    CoralQuery, QueryRuntimeConfig, QuerySource, UdfRuntimeDefinition, UdfRuntimeImplementation,
-    UdfRuntimePublish, UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
+    CoralQuery, PreparedQueryRuntime, QueryRuntimeConfig, QuerySource, UdfRuntimeDefinition,
+    UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
+    UdfRuntimeTableFunctionPublish,
 };
 use coral_spec::{FunctionImplementationSpec, FunctionSpec};
 
@@ -33,7 +34,30 @@ pub(crate) async fn infer_runtime_functions(
             .await
             .map_err(|error| runtime_validation_error(&error))?;
 
-    Ok(runtime_functions
+    Ok(apply_signatures(runtime_functions, signatures))
+}
+
+pub(crate) async fn infer_runtime_functions_in_prepared_runtime(
+    runtime: &PreparedQueryRuntime,
+    runtime_functions: Vec<UdfRuntimeDefinition>,
+) -> Result<Vec<Result<UdfRuntimeDefinition, AppError>>, AppError> {
+    let sql_definitions = runtime_functions
+        .iter()
+        .map(runtime_sql_definition)
+        .collect();
+    let signatures = runtime
+        .infer_udf_signatures(sql_definitions)
+        .await
+        .map_err(|error| runtime_validation_error(&error))?;
+
+    Ok(apply_signatures(runtime_functions, signatures))
+}
+
+fn apply_signatures(
+    runtime_functions: Vec<UdfRuntimeDefinition>,
+    signatures: Vec<Result<UdfRuntimeSignature, coral_engine::CoreError>>,
+) -> Vec<Result<UdfRuntimeDefinition, AppError>> {
+    runtime_functions
         .into_iter()
         .zip(signatures)
         .map(|(mut function, signature)| {
@@ -42,7 +66,7 @@ pub(crate) async fn infer_runtime_functions(
             function.result_columns = signature.result_columns;
             Ok(function)
         })
-        .collect())
+        .collect()
 }
 
 fn runtime_validation_error(error: &coral_engine::CoreError) -> AppError {

--- a/crates/coral-app/src/functions/validation.rs
+++ b/crates/coral-app/src/functions/validation.rs
@@ -1,16 +1,12 @@
 use std::collections::{BTreeSet, HashSet};
 
 use coral_engine::{QuerySource, RuntimeSourceComponent, UdfRuntimeDefinition};
-use coral_spec::FunctionSpec;
 
 use crate::bootstrap::AppError;
 
 pub(crate) type SqlPublishTargets = HashSet<SqlPublishTarget>;
 
-pub(crate) fn initial_sql_publish_targets(
-    _spec: &FunctionSpec,
-    selected_sources: &[QuerySource],
-) -> SqlPublishTargets {
+pub(crate) fn initial_sql_publish_targets(selected_sources: &[QuerySource]) -> SqlPublishTargets {
     source_sql_publish_targets(selected_sources)
 }
 
@@ -130,7 +126,7 @@ mod tests {
         RuntimeSourcePackage, UdfRuntimeImplementation, UdfRuntimePublish,
         UdfRuntimeTableFunctionPublish,
     };
-    use coral_spec::{parse_function_sql, parse_source_manifest_yaml};
+    use coral_spec::parse_source_manifest_yaml;
 
     use super::*;
 
@@ -206,17 +202,7 @@ tables:
 
     #[test]
     fn functions_schema_still_checks_source_publish_targets() {
-        let spec = parse_function_sql(
-            r"/*
-name: review_queue
-schema: functions
-*/
-select 1 as id
-",
-        )
-        .expect("function spec");
-
-        let targets = initial_sql_publish_targets(&spec, &[functions_source()]);
+        let targets = initial_sql_publish_targets(&[functions_source()]);
 
         assert!(targets.contains(&SqlPublishTarget::new("functions", "review_queue")));
     }

--- a/crates/coral-app/src/functions/validation.rs
+++ b/crates/coral-app/src/functions/validation.rs
@@ -35,15 +35,15 @@ pub(crate) fn source_sql_publish_targets_for_schemas(
     selected_sources: &[QuerySource],
     schemas: &BTreeSet<String>,
 ) -> SqlPublishTargets {
-    let schema_sources = selected_sources
-        .iter()
-        .filter(|source| schemas.contains(source.source_name()))
-        .cloned()
-        .collect::<Vec<_>>();
-    if schema_sources.is_empty() {
-        return HashSet::new();
+    let mut targets = HashSet::new();
+    for source in selected_sources {
+        for component in source.components() {
+            if schemas.contains(component.source_name()) {
+                record_source_component_sql_targets(component, &mut targets);
+            }
+        }
     }
-    source_sql_publish_targets(&schema_sources)
+    targets
 }
 
 pub(crate) fn unchecked_source_publish_schemas(
@@ -127,34 +127,62 @@ mod tests {
     use std::collections::BTreeMap;
 
     use coral_engine::{
-        UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeTableFunctionPublish,
+        RuntimeSourcePackage, UdfRuntimeImplementation, UdfRuntimePublish,
+        UdfRuntimeTableFunctionPublish,
     };
     use coral_spec::{parse_function_sql, parse_source_manifest_yaml};
 
     use super::*;
 
     fn functions_source() -> QuerySource {
-        let manifest = parse_source_manifest_yaml(
+        http_source("functions", "review_queue")
+    }
+
+    fn http_source(schema: &str, table: &str) -> QuerySource {
+        let manifest = parse_source_manifest_yaml(&format!(
             r"
-name: functions
+name: {schema}
 version: 0.1.0
 dsl_version: 3
 backend: http
 base_url: https://example.com
 tables:
-  - name: review_queue
-    description: Existing review queue
+  - name: {table}
+    description: Existing table
     request:
       method: GET
-      path: /review-queue
-    response: {}
+      path: /{table}
+    response: {{}}
     columns:
       - name: id
         type: Int64
-",
-        )
+"
+        ))
         .expect("source manifest");
         QuerySource::new(manifest, BTreeMap::new(), BTreeMap::new())
+    }
+
+    fn multi_schema_source() -> QuerySource {
+        let primary = http_source("logical", "primary_table");
+        let secondary = http_source("secondary", "review_queue");
+        QuerySource::from_runtime_components(
+            RuntimeSourcePackage {
+                source_name: "logical".to_string(),
+                authored_version: None,
+                description: String::new(),
+                declared_inputs: Vec::new(),
+                test_queries: Vec::new(),
+                components: primary
+                    .components()
+                    .iter()
+                    .chain(secondary.components())
+                    .cloned()
+                    .collect(),
+            },
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect("multi-schema source")
     }
 
     fn runtime_function() -> UdfRuntimeDefinition {
@@ -199,5 +227,16 @@ select 1 as id
             unchecked_source_publish_schemas(&runtime_function(), &BTreeSet::new()),
             BTreeSet::from(["functions".to_string()])
         );
+    }
+
+    #[test]
+    fn schema_filter_checks_secondary_source_components() {
+        let targets = source_sql_publish_targets_for_schemas(
+            &[multi_schema_source()],
+            &BTreeSet::from(["secondary".to_string()]),
+        );
+
+        assert!(targets.contains(&SqlPublishTarget::new("secondary", "review_queue")));
+        assert!(!targets.contains(&SqlPublishTarget::new("logical", "primary_table")));
     }
 }

--- a/crates/coral-app/src/functions/validation.rs
+++ b/crates/coral-app/src/functions/validation.rs
@@ -8,14 +8,10 @@ use crate::bootstrap::AppError;
 pub(crate) type SqlPublishTargets = HashSet<SqlPublishTarget>;
 
 pub(crate) fn initial_sql_publish_targets(
-    spec: &FunctionSpec,
+    _spec: &FunctionSpec,
     selected_sources: &[QuerySource],
 ) -> SqlPublishTargets {
-    if spec.schema() == "functions" {
-        HashSet::new()
-    } else {
-        source_sql_publish_targets(selected_sources)
-    }
+    source_sql_publish_targets(selected_sources)
 }
 
 pub(crate) fn record_sql_publish_target(
@@ -55,10 +51,10 @@ pub(crate) fn unchecked_source_publish_schemas(
     checked: &BTreeSet<String>,
 ) -> BTreeSet<String> {
     let schema = &function.publish.table_function.schema;
-    if schema != "functions" && !checked.contains(schema) {
-        BTreeSet::from([schema.clone()])
-    } else {
+    if checked.contains(schema) {
         BTreeSet::new()
+    } else {
+        BTreeSet::from([schema.clone()])
     }
 }
 
@@ -123,5 +119,85 @@ impl SqlPublishTarget {
 
     fn display_name(&self) -> String {
         format!("{}.{}", self.schema, self.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use coral_engine::{
+        UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeTableFunctionPublish,
+    };
+    use coral_spec::{parse_function_sql, parse_source_manifest_yaml};
+
+    use super::*;
+
+    fn functions_source() -> QuerySource {
+        let manifest = parse_source_manifest_yaml(
+            r"
+name: functions
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: review_queue
+    description: Existing review queue
+    request:
+      method: GET
+      path: /review-queue
+    response: {}
+    columns:
+      - name: id
+        type: Int64
+",
+        )
+        .expect("source manifest");
+        QuerySource::new(manifest, BTreeMap::new(), BTreeMap::new())
+    }
+
+    fn runtime_function() -> UdfRuntimeDefinition {
+        UdfRuntimeDefinition {
+            name: "review_queue".to_string(),
+            description: String::new(),
+            arguments: Vec::new(),
+            implementation: UdfRuntimeImplementation::CoralSql {
+                query: "select 1 as id".to_string(),
+            },
+            publish: UdfRuntimePublish {
+                table_function: UdfRuntimeTableFunctionPublish {
+                    schema: "functions".to_string(),
+                    name: "review_queue".to_string(),
+                    description: String::new(),
+                },
+            },
+            result_columns: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn functions_schema_still_checks_source_publish_targets() {
+        let spec = parse_function_sql(
+            r"/*
+name: review_queue
+schema: functions
+*/
+select 1 as id
+",
+        )
+        .expect("function spec");
+
+        let targets = initial_sql_publish_targets(&spec, &[functions_source()]);
+
+        assert!(targets.contains(&SqlPublishTarget::new("functions", "review_queue")));
+    }
+
+    #[test]
+    fn functions_schema_is_not_treated_as_prechecked() {
+        assert_eq!(
+            unchecked_source_publish_schemas(&runtime_function(), &BTreeSet::new()),
+            BTreeSet::from(["functions".to_string()])
+        );
     }
 }

--- a/crates/coral-app/src/functions/validation.rs
+++ b/crates/coral-app/src/functions/validation.rs
@@ -1,0 +1,127 @@
+use std::collections::{BTreeSet, HashSet};
+
+use coral_engine::{QuerySource, RuntimeSourceComponent, UdfRuntimeDefinition};
+use coral_spec::FunctionSpec;
+
+use crate::bootstrap::AppError;
+
+pub(crate) type SqlPublishTargets = HashSet<SqlPublishTarget>;
+
+pub(crate) fn initial_sql_publish_targets(
+    spec: &FunctionSpec,
+    selected_sources: &[QuerySource],
+) -> SqlPublishTargets {
+    if spec.schema() == "functions" {
+        HashSet::new()
+    } else {
+        source_sql_publish_targets(selected_sources)
+    }
+}
+
+pub(crate) fn record_sql_publish_target(
+    function: &UdfRuntimeDefinition,
+    publish_targets: &mut SqlPublishTargets,
+) -> Result<(), AppError> {
+    let target = SqlPublishTarget::new(
+        &function.publish.table_function.schema,
+        &function.publish.table_function.name,
+    );
+    if !publish_targets.insert(target.clone()) {
+        return Err(AppError::FailedPrecondition(format!(
+            "function publish target '{}' is installed more than once",
+            target.display_name()
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn source_sql_publish_targets_for_schemas(
+    selected_sources: &[QuerySource],
+    schemas: &BTreeSet<String>,
+) -> SqlPublishTargets {
+    let schema_sources = selected_sources
+        .iter()
+        .filter(|source| schemas.contains(source.source_name()))
+        .cloned()
+        .collect::<Vec<_>>();
+    if schema_sources.is_empty() {
+        return HashSet::new();
+    }
+    source_sql_publish_targets(&schema_sources)
+}
+
+pub(crate) fn unchecked_source_publish_schemas(
+    function: &UdfRuntimeDefinition,
+    checked: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    let schema = &function.publish.table_function.schema;
+    if schema != "functions" && !checked.contains(schema) {
+        BTreeSet::from([schema.clone()])
+    } else {
+        BTreeSet::new()
+    }
+}
+
+fn source_sql_publish_targets(selected_sources: &[QuerySource]) -> SqlPublishTargets {
+    let mut targets = HashSet::new();
+    for source in selected_sources {
+        for component in source.components() {
+            record_source_component_sql_targets(component, &mut targets);
+        }
+    }
+    targets
+}
+
+fn record_source_component_sql_targets(
+    component: &RuntimeSourceComponent,
+    targets: &mut SqlPublishTargets,
+) {
+    match component {
+        RuntimeSourceComponent::Http(manifest) => {
+            for table in &manifest.tables {
+                targets.insert(SqlPublishTarget::new(&manifest.common.name, table.name()));
+            }
+            for function in &manifest.functions {
+                targets.insert(SqlPublishTarget::new(&manifest.common.name, &function.name));
+            }
+        }
+        RuntimeSourceComponent::File(manifest) => {
+            for table in &manifest.tables {
+                targets.insert(SqlPublishTarget::new(&manifest.common.name, table.name()));
+            }
+        }
+        RuntimeSourceComponent::Mcp(manifest) => {
+            for table in &manifest.tables {
+                targets.insert(SqlPublishTarget::new(
+                    &manifest.common.name,
+                    &table.common.name,
+                ));
+            }
+            for function in &manifest.functions {
+                targets.insert(SqlPublishTarget::new(
+                    &manifest.common.name,
+                    &function.common.name,
+                ));
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct SqlPublishTarget {
+    schema: String,
+    name: String,
+}
+
+impl SqlPublishTarget {
+    fn new(schema: &str, name: &str) -> Self {
+        Self {
+            schema: schema.to_ascii_lowercase(),
+            name: name.to_ascii_lowercase(),
+        }
+    }
+
+    fn display_name(&self) -> String {
+        format!("{}.{}", self.schema, self.name)
+    }
+}

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1,6 +1,6 @@
 //! Query-time loading, validation, and execution over installed sources.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
@@ -11,7 +11,7 @@ use coral_engine::{
     RuntimeSourcePackage, SourceInputResolver, SourceValidationReport, StatusCode, TableInfo,
     UdfRuntimeDefinition,
 };
-use coral_spec::{ManifestInputKind, ManifestInputSpec, parse_function_sql};
+use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::trace::Status as OtelStatus;
 use serde_json::json;
 use tracing::Instrument as _;
@@ -554,6 +554,13 @@ impl QueryManager {
         Ok(runtime)
     }
 
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "function lifecycle service callers land upstack in the split stack"
+        )
+    )]
     pub(crate) async fn list_functions(
         &self,
         workspace_name: &WorkspaceName,
@@ -571,10 +578,21 @@ impl QueryManager {
             .map_err(QueryManagerError::App)
     }
 
+    #[expect(
+        dead_code,
+        reason = "function lifecycle service callers land upstack in the split stack"
+    )]
     pub(crate) fn function_manager(&self) -> FunctionManager {
         self.function_manager.clone()
     }
 
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "function lifecycle service callers land upstack in the split stack"
+        )
+    )]
     pub(crate) async fn validate_udf_sql(
         &self,
         workspace_name: &WorkspaceName,
@@ -593,7 +611,7 @@ impl QueryManager {
                 .load_config_unlocked()
                 .map_err(QueryManagerError::App)?;
             let loaded_sources = self
-                .load_function_validation_sources(workspace_name, &config, raw_sql)
+                .load_query_sources_from_config(workspace_name, &config)
                 .map_err(QueryManagerError::App)?;
             (loaded_sources, config)
         };
@@ -607,28 +625,6 @@ impl QueryManager {
             )
             .await
             .map_err(QueryManagerError::App)
-    }
-
-    fn load_function_validation_sources(
-        &self,
-        workspace_name: &WorkspaceName,
-        config: &AppConfig,
-        raw_sql: &str,
-    ) -> Result<Vec<LoadedQuerySource>, AppError> {
-        let workspace_sources = config.workspace_sources(workspace_name);
-        let source_names = function_validation_source_names(raw_sql, &workspace_sources)?;
-        if source_names.is_empty() {
-            return self.load_query_sources_from_config(workspace_name, config);
-        }
-
-        let mut loaded_sources = Vec::new();
-        for source in workspace_sources {
-            if source_names.contains(&source.name) {
-                let (loaded_source, _version) = self.load_query_source(workspace_name, &source)?;
-                loaded_sources.push(loaded_source);
-            }
-        }
-        Ok(loaded_sources)
     }
 
     async fn runtime_config_with_udfs(
@@ -661,46 +657,6 @@ impl QueryManager {
             .map_err(QueryManagerError::App)?;
         Ok(runtime.with_udfs(functions))
     }
-}
-
-fn function_validation_source_names(
-    raw_sql: &str,
-    installed_sources: &[InstalledSource],
-) -> Result<BTreeSet<SourceName>, AppError> {
-    let spec = parse_function_sql(raw_sql)
-        .map_err(|error| AppError::InvalidInput(format!("function validation failed: {error}")))?;
-    let query = spec.implementation().coral_sql.query.to_ascii_lowercase();
-    let mut names = installed_sources
-        .iter()
-        .filter(|source| contains_schema_reference(&query, source.name.as_str()))
-        .map(|source| source.name.clone())
-        .collect::<BTreeSet<_>>();
-
-    let schema = spec.schema();
-    if schema != "functions"
-        && let Some(source) = installed_sources
-            .iter()
-            .find(|source| source.name.as_str() == schema)
-    {
-        names.insert(source.name.clone());
-    }
-
-    Ok(names)
-}
-
-fn contains_schema_reference(query: &str, schema: &str) -> bool {
-    let needle = format!("{schema}.");
-    let bytes = query.as_bytes();
-    query.match_indices(&needle).any(|(index, _)| {
-        index == 0
-            || bytes
-                .get(index.saturating_sub(1))
-                .is_some_and(|byte| !is_sql_identifier_byte(*byte))
-    })
-}
-
-fn is_sql_identifier_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 fn query_sources_from_loaded(loaded_sources: &[LoadedQuerySource]) -> Vec<QuerySource> {
@@ -1054,17 +1010,6 @@ mod tests {
         }
     }
 
-    fn installed_source(name: &str) -> InstalledSource {
-        InstalledSource {
-            name: SourceName::parse(name).expect("source name"),
-            version: None,
-            variables: BTreeMap::new(),
-            secrets: Vec::new(),
-            credential_storage: None,
-            origin: SourceOrigin::Bundled,
-        }
-    }
-
     #[tokio::test]
     async fn load_query_sources_fails_closed_for_missing_workspace() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
@@ -1101,37 +1046,6 @@ mod tests {
                 panic!("expected app error for missing workspace, got {error}");
             }
         }
-    }
-
-    #[test]
-    fn function_validation_source_names_uses_sql_and_publish_schemas() {
-        let sources = vec![installed_source("github"), installed_source("codex")];
-        let function = r"/*
-name: codex_validation_smoke
-schema: functions
-*/
-
-select session_file from codex.events limit 1
-";
-
-        let names = function_validation_source_names(function, &sources).expect("source names");
-
-        assert_eq!(
-            names,
-            BTreeSet::from([SourceName::parse("codex").expect("source name")])
-        );
-
-        let source_schema_function = function.replace("schema: functions", "schema: github");
-        let names = function_validation_source_names(&source_schema_function, &sources)
-            .expect("source names");
-
-        assert_eq!(
-            names,
-            BTreeSet::from([
-                SourceName::parse("codex").expect("source name"),
-                SourceName::parse("github").expect("source name"),
-            ])
-        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use coral_engine::{
-    CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, QueryExecution,
+    CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, PreparedQueryRuntime, QueryExecution,
     QueryExecutionProvenance, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
     RuntimeSourcePackage, SourceInputResolver, SourceValidationReport, StatusCode, TableInfo,
     UdfRuntimeDefinition,
@@ -153,17 +153,14 @@ impl QueryManager {
                     .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config_with_udfs(
+                    .prepared_runtime_with_udfs(
                         workspace_name,
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::StoredOnly,
                     )
                     .await?;
-                let sources = query_sources_from_loaded(&loaded_sources);
-                CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
-                    .await
-                    .map_err(QueryManagerError::Core)
+                Ok(runtime.list_tables(schema_filter, table_filter))
             },
             |tables| Some(u64::try_from(tables.len()).unwrap_or(u64::MAX)),
             |_, _| {},
@@ -189,17 +186,14 @@ impl QueryManager {
                     .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config_with_udfs(
+                    .prepared_runtime_with_udfs(
                         workspace_name,
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::StoredOnly,
                     )
                     .await?;
-                let sources = query_sources_from_loaded(&loaded_sources);
-                CoralQuery::list_catalog(&sources, runtime, schema_filter)
-                    .await
-                    .map_err(QueryManagerError::Core)
+                Ok(runtime.list_catalog(schema_filter))
             },
             |catalog| {
                 Some(
@@ -236,17 +230,14 @@ impl QueryManager {
                     .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config_with_udfs(
+                    .prepared_runtime_with_udfs(
                         workspace_name,
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::Refreshing,
                     )
                     .await?;
-                let sources = query_sources_from_loaded(&loaded_sources);
-                CoralQuery::describe_table(&sources, runtime, schema_name, table_name)
-                    .await
-                    .map_err(QueryManagerError::Core)
+                Ok(runtime.describe_table(schema_name, table_name))
             },
             |_| None,
             |_, _| {},
@@ -271,15 +262,15 @@ impl QueryManager {
                     .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config_with_udfs(
+                    .prepared_runtime_with_udfs(
                         workspace_name,
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::Refreshing,
                     )
                     .await?;
-                let sources = query_sources_from_loaded(&loaded_sources);
-                CoralQuery::execute_sql(&sources, runtime, sql)
+                runtime
+                    .execute_sql(sql)
                     .await
                     .map_err(QueryManagerError::Core)
             },
@@ -306,15 +297,15 @@ impl QueryManager {
                     .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config_with_udfs(
+                    .prepared_runtime_with_udfs(
                         workspace_name,
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::Refreshing,
                     )
                     .await?;
-                let sources = query_sources_from_loaded(&loaded_sources);
-                CoralQuery::explain_sql(&sources, runtime, sql)
+                runtime
+                    .explain_sql(sql)
                     .await
                     .map_err(QueryManagerError::Core)
             },
@@ -658,14 +649,14 @@ impl QueryManager {
             .map_err(QueryManagerError::App)
     }
 
-    async fn runtime_config_with_udfs(
+    async fn prepared_runtime_with_udfs(
         &self,
         workspace_name: &WorkspaceName,
         selected_sources: &[LoadedQuerySource],
         config: &AppConfig,
         credential_resolution_mode: CredentialResolutionMode,
-    ) -> Result<QueryRuntimeConfig, QueryManagerError> {
-        let runtime = self
+    ) -> Result<PreparedQueryRuntime, QueryManagerError> {
+        let runtime_config = self
             .runtime_config_with_credential_mode(
                 workspace_name,
                 selected_sources,
@@ -674,19 +665,18 @@ impl QueryManager {
             )
             .map_err(QueryManagerError::App)?;
         let query_sources = query_sources_from_loaded(selected_sources);
+        let runtime = CoralQuery::prepare(&query_sources, runtime_config)
+            .await
+            .map_err(QueryManagerError::Core)?;
         let functions = self
             .function_manager
-            .load_runtime_udfs(workspace_name, &query_sources, || {
-                self.runtime_config_with_credential_mode(
-                    workspace_name,
-                    selected_sources,
-                    config,
-                    credential_resolution_mode,
-                )
-            })
+            .load_runtime_udfs(workspace_name, &query_sources, &runtime)
             .await
             .map_err(QueryManagerError::App)?;
-        Ok(runtime.with_udfs(functions))
+        runtime
+            .with_udfs(functions)
+            .await
+            .map_err(QueryManagerError::Core)
     }
 }
 
@@ -967,8 +957,8 @@ mod tests {
 
     use coral_engine::{
         EngineExtensions, QueryExecution, QueryExecutionProvenance, QueryTableFunctionUsage,
-        QueryTableUsage, SourceInputResolutionContext, SourceInputResolver,
-        SourceInputResolverError,
+        QueryTableUsage, SourceDecorator, SourceDecoratorError, SourceInputResolutionContext,
+        SourceInputResolver, SourceInputResolverError, SourceTables,
     };
     use coral_spec::parse_source_manifest_yaml;
     use serde_json::{Value, json};
@@ -2014,6 +2004,89 @@ select 1 as value
             panic!("function should be invalid while source preparation is unavailable");
         };
         assert!(error.contains("configured for keychain storage"));
+    }
+
+    struct PrepareCountingDecorator {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl SourceDecorator for PrepareCountingDecorator {
+        fn name(&self) -> &'static str {
+            "prepare-counter"
+        }
+
+        fn prepare(
+            &mut self,
+            _selected_sources: &[QuerySource],
+        ) -> Result<(), SourceDecoratorError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn decorate_source(
+            &mut self,
+            _source: &QuerySource,
+            tables: SourceTables,
+        ) -> Result<SourceTables, SourceDecoratorError> {
+            Ok(tables)
+        }
+    }
+
+    struct PrepareCountingExtensionsProvider {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl EngineExtensionsProvider for PrepareCountingExtensionsProvider {
+        fn extensions_for(&self, _selected_sources: &[QuerySource]) -> EngineExtensions {
+            let mut extensions = EngineExtensions::default();
+            extensions
+                .source_decorators
+                .push(Box::new(PrepareCountingDecorator {
+                    calls: Arc::clone(&self.calls),
+                }));
+            extensions
+        }
+    }
+
+    #[tokio::test]
+    async fn function_enabled_query_prepares_source_decorators_once() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let provider = Arc::new(PrepareCountingExtensionsProvider {
+            calls: Arc::clone(&calls),
+        });
+        let fixture = query_manager_with(QueryRuntimeContext::default(), vec![provider]).await;
+        let workspace_name = WorkspaceName::default();
+        let function_sql = r"/*
+name: constant_value
+schema: functions
+description: Returns a constant value
+*/
+
+select 1 as value
+";
+        let validated = fixture
+            .manager
+            .validate_udf_sql(&workspace_name, function_sql)
+            .await
+            .expect("validate constant function");
+        fixture
+            .manager
+            .function_manager
+            .install_validated_user_function(&workspace_name, function_sql, &validated)
+            .expect("install constant function");
+        calls.store(0, Ordering::SeqCst);
+
+        fixture
+            .manager
+            .execute_sql(
+                &workspace_name,
+                "select value from functions.constant_value()",
+                &QueryAttribution::default(),
+            )
+            .await
+            .expect("execute constant function");
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[derive(Debug)]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -35,7 +35,7 @@ use crate::sources::runtime_package::runtime_components_for_v4_source;
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::task::id::TaskId;
 use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
-use crate::workspaces::{WorkspaceManager, WorkspaceName};
+use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceManager, WorkspaceName};
 
 #[derive(Debug)]
 pub(crate) enum QueryManagerError {
@@ -73,7 +73,8 @@ pub(crate) struct QueryManager {
 }
 
 impl QueryManager {
-    pub(crate) fn new(
+    #[cfg(test)]
+    pub(crate) fn new_for_tests(
         config_store: ConfigStore,
         workspace_manager: WorkspaceManager,
         credential_manager: CredentialManager,
@@ -81,7 +82,27 @@ impl QueryManager {
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
-        let function_manager = FunctionManager::new(config_store.clone(), &layout);
+        Self::new(
+            config_store,
+            workspace_manager,
+            credential_manager,
+            runtime_context,
+            layout,
+            WorkspaceLifecycleLock::default(),
+            engine_extensions_providers,
+        )
+    }
+
+    pub(crate) fn new(
+        config_store: ConfigStore,
+        workspace_manager: WorkspaceManager,
+        credential_manager: CredentialManager,
+        runtime_context: QueryRuntimeContext,
+        layout: AppStateLayout,
+        lifecycle_lock: WorkspaceLifecycleLock,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    ) -> Self {
+        let function_manager = FunctionManager::new(config_store.clone(), &layout, lifecycle_lock);
         Self::with_function_manager(
             config_store,
             workspace_manager,
@@ -974,7 +995,7 @@ mod tests {
             None,
             Arc::clone(&db),
         );
-        let manager = QueryManager::new(
+        let manager = QueryManager::new_for_tests(
             config_store,
             workspace_manager,
             credential_manager,
@@ -1903,7 +1924,7 @@ surfaces:
             None,
             Arc::clone(&db),
         );
-        let manager = QueryManager::new(
+        let manager = QueryManager::new_for_tests(
             config_store,
             workspace_manager,
             credential_manager,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -586,10 +586,20 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<FunctionListing>, QueryManagerError> {
-        let (loaded_sources, config) = self
-            .load_query_sources(workspace_name)
-            .await
-            .map_err(QueryManagerError::App)?;
+        let (loaded_sources, config) = match self.load_query_sources(workspace_name).await {
+            Ok(loaded) => loaded,
+            Err(
+                error @ (AppError::Credentials(CredentialsError::Unavailable(_))
+                | AppError::MissingOrIncompatibleV4Materialization { .. }
+                | AppError::InvalidV4ProjectionOverride { .. }),
+            ) => {
+                return self
+                    .function_manager
+                    .list_functions_with_preparation_failure(workspace_name, &error)
+                    .map_err(QueryManagerError::App);
+            }
+            Err(error) => return Err(QueryManagerError::App(error)),
+        };
         let sources = query_sources_from_loaded(&loaded_sources);
         self.function_manager
             .list_functions(workspace_name, &sources, || {
@@ -1007,6 +1017,55 @@ mod tests {
             _temp: temp,
             manager,
         }
+    }
+
+    async fn query_manager_with_unavailable_keychain() -> QueryManagerFixture {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let db = test_db(&layout, &config_store).await;
+        let credential_store = CredentialStore::with_unavailable_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::Keychain,
+        );
+        let credential_manager = CredentialManager::new(credential_store);
+        let workspace_manager = WorkspaceManager::new_for_tests(
+            config_store.clone(),
+            credential_manager.clone(),
+            layout.clone(),
+            None,
+            Arc::clone(&db),
+        );
+        let manager = QueryManager::new_for_tests(
+            config_store,
+            workspace_manager,
+            credential_manager,
+            QueryRuntimeContext::default(),
+            layout,
+            Vec::new(),
+        );
+        QueryManagerFixture {
+            _temp: temp,
+            manager,
+        }
+    }
+
+    fn install_keychain_github_source(config_store: &ConfigStore, workspace_name: &WorkspaceName) {
+        config_store
+            .upsert_source(
+                workspace_name,
+                InstalledSource {
+                    name: SourceName::parse("github").expect("source name"),
+                    version: None,
+                    variables: BTreeMap::new(),
+                    secrets: vec!["GITHUB_TOKEN".to_string()],
+                    credential_storage: Some(CredentialStorageKind::Keychain),
+                    origin: SourceOrigin::Bundled,
+                },
+            )
+            .expect("persist source");
     }
 
     async fn test_db(layout: &AppStateLayout, config_store: &ConfigStore) -> Arc<CoralDb> {
@@ -1891,48 +1950,12 @@ surfaces:
 
     #[tokio::test]
     async fn load_query_sources_fails_closed_for_unavailable_keychain_source() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        layout.ensure().expect("ensure layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let db = test_db(&layout, &config_store).await;
+        let fixture = query_manager_with_unavailable_keychain().await;
         let workspace_name = WorkspaceName::default();
-        let source_name = SourceName::parse("github").expect("source name");
-        config_store
-            .upsert_source(
-                &workspace_name,
-                InstalledSource {
-                    name: source_name,
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: vec!["GITHUB_TOKEN".to_string()],
-                    credential_storage: Some(CredentialStorageKind::Keychain),
-                    origin: SourceOrigin::Bundled,
-                },
-            )
-            .expect("persist source");
-        let credential_store = CredentialStore::with_unavailable_keychain_for_test(
-            layout.clone(),
-            CredentialStoragePreference::Keychain,
-        );
-        let credential_manager = CredentialManager::new(credential_store);
-        let workspace_manager = WorkspaceManager::new_for_tests(
-            config_store.clone(),
-            credential_manager.clone(),
-            layout.clone(),
-            None,
-            Arc::clone(&db),
-        );
-        let manager = QueryManager::new_for_tests(
-            config_store,
-            workspace_manager,
-            credential_manager,
-            QueryRuntimeContext::default(),
-            layout,
-            Vec::new(),
-        );
-        let error = manager
+        install_keychain_github_source(&fixture.manager.config_store, &workspace_name);
+
+        let error = fixture
+            .manager
             .load_query_sources(&workspace_name)
             .await
             .expect_err("unavailable keychain should fail closed");
@@ -1950,6 +1973,47 @@ surfaces:
                 .contains("configured for keychain storage"),
             "keychain-routed query failure should name the routed backend: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn list_functions_keeps_inventory_visible_when_source_preparation_fails() {
+        let fixture = query_manager_with_unavailable_keychain().await;
+        let workspace_name = WorkspaceName::default();
+        let function_sql = r"/*
+name: constant_value
+schema: functions
+description: Returns a constant value
+*/
+
+select 1 as value
+";
+        let validated = fixture
+            .manager
+            .validate_udf_sql(&workspace_name, function_sql)
+            .await
+            .expect("validate constant function before source failure");
+        fixture
+            .manager
+            .function_manager
+            .install_validated_user_function(&workspace_name, function_sql, &validated)
+            .expect("install constant function");
+        install_keychain_github_source(&fixture.manager.config_store, &workspace_name);
+
+        let functions = fixture
+            .manager
+            .list_functions(&workspace_name)
+            .await
+            .expect("source preparation failure should not hide function inventory");
+
+        let function = functions
+            .first()
+            .expect("installed function remains visible");
+        assert_eq!(function.name.as_str(), "constant_value");
+        let crate::functions::manager::FunctionRuntimeStatus::Invalid(error) = &function.runtime
+        else {
+            panic!("function should be invalid while source preparation is unavailable");
+        };
+        assert!(error.contains("configured for keychain storage"));
     }
 
     #[derive(Debug)]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1681,6 +1681,10 @@ pagination:
     }
 
     #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "covers function validation, catalog publication, listing, and execution together"
+    )]
     async fn user_function_publishes_table_function_and_executes_against_installed_source() {
         let fake_home = tempfile::tempdir().expect("fake home");
         let data_dir = fake_home.path().join("fixture-data");
@@ -1786,6 +1790,8 @@ where type = $kind
         let function = functions.first().expect("function");
         let column = function
             .definition
+            .as_ref()
+            .expect("runtime-ready function")
             .result_columns
             .first()
             .expect("text result column");

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1788,10 +1788,11 @@ where type = $kind
             .expect("functions");
         assert_eq!(functions.len(), 1);
         let function = functions.first().expect("function");
-        let column = function
-            .definition
-            .as_ref()
-            .expect("runtime-ready function")
+        let crate::functions::manager::FunctionRuntimeStatus::Ready(definition) = &function.runtime
+        else {
+            panic!("function should be runtime-ready");
+        };
+        let column = definition
             .result_columns
             .first()
             .expect("text result column");

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1,6 +1,6 @@
 //! Query-time loading, validation, and execution over installed sources.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
@@ -9,8 +9,9 @@ use coral_engine::{
     CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, QueryExecution,
     QueryExecutionProvenance, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
     RuntimeSourcePackage, SourceInputResolver, SourceValidationReport, StatusCode, TableInfo,
+    UdfRuntimeDefinition,
 };
-use coral_spec::{ManifestInputKind, ManifestInputSpec};
+use coral_spec::{ManifestInputKind, ManifestInputSpec, parse_function_sql};
 use opentelemetry::trace::Status as OtelStatus;
 use serde_json::json;
 use tracing::Instrument as _;
@@ -18,6 +19,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
+use crate::functions::manager::{FunctionListing, FunctionManager};
 use crate::query::QueryAttribution;
 use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_providers};
 use crate::query::input_resolver::{
@@ -64,6 +66,7 @@ pub(crate) struct QueryManager {
     config_store: ConfigStore,
     workspace_manager: Arc<WorkspaceManager>,
     credential_manager: CredentialManager,
+    function_manager: FunctionManager,
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
@@ -78,10 +81,32 @@ impl QueryManager {
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
+        let function_manager = FunctionManager::new(config_store.clone(), &layout);
+        Self::with_function_manager(
+            config_store,
+            workspace_manager,
+            credential_manager,
+            function_manager,
+            runtime_context,
+            layout,
+            engine_extensions_providers,
+        )
+    }
+
+    pub(crate) fn with_function_manager(
+        config_store: ConfigStore,
+        workspace_manager: WorkspaceManager,
+        credential_manager: CredentialManager,
+        function_manager: FunctionManager,
+        runtime_context: QueryRuntimeContext,
+        layout: AppStateLayout,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    ) -> Self {
         Self {
             config_store,
             workspace_manager: Arc::new(workspace_manager),
             credential_manager,
+            function_manager,
             runtime_context,
             layout,
             engine_extensions_providers,
@@ -107,13 +132,13 @@ impl QueryManager {
                     .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config_with_credential_mode(
+                    .runtime_config_with_udfs(
                         workspace_name,
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::StoredOnly,
                     )
-                    .map_err(QueryManagerError::App)?;
+                    .await?;
                 let sources = query_sources_from_loaded(&loaded_sources);
                 CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
                     .await
@@ -143,13 +168,13 @@ impl QueryManager {
                     .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config_with_credential_mode(
+                    .runtime_config_with_udfs(
                         workspace_name,
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::StoredOnly,
                     )
-                    .map_err(QueryManagerError::App)?;
+                    .await?;
                 let sources = query_sources_from_loaded(&loaded_sources);
                 CoralQuery::list_catalog(&sources, runtime, schema_filter)
                     .await
@@ -190,8 +215,13 @@ impl QueryManager {
                     .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &loaded_sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                    .runtime_config_with_udfs(
+                        workspace_name,
+                        &loaded_sources,
+                        &config,
+                        CredentialResolutionMode::Refreshing,
+                    )
+                    .await?;
                 let sources = query_sources_from_loaded(&loaded_sources);
                 CoralQuery::describe_table(&sources, runtime, schema_name, table_name)
                     .await
@@ -220,8 +250,13 @@ impl QueryManager {
                     .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &loaded_sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                    .runtime_config_with_udfs(
+                        workspace_name,
+                        &loaded_sources,
+                        &config,
+                        CredentialResolutionMode::Refreshing,
+                    )
+                    .await?;
                 let sources = query_sources_from_loaded(&loaded_sources);
                 CoralQuery::execute_sql(&sources, runtime, sql)
                     .await
@@ -250,8 +285,13 @@ impl QueryManager {
                     .await
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
-                    .runtime_config(workspace_name, &loaded_sources, &config)
-                    .map_err(QueryManagerError::App)?;
+                    .runtime_config_with_udfs(
+                        workspace_name,
+                        &loaded_sources,
+                        &config,
+                        CredentialResolutionMode::Refreshing,
+                    )
+                    .await?;
                 let sources = query_sources_from_loaded(&loaded_sources);
                 CoralQuery::explain_sql(&sources, runtime, sql)
                     .await
@@ -513,6 +553,154 @@ impl QueryManager {
         runtime.dependent_join = config.dependent_join_config(&selected_source_names)?;
         Ok(runtime)
     }
+
+    pub(crate) async fn list_functions(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<FunctionListing>, QueryManagerError> {
+        let (loaded_sources, config) = self
+            .load_query_sources(workspace_name)
+            .await
+            .map_err(QueryManagerError::App)?;
+        let sources = query_sources_from_loaded(&loaded_sources);
+        self.function_manager
+            .list_functions(workspace_name, &sources, || {
+                self.runtime_config(workspace_name, &loaded_sources, &config)
+            })
+            .await
+            .map_err(QueryManagerError::App)
+    }
+
+    pub(crate) fn function_manager(&self) -> FunctionManager {
+        self.function_manager.clone()
+    }
+
+    pub(crate) async fn validate_udf_sql(
+        &self,
+        workspace_name: &WorkspaceName,
+        raw_sql: &str,
+    ) -> Result<UdfRuntimeDefinition, QueryManagerError> {
+        self.require_workspace(workspace_name)
+            .await
+            .map_err(QueryManagerError::App)?;
+        let (loaded_sources, config) = {
+            let _state_lock = self
+                .config_store
+                .state_lock_shared()
+                .map_err(QueryManagerError::App)?;
+            let config = self
+                .config_store
+                .load_config_unlocked()
+                .map_err(QueryManagerError::App)?;
+            let loaded_sources = self
+                .load_function_validation_sources(workspace_name, &config, raw_sql)
+                .map_err(QueryManagerError::App)?;
+            (loaded_sources, config)
+        };
+        let sources = query_sources_from_loaded(&loaded_sources);
+        self.function_manager
+            .validate_user_function_sql(
+                workspace_name,
+                &sources,
+                || self.runtime_config(workspace_name, &loaded_sources, &config),
+                raw_sql,
+            )
+            .await
+            .map_err(QueryManagerError::App)
+    }
+
+    fn load_function_validation_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+        config: &AppConfig,
+        raw_sql: &str,
+    ) -> Result<Vec<LoadedQuerySource>, AppError> {
+        let workspace_sources = config.workspace_sources(workspace_name);
+        let source_names = function_validation_source_names(raw_sql, &workspace_sources)?;
+        if source_names.is_empty() {
+            return self.load_query_sources_from_config(workspace_name, config);
+        }
+
+        let mut loaded_sources = Vec::new();
+        for source in workspace_sources {
+            if source_names.contains(&source.name) {
+                let (loaded_source, _version) = self.load_query_source(workspace_name, &source)?;
+                loaded_sources.push(loaded_source);
+            }
+        }
+        Ok(loaded_sources)
+    }
+
+    async fn runtime_config_with_udfs(
+        &self,
+        workspace_name: &WorkspaceName,
+        selected_sources: &[LoadedQuerySource],
+        config: &AppConfig,
+        credential_resolution_mode: CredentialResolutionMode,
+    ) -> Result<QueryRuntimeConfig, QueryManagerError> {
+        let runtime = self
+            .runtime_config_with_credential_mode(
+                workspace_name,
+                selected_sources,
+                config,
+                credential_resolution_mode,
+            )
+            .map_err(QueryManagerError::App)?;
+        let query_sources = query_sources_from_loaded(selected_sources);
+        let functions = self
+            .function_manager
+            .load_runtime_udfs(workspace_name, &query_sources, || {
+                self.runtime_config_with_credential_mode(
+                    workspace_name,
+                    selected_sources,
+                    config,
+                    credential_resolution_mode,
+                )
+            })
+            .await
+            .map_err(QueryManagerError::App)?;
+        Ok(runtime.with_udfs(functions))
+    }
+}
+
+fn function_validation_source_names(
+    raw_sql: &str,
+    installed_sources: &[InstalledSource],
+) -> Result<BTreeSet<SourceName>, AppError> {
+    let spec = parse_function_sql(raw_sql)
+        .map_err(|error| AppError::InvalidInput(format!("function validation failed: {error}")))?;
+    let query = spec.implementation().coral_sql.query.to_ascii_lowercase();
+    let mut names = installed_sources
+        .iter()
+        .filter(|source| contains_schema_reference(&query, source.name.as_str()))
+        .map(|source| source.name.clone())
+        .collect::<BTreeSet<_>>();
+
+    let schema = spec.schema();
+    if schema != "functions"
+        && let Some(source) = installed_sources
+            .iter()
+            .find(|source| source.name.as_str() == schema)
+    {
+        names.insert(source.name.clone());
+    }
+
+    Ok(names)
+}
+
+fn contains_schema_reference(query: &str, schema: &str) -> bool {
+    let needle = format!("{schema}.");
+    let bytes = query.as_bytes();
+    query.match_indices(&needle).any(|(index, _)| {
+        index == 0
+            || bytes
+                .get(index.saturating_sub(1))
+                .is_some_and(|byte| !is_sql_identifier_byte(*byte))
+    })
+}
+
+fn is_sql_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 fn query_sources_from_loaded(loaded_sources: &[LoadedQuerySource]) -> Vec<QuerySource> {
@@ -866,6 +1054,17 @@ mod tests {
         }
     }
 
+    fn installed_source(name: &str) -> InstalledSource {
+        InstalledSource {
+            name: SourceName::parse(name).expect("source name"),
+            version: None,
+            variables: BTreeMap::new(),
+            secrets: Vec::new(),
+            credential_storage: None,
+            origin: SourceOrigin::Bundled,
+        }
+    }
+
     #[tokio::test]
     async fn load_query_sources_fails_closed_for_missing_workspace() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
@@ -902,6 +1101,37 @@ mod tests {
                 panic!("expected app error for missing workspace, got {error}");
             }
         }
+    }
+
+    #[test]
+    fn function_validation_source_names_uses_sql_and_publish_schemas() {
+        let sources = vec![installed_source("github"), installed_source("codex")];
+        let function = r"/*
+name: codex_validation_smoke
+schema: functions
+*/
+
+select session_file from codex.events limit 1
+";
+
+        let names = function_validation_source_names(function, &sources).expect("source names");
+
+        assert_eq!(
+            names,
+            BTreeSet::from([SourceName::parse("codex").expect("source name")])
+        );
+
+        let source_schema_function = function.replace("schema: functions", "schema: github");
+        let names = function_validation_source_names(&source_schema_function, &sources)
+            .expect("source names");
+
+        assert_eq!(
+            names,
+            BTreeSet::from([
+                SourceName::parse("codex").expect("source name"),
+                SourceName::parse("github").expect("source name"),
+            ])
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -1534,6 +1764,132 @@ pagination:
                     .expect("query param")
             })
             .collect()
+    }
+
+    #[tokio::test]
+    async fn user_function_publishes_table_function_and_executes_against_installed_source() {
+        let fake_home = tempfile::tempdir().expect("fake home");
+        let data_dir = fake_home.path().join("fixture-data");
+        std::fs::create_dir_all(&data_dir).expect("create data dir");
+        std::fs::write(
+            data_dir.join("messages.jsonl"),
+            r#"{"type":"user","text":"hello"}
+{"type":"assistant","text":"world"}
+"#,
+        )
+        .expect("write fixture");
+
+        let fixture = query_manager_with(
+            QueryRuntimeContext {
+                home_dir: Some(fake_home.path().to_path_buf()),
+                ..QueryRuntimeContext::default()
+            },
+            Vec::new(),
+        )
+        .await;
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let workspace_name = WorkspaceName::default();
+        let source_manager = SourceManager::new_for_tests(
+            fixture.manager.config_store.clone(),
+            fixture.manager.credential_manager.clone(),
+            fixture.manager.layout.clone(),
+        );
+        source_manager
+            .import_source(
+                &workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: r#"
+name: function_demo
+version: 0.1.0
+dsl_version: 3
+backend: file
+tables:
+  - name: messages
+    description: Fixture messages
+    format: jsonl
+    source:
+      location: file://~/fixture-data/
+      glob: "**/*.jsonl"
+    columns:
+      - name: type
+        type: Utf8
+      - name: text
+        type: Utf8
+"#
+                    .to_string(),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect("import source");
+
+        let function_sql = r"/*
+name: messages_by_type
+schema: functions
+description: Messages filtered by sender type
+*/
+
+select text
+from function_demo.messages
+where type = $kind
+";
+        let validated_function = fixture
+            .manager
+            .validate_udf_sql(&workspace_name, function_sql)
+            .await
+            .expect("validate function");
+        fixture
+            .manager
+            .function_manager
+            .install_validated_user_function(&workspace_name, function_sql, &validated_function)
+            .expect("install function");
+
+        let catalog = fixture
+            .manager
+            .list_catalog(
+                &workspace_name,
+                Some("functions"),
+                &QueryAttribution::default(),
+            )
+            .await
+            .expect("catalog");
+        let function_function = catalog.table_functions.first().expect("function function");
+        assert_eq!(function_function.function_name, "messages_by_type");
+        assert_eq!(
+            function_function
+                .result_columns
+                .first()
+                .expect("text result column")
+                .name,
+            "text"
+        );
+
+        let functions = fixture
+            .manager
+            .list_functions(&workspace_name)
+            .await
+            .expect("functions");
+        assert_eq!(functions.len(), 1);
+        let function = functions.first().expect("function");
+        let column = function
+            .definition
+            .result_columns
+            .first()
+            .expect("text result column");
+        assert_eq!(column.name, "text");
+
+        let execution = fixture
+            .manager
+            .execute_sql(
+                &workspace_name,
+                "select text from functions.messages_by_type(kind => 'user')",
+                &QueryAttribution::default(),
+            )
+            .await
+            .expect("function query");
+        assert_eq!(
+            execution_to_rows(&execution),
+            vec![json!({"text": "hello"})]
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -185,8 +185,9 @@ impl SourceServiceApi for SourceService {
                 bindings: source_bindings_from_proto(request.variables, request.secrets),
             };
             let response_workspace_name = workspace_name.clone();
+            let install_workspace_name = workspace_name.clone();
             let installed = run_blocking_source_operation(move || {
-                sources.create_bundled_source(&workspace_name, &command)
+                sources.create_bundled_source(&install_workspace_name, &command)
             })
             .await?;
             Ok(Response::new(CreateBundledSourceResponse {
@@ -224,14 +225,15 @@ impl SourceServiceApi for SourceService {
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
-                        sources
+                        let installed = sources
                             .create_bundled_source_with_oauth(
                                 &workspace_name,
                                 command,
                                 event_sender,
                             )
                             .await
-                            .map_err(app_status)
+                            .map_err(app_status)?;
+                        Ok(installed)
                     })
                 });
             Ok(Response::new(Box::pin(stream.map(|response| {

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -185,9 +185,8 @@ impl SourceServiceApi for SourceService {
                 bindings: source_bindings_from_proto(request.variables, request.secrets),
             };
             let response_workspace_name = workspace_name.clone();
-            let install_workspace_name = workspace_name.clone();
             let installed = run_blocking_source_operation(move || {
-                sources.create_bundled_source(&install_workspace_name, &command)
+                sources.create_bundled_source(&workspace_name, &command)
             })
             .await?;
             Ok(Response::new(CreateBundledSourceResponse {
@@ -225,15 +224,14 @@ impl SourceServiceApi for SourceService {
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
-                        let installed = sources
+                        sources
                             .create_bundled_source_with_oauth(
                                 &workspace_name,
                                 command,
                                 event_sender,
                             )
                             .await
-                            .map_err(app_status)?;
-                        Ok(installed)
+                            .map_err(app_status)
                     })
                 });
             Ok(Response::new(Box::pin(stream.map(|response| {

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -727,13 +727,6 @@ impl ConfigStore {
     ///
     /// Callers must already hold the state lock while using function artifacts
     /// associated with the returned inventory.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "function runtime loading consumes inventory in the next stack branch"
-        )
-    )]
     pub(crate) fn list_workspace_functions_unlocked(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -83,7 +83,146 @@ pub use contracts::{
 /// High-level query operations for the local query engine.
 pub struct CoralQuery;
 
+/// One request-scoped query runtime with its sources already registered.
+///
+/// The runtime can infer and install UDFs without rebuilding its underlying
+/// `DataFusion` session. Its internals remain engine-owned.
+pub struct PreparedQueryRuntime {
+    inner: runtime::query::QueryRuntimeAdapter,
+}
+
+impl PreparedQueryRuntime {
+    /// Lists queryable tables from this prepared runtime.
+    #[must_use]
+    pub fn list_tables(
+        &self,
+        schema_filter: Option<&str>,
+        table_filter: Option<&str>,
+    ) -> Vec<TableInfo> {
+        self.inner.list_tables(schema_filter, table_filter)
+    }
+
+    /// Lists queryable catalog metadata from this prepared runtime.
+    #[must_use]
+    pub fn list_catalog(&self, schema_filter: Option<&str>) -> CatalogInfo {
+        self.inner.catalog_info(schema_filter)
+    }
+
+    /// Describes one table from this prepared runtime.
+    #[must_use]
+    pub fn describe_table(&self, schema_name: &str, table_name: &str) -> DescribeTableInfo {
+        self.inner.describe_table(schema_name, table_name)
+    }
+
+    /// Infers typed signatures for multiple UDFs against this runtime.
+    ///
+    /// The outer result reports runtime failures. Each inner result reports
+    /// validation for the UDF at the same input position.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if a UDF cannot be planned against the prepared
+    /// source runtime.
+    pub async fn infer_udf_signatures(
+        &self,
+        udfs: Vec<UdfRuntimeSqlDefinition>,
+    ) -> Result<Vec<Result<UdfRuntimeSignature, CoreError>>, CoreError> {
+        let mut results = Vec::with_capacity(udfs.len());
+        for udf in udfs {
+            if udf.sql().trim().is_empty() {
+                results.push(Err(CoreError::InvalidInput(format!(
+                    "udf '{}' SQL body cannot be empty",
+                    udf.name
+                ))));
+                continue;
+            }
+            results.push(runtime::udfs::infer_udf_signature(&self.inner, &udf).await);
+        }
+        Ok(results)
+    }
+
+    /// Installs validated UDFs into this prepared runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if UDF publication conflicts with the prepared
+    /// catalog or a UDF body cannot be planned.
+    pub async fn with_udfs(mut self, udfs: Vec<UdfRuntimeDefinition>) -> Result<Self, CoreError> {
+        self.inner.install_udfs(udfs).await?;
+        Ok(self)
+    }
+
+    /// Executes one `SQL` statement over this prepared runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the SQL is empty or cannot be executed.
+    pub async fn execute_sql(&self, sql: &str) -> Result<QueryExecution, CoreError> {
+        self.execute_sql_with_params(sql, QueryParameters::new())
+            .await
+    }
+
+    /// Executes one parameterized `SQL` statement over this prepared runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the SQL is empty, parameter binding fails, or
+    /// the statement cannot be executed.
+    pub async fn execute_sql_with_params(
+        &self,
+        sql: &str,
+        params: QueryParameters,
+    ) -> Result<QueryExecution, CoreError> {
+        if sql.trim().is_empty() {
+            return Err(CoreError::InvalidInput("SQL must not be empty".to_string()));
+        }
+        self.inner.execute_sql(sql, &params).await
+    }
+
+    /// Explains one `SQL` statement against this prepared runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the SQL is empty or cannot be planned.
+    pub async fn explain_sql(&self, sql: &str) -> Result<QueryPlan, CoreError> {
+        self.explain_sql_with_params(sql, QueryParameters::new())
+            .await
+    }
+
+    /// Explains one parameterized `SQL` statement against this runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the SQL is empty, parameter binding fails, or
+    /// the statement cannot be planned.
+    pub async fn explain_sql_with_params(
+        &self,
+        sql: &str,
+        params: QueryParameters,
+    ) -> Result<QueryPlan, CoreError> {
+        if sql.trim().is_empty() {
+            return Err(CoreError::InvalidInput("SQL must not be empty".to_string()));
+        }
+        self.inner.explain_sql(sql, &params).await
+    }
+}
+
 impl CoralQuery {
+    /// Builds one request-scoped runtime from the selected sources.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if source compilation, registration, or runtime
+    /// construction fails.
+    pub async fn prepare(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+    ) -> Result<PreparedQueryRuntime, CoreError> {
+        Ok(PreparedQueryRuntime {
+            inner: runtime::query::build_runtime(sources, runtime).await?,
+        })
+    }
+
     /// Lists queryable tables from the provided source set.
     ///
     /// When `schema_filter` is present, only tables for that visible `SQL`
@@ -100,7 +239,7 @@ impl CoralQuery {
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, CoreError> {
-        Ok(runtime::query::build_runtime(sources, runtime)
+        Ok(Self::prepare(sources, runtime)
             .await?
             .list_tables(schema_filter, table_filter))
     }
@@ -122,9 +261,9 @@ impl CoralQuery {
         runtime: QueryRuntimeConfig,
         schema_filter: Option<&str>,
     ) -> Result<CatalogInfo, CoreError> {
-        Ok(runtime::query::build_runtime(sources, runtime)
+        Ok(Self::prepare(sources, runtime)
             .await?
-            .catalog_info(schema_filter))
+            .list_catalog(schema_filter))
     }
 
     /// Describes one table or returns lightweight table metadata for missing-table help.
@@ -143,7 +282,7 @@ impl CoralQuery {
         schema_name: &str,
         table_name: &str,
     ) -> Result<DescribeTableInfo, CoreError> {
-        Ok(runtime::query::build_runtime(sources, runtime)
+        Ok(Self::prepare(sources, runtime)
             .await?
             .describe_table(schema_name, table_name))
     }
@@ -180,9 +319,9 @@ impl CoralQuery {
             return Err(CoreError::InvalidInput("SQL must not be empty".to_string()));
         }
 
-        runtime::query::build_runtime(sources, runtime)
+        Self::prepare(sources, runtime)
             .await?
-            .execute_sql(sql, &params)
+            .execute_sql_with_params(sql, params)
             .await
     }
 
@@ -221,19 +360,10 @@ impl CoralQuery {
             return Ok(Vec::new());
         }
 
-        let query_runtime = runtime::query::build_runtime(sources, runtime).await?;
-        let mut results = Vec::with_capacity(udfs.len());
-        for udf in udfs {
-            if udf.sql().trim().is_empty() {
-                results.push(Err(CoreError::InvalidInput(format!(
-                    "udf '{}' SQL body cannot be empty",
-                    udf.name
-                ))));
-                continue;
-            }
-            results.push(runtime::udfs::infer_udf_signature(&query_runtime, &udf).await);
-        }
-        Ok(results)
+        Self::prepare(sources, runtime)
+            .await?
+            .infer_udf_signatures(udfs)
+            .await
     }
 
     /// Explains one `SQL` statement with logical and physical plan renderings.
@@ -271,9 +401,9 @@ impl CoralQuery {
             return Err(CoreError::InvalidInput("SQL must not be empty".to_string()));
         }
 
-        runtime::query::build_runtime(sources, runtime)
+        Self::prepare(sources, runtime)
             .await?
-            .explain_sql(sql, &params)
+            .explain_sql_with_params(sql, params)
             .await
     }
 

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -198,14 +198,42 @@ impl CoralQuery {
         runtime: QueryRuntimeConfig,
         udf: UdfRuntimeSqlDefinition,
     ) -> Result<UdfRuntimeSignature, CoreError> {
-        if udf.sql().trim().is_empty() {
-            return Err(CoreError::InvalidInput(format!(
-                "udf '{}' SQL body cannot be empty",
-                udf.name
-            )));
+        let mut results = Self::infer_udf_signatures(sources, runtime, vec![udf]).await?;
+        results.pop().ok_or_else(|| {
+            CoreError::InvalidInput("UDF signature inference returned no result".to_string())
+        })?
+    }
+
+    /// Infers typed signatures for multiple UDFs through one source runtime.
+    ///
+    /// The outer result reports source runtime construction failures. Each
+    /// inner result reports validation for the UDF at the same input position.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the shared source runtime cannot be built.
+    pub async fn infer_udf_signatures(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+        udfs: Vec<UdfRuntimeSqlDefinition>,
+    ) -> Result<Vec<Result<UdfRuntimeSignature, CoreError>>, CoreError> {
+        if udfs.is_empty() {
+            return Ok(Vec::new());
         }
+
         let query_runtime = runtime::query::build_runtime(sources, runtime).await?;
-        runtime::udfs::infer_udf_signature(&query_runtime, &udf).await
+        let mut results = Vec::with_capacity(udfs.len());
+        for udf in udfs {
+            if udf.sql().trim().is_empty() {
+                results.push(Err(CoreError::InvalidInput(format!(
+                    "udf '{}' SQL body cannot be empty",
+                    udf.name
+                ))));
+                continue;
+            }
+            results.push(runtime::udfs::infer_udf_signature(&query_runtime, &udf).await);
+        }
+        Ok(results)
     }
 
     /// Explains one `SQL` statement with logical and physical plan renderings.

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -19,8 +19,8 @@ use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
 use tokio::sync::OnceCell;
 use tracing::{Instrument as _, info_span};
 
-use crate::backends::compile_query_source;
 use crate::backends::http::ProviderQueryError;
+use crate::backends::{RegisteredSource, compile_query_source};
 use crate::runtime::catalog;
 use crate::runtime::dependent_join::error::resolver_rows_exceeded;
 use crate::runtime::dependent_join::optimizer;
@@ -55,6 +55,9 @@ pub(crate) struct QueryRuntimeAdapter {
     ctx: Arc<SessionContext>,
     fallback_runtime: Option<FallbackRuntime>,
     memory: QueryMemoryConfig,
+    active_sources: Vec<RegisteredSource>,
+    source_function_names: HashSet<ScopedTableFunctionName>,
+    udfs_installed: bool,
     tables: Vec<TableInfo>,
     table_functions: Vec<TableFunctionInfo>,
     failures: Vec<SourceRegistrationFailure>,
@@ -86,6 +89,8 @@ struct FallbackRuntimeConfig {
 
 struct RegisteredRuntime {
     ctx: Arc<SessionContext>,
+    active_sources: Vec<RegisteredSource>,
+    source_function_names: HashSet<ScopedTableFunctionName>,
     tables: Vec<TableInfo>,
     table_functions: Vec<TableFunctionInfo>,
     failures: Vec<SourceRegistrationFailure>,
@@ -129,6 +134,7 @@ async fn build_runtime_inner(
     } = runtime;
     let request_authenticators = extensions.request_authenticators.clone();
     let source_input_resolver = extensions.source_input_resolver.clone();
+    let udfs_installed = !udfs.is_empty();
     // Resolver-row overflow can retry without the dependent-join optimizer only
     // when runtime registration is replayable. Source decorators are mutable
     // one-shot registration hooks today, so decorated runtimes keep resolver-row
@@ -164,6 +170,9 @@ async fn build_runtime_inner(
         ctx: primary.ctx,
         fallback_runtime,
         memory,
+        active_sources: primary.active_sources,
+        source_function_names: primary.source_function_names,
+        udfs_installed,
         tables: primary.tables,
         table_functions: primary.table_functions,
         failures: primary.failures,
@@ -202,7 +211,7 @@ async fn build_registered_runtime(
     install_table_function_call_planners(
         &ctx,
         source_functions,
-        source_function_names,
+        source_function_names.clone(),
         config.udfs,
         &tables,
     )
@@ -217,6 +226,8 @@ async fn build_registered_runtime(
 
     Ok(RegisteredRuntime {
         ctx,
+        active_sources: registration.active_sources,
+        source_function_names,
         tables,
         table_functions,
         failures: registration.failures,
@@ -350,6 +361,53 @@ async fn register_runtime_sources(
 }
 
 impl QueryRuntimeAdapter {
+    pub(crate) async fn install_udfs(
+        &mut self,
+        udfs: Vec<UdfRuntimeDefinition>,
+    ) -> Result<(), CoreError> {
+        if udfs.is_empty() {
+            return Ok(());
+        }
+        if self.udfs_installed {
+            return Err(CoreError::FailedPrecondition(
+                "query runtime already has installed UDFs".to_string(),
+            ));
+        }
+        if self
+            .fallback_runtime
+            .as_ref()
+            .is_some_and(FallbackRuntime::is_built)
+        {
+            return Err(CoreError::FailedPrecondition(
+                "cannot install UDFs after query execution has initialized the fallback runtime"
+                    .to_string(),
+            ));
+        }
+
+        let udf_table_functions = published_table_functions(&udfs, &self.source_function_names)
+            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+        let udf_calls = Box::pin(UdfCallRegistry::new(
+            &self.ctx,
+            &udfs,
+            self.source_function_names.clone(),
+        ))
+        .await
+        .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+        catalog::register(&self.ctx, &self.active_sources, &udf_table_functions)
+            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+        udf_calls
+            .install(&self.ctx)
+            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+
+        self.table_functions =
+            catalog::collect_table_functions(&self.active_sources, &udf_table_functions);
+        if let Some(fallback_runtime) = &mut self.fallback_runtime {
+            fallback_runtime.config.udfs = udfs;
+        }
+        self.udfs_installed = true;
+        Ok(())
+    }
+
     pub(crate) fn list_tables(
         &self,
         source_filter: Option<&str>,
@@ -1080,6 +1138,10 @@ impl FallbackRuntime {
             .get_or_try_init(|| async { self.config.build_without_dependent_join().await })
             .await
     }
+
+    fn is_built(&self) -> bool {
+        self.runtime.get().is_some()
+    }
 }
 
 pub(crate) fn read_only_sql_options() -> SQLOptions {
@@ -1140,6 +1202,8 @@ mod tests {
     use super::*;
     use crate::{
         ColumnInfo, DependentJoinConfig, MemorySize, QueryMemoryConfig, QueryRuntimeContext,
+        UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn,
+        UdfRuntimeTableFunctionPublish,
     };
 
     fn adapter_with_table() -> QueryRuntimeAdapter {
@@ -1147,6 +1211,9 @@ mod tests {
             ctx: Arc::new(SessionContext::new()),
             fallback_runtime: None,
             memory: QueryMemoryConfig::default(),
+            active_sources: Vec::new(),
+            source_function_names: HashSet::new(),
+            udfs_installed: false,
             tables: vec![TableInfo {
                 schema_name: "demo".to_string(),
                 table_name: "events".to_string(),
@@ -1249,6 +1316,60 @@ mod tests {
         assert!(
             error.to_string().contains("Resources exhausted"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn late_udf_install_is_retained_by_fallback_runtime() {
+        let mut runtime = build_runtime(&[], QueryRuntimeConfig::default())
+            .await
+            .expect("primary runtime");
+        runtime
+            .install_udfs(vec![UdfRuntimeDefinition {
+                name: "constant_value".to_string(),
+                description: "Returns one value".to_string(),
+                arguments: Vec::new(),
+                implementation: UdfRuntimeImplementation::CoralSql {
+                    query: "select 1 as value".to_string(),
+                },
+                publish: UdfRuntimePublish {
+                    table_function: UdfRuntimeTableFunctionPublish {
+                        schema: "functions".to_string(),
+                        name: "constant_value".to_string(),
+                        description: "Returns one value".to_string(),
+                    },
+                },
+                result_columns: vec![UdfRuntimeResultColumn {
+                    name: "value".to_string(),
+                    data_type: DataType::Int64,
+                    nullable: false,
+                }],
+            }])
+            .await
+            .expect("late UDF install");
+
+        let fallback = runtime
+            .fallback_runtime
+            .as_ref()
+            .expect("dependent join fallback")
+            .get_or_build_without_dependent_join()
+            .await
+            .expect("fallback runtime");
+        let batches = fallback
+            .ctx
+            .sql("select value from functions.constant_value()")
+            .await
+            .expect("plan fallback UDF query")
+            .collect()
+            .await
+            .expect("execute fallback UDF query");
+
+        assert_eq!(
+            batches
+                .iter()
+                .map(arrow::array::RecordBatch::num_rows)
+                .sum::<usize>(),
+            1
         );
     }
 }

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -654,15 +654,17 @@ async fn published_udf_table_function_coerces_arguments_in_the_expanded_body() {
         publish: udf_publish("format_id"),
         result_columns: vec![udf_result_column("formatted_id", DataType::Utf8View)],
     };
-    let runtime = test_runtime().with_udfs(vec![udf]);
+    let runtime = CoralQuery::prepare(&[], test_runtime())
+        .await
+        .expect("prepare source runtime")
+        .with_udfs(vec![udf])
+        .await
+        .expect("install UDF after source preparation");
 
-    let execution = CoralQuery::execute_sql(
-        &[],
-        runtime,
-        "select formatted_id from udfs.format_id(id => 42)",
-    )
-    .await
-    .expect("expanded UDF body should receive normal DataFusion type coercion");
+    let execution = runtime
+        .execute_sql("select formatted_id from udfs.format_id(id => 42)")
+        .await
+        .expect("expanded UDF body should receive normal DataFusion type coercion");
 
     let batch = execution
         .batches()
@@ -909,31 +911,35 @@ async fn udf_can_share_source_schema_and_call_source_function_with_params() {
         3.0,
     )
     .await;
-    let runtime = test_runtime().with_udfs(vec![review_queue_udf_published_as(
-        "shared_udf_schema",
-        "shared_udf_schema",
-    )]);
+    let runtime = CoralQuery::prepare(&[source], test_runtime())
+        .await
+        .expect("prepare source runtime")
+        .with_udfs(vec![review_queue_udf_published_as(
+            "shared_udf_schema",
+            "shared_udf_schema",
+        )])
+        .await
+        .expect("install shared-schema UDF");
 
-    let execution = CoralQuery::execute_sql_with_params(
-        &[source],
-        runtime,
-        "select title, score from shared_udf_schema.review_queue(\
+    let execution = runtime
+        .execute_sql_with_params(
+            "select title, score from shared_udf_schema.review_queue(\
              query => $query, \
              mode => $mode, \
              min_score => 1, \
              payload => NULL, \
              since => TIMESTAMP '2024-01-01T00:00:00Z'\
          )",
-        QueryParameters::from([
-            (
-                "query".to_string(),
-                QueryParameterValue::string(REVIEW_QUERY),
-            ),
-            ("mode".to_string(), QueryParameterValue::string("semantic")),
-        ]),
-    )
-    .await
-    .expect("schema-shared udf should call source function with params");
+            QueryParameters::from([
+                (
+                    "query".to_string(),
+                    QueryParameterValue::string(REVIEW_QUERY),
+                ),
+                ("mode".to_string(), QueryParameterValue::string("semantic")),
+            ]),
+        )
+        .await
+        .expect("schema-shared udf should call source function with params");
 
     assert_eq!(
         execution_to_rows(&execution),

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -580,6 +580,36 @@ async fn infer_udf_signature_rejects_conflicting_argument_types() {
 }
 
 #[tokio::test]
+async fn infer_udf_signatures_returns_per_function_results() {
+    let results = CoralQuery::infer_udf_signatures(
+        &[],
+        test_runtime(),
+        vec![
+            udf_sql("typed_value", "select cast($value as VARCHAR) as value"),
+            udf_sql("ambiguous_value", "select $value as value"),
+        ],
+    )
+    .await
+    .expect("shared runtime should build");
+    let mut results = results.into_iter();
+
+    let signature = results
+        .next()
+        .expect("typed result")
+        .expect("typed udf should validate");
+    assert_eq!(
+        argument_types(&signature),
+        [("value", ManifestDataType::Utf8)]
+    );
+    let error = results
+        .next()
+        .expect("ambiguous result")
+        .expect_err("ambiguous udf should fail independently");
+    assert!(error.to_string().contains("has no inferred type"));
+    assert!(results.next().is_none());
+}
+
+#[tokio::test]
 async fn published_udf_table_function_executes_udf_sql() {
     let (_temp, source) = events_source("published_udf_events");
     let runtime = test_runtime().with_udfs(vec![min_id_udf("published_udf_events")]);


### PR DESCRIPTION
## Why

Connect app-owned installed functions to the query runtime for the selected workspace. This is the assembly layer: `coral-app` reads authored artifacts and active sources, while `coral-engine` remains responsible for SQL planning and execution.

## What changed

- Parses installed artifacts into engine `UdfRuntimeDefinition`s.
- Prepares one request-scoped engine runtime for the selected sources, then uses that same runtime for signature inference, UDF installation, and the catalog/query operation.
- Validates SQL publication collisions against source schemas and other installed functions.
- Keeps invalid or stale installed functions in inventory with an error status, but does not publish them into the runtime.
- Passes the bootstrap-owned `WorkspaceLifecycleLock` through `QueryManager` to `FunctionManager`, so function mutation shares the established workspace/source lifecycle order.

## Parameter contract

DataFusion inference is authoritative. Source declarations supply schema information for source relations; they do not guess unresolved function parameter types. If a parameter remains untyped or has conflicting uses, installation fails and the author must add an explicit `CAST`.

## Boundaries

- `coral-app` owns artifact interpretation, runtime package assembly, and lifecycle-lock composition.
- `coral-engine` owns the request-scoped prepared runtime, signature inference, UDF installation, planning, and execution.
- The prepared runtime is not persisted or shared across requests.
- No gRPC or CLI surface is added here.

## Validation

- Manager tests cover ready/invalid inventory, runtime publication, lifecycle lock ordering, rollback failures, and one source-decorator preparation per function-enabled query.
- Validation tests cover source and installed-function publication collisions.
- Query integration executes an installed function against an installed source.
- Engine tests cover late UDF installation through analyzer coercion, source table-function calls, catalog publication, and dependent-join fallback.
- `make rust-checks` (1,699 tests, clippy, formatting, and rustdoc)
- `make perf-check` (199 ms mean against the 750 ms limit)