### PR TITLE
feat(app): expose function lifecycle service

### DIFF
--- a/crates/coral-app/build.rs
+++ b/crates/coral-app/build.rs
@@ -1,4 +1,4 @@
-//! Build script for bundled source manifests.
+//! Build script for bundled source packages.
 
 #![allow(
     clippy::disallowed_methods,

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -16,6 +16,7 @@ use axum::extract::Request as AxumRequest;
 use axum::response::Response as AxumResponse;
 use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
+use coral_api::v1::function_service_server::FunctionServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::search_service_server::SearchServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
@@ -49,6 +50,7 @@ use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
 };
 use crate::feedback::service::FeedbackService;
+use crate::functions::service::FunctionService;
 use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
@@ -499,6 +501,7 @@ async fn start_server(
     let source_service = SourceService::new(source, query.clone(), workspace.clone());
     let workspace_service = WorkspaceService::new(workspace);
     let catalog_service = CatalogService::new(query.clone());
+    let function_service = FunctionService::new(query.function_manager(), query.clone());
     let query_service = QueryService::new(query);
     let search_service = SearchService::new(search);
     let feedback_service = FeedbackService::new(feedback);
@@ -514,6 +517,10 @@ async fn start_server(
                 .max_encoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE),
         )
         .add_service(FeedbackServiceServer::new(feedback_service))
+        .add_service(
+            FunctionServiceServer::new(function_service)
+                .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
+        )
         .add_service(TaskServiceServer::new(task_service))
         .add_service(
             QueryServiceServer::new(query_service)

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -501,7 +501,7 @@ async fn start_server(
     let source_service = SourceService::new(source, query.clone(), workspace.clone());
     let workspace_service = WorkspaceService::new(workspace);
     let catalog_service = CatalogService::new(query.clone());
-    let function_service = FunctionService::new(query.function_manager(), query.clone());
+    let function_service = FunctionService::new(query.clone());
     let query_service = QueryService::new(query);
     let search_service = SearchService::new(search);
     let feedback_service = FeedbackService::new(feedback);
@@ -517,10 +517,7 @@ async fn start_server(
                 .max_encoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE),
         )
         .add_service(FeedbackServiceServer::new(feedback_service))
-        .add_service(
-            FunctionServiceServer::new(function_service)
-                .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
-        )
+        .add_service(FunctionServiceServer::new(function_service))
         .add_service(TaskServiceServer::new(task_service))
         .add_service(
             QueryServiceServer::new(query_service)

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -19,7 +19,7 @@ use crate::functions::validation::{
     source_sql_publish_targets_for_schemas, unchecked_source_publish_schemas,
 };
 use crate::state::{AppStateLayout, ConfigStore};
-use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
+use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceName};
 
 #[derive(Clone)]
 pub(crate) struct FunctionManager {
@@ -51,6 +51,11 @@ pub(crate) enum FunctionRuntimeStatus {
     Invalid(String),
 }
 
+pub(crate) enum ValidatedFunctionInstall {
+    Installed,
+    WorkspaceChanged,
+}
+
 enum FunctionCandidate {
     Listing(FunctionListing),
     Pending {
@@ -77,25 +82,37 @@ impl FunctionManager {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn install_validated_user_function(
         &self,
         workspace_name: &WorkspaceName,
         raw_sql: &str,
         runtime_function: &UdfRuntimeDefinition,
     ) -> Result<InstalledFunction, AppError> {
-        let function = parse_function_sql(raw_sql).map_err(|error| {
-            AppError::InvalidInput(format!("function validation failed: {error}"))
-        })?;
-        let function_name = FunctionName::parse(function.name())?;
-        if function_name.as_str() != runtime_function.name {
-            return Err(AppError::FailedPrecondition(format!(
-                "validated function '{}' does not match installed function '{}'",
-                runtime_function.name, function_name
-            )));
-        }
+        let function_name = validated_function_name(raw_sql, runtime_function)?;
         self.install_user_function_artifact(workspace_name, &function_name, raw_sql)
     }
 
+    pub(crate) fn install_validated_user_function_if_unchanged(
+        &self,
+        workspace_name: &WorkspaceName,
+        raw_sql: &str,
+        runtime_function: &UdfRuntimeDefinition,
+        revision: WorkspaceLifecycleRevision,
+    ) -> Result<ValidatedFunctionInstall, AppError> {
+        let function_name = validated_function_name(raw_sql, runtime_function)?;
+        let Some(_lifecycle_guard) = self.lifecycle_lock.lock_if_unchanged(revision) else {
+            return Ok(ValidatedFunctionInstall::WorkspaceChanged);
+        };
+        self.install_user_function_artifact_with_lifecycle_lock(
+            workspace_name,
+            &function_name,
+            raw_sql,
+        )?;
+        Ok(ValidatedFunctionInstall::Installed)
+    }
+
+    #[cfg(test)]
     fn install_user_function_artifact(
         &self,
         workspace_name: &WorkspaceName,
@@ -103,6 +120,19 @@ impl FunctionManager {
         raw_sql: &str,
     ) -> Result<InstalledFunction, AppError> {
         let _lifecycle_guard = self.lifecycle_lock.lock();
+        self.install_user_function_artifact_with_lifecycle_lock(
+            workspace_name,
+            function_name,
+            raw_sql,
+        )
+    }
+
+    fn install_user_function_artifact_with_lifecycle_lock(
+        &self,
+        workspace_name: &WorkspaceName,
+        function_name: &FunctionName,
+        raw_sql: &str,
+    ) -> Result<InstalledFunction, AppError> {
         let _state_lock = self.config_store.state_lock_exclusive()?;
         let installed = InstalledFunction {
             name: function_name.clone(),
@@ -137,10 +167,10 @@ impl FunctionManager {
         mut runtime_config: impl FnMut() -> Result<QueryRuntimeConfig, AppError>,
         raw_sql: &str,
     ) -> Result<UdfRuntimeDefinition, AppError> {
-        let spec = parse_function_sql(raw_sql).map_err(|error| {
+        let function = parse_function_sql(raw_sql).map_err(|error| {
             AppError::InvalidInput(format!("function validation failed: {error}"))
         })?;
-        let function_name = FunctionName::parse(spec.name())?;
+        let function_name = FunctionName::parse(function.name())?;
         let mut sql_publish_targets = initial_sql_publish_targets(selected_sources);
         self.record_installed_function_sql_publish_targets(
             workspace_name,
@@ -148,7 +178,7 @@ impl FunctionManager {
             &mut sql_publish_targets,
         )?;
         let runtime_function =
-            infer_runtime_function(selected_sources, runtime_config()?, &spec).await?;
+            infer_runtime_function(selected_sources, runtime_config()?, &function).await?;
         record_sql_publish_target(&runtime_function, &mut sql_publish_targets)?;
         Ok(runtime_function)
     }
@@ -376,6 +406,22 @@ impl FunctionManager {
         }
         Ok(())
     }
+}
+
+fn validated_function_name(
+    raw_sql: &str,
+    runtime_function: &UdfRuntimeDefinition,
+) -> Result<FunctionName, AppError> {
+    let function = parse_function_sql(raw_sql)
+        .map_err(|error| AppError::InvalidInput(format!("function validation failed: {error}")))?;
+    let function_name = FunctionName::parse(function.name())?;
+    if function_name.as_str() != runtime_function.name {
+        return Err(AppError::FailedPrecondition(format!(
+            "validated function '{}' does not match installed function '{}'",
+            runtime_function.name, function_name
+        )));
+    }
+    Ok(function_name)
 }
 
 fn parse_function_artifact(artifact: &FunctionArtifact) -> Result<FunctionSpec, String> {

--- a/crates/coral-app/src/functions/mod.rs
+++ b/crates/coral-app/src/functions/mod.rs
@@ -1,15 +1,9 @@
 //! Function lifecycle and inventory workflow.
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "function lifecycle service and CLI callers land upstack in the split stack"
-    )
-)]
 
 pub(crate) mod manager;
 pub(crate) mod model;
 mod runtime;
+pub(crate) mod service;
 mod store;
 mod validation;
 

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -2,9 +2,9 @@
 
 use coral_api::v1::function_service_server::FunctionService as FunctionServiceApi;
 use coral_api::v1::{
-    AddFunctionRequest, AddFunctionResponse, Function, FunctionArgument, FunctionPublish,
-    FunctionResultColumn, FunctionTableFunctionPublish, ListFunctionsRequest,
-    ListFunctionsResponse, RemoveFunctionRequest, RemoveFunctionResponse,
+    AddFunctionRequest, AddFunctionResponse, DeleteFunctionRequest, DeleteFunctionResponse,
+    Function, FunctionArgument, FunctionPublish, FunctionTableFunctionPublish,
+    ListFunctionsRequest, ListFunctionsResponse, TableFunctionResultColumn,
 };
 use coral_engine::{UdfRuntimeDefinition, UdfRuntimePublish, UdfRuntimeTableFunctionPublish};
 use tonic::{Request, Response, Status};
@@ -49,11 +49,11 @@ impl FunctionServiceApi for FunctionService {
                 .validate_udf_sql(&workspace_name, &inner.sql)
                 .await
                 .map_err(query_status)?;
-            let function = functions
+            functions
                 .install_validated_user_function(&workspace_name, &inner.sql, &runtime_function)
                 .map_err(app_status)?;
             Ok(Response::new(AddFunctionResponse {
-                name: function.name.as_str().to_string(),
+                function: Some(runtime_function_to_proto(&workspace_name, runtime_function)),
             }))
         })
         .await
@@ -80,10 +80,10 @@ impl FunctionServiceApi for FunctionService {
         .await
     }
 
-    async fn remove_function(
+    async fn delete_function(
         &self,
-        request: Request<RemoveFunctionRequest>,
-    ) -> Result<Response<RemoveFunctionResponse>, Status> {
+        request: Request<DeleteFunctionRequest>,
+    ) -> Result<Response<DeleteFunctionResponse>, Status> {
         let span = grpc_span(&request);
         let functions = self.functions.clone();
         instrument_grpc(span, async move {
@@ -93,7 +93,7 @@ impl FunctionServiceApi for FunctionService {
             functions
                 .remove_user_function(&workspace_name, &function_name)
                 .map_err(app_status)?;
-            Ok(Response::new(RemoveFunctionResponse {}))
+            Ok(Response::new(DeleteFunctionResponse {}))
         })
         .await
     }
@@ -123,10 +123,11 @@ fn runtime_function_to_proto(
         result_columns: function
             .result_columns
             .into_iter()
-            .map(|column| FunctionResultColumn {
+            .map(|column| TableFunctionResultColumn {
                 name: column.name,
                 data_type: column.data_type.to_string(),
                 nullable: column.nullable,
+                description: String::new(),
             })
             .collect(),
     }
@@ -144,7 +145,7 @@ fn function_table_function_publish_to_proto(
     publish: UdfRuntimeTableFunctionPublish,
 ) -> FunctionTableFunctionPublish {
     FunctionTableFunctionPublish {
-        schema: publish.schema,
+        schema_name: publish.schema,
         name: publish.name,
         description: publish.description,
     }

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -121,7 +121,7 @@ fn runtime_function_to_proto(function: UdfRuntimeDefinition) -> Function {
                 name: column.name,
                 data_type: column.data_type.to_string(),
                 nullable: column.nullable,
-                description: column.description,
+                description: String::new(),
             })
             .collect(),
     }

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -13,7 +13,10 @@ use crate::bootstrap::app_status;
 use crate::functions::manager::{FunctionListing, FunctionManager};
 use crate::functions::model::FunctionName;
 use crate::query::manager::QueryManager;
-use crate::transport::{grpc_span, instrument_grpc, query_status, workspace_name_from_proto};
+use crate::transport::{
+    grpc_span, instrument_grpc, query_status, workspace_name_from_proto, workspace_to_proto,
+};
+use crate::workspaces::WorkspaceName;
 
 #[derive(Clone)]
 pub(crate) struct FunctionService {
@@ -70,7 +73,7 @@ impl FunctionServiceApi for FunctionService {
                 .await
                 .map_err(query_status)?
                 .into_iter()
-                .map(function_listing_to_proto)
+                .map(|listing| function_listing_to_proto(&workspace_name, listing))
                 .collect();
             Ok(Response::new(ListFunctionsResponse { functions }))
         })
@@ -96,12 +99,16 @@ impl FunctionServiceApi for FunctionService {
     }
 }
 
-fn function_listing_to_proto(listing: FunctionListing) -> Function {
-    runtime_function_to_proto(listing.definition)
+fn function_listing_to_proto(workspace_name: &WorkspaceName, listing: FunctionListing) -> Function {
+    runtime_function_to_proto(workspace_name, listing.definition)
 }
 
-fn runtime_function_to_proto(function: UdfRuntimeDefinition) -> Function {
+fn runtime_function_to_proto(
+    workspace_name: &WorkspaceName,
+    function: UdfRuntimeDefinition,
+) -> Function {
     Function {
+        workspace: Some(workspace_to_proto(workspace_name)),
         name: function.name,
         description: function.description,
         arguments: function
@@ -110,7 +117,6 @@ fn runtime_function_to_proto(function: UdfRuntimeDefinition) -> Function {
             .map(|argument| FunctionArgument {
                 name: argument.name,
                 data_type: argument.data_type.as_manifest_str().to_string(),
-                description: String::new(),
             })
             .collect(),
         publish: Some(function_publish_to_proto(function.publish)),
@@ -121,7 +127,6 @@ fn runtime_function_to_proto(function: UdfRuntimeDefinition) -> Function {
                 name: column.name,
                 data_type: column.data_type.to_string(),
                 nullable: column.nullable,
-                description: String::new(),
             })
             .collect(),
     }

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -110,7 +110,7 @@ fn runtime_function_to_proto(function: UdfRuntimeDefinition) -> Function {
             .map(|argument| FunctionArgument {
                 name: argument.name,
                 data_type: argument.data_type.as_manifest_str().to_string(),
-                description: argument.description,
+                description: String::new(),
             })
             .collect(),
         publish: Some(function_publish_to_proto(function.publish)),

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -3,14 +3,15 @@
 use coral_api::v1::function_service_server::FunctionService as FunctionServiceApi;
 use coral_api::v1::{
     AddFunctionRequest, AddFunctionResponse, DeleteFunctionRequest, DeleteFunctionResponse,
-    Function, FunctionArgument, FunctionPublish, FunctionTableFunctionPublish,
-    ListFunctionsRequest, ListFunctionsResponse, TableFunctionResultColumn,
+    Function, FunctionArgument, FunctionRuntimeInvalid, FunctionRuntimeReady,
+    FunctionTableFunctionPublish, ListFunctionsRequest, ListFunctionsResponse,
+    TableFunctionResultColumn, function,
 };
-use coral_engine::{UdfRuntimeDefinition, UdfRuntimePublish, UdfRuntimeTableFunctionPublish};
+use coral_engine::{UdfRuntimeDefinition, UdfRuntimeTableFunctionPublish};
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
-use crate::functions::manager::{FunctionListing, FunctionManager};
+use crate::functions::manager::{FunctionListing, FunctionRuntimeStatus};
 use crate::functions::model::FunctionName;
 use crate::query::manager::QueryManager;
 use crate::transport::{
@@ -20,14 +21,12 @@ use crate::workspaces::WorkspaceName;
 
 #[derive(Clone)]
 pub(crate) struct FunctionService {
-    functions: FunctionManager,
     queries: QueryManager,
 }
 
 impl FunctionService {
-    pub(crate) fn new(function_manager: FunctionManager, query_manager: QueryManager) -> Self {
+    pub(crate) fn new(query_manager: QueryManager) -> Self {
         Self {
-            functions: function_manager,
             queries: query_manager,
         }
     }
@@ -40,7 +39,6 @@ impl FunctionServiceApi for FunctionService {
         request: Request<AddFunctionRequest>,
     ) -> Result<Response<AddFunctionResponse>, Status> {
         let span = grpc_span(&request);
-        let functions = self.functions.clone();
         let queries = self.queries.clone();
         instrument_grpc(span, async move {
             let inner = request.into_inner();
@@ -49,7 +47,8 @@ impl FunctionServiceApi for FunctionService {
                 .validate_udf_sql(&workspace_name, &inner.sql)
                 .await
                 .map_err(query_status)?;
-            functions
+            queries
+                .function_manager()
                 .install_validated_user_function(&workspace_name, &inner.sql, &runtime_function)
                 .map_err(app_status)?;
             Ok(Response::new(AddFunctionResponse {
@@ -85,12 +84,13 @@ impl FunctionServiceApi for FunctionService {
         request: Request<DeleteFunctionRequest>,
     ) -> Result<Response<DeleteFunctionResponse>, Status> {
         let span = grpc_span(&request);
-        let functions = self.functions.clone();
+        let queries = self.queries.clone();
         instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
             let function_name = FunctionName::parse(&inner.name).map_err(app_status)?;
-            functions
+            queries
+                .function_manager()
                 .remove_user_function(&workspace_name, &function_name)
                 .map_err(app_status)?;
             Ok(Response::new(DeleteFunctionResponse {}))
@@ -100,44 +100,52 @@ impl FunctionServiceApi for FunctionService {
 }
 
 fn function_listing_to_proto(workspace_name: &WorkspaceName, listing: FunctionListing) -> Function {
-    runtime_function_to_proto(workspace_name, listing.definition)
+    match listing.runtime {
+        FunctionRuntimeStatus::Ready(definition) => {
+            runtime_function_to_proto(workspace_name, definition)
+        }
+        FunctionRuntimeStatus::Invalid(reason) => Function {
+            name: listing.name.to_string(),
+            workspace: Some(workspace_to_proto(workspace_name)),
+            runtime: Some(function::Runtime::Invalid(FunctionRuntimeInvalid {
+                reason,
+            })),
+        },
+    }
 }
 
 fn runtime_function_to_proto(
     workspace_name: &WorkspaceName,
     function: UdfRuntimeDefinition,
 ) -> Function {
+    let name = function.name;
     Function {
         workspace: Some(workspace_to_proto(workspace_name)),
-        name: function.name,
-        description: function.description,
-        arguments: function
-            .arguments
-            .into_iter()
-            .map(|argument| FunctionArgument {
-                name: argument.name,
-                data_type: argument.data_type.as_manifest_str().to_string(),
-            })
-            .collect(),
-        publish: Some(function_publish_to_proto(function.publish)),
-        result_columns: function
-            .result_columns
-            .into_iter()
-            .map(|column| TableFunctionResultColumn {
-                name: column.name,
-                data_type: column.data_type.to_string(),
-                nullable: column.nullable,
-                description: String::new(),
-            })
-            .collect(),
-    }
-}
-
-fn function_publish_to_proto(publish: UdfRuntimePublish) -> FunctionPublish {
-    FunctionPublish {
-        table_function: Some(function_table_function_publish_to_proto(
-            publish.table_function,
-        )),
+        name,
+        runtime: Some(function::Runtime::Ready(FunctionRuntimeReady {
+            description: function.description,
+            arguments: function
+                .arguments
+                .into_iter()
+                .map(|argument| FunctionArgument {
+                    name: argument.name,
+                    data_type: argument.data_type.as_manifest_str().to_string(),
+                })
+                .collect(),
+            table_function: Some(function_table_function_publish_to_proto(
+                function.publish.table_function,
+            )),
+            result_columns: function
+                .result_columns
+                .into_iter()
+                .map(|column| TableFunctionResultColumn {
+                    name: column.name,
+                    data_type: column.data_type.to_string(),
+                    nullable: column.nullable,
+                    description: String::new(),
+                })
+                .collect(),
+        })),
     }
 }
 
@@ -148,5 +156,32 @@ fn function_table_function_publish_to_proto(
         schema_name: publish.schema,
         name: publish.name,
         description: publish.description,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_function_listing_keeps_inventory_identity_and_error() {
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let listing = FunctionListing {
+            name: FunctionName::parse("review_queue").expect("function"),
+            runtime: FunctionRuntimeStatus::Invalid("function file is missing".to_string()),
+        };
+
+        let function = function_listing_to_proto(&workspace, listing);
+
+        assert_eq!(function.name, "review_queue");
+        assert!(matches!(
+            function.runtime,
+            Some(function::Runtime::Invalid(FunctionRuntimeInvalid { reason }))
+                if reason == "function file is missing"
+        ));
+        assert_eq!(
+            function.workspace.expect("workspace").name,
+            workspace.as_str()
+        );
     }
 }

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -44,13 +44,9 @@ impl FunctionServiceApi for FunctionService {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
             let runtime_function = queries
-                .validate_udf_sql(&workspace_name, &inner.sql)
+                .add_user_function(&workspace_name, &inner.sql)
                 .await
                 .map_err(query_status)?;
-            queries
-                .function_manager()
-                .install_validated_user_function(&workspace_name, &inner.sql, &runtime_function)
-                .map_err(app_status)?;
             Ok(Response::new(AddFunctionResponse {
                 function: Some(runtime_function_to_proto(&workspace_name, runtime_function)),
             }))

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -1,0 +1,146 @@
+//! Implements the gRPC `FunctionService`.
+
+use coral_api::v1::function_service_server::FunctionService as FunctionServiceApi;
+use coral_api::v1::{
+    AddFunctionRequest, AddFunctionResponse, Function, FunctionArgument, FunctionPublish,
+    FunctionResultColumn, FunctionTableFunctionPublish, ListFunctionsRequest,
+    ListFunctionsResponse, RemoveFunctionRequest, RemoveFunctionResponse,
+};
+use coral_engine::{UdfRuntimeDefinition, UdfRuntimePublish, UdfRuntimeTableFunctionPublish};
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::app_status;
+use crate::functions::manager::{FunctionListing, FunctionManager};
+use crate::functions::model::FunctionName;
+use crate::query::manager::QueryManager;
+use crate::transport::{grpc_span, instrument_grpc, query_status, workspace_name_from_proto};
+
+#[derive(Clone)]
+pub(crate) struct FunctionService {
+    functions: FunctionManager,
+    queries: QueryManager,
+}
+
+impl FunctionService {
+    pub(crate) fn new(function_manager: FunctionManager, query_manager: QueryManager) -> Self {
+        Self {
+            functions: function_manager,
+            queries: query_manager,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl FunctionServiceApi for FunctionService {
+    async fn add_function(
+        &self,
+        request: Request<AddFunctionRequest>,
+    ) -> Result<Response<AddFunctionResponse>, Status> {
+        let span = grpc_span(&request);
+        let functions = self.functions.clone();
+        let queries = self.queries.clone();
+        instrument_grpc(span, async move {
+            let inner = request.into_inner();
+            let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            let runtime_function = queries
+                .validate_udf_sql(&workspace_name, &inner.sql)
+                .await
+                .map_err(query_status)?;
+            let function = functions
+                .install_validated_user_function(&workspace_name, &inner.sql, &runtime_function)
+                .map_err(app_status)?;
+            Ok(Response::new(AddFunctionResponse {
+                name: function.name.as_str().to_string(),
+            }))
+        })
+        .await
+    }
+
+    async fn list_functions(
+        &self,
+        request: Request<ListFunctionsRequest>,
+    ) -> Result<Response<ListFunctionsResponse>, Status> {
+        let span = grpc_span(&request);
+        let queries = self.queries.clone();
+        instrument_grpc(span, async move {
+            let inner = request.into_inner();
+            let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            let functions = queries
+                .list_functions(&workspace_name)
+                .await
+                .map_err(query_status)?
+                .into_iter()
+                .map(function_listing_to_proto)
+                .collect();
+            Ok(Response::new(ListFunctionsResponse { functions }))
+        })
+        .await
+    }
+
+    async fn remove_function(
+        &self,
+        request: Request<RemoveFunctionRequest>,
+    ) -> Result<Response<RemoveFunctionResponse>, Status> {
+        let span = grpc_span(&request);
+        let functions = self.functions.clone();
+        instrument_grpc(span, async move {
+            let inner = request.into_inner();
+            let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            let function_name = FunctionName::parse(&inner.name).map_err(app_status)?;
+            functions
+                .remove_user_function(&workspace_name, &function_name)
+                .map_err(app_status)?;
+            Ok(Response::new(RemoveFunctionResponse {}))
+        })
+        .await
+    }
+}
+
+fn function_listing_to_proto(listing: FunctionListing) -> Function {
+    runtime_function_to_proto(listing.definition)
+}
+
+fn runtime_function_to_proto(function: UdfRuntimeDefinition) -> Function {
+    Function {
+        name: function.name,
+        description: function.description,
+        arguments: function
+            .arguments
+            .into_iter()
+            .map(|argument| FunctionArgument {
+                name: argument.name,
+                data_type: argument.data_type.as_manifest_str().to_string(),
+                description: argument.description,
+            })
+            .collect(),
+        publish: Some(function_publish_to_proto(function.publish)),
+        result_columns: function
+            .result_columns
+            .into_iter()
+            .map(|column| FunctionResultColumn {
+                name: column.name,
+                data_type: column.data_type.to_string(),
+                nullable: column.nullable,
+                description: column.description,
+            })
+            .collect(),
+    }
+}
+
+fn function_publish_to_proto(publish: UdfRuntimePublish) -> FunctionPublish {
+    FunctionPublish {
+        table_function: Some(function_table_function_publish_to_proto(
+            publish.table_function,
+        )),
+    }
+}
+
+fn function_table_function_publish_to_proto(
+    publish: UdfRuntimeTableFunctionPublish,
+) -> FunctionTableFunctionPublish {
+    FunctionTableFunctionPublish {
+        schema: publish.schema,
+        name: publish.name,
+        description: publish.description,
+    }
+}

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -566,13 +566,6 @@ impl QueryManager {
         Ok(runtime)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "function lifecycle service callers land upstack in the split stack"
-        )
-    )]
     pub(crate) async fn list_functions(
         &self,
         workspace_name: &WorkspaceName,
@@ -600,21 +593,10 @@ impl QueryManager {
             .map_err(QueryManagerError::App)
     }
 
-    #[expect(
-        dead_code,
-        reason = "function lifecycle service callers land upstack in the split stack"
-    )]
     pub(crate) fn function_manager(&self) -> FunctionManager {
         self.function_manager.clone()
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "function lifecycle service callers land upstack in the split stack"
-        )
-    )]
     pub(crate) async fn validate_udf_sql(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -19,7 +19,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
-use crate::functions::manager::{FunctionListing, FunctionManager};
+use crate::functions::manager::{FunctionListing, FunctionManager, ValidatedFunctionInstall};
 use crate::query::QueryAttribution;
 use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_providers};
 use crate::query::input_resolver::{
@@ -35,7 +35,9 @@ use crate::sources::runtime_package::runtime_components_for_v4_source;
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::task::id::TaskId;
 use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
-use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceManager, WorkspaceName};
+use crate::workspaces::{
+    WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceManager, WorkspaceName,
+};
 
 #[derive(Debug)]
 pub(crate) enum QueryManagerError {
@@ -67,6 +69,7 @@ pub(crate) struct QueryManager {
     workspace_manager: Arc<WorkspaceManager>,
     credential_manager: CredentialManager,
     function_manager: FunctionManager,
+    lifecycle_lock: WorkspaceLifecycleLock,
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
@@ -102,32 +105,14 @@ impl QueryManager {
         lifecycle_lock: WorkspaceLifecycleLock,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
-        let function_manager = FunctionManager::new(config_store.clone(), &layout, lifecycle_lock);
-        Self::with_function_manager(
-            config_store,
-            workspace_manager,
-            credential_manager,
-            function_manager,
-            runtime_context,
-            layout,
-            engine_extensions_providers,
-        )
-    }
-
-    pub(crate) fn with_function_manager(
-        config_store: ConfigStore,
-        workspace_manager: WorkspaceManager,
-        credential_manager: CredentialManager,
-        function_manager: FunctionManager,
-        runtime_context: QueryRuntimeContext,
-        layout: AppStateLayout,
-        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-    ) -> Self {
+        let function_manager =
+            FunctionManager::new(config_store.clone(), &layout, lifecycle_lock.clone());
         Self {
             config_store,
             workspace_manager: Arc::new(workspace_manager),
             credential_manager,
             function_manager,
+            lifecycle_lock,
             runtime_context,
             layout,
             engine_extensions_providers,
@@ -597,6 +582,7 @@ impl QueryManager {
         self.function_manager.clone()
     }
 
+    #[cfg(test)]
     pub(crate) async fn validate_udf_sql(
         &self,
         workspace_name: &WorkspaceName,
@@ -605,6 +591,72 @@ impl QueryManager {
         self.require_workspace(workspace_name)
             .await
             .map_err(QueryManagerError::App)?;
+        let _lifecycle_snapshot = self.lifecycle_lock.snapshot();
+        let (loaded_sources, config) = self.load_function_validation_sources(workspace_name)?;
+        self.validate_udf_sql_against_snapshot(workspace_name, raw_sql, &loaded_sources, &config)
+            .await
+    }
+
+    pub(crate) async fn add_user_function(
+        &self,
+        workspace_name: &WorkspaceName,
+        raw_sql: &str,
+    ) -> Result<UdfRuntimeDefinition, QueryManagerError> {
+        for _ in 0..2 {
+            let revision = self.lifecycle_lock.snapshot().revision();
+            self.require_workspace(workspace_name)
+                .await
+                .map_err(QueryManagerError::App)?;
+            let Some((loaded_sources, config)) =
+                self.function_validation_snapshot_if_unchanged(workspace_name, revision)?
+            else {
+                continue;
+            };
+            let runtime_function = self
+                .validate_udf_sql_against_snapshot(
+                    workspace_name,
+                    raw_sql,
+                    &loaded_sources,
+                    &config,
+                )
+                .await?;
+            match self
+                .function_manager
+                .install_validated_user_function_if_unchanged(
+                    workspace_name,
+                    raw_sql,
+                    &runtime_function,
+                    revision,
+                )
+                .map_err(QueryManagerError::App)?
+            {
+                ValidatedFunctionInstall::Installed => return Ok(runtime_function),
+                ValidatedFunctionInstall::WorkspaceChanged => {}
+            }
+        }
+        Err(QueryManagerError::App(AppError::FailedPrecondition(
+            "workspace changed repeatedly while the function was being validated; retry the add"
+                .to_string(),
+        )))
+    }
+
+    fn function_validation_snapshot_if_unchanged(
+        &self,
+        workspace_name: &WorkspaceName,
+        revision: WorkspaceLifecycleRevision,
+    ) -> Result<Option<(Vec<LoadedQuerySource>, AppConfig)>, QueryManagerError> {
+        let lifecycle_snapshot = self.lifecycle_lock.snapshot();
+        if lifecycle_snapshot.revision() != revision {
+            return Ok(None);
+        }
+        let (loaded_sources, config) = self.load_function_validation_sources(workspace_name)?;
+        Ok(Some((loaded_sources, config)))
+    }
+
+    fn load_function_validation_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<(Vec<LoadedQuerySource>, AppConfig), QueryManagerError> {
         let (loaded_sources, config) = {
             let _state_lock = self
                 .config_store
@@ -619,12 +671,22 @@ impl QueryManager {
                 .map_err(QueryManagerError::App)?;
             (loaded_sources, config)
         };
-        let sources = query_sources_from_loaded(&loaded_sources);
+        Ok((loaded_sources, config))
+    }
+
+    async fn validate_udf_sql_against_snapshot(
+        &self,
+        workspace_name: &WorkspaceName,
+        raw_sql: &str,
+        loaded_sources: &[LoadedQuerySource],
+        config: &AppConfig,
+    ) -> Result<UdfRuntimeDefinition, QueryManagerError> {
+        let sources = query_sources_from_loaded(loaded_sources);
         self.function_manager
             .validate_user_function_sql(
                 workspace_name,
                 &sources,
-                || self.runtime_config(workspace_name, &loaded_sources, &config),
+                || self.runtime_config(workspace_name, loaded_sources, config),
                 raw_sql,
             )
             .await
@@ -1733,22 +1795,72 @@ pagination:
     }
 
     #[tokio::test]
-    #[expect(
-        clippy::too_many_lines,
-        reason = "covers function validation, catalog publication, listing, and execution together"
-    )]
+    async fn add_user_function_revalidates_when_source_changes_before_commit() {
+        let fake_home = tempfile::tempdir().expect("fake home");
+        let mut fixture = query_manager_with(
+            QueryRuntimeContext {
+                home_dir: Some(fake_home.path().to_path_buf()),
+                ..QueryRuntimeContext::default()
+            },
+            Vec::new(),
+        )
+        .await;
+        let workspace_name = WorkspaceName::default();
+        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        let calls = Arc::new(AtomicUsize::new(0));
+        let config_store = fixture.manager.config_store.clone();
+        let lifecycle_lock = fixture.manager.lifecycle_lock.clone();
+        let workspace = workspace_name.clone();
+        let source_name = SourceName::parse("function_demo").expect("source name");
+        fixture.manager.engine_extensions_providers.push(Arc::new(
+            PrepareCountingExtensionsProvider {
+                calls: Arc::clone(&calls),
+                on_first_prepare: Some(Arc::new(move || {
+                    let _lifecycle_guard = lifecycle_lock.lock();
+                    config_store
+                        .remove_source(&workspace, &source_name)
+                        .expect("remove source during function validation");
+                })),
+            },
+        ));
+        let function_sql = r"/*
+name: demo_items
+schema: functions
+description: Returns demo messages
+*/
+
+select text from function_demo.messages
+";
+
+        let error = fixture
+            .manager
+            .add_user_function(&workspace_name, function_sql)
+            .await
+            .expect_err("source change should invalidate the original validation snapshot");
+
+        let detail = match error {
+            QueryManagerError::App(error) => error.to_string(),
+            QueryManagerError::Core(error) => error.to_string(),
+        };
+        assert!(
+            detail.contains("function_demo.messages"),
+            "unexpected error: {detail}"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert!(
+            fixture
+                .manager
+                .list_functions(&workspace_name)
+                .await
+                .expect("list functions")
+                .is_empty(),
+            "stale validation must not install the function"
+        );
+    }
+
+    #[tokio::test]
     async fn user_function_publishes_table_function_and_executes_against_installed_source() {
         let fake_home = tempfile::tempdir().expect("fake home");
-        let data_dir = fake_home.path().join("fixture-data");
-        std::fs::create_dir_all(&data_dir).expect("create data dir");
-        std::fs::write(
-            data_dir.join("messages.jsonl"),
-            r#"{"type":"user","text":"hello"}
-{"type":"assistant","text":"world"}
-"#,
-        )
-        .expect("write fixture");
-
         let fixture = query_manager_with(
             QueryRuntimeContext {
                 home_dir: Some(fake_home.path().to_path_buf()),
@@ -1757,41 +1869,8 @@ pagination:
             Vec::new(),
         )
         .await;
-        fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = WorkspaceName::default();
-        let source_manager = SourceManager::new_for_tests(
-            fixture.manager.config_store.clone(),
-            fixture.manager.credential_manager.clone(),
-            fixture.manager.layout.clone(),
-        );
-        source_manager
-            .import_source(
-                &workspace_name,
-                &ImportSourceCommand {
-                    manifest_yaml: r#"
-name: function_demo
-version: 0.1.0
-dsl_version: 3
-backend: file
-tables:
-  - name: messages
-    description: Fixture messages
-    format: jsonl
-    source:
-      location: file://~/fixture-data/
-      glob: "**/*.jsonl"
-    columns:
-      - name: type
-        type: Utf8
-      - name: text
-        type: Utf8
-"#
-                    .to_string(),
-                    bindings: SourceBindings::default(),
-                },
-            )
-            .expect("import source");
-
+        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
         let function_sql = r"/*
 name: messages_by_type
 schema: functions
@@ -1863,6 +1942,54 @@ where type = $kind
             execution_to_rows(&execution),
             vec![json!({"text": "hello"})]
         );
+    }
+
+    fn install_function_demo_source(
+        manager: &QueryManager,
+        workspace_name: &WorkspaceName,
+        fake_home: &std::path::Path,
+    ) {
+        let data_dir = fake_home.join("fixture-data");
+        std::fs::create_dir_all(&data_dir).expect("create data dir");
+        std::fs::write(
+            data_dir.join("messages.jsonl"),
+            r#"{"type":"user","text":"hello"}
+{"type":"assistant","text":"world"}
+"#,
+        )
+        .expect("write fixture");
+        let source_manager = SourceManager::new_for_tests(
+            manager.config_store.clone(),
+            manager.credential_manager.clone(),
+            manager.layout.clone(),
+        );
+        source_manager
+            .import_source(
+                workspace_name,
+                &ImportSourceCommand {
+                    manifest_yaml: r#"
+name: function_demo
+version: 0.1.0
+dsl_version: 3
+backend: file
+tables:
+  - name: messages
+    description: Fixture messages
+    format: jsonl
+    source:
+      location: file://~/fixture-data/
+      glob: "**/*.jsonl"
+    columns:
+      - name: type
+        type: Utf8
+      - name: text
+        type: Utf8
+"#
+                    .to_string(),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect("import source");
     }
 
     #[tokio::test]
@@ -1990,6 +2117,7 @@ select 1 as value
 
     struct PrepareCountingDecorator {
         calls: Arc<AtomicUsize>,
+        on_first_prepare: Option<Arc<dyn Fn() + Send + Sync>>,
     }
 
     impl SourceDecorator for PrepareCountingDecorator {
@@ -2001,7 +2129,11 @@ select 1 as value
             &mut self,
             _selected_sources: &[QuerySource],
         ) -> Result<(), SourceDecoratorError> {
-            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0
+                && let Some(on_first_prepare) = &self.on_first_prepare
+            {
+                on_first_prepare();
+            }
             Ok(())
         }
 
@@ -2016,6 +2148,7 @@ select 1 as value
 
     struct PrepareCountingExtensionsProvider {
         calls: Arc<AtomicUsize>,
+        on_first_prepare: Option<Arc<dyn Fn() + Send + Sync>>,
     }
 
     impl EngineExtensionsProvider for PrepareCountingExtensionsProvider {
@@ -2025,6 +2158,7 @@ select 1 as value
                 .source_decorators
                 .push(Box::new(PrepareCountingDecorator {
                     calls: Arc::clone(&self.calls),
+                    on_first_prepare: self.on_first_prepare.clone(),
                 }));
             extensions
         }
@@ -2035,6 +2169,7 @@ select 1 as value
         let calls = Arc::new(AtomicUsize::new(0));
         let provider = Arc::new(PrepareCountingExtensionsProvider {
             calls: Arc::clone(&calls),
+            on_first_prepare: None,
         });
         let fixture = query_manager_with(QueryRuntimeContext::default(), vec![provider]).await;
         let workspace_name = WorkspaceName::default();

--- a/crates/coral-app/src/workspaces/mod.rs
+++ b/crates/coral-app/src/workspaces/mod.rs
@@ -5,7 +5,9 @@ pub(crate) mod paths;
 pub(crate) mod service;
 
 pub(crate) use manager::WorkspaceManager;
-pub(crate) use model::{DeletedWorkspace, WorkspaceLifecycleLock, WorkspaceRecord};
+pub(crate) use model::{
+    DeletedWorkspace, WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceRecord,
+};
 pub use name::DEFAULT_WORKSPACE_ID;
 pub(crate) use name::WorkspaceName;
 pub(crate) use paths::WorkspacePaths;

--- a/crates/coral-app/src/workspaces/model.rs
+++ b/crates/coral-app/src/workspaces/model.rs
@@ -17,24 +17,73 @@ pub(crate) struct DeletedWorkspace {
     pub(crate) sources: Vec<InstalledSource>,
 }
 
+#[derive(Debug, Default)]
+struct WorkspaceLifecycleState {
+    revision: u64,
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct WorkspaceLifecycleLock {
-    inner: Arc<Mutex<()>>,
+    inner: Arc<Mutex<WorkspaceLifecycleState>>,
 }
 
 impl WorkspaceLifecycleLock {
+    /// Serializes a workspace lifecycle write and advances the revision when
+    /// the write guard is released.
     #[must_use = "bind the returned guard for the full critical section"]
     pub(crate) fn lock(&self) -> WorkspaceLifecycleGuard<'_> {
         WorkspaceLifecycleGuard {
-            _guard: self
-                .inner
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            guard: self.lock_inner(),
         }
+    }
+
+    #[must_use = "bind the returned snapshot while loading workspace state"]
+    pub(crate) fn snapshot(&self) -> WorkspaceLifecycleSnapshot<'_> {
+        WorkspaceLifecycleSnapshot {
+            guard: self.lock_inner(),
+        }
+    }
+
+    pub(crate) fn lock_if_unchanged(
+        &self,
+        revision: WorkspaceLifecycleRevision,
+    ) -> Option<WorkspaceLifecycleGuard<'_>> {
+        let guard = self.lock_inner();
+        if guard.revision == revision.0 {
+            Some(WorkspaceLifecycleGuard { guard })
+        } else {
+            None
+        }
+    }
+
+    fn lock_inner(&self) -> MutexGuard<'_, WorkspaceLifecycleState> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 
 #[must_use]
 pub(crate) struct WorkspaceLifecycleGuard<'a> {
-    _guard: MutexGuard<'a, ()>,
+    guard: MutexGuard<'a, WorkspaceLifecycleState>,
 }
+
+impl Drop for WorkspaceLifecycleGuard<'_> {
+    fn drop(&mut self) {
+        self.guard.revision = self.guard.revision.wrapping_add(1);
+    }
+}
+
+#[must_use]
+pub(crate) struct WorkspaceLifecycleSnapshot<'a> {
+    guard: MutexGuard<'a, WorkspaceLifecycleState>,
+}
+
+impl WorkspaceLifecycleSnapshot<'_> {
+    pub(crate) fn revision(&self) -> WorkspaceLifecycleRevision {
+        WorkspaceLifecycleRevision(self.guard.revision)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WorkspaceLifecycleRevision(u64);

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -7,6 +7,8 @@
 
 #[path = "grpc/catalog_discovery_tests.rs"]
 mod catalog_discovery_tests;
+#[path = "grpc/function_lifecycle_tests.rs"]
+mod function_lifecycle_tests;
 #[path = "grpc/harness.rs"]
 mod harness;
 #[path = "grpc/oauth_refresh_tests.rs"]

--- a/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
@@ -1,0 +1,129 @@
+use coral_api::v1::{
+    AddFunctionRequest, CreateWorkspaceRequest, DeleteFunctionRequest, ListFunctionsRequest,
+    Workspace, function,
+};
+use coral_client::default_workspace;
+use tonic::Request;
+
+use crate::harness::GrpcHarness;
+
+fn workspace(name: &str) -> Workspace {
+    Workspace {
+        name: name.to_string(),
+    }
+}
+
+fn function_sql(body: &str) -> String {
+    format!(
+        r"/*
+name: echo_value
+schema: functions
+description: Echo one value
+*/
+
+{body}
+"
+    )
+}
+
+#[tokio::test]
+async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
+    let harness = GrpcHarness::new().await;
+    let work = workspace("work");
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(work.clone()),
+        }))
+        .await
+        .expect("create workspace");
+
+    let added = harness
+        .function_client()
+        .add_function(Request::new(AddFunctionRequest {
+            workspace: Some(work.clone()),
+            sql: function_sql("select cast($value as VARCHAR) as value"),
+        }))
+        .await
+        .expect("add function")
+        .into_inner()
+        .function
+        .expect("added function");
+    assert_eq!(added.name, "echo_value");
+    assert_eq!(added.workspace.as_ref(), Some(&work));
+    assert!(matches!(added.runtime, Some(function::Runtime::Ready(_))));
+
+    let default_functions = harness
+        .function_client()
+        .list_functions(Request::new(ListFunctionsRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await
+        .expect("list default functions")
+        .into_inner()
+        .functions;
+    assert!(default_functions.is_empty());
+
+    let work_functions = harness
+        .function_client()
+        .list_functions(Request::new(ListFunctionsRequest {
+            workspace: Some(work.clone()),
+        }))
+        .await
+        .expect("list work functions")
+        .into_inner()
+        .functions;
+    assert_eq!(work_functions.len(), 1);
+
+    harness
+        .function_client()
+        .delete_function(Request::new(DeleteFunctionRequest {
+            workspace: Some(work.clone()),
+            name: "echo_value".to_string(),
+        }))
+        .await
+        .expect("delete function");
+
+    let remaining = harness
+        .function_client()
+        .list_functions(Request::new(ListFunctionsRequest {
+            workspace: Some(work),
+        }))
+        .await
+        .expect("list functions after delete")
+        .into_inner()
+        .functions;
+    assert!(remaining.is_empty());
+}
+
+#[tokio::test]
+async fn untyped_function_is_not_persisted() {
+    let harness = GrpcHarness::new().await;
+
+    let error = harness
+        .function_client()
+        .add_function(Request::new(AddFunctionRequest {
+            workspace: Some(default_workspace()),
+            sql: function_sql("select $value as value"),
+        }))
+        .await
+        .expect_err("untyped function should fail");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+
+    let functions = harness
+        .function_client()
+        .list_functions(Request::new(ListFunctionsRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await
+        .expect("list functions")
+        .into_inner()
+        .functions;
+    assert!(functions.is_empty());
+    assert!(
+        !harness
+            .config_dir()
+            .join("workspaces/default/functions/echo_value")
+            .exists()
+    );
+}

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -7,8 +7,8 @@ use coral_api::v1::{
     ValidateSourceResponse, catalog_item, import_source_response,
 };
 use coral_client::{
-    AppClient, CatalogClient, QueryClient, SearchClient, SourceClient, WorkspaceClient,
-    batches_to_json_rows, decode_execute_sql_response, default_workspace,
+    AppClient, CatalogClient, FunctionClient, QueryClient, SearchClient, SourceClient,
+    WorkspaceClient, batches_to_json_rows, decode_execute_sql_response, default_workspace,
     local::{RunningServer, ServerBuilder},
 };
 use serde_json::{Value, json};
@@ -82,6 +82,10 @@ impl GrpcHarness {
 
     pub(crate) fn query_client(&self) -> QueryClient {
         self.app.query_client()
+    }
+
+    pub(crate) fn function_client(&self) -> FunctionClient {
+        self.app.function_client()
     }
 
     pub(crate) fn workspace_client(&self) -> WorkspaceClient {

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -267,7 +267,6 @@ async fn validate_source_returns_table_functions() {
     assert_eq!(function.name, "search_issues");
     assert_eq!(function.arguments.len(), 1);
     assert_eq!(function.arguments[0].name, "q");
-    assert!(function.arguments[0].required);
     assert_eq!(function.result_columns.len(), 1);
     assert_eq!(function.result_columns[0].name, "title");
     assert!(validated.query_tests.is_empty());


### PR DESCRIPTION
## Why

Expose the app-owned function lifecycle over gRPC without letting validation and persistence observe different workspace state. The service stays a thin adapter over the managers used by query execution.

## What changed

- Registers `FunctionService` in local server bootstrap.
- `AddFunction` delegates to one `QueryManager` operation. It captures the shared workspace lifecycle revision, loads that revision’s source/config snapshot, validates without holding the lifecycle lock across `await`, and commits only if the revision is unchanged.
- A concurrent source, function, or workspace mutation causes one reload and revalidation. Repeated mutation returns `FailedPrecondition` and persists nothing.
- `ListFunctions` returns every installed function as typed `ready` or `invalid` state.
- `DeleteFunction` removes the workspace-owned inventory entry and artifact.
- The service derives its `FunctionManager` from `QueryManager`, so lifecycle calls cannot be wired to a different manager than query execution.

## Failure contract

Ambiguous or conflicting parameter inference returns `FailedPrecondition`, persists nothing, and requires an explicit `CAST`. Invalid functions already present on disk remain listable and removable.

## Not in this PR

- CLI or MCP presentation.
- Function authoring helpers or bundled functions.
- A new transaction or persisted snapshot layer.

## Validation

- Regression removes a referenced source during validation, proves the stale result is rejected, revalidates against current state, and verifies no function is installed.
- gRPC lifecycle test covers add, list, delete, and workspace isolation.
- gRPC failure test covers untyped-parameter rejection and verifies no persistence.
- `make rust-checks`: 1,706 tests passed; clippy, formatting, and rustdoc clean.
