### PR TITLE
feat(cli): add function lifecycle commands

### DIFF
--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -244,6 +244,77 @@ coral workspace remove work
 
 The `default` workspace cannot be removed.
 
+## `coral functions`
+
+Manage workspace functions. A function is a SQL artifact with SQL comment frontmatter that defines a reusable, typed query and publishes it as a SQL table function.
+
+User-installed functions are added to the current workspace with `coral functions add`. Functions commonly publish under `functions.*`.
+
+### `coral functions add --file <PATH>`
+
+Validate, then install or replace, a user-installed function from a SQL artifact.
+
+```shellscript
+coral functions add --file ./open-prs.function.sql
+```
+
+#### Options
+
+| Option          | Type | Default  | Description                  |
+| --------------- | ---- | -------- | ---------------------------- |
+| `--file <PATH>` | path | required | Function SQL artifact to install |
+
+Coral validates the function before storing it in the current workspace. Validation checks the frontmatter shape, installed-source references, SQL publish target collisions, and whether the SQL plans against the current workspace sources. Result columns are inferred from the planned SQL. If runtime validation fails, the function is not installed.
+
+Example function:
+
+```sql
+/*
+name: open_prs
+schema: functions
+description: All open PRs in the specified repo
+arguments:
+  owner:
+    data_type: Utf8
+  repo:
+    data_type: Utf8
+*/
+
+select number, title, html_url as url
+from github.pulls(owner => $owner, repo => $repo, state => 'open')
+```
+
+The `schema` and `name` frontmatter fields expose the function through SQL as `schema.name(...)`. Each `$argument` used in the SQL body must be declared under `arguments`.
+
+### `coral functions list`
+
+List configured functions.
+
+```shellscript
+coral functions list
+```
+
+The output is inventory-only and does not re-run runtime validation, so it stays fast. Coral shows each function's table-function target and declared result columns from the installed function YAML.
+
+If a function publishes a SQL table function and declares required inputs, call it with named arguments:
+
+```sql
+select *
+from functions.open_prs(owner => 'withcoral', repo => 'coral')
+```
+
+Functions without required inputs can be called with empty parentheses.
+
+### `coral functions remove <NAME>`
+
+Remove the user-installed function named `<NAME>`.
+
+```shellscript
+coral functions remove open_prs
+```
+
+Only user-installed functions are managed by this command.
+
 ## `coral onboard`
 
 Run the guided source setup flow.

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -290,7 +290,7 @@ List configured functions.
 coral functions list
 ```
 
-Coral replans the installed artifacts against the current workspace and lists the runtime-ready functions. It shows each function's table-function target and the result columns inferred from the planned SQL. An artifact that is missing, invalid, or no longer plans successfully is skipped with a warning.
+The list includes every installed function. Runtime-ready entries show their inferred arguments, table-function target, and result-column preview. An artifact that is missing, invalid, or no longer plans successfully stays visible with an `invalid` status and an actionable reason below the table.
 
 If a function publishes a SQL table function and declares required inputs, call it with named arguments:
 

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -273,18 +273,14 @@ Example function:
 name: open_prs
 schema: functions
 description: All open PRs in the specified repo
-arguments:
-  owner:
-    data_type: Utf8
-  repo:
-    data_type: Utf8
 */
 
 select number, title, html_url as url
-from github.pulls(owner => $owner, repo => $repo, state => 'open')
+from github.pulls
+where owner = $owner and repo = $repo and state = 'open'
 ```
 
-The `schema` and `name` frontmatter fields expose the function through SQL as `schema.name(...)`. Each `$argument` used in the SQL body must be declared under `arguments`.
+The `schema` and `name` frontmatter fields expose the function through SQL as `schema.name(...)`. Coral infers each required argument and its type from `$argument` uses in the SQL body. If the surrounding SQL does not provide enough type evidence, add an explicit cast such as `cast($limit as BIGINT)`.
 
 ### `coral functions list`
 
@@ -294,7 +290,7 @@ List configured functions.
 coral functions list
 ```
 
-The output is inventory-only and does not re-run runtime validation, so it stays fast. Coral shows each function's table-function target and declared result columns from the installed function YAML.
+Coral replans the installed artifacts against the current workspace and lists the runtime-ready functions. It shows each function's table-function target and the result columns inferred from the planned SQL. An artifact that is missing, invalid, or no longer plans successfully is skipped with a warning.
 
 If a function publishes a SQL table function and declares required inputs, call it with named arguments:
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -18,6 +18,7 @@ mod query_error;
 mod source_ops;
 
 use std::borrow::Cow;
+use std::fmt::Write as _;
 use std::path::PathBuf;
 #[cfg(feature = "embedded-ui")]
 use std::sync::Arc;
@@ -28,8 +29,9 @@ use clap::{
 };
 use clap_complete::{Shell, generate};
 use coral_api::v1::{
-    CreateWorkspaceRequest, DeleteWorkspaceRequest, ExecuteSqlRequest, ListWorkspacesRequest,
-    SearchRequest, Workspace,
+    AddFunctionRequest, CreateWorkspaceRequest, DeleteWorkspaceRequest, ExecuteSqlRequest,
+    Function, ListFunctionsRequest, ListWorkspacesRequest, RemoveFunctionRequest, SearchRequest,
+    Workspace,
 };
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
@@ -79,6 +81,9 @@ enum Command {
     Source(SourceArgs),
     /// Manage workspaces
     Workspace(WorkspaceArgs),
+    /// Manage functions
+    #[command(name = "functions")]
+    Function(FunctionArgs),
     /// Interactive wizard to set up Coral and explore use cases
     Onboard,
     /// Start the MCP server over stdio
@@ -279,6 +284,30 @@ struct FeaturesArgs {
     command: FeaturesCommand,
 }
 
+#[derive(Debug, Args)]
+/// Manage functions
+struct FunctionArgs {
+    #[command(subcommand)]
+    command: FunctionCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum FunctionCommand {
+    /// List installed functions
+    List,
+    /// Add or replace a user function
+    Add {
+        /// Path to a function SQL artifact
+        #[arg(long)]
+        file: PathBuf,
+    },
+    /// Remove a user function
+    Remove {
+        /// Name of the function to remove
+        name: String,
+    },
+}
+
 #[derive(Debug, Subcommand)]
 enum FeaturesCommand {
     /// List experimental runtime features and their current status
@@ -424,6 +453,7 @@ impl Command {
             | Command::Search(_)
             | Command::Source(_)
             | Command::Workspace(_)
+            | Command::Function(_)
             | Command::Onboard
             | Command::McpStdio(_) => RequiredRuntime::AppClient,
             Command::Features(_) | Command::Completion(_) => RequiredRuntime::None,
@@ -442,6 +472,7 @@ impl Command {
             Command::Sql(_)
                 | Command::Search(_)
                 | Command::Source(_)
+                | Command::Function(_)
                 | Command::Onboard
                 | Command::McpStdio(_)
         )
@@ -623,6 +654,7 @@ async fn run_no_runtime_command(
         | Command::Search(_)
         | Command::Source(_)
         | Command::Workspace(_)
+        | Command::Function(_)
         | Command::Onboard
         | Command::McpStdio(_) => {
             unreachable!("app client commands are routed through app runtime startup")
@@ -662,6 +694,7 @@ async fn run_app_command(
         Command::Search(args) => run_search(&app, workspace, args).await?,
         Command::Source(args) => run_source(&app, workspace, args).await?,
         Command::Workspace(args) => run_workspace(&app, args).await?,
+        Command::Function(args) => run_function(&app, workspace, args).await?,
         Command::Onboard => {
             onboard::run(&app, workspace).await?;
         }
@@ -907,6 +940,115 @@ async fn run_search(
     Ok(())
 }
 
+async fn run_function(
+    app: &AppClient,
+    workspace: &Workspace,
+    args: FunctionArgs,
+) -> Result<(), CliError> {
+    match args.command {
+        FunctionCommand::List => {
+            let mut client = app.function_client();
+            let functions = client
+                .list_functions(Request::new(ListFunctionsRequest {
+                    workspace: Some(workspace.clone()),
+                }))
+                .await
+                .map_err(anyhow::Error::from)?
+                .into_inner()
+                .functions;
+            if functions.is_empty() {
+                println!("No runtime-ready functions.");
+            } else {
+                let rows = functions.into_iter().map(|function| {
+                    [
+                        function.name.clone(),
+                        function_publish_summary(&function),
+                        function_columns_summary(&function),
+                    ]
+                });
+                print_text_table(["Function", "Publish", "Columns"], rows);
+            }
+        }
+        FunctionCommand::Add { file } => {
+            let sql = std::fs::read_to_string(&file).map_err(anyhow::Error::from)?;
+            let mut client = app.function_client();
+            let function = client
+                .add_function(Request::new(AddFunctionRequest {
+                    workspace: Some(workspace.clone()),
+                    sql,
+                }))
+                .await
+                .map_err(anyhow::Error::from)?
+                .into_inner();
+            println!("Added function {}", function.name);
+        }
+        FunctionCommand::Remove { name } => {
+            let name = function_name_arg(&name)?;
+            let mut client = app.function_client();
+            client
+                .remove_function(Request::new(RemoveFunctionRequest {
+                    workspace: Some(workspace.clone()),
+                    name: name.clone(),
+                }))
+                .await
+                .map_err(anyhow::Error::from)?;
+            println!("Removed function {name}");
+        }
+    }
+    Ok(())
+}
+
+fn function_publish_summary(function: &Function) -> String {
+    let Some(publish) = function.publish.as_ref() else {
+        return "-".to_string();
+    };
+    let mut targets = Vec::new();
+    if let Some(target) = publish.table_function.as_ref() {
+        targets.push(format!("sql: {}.{}", target.schema, target.name));
+    }
+    if targets.is_empty() {
+        "-".to_string()
+    } else {
+        targets.join(", ")
+    }
+}
+
+fn function_columns_summary(function: &Function) -> String {
+    if function.result_columns.is_empty() {
+        return "-".to_string();
+    }
+    let visible_columns = function
+        .result_columns
+        .iter()
+        .map(|column| column.name.as_str())
+        .take(4)
+        .collect::<Vec<_>>();
+    let hidden_count = function
+        .result_columns
+        .len()
+        .saturating_sub(visible_columns.len());
+    let mut summary = visible_columns.join(", ");
+    if hidden_count > 0 {
+        write!(summary, ", +{hidden_count}").expect("writing to String should not fail");
+    }
+    summary
+}
+
+fn function_name_arg(name: &str) -> Result<String, anyhow::Error> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow::anyhow!("missing function name"));
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(anyhow::anyhow!(
+            "function name must not contain '/' or '\\\\'"
+        ));
+    }
+    if trimmed == "." || trimmed == ".." {
+        return Err(anyhow::anyhow!("function name must not be '.' or '..'"));
+    }
+    Ok(trimmed.to_string())
+}
 fn print_batches(
     batches: &[arrow::record_batch::RecordBatch],
     format: OutputFormat,
@@ -1078,8 +1220,9 @@ async fn run_source_add(
 #[cfg(test)]
 mod tests {
     use clap::{CommandFactory, Parser};
+    use coral_api::v1::{Function, FunctionResultColumn};
 
-    use super::{Cli, RequiredRuntime, command_enables_stderr_logs};
+    use super::{Cli, RequiredRuntime, command_enables_stderr_logs, function_columns_summary};
 
     #[test]
     fn server_command_is_not_available() {
@@ -1127,6 +1270,46 @@ mod tests {
         let cli = Cli::try_parse_from(["coral", "source", "list"]).expect("source list parses");
 
         assert_eq!(cli.command.required_runtime(), RequiredRuntime::AppClient);
+
+        let cli =
+            Cli::try_parse_from(["coral", "functions", "list"]).expect("functions list parses");
+
+        assert_eq!(cli.command.required_runtime(), RequiredRuntime::AppClient);
+    }
+
+    #[test]
+    fn function_columns_summary_shows_hidden_column_count() {
+        let mut function = Function {
+            result_columns: [
+                "number",
+                "title",
+                "html_url",
+                "state",
+                "author",
+                "updated_at",
+            ]
+            .into_iter()
+            .map(|name| FunctionResultColumn {
+                name: name.to_string(),
+                ..FunctionResultColumn::default()
+            })
+            .collect(),
+            ..Function::default()
+        };
+
+        assert_eq!(
+            function_columns_summary(&function),
+            "number, title, html_url, state, +2"
+        );
+
+        function.result_columns.truncate(4);
+        assert_eq!(
+            function_columns_summary(&function),
+            "number, title, html_url, state"
+        );
+
+        function.result_columns.clear();
+        assert_eq!(function_columns_summary(&function), "-");
     }
 
     #[test]
@@ -1174,6 +1357,8 @@ mod tests {
         let search =
             Cli::try_parse_from(["coral", "search", "github", "issues"]).expect("search parses");
         let source = Cli::try_parse_from(["coral", "source", "list"]).expect("source parses");
+        let functions =
+            Cli::try_parse_from(["coral", "functions", "list"]).expect("functions parses");
         let onboard = Cli::try_parse_from(["coral", "onboard"]).expect("onboard parses");
         let workspace =
             Cli::try_parse_from(["coral", "workspace", "list"]).expect("workspace parses");
@@ -1182,6 +1367,7 @@ mod tests {
         assert!(sql.command.uses_selected_workspace());
         assert!(search.command.uses_selected_workspace());
         assert!(source.command.uses_selected_workspace());
+        assert!(functions.command.uses_selected_workspace());
         assert!(onboard.command.uses_selected_workspace());
         assert!(mcp.command.uses_selected_workspace());
         assert!(!workspace.command.uses_selected_workspace());

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -30,8 +30,8 @@ use clap::{
 use clap_complete::{Shell, generate};
 use coral_api::v1::{
     AddFunctionRequest, CreateWorkspaceRequest, DeleteFunctionRequest, DeleteWorkspaceRequest,
-    ExecuteSqlRequest, Function, ListFunctionsRequest, ListWorkspacesRequest, SearchRequest,
-    Workspace,
+    ExecuteSqlRequest, Function, FunctionRuntimeReady, ListFunctionsRequest, ListWorkspacesRequest,
+    SearchRequest, Workspace, function,
 };
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
@@ -957,16 +957,22 @@ async fn run_function(
                 .into_inner()
                 .functions;
             if functions.is_empty() {
-                println!("No runtime-ready functions.");
+                println!("No installed functions.");
             } else {
-                let rows = functions.into_iter().map(|function| {
+                let rows = functions.iter().map(|function| {
                     [
                         function.name.clone(),
-                        function_publish_summary(&function),
-                        function_columns_summary(&function),
+                        function_status_summary(function),
+                        function_arguments_summary(function),
+                        function_publish_summary(function),
+                        function_columns_summary(function),
                     ]
                 });
-                print_text_table(["Function", "Publish", "Columns"], rows);
+                print_text_table(
+                    ["Function", "Status", "Arguments", "Publish", "Columns"],
+                    rows,
+                );
+                print_function_invalid_details(&functions);
             }
         }
         FunctionCommand::Add { file } => {
@@ -1001,32 +1007,77 @@ async fn run_function(
     Ok(())
 }
 
-fn function_publish_summary(function: &Function) -> String {
-    let Some(publish) = function.publish.as_ref() else {
-        return "-".to_string();
-    };
-    let mut targets = Vec::new();
-    if let Some(target) = publish.table_function.as_ref() {
-        targets.push(format!("sql: {}.{}", target.schema_name, target.name));
-    }
-    if targets.is_empty() {
-        "-".to_string()
-    } else {
-        targets.join(", ")
+fn function_status_summary(function: &Function) -> String {
+    match function.runtime.as_ref() {
+        Some(function::Runtime::Ready(_)) => "ready".to_string(),
+        Some(function::Runtime::Invalid(_)) | None => "invalid".to_string(),
     }
 }
 
-fn function_columns_summary(function: &Function) -> String {
-    if function.result_columns.is_empty() {
+fn print_function_invalid_details(functions: &[Function]) {
+    let mut invalid_functions = functions.iter().filter_map(|function| {
+        function_invalid_reason(function).map(|reason| (function.name.as_str(), reason))
+    });
+    let Some((first_name, first_reason)) = invalid_functions.next() else {
+        return;
+    };
+
+    println!("\nInvalid functions:");
+    for (name, reason) in std::iter::once((first_name, first_reason)).chain(invalid_functions) {
+        println!("  {name}:");
+        for line in reason.lines() {
+            println!("    {line}");
+        }
+    }
+}
+
+fn function_invalid_reason(function: &Function) -> Option<&str> {
+    match function.runtime.as_ref() {
+        Some(function::Runtime::Ready(_)) => None,
+        Some(function::Runtime::Invalid(invalid)) => Some(invalid.reason.as_str()),
+        None => Some("runtime status unavailable"),
+    }
+}
+
+fn function_publish_summary(function: &Function) -> String {
+    let Some(ready) = function_runtime_ready(function) else {
+        return "-".to_string();
+    };
+    ready.table_function.as_ref().map_or_else(
+        || "-".to_string(),
+        |target| format!("sql: {}.{}", target.schema_name, target.name),
+    )
+}
+
+fn function_arguments_summary(function: &Function) -> String {
+    let Some(ready) = function_runtime_ready(function) else {
+        return "-".to_string();
+    };
+    if ready.arguments.is_empty() {
         return "-".to_string();
     }
-    let visible_columns = function
+    ready
+        .arguments
+        .iter()
+        .map(|argument| format!("{}: {}", argument.name, argument.data_type))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn function_columns_summary(function: &Function) -> String {
+    let Some(ready) = function_runtime_ready(function) else {
+        return "-".to_string();
+    };
+    if ready.result_columns.is_empty() {
+        return "-".to_string();
+    }
+    let visible_columns = ready
         .result_columns
         .iter()
         .map(|column| column.name.as_str())
         .take(4)
         .collect::<Vec<_>>();
-    let hidden_count = function
+    let hidden_count = ready
         .result_columns
         .len()
         .saturating_sub(visible_columns.len());
@@ -1035,6 +1086,13 @@ fn function_columns_summary(function: &Function) -> String {
         write!(summary, ", +{hidden_count}").expect("writing to String should not fail");
     }
     summary
+}
+
+fn function_runtime_ready(function: &Function) -> Option<&FunctionRuntimeReady> {
+    match function.runtime.as_ref() {
+        Some(function::Runtime::Ready(ready)) => Some(ready),
+        Some(function::Runtime::Invalid(_)) | None => None,
+    }
 }
 
 fn function_name_arg(name: &str) -> Result<String, anyhow::Error> {
@@ -1223,9 +1281,14 @@ async fn run_source_add(
 #[cfg(test)]
 mod tests {
     use clap::{CommandFactory, Parser};
-    use coral_api::v1::{Function, TableFunctionResultColumn};
+    use coral_api::v1::{
+        Function, FunctionRuntimeInvalid, FunctionRuntimeReady, TableFunctionResultColumn, function,
+    };
 
-    use super::{Cli, RequiredRuntime, command_enables_stderr_logs, function_columns_summary};
+    use super::{
+        Cli, RequiredRuntime, command_enables_stderr_logs, function_columns_summary,
+        function_status_summary,
+    };
 
     #[test]
     fn server_command_is_not_available() {
@@ -1283,20 +1346,23 @@ mod tests {
     #[test]
     fn function_columns_summary_shows_hidden_column_count() {
         let mut function = Function {
-            result_columns: [
-                "number",
-                "title",
-                "html_url",
-                "state",
-                "author",
-                "updated_at",
-            ]
-            .into_iter()
-            .map(|name| TableFunctionResultColumn {
-                name: name.to_string(),
-                ..TableFunctionResultColumn::default()
-            })
-            .collect(),
+            runtime: Some(function::Runtime::Ready(FunctionRuntimeReady {
+                result_columns: [
+                    "number",
+                    "title",
+                    "html_url",
+                    "state",
+                    "author",
+                    "updated_at",
+                ]
+                .into_iter()
+                .map(|name| TableFunctionResultColumn {
+                    name: name.to_string(),
+                    ..TableFunctionResultColumn::default()
+                })
+                .collect(),
+                ..FunctionRuntimeReady::default()
+            })),
             ..Function::default()
         };
 
@@ -1305,13 +1371,19 @@ mod tests {
             "number, title, html_url, state, +2"
         );
 
-        function.result_columns.truncate(4);
+        match function.runtime.as_mut() {
+            Some(function::Runtime::Ready(ready)) => ready.result_columns.truncate(4),
+            Some(function::Runtime::Invalid(_)) | None => panic!("ready function"),
+        }
         assert_eq!(
             function_columns_summary(&function),
             "number, title, html_url, state"
         );
 
-        function.result_columns.clear();
+        match function.runtime.as_mut() {
+            Some(function::Runtime::Ready(ready)) => ready.result_columns.clear(),
+            Some(function::Runtime::Invalid(_)) | None => panic!("ready function"),
+        }
         assert_eq!(function_columns_summary(&function), "-");
     }
 
@@ -1331,6 +1403,23 @@ mod tests {
             .expect_err("limit above the server cap should fail before contacting the server");
         Cli::try_parse_from(["coral", "search", "--limit", "50", "github"])
             .expect("server maximum should parse");
+    }
+
+    #[test]
+    fn function_status_summary_stays_on_one_line() {
+        let function = Function {
+            runtime: Some(function::Runtime::Invalid(FunctionRuntimeInvalid {
+                reason: "source 'github' is not installed".to_string(),
+            })),
+            ..Function::default()
+        };
+
+        assert_eq!(function_status_summary(&function), "invalid");
+        let ready = Function {
+            runtime: Some(function::Runtime::Ready(FunctionRuntimeReady::default())),
+            ..Function::default()
+        };
+        assert_eq!(function_status_summary(&ready), "ready");
     }
 
     #[test]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -29,8 +29,8 @@ use clap::{
 };
 use clap_complete::{Shell, generate};
 use coral_api::v1::{
-    AddFunctionRequest, CreateWorkspaceRequest, DeleteWorkspaceRequest, ExecuteSqlRequest,
-    Function, ListFunctionsRequest, ListWorkspacesRequest, RemoveFunctionRequest, SearchRequest,
+    AddFunctionRequest, CreateWorkspaceRequest, DeleteFunctionRequest, DeleteWorkspaceRequest,
+    ExecuteSqlRequest, Function, ListFunctionsRequest, ListWorkspacesRequest, SearchRequest,
     Workspace,
 };
 #[cfg(feature = "embedded-ui")]
@@ -980,13 +980,16 @@ async fn run_function(
                 .await
                 .map_err(anyhow::Error::from)?
                 .into_inner();
+            let function = function.function.ok_or_else(|| {
+                anyhow::anyhow!("function service returned no function after add")
+            })?;
             println!("Added function {}", function.name);
         }
         FunctionCommand::Remove { name } => {
             let name = function_name_arg(&name)?;
             let mut client = app.function_client();
             client
-                .remove_function(Request::new(RemoveFunctionRequest {
+                .delete_function(Request::new(DeleteFunctionRequest {
                     workspace: Some(workspace.clone()),
                     name: name.clone(),
                 }))
@@ -1004,7 +1007,7 @@ fn function_publish_summary(function: &Function) -> String {
     };
     let mut targets = Vec::new();
     if let Some(target) = publish.table_function.as_ref() {
-        targets.push(format!("sql: {}.{}", target.schema, target.name));
+        targets.push(format!("sql: {}.{}", target.schema_name, target.name));
     }
     if targets.is_empty() {
         "-".to_string()

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -1223,7 +1223,7 @@ async fn run_source_add(
 #[cfg(test)]
 mod tests {
     use clap::{CommandFactory, Parser};
-    use coral_api::v1::{Function, FunctionResultColumn};
+    use coral_api::v1::{Function, TableFunctionResultColumn};
 
     use super::{Cli, RequiredRuntime, command_enables_stderr_logs, function_columns_summary};
 
@@ -1292,9 +1292,9 @@ mod tests {
                 "updated_at",
             ]
             .into_iter()
-            .map(|name| FunctionResultColumn {
+            .map(|name| TableFunctionResultColumn {
                 name: name.to_string(),
-                ..FunctionResultColumn::default()
+                ..TableFunctionResultColumn::default()
             })
             .collect(),
             ..Function::default()

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -170,6 +170,25 @@ async fn source_list_accepts_workspace_flag_after_subcommand() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn functions_list_uses_workspace_flag() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["--workspace", "work", "functions", "list"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert_eq!(stdout.trim(), "No runtime-ready functions.");
+    let requests = server.list_functions_requests();
+    assert_eq!(requests.len(), 1, "expected one list_functions call");
+    assert_workspace_name(requests[0].workspace.as_ref(), "work");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn workspace_list_renders_configured_workspaces() {
     let server = MockServer::start_with_config(MockServerConfig::default().with_list_workspaces(
         ListWorkspacesResponse {

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -17,8 +17,10 @@ use arrow::record_batch::RecordBatch;
 #[cfg(feature = "embedded-ui")]
 use assert_cmd::Command;
 use coral_api::v1::{
-    DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, ListWorkspacesResponse,
-    Source, SourceCredentialStorage, SourceInfo, SourceOrigin, Workspace,
+    AddFunctionResponse, DiscoverSourcesResponse, ExecuteSqlResponse, Function, FunctionArgument,
+    FunctionRuntimeInvalid, FunctionRuntimeReady, ListFunctionsResponse, ListSourcesResponse,
+    ListWorkspacesResponse, Source, SourceCredentialStorage, SourceInfo, SourceOrigin, Workspace,
+    function,
 };
 use tempfile::tempdir;
 use tonic::Code;
@@ -180,10 +182,131 @@ async fn functions_list_uses_workspace_flag() {
         .success();
 
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
-    assert_eq!(stdout.trim(), "No runtime-ready functions.");
+    assert_eq!(stdout.trim(), "No installed functions.");
     let requests = server.list_functions_requests();
     assert_eq!(requests.len(), 1, "expected one list_functions call");
     assert_workspace_name(requests[0].workspace.as_ref(), "work");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn functions_list_renders_runtime_details() {
+    let server = MockServer::start_with_config(MockServerConfig::default().with_list_functions(
+        ListFunctionsResponse {
+            functions: vec![
+                Function {
+                    name: "github_issues".to_string(),
+                    runtime: Some(function::Runtime::Ready(FunctionRuntimeReady {
+                        arguments: vec![
+                            FunctionArgument {
+                                name: "owner".to_string(),
+                                data_type: "Utf8".to_string(),
+                            },
+                            FunctionArgument {
+                                name: "repo".to_string(),
+                                data_type: "Utf8".to_string(),
+                            },
+                        ],
+                        ..FunctionRuntimeReady::default()
+                    })),
+                    ..Function::default()
+                },
+                Function {
+                    name: "broken_function".to_string(),
+                    runtime: Some(function::Runtime::Invalid(FunctionRuntimeInvalid {
+                        reason: "could not plan function\nsource is unavailable\nHint: reinstall the source"
+                            .to_string(),
+                    })),
+                    ..Function::default()
+                },
+            ],
+        },
+    ))
+    .await;
+
+    let assert = server.cmd().args(["functions", "list"]).assert().success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("Arguments"),
+        "missing arguments header: {stdout}"
+    );
+    assert!(
+        stdout.contains("owner: Utf8, repo: Utf8"),
+        "missing inferred arguments: {stdout}"
+    );
+    let invalid_row = stdout
+        .lines()
+        .find(|line| line.starts_with("broken_function"))
+        .expect("invalid function row");
+    assert!(invalid_row.contains("invalid"), "invalid status: {stdout}");
+    assert!(
+        !invalid_row.contains("could not plan function"),
+        "validation reason leaked into table: {stdout}"
+    );
+    assert!(
+        stdout.contains(
+            "Invalid functions:\n  broken_function:\n    could not plan function\n    source is unavailable\n    Hint: reinstall the source"
+        ),
+        "missing indented validation reason: {stdout}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn functions_add_sends_file_to_selected_workspace() {
+    let temp = tempdir().expect("temp dir");
+    let function_file = temp.path().join("echo_value.sql");
+    let sql = "/* name: echo_value */ select 1 as value\n";
+    std::fs::write(&function_file, sql).expect("write function");
+    let server = MockServer::start_with_config(MockServerConfig::default().with_add_function(
+        AddFunctionResponse {
+            function: Some(Function {
+                name: "echo_value".to_string(),
+                runtime: Some(function::Runtime::Ready(FunctionRuntimeReady::default())),
+                ..Function::default()
+            }),
+        },
+    ))
+    .await;
+
+    let assert = server
+        .cmd()
+        .args(["--workspace", "work", "functions", "add", "--file"])
+        .arg(&function_file)
+        .assert()
+        .success();
+    assert_eq!(
+        String::from_utf8_lossy(&assert.get_output().stdout).trim(),
+        "Added function echo_value"
+    );
+    let requests = server.add_function_requests();
+    assert_eq!(requests.len(), 1);
+    assert_workspace_name(requests[0].workspace.as_ref(), "work");
+    assert_eq!(requests[0].sql, sql);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn functions_remove_uses_selected_workspace() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["--workspace", "work", "functions", "remove", "echo_value"])
+        .assert()
+        .success();
+    assert_eq!(
+        String::from_utf8_lossy(&assert.get_output().stdout).trim(),
+        "Removed function echo_value"
+    );
+    let requests = server.delete_function_requests();
+    assert_eq!(requests.len(), 1);
+    assert_workspace_name(requests[0].workspace.as_ref(), "work");
+    assert_eq!(requests[0].name, "echo_value");
 
     server.shutdown().await;
 }

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -586,6 +586,9 @@ pub(crate) struct MockServerConfig {
     list_workspaces: MockResult<ListWorkspacesResponse>,
     validate_source: MockResult<ValidateSourceResponse>,
     delete_source: MockResult<()>,
+    add_function: MockResult<AddFunctionResponse>,
+    list_functions: MockResult<ListFunctionsResponse>,
+    delete_function: MockResult<()>,
 }
 
 impl Default for MockServerConfig {
@@ -621,6 +624,11 @@ impl Default for MockServerConfig {
             }),
             validate_source: MockResult::ok(mock_validate_response()),
             delete_source: MockResult::ok(()),
+            add_function: MockResult::ok(AddFunctionResponse { function: None }),
+            list_functions: MockResult::ok(ListFunctionsResponse {
+                functions: Vec::new(),
+            }),
+            delete_function: MockResult::ok(()),
         }
     }
 }
@@ -643,6 +651,16 @@ impl MockServerConfig {
 
     pub(crate) fn with_execute_sql(mut self, response: ExecuteSqlResponse) -> Self {
         self.execute_sql_override = Some(MockResult::ok(response));
+        self
+    }
+
+    pub(crate) fn with_add_function(mut self, response: AddFunctionResponse) -> Self {
+        self.add_function = MockResult::ok(response);
+        self
+    }
+
+    pub(crate) fn with_list_functions(mut self, response: ListFunctionsResponse) -> Self {
+        self.list_functions = MockResult::ok(response);
         self
     }
 
@@ -1011,6 +1029,7 @@ struct MockSourceService {
 
 #[derive(Clone)]
 struct MockFunctionService {
+    config: Arc<MockServerConfig>,
     captured: Arc<Captured>,
 }
 
@@ -1025,9 +1044,11 @@ impl FunctionService for MockFunctionService {
             .lock()
             .expect("add_function capture")
             .push(request.into_inner());
-        Err(Status::unimplemented(
-            "mock function add is not implemented",
-        ))
+        self.config
+            .add_function
+            .clone()
+            .into_tonic_result()
+            .map(Response::new)
     }
 
     async fn list_functions(
@@ -1039,9 +1060,11 @@ impl FunctionService for MockFunctionService {
             .lock()
             .expect("list_functions capture")
             .push(request.into_inner());
-        Ok(Response::new(ListFunctionsResponse {
-            functions: Vec::new(),
-        }))
+        self.config
+            .list_functions
+            .clone()
+            .into_tonic_result()
+            .map(Response::new)
     }
 
     async fn delete_function(
@@ -1053,9 +1076,11 @@ impl FunctionService for MockFunctionService {
             .lock()
             .expect("remove_function capture")
             .push(request.into_inner());
-        Err(Status::unimplemented(
-            "mock function delete is not implemented",
-        ))
+        self.config
+            .delete_function
+            .clone()
+            .into_tonic_result()
+            .map(|()| Response::new(DeleteFunctionResponse {}))
     }
 }
 
@@ -1319,6 +1344,7 @@ impl MockServer {
                     captured: workspace_captured,
                 }))
                 .add_service(FunctionServiceServer::new(MockFunctionService {
+                    config: Arc::clone(&config),
                     captured: function_captured,
                 }))
                 .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
@@ -1444,6 +1470,22 @@ impl MockServer {
             .list_functions
             .lock()
             .expect("list_functions capture")
+            .clone()
+    }
+
+    pub(crate) fn add_function_requests(&self) -> Vec<AddFunctionRequest> {
+        self.captured
+            .add_function
+            .lock()
+            .expect("add_function capture")
+            .clone()
+    }
+
+    pub(crate) fn delete_function_requests(&self) -> Vec<DeleteFunctionRequest> {
+        self.captured
+            .remove_function
+            .lock()
+            .expect("remove_function capture")
             .clone()
     }
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -14,29 +14,31 @@ use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
 use assert_cmd::Command;
 use coral_api::v1::catalog_service_server::{CatalogService, CatalogServiceServer};
+use coral_api::v1::function_service_server::{FunctionService, FunctionServiceServer};
 use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::search_service_server::{SearchService, SearchServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::workspace_service_server::{WorkspaceService, WorkspaceServiceServer};
 use coral_api::v1::{
-    CatalogCounts, CatalogItem, CatalogMetadata, CatalogSearchResult, Column, ColumnHint,
-    ColumnSearchResult, CreateBundledSourceRequest, CreateBundledSourceResponse,
-    CreateBundledSourceWithOAuthRequest, CreateBundledSourceWithOAuthResponse,
-    CreateWorkspaceRequest, CreateWorkspaceResponse, DeleteSourceRequest, DeleteSourceResponse,
-    DeleteWorkspaceRequest, DeleteWorkspaceResponse, DescribeTableRequest, DescribeTableResponse,
-    DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse,
-    ExplainSqlRequest, ExplainSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse,
-    GetSourceRequest, GetSourceResponse, ImportSourceRequest, ImportSourceResponse,
-    ListCatalogRequest, ListCatalogResponse, ListColumnsRequest, ListColumnsResponse,
+    AddFunctionRequest, AddFunctionResponse, CatalogCounts, CatalogItem, CatalogMetadata,
+    CatalogSearchResult, Column, ColumnHint, ColumnSearchResult, CreateBundledSourceRequest,
+    CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
+    CreateBundledSourceWithOAuthResponse, CreateWorkspaceRequest, CreateWorkspaceResponse,
+    DeleteSourceRequest, DeleteSourceResponse, DeleteWorkspaceRequest, DeleteWorkspaceResponse,
+    DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
+    ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
+    GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest, GetSourceResponse,
+    ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListCatalogResponse,
+    ListColumnsRequest, ListColumnsResponse, ListFunctionsRequest, ListFunctionsResponse,
     ListSourcesRequest, ListSourcesResponse, ListWorkspacesRequest, ListWorkspacesResponse,
-    PaginationRequest, PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse,
-    SearchFieldRole, SearchProvider, SearchProviderCoverage, SearchProviderState, SearchRequest,
-    SearchResponse, SearchResult, SearchResultTruncation, SearchSurfaceKind,
-    SearchTableColumnPreview, SearchTableColumnPreviewColumn, Source, SourceCredentialStorage,
-    SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableSummary,
-    ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
-    create_bundled_source_with_o_auth_response, import_source_response, search_result,
-    source_input_spec::Input as ProtoSourceInput,
+    PaginationRequest, PaginationResponse, QueryPlan, RemoveFunctionRequest,
+    RemoveFunctionResponse, SearchCatalogRequest, SearchCatalogResponse, SearchFieldRole,
+    SearchProvider, SearchProviderCoverage, SearchProviderState, SearchRequest, SearchResponse,
+    SearchResult, SearchResultTruncation, SearchSurfaceKind, SearchTableColumnPreview,
+    SearchTableColumnPreviewColumn, Source, SourceCredentialStorage, SourceInfo, SourceInputSpec,
+    SourceOrigin, SourceSecretInput, Table, TableSummary, ValidateSourceRequest,
+    ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
+    import_source_response, search_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_TASK_ID_METADATA_KEY,
@@ -740,6 +742,9 @@ struct Captured {
     import_source: Mutex<Vec<ImportSourceRequest>>,
     delete_source: Mutex<Vec<DeleteSourceRequest>>,
     validate_source: Mutex<Vec<ValidateSourceRequest>>,
+    add_function: Mutex<Vec<AddFunctionRequest>>,
+    list_functions: Mutex<Vec<ListFunctionsRequest>>,
+    remove_function: Mutex<Vec<RemoveFunctionRequest>>,
     list_workspaces: Mutex<Vec<ListWorkspacesRequest>>,
     create_workspace: Mutex<Vec<CreateWorkspaceRequest>>,
     delete_workspace: Mutex<Vec<DeleteWorkspaceRequest>>,
@@ -1004,6 +1009,56 @@ struct MockSourceService {
     captured: Arc<Captured>,
 }
 
+#[derive(Clone)]
+struct MockFunctionService {
+    captured: Arc<Captured>,
+}
+
+#[tonic::async_trait]
+impl FunctionService for MockFunctionService {
+    async fn add_function(
+        &self,
+        request: Request<AddFunctionRequest>,
+    ) -> Result<Response<AddFunctionResponse>, Status> {
+        self.captured
+            .add_function
+            .lock()
+            .expect("add_function capture")
+            .push(request.into_inner());
+        Err(Status::unimplemented(
+            "mock function add is not implemented",
+        ))
+    }
+
+    async fn list_functions(
+        &self,
+        request: Request<ListFunctionsRequest>,
+    ) -> Result<Response<ListFunctionsResponse>, Status> {
+        self.captured
+            .list_functions
+            .lock()
+            .expect("list_functions capture")
+            .push(request.into_inner());
+        Ok(Response::new(ListFunctionsResponse {
+            functions: Vec::new(),
+        }))
+    }
+
+    async fn remove_function(
+        &self,
+        request: Request<RemoveFunctionRequest>,
+    ) -> Result<Response<RemoveFunctionResponse>, Status> {
+        self.captured
+            .remove_function
+            .lock()
+            .expect("remove_function capture")
+            .push(request.into_inner());
+        Err(Status::unimplemented(
+            "mock function remove is not implemented",
+        ))
+    }
+}
+
 type MockBundledSourceStream =
     Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithOAuthResponse, Status>> + Send>>;
 type MockImportSourceStream =
@@ -1236,6 +1291,7 @@ impl MockServer {
         let search_captured = Arc::clone(&captured);
         let catalog_captured = Arc::clone(&captured);
         let source_captured = Arc::clone(&captured);
+        let function_captured = Arc::clone(&captured);
         let workspace_captured = Arc::clone(&captured);
         let query_config = Arc::clone(&config);
         let search_config = Arc::clone(&config);
@@ -1261,6 +1317,9 @@ impl MockServer {
                 .add_service(WorkspaceServiceServer::new(MockWorkspaceService {
                     config: workspace_config,
                     captured: workspace_captured,
+                }))
+                .add_service(FunctionServiceServer::new(MockFunctionService {
+                    captured: function_captured,
                 }))
                 .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                     drop(shutdown_rx.await);
@@ -1377,6 +1436,14 @@ impl MockServer {
             .validate_source
             .lock()
             .expect("validate_source capture")
+            .clone()
+    }
+
+    pub(crate) fn list_functions_requests(&self) -> Vec<ListFunctionsRequest> {
+        self.captured
+            .list_functions
+            .lock()
+            .expect("list_functions capture")
             .clone()
     }
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -24,17 +24,17 @@ use coral_api::v1::{
     CatalogSearchResult, Column, ColumnHint, ColumnSearchResult, CreateBundledSourceRequest,
     CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
     CreateBundledSourceWithOAuthResponse, CreateWorkspaceRequest, CreateWorkspaceResponse,
-    DeleteSourceRequest, DeleteSourceResponse, DeleteWorkspaceRequest, DeleteWorkspaceResponse,
-    DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
-    ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
-    GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest, GetSourceResponse,
-    ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListCatalogResponse,
-    ListColumnsRequest, ListColumnsResponse, ListFunctionsRequest, ListFunctionsResponse,
-    ListSourcesRequest, ListSourcesResponse, ListWorkspacesRequest, ListWorkspacesResponse,
-    PaginationRequest, PaginationResponse, QueryPlan, RemoveFunctionRequest,
-    RemoveFunctionResponse, SearchCatalogRequest, SearchCatalogResponse, SearchFieldRole,
-    SearchProvider, SearchProviderCoverage, SearchProviderState, SearchRequest, SearchResponse,
-    SearchResult, SearchResultTruncation, SearchSurfaceKind, SearchTableColumnPreview,
+    DeleteFunctionRequest, DeleteFunctionResponse, DeleteSourceRequest, DeleteSourceResponse,
+    DeleteWorkspaceRequest, DeleteWorkspaceResponse, DescribeTableRequest, DescribeTableResponse,
+    DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse,
+    ExplainSqlRequest, ExplainSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse,
+    GetSourceRequest, GetSourceResponse, ImportSourceRequest, ImportSourceResponse,
+    ListCatalogRequest, ListCatalogResponse, ListColumnsRequest, ListColumnsResponse,
+    ListFunctionsRequest, ListFunctionsResponse, ListSourcesRequest, ListSourcesResponse,
+    ListWorkspacesRequest, ListWorkspacesResponse, PaginationRequest, PaginationResponse,
+    QueryPlan, SearchCatalogRequest, SearchCatalogResponse, SearchFieldRole, SearchProvider,
+    SearchProviderCoverage, SearchProviderState, SearchRequest, SearchResponse, SearchResult,
+    SearchResultTruncation, SearchSurfaceKind, SearchTableColumnPreview,
     SearchTableColumnPreviewColumn, Source, SourceCredentialStorage, SourceInfo, SourceInputSpec,
     SourceOrigin, SourceSecretInput, Table, TableSummary, ValidateSourceRequest,
     ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
@@ -744,7 +744,7 @@ struct Captured {
     validate_source: Mutex<Vec<ValidateSourceRequest>>,
     add_function: Mutex<Vec<AddFunctionRequest>>,
     list_functions: Mutex<Vec<ListFunctionsRequest>>,
-    remove_function: Mutex<Vec<RemoveFunctionRequest>>,
+    remove_function: Mutex<Vec<DeleteFunctionRequest>>,
     list_workspaces: Mutex<Vec<ListWorkspacesRequest>>,
     create_workspace: Mutex<Vec<CreateWorkspaceRequest>>,
     delete_workspace: Mutex<Vec<DeleteWorkspaceRequest>>,
@@ -1044,17 +1044,17 @@ impl FunctionService for MockFunctionService {
         }))
     }
 
-    async fn remove_function(
+    async fn delete_function(
         &self,
-        request: Request<RemoveFunctionRequest>,
-    ) -> Result<Response<RemoveFunctionResponse>, Status> {
+        request: Request<DeleteFunctionRequest>,
+    ) -> Result<Response<DeleteFunctionResponse>, Status> {
         self.captured
             .remove_function
             .lock()
             .expect("remove_function capture")
             .push(request.into_inner());
         Err(Status::unimplemented(
-            "mock function remove is not implemented",
+            "mock function delete is not implemented",
         ))
     }
 }


### PR DESCRIPTION
## Why

Add the user-facing CLI for the function lifecycle API while keeping validation, persistence, and runtime behavior in `coral-app`.

```bash
coral functions add --file open_prs.sql
coral functions list
coral functions remove open_prs
```

## What changed

- Adds workspace-aware `functions add`, `functions list`, and `functions remove` commands.
- Renders ready functions with their publication target, arguments, and result-column preview.
- Renders invalid installed functions with the app-provided reason so users can fix or remove them.
- Documents the commands and the explicit-`CAST` requirement when parameter inference is ambiguous.

The CLI only reads files, sends typed requests, and formats responses. It does not duplicate validation or runtime logic.

## Validation

- CLI e2e coverage verifies the exact add artifact/workspace request.
- CLI e2e coverage verifies list workspace scoping and the exact delete request.
- Unit coverage verifies ready and invalid status rendering.
- `make rust-checks`
- `make docs-check`
- `make perf-check` (271 ms mean; 750 ms limit)
