### PR TITLE
refactor(types): consolidate scalar type conversions around ManifestDataType

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -6,10 +6,10 @@ use std::sync::{Arc, OnceLock};
 use crate::{QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceInputResolver};
 use async_trait::async_trait;
 use coral_spec::{
-    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec,
-    SearchLimitsSpec, SourceBackend, SourceTableFunctionSpec, TableCommon,
+    ColumnSpec, FilterSpec, ManifestInputKind, ManifestInputSpec, SearchLimitsSpec, SourceBackend,
+    SourceTableFunctionSpec, TableCommon,
 };
-use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::Expr;
@@ -368,22 +368,10 @@ fn serialize_search_limits(limits: &SearchLimitsSpec) -> String {
     serde_json::to_string(limits).expect("search limits json")
 }
 
-pub(crate) fn manifest_data_type_to_arrow(data_type: ManifestDataType) -> DataType {
-    match data_type {
-        ManifestDataType::Utf8 | ManifestDataType::Json => DataType::Utf8,
-        ManifestDataType::Int64 => DataType::Int64,
-        ManifestDataType::Boolean => DataType::Boolean,
-        ManifestDataType::Float64 => DataType::Float64,
-        ManifestDataType::Timestamp => {
-            DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into()))
-        }
-    }
-}
-
 pub(crate) fn arrow_type_for_column(column: &ColumnSpec) -> datafusion::error::Result<DataType> {
     column
         .manifest_data_type()
-        .map(manifest_data_type_to_arrow)
+        .map(crate::types::arrow_column_type)
         .map_err(|error| DataFusionError::Execution(error.to_string()))
 }
 

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -210,7 +210,7 @@ pub(crate) fn registered_filters_from_specs(filters: &[FilterSpec]) -> Vec<Regis
             name: filter.name.clone(),
             mode: filter.mode.as_str().to_string(),
             required: filter.required,
-            data_type: filter.data_type.clone(),
+            data_type: filter.data_type.as_manifest_str().to_string(),
             description: filter.description.clone(),
         })
         .collect()
@@ -228,7 +228,7 @@ pub(crate) fn registered_columns_from_specs(
                 .find(|filter| filter.name == column.name.as_str());
             RegisteredColumn {
                 name: column.name.clone(),
-                data_type: column.data_type.clone(),
+                data_type: column.data_type.as_manifest_str().to_string(),
                 nullable: column.nullable,
                 is_virtual: column.r#virtual,
                 is_required_filter: filter.is_some_and(|filter| filter.required),
@@ -368,11 +368,8 @@ fn serialize_search_limits(limits: &SearchLimitsSpec) -> String {
     serde_json::to_string(limits).expect("search limits json")
 }
 
-pub(crate) fn arrow_type_for_column(column: &ColumnSpec) -> datafusion::error::Result<DataType> {
-    column
-        .manifest_data_type()
-        .map(crate::types::arrow_column_type)
-        .map_err(|error| DataFusionError::Execution(error.to_string()))
+pub(crate) fn arrow_type_for_column(column: &ColumnSpec) -> DataType {
+    crate::types::arrow_column_type(column.data_type)
 }
 
 pub(crate) fn schema_from_columns(
@@ -390,7 +387,7 @@ pub(crate) fn schema_from_columns(
     for column in columns {
         fields.push(Field::new(
             &column.name,
-            arrow_type_for_column(column)?,
+            arrow_type_for_column(column),
             column.nullable,
         ));
     }

--- a/crates/coral-engine/src/backends/file/json.rs
+++ b/crates/coral-engine/src/backends/file/json.rs
@@ -134,7 +134,7 @@ impl JsonFileTableProvider {
         let metadata_columns = FileMetadataColumns::try_new(&table.source.metadata)?;
         let table_schema = metadata_columns.extend_table_schema_if_present(table_schema);
         let schema = Arc::clone(table_schema.table_schema());
-        let json_fields = Arc::new(json_field_names(table.columns())?);
+        let json_fields = Arc::new(json_field_names(table.columns()));
 
         Ok(Self {
             source_schema: source_schema.to_string(),
@@ -156,7 +156,7 @@ pub(super) fn requires_custom_provider(table: &FileTableSpec) -> Result<bool> {
     let metadata_columns = FileMetadataColumns::try_new(&table.source.metadata)?;
     Ok(!table.source.partitions.is_empty()
         || metadata_columns.has_row_columns()
-        || !json_field_names(table.columns())?.is_empty())
+        || !json_field_names(table.columns()).is_empty())
 }
 
 #[async_trait]
@@ -878,13 +878,10 @@ fn datafusion_error_to_arrow(error: DataFusionError) -> ArrowError {
     ArrowError::ExternalError(Box::new(error))
 }
 
-fn json_field_names(columns: &[ColumnSpec]) -> Result<HashSet<String>> {
+fn json_field_names(columns: &[ColumnSpec]) -> HashSet<String> {
     columns
         .iter()
-        .filter_map(|column| match column.manifest_data_type() {
-            Ok(ManifestDataType::Json) => Some(Ok(column.name.clone())),
-            Ok(_) => None,
-            Err(error) => Some(Err(DataFusionError::Execution(error.to_string()))),
-        })
+        .filter(|column| column.data_type == ManifestDataType::Json)
+        .map(|column| column.name.clone())
         .collect()
 }

--- a/crates/coral-engine/src/backends/file/partitions.rs
+++ b/crates/coral-engine/src/backends/file/partitions.rs
@@ -13,105 +13,85 @@ use coral_spec::backends::file::{FilePartitionDataType, PartitionColumnSpec, Par
 
 use super::listing::parse_bool;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PartitionDataType {
-    Utf8,
-    Int64,
-    Boolean,
-    Float64,
-    Json,
+fn arrow_type(data_type: FilePartitionDataType) -> DataType {
+    crate::types::arrow_column_type(data_type.into())
 }
 
-impl PartitionDataType {
-    fn from_spec(data_type: FilePartitionDataType) -> Self {
-        match data_type {
-            FilePartitionDataType::Utf8 => Self::Utf8,
-            FilePartitionDataType::Int64 => Self::Int64,
-            FilePartitionDataType::Boolean => Self::Boolean,
-            FilePartitionDataType::Float64 => Self::Float64,
-            FilePartitionDataType::Json => Self::Json,
+fn scalar_from_path(
+    data_type: FilePartitionDataType,
+    name: &str,
+    raw: &str,
+) -> Result<ScalarValue> {
+    let decoded = urlencoding::decode(raw).map_err(|error| {
+        DataFusionError::Execution(format!("partition '{name}' has invalid encoding: {error}"))
+    })?;
+    let decoded = decoded.as_ref();
+
+    match data_type {
+        FilePartitionDataType::Utf8 | FilePartitionDataType::Json => {
+            Ok(ScalarValue::Utf8(Some(decoded.to_string())))
         }
-    }
-
-    fn arrow_type(self) -> DataType {
-        match self {
-            Self::Utf8 | Self::Json => DataType::Utf8,
-            Self::Int64 => DataType::Int64,
-            Self::Boolean => DataType::Boolean,
-            Self::Float64 => DataType::Float64,
+        FilePartitionDataType::Int64 => decoded
+            .parse::<i64>()
+            .map(|value| ScalarValue::Int64(Some(value)))
+            .map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "partition '{name}' value '{decoded}' is not Int64: {error}",
+                ))
+            }),
+        FilePartitionDataType::Boolean => {
+            parse_bool(decoded).map(|value| ScalarValue::Boolean(Some(value)))
         }
-    }
-
-    fn scalar_from_path(self, name: &str, raw: &str) -> Result<ScalarValue> {
-        let decoded = urlencoding::decode(raw).map_err(|error| {
-            DataFusionError::Execution(format!("partition '{name}' has invalid encoding: {error}"))
-        })?;
-        let decoded = decoded.as_ref();
-
-        match self {
-            Self::Utf8 | Self::Json => Ok(ScalarValue::Utf8(Some(decoded.to_string()))),
-            Self::Int64 => decoded
-                .parse::<i64>()
-                .map(|value| ScalarValue::Int64(Some(value)))
-                .map_err(|error| {
-                    DataFusionError::Execution(format!(
-                        "partition '{name}' value '{decoded}' is not Int64: {error}",
-                    ))
-                }),
-            Self::Boolean => parse_bool(decoded).map(|value| ScalarValue::Boolean(Some(value))),
-            Self::Float64 => {
-                let value = decoded.parse::<f64>().map_err(|error| {
-                    DataFusionError::Execution(format!(
-                        "partition '{name}' value '{decoded}' is not Float64: {error}",
-                    ))
-                })?;
-                if !value.is_finite() {
-                    return Err(DataFusionError::Execution(format!(
-                        "partition '{name}' value '{decoded}' is not finite",
-                    )));
-                }
-                Ok(ScalarValue::Float64(Some(value)))
+        FilePartitionDataType::Float64 => {
+            let value = decoded.parse::<f64>().map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "partition '{name}' value '{decoded}' is not Float64: {error}",
+                ))
+            })?;
+            if !value.is_finite() {
+                return Err(DataFusionError::Execution(format!(
+                    "partition '{name}' value '{decoded}' is not finite",
+                )));
             }
+            Ok(ScalarValue::Float64(Some(value)))
         }
     }
+}
 
-    fn boolean_scalar(self, value: bool) -> Option<ScalarValue> {
-        (self == Self::Boolean).then_some(ScalarValue::Boolean(Some(value)))
-    }
+fn boolean_scalar(data_type: FilePartitionDataType, value: bool) -> Option<ScalarValue> {
+    (data_type == FilePartitionDataType::Boolean).then_some(ScalarValue::Boolean(Some(value)))
+}
 
-    fn cast_literal(self, expr: &Expr) -> Option<ScalarValue> {
-        let literal = literal_scalar(expr)?;
-        literal
-            .cast_to(&self.arrow_type())
-            .ok()
-            .filter(|value| !value.is_null())
-    }
+fn cast_literal(data_type: FilePartitionDataType, expr: &Expr) -> Option<ScalarValue> {
+    let literal = literal_scalar(expr)?;
+    literal
+        .cast_to(&arrow_type(data_type))
+        .ok()
+        .filter(|value| !value.is_null())
 }
 
 #[derive(Debug, Clone)]
 struct PartitionColumn {
     name: String,
-    data_type: PartitionDataType,
+    data_type: FilePartitionDataType,
     path: PartitionPathSpec,
 }
 
 impl PartitionColumn {
     fn from_spec(spec: &PartitionColumnSpec) -> Self {
-        let name = spec.name.clone();
-        let data_type = PartitionDataType::from_spec(spec.data_type);
         Self {
-            name,
-            data_type,
+            name: spec.name.clone(),
+            data_type: spec.data_type,
             path: spec.path.clone(),
         }
     }
 
     fn arrow_pair(&self) -> (String, DataType) {
-        (self.name.clone(), self.data_type.arrow_type())
+        (self.name.clone(), arrow_type(self.data_type))
     }
 
     fn arrow_field(&self) -> FieldRef {
-        Arc::new(Field::new(&self.name, self.data_type.arrow_type(), true))
+        Arc::new(Field::new(&self.name, arrow_type(self.data_type), true))
     }
 }
 
@@ -315,7 +295,7 @@ fn partition_constraint(expr: &Expr, partitions: &PartitionColumns) -> Option<Pa
             let values = in_list
                 .list
                 .iter()
-                .map(|expr| partition.data_type.cast_literal(expr))
+                .map(|expr| cast_literal(partition.data_type, expr))
                 .collect::<Option<HashSet<_>>>()?;
             Some(PartitionConstraint { index, values })
         }
@@ -339,7 +319,7 @@ fn boolean_partition_constraint(
     let partition = partitions.get(index)?;
     Some(PartitionConstraint {
         index,
-        values: HashSet::from([partition.data_type.boolean_scalar(value)?]),
+        values: HashSet::from([boolean_scalar(partition.data_type, value)?]),
     })
 }
 
@@ -350,7 +330,7 @@ fn extract_partition_equality(
 ) -> Option<(usize, ScalarValue)> {
     let index = partitions.index_of_expr_column(left)?;
     let partition = partitions.get(index)?;
-    Some((index, partition.data_type.cast_literal(right)?))
+    Some((index, cast_literal(partition.data_type, right)?))
 }
 
 fn expr_column_name(expr: &Expr) -> Option<&str> {
@@ -408,11 +388,11 @@ pub(super) fn partition_values_for_path(
             }
         };
 
-        values.push(
-            partition
-                .data_type
-                .scalar_from_path(&partition.name, raw_value)?,
-        );
+        values.push(scalar_from_path(
+            partition.data_type,
+            &partition.name,
+            raw_value,
+        )?);
     }
 
     Ok(PartitionValues { values })

--- a/crates/coral-engine/src/backends/mcp/provider.rs
+++ b/crates/coral-engine/src/backends/mcp/provider.rs
@@ -108,9 +108,7 @@ impl TableProvider for McpTableProvider {
                         &self.source_schema,
                         self.table.name(),
                         &filter.name,
-                        filter
-                            .manifest_data_type()
-                            .map_err(|error| DataFusionError::Plan(error.to_string()))?,
+                        filter.data_type,
                         value,
                     )?;
                     arguments.insert(tool_arg.to_string(), typed);

--- a/crates/coral-engine/src/backends/shared/filter_expr.rs
+++ b/crates/coral-engine/src/backends/shared/filter_expr.rs
@@ -419,7 +419,7 @@ mod tests {
         FilterExtraction, extract_exact_filter_values_checked, extract_filter_values,
         extract_filter_values_checked,
     };
-    use coral_spec::{FilterMode, FilterSpec};
+    use coral_spec::{FilterMode, FilterSpec, ManifestDataType};
     use datafusion::logical_expr::{Expr, col, lit};
     use std::collections::HashMap;
     use std::ops::Not;
@@ -441,7 +441,7 @@ mod tests {
     fn filter(name: &str, required: bool, mode: FilterMode) -> FilterSpec {
         FilterSpec {
             name: name.into(),
-            data_type: "Utf8".into(),
+            data_type: ManifestDataType::Utf8,
             required,
             mode,
             description: String::new(),
@@ -631,7 +631,7 @@ mod tests {
 #[cfg(test)]
 mod pushdown_classification_tests {
     use super::{classify_filter, classify_filter_pushdown_for_consumed};
-    use coral_spec::{FilterMode, FilterSpec};
+    use coral_spec::{FilterMode, FilterSpec, ManifestDataType};
     use datafusion::common::Column;
     use datafusion::logical_expr::{
         Expr, Operator, TableProviderFilterPushDown, binary_expr, expr::Like, lit,
@@ -650,7 +650,7 @@ mod pushdown_classification_tests {
     fn filter(name: &str) -> FilterSpec {
         FilterSpec {
             name: name.to_string(),
-            data_type: "Utf8".to_string(),
+            data_type: ManifestDataType::Utf8,
             required: false,
             mode: FilterMode::Equality,
             description: String::new(),

--- a/crates/coral-engine/src/backends/shared/filter_expr.rs
+++ b/crates/coral-engine/src/backends/shared/filter_expr.rs
@@ -402,6 +402,7 @@ pub(crate) fn literal_to_string(expr: &Expr) -> Option<String> {
     match expr {
         Expr::Literal(ScalarValue::Utf8(Some(v)), _) => Some(v.clone()),
         Expr::Literal(ScalarValue::LargeUtf8(Some(v)), _) => Some(v.clone()),
+        Expr::Literal(ScalarValue::Utf8View(Some(v)), _) => Some(v.clone()),
         Expr::Literal(ScalarValue::Int64(Some(v)), _) => Some(v.to_string()),
         Expr::Literal(ScalarValue::Int32(Some(v)), _) => Some(v.to_string()),
         Expr::Literal(ScalarValue::Float64(Some(v)), _) => Some(v.to_string()),
@@ -446,6 +447,25 @@ mod tests {
             mode,
             description: String::new(),
             lookup_key: false,
+        }
+    }
+
+    #[test]
+    fn literal_to_string_accepts_every_string_literal_variant() {
+        use datafusion::common::ScalarValue;
+
+        for scalar in [
+            ScalarValue::Utf8(Some("alice".to_string())),
+            ScalarValue::LargeUtf8(Some("alice".to_string())),
+            ScalarValue::Utf8View(Some("alice".to_string())),
+        ] {
+            let variant = format!("{scalar:?}");
+            let expr = Expr::Literal(scalar, None);
+            assert_eq!(
+                super::literal_to_string(&expr).as_deref(),
+                Some("alice"),
+                "string literal variant should extract: {variant}"
+            );
         }
     }
 

--- a/crates/coral-engine/src/backends/shared/mapping.rs
+++ b/crates/coral-engine/src/backends/shared/mapping.rs
@@ -37,11 +37,8 @@ pub(crate) fn convert_items(
 
     for column in columns {
         let expr = column.resolved_expr();
-        let data_type = column
-            .manifest_data_type()
-            .map_err(|error| DataFusionError::Execution(error.to_string()))?;
 
-        match data_type {
+        match column.data_type {
             ManifestDataType::Utf8 => {
                 let array: StringArray = items
                     .iter()

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -12,10 +12,10 @@ pub use catalog::{
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{
     DependentJoinConfig, DependentJoinSourceConfig, EffectiveDependentJoinConfig, MemorySize,
-    QueryExecution, QueryExecutionProvenance, QueryMemoryConfig, QueryParameterType,
-    QueryParameterValue, QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
-    QuerySource, QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure, QueryTestResult,
-    QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
+    QueryExecution, QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue,
+    QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure, QueryTestResult, QueryTestSuccess,
+    RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -434,20 +434,6 @@ impl FromIterator<(String, QueryParameterValue)> for QueryParameters {
     }
 }
 
-/// Scalar types supported by named SQL query parameters.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum QueryParameterType {
-    /// UTF-8 string.
-    String,
-    /// 64-bit signed integer.
-    Integer,
-    /// 64-bit floating point value.
-    Float,
-    /// Boolean.
-    Boolean,
-}
-
 /// One typed SQL query parameter value.
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -70,12 +70,11 @@ pub use composition::{
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
     DescribeTableInfo, EffectiveDependentJoinConfig, MemorySize, QueryExecution,
-    QueryExecutionProvenance, QueryMemoryConfig, QueryParameterType, QueryParameterValue,
-    QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-    QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure, QueryTestResult, QueryTestSuccess,
-    RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport, StatusCode,
-    StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
-    TableFunctionResultColumnInfo, TableInfo,
+    QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
+    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage,
+    QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
+    RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
+    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
 };
 
 /// High-level query operations for the local query engine.

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -59,6 +59,7 @@ mod backends;
 mod composition;
 pub mod contracts;
 mod runtime;
+mod types;
 
 pub use backends::mcp::discover_tool_catalog as discover_mcp_tool_catalog;
 pub use composition::{

--- a/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
@@ -608,13 +608,6 @@ fn is_lookup_key_data_type(data_type: &DataType) -> bool {
     )
 }
 
-fn is_string_data_type(data_type: &DataType) -> bool {
-    matches!(
-        data_type,
-        DataType::Utf8 | DataType::Utf8View | DataType::LargeUtf8
-    )
-}
-
 fn is_join_cast_supported(
     side: JoinOperandSide,
     source_type: &DataType,
@@ -624,7 +617,7 @@ fn is_join_cast_supported(
         return true;
     }
 
-    if is_string_data_type(source_type) && is_string_data_type(target_type) {
+    if crate::types::is_string_family(source_type) && crate::types::is_string_family(target_type) {
         return true;
     }
 

--- a/crates/coral-engine/src/types.rs
+++ b/crates/coral-engine/src/types.rs
@@ -31,7 +31,7 @@ pub(crate) fn arrow_column_type(data_type: ManifestDataType) -> DataType {
 /// Whether an Arrow type is one of the string representations
 /// (`Utf8`, `LargeUtf8`, `Utf8View`).
 ///
-/// DataFusion may materialize any of the three for logically-string data,
+/// `DataFusion` may materialize any of the three for logically-string data,
 /// so string-typed checks must accept the whole family.
 pub(crate) fn is_string_family(data_type: &DataType) -> bool {
     matches!(

--- a/crates/coral-engine/src/types.rs
+++ b/crates/coral-engine/src/types.rs
@@ -1,12 +1,16 @@
 //! Canonical conversions between the coral-spec scalar vocabulary and
 //! Arrow/DataFusion types.
 //!
-//! Every `ManifestDataType`-to-Arrow lowering lives here so that the
-//! policies stay adjacent and reviewable. There is deliberately more than
-//! one lowering: column schemas want real Arrow types, while SQL parameter
-//! binding lowers string-shaped types to plain strings. When adding a
-//! `ManifestDataType` variant, the exhaustive matches in this module are
-//! the engine-side checklist.
+//! This module is the home for `ManifestDataType`-to-Arrow *type-level*
+//! policies, so that when more than one lowering exists (column schemas
+//! want real Arrow types; string-shaped parameter binding wants plain
+//! strings) the policies sit adjacent and reviewable. Today it holds the
+//! column-schema lowering; value-level `ManifestDataType` switches still
+//! live with their backends (`convert_items` in `backends/shared/mapping.rs`
+//! builds Arrow arrays per variant, and `coerce_filter_value` /
+//! `coerce_call_arg_value` in the MCP backend coerce JSON values). All of
+//! those matches are wildcard-free, so adding a `ManifestDataType` variant
+//! breaks each of them loudly.
 
 use coral_spec::ManifestDataType;
 use datafusion::arrow::datatypes::{DataType, TimeUnit};

--- a/crates/coral-engine/src/types.rs
+++ b/crates/coral-engine/src/types.rs
@@ -1,0 +1,41 @@
+//! Canonical conversions between the coral-spec scalar vocabulary and
+//! Arrow/DataFusion types.
+//!
+//! Every `ManifestDataType`-to-Arrow lowering lives here so that the
+//! policies stay adjacent and reviewable. There is deliberately more than
+//! one lowering: column schemas want real Arrow types, while SQL parameter
+//! binding lowers string-shaped types to plain strings. When adding a
+//! `ManifestDataType` variant, the exhaustive matches in this module are
+//! the engine-side checklist.
+
+use coral_spec::ManifestDataType;
+use datafusion::arrow::datatypes::{DataType, TimeUnit};
+
+/// Lowers a manifest data type into the Arrow type used for table and
+/// result-column schemas.
+///
+/// This is the column-schema policy: `Timestamp` becomes a real
+/// microsecond-precision UTC Arrow timestamp, and `Json` is stored as text.
+pub(crate) fn arrow_column_type(data_type: ManifestDataType) -> DataType {
+    match data_type {
+        ManifestDataType::Utf8 | ManifestDataType::Json => DataType::Utf8,
+        ManifestDataType::Int64 => DataType::Int64,
+        ManifestDataType::Boolean => DataType::Boolean,
+        ManifestDataType::Float64 => DataType::Float64,
+        ManifestDataType::Timestamp => {
+            DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".into()))
+        }
+    }
+}
+
+/// Whether an Arrow type is one of the string representations
+/// (`Utf8`, `LargeUtf8`, `Utf8View`).
+///
+/// DataFusion may materialize any of the three for logically-string data,
+/// so string-typed checks must accept the whole family.
+pub(crate) fn is_string_family(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
+    )
+}

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use coral_engine::{CoralQuery, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage};
 use coral_spec::backends::http::HttpSourceManifest;
 use coral_spec::parse_source_manifest_yaml;
-use coral_spec::{FilterMode, FilterSpec};
+use coral_spec::{FilterMode, FilterSpec, ManifestDataType};
 use serde_json::json;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -295,7 +295,7 @@ tables:
     let table = manifest.tables.first_mut().expect("file manifest table");
     table.common.filters.push(FilterSpec {
         name: "id".to_string(),
-        data_type: "Utf8".to_string(),
+        data_type: ManifestDataType::Utf8,
         required: false,
         mode: FilterMode::Equality,
         description: String::new(),

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -743,7 +743,7 @@ impl FileSourceManifest {
 
 #[cfg(test)]
 mod tests {
-    use super::{FileFormat, FileSourceManifest};
+    use super::{FileFormat, FilePartitionDataType, FileSourceManifest};
     use crate::ManifestInputKind;
     use serde_json::json;
 
@@ -1332,5 +1332,29 @@ mod tests {
         .expect_err("non-csv option should fail");
 
         assert!(error.to_string().contains("only supported for format=csv"));
+    }
+
+    #[test]
+    fn partition_data_type_is_the_partition_legal_subset() {
+        use crate::ManifestDataType;
+
+        for data_type in ManifestDataType::ALL {
+            match FilePartitionDataType::try_from(data_type) {
+                Ok(partition_type) => assert_eq!(
+                    ManifestDataType::from(partition_type),
+                    data_type,
+                    "partition subset must round trip through the upcast"
+                ),
+                Err(error) => {
+                    assert_eq!(data_type, ManifestDataType::Timestamp);
+                    assert!(
+                        error.to_string().contains(
+                            "type=Timestamp is not supported for backend=file path partitions"
+                        ),
+                        "unexpected error: {error}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -417,9 +417,10 @@ impl FilePartitionDataType {
     }
 }
 
-/// The partition-legal subset of the manifest scalar vocabulary.
+/// Narrows a manifest scalar to the partition-legal subset.
 ///
-/// Fails exactly when the scalar cannot be a file path partition value.
+/// Fails exactly when the scalar cannot be a file path partition value —
+/// today only `Timestamp`.
 impl TryFrom<ManifestDataType> for FilePartitionDataType {
     type Error = ManifestError;
 
@@ -455,8 +456,7 @@ impl<'de> Deserialize<'de> for FilePartitionDataType {
     where
         D: Deserializer<'de>,
     {
-        let value = String::deserialize(deserializer)?;
-        let data_type: ManifestDataType = value.parse().map_err(serde::de::Error::custom)?;
+        let data_type = ManifestDataType::deserialize(deserializer)?;
         Self::try_from(data_type).map_err(serde::de::Error::custom)
     }
 }
@@ -1346,7 +1346,12 @@ mod tests {
                     "partition subset must round trip through the upcast"
                 ),
                 Err(error) => {
-                    assert_eq!(data_type, ManifestDataType::Timestamp);
+                    assert_eq!(
+                        data_type,
+                        ManifestDataType::Timestamp,
+                        "Timestamp is the only partition-illegal scalar; if a new \
+                         variant is deliberately rejected, extend this assertion"
+                    );
                     assert!(
                         error.to_string().contains(
                             "type=Timestamp is not supported for backend=file path partitions"

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -16,7 +16,6 @@ use std::collections::{BTreeSet, HashSet};
 use std::fmt;
 use url::Url;
 
-use crate::common::parse_manifest_data_type;
 use crate::inputs::{
     collect_source_inputs_value, declared_secret_input_names, required_secret_input_names,
 };
@@ -414,16 +413,17 @@ pub enum FilePartitionDataType {
 impl FilePartitionDataType {
     #[must_use]
     pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Utf8 => "Utf8",
-            Self::Int64 => "Int64",
-            Self::Boolean => "Boolean",
-            Self::Float64 => "Float64",
-            Self::Json => "Json",
-        }
+        ManifestDataType::from(self).as_manifest_str()
     }
+}
 
-    fn from_manifest(data_type: ManifestDataType) -> Result<Self> {
+/// The partition-legal subset of the manifest scalar vocabulary.
+///
+/// Fails exactly when the scalar cannot be a file path partition value.
+impl TryFrom<ManifestDataType> for FilePartitionDataType {
+    type Error = ManifestError;
+
+    fn try_from(data_type: ManifestDataType) -> Result<Self> {
         match data_type {
             ManifestDataType::Utf8 => Ok(Self::Utf8),
             ManifestDataType::Int64 => Ok(Self::Int64),
@@ -437,14 +437,27 @@ impl FilePartitionDataType {
     }
 }
 
+/// Every partition type is a manifest scalar type.
+impl From<FilePartitionDataType> for ManifestDataType {
+    fn from(data_type: FilePartitionDataType) -> Self {
+        match data_type {
+            FilePartitionDataType::Utf8 => Self::Utf8,
+            FilePartitionDataType::Int64 => Self::Int64,
+            FilePartitionDataType::Boolean => Self::Boolean,
+            FilePartitionDataType::Float64 => Self::Float64,
+            FilePartitionDataType::Json => Self::Json,
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for FilePartitionDataType {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
         let value = String::deserialize(deserializer)?;
-        let data_type = parse_manifest_data_type(&value).map_err(serde::de::Error::custom)?;
-        Self::from_manifest(data_type).map_err(serde::de::Error::custom)
+        let data_type: ManifestDataType = value.parse().map_err(serde::de::Error::custom)?;
+        Self::try_from(data_type).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/coral-spec/src/backends/mcp.rs
+++ b/crates/coral-spec/src/backends/mcp.rs
@@ -12,9 +12,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    ColumnSpec, DeclaredRelation, FilterMode, FilterSpec, FunctionArgBinding, ManifestError,
-    ManifestInputKind, ManifestInputSpec, PaginationSpec, RequestSpec, ResponseSpec, Result,
-    SourceBackend, SourceManifestCommon, SourceTableFunctionKind, SourceTableFunctionSpec,
+    ColumnSpec, DeclaredRelation, FilterMode, FilterSpec, FunctionArgBinding, ManifestDataType,
+    ManifestError, ManifestInputKind, ManifestInputSpec, PaginationSpec, RequestSpec, ResponseSpec,
+    Result, SourceBackend, SourceManifestCommon, SourceTableFunctionKind, SourceTableFunctionSpec,
     TableCommon, TableFunctionArgSpec, ValueSourceSpec,
     inputs::{
         collect_source_inputs_value, declared_secret_input_names, required_secret_input_names,
@@ -217,7 +217,7 @@ pub struct McpOffsetPaginationSpec {
 pub struct McpTableFilterSpec {
     pub name: String,
     #[serde(rename = "type", default = "default_mcp_filter_data_type")]
-    pub data_type: String,
+    pub data_type: ManifestDataType,
     #[serde(default)]
     pub required: bool,
     #[serde(default)]
@@ -294,15 +294,15 @@ impl McpTableFunctionSpec {
     }
 }
 
-fn default_mcp_filter_data_type() -> String {
-    "Utf8".to_string()
+fn default_mcp_filter_data_type() -> ManifestDataType {
+    ManifestDataType::Utf8
 }
 
 impl McpTableFilterSpec {
     fn filter_spec(&self) -> FilterSpec {
         FilterSpec {
             name: self.name.clone(),
-            data_type: self.data_type.clone(),
+            data_type: self.data_type,
             required: self.required,
             mode: self.mode,
             description: self.description.clone(),

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -106,19 +106,34 @@ pub enum ManifestDataType {
 }
 
 impl ManifestDataType {
-    /// Every manifest data type, for variants-driven tests and tooling.
+    /// Every manifest data type, in canonical declaration order.
     ///
-    /// Keep in sync with the enum; the exhaustive match in
-    /// [`Self::as_manifest_str`] is the compiler prompt when a variant is
-    /// added.
-    pub const ALL: [Self; 6] = [
-        Self::Utf8,
-        Self::Int64,
-        Self::Boolean,
-        Self::Float64,
-        Self::Timestamp,
-        Self::Json,
-    ];
+    /// [`FromStr`](std::str::FromStr) and the lattice enforcement tests
+    /// treat this array as the source of truth for the variant set.
+    pub const ALL: [Self; 6] = {
+        // Exhaustiveness witness: adding a variant breaks this match, and
+        // the new variant must be added to the array below in the same
+        // edit.
+        const fn witness(data_type: ManifestDataType) {
+            match data_type {
+                ManifestDataType::Utf8
+                | ManifestDataType::Int64
+                | ManifestDataType::Boolean
+                | ManifestDataType::Float64
+                | ManifestDataType::Timestamp
+                | ManifestDataType::Json => {}
+            }
+        }
+        let _ = witness;
+        [
+            Self::Utf8,
+            Self::Int64,
+            Self::Boolean,
+            Self::Float64,
+            Self::Timestamp,
+            Self::Json,
+        ]
+    };
 
     /// Returns the source-manifest spelling for this data type.
     ///
@@ -152,7 +167,10 @@ impl std::str::FromStr for ManifestDataType {
             .into_iter()
             .find(|data_type| data_type.as_manifest_str() == s)
             .ok_or_else(|| {
-                ManifestError::validation(format!("unsupported data type '{s}' in source manifest"))
+                let expected = Self::ALL.map(Self::as_manifest_str).join(", ");
+                ManifestError::validation(format!(
+                    "unsupported data type '{s}' in source manifest; expected one of: {expected}"
+                ))
             })
     }
 }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -1319,4 +1319,32 @@ mod tests {
                 .contains("demo.items pagination.mode=offset requires offset_step or page_size")
         );
     }
+
+    #[test]
+    fn manifest_data_type_all_round_trips_through_spelling_and_serde() {
+        for data_type in ManifestDataType::ALL {
+            let spelled = data_type.to_string();
+            assert_eq!(
+                spelled.parse::<ManifestDataType>().expect("round trip"),
+                data_type,
+                "Display/FromStr round trip failed for {spelled}"
+            );
+            assert_eq!(
+                serde_json::to_value(data_type).expect("serialize"),
+                Value::String(spelled.clone()),
+                "serde spelling diverged from as_manifest_str for {spelled}"
+            );
+        }
+    }
+
+    #[test]
+    fn manifest_data_type_rejects_unknown_spelling() {
+        let error = "Banana"
+            .parse::<ManifestDataType>()
+            .expect_err("unknown spelling should fail");
+        assert!(
+            error.to_string().contains("unsupported data type 'Banana'"),
+            "unexpected error: {error}"
+        );
+    }
 }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -226,7 +226,7 @@ pub enum FilterMode {
 pub struct FilterSpec {
     pub name: String,
     #[serde(rename = "type", default = "default_filter_data_type")]
-    pub data_type: String,
+    pub data_type: ManifestDataType,
     #[serde(default)]
     pub required: bool,
     #[serde(default)]
@@ -237,20 +237,8 @@ pub struct FilterSpec {
     pub lookup_key: bool,
 }
 
-impl FilterSpec {
-    /// Convert this filter's declared type into a normalized manifest data type.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ManifestError`] if the manifest references an unsupported
-    /// data type.
-    pub fn manifest_data_type(&self) -> Result<ManifestDataType> {
-        parse_manifest_data_type(&self.data_type)
-    }
-}
-
-fn default_filter_data_type() -> String {
-    "Utf8".to_string()
+fn default_filter_data_type() -> ManifestDataType {
+    ManifestDataType::Utf8
 }
 
 /// Source-scoped table-function semantic class.
@@ -873,7 +861,7 @@ pub struct PageSizeSpec {
 pub struct ColumnSpec {
     pub name: String,
     #[serde(rename = "type")]
-    pub data_type: String,
+    pub data_type: ManifestDataType,
     #[serde(default = "default_nullable")]
     pub nullable: bool,
     #[serde(default)]
@@ -886,16 +874,6 @@ pub struct ColumnSpec {
 }
 
 impl ColumnSpec {
-    /// Convert this manifest type into a normalized manifest data type.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`ManifestError`] if the manifest references an unsupported
-    /// data type.
-    pub fn manifest_data_type(&self) -> Result<ManifestDataType> {
-        parse_manifest_data_type(&self.data_type)
-    }
-
     #[must_use]
     pub fn resolved_expr(&self) -> ExprSpec {
         self.expr.clone().unwrap_or_else(|| ExprSpec::Path {
@@ -1015,16 +993,6 @@ fn default_value_field() -> String {
     "value".to_string()
 }
 
-/// Parse a manifest data type name into a normalized manifest data type.
-///
-/// # Errors
-///
-/// Returns a [`ManifestError`] if `s` is not one of the supported manifest
-/// data type names.
-pub(crate) fn parse_manifest_data_type(s: &str) -> Result<ManifestDataType> {
-    s.parse()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1056,7 +1024,7 @@ mod tests {
             vec![],
             vec![FilterSpec {
                 name: "id".into(),
-                data_type: "Utf8".into(),
+                data_type: ManifestDataType::Utf8,
                 required: false,
                 mode: FilterMode::default(),
                 description: String::new(),
@@ -1094,7 +1062,7 @@ mod tests {
             vec![
                 FilterSpec {
                     name: "id".into(),
-                    data_type: "Utf8".into(),
+                    data_type: ManifestDataType::Utf8,
                     required: false,
                     mode: FilterMode::default(),
                     description: String::new(),
@@ -1102,7 +1070,7 @@ mod tests {
                 },
                 FilterSpec {
                     name: "org".into(),
-                    data_type: "Utf8".into(),
+                    data_type: ManifestDataType::Utf8,
                     required: false,
                     mode: FilterMode::default(),
                     description: String::new(),
@@ -1249,7 +1217,7 @@ mod tests {
             "name": "q"
         }))
         .unwrap();
-        assert_eq!(spec.data_type, "Utf8");
+        assert_eq!(spec.data_type, ManifestDataType::Utf8);
         assert_eq!(spec.description, "");
     }
 

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -82,9 +82,14 @@ pub enum SourceBackend {
     Mcp,
 }
 
-/// Normalized scalar data types supported by the source-spec DSL.
+/// The normalized scalar type vocabulary shared by source specs, the query
+/// runtime, and catalog surfaces.
 ///
-/// The engine is responsible for mapping these into runtime-specific types.
+/// This is the hub every other scalar vocabulary converts through: v4 IR
+/// scalars lower into it, and the engine maps it into runtime-specific
+/// (Arrow) types. The variant spellings ("Utf8", "Int64", ...) are a wire
+/// contract pinned by the `PascalCase` serde representation and the manifest
+/// JSON schema.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub enum ManifestDataType {
@@ -98,6 +103,58 @@ pub enum ManifestDataType {
     /// `json_get_str`, `json_as_text`, etc.); the JSON functions also
     /// work on plain `Utf8` columns whose values happen to be JSON.
     Json,
+}
+
+impl ManifestDataType {
+    /// Every manifest data type, for variants-driven tests and tooling.
+    ///
+    /// Keep in sync with the enum; the exhaustive match in
+    /// [`Self::as_manifest_str`] is the compiler prompt when a variant is
+    /// added.
+    pub const ALL: [Self; 6] = [
+        Self::Utf8,
+        Self::Int64,
+        Self::Boolean,
+        Self::Float64,
+        Self::Timestamp,
+        Self::Json,
+    ];
+
+    /// Returns the source-manifest spelling for this data type.
+    ///
+    /// This must stay aligned with the enum's `PascalCase` serde
+    /// representation and the `manifest_data_type` definition in the manifest
+    /// JSON schema.
+    #[must_use]
+    pub fn as_manifest_str(self) -> &'static str {
+        match self {
+            Self::Utf8 => "Utf8",
+            Self::Int64 => "Int64",
+            Self::Boolean => "Boolean",
+            Self::Float64 => "Float64",
+            Self::Timestamp => "Timestamp",
+            Self::Json => "Json",
+        }
+    }
+}
+
+impl std::fmt::Display for ManifestDataType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_manifest_str())
+    }
+}
+
+impl std::str::FromStr for ManifestDataType {
+    type Err = ManifestError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::ALL
+            .into_iter()
+            .find(|data_type| data_type.as_manifest_str() == s)
+            .ok_or_else(|| {
+                ManifestError::validation(format!("unsupported data type '{s}' in source manifest"))
+            })
+    }
 }
 
 /// One request or auth header declared in the source spec.
@@ -965,17 +1022,7 @@ fn default_value_field() -> String {
 /// Returns a [`ManifestError`] if `s` is not one of the supported manifest
 /// data type names.
 pub(crate) fn parse_manifest_data_type(s: &str) -> Result<ManifestDataType> {
-    match s {
-        "Utf8" => Ok(ManifestDataType::Utf8),
-        "Int64" => Ok(ManifestDataType::Int64),
-        "Boolean" => Ok(ManifestDataType::Boolean),
-        "Float64" => Ok(ManifestDataType::Float64),
-        "Timestamp" => Ok(ManifestDataType::Timestamp),
-        "Json" => Ok(ManifestDataType::Json),
-        other => Err(ManifestError::validation(format!(
-            "unsupported data type '{other}' in source manifest"
-        ))),
-    }
+    s.parse()
 }
 
 #[cfg(test)]

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -717,25 +717,50 @@ tables:
         );
     }
 
+    fn schema_enum_spellings(schema: &serde_json::Value, def: &str) -> Vec<String> {
+        schema
+            .pointer(&format!("/$defs/{def}/enum"))
+            .and_then(serde_json::Value::as_array)
+            .unwrap_or_else(|| panic!("$defs.{def}.enum should be a list"))
+            .iter()
+            .map(|value| {
+                value
+                    .as_str()
+                    .expect("enum entries should be strings")
+                    .to_string()
+            })
+            .collect()
+    }
+
     #[test]
-    fn manifest_schema_data_type_enum_matches_rust_variants() {
+    fn manifest_schema_data_type_enums_match_rust_variants() {
         let schema: serde_json::Value =
             serde_json::from_str(include_str!("schema/source_manifest.schema.json"))
                 .expect("bundled schema should parse");
-        let schema_spellings: Vec<&str> = schema
-            .pointer("/$defs/manifest_data_type/enum")
-            .and_then(serde_json::Value::as_array)
-            .expect("manifest_data_type enum should be a list")
+
+        let rust_spellings: Vec<String> = crate::ManifestDataType::ALL
             .iter()
-            .map(|value| value.as_str().expect("enum entries should be strings"))
-            .collect();
-        let rust_spellings: Vec<&str> = crate::ManifestDataType::ALL
-            .iter()
-            .map(|data_type| data_type.as_manifest_str())
+            .map(|data_type| data_type.as_manifest_str().to_string())
             .collect();
         assert_eq!(
-            schema_spellings, rust_spellings,
-            "source_manifest.schema.json $defs.manifest_data_type must list exactly the ManifestDataType variants"
+            schema_enum_spellings(&schema, "manifest_data_type"),
+            rust_spellings,
+            "source_manifest.schema.json $defs.manifest_data_type must list the \
+             ManifestDataType variants in declaration order"
+        );
+
+        let partition_spellings: Vec<String> = crate::ManifestDataType::ALL
+            .iter()
+            .filter(|data_type| {
+                crate::backends::file::FilePartitionDataType::try_from(**data_type).is_ok()
+            })
+            .map(|data_type| data_type.as_manifest_str().to_string())
+            .collect();
+        assert_eq!(
+            schema_enum_spellings(&schema, "file_partition_data_type"),
+            partition_spellings,
+            "source_manifest.schema.json $defs.file_partition_data_type must list the \
+             partition-legal ManifestDataType variants in declaration order"
         );
     }
 }

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -716,4 +716,26 @@ tables:
             "unexpected error: {error}"
         );
     }
+
+    #[test]
+    fn manifest_schema_data_type_enum_matches_rust_variants() {
+        let schema: serde_json::Value =
+            serde_json::from_str(include_str!("schema/source_manifest.schema.json"))
+                .expect("bundled schema should parse");
+        let schema_spellings: Vec<&str> = schema
+            .pointer("/$defs/manifest_data_type/enum")
+            .and_then(serde_json::Value::as_array)
+            .expect("manifest_data_type enum should be a list")
+            .iter()
+            .map(|value| value.as_str().expect("enum entries should be strings"))
+            .collect();
+        let rust_spellings: Vec<&str> = crate::ManifestDataType::ALL
+            .iter()
+            .map(|data_type| data_type.as_manifest_str())
+            .collect();
+        assert_eq!(
+            schema_spellings, rust_spellings,
+            "source_manifest.schema.json $defs.manifest_data_type must list exactly the ManifestDataType variants"
+        );
+    }
 }

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -749,7 +749,7 @@
       "required": ["name", "tool_arg"],
       "properties": {
         "name": { "type": "string", "minLength": 1 },
-        "type": { "type": "string", "enum": ["Utf8", "Int64", "Boolean", "Float64", "Timestamp", "Json"] },
+        "type": { "$ref": "#/$defs/manifest_data_type" },
         "required": { "type": "boolean" },
         "mode": { "type": "string", "enum": ["equality", "search", "contains"] },
         "description": { "type": "string" },

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -115,6 +115,25 @@ pub enum IrScalarType {
     Json,
 }
 
+impl IrScalarType {
+    /// Lowers this import-side scalar into the normalized manifest vocabulary.
+    ///
+    /// This is the single v4-to-runtime type bridge. It is deliberately
+    /// lossy: `Id` collapses into `Utf8` because the runtime does not
+    /// distinguish identifiers from other strings.
+    #[must_use]
+    pub fn lower(self) -> crate::ManifestDataType {
+        match self {
+            Self::String | Self::Id => crate::ManifestDataType::Utf8,
+            Self::Integer => crate::ManifestDataType::Int64,
+            Self::Number => crate::ManifestDataType::Float64,
+            Self::Boolean => crate::ManifestDataType::Boolean,
+            Self::Timestamp => crate::ManifestDataType::Timestamp,
+            Self::Json => crate::ManifestDataType::Json,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum IrInputLocation {

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -51,9 +51,9 @@ pub use parameter_metadata::{
 };
 pub use projections::{
     Projection, ProjectionCatalog, ProjectionColumn, ProjectionInput, ProjectionKind,
-    ProjectionVisibility, SqlInputExposure, generate_projection_catalog, manifest_data_type_name,
-    mcp_projection_arg_specs, projection_arg_specs, projection_column_specs,
-    projection_filter_specs, request_spec_for_projection,
+    ProjectionVisibility, SqlInputExposure, generate_projection_catalog, mcp_projection_arg_specs,
+    projection_arg_specs, projection_column_specs, projection_filter_specs,
+    request_spec_for_projection,
 };
 pub use schema::generated_v4_source_manifest_schema;
 pub use surfaces::{

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{
-    HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
-    IrScalarType, IrType, IrTypeShape, OutputCardinality, RestExecutionAttachment, SemanticIr,
+    HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput, IrType,
+    IrTypeShape, OutputCardinality, RestExecutionAttachment, SemanticIr,
 };
 use crate::v4::manifest::V4SourceManifest;
 use crate::v4::naming::{normalize_identifier, normalize_sql_identifier, stable_suffix};

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -114,7 +114,7 @@ fn generate_projection(
                 source_location: input.location,
                 wire_name: input.name.clone(),
                 required: projection_input_required(input),
-                data_type: manifest_type(input.data_type),
+                data_type: input.data_type.lower(),
                 default_value: input.default_value.clone(),
                 description: input.description.clone(),
             }
@@ -361,22 +361,11 @@ fn projection_columns(ir: &SemanticIr, operation: &IrOperation) -> Vec<Projectio
 
 fn projection_data_type(ty: &IrType) -> ManifestDataType {
     match &ty.shape {
-        IrTypeShape::Scalar(scalar) => manifest_type(*scalar),
+        IrTypeShape::Scalar(scalar) => scalar.lower(),
         IrTypeShape::Enum { .. } => ManifestDataType::Utf8,
         IrTypeShape::Json
         | IrTypeShape::Object { .. }
         | IrTypeShape::List { .. }
         | IrTypeShape::Map { .. } => ManifestDataType::Json,
-    }
-}
-
-fn manifest_type(scalar: IrScalarType) -> ManifestDataType {
-    match scalar {
-        IrScalarType::String | IrScalarType::Id => ManifestDataType::Utf8,
-        IrScalarType::Integer => ManifestDataType::Int64,
-        IrScalarType::Number => ManifestDataType::Float64,
-        IrScalarType::Boolean => ManifestDataType::Boolean,
-        IrScalarType::Timestamp => ManifestDataType::Timestamp,
-        IrScalarType::Json => ManifestDataType::Json,
     }
 }

--- a/crates/coral-spec/src/v4/projections/mod.rs
+++ b/crates/coral-spec/src/v4/projections/mod.rs
@@ -8,6 +8,6 @@ pub use derive::generate_projection_catalog;
 pub use model::*;
 pub(super) use pagination::pagination_query_param_names;
 pub use runtime::{
-    manifest_data_type_name, mcp_projection_arg_specs, projection_arg_specs,
-    projection_column_specs, projection_filter_specs, request_spec_for_projection,
+    mcp_projection_arg_specs, projection_arg_specs, projection_column_specs,
+    projection_filter_specs, request_spec_for_projection,
 };

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -17,7 +17,7 @@ pub fn projection_filter_specs(projection: &Projection) -> Vec<FilterSpec> {
         .filter(|input| input.sql_exposure == SqlInputExposure::Filter)
         .map(|input| FilterSpec {
             name: input.name.clone(),
-            data_type: manifest_data_type_name(input.data_type).to_string(),
+            data_type: input.data_type.as_manifest_str().to_string(),
             required: input.required,
             mode: FilterMode::Equality,
             description: input.description.clone(),
@@ -64,7 +64,7 @@ pub fn projection_column_specs(projection: &Projection) -> Vec<ColumnSpec> {
         .iter()
         .map(|column| ColumnSpec {
             name: column.name.clone(),
-            data_type: manifest_data_type_name(column.data_type).to_string(),
+            data_type: column.data_type.as_manifest_str().to_string(),
             nullable: column.nullable,
             r#virtual: false,
             description: column.description.clone(),
@@ -85,7 +85,7 @@ pub fn projection_column_specs(projection: &Projection) -> Vec<ColumnSpec> {
             .filter(|input| !existing.contains(&input.name))
             .map(|input| ColumnSpec {
                 name: input.name.clone(),
-                data_type: manifest_data_type_name(input.data_type).to_string(),
+                data_type: input.data_type.as_manifest_str().to_string(),
                 nullable: !input.required,
                 r#virtual: true,
                 description: input.description.clone(),
@@ -95,17 +95,6 @@ pub fn projection_column_specs(projection: &Projection) -> Vec<ColumnSpec> {
             }),
     );
     columns
-}
-
-pub fn manifest_data_type_name(data_type: ManifestDataType) -> &'static str {
-    match data_type {
-        ManifestDataType::Utf8 => "Utf8",
-        ManifestDataType::Int64 => "Int64",
-        ManifestDataType::Boolean => "Boolean",
-        ManifestDataType::Float64 => "Float64",
-        ManifestDataType::Timestamp => "Timestamp",
-        ManifestDataType::Json => "Json",
-    }
 }
 
 pub fn request_spec_for_projection(

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -4,8 +4,8 @@ use serde_json::Value;
 
 use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, IrOperation};
 use crate::{
-    ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding, ManifestDataType,
-    ParsedTemplate, RequestSpec, Result, TableFunctionArgSpec,
+    ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding, ParsedTemplate, RequestSpec,
+    Result, TableFunctionArgSpec,
 };
 
 use super::model::{Projection, SqlInputExposure};
@@ -17,7 +17,7 @@ pub fn projection_filter_specs(projection: &Projection) -> Vec<FilterSpec> {
         .filter(|input| input.sql_exposure == SqlInputExposure::Filter)
         .map(|input| FilterSpec {
             name: input.name.clone(),
-            data_type: input.data_type.as_manifest_str().to_string(),
+            data_type: input.data_type,
             required: input.required,
             mode: FilterMode::Equality,
             description: input.description.clone(),
@@ -64,7 +64,7 @@ pub fn projection_column_specs(projection: &Projection) -> Vec<ColumnSpec> {
         .iter()
         .map(|column| ColumnSpec {
             name: column.name.clone(),
-            data_type: column.data_type.as_manifest_str().to_string(),
+            data_type: column.data_type,
             nullable: column.nullable,
             r#virtual: false,
             description: column.description.clone(),
@@ -85,7 +85,7 @@ pub fn projection_column_specs(projection: &Projection) -> Vec<ColumnSpec> {
             .filter(|input| !existing.contains(&input.name))
             .map(|input| ColumnSpec {
                 name: input.name.clone(),
-                data_type: input.data_type.as_manifest_str().to_string(),
+                data_type: input.data_type,
                 nullable: !input.required,
                 r#virtual: true,
                 description: input.description.clone(),

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -251,7 +251,6 @@ pub(crate) fn validate_filters_and_column_exprs(
                 filter.name
             )));
         }
-        filter.manifest_data_type()?;
     }
 
     validate_column_exprs(columns, &known_filters, &HashSet::new(), schema, table)?;
@@ -328,9 +327,7 @@ pub(crate) fn validate_detail_hint_references(
                     hint.table, hint.detail_filter
                 )));
             };
-            let search_result_type = search_result_column.manifest_data_type()?;
-            let detail_filter_type = detail_filter.manifest_data_type()?;
-            if search_result_type != detail_filter_type {
+            if search_result_column.data_type != detail_filter.data_type {
                 return Err(ManifestError::validation(format!(
                     "{context} search_result_column '{}' type '{}' does not match target table '{}' detail_filter '{}' type '{}'",
                     hint.search_result_column,
@@ -518,12 +515,6 @@ pub(crate) fn validate_unique_values(values: &[String], context: &str) -> Result
 pub(crate) fn validate_columns(columns: &[ColumnSpec], schema: &str, table: &str) -> Result<()> {
     let mut seen_columns = HashSet::new();
     for col in columns {
-        col.manifest_data_type().map_err(|error| {
-            ManifestError::validation(format!(
-                "{schema}.{table} column '{}' has invalid type '{}': {error}",
-                col.name, col.data_type
-            ))
-        })?;
         if !seen_columns.insert(col.name.clone()) {
             return Err(ManifestError::validation(format!(
                 "{schema}.{table} has duplicate column '{}'",
@@ -972,14 +963,13 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        DeclaredRelation, HttpTableValidation, validate_columns,
-        validate_declared_relation_namespace, validate_filters_and_column_exprs,
-        validate_http_function, validate_http_table,
+        DeclaredRelation, HttpTableValidation, validate_declared_relation_namespace,
+        validate_filters_and_column_exprs, validate_http_function, validate_http_table,
     };
     use crate::common::{
         ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding,
-        MAX_SEARCH_CANDIDATES_PER_QUERY, MAX_SEARCH_TOP_K, PaginationSpec, QueryParamSpec,
-        RequestRouteSpec, RequestSpec, SearchLimitsSpec, SourceTableFunctionKind,
+        MAX_SEARCH_CANDIDATES_PER_QUERY, MAX_SEARCH_TOP_K, ManifestDataType, PaginationSpec,
+        QueryParamSpec, RequestRouteSpec, RequestSpec, SearchLimitsSpec, SourceTableFunctionKind,
         SourceTableFunctionSpec, TableFunctionArgSpec, ValueSourceSpec,
     };
     use crate::parse_source_manifest_value;
@@ -989,7 +979,7 @@ mod tests {
     fn test_column() -> ColumnSpec {
         ColumnSpec {
             name: "id".to_string(),
-            data_type: "Utf8".to_string(),
+            data_type: ManifestDataType::Utf8,
             nullable: true,
             r#virtual: false,
             description: String::new(),
@@ -1000,7 +990,7 @@ mod tests {
     fn test_filters() -> Vec<FilterSpec> {
         vec![FilterSpec {
             name: "id".to_string(),
-            data_type: "Utf8".to_string(),
+            data_type: ManifestDataType::Utf8,
             required: false,
             mode: FilterMode::Equality,
             description: String::new(),
@@ -1011,7 +1001,7 @@ mod tests {
     fn lookup_key_filter(name: &str) -> FilterSpec {
         FilterSpec {
             name: name.to_string(),
-            data_type: "Utf8".to_string(),
+            data_type: ManifestDataType::Utf8,
             required: false,
             mode: FilterMode::Equality,
             description: String::new(),
@@ -1026,17 +1016,15 @@ mod tests {
     }
 
     #[test]
-    fn validate_columns_rejects_invalid_column_type() {
-        let mut column = test_column();
-        column.data_type = "Banana".to_string();
-
-        let error = validate_columns(&[column], "demo", "messages")
-            .expect_err("column types should be validated");
+    fn column_spec_rejects_invalid_column_type_at_parse_time() {
+        let error = serde_json::from_value::<ColumnSpec>(json!({
+            "name": "id",
+            "type": "Banana",
+        }))
+        .expect_err("column types should be validated during deserialization");
 
         assert!(
-            error
-                .to_string()
-                .contains("demo.messages column 'id' has invalid type 'Banana'"),
+            error.to_string().contains("unknown variant `Banana`"),
             "unexpected error: {error}"
         );
     }
@@ -1720,7 +1708,7 @@ mod tests {
     fn validate_http_table_allows_contains_filters_without_search_limits() {
         let filters = vec![FilterSpec {
             name: "query".to_string(),
-            data_type: "Utf8".to_string(),
+            data_type: ManifestDataType::Utf8,
             required: false,
             mode: FilterMode::Contains,
             description: String::new(),
@@ -1776,7 +1764,7 @@ mod tests {
         }];
         let filters = vec![FilterSpec {
             name: "query".to_string(),
-            data_type: "Utf8".to_string(),
+            data_type: ManifestDataType::Utf8,
             required: false,
             mode: FilterMode::Contains,
             description: String::new(),


### PR DESCRIPTION
## Summary
- Add `ManifestDataType::ALL`, `as_manifest_str`, `Display`, and `FromStr` so the scalar variant list and its manifest spelling are defined in one place.
- Add `coral-engine/src/types.rs` as the home for `ManifestDataType`-to-Arrow mappings (`arrow_column_type`, `is_string_family`), replacing per-module copies.
- Store `ColumnSpec`, `FilterSpec`, and `McpTableFilterSpec` `data_type` as `ManifestDataType` instead of `String`, so consumers stop re-parsing type names on every use.
- Give `FilePartitionDataType` a `TryFrom<ManifestDataType>`/`From` pair and delete the engine's private duplicate `PartitionDataType`.
- Publicize the v4-to-v3 scalar lowering as `IrScalarType::lower`.
- Delete the never-used `QueryParameterType` enum; add the missing `Utf8View` arm in `literal_to_string`.
- Add tests pinning the JSON-schema type enums, the spelling round-trip, and the partition-legal subset to the Rust enum.

## Why
The scalar type vocabulary was maintained by hand in several places that had to agree: the enum, a hand-written parse table, a second string table in the v4 projection layer, two JSON-schema enums (one an inline copy), stringly `data_type` fields re-parsed by every consumer, and per-module Arrow mappings. Some had already drifted: `literal_to_string` was the one string extractor missing `Utf8View`, so a `Utf8View` literal bound on the MCP backend but not over HTTP.

After this change the variant list exists once, every conversion is either serde or a named function, and adding a variant fails compilation (or a golden test, for the JSON schema) at each site that needs a decision.

## Behavior
Wire and catalog output are unchanged. The manifest spellings (`Utf8`, `Int64`, ...) are pinned by serde and by new tests, and `coral.columns` / `coral.table_functions` output is byte-identical (verified against a real workspace: 19,936 catalog rows compared between a CLI built from this branch and one built from main).

One intended change: a manifest with an invalid `type:` fails when the manifest is parsed instead of at first query. In practice schema validation already rejected these at `source add` before serde ran, and that error is unchanged:

```
$ coral source add --file bad.yaml
Error: source manifest failed schema validation:
  /tables/0/columns/0/type: "Banana" is not one of "Utf8", "Int64" or 4 other candidates
```

Workspace-internal API removals: `QueryParameterType`, `coral_spec::v4::manifest_data_type_name`, `ColumnSpec::manifest_data_type()`, `FilterSpec::manifest_data_type()`. In-flight branches referencing these need mechanical fixes on rebase; the functions stack's "centralize manifest data type names" commit is superseded by `as_manifest_str` landing here, and its private `is_string_data_type` in `runtime/query.rs` can use `types::is_string_family`.

## Not in this PR
- Renaming `ManifestDataType` (mechanical follow-up once the functions stack lands; the Rust identifier is not part of any wire format).
- `coral.columns` renders Arrow type strings for schema-inferred tables but manifest spellings for declared tables; unchanged here, tracked separately.
- The docs data-type reference table still hand-duplicates the spellings with no enforcement.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- Built the CLI from this branch and from main against a copy of a real workspace config: byte-identical catalog output, identical live query results over file and HTTP sources, identical invalid-manifest errors from `source add`.
