### PR TITLE
feat(sources/community/agentmail): add AgentMail community source

### DIFF
--- a/sources/community/agentmail/README.md
+++ b/sources/community/agentmail/README.md
@@ -90,7 +90,10 @@ Email messages in an AgentMail inbox. Includes sender, recipients, subject, prev
 | `to` | Utf8 | | Filter by recipient (substring match) |
 | `subject` | Utf8 | | Filter by subject (substring match) |
 | `include_spam` | Boolean | | Include spam messages (default false) |
+| `include_blocked` | Boolean | | Include blocked messages (default false) |
+| `include_unauthenticated` | Boolean | | Include unauthenticated messages (default false) |
 | `include_trash` | Boolean | | Include trashed messages (default false) |
+| `ascending` | Boolean | | Sort in ascending temporal order (default false) |
 
 **Columns**
 
@@ -129,7 +132,10 @@ Email threads (conversations) in an AgentMail inbox. Groups messages into conver
 | `recipients` | Utf8 | | Filter by recipient (substring match) |
 | `subject` | Utf8 | | Filter by subject (substring match) |
 | `include_spam` | Boolean | | Include spam threads (default false) |
+| `include_blocked` | Boolean | | Include blocked threads (default false) |
+| `include_unauthenticated` | Boolean | | Include unauthenticated threads (default false) |
 | `include_trash` | Boolean | | Include trashed threads (default false) |
+| `ascending` | Boolean | | Sort in ascending temporal order (default false) |
 
 **Columns**
 

--- a/sources/community/agentmail/README.md
+++ b/sources/community/agentmail/README.md
@@ -16,16 +16,18 @@ coral source add --file sources/community/agentmail/manifest.yaml
 
 ## Credentials
 
-To use this source, you will need an AgentMail API key.
+To use this source, you will need an AgentMail **organization-level** API key with read permissions.
 
 1. Sign up at [agentmail.to](https://agentmail.to).
 2. Navigate to your dashboard at [app.agentmail.to](https://app.agentmail.to).
-3. Copy your API key (starts with `am_us_`).
+3. Create an API key (starts with `am_`) with the following read permissions: `inbox_read`, `message_read`, `thread_read`, `domain_read`.
 4. Provide it when prompted by `coral source add` or set it as an environment variable:
 
 ```bash
-export AGENTMAIL_API_KEY="am_us_your-api-key"
+export AGENTMAIL_API_KEY="am_your-api-key"
 ```
+
+**Note:** Inbox-scoped API keys only support the `messages` and `threads` tables for that specific inbox. Organization-level keys are required to list all inboxes and domains. See [AgentMail Permissions](https://docs.agentmail.to/permissions) for details.
 
 ## Quick Start
 
@@ -81,6 +83,14 @@ Email messages in an AgentMail inbox. Includes sender, recipients, subject, prev
 | Filter | Type | Required | Description |
 |--------|------|----------|-------------|
 | `inbox_id` | Utf8 | Yes | ID of the inbox to list messages from |
+| `labels` | Utf8 | | Filter by label (comma-separated) |
+| `before` | Utf8 | | Only messages before this timestamp (ISO 8601) |
+| `after` | Utf8 | | Only messages after this timestamp (ISO 8601) |
+| `from` | Utf8 | | Filter by sender (substring match) |
+| `to` | Utf8 | | Filter by recipient (substring match) |
+| `subject` | Utf8 | | Filter by subject (substring match) |
+| `include_spam` | Boolean | | Include spam messages (default false) |
+| `include_trash` | Boolean | | Include trashed messages (default false) |
 
 **Columns**
 
@@ -112,6 +122,14 @@ Email threads (conversations) in an AgentMail inbox. Groups messages into conver
 | Filter | Type | Required | Description |
 |--------|------|----------|-------------|
 | `inbox_id` | Utf8 | Yes | ID of the inbox to list threads from |
+| `labels` | Utf8 | | Filter by label (comma-separated) |
+| `before` | Utf8 | | Only threads before this timestamp (ISO 8601) |
+| `after` | Utf8 | | Only threads after this timestamp (ISO 8601) |
+| `senders` | Utf8 | | Filter by sender (substring match) |
+| `recipients` | Utf8 | | Filter by recipient (substring match) |
+| `subject` | Utf8 | | Filter by subject (substring match) |
+| `include_spam` | Boolean | | Include spam threads (default false) |
+| `include_trash` | Boolean | | Include trashed threads (default false) |
 
 **Columns**
 
@@ -151,7 +169,7 @@ Custom domains configured in AgentMail. Includes feedback settings and subdomain
 
 ## Source scope
 
-- Targets the AgentMail API at `https://api.agentmail.to/v0`.
+- Targets the AgentMail API at `https://api.agentmail.to/v0`. The EU endpoint (`https://api.agentmail.eu/v0`) is not supported in this version.
 - Requires `AGENTMAIL_API_KEY` authentication as a Bearer token.
 - `messages` and `threads` require an `inbox_id` filter (URL path segment). Use `inboxes` to discover inbox IDs.
 - Cursor-based pagination (`page_token` query param) on all tables with `limit` default 50, max 100.
@@ -162,8 +180,8 @@ Custom domains configured in AgentMail. Includes feedback settings and subdomain
 
 - The source provides read-only list access only. Send, reply, forward, draft, webhook, and pod management endpoints are out of scope.
 - Message body text (HTML/plain) is not returned by the list endpoint — only `preview` (text snippet). Use the Get Message endpoint directly for full body content.
-- Attachment binary content is not accessible through this source — only attachment metadata (id, filename, size, content_type).
-- The `messages` and `threads` tables do not expose all available API filters (labels, before, after, include_spam, etc.) in this version.
+- Attachment binary content is not accessible through this source — only attachment metadata (attachment_id, filename, size, content_type).
+- The `messages` and `threads` filter substring matches (`from`, `to`, `subject`, `senders`, `recipients`) are served by AgentMail's search backend, which caps `limit` at 100.
 - Rate limits apply based on your AgentMail plan.
 
 ## Provider docs

--- a/sources/community/agentmail/README.md
+++ b/sources/community/agentmail/README.md
@@ -1,0 +1,306 @@
+# AgentMail
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 4
+
+Query inboxes, messages, threads, and domains from AgentMail. Provides read-only access to AI agent email infrastructure including conversations, attachments, and domain configuration.
+
+## Installation
+
+Install the source via the CLI:
+
+```bash
+coral source add --file sources/community/agentmail/manifest.yaml
+```
+
+## Credentials
+
+To use this source, you will need an AgentMail API key.
+
+1. Sign up at [agentmail.to](https://agentmail.to).
+2. Navigate to your dashboard at [app.agentmail.to](https://app.agentmail.to).
+3. Copy your API key (starts with `am_us_`).
+4. Provide it when prompted by `coral source add` or set it as an environment variable:
+
+```bash
+export AGENTMAIL_API_KEY="am_us_your-api-key"
+```
+
+## Quick Start
+
+```sql
+-- List all inboxes
+SELECT inbox_id, email, display_name, created_at
+FROM agentmail.inboxes;
+
+-- List messages in an inbox
+SELECT message_id, subject, "from", preview
+FROM agentmail.messages
+WHERE inbox_id = 'your-inbox-id'
+LIMIT 10;
+
+-- List threads in an inbox
+SELECT thread_id, subject, message_count, preview
+FROM agentmail.threads
+WHERE inbox_id = 'your-inbox-id'
+LIMIT 10;
+
+-- List configured domains
+SELECT domain_id, domain, feedback_enabled, created_at
+FROM agentmail.domains;
+```
+
+## Tables
+
+### `inboxes`
+
+Email inboxes managed by AgentMail. Each inbox is an API-first email account for an AI agent with its own address and metadata. No required filters.
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `inbox_id` | Utf8 | Unique identifier for the inbox |
+| `email` | Utf8 | Email address of the inbox |
+| `display_name` | Utf8 | Display name shown in emails |
+| `pod_id` | Utf8 | ID of the pod this inbox belongs to |
+| `client_id` | Utf8 | Client-assigned identifier for the inbox |
+| `metadata` | Json | Custom key-value metadata attached to the inbox |
+| `updated_at` | Timestamp | When the inbox was last updated (ISO 8601) |
+| `created_at` | Timestamp | When the inbox was created (ISO 8601) |
+
+---
+
+### `messages`
+
+Email messages in an AgentMail inbox. Includes sender, recipients, subject, preview text, labels, and attachment metadata. Requires `inbox_id` filter.
+
+**Filters**
+
+| Filter | Type | Required | Description |
+|--------|------|----------|-------------|
+| `inbox_id` | Utf8 | Yes | ID of the inbox to list messages from |
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `inbox_id` | Utf8 | ID of the inbox containing this message |
+| `thread_id` | Utf8 | ID of the thread this message belongs to |
+| `message_id` | Utf8 | Unique identifier for the message |
+| `from` | Utf8 | Sender address |
+| `to` | Json | Recipient addresses (JSON array) |
+| `cc` | Json | CC recipient addresses (JSON array) |
+| `bcc` | Json | BCC recipient addresses (JSON array) |
+| `subject` | Utf8 | Subject line of the message |
+| `preview` | Utf8 | Text preview of the message body |
+| `labels` | Json | Labels assigned to the message (JSON array) |
+| `size` | Int64 | Size of the message in bytes |
+| `attachments` | Json | Attachment metadata (JSON array) |
+| `timestamp` | Timestamp | When the message was sent or drafted (ISO 8601) |
+| `created_at` | Timestamp | When the message was created (ISO 8601) |
+
+---
+
+### `threads`
+
+Email threads (conversations) in an AgentMail inbox. Groups messages into conversations with sender/recipient summaries, message counts, and preview text. Requires `inbox_id` filter.
+
+**Filters**
+
+| Filter | Type | Required | Description |
+|--------|------|----------|-------------|
+| `inbox_id` | Utf8 | Yes | ID of the inbox to list threads from |
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `inbox_id` | Utf8 | ID of the inbox containing this thread |
+| `thread_id` | Utf8 | Unique identifier for the thread |
+| `subject` | Utf8 | Subject line of the thread |
+| `preview` | Utf8 | Text preview of the last message |
+| `senders` | Json | Sender addresses in the thread (JSON array) |
+| `recipients` | Json | Recipient addresses in the thread (JSON array) |
+| `labels` | Json | Labels assigned to the thread (JSON array) |
+| `message_count` | Int64 | Number of messages in the thread |
+| `last_message_id` | Utf8 | ID of the last message in the thread |
+| `size` | Int64 | Total size of the thread in bytes |
+| `timestamp` | Timestamp | Timestamp of last sent or received message (ISO 8601) |
+| `created_at` | Timestamp | When the thread was created (ISO 8601) |
+
+---
+
+### `domains`
+
+Custom domains configured in AgentMail. Includes feedback settings and subdomain configuration. No required filters.
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `domain_id` | Utf8 | Unique identifier for the domain |
+| `domain` | Utf8 | Domain name (e.g. example.com) |
+| `pod_id` | Utf8 | ID of the pod this domain belongs to |
+| `feedback_enabled` | Boolean | Whether bounce/complaint notifications are sent to inboxes |
+| `subdomains_enabled` | Boolean | Whether inboxes on any subdomain are allowed |
+| `client_id` | Utf8 | Client-assigned identifier for the domain |
+| `updated_at` | Timestamp | When the domain was last updated (ISO 8601) |
+| `created_at` | Timestamp | When the domain was created (ISO 8601) |
+
+## Source scope
+
+- Targets the AgentMail API at `https://api.agentmail.to/v0`.
+- Requires `AGENTMAIL_API_KEY` authentication as a Bearer token.
+- `messages` and `threads` require an `inbox_id` filter (URL path segment). Use `inboxes` to discover inbox IDs.
+- Cursor-based pagination (`page_token` query param) on all tables with `limit` default 50, max 100.
+- 2 declared test queries (`inboxes` + `domains`) are source-independent.
+- Provides read-only access. Creating, sending, updating, or deleting inboxes, messages, threads, or domains is intentionally out of scope.
+
+## Limitations
+
+- The source provides read-only list access only. Send, reply, forward, draft, webhook, and pod management endpoints are out of scope.
+- Message body text (HTML/plain) is not returned by the list endpoint — only `preview` (text snippet). Use the Get Message endpoint directly for full body content.
+- Attachment binary content is not accessible through this source — only attachment metadata (id, filename, size, content_type).
+- The `messages` and `threads` tables do not expose all available API filters (labels, before, after, include_spam, etc.) in this version.
+- Rate limits apply based on your AgentMail plan.
+
+## Provider docs
+
+- AgentMail introduction: https://docs.agentmail.to/introduction
+- Inboxes API: https://docs.agentmail.to/api-reference/inboxes/list
+- Messages API: https://docs.agentmail.to/api-reference/inboxes/messages/list
+- Threads API: https://docs.agentmail.to/api-reference/inboxes/threads/list
+- Domains API: https://docs.agentmail.to/api-reference/domains/list
+- API keys: https://app.agentmail.to
+
+## Live validation output
+
+Validated against a live AgentMail account with a valid `AGENTMAIL_API_KEY`.
+
+```bash
+$ coral source lint sources/community/agentmail/manifest.yaml
+Manifest is valid
+```
+
+```bash
+$ coral source add --file sources/community/agentmail/manifest.yaml
+Added source agentmail
+
+  ✓ agentmail connected successfully
+
+    agentmail (4 tables)
+    ├─ domains
+    ├─ inboxes
+    ├─ messages
+    └─ threads
+    Query tests
+    2 declared · 2 passed · 0 failed
+
+    ✓ SELECT inbox_id, email, created_at FROM agentmail.inboxes LIMIT 3
+      1 row
+
+    ✓ SELECT domain_id, domain, created_at FROM agentmail.domains LIMIT 3
+      0 rows
+```
+
+**Table introspection:**
+
+```sql
+SELECT table_name, description, required_filters
+FROM coral.tables
+WHERE schema_name = 'agentmail'
+ORDER BY table_name;
+```
+
+```text
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| table_name | description                                                                                                                                                | required_filters |
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+| domains    | Custom domains configured in AgentMail. Includes verification status, feedback settings, and subdomain configuration.                                      |                  |
+| inboxes    | Email inboxes managed by AgentMail. Each inbox is an API-first email account for an AI agent with its own address and metadata.                            |                  |
+| messages   | Email messages in an AgentMail inbox. Includes sender, recipients, subject, preview text, labels, and attachment metadata.                                 | inbox_id         |
+| threads    | Email threads (conversations) in an AgentMail inbox. Groups messages into conversations with sender/recipient summaries, message counts, and preview text. | inbox_id         |
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------+
+```
+
+**Inputs introspection:**
+
+```sql
+SELECT key, kind, required, is_set
+FROM coral.inputs
+WHERE schema_name = 'agentmail'
+ORDER BY key;
+```
+
+```text
++-------------------+--------+----------+--------+
+| key               | kind   | required | is_set |
++-------------------+--------+----------+--------+
+| AGENTMAIL_API_KEY | secret | true     | true   |
++-------------------+--------+----------+--------+
+```
+
+```bash
+$ coral source test agentmail
+  ✓ agentmail connected successfully
+  Secrets: keychain
+    Query tests
+    2 declared · 2 passed · 0 failed
+
+    ✓ SELECT inbox_id, email, created_at FROM agentmail.inboxes LIMIT 3
+      1 row
+
+    ✓ SELECT domain_id, domain, created_at FROM agentmail.domains LIMIT 3
+      0 rows
+```
+
+**Live inboxes proof:**
+
+```sql
+SELECT inbox_id, email, display_name, created_at
+FROM agentmail.inboxes;
+```
+
+```text
++--------------------+--------------------+--------------+--------------------------+
+| inbox_id           | email              | display_name | created_at               |
++--------------------+--------------------+--------------+--------------------------+
+| user_abc@agent... | user_abc@agent... | AgentMail    | 2026-06-07T14:58:11.359Z |
++--------------------+--------------------+--------------+--------------------------+
+```
+
+**Live messages proof:**
+
+```sql
+SELECT message_id, subject, "from", preview
+FROM agentmail.messages
+WHERE inbox_id = 'user_abc@agentmail.to'
+LIMIT 3;
+```
+
+```text
++------------------+-------------------+--------------------------+---------------------+
+| message_id       | subject           | from                     | preview             |
++------------------+-------------------+--------------------------+---------------------+
+| <msg_abc123...>  | learn for english | User <user@example.com>  | we work for english |
++------------------+-------------------+--------------------------+---------------------+
+```
+
+**Live threads proof:**
+
+```sql
+SELECT thread_id, subject, message_count, preview
+FROM agentmail.threads
+WHERE inbox_id = 'user_abc@agentmail.to'
+LIMIT 3;
+```
+
+```text
++--------------------------------------+-------------------+---------------+---------------------+
+| thread_id                            | subject           | message_count | preview             |
++--------------------------------------+-------------------+---------------+---------------------+
+| thr_abc123-xxxx-xxxx-xxxx-xxxxxxxxxx | learn for english | 1             | we work for english |
++--------------------------------------+-------------------+---------------+---------------------+
+```

--- a/sources/community/agentmail/manifest.yaml
+++ b/sources/community/agentmail/manifest.yaml
@@ -1,0 +1,459 @@
+name: agentmail
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query inboxes, messages, threads, and domains from AgentMail.
+  Provides read-only access to AI agent email infrastructure
+  including conversations, attachments, and domain configuration.
+base_url: https://api.agentmail.to/v0
+
+inputs:
+  AGENTMAIL_API_KEY:
+    kind: secret
+    hint: >-
+      AgentMail API key from https://app.agentmail.to.
+      Keys start with `am_us_`.
+    credential:
+      methods:
+        - type: source_config
+          label: Paste API key
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: bearer
+      key: AGENTMAIL_API_KEY
+
+test_queries:
+  - SELECT inbox_id, email, created_at FROM agentmail.inboxes LIMIT 3
+  - SELECT domain_id, domain, created_at FROM agentmail.domains LIMIT 3
+
+tables:
+
+  # --------------------------------------------------------------------------
+  # agentmail.inboxes — List all inboxes
+  # GET /v0/inboxes
+  # Cursor pagination via page_token / next_page_token.
+  # --------------------------------------------------------------------------
+  - name: inboxes
+    description: >-
+      Email inboxes managed by AgentMail. Each inbox is an API-first
+      email account for an AI agent with its own address and metadata.
+    guide: |
+      No required filters. Start with:
+        SELECT inbox_id, email, display_name, created_at
+        FROM agentmail.inboxes LIMIT 10
+      Use the inbox_id to query messages and threads for a specific inbox.
+    request:
+      method: GET
+      path: /inboxes
+    response:
+      rows_path:
+        - inboxes
+    pagination:
+      mode: cursor_query
+      cursor_param: page_token
+      response_cursor_path:
+        - next_page_token
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    fetch_limit_default: 50
+    columns:
+      - name: inbox_id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the inbox.
+      - name: email
+        type: Utf8
+        nullable: false
+        description: Email address of the inbox.
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Display name shown in emails.
+        expr:
+          kind: path
+          path:
+            - display_name
+      - name: pod_id
+        type: Utf8
+        nullable: true
+        description: ID of the pod this inbox belongs to.
+        expr:
+          kind: path
+          path:
+            - pod_id
+      - name: client_id
+        type: Utf8
+        nullable: true
+        description: Client-assigned identifier for the inbox.
+        expr:
+          kind: path
+          path:
+            - client_id
+      - name: metadata
+        type: Json
+        nullable: true
+        description: Custom key-value metadata attached to the inbox.
+      - name: updated_at
+        type: Timestamp
+        nullable: false
+        description: When the inbox was last updated (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: When the inbox was created (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+
+  # --------------------------------------------------------------------------
+  # agentmail.messages — List messages in an inbox
+  # GET /v0/inboxes/{inbox_id}/messages
+  # Requires inbox_id filter. Cursor pagination.
+  # --------------------------------------------------------------------------
+  - name: messages
+    description: >-
+      Email messages in an AgentMail inbox. Includes sender, recipients,
+      subject, preview text, labels, and attachment metadata.
+    guide: |
+      inbox_id is required. Start by listing inboxes to get an inbox_id:
+        SELECT inbox_id, email FROM agentmail.inboxes LIMIT 5
+      Then query messages:
+        SELECT message_id, subject, "from", preview
+        FROM agentmail.messages
+        WHERE inbox_id = 'your-inbox-id' LIMIT 10
+    filters:
+      - name: inbox_id
+        required: true
+    request:
+      method: GET
+      path: /inboxes/{{filter.inbox_id}}/messages
+    response:
+      rows_path:
+        - messages
+    pagination:
+      mode: cursor_query
+      cursor_param: page_token
+      response_cursor_path:
+        - next_page_token
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    fetch_limit_default: 50
+    columns:
+      - name: inbox_id
+        type: Utf8
+        nullable: false
+        description: ID of the inbox containing this message.
+        expr:
+          kind: path
+          path:
+            - inbox_id
+      - name: thread_id
+        type: Utf8
+        nullable: false
+        description: ID of the thread this message belongs to.
+        expr:
+          kind: path
+          path:
+            - thread_id
+      - name: message_id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the message.
+        expr:
+          kind: path
+          path:
+            - message_id
+      - name: from
+        type: Utf8
+        nullable: false
+        description: Sender address.
+        expr:
+          kind: path
+          path:
+            - from
+      - name: to
+        type: Json
+        nullable: false
+        description: Recipient addresses (JSON array).
+      - name: cc
+        type: Json
+        nullable: true
+        description: CC recipient addresses (JSON array).
+      - name: bcc
+        type: Json
+        nullable: true
+        description: BCC recipient addresses (JSON array).
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Subject line of the message.
+      - name: preview
+        type: Utf8
+        nullable: true
+        description: Text preview of the message body.
+      - name: labels
+        type: Json
+        nullable: false
+        description: Labels assigned to the message (JSON array).
+      - name: size
+        type: Int64
+        nullable: false
+        description: Size of the message in bytes.
+      - name: attachments
+        type: Json
+        nullable: true
+        description: Attachment metadata (JSON array with id, filename, size, content_type).
+      - name: timestamp
+        type: Timestamp
+        nullable: false
+        description: When the message was sent or drafted (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - timestamp
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: When the message was created (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+
+  # --------------------------------------------------------------------------
+  # agentmail.threads — List threads in an inbox
+  # GET /v0/inboxes/{inbox_id}/threads
+  # Requires inbox_id filter. Cursor pagination.
+  # --------------------------------------------------------------------------
+  - name: threads
+    description: >-
+      Email threads (conversations) in an AgentMail inbox. Groups
+      messages into conversations with sender/recipient summaries,
+      message counts, and preview text.
+    guide: |
+      inbox_id is required. Start by listing inboxes to get an inbox_id:
+        SELECT inbox_id, email FROM agentmail.inboxes LIMIT 5
+      Then query threads:
+        SELECT thread_id, subject, message_count, preview
+        FROM agentmail.threads
+        WHERE inbox_id = 'your-inbox-id' LIMIT 10
+    filters:
+      - name: inbox_id
+        required: true
+    request:
+      method: GET
+      path: /inboxes/{{filter.inbox_id}}/threads
+    response:
+      rows_path:
+        - threads
+    pagination:
+      mode: cursor_query
+      cursor_param: page_token
+      response_cursor_path:
+        - next_page_token
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    fetch_limit_default: 50
+    columns:
+      - name: inbox_id
+        type: Utf8
+        nullable: false
+        description: ID of the inbox containing this thread.
+        expr:
+          kind: path
+          path:
+            - inbox_id
+      - name: thread_id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the thread.
+        expr:
+          kind: path
+          path:
+            - thread_id
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Subject line of the thread.
+      - name: preview
+        type: Utf8
+        nullable: true
+        description: Text preview of the last message in the thread.
+      - name: senders
+        type: Json
+        nullable: false
+        description: Sender addresses in the thread (JSON array).
+      - name: recipients
+        type: Json
+        nullable: false
+        description: Recipient addresses in the thread (JSON array).
+      - name: labels
+        type: Json
+        nullable: false
+        description: Labels assigned to the thread (JSON array).
+      - name: message_count
+        type: Int64
+        nullable: false
+        description: Number of messages in the thread.
+        expr:
+          kind: path
+          path:
+            - message_count
+      - name: last_message_id
+        type: Utf8
+        nullable: false
+        description: ID of the last message in the thread.
+        expr:
+          kind: path
+          path:
+            - last_message_id
+      - name: size
+        type: Int64
+        nullable: false
+        description: Total size of the thread in bytes.
+      - name: timestamp
+        type: Timestamp
+        nullable: false
+        description: Timestamp of last sent or received message (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - timestamp
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: When the thread was created (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+
+  # --------------------------------------------------------------------------
+  # agentmail.domains — List domains
+  # GET /v0/domains
+  # No required filters. Cursor pagination.
+  # --------------------------------------------------------------------------
+  - name: domains
+    description: >-
+      Custom domains configured in AgentMail. Includes verification
+      status, feedback settings, and subdomain configuration.
+    guide: |
+      No required filters. Start with:
+        SELECT domain_id, domain, feedback_enabled, created_at
+        FROM agentmail.domains
+    request:
+      method: GET
+      path: /domains
+    response:
+      rows_path:
+        - domains
+    pagination:
+      mode: cursor_query
+      cursor_param: page_token
+      response_cursor_path:
+        - next_page_token
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+    fetch_limit_default: 50
+    columns:
+      - name: domain_id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the domain.
+        expr:
+          kind: path
+          path:
+            - domain_id
+      - name: domain
+        type: Utf8
+        nullable: false
+        description: Domain name (e.g. example.com).
+      - name: pod_id
+        type: Utf8
+        nullable: true
+        description: ID of the pod this domain belongs to.
+        expr:
+          kind: path
+          path:
+            - pod_id
+      - name: feedback_enabled
+        type: Boolean
+        nullable: false
+        description: Whether bounce and complaint notifications are sent to inboxes.
+        expr:
+          kind: path
+          path:
+            - feedback_enabled
+      - name: subdomains_enabled
+        type: Boolean
+        nullable: false
+        description: Whether inboxes on any subdomain of this domain are allowed.
+        expr:
+          kind: path
+          path:
+            - subdomains_enabled
+      - name: client_id
+        type: Utf8
+        nullable: true
+        description: Client-assigned identifier for the domain.
+        expr:
+          kind: path
+          path:
+            - client_id
+      - name: updated_at
+        type: Timestamp
+        nullable: false
+        description: When the domain was last updated (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: When the domain was created (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at

--- a/sources/community/agentmail/manifest.yaml
+++ b/sources/community/agentmail/manifest.yaml
@@ -155,7 +155,10 @@ tables:
       - name: to
       - name: subject
       - name: include_spam
+      - name: include_blocked
+      - name: include_unauthenticated
       - name: include_trash
+      - name: ascending
     request:
       method: GET
       path: /inboxes/{{filter.inbox_id}}/messages
@@ -181,9 +184,18 @@ tables:
         - name: include_spam
           from: filter_bool
           key: include_spam
+        - name: include_blocked
+          from: filter_bool
+          key: include_blocked
+        - name: include_unauthenticated
+          from: filter_bool
+          key: include_unauthenticated
         - name: include_trash
           from: filter_bool
           key: include_trash
+        - name: ascending
+          from: filter_bool
+          key: ascending
     response:
       rows_path:
         - messages
@@ -317,7 +329,10 @@ tables:
       - name: recipients
       - name: subject
       - name: include_spam
+      - name: include_blocked
+      - name: include_unauthenticated
       - name: include_trash
+      - name: ascending
     request:
       method: GET
       path: /inboxes/{{filter.inbox_id}}/threads
@@ -343,9 +358,18 @@ tables:
         - name: include_spam
           from: filter_bool
           key: include_spam
+        - name: include_blocked
+          from: filter_bool
+          key: include_blocked
+        - name: include_unauthenticated
+          from: filter_bool
+          key: include_unauthenticated
         - name: include_trash
           from: filter_bool
           key: include_trash
+        - name: ascending
+          from: filter_bool
+          key: ascending
     response:
       rows_path:
         - threads

--- a/sources/community/agentmail/manifest.yaml
+++ b/sources/community/agentmail/manifest.yaml
@@ -12,8 +12,10 @@ inputs:
   AGENTMAIL_API_KEY:
     kind: secret
     hint: >-
-      AgentMail API key from https://app.agentmail.to.
-      Keys start with `am_us_`.
+      AgentMail organization-level API key from https://app.agentmail.to.
+      Keys start with `am_`. Requires read permissions: inbox_read,
+      message_read, thread_read, domain_read. Inbox-scoped keys only
+      support the messages and threads tables for that inbox.
     credential:
       methods:
         - type: source_config
@@ -138,12 +140,50 @@ tables:
         SELECT message_id, subject, "from", preview
         FROM agentmail.messages
         WHERE inbox_id = 'your-inbox-id' LIMIT 10
+      Filter by time range:
+        SELECT message_id, subject, timestamp
+        FROM agentmail.messages
+        WHERE inbox_id = 'your-inbox-id'
+          AND after = '2026-01-01T00:00:00Z' LIMIT 10
     filters:
       - name: inbox_id
         required: true
+      - name: labels
+      - name: before
+      - name: after
+      - name: from
+      - name: to
+      - name: subject
+      - name: include_spam
+      - name: include_trash
     request:
       method: GET
       path: /inboxes/{{filter.inbox_id}}/messages
+      query:
+        - name: labels
+          from: filter
+          key: labels
+        - name: before
+          from: filter
+          key: before
+        - name: after
+          from: filter
+          key: after
+        - name: from
+          from: filter
+          key: from
+        - name: to
+          from: filter
+          key: to
+        - name: subject
+          from: filter
+          key: subject
+        - name: include_spam
+          from: filter_bool
+          key: include_spam
+        - name: include_trash
+          from: filter_bool
+          key: include_trash
     response:
       rows_path:
         - messages
@@ -221,7 +261,7 @@ tables:
       - name: attachments
         type: Json
         nullable: true
-        description: Attachment metadata (JSON array with id, filename, size, content_type).
+        description: Attachment metadata (JSON array with attachment_id, filename, size, content_type).
       - name: timestamp
         type: Timestamp
         nullable: false
@@ -262,12 +302,50 @@ tables:
         SELECT thread_id, subject, message_count, preview
         FROM agentmail.threads
         WHERE inbox_id = 'your-inbox-id' LIMIT 10
+      Filter by time range:
+        SELECT thread_id, subject, timestamp
+        FROM agentmail.threads
+        WHERE inbox_id = 'your-inbox-id'
+          AND after = '2026-01-01T00:00:00Z' LIMIT 10
     filters:
       - name: inbox_id
         required: true
+      - name: labels
+      - name: before
+      - name: after
+      - name: senders
+      - name: recipients
+      - name: subject
+      - name: include_spam
+      - name: include_trash
     request:
       method: GET
       path: /inboxes/{{filter.inbox_id}}/threads
+      query:
+        - name: labels
+          from: filter
+          key: labels
+        - name: before
+          from: filter
+          key: before
+        - name: after
+          from: filter
+          key: after
+        - name: senders
+          from: filter
+          key: senders
+        - name: recipients
+          from: filter
+          key: recipients
+        - name: subject
+          from: filter
+          key: subject
+        - name: include_spam
+          from: filter_bool
+          key: include_spam
+        - name: include_trash
+          from: filter_bool
+          key: include_trash
     response:
       rows_path:
         - threads


### PR DESCRIPTION
## Summary

Add an AgentMail community source so Coral can query AI agent email inboxes, messages, threads, and domains through SQL.

## Files contributed

| File | Purpose |
| --- | --- |
| `sources/community/agentmail/manifest.yaml` | Coral source manifest defining 4 tables: `inboxes`, `messages`, `threads`, `domains` |
| `sources/community/agentmail/README.md` | Full documentation with credentials, tables, queries, and validation |

## Why this source

[AgentMail](https://agentmail.to) is an email API platform built for AI agents — providing API-first inboxes for agents to send, receive, and manage email. Coral does not currently include an AgentMail source. Adding this enables users to query agent email infrastructure through SQL: list inboxes, read message metadata, browse threaded conversations, and inspect domain configuration.

## Provider docs

- AgentMail introduction: https://docs.agentmail.to/introduction
- Inboxes API: https://docs.agentmail.to/api-reference/inboxes/list
- Messages API: https://docs.agentmail.to/api-reference/inboxes/messages/list
- Threads API: https://docs.agentmail.to/api-reference/inboxes/threads/list
- Domains API: https://docs.agentmail.to/api-reference/domains/list
- Permissions: https://docs.agentmail.to/permissions

## Source shape

| Table | Required Filters | Optional Filters | Description |
|-------|-----------------|------------------|-------------|
| `inboxes` | — | — | Agent email inboxes with address, display name, metadata (8 columns) |
| `messages` | `inbox_id` | `labels`, `before`, `after`, `from`, `to`, `subject`, `include_spam`, `include_blocked`, `include_unauthenticated`, `include_trash`, `ascending` | Email messages with sender, recipients, subject, preview, labels (14 columns) |
| `threads` | `inbox_id` | `labels`, `before`, `after`, `senders`, `recipients`, `subject`, `include_spam`, `include_blocked`, `include_unauthenticated`, `include_trash`, `ascending` | Email threads with message count, senders, recipients, preview (12 columns) |
| `domains` | — | — | Custom domains with feedback and subdomain settings (8 columns) |

## Source scope

- **Base URL:** `https://api.agentmail.to/v0` (EU endpoint `api.agentmail.eu` not supported in this version)
- **Auth:** Bearer token (`AGENTMAIL_API_KEY`, keys start with `am_`). Requires organization-level key with `inbox_read`, `message_read`, `thread_read`, `domain_read` permissions.
- **Tables:** `inboxes`, `messages`, `threads`, `domains`
- **Pagination:** Cursor-based (`page_token` / `next_page_token`), limit default 50, max 100
- `messages` and `threads` require `inbox_id` filter (URL path segment) plus 8 optional server-side filters each
- Substring filters (`from`/`to`/`subject`/`senders`/`recipients`) are served by AgentMail search backend (caps `limit` at 100)
- Read-only access — send, reply, draft, webhook, and pod management are out of scope
- 2 declared test queries (`inboxes` + `domains`) are source-independent

## Validation

```bash
$ coral source lint sources/community/agentmail/manifest.yaml
Manifest is valid
```

```bash
$ coral source add --file sources/community/agentmail/manifest.yaml
Added source agentmail

  ✓ agentmail connected successfully

    agentmail (4 tables)
    ├─ domains
    ├─ inboxes
    ├─ messages
    └─ threads
    Query tests
    2 declared · 2 passed · 0 failed

    ✓ SELECT inbox_id, email, created_at FROM agentmail.inboxes LIMIT 3
      1 row

    ✓ SELECT domain_id, domain, created_at FROM agentmail.domains LIMIT 3
      0 rows
```

### Live inboxes proof

```sql
SELECT inbox_id, email, display_name, created_at FROM agentmail.inboxes;
```

```text
+--------------------+--------------------+--------------+--------------------------+
| inbox_id           | email              | display_name | created_at               |
+--------------------+--------------------+--------------+--------------------------+
| user_abc@agent... | user_abc@agent... | AgentMail    | 2026-06-07T14:58:11.359Z |
+--------------------+--------------------+--------------+--------------------------+
```

### Live messages proof

```sql
SELECT message_id, subject, "from", preview
FROM agentmail.messages
WHERE inbox_id = 'user_abc@agentmail.to'
LIMIT 3;
```

```text
+------------------+-------------------+--------------------------+---------------------+
| message_id       | subject           | from                     | preview             |
+------------------+-------------------+--------------------------+---------------------+
| <msg_abc123...>  | learn for english | User <user@example.com>  | we work for english |
+------------------+-------------------+--------------------------+---------------------+
```

### Live threads proof

```sql
SELECT thread_id, subject, message_count, preview
FROM agentmail.threads
WHERE inbox_id = 'user_abc@agentmail.to'
LIMIT 3;
```

```text
+--------------------------------------+-------------------+---------------+---------------------+
| thread_id                            | subject           | message_count | preview             |
+--------------------------------------+-------------------+---------------+---------------------+
| thr_abc123-xxxx-xxxx-xxxx-xxxxxxxxxx | learn for english | 1             | we work for english |
+--------------------------------------+-------------------+---------------+---------------------+
```

Closes #1538