### PR TITLE
docs(agents): record scalar-type conventions from #1536

### DIFF
--- a/crates/coral-engine/AGENTS.md
+++ b/crates/coral-engine/AGENTS.md
@@ -35,6 +35,12 @@ registration, and query execution.
   types when `coral-app` can assemble existing backend-ready component specs.
 - Keep this crate transport-neutral. Arrow IPC, CLI formatting, and MCP-facing
   shaping belong outside `coral-engine`.
+- Type-level `ManifestDataType`-to-Arrow lowerings live in `src/types.rs` as
+  named policy functions (column schemas and parameter binding are distinct
+  policies, not one conversion); do not add per-module conversion matches.
+  Value-level coercions stay with their backends, but every match over
+  `ManifestDataType` must be wildcard-free so a new scalar variant breaks
+  loudly instead of falling through.
 
 ## Adding or restructuring a backend
 

--- a/crates/coral-spec/AGENTS.md
+++ b/crates/coral-spec/AGENTS.md
@@ -31,3 +31,29 @@ discovery, and normalized source-definition models.
   table/function collision checks.
 - Prefer normalized source-spec values over raw YAML plumbing in public
   helpers.
+- `ManifestDataType` is the single scalar-type vocabulary. Spec structs carry
+  it typed — do not add `data_type: String` fields that consumers re-parse,
+  and do not hand-list its variants or spellings anywhere except
+  `ManifestDataType::ALL` and `as_manifest_str`. Restricted subsets (such as
+  `FilePartitionDataType`) are separate enums related to it through
+  `TryFrom`/`From`, not parallel-maintained copies.
+
+## Adding a manifest data type
+
+The exhaustive matches and the lattice tests in this crate walk you through
+most of the change; the parts they cannot reach are listed last.
+
+- Add the variant, its `as_manifest_str` arm, and its entry in
+  `ManifestDataType::ALL` (the witness match inside `ALL`'s initializer
+  breaks first).
+- Decide whether the variant is partition-legal in
+  `TryFrom<ManifestDataType> for FilePartitionDataType`.
+- Lower it from v4 in `IrScalarType::lower` if importers can produce it.
+- Update the `manifest_data_type` (and, if partition-legal,
+  `file_partition_data_type`) enums in
+  `src/schema/source_manifest.schema.json`; the golden tests in
+  `src/schema.rs` fail until they match.
+- Give it an Arrow lowering and value-level handling in `coral-engine`
+  (compiler-enforced there; see that crate's AGENTS.md).
+- Update the data-type table in `docs/reference/source-spec-reference.mdx` —
+  this one is not enforced by any test.


### PR DESCRIPTION
## Summary
- Add the scalar-type invariants from #1536 to the crate AGENTS.md files: `data_type` fields stay typed (no stringly re-parsing, no hand-listed variant copies) in `coral-spec`, and `ManifestDataType`-to-Arrow lowerings stay in `coral-engine/src/types.rs` with wildcard-free matches.
- Add an "Adding a manifest data type" checklist to `coral-spec/AGENTS.md` covering the steps the compiler and golden tests cannot walk you through (the JSON-schema enums and the docs data-type table).

## Why
#1536 made most of the scalar-type lattice self-enforcing, but two things live outside the compiler's reach: where new conversions belong, and the out-of-language steps when adding a variant. Without stating them where contributors and agents read conventions, the old patterns (per-module matches, stringly fields) get rediscovered from surrounding git history.

## Validation
Docs-only; no code changes.
