### PR TITLE
feat(reef): add schema explorer

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -340,6 +340,7 @@ describe('Architectural Tests', () => {
       expect(routeConfig).toContain("layout('routes/app-shell.tsx', [")
       expect(routeConfig).toContain("index('routes/index.tsx')")
       expect(routeConfig).toContain("route('sources', 'routes/sources.tsx')")
+      expect(routeConfig).toContain("route('schema', 'routes/schema.tsx')")
       expect(routeConfig).toContain("route('traces', 'routes/traces.tsx')")
       // Settings is gated to the desktop build, but the route entry is still present.
       expect(routeConfig).toContain("route('settings', 'routes/settings.tsx')")
@@ -347,7 +348,7 @@ describe('Architectural Tests', () => {
       // Structural check: every route is nested inside the layout, and settings
       // keeps its desktop-only conditional spread.
       expect(routeConfig).toMatch(
-        /layout\(\s*'routes\/app-shell\.tsx',\s*\[\s*index\('routes\/index\.tsx'\),\s*route\('sources', 'routes\/sources\.tsx'\),\s*route\('traces', 'routes\/traces\.tsx'\),\s*\.\.\.\(\s*isDesktopApp\s*\?\s*\[route\('settings', 'routes\/settings\.tsx'\)\]\s*:\s*\[\]\),?\s*\]\s*\)/,
+        /layout\(\s*'routes\/app-shell\.tsx',\s*\[\s*index\('routes\/index\.tsx'\),\s*route\('sources', 'routes\/sources\.tsx'\),\s*route\('schema', 'routes\/schema\.tsx'\),\s*route\('traces', 'routes\/traces\.tsx'\),\s*\.\.\.\(\s*isDesktopApp\s*\?\s*\[route\('settings', 'routes\/settings\.tsx'\)\]\s*:\s*\[\]\),?\s*\]\s*\)/,
       )
     })
 

--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -19,6 +19,7 @@ interface SidebarProps {
 
 const NAV_ITEMS = [
   { icon: 'Plug', label: 'Sources', paths: ['/', '/sources'], to: '/sources' },
+  { icon: 'NotepadText', label: 'Schema', paths: ['/schema'], to: '/schema' },
   { icon: 'Activity', label: 'Traces', paths: ['/traces'], to: '/traces' },
 ] satisfies Array<{ icon: IconName; label: string; paths: string[]; to: string }>
 

--- a/apps/reef/app/lib/coral-clients.ts
+++ b/apps/reef/app/lib/coral-clients.ts
@@ -1,11 +1,16 @@
 import { createClient, type Client } from '@connectrpc/connect'
 
+import { CatalogService } from '@/generated/coral/v1/catalog_pb'
 import { SourceService } from '@/generated/coral/v1/sources_pb'
 
 import { getCoralTransport } from './coral-runtime'
 
 export function getSourceClient(): Promise<Client<typeof SourceService>> {
   return getCoralTransport().then((transport) => createClient(SourceService, transport))
+}
+
+export function getCatalogClient(): Promise<Client<typeof CatalogService>> {
+  return getCoralTransport().then((transport) => createClient(CatalogService, transport))
 }
 
 export const WORKSPACE = { name: 'default' } as const

--- a/apps/reef/app/lib/schema-explorer.ts
+++ b/apps/reef/app/lib/schema-explorer.ts
@@ -1,0 +1,185 @@
+import { create } from '@bufbuild/protobuf'
+
+import {
+  CatalogItemKind,
+  ListCatalogRequestSchema,
+  ListColumnsRequestSchema,
+  type ListColumnsResponse,
+  type TableSummary,
+} from '@/generated/coral/v1/catalog_pb'
+
+import { getCatalogClient, WORKSPACE } from './coral-clients'
+
+export interface ColumnDef {
+  description?: string
+  filterable: boolean
+  name: string
+  nullable: boolean
+  ordinalPosition: number
+  type: string
+  virtual: boolean
+}
+
+export interface TableDef {
+  columns: ColumnDef[]
+  columnsLoaded: boolean
+  description?: string
+  name: string
+  requiredFilters: string[]
+}
+
+export interface SchemaGroup {
+  name: string
+  tables: TableDef[]
+}
+
+export interface SchemaResponse {
+  connectors: SchemaGroup[]
+}
+
+const COLUMN_PAGE_LIMIT = 200
+const COLUMN_PAGE_CONCURRENCY = 6
+
+export async function fetchSchemaFromCoral(): Promise<SchemaResponse> {
+  const tableSummaries = await listTables()
+  if (tableSummaries.length === 0) return { connectors: [] }
+
+  const schemaMap = new Map<string, TableDef[]>()
+  for (const summary of tableSummaries) {
+    if (!summary.schemaName || !summary.name) continue
+
+    const tables = schemaMap.get(summary.schemaName) ?? []
+    tables.push({
+      columns: [],
+      columnsLoaded: false,
+      description: optional(summary.description),
+      name: summary.name,
+      requiredFilters: summary.requiredFilters,
+    })
+    schemaMap.set(summary.schemaName, tables)
+  }
+
+  return {
+    connectors: [...schemaMap.entries()]
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([name, tables]) => ({
+        name,
+        tables: tables.toSorted((left, right) => left.name.localeCompare(right.name)),
+      })),
+  }
+}
+
+export async function fetchTableColumnsFromCoral(
+  schemaName: string,
+  tableName: string,
+): Promise<ColumnDef[]> {
+  return listColumnsForTable(schemaName, tableName)
+}
+
+async function listTables(): Promise<TableSummary[]> {
+  const catalogClient = await getCatalogClient()
+  const response = await catalogClient.listCatalog(
+    create(ListCatalogRequestSchema, {
+      kind: CatalogItemKind.TABLE,
+      workspace: WORKSPACE,
+    }),
+  )
+
+  return response.items.flatMap((item) => (item.item.case === 'table' ? [item.item.value] : []))
+}
+
+async function listColumnsForTable(schemaName: string, tableName: string): Promise<ColumnDef[]> {
+  const firstPage = await listColumnsPage(schemaName, tableName, 0)
+  const columns = columnsFromResponse(firstPage)
+  const pagination = firstPage.pagination
+  if (!pagination?.hasMore) return columns
+
+  const nextOffset = pagination.nextOffset || COLUMN_PAGE_LIMIT
+  if (pagination.totalCount > nextOffset) {
+    const remainingPages = await mapWithConcurrency(
+      pageOffsets(nextOffset, pagination.totalCount, COLUMN_PAGE_LIMIT),
+      COLUMN_PAGE_CONCURRENCY,
+      (offset) => listColumnsPage(schemaName, tableName, offset),
+    )
+    return columns.concat(remainingPages.flatMap(columnsFromResponse))
+  }
+
+  let offset = pagination.nextOffset
+  while (offset > 0) {
+    const page = await listColumnsPage(schemaName, tableName, offset)
+    columns.push(...columnsFromResponse(page))
+    if (!page.pagination?.hasMore) break
+    offset = page.pagination.nextOffset
+  }
+  return columns
+}
+
+async function listColumnsPage(
+  schemaName: string,
+  tableName: string,
+  offset: number,
+): Promise<ListColumnsResponse> {
+  const catalogClient = await getCatalogClient()
+  return catalogClient.listColumns(
+    create(ListColumnsRequestSchema, {
+      pagination: {
+        limit: COLUMN_PAGE_LIMIT,
+        offset,
+      },
+      schemaName,
+      tableName,
+      workspace: WORKSPACE,
+    }),
+  )
+}
+
+function columnsFromResponse(response: ListColumnsResponse): ColumnDef[] {
+  return response.columns.flatMap((result) =>
+    result.column
+      ? [
+          {
+            description: optional(result.column.description),
+            filterable: result.column.isRequiredFilter,
+            name: result.column.name,
+            nullable: result.column.nullable,
+            ordinalPosition: result.column.ordinalPosition,
+            type: result.column.dataType || 'unknown',
+            virtual: result.column.isVirtual,
+          },
+        ]
+      : [],
+  )
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = Array.from<R>({ length: items.length })
+  let cursor = 0
+
+  async function run(): Promise<void> {
+    while (cursor < items.length) {
+      const index = cursor
+      cursor += 1
+      results[index] = await worker(items[index])
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, run))
+  return results
+}
+
+function pageOffsets(firstOffset: number, totalCount: number, limit: number): number[] {
+  const offsets: number[] = []
+  for (let offset = firstOffset; offset < totalCount; offset += limit) {
+    offsets.push(offset)
+  }
+  return offsets
+}
+
+function optional(value: string): string | undefined {
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -8,6 +8,7 @@ export default [
   layout('routes/app-shell.tsx', [
     index('routes/index.tsx'),
     route('sources', 'routes/sources.tsx'),
+    route('schema', 'routes/schema.tsx'),
     route('traces', 'routes/traces.tsx'),
     ...(isDesktopApp ? [route('settings', 'routes/settings.tsx')] : []),
   ]),

--- a/apps/reef/app/routes/schema.tsx
+++ b/apps/reef/app/routes/schema.tsx
@@ -1,0 +1,5 @@
+import { SchemaExplorer } from '@/views/schema-explorer'
+
+export default function SchemaRoute() {
+  return <SchemaExplorer />
+}

--- a/apps/reef/app/styles/theme.ts
+++ b/apps/reef/app/styles/theme.ts
@@ -1,0 +1,4 @@
+export const breakpoints = {
+  sidebarCollapse: '963px',
+  mobile: '640px',
+} as const

--- a/apps/reef/app/views/schema-explorer.css.ts
+++ b/apps/reef/app/views/schema-explorer.css.ts
@@ -1,0 +1,284 @@
+import { style } from '@vanilla-extract/css'
+
+import { breakpoints } from '@/styles/theme'
+import { animation, theme } from '@/wax/theme/theme.css'
+
+export { spinAnimation } from '@/wax/animations/spin.css'
+
+export const root = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  minHeight: 0,
+})
+
+export const header = style({
+  alignItems: 'baseline',
+  borderBlockEnd: `1px solid ${theme.stroke.secondary}`,
+  display: 'flex',
+  flexShrink: 0,
+  gap: 12,
+  minHeight: 56,
+  paddingBlock: 12,
+  paddingInline: 32,
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      alignItems: 'flex-start',
+      flexDirection: 'column',
+      gap: 2,
+      paddingInline: 16,
+    },
+  },
+})
+
+export const body = style({
+  display: 'flex',
+  flex: 1,
+  minHeight: 0,
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      flexDirection: 'column',
+    },
+  },
+})
+
+export const treePanel = style({
+  borderInlineEnd: `1px solid ${theme.stroke.primary}`,
+  display: 'flex',
+  flexDirection: 'column',
+  flexShrink: 0,
+  minHeight: 0,
+  width: 360,
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      borderBlockEnd: `1px solid ${theme.stroke.primary}`,
+      borderInlineEnd: 0,
+      maxHeight: '40%',
+      width: '100%',
+    },
+  },
+})
+
+export const treePanelToolbar = style({
+  borderBlockEnd: `1px solid ${theme.stroke.primary}`,
+  paddingBlock: 10,
+  paddingInline: 12,
+})
+
+export const searchRow = style({
+  position: 'relative',
+})
+
+export const clearButton = style({
+  insetInlineEnd: 8,
+  position: 'absolute',
+  top: '50%',
+  transform: 'translateY(-50%)',
+})
+
+export const treeContent = style({
+  flex: 1,
+  minHeight: 0,
+})
+
+export const treeList = style({
+  padding: 4,
+  paddingInlineEnd: 6,
+})
+
+export const treeEmpty = style({
+  padding: 12,
+  textAlign: 'center',
+})
+
+export const treeError = style({
+  padding: 12,
+})
+
+export const skeletonContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+  padding: 12,
+})
+
+export const skeletonGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+})
+
+export const skeletonChildren = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  marginInlineStart: 18,
+})
+
+export const connectorButton = style({
+  alignItems: 'center',
+  background: 'none',
+  border: 'none',
+  borderRadius: 4,
+  color: theme.content.primary,
+  cursor: 'pointer',
+  display: 'flex',
+  gap: 6,
+  paddingBlock: 5,
+  paddingInline: 8,
+  textAlign: 'left',
+  transition: animation.colorTransition,
+  width: '100%',
+  selectors: {
+    '&:hover': {
+      backgroundColor: theme.surface.onMainContentSubtle,
+    },
+  },
+})
+
+export const connectorName = style({
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+export const connectorTableCount = style({
+  color: theme.content.tertiary,
+  marginInlineStart: 'auto',
+})
+
+export const connectorChildren = style({
+  display: 'flex',
+  flexDirection: 'column',
+  marginInlineStart: 16,
+})
+
+export const tableButton = style({
+  alignItems: 'center',
+  background: 'none',
+  border: 'none',
+  borderRadius: 4,
+  color: theme.content.primary,
+  cursor: 'pointer',
+  display: 'flex',
+  gap: 6,
+  minWidth: 0,
+  paddingBlock: 4,
+  paddingInline: 8,
+  textAlign: 'left',
+  transition: animation.colorTransition,
+  width: '100%',
+  selectors: {
+    '&:hover': {
+      backgroundColor: theme.surface.onMainContentSubtle,
+    },
+  },
+})
+
+export const tableButtonSelected = style({
+  backgroundColor: theme.surface.onMainContent,
+})
+
+export const tableName = style({
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+export const detailPanel = style({
+  flex: 1,
+  minWidth: 0,
+  overflow: 'auto',
+})
+
+export const detailContent = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 18,
+  padding: 18,
+})
+
+export const detailHeader = style({
+  alignItems: 'flex-start',
+  display: 'flex',
+  gap: 12,
+  justifyContent: 'space-between',
+  minWidth: 0,
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      flexDirection: 'column',
+    },
+  },
+})
+
+export const description = style({
+  color: theme.content.secondary,
+  lineHeight: '20px',
+  marginBlockEnd: 0,
+  marginBlockStart: 4,
+  maxWidth: 840,
+})
+
+export const requiredFilterGroup = style({
+  alignItems: 'center',
+  display: 'flex',
+  flexShrink: 0,
+  flexWrap: 'wrap',
+  gap: 6,
+  justifyContent: 'flex-end',
+  maxWidth: '40%',
+  outlineOffset: 2,
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      justifyContent: 'flex-start',
+      maxWidth: '100%',
+    },
+  },
+})
+
+export const section = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  minWidth: 0,
+})
+
+export const virtualRow = style({
+  fontStyle: 'italic',
+})
+
+export const cellTruncate = style({
+  maxWidth: 360,
+})
+
+export const requiredStar = style({
+  color: theme.content.error,
+  cursor: 'help',
+  display: 'inline-flex',
+  font: 'inherit',
+  marginInlineStart: 4,
+  outlineOffset: 2,
+})
+
+export const loadingState = style({
+  alignItems: 'center',
+  display: 'flex',
+  gap: 8,
+  minHeight: 44,
+})
+
+export const emptyInline = style({
+  display: 'block',
+  paddingBlock: 8,
+})
+
+export const detailEmpty = style({
+  alignItems: 'center',
+  display: 'flex',
+  height: '100%',
+  justifyContent: 'center',
+  padding: 24,
+  textAlign: 'center',
+})

--- a/apps/reef/app/views/schema-explorer.tsx
+++ b/apps/reef/app/views/schema-explorer.tsx
@@ -1,0 +1,456 @@
+import classNames from 'classnames'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { ErrorBanner } from '@/components/error-banner'
+import {
+  fetchSchemaFromCoral,
+  fetchTableColumnsFromCoral,
+  type ColumnDef,
+  type SchemaGroup,
+  type SchemaResponse,
+  type TableDef,
+} from '@/lib/schema-explorer'
+import { IconButton } from '@/wax/components/button'
+import { Icon } from '@/wax/components/icon'
+import { TextInput } from '@/wax/components/inputs/text'
+import { Pill } from '@/wax/components/pill'
+import { Container as ScrollArea } from '@/wax/components/scroll-area'
+import { Skeleton } from '@/wax/components/skeleton'
+import { Table } from '@/wax/components/table'
+import { Tooltip } from '@/wax/components/tooltip'
+import { Typography } from '@/wax/components/typography'
+
+import * as styles from './schema-explorer.css'
+
+interface SelectedTable {
+  schemaName: string
+  table: TableDef
+}
+
+interface ColumnLoadState {
+  error?: string
+  key?: string
+  loading: boolean
+}
+
+function SkeletonTree() {
+  return (
+    <div className={styles.skeletonContainer}>
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div className={styles.skeletonGroup} key={index}>
+          <Skeleton borderRadius={4} height={20} width={140} />
+          <div className={styles.skeletonChildren}>
+            <Skeleton borderRadius={4} height={16} width={112} />
+            <Skeleton borderRadius={4} height={16} width={132} />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function schemaMatchesSearch(schema: SchemaGroup, search: string) {
+  if (!search) return true
+  return (
+    schemaNameMatchesSearch(schema, search) ||
+    schema.tables.some((table) => tableMatchesSearch(table, search))
+  )
+}
+
+function schemaNameMatchesSearch(schema: SchemaGroup, search: string) {
+  return schema.name.toLowerCase().includes(search)
+}
+
+function tableMatchesSearch(table: TableDef, search: string) {
+  if (!search) return true
+  if (table.name.toLowerCase().includes(search)) return true
+  if (table.description?.toLowerCase().includes(search)) return true
+  return false
+}
+
+function visibleTablesForSchema(schema: SchemaGroup, search: string) {
+  if (!search || schemaNameMatchesSearch(schema, search)) return schema.tables
+  return schema.tables.filter((table) => tableMatchesSearch(table, search))
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+function tableKey(schemaName: string, tableName: string) {
+  return `${schemaName}.${tableName}`
+}
+
+function withTableColumns(
+  schema: SchemaResponse | null,
+  schemaName: string,
+  tableName: string,
+  columns: ColumnDef[],
+): SchemaResponse | null {
+  if (!schema) return schema
+
+  return {
+    connectors: schema.connectors.map((connector) =>
+      connector.name === schemaName
+        ? {
+            ...connector,
+            tables: connector.tables.map((table) =>
+              table.name === tableName ? { ...table, columns, columnsLoaded: true } : table,
+            ),
+          }
+        : connector,
+    ),
+  }
+}
+
+export function SchemaExplorer() {
+  const [schema, setSchema] = useState<SchemaResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [search, setSearch] = useState('')
+  const [expandedSchemas, setExpandedSchemas] = useState<Set<string>>(new Set())
+  const [selectedTable, setSelectedTable] = useState<SelectedTable | null>(null)
+  const [columnState, setColumnState] = useState<ColumnLoadState>({ loading: false })
+
+  const loadSchema = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+
+    try {
+      const data = await fetchSchemaFromCoral()
+      setSchema(data)
+      setExpandedSchemas(new Set(data.connectors.map((connector) => connector.name)))
+      setSelectedTable(null)
+      setColumnState({ loading: false })
+    } catch (error) {
+      setSchema({ connectors: [] })
+      setLoadError(formatError(error))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadSchema()
+  }, [loadSchema])
+
+  const normalizedSearch = search.trim().toLowerCase()
+  const filteredSchemas = useMemo(
+    () =>
+      schema?.connectors.filter((connector) => schemaMatchesSearch(connector, normalizedSearch)) ??
+      [],
+    [normalizedSearch, schema],
+  )
+
+  const filteredTableCount = filteredSchemas.reduce(
+    (count, connector) => count + visibleTablesForSchema(connector, normalizedSearch).length,
+    0,
+  )
+
+  const toggleSchema = (name: string) => {
+    setExpandedSchemas((previous) => {
+      const next = new Set(previous)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
+
+  const loadTableColumns = useCallback(async (schemaName: string, table: TableDef) => {
+    if (table.columnsLoaded) return
+
+    const key = tableKey(schemaName, table.name)
+    setColumnState({ key, loading: true })
+
+    try {
+      const columns = await fetchTableColumnsFromCoral(schemaName, table.name)
+      setSchema((previous) => withTableColumns(previous, schemaName, table.name, columns))
+      setSelectedTable((previous) =>
+        previous?.schemaName === schemaName && previous.table.name === table.name
+          ? {
+              schemaName,
+              table: {
+                ...previous.table,
+                columns,
+                columnsLoaded: true,
+              },
+            }
+          : previous,
+      )
+      setColumnState((previous) => (previous.key === key ? { loading: false } : previous))
+    } catch (error) {
+      setColumnState((previous) =>
+        previous.key === key ? { error: formatError(error), key, loading: false } : previous,
+      )
+    }
+  }, [])
+
+  const handleSelectTable = (schemaName: string, table: TableDef) => {
+    setSelectedTable({ schemaName, table })
+    void loadTableColumns(schemaName, table)
+  }
+
+  const selectedTableKey = selectedTable
+    ? tableKey(selectedTable.schemaName, selectedTable.table.name)
+    : undefined
+  const selectedColumnsLoading =
+    !!selectedTableKey && columnState.key === selectedTableKey && columnState.loading
+  const selectedColumnsError =
+    selectedTableKey && columnState.key === selectedTableKey ? columnState.error : undefined
+
+  return (
+    <section aria-label="Schema explorer" className={styles.root}>
+      <div className={styles.header}>
+        <Typography.HeadingSmall as="h1">Schema explorer</Typography.HeadingSmall>
+        <Typography.BodySmall as="span" variant="tertiary">
+          {filteredSchemas.length} {filteredSchemas.length === 1 ? 'schema' : 'schemas'} /{' '}
+          {filteredTableCount} {filteredTableCount === 1 ? 'table' : 'tables'}
+        </Typography.BodySmall>
+      </div>
+
+      <div className={styles.body}>
+        <div className={styles.treePanel}>
+          <div className={styles.treePanelToolbar}>
+            <div className={styles.searchRow}>
+              <TextInput
+                icon="Search"
+                onChange={setSearch}
+                placeholder="Filter schemas and tables"
+                type="search"
+                value={search}
+              />
+              {search ? (
+                <IconButton
+                  className={styles.clearButton}
+                  name="X"
+                  onClick={() => setSearch('')}
+                  size="22"
+                  tooltipText="Clear filter"
+                  variant="bare"
+                />
+              ) : null}
+            </div>
+          </div>
+
+          <div className={styles.treeContent}>
+            <ScrollArea constrainWidth>
+              {loading ? (
+                <SkeletonTree />
+              ) : loadError ? (
+                <div className={styles.treeError}>
+                  <ErrorBanner
+                    message={loadError}
+                    onRetry={loadSchema}
+                    title="Failed to load schema"
+                  />
+                </div>
+              ) : normalizedSearch && filteredSchemas.length === 0 ? (
+                <div className={styles.treeEmpty}>
+                  <Typography.BodySmall variant="tertiary">
+                    No results for "{search}"
+                  </Typography.BodySmall>
+                </div>
+              ) : filteredSchemas.length === 0 ? (
+                <div className={styles.treeEmpty}>
+                  <Typography.BodySmall variant="tertiary">
+                    No queryable tables in this workspace.
+                  </Typography.BodySmall>
+                </div>
+              ) : (
+                <div className={styles.treeList}>
+                  {filteredSchemas.map((connector) => {
+                    const expanded = expandedSchemas.has(connector.name)
+                    const connectorChildrenId = `schema-${connector.name}-tables`
+                    const visibleTables = visibleTablesForSchema(connector, normalizedSearch)
+                    return (
+                      <div key={connector.name}>
+                        <button
+                          aria-controls={connectorChildrenId}
+                          aria-expanded={expanded}
+                          className={styles.connectorButton}
+                          onClick={() => toggleSchema(connector.name)}
+                          type="button"
+                        >
+                          <Icon
+                            color="secondary"
+                            name={expanded ? 'ChevronDown' : 'ChevronRight'}
+                            size="14"
+                          />
+                          <Typography.BodyStrong as="span" className={styles.connectorName}>
+                            {connector.name}
+                          </Typography.BodyStrong>
+                          <Typography.BodySmall
+                            as="span"
+                            className={styles.connectorTableCount}
+                            variant="tertiary"
+                          >
+                            {visibleTables.length}
+                          </Typography.BodySmall>
+                        </button>
+
+                        {expanded ? (
+                          <div className={styles.connectorChildren} id={connectorChildrenId}>
+                            {visibleTables.map((table) => {
+                              const key = tableKey(connector.name, table.name)
+                              const isSelected =
+                                selectedTable?.schemaName === connector.name &&
+                                selectedTable.table.name === table.name
+
+                              return (
+                                <button
+                                  aria-current={isSelected ? 'true' : undefined}
+                                  className={classNames(styles.tableButton, {
+                                    [styles.tableButtonSelected]: isSelected,
+                                  })}
+                                  key={key}
+                                  onClick={() => handleSelectTable(connector.name, table)}
+                                  type="button"
+                                >
+                                  <Icon color="secondary" name="Table2" size="14" />
+                                  <Typography.BodyStrong as="span" className={styles.tableName}>
+                                    {table.name}
+                                  </Typography.BodyStrong>
+                                </button>
+                              )
+                            })}
+                          </div>
+                        ) : null}
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </ScrollArea>
+          </div>
+        </div>
+
+        <div className={styles.detailPanel}>
+          {selectedTable ? (
+            <div className={styles.detailContent}>
+              <div className={styles.detailHeader}>
+                <div>
+                  <Typography.HeadingSmall as="h2">
+                    {selectedTable.schemaName}.{selectedTable.table.name}
+                  </Typography.HeadingSmall>
+                  {selectedTable.table.description ? (
+                    <Typography.BodySmall as="p" className={styles.description}>
+                      {selectedTable.table.description}
+                    </Typography.BodySmall>
+                  ) : null}
+                </div>
+                {selectedTable.table.requiredFilters.length > 0 ? (
+                  <Tooltip
+                    content={`The following filters are required: ${selectedTable.table.requiredFilters.join(', ')}`}
+                    side="top"
+                  >
+                    <div
+                      aria-label={`Required filters: ${selectedTable.table.requiredFilters.join(', ')}`}
+                      className={styles.requiredFilterGroup}
+                      tabIndex={0}
+                    >
+                      {selectedTable.table.requiredFilters.map((filter) => (
+                        <Pill color="orange" key={filter}>
+                          {filter}
+                        </Pill>
+                      ))}
+                    </div>
+                  </Tooltip>
+                ) : null}
+              </div>
+
+              <div className={styles.section}>
+                <Typography.BodySmallStrong>Columns</Typography.BodySmallStrong>
+                {selectedColumnsLoading ? (
+                  <div className={styles.loadingState}>
+                    <Icon
+                      className={styles.spinAnimation}
+                      color="secondary"
+                      name="Loader"
+                      size="18"
+                    />
+                    <Typography.BodySmall variant="tertiary">Loading columns</Typography.BodySmall>
+                  </div>
+                ) : selectedColumnsError ? (
+                  <ErrorBanner
+                    message={selectedColumnsError}
+                    onRetry={() =>
+                      selectedTable
+                        ? loadTableColumns(selectedTable.schemaName, selectedTable.table)
+                        : undefined
+                    }
+                    title="Failed to load columns"
+                  />
+                ) : selectedTable.table.columnsLoaded && selectedTable.table.columns.length > 0 ? (
+                  <Table.Wrapper variant="compact">
+                    <Table.Root>
+                      <Table.Head>
+                        <Table.Row>
+                          <Table.HeaderCell>Name</Table.HeaderCell>
+                          <Table.HeaderCell>Type</Table.HeaderCell>
+                          <Table.HeaderCell>Description</Table.HeaderCell>
+                        </Table.Row>
+                      </Table.Head>
+                      <Table.Body>
+                        {selectedTable.table.columns.map((column) => (
+                          <Table.Row
+                            className={classNames({
+                              [styles.virtualRow]: column.virtual,
+                            })}
+                            key={column.name}
+                          >
+                            <Table.Cell>
+                              {column.name}
+                              {column.filterable ? (
+                                <Tooltip
+                                  content="Required filter: queries for this table must include a filter on this field."
+                                  side="top"
+                                >
+                                  <span
+                                    aria-label="Required filter"
+                                    className={styles.requiredStar}
+                                    tabIndex={0}
+                                  >
+                                    *
+                                  </span>
+                                </Tooltip>
+                              ) : null}
+                            </Table.Cell>
+                            <Table.Cell>{column.type}</Table.Cell>
+                            <Table.Cell className={styles.cellTruncate} mono={false}>
+                              {column.description ?? '-'}
+                            </Table.Cell>
+                          </Table.Row>
+                        ))}
+                      </Table.Body>
+                    </Table.Root>
+                  </Table.Wrapper>
+                ) : selectedTable.table.columnsLoaded ? (
+                  <Typography.BodySmall className={styles.emptyInline} variant="tertiary">
+                    No columns reported for this table.
+                  </Typography.BodySmall>
+                ) : (
+                  <div className={styles.loadingState}>
+                    <Icon
+                      className={styles.spinAnimation}
+                      color="secondary"
+                      name="Loader"
+                      size="18"
+                    />
+                    <Typography.BodySmall variant="tertiary">Loading columns</Typography.BodySmall>
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className={styles.detailEmpty}>
+              <Typography.Body variant="secondary">
+                Select a table from the schema tree to inspect its columns.
+              </Typography.Body>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/reef/app/wax/animations/spin.css.ts
+++ b/apps/reef/app/wax/animations/spin.css.ts
@@ -1,0 +1,10 @@
+import { keyframes, style } from '@vanilla-extract/css'
+
+const spin = keyframes({
+  from: { transform: 'rotate(0deg)' },
+  to: { transform: 'rotate(360deg)' },
+})
+
+export const spinAnimation = style({
+  animation: `${spin} 1s linear infinite`,
+})

--- a/apps/reef/app/wax/components/pill/index.ts
+++ b/apps/reef/app/wax/components/pill/index.ts
@@ -1,2 +1,2 @@
 export { Pill } from './pill'
-export type { PillColor, PillProps } from './pill'
+export type { PillColor, PillProps, PillSize } from './pill'

--- a/apps/reef/app/wax/components/pill/pill.tsx
+++ b/apps/reef/app/wax/components/pill/pill.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames'
-import React, { Children, ElementType, isValidElement } from 'react'
+import React, { Children, isValidElement } from 'react'
+import type { ElementType } from 'react'
 
 import * as styles from './pill.css'
 

--- a/apps/reef/app/wax/components/table/table.css.ts
+++ b/apps/reef/app/wax/components/table/table.css.ts
@@ -1,7 +1,7 @@
 import { createVar, fallbackVar, style } from '@vanilla-extract/css'
 import { recipe } from '@vanilla-extract/recipes'
 
-import { theme } from '@/wax/theme/theme.css'
+import { animation, theme } from '@/wax/theme/theme.css'
 
 // The fallback keeps cells styled as the default table style when they're
 // rendered without a Table.Wrapper setting the var.
@@ -101,7 +101,7 @@ export const tbody = style({})
 
 export const tr = style({
   borderBottom: `1px solid ${theme.stroke.primary}`,
-  transition: 'background-color 0.1s ease',
+  transition: animation.colorTransition,
   selectors: {
     'tbody &:hover': {
       backgroundColor: tableVars.rowHoverBackground.value,

--- a/apps/reef/app/wax/components/table/table.stories.tsx
+++ b/apps/reef/app/wax/components/table/table.stories.tsx
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof Table.Root>
 
 function ExampleTable({ tableStyle }: { tableStyle: 'compact' | 'default' }) {
   return (
-    <Table.Wrapper style={tableStyle}>
+    <Table.Wrapper variant={tableStyle}>
       <Table.Root>
         <Table.Head>
           <Table.Row>

--- a/apps/reef/app/wax/components/table/table.tsx
+++ b/apps/reef/app/wax/components/table/table.tsx
@@ -1,51 +1,53 @@
 import classNames from 'classnames'
+import type { KeyboardEvent, ReactNode } from 'react'
 
 import * as styles from './table.css'
 
-type TableStyle = 'compact' | 'default'
+type TableVariant = 'compact' | 'default'
 
 interface TableProps {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 
 interface WrapperProps {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
-  style?: TableStyle
+  variant?: TableVariant
 }
 
 interface TableHeadProps {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 
 interface TableBodyProps {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 
 interface TableRowProps {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
   onClick?: () => void
 }
 
 interface TableHeaderCellProps {
   align?: 'center' | 'left' | 'right'
-  children?: React.ReactNode
+  children?: ReactNode
   className?: string
 }
 
 interface TableCellProps {
   align?: 'center' | 'left' | 'right'
-  children: React.ReactNode
+  children: ReactNode
   className?: string
   mono?: boolean
   title?: string
 }
 
-function Wrapper({ children, className, style: tableStyle = 'default' }: WrapperProps) {
+function Wrapper({ children, className, variant = 'default' }: WrapperProps) {
+  const tableStyle = variant
   return <div className={classNames(styles.wrapper({ tableStyle }), className)}>{children}</div>
 }
 
@@ -62,8 +64,22 @@ function Body({ children, className }: TableBodyProps) {
 }
 
 function Row({ children, className, onClick }: TableRowProps) {
+  const handleKeyDown = (event: KeyboardEvent<HTMLTableRowElement>) => {
+    if (!onClick) return
+    if (event.key !== 'Enter' && event.key !== ' ') return
+
+    event.preventDefault()
+    onClick()
+  }
+
   return (
-    <tr className={classNames(styles.tr, className)} onClick={onClick}>
+    <tr
+      className={classNames(styles.tr, className)}
+      onClick={onClick}
+      onKeyDown={onClick ? handleKeyDown : undefined}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+    >
       {children}
     </tr>
   )

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -17,7 +17,9 @@ use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::AppError;
-use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
+use crate::credentials::{
+    CredentialManager, CredentialSetId, CredentialStorageKind, CredentialsError,
+};
 use crate::episode::EpisodeId;
 use crate::query::QueryAttribution;
 use crate::query::extensions::{
@@ -35,6 +37,8 @@ use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
 use crate::workspaces::WorkspaceName;
 
+const CATALOG_SECRET_PLACEHOLDER: &str = "__coral_catalog_secret_placeholder__";
+
 #[derive(Debug)]
 pub(crate) enum QueryManagerError {
     App(AppError),
@@ -50,7 +54,16 @@ pub(crate) struct ValidatedSource {
 struct LoadedQuerySource {
     source: InstalledSource,
     query_source: QuerySource,
-    credential_material: BTreeMap<String, String>,
+    credential_material: SourceCredentialMaterial,
+}
+
+type SourceCredentialMaterial = BTreeMap<String, String>;
+type SourceSecrets = BTreeMap<String, String>;
+
+#[derive(Debug)]
+struct SourceSecretResolution {
+    credential_material: SourceCredentialMaterial,
+    resolved_secrets: SourceSecrets,
 }
 
 #[derive(Clone)]
@@ -94,7 +107,7 @@ impl QueryManager {
             attribution.episode_id.as_ref(),
             async {
                 let (loaded_sources, config) = self
-                    .load_query_sources(workspace_name)
+                    .load_catalog_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &loaded_sources, &config)
@@ -124,7 +137,7 @@ impl QueryManager {
             attribution.episode_id.as_ref(),
             async {
                 let (loaded_sources, config) = self
-                    .load_query_sources(workspace_name)
+                    .load_catalog_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &loaded_sources, &config)
@@ -165,7 +178,7 @@ impl QueryManager {
             attribution.episode_id.as_ref(),
             async {
                 let (loaded_sources, config) = self
-                    .load_query_sources(workspace_name)
+                    .load_catalog_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self
                     .runtime_config(workspace_name, &loaded_sources, &config)
@@ -331,10 +344,68 @@ impl QueryManager {
         Ok(loaded_sources)
     }
 
+    fn load_catalog_query_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<(Vec<LoadedQuerySource>, AppConfig), AppError> {
+        let _state_lock = self.config_store.state_lock_shared()?;
+        let config = self.config_store.load_config_unlocked()?;
+        let sources = self.load_catalog_query_sources_from_config(workspace_name, &config)?;
+        Ok((sources, config))
+    }
+
+    fn load_catalog_query_sources_from_config(
+        &self,
+        workspace_name: &WorkspaceName,
+        config: &AppConfig,
+    ) -> Result<Vec<LoadedQuerySource>, AppError> {
+        let span = tracing::info_span!(
+            "coral.app.catalog_sources.load",
+            workspace = tracing::field::Empty,
+            source.count = tracing::field::Empty,
+        );
+        span.record(WORKSPACE_SPAN_ATTRIBUTE, workspace_name.as_str());
+        let _guard = span.enter();
+        config.require_workspace(workspace_name)?;
+        let mut loaded_sources = Vec::new();
+        for source in config.workspace_sources(workspace_name) {
+            match self.load_query_source_with_credentials(
+                workspace_name,
+                &source,
+                SourceCredentialMode::CatalogMetadata,
+            ) {
+                Ok((loaded_source, _version)) => loaded_sources.push(loaded_source),
+                Err(error) => {
+                    tracing::error!(
+                        source = %source.name,
+                        detail = %error,
+                        "failed to load source during catalog-source load"
+                    );
+                    return Err(error);
+                }
+            }
+        }
+        span.record("source.count", loaded_sources.len());
+        Ok(loaded_sources)
+    }
+
     fn load_query_source(
         &self,
         workspace_name: &WorkspaceName,
         source: &InstalledSource,
+    ) -> Result<(LoadedQuerySource, Option<String>), AppError> {
+        self.load_query_source_with_credentials(
+            workspace_name,
+            source,
+            SourceCredentialMode::Runtime,
+        )
+    }
+
+    fn load_query_source_with_credentials(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        credential_mode: SourceCredentialMode,
     ) -> Result<(LoadedQuerySource, Option<String>), AppError> {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
         let source_spec = installed.source_spec;
@@ -358,39 +429,10 @@ impl QueryManager {
             None
         };
         validate_required_variables(source, source_spec.declared_inputs())?;
-        let stored_secrets =
-            if let Some(credential_storage) = source.credential_storage_for_material() {
-                let credential_set_id = CredentialSetId::for_source(&source.name);
-                self.credential_manager.read_material(
-                    workspace_name,
-                    &credential_set_id,
-                    credential_storage,
-                )?
-            } else {
-                BTreeMap::new()
-            };
-        let mut resolved_secrets = BTreeMap::new();
-        let missing_secrets: Vec<String> = source_spec
-            .required_secret_names()
-            .into_iter()
-            .filter(|name| !stored_secrets.contains_key(name))
-            .collect();
-        if let Some((first, rest)) = missing_secrets.split_first() {
-            let detail = if rest.is_empty() {
-                format!("secret '{first}'")
-            } else {
-                format!("secret '{first}' and {} other(s)", rest.len())
-            };
-            return Err(AppError::FailedPrecondition(format!(
-                "source '{}' is missing {detail}",
-                source.name
-            )));
-        }
-        for secret_name in source_spec.declared_secret_names() {
-            if let Some(value) = stored_secrets.get(&secret_name) {
-                resolved_secrets.insert(secret_name, value.clone());
-            }
-        }
+        let SourceSecretResolution {
+            credential_material,
+            resolved_secrets,
+        } = self.resolve_source_secrets(workspace_name, source, &source_spec, credential_mode)?;
         let query_source = if let Some(components) = v4_runtime_components {
             QuerySource::from_runtime_components(
                 RuntimeSourcePackage {
@@ -412,10 +454,74 @@ impl QueryManager {
             LoadedQuerySource {
                 source: source.clone(),
                 query_source,
-                credential_material: stored_secrets,
+                credential_material,
             },
             installed.candidate.version,
         ))
+    }
+
+    fn resolve_source_secrets(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        source_spec: &coral_spec::ValidatedSourceManifest,
+        credential_mode: SourceCredentialMode,
+    ) -> Result<SourceSecretResolution, AppError> {
+        match credential_mode {
+            SourceCredentialMode::Runtime => {
+                let stored_secrets = self.read_source_secret_material(workspace_name, source)?;
+                let resolved_secrets =
+                    source_secrets_from_material(source, source_spec, &stored_secrets)?;
+                Ok(SourceSecretResolution {
+                    credential_material: stored_secrets,
+                    resolved_secrets,
+                })
+            }
+            SourceCredentialMode::CatalogMetadata => match source.credential_storage_for_material()
+            {
+                Some(CredentialStorageKind::File) => {
+                    let stored_secrets =
+                        self.read_source_secret_material(workspace_name, source)?;
+                    let resolved_secrets =
+                        source_secrets_from_material(source, source_spec, &stored_secrets)?;
+                    Ok(SourceSecretResolution {
+                        credential_material: stored_secrets,
+                        resolved_secrets,
+                    })
+                }
+                Some(CredentialStorageKind::Keychain) => {
+                    let placeholder_secrets = catalog_placeholder_secrets(
+                        source_spec,
+                        source.secrets.iter().map(String::as_str),
+                    );
+                    Ok(SourceSecretResolution {
+                        credential_material: placeholder_secrets.clone(),
+                        resolved_secrets: placeholder_secrets,
+                    })
+                }
+                None => Ok(SourceSecretResolution {
+                    credential_material: BTreeMap::new(),
+                    resolved_secrets: BTreeMap::new(),
+                }),
+            },
+        }
+    }
+
+    fn read_source_secret_material(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<SourceCredentialMaterial, AppError> {
+        if let Some(credential_storage) = source.credential_storage_for_material() {
+            let credential_set_id = CredentialSetId::for_source(&source.name);
+            self.credential_manager.read_material(
+                workspace_name,
+                &credential_set_id,
+                credential_storage,
+            )
+        } else {
+            Ok(BTreeMap::new())
+        }
     }
 
     fn runtime_config(
@@ -724,6 +830,61 @@ fn validate_required_variables(
         )));
     }
     Ok(())
+}
+
+fn source_secrets_from_material(
+    source: &InstalledSource,
+    source_spec: &coral_spec::ValidatedSourceManifest,
+    stored_secrets: &SourceCredentialMaterial,
+) -> Result<SourceSecrets, AppError> {
+    let missing_secrets: Vec<String> = source_spec
+        .required_secret_names()
+        .into_iter()
+        .filter(|name| !stored_secrets.contains_key(name))
+        .collect();
+    if let Some((first, rest)) = missing_secrets.split_first() {
+        let detail = if rest.is_empty() {
+            format!("secret '{first}'")
+        } else {
+            format!("secret '{first}' and {} other(s)", rest.len())
+        };
+        return Err(AppError::FailedPrecondition(format!(
+            "source '{}' is missing {detail}",
+            source.name
+        )));
+    }
+    Ok(declared_source_secrets(source_spec, stored_secrets))
+}
+
+fn declared_source_secrets(
+    source_spec: &coral_spec::ValidatedSourceManifest,
+    stored_secrets: &SourceCredentialMaterial,
+) -> SourceSecrets {
+    let mut resolved_secrets = BTreeMap::new();
+    for secret_name in source_spec.declared_secret_names() {
+        if let Some(value) = stored_secrets.get(&secret_name) {
+            resolved_secrets.insert(secret_name, value.clone());
+        }
+    }
+    resolved_secrets
+}
+
+fn catalog_placeholder_secrets<'a>(
+    source_spec: &coral_spec::ValidatedSourceManifest,
+    configured_secret_names: impl IntoIterator<Item = &'a str>,
+) -> SourceSecrets {
+    let declared_secret_names = source_spec.declared_secret_names();
+    configured_secret_names
+        .into_iter()
+        .filter(|name| declared_secret_names.contains(*name))
+        .map(|name| (name.to_string(), CATALOG_SECRET_PLACEHOLDER.to_string()))
+        .collect()
+}
+
+#[derive(Clone, Copy)]
+enum SourceCredentialMode {
+    CatalogMetadata,
+    Runtime,
 }
 
 #[cfg(test)]
@@ -1552,6 +1713,151 @@ surfaces:
                 .to_string()
                 .contains("configured for keychain storage"),
             "keychain-routed query failure should name the routed backend: {error}"
+        );
+    }
+
+    #[test]
+    fn load_catalog_query_sources_does_not_read_keychain_material() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("keychain_messages").expect("source name");
+        let manifest_path = layout.manifest_file(&workspace_name, &source_name);
+        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create source dir");
+        std::fs::write(
+            &manifest_path,
+            r"
+name: keychain_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://api.example.com
+inputs:
+  API_TOKEN:
+    kind: secret
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: bearer
+      key: API_TOKEN
+tables:
+  - name: messages
+    description: Messages
+    request:
+      path: /messages
+    columns:
+      - name: id
+        type: Utf8
+",
+        )
+        .expect("write manifest");
+        config_store
+            .upsert_source(
+                &workspace_name,
+                InstalledSource {
+                    name: source_name,
+                    version: Some("0.1.0".to_string()),
+                    variables: BTreeMap::new(),
+                    secrets: vec!["API_TOKEN".to_string()],
+                    credential_storage: Some(CredentialStorageKind::Keychain),
+                    origin: SourceOrigin::Imported,
+                },
+            )
+            .expect("persist source");
+        let credential_store = CredentialStore::with_unavailable_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::Keychain,
+        );
+        let manager = QueryManager::new(
+            config_store,
+            CredentialManager::new(credential_store),
+            QueryRuntimeContext::default(),
+            layout,
+            Vec::new(),
+        );
+
+        let (sources, _config) = manager
+            .load_catalog_query_sources(&workspace_name)
+            .expect("catalog load should not read keychain material");
+
+        assert_eq!(sources.len(), 1);
+        let source = sources.first().expect("catalog source should be present");
+        assert_eq!(
+            source.query_source.secrets(),
+            &BTreeMap::from([(
+                "API_TOKEN".to_string(),
+                CATALOG_SECRET_PLACEHOLDER.to_string()
+            )])
+        );
+    }
+
+    #[test]
+    fn load_catalog_query_sources_fails_closed_for_source_load_error() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("required_variable_messages").expect("source name");
+        let manifest_path = fixture
+            .manager
+            .layout
+            .manifest_file(&workspace_name, &source_name);
+        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create source dir");
+        std::fs::write(
+            &manifest_path,
+            r"
+name: required_variable_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+inputs:
+  API_BASE:
+    kind: variable
+base_url: '{{input.API_BASE}}'
+tables:
+  - name: messages
+    description: Messages
+    request:
+      path: /messages
+    columns:
+      - name: id
+        type: Utf8
+",
+        )
+        .expect("write manifest");
+        fixture
+            .manager
+            .config_store
+            .upsert_source(
+                &workspace_name,
+                InstalledSource {
+                    name: source_name.clone(),
+                    version: Some("0.1.0".to_string()),
+                    variables: BTreeMap::new(),
+                    secrets: Vec::new(),
+                    credential_storage: None,
+                    origin: SourceOrigin::Imported,
+                },
+            )
+            .expect("persist source");
+
+        let error = fixture
+            .manager
+            .load_catalog_query_sources(&workspace_name)
+            .expect_err("catalog load should fail closed");
+
+        assert!(
+            matches!(error, AppError::FailedPrecondition(_)),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            error.to_string().contains("missing variable 'API_BASE'"),
+            "catalog load should surface the source load error: {error}"
         );
     }
 

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -6,14 +6,16 @@
 
 use std::fs;
 
-use coral_api::v1::{ExecuteSqlRequest, SourceSecret, SourceVariable};
+use coral_api::v1::{
+    ExecuteSqlRequest, ListCatalogRequest, PaginationRequest, SourceSecret, SourceVariable,
+};
 use coral_client::{batches_to_json_rows, decode_execute_sql_response, default_workspace};
 use tonic::Request;
 
 use crate::harness::{GrpcHarness, fixture_manifest_with_inputs_yaml, fixture_manifest_yaml};
 
 #[tokio::test]
-async fn broken_source_does_not_block_healthy_sources() {
+async fn broken_source_fails_catalog_but_does_not_block_healthy_query() {
     let harness = GrpcHarness::new().await;
 
     harness
@@ -48,18 +50,23 @@ async fn broken_source_does_not_block_healthy_sources() {
     )
     .expect("remove broken source secret file");
 
-    let tables = harness.list_tables().await;
+    let catalog_error = harness
+        .catalog_client()
+        .list_catalog(Request::new(ListCatalogRequest {
+            workspace: Some(default_workspace()),
+            schema_name: String::new(),
+            kind: 1,
+            pagination: Some(PaginationRequest {
+                limit: 0,
+                offset: 0,
+            }),
+        }))
+        .await
+        .expect_err("broken source should fail catalog listing closed");
+    assert_eq!(catalog_error.code(), tonic::Code::FailedPrecondition);
     assert!(
-        tables
-            .iter()
-            .any(|table| table.schema_name == "local_messages"),
-        "healthy source should remain queryable"
-    );
-    assert!(
-        !tables
-            .iter()
-            .any(|table| table.schema_name == "secured_messages"),
-        "broken source should be omitted from registered tables"
+        catalog_error.message().contains("secured_messages"),
+        "catalog error should identify the broken source: {catalog_error}"
     );
 
     let healthy = harness


### PR DESCRIPTION
Rebased reconstruction of #1368 onto current main.

## What this adds
- **Schema route + nav entry** in Reef with a schema/table explorer: table search, lazy column loading, and required-filter indicators, built on the shared table/pill/tooltip wax primitives.
- **Catalog metadata loading avoids keychain reads** for passive browsing while runtime query credential loading stays strict (`crates/coral-app/src/query/manager.rs`).

## Why a reconstruction, not a literal rebase
The original #1368 branch predated two things now on main:
- **#1463** (Sources & Traces UI) — which #1368 duplicated wholesale, so ~8000 of its lines are already upstream.
- **#1491** (`reef/` → `apps/reef/`, `desktop/` → `apps/desktop/` move) — so every modified file was a modify/delete conflict.

A literal `git rebase` was therefore all conflicts and already-merged noise. Instead I re-applied only the genuinely net-new schema surface on top of main:
- 5 new files (schema explorer view/css/lib/route + spin animation) at `apps/reef` paths.
- `table.*` / `pill.*` taken wholesale (identical to base on main; the `style`→`variant` rename only touches the story, no production usage).
- `coral-clients.ts` adapted to main's memoized `getCoralTransport()` (the original used a now-removed `runtime.url`).
- `routes.ts` / `sidebar.tsx` / `architecture.test.ts` merged (main already had sources/traces; added schema).
- `manager.rs` 3-way merged (clean, zero conflicts); `resilience_tests.rs` taken wholesale.

## Verification (all green locally)
- Reef: typecheck, oxlint, oxfmt, production build, architecture test (6 passed)
- Rust: `cargo check`, `cargo clippy --all-targets`, manager unit tests (15) + resilience integration test

Supersedes #1368.

https://claude.ai/code/session_01LHpYSWV9NFgBWsgRfF3nkA