### PR TITLE
feat(reef): navigation-progress-bar

### DIFF
--- a/apps/reef/app/components/navigation-progress-bar/index.ts
+++ b/apps/reef/app/components/navigation-progress-bar/index.ts
@@ -1,0 +1,1 @@
+export { NavigationProgressBar } from './navigation-progress-bar'

--- a/apps/reef/app/components/navigation-progress-bar/navigation-progress-bar.css.ts
+++ b/apps/reef/app/components/navigation-progress-bar/navigation-progress-bar.css.ts
@@ -1,0 +1,27 @@
+import { keyframes, style } from '@vanilla-extract/css'
+
+import { theme, zIndex } from '@/wax/theme/theme.css'
+
+const progress = keyframes({
+  '0%': { inlineSize: '0%' },
+  '5%': { inlineSize: '30%' },
+  '100%': { inlineSize: '85%' },
+})
+
+export const bar = style({
+  '::after': {
+    animation: `${progress} 8s cubic-bezier(0.1, 0.4, 0.2, 1) forwards`,
+    backgroundColor: theme.content.accentContent.primary,
+    blockSize: '100%',
+    content: '""',
+    display: 'block',
+  },
+  blockSize: 2,
+  inlineSize: '100%',
+  insetBlockStart: 0,
+  insetInlineStart: 0,
+  pointerEvents: 'none',
+  position: 'fixed',
+
+  zIndex: zIndex.notification,
+})

--- a/apps/reef/app/components/navigation-progress-bar/navigation-progress-bar.stories.tsx
+++ b/apps/reef/app/components/navigation-progress-bar/navigation-progress-bar.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { useEffect, useMemo } from 'react'
+import { createMemoryRouter, RouterProvider, useNavigate } from 'react-router'
+
+import { Typography } from '@/wax/components/typography'
+import { theme } from '@/wax/theme/theme.css'
+
+import { NavigationProgressBar } from './navigation-progress-bar'
+
+const PENDING_ROUTE = '/loading'
+
+function createPendingLoader() {
+  return new Promise(() => undefined)
+}
+
+function TriggerPendingNavigation() {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => void navigate(PENDING_ROUTE), 200)
+    return () => window.clearTimeout(timeout)
+  }, [navigate])
+
+  return null
+}
+
+function DemoRoute() {
+  return (
+    <div
+      style={{
+        backgroundColor: theme.surface.main,
+        minBlockSize: 320,
+        overflow: 'hidden',
+        padding: 24,
+        position: 'relative',
+        // Create a containing block so the fixed production bar stays inside each
+        // Storybook theme-comparison panel instead of spanning the preview iframe.
+        transform: 'translateZ(0)',
+      }}
+    >
+      <NavigationProgressBar />
+      <TriggerPendingNavigation />
+      <section style={{ maxInlineSize: 480 }}>
+        <Typography.HeadingMedium>Navigation in progress</Typography.HeadingMedium>
+        <Typography.Body as="p" variant="secondary">
+          The story starts a pending React Router navigation so the global progress bar appears
+          after its short delay.
+        </Typography.Body>
+      </section>
+    </div>
+  )
+}
+
+function NavigationProgressBarStory() {
+  const router = useMemo(
+    () =>
+      createMemoryRouter(
+        [
+          {
+            element: <DemoRoute />,
+            path: '/',
+          },
+          {
+            element: <DemoRoute />,
+            loader: createPendingLoader,
+            path: PENDING_ROUTE,
+          },
+        ],
+        { initialEntries: ['/'] },
+      ),
+    [],
+  )
+
+  return <RouterProvider router={router} />
+}
+
+const meta = {
+  component: NavigationProgressBar,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: () => <NavigationProgressBarStory />,
+  tags: ['autodocs'],
+  title: 'Components/NavigationProgressBar',
+} satisfies Meta<typeof NavigationProgressBar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Active: Story = {}

--- a/apps/reef/app/components/navigation-progress-bar/navigation-progress-bar.tsx
+++ b/apps/reef/app/components/navigation-progress-bar/navigation-progress-bar.tsx
@@ -1,0 +1,11 @@
+import { useNavigationProgress } from '@/utils/use-navigation-progress'
+
+import * as styles from './navigation-progress-bar.css'
+
+export function NavigationProgressBar() {
+  const isNavigating = useNavigationProgress()
+
+  if (!isNavigating) return null
+
+  return <div aria-label="Loading" className={styles.bar} role="progressbar" />
+}

--- a/apps/reef/app/root.tsx
+++ b/apps/reef/app/root.tsx
@@ -5,6 +5,7 @@ import {
   readSidebarCollapsedCookie,
   readSidebarCollapsedCookieValue,
 } from './components/sidebar/sidebar-state'
+import { NavigationProgressBar } from './components/navigation-progress-bar'
 import { ensureCoralRuntime } from './lib/coral-runtime'
 import './styles/globals.css'
 import './wax/theme/global.css'
@@ -105,7 +106,12 @@ export async function clientLoader(_args: Route.ClientLoaderArgs) {
 clientLoader.hydrate = true as const
 
 export default function App() {
-  return <Outlet />
+  return (
+    <>
+      <NavigationProgressBar />
+      <Outlet />
+    </>
+  )
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {

--- a/apps/reef/app/utils/use-navigation-progress.ts
+++ b/apps/reef/app/utils/use-navigation-progress.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+import { useNavigation } from 'react-router'
+
+const DELAY_MS = 150 // Add some delay so we don't flash loading for quick navigations
+
+export function useNavigationProgress(): boolean {
+  const { state } = useNavigation()
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    if (state === 'loading') {
+      const timeout = setTimeout(() => setShow(true), DELAY_MS)
+      return () => clearTimeout(timeout)
+    }
+    setShow(false)
+  }, [state])
+
+  return show
+}


### PR DESCRIPTION
Add a root-level progress bar that waits briefly before showing during React Router loading states, with a scoped Storybook scenario to exercise the fixed-position bar under theme comparison.

Constraint: React Router useNavigation requires router context and Storybook theme comparison renders two themed panels in one iframe.
Rejected: Render the bar from app-shell only | root ownership keeps it available for all route layouts.
Rejected: Override production CSS for Storybook | a transformed story viewport preserves fixed production behavior while containing preview rendering.
Confidence: high
Scope-risk: narrow
Directive: Keep NavigationProgressBar at the route root unless a future global shell replaces root app chrome.
Tested: npm run check --prefix apps/reef; npm run typecheck --prefix apps/reef; npm test --prefix apps/reef; npm run build --prefix apps/reef; npm run build-storybook --prefix apps/reef; playwright-cli check of themeComparison URL.
Not-tested: Manual desktop Electron navigation.