### PR TITLE
fix(app): keep source catalog database authoritative

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -435,6 +435,7 @@ impl ServerBuilder {
             layout.clone(),
             workspace_lifecycle_lock.clone(),
             self.config.engine_extensions_providers,
+            Arc::clone(&coral_db),
             diagnostic_reporter.clone(),
             workspace_pool_registry,
         )
@@ -1165,7 +1166,7 @@ enabled = false
             credential_manager.clone(),
             layout.clone(),
             None,
-            db,
+            Arc::clone(&db),
         );
         let query_manager = QueryManager::new_for_tests(
             config_store.clone(),
@@ -1174,6 +1175,7 @@ enabled = false
             QueryRuntimeContext::default(),
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            Arc::clone(&db),
         );
         let lifecycle_lock = workspace_manager.lifecycle_lock();
         let search = SearchManager::new(
@@ -2098,6 +2100,7 @@ backend = "unsupported"
             QueryRuntimeContext::default(),
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            Arc::clone(&db),
         );
         let search_observations = SearchObservationHandle::new(layout.clone());
         let lifecycle_lock = workspace_manager.lifecycle_lock();
@@ -2264,6 +2267,7 @@ backend = "unsupported"
             },
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            Arc::clone(&db),
         );
         let search_observations = SearchObservationHandle::new(layout.clone());
         let lifecycle_lock = workspace_manager.lifecycle_lock();
@@ -2400,6 +2404,7 @@ tables:
             QueryRuntimeContext::default(),
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            Arc::clone(&db),
         );
         let search_observations = SearchObservationHandle::new(layout.clone());
         let lifecycle_lock = workspace_manager.lifecycle_lock();
@@ -2536,6 +2541,7 @@ tables:
             QueryRuntimeContext::default(),
             layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            Arc::clone(&db),
         );
         let search_observations = SearchObservationHandle::new(layout.clone());
         let lifecycle_lock = workspace_manager.lifecycle_lock();

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -281,6 +281,7 @@ mod tests {
             QueryRuntimeContext::default(),
             deployment.layout,
             Vec::new(),
+            Arc::clone(&deployment.db),
         );
         Fixture {
             _temp: deployment.temp,

--- a/crates/coral-app/src/query/input_resolver.rs
+++ b/crates/coral-app/src/query/input_resolver.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex;
 use crate::bootstrap::AppError;
 use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::sources::model::InstalledSource;
-use crate::state::ConfigStore;
+use crate::state::db::{CoralDb, DbRepos};
 use crate::workspaces::WorkspaceName;
 
 type SourceCredentialMaterial = BTreeMap<String, String>;
@@ -33,7 +33,7 @@ struct SharedSourceCredentialSnapshot {
 #[derive(Clone)]
 pub(crate) struct CredentialRefreshingInputResolver {
     workspace_name: WorkspaceName,
-    config_store: ConfigStore,
+    db: Arc<CoralDb>,
     credential_manager: CredentialManager,
     source_credentials: Arc<SourceCredentialSnapshotByName>,
     delegate: Option<Arc<dyn SourceInputResolver>>,
@@ -42,14 +42,14 @@ pub(crate) struct CredentialRefreshingInputResolver {
 impl CredentialRefreshingInputResolver {
     pub(crate) fn new(
         workspace_name: WorkspaceName,
-        config_store: ConfigStore,
+        db: Arc<CoralDb>,
         credential_manager: CredentialManager,
         source_credentials: BTreeMap<String, SourceCredentialSnapshot>,
         delegate: Option<Arc<dyn SourceInputResolver>>,
     ) -> Self {
         Self {
             workspace_name,
-            config_store,
+            db,
             credential_manager,
             source_credentials: shared_source_credentials(source_credentials),
             delegate,
@@ -152,7 +152,10 @@ impl CredentialRefreshingInputResolver {
             .credential_refresh_lock(&self.workspace_name, &credential_set_id)
             .await
             .map_err(source_input_error)?;
-        if !self.source_config_still_matches_snapshot(&snapshot.source)? {
+        if !self
+            .source_catalog_still_matches_snapshot(&snapshot.source)
+            .await?
+        {
             return self
                 .credential_manager
                 .refresh_material_for_inputs(source.declared_inputs(), material)
@@ -178,18 +181,18 @@ impl CredentialRefreshingInputResolver {
         Ok(())
     }
 
-    fn source_config_still_matches_snapshot(
+    async fn source_catalog_still_matches_snapshot(
         &self,
         snapshot: &InstalledSource,
     ) -> Result<bool, SourceInputResolverError> {
-        match self
-            .config_store
+        let mut session = self.db.as_ref();
+        let current = session
+            .sources()
             .get_source(&self.workspace_name, &snapshot.name)
-        {
-            Ok(current) => Ok(current == *snapshot),
-            Err(AppError::SourceNotFound(_)) => Ok(false),
-            Err(error) => Err(source_input_error(error)),
-        }
+            .await
+            .map_err(AppError::from)
+            .map_err(source_input_error)?;
+        Ok(current.as_ref() == Some(snapshot))
     }
 }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -39,6 +39,7 @@ use crate::sources::runtime_package::{
     RuntimeContractFingerprint, query_source_from_installed_manifest,
 };
 use crate::sources::{SourceName, ensure_database_source_feature_enabled};
+use crate::state::db::{CoralDb, DbRepos};
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::task::activity::{
     PendingTaskQuery, TaskActivityRecorder, TaskQueryRelation, TaskQueryStatus,
@@ -154,6 +155,7 @@ impl SourceDecorator for CatalogFailureRecorder {
 pub(crate) struct QueryManager {
     config_store: ConfigStore,
     workspace_manager: Arc<WorkspaceManager>,
+    db: Arc<CoralDb>,
     credential_manager: CredentialManager,
     function_manager: FunctionManager,
     lifecycle_lock: WorkspaceLifecycleLock,
@@ -176,6 +178,7 @@ impl QueryManager {
         runtime_context: QueryRuntimeContext,
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        db: Arc<CoralDb>,
     ) -> Self {
         Self::new(
             config_store,
@@ -185,6 +188,7 @@ impl QueryManager {
             layout,
             WorkspaceLifecycleLock::default(),
             engine_extensions_providers,
+            db,
         )
     }
 
@@ -197,6 +201,7 @@ impl QueryManager {
         layout: AppStateLayout,
         lifecycle_lock: WorkspaceLifecycleLock,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        db: Arc<CoralDb>,
     ) -> Self {
         Self::with_diagnostic_reporter(
             config_store,
@@ -206,6 +211,7 @@ impl QueryManager {
             layout,
             lifecycle_lock,
             engine_extensions_providers,
+            db,
             SourceDiagnosticReporter::default(),
             Arc::new(WorkspacePoolRegistry::default()),
         )
@@ -224,6 +230,7 @@ impl QueryManager {
         layout: AppStateLayout,
         lifecycle_lock: WorkspaceLifecycleLock,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        db: Arc<CoralDb>,
         diagnostic_reporter: SourceDiagnosticReporter,
         pool_registry: Arc<WorkspacePoolRegistry>,
     ) -> Self {
@@ -232,6 +239,7 @@ impl QueryManager {
         Self {
             config_store,
             workspace_manager: Arc::new(workspace_manager),
+            db,
             credential_manager,
             function_manager,
             lifecycle_lock,
@@ -575,8 +583,10 @@ impl QueryManager {
                 .config_store
                 .load_config_unlocked()
                 .map_err(QueryManagerError::App)?;
-            let source = config
-                .get_source(workspace_name, source_name)
+            let source = self
+                .get_installed_source(workspace_name, source_name)
+                .await
+                .map_err(QueryManagerError::App)?
                 .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
                 .map_err(QueryManagerError::App)?;
             let (loaded_source, version) = self
@@ -611,7 +621,8 @@ impl QueryManager {
         self.require_workspace(workspace_name).await?;
         let _state_lock = self.config_store.state_lock_shared()?;
         let config = self.config_store.load_config_unlocked()?;
-        let sources = self.load_query_sources_from_config(workspace_name, &config);
+        let installed_sources = self.installed_sources(workspace_name).await?;
+        let sources = self.load_query_sources_from_installed(workspace_name, installed_sources);
         Ok((sources, config))
     }
 
@@ -621,10 +632,35 @@ impl QueryManager {
             .await
     }
 
-    fn load_query_sources_from_config(
+    async fn installed_sources(
         &self,
         workspace_name: &WorkspaceName,
-        config: &AppConfig,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        let mut session = self.db.as_ref();
+        session
+            .sources()
+            .list_workspace_sources(workspace_name)
+            .await
+            .map_err(AppError::from)
+    }
+
+    async fn get_installed_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<Option<InstalledSource>, AppError> {
+        let mut session = self.db.as_ref();
+        session
+            .sources()
+            .get_source(workspace_name, source_name)
+            .await
+            .map_err(AppError::from)
+    }
+
+    fn load_query_sources_from_installed(
+        &self,
+        workspace_name: &WorkspaceName,
+        installed_sources: Vec<InstalledSource>,
     ) -> QuerySourceLoad {
         let span = tracing::info_span!(
             "coral.app.query_sources.load",
@@ -638,7 +674,7 @@ impl QueryManager {
         let _guard = span.enter();
         let mut loaded_sources = Vec::new();
         let mut failed_source_names = BTreeSet::new();
-        for source in config.workspace_sources(workspace_name) {
+        for source in installed_sources {
             match self.load_query_source(workspace_name, &source) {
                 Ok((loaded_source, _version)) => {
                     self.diagnostic_reporter.clear_source_load_failure(
@@ -805,7 +841,7 @@ impl QueryManager {
             CredentialResolutionMode::Refreshing => {
                 Arc::new(CredentialRefreshingInputResolver::new(
                     workspace_name.clone(),
-                    self.config_store.clone(),
+                    Arc::clone(&self.db),
                     self.credential_manager.clone(),
                     source_credentials,
                     provider_input_resolver,
@@ -865,7 +901,9 @@ impl QueryManager {
             .await
             .map_err(QueryManagerError::App)?;
         let _lifecycle_snapshot = self.lifecycle_lock.snapshot_async().await;
-        let (loaded_sources, config) = self.load_function_validation_sources(workspace_name)?;
+        let (loaded_sources, config) = self
+            .load_function_validation_sources(workspace_name)
+            .await?;
         self.validate_udf_sql_against_snapshot(workspace_name, artifact, &loaded_sources, &config)
             .await
     }
@@ -934,14 +972,20 @@ impl QueryManager {
         if lifecycle_snapshot.revision() != revision {
             return Ok(None);
         }
-        let (loaded_sources, config) = self.load_function_validation_sources(workspace_name)?;
+        let (loaded_sources, config) = self
+            .load_function_validation_sources(workspace_name)
+            .await?;
         Ok(Some((loaded_sources, config)))
     }
 
-    fn load_function_validation_sources(
+    async fn load_function_validation_sources(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<(Vec<LoadedQuerySource>, AppConfig), QueryManagerError> {
+        let installed_sources = self
+            .installed_sources(workspace_name)
+            .await
+            .map_err(QueryManagerError::App)?;
         let (loaded_sources, config) = {
             let _state_lock = self
                 .config_store
@@ -951,7 +995,8 @@ impl QueryManager {
                 .config_store
                 .load_config_unlocked()
                 .map_err(QueryManagerError::App)?;
-            let source_load = self.load_query_sources_from_config(workspace_name, &config);
+            let source_load =
+                self.load_query_sources_from_installed(workspace_name, installed_sources);
             (source_load.loaded, config)
         };
         Ok((loaded_sources, config))
@@ -1514,6 +1559,7 @@ mod tests {
             runtime_context,
             layout,
             providers,
+            Arc::clone(&db),
         )
         .with_task_activity_recorder(TaskActivityRecorder::new(Arc::clone(&db)));
         QueryManagerFixture {
@@ -1550,6 +1596,7 @@ mod tests {
             QueryRuntimeContext::default(),
             layout,
             Vec::new(),
+            Arc::clone(&db),
         );
         QueryManagerFixture {
             _temp: temp,
@@ -1558,21 +1605,34 @@ mod tests {
         }
     }
 
-    fn install_keychain_github_source(config_store: &ConfigStore, workspace_name: &WorkspaceName) {
-        config_store
-            .upsert_source(
-                workspace_name,
-                InstalledSource {
-                    name: SourceName::parse("github").expect("source name"),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: vec!["GITHUB_TOKEN".to_string()],
-                    credential_storage: Some(CredentialStorageKind::Keychain),
-                    credential_revision: uuid::Uuid::default(),
-                    origin: SourceOrigin::Bundled,
-                },
-            )
+    async fn persist_source(
+        db: &CoralDb,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) {
+        let mut tx = db.begin().await.expect("begin source transaction");
+        tx.sources()
+            .upsert_source(workspace_name, source, 1)
+            .await
             .expect("persist source");
+        tx.commit().await.expect("commit source transaction");
+    }
+
+    async fn install_keychain_github_source(db: &CoralDb, workspace_name: &WorkspaceName) {
+        persist_source(
+            db,
+            workspace_name,
+            &InstalledSource {
+                name: SourceName::parse("github").expect("source name"),
+                version: None,
+                variables: BTreeMap::new(),
+                secrets: vec!["GITHUB_TOKEN".to_string()],
+                credential_storage: Some(CredentialStorageKind::Keychain),
+                credential_revision: uuid::Uuid::default(),
+                origin: SourceOrigin::Bundled,
+            },
+        )
+        .await;
     }
 
     async fn test_db(layout: &AppStateLayout, config_store: &ConfigStore) -> Arc<CoralDb> {
@@ -2606,11 +2666,7 @@ tables:
             credential_revision: uuid::Uuid::default(),
             origin: SourceOrigin::Imported,
         };
-        fixture
-            .manager
-            .config_store
-            .upsert_source(&workspace_name, source.clone())
-            .expect("persist source");
+        persist_source(&fixture.db, &workspace_name, &source).await;
         fixture
             .manager
             .credential_manager
@@ -3204,7 +3260,7 @@ paths:
             fake_home.path(),
         );
         let calls = Arc::new(AtomicUsize::new(0));
-        let config_store = fixture.manager.config_store.clone();
+        let db = Arc::clone(&fixture.db);
         let lifecycle_lock = fixture.manager.lifecycle_lock.clone();
         let workspace = workspace_name.clone();
         let source_name = SourceName::parse("function_demo").expect("source name");
@@ -3213,9 +3269,27 @@ paths:
                 calls: Arc::clone(&calls),
                 on_first_prepare: Some(Arc::new(move || {
                     let _lifecycle_guard = lifecycle_lock.lock();
-                    config_store
-                        .remove_source(&workspace, &source_name)
-                        .expect("remove source during function validation");
+                    let db = Arc::clone(&db);
+                    let workspace = workspace.clone();
+                    let source_name = source_name.clone();
+                    std::thread::spawn(move || {
+                        let runtime = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .expect("build source removal runtime");
+                        runtime.block_on(async move {
+                            let mut tx = db.begin().await.expect("begin source removal");
+                            let removed = tx
+                                .sources()
+                                .remove_source(&workspace, &source_name)
+                                .await
+                                .expect("remove source during function validation");
+                            assert!(removed.is_some(), "source should exist before removal");
+                            tx.commit().await.expect("commit source removal");
+                        });
+                    })
+                    .join()
+                    .expect("join source removal thread");
                 })),
             },
         ));
@@ -3424,8 +3498,9 @@ tables:
             .expect("import source");
     }
 
-    fn install_missing_v4_materialization_source(
+    async fn install_missing_v4_materialization_source(
         manager: &QueryManager,
+        db: &CoralDb,
         workspace_name: &WorkspaceName,
     ) -> SourceName {
         let source_name = SourceName::parse("github_v4_missing_artifacts").expect("source name");
@@ -3443,26 +3518,26 @@ surface:
 ",
         )
         .expect("write manifest");
-        manager
-            .config_store
-            .upsert_source(
-                workspace_name,
-                InstalledSource {
-                    name: source_name.clone(),
-                    version: None,
-                    variables: BTreeMap::new(),
-                    secrets: Vec::new(),
-                    credential_storage: None,
-                    credential_revision: uuid::Uuid::default(),
-                    origin: SourceOrigin::Imported,
-                },
-            )
-            .expect("persist source");
+        persist_source(
+            db,
+            workspace_name,
+            &InstalledSource {
+                name: source_name.clone(),
+                version: None,
+                variables: BTreeMap::new(),
+                secrets: Vec::new(),
+                credential_storage: None,
+                credential_revision: uuid::Uuid::default(),
+                origin: SourceOrigin::Imported,
+            },
+        )
+        .await;
         source_name
     }
 
-    fn install_corrupt_parquet_source(
+    async fn install_corrupt_parquet_source(
         manager: &QueryManager,
+        db: &CoralDb,
         workspace_name: &WorkspaceName,
         fake_home: &std::path::Path,
     ) -> SourceName {
@@ -3493,21 +3568,20 @@ tables:
 "#,
         )
         .expect("write manifest");
-        manager
-            .config_store
-            .upsert_source(
-                workspace_name,
-                InstalledSource {
-                    name: source_name.clone(),
-                    version: Some("0.1.0".to_string()),
-                    variables: BTreeMap::new(),
-                    secrets: Vec::new(),
-                    credential_storage: None,
-                    credential_revision: uuid::Uuid::default(),
-                    origin: SourceOrigin::Imported,
-                },
-            )
-            .expect("persist source");
+        persist_source(
+            db,
+            workspace_name,
+            &InstalledSource {
+                name: source_name.clone(),
+                version: Some("0.1.0".to_string()),
+                variables: BTreeMap::new(),
+                secrets: Vec::new(),
+                credential_storage: None,
+                credential_revision: uuid::Uuid::default(),
+                origin: SourceOrigin::Imported,
+            },
+        )
+        .await;
         source_name
     }
 
@@ -3516,8 +3590,12 @@ tables:
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = test_workspace();
-        let source_name =
-            install_missing_v4_materialization_source(&fixture.manager, &workspace_name);
+        let source_name = install_missing_v4_materialization_source(
+            &fixture.manager,
+            &fixture.db,
+            &workspace_name,
+        )
+        .await;
 
         let (source_load, _) = fixture
             .manager
@@ -3550,8 +3628,12 @@ tables:
             &workspace_name,
             fake_home.path(),
         );
-        let failed_source =
-            install_missing_v4_materialization_source(&fixture.manager, &workspace_name);
+        let failed_source = install_missing_v4_materialization_source(
+            &fixture.manager,
+            &fixture.db,
+            &workspace_name,
+        )
+        .await;
 
         let resolution = fixture
             .manager
@@ -3647,8 +3729,13 @@ tables:
             &workspace_name,
             fake_home.path(),
         );
-        let failed_source =
-            install_corrupt_parquet_source(&fixture.manager, &workspace_name, fake_home.path());
+        let failed_source = install_corrupt_parquet_source(
+            &fixture.manager,
+            &fixture.db,
+            &workspace_name,
+            fake_home.path(),
+        )
+        .await;
 
         let resolution = fixture
             .manager
@@ -3676,7 +3763,7 @@ tables:
     async fn load_query_sources_skips_unavailable_keychain_source() {
         let fixture = query_manager_with_unavailable_keychain().await;
         let workspace_name = test_workspace();
-        install_keychain_github_source(&fixture.manager.config_store, &workspace_name);
+        install_keychain_github_source(&fixture.db, &workspace_name).await;
 
         let (source_load, _) = fixture
             .manager
@@ -3712,7 +3799,7 @@ select 1 as value
             .function_manager
             .install_validated_user_function(&workspace_name, function_sql, &validated)
             .expect("install constant function");
-        install_keychain_github_source(&fixture.manager.config_store, &workspace_name);
+        install_keychain_github_source(&fixture.db, &workspace_name).await;
 
         let functions = fixture
             .manager
@@ -3876,11 +3963,7 @@ select 1 as value
             credential_revision: uuid::Uuid::default(),
             origin: SourceOrigin::Bundled,
         };
-        fixture
-            .manager
-            .config_store
-            .upsert_source(&workspace_name, installed_source.clone())
-            .expect("persist live source");
+        persist_source(&fixture.db, &workspace_name, &installed_source).await;
         fixture
             .manager
             .credential_manager
@@ -4002,11 +4085,7 @@ tables:
 ",
         )
         .expect("write manifest");
-        fixture
-            .manager
-            .config_store
-            .upsert_source(&workspace, installed_source.clone())
-            .expect("persist source");
+        persist_source(&fixture.db, &workspace, &installed_source).await;
         fixture
             .manager
             .credential_manager

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -193,6 +193,10 @@ impl QueryManager {
     }
 
     #[cfg(test)]
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "database handle joins the existing collaborator set the query manager owns"
+    )]
     pub(crate) fn new(
         config_store: ConfigStore,
         workspace_manager: WorkspaceManager,

--- a/crates/coral-app/src/search/observed/live_scope.rs
+++ b/crates/coral-app/src/search/observed/live_scope.rs
@@ -390,11 +390,7 @@ tables:
         credential_revision: Uuid,
     ) {
         let mut source = config_store
-            .load_config()
-            .expect("load config")
-            .workspace_sources(workspace)
-            .into_iter()
-            .find(|source| &source.name == source_name)
+            .get_source(workspace, source_name)
             .expect("installed source");
         source.credential_revision = credential_revision;
         config_store

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -616,6 +616,7 @@ mod tests {
             QueryRuntimeContext::default(),
             layout.clone(),
             Vec::new(),
+            Arc::clone(&db),
         );
         let lifecycle_lock = workspaces.lifecycle_lock();
         let search = SearchManager::new(

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -936,6 +936,7 @@ mod tests {
             QueryRuntimeContext::default(),
             layout.clone(),
             Vec::new(),
+            Arc::clone(&db),
         );
         let config_file = layout.config_file().to_path_buf();
         Fixture {

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -47,6 +47,7 @@ impl AppConfig {
         self.catalog.workspace_sources(workspace_name)
     }
 
+    #[cfg(test)]
     pub(crate) fn get_source(
         &self,
         workspace_name: &WorkspaceName,
@@ -564,6 +565,7 @@ impl ConfigStore {
         self.load_unlocked()
     }
 
+    #[cfg(test)]
     pub(crate) fn load_config(&self) -> Result<AppConfig, AppError> {
         let _lock = self.state_lock_shared()?;
         self.load_config_unlocked()
@@ -718,6 +720,7 @@ impl ConfigStore {
             .ok_or_else(|| AppError::SourceNotFound(format!("{workspace_name}:{source_name}")))
     }
 
+    #[cfg(test)]
     pub(crate) fn get_source(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -31,7 +31,7 @@ pub(crate) struct GrpcHarness {
     config_dir: PathBuf,
     local_trace_store_dir: Option<PathBuf>,
     app: AppClient,
-    _server: RunningServer,
+    server: RunningServer,
 }
 
 pub(crate) struct FailingHttpFixture {
@@ -125,7 +125,7 @@ impl GrpcHarness {
             config_dir,
             local_trace_store_dir,
             app,
-            _server: server,
+            server,
         }
     }
 
@@ -150,6 +150,11 @@ impl GrpcHarness {
 
     pub(crate) fn local_trace_store_dir(&self) -> Option<&Path> {
         self.local_trace_store_dir.as_deref()
+    }
+
+    pub(crate) async fn shutdown(self) {
+        let Self { server, .. } = self;
+        server.shutdown().await.expect("shutdown server");
     }
 
     pub(crate) fn source_client(&self) -> SourceClient {

--- a/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
+++ b/crates/coral-app/tests/grpc/oauth_refresh_tests.rs
@@ -20,6 +20,7 @@ use serde_json::json;
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::sync::Notify;
+use toml_edit::DocumentMut;
 use tonic::{Code, Request};
 
 use crate::harness::{GrpcHarness, default_workspace, fixture_manifest_yaml, source_dir};
@@ -74,6 +75,108 @@ async fn query_refreshes_expired_oauth_access_token_at_request_time() {
         Some("stored-client")
     );
 
+    let material = fs::read_to_string(secret_path).expect("read refreshed material");
+    assert!(material.contains("API_TOKEN=refreshed-token"), "{material}");
+    assert!(
+        material.contains("__coral_oauth.QVBJX1RPS0VO.refresh_token=rotated-refresh-token"),
+        "{material}"
+    );
+}
+
+#[tokio::test]
+async fn db_loaded_source_persists_oauth_refresh_after_config_source_section_is_removed() {
+    let fixture = RefreshingHttpFixture::new().await;
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
+            vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: fixture.base_url.clone(),
+            }],
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "expired-token".to_string(),
+            }],
+        )
+        .await;
+
+    let secret_path = source_dir(harness.config_dir(), "refreshed_messages").join("secrets.env");
+    seed_expired_api_token_material(
+        &secret_path,
+        &fixture.token_url,
+        Some("stored-refresh-token"),
+    );
+    remove_config_source_section(harness.config_dir(), "refreshed_messages");
+
+    let rows = harness
+        .execute_sql_rows("SELECT id FROM refreshed_messages.messages")
+        .await;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], "ok");
+    assert_eq!(
+        fixture.message_authorizations(),
+        vec!["Bearer refreshed-token".to_string()]
+    );
+    let forms = fixture.token_forms();
+    assert_eq!(forms.len(), 1);
+    assert_eq!(
+        forms[0].get("refresh_token").map(String::as_str),
+        Some("stored-refresh-token")
+    );
+
+    let material = fs::read_to_string(secret_path).expect("read refreshed material");
+    assert!(material.contains("API_TOKEN=refreshed-token"), "{material}");
+    assert!(
+        material.contains("__coral_oauth.QVBJX1RPS0VO.refresh_token=rotated-refresh-token"),
+        "{material}"
+    );
+}
+
+#[tokio::test]
+async fn restarted_db_loaded_source_persists_oauth_refresh_after_config_source_section_is_removed()
+{
+    let fixture = RefreshingHttpFixture::new().await;
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let secret_path = source_dir(&config_dir, "refreshed_messages").join("secrets.env");
+
+    {
+        let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+        harness
+            .import_source(
+                oauth_refresh_manifest_yaml(&fixture.base_url, &fixture.token_url),
+                vec![SourceVariable {
+                    key: "API_BASE".to_string(),
+                    value: fixture.base_url.clone(),
+                }],
+                vec![SourceSecret {
+                    key: "API_TOKEN".to_string(),
+                    value: "expired-token".to_string(),
+                }],
+            )
+            .await;
+        seed_expired_api_token_material(
+            &secret_path,
+            &fixture.token_url,
+            Some("stored-refresh-token"),
+        );
+        harness.shutdown().await;
+    }
+    remove_config_source_section(&config_dir, "refreshed_messages");
+
+    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    let rows = harness
+        .execute_sql_rows("SELECT id FROM refreshed_messages.messages")
+        .await;
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], "ok");
+    assert_eq!(
+        fixture.message_authorizations(),
+        vec!["Bearer refreshed-token".to_string()]
+    );
     let material = fs::read_to_string(secret_path).expect("read refreshed material");
     assert!(material.contains("API_TOKEN=refreshed-token"), "{material}");
     assert!(
@@ -621,6 +724,17 @@ __coral_oauth.QVBJX1RPS0VO.token_url={token_url}
         ),
     )
     .expect("seed expired oauth material");
+}
+
+fn remove_config_source_section(config_dir: &Path, source_name: &str) {
+    let config_path = config_dir.join("config.toml");
+    let raw = fs::read_to_string(&config_path).expect("read config");
+    let mut doc = raw.parse::<DocumentMut>().expect("parse config");
+    doc["workspaces"]["default"]["sources"]
+        .as_table_mut()
+        .expect("sources table")
+        .remove(source_name);
+    fs::write(&config_path, doc.to_string()).expect("write config without source section");
 }
 
 fn oauth_refresh_manifest_yaml(base_url: &str, token_url: &str) -> String {

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -16,6 +16,7 @@ use coral_api::v1::{
     source_input_spec::Input as ProtoSourceInput,
 };
 use tempfile::TempDir;
+use toml_edit::DocumentMut;
 use tonic::Request;
 
 use crate::harness::{
@@ -96,6 +97,77 @@ async fn list_and_get_sources_read_database_after_config_becomes_invalid() {
         .source
         .expect("source response");
     assert_eq!(fetched.name, "local_messages");
+    assert_eq!(fetched.version, "0.1.0");
+    assert_eq!(fetched.origin, SourceOrigin::Imported as i32);
+}
+
+#[tokio::test]
+async fn list_catalog_reads_database_after_config_source_section_is_removed() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
+    harness
+        .import_source(manifest_yaml, Vec::new(), Vec::new())
+        .await;
+
+    remove_config_source_section(harness.config_dir(), "local_messages");
+
+    let tables = harness.list_tables().await;
+    assert!(
+        tables
+            .iter()
+            .any(|table| table.schema_name == "local_messages" && table.name == "messages"),
+        "catalog should still load imported source from DB"
+    );
+}
+
+#[tokio::test]
+async fn validate_source_reads_database_after_config_source_section_is_removed() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
+    harness
+        .import_source(manifest_yaml, Vec::new(), Vec::new())
+        .await;
+
+    remove_config_source_section(harness.config_dir(), "local_messages");
+
+    let validated = harness.validate_source("local_messages").await;
+    assert_eq!(validated.tables.len(), 1);
+    assert_eq!(validated.tables[0].schema_name, "local_messages");
+    assert_eq!(validated.tables[0].name, "messages");
+}
+
+#[tokio::test]
+async fn restart_preserves_database_source_after_config_source_section_is_removed() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let manifest_yaml = fixture_manifest_yaml(temp.path());
+
+    {
+        let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+        harness
+            .import_source(manifest_yaml, Vec::new(), Vec::new())
+            .await;
+        harness.shutdown().await;
+    }
+    remove_config_source_section(&config_dir, "local_messages");
+
+    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    let listed = harness.list_sources().await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "local_messages");
+
+    let validated = harness.validate_source("local_messages").await;
+    assert_eq!(validated.tables.len(), 1);
+    assert_eq!(validated.tables[0].schema_name, "local_messages");
+    assert_eq!(validated.tables[0].name, "messages");
+    assert!(
+        harness
+            .list_tables()
+            .await
+            .iter()
+            .any(|table| table.schema_name == "local_messages" && table.name == "messages"),
+        "catalog should agree with source list after restart reconciliation"
+    );
 }
 
 #[tokio::test]
@@ -637,6 +709,17 @@ async fn import_source_missing_required_secret_returns_invalid_argument() {
             .message()
             .contains("missing required source secret 'API_TOKEN'")
     );
+}
+
+fn remove_config_source_section(config_dir: &std::path::Path, source_name: &str) {
+    let config_path = config_dir.join("config.toml");
+    let raw = fs::read_to_string(&config_path).expect("read config");
+    let mut doc = raw.parse::<DocumentMut>().expect("parse config");
+    doc["workspaces"]["default"]["sources"]
+        .as_table_mut()
+        .expect("sources table")
+        .remove(source_name);
+    fs::write(&config_path, doc.to_string()).expect("write config without source section");
 }
 
 #[tokio::test]
@@ -1431,6 +1514,94 @@ async fn import_rolls_back_on_config_write_failure() {
     assert_eq!(error.code(), tonic::Code::Internal);
     assert!(!source_dir(harness.config_dir(), "secured_messages").exists());
     assert!(harness.list_sources().await.is_empty());
+    let config_raw =
+        fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    assert!(!config_raw.contains("[workspaces.default.sources.secured_messages]"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn overwrite_restores_previous_source_on_config_write_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
+    let original_manifest = fixture_manifest_with_inputs_yaml();
+    harness
+        .import_source(
+            original_manifest.clone(),
+            vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "https://example.com".to_string(),
+            }],
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "old-token".to_string(),
+            }],
+        )
+        .await;
+    let updated_manifest = original_manifest.replace("0.1.0", "0.2.0");
+
+    fs::set_permissions(harness.config_dir(), fs::Permissions::from_mode(0o500))
+        .expect("make config dir read-only");
+    let error = harness
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml: updated_manifest,
+            variables: vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "https://example.com".to_string(),
+            }],
+            secrets: vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "new-token".to_string(),
+            }],
+            oauth_credential_retrievals: Vec::new(),
+        }))
+        .await
+        .expect_err("config write should fail");
+
+    fs::set_permissions(harness.config_dir(), fs::Permissions::from_mode(0o700))
+        .expect("restore config dir permissions");
+
+    assert_eq!(error.code(), tonic::Code::Internal);
+    let listed = harness.list_sources().await;
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].name, "secured_messages");
+    assert_eq!(listed[0].version, "0.1.0");
+
+    let fetched = harness
+        .source_client()
+        .get_source(Request::new(GetSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "secured_messages".to_string(),
+        }))
+        .await
+        .expect("get source after rollback")
+        .into_inner()
+        .source
+        .expect("source after rollback");
+    assert_eq!(fetched.version, "0.1.0");
+
+    let installed_manifest =
+        source_dir(harness.config_dir(), "secured_messages").join("manifest.yaml");
+    assert_eq!(
+        fs::read_to_string(&installed_manifest).expect("read restored manifest"),
+        original_manifest
+    );
+    let secret_path = source_dir(harness.config_dir(), "secured_messages").join("secrets.env");
+    let secret_material = fs::read_to_string(&secret_path).expect("read restored secrets");
+    assert!(
+        secret_material.contains("API_TOKEN=old-token"),
+        "{secret_material}"
+    );
+    assert!(
+        !secret_material.contains("API_TOKEN=new-token"),
+        "{secret_material}"
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Intent

Make the source catalog database authoritative across source lifecycle rollback and query-time credential freshness checks.

## What it enables

Source overwrite rollback restores DB rows consistently, removed config source sections no longer hide installed DB sources from list/catalog/validate paths, and OAuth refresh checks compare against DB source snapshots.

## Usage examples

No command or RPC shape changes. After importing a source, deleting its legacy `[workspaces.default.sources.*]` config section does not remove it from source list, catalog list, validation, or OAuth refresh behavior.

## Testing

- `cargo test -p coral-app --test grpc source_lifecycle`
- `cargo test -p coral-app --test grpc oauth_refresh`
- `cargo check -p coral-app --all-targets --all-features --locked`
- `make rust-checks`
