### PR TITLE
feat(search): add local catalog snapshot loader

### DIFF
--- a/crates/coral-app/src/search/catalog/local_snapshot.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot.rs
@@ -76,9 +76,6 @@ impl CatalogSnapshotLoader {
                         .table_functions
                         .extend(source_catalog.table_functions);
                 }
-                Err(error @ AppError::MissingOrIncompatibleV4Materialization { .. }) => {
-                    return Err(error);
-                }
                 Err(error) => {
                     warn!(
                         workspace = %workspace_name,
@@ -195,7 +192,6 @@ fn catalog_info_from_components(components: &[RuntimeSourceComponent]) -> Catalo
         }
     }
 
-    sort_catalog(&mut catalog);
     catalog
 }
 
@@ -210,6 +206,10 @@ fn table_info(schema_name: &str, common: &TableCommon) -> TableInfo {
     }
 }
 
+// Keep this mapping aligned with coral-engine's catalog registration helpers:
+// `registered_columns_from_specs` and `required_filter_names`. The local
+// snapshot must mirror runtime-visible manifest metadata without compiling
+// providers or inferring file schemas.
 fn column_infos_from_specs(columns: &[ColumnSpec], filters: &[FilterSpec]) -> Vec<ColumnInfo> {
     columns
         .iter()

--- a/crates/coral-app/src/search/catalog/local_snapshot.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot.rs
@@ -15,7 +15,6 @@ use coral_engine::{
 use coral_spec::{
     ColumnSpec, FilterSpec, SourceTableFunctionSpec, TableCommon, ValidatedSourceManifest,
 };
-use tracing::warn;
 
 use crate::bootstrap::AppError;
 use crate::sources::catalog::resolve_installed_manifest;
@@ -69,22 +68,11 @@ impl CatalogSnapshotLoader {
         };
 
         for source in config.workspace_sources(workspace_name) {
-            match self.load_source_catalog(workspace_name, &source) {
-                Ok(source_catalog) => {
-                    catalog.tables.extend(source_catalog.tables);
-                    catalog
-                        .table_functions
-                        .extend(source_catalog.table_functions);
-                }
-                Err(error) => {
-                    warn!(
-                        workspace = %workspace_name,
-                        source = %source.name,
-                        detail = %error,
-                        "skipping source during local catalog snapshot load"
-                    );
-                }
-            }
+            let source_catalog = self.load_source_catalog(workspace_name, &source)?;
+            catalog.tables.extend(source_catalog.tables);
+            catalog
+                .table_functions
+                .extend(source_catalog.table_functions);
         }
 
         sort_catalog(&mut catalog);
@@ -220,7 +208,7 @@ fn column_infos_from_specs(columns: &[ColumnSpec], filters: &[FilterSpec]) -> Ve
                 .find(|filter| filter.name == column.name.as_str());
             ColumnInfo {
                 name: column.name.clone(),
-                data_type: column.data_type.clone(),
+                data_type: column.data_type.as_manifest_str().to_string(),
                 nullable: column.nullable,
                 is_virtual: column.r#virtual,
                 is_required_filter: filter.is_some_and(|filter| filter.required),
@@ -258,16 +246,13 @@ fn table_function_info(schema_name: &str, function: &SourceTableFunctionSpec) ->
             .iter()
             .map(|column| TableFunctionResultColumnInfo {
                 name: column.name.clone(),
-                data_type: column.data_type.clone(),
+                data_type: column.data_type.as_manifest_str().to_string(),
                 nullable: column.nullable,
                 description: column.description.clone(),
             })
             .collect(),
         kind: function.kind,
-        search_limits_json: function
-            .search_limits
-            .as_ref()
-            .map(|limits| serde_json::to_string(limits).expect("search limits json")),
+        search_limits: function.search_limits.clone(),
     }
 }
 

--- a/crates/coral-app/src/search/catalog/local_snapshot.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot.rs
@@ -1,0 +1,284 @@
+//! Local catalog snapshot loading without query-runtime provider I/O.
+
+#![cfg_attr(
+    not(test),
+    allow(
+        dead_code,
+        reason = "local catalog snapshot loader is consumed by the follow-up catalog provider PR"
+    )
+)]
+
+use coral_engine::{
+    CatalogInfo, ColumnInfo, RuntimeSourceComponent, TableFunctionArgumentInfo, TableFunctionInfo,
+    TableFunctionResultColumnInfo, TableInfo,
+};
+use coral_spec::{
+    ColumnSpec, FilterSpec, SourceTableFunctionSpec, TableCommon, ValidatedSourceManifest,
+};
+use tracing::warn;
+
+use crate::bootstrap::AppError;
+use crate::sources::catalog::resolve_installed_manifest;
+use crate::sources::materialization::{
+    incompatible_materialization_error, load_v4_materialization,
+};
+use crate::sources::model::InstalledSource;
+use crate::sources::runtime_package::runtime_components_for_v4_source;
+use crate::state::{AppConfig, AppStateLayout, ConfigStore};
+use crate::workspaces::WorkspaceName;
+
+/// Builds catalog metadata from persisted app state and local source artifacts.
+///
+/// This deliberately avoids runtime provider registration: it does not refresh
+/// credentials, infer remote/local file schemas, start MCP processes, or issue
+/// provider HTTP calls. DSL v4 sources still require their published
+/// materialized projection artifacts because those artifacts are the local
+/// catalog source of truth for generated runtime components.
+#[derive(Clone)]
+pub(crate) struct CatalogSnapshotLoader {
+    config_store: ConfigStore,
+    layout: AppStateLayout,
+}
+
+impl CatalogSnapshotLoader {
+    pub(crate) fn new(config_store: ConfigStore, layout: AppStateLayout) -> Self {
+        Self {
+            config_store,
+            layout,
+        }
+    }
+
+    pub(crate) fn load_catalog(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<CatalogInfo, AppError> {
+        let _state_lock = self.config_store.state_lock_shared()?;
+        let config = self.config_store.load_config_unlocked()?;
+        self.load_catalog_from_config(workspace_name, &config)
+    }
+
+    fn load_catalog_from_config(
+        &self,
+        workspace_name: &WorkspaceName,
+        config: &AppConfig,
+    ) -> Result<CatalogInfo, AppError> {
+        config.require_workspace(workspace_name)?;
+        let mut catalog = CatalogInfo {
+            tables: Vec::new(),
+            table_functions: Vec::new(),
+        };
+
+        for source in config.workspace_sources(workspace_name) {
+            match self.load_source_catalog(workspace_name, &source) {
+                Ok(source_catalog) => {
+                    catalog.tables.extend(source_catalog.tables);
+                    catalog
+                        .table_functions
+                        .extend(source_catalog.table_functions);
+                }
+                Err(error @ AppError::MissingOrIncompatibleV4Materialization { .. }) => {
+                    return Err(error);
+                }
+                Err(error) => {
+                    warn!(
+                        workspace = %workspace_name,
+                        source = %source.name,
+                        detail = %error,
+                        "skipping source during local catalog snapshot load"
+                    );
+                }
+            }
+        }
+
+        sort_catalog(&mut catalog);
+        Ok(catalog)
+    }
+
+    fn load_source_catalog(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<CatalogInfo, AppError> {
+        let components = self.runtime_components_for_installed_source(workspace_name, source)?;
+        Ok(catalog_info_from_components(&components))
+    }
+
+    fn runtime_components_for_installed_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+    ) -> Result<Vec<RuntimeSourceComponent>, AppError> {
+        let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
+        let source_spec = installed.source_spec;
+        if let Some(v4) = source_spec.as_v4() {
+            let materialized = load_v4_materialization(
+                &self.layout,
+                workspace_name,
+                &source.name,
+                &installed.manifest_yaml,
+                v4,
+            )?;
+            runtime_components_for_v4_source(v4, &materialized).map_err(|error| {
+                incompatible_materialization_error(
+                    &source.name,
+                    format!("failed to assemble runtime package: {error}"),
+                )
+            })
+        } else {
+            Ok(runtime_components_from_manifest(&source_spec))
+        }
+    }
+}
+
+fn runtime_components_from_manifest(
+    source_spec: &ValidatedSourceManifest,
+) -> Vec<RuntimeSourceComponent> {
+    if let Some(http) = source_spec.as_http() {
+        return vec![RuntimeSourceComponent::Http(http.clone())];
+    }
+    if let Some(file) = source_spec.as_file() {
+        return vec![RuntimeSourceComponent::File(file.clone())];
+    }
+    if let Some(mcp) = source_spec.as_mcp() {
+        return vec![RuntimeSourceComponent::Mcp(mcp.clone())];
+    }
+    Vec::new()
+}
+
+fn catalog_info_from_components(components: &[RuntimeSourceComponent]) -> CatalogInfo {
+    let mut catalog = CatalogInfo {
+        tables: Vec::new(),
+        table_functions: Vec::new(),
+    };
+
+    for component in components {
+        match component {
+            RuntimeSourceComponent::Http(manifest) => {
+                let schema_name = manifest.common.name.as_str();
+                catalog.tables.extend(
+                    manifest
+                        .tables
+                        .iter()
+                        .map(|table| table_info(schema_name, &table.common)),
+                );
+                catalog.table_functions.extend(
+                    manifest
+                        .functions
+                        .iter()
+                        .map(|function| table_function_info(schema_name, function)),
+                );
+            }
+            RuntimeSourceComponent::File(manifest) => {
+                let schema_name = manifest.common.name.as_str();
+                catalog.tables.extend(
+                    manifest
+                        .tables
+                        .iter()
+                        .map(|table| table_info(schema_name, &table.common)),
+                );
+            }
+            RuntimeSourceComponent::Mcp(manifest) => {
+                let schema_name = manifest.common.name.as_str();
+                catalog.tables.extend(
+                    manifest
+                        .tables
+                        .iter()
+                        .map(|table| table_info(schema_name, &table.common)),
+                );
+                catalog.table_functions.extend(
+                    manifest
+                        .functions
+                        .iter()
+                        .map(|function| table_function_info(schema_name, &function.common)),
+                );
+            }
+        }
+    }
+
+    sort_catalog(&mut catalog);
+    catalog
+}
+
+fn table_info(schema_name: &str, common: &TableCommon) -> TableInfo {
+    TableInfo {
+        schema_name: schema_name.to_string(),
+        table_name: common.name.clone(),
+        description: common.description.clone(),
+        guide: common.guide.clone(),
+        columns: column_infos_from_specs(&common.columns, &common.filters),
+        required_filters: required_filter_names(&common.filters),
+    }
+}
+
+fn column_infos_from_specs(columns: &[ColumnSpec], filters: &[FilterSpec]) -> Vec<ColumnInfo> {
+    columns
+        .iter()
+        .enumerate()
+        .map(|(position, column)| {
+            let filter = filters
+                .iter()
+                .find(|filter| filter.name == column.name.as_str());
+            ColumnInfo {
+                name: column.name.clone(),
+                data_type: column.data_type.clone(),
+                nullable: column.nullable,
+                is_virtual: column.r#virtual,
+                is_required_filter: filter.is_some_and(|filter| filter.required),
+                description: column.description.clone(),
+                ordinal_position: u32::try_from(position).unwrap_or(u32::MAX),
+            }
+        })
+        .collect()
+}
+
+fn required_filter_names(filters: &[FilterSpec]) -> Vec<String> {
+    filters
+        .iter()
+        .filter(|filter| filter.required)
+        .map(|filter| filter.name.clone())
+        .collect()
+}
+
+fn table_function_info(schema_name: &str, function: &SourceTableFunctionSpec) -> TableFunctionInfo {
+    TableFunctionInfo {
+        schema_name: schema_name.to_string(),
+        function_name: function.name.clone(),
+        description: function.description.clone(),
+        arguments: function
+            .args
+            .iter()
+            .map(|argument| TableFunctionArgumentInfo {
+                name: argument.name.clone(),
+                required: argument.required,
+                values: argument.values.clone(),
+            })
+            .collect(),
+        result_columns: function
+            .columns
+            .iter()
+            .map(|column| TableFunctionResultColumnInfo {
+                name: column.name.clone(),
+                data_type: column.data_type.clone(),
+                nullable: column.nullable,
+                description: column.description.clone(),
+            })
+            .collect(),
+        kind: function.kind,
+        search_limits_json: function
+            .search_limits
+            .as_ref()
+            .map(|limits| serde_json::to_string(limits).expect("search limits json")),
+    }
+}
+
+fn sort_catalog(catalog: &mut CatalogInfo) {
+    catalog.tables.sort_by(|left, right| {
+        (&left.schema_name, &left.table_name).cmp(&(&right.schema_name, &right.table_name))
+    });
+    catalog.table_functions.sort_by(|left, right| {
+        (&left.schema_name, &left.function_name).cmp(&(&right.schema_name, &right.function_name))
+    });
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
@@ -6,6 +6,7 @@ use tempfile::tempdir;
 use super::{
     CatalogSnapshotLoader, catalog_info_from_components, runtime_components_from_manifest,
 };
+use crate::bootstrap::AppError;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore};
@@ -108,10 +109,10 @@ functions:
         .first()
         .expect("function result column");
     assert_eq!(result_column.name, "title");
-    assert_eq!(
-        function.search_limits_json.as_deref(),
-        Some(r#"{"default_top_k":10,"max_top_k":25,"max_calls_per_query":2}"#)
-    );
+    let search_limits = function.search_limits.as_ref().expect("search limits");
+    assert_eq!(search_limits.default_top_k, 10);
+    assert_eq!(search_limits.max_top_k, 25);
+    assert_eq!(search_limits.max_calls_per_query, 2);
 }
 
 #[test]
@@ -191,7 +192,42 @@ tables:
 }
 
 #[test]
-fn loader_skips_v4_source_with_missing_materialization() {
+fn loader_fails_when_installed_manifest_cannot_be_read() {
+    let temp = tempdir().expect("tempdir");
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+    let config_store = ConfigStore::new(layout.clone());
+    let workspace_name = WorkspaceName::parse("work").expect("workspace");
+    let source_name = SourceName::parse("missing").expect("source");
+
+    config_store
+        .create_workspace(&workspace_name)
+        .expect("create workspace");
+    config_store
+        .upsert_source(
+            &workspace_name,
+            InstalledSource {
+                name: source_name,
+                version: None,
+                variables: BTreeMap::new(),
+                secrets: Vec::new(),
+                credential_storage: None,
+                origin: SourceOrigin::Imported,
+            },
+        )
+        .expect("upsert source");
+
+    let error = CatalogSnapshotLoader::new(config_store, layout)
+        .load_catalog(&workspace_name)
+        .expect_err("missing installed manifest should fail catalog load");
+
+    assert!(
+        matches!(error, AppError::Io(ref io_error) if io_error.kind() == std::io::ErrorKind::NotFound),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn loader_fails_when_v4_source_missing_materialization() {
     let temp = tempdir().expect("tempdir");
     let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
     let config_store = ConfigStore::new(layout.clone());
@@ -239,14 +275,16 @@ surfaces:
 ",
     );
 
-    let catalog = CatalogSnapshotLoader::new(config_store, layout)
+    let error = CatalogSnapshotLoader::new(config_store, layout)
         .load_catalog(&workspace_name)
-        .expect("catalog");
+        .expect_err("missing v4 materialization should fail catalog load");
 
-    assert_eq!(catalog.tables.len(), 1);
-    let table = catalog.tables.first().expect("healthy table");
-    assert_eq!(table.schema_name, "demo");
-    assert_eq!(table.table_name, "messages");
+    match error {
+        AppError::MissingOrIncompatibleV4Materialization { source_name, .. } => {
+            assert_eq!(source_name, stale_v4_source.as_str());
+        }
+        other => panic!("unexpected error: {other}"),
+    }
 }
 
 fn install_imported_source(

--- a/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
@@ -1,0 +1,210 @@
+use std::collections::BTreeMap;
+
+use coral_spec::{SourceTableFunctionKind, parse_source_manifest_yaml};
+use tempfile::tempdir;
+
+use super::{
+    CatalogSnapshotLoader, catalog_info_from_components, runtime_components_from_manifest,
+};
+use crate::sources::SourceName;
+use crate::sources::model::{InstalledSource, SourceOrigin};
+use crate::state::{AppStateLayout, ConfigStore};
+use crate::workspaces::WorkspaceName;
+
+#[test]
+fn local_snapshot_preserves_http_catalog_metadata_without_credentials() {
+    let catalog = catalog_for_manifest(
+        r"
+name: github
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://api.github.com
+inputs:
+  GITHUB_TOKEN:
+    kind: secret
+    required: true
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.GITHUB_TOKEN}}
+tables:
+  - name: issues
+    description: GitHub issues
+    guide: Prefer owner and repo filters.
+    filters:
+      - name: repo
+        required: true
+        description: Repository name
+      - name: state
+        type: Utf8
+    request:
+      method: GET
+      path: /repos/issues
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Issue id
+      - name: repo
+        type: Utf8
+        virtual: true
+        description: Repository filter
+functions:
+  - name: search_issues
+    kind: search
+    description: Search GitHub issues
+    search_limits:
+      default_top_k: 10
+      max_top_k: 25
+      max_calls_per_query: 2
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+    request:
+      method: GET
+      path: /search/issues
+    columns:
+      - name: title
+        type: Utf8
+        description: Issue title
+",
+    );
+
+    let table = catalog
+        .tables
+        .iter()
+        .find(|table| table.table_name == "issues")
+        .expect("issues table");
+    assert_eq!(table.schema_name, "github");
+    assert_eq!(table.required_filters, ["repo".to_string()]);
+    let id_column = table.columns.first().expect("id column");
+    assert_eq!(id_column.name, "id");
+    assert_eq!(id_column.data_type, "Int64");
+    assert!(!id_column.nullable);
+    let repo_column = table
+        .columns
+        .iter()
+        .find(|column| column.name == "repo")
+        .expect("repo column");
+    assert!(repo_column.is_virtual);
+    assert!(repo_column.is_required_filter);
+
+    let function = catalog
+        .table_functions
+        .iter()
+        .find(|function| function.function_name == "search_issues")
+        .expect("search_issues function");
+    assert_eq!(function.kind, SourceTableFunctionKind::Search);
+    let argument = function.arguments.first().expect("function argument");
+    assert_eq!(argument.name, "q");
+    assert!(argument.required);
+    let result_column = function
+        .result_columns
+        .first()
+        .expect("function result column");
+    assert_eq!(result_column.name, "title");
+    assert_eq!(
+        function.search_limits_json.as_deref(),
+        Some(r#"{"default_top_k":10,"max_top_k":25,"max_calls_per_query":2}"#)
+    );
+}
+
+#[test]
+fn local_snapshot_does_not_infer_file_table_columns() {
+    let catalog = catalog_for_manifest(
+        r"
+name: warehouse
+version: 1.0.0
+dsl_version: 3
+backend: file
+tables:
+  - name: events
+    description: Event rows
+    format: parquet
+    source:
+      location: file:///tmp/coral/events/
+",
+    );
+
+    let table = catalog
+        .tables
+        .iter()
+        .find(|table| table.table_name == "events")
+        .expect("events table");
+    assert_eq!(table.schema_name, "warehouse");
+    assert!(
+        table.columns.is_empty(),
+        "local snapshots must not touch files to infer provider schemas"
+    );
+}
+
+#[test]
+fn loader_reads_installed_imported_sources_from_local_state() {
+    let temp = tempdir().expect("tempdir");
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+    let config_store = ConfigStore::new(layout.clone());
+    let workspace_name = WorkspaceName::parse("work").expect("workspace");
+    let source_name = SourceName::parse("demo").expect("source");
+    let manifest_yaml = r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Demo messages
+    request:
+      method: GET
+      path: /messages
+    columns:
+      - name: id
+        type: Utf8
+";
+
+    config_store
+        .create_workspace(&workspace_name)
+        .expect("create workspace");
+    std::fs::create_dir_all(layout.source_dir(&workspace_name, &source_name))
+        .expect("create source dir");
+    std::fs::write(
+        layout.manifest_file(&workspace_name, &source_name),
+        manifest_yaml,
+    )
+    .expect("write manifest");
+    config_store
+        .upsert_source(
+            &workspace_name,
+            InstalledSource {
+                name: source_name,
+                version: Some("1.0.0".to_string()),
+                variables: BTreeMap::new(),
+                secrets: Vec::new(),
+                credential_storage: None,
+                origin: SourceOrigin::Imported,
+            },
+        )
+        .expect("upsert source");
+
+    let catalog = CatalogSnapshotLoader::new(config_store, layout)
+        .load_catalog(&workspace_name)
+        .expect("catalog");
+
+    assert!(
+        catalog
+            .tables
+            .iter()
+            .any(|table| table.schema_name == "demo" && table.table_name == "messages")
+    );
+}
+
+fn catalog_for_manifest(manifest_yaml: &str) -> coral_engine::CatalogInfo {
+    let manifest = parse_source_manifest_yaml(manifest_yaml).expect("manifest");
+    let components = runtime_components_from_manifest(&manifest);
+    catalog_info_from_components(&components)
+}

--- a/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
@@ -170,26 +170,13 @@ tables:
     config_store
         .create_workspace(&workspace_name)
         .expect("create workspace");
-    std::fs::create_dir_all(layout.source_dir(&workspace_name, &source_name))
-        .expect("create source dir");
-    std::fs::write(
-        layout.manifest_file(&workspace_name, &source_name),
+    install_imported_source(
+        &layout,
+        &config_store,
+        &workspace_name,
+        &source_name,
         manifest_yaml,
-    )
-    .expect("write manifest");
-    config_store
-        .upsert_source(
-            &workspace_name,
-            InstalledSource {
-                name: source_name,
-                version: Some("1.0.0".to_string()),
-                variables: BTreeMap::new(),
-                secrets: Vec::new(),
-                credential_storage: None,
-                origin: SourceOrigin::Imported,
-            },
-        )
-        .expect("upsert source");
+    );
 
     let catalog = CatalogSnapshotLoader::new(config_store, layout)
         .load_catalog(&workspace_name)
@@ -201,6 +188,94 @@ tables:
             .iter()
             .any(|table| table.schema_name == "demo" && table.table_name == "messages")
     );
+}
+
+#[test]
+fn loader_skips_v4_source_with_missing_materialization() {
+    let temp = tempdir().expect("tempdir");
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+    let config_store = ConfigStore::new(layout.clone());
+    let workspace_name = WorkspaceName::parse("work").expect("workspace");
+    let healthy_source = SourceName::parse("demo").expect("source");
+    let stale_v4_source = SourceName::parse("stale_v4").expect("source");
+
+    config_store
+        .create_workspace(&workspace_name)
+        .expect("create workspace");
+    install_imported_source(
+        &layout,
+        &config_store,
+        &workspace_name,
+        &healthy_source,
+        r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Demo messages
+    request:
+      method: GET
+      path: /messages
+    columns:
+      - name: id
+        type: Utf8
+",
+    );
+    install_imported_source(
+        &layout,
+        &config_store,
+        &workspace_name,
+        &stale_v4_source,
+        r"
+name: stale_v4
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+",
+    );
+
+    let catalog = CatalogSnapshotLoader::new(config_store, layout)
+        .load_catalog(&workspace_name)
+        .expect("catalog");
+
+    assert_eq!(catalog.tables.len(), 1);
+    let table = catalog.tables.first().expect("healthy table");
+    assert_eq!(table.schema_name, "demo");
+    assert_eq!(table.table_name, "messages");
+}
+
+fn install_imported_source(
+    layout: &AppStateLayout,
+    config_store: &ConfigStore,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    manifest_yaml: &str,
+) {
+    std::fs::create_dir_all(layout.source_dir(workspace_name, source_name))
+        .expect("create source dir");
+    std::fs::write(
+        layout.manifest_file(workspace_name, source_name),
+        manifest_yaml,
+    )
+    .expect("write manifest");
+    config_store
+        .upsert_source(
+            workspace_name,
+            InstalledSource {
+                name: source_name.clone(),
+                version: None,
+                variables: BTreeMap::new(),
+                secrets: Vec::new(),
+                credential_storage: None,
+                origin: SourceOrigin::Imported,
+            },
+        )
+        .expect("upsert source");
 }
 
 fn catalog_for_manifest(manifest_yaml: &str) -> coral_engine::CatalogInfo {

--- a/crates/coral-app/src/search/catalog/mod.rs
+++ b/crates/coral-app/src/search/catalog/mod.rs
@@ -1,3 +1,4 @@
 //! Catalog metadata search primitives.
 
+pub(crate) mod local_snapshot;
 pub(crate) mod sqlite_index;

--- a/crates/coral-app/src/search/catalog/sqlite_index.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index.rs
@@ -77,19 +77,6 @@ impl SqliteCatalogIndex {
         clippy::unused_self,
         reason = "kept as an instance method so catalog provider can own index capability consistently"
     )]
-    pub(crate) fn clear_source(
-        &self,
-        connection: &mut Connection,
-        workspace_name: &WorkspaceName,
-        source_name: &str,
-    ) -> Result<CatalogClearResult, SqliteSearchError> {
-        clear_catalog_source_documents(connection, workspace_name, source_name)
-    }
-
-    #[expect(
-        clippy::unused_self,
-        reason = "kept as an instance method so catalog provider can own index capability consistently"
-    )]
     pub(crate) fn clear_workspace(
         &self,
         connection: &mut Connection,
@@ -344,38 +331,6 @@ fn replace_catalog_documents(
         ],
     )?;
     Ok(())
-}
-
-fn clear_catalog_source_documents(
-    connection: &mut Connection,
-    workspace_name: &WorkspaceName,
-    source_name: &str,
-) -> Result<CatalogClearResult, SqliteSearchError> {
-    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-    transaction.execute(
-        "
-        DELETE FROM catalog_documents_fts
-        WHERE workspace = ?1
-          AND doc_id IN (
-              SELECT doc_id
-              FROM catalog_documents
-              WHERE workspace = ?1 AND source_name = ?2
-          )
-        ",
-        params![workspace_name.as_str(), source_name],
-    )?;
-    let deleted_document_count = transaction.execute(
-        "
-        DELETE FROM catalog_documents
-        WHERE workspace = ?1 AND source_name = ?2
-        ",
-        params![workspace_name.as_str(), source_name],
-    )?;
-    clear_catalog_fingerprint(&transaction, workspace_name)?;
-    transaction.commit()?;
-    Ok(CatalogClearResult {
-        deleted_document_count: u32::try_from(deleted_document_count).unwrap_or(u32::MAX),
-    })
 }
 
 fn clear_catalog_workspace_documents(

--- a/crates/coral-app/src/search/catalog/sqlite_index.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index.rs
@@ -77,6 +77,31 @@ impl SqliteCatalogIndex {
         clippy::unused_self,
         reason = "kept as an instance method so catalog provider can own index capability consistently"
     )]
+    pub(crate) fn clear_source(
+        &self,
+        connection: &mut Connection,
+        workspace_name: &WorkspaceName,
+        source_name: &str,
+    ) -> Result<CatalogClearResult, SqliteSearchError> {
+        clear_catalog_source_documents(connection, workspace_name, source_name)
+    }
+
+    #[expect(
+        clippy::unused_self,
+        reason = "kept as an instance method so catalog provider can own index capability consistently"
+    )]
+    pub(crate) fn clear_workspace(
+        &self,
+        connection: &mut Connection,
+        workspace_name: &WorkspaceName,
+    ) -> Result<CatalogClearResult, SqliteSearchError> {
+        clear_catalog_workspace_documents(connection, workspace_name)
+    }
+
+    #[expect(
+        clippy::unused_self,
+        reason = "kept as an instance method so catalog provider can own index capability consistently"
+    )]
     pub(crate) fn search(
         &self,
         connection: &Connection,
@@ -201,6 +226,11 @@ pub(crate) struct CatalogRefreshResult {
     pub(crate) document_count: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CatalogClearResult {
+    pub(crate) deleted_document_count: u32,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CatalogSearchHits {
     pub(crate) hits: Vec<CatalogSearchHit>,
@@ -312,6 +342,69 @@ fn replace_catalog_documents(
             catalog_fingerprint_key(workspace_name),
             snapshot.fingerprint.as_str()
         ],
+    )?;
+    Ok(())
+}
+
+fn clear_catalog_source_documents(
+    connection: &mut Connection,
+    workspace_name: &WorkspaceName,
+    source_name: &str,
+) -> Result<CatalogClearResult, SqliteSearchError> {
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    transaction.execute(
+        "
+        DELETE FROM catalog_documents_fts
+        WHERE workspace = ?1
+          AND doc_id IN (
+              SELECT doc_id
+              FROM catalog_documents
+              WHERE workspace = ?1 AND source_name = ?2
+          )
+        ",
+        params![workspace_name.as_str(), source_name],
+    )?;
+    let deleted_document_count = transaction.execute(
+        "
+        DELETE FROM catalog_documents
+        WHERE workspace = ?1 AND source_name = ?2
+        ",
+        params![workspace_name.as_str(), source_name],
+    )?;
+    clear_catalog_fingerprint(&transaction, workspace_name)?;
+    transaction.commit()?;
+    Ok(CatalogClearResult {
+        deleted_document_count: u32::try_from(deleted_document_count).unwrap_or(u32::MAX),
+    })
+}
+
+fn clear_catalog_workspace_documents(
+    connection: &mut Connection,
+    workspace_name: &WorkspaceName,
+) -> Result<CatalogClearResult, SqliteSearchError> {
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    transaction.execute(
+        "DELETE FROM catalog_documents_fts WHERE workspace = ?1",
+        params![workspace_name.as_str()],
+    )?;
+    let deleted_document_count = transaction.execute(
+        "DELETE FROM catalog_documents WHERE workspace = ?1",
+        params![workspace_name.as_str()],
+    )?;
+    clear_catalog_fingerprint(&transaction, workspace_name)?;
+    transaction.commit()?;
+    Ok(CatalogClearResult {
+        deleted_document_count: u32::try_from(deleted_document_count).unwrap_or(u32::MAX),
+    })
+}
+
+fn clear_catalog_fingerprint(
+    transaction: &Transaction<'_>,
+    workspace_name: &WorkspaceName,
+) -> Result<(), SqliteSearchError> {
+    transaction.execute(
+        "DELETE FROM search_meta WHERE key = ?1",
+        params![catalog_fingerprint_key(workspace_name)],
     )?;
     Ok(())
 }

--- a/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
@@ -62,48 +62,6 @@ fn refresh_and_search_catalog_metadata() {
 }
 
 #[test]
-fn clear_source_removes_source_documents_and_invalidates_fingerprint() {
-    let temp = tempdir().expect("tempdir");
-    let store = catalog_store(&temp);
-    let workspace = WorkspaceName::default();
-    let snapshot = multi_source_catalog_snapshot();
-    store
-        .refresh_catalog_projection(&snapshot)
-        .expect("refresh catalog");
-    assert!(
-        store
-            .catalog_projection_is_current(&snapshot.fingerprint)
-            .expect("projection current")
-    );
-
-    let result = store
-        .clear_catalog_source("github")
-        .expect("clear source catalog");
-
-    assert_eq!(result.deleted_document_count, 3);
-    assert!(
-        !store
-            .catalog_projection_is_current(&snapshot.fingerprint)
-            .expect("projection invalidated")
-    );
-    assert_eq!(store.catalog_document_count().expect("document count"), 1);
-
-    let connection = store.connect_for_test().expect("connect");
-    let github_fts_count: u32 = connection
-        .query_row(
-            "
-            SELECT count(*)
-            FROM catalog_documents_fts
-            WHERE workspace = ?1 AND doc_id LIKE '%github%'
-            ",
-            [workspace.as_str()],
-            |row| row.get(0),
-        )
-        .expect("fts count");
-    assert_eq!(github_fts_count, 0);
-}
-
-#[test]
 fn clear_workspace_removes_workspace_documents_and_invalidates_fingerprint() {
     let temp = tempdir().expect("tempdir");
     let store = catalog_store(&temp);
@@ -449,26 +407,6 @@ fn catalog_index_snapshot() -> CatalogIndexSnapshot {
             }),
         ],
     }
-}
-
-fn multi_source_catalog_snapshot() -> CatalogIndexSnapshot {
-    let mut snapshot = catalog_index_snapshot();
-    snapshot.documents.push(CatalogIndexDocument {
-        doc_id: "catalog:table:slack.messages".to_string(),
-        doc_kind: CatalogIndexDocumentKind::CatalogTable,
-        source_name: "slack".to_string(),
-        surface_kind: "table".to_string(),
-        surface_name: "messages".to_string(),
-        field_name: String::new(),
-        field_role: String::new(),
-        qualified_name: "slack.messages".to_string(),
-        title: "messages".to_string(),
-        description: "Slack messages".to_string(),
-        searchable_text: "slack messages".to_string(),
-        payload_json: "{}".to_string(),
-    });
-    snapshot.fingerprint = "multi-source-fixture".to_string();
-    snapshot
 }
 
 fn fts_weight_snapshot() -> CatalogIndexSnapshot {

--- a/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
@@ -62,6 +62,70 @@ fn refresh_and_search_catalog_metadata() {
 }
 
 #[test]
+fn clear_source_removes_source_documents_and_invalidates_fingerprint() {
+    let temp = tempdir().expect("tempdir");
+    let store = catalog_store(&temp);
+    let workspace = WorkspaceName::default();
+    let snapshot = multi_source_catalog_snapshot();
+    store
+        .refresh_catalog_projection(&snapshot)
+        .expect("refresh catalog");
+    assert!(
+        store
+            .catalog_projection_is_current(&snapshot.fingerprint)
+            .expect("projection current")
+    );
+
+    let result = store
+        .clear_catalog_source("github")
+        .expect("clear source catalog");
+
+    assert_eq!(result.deleted_document_count, 3);
+    assert!(
+        !store
+            .catalog_projection_is_current(&snapshot.fingerprint)
+            .expect("projection invalidated")
+    );
+    assert_eq!(store.catalog_document_count().expect("document count"), 1);
+
+    let connection = store.connect_for_test().expect("connect");
+    let github_fts_count: u32 = connection
+        .query_row(
+            "
+            SELECT count(*)
+            FROM catalog_documents_fts
+            WHERE workspace = ?1 AND doc_id LIKE '%github%'
+            ",
+            [workspace.as_str()],
+            |row| row.get(0),
+        )
+        .expect("fts count");
+    assert_eq!(github_fts_count, 0);
+}
+
+#[test]
+fn clear_workspace_removes_workspace_documents_and_invalidates_fingerprint() {
+    let temp = tempdir().expect("tempdir");
+    let store = catalog_store(&temp);
+    let snapshot = catalog_index_snapshot();
+    store
+        .refresh_catalog_projection(&snapshot)
+        .expect("refresh catalog");
+
+    let result = store
+        .clear_catalog_workspace()
+        .expect("clear workspace catalog");
+
+    assert_eq!(result.deleted_document_count, 3);
+    assert_eq!(store.catalog_document_count().expect("document count"), 0);
+    assert!(
+        !store
+            .catalog_projection_is_current(&snapshot.fingerprint)
+            .expect("projection invalidated")
+    );
+}
+
+#[test]
 fn search_rejects_unknown_doc_kind_from_storage() {
     let temp = tempdir().expect("tempdir");
     let store = catalog_store(&temp);
@@ -385,6 +449,26 @@ fn catalog_index_snapshot() -> CatalogIndexSnapshot {
             }),
         ],
     }
+}
+
+fn multi_source_catalog_snapshot() -> CatalogIndexSnapshot {
+    let mut snapshot = catalog_index_snapshot();
+    snapshot.documents.push(CatalogIndexDocument {
+        doc_id: "catalog:table:slack.messages".to_string(),
+        doc_kind: CatalogIndexDocumentKind::CatalogTable,
+        source_name: "slack".to_string(),
+        surface_kind: "table".to_string(),
+        surface_name: "messages".to_string(),
+        field_name: String::new(),
+        field_role: String::new(),
+        qualified_name: "slack.messages".to_string(),
+        title: "messages".to_string(),
+        description: "Slack messages".to_string(),
+        searchable_text: "slack messages".to_string(),
+        payload_json: "{}".to_string(),
+    });
+    snapshot.fingerprint = "multi-source-fixture".to_string();
+    snapshot
 }
 
 fn fts_weight_snapshot() -> CatalogIndexSnapshot {

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -15,7 +15,8 @@ use std::time::Duration;
 use rusqlite::{Connection, ErrorCode};
 
 use crate::search::catalog::sqlite_index::{
-    CatalogIndexSnapshot, CatalogRefreshResult, CatalogSearchHits, SqliteCatalogIndex,
+    CatalogClearResult, CatalogIndexSnapshot, CatalogRefreshResult, CatalogSearchHits,
+    SqliteCatalogIndex,
 };
 use crate::state::AppStateLayout;
 use crate::storage::fs::create_new_file_private;
@@ -125,6 +126,19 @@ impl SqliteSearchStore {
     pub(crate) fn catalog_document_count(&self) -> Result<u32, SqliteSearchError> {
         let connection = self.connect()?;
         SqliteCatalogIndex::new().document_count(&connection, &self.workspace_name)
+    }
+
+    pub(crate) fn clear_catalog_source(
+        &self,
+        source_name: &str,
+    ) -> Result<CatalogClearResult, SqliteSearchError> {
+        let mut connection = self.connect()?;
+        SqliteCatalogIndex::new().clear_source(&mut connection, &self.workspace_name, source_name)
+    }
+
+    pub(crate) fn clear_catalog_workspace(&self) -> Result<CatalogClearResult, SqliteSearchError> {
+        let mut connection = self.connect()?;
+        SqliteCatalogIndex::new().clear_workspace(&mut connection, &self.workspace_name)
     }
 
     pub(crate) fn search_catalog(

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -128,14 +128,6 @@ impl SqliteSearchStore {
         SqliteCatalogIndex::new().document_count(&connection, &self.workspace_name)
     }
 
-    pub(crate) fn clear_catalog_source(
-        &self,
-        source_name: &str,
-    ) -> Result<CatalogClearResult, SqliteSearchError> {
-        let mut connection = self.connect()?;
-        SqliteCatalogIndex::new().clear_source(&mut connection, &self.workspace_name, source_name)
-    }
-
     pub(crate) fn clear_catalog_workspace(&self) -> Result<CatalogClearResult, SqliteSearchError> {
         let mut connection = self.connect()?;
         SqliteCatalogIndex::new().clear_workspace(&mut connection, &self.workspace_name)

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -570,7 +570,7 @@ impl SourceManager {
             self.layout.workspace_dir(workspace_name).parent(),
         );
         drop(state_lock);
-        self.clear_catalog_projection_for_source_best_effort(workspace_name, source_name);
+        self.clear_catalog_projection_for_source_lifecycle_best_effort(workspace_name, source_name);
         Ok(removed)
     }
 
@@ -742,11 +742,14 @@ impl SourceManager {
         let mut resolved = stored;
         resolved.version.clone_from(&request.candidate.version);
         drop(state_lock);
-        self.clear_catalog_projection_for_source_best_effort(workspace_name, &source_name);
+        self.clear_catalog_projection_for_source_lifecycle_best_effort(
+            workspace_name,
+            &source_name,
+        );
         Ok(resolved)
     }
 
-    fn clear_catalog_projection_for_source_best_effort(
+    fn clear_catalog_projection_for_source_lifecycle_best_effort(
         &self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
@@ -756,7 +759,7 @@ impl SourceManager {
             return;
         }
         match SqliteSearchStore::open_workspace(&self.layout, workspace_name)
-            .and_then(|store| store.clear_catalog_source(source_name.as_str()))
+            .and_then(|store| store.clear_catalog_workspace())
         {
             Ok(result) => {
                 tracing::debug!(

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -15,6 +15,7 @@ use crate::credentials::{
     CORAL_INTERNAL_KEY_PREFIX, CredentialManager, CredentialMaterialGuard,
     CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialsError,
 };
+use crate::search::sqlite_store::SqliteSearchStore;
 use crate::sources::SourceName;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
@@ -502,7 +503,7 @@ impl SourceManager {
         let credential_guard = self
             .credential_manager
             .material_guard(workspace_name, &credential_set_id)?;
-        let _state_lock = self.config_store.state_lock_exclusive()?;
+        let state_lock = self.config_store.state_lock_exclusive()?;
         let stored = self
             .config_store
             .get_source_unlocked(workspace_name, source_name)?;
@@ -568,6 +569,8 @@ impl SourceManager {
             &self.layout.workspaces_root(),
             self.layout.workspace_dir(workspace_name).parent(),
         );
+        drop(state_lock);
+        self.clear_catalog_projection_for_source_best_effort(workspace_name, source_name);
         Ok(removed)
     }
 
@@ -595,7 +598,7 @@ impl SourceManager {
         let credential_guard = self
             .credential_manager
             .material_guard(workspace_name, &credential_set_id)?;
-        let _state_lock = self.config_store.state_lock_exclusive()?;
+        let state_lock = self.config_store.state_lock_exclusive()?;
         let credential_storage = match self.source_persist_storage_with_state_lock_held(
             workspace_name,
             request.candidate,
@@ -738,7 +741,40 @@ impl SourceManager {
         cleanup_materialization_backup(materialization_backup);
         let mut resolved = stored;
         resolved.version.clone_from(&request.candidate.version);
+        drop(state_lock);
+        self.clear_catalog_projection_for_source_best_effort(workspace_name, &source_name);
         Ok(resolved)
+    }
+
+    fn clear_catalog_projection_for_source_best_effort(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        let search_sqlite_file = self.layout.search_sqlite_file(workspace_name);
+        if !search_sqlite_file.exists() {
+            return;
+        }
+        match SqliteSearchStore::open_workspace(&self.layout, workspace_name)
+            .and_then(|store| store.clear_catalog_source(source_name.as_str()))
+        {
+            Ok(result) => {
+                tracing::debug!(
+                    workspace = %workspace_name,
+                    source = %source_name,
+                    deleted_document_count = result.deleted_document_count,
+                    "cleared SQLite catalog projection for source lifecycle change"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    workspace = %workspace_name,
+                    source = %source_name,
+                    search_sqlite_file = %search_sqlite_file.display(),
+                    "source lifecycle changed, but failed to clear SQLite catalog projection: {error}"
+                );
+            }
+        }
     }
 
     fn prepare_v4_materialization(


### PR DESCRIPTION
## Summary

- add an app-owned `CatalogSnapshotLoader` that builds catalog metadata from installed local source state and DSL v4 materialized projection artifacts
- avoid query-runtime provider registration, credential refresh, MCP startup, HTTP calls, and file schema inference while preparing catalog snapshots
- add SQLite catalog source/workspace clear APIs and best-effort source lifecycle invalidation for add/re-add/delete flows

## Validation

- `cargo test -p coral-app search::catalog:: --lib`
- `cargo test -p coral-app --lib`
- `cargo clippy -p coral-app --all-targets --all-features -- -D warnings`
- `git diff --check`
