### PR TITLE
fix(reef): prebundle protobuf imports for Storybook

### DIFF
--- a/apps/reef/.storybook/main.ts
+++ b/apps/reef/.storybook/main.ts
@@ -54,6 +54,17 @@ const config: StorybookConfig = {
       { find: '~', replacement: resolve(__dirname, '../app') },
       ...existingAliases,
     ]
+
+    config.optimizeDeps ??= {}
+    const existingOptimizeIncludes = config.optimizeDeps.include ?? []
+    config.optimizeDeps.include = [
+      ...new Set([
+        ...existingOptimizeIncludes,
+        '@bufbuild/protobuf',
+        '@bufbuild/protobuf/codegenv2',
+      ]),
+    ]
+
     return config
   },
 }


### PR DESCRIPTION
Keep Storybook preview startup stable when generated protobuf modules are imported by Reef stories; Vite needs the protobuf runtime modules included during dependency optimization.

Constraint: Storybook runs in its own Vite preview server without the React Router app runtime.
Rejected: Leave this in the sources page PR | Review requested this Storybook config concern as a separate parent PR.
Confidence: high
Scope-risk: narrow
Directive: Keep Storybook-only Vite dependency work outside feature UI branches when it is reusable across stories.
Tested: npm run check --prefix apps/reef
Not-tested: Full Storybook build after split.