### PR TITLE
feat(reef): make Wax cards polymorphic

### DIFF
--- a/apps/reef/app/wax/components/card/card-list.stories.tsx
+++ b/apps/reef/app/wax/components/card/card-list.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
+import { Link, MemoryRouter } from 'react-router'
 import { fn } from 'storybook/test'
 
 import { Icon } from '@/wax/components/icon'
@@ -75,5 +76,23 @@ export const Default: Story = {}
 export const Interactive: Story = {
   args: {
     onSelect: fn(),
+  },
+}
+
+export const AsReactRouterLinks: Story = {
+  render: ({ count }) => {
+    const items = makeItems(count)
+    return (
+      <MemoryRouter>
+        <CardList
+          as={Link}
+          getCardProps={(item) => ({
+            prefetch: 'intent' as const,
+            to: `/sources/${item.id}`,
+          })}
+          items={items}
+        />
+      </MemoryRouter>
+    )
   },
 }

--- a/apps/reef/app/wax/components/card/card-list.tsx
+++ b/apps/reef/app/wax/components/card/card-list.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import React, { ElementType, ReactNode } from 'react'
 
 import { Card, type CardHeaderPill } from './card'
 import * as styles from './card-list.css'
@@ -11,25 +11,47 @@ export interface CardItem {
   title: string
 }
 
-export interface CardListProps {
+type CardListCardProps<T extends ElementType> = Omit<
+  React.ComponentPropsWithoutRef<T>,
+  'as' | 'children' | 'className' | 'description' | 'headerPill' | 'icon' | 'title'
+> & {
+  className?: string
+  interactive?: boolean
+}
+
+export interface CardListProps<T extends ElementType = 'div'> {
+  as?: T
+  getCardProps?: (item: CardItem) => CardListCardProps<T>
   items: CardItem[]
   onSelect?: (item: CardItem) => void
 }
 
-export function CardList({ items, onSelect }: CardListProps) {
+export function CardList<T extends ElementType = 'div'>({
+  as,
+  getCardProps,
+  items,
+  onSelect,
+}: CardListProps<T>) {
   return (
     <ul className={styles.grid}>
-      {items.map((item) => (
-        <li className={styles.item} key={item.id}>
-          <Card
-            description={item.description}
-            headerPill={item.headerPill}
-            icon={item.icon}
-            onSelect={onSelect ? () => onSelect(item) : undefined}
-            title={item.title}
-          />
-        </li>
-      ))}
+      {items.map((item) => {
+        const cardProps = getCardProps?.(item)
+        const Component = (onSelect && !as ? 'button' : as) as ElementType | undefined
+
+        return (
+          <li className={styles.item} key={item.id}>
+            <Card
+              as={Component}
+              description={item.description}
+              headerPill={item.headerPill}
+              icon={item.icon}
+              onClick={onSelect ? () => onSelect(item) : undefined}
+              title={item.title}
+              {...cardProps}
+            />
+          </li>
+        )
+      })}
     </ul>
   )
 }

--- a/apps/reef/app/wax/components/card/card.css.ts
+++ b/apps/reef/app/wax/components/card/card.css.ts
@@ -17,6 +17,9 @@ export const card = style({
 
 export const cardButton = style({
   alignItems: 'stretch',
+  color: 'inherit',
+  cursor: 'pointer',
+  font: 'inherit',
   justifyContent: 'flex-start',
   textAlign: 'left',
   selectors: {

--- a/apps/reef/app/wax/components/card/card.stories.tsx
+++ b/apps/reef/app/wax/components/card/card.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
+import { Link, MemoryRouter } from 'react-router'
 import { fn } from 'storybook/test'
 
 import { Icon } from '@/wax/components/icon'
@@ -56,11 +57,31 @@ export const NoIcon: Story = {
 
 export const Interactive: Story = {
   args: {
-    description: 'Click this card — it renders as a button when onSelect is provided.',
+    description: 'Click this card — it renders as a button through the polymorphic as prop.',
     icon: <Icon name="Database" size="20" />,
-    onSelect: fn(),
     title: 'Postgres',
   },
+  render: (args) => (
+    <div style={{ width: 320 }}>
+      <Card {...args} as="button" onClick={fn()} />
+    </div>
+  ),
+}
+
+export const AsReactRouterLink: Story = {
+  args: {
+    description: 'Navigate to the GitHub source details route using React Router Link.',
+    headerPill: { label: 'Core' },
+    icon: <Icon name="GitBranch" size="20" />,
+    title: 'GitHub',
+  },
+  render: (args) => (
+    <MemoryRouter>
+      <div style={{ width: 320 }}>
+        <Card {...args} as={Link} prefetch="intent" to="/sources/github" />
+      </div>
+    </MemoryRouter>
+  ),
 }
 
 export const LongText: Story = {

--- a/apps/reef/app/wax/components/card/card.tsx
+++ b/apps/reef/app/wax/components/card/card.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames'
-import { ReactNode } from 'react'
+import React, { ElementType, ReactNode } from 'react'
 
-import { Button } from '@/wax/components'
 import { Pill, type PillProps } from '@/wax/components/pill'
 import { Typography } from '@/wax/components/typography'
 
@@ -11,15 +10,29 @@ export type CardHeaderPill = Omit<PillProps, 'children' | 'size'> & {
   label: string
 }
 
-export interface CardProps {
+interface CardBaseProps {
+  className?: string
   description: string
   headerPill?: CardHeaderPill
   icon?: ReactNode
-  onSelect?: () => void
+  interactive?: boolean
   title: string
 }
 
-export function Card({ description, headerPill, icon, onSelect, title }: CardProps) {
+export type CardProps<T extends ElementType = 'div'> = CardBaseProps &
+  Omit<React.ComponentPropsWithoutRef<T>, 'as' | keyof CardBaseProps> & {
+    as?: T
+  }
+
+export function Card<T extends ElementType = 'div'>(
+  props: CardProps<T> & { ref?: React.Ref<HTMLElement> },
+) {
+  const { as, className, description, headerPill, icon, interactive, ref, title, ...rest } = props
+
+  const Component = (as ?? 'div') as ElementType
+  const type = 'type' in props ? props.type! : 'button'
+  const isInteractive = interactive ?? (as !== undefined || 'onClick' in props)
+
   const content = (
     <>
       <span className={styles.header}>
@@ -35,19 +48,14 @@ export function Card({ description, headerPill, icon, onSelect, title }: CardPro
     </>
   )
 
-  if (onSelect) {
-    return (
-      <Button.Container
-        className={classNames(styles.card, styles.cardButton)}
-        onClick={onSelect}
-        variant="bare"
-      >
-        {content}
-      </Button.Container>
-    )
+  const componentProps = {
+    className: classNames(styles.card, { [styles.cardButton]: isInteractive }, className),
+    ref,
+    ...rest,
+    ...(Component === 'button' && { type }),
   }
 
-  return <div className={styles.card}>{content}</div>
+  return <Component {...componentProps}>{content}</Component>
 }
 
 function HeaderPill({ className, label, ...props }: CardHeaderPill) {


### PR DESCRIPTION
## Summary

- Replace Card-owned React Router props (`to`, `prefetch`, `preventScrollReset`) with a polymorphic `as` prop, matching other WAX component patterns.
- Add `CardList as` and `getCardProps` so list call sites can render cards as router links, buttons, anchors, or other components without putting route-specific fields on `CardItem`.
- Keep WAX `Card` router-agnostic and presentational while preserving interactive card styling for `as`/`onClick` usage.
- Add Storybook examples for rendering both `Card` and `CardList` as React Router `Link` components.

## Why

Reviewer feedback correctly pointed out that WAX primitives should not import or encode React Router behavior. The source page still needs card-shaped navigation, but that should be composed at the app call site instead of built into the design-system card.

## Validation

- `npm run check --prefix apps/reef`
- `npm run typecheck --prefix apps/reef`
- `npm test --prefix apps/reef`
- `npm run build --prefix apps/reef`
- `npm run build-storybook --prefix apps/reef`
