### PR TITLE
feat(api): add task lifecycle contract

### DIFF
--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -21,6 +21,7 @@ fn main() {
                 "proto/coral/v1/catalog.proto",
                 "proto/coral/v1/resources.proto",
                 "proto/coral/v1/workspaces.proto",
+                "proto/coral/v1/task.proto",
                 "proto/coral/v1/feedback.proto",
                 "proto/coral/v1/sources.proto",
                 "proto/coral/v1/query.proto",

--- a/crates/coral-api/proto/coral/v1/task.proto
+++ b/crates/coral-api/proto/coral/v1/task.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/resources.proto";
+
+// Task lifecycle for intent-bearing units of work.
+service TaskService {
+  // Starts one task.
+  rpc StartTask(StartTaskRequest) returns (StartTaskResponse);
+  // Ends one task.
+  rpc EndTask(EndTaskRequest) returns (EndTaskResponse);
+}
+
+// Starts a task.
+message StartTaskRequest {
+  // Workspace that scopes the task.
+  Workspace workspace = 1;
+  // Natural-language description of the work this task groups.
+  string intent = 2;
+}
+
+// Returns the started task.
+message StartTaskResponse {
+  // Started task resource.
+  Task task = 1;
+}
+
+// Ends a task.
+message EndTaskRequest {
+  // Workspace that scopes the task.
+  Workspace workspace = 1;
+  // Task id to end.
+  string task_id = 2;
+  // Final task status.
+  TaskStatus task_status = 3;
+}
+
+// Returns the task end event.
+message EndTaskResponse {
+  // Persisted task end event.
+  TaskEnd task_end = 1;
+}
+
+// An intent-bearing unit of work.
+message Task {
+  // Server-minted, opaque task id.
+  string task_id = 1;
+}
+
+// A task end event.
+message TaskEnd {
+  // Ended task id.
+  string task_id = 1;
+  // Final task status.
+  TaskStatus task_status = 2;
+}
+
+// Final task status.
+enum TaskStatus {
+  // Unspecified task status; rejected by EndTask.
+  TASK_STATUS_UNSPECIFIED = 0;
+  // Task succeeded.
+  TASK_STATUS_SUCCESS = 1;
+  // Task failed.
+  TASK_STATUS_FAILURE = 2;
+}

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -88,6 +88,19 @@ pub const CORAL_ERROR_DOMAIN: &str = "coral.withcoral.com";
 /// Canonical default workspace name used across local Coral surfaces.
 pub const DEFAULT_WORKSPACE_ID: &str = "default";
 
+/// gRPC metadata key carrying the originating task id on Coral calls after
+/// `TaskService.StartTask`. This is the shared wire-contract constant for
+/// clients and servers that opt into task attribution.
+pub const CORAL_TASK_ID_METADATA_KEY: &str = "coral-task-id";
+
+/// Maximum length of a Coral task id, in bytes. Validated identically server-
+/// and client-side so the contract stays in one place.
+pub const CORAL_TASK_ID_MAX_LEN: usize = 128;
+
+/// Maximum length of a task `intent`, in characters. Generous for a task
+/// description while bounding the per-record lifecycle log size.
+pub const CORAL_TASK_INTENT_MAX_CHARS: usize = 4096;
+
 /// Machine-readable reason for a configured source lookup miss.
 pub const CORAL_ERROR_REASON_SOURCE_NOT_FOUND: &str = "SOURCE_NOT_FOUND";
 


### PR DESCRIPTION
Summary
- Adds the task lifecycle protobuf contract without sessions or subtasks.
- StartTask accepts workspace + intent and returns a UUID task_id.
- EndTask accepts workspace + task_id + task_status, with completed/failed statuses.

Validation
- Full stack validation was run from codex/tasks-sessions-10-docs after rebasing onto origin/main: cargo test -p coral-api -p coral-app -p coral-client -p coral-mcp -p coral-cli; make rust-checks; make docs-check; make perf-check.