### PR TITLE
feat(app): add task domain id

### DIFF
--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -53,6 +53,7 @@ mod search;
 mod sources;
 mod state;
 mod storage;
+mod task;
 pub mod telemetry;
 mod transport;
 mod workspaces;

--- a/crates/coral-app/src/task/id.rs
+++ b/crates/coral-app/src/task/id.rs
@@ -1,0 +1,77 @@
+//! Validated task identifier.
+
+#![allow(
+    dead_code,
+    reason = "The task stack introduces ids before service and store slices consume them."
+)]
+
+use std::fmt;
+
+use crate::bootstrap::AppError;
+
+/// App-owned identity for one validated task id.
+///
+/// Task ids are UUIDs minted by `TaskService.StartTask` and round-trip as the
+/// `coral-task-id` gRPC metadata value on subsequent Coral calls.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct TaskId(uuid::Uuid);
+
+impl TaskId {
+    /// Mint a new server-owned task id.
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self(uuid::Uuid::new_v4())
+    }
+
+    /// Parse and validate a task id from a client or persistence boundary.
+    pub(crate) fn parse(id: &str) -> Result<Self, AppError> {
+        uuid::Uuid::parse_str(id)
+            .map(Self)
+            .map_err(|_err| AppError::InvalidInput("task id must be a UUID".to_string()))
+    }
+
+    /// Borrow the validated UUID for typed boundaries.
+    #[must_use]
+    pub(crate) fn as_uuid(&self) -> &uuid::Uuid {
+        &self.0
+    }
+
+    /// Lower the task id into the validated UUID.
+    #[must_use]
+    pub(crate) fn into_uuid(self) -> uuid::Uuid {
+        self.0
+    }
+}
+
+impl fmt::Display for TaskId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TaskId;
+
+    #[test]
+    fn accepts_uuid() {
+        let task_id =
+            TaskId::parse("550e8400-e29b-41d4-a716-446655440000").expect("task id is valid");
+        assert_eq!(task_id.to_string(), "550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn canonicalizes_simple_uuid() {
+        let task_id = TaskId::parse("550e8400e29b41d4a716446655440000").expect("task id is valid");
+        assert_eq!(task_id.to_string(), "550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn rejects_malformed_ids() {
+        TaskId::parse("").expect_err("empty id must be rejected");
+        TaskId::parse("   ").expect_err("whitespace id must be rejected");
+        TaskId::parse("task_550e8400-e29b-41d4-a716-446655440000")
+            .expect_err("prefixed id must be rejected");
+        TaskId::parse("not-a-uuid").expect_err("malformed id must be rejected");
+    }
+}

--- a/crates/coral-app/src/task/mod.rs
+++ b/crates/coral-app/src/task/mod.rs
@@ -1,0 +1,3 @@
+//! Task lifecycle: intent-bearing units of work.
+
+pub(crate) mod id;


### PR DESCRIPTION
Summary
- Adds the app-owned TaskId domain type.
- Validates UUID task ids and canonicalizes accepted UUID inputs at app boundaries.

Validation
- Full stack validation was run from codex/tasks-sessions-10-docs after rebasing onto origin/main: cargo test -p coral-api -p coral-app -p coral-client -p coral-mcp -p coral-cli; make rust-checks; make docs-check; make perf-check.