### PR TITLE
feat(app): serve task lifecycle rpc

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -19,6 +19,7 @@ use coral_api::v1::feedback_service_server::FeedbackServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::search_service_server::SearchServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
+use coral_api::v1::task_service_server::TaskServiceServer;
 use coral_api::v1::trace_service_server::TraceServiceServer;
 use coral_api::v1::workspace_service_server::WorkspaceServiceServer;
 use coral_api::{
@@ -57,6 +58,9 @@ use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
 use crate::state::{AppStateLayout, ConfigStore};
+use crate::task::manager::TaskManager;
+use crate::task::service::TaskService;
+use crate::task::store::JsonlTaskEventStore;
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcRequestContextLayer;
@@ -312,6 +316,7 @@ impl ServerBuilder {
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
+        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
         let body_capture_max_bytes = telemetry_config
             .trace_history
             .http_body_recording_max_bytes();
@@ -342,6 +347,7 @@ impl ServerBuilder {
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
+                task: task_manager,
             },
             trace_components,
             self.config.user_principal_provider,
@@ -468,6 +474,7 @@ struct ServerManagers {
     query: QueryManager,
     search: SearchManager,
     feedback: FeedbackManager,
+    task: TaskManager,
 }
 
 async fn start_server(
@@ -486,6 +493,7 @@ async fn start_server(
         query,
         search,
         feedback,
+        task,
     } = managers;
     let source_service = SourceService::new(source, query.clone(), workspace.clone());
     let workspace_service = WorkspaceService::new(workspace);
@@ -493,6 +501,7 @@ async fn start_server(
     let query_service = QueryService::new(query);
     let search_service = SearchService::new(search);
     let feedback_service = FeedbackService::new(feedback);
+    let task_service = TaskService::new(task);
     let mut routes = Routes::default()
         .add_service(
             SourceServiceServer::new(source_service)
@@ -504,6 +513,7 @@ async fn start_server(
                 .max_encoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE),
         )
         .add_service(FeedbackServiceServer::new(feedback_service))
+        .add_service(TaskServiceServer::new(task_service))
         .add_service(
             QueryServiceServer::new(query_service)
                 .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
@@ -743,10 +753,12 @@ mod tests {
 
     use coral_api::v1::query_service_client::QueryServiceClient;
     use coral_api::v1::source_service_client::SourceServiceClient;
+    use coral_api::v1::task_service_client::TaskServiceClient;
     use coral_api::v1::trace_service_client::TraceServiceClient;
     use coral_api::v1::{
-        ExecuteSqlRequest, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
-        ListTracesRequest, Workspace, import_source_response,
+        EndTaskRequest, ExecuteSqlRequest, ImportSourceRequest, ImportSourceResponse,
+        ListSourcesRequest, ListTracesRequest, StartTaskRequest, TaskStatus, Workspace,
+        import_source_response,
     };
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
@@ -765,6 +777,8 @@ mod tests {
     use crate::sources::manager::SourceManager;
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
     use crate::state::{AppStateLayout, ConfigStore};
+    use crate::task::manager::TaskManager;
+    use crate::task::store::JsonlTaskEventStore;
     use crate::telemetry::service::TraceService;
     use crate::transport::workspace_to_proto;
     use crate::workspaces::{WorkspaceManager, WorkspaceName};
@@ -879,6 +893,66 @@ backend = "unsupported"
             "unsupported database config should abort startup after database cutover"
         );
     }
+
+    #[tokio::test]
+    async fn task_lifecycle_through_server_persists() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        disable_internal_tracing(&config_dir);
+        let server = ServerBuilder::new()
+            .with_config_dir(config_dir.clone())
+            .start()
+            .await
+            .expect("start server");
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        let mut task_client = TaskServiceClient::new(channel);
+
+        let task = task_client
+            .start_task(Request::new(StartTaskRequest {
+                workspace: Some(default_workspace()),
+                intent: "find the HR onboarding form".to_string(),
+            }))
+            .await
+            .expect("start task")
+            .into_inner()
+            .task
+            .expect("task");
+        uuid::Uuid::parse_str(&task.task_id).expect("task id is a UUID");
+
+        let task_end = task_client
+            .end_task(Request::new(EndTaskRequest {
+                workspace: Some(default_workspace()),
+                task_id: task.task_id.clone(),
+                task_status: TaskStatus::Success as i32,
+            }))
+            .await
+            .expect("end task")
+            .into_inner()
+            .task_end
+            .expect("task end");
+        assert_eq!(task_end.task_id, task.task_id);
+        assert_eq!(task_end.task_status, TaskStatus::Success as i32);
+
+        let layout = AppStateLayout::discover(Some(config_dir)).expect("layout");
+        let workspace = WorkspaceName::default();
+        let tasks =
+            std::fs::read_to_string(layout.task_events_file(&workspace)).expect("task events file");
+        assert!(tasks.contains(&task.task_id));
+        assert!(
+            tasks.contains("find the HR onboarding form"),
+            "task events should contain start intent, got: {tasks}"
+        );
+        assert!(
+            tasks.contains("success"),
+            "task events should contain end status, got: {tasks}"
+        );
+        server.shutdown().await.expect("shutdown");
+    }
+
     #[tokio::test]
     async fn trace_service_lists_empty_store() {
         let temp = TempDir::new().expect("temp dir");
@@ -895,6 +969,7 @@ backend = "unsupported"
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
+        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -921,6 +996,7 @@ backend = "unsupported"
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
+                task: task_manager,
             },
             TraceServerComponents {
                 service: Some(trace_service),
@@ -1332,6 +1408,7 @@ tables:
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
+        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -1359,6 +1436,7 @@ tables:
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
+                task: task_manager,
             },
             TraceServerComponents::default(),
             Arc::new(SingleUserPrincipalProvider),
@@ -1450,6 +1528,7 @@ tables:
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
+        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -1474,6 +1553,7 @@ tables:
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
+                task: task_manager,
             },
             TraceServerComponents::default(),
             Arc::new(SingleUserPrincipalProvider),
@@ -1565,6 +1645,7 @@ tables:
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
+        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -1589,6 +1670,7 @@ tables:
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
+                task: task_manager,
             },
             TraceServerComponents::default(),
             Arc::new(SingleUserPrincipalProvider),

--- a/crates/coral-app/src/task/manager.rs
+++ b/crates/coral-app/src/task/manager.rs
@@ -1,0 +1,61 @@
+//! App-domain task lifecycle orchestration.
+
+use std::sync::Arc;
+
+use super::id::TaskId;
+use super::store::{TaskEnd, TaskEventStore, TaskStart, TaskStatus, TaskStoreError};
+use crate::workspaces::WorkspaceName;
+
+/// Coordinates task lifecycle persistence and validation.
+#[derive(Clone)]
+pub(crate) struct TaskManager {
+    store: Arc<dyn TaskEventStore>,
+}
+
+impl TaskManager {
+    pub(crate) fn new(store: Arc<dyn TaskEventStore>) -> Self {
+        Self { store }
+    }
+
+    pub(crate) fn start_task(
+        &self,
+        workspace: WorkspaceName,
+        intent: String,
+    ) -> Result<TaskStart, TaskManagerError> {
+        let start = TaskStart {
+            id: TaskId::new(),
+            workspace,
+            intent,
+        };
+        self.store.start_task(&start)?;
+        Ok(start)
+    }
+
+    pub(crate) fn end_task(
+        &self,
+        workspace: WorkspaceName,
+        task_id: TaskId,
+        status: TaskStatus,
+    ) -> Result<TaskEnd, TaskManagerError> {
+        if !self.store.contains_started_task(&workspace, &task_id)? {
+            return Err(TaskManagerError::TaskNotFound {
+                task_id: task_id.to_string(),
+            });
+        }
+        let end = TaskEnd {
+            id: task_id,
+            workspace,
+            status,
+        };
+        self.store.end_task(&end)?;
+        Ok(end)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum TaskManagerError {
+    #[error("task '{task_id}' was not found")]
+    TaskNotFound { task_id: String },
+    #[error(transparent)]
+    Store(#[from] TaskStoreError),
+}

--- a/crates/coral-app/src/task/mod.rs
+++ b/crates/coral-app/src/task/mod.rs
@@ -1,4 +1,6 @@
 //! Task lifecycle: intent-bearing units of work.
 
 pub(crate) mod id;
+pub(crate) mod manager;
+pub(crate) mod service;
 pub(crate) mod store;

--- a/crates/coral-app/src/task/service.rs
+++ b/crates/coral-app/src/task/service.rs
@@ -1,0 +1,275 @@
+//! gRPC `TaskService` for task lifecycle events.
+
+use coral_api::v1::task_service_server::TaskService as TaskServiceApi;
+use coral_api::v1::{
+    EndTaskRequest, EndTaskResponse, StartTaskRequest, StartTaskResponse, Task as ProtoTask,
+    TaskEnd as ProtoTaskEnd, TaskStatus as ProtoTaskStatus,
+};
+use tonic::{Request, Response, Status};
+use tracing::warn;
+
+use super::id::TaskId;
+use super::manager::{TaskManager, TaskManagerError};
+use super::store::{TaskEnd, TaskStart, TaskStatus as DomainTaskStatus, TaskStoreError};
+use crate::bootstrap::app_status;
+use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto};
+
+#[derive(Clone)]
+pub(crate) struct TaskService {
+    task: TaskManager,
+}
+
+impl TaskService {
+    pub(crate) fn new(task: TaskManager) -> Self {
+        Self { task }
+    }
+}
+
+#[tonic::async_trait]
+impl TaskServiceApi for TaskService {
+    async fn start_task(
+        &self,
+        request: Request<StartTaskRequest>,
+    ) -> Result<Response<StartTaskResponse>, Status> {
+        let span = grpc_span(&request);
+        let task = self.task.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
+            let start = task
+                .start_task(workspace, request.intent)
+                .map_err(|error| task_manager_status(&error))?;
+            Ok(Response::new(StartTaskResponse {
+                task: Some(task_start_to_proto(&start)),
+            }))
+        })
+        .await
+    }
+
+    async fn end_task(
+        &self,
+        request: Request<EndTaskRequest>,
+    ) -> Result<Response<EndTaskResponse>, Status> {
+        let span = grpc_span(&request);
+        let task = self.task.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
+            let task_id = TaskId::parse(&request.task_id).map_err(app_status)?;
+            let task_status = task_status_from_proto(request.task_status).map_err(app_status)?;
+            let end = task
+                .end_task(workspace, task_id, task_status)
+                .map_err(|error| task_manager_status(&error))?;
+            Ok(Response::new(EndTaskResponse {
+                task_end: Some(task_end_to_proto(&end)),
+            }))
+        })
+        .await
+    }
+}
+
+pub(crate) fn task_start_to_proto(start: &TaskStart) -> ProtoTask {
+    ProtoTask {
+        task_id: start.id.to_string(),
+    }
+}
+
+pub(crate) fn task_end_to_proto(end: &TaskEnd) -> ProtoTaskEnd {
+    ProtoTaskEnd {
+        task_id: end.id.to_string(),
+        task_status: task_status_to_proto(end.status) as i32,
+    }
+}
+
+fn task_status_from_proto(status: i32) -> Result<DomainTaskStatus, crate::bootstrap::AppError> {
+    match ProtoTaskStatus::try_from(status) {
+        Ok(ProtoTaskStatus::Success) => Ok(DomainTaskStatus::Success),
+        Ok(ProtoTaskStatus::Failure) => Ok(DomainTaskStatus::Failure),
+        Ok(ProtoTaskStatus::Unspecified) => Err(crate::bootstrap::AppError::InvalidInput(
+            "task status must be success or failure".to_string(),
+        )),
+        Err(_) => Err(crate::bootstrap::AppError::InvalidInput(
+            "unknown task status".to_string(),
+        )),
+    }
+}
+
+fn task_status_to_proto(status: DomainTaskStatus) -> ProtoTaskStatus {
+    match status {
+        DomainTaskStatus::Success => ProtoTaskStatus::Success,
+        DomainTaskStatus::Failure => ProtoTaskStatus::Failure,
+    }
+}
+
+fn task_manager_status(error: &TaskManagerError) -> Status {
+    match error {
+        TaskManagerError::TaskNotFound { .. } => Status::not_found(error.to_string()),
+        TaskManagerError::Store(TaskStoreError::InvalidIntent { .. }) => {
+            Status::invalid_argument(error.to_string())
+        }
+        TaskManagerError::Store(TaskStoreError::Io(_) | TaskStoreError::Serde(_)) => {
+            warn!(%error, "failed to persist task lifecycle event");
+            Status::internal("failed to persist task lifecycle event")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::sync::Arc;
+
+    use coral_api::v1::{EndTaskRequest, StartTaskRequest, TaskStatus, Workspace};
+    use tempfile::TempDir;
+    use tonic::{Code, Request};
+
+    use super::{TaskService, TaskServiceApi};
+    use crate::state::AppStateLayout;
+    use crate::task::manager::TaskManager;
+    use crate::task::store::JsonlTaskEventStore;
+    use crate::workspaces::WorkspaceName;
+
+    const UNKNOWN_TASK_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+    fn service() -> (TempDir, AppStateLayout, TaskService) {
+        let dir = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(dir.path().join("coral-config")))
+            .expect("layout should resolve");
+        let task = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
+        let service = TaskService::new(task);
+        (dir, layout, service)
+    }
+
+    fn workspace(name: &str) -> Workspace {
+        Workspace {
+            name: name.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn start_task_persists_task() {
+        let (_dir, layout, service) = service();
+
+        let response = service
+            .start_task(Request::new(StartTaskRequest {
+                workspace: Some(workspace("acme")),
+                intent: "Find renewal risk".to_string(),
+            }))
+            .await
+            .expect("start task")
+            .into_inner();
+
+        let task = response.task.expect("task");
+        uuid::Uuid::parse_str(&task.task_id).expect("task id is a UUID");
+        let raw =
+            fs::read_to_string(layout.task_events_file(&WorkspaceName::parse("acme").unwrap()))
+                .expect("task file");
+        assert!(raw.contains(&task.task_id));
+        assert!(raw.contains("Find renewal risk"));
+    }
+
+    #[tokio::test]
+    async fn end_task_persists_success_status() {
+        let (_dir, layout, service) = service();
+
+        let task = service
+            .start_task(Request::new(StartTaskRequest {
+                workspace: Some(workspace("default")),
+                intent: "Find renewal risk".to_string(),
+            }))
+            .await
+            .expect("start task")
+            .into_inner()
+            .task
+            .expect("task");
+        let response = service
+            .end_task(Request::new(EndTaskRequest {
+                workspace: Some(workspace("default")),
+                task_id: task.task_id.clone(),
+                task_status: TaskStatus::Success as i32,
+            }))
+            .await
+            .expect("end task")
+            .into_inner();
+
+        let task_end = response.task_end.expect("task end");
+        assert_eq!(task_end.task_id, task.task_id);
+        assert_eq!(task_end.task_status, TaskStatus::Success as i32);
+        let raw = fs::read_to_string(layout.task_events_file(&WorkspaceName::default()))
+            .expect("task file");
+        assert!(raw.contains("success"), "got: {raw}");
+    }
+
+    #[tokio::test]
+    async fn start_task_rejects_blank_intent() {
+        let (_dir, _layout, service) = service();
+
+        let status = service
+            .start_task(Request::new(StartTaskRequest {
+                workspace: Some(workspace("default")),
+                intent: " ".to_string(),
+            }))
+            .await
+            .expect_err("blank intent must be rejected");
+
+        assert_eq!(status.code(), Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn end_task_rejects_unknown_task() {
+        let (_dir, _layout, service) = service();
+
+        let status = service
+            .end_task(Request::new(EndTaskRequest {
+                workspace: Some(workspace("default")),
+                task_id: UNKNOWN_TASK_ID.to_string(),
+                task_status: TaskStatus::Success as i32,
+            }))
+            .await
+            .expect_err("unknown task must be rejected");
+
+        assert_eq!(status.code(), Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn end_task_rejects_malformed_task_id() {
+        let (_dir, _layout, service) = service();
+
+        let status = service
+            .end_task(Request::new(EndTaskRequest {
+                workspace: Some(workspace("default")),
+                task_id: "not-a-uuid".to_string(),
+                task_status: TaskStatus::Success as i32,
+            }))
+            .await
+            .expect_err("malformed task id must be rejected");
+
+        assert_eq!(status.code(), Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn end_task_rejects_unspecified_status() {
+        let (_dir, _layout, service) = service();
+        let task = service
+            .start_task(Request::new(StartTaskRequest {
+                workspace: Some(workspace("default")),
+                intent: "Find renewal risk".to_string(),
+            }))
+            .await
+            .expect("start task")
+            .into_inner()
+            .task
+            .expect("task");
+
+        let status = service
+            .end_task(Request::new(EndTaskRequest {
+                workspace: Some(workspace("default")),
+                task_id: task.task_id,
+                task_status: TaskStatus::Unspecified as i32,
+            }))
+            .await
+            .expect_err("unspecified status must be rejected");
+
+        assert_eq!(status.code(), Code::InvalidArgument);
+    }
+}


### PR DESCRIPTION
Summary
- Wires TaskService into the app server.
- Mints UUID task ids on StartTask and validates known task ids/statuses on EndTask.

Validation
- Full stack validation was run from codex/tasks-sessions-10-docs after rebasing onto origin/main: cargo test -p coral-api -p coral-app -p coral-client -p coral-mcp -p coral-cli; make rust-checks; make docs-check; make perf-check.