### PR TITLE
feat(app): attribute queries to task ids

### DIFF
--- a/crates/coral-app/src/feedback/manager.rs
+++ b/crates/coral-app/src/feedback/manager.rs
@@ -10,6 +10,7 @@ use crate::feedback::publisher::FeedbackPublisher;
 use crate::feedback::publisher::NoopFeedbackPublisher;
 use crate::state::AppStateLayout;
 use crate::storage::fs::{self as storage_fs, FileLock};
+use crate::task::id::TaskId;
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug, Clone)]
@@ -20,6 +21,7 @@ pub(crate) struct FeedbackReport {
     pub(crate) trying_to_do: String,
     pub(crate) tried: String,
     pub(crate) stuck: String,
+    pub(crate) task_id: Option<TaskId>,
 }
 
 #[derive(Debug, Clone)]
@@ -63,6 +65,8 @@ struct PersistedFeedbackReport<'a> {
     trying_to_do: &'a str,
     tried: &'a str,
     stuck: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    task_id: Option<&'a str>,
 }
 
 #[derive(Clone)]
@@ -90,6 +94,7 @@ impl FeedbackManager {
         trying_to_do: &str,
         tried: &str,
         stuck: &str,
+        task_id: Option<TaskId>,
     ) -> Result<FeedbackSubmission, AppError> {
         let report = FeedbackReport {
             id: Uuid::new_v4().to_string(),
@@ -98,6 +103,7 @@ impl FeedbackManager {
             trying_to_do: required_text("trying_to_do", trying_to_do)?,
             tried: required_text("tried", tried)?,
             stuck: required_text("stuck", stuck)?,
+            task_id,
         };
         self.append_report(&report)?;
         self.spawn_publish(report.clone());
@@ -115,6 +121,7 @@ impl FeedbackManager {
     fn append_report(&self, report: &FeedbackReport) -> Result<(), AppError> {
         let _lock = FileLock::exclusive(self.layout.state_lock())?;
         let file = self.layout.feedback_reports_file(&report.workspace);
+        let task_id = report.task_id.map(|task_id| task_id.to_string());
         let persisted = PersistedFeedbackReport {
             id: &report.id,
             workspace: report.workspace.as_str(),
@@ -122,6 +129,7 @@ impl FeedbackManager {
             trying_to_do: &report.trying_to_do,
             tried: &report.tried,
             stuck: &report.stuck,
+            task_id: task_id.as_deref(),
         };
         let mut line = serde_json::to_vec(&persisted)?;
         line.push(b'\n');
@@ -166,7 +174,7 @@ mod tests {
         let manager = FeedbackManager::new(layout.clone());
 
         let submission = manager
-            .submit_feedback(&workspace, " trying ", " tried ", " stuck ")
+            .submit_feedback(&workspace, " trying ", " tried ", " stuck ", None)
             .expect("feedback should submit");
         let report = submission.report;
 
@@ -182,6 +190,7 @@ mod tests {
         assert_eq!(value["trying_to_do"], "trying");
         assert_eq!(value["tried"], "tried");
         assert_eq!(value["stuck"], "stuck");
+        assert!(value.get("task_id").is_none());
         assert!(
             value["created_at"]
                 .as_str()
@@ -198,7 +207,7 @@ mod tests {
         let manager = FeedbackManager::new(layout.clone());
 
         let error = manager
-            .submit_feedback(&workspace, "trying", " ", "stuck")
+            .submit_feedback(&workspace, "trying", " ", "stuck", None)
             .expect_err("blank feedback should fail");
 
         assert!(
@@ -224,7 +233,7 @@ mod tests {
         );
 
         let submission = manager
-            .submit_feedback(&workspace, "trying", "tried", "stuck")
+            .submit_feedback(&workspace, "trying", "tried", "stuck", None)
             .expect("feedback should submit");
 
         assert!(!submission.report.id.is_empty());
@@ -233,6 +242,28 @@ mod tests {
             .expect("hosted publish task should start")
             .expect("hosted publish task should signal start");
         assert!(layout.feedback_reports_file(&workspace).exists());
+    }
+
+    #[tokio::test]
+    async fn submit_feedback_appends_task_id_when_present() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+        let workspace = WorkspaceName::default();
+        let manager = FeedbackManager::new(layout.clone());
+        let task_id = crate::task::id::TaskId::parse("550e8400-e29b-41d4-a716-446655440000")
+            .expect("task id should parse");
+
+        let submission = manager
+            .submit_feedback(&workspace, "trying", "tried", "stuck", Some(task_id))
+            .expect("feedback should submit");
+
+        assert_eq!(submission.report.task_id.as_ref(), Some(&task_id));
+        let raw = fs::read_to_string(layout.feedback_reports_file(&workspace))
+            .expect("feedback file should exist");
+        let value: Value =
+            serde_json::from_str(raw.lines().next().expect("jsonl record")).expect("valid json");
+        assert_eq!(value["task_id"], task_id.to_string());
     }
 
     struct PendingFeedbackPublisher {

--- a/crates/coral-app/src/feedback/publisher.rs
+++ b/crates/coral-app/src/feedback/publisher.rs
@@ -106,6 +106,7 @@ impl<'a> FeedbackEnvelope<'a> {
                 trying_to_do: &report.trying_to_do,
                 tried: &report.tried,
                 stuck: &report.stuck,
+                task_id: report.task_id.map(|task_id| task_id.to_string()),
             },
             client: FeedbackEnvelopeClient {
                 coral_version: env!("CARGO_PKG_VERSION"),
@@ -122,6 +123,8 @@ struct FeedbackEnvelopeReport<'a> {
     trying_to_do: &'a str,
     tried: &'a str,
     stuck: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    task_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -174,6 +177,7 @@ mod tests {
             trying_to_do: "trying".to_string(),
             tried: "tried".to_string(),
             stuck: "stuck".to_string(),
+            task_id: None,
         };
         let publisher = HostedFeedbackPublisher::with_endpoint(format!("http://{addr}/ingest"));
 
@@ -195,10 +199,38 @@ mod tests {
         assert_eq!(body["report"]["trying_to_do"], "trying");
         assert_eq!(body["report"]["tried"], "tried");
         assert_eq!(body["report"]["stuck"], "stuck");
+        assert!(
+            body["report"].get("task_id").is_none(),
+            "task_id should be omitted when feedback is not task attributed"
+        );
         assert_eq!(body["client"]["coral_version"], env!("CARGO_PKG_VERSION"));
         assert_eq!(body["client"].as_object().expect("client object").len(), 1);
 
         server.abort();
+    }
+
+    #[test]
+    fn feedback_envelope_includes_task_id_when_present() {
+        let report = FeedbackReport {
+            id: "feedback-123".to_string(),
+            workspace: WorkspaceName::default(),
+            created_at: Utc::now(),
+            trying_to_do: "trying".to_string(),
+            tried: "tried".to_string(),
+            stuck: "stuck".to_string(),
+            task_id: Some(
+                crate::task::id::TaskId::parse("550e8400-e29b-41d4-a716-446655440000")
+                    .expect("task id"),
+            ),
+        };
+
+        let body = serde_json::to_value(super::FeedbackEnvelope::new(&report))
+            .expect("feedback envelope JSON");
+
+        assert_eq!(
+            body["report"]["task_id"],
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
     }
 
     async fn read_http_body(stream: &mut tokio::net::TcpStream) -> Vec<u8> {

--- a/crates/coral-app/src/feedback/service.rs
+++ b/crates/coral-app/src/feedback/service.rs
@@ -6,6 +6,7 @@ use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
 use crate::feedback::manager::{FeedbackManager, FeedbackReport};
+use crate::task::id::TaskId;
 use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto, workspace_to_proto};
 
 #[derive(Clone)]
@@ -26,6 +27,7 @@ impl FeedbackServiceApi for FeedbackService {
         request: Request<SubmitFeedbackRequest>,
     ) -> Result<Response<SubmitFeedbackResponse>, Status> {
         let span = grpc_span(&request);
+        let task_id = request.extensions().get::<TaskId>().copied();
         let feedback = self.feedback.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -36,6 +38,7 @@ impl FeedbackServiceApi for FeedbackService {
                     &request.trying_to_do,
                     &request.tried,
                     &request.stuck,
+                    task_id,
                 )
                 .map_err(app_status)?;
             Ok(Response::new(SubmitFeedbackResponse {

--- a/crates/coral-app/src/query/attribution.rs
+++ b/crates/coral-app/src/query/attribution.rs
@@ -2,15 +2,27 @@
 
 use tonic::codegen::http;
 
+use crate::task::id::TaskId;
+
 /// Request-scoped attribution threaded from the gRPC service edge into the query
 /// manager, so transport concerns (gRPC metadata, OpenTelemetry baggage) stay
 /// out of the manager and off the deeper query path.
+///
+/// It carries the optional originating task; the manager stamps `task.id` on
+/// the `coral.query` span so trace consumers can join a task's queries to the
+/// intent registered by `TaskService.StartTask`. Intent itself is never carried
+/// here; only the opaque id is propagated.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct QueryAttribution;
+pub(crate) struct QueryAttribution {
+    /// The task whose intent this query served, when the caller supplied a
+    /// valid `coral-task-id`; `None` for an untagged query.
+    pub(crate) task_id: Option<TaskId>,
+}
 
 impl QueryAttribution {
     pub(crate) fn from_extensions(extensions: &http::Extensions) -> Self {
-        let _ = extensions;
-        Self
+        Self {
+            task_id: extensions.get::<TaskId>().copied(),
+        }
     }
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -31,6 +31,7 @@ use crate::sources::materialization::{
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::runtime_components_for_v4_source;
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
+use crate::task::id::TaskId;
 use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
 use crate::workspaces::{WorkspaceManager, WorkspaceName};
 
@@ -92,13 +93,14 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
-        _attribution: &QueryAttribution,
+        attribution: &QueryAttribution,
     ) -> Result<Vec<TableInfo>, QueryManagerError> {
         let trace_sql = list_tables_trace_sql(schema_filter, table_filter);
         run_query_operation(
             QueryOperation::ListTables,
             workspace_name,
             &trace_sql,
+            attribution.task_id.as_ref(),
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
@@ -127,13 +129,14 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         schema_filter: Option<&str>,
-        _attribution: &QueryAttribution,
+        attribution: &QueryAttribution,
     ) -> Result<CatalogInfo, QueryManagerError> {
         let trace_sql = list_catalog_trace_sql(schema_filter);
         run_query_operation(
             QueryOperation::ListCatalog,
             workspace_name,
             &trace_sql,
+            attribution.task_id.as_ref(),
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
@@ -173,13 +176,14 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         schema_name: &str,
         table_name: &str,
-        _attribution: &QueryAttribution,
+        attribution: &QueryAttribution,
     ) -> Result<DescribeTableInfo, QueryManagerError> {
         let trace_sql = describe_table_trace_sql(schema_name, table_name);
         run_query_operation(
             QueryOperation::DescribeTable,
             workspace_name,
             &trace_sql,
+            attribution.task_id.as_ref(),
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
@@ -203,12 +207,13 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         sql: &str,
-        _attribution: &QueryAttribution,
+        attribution: &QueryAttribution,
     ) -> Result<QueryExecution, QueryManagerError> {
         run_query_operation(
             QueryOperation::ExecuteSql,
             workspace_name,
             sql,
+            attribution.task_id.as_ref(),
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
@@ -232,12 +237,13 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         sql: &str,
-        _attribution: &QueryAttribution,
+        attribution: &QueryAttribution,
     ) -> Result<QueryPlan, QueryManagerError> {
         run_query_operation(
             QueryOperation::ExplainSql,
             workspace_name,
             sql,
+            attribution.task_id.as_ref(),
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
@@ -561,6 +567,7 @@ async fn run_query_operation<T, Fut, RowCount>(
     operation: QueryOperation,
     workspace_name: &WorkspaceName,
     sql: &str,
+    task_id: Option<&TaskId>,
     query: Fut,
     row_count: RowCount,
     record_success_fields: impl FnOnce(&tracing::Span, &T),
@@ -570,7 +577,7 @@ where
     RowCount: FnOnce(&T) -> Option<u64>,
 {
     let started_at = Instant::now();
-    let query_span = create_query_span(operation, workspace_name, sql);
+    let query_span = create_query_span(operation, workspace_name, sql, task_id);
     let result = query.instrument(query_span.clone()).await;
 
     let row_count = result.as_ref().ok().and_then(row_count);
@@ -608,6 +615,7 @@ fn create_query_span(
     operation: QueryOperation,
     workspace_name: &WorkspaceName,
     sql: &str,
+    task_id: Option<&TaskId>,
 ) -> tracing::Span {
     let operation = operation.as_str();
     let span = tracing::info_span!(
@@ -616,6 +624,7 @@ fn create_query_span(
         operation = operation,
         workspace = tracing::field::Empty,
         sql = %sql,
+        task.id = tracing::field::Empty,
         row_count = tracing::field::Empty,
         coral.query.sources = tracing::field::Empty,
         coral.query.tables = tracing::field::Empty,
@@ -625,6 +634,9 @@ fn create_query_span(
         error.type = tracing::field::Empty,
         exception.message = tracing::field::Empty,
     );
+    if let Some(task_id) = task_id {
+        span.record("task.id", tracing::field::display(task_id));
+    }
     span.record(WORKSPACE_SPAN_ATTRIBUTE, workspace_name.as_str());
     span
 }
@@ -891,6 +903,90 @@ mod tests {
         }
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn execute_sql_stamps_task_id_on_query_span() {
+        use coral_api::v1::query_service_server::QueryService as QueryServiceApi;
+        use coral_api::v1::{ExecuteSqlRequest, Workspace};
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+        use tonic::Request;
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        use crate::query::service::QueryService;
+
+        // Capture finished spans into memory via a scoped subscriber so the
+        // assertion exercises the real metadata -> manager -> span path end to end.
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("task-attribution-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
+        let service = QueryService::new(fixture.manager.clone());
+
+        let mut request = Request::new(ExecuteSqlRequest {
+            workspace: Some(Workspace {
+                name: WorkspaceName::default().as_str().to_string(),
+            }),
+            sql: "SELECT 1".to_string(),
+        });
+        request.extensions_mut().insert(
+            crate::task::id::TaskId::parse("550e8400-e29b-41d4-a716-446655440000")
+                .expect("task id"),
+        );
+
+        // The query may fail (the fixture has no installed sources); the
+        // `coral.query` span is created and stamped before execution regardless.
+        let _result = service.execute_sql(request).await;
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let query_span = spans
+            .iter()
+            .find(|span| span.name == "coral.query")
+            .expect("coral.query span recorded");
+        let task_attr = query_span
+            .attributes
+            .iter()
+            .find(|attribute| attribute.key.as_str() == "task.id")
+            .expect("task.id attribute present");
+        assert_eq!(
+            task_attr.value.as_str(),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn catalog_service_stamps_task_id_on_query_spans() {
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        use crate::catalog::service::CatalogService;
+
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("catalog-task-attribution-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
+        let service = CatalogService::new(fixture.manager.clone());
+
+        call_catalog_tools_with_task(&service).await;
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        assert_catalog_task_spans(&spans);
+    }
+
     #[test]
     fn query_provenance_records_trace_attributes() {
         use opentelemetry::trace::TracerProvider as _;
@@ -910,6 +1006,7 @@ mod tests {
             QueryOperation::ExecuteSql,
             &WorkspaceName::default(),
             "SELECT title FROM github.issues",
+            None,
         );
         let provenance = QueryExecutionProvenance::new(
             "SELECT title FROM github.issues",
@@ -951,6 +1048,116 @@ mod tests {
                 r#"[{"source_name":"github","schema_name":"github","function_name":"search_issues"}]"#
                     .to_string()
             )
+        );
+    }
+
+    async fn call_catalog_tools_with_task(service: &crate::catalog::service::CatalogService) {
+        use coral_api::v1::catalog_service_server::CatalogService as CatalogServiceApi;
+        use coral_api::v1::{
+            DescribeTableRequest, ListCatalogRequest, ListColumnsRequest, PaginationRequest,
+            SearchCatalogRequest,
+        };
+
+        let _list_catalog_result = service
+            .list_catalog(tagged_catalog_request(ListCatalogRequest {
+                workspace: Some(default_workspace_proto()),
+                schema_name: String::new(),
+                kind: 0,
+                pagination: Some(PaginationRequest {
+                    limit: 10,
+                    offset: 0,
+                }),
+            }))
+            .await;
+        let _search_catalog_result = service
+            .search_catalog(tagged_catalog_request(SearchCatalogRequest {
+                workspace: Some(default_workspace_proto()),
+                pattern: "tables".to_string(),
+                ignore_case: true,
+                schema_name: String::new(),
+                kind: 0,
+                pagination: Some(PaginationRequest {
+                    limit: 10,
+                    offset: 0,
+                }),
+            }))
+            .await;
+        let _describe_table_result = service
+            .describe_table(tagged_catalog_request(DescribeTableRequest {
+                workspace: Some(default_workspace_proto()),
+                schema_name: "coral".to_string(),
+                table_name: "tables".to_string(),
+            }))
+            .await;
+        let _list_columns_result = service
+            .list_columns(tagged_catalog_request(ListColumnsRequest {
+                workspace: Some(default_workspace_proto()),
+                schema_name: "coral".to_string(),
+                table_name: "tables".to_string(),
+                pattern: None,
+                ignore_case: true,
+                required_only: false,
+                pagination: Some(PaginationRequest {
+                    limit: 10,
+                    offset: 0,
+                }),
+            }))
+            .await;
+    }
+
+    fn default_workspace_proto() -> coral_api::v1::Workspace {
+        coral_api::v1::Workspace {
+            name: WorkspaceName::default().as_str().to_string(),
+        }
+    }
+
+    fn tagged_catalog_request<T>(message: T) -> tonic::Request<T> {
+        let mut request = tonic::Request::new(message);
+        request.extensions_mut().insert(
+            crate::task::id::TaskId::parse("650e8400-e29b-41d4-a716-446655440000")
+                .expect("task id"),
+        );
+        request
+    }
+
+    fn assert_catalog_task_spans(spans: &[opentelemetry_sdk::trace::SpanData]) {
+        let attributed_query_spans = spans
+            .iter()
+            .filter(|span| {
+                span.name == "coral.query"
+                    && span.attributes.iter().any(|attribute| {
+                        attribute.key.as_str() == "task.id"
+                            && attribute.value.as_str() == "650e8400-e29b-41d4-a716-446655440000"
+                    })
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            attributed_query_spans.len() >= 4,
+            "each catalog service call should stamp a backend query span: {spans:?}"
+        );
+        let operations = attributed_query_spans
+            .iter()
+            .flat_map(|span| {
+                span.attributes
+                    .iter()
+                    .filter(|attribute| attribute.key.as_str() == "operation")
+                    .map(|attribute| attribute.value.as_str().to_string())
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            operations
+                .iter()
+                .any(|operation| operation == "list_catalog")
+        );
+        assert!(
+            operations
+                .iter()
+                .any(|operation| operation == "describe_table")
+        );
+        assert!(
+            operations
+                .iter()
+                .any(|operation| operation == "list_tables")
         );
     }
 
@@ -1152,7 +1359,7 @@ surfaces:
             .execute_sql(
                 &workspace_name,
                 "SELECT id, title FROM github_v4_query.issues",
-                &QueryAttribution,
+                &QueryAttribution::default(),
             )
             .await
             .expect("query executes");
@@ -1233,7 +1440,7 @@ surfaces:
             .execute_sql(
                 &workspace_name,
                 "SELECT id FROM github_v4_pagination_override.widgets LIMIT 3",
-                &QueryAttribution,
+                &QueryAttribution::default(),
             )
             .await
             .expect("query executes");

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use coral_api::{
-    CORAL_ERROR_DOMAIN, grpc_response_status_code,
+    CORAL_ERROR_DOMAIN, CORAL_TASK_ID_METADATA_KEY, grpc_response_status_code,
     v1::{
         CatalogItem as ProtoCatalogItem, CatalogSearchResult as ProtoCatalogSearchResult, Column,
         ColumnSearchResult as ProtoColumnSearchResult,
@@ -37,6 +37,7 @@ use crate::identity::{
 };
 use crate::query::manager::QueryManagerError;
 use crate::request_context::RequestContext;
+use crate::task::id::TaskId;
 use crate::workspaces::WorkspaceName;
 
 struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
@@ -281,6 +282,24 @@ fn grpc_method<T>(request: &Request<T>) -> GrpcMethodMetadata {
 fn annotate_request_context<B>(request: &mut http::Request<B>) {
     if let Some(method) = GrpcServerMethod::from_path(request.uri().path()) {
         request.extensions_mut().insert(method);
+    }
+    if let Some(task_id) = request
+        .headers()
+        .get(CORAL_TASK_ID_METADATA_KEY)
+        .and_then(task_id_from_header_value)
+    {
+        request.extensions_mut().insert(task_id);
+    }
+}
+
+fn task_id_from_header_value(value: &http::HeaderValue) -> Option<TaskId> {
+    let value = value.to_str().ok()?;
+    match TaskId::parse(value) {
+        Ok(task_id) => Some(task_id),
+        Err(error) => {
+            tracing::debug!(%error, "ignoring malformed coral-task-id metadata");
+            None
+        }
     }
 }
 
@@ -599,13 +618,13 @@ mod tests {
     )]
 
     use coral_api::{
-        grpc_response_status_code,
+        CORAL_TASK_ID_METADATA_KEY, grpc_response_status_code,
         v1::{QueryTestFailure, Workspace, query_test_result},
     };
     use tonic::{Code, Request};
 
     use super::{
-        GrpcMethodMetadata, GrpcServerMethod, grpc_method, query_status,
+        GrpcMethodMetadata, GrpcServerMethod, annotate_request_context, grpc_method, query_status,
         query_test_result_to_proto, table_function_to_proto, table_summary_to_proto,
         table_to_proto, user_principal_provider_status, workspace_name_from_proto,
         workspace_to_proto,
@@ -613,6 +632,7 @@ mod tests {
     use crate::bootstrap::AppError;
     use crate::identity::UserPrincipalProviderError;
     use crate::query::manager::QueryManagerError;
+    use crate::task::id::TaskId;
     use crate::workspaces::WorkspaceName;
     use coral_engine::{
         ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableFunctionInfo,
@@ -723,6 +743,50 @@ mod tests {
             workspace_name_from_proto(Some(&workspace)).expect("workspace should parse");
 
         assert_eq!(workspace_name.as_str(), "default");
+    }
+
+    #[test]
+    fn annotate_request_context_extracts_valid_task_id() {
+        let mut request = tonic::codegen::http::Request::builder()
+            .uri("/coral.v1.QueryService/ExecuteSql")
+            .header(
+                CORAL_TASK_ID_METADATA_KEY,
+                "750e8400-e29b-41d4-a716-446655440000",
+            )
+            .body(())
+            .expect("request");
+
+        annotate_request_context(&mut request);
+
+        let task_id = request
+            .extensions()
+            .get::<TaskId>()
+            .expect("task id extension");
+        assert_eq!(task_id.to_string(), "750e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn annotate_request_context_ignores_absent_and_malformed_task_id() {
+        let mut absent = tonic::codegen::http::Request::builder()
+            .uri("/coral.v1.QueryService/ExecuteSql")
+            .body(())
+            .expect("request");
+        annotate_request_context(&mut absent);
+        assert!(
+            absent.extensions().get::<TaskId>().is_none(),
+            "a missing coral-task-id yields no attribution"
+        );
+
+        let mut malformed = tonic::codegen::http::Request::builder()
+            .uri("/coral.v1.QueryService/ExecuteSql")
+            .header(CORAL_TASK_ID_METADATA_KEY, "has space")
+            .body(())
+            .expect("request");
+        annotate_request_context(&mut malformed);
+        assert!(
+            malformed.extensions().get::<TaskId>().is_none(),
+            "a malformed id is ignored, not surfaced"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Summary
- Reads coral-task-id metadata at the app transport boundary.
- Attributes SQL, catalog, and feedback/query follow-up work to validated task ids where present.

Validation
- Full stack validation was run from codex/tasks-sessions-10-docs after rebasing onto origin/main: cargo test -p coral-api -p coral-app -p coral-client -p coral-mcp -p coral-cli; make rust-checks; make docs-check; make perf-check.