### PR TITLE
feat(client): propagate task attribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
  "tonic",
  "tonic-types",
  "tracing",

--- a/crates/coral-client/Cargo.toml
+++ b/crates/coral-client/Cargo.toml
@@ -17,6 +17,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tonic.workspace = true
 tonic-types.workspace = true
 tracing.workspace = true

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -6,6 +6,7 @@ use coral_api::v1::feedback_service_client::FeedbackServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::search_service_client::SearchServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
+use coral_api::v1::task_service_client::TaskServiceClient;
 use coral_api::v1::workspace_service_client::WorkspaceServiceClient;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
@@ -56,6 +57,9 @@ pub type SearchClient = SearchServiceClient<GrpcService>;
 /// Public feedback-submission gRPC client.
 pub type FeedbackClient = FeedbackServiceClient<GrpcService>;
 
+/// Public task-lifecycle gRPC client.
+pub type TaskClient = TaskServiceClient<GrpcService>;
+
 /// Public Coral client handle.
 ///
 /// Wraps the generated gRPC clients for a Coral endpoint.
@@ -67,6 +71,7 @@ pub struct AppClient {
     query: QueryClient,
     search: SearchClient,
     feedback: FeedbackClient,
+    task: TaskClient,
 }
 
 impl AppClient {
@@ -92,7 +97,8 @@ impl AppClient {
             .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
         let search_client = SearchClient::new(grpc_service(channel.clone(), &grpc_endpoint))
             .max_decoding_message_size(SEARCH_RESPONSE_MAX_MESSAGE_SIZE);
-        let feedback_client = FeedbackClient::new(grpc_service(channel, &grpc_endpoint));
+        let feedback_client = FeedbackClient::new(grpc_service(channel.clone(), &grpc_endpoint));
+        let task_client = TaskClient::new(grpc_service(channel, &grpc_endpoint));
         Ok(Self {
             source: source_client,
             workspace: workspace_client,
@@ -100,6 +106,7 @@ impl AppClient {
             query: query_client,
             search: search_client,
             feedback: feedback_client,
+            task: task_client,
         })
     }
 
@@ -137,6 +144,12 @@ impl AppClient {
     /// Returns a cloned feedback-submission client.
     pub fn feedback_client(&self) -> FeedbackClient {
         self.feedback.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned task-lifecycle client.
+    pub fn task_client(&self) -> TaskClient {
+        self.task.clone()
     }
 }
 

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -42,9 +42,10 @@ use serde_json::Value;
 
 pub use client::{
     AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, QueryClient, SearchClient,
-    SourceClient, WorkspaceClient, default_workspace, workspace,
+    SourceClient, TaskClient, WorkspaceClient, default_workspace, workspace,
 };
 pub use error::{ClientError, QueryResultError};
+pub use propagation::with_task_metadata;
 pub use search::{
     SearchResponseValue, format_schema_table_equivalent, format_search_response_json,
     format_search_response_text, format_sql_identifier, minimal_table_function_call_example,

--- a/crates/coral-client/src/propagation.rs
+++ b/crates/coral-client/src/propagation.rs
@@ -1,6 +1,14 @@
 //! W3C Trace Context propagation for tonic gRPC clients.
 
+use std::future::Future;
+
+use coral_api::CORAL_TASK_ID_METADATA_KEY;
 use opentelemetry::propagation::Injector;
+use tonic::metadata::{Ascii, MetadataValue};
+
+tokio::task_local! {
+    static TASK_ID: Option<MetadataValue<Ascii>>;
+}
 
 struct MetadataInjector<'a>(&'a mut tonic::metadata::MetadataMap);
 
@@ -14,6 +22,19 @@ impl Injector for MetadataInjector<'_> {
     }
 }
 
+/// Runs a future with optional task attribution for Coral client calls made in
+/// the same async task.
+///
+/// This is intentionally best-effort: task-local values do not automatically
+/// cross an interior `tokio::spawn`, so a spawned task may lose attribution
+/// unless the caller scopes it again.
+pub async fn with_task_metadata<F>(task_id: Option<MetadataValue<Ascii>>, future: F) -> F::Output
+where
+    F: Future,
+{
+    TASK_ID.scope(task_id, future).await
+}
+
 /// tonic client interceptor that injects request-scoped Coral metadata into
 /// outgoing gRPC request metadata.
 #[derive(Clone)]
@@ -25,6 +46,50 @@ impl tonic::service::Interceptor for RequestContextInterceptor {
         mut request: tonic::Request<()>,
     ) -> Result<tonic::Request<()>, tonic::Status> {
         coral_telemetry::inject_current_context(&mut MetadataInjector(request.metadata_mut()));
+        if let Ok(Some(task_id)) = TASK_ID.try_with(Clone::clone) {
+            request
+                .metadata_mut()
+                .insert(CORAL_TASK_ID_METADATA_KEY, task_id);
+        }
         Ok(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use coral_api::CORAL_TASK_ID_METADATA_KEY;
+    use tonic::service::Interceptor as _;
+
+    use super::{RequestContextInterceptor, with_task_metadata};
+
+    #[tokio::test]
+    async fn request_context_interceptor_injects_scoped_task_id() {
+        let task_id = "550e8400-e29b-41d4-a716-446655440000"
+            .parse()
+            .expect("metadata value");
+
+        let request = with_task_metadata(Some(task_id), async {
+            RequestContextInterceptor
+                .call(tonic::Request::new(()))
+                .expect("interceptor")
+        })
+        .await;
+
+        assert_eq!(
+            request
+                .metadata()
+                .get(CORAL_TASK_ID_METADATA_KEY)
+                .and_then(|value| value.to_str().ok()),
+            Some("550e8400-e29b-41d4-a716-446655440000")
+        );
+    }
+
+    #[test]
+    fn request_context_interceptor_omits_task_id_without_scope() {
+        let request = RequestContextInterceptor
+            .call(tonic::Request::new(()))
+            .expect("interceptor");
+
+        assert!(request.metadata().get(CORAL_TASK_ID_METADATA_KEY).is_none());
     }
 }


### PR DESCRIPTION
Summary
- Adds client-side task attribution propagation.
- Injects coral-task-id metadata for scoped outgoing Coral calls.

Validation
- Full stack validation was run from codex/tasks-sessions-10-docs after rebasing onto origin/main: cargo test -p coral-api -p coral-app -p coral-client -p coral-mcp -p coral-cli; make rust-checks; make docs-check; make perf-check.