### PR TITLE
feat(mcp): expose task lifecycle tools

### DIFF
--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -707,6 +707,7 @@ async fn run_app_command(
                 app,
                 coral_mcp::McpOptions {
                     feedback_enabled: features.enabled(coral_app::features::Feature::Feedback),
+                    tasks_enabled: false,
                     trace_parent: ctx.and_then(|ctx| ctx.trace_parent.clone()),
                     source_names,
                     query_examples,

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! The exposed MCP surface is intentionally small:
 //!
-//! - tools: `sql`, `search`, paginated `list_catalog`, `describe_table`, `list_columns`, and optionally `feedback`
+//! - tools: `sql`, `search`, paginated `list_catalog`, `describe_table`, `list_columns`, and optionally `feedback`, `start_task`, and `end_task`
 //! - resources: `coral://guide`, `coral://tables`
 //!
 //! Protocol lifecycle, initialization, and stdio transport behavior should stay
@@ -99,6 +99,8 @@ impl McpQueryExample {
 pub struct McpOptions {
     /// Expose the feedback submission tool.
     pub feedback_enabled: bool,
+    /// Expose the task lifecycle and attribution surface.
+    pub tasks_enabled: bool,
     /// Optional W3C traceparent used to parent each MCP request span.
     pub trace_parent: Option<String>,
     /// Installed source names to include in MCP initialize instructions.

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -2,14 +2,15 @@
 
 use coral_api::v1::{
     CatalogItemKind as ProtoCatalogItemKind, DescribeTableRequest, DescribeTableResponse,
-    ExecuteSqlRequest, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
-    ListSourcesRequest, PaginationRequest, SearchRequest, Source, SubmitFeedbackRequest,
-    TableSummary as ProtoTableSummary, catalog_item,
+    EndTaskRequest, ExecuteSqlRequest, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
+    ListSourcesRequest, PaginationRequest, SearchRequest, Source, StartTaskRequest,
+    SubmitFeedbackRequest, TableSummary as ProtoTableSummary, TaskStatus as ProtoTaskStatus,
+    catalog_item,
 };
 use coral_client::{
-    AppClient, CatalogClient, FeedbackClient, QueryClient, SearchClient, SourceClient,
+    AppClient, CatalogClient, FeedbackClient, QueryClient, SearchClient, SourceClient, TaskClient,
     batches_to_json_rows_json_safe_numbers, decode_execute_sql_response, default_workspace,
-    search_response_json_value,
+    search_response_json_value, with_task_metadata,
 };
 use rmcp::{
     ErrorData, ServerHandler,
@@ -22,18 +23,23 @@ use rmcp::{
 };
 use serde::Serialize;
 use serde_json::{Map, Value};
-use tonic::Request;
+use tonic::{
+    Request,
+    metadata::{Ascii, MetadataValue},
+};
 
 use crate::{
     McpOptions, McpQueryExample,
     surface::{
-        CatalogToolKind, FeedbackStoredValue, SqlBatchValue, SqlQueryResultValue,
+        CatalogToolKind, EndTaskArguments, FeedbackStoredValue, SqlBatchValue, SqlQueryResultValue,
+        StartTaskArguments, TaskEndedValue, TaskId, TaskStartedValue, TaskStatus, ToolAvailability,
         ToolDescriptionContext, ToolName, available_tools, build_tool_result,
-        describe_table_arguments, describe_table_value, feedback_arguments, guide_resource,
-        guide_resource_content, initial_instructions, list_catalog_arguments, list_catalog_value,
-        list_columns_arguments, list_columns_table_fallback_value, list_columns_value,
-        search_arguments, sql_arguments, status_to_error_data, tables_resource,
-        tables_resource_content, tool_error_from_status, tool_error_result,
+        describe_table_arguments, describe_table_value, end_task_arguments, feedback_arguments,
+        guide_resource, guide_resource_content, initial_instructions, list_catalog_arguments,
+        list_catalog_value, list_columns_arguments, list_columns_table_fallback_value,
+        list_columns_value, required_task_id_argument, required_tool_intent_argument,
+        search_arguments, sql_arguments, start_task_arguments, status_to_error_data,
+        tables_resource, tables_resource_content, tool_error_from_status, tool_error_result,
     },
     telemetry,
 };
@@ -58,6 +64,45 @@ fn serialize_tool_value(value: impl Serialize) -> Result<Value, tonic::Status> {
     serde_json::to_value(value).map_err(|error| tonic::Status::internal(error.to_string()))
 }
 
+fn task_id_from_backend_response(
+    operation: &'static str,
+    value: &str,
+) -> Result<TaskId, tonic::Status> {
+    if value.is_empty() {
+        return Err(tonic::Status::internal(format!(
+            "{operation} response missing task_id"
+        )));
+    }
+    TaskId::from_uuid_str(value)
+        .map_err(|_err| tonic::Status::internal(format!("{operation} response invalid task_id")))
+}
+
+fn task_started_value(task: &coral_api::v1::Task) -> Result<TaskStartedValue, tonic::Status> {
+    let task_id = task_id_from_backend_response("start task", &task.task_id)?;
+    Ok(TaskStartedValue {
+        task_id,
+        message: "Task started.",
+        instructions: "Pass this task_id as task_id on subsequent Coral MCP tool calls for this work, then call end_task when the task is complete.",
+    })
+}
+
+fn task_status_to_proto(status: TaskStatus) -> ProtoTaskStatus {
+    match status {
+        TaskStatus::Success => ProtoTaskStatus::Success,
+        TaskStatus::Failure => ProtoTaskStatus::Failure,
+    }
+}
+
+fn task_status_from_proto(status: i32) -> Result<TaskStatus, tonic::Status> {
+    match ProtoTaskStatus::try_from(status) {
+        Ok(ProtoTaskStatus::Success) => Ok(TaskStatus::Success),
+        Ok(ProtoTaskStatus::Failure) => Ok(TaskStatus::Failure),
+        Ok(ProtoTaskStatus::Unspecified) | Err(_) => Err(tonic::Status::internal(
+            "end task response missing task status",
+        )),
+    }
+}
+
 impl ToolCallOutcome {
     fn success(value: Value) -> Self {
         Self::Payload(value)
@@ -71,6 +116,102 @@ impl ToolCallOutcome {
     }
 }
 
+#[derive(Debug, Default)]
+struct TaskCallContext {
+    task_id: Option<TaskId>,
+    task_id_metadata: Option<MetadataValue<Ascii>>,
+    intent: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TaskContextRequirement {
+    None,
+    Intent,
+    TaskId,
+    TaskIdAndIntent,
+}
+
+impl TaskContextRequirement {
+    fn requires_intent(self) -> bool {
+        matches!(self, Self::Intent | Self::TaskIdAndIntent)
+    }
+
+    fn requires_task_id(self) -> bool {
+        matches!(self, Self::TaskId | Self::TaskIdAndIntent)
+    }
+}
+
+impl TaskCallContext {
+    fn from_tool_request(
+        options: &McpOptions,
+        tool_name: Option<ToolName>,
+        arguments: Option<&Map<String, Value>>,
+    ) -> Result<Self, ErrorData> {
+        let Some(tool_name) = tool_name else {
+            return Ok(Self::default());
+        };
+        let requirement = task_context_requirement(options, tool_name);
+        if requirement == TaskContextRequirement::None {
+            return Ok(Self::default());
+        }
+        let intent = requirement
+            .requires_intent()
+            .then(|| required_tool_intent_argument(arguments, "intent"))
+            .transpose()?;
+        let task_id = requirement
+            .requires_task_id()
+            .then(|| required_task_id_argument(arguments, "task_id"))
+            .transpose()?;
+        let task_id_metadata = task_id
+            .as_ref()
+            .map(ToString::to_string)
+            .map(|task_id| {
+                task_id.parse().map_err(|error| {
+                    ErrorData::invalid_params(
+                        format!("argument 'task_id' is not valid metadata: {error}"),
+                        None,
+                    )
+                })
+            })
+            .transpose()?;
+        Ok(Self {
+            task_id,
+            task_id_metadata,
+            intent,
+        })
+    }
+
+    fn record_telemetry(&self, span: &tracing::Span) {
+        if let Some(task_id) = self.task_id.as_ref() {
+            telemetry::record_task_id(span, &task_id.to_string());
+        }
+        if let Some(intent) = self.intent.as_ref() {
+            telemetry::record_tool_intent(span, intent);
+        }
+    }
+
+    fn into_metadata(self) -> Option<MetadataValue<Ascii>> {
+        self.task_id_metadata
+    }
+}
+
+fn task_context_requirement(options: &McpOptions, tool_name: ToolName) -> TaskContextRequirement {
+    if !options.tasks_enabled {
+        return TaskContextRequirement::None;
+    }
+    match tool_name {
+        ToolName::Sql
+        | ToolName::Search
+        | ToolName::ListCatalog
+        | ToolName::DescribeTable
+        | ToolName::ListColumns => TaskContextRequirement::TaskIdAndIntent,
+        ToolName::StartTask => TaskContextRequirement::Intent,
+        ToolName::EndTask => TaskContextRequirement::TaskId,
+        ToolName::Feedback if options.feedback_enabled => TaskContextRequirement::TaskIdAndIntent,
+        ToolName::Feedback => TaskContextRequirement::None,
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct CoralMcpServer {
     source: SourceClient,
@@ -78,6 +219,7 @@ pub(crate) struct CoralMcpServer {
     query: QueryClient,
     search: SearchClient,
     feedback: FeedbackClient,
+    task: TaskClient,
     startup_context: McpStartupContext,
     options: McpOptions,
 }
@@ -137,6 +279,7 @@ impl CoralMcpServer {
             query: app.query_client(),
             search: app.search_client(),
             feedback: app.feedback_client(),
+            task: app.task_client(),
             startup_context,
             options,
         }
@@ -297,11 +440,15 @@ impl CoralMcpServer {
     async fn execute_sql_batch(
         &self,
         queries: Vec<String>,
+        task_id_metadata: Option<MetadataValue<Ascii>>,
     ) -> Result<SqlBatchValue, tonic::Status> {
         let mut tasks = tokio::task::JoinSet::new();
         for (index, sql) in queries.into_iter().enumerate() {
             let server = self.clone();
-            tasks.spawn(async move { server.execute_one_sql_query(index, sql).await });
+            let task_id_metadata = task_id_metadata.clone();
+            tasks.spawn(async move {
+                with_task_metadata(task_id_metadata, server.execute_one_sql_query(index, sql)).await
+            });
         }
 
         let mut results = Vec::new();
@@ -309,6 +456,49 @@ impl CoralMcpServer {
             results.push(joined.map_err(|error| tonic::Status::internal(error.to_string()))?);
         }
         Ok(SqlBatchValue::from_unordered(results))
+    }
+
+    async fn start_task_value(
+        &self,
+        arguments: StartTaskArguments,
+    ) -> Result<Value, tonic::Status> {
+        let mut task_client = self.task.clone();
+        let task = task_client
+            .start_task(Request::new(StartTaskRequest {
+                workspace: Some(self.workspace()),
+                intent: arguments.intent,
+            }))
+            .await?
+            .into_inner()
+            .task
+            .ok_or_else(|| tonic::Status::internal("start task response missing task"))?;
+        serialize_tool_value(task_started_value(&task)?)
+    }
+
+    async fn end_task_value(&self, arguments: EndTaskArguments) -> Result<Value, tonic::Status> {
+        let mut task_client = self.task.clone();
+        let task_end = task_client
+            .end_task(Request::new(EndTaskRequest {
+                workspace: Some(self.workspace()),
+                task_id: arguments.task_id.to_string(),
+                task_status: task_status_to_proto(arguments.task_status) as i32,
+            }))
+            .await?
+            .into_inner()
+            .task_end
+            .ok_or_else(|| tonic::Status::internal("end task response missing task_end"))?;
+        let task_id = task_id_from_backend_response("end task", &task_end.task_id)?;
+        if task_id != arguments.task_id {
+            return Err(tonic::Status::internal(
+                "end task response task_id did not match request",
+            ));
+        }
+        serialize_tool_value(TaskEndedValue {
+            task_id,
+            task_status: task_status_from_proto(task_end.task_status)?,
+            success: "Task ended.",
+            note: "Task status recorded.",
+        })
     }
 
     async fn submit_feedback_value(
@@ -411,11 +601,15 @@ impl CoralMcpServer {
     async fn dispatch_tool(
         &self,
         request: CallToolRequestParams,
+        task_id_metadata: Option<MetadataValue<Ascii>>,
     ) -> Result<ToolCallOutcome, ErrorData> {
         match request.name.as_ref().parse::<ToolName>().ok() {
             Some(ToolName::Sql) => {
                 let arguments = sql_arguments(request.arguments.as_ref())?;
-                match self.execute_sql_batch(arguments.queries).await {
+                match self
+                    .execute_sql_batch(arguments.queries, task_id_metadata)
+                    .await
+                {
                     Ok(batch) => Ok(ToolCallOutcome::SqlBatch(batch)),
                     Err(status) => Ok(ToolCallOutcome::ToolError {
                         operation: "Query",
@@ -436,6 +630,26 @@ impl CoralMcpServer {
                 self.list_columns_tool_result(request.arguments.as_ref())
                     .await
             }
+            Some(ToolName::StartTask) if self.options.tasks_enabled => {
+                let arguments = start_task_arguments(request.arguments.as_ref())?;
+                match self.start_task_value(arguments).await {
+                    Ok(value) => Ok(ToolCallOutcome::success(value)),
+                    Err(status) if status.code() == tonic::Code::InvalidArgument => {
+                        Err(status_to_error_data(&status))
+                    }
+                    Err(status) => Ok(ToolCallOutcome::ToolError {
+                        operation: "Task start",
+                        status,
+                    }),
+                }
+            }
+            Some(ToolName::EndTask) if self.options.tasks_enabled => {
+                let arguments = end_task_arguments(request.arguments.as_ref())?;
+                Ok(ToolCallOutcome::from_value_result(
+                    "Task end",
+                    self.end_task_value(arguments).await,
+                ))
+            }
             Some(ToolName::Feedback) if self.options.feedback_enabled => {
                 let arguments = feedback_arguments(request.arguments.as_ref())?;
                 Ok(ToolCallOutcome::from_value_result(
@@ -448,10 +662,9 @@ impl CoralMcpServer {
                     .await,
                 ))
             }
-            None | Some(ToolName::Feedback) => Err(ErrorData::invalid_params(
-                format!("tool '{}' not found", request.name),
-                None,
-            )),
+            None | Some(ToolName::StartTask | ToolName::EndTask | ToolName::Feedback) => Err(
+                ErrorData::invalid_params(format!("tool '{}' not found", request.name), None),
+            ),
         }
     }
 
@@ -552,7 +765,13 @@ impl ServerHandler for CoralMcpServer {
                 visible_function_count,
                 source_names,
             );
-            let tools = available_tools(&tool_context, self.options.feedback_enabled);
+            let tools = available_tools(
+                &tool_context,
+                ToolAvailability {
+                    tasks_enabled: self.options.tasks_enabled,
+                    feedback_enabled: self.options.feedback_enabled,
+                },
+            );
             Ok(ListToolsResult::with_all_items(tools))
         })
         .await
@@ -565,7 +784,32 @@ impl ServerHandler for CoralMcpServer {
     ) -> Result<CallToolResult, ErrorData> {
         let span =
             telemetry::call_tool_span(request.name.as_ref(), self.options.trace_parent.as_deref());
-        let outcome = telemetry::instrument(span.clone(), self.dispatch_tool(request)).await;
+        let tool_name = request.name.as_ref().parse::<ToolName>().ok();
+        let inject_task_metadata =
+            !matches!(tool_name, Some(ToolName::StartTask | ToolName::EndTask));
+        let task_context = TaskCallContext::from_tool_request(
+            &self.options,
+            tool_name,
+            request.arguments.as_ref(),
+        );
+        let outcome = match task_context {
+            Ok(task_context) => {
+                task_context.record_telemetry(&span);
+                let task_id_metadata = inject_task_metadata
+                    .then(|| task_context.into_metadata())
+                    .flatten();
+                let dispatch_task_id_metadata = task_id_metadata.clone();
+                telemetry::instrument(
+                    span.clone(),
+                    with_task_metadata(
+                        task_id_metadata,
+                        self.dispatch_tool(request, dispatch_task_id_metadata),
+                    ),
+                )
+                .await
+            }
+            Err(error) => Err(error),
+        };
         finish_tool_call(&span, outcome)
     }
 
@@ -728,8 +972,26 @@ fn normalize_query_examples(
 
 #[cfg(test)]
 mod startup_context_tests {
-    use super::{MAX_INITIAL_QUERY_EXAMPLES, McpStartupContext};
+    use super::{MAX_INITIAL_QUERY_EXAMPLES, McpStartupContext, task_id_from_backend_response};
     use crate::McpQueryExample;
+
+    #[test]
+    fn task_id_from_backend_response_canonicalizes_uuid() {
+        let task_id =
+            task_id_from_backend_response("start task", "550e8400e29b41d4a716446655440000")
+                .expect("task id should parse");
+
+        assert_eq!(task_id.to_string(), "550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn task_id_from_backend_response_rejects_malformed_uuid() {
+        let status = task_id_from_backend_response("end task", "not-a-uuid")
+            .expect_err("malformed backend task id should fail");
+
+        assert_eq!(status.code(), tonic::Code::Internal);
+        assert_eq!(status.message(), "end task response invalid task_id");
+    }
 
     #[test]
     fn startup_context_sorts_and_dedupes_source_names() {

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -11,6 +11,7 @@ mod schema;
 mod search;
 mod source_names;
 mod sql;
+mod task;
 mod tool_names;
 mod tools;
 mod values;
@@ -29,5 +30,10 @@ pub(crate) use resources::{
 };
 pub(crate) use search::search_arguments;
 pub(crate) use sql::{SqlBatchValue, SqlQueryResultValue, sql_arguments};
+pub(crate) use task::{
+    EndTaskArguments, StartTaskArguments, TaskEndedValue, TaskId, TaskStartedValue, TaskStatus,
+    end_task_arguments, required_task_id_argument, required_tool_intent_argument,
+    start_task_arguments,
+};
 pub(crate) use tool_names::ToolName;
-pub(crate) use tools::{available_tools, build_tool_result};
+pub(crate) use tools::{ToolAvailability, available_tools, build_tool_result};

--- a/crates/coral-mcp/src/surface/task.rs
+++ b/crates/coral-mcp/src/surface/task.rs
@@ -1,0 +1,416 @@
+use std::{borrow::Cow, fmt, sync::Arc};
+
+use coral_api::CORAL_TASK_INTENT_MAX_CHARS;
+use rmcp::{
+    ErrorData,
+    model::{Tool, ToolAnnotations},
+};
+use schemars::{JsonSchema, Schema, SchemaGenerator};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+
+use super::{
+    arguments::required_string_argument,
+    schema::{tool_input_schema, tool_output_schema},
+    tool_names::ToolName,
+};
+
+const TASK_ID_ARGUMENT_DESCRIPTION: &str = "Task id returned by start_task. Pass it on subsequent Coral tool calls for the same work so Coral can attribute those calls to that task.";
+const TOOL_INTENT_ARGUMENT_DESCRIPTION: &str =
+    "Natural-language description of why this MCP tool call is needed for the current task.";
+const TOOL_INTENT_JSON_SCHEMA_PATTERN: &str = r".*\S.*";
+const TASK_ID_LEN: usize = 36;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub(crate) struct TaskId(uuid::Uuid);
+
+impl TaskId {
+    pub(crate) fn from_uuid_str(value: &str) -> Result<Self, uuid::Error> {
+        uuid::Uuid::parse_str(value).map(Self)
+    }
+
+    pub(crate) fn parse_argument(key: &str, value: &str) -> Result<Self, ErrorData> {
+        Self::from_uuid_str(value).map_err(|_err| {
+            ErrorData::invalid_params(format!("argument '{key}' must be a UUID"), None)
+        })
+    }
+}
+
+impl fmt::Display for TaskId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl JsonSchema for TaskId {
+    fn inline_schema() -> bool {
+        true
+    }
+
+    fn schema_name() -> Cow<'static, str> {
+        "TaskId".into()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        Schema::from(task_id_schema_map(None))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TaskStatus {
+    Success,
+    Failure,
+}
+
+pub(crate) struct StartTaskArguments {
+    pub(crate) intent: String,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+#[expect(
+    dead_code,
+    reason = "schema-only struct for the end_task input contract"
+)]
+pub(crate) struct EndTaskArgumentsSchema {
+    #[schemars(description = "Task id returned by start_task.")]
+    task_id: TaskId,
+    #[schemars(description = "Final task status.")]
+    task_status: TaskStatus,
+}
+
+pub(crate) struct EndTaskArguments {
+    pub(crate) task_id: TaskId,
+    pub(crate) task_status: TaskStatus,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct TaskStartedValue {
+    pub(crate) task_id: TaskId,
+    pub(crate) message: &'static str,
+    pub(crate) instructions: &'static str,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub(crate) struct TaskEndedValue {
+    pub(crate) task_id: TaskId,
+    pub(crate) task_status: TaskStatus,
+    pub(crate) success: &'static str,
+    pub(crate) note: &'static str,
+}
+
+pub(crate) fn start_task_tool() -> Tool {
+    Tool::new(
+        ToolName::StartTask.as_str(),
+        "Start a Coral task for the current unit of work.",
+        start_task_input_schema(),
+    )
+    .with_raw_output_schema(tool_output_schema::<TaskStartedValue>())
+    .with_annotations(
+        ToolAnnotations::with_title("Start Task")
+            .read_only(false)
+            .destructive(false)
+            .idempotent(false)
+            .open_world(false),
+    )
+}
+
+fn start_task_input_schema() -> Arc<Map<String, Value>> {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "intent": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": CORAL_TASK_INTENT_MAX_CHARS,
+                "pattern": TOOL_INTENT_JSON_SCHEMA_PATTERN,
+                "description": "Natural-language description of the work this task should group."
+            }
+        },
+        "required": ["intent"],
+        "additionalProperties": false
+    });
+    Arc::new(
+        schema
+            .as_object()
+            .expect("start_task input schema is an object")
+            .clone(),
+    )
+}
+
+pub(crate) fn end_task_tool() -> Tool {
+    Tool::new(
+        ToolName::EndTask.as_str(),
+        "End a Coral task with a final status.",
+        tool_input_schema::<EndTaskArgumentsSchema>(),
+    )
+    .with_raw_output_schema(tool_output_schema::<TaskEndedValue>())
+    .with_annotations(
+        ToolAnnotations::with_title("End Task")
+            .read_only(false)
+            .destructive(false)
+            .idempotent(false)
+            .open_world(false),
+    )
+}
+
+pub(crate) fn start_task_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<StartTaskArguments, ErrorData> {
+    reject_unknown_arguments(arguments, &["intent"])?;
+    Ok(StartTaskArguments {
+        intent: required_tool_intent_argument(arguments, "intent")?,
+    })
+}
+
+pub(crate) fn end_task_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<EndTaskArguments, ErrorData> {
+    reject_unknown_arguments(arguments, &["task_id", "task_status"])?;
+    Ok(EndTaskArguments {
+        task_id: required_task_id_argument(arguments, "task_id")?,
+        task_status: required_task_status_argument(arguments, "task_status")?,
+    })
+}
+
+pub(crate) fn required_task_id_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+) -> Result<TaskId, ErrorData> {
+    let value = required_string_argument(arguments, key)?;
+    TaskId::parse_argument(key, &value)
+}
+
+fn required_task_status_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+) -> Result<TaskStatus, ErrorData> {
+    let value = required_string_argument(arguments, key)?;
+    match value.as_str() {
+        "success" => Ok(TaskStatus::Success),
+        "failure" => Ok(TaskStatus::Failure),
+        _ => Err(ErrorData::invalid_params(
+            format!("argument '{key}' must be 'success' or 'failure'"),
+            None,
+        )),
+    }
+}
+
+fn reject_unknown_arguments(
+    arguments: Option<&Map<String, Value>>,
+    allowed: &[&str],
+) -> Result<(), ErrorData> {
+    let Some(arguments) = arguments else {
+        return Ok(());
+    };
+    if let Some(key) = arguments
+        .keys()
+        .find(|key| !allowed.contains(&key.as_str()))
+    {
+        return Err(ErrorData::invalid_params(
+            format!("unknown argument '{key}'"),
+            None,
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn required_tool_intent_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+) -> Result<String, ErrorData> {
+    let intent = required_string_argument(arguments, key)?;
+    if intent.chars().count() > CORAL_TASK_INTENT_MAX_CHARS {
+        return Err(ErrorData::invalid_params(
+            format!("argument '{key}' must be at most {CORAL_TASK_INTENT_MAX_CHARS} characters"),
+            None,
+        ));
+    }
+    Ok(intent)
+}
+
+pub(crate) fn with_task_context_arguments(mut tool: Tool) -> Tool {
+    let schema = Arc::make_mut(&mut tool.input_schema);
+    add_task_id_property(schema);
+    add_tool_intent_property(schema);
+    require_properties(schema, &["task_id", "intent"]);
+    tool
+}
+
+fn add_task_id_property(schema: &mut Map<String, Value>) {
+    schema
+        .entry("properties")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .expect("tool input properties are an object")
+        .insert(
+            "task_id".to_string(),
+            task_id_schema(Some(TASK_ID_ARGUMENT_DESCRIPTION)),
+        );
+}
+
+fn add_tool_intent_property(schema: &mut Map<String, Value>) {
+    schema
+        .entry("properties")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .expect("tool input properties are an object")
+        .insert(
+            "intent".to_string(),
+            json!({
+                "type": "string",
+                "minLength": 1,
+                "maxLength": CORAL_TASK_INTENT_MAX_CHARS,
+                "pattern": TOOL_INTENT_JSON_SCHEMA_PATTERN,
+                "description": TOOL_INTENT_ARGUMENT_DESCRIPTION
+            }),
+        );
+}
+
+fn require_properties(schema: &mut Map<String, Value>, properties: &[&str]) {
+    let required = schema
+        .entry("required")
+        .or_insert_with(|| json!([]))
+        .as_array_mut()
+        .expect("tool input required fields are an array");
+    for property in properties {
+        if !required
+            .iter()
+            .any(|value| value.as_str() == Some(property))
+        {
+            required.push(Value::String((*property).to_string()));
+        }
+    }
+}
+
+fn task_id_schema(description: Option<&str>) -> Value {
+    Value::Object(task_id_schema_map(description))
+}
+
+fn task_id_schema_map(description: Option<&str>) -> Map<String, Value> {
+    let mut schema = Map::from_iter([
+        ("type".to_string(), json!("string")),
+        ("format".to_string(), json!("uuid")),
+        ("minLength".to_string(), json!(TASK_ID_LEN)),
+        ("maxLength".to_string(), json!(TASK_ID_LEN)),
+    ]);
+    if let Some(description) = description {
+        schema.insert("description".to_string(), json!(description));
+    }
+    schema
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Map, Value, json};
+
+    use super::{TaskStatus, end_task_arguments, required_task_id_argument, start_task_arguments};
+
+    const TASK_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+
+    #[test]
+    fn task_id_argument_accepts_uuid() {
+        let arguments = Map::from_iter([("task_id".to_string(), Value::String(TASK_ID.into()))]);
+
+        let parsed =
+            required_task_id_argument(Some(&arguments), "task_id").expect("task id should parse");
+
+        assert_eq!(parsed.to_string(), TASK_ID);
+    }
+
+    #[test]
+    fn task_id_argument_rejects_malformed_uuid() {
+        let arguments =
+            Map::from_iter([("task_id".to_string(), Value::String("task-1".to_string()))]);
+
+        let error = required_task_id_argument(Some(&arguments), "task_id")
+            .expect_err("task id should be rejected");
+
+        assert!(error.to_string().contains("must be a UUID"));
+    }
+
+    #[test]
+    fn start_task_argument_parses_intent() {
+        let parsed = start_task_arguments(Some(&Map::from_iter([(
+            "intent".to_string(),
+            json!("Investigate renewal risk"),
+        )])))
+        .expect("start task arguments");
+
+        assert_eq!(parsed.intent, "Investigate renewal risk");
+    }
+
+    #[test]
+    fn start_task_argument_rejects_overlong_intent() {
+        let overlong_intent = "a".repeat(coral_api::CORAL_TASK_INTENT_MAX_CHARS + 1);
+
+        let result = start_task_arguments(Some(&Map::from_iter([(
+            "intent".to_string(),
+            Value::String(overlong_intent),
+        )])));
+        let Err(error) = result else {
+            panic!("overlong intent should be rejected");
+        };
+
+        assert!(error.to_string().contains("must be at most"));
+    }
+
+    #[test]
+    fn end_task_argument_parses_status() {
+        let parsed = end_task_arguments(Some(&Map::from_iter([
+            ("task_id".to_string(), json!(TASK_ID)),
+            ("task_status".to_string(), json!("success")),
+        ])))
+        .expect("end task arguments");
+
+        assert_eq!(parsed.task_id.to_string(), TASK_ID);
+        assert_eq!(parsed.task_status, TaskStatus::Success);
+    }
+
+    #[test]
+    fn start_task_schema_requires_only_intent() {
+        let tool = super::start_task_tool();
+        let schema = Value::Object((*tool.input_schema).clone());
+        let compiled = jsonschema::validator_for(&schema).expect("start_task schema compiles");
+
+        assert!(compiled.is_valid(&json!({
+            "intent": "Investigate renewal risk"
+        })));
+        assert!(!compiled.is_valid(&json!({
+            "intent": "",
+        })));
+        assert!(!compiled.is_valid(&json!({
+            "intent": " ",
+        })));
+        assert!(!compiled.is_valid(&json!({
+            "intent": "Investigate renewal risk",
+            "initialize_session": true
+        })));
+    }
+
+    #[test]
+    fn end_task_schema_rejects_unknown_fields() {
+        let tool = super::end_task_tool();
+        let schema = Value::Object((*tool.input_schema).clone());
+        let compiled = jsonschema::validator_for(&schema).expect("end_task schema compiles");
+
+        assert!(compiled.is_valid(&json!({
+            "task_id": TASK_ID,
+            "task_status": "success"
+        })));
+        assert!(!compiled.is_valid(&json!({
+            "intent": "Record task completion",
+            "task_id": TASK_ID,
+            "task_status": "success",
+        })));
+        assert!(!compiled.is_valid(&json!({
+            "task_id": TASK_ID,
+            "task_status": "success",
+            "extra": true
+        })));
+    }
+}

--- a/crates/coral-mcp/src/surface/tool_names.rs
+++ b/crates/coral-mcp/src/surface/tool_names.rs
@@ -7,6 +7,8 @@ pub(crate) enum ToolName {
     ListCatalog,
     DescribeTable,
     ListColumns,
+    StartTask,
+    EndTask,
     Feedback,
 }
 
@@ -18,6 +20,8 @@ impl ToolName {
             Self::ListCatalog => "list_catalog",
             Self::DescribeTable => "describe_table",
             Self::ListColumns => "list_columns",
+            Self::StartTask => "start_task",
+            Self::EndTask => "end_task",
             Self::Feedback => "feedback",
         }
     }
@@ -36,6 +40,8 @@ impl FromStr for ToolName {
             "list_catalog" => Ok(Self::ListCatalog),
             "describe_table" => Ok(Self::DescribeTable),
             "list_columns" => Ok(Self::ListColumns),
+            "start_task" => Ok(Self::StartTask),
+            "end_task" => Ok(Self::EndTask),
             "feedback" => Ok(Self::Feedback),
             _ => Err(UnknownToolName),
         }

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -6,10 +6,17 @@ use super::context::ToolDescriptionContext;
 use super::feedback::feedback_tool;
 use super::search::search_tool;
 use super::sql::sql_tool;
+use super::task::{end_task_tool, start_task_tool, with_task_context_arguments};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ToolAvailability {
+    pub(crate) tasks_enabled: bool,
+    pub(crate) feedback_enabled: bool,
+}
 
 pub(crate) fn available_tools(
     context: &ToolDescriptionContext,
-    feedback_enabled: bool,
+    availability: ToolAvailability,
 ) -> Vec<Tool> {
     let mut tools = vec![
         sql_tool(context),
@@ -18,8 +25,19 @@ pub(crate) fn available_tools(
         describe_table_tool(),
         list_columns_tool(),
     ];
-    if feedback_enabled {
-        tools.push(feedback_tool());
+    if availability.tasks_enabled {
+        tools = tools.into_iter().map(with_task_context_arguments).collect();
+        tools.push(start_task_tool());
+        tools.push(end_task_tool());
+    }
+    if availability.feedback_enabled {
+        let feedback = feedback_tool();
+        let feedback = if availability.tasks_enabled {
+            with_task_context_arguments(feedback)
+        } else {
+            feedback
+        };
+        tools.push(feedback);
     }
     tools
 }
@@ -35,7 +53,24 @@ mod tests {
     use rmcp::model::Tool;
     use serde_json::{Value, json};
 
-    use super::{ToolDescriptionContext, available_tools, build_tool_result};
+    use super::{ToolAvailability, ToolDescriptionContext, available_tools, build_tool_result};
+
+    const BASE_TOOLS: ToolAvailability = ToolAvailability {
+        tasks_enabled: false,
+        feedback_enabled: false,
+    };
+    const TASK_TOOLS: ToolAvailability = ToolAvailability {
+        tasks_enabled: true,
+        feedback_enabled: false,
+    };
+    const FEEDBACK_TOOLS: ToolAvailability = ToolAvailability {
+        tasks_enabled: false,
+        feedback_enabled: true,
+    };
+    const TASK_AND_FEEDBACK_TOOLS: ToolAvailability = ToolAvailability {
+        tasks_enabled: true,
+        feedback_enabled: true,
+    };
 
     #[test]
     fn success_tool_result_uses_structured_content_only() {
@@ -66,7 +101,7 @@ mod tests {
         let context =
             ToolDescriptionContext::new(42, 3, vec!["github".to_string(), "linear".to_string()]);
 
-        let tools = available_tools(&context, false);
+        let tools = available_tools(&context, BASE_TOOLS);
         let sql_tool = tool_by_name(&tools, "sql");
         let sql_description = sql_tool.description.as_deref().expect("sql description");
         assert!(sql_description.contains("Connected sources/schemas include: github, linear"));
@@ -100,20 +135,94 @@ mod tests {
     }
 
     #[test]
+    fn available_tools_decorate_task_aware_tools() {
+        let context = ToolDescriptionContext::new(1, 0, Vec::new());
+        let tools = available_tools(&context, TASK_TOOLS);
+        let sql_tool = tool_by_name(&tools, "sql");
+        let task_id_schema = sql_tool
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .and_then(|properties| properties.get("task_id"))
+            .expect("task_id schema");
+        let intent_schema = sql_tool
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .and_then(|properties| properties.get("intent"))
+            .expect("intent schema");
+
+        assert_eq!(
+            task_id_schema.get("description").and_then(Value::as_str),
+            Some(
+                "Task id returned by start_task. Pass it on subsequent Coral tool calls for the same work so Coral can attribute those calls to that task."
+            )
+        );
+        assert_eq!(
+            intent_schema.get("description").and_then(Value::as_str),
+            Some(
+                "Natural-language description of why this MCP tool call is needed for the current task."
+            )
+        );
+        let required = sql_tool
+            .input_schema
+            .get("required")
+            .and_then(Value::as_array)
+            .expect("sql required fields");
+        assert!(
+            required
+                .iter()
+                .any(|field| field.as_str() == Some("task_id"))
+        );
+        assert!(
+            required
+                .iter()
+                .any(|field| field.as_str() == Some("intent"))
+        );
+
+        let start_task = tool_by_name(&tools, "start_task");
+        let properties = start_task
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("start_task properties");
+        assert!(!properties.contains_key("task_id"));
+        assert!(properties.contains_key("intent"));
+        let end_task = tool_by_name(&tools, "end_task");
+        let properties = end_task
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("end_task properties");
+        assert!(properties.contains_key("task_id"));
+        assert!(!properties.contains_key("intent"));
+        assert!(properties.contains_key("task_status"));
+    }
+
+    #[test]
     fn available_tools_add_feedback_last_when_enabled() {
         let context = ToolDescriptionContext::new(1, 0, Vec::new());
-        let tools = available_tools(&context, true);
+        let tools = available_tools(&context, TASK_AND_FEEDBACK_TOOLS);
 
         assert_eq!(
             tools.last().map(|tool| tool.name.as_ref()),
             Some("feedback")
         );
+        let properties = tools
+            .last()
+            .expect("feedback tool")
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("feedback properties");
+        assert!(properties.contains_key("task_id"));
+        assert!(properties.contains_key("intent"));
     }
 
     #[test]
     fn available_tools_keep_default_order() {
         let context = ToolDescriptionContext::new(1, 0, Vec::new());
-        let tools = available_tools(&context, false);
+        let tools = available_tools(&context, BASE_TOOLS);
         let names = tools
             .iter()
             .map(|tool| tool.name.as_ref())
@@ -138,7 +247,7 @@ mod tests {
             .collect::<Vec<_>>();
         let context = ToolDescriptionContext::new(1, 0, names);
 
-        let tools = available_tools(&context, false);
+        let tools = available_tools(&context, BASE_TOOLS);
         let description = tool_by_name(&tools, "sql")
             .description
             .as_deref()
@@ -152,10 +261,49 @@ mod tests {
     }
 
     #[test]
+    fn available_tools_do_not_mutate_base_tool_schemas() {
+        let context = ToolDescriptionContext::new(1, 0, Vec::new());
+        let default_tools = available_tools(&context, BASE_TOOLS);
+        let task_tools = available_tools(&context, TASK_TOOLS);
+
+        let default_properties = tool_by_name(&default_tools, "sql")
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("default properties");
+        let task_properties = tool_by_name(&task_tools, "sql")
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("task properties");
+
+        assert!(!default_properties.contains_key("task_id"));
+        assert!(!default_properties.contains_key("intent"));
+        assert!(task_properties.contains_key("task_id"));
+        assert!(task_properties.contains_key("intent"));
+    }
+
+    #[test]
+    fn feedback_tool_is_not_decorated_when_tasks_are_disabled() {
+        let context = ToolDescriptionContext::new(1, 0, Vec::new());
+        let tools = available_tools(&context, FEEDBACK_TOOLS);
+        let feedback = tools.last().expect("feedback tool");
+        let properties = feedback
+            .input_schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .expect("feedback properties");
+
+        assert_eq!(feedback.name, "feedback");
+        assert!(!properties.contains_key("task_id"));
+        assert!(!properties.contains_key("intent"));
+    }
+
+    #[test]
     fn all_advertised_tools_have_object_input_schemas() {
         let context = ToolDescriptionContext::new(1, 0, Vec::new());
 
-        for tool in available_tools(&context, true) {
+        for tool in available_tools(&context, TASK_AND_FEEDBACK_TOOLS) {
             assert_eq!(
                 tool.input_schema.get("type"),
                 Some(&Value::String("object".into()))

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -51,8 +51,10 @@ pub(crate) fn call_tool_span(tool_name: &str, trace_parent: Option<&str>) -> tra
         exception.message = field::Empty,
         mcp.method = "tools/call",
         mcp.tool.name = tool_name,
+        mcp.tool.intent = field::Empty,
         otel.kind = "server",
         otel.name = "coral.mcp.call_tool",
+        task.id = field::Empty,
         status = field::Empty,
     );
     apply_trace_parent(&span, trace_parent);
@@ -127,6 +129,14 @@ pub(crate) fn record_sql_batch_partial_failure(span: &tracing::Span) {
 pub(crate) fn record_success(span: &tracing::Span) {
     span.record("status", "ok");
     span.set_status(OtelStatus::Ok);
+}
+
+pub(crate) fn record_task_id(span: &tracing::Span, task_id: &str) {
+    span.record("task.id", task_id);
+}
+
+pub(crate) fn record_tool_intent(span: &tracing::Span, intent: &str) {
+    span.record("mcp.tool.intent", intent);
 }
 
 fn record_error(span: &tracing::Span, error_type: &str, message: impl std::fmt::Display) {

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -295,6 +295,105 @@ fn tool_by_name<'a>(tools: &'a [Tool], name: &str) -> &'a Tool {
         .expect("tool should be listed")
 }
 
+fn tool_input_properties(tool: &Tool) -> &Map<String, Value> {
+    tool.input_schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .unwrap_or_else(|| panic!("tool '{}' should advertise input properties", tool.name))
+}
+
+fn assert_tool_advertises_task_context(tool: &Tool) {
+    let properties = tool_input_properties(tool);
+    let task_id_schema = properties
+        .get("task_id")
+        .unwrap_or_else(|| panic!("tool '{}' should advertise task_id", tool.name));
+    assert_task_id_schema(task_id_schema, tool.name.as_ref());
+    let intent_schema = properties
+        .get("intent")
+        .unwrap_or_else(|| panic!("tool '{}' should advertise intent", tool.name));
+    assert_intent_schema(intent_schema, tool.name.as_ref());
+    let required = tool
+        .input_schema
+        .get("required")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("tool '{}' should advertise required fields", tool.name));
+    assert!(
+        required
+            .iter()
+            .any(|field| field.as_str() == Some("task_id")),
+        "tool '{}' should require task_id",
+        tool.name
+    );
+    assert!(
+        required
+            .iter()
+            .any(|field| field.as_str() == Some("intent")),
+        "tool '{}' should require intent",
+        tool.name
+    );
+}
+
+fn assert_task_id_schema(schema: &Value, label: &str) {
+    assert_eq!(
+        schema.get("format").and_then(Value::as_str),
+        Some("uuid"),
+        "{label} task id schema should advertise UUID format"
+    );
+    let compiled = jsonschema::validator_for(schema)
+        .unwrap_or_else(|error| panic!("{label} task id schema should compile: {error}"));
+    let valid = json!("550e8400-e29b-41d4-a716-446655440000");
+    let details = validation_error_details(&compiled, &valid);
+    assert!(
+        details.is_empty(),
+        "{label} task id schema rejected valid value {valid}: {details}"
+    );
+    for invalid in [
+        json!(null),
+        json!(""),
+        json!("task-1"),
+        json!("550e8400e29b41d4a716446655440000"),
+        json!("not-a-uuid"),
+    ] {
+        assert!(
+            !compiled.is_valid(&invalid),
+            "{label} task id schema accepted invalid value {invalid}"
+        );
+    }
+}
+
+fn assert_intent_schema(schema: &Value, label: &str) {
+    let compiled = jsonschema::validator_for(schema)
+        .unwrap_or_else(|error| panic!("{label} intent schema should compile: {error}"));
+    let valid = json!("Find relevant customer tables");
+    let details = validation_error_details(&compiled, &valid);
+    assert!(
+        details.is_empty(),
+        "{label} intent schema rejected valid value {valid}: {details}"
+    );
+    for invalid in [json!(null), json!(""), json!(" ")] {
+        assert!(
+            !compiled.is_valid(&invalid),
+            "{label} intent schema accepted invalid value {invalid}"
+        );
+    }
+}
+
+fn assert_tool_omits_task_id(tool: &Tool) {
+    assert!(
+        !tool_input_properties(tool).contains_key("task_id"),
+        "tool '{}' should not advertise task_id by default",
+        tool.name
+    );
+}
+
+fn assert_tool_omits_intent(tool: &Tool) {
+    assert!(
+        !tool_input_properties(tool).contains_key("intent"),
+        "tool '{}' should not advertise task intent by default",
+        tool.name
+    );
+}
+
 fn assert_matches_output_schema(tool: &Tool, value: &Value) {
     let schema = Value::Object(
         tool.output_schema
@@ -342,6 +441,276 @@ fn assert_tool_error_text_contains(result: &CallToolResult, expected: &str) {
         text.contains(expected),
         "tool error text should contain {expected:?}, got {text:?}"
     );
+}
+
+#[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "This end-to-end MCP task test verifies feature-gated tool advertisement, persistence, tagged follow-up calls, and validation together."
+)]
+async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_session_with_options(
+        &temp,
+        McpOptions {
+            tasks_enabled: true,
+            ..McpOptions::default()
+        },
+    )
+    .await;
+    let client = &session.client;
+
+    let tools = client.list_all_tools().await.expect("tools");
+    assert_eq!(
+        tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>(),
+        vec![
+            "sql",
+            "search",
+            "list_catalog",
+            "describe_table",
+            "list_columns",
+            "start_task",
+            "end_task"
+        ]
+    );
+    for name in [
+        "sql",
+        "search",
+        "list_catalog",
+        "describe_table",
+        "list_columns",
+    ] {
+        assert_tool_advertises_task_context(tool_by_name(&tools, name));
+    }
+    let start_task_tool = tool_by_name(&tools, "start_task");
+    assert!(!tool_input_properties(start_task_tool).contains_key("task_id"));
+    assert!(
+        !tool_input_properties(start_task_tool).contains_key("initialize_session"),
+        "start_task should not accept initialize_session"
+    );
+    let start_annotations = start_task_tool
+        .annotations
+        .as_ref()
+        .expect("start task annotations");
+    assert_eq!(start_annotations.read_only_hint, Some(false));
+    assert_eq!(start_annotations.destructive_hint, Some(false));
+    assert_eq!(start_annotations.idempotent_hint, Some(false));
+    assert_eq!(start_annotations.open_world_hint, Some(false));
+    let end_task_tool = tool_by_name(&tools, "end_task");
+    assert!(tool_input_properties(end_task_tool).contains_key("task_id"));
+    assert!(!tool_input_properties(end_task_tool).contains_key("intent"));
+
+    let root = client
+        .call_tool(
+            CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
+                "intent": "Investigate customer renewal risk"
+            }))),
+        )
+        .await
+        .expect("start task");
+    assert_eq!(root.is_error, Some(false));
+    assert_structured_content_only(&root);
+    let root = root.structured_content.expect("root structured content");
+    assert_matches_output_schema(start_task_tool, &root);
+    let root_task_id = root["task_id"].as_str().expect("root task id").to_string();
+    uuid::Uuid::parse_str(&root_task_id).expect("task id is a UUID");
+    assert_eq!(root["message"], "Task started.");
+    assert!(
+        root["instructions"]
+            .as_str()
+            .expect("instructions")
+            .contains("end_task")
+    );
+
+    let sql = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "queries": ["SELECT 1 AS ok"],
+                "intent": "Verify task-scoped SQL execution",
+                "task_id": root_task_id
+            }))),
+        )
+        .await
+        .expect("tagged sql");
+    assert_eq!(sql.is_error, Some(false));
+    assert_structured_content_only(&sql);
+    assert_eq!(
+        sql.structured_content.expect("sql structured")["results"][0]["rows"][0]["ok"],
+        "1"
+    );
+
+    let end = client
+        .call_tool(
+            CallToolRequestParams::new("end_task").with_arguments(json_object(&json!({
+                "task_id": root_task_id,
+                "task_status": "success"
+            }))),
+        )
+        .await
+        .expect("end task");
+    assert_eq!(end.is_error, Some(false));
+    assert_structured_content_only(&end);
+    let end = end.structured_content.expect("end structured content");
+    assert_matches_output_schema(end_task_tool, &end);
+    assert_eq!(end["success"], "Task ended.");
+    assert_eq!(end["task_status"], "success");
+
+    let invalid_task_id = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "queries": ["SELECT 1"],
+                "intent": "Validate bad task id handling",
+                "task_id": "has space"
+            }))),
+        )
+        .await
+        .expect_err("invalid task_id should fail before query dispatch");
+    assert!(
+        invalid_task_id
+            .to_string()
+            .contains("argument 'task_id' must be a UUID")
+    );
+
+    let missing_task_id = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "queries": ["SELECT 1"],
+                "intent": "Validate missing task id handling"
+            }))),
+        )
+        .await
+        .expect_err("missing task_id should fail before query dispatch");
+    assert!(
+        missing_task_id
+            .to_string()
+            .contains("missing string argument 'task_id'")
+    );
+
+    let missing_tool_intent = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "queries": ["SELECT 1"],
+                "task_id": root_task_id
+            }))),
+        )
+        .await
+        .expect_err("missing intent should fail before query dispatch");
+    assert!(
+        missing_tool_intent
+            .to_string()
+            .contains("missing string argument 'intent'")
+    );
+
+    let invalid_initializer = client
+        .call_tool(
+            CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
+                "intent": "Open another task",
+                "initialize_session": true
+            }))),
+        )
+        .await
+        .expect_err("old initializer should fail before starting a task");
+    assert!(
+        invalid_initializer
+            .to_string()
+            .contains("unknown argument 'initialize_session'")
+    );
+
+    let tasks_path = temp
+        .path()
+        .join("coral-config/workspaces/default/tasks/tasks.jsonl");
+    let raw = fs::read_to_string(&tasks_path).expect("task file should exist");
+    let records = raw
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("task JSONL should parse"))
+        .collect::<Vec<_>>();
+    assert_eq!(records.len(), 2);
+    let root_record = records
+        .iter()
+        .find(|record| record["task_id"] == root_task_id.as_str())
+        .expect("root task record");
+    assert_eq!(root_record["workspace"], "default");
+    assert_eq!(root_record["intent"], "Investigate customer renewal risk");
+    let end_record = records
+        .iter()
+        .find(|record| record["task_id"] == root_task_id.as_str() && record["event"] == "end")
+        .expect("task end record");
+    assert_eq!(end_record["task_status"], "success");
+
+    let blank_intent = client
+        .call_tool(
+            CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
+                "intent": " "
+            }))),
+        )
+        .await
+        .expect_err("blank intent should fail before persistence");
+    assert!(
+        blank_intent
+            .to_string()
+            .contains("missing string argument 'intent'")
+    );
+    let raw_after_error = fs::read_to_string(&tasks_path).expect("task file should exist");
+    assert_eq!(raw_after_error.lines().count(), 2);
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_task_tools_are_disabled_by_default() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_session(&temp).await;
+    let client = &session.client;
+
+    let tools = client.list_all_tools().await.expect("tools");
+    assert!(
+        tools
+            .iter()
+            .all(|tool| tool.name.as_ref() != "start_task" && tool.name.as_ref() != "end_task"),
+        "task tools should not be listed by default"
+    );
+    for tool in &tools {
+        assert_tool_omits_task_id(tool);
+        assert_tool_omits_intent(tool);
+    }
+
+    let start_task = client
+        .call_tool(
+            CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
+                "intent": "Investigate customer renewal risk"
+            }))),
+        )
+        .await
+        .expect_err("start_task should not be exposed by default");
+    assert!(
+        start_task
+            .to_string()
+            .contains("tool 'start_task' not found")
+    );
+    let open_episode = client
+        .call_tool(
+            CallToolRequestParams::new("open_episode").with_arguments(json_object(&json!({
+                "intent": "Investigate customer renewal risk"
+            }))),
+        )
+        .await
+        .expect_err("open_episode should not be exposed");
+    assert!(
+        open_episode
+            .to_string()
+            .contains("tool 'open_episode' not found")
+    );
+    assert!(
+        !temp
+            .path()
+            .join("coral-config/workspaces/default/tasks/tasks.jsonl")
+            .exists()
+    );
+
+    session.shutdown().await;
 }
 
 #[tokio::test]
@@ -1093,6 +1462,72 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
     )
     .expect("feedback file should still exist");
     assert_eq!(raw_after_error.lines().count(), 1);
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_feedback_tool_accepts_task_id_when_tasks_enabled() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_session_with_options(
+        &temp,
+        McpOptions {
+            tasks_enabled: true,
+            feedback_enabled: true,
+            ..McpOptions::default()
+        },
+    )
+    .await;
+    let client = &session.client;
+
+    let tools = client.list_all_tools().await.expect("tools");
+    assert_tool_advertises_task_context(tool_by_name(&tools, "feedback"));
+
+    let feedback = client
+        .call_tool(
+            CallToolRequestParams::new("feedback").with_arguments(json_object(&json!({
+                "trying_to_do": "Finish a task-scoped task",
+                "tried": "Started a task and inspected failing output",
+                "stuck": "The final step still needs user judgment",
+                "intent": "Record blocked final task step",
+                "task_id": "550e8400-e29b-41d4-a716-446655440000"
+            }))),
+        )
+        .await
+        .expect("task-tagged feedback");
+    assert_eq!(feedback.is_error, Some(false));
+    assert_eq!(
+        feedback.structured_content.expect("structured content")["message"],
+        "Feedback report stored."
+    );
+
+    let raw = fs::read_to_string(
+        temp.path()
+            .join("coral-config/workspaces/default/feedback/reports.jsonl"),
+    )
+    .expect("feedback file should exist");
+    let records = raw.lines().collect::<Vec<_>>();
+    assert_eq!(records.len(), 1);
+    let record: Value = serde_json::from_str(records[0]).expect("feedback JSONL should parse");
+    assert_eq!(record["task_id"], "550e8400-e29b-41d4-a716-446655440000");
+
+    let invalid_task_id = client
+        .call_tool(
+            CallToolRequestParams::new("feedback").with_arguments(json_object(&json!({
+                "trying_to_do": "Finish a task-scoped task",
+                "tried": "Started a task and inspected failing output",
+                "stuck": "The final step still needs user judgment",
+                "intent": "Validate bad feedback task id handling",
+                "task_id": "has space"
+            }))),
+        )
+        .await
+        .expect_err("invalid task_id should fail before feedback dispatch");
+    assert!(
+        invalid_task_id
+            .to_string()
+            .contains("argument 'task_id' must be a UUID")
+    );
 
     session.shutdown().await;
 }


### PR DESCRIPTION
Summary
- Exposes feature-gated MCP task lifecycle tools.
- start_task accepts only intent and returns a UUID task id.
- end_task accepts task_id and task_status, using completed/failed statuses.
- Keeps tasks default-disabled and rejects removed initialize_session/open_episode surface.

Validation
- Full stack validation was run from codex/tasks-sessions-10-docs after rebasing onto origin/main: cargo test -p coral-api -p coral-app -p coral-client -p coral-mcp -p coral-cli; make rust-checks; make docs-check; make perf-check.