### PR TITLE
feat(cli): add tasks runtime feature

### DIFF
--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -15,6 +15,9 @@ use crate::state::{
 pub enum Feature {
     /// Expose the optional MCP `feedback` tool.
     Feedback,
+    /// Expose MCP task lifecycle tools and task attribution for follow-up Coral
+    /// MCP tool calls via the `coral-task-id` metadata key.
+    Tasks,
 }
 
 impl Feature {
@@ -65,14 +68,24 @@ struct FeatureSpec {
     disable_flag: &'static str,
 }
 
-const FEATURE_SPECS: &[FeatureSpec] = &[FeatureSpec {
-    feature: Feature::Feedback,
-    key: "feedback",
-    default_enabled: false,
-    description: "Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral.",
-    enable_flag: "enable-feedback",
-    disable_flag: "disable-feedback",
-}];
+const FEATURE_SPECS: &[FeatureSpec] = &[
+    FeatureSpec {
+        feature: Feature::Feedback,
+        key: "feedback",
+        default_enabled: false,
+        description: "Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral.",
+        enable_flag: "enable-feedback",
+        disable_flag: "disable-feedback",
+    },
+    FeatureSpec {
+        feature: Feature::Tasks,
+        key: "tasks",
+        default_enabled: false,
+        description: "Exposes MCP task lifecycle tools and tags follow-up Coral tool calls with task ids. Off by default.",
+        enable_flag: "enable-tasks",
+        disable_flag: "disable-tasks",
+    },
+];
 
 /// How a feature's value is configured in Coral's local config.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -707,7 +707,7 @@ async fn run_app_command(
                 app,
                 coral_mcp::McpOptions {
                     feedback_enabled: features.enabled(coral_app::features::Feature::Feedback),
-                    tasks_enabled: false,
+                    tasks_enabled: features.enabled(coral_app::features::Feature::Tasks),
                     trace_parent: ctx.and_then(|ctx| ctx.trace_parent.clone()),
                     source_names,
                     query_examples,

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -38,7 +38,9 @@ use coral_api::v1::{
     create_bundled_source_with_o_auth_response, import_source_response, search_result,
     source_input_spec::Input as ProtoSourceInput,
 };
-use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
+use coral_api::{
+    CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_TASK_ID_METADATA_KEY,
+};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -724,6 +726,7 @@ fn list_catalog_response(request: &ListCatalogRequest) -> ListCatalogResponse {
 struct Captured {
     execute_sql: Mutex<Vec<ExecuteSqlRequest>>,
     search: Mutex<Vec<SearchRequest>>,
+    execute_sql_task_ids: Mutex<Vec<Option<String>>>,
     list_catalog: Mutex<Vec<ListCatalogRequest>>,
     search_catalog: Mutex<Vec<SearchCatalogRequest>>,
     describe_table: Mutex<Vec<DescribeTableRequest>>,
@@ -792,12 +795,22 @@ impl QueryService for MockQueryService {
         &self,
         request: Request<ExecuteSqlRequest>,
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
+        let task_id = request
+            .metadata()
+            .get(CORAL_TASK_ID_METADATA_KEY)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
         let request = request.into_inner();
         self.captured
             .execute_sql
             .lock()
             .expect("execute_sql capture")
             .push(request.clone());
+        self.captured
+            .execute_sql_task_ids
+            .lock()
+            .expect("execute_sql task id capture")
+            .push(task_id);
         let sql = request.sql;
         if sql
             .trim_start()
@@ -1293,6 +1306,14 @@ impl MockServer {
 
     pub(crate) fn search_requests(&self) -> Vec<SearchRequest> {
         self.captured.search.lock().expect("search capture").clone()
+    }
+
+    pub(crate) fn execute_sql_task_ids(&self) -> Vec<Option<String>> {
+        self.captured
+            .execute_sql_task_ids
+            .lock()
+            .expect("execute_sql task id capture")
+            .clone()
     }
 
     pub(crate) fn discover_sources_requests(&self) -> Vec<DiscoverSourcesRequest> {

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -231,10 +231,6 @@ fn text_content(result: &rmcp::model::ReadResourceResult) -> &str {
     }
 }
 
-#[expect(
-    dead_code,
-    reason = "Episode removal leaves this schema helper unused until task feature tests reintroduce schema assertions later in the stack."
-)]
 fn tool_input_properties(tool: &rmcp::model::Tool) -> &Map<String, Value> {
     tool.input_schema
         .get("properties")
@@ -809,6 +805,90 @@ async fn mcp_stdio_enable_feedback_flag_lists_feedback_tool()
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_enable_tasks_flag_lists_task_tools() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let client = start_mcp_client_with_args(&server, &["--enable-tasks"]).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert_eq!(
+        tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>(),
+        vec![
+            "sql",
+            "search",
+            "list_catalog",
+            "describe_table",
+            "list_columns",
+            "start_task",
+            "end_task"
+        ]
+    );
+    for tool in tools
+        .iter()
+        .filter(|tool| !matches!(tool.name.as_ref(), "start_task" | "end_task"))
+    {
+        let required = tool
+            .input_schema
+            .get("required")
+            .and_then(Value::as_array)
+            .unwrap_or_else(|| panic!("tool '{}' should advertise required fields", tool.name));
+        assert!(
+            tool_input_properties(tool).contains_key("task_id"),
+            "tool '{}' should advertise task_id",
+            tool.name
+        );
+        assert!(
+            tool_input_properties(tool).contains_key("intent"),
+            "tool '{}' should advertise intent",
+            tool.name
+        );
+        assert!(
+            required
+                .iter()
+                .any(|field| field.as_str() == Some("task_id")),
+            "tool '{}' should require task_id",
+            tool.name
+        );
+        assert!(
+            required
+                .iter()
+                .any(|field| field.as_str() == Some("intent")),
+            "tool '{}' should require intent",
+            tool.name
+        );
+    }
+    let start_task = tools
+        .iter()
+        .find(|tool| tool.name.as_ref() == "start_task")
+        .expect("start_task tool should be listed");
+    assert!(
+        tool_input_properties(start_task).contains_key("intent"),
+        "start_task should accept intent"
+    );
+    assert!(
+        !tool_input_properties(start_task).contains_key("initialize_session"),
+        "start_task should not accept initialize_session"
+    );
+    let end_task = tools
+        .iter()
+        .find(|tool| tool.name.as_ref() == "end_task")
+        .expect("end_task tool should be listed");
+    assert!(tool_input_properties(end_task).contains_key("task_id"));
+    assert!(!tool_input_properties(end_task).contains_key("intent"));
+    assert!(tool_input_properties(end_task).contains_key("task_status"));
+    assert!(
+        tools.iter().any(|tool| tool.name.as_ref() == "end_task"),
+        "end_task tool should be listed"
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn mcp_stdio_feature_config_enables_feedback_tool() -> Result<(), Box<dyn std::error::Error>>
 {
     let server = MockServer::start().await;
@@ -825,6 +905,33 @@ feedback = true
     assert!(
         tools.iter().any(|tool| tool.name.as_ref() == "feedback"),
         "feedback tool should be listed when [features].feedback is true"
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_feature_config_enables_task_tools() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    write_config(
+        &server,
+        r"
+[features]
+tasks = true
+",
+    )?;
+    let client = start_mcp_client(&server).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert!(
+        tools.iter().any(|tool| tool.name.as_ref() == "start_task"),
+        "start_task tool should be listed when [features].tasks is true"
+    );
+    assert!(
+        tools.iter().any(|tool| tool.name.as_ref() == "end_task"),
+        "end_task tool should be listed when [features].tasks is true"
     );
 
     client.cancel().await?;
@@ -1322,6 +1429,41 @@ async fn mcp_stdio_sql_batch_records_each_execute_sql_request()
         requests
             .iter()
             .any(|request| request.sql == "SELECT 'second' AS label")
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_sql_batch_propagates_task_id_to_each_query()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let client = start_mcp_client_with_args(&server, &["--enable-tasks"]).await?;
+
+    let sql = structured_tool_content(
+        &client,
+        CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+            "queries": [
+                "SELECT 'first' AS label",
+                "SELECT 'second' AS label"
+            ],
+            "intent": "Run a task-scoped SQL batch",
+            "task_id": "550e8400-e29b-41d4-a716-446655440000"
+        }))),
+    )
+    .await?;
+    assert_eq!(sql["total_count"], 2);
+    assert_eq!(sql["success_count"], 2);
+
+    let task_ids = server.execute_sql_task_ids();
+    assert_eq!(task_ids.len(), 2);
+    assert!(
+        task_ids
+            .iter()
+            .all(|task_id| task_id.as_deref() == Some("550e8400-e29b-41d4-a716-446655440000")),
+        "expected every batch query to carry coral-task-id, got {task_ids:?}"
     );
 
     client.cancel().await?;


### PR DESCRIPTION
Summary
- Adds the tasks runtime feature to CLI/MCP feature handling.
- Covers flag/config enablement and task-id propagation through MCP SQL batch calls.

Validation
- Full stack validation was run from codex/tasks-sessions-10-docs after rebasing onto origin/main: cargo test -p coral-api -p coral-app -p coral-client -p coral-mcp -p coral-cli; make rust-checks; make docs-check; make perf-check.