### PR TITLE
docs(mcp): document task lifecycle

### DIFF
--- a/apps/docs/guides/use-coral-over-mcp.mdx
+++ b/apps/docs/guides/use-coral-over-mcp.mdx
@@ -3,7 +3,7 @@ title: "Use Coral over MCP"
 description: "Set up MCP for Claude Code, Cursor, and other agents."
 ---
 
-Coral ships with a built-in MCP server that presents Coral to agents as a read-only SQL database with catalog discovery.
+Coral ships with a built-in MCP server that presents Coral to agents as a read-only SQL database with catalog discovery. Optional task lifecycle tools can tag a unit of agent work so Coral can attribute follow-up SQL and catalog calls to that task.
 
 <Note>
 Before setting up a client, make sure you have [connected at least one source](/getting-started/quickstart).
@@ -200,6 +200,30 @@ Coral gives your agent a read-only SQL view over the sources you have installed 
 Set up and update sources with the CLI. The MCP server is the agent-facing query surface, not a source installer.
 
 Only connect Coral to agents you trust. A connected agent can query any source installed in that Coral workspace. See [Security](/project/security) for more detail.
+
+## Task attribution
+
+Task lifecycle tools are off by default. Enable them for one MCP server process with:
+
+```shellscript
+coral --enable-tasks mcp-stdio
+```
+
+Or persist the setting:
+
+```shellscript
+coral features enable tasks
+```
+
+When enabled, Coral exposes `start_task` and `end_task`. `start_task` accepts
+an `intent` and returns a UUID `task_id`. `end_task` requires that `task_id`,
+a per-call `intent`, and `task_status`, either `completed` or `failed`.
+
+The returned `task_id` and a per-call `intent` are required on follow-up `sql`,
+`search`, `list_catalog`, `describe_table`, `list_columns`, and `feedback`
+calls. Coral stores task lifecycle events locally under the selected workspace.
+Only the opaque task id is propagated as request metadata; per-call intent stays
+on the MCP tool-call telemetry event.
 
 ## How to ask for Coral
 

--- a/apps/docs/project/architecture.mdx
+++ b/apps/docs/project/architecture.mdx
@@ -66,6 +66,7 @@ The local server and core orchestrator.
 | Source management | Install, add from file, list, validate, remove (`sources/`) |
 | Workspace state and lifecycle | Workspace service plus config, secrets, and layout (`workspaces/`, `state/`, `storage/`) |
 | Feedback persistence | Workspace-scoped blocked-agent feedback reports (`feedback/`) |
+| Task persistence | Workspace-scoped task lifecycle logs (`task/`) |
 | Query orchestration | Loads sources, builds the engine, executes SQL (`query/`) |
 | Catalog discovery | Lists/searches/describes query-visible tables and columns (`catalog/`) |
 | Universal Search | Owns the `SearchService` shell and app-domain search result contract (`search/`) |
@@ -104,7 +105,7 @@ The MCP stdio server.
 | --------------- | ------------------------------------------------------------------- |
 | MCP protocol    | Tool and resource handlers via the `rmcp` SDK (`server.rs`)         |
 | Surface shaping | Tool/resource/error helpers split across `surface/{mod,tools,resources,errors}.rs`; discovery semantics come from `coral-app` |
-| Tools           | `sql`, `search`, `list_catalog`, `describe_table`, `list_columns`, optional `feedback` |
+| Tools           | `sql`, `search`, `list_catalog`, `describe_table`, `list_columns`, optional `feedback`, optional `start_task`/`end_task` |
 | Resources       | `coral://guide`, `coral://tables`                                   |
 
 Uses `coral-client` to reach `coral-app`, same transport as the CLI.
@@ -118,7 +119,7 @@ The shared gRPC contract.
 | Protobuf definitions | `proto/coral/v1/` transport contracts for Coral services and messages |
 | Generated bindings   | Tonic-generated Rust types and service traits                                          |
 
-All inter-crate communication between `coral-client` and `coral-app` goes through these generated types. The active service contracts include source management, query execution, catalog discovery, workspaces, feedback, episodes, traces, and Universal Search.
+All inter-crate communication between `coral-client` and `coral-app` goes through these generated types. The active service contracts include source management, query execution, catalog discovery, workspaces, feedback, tasks, traces, and Universal Search.
 
 `SearchService` powers metadata search over Coral's catalog. It returns typed,
 bounded matches for tables, table functions, columns, and filters, plus status,

--- a/apps/docs/project/security.mdx
+++ b/apps/docs/project/security.mdx
@@ -26,7 +26,8 @@ This release is intended for single-user local use:
 
 Coral reduces data exposure by keeping execution local and by exposing a narrow
 MCP surface: `sql`, `search`, `list_catalog`, `describe_table`,
-`list_columns`, optional `feedback`, `coral://guide`, and `coral://tables`.
+`list_columns`, optional `feedback`, optional `start_task`/`end_task`,
+`coral://guide`, and `coral://tables`.
 MCP tool and resource metadata can include installed source/schema names so
 clients can route source-specific requests to Coral during discovery.
 Secret values are not returned through `coral.inputs`; secret rows show only

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -13,6 +13,8 @@ coral --enable-<FEATURE> <COMMAND>
 coral --disable-<FEATURE> <COMMAND>
 coral --enable-feedback mcp-stdio
 coral --disable-feedback mcp-stdio
+coral --enable-tasks mcp-stdio
+coral --disable-tasks mcp-stdio
 ```
 
 These flags do not edit `config.toml`. Use `coral features enable <FEATURE>` or
@@ -202,7 +204,8 @@ coral source remove github
 
 Manage local workspaces. Workspaces isolate installed source metadata and
 workspace-scoped artifacts such as source manifests, local credential material,
-feedback reports, and workspace-attributed local trace history.
+feedback reports, task lifecycle logs, and workspace-attributed local trace
+history.
 
 Imported source specs and source credential material are attached to the source
 installation in that workspace. Reusable global source specs and reusable
@@ -271,6 +274,7 @@ feature is listed in [Configuration](/reference/configuration#runtime-features).
 
 ```shellscript
 coral features enable feedback
+coral features enable tasks
 ```
 
 ### `coral features disable <FEATURE>`
@@ -279,6 +283,7 @@ Persistently disables an experimental runtime feature.
 
 ```shellscript
 coral features disable feedback
+coral features disable tasks
 ```
 
 ## `coral ui`
@@ -334,6 +339,12 @@ By default, this server exposes:
 | Resource | `coral://tables` | JSON summaries of query-visible database tables, including Coral catalog tables and required filters |
 
 When the `feedback` feature is enabled, the server also exposes a non-read-only `feedback` tool for blocked-agent reports. Feedback reports are stored locally and anonymous copies may be uploaded to Coral.
+
+When the `tasks` feature is enabled, the server also exposes `start_task` and
+`end_task`. `start_task` accepts an `intent` and returns a UUID `task_id`.
+`end_task` accepts that `task_id`, a per-call `intent`, and `task_status`
+(`completed` or `failed`). Follow-up Coral MCP tools require both `task_id` and
+a per-call `intent` for task attribution.
 
 Discovery helpers include the `coral` system schema, so `search`,
 `list_catalog`, `describe_table`, `list_columns`, and `coral://tables` can

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -50,6 +50,7 @@ Experimental runtime features are configured under `[features]`.
 ```toml
 [features]
 feedback = true
+tasks = true
 ```
 
 You can inspect available features and their effective state with:
@@ -63,6 +64,8 @@ Enable or disable a feature with:
 ```shellscript
 coral features enable feedback
 coral features disable feedback
+coral features enable tasks
+coral features disable tasks
 ```
 
 Feature values must be booleans. Unknown feature keys are preserved in `config.toml` but ignored by Coral.
@@ -70,6 +73,7 @@ Feature values must be booleans. Unknown feature keys are preserved in `config.t
 | Feature | Default | Description |
 | ------- | ------- | ----------- |
 | `feedback` | `false` | Experimental. Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral. |
+| `tasks` | `false` | Experimental. Exposes MCP `start_task` and `end_task`, and requires follow-up Coral MCP tool calls to carry `task_id` plus per-call `intent` attribution. |
 
 ## OpenTelemetry
 


### PR DESCRIPTION
Summary
- Documents the task-only MCP lifecycle.
- Updates architecture and CLI/MCP reference docs to describe start_task, end_task, task ids, task event logs, and the default-disabled tasks feature.

Validation
- Full stack validation was run from this top branch after rebasing onto origin/main: cargo test -p coral-api -p coral-app -p coral-client -p coral-mcp -p coral-cli; make rust-checks; make docs-check; make perf-check.