### PR TITLE
ci: skip validate on draft PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 permissions:
   contents: read
@@ -19,6 +24,7 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     permissions:
       contents: read
       pull-requests: read
@@ -673,7 +679,7 @@ jobs:
       ]
     # Run even when upstream jobs fail or are conditionally skipped so this
     # job can act as the single required status check for the workflow.
-    if: ${{ always() }}
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     steps:
       - name: Check all job results
         env:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,7 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - converted_to_draft
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,11 @@
   latency. CI installs the bundled `github` source with fake credentials and
   fails when release `coral sql "select * from coral.tables"` has a hyperfine
   mean above 750 ms.
-- The `Validate` workflow intentionally skips draft pull request runs and
-  starts again on `ready_for_review`, including Graphite descendants that
-  inherit the workflow. Keep that draft gate aligned between the initial change
-  detector and final aggregate `validate` job.
+- The `Validate` workflow intentionally skips draft pull request runs, starts
+  again on `ready_for_review`, and still triggers on `converted_to_draft` so the
+  replacement skipped run cancels any in-progress validation for the PR branch.
+  Keep that draft gate aligned between the initial change detector and final
+  aggregate `validate` job.
 - `make rust-checks` is the Rust-only local gate and should keep using
   `--all-features`; the embedded UI feature is a normal CLI build surface.
 - The built UI artifact is produced by repo/CI orchestration (`make ui-build`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,10 @@
   latency. CI installs the bundled `github` source with fake credentials and
   fails when release `coral sql "select * from coral.tables"` has a hyperfine
   mean above 750 ms.
+- The `Validate` workflow intentionally skips draft pull request runs and
+  starts again on `ready_for_review`, including Graphite descendants that
+  inherit the workflow. Keep that draft gate aligned between the initial change
+  detector and final aggregate `validate` job.
 - `make rust-checks` is the Rust-only local gate and should keep using
   `--all-features`; the embedded UI feature is a normal CLI build surface.
 - The built UI artifact is produced by repo/CI orchestration (`make ui-build`


### PR DESCRIPTION
## Intent
Skip the expensive `Validate` workflow while Graphite stack PRs are still drafts, without changing validation behavior for ready PRs or pushes to `main`.

## What it enables
Draft PRs on this branch and descendants based on it can be submitted and iterated without burning the full validation matrix. When a PR is marked ready for review, the workflow runs again through the `ready_for_review` pull request event, and the final aggregate `validate` job remains the required status for non-draft PRs.

## Usage examples
- Submit Graphite stack branches as draft while iterating; `Validate` is skipped.
- Mark a PR ready for review; `Validate` starts from the `ready_for_review` event.
- Push to `main`; `Validate` still runs normally.

## Validation
- `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/validate.yml"); puts "yaml ok"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/validate.yml`
- Explicit check that `ready_for_review` and both draft gates are present.