### PR TITLE
fix(mcp): scope startup query history to workspace

### DIFF
--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -7,7 +7,7 @@ mod env;
 mod error;
 mod server;
 
-use crate::state::{AppStateLayout, ConfigStore};
+use crate::state::AppStateLayout;
 use crate::telemetry::{
     TelemetryConfig, TraceQueryHistoryEntry, TraceQueryTableFunctionUsage, TraceQueryTableUsage,
 };
@@ -26,32 +26,22 @@ pub(crate) fn discover_app_state_layout(
     env::AppEnvironment::discover().app_state_layout(config_dir_override)
 }
 
-/// Loads installed source names for the default workspace from local config only.
-///
-/// This is intentionally narrower than starting the local server and calling
-/// `ListSources`: startup surfaces such as MCP initialize only need source
-/// identity, not enriched source records, manifest versions, or query runtime
-/// setup.
-///
-/// # Errors
-///
-/// Returns [`AppError`] when the app state layout cannot be discovered or
-/// created, or when local config cannot be read or decoded.
-pub fn default_workspace_source_names() -> Result<Vec<String>, AppError> {
-    let layout = discover_app_state_layout(None)?;
-    layout.ensure()?;
-    ConfigStore::new(layout).list_workspace_source_names(&WorkspaceName::default())
-}
-
-/// Startup context loaded from local state for default-workspace MCP sessions.
+/// Startup context for one workspace's MCP session.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DefaultWorkspaceMcpStartupContext {
+pub struct WorkspaceMcpStartupContext {
+    workspace_name: String,
     source_names: Vec<String>,
     query_history: Vec<McpQueryHistoryEntry>,
 }
 
-impl DefaultWorkspaceMcpStartupContext {
-    /// Installed source names in the default workspace.
+impl WorkspaceMcpStartupContext {
+    /// Workspace name used to load this startup context.
+    #[must_use]
+    pub fn workspace_name(&self) -> &str {
+        &self.workspace_name
+    }
+
+    /// Installed source names supplied by the caller for the selected workspace.
     #[must_use]
     pub fn source_names(&self) -> &[String] {
         &self.source_names
@@ -67,6 +57,7 @@ impl DefaultWorkspaceMcpStartupContext {
 /// One successful query-history entry for MCP startup context.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct McpQueryHistoryEntry {
+    workspace_name: String,
     sql: String,
     sources: Vec<String>,
     tables: Vec<McpQueryTableUsage>,
@@ -75,6 +66,12 @@ pub struct McpQueryHistoryEntry {
 }
 
 impl McpQueryHistoryEntry {
+    /// Workspace that produced this query span.
+    #[must_use]
+    pub fn workspace_name(&self) -> &str {
+        &self.workspace_name
+    }
+
     /// SQL text recorded on the query span.
     #[must_use]
     pub fn sql(&self) -> &str {
@@ -107,6 +104,7 @@ impl McpQueryHistoryEntry {
 
     fn from_trace(entry: TraceQueryHistoryEntry) -> Self {
         Self {
+            workspace_name: entry.workspace,
             sql: entry.sql,
             sources: entry.sources,
             tables: entry
@@ -196,20 +194,24 @@ impl McpQueryTableFunctionUsage {
     }
 }
 
-/// Loads default-workspace source names and trace-backed query history without
-/// starting the local server.
+/// Builds MCP startup context for one workspace from caller-supplied source
+/// names and trace-backed query history, without starting another local server.
 ///
 /// # Errors
 ///
-/// Returns [`AppError`] when local app state, config, or trace history cannot
-/// be read. Older trace records that do not carry query provenance are ignored.
-pub fn default_workspace_mcp_startup_context(
+/// Returns [`AppError`] when local app state, telemetry config, or trace history
+/// cannot be read. Source names must already come from the normal source
+/// service path. Older trace records that do not carry workspace/query
+/// provenance are ignored.
+pub fn workspace_mcp_startup_context(
+    workspace_name: &str,
+    source_names: impl IntoIterator<Item = String>,
     query_history_limit: usize,
-) -> Result<DefaultWorkspaceMcpStartupContext, AppError> {
+) -> Result<WorkspaceMcpStartupContext, AppError> {
+    let workspace_name = WorkspaceName::parse(workspace_name)?;
+    let source_names = source_names.into_iter().collect();
     let layout = discover_app_state_layout(None)?;
     layout.ensure()?;
-    let source_names =
-        ConfigStore::new(layout.clone()).list_workspace_source_names(&WorkspaceName::default())?;
     let telemetry_config = TelemetryConfig::load(&layout)?;
     let query_history = if telemetry_config.trace_history.enabled {
         let query_history = crate::telemetry::list_local_query_history(
@@ -222,6 +224,7 @@ pub fn default_workspace_mcp_startup_context(
             ))
         })?
         .into_iter()
+        .filter(|entry| entry.workspace.as_str() == workspace_name.as_str())
         .map(McpQueryHistoryEntry::from_trace)
         .collect::<Vec<_>>();
         select_mcp_query_history(query_history, query_history_limit)
@@ -229,7 +232,8 @@ pub fn default_workspace_mcp_startup_context(
         Vec::new()
     };
 
-    Ok(DefaultWorkspaceMcpStartupContext {
+    Ok(WorkspaceMcpStartupContext {
+        workspace_name: workspace_name.as_str().to_string(),
         source_names,
         query_history,
     })
@@ -382,6 +386,7 @@ mod tests {
     ) -> McpQueryHistoryEntry {
         let table_source = sources.first().copied().unwrap_or("source");
         McpQueryHistoryEntry {
+            workspace_name: "default".to_string(),
             sql: sql.to_string(),
             sources: sources.iter().map(|source| (*source).to_string()).collect(),
             tables: (0..table_count)

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -572,19 +572,6 @@ impl ConfigStore {
         Ok(config.workspace_sources(workspace_name))
     }
 
-    pub(crate) fn list_workspace_source_names(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<Vec<String>, AppError> {
-        let config = self.load_config()?;
-        config.require_workspace(workspace_name)?;
-        Ok(config
-            .workspace_sources(workspace_name)
-            .into_iter()
-            .map(|source| source.name.as_str().to_string())
-            .collect())
-    }
-
     /// Loads one installed source without taking the app state lock.
     ///
     /// Callers must already hold the state lock while using source artifacts

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -478,6 +478,7 @@ pub(crate) struct TraceDetailRecord {
 pub(crate) struct TraceQueryHistoryEntry {
     pub(crate) trace_id: String,
     pub(crate) span_id: String,
+    pub(crate) workspace: String,
     pub(crate) sql: String,
     pub(crate) sources: Vec<String>,
     pub(crate) tables: Vec<TraceQueryTableUsage>,
@@ -1654,6 +1655,7 @@ fn query_history_entry_from_span(
     if sql.trim().is_empty() {
         return None;
     }
+    let workspace = attr_string(&attributes, WORKSPACE_SPAN_ATTRIBUTE)?;
     let row_count = attr_u64(&attributes, "row_count")?;
     let sources = attr_string_array(&attributes, super::QUERY_TRACE_SOURCES_ATTR)?;
     let tables =
@@ -1666,6 +1668,7 @@ fn query_history_entry_from_span(
     Some(TraceQueryHistoryEntry {
         trace_id: span.trace_id.clone(),
         span_id: span.span_id.clone(),
+        workspace,
         sql,
         sources,
         tables,
@@ -1839,6 +1842,7 @@ mod tests {
         JSONL_MAX_FILE_AGE, JsonlSpanExporter, RollingJsonlWriter, StoredTraceStatus,
         TraceSpanRecord, TraceStore, unix_nanos,
     };
+    use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
 
     const TRACE_RETENTION: Duration = Duration::from_hours(7 * 24);
 
@@ -2027,13 +2031,30 @@ mod tests {
         legacy_record.attributes_json =
             r#"{"sql":"SELECT old","status":"ok","row_count":1}"#.to_string();
 
+        let mut missing_workspace_record = trace_record("missing-workspace-trace", "span");
+        missing_workspace_record.attributes_json = query_history_attributes(
+            None,
+            "SELECT missing_workspace",
+            r#"["github"]"#,
+            "[]",
+            "[]",
+            1,
+        );
+
         let mut malformed_record = trace_record("malformed-trace", "malformed-span");
-        malformed_record.attributes_json =
-            query_history_attributes("SELECT malformed", "not-json", "[]", "[]", 1);
+        malformed_record.attributes_json = query_history_attributes(
+            Some("default"),
+            "SELECT malformed",
+            "not-json",
+            "[]",
+            "[]",
+            1,
+        );
 
         let mut valid_record = trace_record("valid-trace", "valid-span");
         valid_record.end_time_unix_nanos = 42;
         valid_record.attributes_json = query_history_attributes(
+            Some("default"),
             "SELECT title FROM github.issues",
             r#"["github"]"#,
             r#"[{"source_name":"github","schema_name":"github","table_name":"issues"}]"#,
@@ -2042,7 +2063,15 @@ mod tests {
         );
 
         let path = dir.join(timestamped_jsonl_path(SystemTime::now()));
-        write_record_file_lines(&path, &[legacy_record, malformed_record, valid_record]);
+        write_record_file_lines(
+            &path,
+            &[
+                legacy_record,
+                missing_workspace_record,
+                malformed_record,
+                valid_record,
+            ],
+        );
 
         let history = TraceStore::new(dir)
             .list_query_history_sync()
@@ -2050,6 +2079,7 @@ mod tests {
 
         assert_eq!(history.len(), 1);
         let entry = history.first().expect("history entry");
+        assert_eq!(entry.workspace, "default");
         assert_eq!(entry.sql, "SELECT title FROM github.issues");
         assert_eq!(entry.sources, ["github"]);
         assert_eq!(entry.row_count, 15);
@@ -2611,6 +2641,7 @@ mod tests {
     }
 
     fn query_history_attributes(
+        workspace: Option<&str>,
         sql: &str,
         sources_json: &str,
         tables_json: &str,
@@ -2618,6 +2649,9 @@ mod tests {
         row_count: u64,
     ) -> String {
         let mut attributes = serde_json::Map::new();
+        if let Some(workspace) = workspace {
+            attributes.insert(WORKSPACE_SPAN_ATTRIBUTE.to_string(), json!(workspace));
+        }
         attributes.insert("sql".to_string(), json!(sql));
         attributes.insert("status".to_string(), json!("ok"));
         attributes.insert("row_count".to_string(), json!(row_count));

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -647,29 +647,31 @@ async fn run_app_command(
                     Vec::new()
                 }
             };
-            let query_examples = if workspace.name == DEFAULT_WORKSPACE_ID {
-                match coral_app::bootstrap::default_workspace_mcp_startup_context(
+            let (source_names, query_examples) =
+                match coral_app::bootstrap::workspace_mcp_startup_context(
+                    &workspace.name,
+                    source_names.clone(),
                     MCP_INITIAL_QUERY_EXAMPLE_LIMIT,
                 ) {
-                    Ok(context) => context
-                        .query_history()
-                        .iter()
-                        .map(|entry| {
-                            coral_mcp::McpQueryExample::new(entry.sql())
-                                .with_sources(entry.sources().iter().cloned())
-                                .with_row_count(entry.row_count())
-                        })
-                        .collect(),
+                    Ok(context) => (
+                        context.source_names().to_vec(),
+                        context
+                            .query_history()
+                            .iter()
+                            .map(|entry| {
+                                coral_mcp::McpQueryExample::new(entry.sql())
+                                    .with_sources(entry.sources().iter().cloned())
+                                    .with_row_count(entry.row_count())
+                            })
+                            .collect(),
+                    ),
                     Err(error) => {
                         eprintln!(
                             "warning: failed to load MCP startup context for initialize instructions: {error}"
                         );
-                        Vec::new()
+                        (source_names, Vec::new())
                     }
-                }
-            } else {
-                Vec::new()
-            };
+                };
             Box::pin(coral_mcp::run_stdio_with_client(
                 app,
                 coral_mcp::McpOptions {

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -60,6 +60,52 @@ origin = "bundled"
     )
 }
 
+fn write_query_history_trace_records(
+    config_dir: &Path,
+    records: &[Value],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let trace_dir = config_dir.join("telemetry").join("traces");
+    fs::create_dir_all(&trace_dir)?;
+    let mut lines = String::new();
+    for record in records {
+        lines.push_str(&serde_json::to_string(record)?);
+        lines.push('\n');
+    }
+    fs::write(
+        trace_dir.join("spans-00000000000000000001-test-0000000000000000.jsonl"),
+        lines,
+    )?;
+    Ok(())
+}
+
+fn query_history_trace_record(
+    workspace: &str,
+    trace_id: &str,
+    sql: &str,
+    sources: &[&str],
+    row_count: u64,
+    end_time_unix_nanos: i64,
+) -> Value {
+    let attributes = json!({
+        "workspace": workspace,
+        "sql": sql,
+        "status": "ok",
+        "row_count": row_count,
+        "coral.query.sources": sources,
+        "coral.query.tables": [],
+        "coral.query.table_functions": [],
+    });
+
+    json!({
+        "trace_id": trace_id,
+        "span_id": format!("{trace_id}-span"),
+        "name": "coral.query",
+        "status": "ok",
+        "end_time_unix_nanos": end_time_unix_nanos,
+        "attributes_json": attributes.to_string(),
+    })
+}
+
 fn assert_workspace_name(workspace: Option<&Workspace>, expected: &str) {
     assert_eq!(
         workspace.map(|workspace| workspace.name.as_str()),
@@ -520,6 +566,27 @@ async fn mcp_stdio_workspace_flag_scopes_server_instance() -> Result<(), Box<dyn
     ))
     .await;
     write_workspace_scoped_source_config(&server)?;
+    write_query_history_trace_records(
+        server.config_dir(),
+        &[
+            query_history_trace_record(
+                "default",
+                "default-history",
+                "SELECT title FROM github.issues",
+                &["github"],
+                7,
+                10,
+            ),
+            query_history_trace_record(
+                "work",
+                "work-history",
+                "SELECT title FROM linear.issues",
+                &["linear"],
+                3,
+                20,
+            ),
+        ],
+    )?;
     let mut child = Command::new(env!("CARGO_BIN_EXE_coral"))
         .arg("mcp-stdio")
         .args(["--workspace", "work"])
@@ -534,44 +601,7 @@ async fn mcp_stdio_workspace_flag_scopes_server_instance() -> Result<(), Box<dyn
     let stdout = child.stdout.take().expect("mcp stdio stdout");
     let mut stdout = BufReader::new(stdout);
 
-    write_jsonrpc_message(
-        &mut stdin,
-        &json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2025-06-18",
-                "capabilities": {},
-                "clientInfo": {
-                    "name": "coral-cli-workspace-stdio-test",
-                    "version": "0.0.0"
-                }
-            }
-        }),
-    )
-    .await?;
-    let initialize = read_jsonrpc_response(&mut stdout, 1).await?;
-    let instructions = initialize
-        .pointer("/result/instructions")
-        .and_then(Value::as_str)
-        .expect("initialize response should include instructions");
-    assert!(
-        instructions.contains("Current Coral workspace: work."),
-        "initialize instructions should include selected workspace: {instructions}"
-    );
-    assert!(
-        instructions.contains("Connected Coral sources: linear."),
-        "initialize instructions should include app-provided source names: {instructions}"
-    );
-    assert!(
-        !instructions.contains("Connected Coral sources: jira."),
-        "initialize instructions should not use config-store source names: {instructions}"
-    );
-    assert!(
-        !instructions.contains("Recent successful Coral SQL examples"),
-        "non-default workspace initialize instructions should not use default-workspace query history: {instructions}"
-    );
+    assert_workspace_initialize_instructions(&mut stdin, &mut stdout).await?;
 
     write_jsonrpc_message(
         &mut stdin,
@@ -615,6 +645,61 @@ async fn mcp_stdio_workspace_flag_scopes_server_instance() -> Result<(), Box<dyn
         child.wait().await?;
     }
     server.shutdown().await;
+    Ok(())
+}
+
+async fn assert_workspace_initialize_instructions(
+    stdin: &mut ChildStdin,
+    stdout: &mut BufReader<ChildStdout>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    write_jsonrpc_message(
+        stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "coral-cli-workspace-stdio-test",
+                    "version": "0.0.0"
+                }
+            }
+        }),
+    )
+    .await?;
+    let initialize = read_jsonrpc_response(stdout, 1).await?;
+    let instructions = initialize
+        .pointer("/result/instructions")
+        .and_then(Value::as_str)
+        .expect("initialize response should include instructions");
+    assert!(
+        instructions.contains("Current Coral workspace: work."),
+        "initialize instructions should include selected workspace: {instructions}"
+    );
+    assert!(
+        instructions.contains("Connected Coral sources: linear."),
+        "initialize instructions should include app-provided source names: {instructions}"
+    );
+    assert!(
+        !instructions.contains("Connected Coral sources: jira."),
+        "initialize instructions should not use config-store source names: {instructions}"
+    );
+    assert!(
+        instructions.contains("Recent successful Coral SQL examples"),
+        "non-default workspace initialize instructions should include workspace query history: {instructions}"
+    );
+    assert!(
+        instructions.contains(
+            "1. sources: linear; row_count: 3\n```sql\nSELECT title FROM linear.issues\n```"
+        ),
+        "initialize instructions should include selected workspace query history: {instructions}"
+    );
+    assert!(
+        !instructions.contains("SELECT title FROM github.issues"),
+        "initialize instructions should not include default workspace query history: {instructions}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Intent
MCP initialize instructions were only able to use default-workspace query-history examples. That made non-default MCP sessions either lose useful examples or risk being coupled to default-workspace history.

This change makes startup query history workspace-aware while preserving the normal source-loading ownership boundary: source names still come from the running app's source service/source manager path, and trace-backed examples are filtered by the workspace recorded on query spans.

## What it enables
Non-default MCP workspaces can receive relevant recent SQL examples in initialize instructions without leaking examples from the default workspace.

It also removes the old config-store shortcut for source-name-only loading, so source data is no longer read through a separate bootstrap-only path.

## Usage examples
Start MCP for a non-default workspace:

```sh
coral mcp-stdio --workspace work
```

If trace history contains successful `work` queries, initialize instructions can now include `work` examples such as:

```sql
SELECT title FROM linear.issues
```

Default-workspace query examples are not included in that non-default session.

## Validation
- `cargo fmt --all`
- `cargo test -p coral-app --lib`
- `cargo test -p coral-cli --features cli-test-server --test mcp mcp_stdio_workspace_flag_scopes_server_instance`
- `cargo test -p coral-cli --features cli-test-server --test mcp mcp_stdio_initialize_includes_trace_backed_query_examples`
- `git diff --check`