### PR TITLE
feat(search): add search maintenance controls

### DIFF
--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -93,7 +93,8 @@ Manage Coral's local search indexes.
 
 ### `coral search-index rebuild`
 
-Rebuild an app-owned local search index.
+Rebuild a local search index. Coral skips the rebuild when the index is already
+up to date unless you pass `--force`.
 
 ```shellscript
 coral search-index rebuild --provider catalog
@@ -111,11 +112,10 @@ coral search-index rebuild --provider catalog --force
 
 Clear Coral's local search data for one workspace.
 
-This command is destructive, so it requires `--yes` and the global
-`--workspace` flag. Use `--workspace NAME` to clear `NAME`. Use bare
-`--workspace` to clear the workspace Coral would otherwise select:
-`CORAL_WORKSPACE` when set, otherwise `default`. The global flag may appear
-after `clear`.
+Clear deletes local search data, so Coral requires both `--yes` and
+`--workspace`. Use `--workspace NAME` to clear that workspace. Use
+`--workspace` with no name to clear the workspace Coral would normally use for
+this command: `CORAL_WORKSPACE` if it is set, or `default` otherwise.
 
 ```shellscript
 coral search-index clear --scope all --workspace --yes

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -89,7 +89,7 @@ For catalog search, the `catalog_metadata` provider status reports whether searc
 
 ## `coral search-index`
 
-Manage app-owned local search indexes.
+Manage Coral's local search indexes.
 
 ### `coral search-index rebuild`
 
@@ -109,11 +109,13 @@ coral search-index rebuild --provider catalog --force
 
 ### `coral search-index clear`
 
-Clear app-owned local search data for the current workspace.
-The global `--workspace [NAME]` flag is required as destructive confirmation:
-use it bare to confirm the selected workspace, or pass a name to select and
-confirm that workspace. Although `--workspace` is global, it may appear inside
-the `search-index clear` command.
+Clear Coral's local search data for one workspace.
+
+This command is destructive, so it requires `--yes` and the global
+`--workspace` flag. Use `--workspace NAME` to clear `NAME`. Use bare
+`--workspace` to clear the workspace Coral would otherwise select:
+`CORAL_WORKSPACE` when set, otherwise `default`. The global flag may appear
+after `clear`.
 
 ```shellscript
 coral search-index clear --scope all --workspace --yes

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -97,38 +97,35 @@ Rebuild a local search index. Coral skips the rebuild when the index is already
 up to date unless you pass `--force`.
 
 ```shellscript
-coral search-index rebuild --provider catalog
-coral search-index rebuild --provider catalog --force
+coral search-index rebuild
+coral search-index rebuild --force
 ```
 
 #### Options
 
-| Option               | Type | Default   | Description                                                     |
-| -------------------- | ---- | --------- | --------------------------------------------------------------- |
-| `--provider catalog` | enum | `catalog` | Search index provider to rebuild                                |
-| `--force`            | flag | `false`   | Rebuild even when the stored projection fingerprint is current   |
+| Option    | Type | Default | Description                                                    |
+| --------- | ---- | ------- | -------------------------------------------------------------- |
+| `--force` | flag | `false` | Rebuild even when the stored projection fingerprint is current |
 
 ### `coral search-index clear`
 
 Clear Coral's local search data for one workspace.
 
-Clear deletes local search data, so Coral requires both `--yes` and
-`--workspace`. Use `--workspace NAME` to clear that workspace. Use
-`--workspace` with no name to clear the workspace Coral would normally use for
-this command: `CORAL_WORKSPACE` if it is set, or `default` otherwise.
+Clear deletes local search data, so Coral requires both `--yes` and an explicit
+`--workspace NAME`.
 
 ```shellscript
-coral search-index clear --scope all --workspace --yes
 coral search-index clear --scope all --workspace work --yes
 ```
 
 #### Options
 
-| Option                      | Type        | Default  | Description                                      |
-| --------------------------- | ----------- | -------- | ------------------------------------------------ |
-| `--scope all`               | enum        | required | Search data scope to clear                       |
-| global `--workspace [NAME]` | flag/string | required | Confirm workspace-scoped deletion; with `NAME`, also select that workspace |
-| `--yes`                     | flag        | required | Confirm destructive search-data deletion         |
+| Option                    | Type   | Default  | Description                               |
+| ------------------------- | ------ | -------- | ----------------------------------------- |
+| `--scope all`             | enum   | required | Search data scope to clear                |
+| global `--workspace NAME` | string | required | Workspace whose search data will be cleared |
+| `--yes`                   | flag   | required | Confirm destructive search-data deletion  |
+
 ## `coral source`
 
 Manage configured sources, either the bundled ones, or your custom source specs.

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -87,6 +87,46 @@ With `--json`, the response separates `results`, `provider_statuses`, and `trunc
 
 For catalog search, the `catalog_metadata` provider status reports whether search found matches, completed with no matches, returned partial coverage, or failed. `truncation` reports when more matches were available than returned.
 
+## `coral search-index`
+
+Manage app-owned local search indexes.
+
+### `coral search-index rebuild`
+
+Rebuild an app-owned local search index.
+
+```shellscript
+coral search-index rebuild --provider catalog
+coral search-index rebuild --provider catalog --force
+```
+
+#### Options
+
+| Option               | Type | Default   | Description                                                     |
+| -------------------- | ---- | --------- | --------------------------------------------------------------- |
+| `--provider catalog` | enum | `catalog` | Search index provider to rebuild                                |
+| `--force`            | flag | `false`   | Rebuild even when the stored projection fingerprint is current   |
+
+### `coral search-index clear`
+
+Clear app-owned local search data for the current workspace.
+The global `--workspace [NAME]` flag is required as destructive confirmation:
+use it bare to confirm the selected workspace, or pass a name to select and
+confirm that workspace. Although `--workspace` is global, it may appear inside
+the `search-index clear` command.
+
+```shellscript
+coral search-index clear --scope all --workspace --yes
+coral search-index clear --scope all --workspace work --yes
+```
+
+#### Options
+
+| Option                      | Type        | Default  | Description                                      |
+| --------------------------- | ----------- | -------- | ------------------------------------------------ |
+| `--scope all`               | enum        | required | Search data scope to clear                       |
+| global `--workspace [NAME]` | flag/string | required | Confirm workspace-scoped deletion; with `NAME`, also select that workspace |
+| `--yes`                     | flag        | required | Confirm destructive search-data deletion         |
 ## `coral source`
 
 Manage configured sources, either the bundled ones, or your custom source specs.

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -93,7 +93,7 @@ Manage Coral's local search indexes.
 
 ### `coral search-index rebuild`
 
-Rebuild a local search index. Coral skips the rebuild when the index is already
+Rebuild all local search indexes. Coral skips a rebuild when an index is already
 up to date unless you pass `--force`.
 
 ```shellscript

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -114,6 +114,9 @@ Clear Coral's local search data for one workspace.
 Clear deletes local search data, so Coral requires both `--yes` and an explicit
 `--workspace NAME`.
 
+`all` is currently the only supported scope. It clears all local search data
+for the selected workspace.
+
 ```shellscript
 coral search-index clear --scope all --workspace work --yes
 ```
@@ -122,7 +125,7 @@ coral search-index clear --scope all --workspace work --yes
 
 | Option                    | Type   | Default  | Description                               |
 | ------------------------- | ------ | -------- | ----------------------------------------- |
-| `--scope all`             | enum   | required | Search data scope to clear                |
+| `--scope <SCOPE>`         | enum   | required | Scope to clear. Supported value: `all`    |
 | global `--workspace NAME` | string | required | Workspace whose search data will be cleared |
 | `--yes`                   | flag   | required | Confirm destructive search-data deletion  |
 

--- a/crates/coral-api/proto/coral/v1/search.proto
+++ b/crates/coral-api/proto/coral/v1/search.proto
@@ -29,19 +29,17 @@ message SearchResponse {
   SearchResultTruncation truncation = 3;
 }
 
-// Search index maintenance request.
+// Request to rebuild all app-owned local search indexes.
 message RebuildSearchIndexRequest {
   // Workspace whose local search data should be rebuilt.
   Workspace workspace = 1;
-  // Index provider to rebuild.
-  SearchIndexProvider provider = 2;
   // Force a rebuild even when the persisted fingerprint says the projection is current.
-  bool force = 3;
+  bool force = 2;
 }
 
 // Search index maintenance response.
 message RebuildSearchIndexResponse {
-  // Maintenance results for the providers selected by the request.
+  // Maintenance results for rebuilt providers.
   repeated SearchMaintenanceResult results = 1;
 }
 
@@ -61,14 +59,6 @@ message ClearSearchDataResponse {
   repeated SearchMaintenanceResult results = 1;
   // Best-effort local storage cleanup after data removal.
   SearchStorageCleanupResult storage_cleanup = 2;
-}
-
-// Search index provider selection for maintenance.
-enum SearchIndexProvider {
-  // Unknown index provider.
-  SEARCH_INDEX_PROVIDER_UNSPECIFIED = 0;
-  // Catalog metadata provider.
-  SEARCH_INDEX_PROVIDER_CATALOG = 1;
 }
 
 // Search data scope for destructive maintenance.

--- a/crates/coral-api/proto/coral/v1/search.proto
+++ b/crates/coral-api/proto/coral/v1/search.proto
@@ -41,8 +41,8 @@ message RebuildSearchIndexRequest {
 
 // Search index maintenance response.
 message RebuildSearchIndexResponse {
-  // Per-provider maintenance results.
-  repeated SearchMaintenanceProviderResult provider_results = 1;
+  // Maintenance results for the providers selected by the request.
+  repeated SearchMaintenanceResult results = 1;
 }
 
 // Search data removal request.
@@ -51,16 +51,16 @@ message ClearSearchDataRequest {
   Workspace workspace = 1;
   // Data scope to remove.
   SearchDataScope scope = 2;
-  // Removal target. PR 4A supports workspace-scoped clears only.
+  // Removal target.
   SearchClearTarget target = 3;
 }
 
 // Search data removal response.
 message ClearSearchDataResponse {
-  // Per-provider maintenance results.
-  repeated SearchMaintenanceProviderResult provider_results = 1;
-  // Best-effort SQLite compaction status after row deletion.
-  SearchCompactionStatus compaction = 2;
+  // Maintenance results for the affected providers.
+  repeated SearchMaintenanceResult results = 1;
+  // Best-effort local storage cleanup after data removal.
+  SearchStorageCleanupResult storage_cleanup = 2;
 }
 
 // Search index provider selection for maintenance.
@@ -69,43 +69,33 @@ enum SearchIndexProvider {
   SEARCH_INDEX_PROVIDER_UNSPECIFIED = 0;
   // Catalog metadata provider.
   SEARCH_INDEX_PROVIDER_CATALOG = 1;
-  // Local observed-value provider.
-  SEARCH_INDEX_PROVIDER_OBSERVED_VALUES = 2;
-  // All available index providers.
-  SEARCH_INDEX_PROVIDER_ALL = 3;
 }
 
 // Search data scope for destructive maintenance.
 enum SearchDataScope {
   // Unknown data scope.
   SEARCH_DATA_SCOPE_UNSPECIFIED = 0;
-  // Local observed-value memory only.
-  SEARCH_DATA_SCOPE_OBSERVED = 1;
-  // All app-owned local search data for the target.
+  // All local search data for the target.
   SEARCH_DATA_SCOPE_ALL = 2;
 }
 
 // Target for destructive search-data maintenance.
 message SearchClearTarget {
-  // Workspace or source target selected for the clear operation.
+  // Workspace target selected for the clear operation.
   oneof target {
     // Clear the selected scope for the whole workspace.
     bool workspace = 1;
-    // Reserved for source-scoped clear in a later PR.
-    string source_name = 2;
   }
 }
 
-// Provider-local maintenance result.
-message SearchMaintenanceProviderResult {
+// Outcome of one provider maintenance step.
+message SearchMaintenanceResult {
   // Provider that handled this maintenance step.
   SearchProvider provider = 1;
-  // Provider state after the maintenance step.
-  SearchProviderState state = 2;
+  // Outcome of the maintenance step.
+  SearchMaintenanceState state = 2;
   // Human-readable note.
   string note = 3;
-  // Structured provider-local maintenance coverage.
-  SearchProviderCoverage coverage = 4;
   // Provider-specific maintenance detail.
   oneof detail {
     // Catalog rebuild detail.
@@ -113,6 +103,22 @@ message SearchMaintenanceProviderResult {
     // Catalog clear detail.
     CatalogClearResult catalog_clear = 11;
   }
+}
+
+// State of one maintenance step.
+enum SearchMaintenanceState {
+  // Unknown maintenance state.
+  SEARCH_MAINTENANCE_STATE_UNSPECIFIED = 0;
+  // The requested maintenance work completed.
+  SEARCH_MAINTENANCE_STATE_COMPLETED = 1;
+  // No work was needed because the maintained state was already current.
+  SEARCH_MAINTENANCE_STATE_NOOP = 2;
+  // The maintenance step was intentionally skipped.
+  SEARCH_MAINTENANCE_STATE_SKIPPED = 3;
+  // Only part of the requested maintenance work completed.
+  SEARCH_MAINTENANCE_STATE_PARTIAL = 4;
+  // The maintenance step failed without failing the enclosing request.
+  SEARCH_MAINTENANCE_STATE_FAILED = 5;
 }
 
 // Catalog rebuild detail.
@@ -133,14 +139,12 @@ message CatalogClearResult {
   uint32 deleted_document_count = 1;
 }
 
-// Best-effort SQLite compaction status after destructive maintenance.
-message SearchCompactionStatus {
-  // Whether `PRAGMA wal_checkpoint(TRUNCATE)` completed.
-  bool wal_checkpoint_truncate_completed = 1;
-  // Whether `VACUUM` completed.
-  bool vacuum_completed = 2;
-  // Human-readable compaction note.
-  string note = 3;
+// Best-effort local storage cleanup after destructive maintenance.
+message SearchStorageCleanupResult {
+  // Outcome of the cleanup step.
+  SearchMaintenanceState state = 1;
+  // Human-readable cleanup note.
+  string note = 2;
 }
 
 // Result truncation metadata.

--- a/crates/coral-api/proto/coral/v1/search.proto
+++ b/crates/coral-api/proto/coral/v1/search.proto
@@ -29,6 +29,120 @@ message SearchResponse {
   SearchResultTruncation truncation = 3;
 }
 
+// Search index maintenance request.
+message RebuildSearchIndexRequest {
+  // Workspace whose local search data should be rebuilt.
+  Workspace workspace = 1;
+  // Index provider to rebuild.
+  SearchIndexProvider provider = 2;
+  // Force a rebuild even when the persisted fingerprint says the projection is current.
+  bool force = 3;
+}
+
+// Search index maintenance response.
+message RebuildSearchIndexResponse {
+  // Per-provider maintenance results.
+  repeated SearchMaintenanceProviderResult provider_results = 1;
+}
+
+// Search data removal request.
+message ClearSearchDataRequest {
+  // Workspace whose local search data should be removed.
+  Workspace workspace = 1;
+  // Data scope to remove.
+  SearchDataScope scope = 2;
+  // Removal target. PR 4A supports workspace-scoped clears only.
+  SearchClearTarget target = 3;
+}
+
+// Search data removal response.
+message ClearSearchDataResponse {
+  // Per-provider maintenance results.
+  repeated SearchMaintenanceProviderResult provider_results = 1;
+  // Best-effort SQLite compaction status after row deletion.
+  SearchCompactionStatus compaction = 2;
+}
+
+// Search index provider selection for maintenance.
+enum SearchIndexProvider {
+  // Unknown index provider.
+  SEARCH_INDEX_PROVIDER_UNSPECIFIED = 0;
+  // Catalog metadata provider.
+  SEARCH_INDEX_PROVIDER_CATALOG = 1;
+  // Local observed-value provider.
+  SEARCH_INDEX_PROVIDER_OBSERVED_VALUES = 2;
+  // All available index providers.
+  SEARCH_INDEX_PROVIDER_ALL = 3;
+}
+
+// Search data scope for destructive maintenance.
+enum SearchDataScope {
+  // Unknown data scope.
+  SEARCH_DATA_SCOPE_UNSPECIFIED = 0;
+  // Local observed-value memory only.
+  SEARCH_DATA_SCOPE_OBSERVED = 1;
+  // All app-owned local search data for the target.
+  SEARCH_DATA_SCOPE_ALL = 2;
+}
+
+// Target for destructive search-data maintenance.
+message SearchClearTarget {
+  // Workspace or source target selected for the clear operation.
+  oneof target {
+    // Clear the selected scope for the whole workspace.
+    bool workspace = 1;
+    // Reserved for source-scoped clear in a later PR.
+    string source_name = 2;
+  }
+}
+
+// Provider-local maintenance result.
+message SearchMaintenanceProviderResult {
+  // Provider that handled this maintenance step.
+  SearchProvider provider = 1;
+  // Provider state after the maintenance step.
+  SearchProviderState state = 2;
+  // Human-readable note.
+  string note = 3;
+  // Structured provider-local maintenance coverage.
+  SearchProviderCoverage coverage = 4;
+  // Provider-specific maintenance detail.
+  oneof detail {
+    // Catalog rebuild detail.
+    CatalogRebuildResult catalog_rebuild = 10;
+    // Catalog clear detail.
+    CatalogClearResult catalog_clear = 11;
+  }
+}
+
+// Catalog rebuild detail.
+message CatalogRebuildResult {
+  // Document rows present before rebuild.
+  uint32 old_document_count = 1;
+  // Document rows present after rebuild.
+  uint32 new_document_count = 2;
+  // Whether the catalog fingerprint differed from the snapshot being rebuilt.
+  bool projection_changed = 3;
+  // Whether a delete-and-reinsert rebuild was performed.
+  bool rebuild_performed = 4;
+}
+
+// Catalog clear detail.
+message CatalogClearResult {
+  // Catalog document rows deleted from the workspace projection.
+  uint32 deleted_document_count = 1;
+}
+
+// Best-effort SQLite compaction status after destructive maintenance.
+message SearchCompactionStatus {
+  // Whether `PRAGMA wal_checkpoint(TRUNCATE)` completed.
+  bool wal_checkpoint_truncate_completed = 1;
+  // Whether `VACUUM` completed.
+  bool vacuum_completed = 2;
+  // Human-readable compaction note.
+  string note = 3;
+}
+
 // Result truncation metadata.
 message SearchResultTruncation {
   // Whether more results were available than returned.
@@ -223,4 +337,8 @@ message ObservedValue {
 service SearchService {
   // Routes a clue to typed Coral search hints.
   rpc Search(SearchRequest) returns (SearchResponse);
+  // Rebuilds app-owned local search index projections.
+  rpc RebuildSearchIndex(RebuildSearchIndexRequest) returns (RebuildSearchIndexResponse);
+  // Clears app-owned local search data for a workspace-scoped target.
+  rpc ClearSearchData(ClearSearchDataRequest) returns (ClearSearchDataResponse);
 }

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -64,6 +64,12 @@ pub enum AppError {
     /// A required remote dependency was unavailable.
     #[error("unavailable: {0}")]
     Unavailable(String),
+    /// The server exhausted a resource required to complete the request.
+    #[error("resource exhausted: {0}")]
+    ResourceExhausted(String),
+    /// An internal server operation failed.
+    #[error("internal error: {0}")]
+    Internal(String),
     /// Filesystem access failed.
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -261,8 +267,10 @@ fn app_code(error: &AppError) -> Code {
             Code::FailedPrecondition
         }
         AppError::Unavailable(_) => Code::Unavailable,
+        AppError::ResourceExhausted(_) => Code::ResourceExhausted,
         AppError::Io(error) if error.kind() == std::io::ErrorKind::NotFound => Code::NotFound,
-        AppError::Io(_)
+        AppError::Internal(_)
+        | AppError::Io(_)
         | AppError::Yaml(_)
         | AppError::TomlDecode(_)
         | AppError::TomlEditDecode(_)
@@ -390,6 +398,22 @@ mod tests {
             "remote descriptor timed out".to_string(),
         ));
         assert_eq!(status.code(), Code::Unavailable);
+    }
+
+    #[test]
+    fn app_status_maps_resource_exhausted() {
+        let status = app_status(AppError::ResourceExhausted(
+            "local storage is full".to_string(),
+        ));
+
+        assert_eq!(status.code(), Code::ResourceExhausted);
+    }
+
+    #[test]
+    fn app_status_maps_internal() {
+        let status = app_status(AppError::Internal("storage failure".to_string()));
+
+        assert_eq!(status.code(), Code::Internal);
     }
 
     #[test]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -935,6 +935,8 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::InvalidV4ProjectionOverride { .. } => "INVALID_V4_PROJECTION_OVERRIDE",
         AppError::CredentialRefresh(_) => "CREDENTIAL_REFRESH",
         AppError::Unavailable(_) => "UNAVAILABLE",
+        AppError::ResourceExhausted(_) => "RESOURCE_EXHAUSTED",
+        AppError::Internal(_) => "INTERNAL",
         AppError::Io(_) => "IO",
         AppError::Yaml(_) => "YAML",
         AppError::TomlDecode(_) | AppError::TomlEditDecode(_) => "TOML_DECODE",

--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -15,14 +15,23 @@ use crate::search::catalog::snapshot::{
 use crate::search::catalog::sqlite_index::{
     CatalogIndexDocumentKind, CatalogRefreshResult, CatalogSearchHit, CatalogSearchHits,
 };
+use crate::search::maintenance::{
+    CatalogClearMaintenanceResult, CatalogRebuildMaintenanceResult, SearchClearTarget,
+    SearchCompactionStatus, SearchDataScope, SearchMaintenanceDetail,
+    SearchMaintenanceProviderResult, SearchProviderClearOutcome, SearchProviderClearRequest,
+    SearchProviderMaintenance, SearchProviderRebuildRequest,
+};
 use crate::search::provider::ProviderSearchOutcome;
 use crate::search::result::{
     CatalogMetadataResult, ColumnHintResult, ProviderCoverage, ProviderStatus, SearchCandidate,
-    SearchFieldRole, SearchPayload, SearchProviderKind, SearchProviderState, SearchRequest,
-    SearchSurfaceKind, TableColumnPreview, TableColumnPreviewColumn,
+    SearchFieldRole, SearchManagerError, SearchPayload, SearchProviderKind, SearchProviderState,
+    SearchRequest, SearchSurfaceKind, TableColumnPreview, TableColumnPreviewColumn,
 };
-use crate::search::sqlite_store::{SqliteSearchError, SqliteSearchStore};
+use crate::search::sqlite_store::{
+    SqliteSearchCompactionResult, SqliteSearchError, SqliteSearchStore,
+};
 use crate::state::AppStateLayout;
+use crate::workspaces::WorkspaceName;
 
 const CATALOG_PROVIDER_RETRIEVAL_MULTIPLIER: usize = 5;
 const CATALOG_PROVIDER_MIN_RETRIEVAL_LIMIT: usize = 25;
@@ -83,7 +92,14 @@ impl CatalogMetadataProvider {
     }
 
     fn load_catalog(&self, request: &SearchRequest) -> Result<CatalogInfo, AppError> {
-        self.catalog_loader.load_catalog(&request.workspace_name)
+        self.load_catalog_for_workspace(&request.workspace_name)
+    }
+
+    fn load_catalog_for_workspace(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<CatalogInfo, AppError> {
+        self.catalog_loader.load_catalog(workspace_name)
     }
 
     fn prepare_projection(
@@ -177,6 +193,142 @@ impl CatalogMetadataProvider {
             .saturating_mul(CATALOG_PROVIDER_RETRIEVAL_MULTIPLIER)
             .max(CATALOG_PROVIDER_MIN_RETRIEVAL_LIMIT);
         store.search_catalog(&request.terms, retrieval_limit)
+    }
+}
+
+impl SearchProviderMaintenance for CatalogMetadataProvider {
+    fn rebuild_index(
+        &self,
+        request: SearchProviderRebuildRequest<'_>,
+    ) -> Result<SearchMaintenanceProviderResult, SearchManagerError> {
+        let catalog = self.load_catalog_for_workspace(request.workspace_name)?;
+        let snapshot = CatalogSearchSnapshot::from_catalog(&catalog).index_snapshot();
+        let store = SqliteSearchStore::open_workspace(&self.layout, request.workspace_name)
+            .map_err(|error| search_sqlite_app_error(&error))?;
+        let result = store
+            .rebuild_catalog_projection(&snapshot, request.force)
+            .map_err(|error| search_sqlite_app_error(&error))?;
+        Ok(catalog_rebuild_provider_result(
+            result.old_document_count,
+            result.new_document_count,
+            result.projection_changed,
+            result.rebuild_performed,
+            request.force,
+        ))
+    }
+
+    fn clear_data(
+        &self,
+        request: SearchProviderClearRequest<'_>,
+    ) -> Result<SearchProviderClearOutcome, SearchManagerError> {
+        if request.scope != SearchDataScope::All {
+            return Err(AppError::InvalidInput(
+                "catalog search provider supports only all search-data clear scope".to_string(),
+            )
+            .into());
+        }
+        match request.target {
+            SearchClearTarget::Workspace => {
+                let store =
+                    SqliteSearchStore::open_workspace(&self.layout, request.workspace_name)
+                        .map_err(|error| search_sqlite_app_error(&error))?;
+                let result = store
+                    .clear_catalog_workspace()
+                    .map_err(|error| search_sqlite_app_error(&error))?;
+                let compaction = store.compact_after_clear();
+                Ok(SearchProviderClearOutcome {
+                    provider_result: catalog_clear_provider_result(result.deleted_document_count),
+                    compaction: search_compaction_status(compaction),
+                })
+            }
+            SearchClearTarget::Source(source_name) => Err(AppError::InvalidInput(format!(
+                "source-scoped catalog search-data clear is not implemented yet for source '{source_name}'"
+            ))
+            .into()),
+        }
+    }
+}
+
+fn catalog_rebuild_provider_result(
+    old_document_count: u32,
+    new_document_count: u32,
+    projection_changed: bool,
+    rebuild_performed: bool,
+    force: bool,
+) -> SearchMaintenanceProviderResult {
+    let note = if rebuild_performed && force {
+        "force rebuilt catalog search projection"
+    } else if rebuild_performed {
+        "rebuilt catalog search projection"
+    } else {
+        "catalog search projection already current"
+    }
+    .to_string();
+    SearchMaintenanceProviderResult {
+        provider: SearchProviderKind::CatalogMetadata,
+        state: if new_document_count == 0 {
+            SearchProviderState::Empty
+        } else {
+            SearchProviderState::ResultsFound
+        },
+        note,
+        coverage: ProviderCoverage {
+            eligible_units: new_document_count,
+            searched_units: new_document_count,
+            failed_units: 0,
+            returned_count: new_document_count,
+            has_more: false,
+            budget_exhausted: false,
+            timed_out: false,
+            stale_index: false,
+        },
+        detail: Some(SearchMaintenanceDetail::CatalogRebuild(
+            CatalogRebuildMaintenanceResult {
+                old_document_count,
+                new_document_count,
+                projection_changed,
+                rebuild_performed,
+            },
+        )),
+    }
+}
+
+fn catalog_clear_provider_result(deleted_document_count: u32) -> SearchMaintenanceProviderResult {
+    SearchMaintenanceProviderResult {
+        provider: SearchProviderKind::CatalogMetadata,
+        state: SearchProviderState::Empty,
+        note: "cleared catalog search projection".to_string(),
+        coverage: ProviderCoverage {
+            eligible_units: deleted_document_count,
+            searched_units: deleted_document_count,
+            failed_units: 0,
+            returned_count: 0,
+            has_more: false,
+            budget_exhausted: false,
+            timed_out: false,
+            stale_index: false,
+        },
+        detail: Some(SearchMaintenanceDetail::CatalogClear(
+            CatalogClearMaintenanceResult {
+                deleted_document_count,
+            },
+        )),
+    }
+}
+
+fn search_compaction_status(result: SqliteSearchCompactionResult) -> SearchCompactionStatus {
+    SearchCompactionStatus {
+        wal_checkpoint_truncate_completed: result.wal_checkpoint_truncate_completed,
+        vacuum_completed: result.vacuum_completed,
+        note: result.note,
+    }
+}
+
+fn search_sqlite_app_error(error: &SqliteSearchError) -> AppError {
+    if error.is_lock_contention() {
+        AppError::Unavailable(format!("SQLite search maintenance is busy: {error}"))
+    } else {
+        AppError::FailedPrecondition(format!("SQLite search maintenance failed: {error}"))
     }
 }
 

--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -795,6 +795,13 @@ mod tests {
             AppError::ResourceExhausted(_)
         ));
         assert!(matches!(
+            search_sqlite_app_error(&SqliteSearchError::Io(std::io::Error::new(
+                std::io::ErrorKind::StorageFull,
+                "fixture disk full",
+            ))),
+            AppError::ResourceExhausted(_)
+        ));
+        assert!(matches!(
             search_sqlite_app_error(&sqlite_failure(rusqlite::ffi::SQLITE_CORRUPT)),
             AppError::Internal(_)
         ));

--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -17,9 +17,9 @@ use crate::search::catalog::sqlite_index::{
 };
 use crate::search::maintenance::{
     CatalogClearMaintenanceResult, CatalogRebuildMaintenanceResult, SearchClearTarget,
-    SearchCompactionStatus, SearchDataScope, SearchMaintenanceDetail,
-    SearchMaintenanceProviderResult, SearchProviderClearOutcome, SearchProviderClearRequest,
-    SearchProviderMaintenance, SearchProviderRebuildRequest,
+    SearchDataScope, SearchMaintenanceDetail, SearchMaintenanceResult, SearchMaintenanceState,
+    SearchProviderClearOutcome, SearchProviderClearRequest, SearchProviderMaintenance,
+    SearchProviderRebuildRequest, SearchStorageCleanupResult,
 };
 use crate::search::provider::ProviderSearchOutcome;
 use crate::search::result::{
@@ -31,7 +31,6 @@ use crate::search::sqlite_store::{
     SqliteSearchCompactionResult, SqliteSearchError, SqliteSearchStore,
 };
 use crate::state::AppStateLayout;
-use crate::workspaces::WorkspaceName;
 
 const CATALOG_PROVIDER_RETRIEVAL_MULTIPLIER: usize = 5;
 const CATALOG_PROVIDER_MIN_RETRIEVAL_LIMIT: usize = 25;
@@ -92,14 +91,7 @@ impl CatalogMetadataProvider {
     }
 
     fn load_catalog(&self, request: &SearchRequest) -> Result<CatalogInfo, AppError> {
-        self.load_catalog_for_workspace(&request.workspace_name)
-    }
-
-    fn load_catalog_for_workspace(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<CatalogInfo, AppError> {
-        self.catalog_loader.load_catalog(workspace_name)
+        self.catalog_loader.load_catalog(&request.workspace_name)
     }
 
     fn prepare_projection(
@@ -200,8 +192,8 @@ impl SearchProviderMaintenance for CatalogMetadataProvider {
     fn rebuild_index(
         &self,
         request: SearchProviderRebuildRequest<'_>,
-    ) -> Result<SearchMaintenanceProviderResult, SearchManagerError> {
-        let catalog = self.load_catalog_for_workspace(request.workspace_name)?;
+    ) -> Result<SearchMaintenanceResult, SearchManagerError> {
+        let catalog = self.catalog_loader.load_catalog(request.workspace_name)?;
         let snapshot = CatalogSearchSnapshot::from_catalog(&catalog).index_snapshot();
         let store = SqliteSearchStore::open_workspace(&self.layout, request.workspace_name)
             .map_err(|error| search_sqlite_app_error(&error))?;
@@ -229,22 +221,17 @@ impl SearchProviderMaintenance for CatalogMetadataProvider {
         }
         match request.target {
             SearchClearTarget::Workspace => {
-                let store =
-                    SqliteSearchStore::open_workspace(&self.layout, request.workspace_name)
-                        .map_err(|error| search_sqlite_app_error(&error))?;
+                let store = SqliteSearchStore::open_workspace(&self.layout, request.workspace_name)
+                    .map_err(|error| search_sqlite_app_error(&error))?;
                 let result = store
                     .clear_catalog_workspace()
                     .map_err(|error| search_sqlite_app_error(&error))?;
                 let compaction = store.compact_after_clear();
                 Ok(SearchProviderClearOutcome {
-                    provider_result: catalog_clear_provider_result(result.deleted_document_count),
-                    compaction: search_compaction_status(compaction),
+                    result: catalog_clear_provider_result(result.deleted_document_count),
+                    storage_cleanup: search_storage_cleanup_result(&compaction),
                 })
             }
-            SearchClearTarget::Source(source_name) => Err(AppError::InvalidInput(format!(
-                "source-scoped catalog search-data clear is not implemented yet for source '{source_name}'"
-            ))
-            .into()),
         }
     }
 }
@@ -255,7 +242,7 @@ fn catalog_rebuild_provider_result(
     projection_changed: bool,
     rebuild_performed: bool,
     force: bool,
-) -> SearchMaintenanceProviderResult {
+) -> SearchMaintenanceResult {
     let note = if rebuild_performed && force {
         "force rebuilt catalog search projection"
     } else if rebuild_performed {
@@ -264,24 +251,14 @@ fn catalog_rebuild_provider_result(
         "catalog search projection already current"
     }
     .to_string();
-    SearchMaintenanceProviderResult {
+    SearchMaintenanceResult {
         provider: SearchProviderKind::CatalogMetadata,
-        state: if new_document_count == 0 {
-            SearchProviderState::Empty
+        state: if rebuild_performed {
+            SearchMaintenanceState::Completed
         } else {
-            SearchProviderState::ResultsFound
+            SearchMaintenanceState::Noop
         },
         note,
-        coverage: ProviderCoverage {
-            eligible_units: new_document_count,
-            searched_units: new_document_count,
-            failed_units: 0,
-            returned_count: new_document_count,
-            has_more: false,
-            budget_exhausted: false,
-            timed_out: false,
-            stale_index: false,
-        },
         detail: Some(SearchMaintenanceDetail::CatalogRebuild(
             CatalogRebuildMaintenanceResult {
                 old_document_count,
@@ -293,21 +270,15 @@ fn catalog_rebuild_provider_result(
     }
 }
 
-fn catalog_clear_provider_result(deleted_document_count: u32) -> SearchMaintenanceProviderResult {
-    SearchMaintenanceProviderResult {
+fn catalog_clear_provider_result(deleted_document_count: u32) -> SearchMaintenanceResult {
+    SearchMaintenanceResult {
         provider: SearchProviderKind::CatalogMetadata,
-        state: SearchProviderState::Empty,
-        note: "cleared catalog search projection".to_string(),
-        coverage: ProviderCoverage {
-            eligible_units: deleted_document_count,
-            searched_units: deleted_document_count,
-            failed_units: 0,
-            returned_count: 0,
-            has_more: false,
-            budget_exhausted: false,
-            timed_out: false,
-            stale_index: false,
+        state: if deleted_document_count == 0 {
+            SearchMaintenanceState::Noop
+        } else {
+            SearchMaintenanceState::Completed
         },
+        note: "cleared catalog search projection".to_string(),
         detail: Some(SearchMaintenanceDetail::CatalogClear(
             CatalogClearMaintenanceResult {
                 deleted_document_count,
@@ -316,19 +287,53 @@ fn catalog_clear_provider_result(deleted_document_count: u32) -> SearchMaintenan
     }
 }
 
-fn search_compaction_status(result: SqliteSearchCompactionResult) -> SearchCompactionStatus {
-    SearchCompactionStatus {
-        wal_checkpoint_truncate_completed: result.wal_checkpoint_truncate_completed,
-        vacuum_completed: result.vacuum_completed,
-        note: result.note,
+fn search_storage_cleanup_result(
+    result: &SqliteSearchCompactionResult,
+) -> SearchStorageCleanupResult {
+    let (state, note) = match (
+        result.wal_checkpoint_truncate_completed,
+        result.vacuum_completed,
+    ) {
+        (true, true) => (
+            SearchMaintenanceState::Completed,
+            "local search storage cleanup completed",
+        ),
+        (true, false) | (false, true) => (
+            SearchMaintenanceState::Partial,
+            "local search storage cleanup partially completed",
+        ),
+        (false, false) => (
+            SearchMaintenanceState::Failed,
+            "local search storage cleanup did not complete",
+        ),
+    };
+    if state != SearchMaintenanceState::Completed {
+        tracing::warn!(
+            wal_checkpoint_truncate_completed = result.wal_checkpoint_truncate_completed,
+            vacuum_completed = result.vacuum_completed,
+            detail = %result.note,
+            "local search storage cleanup did not fully complete"
+        );
+    }
+    SearchStorageCleanupResult {
+        state,
+        note: note.to_string(),
     }
 }
 
 fn search_sqlite_app_error(error: &SqliteSearchError) -> AppError {
     if error.is_lock_contention() {
-        AppError::Unavailable(format!("SQLite search maintenance is busy: {error}"))
+        AppError::Unavailable(format!("search maintenance storage is busy: {error}"))
+    } else if error.is_storage_exhaustion() {
+        AppError::ResourceExhausted(format!("search maintenance storage is exhausted: {error}"))
+    } else if matches!(
+        error,
+        SqliteSearchError::UnsupportedCapability { .. }
+            | SqliteSearchError::UnsupportedSchemaVersion { .. }
+    ) {
+        AppError::FailedPrecondition(format!("search maintenance is not supported: {error}"))
     } else {
-        AppError::FailedPrecondition(format!("SQLite search maintenance failed: {error}"))
+        AppError::Internal(format!("search maintenance storage failed: {error}"))
     }
 }
 
@@ -758,13 +763,14 @@ mod tests {
 
     use super::{
         CatalogProjection, MAX_COLUMN_HINTS_PER_SURFACE, catalog_provider_note,
-        catalog_search_outcome,
+        catalog_search_outcome, search_sqlite_app_error,
     };
+    use crate::bootstrap::AppError;
     use crate::search::catalog::sqlite_index::{
         CatalogIndexDocumentKind, CatalogRefreshResult, CatalogSearchHit, CatalogSearchHits,
     };
     use crate::search::result::{SearchProviderState, SearchRequest};
-    use crate::search::sqlite_store::SqliteSearchStore;
+    use crate::search::sqlite_store::{SqliteSearchError, SqliteSearchStore};
     use crate::workspaces::WorkspaceName;
 
     #[test]
@@ -776,6 +782,35 @@ mod tests {
             note,
             "Catalog metadata returned 3 search hints from cached SQLite projection because refresh is currently locked"
         );
+    }
+
+    #[test]
+    fn maintenance_error_mapping_preserves_retry_and_failure_categories() {
+        assert!(matches!(
+            search_sqlite_app_error(&sqlite_failure(rusqlite::ffi::SQLITE_BUSY)),
+            AppError::Unavailable(_)
+        ));
+        assert!(matches!(
+            search_sqlite_app_error(&sqlite_failure(rusqlite::ffi::SQLITE_FULL)),
+            AppError::ResourceExhausted(_)
+        ));
+        assert!(matches!(
+            search_sqlite_app_error(&sqlite_failure(rusqlite::ffi::SQLITE_CORRUPT)),
+            AppError::Internal(_)
+        ));
+        assert!(matches!(
+            search_sqlite_app_error(&SqliteSearchError::UnsupportedCapability {
+                feature: "FTS5",
+                sqlite_version: "fixture".to_string(),
+            }),
+            AppError::FailedPrecondition(_)
+        ));
+        assert!(matches!(
+            search_sqlite_app_error(&SqliteSearchError::Io(std::io::Error::other(
+                "fixture storage failure"
+            ))),
+            AppError::Internal(_)
+        ));
     }
 
     #[test]
@@ -818,6 +853,13 @@ mod tests {
                 .note
                 .contains("2 matching column hint(s) exceeded the per-surface cap")
         );
+    }
+
+    fn sqlite_failure(code: i32) -> SqliteSearchError {
+        SqliteSearchError::Sqlite(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(code),
+            None,
+        ))
     }
 
     fn column_cap_catalog(column_count: usize) -> CatalogInfo {

--- a/crates/coral-app/src/search/catalog/sqlite_index.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index.rs
@@ -52,6 +52,20 @@ impl SqliteCatalogIndex {
         clippy::unused_self,
         reason = "kept as an instance method so catalog provider can own index capability consistently"
     )]
+    pub(crate) fn rebuild(
+        &self,
+        connection: &mut Connection,
+        workspace_name: &WorkspaceName,
+        snapshot: &CatalogIndexSnapshot,
+        force: bool,
+    ) -> Result<CatalogRebuildResult, SqliteSearchError> {
+        rebuild_catalog_documents(connection, workspace_name, snapshot, force)
+    }
+
+    #[expect(
+        clippy::unused_self,
+        reason = "kept as an instance method so catalog provider can own index capability consistently"
+    )]
     pub(crate) fn projection_is_current(
         &self,
         connection: &Connection,
@@ -159,6 +173,36 @@ fn refresh_catalog_documents_after_stale_check(
     })
 }
 
+fn rebuild_catalog_documents(
+    connection: &mut Connection,
+    workspace_name: &WorkspaceName,
+    snapshot: &CatalogIndexSnapshot,
+    force: bool,
+) -> Result<CatalogRebuildResult, SqliteSearchError> {
+    let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let current_fingerprint = catalog_fingerprint(&transaction, workspace_name)?;
+    let old_document_count = catalog_document_count(&transaction, workspace_name)?;
+    let projection_changed = current_fingerprint.as_deref() != Some(snapshot.fingerprint.as_str());
+    let rebuild_performed = force || projection_changed;
+
+    if rebuild_performed {
+        replace_catalog_documents(&transaction, workspace_name, snapshot)?;
+    }
+
+    let new_document_count = if rebuild_performed {
+        catalog_document_count(&transaction, workspace_name)?
+    } else {
+        old_document_count
+    };
+    transaction.commit()?;
+    Ok(CatalogRebuildResult {
+        old_document_count,
+        new_document_count,
+        projection_changed,
+        rebuild_performed,
+    })
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CatalogIndexSnapshot {
     pub(crate) documents: Vec<CatalogIndexDocument>,
@@ -211,6 +255,14 @@ impl CatalogIndexDocumentKind {
 pub(crate) struct CatalogRefreshResult {
     pub(crate) refreshed: bool,
     pub(crate) document_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CatalogRebuildResult {
+    pub(crate) old_document_count: u32,
+    pub(crate) new_document_count: u32,
+    pub(crate) projection_changed: bool,
+    pub(crate) rebuild_performed: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
@@ -76,10 +76,91 @@ fn clear_workspace_removes_workspace_documents_and_invalidates_fingerprint() {
 
     assert_eq!(result.deleted_document_count, 3);
     assert_eq!(store.catalog_document_count().expect("document count"), 0);
+    assert_eq!(
+        catalog_fts_document_count(&store),
+        0,
+        "clear should remove workspace FTS rows"
+    );
+    assert_eq!(
+        schema_version(&store),
+        crate::search::sqlite_store::SEARCH_SQLITE_SCHEMA_VERSION.to_string(),
+        "clear should leave schema metadata intact"
+    );
     assert!(
         !store
             .catalog_projection_is_current(&snapshot.fingerprint)
             .expect("projection invalidated")
+    );
+}
+
+#[test]
+fn forced_rebuild_runs_when_fingerprint_is_unchanged() {
+    let temp = tempdir().expect("tempdir");
+    let store = catalog_store(&temp);
+    let snapshot = catalog_index_snapshot();
+    store
+        .refresh_catalog_projection(&snapshot)
+        .expect("refresh catalog");
+
+    {
+        let connection = store.connect_for_test().expect("connect");
+        let workspace_name = WorkspaceName::default();
+        connection
+            .execute(
+                "DELETE FROM catalog_documents WHERE workspace = ?1 AND doc_id = ?2",
+                (
+                    workspace_name.as_str(),
+                    "catalog:function:github.search_deployments",
+                ),
+            )
+            .expect("corrupt catalog projection");
+    }
+    assert!(
+        store
+            .catalog_projection_is_current(&snapshot.fingerprint)
+            .expect("fingerprint should still be current"),
+        "the corruption keeps the fingerprint current so normal refresh would skip"
+    );
+    assert_eq!(store.catalog_document_count().expect("document count"), 2);
+
+    let rebuild = store
+        .rebuild_catalog_projection(&snapshot, true)
+        .expect("force rebuild catalog");
+
+    assert_eq!(rebuild.old_document_count, 2);
+    assert_eq!(rebuild.new_document_count, 3);
+    assert!(!rebuild.projection_changed);
+    assert!(rebuild.rebuild_performed);
+    assert_eq!(store.catalog_document_count().expect("document count"), 3);
+    assert_eq!(
+        catalog_fts_document_count(&store),
+        3,
+        "force rebuild should recreate matching FTS rows"
+    );
+}
+
+#[test]
+fn compaction_reports_checkpoint_and_vacuum_status() {
+    let temp = tempdir().expect("tempdir");
+    let store = catalog_store(&temp);
+    store
+        .refresh_catalog_projection(&catalog_index_snapshot())
+        .expect("refresh catalog");
+    store
+        .clear_catalog_workspace()
+        .expect("clear workspace catalog");
+
+    let compaction = store.compact_after_clear();
+
+    assert!(
+        compaction.wal_checkpoint_truncate_completed,
+        "WAL checkpoint/truncate should complete: {}",
+        compaction.note
+    );
+    assert!(
+        compaction.vacuum_completed,
+        "VACUUM should complete: {}",
+        compaction.note
     );
 }
 
@@ -391,6 +472,30 @@ fn probe_past_limit_reports_retrieval_limited() {
 fn catalog_store(temp: &TempDir) -> SqliteSearchStore {
     SqliteSearchStore::open(temp.path().join("search.sqlite3"), WorkspaceName::default())
         .expect("store")
+}
+
+fn catalog_fts_document_count(store: &SqliteSearchStore) -> u32 {
+    let connection = store.connect_for_test().expect("connect");
+    let workspace_name = WorkspaceName::default();
+    let count: i64 = connection
+        .query_row(
+            "SELECT count(*) FROM catalog_documents_fts WHERE workspace = ?1",
+            [workspace_name.as_str()],
+            |row| row.get(0),
+        )
+        .expect("FTS count");
+    u32::try_from(count).expect("FTS count should fit")
+}
+
+fn schema_version(store: &SqliteSearchStore) -> String {
+    let connection = store.connect_for_test().expect("connect");
+    connection
+        .query_row(
+            "SELECT value FROM search_meta WHERE key = 'schema_version'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("schema version")
 }
 
 fn catalog_index_snapshot() -> CatalogIndexSnapshot {

--- a/crates/coral-app/src/search/maintenance.rs
+++ b/crates/coral-app/src/search/maintenance.rs
@@ -1,8 +1,6 @@
 //! Transport-neutral Universal Search maintenance models.
 
-use crate::search::result::{
-    ProviderCoverage, SearchManagerError, SearchProviderKind, SearchProviderState,
-};
+use crate::search::result::{SearchManagerError, SearchProviderKind};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug, Clone)]
@@ -14,7 +12,7 @@ pub(crate) struct RebuildSearchIndexRequest {
 
 #[derive(Debug, Clone)]
 pub(crate) struct RebuildSearchIndexResponse {
-    pub(crate) provider_results: Vec<SearchMaintenanceProviderResult>,
+    pub(crate) results: Vec<SearchMaintenanceResult>,
 }
 
 #[derive(Debug, Clone)]
@@ -26,15 +24,15 @@ pub(crate) struct ClearSearchDataRequest {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ClearSearchDataResponse {
-    pub(crate) provider_results: Vec<SearchMaintenanceProviderResult>,
-    pub(crate) compaction: SearchCompactionStatus,
+    pub(crate) results: Vec<SearchMaintenanceResult>,
+    pub(crate) storage_cleanup: SearchStorageCleanupResult,
 }
 
 pub(crate) trait SearchProviderMaintenance {
     fn rebuild_index(
         &self,
         request: SearchProviderRebuildRequest<'_>,
-    ) -> Result<SearchMaintenanceProviderResult, SearchManagerError>;
+    ) -> Result<SearchMaintenanceResult, SearchManagerError>;
 
     fn clear_data(
         &self,
@@ -57,36 +55,39 @@ pub(crate) struct SearchProviderClearRequest<'a> {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SearchProviderClearOutcome {
-    pub(crate) provider_result: SearchMaintenanceProviderResult,
-    pub(crate) compaction: SearchCompactionStatus,
+    pub(crate) result: SearchMaintenanceResult,
+    pub(crate) storage_cleanup: SearchStorageCleanupResult,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SearchIndexProvider {
     Catalog,
-    ObservedValues,
-    All,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SearchDataScope {
-    Observed,
     All,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum SearchClearTarget {
     Workspace,
-    Source(String),
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct SearchMaintenanceProviderResult {
+pub(crate) struct SearchMaintenanceResult {
     pub(crate) provider: SearchProviderKind,
-    pub(crate) state: SearchProviderState,
+    pub(crate) state: SearchMaintenanceState,
     pub(crate) note: String,
-    pub(crate) coverage: ProviderCoverage,
     pub(crate) detail: Option<SearchMaintenanceDetail>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SearchMaintenanceState {
+    Completed,
+    Noop,
+    Partial,
+    Failed,
 }
 
 #[derive(Debug, Clone)]
@@ -109,8 +110,7 @@ pub(crate) struct CatalogClearMaintenanceResult {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SearchCompactionStatus {
-    pub(crate) wal_checkpoint_truncate_completed: bool,
-    pub(crate) vacuum_completed: bool,
+pub(crate) struct SearchStorageCleanupResult {
+    pub(crate) state: SearchMaintenanceState,
     pub(crate) note: String,
 }

--- a/crates/coral-app/src/search/maintenance.rs
+++ b/crates/coral-app/src/search/maintenance.rs
@@ -1,0 +1,116 @@
+//! Transport-neutral Universal Search maintenance models.
+
+use crate::search::result::{
+    ProviderCoverage, SearchManagerError, SearchProviderKind, SearchProviderState,
+};
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, Clone)]
+pub(crate) struct RebuildSearchIndexRequest {
+    pub(crate) workspace_name: WorkspaceName,
+    pub(crate) provider: SearchIndexProvider,
+    pub(crate) force: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RebuildSearchIndexResponse {
+    pub(crate) provider_results: Vec<SearchMaintenanceProviderResult>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ClearSearchDataRequest {
+    pub(crate) workspace_name: WorkspaceName,
+    pub(crate) scope: SearchDataScope,
+    pub(crate) target: SearchClearTarget,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ClearSearchDataResponse {
+    pub(crate) provider_results: Vec<SearchMaintenanceProviderResult>,
+    pub(crate) compaction: SearchCompactionStatus,
+}
+
+pub(crate) trait SearchProviderMaintenance {
+    fn rebuild_index(
+        &self,
+        request: SearchProviderRebuildRequest<'_>,
+    ) -> Result<SearchMaintenanceProviderResult, SearchManagerError>;
+
+    fn clear_data(
+        &self,
+        request: SearchProviderClearRequest<'_>,
+    ) -> Result<SearchProviderClearOutcome, SearchManagerError>;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SearchProviderRebuildRequest<'a> {
+    pub(crate) workspace_name: &'a WorkspaceName,
+    pub(crate) force: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SearchProviderClearRequest<'a> {
+    pub(crate) workspace_name: &'a WorkspaceName,
+    pub(crate) scope: SearchDataScope,
+    pub(crate) target: &'a SearchClearTarget,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SearchProviderClearOutcome {
+    pub(crate) provider_result: SearchMaintenanceProviderResult,
+    pub(crate) compaction: SearchCompactionStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SearchIndexProvider {
+    Catalog,
+    ObservedValues,
+    All,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SearchDataScope {
+    Observed,
+    All,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SearchClearTarget {
+    Workspace,
+    Source(String),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SearchMaintenanceProviderResult {
+    pub(crate) provider: SearchProviderKind,
+    pub(crate) state: SearchProviderState,
+    pub(crate) note: String,
+    pub(crate) coverage: ProviderCoverage,
+    pub(crate) detail: Option<SearchMaintenanceDetail>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum SearchMaintenanceDetail {
+    CatalogRebuild(CatalogRebuildMaintenanceResult),
+    CatalogClear(CatalogClearMaintenanceResult),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CatalogRebuildMaintenanceResult {
+    pub(crate) old_document_count: u32,
+    pub(crate) new_document_count: u32,
+    pub(crate) projection_changed: bool,
+    pub(crate) rebuild_performed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CatalogClearMaintenanceResult {
+    pub(crate) deleted_document_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SearchCompactionStatus {
+    pub(crate) wal_checkpoint_truncate_completed: bool,
+    pub(crate) vacuum_completed: bool,
+    pub(crate) note: String,
+}

--- a/crates/coral-app/src/search/maintenance.rs
+++ b/crates/coral-app/src/search/maintenance.rs
@@ -6,7 +6,6 @@ use crate::workspaces::WorkspaceName;
 #[derive(Debug, Clone)]
 pub(crate) struct RebuildSearchIndexRequest {
     pub(crate) workspace_name: WorkspaceName,
-    pub(crate) provider: SearchIndexProvider,
     pub(crate) force: bool,
 }
 
@@ -57,11 +56,6 @@ pub(crate) struct SearchProviderClearRequest<'a> {
 pub(crate) struct SearchProviderClearOutcome {
     pub(crate) result: SearchMaintenanceResult,
     pub(crate) storage_cleanup: SearchStorageCleanupResult,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SearchIndexProvider {
-    Catalog,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -9,8 +9,8 @@ use crate::search::catalog::provider::CatalogMetadataProvider;
 use crate::search::engine::UniversalSearchEngine;
 use crate::search::maintenance::{
     ClearSearchDataRequest, ClearSearchDataResponse, RebuildSearchIndexRequest,
-    RebuildSearchIndexResponse, SearchIndexProvider, SearchMaintenanceResult,
-    SearchProviderClearRequest, SearchProviderMaintenance, SearchProviderRebuildRequest,
+    RebuildSearchIndexResponse, SearchMaintenanceResult, SearchProviderClearRequest,
+    SearchProviderMaintenance, SearchProviderRebuildRequest,
 };
 use crate::search::result::{SearchManagerError, SearchRequest, SearchResponse};
 use crate::state::{AppStateLayout, ConfigStore};
@@ -65,9 +65,7 @@ impl SearchManager {
         &self,
         request: &RebuildSearchIndexRequest,
     ) -> Result<RebuildSearchIndexResponse, SearchManagerError> {
-        let result = match request.provider {
-            SearchIndexProvider::Catalog => self.rebuild_catalog_index(request)?,
-        };
+        let result = self.rebuild_catalog_index(request)?;
         Ok(RebuildSearchIndexResponse {
             results: vec![result],
         })

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -1,15 +1,27 @@
 //! App-level Universal Search manager.
 
+use tokio::task;
+
+use crate::bootstrap::AppError;
 use crate::query::QueryAttribution;
 use crate::search::catalog::local_snapshot::CatalogSnapshotLoader;
 use crate::search::catalog::provider::CatalogMetadataProvider;
 use crate::search::engine::UniversalSearchEngine;
-use crate::search::result::{SearchManagerError, SearchRequest, SearchResponse};
+use crate::search::maintenance::{
+    ClearSearchDataRequest, ClearSearchDataResponse, RebuildSearchIndexRequest,
+    RebuildSearchIndexResponse, SearchIndexProvider, SearchMaintenanceProviderResult,
+    SearchProviderClearRequest, SearchProviderMaintenance, SearchProviderRebuildRequest,
+};
+use crate::search::result::{
+    ProviderCoverage, SearchManagerError, SearchProviderKind, SearchProviderState, SearchRequest,
+    SearchResponse,
+};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::WorkspaceManager;
 
 #[derive(Clone)]
 pub(crate) struct SearchManager {
+    catalog: CatalogMetadataProvider,
     engine: UniversalSearchEngine,
     workspaces: WorkspaceManager,
 }
@@ -23,6 +35,7 @@ impl SearchManager {
         let catalog_loader = CatalogSnapshotLoader::new(config_store.clone(), layout.clone());
         let catalog = CatalogMetadataProvider::new(layout, catalog_loader);
         Self {
+            catalog: catalog.clone(),
             engine: UniversalSearchEngine::new(catalog),
             workspaces: workspace_manager,
         }
@@ -37,5 +50,99 @@ impl SearchManager {
             .require_workspace(&request.workspace_name)
             .await?;
         Ok(self.engine.search(request, attribution))
+    }
+
+    pub(crate) async fn rebuild_index(
+        &self,
+        request: &RebuildSearchIndexRequest,
+    ) -> Result<RebuildSearchIndexResponse, SearchManagerError> {
+        self.workspaces
+            .require_workspace(&request.workspace_name)
+            .await?;
+        let search = self.clone();
+        let request = request.clone();
+        run_blocking_search_operation(move || search.rebuild_index_blocking(&request)).await
+    }
+
+    fn rebuild_index_blocking(
+        &self,
+        request: &RebuildSearchIndexRequest,
+    ) -> Result<RebuildSearchIndexResponse, SearchManagerError> {
+        let provider_results = match request.provider {
+            SearchIndexProvider::Catalog => vec![self.rebuild_catalog_index(request)?],
+            SearchIndexProvider::ObservedValues => vec![skipped_rebuild_provider_result(
+                SearchProviderKind::ObservedValues,
+                "observed-value search index rebuild is not implemented yet",
+            )],
+            SearchIndexProvider::All => vec![
+                self.rebuild_catalog_index(request)?,
+                skipped_rebuild_provider_result(
+                    SearchProviderKind::ObservedValues,
+                    "observed-value search index rebuild is not implemented yet",
+                ),
+            ],
+        };
+        Ok(RebuildSearchIndexResponse { provider_results })
+    }
+
+    pub(crate) async fn clear_data(
+        &self,
+        request: &ClearSearchDataRequest,
+    ) -> Result<ClearSearchDataResponse, SearchManagerError> {
+        self.workspaces
+            .require_workspace(&request.workspace_name)
+            .await?;
+        let search = self.clone();
+        let request = request.clone();
+        run_blocking_search_operation(move || search.clear_data_blocking(&request)).await
+    }
+
+    fn clear_data_blocking(
+        &self,
+        request: &ClearSearchDataRequest,
+    ) -> Result<ClearSearchDataResponse, SearchManagerError> {
+        let outcome = self.catalog.clear_data(SearchProviderClearRequest {
+            workspace_name: &request.workspace_name,
+            scope: request.scope,
+            target: &request.target,
+        })?;
+        Ok(ClearSearchDataResponse {
+            provider_results: vec![outcome.provider_result],
+            compaction: outcome.compaction,
+        })
+    }
+
+    fn rebuild_catalog_index(
+        &self,
+        request: &RebuildSearchIndexRequest,
+    ) -> Result<SearchMaintenanceProviderResult, SearchManagerError> {
+        self.catalog.rebuild_index(SearchProviderRebuildRequest {
+            workspace_name: &request.workspace_name,
+            force: request.force,
+        })
+    }
+}
+
+async fn run_blocking_search_operation<T, F>(operation: F) -> Result<T, SearchManagerError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, SearchManagerError> + Send + 'static,
+{
+    let span = tracing::Span::current();
+    task::spawn_blocking(move || span.in_scope(operation))
+        .await
+        .map_err(AppError::from)?
+}
+
+fn skipped_rebuild_provider_result(
+    provider: SearchProviderKind,
+    note: &'static str,
+) -> SearchMaintenanceProviderResult {
+    SearchMaintenanceProviderResult {
+        provider,
+        state: SearchProviderState::Skipped,
+        note: note.to_string(),
+        coverage: ProviderCoverage::default(),
+        detail: None,
     }
 }

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -9,13 +9,10 @@ use crate::search::catalog::provider::CatalogMetadataProvider;
 use crate::search::engine::UniversalSearchEngine;
 use crate::search::maintenance::{
     ClearSearchDataRequest, ClearSearchDataResponse, RebuildSearchIndexRequest,
-    RebuildSearchIndexResponse, SearchIndexProvider, SearchMaintenanceProviderResult,
+    RebuildSearchIndexResponse, SearchIndexProvider, SearchMaintenanceResult,
     SearchProviderClearRequest, SearchProviderMaintenance, SearchProviderRebuildRequest,
 };
-use crate::search::result::{
-    ProviderCoverage, SearchManagerError, SearchProviderKind, SearchProviderState, SearchRequest,
-    SearchResponse,
-};
+use crate::search::result::{SearchManagerError, SearchRequest, SearchResponse};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::WorkspaceManager;
 
@@ -68,21 +65,12 @@ impl SearchManager {
         &self,
         request: &RebuildSearchIndexRequest,
     ) -> Result<RebuildSearchIndexResponse, SearchManagerError> {
-        let provider_results = match request.provider {
-            SearchIndexProvider::Catalog => vec![self.rebuild_catalog_index(request)?],
-            SearchIndexProvider::ObservedValues => vec![skipped_rebuild_provider_result(
-                SearchProviderKind::ObservedValues,
-                "observed-value search index rebuild is not implemented yet",
-            )],
-            SearchIndexProvider::All => vec![
-                self.rebuild_catalog_index(request)?,
-                skipped_rebuild_provider_result(
-                    SearchProviderKind::ObservedValues,
-                    "observed-value search index rebuild is not implemented yet",
-                ),
-            ],
+        let result = match request.provider {
+            SearchIndexProvider::Catalog => self.rebuild_catalog_index(request)?,
         };
-        Ok(RebuildSearchIndexResponse { provider_results })
+        Ok(RebuildSearchIndexResponse {
+            results: vec![result],
+        })
     }
 
     pub(crate) async fn clear_data(
@@ -107,15 +95,15 @@ impl SearchManager {
             target: &request.target,
         })?;
         Ok(ClearSearchDataResponse {
-            provider_results: vec![outcome.provider_result],
-            compaction: outcome.compaction,
+            results: vec![outcome.result],
+            storage_cleanup: outcome.storage_cleanup,
         })
     }
 
     fn rebuild_catalog_index(
         &self,
         request: &RebuildSearchIndexRequest,
-    ) -> Result<SearchMaintenanceProviderResult, SearchManagerError> {
+    ) -> Result<SearchMaintenanceResult, SearchManagerError> {
         self.catalog.rebuild_index(SearchProviderRebuildRequest {
             workspace_name: &request.workspace_name,
             force: request.force,
@@ -132,17 +120,4 @@ where
     task::spawn_blocking(move || span.in_scope(operation))
         .await
         .map_err(AppError::from)?
-}
-
-fn skipped_rebuild_provider_result(
-    provider: SearchProviderKind,
-    note: &'static str,
-) -> SearchMaintenanceProviderResult {
-    SearchMaintenanceProviderResult {
-        provider,
-        state: SearchProviderState::Skipped,
-        note: note.to_string(),
-        coverage: ProviderCoverage::default(),
-        detail: None,
-    }
 }

--- a/crates/coral-app/src/search/mod.rs
+++ b/crates/coral-app/src/search/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod catalog;
 pub(crate) mod engine;
+pub(crate) mod maintenance;
 pub(crate) mod manager;
 pub(crate) mod provider;
 pub(crate) mod result;

--- a/crates/coral-app/src/search/result.rs
+++ b/crates/coral-app/src/search/result.rs
@@ -96,6 +96,13 @@ pub(crate) enum SearchProviderState {
     ResultsFound,
     Empty,
     NotEnabled,
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "provider-skip execution is introduced by a later branch in the search stack"
+        )
+    )]
     Skipped,
     Partial,
     Error,

--- a/crates/coral-app/src/search/result.rs
+++ b/crates/coral-app/src/search/result.rs
@@ -96,13 +96,6 @@ pub(crate) enum SearchProviderState {
     ResultsFound,
     Empty,
     NotEnabled,
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "reserved for request-level provider gating in concrete provider PRs"
-        )
-    )]
     Skipped,
     Partial,
     Error,

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -1,9 +1,19 @@
 //! Implements the gRPC `SearchService`.
 
+use coral_api::v1::search_clear_target::Target as ProtoSearchClearTargetKind;
+use coral_api::v1::search_maintenance_provider_result::Detail as ProtoMaintenanceDetail;
 use coral_api::v1::search_result::Payload;
 use coral_api::v1::search_service_server::SearchService as SearchServiceApi;
 use coral_api::v1::{
-    CatalogMetadata, ColumnHint, SearchFieldRole as ProtoSearchFieldRole,
+    CatalogClearResult as ProtoCatalogClearResult, CatalogMetadata,
+    CatalogRebuildResult as ProtoCatalogRebuildResult,
+    ClearSearchDataRequest as ProtoClearSearchDataRequest,
+    ClearSearchDataResponse as ProtoClearSearchDataResponse, ColumnHint,
+    RebuildSearchIndexRequest as ProtoRebuildSearchIndexRequest,
+    RebuildSearchIndexResponse as ProtoRebuildSearchIndexResponse,
+    SearchCompactionStatus as ProtoSearchCompactionStatus, SearchDataScope as ProtoSearchDataScope,
+    SearchFieldRole as ProtoSearchFieldRole, SearchIndexProvider as ProtoSearchIndexProvider,
+    SearchMaintenanceProviderResult as ProtoSearchMaintenanceProviderResult,
     SearchProvider as ProtoSearchProvider, SearchProviderCoverage, SearchProviderState,
     SearchProviderStatus, SearchRequest as ProtoSearchRequest,
     SearchResponse as ProtoSearchResponse, SearchResult as ProtoSearchResult,
@@ -12,8 +22,17 @@ use coral_api::v1::{
 };
 use tonic::{Request, Response, Status};
 
-use crate::bootstrap::app_status;
+use crate::bootstrap::{AppError, app_status};
 use crate::query::QueryAttribution;
+use crate::search::maintenance::{
+    CatalogClearMaintenanceResult, CatalogRebuildMaintenanceResult,
+    ClearSearchDataRequest as DomainClearSearchDataRequest,
+    ClearSearchDataResponse as DomainClearSearchDataResponse,
+    RebuildSearchIndexRequest as DomainRebuildSearchIndexRequest,
+    RebuildSearchIndexResponse as DomainRebuildSearchIndexResponse, SearchClearTarget,
+    SearchCompactionStatus, SearchDataScope, SearchIndexProvider, SearchMaintenanceDetail,
+    SearchMaintenanceProviderResult,
+};
 use crate::search::manager::SearchManager;
 use crate::search::result::{
     CatalogMetadataResult, ColumnHintResult, ProviderCoverage, ProviderStatus, SearchFieldRole,
@@ -60,6 +79,49 @@ impl SearchServiceApi for SearchService {
         })
         .await
     }
+
+    async fn rebuild_search_index(
+        &self,
+        request: Request<ProtoRebuildSearchIndexRequest>,
+    ) -> Result<Response<ProtoRebuildSearchIndexResponse>, Status> {
+        let span = grpc_span(&request);
+        let search = self.search.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let request = DomainRebuildSearchIndexRequest {
+                workspace_name,
+                provider: index_provider_from_proto(proto_index_provider(request.provider)?)?,
+                force: request.force,
+            };
+            let response = search
+                .rebuild_index(&request)
+                .await
+                .map_err(search_status)?;
+            Ok(Response::new(rebuild_response_to_proto(response)))
+        })
+        .await
+    }
+
+    async fn clear_search_data(
+        &self,
+        request: Request<ProtoClearSearchDataRequest>,
+    ) -> Result<Response<ProtoClearSearchDataResponse>, Status> {
+        let span = grpc_span(&request);
+        let search = self.search.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let request = DomainClearSearchDataRequest {
+                workspace_name,
+                scope: data_scope_from_proto(proto_data_scope(request.scope)?)?,
+                target: clear_target_from_proto(request.target)?,
+            };
+            let response = search.clear_data(&request).await.map_err(search_status)?;
+            Ok(Response::new(clear_response_to_proto(response)))
+        })
+        .await
+    }
 }
 
 fn search_status(error: SearchManagerError) -> Status {
@@ -92,6 +154,138 @@ fn search_response_to_proto(response: SearchResponse) -> ProtoSearchResponse {
             max_results: response.truncation.max_results,
             note: response.truncation.note,
         }),
+    }
+}
+
+fn rebuild_response_to_proto(
+    response: DomainRebuildSearchIndexResponse,
+) -> ProtoRebuildSearchIndexResponse {
+    ProtoRebuildSearchIndexResponse {
+        provider_results: response
+            .provider_results
+            .into_iter()
+            .map(maintenance_provider_result_to_proto)
+            .collect(),
+    }
+}
+
+fn clear_response_to_proto(
+    response: DomainClearSearchDataResponse,
+) -> ProtoClearSearchDataResponse {
+    ProtoClearSearchDataResponse {
+        provider_results: response
+            .provider_results
+            .into_iter()
+            .map(maintenance_provider_result_to_proto)
+            .collect(),
+        compaction: Some(compaction_status_to_proto(response.compaction)),
+    }
+}
+
+fn maintenance_provider_result_to_proto(
+    result: SearchMaintenanceProviderResult,
+) -> ProtoSearchMaintenanceProviderResult {
+    ProtoSearchMaintenanceProviderResult {
+        provider: provider_kind_to_proto(result.provider) as i32,
+        state: provider_state_to_proto(result.state) as i32,
+        note: result.note,
+        coverage: Some(provider_coverage_to_proto(&result.coverage)),
+        detail: result.detail.as_ref().map(maintenance_detail_to_proto),
+    }
+}
+
+fn maintenance_detail_to_proto(detail: &SearchMaintenanceDetail) -> ProtoMaintenanceDetail {
+    match detail {
+        SearchMaintenanceDetail::CatalogRebuild(result) => {
+            ProtoMaintenanceDetail::CatalogRebuild(catalog_rebuild_to_proto(*result))
+        }
+        SearchMaintenanceDetail::CatalogClear(result) => {
+            ProtoMaintenanceDetail::CatalogClear(catalog_clear_to_proto(*result))
+        }
+    }
+}
+
+fn catalog_rebuild_to_proto(result: CatalogRebuildMaintenanceResult) -> ProtoCatalogRebuildResult {
+    ProtoCatalogRebuildResult {
+        old_document_count: result.old_document_count,
+        new_document_count: result.new_document_count,
+        projection_changed: result.projection_changed,
+        rebuild_performed: result.rebuild_performed,
+    }
+}
+
+fn catalog_clear_to_proto(result: CatalogClearMaintenanceResult) -> ProtoCatalogClearResult {
+    ProtoCatalogClearResult {
+        deleted_document_count: result.deleted_document_count,
+    }
+}
+
+fn compaction_status_to_proto(status: SearchCompactionStatus) -> ProtoSearchCompactionStatus {
+    ProtoSearchCompactionStatus {
+        wal_checkpoint_truncate_completed: status.wal_checkpoint_truncate_completed,
+        vacuum_completed: status.vacuum_completed,
+        note: status.note,
+    }
+}
+
+fn proto_index_provider(value: i32) -> Result<ProtoSearchIndexProvider, Status> {
+    ProtoSearchIndexProvider::try_from(value).map_err(|_error| {
+        app_status(AppError::InvalidInput(format!(
+            "invalid search index provider value {value}"
+        )))
+    })
+}
+
+fn index_provider_from_proto(
+    provider: ProtoSearchIndexProvider,
+) -> Result<SearchIndexProvider, Status> {
+    match provider {
+        ProtoSearchIndexProvider::Catalog => Ok(SearchIndexProvider::Catalog),
+        ProtoSearchIndexProvider::ObservedValues => Ok(SearchIndexProvider::ObservedValues),
+        ProtoSearchIndexProvider::All => Ok(SearchIndexProvider::All),
+        ProtoSearchIndexProvider::Unspecified => Err(app_status(AppError::InvalidInput(
+            "search index provider is required".to_string(),
+        ))),
+    }
+}
+
+fn proto_data_scope(value: i32) -> Result<ProtoSearchDataScope, Status> {
+    ProtoSearchDataScope::try_from(value).map_err(|_error| {
+        app_status(AppError::InvalidInput(format!(
+            "invalid search data scope value {value}"
+        )))
+    })
+}
+
+fn data_scope_from_proto(scope: ProtoSearchDataScope) -> Result<SearchDataScope, Status> {
+    match scope {
+        ProtoSearchDataScope::Observed => Ok(SearchDataScope::Observed),
+        ProtoSearchDataScope::All => Ok(SearchDataScope::All),
+        ProtoSearchDataScope::Unspecified => Err(app_status(AppError::InvalidInput(
+            "search data scope is required".to_string(),
+        ))),
+    }
+}
+
+fn clear_target_from_proto(
+    target: Option<coral_api::v1::SearchClearTarget>,
+) -> Result<SearchClearTarget, Status> {
+    match target.and_then(|target| target.target) {
+        Some(ProtoSearchClearTargetKind::Workspace(true)) => Ok(SearchClearTarget::Workspace),
+        Some(ProtoSearchClearTargetKind::Workspace(false)) => Err(app_status(
+            AppError::InvalidInput("search clear workspace target must be true".to_string()),
+        )),
+        Some(ProtoSearchClearTargetKind::SourceName(source_name))
+            if !source_name.trim().is_empty() =>
+        {
+            Ok(SearchClearTarget::Source(source_name))
+        }
+        Some(ProtoSearchClearTargetKind::SourceName(_)) => Err(app_status(AppError::InvalidInput(
+            "search clear source_name target must not be empty".to_string(),
+        ))),
+        None => Err(app_status(AppError::InvalidInput(
+            "search clear target is required".to_string(),
+        ))),
     }
 }
 

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -12,7 +12,6 @@ use coral_api::v1::{
     RebuildSearchIndexRequest as ProtoRebuildSearchIndexRequest,
     RebuildSearchIndexResponse as ProtoRebuildSearchIndexResponse,
     SearchDataScope as ProtoSearchDataScope, SearchFieldRole as ProtoSearchFieldRole,
-    SearchIndexProvider as ProtoSearchIndexProvider,
     SearchMaintenanceResult as ProtoSearchMaintenanceResult,
     SearchMaintenanceState as ProtoSearchMaintenanceState, SearchProvider as ProtoSearchProvider,
     SearchProviderCoverage, SearchProviderState, SearchProviderStatus,
@@ -32,8 +31,8 @@ use crate::search::maintenance::{
     ClearSearchDataResponse as DomainClearSearchDataResponse,
     RebuildSearchIndexRequest as DomainRebuildSearchIndexRequest,
     RebuildSearchIndexResponse as DomainRebuildSearchIndexResponse, SearchClearTarget,
-    SearchDataScope, SearchIndexProvider, SearchMaintenanceDetail, SearchMaintenanceResult,
-    SearchMaintenanceState, SearchStorageCleanupResult,
+    SearchDataScope, SearchMaintenanceDetail, SearchMaintenanceResult, SearchMaintenanceState,
+    SearchStorageCleanupResult,
 };
 use crate::search::manager::SearchManager;
 use crate::search::result::{
@@ -93,7 +92,6 @@ impl SearchServiceApi for SearchService {
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let request = DomainRebuildSearchIndexRequest {
                 workspace_name,
-                provider: index_provider_from_proto(proto_index_provider(request.provider)?)?,
                 force: request.force,
             };
             let response = search
@@ -232,25 +230,6 @@ fn maintenance_state_to_proto(state: SearchMaintenanceState) -> ProtoSearchMaint
         SearchMaintenanceState::Noop => ProtoSearchMaintenanceState::Noop,
         SearchMaintenanceState::Partial => ProtoSearchMaintenanceState::Partial,
         SearchMaintenanceState::Failed => ProtoSearchMaintenanceState::Failed,
-    }
-}
-
-fn proto_index_provider(value: i32) -> Result<ProtoSearchIndexProvider, Status> {
-    ProtoSearchIndexProvider::try_from(value).map_err(|_error| {
-        app_status(AppError::InvalidInput(format!(
-            "invalid search index provider value {value}"
-        )))
-    })
-}
-
-fn index_provider_from_proto(
-    provider: ProtoSearchIndexProvider,
-) -> Result<SearchIndexProvider, Status> {
-    match provider {
-        ProtoSearchIndexProvider::Catalog => Ok(SearchIndexProvider::Catalog),
-        ProtoSearchIndexProvider::Unspecified => Err(app_status(AppError::InvalidInput(
-            "search index provider is required".to_string(),
-        ))),
     }
 }
 

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -1,7 +1,7 @@
 //! Implements the gRPC `SearchService`.
 
 use coral_api::v1::search_clear_target::Target as ProtoSearchClearTargetKind;
-use coral_api::v1::search_maintenance_provider_result::Detail as ProtoMaintenanceDetail;
+use coral_api::v1::search_maintenance_result::Detail as ProtoMaintenanceDetail;
 use coral_api::v1::search_result::Payload;
 use coral_api::v1::search_service_server::SearchService as SearchServiceApi;
 use coral_api::v1::{
@@ -11,13 +11,15 @@ use coral_api::v1::{
     ClearSearchDataResponse as ProtoClearSearchDataResponse, ColumnHint,
     RebuildSearchIndexRequest as ProtoRebuildSearchIndexRequest,
     RebuildSearchIndexResponse as ProtoRebuildSearchIndexResponse,
-    SearchCompactionStatus as ProtoSearchCompactionStatus, SearchDataScope as ProtoSearchDataScope,
-    SearchFieldRole as ProtoSearchFieldRole, SearchIndexProvider as ProtoSearchIndexProvider,
-    SearchMaintenanceProviderResult as ProtoSearchMaintenanceProviderResult,
-    SearchProvider as ProtoSearchProvider, SearchProviderCoverage, SearchProviderState,
-    SearchProviderStatus, SearchRequest as ProtoSearchRequest,
-    SearchResponse as ProtoSearchResponse, SearchResult as ProtoSearchResult,
-    SearchResultTruncation, SearchSurfaceKind as ProtoSearchSurfaceKind, SearchTableColumnPreview,
+    SearchDataScope as ProtoSearchDataScope, SearchFieldRole as ProtoSearchFieldRole,
+    SearchIndexProvider as ProtoSearchIndexProvider,
+    SearchMaintenanceResult as ProtoSearchMaintenanceResult,
+    SearchMaintenanceState as ProtoSearchMaintenanceState, SearchProvider as ProtoSearchProvider,
+    SearchProviderCoverage, SearchProviderState, SearchProviderStatus,
+    SearchRequest as ProtoSearchRequest, SearchResponse as ProtoSearchResponse,
+    SearchResult as ProtoSearchResult, SearchResultTruncation,
+    SearchStorageCleanupResult as ProtoSearchStorageCleanupResult,
+    SearchSurfaceKind as ProtoSearchSurfaceKind, SearchTableColumnPreview,
     SearchTableColumnPreviewColumn,
 };
 use tonic::{Request, Response, Status};
@@ -30,8 +32,8 @@ use crate::search::maintenance::{
     ClearSearchDataResponse as DomainClearSearchDataResponse,
     RebuildSearchIndexRequest as DomainRebuildSearchIndexRequest,
     RebuildSearchIndexResponse as DomainRebuildSearchIndexResponse, SearchClearTarget,
-    SearchCompactionStatus, SearchDataScope, SearchIndexProvider, SearchMaintenanceDetail,
-    SearchMaintenanceProviderResult,
+    SearchDataScope, SearchIndexProvider, SearchMaintenanceDetail, SearchMaintenanceResult,
+    SearchMaintenanceState, SearchStorageCleanupResult,
 };
 use crate::search::manager::SearchManager;
 use crate::search::result::{
@@ -161,10 +163,10 @@ fn rebuild_response_to_proto(
     response: DomainRebuildSearchIndexResponse,
 ) -> ProtoRebuildSearchIndexResponse {
     ProtoRebuildSearchIndexResponse {
-        provider_results: response
-            .provider_results
+        results: response
+            .results
             .into_iter()
-            .map(maintenance_provider_result_to_proto)
+            .map(maintenance_result_to_proto)
             .collect(),
     }
 }
@@ -173,23 +175,20 @@ fn clear_response_to_proto(
     response: DomainClearSearchDataResponse,
 ) -> ProtoClearSearchDataResponse {
     ProtoClearSearchDataResponse {
-        provider_results: response
-            .provider_results
+        results: response
+            .results
             .into_iter()
-            .map(maintenance_provider_result_to_proto)
+            .map(maintenance_result_to_proto)
             .collect(),
-        compaction: Some(compaction_status_to_proto(response.compaction)),
+        storage_cleanup: Some(storage_cleanup_to_proto(response.storage_cleanup)),
     }
 }
 
-fn maintenance_provider_result_to_proto(
-    result: SearchMaintenanceProviderResult,
-) -> ProtoSearchMaintenanceProviderResult {
-    ProtoSearchMaintenanceProviderResult {
+fn maintenance_result_to_proto(result: SearchMaintenanceResult) -> ProtoSearchMaintenanceResult {
+    ProtoSearchMaintenanceResult {
         provider: provider_kind_to_proto(result.provider) as i32,
-        state: provider_state_to_proto(result.state) as i32,
+        state: maintenance_state_to_proto(result.state) as i32,
         note: result.note,
-        coverage: Some(provider_coverage_to_proto(&result.coverage)),
         detail: result.detail.as_ref().map(maintenance_detail_to_proto),
     }
 }
@@ -220,11 +219,19 @@ fn catalog_clear_to_proto(result: CatalogClearMaintenanceResult) -> ProtoCatalog
     }
 }
 
-fn compaction_status_to_proto(status: SearchCompactionStatus) -> ProtoSearchCompactionStatus {
-    ProtoSearchCompactionStatus {
-        wal_checkpoint_truncate_completed: status.wal_checkpoint_truncate_completed,
-        vacuum_completed: status.vacuum_completed,
-        note: status.note,
+fn storage_cleanup_to_proto(result: SearchStorageCleanupResult) -> ProtoSearchStorageCleanupResult {
+    ProtoSearchStorageCleanupResult {
+        state: maintenance_state_to_proto(result.state) as i32,
+        note: result.note,
+    }
+}
+
+fn maintenance_state_to_proto(state: SearchMaintenanceState) -> ProtoSearchMaintenanceState {
+    match state {
+        SearchMaintenanceState::Completed => ProtoSearchMaintenanceState::Completed,
+        SearchMaintenanceState::Noop => ProtoSearchMaintenanceState::Noop,
+        SearchMaintenanceState::Partial => ProtoSearchMaintenanceState::Partial,
+        SearchMaintenanceState::Failed => ProtoSearchMaintenanceState::Failed,
     }
 }
 
@@ -241,8 +248,6 @@ fn index_provider_from_proto(
 ) -> Result<SearchIndexProvider, Status> {
     match provider {
         ProtoSearchIndexProvider::Catalog => Ok(SearchIndexProvider::Catalog),
-        ProtoSearchIndexProvider::ObservedValues => Ok(SearchIndexProvider::ObservedValues),
-        ProtoSearchIndexProvider::All => Ok(SearchIndexProvider::All),
         ProtoSearchIndexProvider::Unspecified => Err(app_status(AppError::InvalidInput(
             "search index provider is required".to_string(),
         ))),
@@ -259,7 +264,6 @@ fn proto_data_scope(value: i32) -> Result<ProtoSearchDataScope, Status> {
 
 fn data_scope_from_proto(scope: ProtoSearchDataScope) -> Result<SearchDataScope, Status> {
     match scope {
-        ProtoSearchDataScope::Observed => Ok(SearchDataScope::Observed),
         ProtoSearchDataScope::All => Ok(SearchDataScope::All),
         ProtoSearchDataScope::Unspecified => Err(app_status(AppError::InvalidInput(
             "search data scope is required".to_string(),
@@ -275,14 +279,6 @@ fn clear_target_from_proto(
         Some(ProtoSearchClearTargetKind::Workspace(false)) => Err(app_status(
             AppError::InvalidInput("search clear workspace target must be true".to_string()),
         )),
-        Some(ProtoSearchClearTargetKind::SourceName(source_name))
-            if !source_name.trim().is_empty() =>
-        {
-            Ok(SearchClearTarget::Source(source_name))
-        }
-        Some(ProtoSearchClearTargetKind::SourceName(_)) => Err(app_status(AppError::InvalidInput(
-            "search clear source_name target must not be empty".to_string(),
-        ))),
         None => Err(app_status(AppError::InvalidInput(
             "search clear target is required".to_string(),
         ))),

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -257,14 +257,20 @@ impl SqliteSearchError {
     }
 
     pub(crate) fn is_storage_exhaustion(&self) -> bool {
-        matches!(
-            self,
-            Self::Sqlite(error)
-                if matches!(
-                    error.sqlite_error_code(),
-                    Some(ErrorCode::DiskFull | ErrorCode::OutOfMemory | ErrorCode::TooBig)
-                )
-        )
+        match self {
+            Self::Io(error) => matches!(
+                error.kind(),
+                io::ErrorKind::StorageFull
+                    | io::ErrorKind::QuotaExceeded
+                    | io::ErrorKind::OutOfMemory
+                    | io::ErrorKind::FileTooLarge
+            ),
+            Self::Sqlite(error) => matches!(
+                error.sqlite_error_code(),
+                Some(ErrorCode::DiskFull | ErrorCode::OutOfMemory | ErrorCode::TooBig)
+            ),
+            Self::UnsupportedCapability { .. } | Self::UnsupportedSchemaVersion { .. } => false,
+        }
     }
 }
 
@@ -290,7 +296,11 @@ fn wal_checkpoint_truncate(
 }
 
 fn ensure_sqlite_file(path: &Path) -> Result<(), SqliteSearchError> {
-    match create_new_file_private(path) {
+    sqlite_file_creation_result(create_new_file_private(path))
+}
+
+fn sqlite_file_creation_result(result: io::Result<std::fs::File>) -> Result<(), SqliteSearchError> {
+    match result {
         Ok(file) => {
             drop(file);
             Ok(())
@@ -317,29 +327,45 @@ fn detect_capabilities(
 ) -> Result<SqliteSearchCapabilities, SqliteSearchError> {
     let sqlite_version =
         connection.query_row("SELECT sqlite_version()", [], |row| row.get::<_, String>(0))?;
-    let fts5 = connection
-        .execute_batch(
-            "
-            CREATE VIRTUAL TABLE temp.coral_search_fts5_check USING fts5(value);
-            DROP TABLE temp.coral_search_fts5_check;
-            ",
-        )
-        .is_ok();
-    let trigram = connection
-        .execute_batch(
+    let fts5 = probe_capability(
+        connection,
+        "
+        CREATE VIRTUAL TABLE temp.coral_search_fts5_check USING fts5(value);
+        DROP TABLE temp.coral_search_fts5_check;
+        ",
+    )?;
+    let trigram = if fts5 {
+        probe_capability(
+            connection,
             "
             CREATE VIRTUAL TABLE temp.coral_search_trigram_check
             USING fts5(value, tokenize = 'trigram');
             DROP TABLE temp.coral_search_trigram_check;
             ",
-        )
-        .is_ok();
+        )?
+    } else {
+        false
+    };
 
     Ok(SqliteSearchCapabilities {
         sqlite_version,
         fts5,
         trigram,
     })
+}
+
+fn probe_capability(connection: &Connection, sql: &str) -> Result<bool, SqliteSearchError> {
+    classify_capability_probe(connection.execute_batch(sql))
+}
+
+fn classify_capability_probe(result: rusqlite::Result<()>) -> Result<bool, SqliteSearchError> {
+    match result {
+        Ok(()) => Ok(true),
+        Err(rusqlite::Error::SqliteFailure(error, _)) if error.code == ErrorCode::Unknown => {
+            Ok(false)
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 fn ensure_supported(capabilities: &SqliteSearchCapabilities) -> Result<(), SqliteSearchError> {
@@ -433,14 +459,15 @@ fn schema_is_current(connection: &Connection) -> Result<bool, SqliteSearchError>
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{io, time::Duration};
 
     use rusqlite::{Connection, OptionalExtension as _};
     use tempfile::tempdir;
 
     use super::{
         SEARCH_SQLITE_MIGRATIONS, SEARCH_SQLITE_SCHEMA_VERSION, SqliteSearchError,
-        SqliteSearchStore, WalCheckpointOutcome, configure_connection, wal_checkpoint_truncate,
+        SqliteSearchStore, WalCheckpointOutcome, classify_capability_probe, configure_connection,
+        sqlite_file_creation_result, wal_checkpoint_truncate,
     };
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
@@ -525,6 +552,57 @@ mod tests {
         ));
 
         assert!(error.is_storage_exhaustion());
+    }
+
+    #[test]
+    fn storage_full_file_creation_error_preserves_exhaustion_category() {
+        let error = sqlite_file_creation_result(Err(io::Error::new(
+            io::ErrorKind::StorageFull,
+            "fixture disk full",
+        )))
+        .expect_err("storage-full file creation must fail");
+
+        assert!(matches!(
+            &error,
+            SqliteSearchError::Io(error) if error.kind() == io::ErrorKind::StorageFull
+        ));
+        assert!(error.is_storage_exhaustion());
+    }
+
+    #[test]
+    fn capability_probe_only_treats_plain_sqlite_error_as_unsupported() {
+        assert!(classify_capability_probe(Ok(())).expect("successful probe"));
+        assert!(
+            !classify_capability_probe(Err(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
+                Some("fixture unsupported capability".to_string()),
+            )))
+            .expect("plain SQLite error should mean unsupported capability")
+        );
+    }
+
+    #[test]
+    fn capability_probe_preserves_operational_sqlite_errors() {
+        for code in [
+            rusqlite::ffi::SQLITE_FULL,
+            rusqlite::ffi::SQLITE_NOMEM,
+            rusqlite::ffi::SQLITE_IOERR,
+            rusqlite::ffi::SQLITE_CORRUPT,
+        ] {
+            let expected = rusqlite::ffi::Error::new(code).code;
+            let error = classify_capability_probe(Err(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(code),
+                None,
+            )))
+            .expect_err("operational probe failure must be preserved");
+
+            match error {
+                SqliteSearchError::Sqlite(error) => {
+                    assert_eq!(error.sqlite_error_code(), Some(expected));
+                }
+                other => panic!("expected SQLite error for code {code}, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -15,8 +15,8 @@ use std::time::Duration;
 use rusqlite::{Connection, ErrorCode};
 
 use crate::search::catalog::sqlite_index::{
-    CatalogClearResult, CatalogIndexSnapshot, CatalogRefreshResult, CatalogSearchHits,
-    SqliteCatalogIndex,
+    CatalogClearResult, CatalogIndexSnapshot, CatalogRebuildResult, CatalogRefreshResult,
+    CatalogSearchHits, SqliteCatalogIndex,
 };
 use crate::state::AppStateLayout;
 use crate::storage::fs::create_new_file_private;
@@ -123,6 +123,15 @@ impl SqliteSearchStore {
         SqliteCatalogIndex::new().refresh(&mut connection, &self.workspace_name, snapshot)
     }
 
+    pub(crate) fn rebuild_catalog_projection(
+        &self,
+        snapshot: &CatalogIndexSnapshot,
+        force: bool,
+    ) -> Result<CatalogRebuildResult, SqliteSearchError> {
+        let mut connection = self.connect()?;
+        SqliteCatalogIndex::new().rebuild(&mut connection, &self.workspace_name, snapshot, force)
+    }
+
     pub(crate) fn catalog_document_count(&self) -> Result<u32, SqliteSearchError> {
         let connection = self.connect()?;
         SqliteCatalogIndex::new().document_count(&connection, &self.workspace_name)
@@ -131,6 +140,42 @@ impl SqliteSearchStore {
     pub(crate) fn clear_catalog_workspace(&self) -> Result<CatalogClearResult, SqliteSearchError> {
         let mut connection = self.connect()?;
         SqliteCatalogIndex::new().clear_workspace(&mut connection, &self.workspace_name)
+    }
+
+    pub(crate) fn compact_after_clear(&self) -> SqliteSearchCompactionResult {
+        let mut notes = Vec::new();
+        let wal_checkpoint_truncate_completed =
+            match self.execute_maintenance_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
+                Ok(()) => true,
+                Err(error) => {
+                    notes.push(format!("WAL checkpoint/truncate failed: {error}"));
+                    false
+                }
+            };
+        let vacuum_completed = match self.execute_maintenance_batch("VACUUM;") {
+            Ok(()) => true,
+            Err(error) => {
+                notes.push(format!("VACUUM failed: {error}"));
+                false
+            }
+        };
+
+        let note = if notes.is_empty() {
+            "WAL checkpoint/truncate and VACUUM completed".to_string()
+        } else {
+            notes.join("; ")
+        };
+        SqliteSearchCompactionResult {
+            wal_checkpoint_truncate_completed,
+            vacuum_completed,
+            note,
+        }
+    }
+
+    fn execute_maintenance_batch(&self, sql: &str) -> Result<(), SqliteSearchError> {
+        let connection = self.connect()?;
+        connection.execute_batch(sql)?;
+        Ok(())
     }
 
     pub(crate) fn search_catalog(
@@ -148,6 +193,13 @@ pub(crate) struct SqliteSearchCapabilities {
     pub(crate) sqlite_version: String,
     pub(crate) fts5: bool,
     pub(crate) trigram: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SqliteSearchCompactionResult {
+    pub(crate) wal_checkpoint_truncate_completed: bool,
+    pub(crate) vacuum_completed: bool,
+    pub(crate) note: String,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -144,14 +144,22 @@ impl SqliteSearchStore {
 
     pub(crate) fn compact_after_clear(&self) -> SqliteSearchCompactionResult {
         let mut notes = Vec::new();
-        let wal_checkpoint_truncate_completed =
-            match self.execute_maintenance_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
-                Ok(()) => true,
-                Err(error) => {
-                    notes.push(format!("WAL checkpoint/truncate failed: {error}"));
-                    false
-                }
-            };
+        let wal_checkpoint_truncate_completed = match self.wal_checkpoint_truncate() {
+            Ok(WalCheckpointOutcome::Completed) => true,
+            Ok(WalCheckpointOutcome::Busy {
+                log_frame_count,
+                checkpointed_frame_count,
+            }) => {
+                notes.push(format!(
+                        "WAL checkpoint/truncate did not complete because a reader is active (log frames: {log_frame_count}, checkpointed frames: {checkpointed_frame_count})"
+                    ));
+                false
+            }
+            Err(error) => {
+                notes.push(format!("WAL checkpoint/truncate failed: {error}"));
+                false
+            }
+        };
         let vacuum_completed = match self.execute_maintenance_batch("VACUUM;") {
             Ok(()) => true,
             Err(error) => {
@@ -170,6 +178,11 @@ impl SqliteSearchStore {
             vacuum_completed,
             note,
         }
+    }
+
+    fn wal_checkpoint_truncate(&self) -> Result<WalCheckpointOutcome, SqliteSearchError> {
+        let connection = self.connect()?;
+        wal_checkpoint_truncate(&connection)
     }
 
     fn execute_maintenance_batch(&self, sql: &str) -> Result<(), SqliteSearchError> {
@@ -202,6 +215,15 @@ pub(crate) struct SqliteSearchCompactionResult {
     pub(crate) note: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WalCheckpointOutcome {
+    Completed,
+    Busy {
+        log_frame_count: i64,
+        checkpointed_frame_count: i64,
+    },
+}
+
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum SqliteSearchError {
     #[error(transparent)]
@@ -232,6 +254,38 @@ impl SqliteSearchError {
                     Some(ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
                 )
         )
+    }
+
+    pub(crate) fn is_storage_exhaustion(&self) -> bool {
+        matches!(
+            self,
+            Self::Sqlite(error)
+                if matches!(
+                    error.sqlite_error_code(),
+                    Some(ErrorCode::DiskFull | ErrorCode::OutOfMemory | ErrorCode::TooBig)
+                )
+        )
+    }
+}
+
+fn wal_checkpoint_truncate(
+    connection: &Connection,
+) -> Result<WalCheckpointOutcome, SqliteSearchError> {
+    let (busy, log_frame_count, checkpointed_frame_count) =
+        connection.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        })?;
+    if busy == 0 {
+        Ok(WalCheckpointOutcome::Completed)
+    } else {
+        Ok(WalCheckpointOutcome::Busy {
+            log_frame_count,
+            checkpointed_frame_count,
+        })
     }
 }
 
@@ -379,12 +433,14 @@ fn schema_is_current(connection: &Connection) -> Result<bool, SqliteSearchError>
 
 #[cfg(test)]
 mod tests {
-    use rusqlite::OptionalExtension as _;
+    use std::time::Duration;
+
+    use rusqlite::{Connection, OptionalExtension as _};
     use tempfile::tempdir;
 
     use super::{
         SEARCH_SQLITE_MIGRATIONS, SEARCH_SQLITE_SCHEMA_VERSION, SqliteSearchError,
-        SqliteSearchStore,
+        SqliteSearchStore, WalCheckpointOutcome, configure_connection, wal_checkpoint_truncate,
     };
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
@@ -459,6 +515,58 @@ mod tests {
         };
 
         assert!(!error.is_lock_contention());
+    }
+
+    #[test]
+    fn disk_full_error_is_storage_exhaustion() {
+        let error = SqliteSearchError::Sqlite(rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_FULL),
+            None,
+        ));
+
+        assert!(error.is_storage_exhaustion());
+    }
+
+    #[test]
+    fn wal_checkpoint_reports_reader_contention() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("checkpoint.sqlite3");
+        let writer = Connection::open(&path).expect("writer");
+        configure_connection(&writer).expect("configure writer");
+        writer
+            .pragma_update(None, "wal_autocheckpoint", 0)
+            .expect("disable automatic checkpoints");
+        writer
+            .execute_batch(
+                "
+                CREATE TABLE records (value TEXT NOT NULL);
+                INSERT INTO records (value) VALUES ('initial');
+                PRAGMA wal_checkpoint(TRUNCATE);
+                ",
+            )
+            .expect("seed database");
+
+        let reader = Connection::open(&path).expect("reader");
+        configure_connection(&reader).expect("configure reader");
+        reader.execute_batch("BEGIN").expect("begin reader");
+        let count: i64 = reader
+            .query_row("SELECT COUNT(*) FROM records", [], |row| row.get(0))
+            .expect("establish reader snapshot");
+        assert_eq!(count, 1);
+
+        writer
+            .execute("INSERT INTO records (value) VALUES ('new')", [])
+            .expect("write after reader snapshot");
+
+        let checkpoint = Connection::open(&path).expect("checkpoint connection");
+        configure_connection(&checkpoint).expect("configure checkpoint connection");
+        checkpoint
+            .busy_timeout(Duration::ZERO)
+            .expect("disable checkpoint wait");
+        let outcome = wal_checkpoint_truncate(&checkpoint).expect("checkpoint result");
+
+        assert!(matches!(outcome, WalCheckpointOutcome::Busy { .. }));
+        reader.execute_batch("ROLLBACK").expect("end reader");
     }
 
     #[test]

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -5,9 +5,10 @@
 
 use coral_api::v1::{
     ClearSearchDataRequest, RebuildSearchIndexRequest, SearchClearTarget, SearchDataScope,
-    SearchFieldRole, SearchIndexProvider, SearchProvider, SearchProviderState, SearchRequest,
-    SearchSurfaceKind, TableFunctionKind, ValidateSourceRequest, Workspace, catalog_item,
-    search_clear_target, search_maintenance_provider_result, search_result,
+    SearchFieldRole, SearchIndexProvider, SearchMaintenanceState, SearchProvider,
+    SearchProviderState, SearchRequest, SearchSurfaceKind, TableFunctionKind,
+    ValidateSourceRequest, Workspace, catalog_item, search_clear_target, search_maintenance_result,
+    search_result,
 };
 use coral_client::default_workspace;
 use serde_json::json;
@@ -233,21 +234,10 @@ async fn rebuild_search_index_forces_catalog_projection_refresh() {
     assert!(first_detail.new_document_count > 0);
     assert!(first_detail.projection_changed);
     assert!(first_detail.rebuild_performed);
-    let first_coverage = catalog_rebuild_provider_result(&first)
-        .coverage
-        .as_ref()
-        .expect("catalog rebuild coverage");
     assert_eq!(
-        first_coverage.eligible_units,
-        first_detail.new_document_count
-    );
-    assert_eq!(
-        first_coverage.searched_units,
-        first_detail.new_document_count
-    );
-    assert!(
-        !first_coverage.stale_index,
-        "successful rebuilds should not report stale index state"
+        SearchMaintenanceState::try_from(catalog_rebuild_result(&first).state)
+            .expect("maintenance state"),
+        SearchMaintenanceState::Completed
     );
 
     let forced = harness
@@ -274,76 +264,11 @@ async fn rebuild_search_index_forces_catalog_projection_refresh() {
         forced_detail.rebuild_performed,
         "force should rebuild even when the fingerprint is current"
     );
-    let forced_coverage = catalog_rebuild_provider_result(&forced)
-        .coverage
-        .as_ref()
-        .expect("forced catalog rebuild coverage");
-    assert!(
-        !forced_coverage.stale_index,
-        "forced rebuilds should not report stale index state"
-    );
-}
-
-#[tokio::test]
-async fn rebuild_search_index_all_rebuilds_catalog_and_skips_unimplemented_providers() {
-    let harness = GrpcHarness::new().await;
-    harness
-        .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
-        .await;
-
-    let response = harness
-        .search_client()
-        .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
-            workspace: Some(default_workspace()),
-            provider: SearchIndexProvider::All as i32,
-            force: false,
-        }))
-        .await
-        .expect("rebuild all search indexes")
-        .into_inner();
-
-    assert_eq!(response.provider_results.len(), 2);
-    let catalog_detail = catalog_rebuild_detail(&response);
-    assert!(catalog_detail.new_document_count > 0);
-
-    let observed = rebuild_provider_result(&response, SearchProvider::ObservedValues);
     assert_eq!(
-        SearchProviderState::try_from(observed.state).expect("observed provider state"),
-        SearchProviderState::Skipped
+        SearchMaintenanceState::try_from(catalog_rebuild_result(&forced).state)
+            .expect("maintenance state"),
+        SearchMaintenanceState::Completed
     );
-    assert!(
-        observed.detail.is_none(),
-        "skipped providers should not invent provider-specific detail"
-    );
-    assert!(
-        observed.note.contains("not implemented yet"),
-        "skipped provider should explain why it did not run: {}",
-        observed.note
-    );
-}
-
-#[tokio::test]
-async fn rebuild_search_index_observed_values_reports_skipped_provider() {
-    let harness = GrpcHarness::new().await;
-
-    let response = harness
-        .search_client()
-        .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
-            workspace: Some(default_workspace()),
-            provider: SearchIndexProvider::ObservedValues as i32,
-            force: false,
-        }))
-        .await
-        .expect("rebuild observed-value search index")
-        .into_inner();
-
-    assert_eq!(response.provider_results.len(), 1);
-    let observed = rebuild_provider_result(&response, SearchProvider::ObservedValues);
-    assert_eq!(
-        SearchProviderState::try_from(observed.state).expect("observed provider state"),
-        SearchProviderState::Skipped
-    );
-    assert!(observed.detail.is_none());
 }
 
 #[tokio::test]
@@ -377,9 +302,17 @@ async fn clear_search_data_removes_catalog_projection_and_next_search_recreates_
 
     let clear_detail = catalog_clear_detail(&clear);
     assert!(clear_detail.deleted_document_count > 0);
-    let compaction = clear.compaction.as_ref().expect("compaction status");
-    assert!(compaction.wal_checkpoint_truncate_completed);
-    assert!(compaction.vacuum_completed);
+    let cleanup = clear
+        .storage_cleanup
+        .as_ref()
+        .expect("storage cleanup result");
+    assert_eq!(
+        SearchMaintenanceState::try_from(cleanup.state).expect("cleanup state"),
+        SearchMaintenanceState::Completed
+    );
+    assert!(!cleanup.note.contains("SQLite"));
+    assert!(!cleanup.note.contains("WAL"));
+    assert!(!cleanup.note.contains("VACUUM"));
 
     let response = harness
         .search_client()
@@ -576,29 +509,22 @@ fn assert_empty_provider_coverage(status: &coral_api::v1::SearchProviderStatus) 
 fn catalog_rebuild_detail(
     response: &coral_api::v1::RebuildSearchIndexResponse,
 ) -> &coral_api::v1::CatalogRebuildResult {
-    let result = catalog_rebuild_provider_result(response);
+    let result = catalog_rebuild_result(response);
     match result.detail.as_ref() {
-        Some(search_maintenance_provider_result::Detail::CatalogRebuild(detail)) => detail,
-        Some(search_maintenance_provider_result::Detail::CatalogClear(_)) | None => {
+        Some(search_maintenance_result::Detail::CatalogRebuild(detail)) => detail,
+        Some(search_maintenance_result::Detail::CatalogClear(_)) | None => {
             panic!("expected catalog rebuild detail")
         }
     }
 }
 
-fn catalog_rebuild_provider_result(
+fn catalog_rebuild_result(
     response: &coral_api::v1::RebuildSearchIndexResponse,
-) -> &coral_api::v1::SearchMaintenanceProviderResult {
-    rebuild_provider_result(response, SearchProvider::CatalogMetadata)
-}
-
-fn rebuild_provider_result(
-    response: &coral_api::v1::RebuildSearchIndexResponse,
-    provider: SearchProvider,
-) -> &coral_api::v1::SearchMaintenanceProviderResult {
+) -> &coral_api::v1::SearchMaintenanceResult {
     response
-        .provider_results
+        .results
         .iter()
-        .find(|result| result.provider == provider as i32)
+        .find(|result| result.provider == SearchProvider::CatalogMetadata as i32)
         .expect("provider result")
 }
 
@@ -606,11 +532,11 @@ fn catalog_clear_detail(
     response: &coral_api::v1::ClearSearchDataResponse,
 ) -> &coral_api::v1::CatalogClearResult {
     response
-        .provider_results
+        .results
         .iter()
         .find_map(|result| match result.detail.as_ref()? {
-            search_maintenance_provider_result::Detail::CatalogClear(detail) => Some(detail),
-            search_maintenance_provider_result::Detail::CatalogRebuild(_) => None,
+            search_maintenance_result::Detail::CatalogClear(detail) => Some(detail),
+            search_maintenance_result::Detail::CatalogRebuild(_) => None,
         })
         .expect("catalog clear detail")
 }

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -5,10 +5,9 @@
 
 use coral_api::v1::{
     ClearSearchDataRequest, RebuildSearchIndexRequest, SearchClearTarget, SearchDataScope,
-    SearchFieldRole, SearchIndexProvider, SearchMaintenanceState, SearchProvider,
-    SearchProviderState, SearchRequest, SearchSurfaceKind, TableFunctionKind,
-    ValidateSourceRequest, Workspace, catalog_item, search_clear_target, search_maintenance_result,
-    search_result,
+    SearchFieldRole, SearchMaintenanceState, SearchProvider, SearchProviderState, SearchRequest,
+    SearchSurfaceKind, TableFunctionKind, ValidateSourceRequest, Workspace, catalog_item,
+    search_clear_target, search_maintenance_result, search_result,
 };
 use coral_client::default_workspace;
 use serde_json::json;
@@ -223,7 +222,6 @@ async fn rebuild_search_index_forces_catalog_projection_refresh() {
         .search_client()
         .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
             workspace: Some(default_workspace()),
-            provider: SearchIndexProvider::Catalog as i32,
             force: false,
         }))
         .await
@@ -244,7 +242,6 @@ async fn rebuild_search_index_forces_catalog_projection_refresh() {
         .search_client()
         .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
             workspace: Some(default_workspace()),
-            provider: SearchIndexProvider::Catalog as i32,
             force: true,
         }))
         .await
@@ -282,7 +279,6 @@ async fn clear_search_data_removes_catalog_projection_and_next_search_recreates_
         .search_client()
         .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
             workspace: Some(default_workspace()),
-            provider: SearchIndexProvider::Catalog as i32,
             force: false,
         }))
         .await

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -4,8 +4,10 @@
 )]
 
 use coral_api::v1::{
-    SearchFieldRole, SearchProvider, SearchProviderState, SearchRequest, SearchSurfaceKind,
-    TableFunctionKind, ValidateSourceRequest, Workspace, catalog_item, search_result,
+    ClearSearchDataRequest, RebuildSearchIndexRequest, SearchClearTarget, SearchDataScope,
+    SearchFieldRole, SearchIndexProvider, SearchProvider, SearchProviderState, SearchRequest,
+    SearchSurfaceKind, TableFunctionKind, ValidateSourceRequest, Workspace, catalog_item,
+    search_clear_target, search_maintenance_provider_result, search_result,
 };
 use coral_client::default_workspace;
 use serde_json::json;
@@ -210,6 +212,202 @@ async fn search_returns_catalog_metadata_for_search_functions_and_column_hints()
 }
 
 #[tokio::test]
+async fn rebuild_search_index_forces_catalog_projection_refresh() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
+        .await;
+
+    let first = harness
+        .search_client()
+        .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
+            workspace: Some(default_workspace()),
+            provider: SearchIndexProvider::Catalog as i32,
+            force: false,
+        }))
+        .await
+        .expect("rebuild catalog")
+        .into_inner();
+    let first_detail = catalog_rebuild_detail(&first);
+    assert_eq!(first_detail.old_document_count, 0);
+    assert!(first_detail.new_document_count > 0);
+    assert!(first_detail.projection_changed);
+    assert!(first_detail.rebuild_performed);
+    let first_coverage = catalog_rebuild_provider_result(&first)
+        .coverage
+        .as_ref()
+        .expect("catalog rebuild coverage");
+    assert_eq!(
+        first_coverage.eligible_units,
+        first_detail.new_document_count
+    );
+    assert_eq!(
+        first_coverage.searched_units,
+        first_detail.new_document_count
+    );
+    assert!(
+        !first_coverage.stale_index,
+        "successful rebuilds should not report stale index state"
+    );
+
+    let forced = harness
+        .search_client()
+        .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
+            workspace: Some(default_workspace()),
+            provider: SearchIndexProvider::Catalog as i32,
+            force: true,
+        }))
+        .await
+        .expect("force rebuild catalog")
+        .into_inner();
+    let forced_detail = catalog_rebuild_detail(&forced);
+    assert_eq!(
+        forced_detail.old_document_count,
+        first_detail.new_document_count
+    );
+    assert_eq!(
+        forced_detail.new_document_count,
+        first_detail.new_document_count
+    );
+    assert!(!forced_detail.projection_changed);
+    assert!(
+        forced_detail.rebuild_performed,
+        "force should rebuild even when the fingerprint is current"
+    );
+    let forced_coverage = catalog_rebuild_provider_result(&forced)
+        .coverage
+        .as_ref()
+        .expect("forced catalog rebuild coverage");
+    assert!(
+        !forced_coverage.stale_index,
+        "forced rebuilds should not report stale index state"
+    );
+}
+
+#[tokio::test]
+async fn rebuild_search_index_all_rebuilds_catalog_and_skips_unimplemented_providers() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
+        .await;
+
+    let response = harness
+        .search_client()
+        .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
+            workspace: Some(default_workspace()),
+            provider: SearchIndexProvider::All as i32,
+            force: false,
+        }))
+        .await
+        .expect("rebuild all search indexes")
+        .into_inner();
+
+    assert_eq!(response.provider_results.len(), 2);
+    let catalog_detail = catalog_rebuild_detail(&response);
+    assert!(catalog_detail.new_document_count > 0);
+
+    let observed = rebuild_provider_result(&response, SearchProvider::ObservedValues);
+    assert_eq!(
+        SearchProviderState::try_from(observed.state).expect("observed provider state"),
+        SearchProviderState::Skipped
+    );
+    assert!(
+        observed.detail.is_none(),
+        "skipped providers should not invent provider-specific detail"
+    );
+    assert!(
+        observed.note.contains("not implemented yet"),
+        "skipped provider should explain why it did not run: {}",
+        observed.note
+    );
+}
+
+#[tokio::test]
+async fn rebuild_search_index_observed_values_reports_skipped_provider() {
+    let harness = GrpcHarness::new().await;
+
+    let response = harness
+        .search_client()
+        .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
+            workspace: Some(default_workspace()),
+            provider: SearchIndexProvider::ObservedValues as i32,
+            force: false,
+        }))
+        .await
+        .expect("rebuild observed-value search index")
+        .into_inner();
+
+    assert_eq!(response.provider_results.len(), 1);
+    let observed = rebuild_provider_result(&response, SearchProvider::ObservedValues);
+    assert_eq!(
+        SearchProviderState::try_from(observed.state).expect("observed provider state"),
+        SearchProviderState::Skipped
+    );
+    assert!(observed.detail.is_none());
+}
+
+#[tokio::test]
+async fn clear_search_data_removes_catalog_projection_and_next_search_recreates_it() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(searchable_manifest_yaml(), Vec::new(), Vec::new())
+        .await;
+
+    harness
+        .search_client()
+        .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
+            workspace: Some(default_workspace()),
+            provider: SearchIndexProvider::Catalog as i32,
+            force: false,
+        }))
+        .await
+        .expect("seed catalog projection");
+    let clear = harness
+        .search_client()
+        .clear_search_data(Request::new(ClearSearchDataRequest {
+            workspace: Some(default_workspace()),
+            scope: SearchDataScope::All as i32,
+            target: Some(SearchClearTarget {
+                target: Some(search_clear_target::Target::Workspace(true)),
+            }),
+        }))
+        .await
+        .expect("clear search data")
+        .into_inner();
+
+    let clear_detail = catalog_clear_detail(&clear);
+    assert!(clear_detail.deleted_document_count > 0);
+    let compaction = clear.compaction.as_ref().expect("compaction status");
+    assert!(compaction.wal_checkpoint_truncate_completed);
+    assert!(compaction.vacuum_completed);
+
+    let response = harness
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: "messages title".to_string(),
+            limit: 10,
+        }))
+        .await
+        .expect("search after clear")
+        .into_inner();
+
+    assert_provider_state(
+        &response,
+        SearchProvider::CatalogMetadata,
+        SearchProviderState::ResultsFound,
+    );
+    assert!(
+        response.results.iter().any(|result| matches!(
+            result.payload.as_ref(),
+            Some(search_result::Payload::CatalogMetadata(metadata))
+                if metadata.item.as_ref().and_then(|item| item.item.as_ref()).is_some()
+        )),
+        "next search should recreate and use the catalog projection"
+    );
+}
+
+#[tokio::test]
 async fn search_table_preview_columns_do_not_inherit_table_matched_fields() {
     let harness = GrpcHarness::new().await;
     harness
@@ -373,6 +571,48 @@ fn assert_empty_provider_coverage(status: &coral_api::v1::SearchProviderStatus) 
     assert!(!coverage.budget_exhausted);
     assert!(!coverage.timed_out);
     assert!(!coverage.stale_index);
+}
+
+fn catalog_rebuild_detail(
+    response: &coral_api::v1::RebuildSearchIndexResponse,
+) -> &coral_api::v1::CatalogRebuildResult {
+    let result = catalog_rebuild_provider_result(response);
+    match result.detail.as_ref() {
+        Some(search_maintenance_provider_result::Detail::CatalogRebuild(detail)) => detail,
+        Some(search_maintenance_provider_result::Detail::CatalogClear(_)) | None => {
+            panic!("expected catalog rebuild detail")
+        }
+    }
+}
+
+fn catalog_rebuild_provider_result(
+    response: &coral_api::v1::RebuildSearchIndexResponse,
+) -> &coral_api::v1::SearchMaintenanceProviderResult {
+    rebuild_provider_result(response, SearchProvider::CatalogMetadata)
+}
+
+fn rebuild_provider_result(
+    response: &coral_api::v1::RebuildSearchIndexResponse,
+    provider: SearchProvider,
+) -> &coral_api::v1::SearchMaintenanceProviderResult {
+    response
+        .provider_results
+        .iter()
+        .find(|result| result.provider == provider as i32)
+        .expect("provider result")
+}
+
+fn catalog_clear_detail(
+    response: &coral_api::v1::ClearSearchDataResponse,
+) -> &coral_api::v1::CatalogClearResult {
+    response
+        .provider_results
+        .iter()
+        .find_map(|result| match result.detail.as_ref()? {
+            search_maintenance_provider_result::Detail::CatalogClear(detail) => Some(detail),
+            search_maintenance_provider_result::Detail::CatalogRebuild(_) => None,
+        })
+        .expect("catalog clear detail")
 }
 
 fn searchable_manifest_yaml() -> String {

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -80,7 +80,7 @@ enum Command {
     Sql(SqlArgs),
     /// Find relevant Coral tables, functions, columns, and filters
     Search(SearchArgs),
-    /// Manage app-owned local search indexes
+    /// Manage Coral's local search indexes
     SearchIndex(SearchIndexArgs),
     /// Manage data sources
     Source(SourceArgs),
@@ -157,7 +157,7 @@ struct SearchArgs {
 }
 
 #[derive(Debug, Args)]
-/// Manage app-owned local search indexes
+/// Manage Coral's local search indexes
 struct SearchIndexArgs {
     #[command(subcommand)]
     command: SearchIndexCommand,
@@ -167,7 +167,13 @@ struct SearchIndexArgs {
 enum SearchIndexCommand {
     /// Rebuild an app-owned local search index
     Rebuild(SearchRebuildArgs),
-    /// Clear app-owned local search data
+    /// Clear Coral's local search data for one workspace.
+    ///
+    /// This command is destructive, so it requires `--yes` and the global
+    /// `--workspace` flag. Use `--workspace NAME` to clear `NAME`. Use bare
+    /// `--workspace` to clear the workspace Coral would otherwise select:
+    /// `CORAL_WORKSPACE` when set, otherwise `default`. The global flag may appear
+    /// after `clear`.
     Clear(SearchClearArgs),
 }
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -165,15 +165,16 @@ struct SearchIndexArgs {
 
 #[derive(Debug, Subcommand)]
 enum SearchIndexCommand {
-    /// Rebuild an app-owned local search index
+    /// Rebuild a local search index.
+    ///
+    /// Coral skips the rebuild when the index is already up to date unless you pass `--force`.
     Rebuild(SearchRebuildArgs),
     /// Clear Coral's local search data for one workspace.
     ///
-    /// This command is destructive, so it requires `--yes` and the global
-    /// `--workspace` flag. Use `--workspace NAME` to clear `NAME`. Use bare
-    /// `--workspace` to clear the workspace Coral would otherwise select:
-    /// `CORAL_WORKSPACE` when set, otherwise `default`. The global flag may appear
-    /// after `clear`.
+    /// Clear deletes local search data, so Coral requires both `--yes` and
+    /// `--workspace`. Use `--workspace NAME` to clear that workspace. Use
+    /// `--workspace` with no name to clear the workspace Coral would normally use
+    /// for this command: `CORAL_WORKSPACE` if it is set, or `default` otherwise.
     Clear(SearchClearArgs),
 }
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -32,8 +32,8 @@ use coral_api::v1::{
     AddFunctionRequest, ClearSearchDataRequest, CreateWorkspaceRequest, DeleteFunctionRequest,
     DeleteWorkspaceRequest, ExecuteSqlRequest, Function, FunctionRuntimeReady,
     ListFunctionsRequest, ListWorkspacesRequest, RebuildSearchIndexRequest, SearchClearTarget,
-    SearchDataScope, SearchIndexProvider, SearchProvider, SearchRequest, Workspace, function,
-    search_clear_target, search_maintenance_result,
+    SearchDataScope, SearchProvider, SearchRequest, Workspace, function, search_clear_target,
+    search_maintenance_result,
 };
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
@@ -164,7 +164,7 @@ struct SearchIndexArgs {
 
 #[derive(Debug, Subcommand)]
 enum SearchIndexCommand {
-    /// Rebuild a local search index.
+    /// Rebuild all local search indexes.
     ///
     /// Coral skips the rebuild when the index is already up to date unless you pass `--force`.
     Rebuild(SearchRebuildArgs),
@@ -1195,7 +1195,6 @@ async fn run_search_index(
                 .search_client()
                 .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
                     workspace: Some(workspace.clone()),
-                    provider: SearchIndexProvider::Catalog as i32,
                     force: args.force,
                 }))
                 .await

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -33,7 +33,7 @@ use coral_api::v1::{
     DeleteWorkspaceRequest, ExecuteSqlRequest, Function, FunctionRuntimeReady,
     ListFunctionsRequest, ListWorkspacesRequest, RebuildSearchIndexRequest, SearchClearTarget,
     SearchDataScope, SearchIndexProvider, SearchProvider, SearchRequest, Workspace, function,
-    search_clear_target, search_maintenance_provider_result,
+    search_clear_target, search_maintenance_result,
 };
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
@@ -56,7 +56,6 @@ const MCP_INITIAL_QUERY_EXAMPLE_LIMIT: usize = 5;
 const DEFAULT_SEARCH_LIMIT: u32 = 10;
 const MIN_SEARCH_LIMIT: u32 = 1;
 const MAX_SEARCH_LIMIT: u32 = 50;
-const CURRENT_WORKSPACE_CONFIRMATION: &str = "__coral_current_workspace_confirmation__";
 
 #[derive(Debug, Parser)]
 #[command(
@@ -171,26 +170,16 @@ enum SearchIndexCommand {
     Rebuild(SearchRebuildArgs),
     /// Clear Coral's local search data for one workspace.
     ///
-    /// Clear deletes local search data, so Coral requires both `--yes` and
-    /// `--workspace`. Use `--workspace NAME` to clear that workspace. Use
-    /// `--workspace` with no name to clear the workspace Coral would normally use
-    /// for this command: `CORAL_WORKSPACE` if it is set, or `default` otherwise.
+    /// Clear deletes local search data, so Coral requires both `--yes` and an
+    /// explicit `--workspace NAME`.
     Clear(SearchClearArgs),
 }
 
 #[derive(Debug, Args)]
 struct SearchRebuildArgs {
-    /// Search index provider to rebuild
-    #[arg(long, value_enum, default_value = "catalog")]
-    provider: SearchRebuildProvider,
     /// Rebuild even when the stored projection fingerprint is current
     #[arg(long)]
     force: bool,
-}
-
-#[derive(Debug, Clone, Copy, ValueEnum)]
-enum SearchRebuildProvider {
-    Catalog,
 }
 
 #[derive(Debug, Args)]
@@ -198,9 +187,9 @@ struct SearchClearArgs {
     /// Search data scope to clear
     #[arg(long, value_enum)]
     scope: SearchClearScope,
-    /// Set when the global `--workspace` selector is present for this clear command.
+    /// Set when an explicit global `--workspace NAME` selector is present.
     #[arg(skip)]
-    workspace_scope: bool,
+    explicit_workspace: bool,
     /// Confirm destructive search-data deletion
     #[arg(long, required = true, action = ArgAction::SetTrue)]
     yes: bool,
@@ -218,8 +207,7 @@ struct WorkspaceSelectionArgs {
         long = "workspace",
         value_name = "NAME",
         global = true,
-        num_args = 0..=1,
-        default_missing_value = CURRENT_WORKSPACE_CONFIRMATION
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
     )]
     workspace: Option<String>,
 }
@@ -546,15 +534,6 @@ impl Command {
         )
     }
 
-    fn accepts_bare_workspace_flag(&self) -> bool {
-        matches!(
-            self,
-            Command::SearchIndex(SearchIndexArgs {
-                command: SearchIndexCommand::Clear(_),
-            })
-        )
-    }
-
     fn apply_workspace_flag_presence(&mut self, present: bool) {
         if let Command::SearchIndex(args) = self {
             args.apply_workspace_flag_presence(present);
@@ -565,7 +544,7 @@ impl Command {
 impl SearchIndexArgs {
     fn apply_workspace_flag_presence(&mut self, present: bool) {
         if let SearchIndexCommand::Clear(args) = &mut self.command {
-            args.workspace_scope = present;
+            args.explicit_workspace = present;
         }
     }
 }
@@ -627,16 +606,6 @@ pub async fn run_from_env() -> Result<(), CliError> {
         mut command,
     } = Cli::parse();
     let workspace_flag_present = workspace_selection.workspace.is_some();
-    let bare_workspace_flag_present = workspace_selection
-        .workspace
-        .as_deref()
-        .is_some_and(is_current_workspace_confirmation);
-    if bare_workspace_flag_present && !command.accepts_bare_workspace_flag() {
-        return Err(anyhow::anyhow!(
-            "`--workspace` requires a workspace name except for `coral search-index clear --workspace --yes`"
-        )
-        .into());
-    }
     command.apply_workspace_flag_presence(workspace_flag_present);
     let feature_overrides = feature_overrides.into_overrides();
     let ctx = coral_app::RunContext {
@@ -691,13 +660,8 @@ fn selected_workspace(cli_workspace: Option<String>) -> Workspace {
 
 fn selected_workspace_name(cli_workspace: Option<String>, env_workspace: Option<String>) -> String {
     cli_workspace
-        .filter(|value| !value.is_empty() && !is_current_workspace_confirmation(value))
         .or_else(|| env_workspace.filter(|value| !value.is_empty()))
         .unwrap_or_else(|| DEFAULT_WORKSPACE_ID.to_string())
-}
-
-fn is_current_workspace_confirmation(value: &str) -> bool {
-    value == CURRENT_WORKSPACE_CONFIRMATION
 }
 
 /// Returns the embedded Coral UI assets for the local server to serve.
@@ -1231,7 +1195,7 @@ async fn run_search_index(
                 .search_client()
                 .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
                     workspace: Some(workspace.clone()),
-                    provider: search_rebuild_provider_to_proto(args.provider) as i32,
+                    provider: SearchIndexProvider::Catalog as i32,
                     force: args.force,
                 }))
                 .await
@@ -1240,9 +1204,9 @@ async fn run_search_index(
             print_search_rebuild_response(&response);
         }
         SearchIndexCommand::Clear(args) => {
-            if !args.workspace_scope || !args.yes {
+            if !args.explicit_workspace || !args.yes {
                 return Err(anyhow::anyhow!(
-                    "`coral search-index clear --scope all` requires --workspace and --yes"
+                    "`coral search-index clear --scope all` requires an explicit `--workspace NAME` and `--yes`"
                 )
                 .into());
             }
@@ -1264,12 +1228,6 @@ async fn run_search_index(
     Ok(())
 }
 
-fn search_rebuild_provider_to_proto(provider: SearchRebuildProvider) -> SearchIndexProvider {
-    match provider {
-        SearchRebuildProvider::Catalog => SearchIndexProvider::Catalog,
-    }
-}
-
 fn search_clear_scope_to_proto(scope: SearchClearScope) -> SearchDataScope {
     match scope {
         SearchClearScope::All => SearchDataScope::All,
@@ -1277,17 +1235,24 @@ fn search_clear_scope_to_proto(scope: SearchClearScope) -> SearchDataScope {
 }
 
 fn print_search_rebuild_response(response: &coral_api::v1::RebuildSearchIndexResponse) {
-    for result in &response.provider_results {
+    for result in &response.results {
         match result.detail.as_ref() {
-            Some(search_maintenance_provider_result::Detail::CatalogRebuild(detail)) => {
-                println!(
-                    "Rebuilt {} search index: old documents {}, new documents {}, projection changed {}, rebuild performed {}.",
-                    search_provider_label(result.provider),
-                    detail.old_document_count,
-                    detail.new_document_count,
-                    yes_no(detail.projection_changed),
-                    yes_no(detail.rebuild_performed)
-                );
+            Some(search_maintenance_result::Detail::CatalogRebuild(detail)) => {
+                if detail.rebuild_performed {
+                    println!(
+                        "Rebuilt {} search index: old documents {}, new documents {}, projection changed {}.",
+                        search_provider_label(result.provider),
+                        detail.old_document_count,
+                        detail.new_document_count,
+                        yes_no(detail.projection_changed)
+                    );
+                } else {
+                    println!(
+                        "Skipped rebuilding {} search index: projection already current with {} documents.",
+                        search_provider_label(result.provider),
+                        detail.new_document_count
+                    );
+                }
             }
             _ => {
                 println!(
@@ -1301,9 +1266,9 @@ fn print_search_rebuild_response(response: &coral_api::v1::RebuildSearchIndexRes
 }
 
 fn print_search_clear_response(response: &coral_api::v1::ClearSearchDataResponse) {
-    for result in &response.provider_results {
+    for result in &response.results {
         match result.detail.as_ref() {
-            Some(search_maintenance_provider_result::Detail::CatalogClear(detail)) => {
+            Some(search_maintenance_result::Detail::CatalogClear(detail)) => {
                 println!(
                     "Cleared {} search data: deleted {} documents.",
                     search_provider_label(result.provider),
@@ -1319,13 +1284,8 @@ fn print_search_clear_response(response: &coral_api::v1::ClearSearchDataResponse
             }
         }
     }
-    if let Some(compaction) = response.compaction.as_ref() {
-        println!(
-            "Compaction: WAL checkpoint/truncate {}, VACUUM {}. {}",
-            completed_label(compaction.wal_checkpoint_truncate_completed),
-            completed_label(compaction.vacuum_completed),
-            compaction.note
-        );
+    if let Some(storage_cleanup) = response.storage_cleanup.as_ref() {
+        println!("Storage cleanup: {}.", storage_cleanup.note);
     }
 }
 
@@ -1340,10 +1300,6 @@ fn search_provider_label(provider: i32) -> &'static str {
 
 fn yes_no(value: bool) -> &'static str {
     if value { "yes" } else { "no" }
-}
-
-fn completed_label(value: bool) -> &'static str {
-    if value { "completed" } else { "not completed" }
 }
 
 fn print_batches(
@@ -1643,8 +1599,8 @@ mod tests {
     }
 
     #[test]
-    fn search_index_clear_accepts_bare_workspace_confirmation() {
-        let cli = Cli::try_parse_from([
+    fn workspace_flag_requires_a_non_empty_name() {
+        Cli::try_parse_from([
             "coral",
             "search-index",
             "clear",
@@ -1653,25 +1609,37 @@ mod tests {
             "--workspace",
             "--yes",
         ])
-        .expect("search-index clear workspace confirmation parses");
-
-        assert_eq!(
-            cli.workspace_selection.workspace.as_deref(),
-            Some(super::CURRENT_WORKSPACE_CONFIRMATION)
-        );
-        assert!(cli.command.accepts_bare_workspace_flag());
+        .expect_err("bare workspace flag must be rejected");
+        Cli::try_parse_from([
+            "coral",
+            "search-index",
+            "clear",
+            "--scope",
+            "all",
+            "--workspace",
+            "",
+            "--yes",
+        ])
+        .expect_err("empty workspace name must be rejected");
     }
 
     #[test]
-    fn non_clear_commands_do_not_accept_bare_workspace_confirmation() {
-        let cli = Cli::try_parse_from(["coral", "source", "list", "--workspace"])
-            .expect("bare workspace parses before runtime validation");
-
+    fn former_workspace_confirmation_marker_is_a_regular_name() {
+        let cli = Cli::try_parse_from([
+            "coral",
+            "search-index",
+            "clear",
+            "--scope",
+            "all",
+            "--workspace",
+            "__coral_current_workspace_confirmation__",
+            "--yes",
+        ])
+        .expect("former confirmation marker should parse as a workspace name");
         assert_eq!(
             cli.workspace_selection.workspace.as_deref(),
-            Some(super::CURRENT_WORKSPACE_CONFIRMATION)
+            Some("__coral_current_workspace_confirmation__")
         );
-        assert!(!cli.command.accepts_bare_workspace_flag());
     }
 
     #[test]
@@ -1709,20 +1677,13 @@ mod tests {
     }
 
     #[test]
-    fn selected_workspace_treats_empty_cli_value_as_unset() {
-        let workspace = super::selected_workspace_name(Some(String::new()), None);
-
-        assert_eq!(workspace, super::DEFAULT_WORKSPACE_ID);
-    }
-
-    #[test]
-    fn selected_workspace_treats_confirmation_marker_as_unset() {
+    fn selected_workspace_preserves_former_confirmation_marker() {
         let workspace = super::selected_workspace_name(
-            Some(super::CURRENT_WORKSPACE_CONFIRMATION.to_string()),
+            Some("__coral_current_workspace_confirmation__".to_string()),
             None,
         );
 
-        assert_eq!(workspace, super::DEFAULT_WORKSPACE_ID);
+        assert_eq!(workspace, "__coral_current_workspace_confirmation__");
     }
 
     #[test]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -29,9 +29,11 @@ use clap::{
 };
 use clap_complete::{Shell, generate};
 use coral_api::v1::{
-    AddFunctionRequest, CreateWorkspaceRequest, DeleteFunctionRequest, DeleteWorkspaceRequest,
-    ExecuteSqlRequest, Function, FunctionRuntimeReady, ListFunctionsRequest, ListWorkspacesRequest,
-    SearchRequest, Workspace, function,
+    AddFunctionRequest, ClearSearchDataRequest, CreateWorkspaceRequest, DeleteFunctionRequest,
+    DeleteWorkspaceRequest, ExecuteSqlRequest, Function, FunctionRuntimeReady,
+    ListFunctionsRequest, ListWorkspacesRequest, RebuildSearchIndexRequest, SearchClearTarget,
+    SearchDataScope, SearchIndexProvider, SearchProvider, SearchRequest, Workspace, function,
+    search_clear_target, search_maintenance_provider_result,
 };
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
@@ -54,6 +56,7 @@ const MCP_INITIAL_QUERY_EXAMPLE_LIMIT: usize = 5;
 const DEFAULT_SEARCH_LIMIT: u32 = 10;
 const MIN_SEARCH_LIMIT: u32 = 1;
 const MAX_SEARCH_LIMIT: u32 = 50;
+const CURRENT_WORKSPACE_CONFIRMATION: &str = "__coral_current_workspace_confirmation__";
 
 #[derive(Debug, Parser)]
 #[command(
@@ -77,6 +80,8 @@ enum Command {
     Sql(SqlArgs),
     /// Find relevant Coral tables, functions, columns, and filters
     Search(SearchArgs),
+    /// Manage app-owned local search indexes
+    SearchIndex(SearchIndexArgs),
     /// Manage data sources
     Source(SourceArgs),
     /// Manage workspaces
@@ -152,9 +157,63 @@ struct SearchArgs {
 }
 
 #[derive(Debug, Args)]
+/// Manage app-owned local search indexes
+struct SearchIndexArgs {
+    #[command(subcommand)]
+    command: SearchIndexCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum SearchIndexCommand {
+    /// Rebuild an app-owned local search index
+    Rebuild(SearchRebuildArgs),
+    /// Clear app-owned local search data
+    Clear(SearchClearArgs),
+}
+
+#[derive(Debug, Args)]
+struct SearchRebuildArgs {
+    /// Search index provider to rebuild
+    #[arg(long, value_enum, default_value = "catalog")]
+    provider: SearchRebuildProvider,
+    /// Rebuild even when the stored projection fingerprint is current
+    #[arg(long)]
+    force: bool,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum SearchRebuildProvider {
+    Catalog,
+}
+
+#[derive(Debug, Args)]
+struct SearchClearArgs {
+    /// Search data scope to clear
+    #[arg(long, value_enum)]
+    scope: SearchClearScope,
+    /// Set when the global `--workspace` selector is present for this clear command.
+    #[arg(skip)]
+    workspace_scope: bool,
+    /// Confirm destructive search-data deletion
+    #[arg(long, required = true, action = ArgAction::SetTrue)]
+    yes: bool,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum SearchClearScope {
+    All,
+}
+
+#[derive(Debug, Args)]
 struct WorkspaceSelectionArgs {
     /// Workspace to target. Overrides `CORAL_WORKSPACE`.
-    #[arg(long = "workspace", value_name = "NAME", global = true)]
+    #[arg(
+        long = "workspace",
+        value_name = "NAME",
+        global = true,
+        num_args = 0..=1,
+        default_missing_value = CURRENT_WORKSPACE_CONFIRMATION
+    )]
     workspace: Option<String>,
 }
 
@@ -451,6 +510,7 @@ impl Command {
         match self {
             Command::Sql(_)
             | Command::Search(_)
+            | Command::SearchIndex(_)
             | Command::Source(_)
             | Command::Workspace(_)
             | Command::Function(_)
@@ -471,11 +531,35 @@ impl Command {
             self,
             Command::Sql(_)
                 | Command::Search(_)
+                | Command::SearchIndex(_)
                 | Command::Source(_)
                 | Command::Function(_)
                 | Command::Onboard
                 | Command::McpStdio(_)
         )
+    }
+
+    fn accepts_bare_workspace_flag(&self) -> bool {
+        matches!(
+            self,
+            Command::SearchIndex(SearchIndexArgs {
+                command: SearchIndexCommand::Clear(_),
+            })
+        )
+    }
+
+    fn apply_workspace_flag_presence(&mut self, present: bool) {
+        if let Command::SearchIndex(args) = self {
+            args.apply_workspace_flag_presence(present);
+        }
+    }
+}
+
+impl SearchIndexArgs {
+    fn apply_workspace_flag_presence(&mut self, present: bool) {
+        if let SearchIndexCommand::Clear(args) = &mut self.command {
+            args.workspace_scope = present;
+        }
     }
 }
 
@@ -533,8 +617,20 @@ pub async fn run_from_env() -> Result<(), CliError> {
     let Cli {
         feature_overrides,
         workspace_selection,
-        command,
+        mut command,
     } = Cli::parse();
+    let workspace_flag_present = workspace_selection.workspace.is_some();
+    let bare_workspace_flag_present = workspace_selection
+        .workspace
+        .as_deref()
+        .is_some_and(is_current_workspace_confirmation);
+    if bare_workspace_flag_present && !command.accepts_bare_workspace_flag() {
+        return Err(anyhow::anyhow!(
+            "`--workspace` requires a workspace name except for `coral search-index clear --workspace --yes`"
+        )
+        .into());
+    }
+    command.apply_workspace_flag_presence(workspace_flag_present);
     let feature_overrides = feature_overrides.into_overrides();
     let ctx = coral_app::RunContext {
         trace_parent: env::trace_parent(),
@@ -588,9 +684,13 @@ fn selected_workspace(cli_workspace: Option<String>) -> Workspace {
 
 fn selected_workspace_name(cli_workspace: Option<String>, env_workspace: Option<String>) -> String {
     cli_workspace
-        .filter(|value| !value.is_empty())
+        .filter(|value| !value.is_empty() && !is_current_workspace_confirmation(value))
         .or_else(|| env_workspace.filter(|value| !value.is_empty()))
         .unwrap_or_else(|| DEFAULT_WORKSPACE_ID.to_string())
+}
+
+fn is_current_workspace_confirmation(value: &str) -> bool {
+    value == CURRENT_WORKSPACE_CONFIRMATION
 }
 
 /// Returns the embedded Coral UI assets for the local server to serve.
@@ -652,6 +752,7 @@ async fn run_no_runtime_command(
         Command::Ui(args) => run_ui(args).await.map_err(Into::into),
         Command::Sql(_)
         | Command::Search(_)
+        | Command::SearchIndex(_)
         | Command::Source(_)
         | Command::Workspace(_)
         | Command::Function(_)
@@ -692,6 +793,7 @@ async fn run_app_command(
             print_batches(result.batches(), args.format)?;
         }
         Command::Search(args) => run_search(&app, workspace, args).await?,
+        Command::SearchIndex(args) => run_search_index(&app, workspace, args).await?,
         Command::Source(args) => run_source(&app, workspace, args).await?,
         Command::Workspace(args) => run_workspace(&app, args).await?,
         Command::Function(args) => run_function(&app, workspace, args).await?,
@@ -1110,6 +1212,133 @@ fn function_name_arg(name: &str) -> Result<String, anyhow::Error> {
     }
     Ok(trimmed.to_string())
 }
+
+async fn run_search_index(
+    app: &AppClient,
+    workspace: &Workspace,
+    args: SearchIndexArgs,
+) -> Result<(), CliError> {
+    match args.command {
+        SearchIndexCommand::Rebuild(args) => {
+            let response = app
+                .search_client()
+                .rebuild_search_index(Request::new(RebuildSearchIndexRequest {
+                    workspace: Some(workspace.clone()),
+                    provider: search_rebuild_provider_to_proto(args.provider) as i32,
+                    force: args.force,
+                }))
+                .await
+                .map_err(anyhow::Error::from)?
+                .into_inner();
+            print_search_rebuild_response(&response);
+        }
+        SearchIndexCommand::Clear(args) => {
+            if !args.workspace_scope || !args.yes {
+                return Err(anyhow::anyhow!(
+                    "`coral search-index clear --scope all` requires --workspace and --yes"
+                )
+                .into());
+            }
+            let response = app
+                .search_client()
+                .clear_search_data(Request::new(ClearSearchDataRequest {
+                    workspace: Some(workspace.clone()),
+                    scope: search_clear_scope_to_proto(args.scope) as i32,
+                    target: Some(SearchClearTarget {
+                        target: Some(search_clear_target::Target::Workspace(true)),
+                    }),
+                }))
+                .await
+                .map_err(anyhow::Error::from)?
+                .into_inner();
+            print_search_clear_response(&response);
+        }
+    }
+    Ok(())
+}
+
+fn search_rebuild_provider_to_proto(provider: SearchRebuildProvider) -> SearchIndexProvider {
+    match provider {
+        SearchRebuildProvider::Catalog => SearchIndexProvider::Catalog,
+    }
+}
+
+fn search_clear_scope_to_proto(scope: SearchClearScope) -> SearchDataScope {
+    match scope {
+        SearchClearScope::All => SearchDataScope::All,
+    }
+}
+
+fn print_search_rebuild_response(response: &coral_api::v1::RebuildSearchIndexResponse) {
+    for result in &response.provider_results {
+        match result.detail.as_ref() {
+            Some(search_maintenance_provider_result::Detail::CatalogRebuild(detail)) => {
+                println!(
+                    "Rebuilt {} search index: old documents {}, new documents {}, projection changed {}, rebuild performed {}.",
+                    search_provider_label(result.provider),
+                    detail.old_document_count,
+                    detail.new_document_count,
+                    yes_no(detail.projection_changed),
+                    yes_no(detail.rebuild_performed)
+                );
+            }
+            _ => {
+                println!(
+                    "{} search index maintenance: {}",
+                    search_provider_label(result.provider),
+                    result.note
+                );
+            }
+        }
+    }
+}
+
+fn print_search_clear_response(response: &coral_api::v1::ClearSearchDataResponse) {
+    for result in &response.provider_results {
+        match result.detail.as_ref() {
+            Some(search_maintenance_provider_result::Detail::CatalogClear(detail)) => {
+                println!(
+                    "Cleared {} search data: deleted {} documents.",
+                    search_provider_label(result.provider),
+                    detail.deleted_document_count
+                );
+            }
+            _ => {
+                println!(
+                    "{} search data maintenance: {}",
+                    search_provider_label(result.provider),
+                    result.note
+                );
+            }
+        }
+    }
+    if let Some(compaction) = response.compaction.as_ref() {
+        println!(
+            "Compaction: WAL checkpoint/truncate {}, VACUUM {}. {}",
+            completed_label(compaction.wal_checkpoint_truncate_completed),
+            completed_label(compaction.vacuum_completed),
+            compaction.note
+        );
+    }
+}
+
+fn search_provider_label(provider: i32) -> &'static str {
+    match SearchProvider::try_from(provider).ok() {
+        Some(SearchProvider::CatalogMetadata) => "catalog",
+        Some(SearchProvider::ObservedValues) => "observed-values",
+        Some(SearchProvider::NativeFanout) => "native-fanout",
+        Some(SearchProvider::Unspecified) | None => "unknown",
+    }
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value { "yes" } else { "no" }
+}
+
+fn completed_label(value: bool) -> &'static str {
+    if value { "completed" } else { "not completed" }
+}
+
 fn print_batches(
     batches: &[arrow::record_batch::RecordBatch],
     format: OutputFormat,
@@ -1396,6 +1625,49 @@ mod tests {
     }
 
     #[test]
+    fn search_rebuild_parses_as_free_text_query() {
+        let cli = Cli::try_parse_from(["coral", "search", "rebuild"])
+            .expect("search rebuild should parse as query text");
+
+        let super::Command::Search(args) = cli.command else {
+            panic!("expected search command");
+        };
+        assert_eq!(args.query, vec!["rebuild".to_string()]);
+    }
+
+    #[test]
+    fn search_index_clear_accepts_bare_workspace_confirmation() {
+        let cli = Cli::try_parse_from([
+            "coral",
+            "search-index",
+            "clear",
+            "--scope",
+            "all",
+            "--workspace",
+            "--yes",
+        ])
+        .expect("search-index clear workspace confirmation parses");
+
+        assert_eq!(
+            cli.workspace_selection.workspace.as_deref(),
+            Some(super::CURRENT_WORKSPACE_CONFIRMATION)
+        );
+        assert!(cli.command.accepts_bare_workspace_flag());
+    }
+
+    #[test]
+    fn non_clear_commands_do_not_accept_bare_workspace_confirmation() {
+        let cli = Cli::try_parse_from(["coral", "source", "list", "--workspace"])
+            .expect("bare workspace parses before runtime validation");
+
+        assert_eq!(
+            cli.workspace_selection.workspace.as_deref(),
+            Some(super::CURRENT_WORKSPACE_CONFIRMATION)
+        );
+        assert!(!cli.command.accepts_bare_workspace_flag());
+    }
+
+    #[test]
     fn search_limit_rejects_values_outside_cli_contract() {
         Cli::try_parse_from(["coral", "search", "--limit", "0", "github"])
             .expect_err("zero limit should fail before contacting the server");
@@ -1432,6 +1704,16 @@ mod tests {
     #[test]
     fn selected_workspace_treats_empty_cli_value_as_unset() {
         let workspace = super::selected_workspace_name(Some(String::new()), None);
+
+        assert_eq!(workspace, super::DEFAULT_WORKSPACE_ID);
+    }
+
+    #[test]
+    fn selected_workspace_treats_confirmation_marker_as_unset() {
+        let workspace = super::selected_workspace_name(
+            Some(super::CURRENT_WORKSPACE_CONFIRMATION.to_string()),
+            None,
+        );
 
         assert_eq!(workspace, super::DEFAULT_WORKSPACE_ID);
     }

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -17,10 +17,12 @@ use arrow::record_batch::RecordBatch;
 #[cfg(feature = "embedded-ui")]
 use assert_cmd::Command;
 use coral_api::v1::{
-    AddFunctionResponse, DiscoverSourcesResponse, ExecuteSqlResponse, Function, FunctionArgument,
-    FunctionRuntimeInvalid, FunctionRuntimeReady, ListFunctionsResponse, ListSourcesResponse,
-    ListWorkspacesResponse, SearchDataScope, SearchIndexProvider, Source, SourceCredentialStorage,
-    SourceInfo, SourceOrigin, Workspace, function, search_clear_target,
+    AddFunctionResponse, CatalogRebuildResult, DiscoverSourcesResponse, ExecuteSqlResponse,
+    Function, FunctionArgument, FunctionRuntimeInvalid, FunctionRuntimeReady,
+    ListFunctionsResponse, ListSourcesResponse, ListWorkspacesResponse, RebuildSearchIndexResponse,
+    SearchDataScope, SearchIndexProvider, SearchMaintenanceResult, SearchMaintenanceState,
+    SearchProvider, Source, SourceCredentialStorage, SourceInfo, SourceOrigin, Workspace, function,
+    search_clear_target, search_maintenance_result,
 };
 use tempfile::tempdir;
 use tonic::Code;
@@ -1038,13 +1040,7 @@ async fn search_index_rebuild_calls_app_maintenance_rpc() {
 
     let assert = server
         .cmd()
-        .args([
-            "search-index",
-            "rebuild",
-            "--provider",
-            "catalog",
-            "--force",
-        ])
+        .args(["search-index", "rebuild", "--force"])
         .assert()
         .success();
 
@@ -1068,6 +1064,48 @@ async fn search_index_rebuild_calls_app_maintenance_rpc() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn search_index_rebuild_reports_current_projection_as_skipped() {
+    let server = MockServer::start_with_config(
+        MockServerConfig::default().with_rebuild_search_index(RebuildSearchIndexResponse {
+            results: vec![SearchMaintenanceResult {
+                provider: SearchProvider::CatalogMetadata as i32,
+                state: SearchMaintenanceState::Noop as i32,
+                note: "catalog search projection already current".to_string(),
+                detail: Some(search_maintenance_result::Detail::CatalogRebuild(
+                    CatalogRebuildResult {
+                        old_document_count: 3,
+                        new_document_count: 3,
+                        projection_changed: false,
+                        rebuild_performed: false,
+                    },
+                )),
+            }],
+        }),
+    )
+    .await;
+
+    let assert = server
+        .cmd()
+        .args(["search-index", "rebuild"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+
+    assert!(
+        stdout.contains(
+            "Skipped rebuilding catalog search index: projection already current with 3 documents."
+        ),
+        "expected no-op rebuild output: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Rebuilt catalog"),
+        "no-op rebuild must not claim a rebuild: {stdout}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn search_index_clear_calls_app_maintenance_rpc() {
     let server = MockServer::start().await;
 
@@ -1079,6 +1117,7 @@ async fn search_index_clear_calls_app_maintenance_rpc() {
             "--scope",
             "all",
             "--workspace",
+            "default",
             "--yes",
         ])
         .assert()
@@ -1090,8 +1129,8 @@ async fn search_index_clear_calls_app_maintenance_rpc() {
         "expected clear output: {stdout}"
     );
     assert!(
-        stdout.contains("Compaction: WAL checkpoint/truncate completed, VACUUM completed"),
-        "expected compaction output: {stdout}"
+        stdout.contains("Storage cleanup: local search storage cleanup completed."),
+        "expected storage cleanup output: {stdout}"
     );
 
     assert!(
@@ -1130,6 +1169,29 @@ async fn search_index_clear_calls_app_maintenance_rpc() {
     assert_eq!(requests.len(), 2, "expected second clear call");
     assert_workspace_name(requests[1].workspace.as_ref(), "work");
 
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_index_clear_requires_explicit_workspace_even_when_env_is_set() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .env("CORAL_WORKSPACE", "work")
+        .args(["search-index", "clear", "--scope", "all", "--yes"])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("requires an explicit `--workspace NAME` and `--yes`"),
+        "expected explicit workspace error: {stderr}"
+    );
+
+    assert!(
+        server.clear_search_data_requests().is_empty(),
+        "implicit environment selection must not authorize destructive clear"
+    );
     server.shutdown().await;
 }
 

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -19,8 +19,8 @@ use assert_cmd::Command;
 use coral_api::v1::{
     AddFunctionResponse, DiscoverSourcesResponse, ExecuteSqlResponse, Function, FunctionArgument,
     FunctionRuntimeInvalid, FunctionRuntimeReady, ListFunctionsResponse, ListSourcesResponse,
-    ListWorkspacesResponse, Source, SourceCredentialStorage, SourceInfo, SourceOrigin, Workspace,
-    function,
+    ListWorkspacesResponse, SearchDataScope, SearchIndexProvider, Source, SourceCredentialStorage,
+    SourceInfo, SourceOrigin, Workspace, function, search_clear_target,
 };
 use tempfile::tempdir;
 use tonic::Code;
@@ -1011,6 +1011,124 @@ async fn search_json_output_preserves_typed_payloads_and_statuses() {
     assert_eq!(requests[0].query, "messages");
     assert_eq!(requests[0].limit, 5);
     assert_default_workspace(requests[0].workspace.as_ref());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_rebuild_remains_free_text_query() {
+    let server = MockServer::start().await;
+
+    server.cmd().args(["search", "rebuild"]).assert().success();
+
+    let requests = server.search_requests();
+    assert_eq!(requests.len(), 1, "expected one search call");
+    assert_eq!(requests[0].query, "rebuild");
+    assert!(
+        server.rebuild_search_index_requests().is_empty(),
+        "plain search must not call maintenance"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_index_rebuild_calls_app_maintenance_rpc() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args([
+            "search-index",
+            "rebuild",
+            "--provider",
+            "catalog",
+            "--force",
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("Rebuilt catalog search index"),
+        "expected rebuild output: {stdout}"
+    );
+
+    assert!(
+        server.search_requests().is_empty(),
+        "maintenance command must not call Search"
+    );
+    let requests = server.rebuild_search_index_requests();
+    assert_eq!(requests.len(), 1, "expected one rebuild call");
+    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_eq!(requests[0].provider, SearchIndexProvider::Catalog as i32);
+    assert!(requests[0].force);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_index_clear_calls_app_maintenance_rpc() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args([
+            "search-index",
+            "clear",
+            "--scope",
+            "all",
+            "--workspace",
+            "--yes",
+        ])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("Cleared catalog search data"),
+        "expected clear output: {stdout}"
+    );
+    assert!(
+        stdout.contains("Compaction: WAL checkpoint/truncate completed, VACUUM completed"),
+        "expected compaction output: {stdout}"
+    );
+
+    assert!(
+        server.search_requests().is_empty(),
+        "maintenance command must not call Search"
+    );
+    let requests = server.clear_search_data_requests();
+    assert_eq!(requests.len(), 1, "expected one clear call");
+    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_eq!(requests[0].scope, SearchDataScope::All as i32);
+    match requests[0]
+        .target
+        .as_ref()
+        .and_then(|target| target.target.as_ref())
+    {
+        Some(search_clear_target::Target::Workspace(workspace_scope)) => {
+            assert!(*workspace_scope);
+        }
+        other => panic!("expected workspace clear target, got {other:?}"),
+    }
+
+    server
+        .cmd()
+        .args([
+            "search-index",
+            "clear",
+            "--scope",
+            "all",
+            "--workspace",
+            "work",
+            "--yes",
+        ])
+        .assert()
+        .success();
+    let requests = server.clear_search_data_requests();
+    assert_eq!(requests.len(), 2, "expected second clear call");
+    assert_workspace_name(requests[1].workspace.as_ref(), "work");
 
     server.shutdown().await;
 }

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -20,9 +20,9 @@ use coral_api::v1::{
     AddFunctionResponse, CatalogRebuildResult, DiscoverSourcesResponse, ExecuteSqlResponse,
     Function, FunctionArgument, FunctionRuntimeInvalid, FunctionRuntimeReady,
     ListFunctionsResponse, ListSourcesResponse, ListWorkspacesResponse, RebuildSearchIndexResponse,
-    SearchDataScope, SearchIndexProvider, SearchMaintenanceResult, SearchMaintenanceState,
-    SearchProvider, Source, SourceCredentialStorage, SourceInfo, SourceOrigin, Workspace, function,
-    search_clear_target, search_maintenance_result,
+    SearchDataScope, SearchMaintenanceResult, SearchMaintenanceState, SearchProvider, Source,
+    SourceCredentialStorage, SourceInfo, SourceOrigin, Workspace, function, search_clear_target,
+    search_maintenance_result,
 };
 use tempfile::tempdir;
 use tonic::Code;
@@ -1057,7 +1057,6 @@ async fn search_index_rebuild_calls_app_maintenance_rpc() {
     let requests = server.rebuild_search_index_requests();
     assert_eq!(requests.len(), 1, "expected one rebuild call");
     assert_default_workspace(requests[0].workspace.as_ref());
-    assert_eq!(requests[0].provider, SearchIndexProvider::Catalog as i32);
     assert!(requests[0].force);
 
     server.shutdown().await;

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -32,16 +32,16 @@ use coral_api::v1::{
     GetSourceRequest, GetSourceResponse, ImportSourceRequest, ImportSourceResponse,
     ListCatalogRequest, ListCatalogResponse, ListColumnsRequest, ListColumnsResponse,
     ListFunctionsRequest, ListFunctionsResponse, ListSourcesRequest, ListSourcesResponse,
-    ListWorkspacesRequest, ListWorkspacesResponse, PaginationRequest, PaginationResponse, QueryPlan,
-    RebuildSearchIndexRequest, RebuildSearchIndexResponse, SearchCatalogRequest,
-    SearchCatalogResponse, SearchCompactionStatus, SearchFieldRole, SearchMaintenanceProviderResult,
+    ListWorkspacesRequest, ListWorkspacesResponse, PaginationRequest, PaginationResponse,
+    QueryPlan, RebuildSearchIndexRequest, RebuildSearchIndexResponse, SearchCatalogRequest,
+    SearchCatalogResponse, SearchFieldRole, SearchMaintenanceResult, SearchMaintenanceState,
     SearchProvider, SearchProviderCoverage, SearchProviderState, SearchRequest, SearchResponse,
-    SearchResult, SearchResultTruncation, SearchSurfaceKind, SearchTableColumnPreview,
-    SearchTableColumnPreviewColumn, Source, SourceCredentialStorage, SourceInfo, SourceInputSpec,
-    SourceOrigin, SourceSecretInput, Table, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
-    import_source_response, search_maintenance_provider_result, search_result,
-    source_input_spec::Input as ProtoSourceInput,
+    SearchResult, SearchResultTruncation, SearchStorageCleanupResult, SearchSurfaceKind,
+    SearchTableColumnPreview, SearchTableColumnPreviewColumn, Source, SourceCredentialStorage,
+    SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableSummary,
+    ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
+    create_bundled_source_with_o_auth_response, import_source_response, search_maintenance_result,
+    search_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_TASK_ID_METADATA_KEY,
@@ -447,21 +447,11 @@ fn mock_search_response() -> SearchResponse {
 
 fn mock_rebuild_search_index_response() -> RebuildSearchIndexResponse {
     RebuildSearchIndexResponse {
-        provider_results: vec![SearchMaintenanceProviderResult {
+        results: vec![SearchMaintenanceResult {
             provider: SearchProvider::CatalogMetadata as i32,
-            state: SearchProviderState::ResultsFound as i32,
+            state: SearchMaintenanceState::Completed as i32,
             note: "force rebuilt catalog search projection".to_string(),
-            coverage: Some(SearchProviderCoverage {
-                eligible_units: 2,
-                searched_units: 3,
-                failed_units: 0,
-                returned_count: 3,
-                has_more: false,
-                budget_exhausted: false,
-                timed_out: false,
-                stale_index: false,
-            }),
-            detail: Some(search_maintenance_provider_result::Detail::CatalogRebuild(
+            detail: Some(search_maintenance_result::Detail::CatalogRebuild(
                 CatalogRebuildResult {
                     old_document_count: 2,
                     new_document_count: 3,
@@ -475,30 +465,19 @@ fn mock_rebuild_search_index_response() -> RebuildSearchIndexResponse {
 
 fn mock_clear_search_data_response() -> ClearSearchDataResponse {
     ClearSearchDataResponse {
-        provider_results: vec![SearchMaintenanceProviderResult {
+        results: vec![SearchMaintenanceResult {
             provider: SearchProvider::CatalogMetadata as i32,
-            state: SearchProviderState::Empty as i32,
+            state: SearchMaintenanceState::Completed as i32,
             note: "cleared catalog search projection".to_string(),
-            coverage: Some(SearchProviderCoverage {
-                eligible_units: 3,
-                searched_units: 3,
-                failed_units: 0,
-                returned_count: 0,
-                has_more: false,
-                budget_exhausted: false,
-                timed_out: false,
-                stale_index: false,
-            }),
-            detail: Some(search_maintenance_provider_result::Detail::CatalogClear(
+            detail: Some(search_maintenance_result::Detail::CatalogClear(
                 CatalogClearResult {
                     deleted_document_count: 3,
                 },
             )),
         }],
-        compaction: Some(SearchCompactionStatus {
-            wal_checkpoint_truncate_completed: true,
-            vacuum_completed: true,
-            note: "WAL checkpoint/truncate and VACUUM completed".to_string(),
+        storage_cleanup: Some(SearchStorageCleanupResult {
+            state: SearchMaintenanceState::Completed as i32,
+            note: "local search storage cleanup completed".to_string(),
         }),
     }
 }
@@ -699,6 +678,14 @@ impl Default for MockServerConfig {
 }
 
 impl MockServerConfig {
+    pub(crate) fn with_rebuild_search_index(
+        mut self,
+        response: RebuildSearchIndexResponse,
+    ) -> Self {
+        self.rebuild_search_index = MockResult::ok(response);
+        self
+    }
+
     pub(crate) fn with_discover_sources(mut self, response: DiscoverSourcesResponse) -> Self {
         self.discover_sources = MockResult::ok(response);
         self

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -20,8 +20,9 @@ use coral_api::v1::search_service_server::{SearchService, SearchServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::workspace_service_server::{WorkspaceService, WorkspaceServiceServer};
 use coral_api::v1::{
-    AddFunctionRequest, AddFunctionResponse, CatalogCounts, CatalogItem, CatalogMetadata,
-    CatalogSearchResult, Column, ColumnHint, ColumnSearchResult, CreateBundledSourceRequest,
+    AddFunctionRequest, AddFunctionResponse, CatalogClearResult, CatalogCounts, CatalogItem,
+    CatalogMetadata, CatalogRebuildResult, CatalogSearchResult, ClearSearchDataRequest,
+    ClearSearchDataResponse, Column, ColumnHint, ColumnSearchResult, CreateBundledSourceRequest,
     CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
     CreateBundledSourceWithOAuthResponse, CreateWorkspaceRequest, CreateWorkspaceResponse,
     DeleteFunctionRequest, DeleteFunctionResponse, DeleteSourceRequest, DeleteSourceResponse,
@@ -31,14 +32,16 @@ use coral_api::v1::{
     GetSourceRequest, GetSourceResponse, ImportSourceRequest, ImportSourceResponse,
     ListCatalogRequest, ListCatalogResponse, ListColumnsRequest, ListColumnsResponse,
     ListFunctionsRequest, ListFunctionsResponse, ListSourcesRequest, ListSourcesResponse,
-    ListWorkspacesRequest, ListWorkspacesResponse, PaginationRequest, PaginationResponse,
-    QueryPlan, SearchCatalogRequest, SearchCatalogResponse, SearchFieldRole, SearchProvider,
-    SearchProviderCoverage, SearchProviderState, SearchRequest, SearchResponse, SearchResult,
-    SearchResultTruncation, SearchSurfaceKind, SearchTableColumnPreview,
+    ListWorkspacesRequest, ListWorkspacesResponse, PaginationRequest, PaginationResponse, QueryPlan,
+    RebuildSearchIndexRequest, RebuildSearchIndexResponse, SearchCatalogRequest,
+    SearchCatalogResponse, SearchCompactionStatus, SearchFieldRole, SearchMaintenanceProviderResult,
+    SearchProvider, SearchProviderCoverage, SearchProviderState, SearchRequest, SearchResponse,
+    SearchResult, SearchResultTruncation, SearchSurfaceKind, SearchTableColumnPreview,
     SearchTableColumnPreviewColumn, Source, SourceCredentialStorage, SourceInfo, SourceInputSpec,
     SourceOrigin, SourceSecretInput, Table, TableSummary, ValidateSourceRequest,
     ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
-    import_source_response, search_result, source_input_spec::Input as ProtoSourceInput,
+    import_source_response, search_maintenance_provider_result, search_result,
+    source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_TASK_ID_METADATA_KEY,
@@ -442,6 +445,64 @@ fn mock_search_response() -> SearchResponse {
     }
 }
 
+fn mock_rebuild_search_index_response() -> RebuildSearchIndexResponse {
+    RebuildSearchIndexResponse {
+        provider_results: vec![SearchMaintenanceProviderResult {
+            provider: SearchProvider::CatalogMetadata as i32,
+            state: SearchProviderState::ResultsFound as i32,
+            note: "force rebuilt catalog search projection".to_string(),
+            coverage: Some(SearchProviderCoverage {
+                eligible_units: 2,
+                searched_units: 3,
+                failed_units: 0,
+                returned_count: 3,
+                has_more: false,
+                budget_exhausted: false,
+                timed_out: false,
+                stale_index: false,
+            }),
+            detail: Some(search_maintenance_provider_result::Detail::CatalogRebuild(
+                CatalogRebuildResult {
+                    old_document_count: 2,
+                    new_document_count: 3,
+                    projection_changed: false,
+                    rebuild_performed: true,
+                },
+            )),
+        }],
+    }
+}
+
+fn mock_clear_search_data_response() -> ClearSearchDataResponse {
+    ClearSearchDataResponse {
+        provider_results: vec![SearchMaintenanceProviderResult {
+            provider: SearchProvider::CatalogMetadata as i32,
+            state: SearchProviderState::Empty as i32,
+            note: "cleared catalog search projection".to_string(),
+            coverage: Some(SearchProviderCoverage {
+                eligible_units: 3,
+                searched_units: 3,
+                failed_units: 0,
+                returned_count: 0,
+                has_more: false,
+                budget_exhausted: false,
+                timed_out: false,
+                stale_index: false,
+            }),
+            detail: Some(search_maintenance_provider_result::Detail::CatalogClear(
+                CatalogClearResult {
+                    deleted_document_count: 3,
+                },
+            )),
+        }],
+        compaction: Some(SearchCompactionStatus {
+            wal_checkpoint_truncate_completed: true,
+            vacuum_completed: true,
+            note: "WAL checkpoint/truncate and VACUUM completed".to_string(),
+        }),
+    }
+}
+
 fn mock_provider_status(
     provider: SearchProvider,
     state: SearchProviderState,
@@ -581,6 +642,8 @@ impl<T> MockResult<T> {
 pub(crate) struct MockServerConfig {
     execute_sql_override: Option<MockResult<ExecuteSqlResponse>>,
     search: MockResult<SearchResponse>,
+    rebuild_search_index: MockResult<RebuildSearchIndexResponse>,
+    clear_search_data: MockResult<ClearSearchDataResponse>,
     discover_sources: MockResult<DiscoverSourcesResponse>,
     list_sources: MockResult<ListSourcesResponse>,
     list_workspaces: MockResult<ListWorkspacesResponse>,
@@ -596,6 +659,8 @@ impl Default for MockServerConfig {
         Self {
             execute_sql_override: None,
             search: MockResult::ok(mock_search_response()),
+            rebuild_search_index: MockResult::ok(mock_rebuild_search_index_response()),
+            clear_search_data: MockResult::ok(mock_clear_search_data_response()),
             discover_sources: MockResult::ok(mock_discover_response()),
             list_sources: MockResult::ok(ListSourcesResponse {
                 sources: vec![
@@ -747,6 +812,8 @@ struct Captured {
     execute_sql: Mutex<Vec<ExecuteSqlRequest>>,
     search: Mutex<Vec<SearchRequest>>,
     execute_sql_task_ids: Mutex<Vec<Option<String>>>,
+    rebuild_search_index: Mutex<Vec<RebuildSearchIndexRequest>>,
+    clear_search_data: Mutex<Vec<ClearSearchDataRequest>>,
     list_catalog: Mutex<Vec<ListCatalogRequest>>,
     search_catalog: Mutex<Vec<SearchCatalogRequest>>,
     describe_table: Mutex<Vec<DescribeTableRequest>>,
@@ -802,6 +869,37 @@ impl SearchService for MockSearchService {
             .push(request.into_inner());
         Ok(Response::new(
             self.config.search.clone().into_tonic_result()?,
+        ))
+    }
+
+    async fn rebuild_search_index(
+        &self,
+        request: Request<RebuildSearchIndexRequest>,
+    ) -> Result<Response<RebuildSearchIndexResponse>, Status> {
+        self.captured
+            .rebuild_search_index
+            .lock()
+            .expect("rebuild search index capture")
+            .push(request.into_inner());
+        Ok(Response::new(
+            self.config
+                .rebuild_search_index
+                .clone()
+                .into_tonic_result()?,
+        ))
+    }
+
+    async fn clear_search_data(
+        &self,
+        request: Request<ClearSearchDataRequest>,
+    ) -> Result<Response<ClearSearchDataResponse>, Status> {
+        self.captured
+            .clear_search_data
+            .lock()
+            .expect("clear search data capture")
+            .push(request.into_inner());
+        Ok(Response::new(
+            self.config.clear_search_data.clone().into_tonic_result()?,
         ))
     }
 }
@@ -1398,6 +1496,22 @@ impl MockServer {
             .execute_sql_task_ids
             .lock()
             .expect("execute_sql task id capture")
+            .clone()
+    }
+
+    pub(crate) fn rebuild_search_index_requests(&self) -> Vec<RebuildSearchIndexRequest> {
+        self.captured
+            .rebuild_search_index
+            .lock()
+            .expect("rebuild search index capture")
+            .clone()
+    }
+
+    pub(crate) fn clear_search_data_requests(&self) -> Vec<ClearSearchDataRequest> {
+        self.captured
+            .clear_search_data
+            .lock()
+            .expect("clear search data capture")
             .clone()
     }
 


### PR DESCRIPTION


## Feature flag

Catalog search maintenance remains available regardless of `observed_values_search`. The observed-value maintenance paths introduced later in this stack are the paths gated by the default-off feature.
