### PR TITLE
refactor(engine): add manifest type lowering policies

### DIFF
--- a/crates/coral-engine/src/types.rs
+++ b/crates/coral-engine/src/types.rs
@@ -4,13 +4,14 @@
 //! This module is the home for `ManifestDataType`-to-Arrow *type-level*
 //! policies, so that when more than one lowering exists (column schemas
 //! want real Arrow types; string-shaped parameter binding wants plain
-//! strings) the policies sit adjacent and reviewable. Today it holds the
-//! column-schema lowering; value-level `ManifestDataType` switches still
-//! live with their backends (`convert_items` in `backends/shared/mapping.rs`
-//! builds Arrow arrays per variant, and `coerce_filter_value` /
-//! `coerce_call_arg_value` in the MCP backend coerce JSON values). All of
-//! those matches are wildcard-free, so adding a `ManifestDataType` variant
-//! breaks each of them loudly.
+//! strings) the policies sit adjacent and reviewable. It holds column-schema
+//! lowering, SQL parameter binding lowering, Arrow-to-manifest inference, and
+//! type-claim compatibility. Value-level `ManifestDataType` switches still live
+//! with their backends (`convert_items` in `backends/shared/mapping.rs` builds
+//! Arrow arrays per variant, and `coerce_filter_value` / `coerce_call_arg_value`
+//! in the MCP backend coerce JSON values). All of those matches are
+//! wildcard-free, so adding a `ManifestDataType` variant breaks each of them
+//! loudly.
 
 use coral_spec::ManifestDataType;
 use datafusion::arrow::datatypes::{DataType, TimeUnit};
@@ -32,6 +33,44 @@ pub(crate) fn arrow_column_type(data_type: ManifestDataType) -> DataType {
     }
 }
 
+/// Lowers a manifest data type into the Arrow type used while binding SQL
+/// parameter placeholders.
+///
+/// This is the parameter-binding policy: `Json` and `Timestamp` are declared
+/// manifest types, but they bind through `DataFusion` as string-shaped values.
+pub(crate) fn arrow_parameter_type(data_type: ManifestDataType) -> DataType {
+    match data_type {
+        ManifestDataType::Utf8 | ManifestDataType::Json | ManifestDataType::Timestamp => {
+            DataType::Utf8
+        }
+        ManifestDataType::Int64 => DataType::Int64,
+        ManifestDataType::Boolean => DataType::Boolean,
+        ManifestDataType::Float64 => DataType::Float64,
+    }
+}
+
+/// Resolves a DataFusion/Arrow inferred parameter type into Coral manifest
+/// spelling when the type can be expressed in function metadata.
+pub(crate) fn manifest_data_type_for_arrow(data_type: &DataType) -> Option<ManifestDataType> {
+    match data_type {
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Some(ManifestDataType::Utf8),
+        DataType::Int64 => Some(ManifestDataType::Int64),
+        DataType::Float64 => Some(ManifestDataType::Float64),
+        DataType::Boolean => Some(ManifestDataType::Boolean),
+        DataType::Timestamp(_, _) => Some(ManifestDataType::Timestamp),
+        _ => None,
+    }
+}
+
+/// Whether a declared manifest type is compatible with one Arrow-inferred
+/// claim for the same SQL placeholder.
+pub(crate) fn manifest_claim_accepts_arrow(declared: ManifestDataType, arrow: &DataType) -> bool {
+    let declared_arrow = arrow_parameter_type(declared);
+    declared_arrow == *arrow
+        || (is_string_family(&declared_arrow) && is_string_family(arrow))
+        || (declared == ManifestDataType::Timestamp && matches!(arrow, DataType::Timestamp(_, _)))
+}
+
 /// Whether an Arrow type is one of the string representations
 /// (`Utf8`, `LargeUtf8`, `Utf8View`).
 ///
@@ -42,4 +81,85 @@ pub(crate) fn is_string_family(data_type: &DataType) -> bool {
         data_type,
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL: [ManifestDataType; 6] = [
+        ManifestDataType::Utf8,
+        ManifestDataType::Json,
+        ManifestDataType::Int64,
+        ManifestDataType::Float64,
+        ManifestDataType::Boolean,
+        ManifestDataType::Timestamp,
+    ];
+
+    fn assert_all_manifest_data_types_covered(data_type: ManifestDataType) {
+        match data_type {
+            ManifestDataType::Utf8
+            | ManifestDataType::Json
+            | ManifestDataType::Int64
+            | ManifestDataType::Float64
+            | ManifestDataType::Boolean
+            | ManifestDataType::Timestamp => {}
+        }
+    }
+
+    #[test]
+    fn every_variant_accepts_its_own_lowerings() {
+        for data_type in ALL {
+            assert_all_manifest_data_types_covered(data_type);
+
+            assert!(
+                manifest_claim_accepts_arrow(data_type, &arrow_parameter_type(data_type)),
+                "{data_type} should accept its parameter lowering"
+            );
+            assert!(
+                manifest_claim_accepts_arrow(data_type, &arrow_column_type(data_type)),
+                "{data_type} should accept its column lowering"
+            );
+        }
+    }
+
+    #[test]
+    fn every_lowering_resolves_to_some_manifest_type() {
+        for data_type in ALL {
+            assert_all_manifest_data_types_covered(data_type);
+
+            assert!(
+                manifest_data_type_for_arrow(&arrow_parameter_type(data_type)).is_some(),
+                "{data_type} parameter lowering should resolve to some manifest type"
+            );
+            assert!(
+                manifest_data_type_for_arrow(&arrow_column_type(data_type)).is_some(),
+                "{data_type} column lowering should resolve to some manifest type"
+            );
+        }
+    }
+
+    #[test]
+    fn string_shaped_lowerings_resolve_to_utf8_not_their_semantic_type() {
+        assert_eq!(
+            manifest_data_type_for_arrow(&arrow_parameter_type(ManifestDataType::Json)),
+            Some(ManifestDataType::Utf8)
+        );
+        assert_eq!(
+            manifest_data_type_for_arrow(&arrow_parameter_type(ManifestDataType::Timestamp)),
+            Some(ManifestDataType::Utf8)
+        );
+        assert_eq!(
+            manifest_data_type_for_arrow(&arrow_column_type(ManifestDataType::Timestamp)),
+            Some(ManifestDataType::Timestamp)
+        );
+        assert_eq!(
+            manifest_data_type_for_arrow(&DataType::LargeUtf8),
+            Some(ManifestDataType::Utf8)
+        );
+        assert_eq!(
+            manifest_data_type_for_arrow(&DataType::Utf8View),
+            Some(ManifestDataType::Utf8)
+        );
+    }
 }

--- a/crates/coral-engine/src/types.rs
+++ b/crates/coral-engine/src/types.rs
@@ -51,6 +51,13 @@ pub(crate) fn arrow_parameter_type(data_type: ManifestDataType) -> DataType {
 
 /// Resolves a DataFusion/Arrow inferred parameter type into Coral manifest
 /// spelling when the type can be expressed in function metadata.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Used by the function signature inference PR stacked on this one"
+    )
+)]
 pub(crate) fn manifest_data_type_for_arrow(data_type: &DataType) -> Option<ManifestDataType> {
     match data_type {
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Some(ManifestDataType::Utf8),
@@ -64,6 +71,13 @@ pub(crate) fn manifest_data_type_for_arrow(data_type: &DataType) -> Option<Manif
 
 /// Whether a declared manifest type is compatible with one Arrow-inferred
 /// claim for the same SQL placeholder.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Used by the function signature inference PR stacked on this one"
+    )
+)]
 pub(crate) fn manifest_claim_accepts_arrow(declared: ManifestDataType, arrow: &DataType) -> bool {
     let declared_arrow = arrow_parameter_type(declared);
     declared_arrow == *arrow


### PR DESCRIPTION
## Summary
- Add the engine type-policy functions that lower `ManifestDataType` into Arrow/DataFusion roles.
- Keep column-schema lowering and SQL-parameter lowering adjacent in `types.rs`.
- Add invariant tests covering validate/execute parity and the intentionally lossy reverse inference for string-shaped types.

## Why
Function SQL validation needs to compare declared Coral manifest types with Arrow/DataFusion types inferred by planning. That comparison is not a single universal conversion: columns, SQL parameters, and reverse inference use different policies.

This PR isolates those policies before the function-signature inference PR, so reviewers can evaluate the type rules separately from the UDF planning flow.

## Behavior
Examples:

```text
Json column schema      -> Arrow Utf8
Json SQL parameter      -> Arrow Utf8
Utf8 Arrow evidence     -> Manifest Utf8
Timestamp column schema -> Arrow Timestamp
Timestamp parameter     -> Arrow Utf8
```

The reverse path is deliberately best-effort. Once `Json` or parameter-shaped `Timestamp` lowers to `Utf8`, the semantic bit is gone unless another source provides declared evidence.

## Not in this PR
- UDF/function runtime contracts.
- SQL signature inference.
- Function table-function registration.
- App or CLI lifecycle surfaces.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p coral-engine --lib --all-features --locked types::tests`
- `cargo clippy -p coral-engine --all-targets --all-features --locked -- -D warnings`
