### PR TITLE
feat(spec): infer OpenAPI pagination hints

### DIFF
--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -164,7 +164,6 @@ pub(super) async fn fetch_rows(
                 table_headers: &active_request.headers,
                 table_name: target.name(),
                 method: active_request.method,
-                base_url: &base_url,
                 url: &url,
                 query_pairs: &query_pairs,
                 body: body.as_ref(),

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -175,11 +175,12 @@ pub(super) async fn fetch_rows(
                 render_context,
                 allow_404_empty: target.response().allow_404_empty,
                 link_header_require_results: pagination.link_header_require_results,
+                response_cursor_header: target.pagination().response_cursor_header.as_deref(),
             },
         )
         .await?;
 
-        let Some((payload, next_url)) = request else {
+        let Some((payload, pagination_hints)) = request else {
             break;
         };
 
@@ -231,12 +232,13 @@ pub(super) async fn fetch_rows(
         match &pagination.mode {
             ValidatedPaginationMode::None => break,
             ValidatedPaginationMode::CursorQuery | ValidatedPaginationMode::CursorBody => {
-                let next_cursor =
+                let next_cursor = pagination_hints.cursor.or_else(|| {
                     get_path_value(&payload, &target.pagination().response_cursor_path)
                         .and_then(Value::as_str)
                         .map(str::trim)
                         .filter(|s| !s.is_empty())
-                        .map(ToOwned::to_owned);
+                        .map(ToOwned::to_owned)
+                });
                 match next_cursor {
                     Some(cursor) => state.cursor = Some(cursor),
                     None => break,
@@ -265,10 +267,12 @@ pub(super) async fn fetch_rows(
                     })?;
                 state.offset = state.offset.saturating_add(step);
             }
-            ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto => match next_url {
-                Some(next) => state.next_url = Some(next),
-                None => break,
-            },
+            ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto => {
+                match pagination_hints.next_url {
+                    Some(next) => state.next_url = Some(next),
+                    None => break,
+                }
+            }
         }
     }
 

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -176,6 +176,7 @@ pub(super) async fn fetch_rows(
                 allow_404_empty: target.response().allow_404_empty,
                 link_header_require_results: pagination.link_header_require_results,
                 response_cursor_header: target.pagination().response_cursor_header.as_deref(),
+                next_url_header: target.pagination().next_url_header.as_deref(),
             },
         )
         .await?;

--- a/crates/coral-engine/src/backends/http/pagination.rs
+++ b/crates/coral-engine/src/backends/http/pagination.rs
@@ -144,10 +144,10 @@ pub(super) fn pagination_state_values(state: &PageState) -> HashMap<String, Stri
 
 pub(super) fn extract_next_link_url(
     headers: &HeaderMap,
-    base_url: &str,
+    request_url: &str,
     require_results_true: bool,
 ) -> Result<Option<String>> {
-    let base = pagination_base_url(base_url)?;
+    let base = pagination_request_url(request_url)?;
 
     for header in headers.get_all("link") {
         let Ok(header) = header.to_str() else {
@@ -182,7 +182,7 @@ pub(super) fn extract_next_link_url(
 
 pub(super) fn extract_next_url_header(
     headers: &HeaderMap,
-    base_url: &str,
+    request_url: &str,
     header_name: Option<&str>,
 ) -> Result<Option<String>> {
     let Some(header_name) = header_name else {
@@ -193,7 +193,7 @@ pub(super) fn extract_next_url_header(
             "invalid pagination next URL header '{header_name}': {error}"
         ))
     })?;
-    let base = pagination_base_url(base_url)?;
+    let base = pagination_request_url(request_url)?;
     for header in headers.get_all(name) {
         let Ok(value) = header.to_str() else {
             continue;
@@ -234,10 +234,10 @@ pub(super) fn extract_response_cursor_header(
     Ok(None)
 }
 
-fn pagination_base_url(base_url: &str) -> Result<reqwest::Url> {
-    reqwest::Url::parse(base_url).map_err(|e| {
+fn pagination_request_url(request_url: &str) -> Result<reqwest::Url> {
+    reqwest::Url::parse(request_url).map_err(|e| {
         DataFusionError::Execution(format!(
-            "invalid base URL for pagination links '{base_url}': {e}"
+            "invalid request URL for pagination links '{request_url}': {e}"
         ))
     })
 }
@@ -293,6 +293,24 @@ mod tests {
         );
 
         let next = extract_next_link_url(&headers, "https://api.example.com", false).unwrap();
+
+        assert_eq!(
+            next,
+            Some("https://api.example.com/v1/resources?page=2".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_next_link_url_resolves_query_links_against_request_path() {
+        let mut headers = HeaderMap::new();
+        headers.insert("link", HeaderValue::from_static("<?page=2>; rel=\"next\""));
+
+        let next = extract_next_link_url(
+            &headers,
+            "https://api.example.com/v1/resources?page=1",
+            false,
+        )
+        .unwrap();
 
         assert_eq!(
             next,
@@ -402,6 +420,24 @@ mod tests {
         let next =
             extract_next_url_header(&headers, "https://api.example.com", Some("X-Next-Page-Url"))
                 .unwrap();
+
+        assert_eq!(
+            next,
+            Some("https://api.example.com/v1/resources?page=2".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_next_url_header_resolves_query_links_against_request_path() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-next-page-url", HeaderValue::from_static("?page=2"));
+
+        let next = extract_next_url_header(
+            &headers,
+            "https://api.example.com/v1/resources?page=1",
+            Some("X-Next-Page-Url"),
+        )
+        .unwrap();
 
         assert_eq!(
             next,

--- a/crates/coral-engine/src/backends/http/pagination.rs
+++ b/crates/coral-engine/src/backends/http/pagination.rs
@@ -147,11 +147,7 @@ pub(super) fn extract_next_link_url(
     base_url: &str,
     require_results_true: bool,
 ) -> Result<Option<String>> {
-    let base = reqwest::Url::parse(base_url).map_err(|e| {
-        DataFusionError::Execution(format!(
-            "invalid base URL for pagination links '{base_url}': {e}"
-        ))
-    })?;
+    let base = pagination_base_url(base_url)?;
 
     for header in headers.get_all("link") {
         let Ok(header) = header.to_str() else {
@@ -174,18 +170,41 @@ pub(super) fn extract_next_link_url(
             let next_raw = item.get(start + 1..end).ok_or_else(|| {
                 DataFusionError::Execution(format!("invalid pagination Link header item '{item}'"))
             })?;
-            let next_url = base.join(next_raw).map_err(|e| {
-                DataFusionError::Execution(format!(
-                    "invalid pagination next link '{next_raw}': {e}"
-                ))
-            })?;
-            if next_url.origin() != base.origin() {
-                return Err(DataFusionError::Execution(format!(
-                    "pagination next link must stay on origin {}: {next_raw}",
-                    base.origin().ascii_serialization()
-                )));
-            }
-            return Ok(Some(next_url.to_string()));
+            return Ok(Some(resolve_pagination_next_url(
+                &base,
+                next_raw,
+                "next link",
+            )?));
+        }
+    }
+    Ok(None)
+}
+
+pub(super) fn extract_next_url_header(
+    headers: &HeaderMap,
+    base_url: &str,
+    header_name: Option<&str>,
+) -> Result<Option<String>> {
+    let Some(header_name) = header_name else {
+        return Ok(None);
+    };
+    let name = HeaderName::try_from(header_name).map_err(|error| {
+        DataFusionError::Execution(format!(
+            "invalid pagination next URL header '{header_name}': {error}"
+        ))
+    })?;
+    let base = pagination_base_url(base_url)?;
+    for header in headers.get_all(name) {
+        let Ok(value) = header.to_str() else {
+            continue;
+        };
+        let value = value.trim();
+        if !value.is_empty() {
+            return Ok(Some(resolve_pagination_next_url(
+                &base,
+                value,
+                "next URL header value",
+            )?));
         }
     }
     Ok(None)
@@ -215,6 +234,27 @@ pub(super) fn extract_response_cursor_header(
     Ok(None)
 }
 
+fn pagination_base_url(base_url: &str) -> Result<reqwest::Url> {
+    reqwest::Url::parse(base_url).map_err(|e| {
+        DataFusionError::Execution(format!(
+            "invalid base URL for pagination links '{base_url}': {e}"
+        ))
+    })
+}
+
+fn resolve_pagination_next_url(base: &reqwest::Url, next_raw: &str, label: &str) -> Result<String> {
+    let next_url = base.join(next_raw).map_err(|e| {
+        DataFusionError::Execution(format!("invalid pagination {label} '{next_raw}': {e}"))
+    })?;
+    if next_url.origin() != base.origin() {
+        return Err(DataFusionError::Execution(format!(
+            "pagination {label} must stay on origin {}: {next_raw}",
+            base.origin().ascii_serialization()
+        )));
+    }
+    Ok(next_url.to_string())
+}
+
 fn link_param_matches(item: &str, name: &str, expected: &str) -> bool {
     item.split(';').skip(1).any(|param| {
         let Some((key, value)) = param.trim().split_once('=') else {
@@ -235,7 +275,8 @@ mod tests {
 
     use super::{
         PageState, apply_pagination_body_fields, apply_pagination_query_pairs,
-        extract_next_link_url, extract_response_cursor_header, page_is_exhausted,
+        extract_next_link_url, extract_next_url_header, extract_response_cursor_header,
+        page_is_exhausted,
     };
     use crate::backends::http::test_support::{test_http_request_target, test_http_table_spec};
     use coral_spec::{
@@ -347,6 +388,42 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("invalid pagination response cursor header")
+        );
+    }
+
+    #[test]
+    fn extract_next_url_header_resolves_relative_links_on_same_origin() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-next-page-url",
+            HeaderValue::from_static("/v1/resources?page=2"),
+        );
+
+        let next =
+            extract_next_url_header(&headers, "https://api.example.com", Some("X-Next-Page-Url"))
+                .unwrap();
+
+        assert_eq!(
+            next,
+            Some("https://api.example.com/v1/resources?page=2".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_next_url_header_rejects_cross_origin_absolute_links() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-next-page-url",
+            HeaderValue::from_static("https://attacker.example/steal"),
+        );
+
+        let err =
+            extract_next_url_header(&headers, "https://api.example.com", Some("X-Next-Page-Url"))
+                .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("pagination next URL header value must stay on origin")
         );
     }
 

--- a/crates/coral-engine/src/backends/http/pagination.rs
+++ b/crates/coral-engine/src/backends/http/pagination.rs
@@ -40,8 +40,12 @@ pub(super) fn apply_pagination_query_pairs(
     match &pagination.mode {
         ValidatedPaginationMode::None
         | ValidatedPaginationMode::Auto
-        | ValidatedPaginationMode::CursorBody
-        | ValidatedPaginationMode::LinkHeader => {}
+        | ValidatedPaginationMode::CursorBody => {}
+        ValidatedPaginationMode::LinkHeader => {
+            if let Some(name) = &target.pagination().page_param {
+                params.push((name.clone(), state.page.to_string()));
+            }
+        }
         ValidatedPaginationMode::CursorQuery => {
             if let Some(cursor) = &state.cursor {
                 let name = target.pagination().cursor_param.clone().ok_or_else(|| {
@@ -509,6 +513,53 @@ mod tests {
         assert!(matches!(
             pagination.mode,
             ValidatedPaginationMode::Offset(_)
+        ));
+    }
+
+    #[test]
+    fn apply_pagination_query_pairs_uses_link_header_initial_page_param() {
+        let mut table = test_http_table_spec(
+            &json!([]),
+            &RequestSpec {
+                method: HttpMethod::GET,
+                path: ParsedTemplate::parse("/items").expect("template"),
+                query: vec![],
+                body: BodySpec::default(),
+                headers: vec![],
+            },
+        );
+        table.pagination = PaginationSpec {
+            mode: PaginationMode::LinkHeader,
+            page_size: Some(coral_spec::PageSizeSpec {
+                default: 25,
+                max: 100,
+                query_param: Some("per_page".to_string()),
+                body_path: vec![],
+            }),
+            page_param: Some("page".to_string()),
+            page_start: 1,
+            ..PaginationSpec::default()
+        };
+        let pagination = table.pagination.validated("demo", "items").unwrap();
+        let mut params = Vec::new();
+        let state = PageState {
+            page: 1,
+            ..PageState::default()
+        };
+
+        let target = test_http_request_target(&table);
+        apply_pagination_query_pairs(&mut params, &target, &pagination, &state, Some(25)).unwrap();
+
+        assert_eq!(
+            params,
+            vec![
+                ("per_page".to_string(), "25".to_string()),
+                ("page".to_string(), "1".to_string()),
+            ]
+        );
+        assert!(matches!(
+            pagination.mode,
+            ValidatedPaginationMode::LinkHeader
         ));
     }
 

--- a/crates/coral-engine/src/backends/http/pagination.rs
+++ b/crates/coral-engine/src/backends/http/pagination.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use datafusion::error::{DataFusionError, Result};
-use reqwest::header::HeaderMap;
+use reqwest::header::{HeaderMap, HeaderName};
 use serde_json::{Map, Value, json};
 
 use crate::backends::http::request::{RequestBody, set_path_value};
@@ -16,6 +16,12 @@ pub(super) struct PageState {
     pub(super) page: i64,
     pub(super) offset: i64,
     pub(super) next_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct ResponsePaginationHints {
+    pub(super) next_url: Option<String>,
+    pub(super) cursor: Option<String>,
 }
 
 pub(super) fn apply_pagination_query_pairs(
@@ -185,6 +191,30 @@ pub(super) fn extract_next_link_url(
     Ok(None)
 }
 
+pub(super) fn extract_response_cursor_header(
+    headers: &HeaderMap,
+    header_name: Option<&str>,
+) -> Result<Option<String>> {
+    let Some(header_name) = header_name else {
+        return Ok(None);
+    };
+    let name = HeaderName::try_from(header_name).map_err(|error| {
+        DataFusionError::Execution(format!(
+            "invalid pagination response cursor header '{header_name}': {error}"
+        ))
+    })?;
+    for header in headers.get_all(name) {
+        let Ok(value) = header.to_str() else {
+            continue;
+        };
+        let value = value.trim();
+        if !value.is_empty() {
+            return Ok(Some(value.to_string()));
+        }
+    }
+    Ok(None)
+}
+
 fn link_param_matches(item: &str, name: &str, expected: &str) -> bool {
     item.split(';').skip(1).any(|param| {
         let Some((key, value)) = param.trim().split_once('=') else {
@@ -205,7 +235,7 @@ mod tests {
 
     use super::{
         PageState, apply_pagination_body_fields, apply_pagination_query_pairs,
-        extract_next_link_url, page_is_exhausted,
+        extract_next_link_url, extract_response_cursor_header, page_is_exhausted,
     };
     use crate::backends::http::test_support::{test_http_request_target, test_http_table_spec};
     use coral_spec::{
@@ -294,6 +324,29 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("invalid pagination Link header item")
+        );
+    }
+
+    #[test]
+    fn extract_response_cursor_header_uses_first_non_empty_value() {
+        let mut headers = HeaderMap::new();
+        headers.append("x-next-cursor", HeaderValue::from_static("   "));
+        headers.append("x-next-cursor", HeaderValue::from_static("abc123"));
+
+        let cursor = extract_response_cursor_header(&headers, Some("X-Next-Cursor")).unwrap();
+
+        assert_eq!(cursor.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn extract_response_cursor_header_rejects_invalid_config_name() {
+        let headers = HeaderMap::new();
+
+        let err = extract_response_cursor_header(&headers, Some("not a header")).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("invalid pagination response cursor header")
         );
     }
 

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -43,7 +43,6 @@ pub(super) struct OutgoingHttpRequest<'a> {
     pub(super) table_headers: &'a [HeaderSpec],
     pub(super) table_name: &'a str,
     pub(super) method: HttpMethod,
-    pub(super) base_url: &'a str,
     pub(super) url: &'a str,
     pub(super) query_pairs: &'a [(String, String)],
     pub(super) body: Option<&'a RequestBody>,
@@ -80,7 +79,6 @@ pub(super) async fn execute_request(
         table_headers,
         table_name,
         method,
-        base_url,
         url,
         query_pairs,
         body,
@@ -308,7 +306,7 @@ pub(super) async fn execute_request(
             }
 
             let next_url =
-                extract_next_link_url(response.headers(), base_url, link_header_require_results)
+                extract_next_link_url(response.headers(), url, link_header_require_results)
                     .map_err(|error| {
                         record_http_processing_error(&request_span, "PAGINATION", &error);
                         pagination_error(
@@ -323,19 +321,17 @@ pub(super) async fn execute_request(
                 Ok(next_url) => next_url,
                 Err(error) => break 'response ResponseOutcome::Done(Err(error)),
             };
-            let header_next_url =
-                extract_next_url_header(response.headers(), base_url, next_url_header).map_err(
-                    |error| {
-                        record_http_processing_error(&request_span, "PAGINATION", &error);
-                        pagination_error(
-                            source_schema,
-                            table_name,
-                            Some(method_label),
-                            Some(&logged_url),
-                            &error,
-                        )
-                    },
-                );
+            let header_next_url = extract_next_url_header(response.headers(), url, next_url_header)
+                .map_err(|error| {
+                    record_http_processing_error(&request_span, "PAGINATION", &error);
+                    pagination_error(
+                        source_schema,
+                        table_name,
+                        Some(method_label),
+                        Some(&logged_url),
+                        &error,
+                    )
+                });
             let next_url = match header_next_url {
                 Ok(header_next_url) => next_url.or(header_next_url),
                 Err(error) => break 'response ResponseOutcome::Done(Err(error)),
@@ -542,7 +538,6 @@ mod tests {
                 table_headers: &[],
                 table_name: "items",
                 method: HttpMethod::GET,
-                base_url: &base_url,
                 url: &url,
                 query_pairs: &query_pairs,
                 body: None,

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -17,7 +17,9 @@ use crate::RequestAuthenticator;
 use crate::backends::http::ProviderQueryError;
 use crate::backends::http::auth::resolve_auth_headers;
 use crate::backends::http::error::{pagination_error, provider_error};
-use crate::backends::http::pagination::extract_next_link_url;
+use crate::backends::http::pagination::{
+    ResponsePaginationHints, extract_next_link_url, extract_response_cursor_header,
+};
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::backends::http::request::RequestBody;
 use crate::backends::http::response::{ResponseDecodeContext, decode_response_body};
@@ -51,6 +53,7 @@ pub(super) struct OutgoingHttpRequest<'a> {
     pub(super) render_context: RenderContext<'a>,
     pub(super) allow_404_empty: bool,
     pub(super) link_header_require_results: bool,
+    pub(super) response_cursor_header: Option<&'a str>,
 }
 
 #[expect(
@@ -61,9 +64,9 @@ pub(super) async fn execute_request(
     http: &reqwest::Client,
     request_timeout: Duration,
     request: OutgoingHttpRequest<'_>,
-) -> Result<Option<(Value, Option<String>)>> {
+) -> Result<Option<(Value, ResponsePaginationHints)>> {
     enum ResponseOutcome {
-        Done(Result<Option<(Value, Option<String>)>>),
+        Done(Result<Option<(Value, ResponsePaginationHints)>>),
         Retry(Duration),
     }
 
@@ -86,6 +89,7 @@ pub(super) async fn execute_request(
         render_context,
         allow_404_empty,
         link_header_require_results,
+        response_cursor_header,
     } = request;
     let mut server_error_retries = 0usize;
     let mut throttle_retries = 0usize;
@@ -316,6 +320,22 @@ pub(super) async fn execute_request(
                 Ok(next_url) => next_url,
                 Err(error) => break 'response ResponseOutcome::Done(Err(error)),
             };
+            let cursor = extract_response_cursor_header(response.headers(), response_cursor_header)
+                .map_err(|error| {
+                    record_http_processing_error(&request_span, "PAGINATION", &error);
+                    pagination_error(
+                        source_schema,
+                        table_name,
+                        Some(method_label),
+                        Some(&logged_url),
+                        &error,
+                    )
+                });
+            let cursor = match cursor {
+                Ok(cursor) => cursor,
+                Err(error) => break 'response ResponseOutcome::Done(Err(error)),
+            };
+            let pagination = ResponsePaginationHints { next_url, cursor };
 
             match decode_response_body(
                 response,
@@ -333,7 +353,7 @@ pub(super) async fn execute_request(
             .instrument(request_span.clone())
             .await
             {
-                Ok(payload) => ResponseOutcome::Done(Ok(Some((payload, next_url)))),
+                Ok(payload) => ResponseOutcome::Done(Ok(Some((payload, pagination)))),
                 Err(mut error) => {
                     // `Decode { retryable }` marks a transient (truncated/EOF) body. Only
                     // idempotent GET requests may be retried or surfaced as retryable.
@@ -513,6 +533,7 @@ mod tests {
                 render_context,
                 allow_404_empty: false,
                 link_header_require_results: false,
+                response_cursor_header: None,
             },
         )
         .await

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -18,7 +18,8 @@ use crate::backends::http::ProviderQueryError;
 use crate::backends::http::auth::resolve_auth_headers;
 use crate::backends::http::error::{pagination_error, provider_error};
 use crate::backends::http::pagination::{
-    ResponsePaginationHints, extract_next_link_url, extract_response_cursor_header,
+    ResponsePaginationHints, extract_next_link_url, extract_next_url_header,
+    extract_response_cursor_header,
 };
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::backends::http::request::RequestBody;
@@ -54,6 +55,7 @@ pub(super) struct OutgoingHttpRequest<'a> {
     pub(super) allow_404_empty: bool,
     pub(super) link_header_require_results: bool,
     pub(super) response_cursor_header: Option<&'a str>,
+    pub(super) next_url_header: Option<&'a str>,
 }
 
 #[expect(
@@ -90,6 +92,7 @@ pub(super) async fn execute_request(
         allow_404_empty,
         link_header_require_results,
         response_cursor_header,
+        next_url_header,
     } = request;
     let mut server_error_retries = 0usize;
     let mut throttle_retries = 0usize;
@@ -320,6 +323,23 @@ pub(super) async fn execute_request(
                 Ok(next_url) => next_url,
                 Err(error) => break 'response ResponseOutcome::Done(Err(error)),
             };
+            let header_next_url =
+                extract_next_url_header(response.headers(), base_url, next_url_header).map_err(
+                    |error| {
+                        record_http_processing_error(&request_span, "PAGINATION", &error);
+                        pagination_error(
+                            source_schema,
+                            table_name,
+                            Some(method_label),
+                            Some(&logged_url),
+                            &error,
+                        )
+                    },
+                );
+            let next_url = match header_next_url {
+                Ok(header_next_url) => next_url.or(header_next_url),
+                Err(error) => break 'response ResponseOutcome::Done(Err(error)),
+            };
             let cursor = extract_response_cursor_header(response.headers(), response_cursor_header)
                 .map_err(|error| {
                     record_http_processing_error(&request_span, "PAGINATION", &error);
@@ -534,6 +554,7 @@ mod tests {
                 allow_404_empty: false,
                 link_header_require_results: false,
                 response_cursor_header: None,
+                next_url_header: None,
             },
         )
         .await

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -2197,6 +2197,48 @@ async fn pagination_offset_mode() {
 }
 
 #[tokio::test]
+async fn pagination_cursor_query_uses_response_header() {
+    let server = MockServer::start().await;
+    let rows = users_rows();
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param_is_missing("cursor"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .append_header("X-Next-Cursor", "cursor-2")
+                .set_body_json(json!({ "data": &rows[..2] })),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param("cursor", "cursor-2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": &rows[2..] })))
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_cursor_header", &server.uri());
+    manifest["tables"][0]["pagination"] = json!({
+        "mode": "cursor_query",
+        "cursor_param": "cursor",
+        "response_cursor_header": "X-Next-Cursor"
+    });
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT id, name, email FROM http_cursor_header.users ORDER BY id",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, users_rows());
+}
+
+#[tokio::test]
 async fn pagination_link_header() {
     let server = MockServer::start().await;
     let rows = users_rows();

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -2279,6 +2279,47 @@ async fn pagination_link_header() {
 }
 
 #[tokio::test]
+async fn pagination_next_url_header() {
+    let server = MockServer::start().await;
+    let rows = users_rows();
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param_is_missing("page"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .append_header("X-Next-Page-Url", "/api/users?page=2")
+                .set_body_json(json!({ "data": &rows[..2] })),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(query_param("page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": &rows[2..] })))
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_next_url", &server.uri());
+    manifest["tables"][0]["pagination"] = json!({
+        "mode": "link_header",
+        "next_url_header": "X-Next-Page-Url"
+    });
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT id, name, email FROM http_next_url.users ORDER BY id",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, users_rows());
+}
+
+#[tokio::test]
 async fn auth_headers_sent_correctly() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -2247,7 +2247,7 @@ async fn pagination_link_header() {
         .and(query_param_is_missing("page"))
         .respond_with(
             ResponseTemplate::new(200)
-                .append_header("Link", "</api/users?page=2>; rel=\"next\"")
+                .append_header("Link", "<?page=2>; rel=\"next\"")
                 .set_body_json(json!({ "data": &rows[..2] })),
         )
         .mount(&server)
@@ -2287,7 +2287,7 @@ async fn pagination_next_url_header() {
         .and(query_param_is_missing("page"))
         .respond_with(
             ResponseTemplate::new(200)
-                .append_header("X-Next-Page-Url", "/api/users?page=2")
+                .append_header("X-Next-Page-Url", "?page=2")
                 .set_body_json(json!({ "data": &rows[..2] })),
         )
         .mount(&server)

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -705,6 +705,8 @@ pub struct PaginationSpec {
     #[serde(default)]
     pub link_header_require_results: bool,
     #[serde(default)]
+    pub next_url_header: Option<String>,
+    #[serde(default)]
     pub max_pages: Option<usize>,
 }
 
@@ -724,6 +726,7 @@ impl Default for PaginationSpec {
             offset_start: 0,
             offset_step: None,
             link_header_require_results: false,
+            next_url_header: None,
             max_pages: None,
         }
     }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -788,6 +788,16 @@ impl PaginationSpec {
         table: &str,
         has_page_size: bool,
     ) -> Result<ValidatedPaginationMode> {
+        if self
+            .response_cursor_header
+            .as_deref()
+            .is_some_and(|header| header.trim().is_empty())
+        {
+            return Err(ManifestError::validation(format!(
+                "{schema}.{table} pagination.response_cursor_header must not be empty"
+            )));
+        }
+
         match self.mode {
             PaginationMode::None => Ok(ValidatedPaginationMode::None),
             PaginationMode::Auto => Ok(ValidatedPaginationMode::Auto),
@@ -1412,6 +1422,40 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("demo.items pagination.mode=offset requires offset_step or page_size")
+        );
+    }
+
+    #[test]
+    fn cursor_query_pagination_rejects_empty_response_cursor_header() {
+        let pagination = PaginationSpec {
+            mode: PaginationMode::CursorQuery,
+            cursor_param: Some("cursor".to_string()),
+            response_cursor_path: vec!["meta".to_string(), "next_cursor".to_string()],
+            response_cursor_header: Some(String::new()),
+            ..PaginationSpec::default()
+        };
+
+        let err = pagination.validated("demo", "items").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("demo.items pagination.response_cursor_header must not be empty")
+        );
+    }
+
+    #[test]
+    fn cursor_body_pagination_rejects_blank_response_cursor_header() {
+        let pagination = PaginationSpec {
+            mode: PaginationMode::CursorBody,
+            cursor_body_path: vec!["cursor".to_string()],
+            response_cursor_path: vec!["meta".to_string(), "next_cursor".to_string()],
+            response_cursor_header: Some("   ".to_string()),
+            ..PaginationSpec::default()
+        };
+
+        let err = pagination.validated("demo", "items").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("demo.items pagination.response_cursor_header must not be empty")
         );
     }
 

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -689,6 +689,8 @@ pub struct PaginationSpec {
     #[serde(default)]
     pub response_cursor_path: Vec<String>,
     #[serde(default)]
+    pub response_cursor_header: Option<String>,
+    #[serde(default)]
     pub page_param: Option<String>,
     #[serde(default)]
     pub page_start: i64,
@@ -714,6 +716,7 @@ impl Default for PaginationSpec {
             cursor_param: None,
             cursor_body_path: Vec::new(),
             response_cursor_path: Vec::new(),
+            response_cursor_header: None,
             page_param: None,
             page_start: 0,
             page_step: default_page_step(),
@@ -791,9 +794,9 @@ impl PaginationSpec {
                         "{schema}.{table} pagination.mode=cursor_query requires cursor_param"
                     )));
                 }
-                if self.response_cursor_path.is_empty() {
+                if self.response_cursor_path.is_empty() && self.response_cursor_header.is_none() {
                     return Err(ManifestError::validation(format!(
-                        "{schema}.{table} pagination.mode=cursor_query requires response_cursor_path"
+                        "{schema}.{table} pagination.mode=cursor_query requires response_cursor_path or response_cursor_header"
                     )));
                 }
                 Ok(ValidatedPaginationMode::CursorQuery)
@@ -804,9 +807,9 @@ impl PaginationSpec {
                         "{schema}.{table} pagination.mode=cursor_body requires cursor_body_path"
                     )));
                 }
-                if self.response_cursor_path.is_empty() {
+                if self.response_cursor_path.is_empty() && self.response_cursor_header.is_none() {
                     return Err(ManifestError::validation(format!(
-                        "{schema}.{table} pagination.mode=cursor_body requires response_cursor_path"
+                        "{schema}.{table} pagination.mode=cursor_body requires response_cursor_path or response_cursor_header"
                     )));
                 }
                 Ok(ValidatedPaginationMode::CursorBody)

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -1278,6 +1278,7 @@
         "offset_start": { "type": "integer" },
         "offset_step": { "type": "integer", "minimum": 1 },
         "link_header_require_results": { "type": "boolean" },
+        "next_url_header": { "type": "string", "minLength": 1 },
         "max_pages": { "type": "integer", "minimum": 1 }
       }
     },

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -1270,6 +1270,7 @@
           "type": "array",
           "items": { "type": "string", "minLength": 1 }
         },
+        "response_cursor_header": { "type": "string", "minLength": 1 },
         "page_param": { "type": "string", "minLength": 1 },
         "page_start": { "type": "integer" },
         "page_step": { "type": "integer", "minimum": 1 },

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1001,6 +1001,124 @@ paths:
 }
 
 #[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "The OpenAPI fixture keeps related response-driven pagination cases together."
+)]
+fn importer_infers_response_driven_pagination_modes() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: response_pagination
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /cursor:
+    get:
+      operationId: cursor/list
+      parameters:
+        - {name: cursor, in: query, schema: {type: string}}
+        - {name: limit, in: query, schema: {type: integer, default: 20}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
+                  meta:
+                    type: object
+                    properties:
+                      nextCursor: {type: string}
+  /link:
+    get:
+      operationId: link/list
+      parameters:
+        - {name: page, in: query, schema: {type: integer}}
+        - {name: per_page, in: query, schema: {type: integer, default: 30}}
+      responses:
+        '200':
+          headers:
+            Link:
+              schema: {type: string}
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+  /singleton:
+    get:
+      operationId: singleton/get
+      parameters:
+        - {name: cursor, in: query, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: {type: string}
+                  nextCursor: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("response pagination import");
+    let operations = ir
+        .operations
+        .iter()
+        .map(|operation| (operation.id.as_str(), operation))
+        .collect::<BTreeMap<_, _>>();
+
+    let cursor = &rest_execution(operations.get("cursor_list").expect("cursor")).pagination;
+    assert_eq!(cursor.mode, PaginationMode::CursorQuery);
+    assert_eq!(cursor.cursor_param.as_deref(), Some("cursor"));
+    assert_eq!(cursor.response_cursor_path, ["meta", "nextCursor"]);
+    assert_eq!(
+        cursor
+            .page_size
+            .as_ref()
+            .and_then(|page_size| page_size.query_param.as_deref()),
+        Some("limit")
+    );
+
+    let link = &rest_execution(operations.get("link_list").expect("link")).pagination;
+    assert_eq!(link.mode, PaginationMode::LinkHeader);
+    assert_eq!(link.page_param, None);
+    assert_eq!(
+        link.page_size
+            .as_ref()
+            .and_then(|page_size| page_size.query_param.as_deref()),
+        Some("per_page")
+    );
+
+    let singleton = &rest_execution(operations.get("singleton_get").expect("singleton")).pagination;
+    assert_eq!(singleton.mode, PaginationMode::None);
+}
+
+#[test]
 fn importer_treats_path_parameters_as_required_when_required_is_omitted() {
     let manifest = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1235,7 +1235,8 @@ paths:
 
     let link = &rest_execution(operations.get("link_list").expect("link")).pagination;
     assert_eq!(link.mode, PaginationMode::LinkHeader);
-    assert_eq!(link.page_param, None);
+    assert_eq!(link.page_param.as_deref(), Some("page"));
+    assert_eq!(link.page_start, 1);
     assert_eq!(
         link.page_size
             .as_ref()

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1103,6 +1103,24 @@ paths:
                       type: object
                       properties:
                         id: {type: string}
+  /next-url-header:
+    get:
+      operationId: next-url-header/list
+      parameters:
+        - {name: limit, in: query, schema: {type: integer, default: 25}}
+      responses:
+        '200':
+          headers:
+            X-Next-Page-Url:
+              schema: {type: string}
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
 "
         .as_bytes(),
     )
@@ -1147,6 +1165,22 @@ paths:
         Some("X-Next-Cursor")
     );
     assert!(cursor_header.response_cursor_path.is_empty());
+
+    let next_url = &rest_execution(
+        operations
+            .get("next_url_header_list")
+            .expect("next URL header"),
+    )
+    .pagination;
+    assert_eq!(next_url.mode, PaginationMode::LinkHeader);
+    assert_eq!(next_url.next_url_header.as_deref(), Some("X-Next-Page-Url"));
+    assert_eq!(
+        next_url
+            .page_size
+            .as_ref()
+            .and_then(|page_size| page_size.query_param.as_deref()),
+        Some("limit")
+    );
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1082,6 +1082,27 @@ paths:
                 properties:
                   id: {type: string}
                   nextCursor: {type: string}
+  /cursor-header:
+    get:
+      operationId: cursor-header/list
+      parameters:
+        - {name: pageToken, in: query, schema: {type: string}}
+      responses:
+        '200':
+          headers:
+            X-Next-Cursor:
+              schema: {type: string}
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
 "
         .as_bytes(),
     )
@@ -1116,6 +1137,16 @@ paths:
 
     let singleton = &rest_execution(operations.get("singleton_get").expect("singleton")).pagination;
     assert_eq!(singleton.mode, PaginationMode::None);
+
+    let cursor_header =
+        &rest_execution(operations.get("cursor_header_list").expect("cursor header")).pagination;
+    assert_eq!(cursor_header.mode, PaginationMode::CursorQuery);
+    assert_eq!(cursor_header.cursor_param.as_deref(), Some("pageToken"));
+    assert_eq!(
+        cursor_header.response_cursor_header.as_deref(),
+        Some("X-Next-Cursor")
+    );
+    assert!(cursor_header.response_cursor_path.is_empty());
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1103,6 +1103,50 @@ paths:
                       type: object
                       properties:
                         id: {type: string}
+  /cursor-page:
+    get:
+      operationId: cursor-page/list
+      parameters:
+        - {name: page, in: query, schema: {type: string}}
+        - {name: limit, in: query, schema: {type: integer, default: 10}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
+                  next_page:
+                    type: string
+                    nullable: true
+  /numeric-page:
+    get:
+      operationId: numeric-page/list
+      parameters:
+        - {name: page, in: query, schema: {type: integer, default: 1}}
+        - {name: limit, in: query, schema: {type: integer, default: 10}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
+                  next_page:
+                    type: string
+                    nullable: true
   /next-url-header:
     get:
       operationId: next-url-header/list
@@ -1165,6 +1209,24 @@ paths:
         Some("X-Next-Cursor")
     );
     assert!(cursor_header.response_cursor_path.is_empty());
+
+    let cursor_page =
+        &rest_execution(operations.get("cursor_page_list").expect("cursor page")).pagination;
+    assert_eq!(cursor_page.mode, PaginationMode::CursorQuery);
+    assert_eq!(cursor_page.cursor_param.as_deref(), Some("page"));
+    assert_eq!(cursor_page.response_cursor_path, ["next_page"]);
+    assert_eq!(
+        cursor_page
+            .page_size
+            .as_ref()
+            .and_then(|page_size| page_size.query_param.as_deref()),
+        Some("limit")
+    );
+
+    let numeric_page =
+        &rest_execution(operations.get("numeric_page_list").expect("numeric page")).pagination;
+    assert_eq!(numeric_page.mode, PaginationMode::Page);
+    assert_eq!(numeric_page.page_param.as_deref(), Some("page"));
 
     let next_url = &rest_execution(
         operations

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1293,6 +1293,65 @@ paths:
 }
 
 #[test]
+fn importer_keeps_opaque_link_header_page_token_public() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: link_page_token
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - {name: page, in: query, schema: {type: string}}
+        - {name: per_page, in: query, schema: {type: integer, default: 30}}
+      responses:
+        '200':
+          headers:
+            Link:
+              schema: {type: string}
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    let operation = ir.operations.first().expect("operation");
+    let pagination = &rest_execution(operation).pagination;
+    assert_eq!(pagination.mode, PaginationMode::LinkHeader);
+    assert_eq!(pagination.page_param, None);
+    assert_eq!(
+        pagination
+            .page_size
+            .as_ref()
+            .and_then(|page_size| page_size.query_param.as_deref()),
+        Some("per_page")
+    );
+}
+
+#[test]
 fn importer_treats_path_parameters_as_required_when_required_is_omitted() {
     let manifest = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1049,6 +1049,29 @@ paths:
                     type: object
                     properties:
                       nextCursor: {type: string}
+  /pagination-token:
+    get:
+      operationId: pagination-token/list
+      parameters:
+        - {name: max_results, in: query, schema: {type: integer, default: 50}}
+        - {name: pagination_token, in: query, schema: {type: string}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
+                  meta:
+                    type: object
+                    properties:
+                      next_token: {type: string}
   /link:
     get:
       operationId: link/list
@@ -1185,6 +1208,29 @@ paths:
             .as_ref()
             .and_then(|page_size| page_size.query_param.as_deref()),
         Some("limit")
+    );
+
+    let pagination_token = &rest_execution(
+        operations
+            .get("pagination_token_list")
+            .expect("pagination token"),
+    )
+    .pagination;
+    assert_eq!(pagination_token.mode, PaginationMode::CursorQuery);
+    assert_eq!(
+        pagination_token.cursor_param.as_deref(),
+        Some("pagination_token")
+    );
+    assert_eq!(
+        pagination_token.response_cursor_path,
+        ["meta", "next_token"]
+    );
+    assert_eq!(
+        pagination_token
+            .page_size
+            .as_ref()
+            .and_then(|page_size| page_size.query_param.as_deref()),
+        Some("max_results")
     );
 
     let link = &rest_execution(operations.get("link_list").expect("link")).pagination;

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use super::*;
-use crate::{SourceTableFunctionKind, parse_source_manifest_yaml};
+use crate::{PaginationMode, SourceTableFunctionKind, parse_source_manifest_yaml};
 
 #[test]
 fn extracts_openapi_document_metadata() {
@@ -917,6 +917,90 @@ paths:
 }
 
 #[test]
+fn importer_infers_common_query_pagination_modes() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: pagination
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /paged:
+    get:
+      operationId: paged/list
+      parameters:
+        - {name: pageNumber, in: query, schema: {type: integer, default: 2}}
+        - {name: pageSize, in: query, schema: {type: integer, default: 25}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+  /offset:
+    get:
+      operationId: offset/list
+      parameters:
+        - {name: offset, in: query, schema: {type: integer, default: 5}}
+        - {name: limit, in: query, schema: {type: integer, default: 50}}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("pagination import");
+    let operations = ir
+        .operations
+        .iter()
+        .map(|operation| (operation.id.as_str(), operation))
+        .collect::<BTreeMap<_, _>>();
+
+    let page = &rest_execution(operations.get("paged_list").expect("paged")).pagination;
+    assert_eq!(page.mode, PaginationMode::Page);
+    assert_eq!(page.page_param.as_deref(), Some("pageNumber"));
+    assert_eq!(page.page_start, 2);
+    let page_size = page.page_size.as_ref().expect("page size");
+    assert_eq!(page_size.default, 25);
+    assert_eq!(page_size.max, 100);
+    assert_eq!(page_size.query_param.as_deref(), Some("pageSize"));
+
+    let offset = &rest_execution(operations.get("offset_list").expect("offset")).pagination;
+    assert_eq!(offset.mode, PaginationMode::Offset);
+    assert_eq!(offset.offset_param.as_deref(), Some("offset"));
+    assert_eq!(offset.offset_start, 5);
+    assert_eq!(offset.offset_step, None);
+    let page_size = offset.page_size.as_ref().expect("limit page size");
+    assert_eq!(page_size.default, 50);
+    assert_eq!(page_size.max, 100);
+    assert_eq!(page_size.query_param.as_deref(), Some("limit"));
+}
+
+#[test]
 fn importer_treats_path_parameters_as_required_when_required_is_omitted() {
     let manifest = parse_source_manifest_yaml(
         r"
@@ -966,6 +1050,13 @@ paths:
     assert_eq!(required.get("id"), Some(&true));
     assert_eq!(required.get("tenant"), Some(&true));
     assert_eq!(required.get("include_archived"), Some(&false));
+}
+
+fn rest_execution(operation: &IrOperation) -> &RestExecutionAttachment {
+    let IrExecutionAttachment::Rest(rest) = &operation.execution else {
+        panic!("operation should be REST");
+    };
+    rest
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -488,6 +488,100 @@ paths:
 }
 
 #[test]
+fn projection_generation_keeps_opaque_link_header_page_tokens_public() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: link_page_tokens
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - {name: page, in: query, schema: {type: string}}
+        - {name: per_page, in: query, schema: {type: integer, default: 30}}
+      responses:
+        '200':
+          headers:
+            Link:
+              schema: {type: string}
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
+    let projection = catalog
+        .projections
+        .iter()
+        .find(|projection| projection.operation_id == "items_list")
+        .expect("items projection");
+    let operation = ir
+        .operations
+        .iter()
+        .find(|operation| operation.id == projection.operation_id)
+        .expect("items operation");
+
+    let IrExecutionAttachment::Rest(rest) = &operation.execution else {
+        panic!("expected REST execution");
+    };
+    assert_eq!(rest.pagination.mode, PaginationMode::LinkHeader);
+    assert_eq!(rest.pagination.page_param, None);
+    assert_eq!(
+        rest.pagination
+            .page_size
+            .as_ref()
+            .and_then(|page_size| page_size.query_param.as_deref()),
+        Some("per_page")
+    );
+    assert_eq!(projection.visibility, ProjectionVisibility::Published);
+
+    let exposures = projection
+        .inputs
+        .iter()
+        .map(|input| (input.wire_name.as_str(), input.sql_exposure))
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(exposures.get("page"), Some(&SqlInputExposure::Filter));
+    assert_eq!(exposures.get("per_page"), Some(&SqlInputExposure::Internal));
+
+    let filter_names = projection_filter_specs(projection)
+        .into_iter()
+        .map(|filter| filter.name)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(filter_names, BTreeSet::from(["page".to_string()]));
+
+    let request = request_spec_for_projection(projection, operation).expect("request");
+    let query_names = request
+        .query
+        .iter()
+        .map(|param| param.name.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(query_names, BTreeSet::from(["page"]));
+}
+
+#[test]
 fn projection_generation_uses_omitted_path_required_for_table_function_args() {
     let manifest = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -399,6 +399,95 @@ surfaces:
 }
 
 #[test]
+fn projection_generation_keeps_link_header_page_inputs_internal() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: link_pages
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: items/list
+      parameters:
+        - {name: page, in: query, schema: {type: integer}}
+        - {name: per_page, in: query, schema: {type: integer, default: 30}}
+      responses:
+        '200':
+          headers:
+            Link:
+              schema: {type: string}
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
+    let projection = catalog
+        .projections
+        .iter()
+        .find(|projection| projection.operation_id == "items_list")
+        .expect("items projection");
+    let operation = ir
+        .operations
+        .iter()
+        .find(|operation| operation.id == projection.operation_id)
+        .expect("items operation");
+
+    let IrExecutionAttachment::Rest(rest) = &operation.execution else {
+        panic!("expected REST execution");
+    };
+    assert_eq!(rest.pagination.mode, PaginationMode::LinkHeader);
+    assert_eq!(rest.pagination.page_param.as_deref(), Some("page"));
+    assert_eq!(
+        rest.pagination
+            .page_size
+            .as_ref()
+            .and_then(|page_size| page_size.query_param.as_deref()),
+        Some("per_page")
+    );
+    assert_eq!(projection.visibility, ProjectionVisibility::Published);
+
+    let exposures = projection
+        .inputs
+        .iter()
+        .map(|input| (input.wire_name.as_str(), input.sql_exposure))
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(exposures.get("page"), Some(&SqlInputExposure::Internal));
+    assert_eq!(exposures.get("per_page"), Some(&SqlInputExposure::Internal));
+
+    let filter_names = projection_filter_specs(projection)
+        .into_iter()
+        .map(|filter| filter.name)
+        .collect::<BTreeSet<_>>();
+    assert!(filter_names.is_empty());
+
+    let request = request_spec_for_projection(projection, operation).expect("request");
+    assert!(request.query.is_empty());
+}
+
+#[test]
 fn projection_generation_uses_omitted_path_required_for_table_function_args() {
     let manifest = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -344,12 +344,18 @@ fn detect_cursor_query_pagination(
             "cursor",
             "marker",
             "nextcursor",
+            "nextpage",
             "nextpagetoken",
             "nexttoken",
+            "page",
             "pagetoken",
             "startingafter",
         ],
     )?;
+    if name_token(&cursor_input.name) == "page" && cursor_input.data_type != IrScalarType::String {
+        return None;
+    }
+
     let response_cursor_path = find_response_cursor_path(&context.schema).unwrap_or_default();
     let response_cursor_header = response_cursor_header(context);
     if response_cursor_path.is_empty() && response_cursor_header.is_none() {
@@ -509,6 +515,7 @@ fn is_response_cursor_property(name: &str, schema: &Value) -> bool {
         "endcursor",
         "nextcursor",
         "nextmarker",
+        "nextpage",
         "nextpagetoken",
         "nexttoken",
     ];

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -345,12 +345,17 @@ fn detect_cursor_query_pagination(
             "startingafter",
         ],
     )?;
-    let response_cursor_path = find_response_cursor_path(&context.schema)?;
+    let response_cursor_path = find_response_cursor_path(&context.schema).unwrap_or_default();
+    let response_cursor_header = response_cursor_header(context);
+    if response_cursor_path.is_empty() && response_cursor_header.is_none() {
+        return None;
+    }
     Some(PaginationSpec {
         mode: PaginationMode::CursorQuery,
         page_size: detect_page_size(inputs),
         cursor_param: Some(cursor_input.name.clone()),
         response_cursor_path,
+        response_cursor_header,
         ..PaginationSpec::default()
     })
 }
@@ -421,6 +426,36 @@ fn response_header<'a>(
         .iter()
         .find(|(name, _)| candidate_tokens.contains(&name_token(name).as_str()))
         .map(|(_, header)| header)
+}
+
+fn response_cursor_header(context: &OpenApiResponsePaginationContext) -> Option<String> {
+    const RESPONSE_CURSOR_HEADER_TOKENS: &[&str] = &[
+        "continuationtoken",
+        "nextcursor",
+        "nextmarker",
+        "nextpagetoken",
+        "nexttoken",
+        "xcontinuationtoken",
+        "xnextcursor",
+        "xnextmarker",
+        "xnextpagetoken",
+        "xnexttoken",
+    ];
+
+    context
+        .headers
+        .iter()
+        .find(|(name, header)| {
+            RESPONSE_CURSOR_HEADER_TOKENS.contains(&name_token(name).as_str())
+                && response_header_allows_string(header)
+        })
+        .map(|(name, _)| name.clone())
+}
+
+fn response_header_allows_string(header: &Value) -> bool {
+    header.get("schema").is_none_or(|schema| {
+        json_schema_type_contains(schema, "string") || schema.get("type").is_none()
+    })
 }
 
 fn find_response_cursor_path(schema: &Value) -> Option<Vec<String>> {

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -305,29 +305,82 @@ fn detect_pagination(
     context: &OpenApiResponsePaginationContext,
 ) -> PaginationSpec {
     let _ = (&context.schema, &context.headers, context.cardinality);
-    let has_page = inputs
+    detect_offset_pagination(inputs)
+        .or_else(|| detect_page_pagination(inputs))
+        .unwrap_or_default()
+}
+
+fn detect_offset_pagination(inputs: &[IrOperationInput]) -> Option<PaginationSpec> {
+    let offset_input = find_query_input(inputs, &["offset"])?;
+    let page_size_input = find_query_input(inputs, &["limit"])?;
+    Some(PaginationSpec {
+        mode: PaginationMode::Offset,
+        page_size: Some(page_size_spec(page_size_input)),
+        offset_param: Some(offset_input.name.clone()),
+        offset_start: numeric_input_default(offset_input).unwrap_or(0),
+        offset_step: None,
+        ..PaginationSpec::default()
+    })
+}
+
+fn detect_page_pagination(inputs: &[IrOperationInput]) -> Option<PaginationSpec> {
+    let page_input = find_query_input(inputs, &["page", "pagenumber", "pagenum"])?;
+    let page_size_input = find_query_input(
+        inputs,
+        &[
+            "limit",
+            "maxresults",
+            "pagesize",
+            "perpage",
+            "resultsperpage",
+        ],
+    )?;
+    Some(PaginationSpec {
+        mode: PaginationMode::Page,
+        page_size: Some(page_size_spec(page_size_input)),
+        page_param: Some(page_input.name.clone()),
+        page_start: numeric_input_default(page_input).unwrap_or(1),
+        page_step: 1,
+        ..PaginationSpec::default()
+    })
+}
+
+fn find_query_input<'a>(
+    inputs: &'a [IrOperationInput],
+    candidate_tokens: &[&str],
+) -> Option<&'a IrOperationInput> {
+    inputs
         .iter()
-        .any(|input| input.location == IrInputLocation::Query && input.name == "page");
-    let has_per_page = inputs
-        .iter()
-        .any(|input| input.location == IrInputLocation::Query && input.name == "per_page");
-    if has_page && has_per_page {
-        PaginationSpec {
-            mode: PaginationMode::Page,
-            page_size: Some(PageSizeSpec {
-                default: 30,
-                max: 100,
-                query_param: Some("per_page".to_string()),
-                body_path: Vec::new(),
-            }),
-            page_param: Some("page".to_string()),
-            page_start: 1,
-            page_step: 1,
-            ..PaginationSpec::default()
-        }
-    } else {
-        PaginationSpec::default()
+        .filter(|input| input.location == IrInputLocation::Query)
+        .find(|input| candidate_tokens.contains(&name_token(&input.name).as_str()))
+}
+
+fn page_size_spec(input: &IrOperationInput) -> PageSizeSpec {
+    const DEFAULT_PAGE_SIZE: usize = 10;
+    const DEFAULT_MAX_PAGE_SIZE: usize = 100;
+
+    let default = numeric_input_default(input)
+        .and_then(|value| usize::try_from(value).ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(DEFAULT_PAGE_SIZE);
+    PageSizeSpec {
+        default,
+        max: default.max(DEFAULT_MAX_PAGE_SIZE),
+        query_param: Some(input.name.clone()),
+        body_path: Vec::new(),
     }
+}
+
+fn numeric_input_default(input: &IrOperationInput) -> Option<i64> {
+    input.default_value.as_deref()?.parse().ok()
+}
+
+fn name_token(value: &str) -> String {
+    value
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 fn fallback_operation_id(method: &str, path: &str) -> String {

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -319,10 +319,15 @@ fn detect_link_header_pagination(
     inputs: &[IrOperationInput],
     context: &OpenApiResponsePaginationContext,
 ) -> Option<PaginationSpec> {
-    response_header(context, &["link"])?;
+    let has_link_header = response_header(context, &["link"]).is_some();
+    let next_url_header = response_next_url_header(context);
+    if !has_link_header && next_url_header.is_none() {
+        return None;
+    }
     Some(PaginationSpec {
         mode: PaginationMode::LinkHeader,
         page_size: detect_page_size(inputs),
+        next_url_header,
         ..PaginationSpec::default()
     })
 }
@@ -447,6 +452,28 @@ fn response_cursor_header(context: &OpenApiResponsePaginationContext) -> Option<
         .iter()
         .find(|(name, header)| {
             RESPONSE_CURSOR_HEADER_TOKENS.contains(&name_token(name).as_str())
+                && response_header_allows_string(header)
+        })
+        .map(|(name, _)| name.clone())
+}
+
+fn response_next_url_header(context: &OpenApiResponsePaginationContext) -> Option<String> {
+    const RESPONSE_NEXT_URL_HEADER_TOKENS: &[&str] = &[
+        "next",
+        "nextpage",
+        "nextpageurl",
+        "nexturl",
+        "xnext",
+        "xnextpage",
+        "xnextpageurl",
+        "xnexturl",
+    ];
+
+    context
+        .headers
+        .iter()
+        .find(|(name, header)| {
+            RESPONSE_NEXT_URL_HEADER_TOKENS.contains(&name_token(name).as_str())
                 && response_header_allows_string(header)
         })
         .map(|(name, _)| name.clone())

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -324,7 +324,7 @@ fn detect_link_header_pagination(
     if !has_link_header && next_url_header.is_none() {
         return None;
     }
-    let page_input = find_page_input(inputs);
+    let page_input = find_numeric_page_input(inputs);
     Some(PaginationSpec {
         mode: PaginationMode::LinkHeader,
         page_size: detect_page_size(inputs),
@@ -417,6 +417,15 @@ fn detect_page_size(inputs: &[IrOperationInput]) -> Option<PageSizeSpec> {
 
 fn find_page_input(inputs: &[IrOperationInput]) -> Option<&IrOperationInput> {
     find_query_input(inputs, &["page", "pagenumber", "pagenum"])
+}
+
+fn find_numeric_page_input(inputs: &[IrOperationInput]) -> Option<&IrOperationInput> {
+    find_page_input(inputs).filter(|input| {
+        matches!(
+            input.data_type,
+            IrScalarType::Integer | IrScalarType::Number
+        ) || numeric_input_default(input).is_some()
+    })
 }
 
 fn find_query_input<'a>(

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -5,12 +5,13 @@ use serde_json::{Map, Value};
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{
     HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
-    IrOperationNaming, IrScalarType, RestExecutionAttachment, RestParameterBinding,
-    RestRequestBody,
+    IrOperationNaming, IrScalarType, OutputCardinality, RestExecutionAttachment,
+    RestParameterBinding, RestRequestBody,
 };
 use crate::v4::naming::normalize_identifier;
 use crate::v4::surfaces::json_schema::{
-    json_schema_default_to_string, json_schema_scalar_type_or_string, json_schema_type_display,
+    json_schema_default_to_string, json_schema_scalar_type_or_string, json_schema_type_contains,
+    json_schema_type_display,
 };
 use crate::{ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result};
 
@@ -304,10 +305,54 @@ fn detect_pagination(
     inputs: &[IrOperationInput],
     context: &OpenApiResponsePaginationContext,
 ) -> PaginationSpec {
-    let _ = (&context.schema, &context.headers, context.cardinality);
-    detect_offset_pagination(inputs)
+    if !is_paginated_cardinality(context.cardinality) {
+        return PaginationSpec::default();
+    }
+    detect_link_header_pagination(inputs, context)
+        .or_else(|| detect_cursor_query_pagination(inputs, context))
+        .or_else(|| detect_offset_pagination(inputs))
         .or_else(|| detect_page_pagination(inputs))
         .unwrap_or_default()
+}
+
+fn detect_link_header_pagination(
+    inputs: &[IrOperationInput],
+    context: &OpenApiResponsePaginationContext,
+) -> Option<PaginationSpec> {
+    response_header(context, &["link"])?;
+    Some(PaginationSpec {
+        mode: PaginationMode::LinkHeader,
+        page_size: detect_page_size(inputs),
+        ..PaginationSpec::default()
+    })
+}
+
+fn detect_cursor_query_pagination(
+    inputs: &[IrOperationInput],
+    context: &OpenApiResponsePaginationContext,
+) -> Option<PaginationSpec> {
+    let cursor_input = find_optional_query_input(
+        inputs,
+        &[
+            "after",
+            "continuationtoken",
+            "cursor",
+            "marker",
+            "nextcursor",
+            "nextpagetoken",
+            "nexttoken",
+            "pagetoken",
+            "startingafter",
+        ],
+    )?;
+    let response_cursor_path = find_response_cursor_path(&context.schema)?;
+    Some(PaginationSpec {
+        mode: PaginationMode::CursorQuery,
+        page_size: detect_page_size(inputs),
+        cursor_param: Some(cursor_input.name.clone()),
+        response_cursor_path,
+        ..PaginationSpec::default()
+    })
 }
 
 fn detect_offset_pagination(inputs: &[IrOperationInput]) -> Option<PaginationSpec> {
@@ -325,7 +370,19 @@ fn detect_offset_pagination(inputs: &[IrOperationInput]) -> Option<PaginationSpe
 
 fn detect_page_pagination(inputs: &[IrOperationInput]) -> Option<PaginationSpec> {
     let page_input = find_query_input(inputs, &["page", "pagenumber", "pagenum"])?;
-    let page_size_input = find_query_input(
+    let page_size = detect_page_size(inputs)?;
+    Some(PaginationSpec {
+        mode: PaginationMode::Page,
+        page_size: Some(page_size),
+        page_param: Some(page_input.name.clone()),
+        page_start: numeric_input_default(page_input).unwrap_or(1),
+        page_step: 1,
+        ..PaginationSpec::default()
+    })
+}
+
+fn detect_page_size(inputs: &[IrOperationInput]) -> Option<PageSizeSpec> {
+    find_query_input(
         inputs,
         &[
             "limit",
@@ -334,15 +391,8 @@ fn detect_page_pagination(inputs: &[IrOperationInput]) -> Option<PaginationSpec>
             "perpage",
             "resultsperpage",
         ],
-    )?;
-    Some(PaginationSpec {
-        mode: PaginationMode::Page,
-        page_size: Some(page_size_spec(page_size_input)),
-        page_param: Some(page_input.name.clone()),
-        page_start: numeric_input_default(page_input).unwrap_or(1),
-        page_step: 1,
-        ..PaginationSpec::default()
-    })
+    )
+    .map(page_size_spec)
 }
 
 fn find_query_input<'a>(
@@ -353,6 +403,63 @@ fn find_query_input<'a>(
         .iter()
         .filter(|input| input.location == IrInputLocation::Query)
         .find(|input| candidate_tokens.contains(&name_token(&input.name).as_str()))
+}
+
+fn find_optional_query_input<'a>(
+    inputs: &'a [IrOperationInput],
+    candidate_tokens: &[&str],
+) -> Option<&'a IrOperationInput> {
+    find_query_input(inputs, candidate_tokens).filter(|input| !input.required)
+}
+
+fn response_header<'a>(
+    context: &'a OpenApiResponsePaginationContext,
+    candidate_tokens: &[&str],
+) -> Option<&'a Value> {
+    context
+        .headers
+        .iter()
+        .find(|(name, _)| candidate_tokens.contains(&name_token(name).as_str()))
+        .map(|(_, header)| header)
+}
+
+fn find_response_cursor_path(schema: &Value) -> Option<Vec<String>> {
+    let properties = schema.get("properties").and_then(Value::as_object)?;
+    for (name, property) in properties {
+        if is_response_cursor_property(name, property) {
+            return Some(vec![name.clone()]);
+        }
+    }
+    for (name, property) in properties {
+        if !json_schema_type_contains(property, "object") {
+            continue;
+        }
+        if let Some(mut path) = find_response_cursor_path(property) {
+            path.insert(0, name.clone());
+            return Some(path);
+        }
+    }
+    None
+}
+
+fn is_response_cursor_property(name: &str, schema: &Value) -> bool {
+    const RESPONSE_CURSOR_TOKENS: &[&str] = &[
+        "endcursor",
+        "nextcursor",
+        "nextmarker",
+        "nextpagetoken",
+        "nexttoken",
+    ];
+
+    RESPONSE_CURSOR_TOKENS.contains(&name_token(name).as_str())
+        && (json_schema_type_contains(schema, "string") || schema.get("type").is_none())
+}
+
+fn is_paginated_cardinality(cardinality: OutputCardinality) -> bool {
+    matches!(
+        cardinality,
+        OutputCardinality::List | OutputCardinality::WrappedList
+    )
 }
 
 fn page_size_spec(input: &IrOperationInput) -> PageSizeSpec {

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -15,6 +15,7 @@ use crate::v4::surfaces::json_schema::{
 use crate::{ManifestError, PageSizeSpec, PaginationMode, PaginationSpec, Result};
 
 use super::import::OpenApiImporter;
+use super::responses::OpenApiResponsePaginationContext;
 
 impl OpenApiImporter<'_> {
     pub(super) fn import_operation(
@@ -39,9 +40,9 @@ impl OpenApiImporter<'_> {
         let mut diagnostics = Vec::new();
         let parameters = self.import_parameters(path_item, op_obj, &operation_id, &mut diagnostics);
         let request_body = self.import_request_body(op_obj, &operation_id, &mut diagnostics);
-        let (output, response, entity) =
+        let (output, response, entity, pagination_context) =
             self.import_response(path, op_obj, &operation_id, &mut diagnostics);
-        let pagination = detect_pagination(&parameters);
+        let pagination = detect_pagination(&parameters, &pagination_context);
         let rest_parameters = parameters
             .iter()
             .map(|input| RestParameterBinding {
@@ -299,7 +300,11 @@ fn parameter_is_required(parameter_obj: &Map<String, Value>, location: IrInputLo
         .unwrap_or(false)
 }
 
-fn detect_pagination(inputs: &[IrOperationInput]) -> PaginationSpec {
+fn detect_pagination(
+    inputs: &[IrOperationInput],
+    context: &OpenApiResponsePaginationContext,
+) -> PaginationSpec {
+    let _ = (&context.schema, &context.headers, context.cardinality);
     let has_page = inputs
         .iter()
         .any(|input| input.location == IrInputLocation::Query && input.name == "page");

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -348,6 +348,7 @@ fn detect_cursor_query_pagination(
             "nextpagetoken",
             "nexttoken",
             "page",
+            "paginationtoken",
             "pagetoken",
             "startingafter",
         ],

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -324,9 +324,12 @@ fn detect_link_header_pagination(
     if !has_link_header && next_url_header.is_none() {
         return None;
     }
+    let page_input = find_page_input(inputs);
     Some(PaginationSpec {
         mode: PaginationMode::LinkHeader,
         page_size: detect_page_size(inputs),
+        page_param: page_input.map(|input| input.name.clone()),
+        page_start: page_input.and_then(numeric_input_default).unwrap_or(1),
         next_url_header,
         ..PaginationSpec::default()
     })
@@ -386,7 +389,7 @@ fn detect_offset_pagination(inputs: &[IrOperationInput]) -> Option<PaginationSpe
 }
 
 fn detect_page_pagination(inputs: &[IrOperationInput]) -> Option<PaginationSpec> {
-    let page_input = find_query_input(inputs, &["page", "pagenumber", "pagenum"])?;
+    let page_input = find_page_input(inputs)?;
     let page_size = detect_page_size(inputs)?;
     Some(PaginationSpec {
         mode: PaginationMode::Page,
@@ -410,6 +413,10 @@ fn detect_page_size(inputs: &[IrOperationInput]) -> Option<PageSizeSpec> {
         ],
     )
     .map(page_size_spec)
+}
+
+fn find_page_input(inputs: &[IrOperationInput]) -> Option<&IrOperationInput> {
+    find_query_input(inputs, &["page", "pagenumber", "pagenum"])
 }
 
 fn find_query_input<'a>(

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde_json::{Map, Value};
 
 use crate::ResponseSpec;
@@ -7,6 +9,30 @@ use crate::v4::ir::{
 };
 
 use super::import::OpenApiImporter;
+
+pub(super) struct OpenApiResponsePaginationContext {
+    pub(super) schema: Value,
+    pub(super) headers: BTreeMap<String, Value>,
+    pub(super) cardinality: OutputCardinality,
+}
+
+impl Default for OpenApiResponsePaginationContext {
+    fn default() -> Self {
+        Self {
+            schema: Value::Null,
+            headers: BTreeMap::new(),
+            cardinality: OutputCardinality::None,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct SelectedJsonResponse {
+    status_code: u16,
+    media_type: String,
+    schema: Value,
+    headers: BTreeMap<String, Value>,
+}
 
 impl OpenApiImporter<'_> {
     pub(super) fn import_response(
@@ -19,8 +45,9 @@ impl OpenApiImporter<'_> {
         IrOperationOutput,
         RestResponseAttachment,
         Option<IrEntityCandidate>,
+        OpenApiResponsePaginationContext,
     ) {
-        let Some((status_code, media_type, schema)) = self.select_json_response(
+        let Some(selected) = self.select_json_response(
             operation.get("responses").and_then(Value::as_object),
             operation_id,
             diagnostics,
@@ -38,10 +65,11 @@ impl OpenApiImporter<'_> {
                     response,
                 },
                 None,
+                OpenApiResponsePaginationContext::default(),
             );
         };
 
-        let Some(resolved) = self.resolve_ref(&schema, operation_id, diagnostics) else {
+        let Some(resolved) = self.resolve_ref(&selected.schema, operation_id, diagnostics) else {
             diagnostics.push(Diagnostic::warning(
                 "OPENAPI_RESPONSE_SCHEMA_UNRESOLVED",
                 format!("operation '{operation_id}' response schema could not be resolved"),
@@ -55,11 +83,16 @@ impl OpenApiImporter<'_> {
                     row_path: Vec::new(),
                 },
                 RestResponseAttachment {
-                    status_code,
-                    media_type,
+                    status_code: selected.status_code,
+                    media_type: selected.media_type,
                     response: ResponseSpec::default(),
                 },
                 None,
+                OpenApiResponsePaginationContext {
+                    schema: Value::Null,
+                    headers: selected.headers,
+                    cardinality: OutputCardinality::Unknown,
+                },
             );
         };
         let (cardinality, row_path, row_schema, entity_name) =
@@ -90,11 +123,16 @@ impl OpenApiImporter<'_> {
                 row_path,
             },
             RestResponseAttachment {
-                status_code,
-                media_type,
+                status_code: selected.status_code,
+                media_type: selected.media_type,
                 response,
             },
             entity,
+            OpenApiResponsePaginationContext {
+                schema: resolved,
+                headers: selected.headers,
+                cardinality,
+            },
         )
     }
     fn select_json_response(
@@ -102,7 +140,7 @@ impl OpenApiImporter<'_> {
         responses: Option<&Map<String, Value>>,
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
-    ) -> Option<(u16, String, Value)> {
+    ) -> Option<SelectedJsonResponse> {
         let responses = responses?;
         let mut numeric_candidates = Vec::new();
         let mut range_candidates = Vec::new();
@@ -120,11 +158,13 @@ impl OpenApiImporter<'_> {
                 continue;
             };
             let schema = json.get("schema").cloned().unwrap_or(Value::Null);
-            let candidate = (
-                status.representative_status_code(),
-                "application/json".to_string(),
+            let headers = response_headers(&response, operation_id, diagnostics, self);
+            let candidate = SelectedJsonResponse {
+                status_code: status.representative_status_code(),
+                media_type: "application/json".to_string(),
                 schema,
-            );
+                headers,
+            };
             if status.is_range() {
                 range_candidates.push(candidate);
             } else {
@@ -167,13 +207,36 @@ fn success_response_status(status: &str) -> Option<SuccessResponseStatus> {
 }
 
 fn preferred_numeric_response(
-    candidates: Vec<(u16, String, Value)>,
-) -> Option<(u16, String, Value)> {
+    candidates: Vec<SelectedJsonResponse>,
+) -> Option<SelectedJsonResponse> {
     candidates
         .iter()
-        .position(|(status, _, _)| *status == 200)
+        .position(|candidate| candidate.status_code == 200)
         .and_then(|index| candidates.get(index).cloned())
-        .or_else(|| candidates.into_iter().min_by_key(|(status, _, _)| *status))
+        .or_else(|| {
+            candidates
+                .into_iter()
+                .min_by_key(|candidate| candidate.status_code)
+        })
+}
+
+fn response_headers(
+    response: &Value,
+    operation_id: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+    importer: &OpenApiImporter<'_>,
+) -> BTreeMap<String, Value> {
+    response
+        .get("headers")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flat_map(|headers| headers.iter())
+        .filter_map(|(name, header)| {
+            importer
+                .resolve_ref(header, operation_id, diagnostics)
+                .map(|resolved| (name.clone(), resolved))
+        })
+        .collect()
 }
 
 fn classify_response_schema(


### PR DESCRIPTION
## Summary

This teaches the DSL v4 OpenAPI importer to infer pagination from common OpenAPI request/response shapes, and extends the HTTP runtime so those inferred hints can actually be executed.

The importer now detects pagination for list-like responses, then chooses the first supported pattern it can prove from the operation shape:

- link-header pagination from a declared `Link` response header
- next-page URL header pagination from headers like `X-Next-Page-Url`
- cursor query pagination from cursor-like query params plus response cursor fields or headers
- X-style `pagination_token` cursor pagination from response `meta.next_token`
- token-style `page` cursor pagination when `page` is a string parameter and the response exposes `next_page` / `nextPage`
- offset pagination from `offset` + `limit`
- page-number pagination from numeric `page`/`pageNumber` + page-size params

Runtime support now includes response-cursor headers for `cursor_query` / `cursor_body` and custom next-page URL headers for `link_header`, with same-origin checks for URL-bearing pagination headers.

## Why

Generated v4 sources currently need too much manual pagination cleanup for ordinary OpenAPI specs. The old inference only recognized the exact `page` + `per_page` pattern, which misses common cursor, offset, header, and next URL pagination contracts. This makes generated sources more useful out of the box without guessing pagination for singleton responses.

## Notable details

- OpenAPI response selection now retains resolved response headers and response cardinality as pagination context.
- Header-backed cursor pagination can use `response_cursor_header` instead of `response_cursor_path`.
- Link-header pagination can use `next_url_header` when APIs return the next URL in a custom header rather than RFC 5988 `Link`.
- Optional string `page` parameters are treated as cursor tokens only when the response has a string next-page cursor; numeric `page` remains page-number pagination.
- `pagination_token` is recognized as a cursor query parameter for APIs that return `next_token` in response metadata.
- Pagination-owned query inputs are still hidden from generated projections via the existing projection sync path.
- Generated source-manifest schema is updated for the new pagination fields.

## Validation

Automated checks:

- `make rust-checks`
- `make schema-check`
- `cargo test -p coral-spec v4::openapi_tests:: -- --nocapture`
- `cargo test -p coral-engine --test engine pagination_ -- --nocapture`

Real OpenAPI import smoke tests via `coral source add --file` with isolated `CORAL_CONFIG_DIR`:

- X API: 165 operations; inferred 38 `cursor_query` paginated operations.
- GitHub REST API: 1194 operations; inferred 193 `link_header` and 68 `page` paginated operations.
- Stripe API: 587 operations; inferred 7 `cursor_query` paginated operations for search endpoints using string `page` + response `next_page`.
- GitLab API: 1729 operations; inferred 1 `cursor_query` and 51 `page` paginated operations.

GitHub note: GitHub's REST docs say paginated responses use `Link`, but this import is constrained by the OpenAPI descriptor. The descriptor currently declares `Link` on about 206 operations, including some singleton-shaped responses that this importer intentionally excludes, so the 193 `link_header` result is close to the explicit descriptor signal. Operations with `page`/`per_page` but no declared `Link` header fall back to page-number pagination.

X note: the descriptor has about 39 list-like operations with `pagination_token` or `next_token` plus response `next_token`. This PR now infers 38 of them; the remaining miss has response metadata behind a nested `$ref`, which needs separate response-schema resolution hardening. Tracked in [#1578](https://github.com/withcoral/coral/issues/1578).

Stripe limitation: Stripe's ordinary list endpoints use `starting_after`/`ending_before` with `has_more`, where the next cursor is derived from the last returned row id. This PR does not add a DSL/runtime primitive for "cursor from last row when has_more", so those endpoints correctly remain uninferred rather than being counted as covered. That follow-up is tracked in #1577.

GitLab limitation: GitLab's OpenAPI descriptor has many more `page`/`per_page` operations than the 51 inferred here. The low count is mainly because many paginated endpoints declare a singular response schema ref rather than an array/list response shape, and this PR intentionally gates inferred pagination on list-like cardinality to avoid paginating singleton resources. Supporting those GitLab cases likely needs a separate, explicit cardinality inference strategy for strongly paginated OpenAPI operations. Tracked in [#1579](https://github.com/withcoral/coral/issues/1579).

While testing DigitalOcean's OpenAPI descriptor, I found an unrelated DSL v4 importer/runtime-component issue where all 663 imported operations had `cardinality: none`; that is tracked separately in #1575.