### PR TITLE
feat(engine): cache source registrations across runtime builds

### DIFF
--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -273,12 +273,16 @@ pub(crate) fn engine_extensions_for_providers(
             query_result_observers,
             request_authenticators,
             source_input_resolver,
+            registration_cache,
         } = extra;
         merged.source_decorators.extend(source_decorators);
         merged.query_result_observers.extend(query_result_observers);
         merged.request_authenticators.extend(request_authenticators);
         if source_input_resolver.is_some() {
             merged.source_input_resolver = source_input_resolver;
+        }
+        if registration_cache.is_some() {
+            merged.registration_cache = registration_cache;
         }
     }
     merged

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1,14 +1,14 @@
 //! Query-time loading, validation, and execution over installed sources.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use coral_engine::{
     CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, QueryExecution,
     QueryExecutionProvenance, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-    RuntimeSourcePackage, SourceValidationReport, StatusCode, TableInfo,
+    RegistrationCache, RuntimeSourcePackage, SourceValidationReport, StatusCode, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::trace::Status as OtelStatus;
@@ -62,6 +62,7 @@ pub(crate) struct QueryManager {
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    registration_caches: Arc<Mutex<HashMap<WorkspaceName, Arc<RegistrationCache>>>>,
 }
 
 impl QueryManager {
@@ -78,7 +79,34 @@ impl QueryManager {
             runtime_context,
             layout,
             engine_extensions_providers,
+            registration_caches: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Returns the workspace's registration cache, evicting entries for
+    /// sources that are no longer installed there.
+    ///
+    /// Caches are scoped per workspace so builds in one workspace never
+    /// evict another workspace's entries, and eviction follows the installed
+    /// source set from config rather than any per-build selection.
+    fn workspace_registration_cache(
+        &self,
+        workspace_name: &WorkspaceName,
+        config: &AppConfig,
+    ) -> Arc<RegistrationCache> {
+        let mut caches = self
+            .registration_caches
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        caches.retain(|name, _| config.has_workspace(name));
+        let cache = caches.entry(workspace_name.clone()).or_default();
+        let installed_sources = config.workspace_sources(workspace_name);
+        let installed_names = installed_sources
+            .iter()
+            .map(|source| source.name.as_str())
+            .collect();
+        cache.retain_sources(&installed_names);
+        Arc::clone(cache)
     }
 
     pub(crate) async fn list_tables(
@@ -462,6 +490,8 @@ impl QueryManager {
                 .collect(),
             provider_input_resolver,
         )));
+        extensions.registration_cache =
+            Some(self.workspace_registration_cache(workspace_name, config));
         let mut runtime_context = self.runtime_context.clone();
         runtime_context.trace_context = Some(tracing::Span::current().context());
         let mut runtime = QueryRuntimeConfig::new(runtime_context, extensions);
@@ -795,6 +825,41 @@ mod tests {
             AppError::WorkspaceNotFound(actual) => assert_eq!(actual, workspace_name.as_str()),
             error => panic!("expected WorkspaceNotFound for '{workspace_name}', got {error}"),
         }
+    }
+
+    #[test]
+    fn workspace_registration_caches_are_scoped_and_pruned() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        let config = AppConfig::default();
+        let default_workspace = WorkspaceName::default();
+        let removed_workspace = WorkspaceName::parse("removed").expect("workspace");
+
+        let first = fixture
+            .manager
+            .workspace_registration_cache(&default_workspace, &config);
+        let second = fixture
+            .manager
+            .workspace_registration_cache(&default_workspace, &config);
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "builds in the same workspace share one cache"
+        );
+
+        // A workspace absent from config keeps its cache only until another
+        // build observes the config without it.
+        let orphan = fixture
+            .manager
+            .workspace_registration_cache(&removed_workspace, &config);
+        fixture
+            .manager
+            .workspace_registration_cache(&default_workspace, &config);
+        let recreated = fixture
+            .manager
+            .workspace_registration_cache(&removed_workspace, &config);
+        assert!(
+            !Arc::ptr_eq(&orphan, &recreated),
+            "caches for removed workspaces are pruned"
+        );
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -116,16 +116,19 @@ pub(crate) struct RegisteredSource {
     pub(crate) inputs: Vec<RegisteredInput>,
 }
 
+#[derive(Clone)]
 pub(crate) struct BackendRegistration {
     pub(crate) schemas: Vec<BackendSchemaRegistration>,
     pub(crate) catalogs: Vec<BackendCatalogRegistration>,
 }
 
+#[derive(Clone)]
 pub(crate) struct BackendSchemaRegistration {
     pub(crate) tables: HashMap<String, Arc<dyn TableProvider>>,
     pub(crate) source: RegisteredSource,
 }
 
+#[derive(Clone)]
 pub(crate) struct BackendCatalogRegistration {
     pub(crate) catalog_name: String,
     pub(crate) catalog: Arc<dyn CatalogProvider>,
@@ -171,6 +174,19 @@ pub(crate) trait CompiledBackendSource: Send + Sync {
     fn source_name(&self) -> &str;
 
     fn validate_runtime_capabilities(&self) -> datafusion::error::Result<()>;
+
+    /// Stable fingerprint covering everything [`Self::register`] depends on.
+    ///
+    /// `None` (the default) opts this source out of registration caching.
+    /// Backends that return `Some` promise two things: the fingerprint changes
+    /// whenever the manifest content or resolved inputs that shape
+    /// registration change, and [`Self::register`] returns all of its effects
+    /// through [`BackendRegistration`] without mutating the passed
+    /// [`SessionContext`], so a cached registration can be replayed into a
+    /// fresh session.
+    fn registration_fingerprint(&self) -> Option<String> {
+        None
+    }
 
     /// Register this compiled source into a `DataFusion` session.
     ///

--- a/crates/coral-engine/src/backends/composite.rs
+++ b/crates/coral-engine/src/backends/composite.rs
@@ -46,6 +46,17 @@ impl CompiledBackendSource for CompositeCompiledSource {
         Ok(())
     }
 
+    fn registration_fingerprint(&self) -> Option<String> {
+        // Cacheable only when every component is: one uncacheable component
+        // makes the composed registration unreplayable.
+        let mut combined = String::new();
+        for component in &self.components {
+            combined.push_str(&component.registration_fingerprint()?);
+            combined.push('\n');
+        }
+        Some(combined)
+    }
+
     async fn register(
         &self,
         ctx: &SessionContext,

--- a/crates/coral-engine/src/backends/database.rs
+++ b/crates/coral-engine/src/backends/database.rs
@@ -1,6 +1,7 @@
 //! Relational database backend registration through `datafusion-table-providers`.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -58,6 +59,18 @@ impl CompiledBackendSource for CompiledDatabaseSource {
 
     fn validate_runtime_capabilities(&self) -> DataFusionResult<()> {
         Ok(())
+    }
+
+    fn registration_fingerprint(&self) -> Option<String> {
+        // Registration reads only the manifest and the resolved source
+        // inputs; the Debug rendering covers every manifest field, including
+        // the raw connection templates. DefaultHasher output is only stable
+        // within one process, which is all the in-memory cache needs.
+        let mut hasher = DefaultHasher::new();
+        format!("{:?}", self.manifest).hash(&mut hasher);
+        self.source_secrets.hash(&mut hasher);
+        self.source_variables.hash(&mut hasher);
+        Some(format!("{:016x}", hasher.finish()))
     }
 
     async fn register(
@@ -273,6 +286,8 @@ fn boxed_provider_error(error: Box<dyn std::error::Error + Send + Sync>) -> Data
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::path::Path;
+    use std::sync::Arc;
 
     use coral_spec::{
         DatabaseConnectionSpec, DatabaseProvider, DatabaseSourceManifest, MySqlConnectionSpec,
@@ -281,7 +296,8 @@ mod tests {
 
     use crate::backends::shared::template::RenderContext;
     use crate::{
-        CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
+        CoralQuery, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+        RegistrationCache, RuntimeSourceComponent, RuntimeSourcePackage,
     };
 
     fn template(value: &str) -> ParsedTemplate {
@@ -326,6 +342,99 @@ mod tests {
                 "unexpected error: {message}"
             );
         }
+    }
+
+    fn sqlite_query_source(db_path: &Path) -> QuerySource {
+        let database = DatabaseSourceManifest {
+            common: SourceManifestCommon {
+                dsl_version: 4,
+                name: "cache_db".to_string(),
+                version: String::new(),
+                description: "Cache test database".to_string(),
+                test_queries: Vec::new(),
+            },
+            provider: DatabaseProvider::Sqlite,
+            connection: DatabaseConnectionSpec::Sqlite(SqliteConnectionSpec {
+                path: ParsedTemplate::parse(db_path.to_string_lossy().to_string())
+                    .expect("sqlite path template"),
+            }),
+            declared_inputs: Vec::new(),
+        };
+        QuerySource::from_runtime_components(
+            RuntimeSourcePackage {
+                source_name: "cache_db".to_string(),
+                authored_version: None,
+                description: String::new(),
+                declared_inputs: Vec::new(),
+                test_queries: Vec::new(),
+                components: vec![RuntimeSourceComponent::Database(database)],
+            },
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect("database runtime source")
+    }
+
+    fn runtime_with_cache(cache: &Arc<RegistrationCache>) -> QueryRuntimeConfig {
+        let extensions = EngineExtensions {
+            registration_cache: Some(Arc::clone(cache)),
+            ..EngineExtensions::default()
+        };
+        QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions)
+    }
+
+    fn sqlite_fixture(db_path: &Path) {
+        let conn = rusqlite::Connection::open(db_path).expect("sqlite db");
+        conn.execute_batch(
+            "
+            CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+            INSERT INTO users (id, name) VALUES (1, 'Ada'), (2, 'Lin');
+            ",
+        )
+        .expect("sqlite fixture");
+    }
+
+    #[tokio::test]
+    async fn cached_registration_survives_losing_the_database_catalog() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let db_path = temp.path().join("cache.sqlite");
+        sqlite_fixture(&db_path);
+        let sources = vec![sqlite_query_source(&db_path)];
+        let cache = Arc::new(RegistrationCache::new());
+
+        let tables = CoralQuery::list_tables(
+            &sources,
+            runtime_with_cache(&cache),
+            Some("cache_db"),
+            Some("users"),
+        )
+        .await
+        .expect("list tables with live database");
+        assert_eq!(tables.len(), 1);
+
+        std::fs::remove_file(&db_path).expect("remove sqlite database");
+
+        // Without the cache the source can no longer register at all.
+        let tables = CoralQuery::list_tables(
+            &sources,
+            QueryRuntimeConfig::default(),
+            Some("cache_db"),
+            None,
+        )
+        .await
+        .expect("list tables skips failed source");
+        assert!(tables.is_empty());
+
+        // With the cache the catalog metadata replays without rediscovery.
+        let tables = CoralQuery::list_tables(
+            &sources,
+            runtime_with_cache(&cache),
+            Some("cache_db"),
+            Some("users"),
+        )
+        .await
+        .expect("list tables from cached registration");
+        assert_eq!(tables.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -27,6 +27,10 @@ pub struct EngineExtensions {
     pub request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     /// Request-time resolver for app-managed source inputs.
     pub source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    /// Cross-build cache for backend source registrations. A long-lived owner
+    /// shares one cache across runtime builds so backends that report a
+    /// registration fingerprint skip re-registering when nothing changed.
+    pub registration_cache: Option<Arc<crate::RegistrationCache>>,
 }
 
 /// Neutral policy decision for one source registration failure.

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -67,6 +67,8 @@ pub use composition::{
     RequestAuthenticatorError, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
     SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError, SourceTables,
 };
+pub use runtime::registration_cache::RegistrationCache;
+
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
     DescribeTableInfo, EffectiveDependentJoinConfig, MemorySize, QueryExecution,

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod memory;
 pub(crate) mod pattern_validator;
 pub(crate) mod query;
 pub(crate) mod query_planner;
+pub(crate) mod registration_cache;
 pub(crate) mod registry;
 pub(crate) mod schema_provider;
 pub(crate) mod scoped_table_functions;

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -29,6 +29,7 @@ use crate::runtime::error::{
 use crate::runtime::json::register_json_support;
 use crate::runtime::pattern_validator::register_pattern_validator;
 use crate::runtime::query_planner::CoralQueryPlanner;
+use crate::runtime::registration_cache::RegistrationCache;
 use crate::runtime::registry::{
     CompiledQuerySource, SourceRegistrationCandidate, SourceRegistrationFailure, register_sources,
 };
@@ -67,6 +68,7 @@ struct FallbackRuntimeConfig {
     memory: QueryMemoryConfig,
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    registration_cache: Option<Arc<RegistrationCache>>,
 }
 
 struct RegisteredRuntime {
@@ -102,6 +104,7 @@ async fn build_runtime_inner(
     } = runtime;
     let request_authenticators = extensions.request_authenticators.clone();
     let source_input_resolver = extensions.source_input_resolver.clone();
+    let registration_cache = extensions.registration_cache.clone();
     // Resolver-row overflow can retry without the dependent-join optimizer only
     // when runtime registration is replayable. Source decorators are mutable
     // one-shot registration hooks today, so decorated runtimes keep resolver-row
@@ -117,6 +120,7 @@ async fn build_runtime_inner(
             memory: memory.clone(),
             request_authenticators: request_authenticators.clone(),
             source_input_resolver: source_input_resolver.clone(),
+            registration_cache: registration_cache.clone(),
         })
     });
 
@@ -128,6 +132,7 @@ async fn build_runtime_inner(
         extensions.source_decorators.as_mut_slice(),
         &dependent_join,
         &memory,
+        registration_cache.as_deref(),
     )
     .await?;
 
@@ -143,6 +148,10 @@ async fn build_runtime_inner(
     })
 }
 
+#[expect(
+    clippy::too_many_arguments,
+    reason = "runtime build inputs are assembled once per query from already-destructured config"
+)]
 async fn build_registered_runtime(
     sources: &[QuerySource],
     runtime_context: &QueryRuntimeContext,
@@ -151,6 +160,7 @@ async fn build_registered_runtime(
     source_decorators: &mut [Box<dyn SourceDecorator>],
     dependent_join: &DependentJoinConfig,
     memory: &QueryMemoryConfig,
+    registration_cache: Option<&RegistrationCache>,
 ) -> Result<RegisteredRuntime, CoreError> {
     let ctx = build_session_context(dependent_join, memory)?;
     let registration = register_runtime_sources(
@@ -160,6 +170,7 @@ async fn build_registered_runtime(
         request_authenticators,
         source_input_resolver,
         source_decorators,
+        registration_cache,
     )
     .await?;
     catalog::register(&ctx, &registration.active_sources)
@@ -248,6 +259,7 @@ async fn register_runtime_sources(
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
     source_decorators: &mut [Box<dyn SourceDecorator>],
+    registration_cache: Option<&RegistrationCache>,
 ) -> Result<crate::runtime::registry::SourceRegistrationResult, CoreError> {
     let mut source_candidates = Vec::new();
     for source in sources {
@@ -271,7 +283,13 @@ async fn register_runtime_sources(
             }),
         }
     }
-    register_sources(ctx, source_candidates, source_decorators).await
+    register_sources(
+        ctx,
+        source_candidates,
+        source_decorators,
+        registration_cache,
+    )
+    .await
 }
 
 /// Matches a user-supplied source/schema filter against one table.
@@ -818,6 +836,7 @@ impl FallbackRuntimeConfig {
             source_decorators.as_mut_slice(),
             &self.dependent_join.without_rewrites(),
             &self.memory,
+            self.registration_cache.as_deref(),
         )
         .await
     }
@@ -987,6 +1006,7 @@ mod tests {
             },
             request_authenticators: HashMap::new(),
             source_input_resolver: None,
+            registration_cache: None,
         };
 
         let runtime = fallback

--- a/crates/coral-engine/src/runtime/registration_cache.rs
+++ b/crates/coral-engine/src/runtime/registration_cache.rs
@@ -1,0 +1,168 @@
+//! Cross-build reuse of backend source registrations.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+use std::time::{Duration, Instant};
+
+use crate::backends::BackendRegistration;
+
+/// Default entry lifetime before a cached registration is refreshed.
+const DEFAULT_TTL: Duration = Duration::from_mins(5);
+
+/// Reuses backend registration artifacts across runtime builds.
+///
+/// Runtime builds happen per query, so backends whose registration performs
+/// expensive work (for example remote catalog discovery) would repeat that
+/// work on every query. A long-lived owner (the application layer) holds one
+/// cache and passes it through [`crate::EngineExtensions`]; registration then
+/// replays cached artifacts instead of re-registering.
+///
+/// Entries are keyed by source name and validated against the fingerprint the
+/// backend reports via `CompiledBackendSource::registration_fingerprint`. Only
+/// backends that report a fingerprint participate; every other source
+/// re-registers on each runtime build exactly as before.
+///
+/// The fingerprint only tracks source configuration, so remote schema changes
+/// (for example new tables in a database) are invisible to it. Entries
+/// therefore also expire after a time-to-live: an expired entry is returned
+/// as [`CacheLookup::Stale`] so registration can rebuild it off-lock and swap
+/// the entry, while runtime builds that already hold the old artifacts keep
+/// working unchanged.
+pub struct RegistrationCache {
+    ttl: Duration,
+    entries: Mutex<HashMap<String, CachedRegistration>>,
+}
+
+struct CachedRegistration {
+    fingerprint: String,
+    registration: BackendRegistration,
+    refreshed_at: Instant,
+    #[cfg(test)]
+    force_stale: bool,
+}
+
+impl CachedRegistration {
+    fn is_fresh(&self, ttl: Duration) -> bool {
+        #[cfg(test)]
+        if self.force_stale {
+            return false;
+        }
+        self.refreshed_at.elapsed() < ttl
+    }
+}
+
+/// Outcome of a cache lookup for a fingerprint-matching entry.
+pub(crate) enum CacheLookup {
+    /// The entry is within its time-to-live and can be used as is.
+    Fresh(BackendRegistration),
+    /// The entry outlived its time-to-live. Callers should re-register the
+    /// source and fall back to this registration only when that fails.
+    Stale(BackendRegistration),
+}
+
+impl std::fmt::Debug for RegistrationCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RegistrationCache")
+            .field("ttl", &self.ttl)
+            .field("sources", &self.entries().keys().collect::<Vec<_>>())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for RegistrationCache {
+    fn default() -> Self {
+        Self::with_ttl(DEFAULT_TTL)
+    }
+}
+
+impl RegistrationCache {
+    /// Creates an empty registration cache with the default time-to-live.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates an empty registration cache whose entries expire after `ttl`.
+    #[must_use]
+    pub fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn entries(&self) -> MutexGuard<'_, HashMap<String, CachedRegistration>> {
+        self.entries.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Returns the cached registration for `source_name` when its fingerprint
+    /// still matches, marked fresh or stale by the entry's age.
+    pub(crate) fn lookup(&self, source_name: &str, fingerprint: &str) -> Option<CacheLookup> {
+        let entries = self.entries();
+        let entry = entries.get(source_name)?;
+        if entry.fingerprint != fingerprint {
+            return None;
+        }
+        let registration = entry.registration.clone();
+        Some(if entry.is_fresh(self.ttl) {
+            CacheLookup::Fresh(registration)
+        } else {
+            CacheLookup::Stale(registration)
+        })
+    }
+
+    /// Stores `registration` for `source_name`, replacing any previous entry
+    /// and restarting its time-to-live.
+    pub(crate) fn store(
+        &self,
+        source_name: &str,
+        fingerprint: &str,
+        registration: &BackendRegistration,
+    ) {
+        self.entries().insert(
+            source_name.to_string(),
+            CachedRegistration {
+                fingerprint: fingerprint.to_string(),
+                registration: registration.clone(),
+                refreshed_at: Instant::now(),
+                #[cfg(test)]
+                force_stale: false,
+            },
+        );
+    }
+
+    /// Restarts the time-to-live of the entry for `source_name`.
+    ///
+    /// Used after a failed refresh so a stale entry keeps serving queries and
+    /// the refresh retries once per time-to-live window instead of on every
+    /// runtime build.
+    pub(crate) fn touch(&self, source_name: &str) {
+        if let Some(entry) = self.entries().get_mut(source_name) {
+            entry.refreshed_at = Instant::now();
+            #[cfg(test)]
+            {
+                entry.force_stale = false;
+            }
+        }
+    }
+
+    /// Drops cached entries for sources outside `installed`.
+    ///
+    /// The long-lived owner calls this with the full set of installed source
+    /// names so entries for removed sources release their registration
+    /// artifacts. Per-build source selections must not drive eviction: a
+    /// build that selects a subset (for example single-source validation)
+    /// says nothing about whether the other sources still exist.
+    pub fn retain_sources(&self, installed: &HashSet<&str>) {
+        self.entries()
+            .retain(|source_name, _| installed.contains(source_name.as_str()));
+    }
+
+    /// Marks the entry for `source_name` as expired regardless of its age.
+    #[cfg(test)]
+    pub(crate) fn force_stale(&self, source_name: &str) {
+        if let Some(entry) = self.entries().get_mut(source_name) {
+            entry.force_stale = true;
+        }
+    }
+}

--- a/crates/coral-engine/src/runtime/registration_cache.rs
+++ b/crates/coral-engine/src/runtime/registration_cache.rs
@@ -37,8 +37,15 @@ struct CachedRegistration {
     fingerprint: String,
     registration: BackendRegistration,
     refreshed_at: Instant,
+    refresh_status: RefreshStatus,
     #[cfg(test)]
     force_stale: bool,
+}
+
+#[derive(Clone, Copy)]
+enum RefreshStatus {
+    Idle,
+    Refreshing { started_at: Instant },
 }
 
 impl CachedRegistration {
@@ -55,9 +62,23 @@ impl CachedRegistration {
 pub(crate) enum CacheLookup {
     /// The entry is within its time-to-live and can be used as is.
     Fresh(BackendRegistration),
-    /// The entry outlived its time-to-live. Callers should re-register the
-    /// source and fall back to this registration only when that fails.
-    Stale(BackendRegistration),
+    /// The entry outlived its time-to-live and this caller claimed the refresh.
+    /// Callers should re-register the source and fall back to this registration
+    /// only when that fails.
+    Stale {
+        registration: BackendRegistration,
+        claim: RegistrationRefreshClaim,
+    },
+    /// Another caller is already refreshing this stale entry. Reuse the cached
+    /// registration rather than starting another backend registration.
+    Refreshing(BackendRegistration),
+}
+
+/// Handle for the refresh attempt that moved an entry into `Refreshing`.
+pub(crate) struct RegistrationRefreshClaim {
+    source_name: String,
+    fingerprint: String,
+    started_at: Instant,
 }
 
 impl std::fmt::Debug for RegistrationCache {
@@ -98,17 +119,30 @@ impl RegistrationCache {
     /// Returns the cached registration for `source_name` when its fingerprint
     /// still matches, marked fresh or stale by the entry's age.
     pub(crate) fn lookup(&self, source_name: &str, fingerprint: &str) -> Option<CacheLookup> {
-        let entries = self.entries();
-        let entry = entries.get(source_name)?;
+        let mut entries = self.entries();
+        let entry = entries.get_mut(source_name)?;
         if entry.fingerprint != fingerprint {
             return None;
         }
         let registration = entry.registration.clone();
-        Some(if entry.is_fresh(self.ttl) {
-            CacheLookup::Fresh(registration)
-        } else {
-            CacheLookup::Stale(registration)
-        })
+        if entry.is_fresh(self.ttl) {
+            return Some(CacheLookup::Fresh(registration));
+        }
+        match entry.refresh_status {
+            RefreshStatus::Idle => {
+                let started_at = Instant::now();
+                entry.refresh_status = RefreshStatus::Refreshing { started_at };
+                Some(CacheLookup::Stale {
+                    registration,
+                    claim: RegistrationRefreshClaim {
+                        source_name: source_name.to_string(),
+                        fingerprint: fingerprint.to_string(),
+                        started_at,
+                    },
+                })
+            }
+            RefreshStatus::Refreshing { .. } => Some(CacheLookup::Refreshing(registration)),
+        }
     }
 
     /// Stores `registration` for `source_name`, replacing any previous entry
@@ -119,30 +153,45 @@ impl RegistrationCache {
         fingerprint: &str,
         registration: &BackendRegistration,
     ) {
-        self.entries().insert(
+        let mut entries = self.entries();
+        entries.insert(
             source_name.to_string(),
             CachedRegistration {
                 fingerprint: fingerprint.to_string(),
                 registration: registration.clone(),
                 refreshed_at: Instant::now(),
+                refresh_status: RefreshStatus::Idle,
                 #[cfg(test)]
                 force_stale: false,
             },
         );
     }
 
-    /// Restarts the time-to-live of the entry for `source_name`.
+    /// Restarts the time-to-live after a claimed refresh fails.
     ///
     /// Used after a failed refresh so a stale entry keeps serving queries and
     /// the refresh retries once per time-to-live window instead of on every
-    /// runtime build.
-    pub(crate) fn touch(&self, source_name: &str) {
-        if let Some(entry) = self.entries().get_mut(source_name) {
-            entry.refreshed_at = Instant::now();
-            #[cfg(test)]
-            {
-                entry.force_stale = false;
-            }
+    /// runtime build. The claim check prevents an old failed refresh from
+    /// touching a newer entry that was stored while the refresh was in flight.
+    pub(crate) fn refresh_failed(&self, claim: &RegistrationRefreshClaim) {
+        let mut entries = self.entries();
+        let Some(entry) = entries.get_mut(&claim.source_name) else {
+            return;
+        };
+        if entry.fingerprint != claim.fingerprint {
+            return;
+        }
+        if !matches!(
+            entry.refresh_status,
+            RefreshStatus::Refreshing { started_at } if started_at == claim.started_at
+        ) {
+            return;
+        }
+        entry.refreshed_at = Instant::now();
+        entry.refresh_status = RefreshStatus::Idle;
+        #[cfg(test)]
+        {
+            entry.force_stale = false;
         }
     }
 
@@ -164,5 +213,46 @@ impl RegistrationCache {
         if let Some(entry) = self.entries().get_mut(source_name) {
             entry.force_stale = true;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::backends::BackendRegistration;
+    use crate::runtime::registration_cache::{CacheLookup, RegistrationCache};
+
+    fn registration() -> BackendRegistration {
+        BackendRegistration {
+            schemas: Vec::new(),
+            catalogs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn stale_lookup_claims_refresh_and_ignores_late_old_claims() {
+        let cache = RegistrationCache::with_ttl(Duration::from_hours(1));
+        let registration = registration();
+        cache.store("fake", "v1", &registration);
+        cache.force_stale("fake");
+
+        let claim = match cache.lookup("fake", "v1").expect("stale entry") {
+            CacheLookup::Stale { claim, .. } => claim,
+            _ => panic!("stale entry should be claimed by first lookup"),
+        };
+        assert!(matches!(
+            cache.lookup("fake", "v1"),
+            Some(CacheLookup::Refreshing(_))
+        ));
+
+        cache.store("fake", "v2", &registration);
+        cache.force_stale("fake");
+        cache.refresh_failed(&claim);
+
+        assert!(
+            matches!(cache.lookup("fake", "v2"), Some(CacheLookup::Stale { .. })),
+            "a failed refresh from v1 must not touch the newer v2 entry"
+        );
     }
 }

--- a/crates/coral-engine/src/runtime/registration_cache.rs
+++ b/crates/coral-engine/src/runtime/registration_cache.rs
@@ -49,6 +49,17 @@ enum RefreshStatus {
 }
 
 impl CachedRegistration {
+    fn new(fingerprint: &str, registration: &BackendRegistration) -> Self {
+        Self {
+            fingerprint: fingerprint.to_string(),
+            registration: registration.clone(),
+            refreshed_at: Instant::now(),
+            refresh_status: RefreshStatus::Idle,
+            #[cfg(test)]
+            force_stale: false,
+        }
+    }
+
     fn is_fresh(&self, ttl: Duration) -> bool {
         #[cfg(test)]
         if self.force_stale {
@@ -156,15 +167,24 @@ impl RegistrationCache {
         let mut entries = self.entries();
         entries.insert(
             source_name.to_string(),
-            CachedRegistration {
-                fingerprint: fingerprint.to_string(),
-                registration: registration.clone(),
-                refreshed_at: Instant::now(),
-                refresh_status: RefreshStatus::Idle,
-                #[cfg(test)]
-                force_stale: false,
-            },
+            CachedRegistration::new(fingerprint, registration),
         );
+    }
+
+    /// Stores a successful claimed refresh if the claim still owns the entry.
+    pub(crate) fn refresh_succeeded(
+        &self,
+        claim: &RegistrationRefreshClaim,
+        registration: &BackendRegistration,
+    ) {
+        let mut entries = self.entries();
+        let Some(entry) = entries.get_mut(&claim.source_name) else {
+            return;
+        };
+        if !entry_matches_claim(entry, claim) {
+            return;
+        }
+        *entry = CachedRegistration::new(&claim.fingerprint, registration);
     }
 
     /// Finishes a claimed refresh attempt that failed.
@@ -179,13 +199,7 @@ impl RegistrationCache {
         let Some(entry) = entries.get_mut(&claim.source_name) else {
             return;
         };
-        if entry.fingerprint != claim.fingerprint {
-            return;
-        }
-        if !matches!(
-            entry.refresh_status,
-            RefreshStatus::Refreshing { started_at } if started_at == claim.started_at
-        ) {
+        if !entry_matches_claim(entry, claim) {
             return;
         }
         if defer_retry {
@@ -221,6 +235,14 @@ impl RegistrationCache {
     }
 }
 
+fn entry_matches_claim(entry: &CachedRegistration, claim: &RegistrationRefreshClaim) -> bool {
+    entry.fingerprint == claim.fingerprint
+        && matches!(
+            entry.refresh_status,
+            RefreshStatus::Refreshing { started_at } if started_at == claim.started_at
+        )
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
@@ -237,27 +259,50 @@ mod tests {
 
     #[test]
     fn stale_lookup_claims_refresh_and_ignores_late_old_claims() {
-        let cache = RegistrationCache::with_ttl(Duration::from_hours(1));
         let registration = registration();
-        cache.store("fake", "v1", &registration);
-        cache.force_stale("fake");
 
-        let claim = match cache.lookup("fake", "v1").expect("stale entry") {
-            CacheLookup::Stale { claim, .. } => claim,
-            _ => panic!("stale entry should be claimed by first lookup"),
-        };
-        assert!(matches!(
-            cache.lookup("fake", "v1"),
-            Some(CacheLookup::Refreshing(_))
-        ));
+        {
+            let cache = RegistrationCache::with_ttl(Duration::from_hours(1));
+            cache.store("fake", "v1", &registration);
+            cache.force_stale("fake");
 
-        cache.store("fake", "v2", &registration);
-        cache.force_stale("fake");
-        cache.refresh_failed(&claim, true);
+            let claim = match cache.lookup("fake", "v1").expect("stale entry") {
+                CacheLookup::Stale { claim, .. } => claim,
+                _ => panic!("stale entry should be claimed by first lookup"),
+            };
+            assert!(matches!(
+                cache.lookup("fake", "v1"),
+                Some(CacheLookup::Refreshing(_))
+            ));
 
-        assert!(
-            matches!(cache.lookup("fake", "v2"), Some(CacheLookup::Stale { .. })),
-            "a failed refresh from v1 must not touch the newer v2 entry"
-        );
+            cache.store("fake", "v2", &registration);
+            cache.force_stale("fake");
+            cache.refresh_failed(&claim, true);
+
+            assert!(
+                matches!(cache.lookup("fake", "v2"), Some(CacheLookup::Stale { .. })),
+                "a failed refresh from v1 must not touch the newer v2 entry"
+            );
+        }
+
+        {
+            let cache = RegistrationCache::with_ttl(Duration::from_hours(1));
+            cache.store("fake", "v1", &registration);
+            cache.force_stale("fake");
+
+            let claim = match cache.lookup("fake", "v1").expect("stale entry") {
+                CacheLookup::Stale { claim, .. } => claim,
+                _ => panic!("stale entry should be claimed by first lookup"),
+            };
+
+            cache.store("fake", "v2", &registration);
+            cache.force_stale("fake");
+            cache.refresh_succeeded(&claim, &registration);
+
+            assert!(
+                matches!(cache.lookup("fake", "v2"), Some(CacheLookup::Stale { .. })),
+                "a successful refresh from v1 must not overwrite the newer v2 entry"
+            );
+        }
     }
 }

--- a/crates/coral-engine/src/runtime/registration_cache.rs
+++ b/crates/coral-engine/src/runtime/registration_cache.rs
@@ -167,13 +167,14 @@ impl RegistrationCache {
         );
     }
 
-    /// Restarts the time-to-live after a claimed refresh fails.
+    /// Finishes a claimed refresh attempt that failed.
     ///
     /// Used after a failed refresh so a stale entry keeps serving queries and
     /// the refresh retries once per time-to-live window instead of on every
-    /// runtime build. The claim check prevents an old failed refresh from
-    /// touching a newer entry that was stored while the refresh was in flight.
-    pub(crate) fn refresh_failed(&self, claim: &RegistrationRefreshClaim) {
+    /// runtime build when the caller chooses to defer retry. The claim check
+    /// prevents an old failed refresh from touching a newer entry that was
+    /// stored while the refresh was in flight.
+    pub(crate) fn refresh_failed(&self, claim: &RegistrationRefreshClaim, defer_retry: bool) {
         let mut entries = self.entries();
         let Some(entry) = entries.get_mut(&claim.source_name) else {
             return;
@@ -187,11 +188,15 @@ impl RegistrationCache {
         ) {
             return;
         }
-        entry.refreshed_at = Instant::now();
+        if defer_retry {
+            entry.refreshed_at = Instant::now();
+        }
         entry.refresh_status = RefreshStatus::Idle;
         #[cfg(test)]
         {
-            entry.force_stale = false;
+            if defer_retry {
+                entry.force_stale = false;
+            }
         }
     }
 
@@ -248,7 +253,7 @@ mod tests {
 
         cache.store("fake", "v2", &registration);
         cache.force_stale("fake");
-        cache.refresh_failed(&claim);
+        cache.refresh_failed(&claim, true);
 
         assert!(
             matches!(cache.lookup("fake", "v2"), Some(CacheLookup::Stale { .. })),

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -12,6 +12,7 @@ use crate::backends::{
     BackendSchemaRegistration, CompiledBackendSource, RegisteredSource,
 };
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
+use crate::runtime::registration_cache::{CacheLookup, RegistrationCache};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy};
 
@@ -86,12 +87,13 @@ pub(crate) async fn register_sources(
     ctx: &SessionContext,
     sources: Vec<SourceRegistrationCandidate>,
     source_decorators: &mut [Box<dyn SourceDecorator>],
+    registration_cache: Option<&RegistrationCache>,
 ) -> std::result::Result<SourceRegistrationResult, CoreError> {
     let span = info_span!(
         "coral.engine.sources.register",
         source.count = sources.len(),
     );
-    register_sources_inner(ctx, sources, source_decorators)
+    register_sources_inner(ctx, sources, source_decorators, registration_cache)
         .instrument(span)
         .await
 }
@@ -100,6 +102,7 @@ async fn register_sources_inner(
     ctx: &SessionContext,
     sources: Vec<SourceRegistrationCandidate>,
     source_decorators: &mut [Box<dyn SourceDecorator>],
+    registration_cache: Option<&RegistrationCache>,
 ) -> std::result::Result<SourceRegistrationResult, CoreError> {
     let catalog = ctx.catalog("datafusion").ok_or_else(|| {
         let plan_err = DataFusionError::Plan("catalog 'datafusion' not found".to_string());
@@ -131,6 +134,7 @@ async fn register_sources_inner(
                     &mut seen_schemas,
                     &mut seen_catalogs,
                     compiled_source.as_ref(),
+                    registration_cache,
                 )
                 .await
                 {
@@ -217,6 +221,7 @@ pub(crate) fn register_sources_blocking(
             .map(SourceRegistrationCandidate::Compiled)
             .collect(),
         source_decorators.as_mut_slice(),
+        None,
     ))
 }
 
@@ -226,12 +231,58 @@ async fn register_source(
     seen_schemas: &mut std::collections::HashSet<String>,
     seen_catalogs: &mut std::collections::HashSet<String>,
     source: &dyn CompiledBackendSource,
+    registration_cache: Option<&RegistrationCache>,
 ) -> DataFusionResult<BackendRegistration> {
     source.validate_runtime_capabilities()?;
 
-    let registration = source.register(ctx, registration_context).await?;
+    let fingerprint = source.registration_fingerprint();
+    let cached = match (registration_cache, fingerprint.as_deref()) {
+        (Some(cache), Some(fingerprint)) => cache.lookup(source.source_name(), fingerprint),
+        _ => None,
+    };
+    let stale = match cached {
+        Some(CacheLookup::Fresh(registration)) => {
+            tracing::debug!(
+                source = %source.source_name(),
+                "reusing cached source registration"
+            );
+            claim_registration_schemas(&registration, seen_schemas)?;
+            claim_registration_catalogs(&registration, seen_catalogs)?;
+            return Ok(registration);
+        }
+        Some(CacheLookup::Stale(registration)) => Some(registration),
+        None => None,
+    };
+
+    let registration = match source.register(ctx, registration_context).await {
+        Ok(registration) => registration,
+        Err(error) => {
+            // Availability over freshness: a source that registered before
+            // keeps serving its last known catalog when a refresh fails, and
+            // `touch` defers the next refresh attempt by one time-to-live so
+            // an unreachable source costs one attempt per window, not one
+            // per query.
+            let Some(registration) = stale else {
+                return Err(error);
+            };
+            tracing::warn!(
+                source = %source.source_name(),
+                detail = %error,
+                "source registration refresh failed; keeping stale cached registration"
+            );
+            if let Some(cache) = registration_cache {
+                cache.touch(source.source_name());
+            }
+            claim_registration_schemas(&registration, seen_schemas)?;
+            claim_registration_catalogs(&registration, seen_catalogs)?;
+            return Ok(registration);
+        }
+    };
     claim_registration_schemas(&registration, seen_schemas)?;
     claim_registration_catalogs(&registration, seen_catalogs)?;
+    if let (Some(cache), Some(fingerprint)) = (registration_cache, fingerprint.as_deref()) {
+        cache.store(source.source_name(), fingerprint, &registration);
+    }
 
     Ok(registration)
 }
@@ -459,11 +510,341 @@ fn source_decorator_error(name: &str, error: &crate::SourceDecoratorError) -> Co
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-    use crate::{CoreError, QuerySource, RuntimeSourcePackage};
+    use async_trait::async_trait;
+    use datafusion::error::Result as DataFusionResult;
+    use datafusion::prelude::SessionContext;
 
-    use super::{check_reserved_schema, validate_selected_source_schema_names};
+    use crate::backends::{
+        BackendRegistration, BackendRegistrationContext, BackendSchemaRegistration,
+        CompiledBackendSource, RegisteredSource,
+    };
+    use crate::runtime::registration_cache::RegistrationCache;
+    use crate::{CoreError, QuerySource, RuntimeSourcePackage, SourceDecorator};
+
+    use super::{
+        CompiledQuerySource, SourceRegistrationCandidate, check_reserved_schema, register_sources,
+        validate_selected_source_schema_names,
+    };
+
+    struct CountingSource {
+        name: String,
+        fingerprint: Option<String>,
+        registrations: Arc<AtomicUsize>,
+        fail: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl CompiledBackendSource for CountingSource {
+        fn schema_name(&self) -> &str {
+            &self.name
+        }
+
+        fn source_name(&self) -> &str {
+            &self.name
+        }
+
+        fn validate_runtime_capabilities(&self) -> DataFusionResult<()> {
+            Ok(())
+        }
+
+        fn registration_fingerprint(&self) -> Option<String> {
+            self.fingerprint.clone()
+        }
+
+        async fn register(
+            &self,
+            _ctx: &SessionContext,
+            _registration: &BackendRegistrationContext,
+        ) -> DataFusionResult<BackendRegistration> {
+            self.registrations.fetch_add(1, Ordering::SeqCst);
+            if self.fail.load(Ordering::SeqCst) {
+                return Err(datafusion::error::DataFusionError::Execution(
+                    "simulated registration failure".to_string(),
+                ));
+            }
+            Ok(BackendRegistration {
+                schemas: vec![BackendSchemaRegistration {
+                    tables: HashMap::new(),
+                    source: RegisteredSource {
+                        schema_name: self.name.clone(),
+                        tables: Vec::new(),
+                        table_functions: Vec::new(),
+                        inputs: Vec::new(),
+                    },
+                }],
+                catalogs: Vec::new(),
+            })
+        }
+    }
+
+    fn empty_query_source(name: &str) -> QuerySource {
+        QuerySource::from_runtime_components(
+            RuntimeSourcePackage {
+                source_name: name.to_string(),
+                authored_version: None,
+                description: String::new(),
+                declared_inputs: Vec::new(),
+                test_queries: Vec::new(),
+                components: Vec::new(),
+            },
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect("runtime package")
+    }
+
+    fn counting_candidate(
+        name: &str,
+        fingerprint: Option<&str>,
+        registrations: &Arc<AtomicUsize>,
+    ) -> SourceRegistrationCandidate {
+        failable_candidate(
+            name,
+            fingerprint,
+            registrations,
+            &Arc::new(AtomicBool::new(false)),
+        )
+    }
+
+    fn failable_candidate(
+        name: &str,
+        fingerprint: Option<&str>,
+        registrations: &Arc<AtomicUsize>,
+        fail: &Arc<AtomicBool>,
+    ) -> SourceRegistrationCandidate {
+        SourceRegistrationCandidate::Compiled(CompiledQuerySource {
+            source: empty_query_source(name),
+            compiled: Box::new(CountingSource {
+                name: name.to_string(),
+                fingerprint: fingerprint.map(ToString::to_string),
+                registrations: Arc::clone(registrations),
+                fail: Arc::clone(fail),
+            }),
+        })
+    }
+
+    async fn register_once(
+        candidates: Vec<SourceRegistrationCandidate>,
+        cache: Option<&RegistrationCache>,
+    ) -> super::SourceRegistrationResult {
+        let mut source_decorators: Vec<Box<dyn SourceDecorator>> = Vec::new();
+        register_sources(
+            &SessionContext::new(),
+            candidates,
+            source_decorators.as_mut_slice(),
+            cache,
+        )
+        .await
+        .expect("register sources")
+    }
+
+    #[tokio::test]
+    async fn cached_registration_skips_backend_register_when_fingerprint_matches() {
+        let registrations = Arc::new(AtomicUsize::new(0));
+        let cache = RegistrationCache::new();
+
+        for _ in 0..2 {
+            let result = register_once(
+                vec![counting_candidate("fake", Some("v1"), &registrations)],
+                Some(&cache),
+            )
+            .await;
+            assert_eq!(result.active_sources.len(), 1);
+            assert!(result.failures.is_empty());
+        }
+
+        assert_eq!(registrations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn fingerprint_change_invalidates_cached_registration() {
+        let registrations = Arc::new(AtomicUsize::new(0));
+        let cache = RegistrationCache::new();
+
+        register_once(
+            vec![counting_candidate("fake", Some("v1"), &registrations)],
+            Some(&cache),
+        )
+        .await;
+        register_once(
+            vec![counting_candidate("fake", Some("v2"), &registrations)],
+            Some(&cache),
+        )
+        .await;
+
+        assert_eq!(registrations.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn sources_without_fingerprint_register_every_time() {
+        let registrations = Arc::new(AtomicUsize::new(0));
+        let cache = RegistrationCache::new();
+
+        for _ in 0..2 {
+            register_once(
+                vec![counting_candidate("fake", None, &registrations)],
+                Some(&cache),
+            )
+            .await;
+        }
+
+        assert_eq!(registrations.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn expired_cached_registration_refreshes_via_backend() {
+        let registrations = Arc::new(AtomicUsize::new(0));
+        let cache = RegistrationCache::with_ttl(std::time::Duration::ZERO);
+
+        for _ in 0..2 {
+            let result = register_once(
+                vec![counting_candidate("fake", Some("v1"), &registrations)],
+                Some(&cache),
+            )
+            .await;
+            assert_eq!(result.active_sources.len(), 1);
+            assert!(result.failures.is_empty());
+        }
+
+        assert_eq!(registrations.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn failed_refresh_serves_stale_cached_registration() {
+        let registrations = Arc::new(AtomicUsize::new(0));
+        let fail = Arc::new(AtomicBool::new(false));
+        let cache = RegistrationCache::with_ttl(std::time::Duration::ZERO);
+
+        register_once(
+            vec![failable_candidate(
+                "fake",
+                Some("v1"),
+                &registrations,
+                &fail,
+            )],
+            Some(&cache),
+        )
+        .await;
+
+        fail.store(true, Ordering::SeqCst);
+        let result = register_once(
+            vec![failable_candidate(
+                "fake",
+                Some("v1"),
+                &registrations,
+                &fail,
+            )],
+            Some(&cache),
+        )
+        .await;
+
+        assert_eq!(result.active_sources.len(), 1);
+        assert!(result.failures.is_empty());
+        assert_eq!(registrations.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn failed_refresh_defers_next_attempt_by_one_ttl() {
+        let registrations = Arc::new(AtomicUsize::new(0));
+        let fail = Arc::new(AtomicBool::new(false));
+        let cache = RegistrationCache::with_ttl(std::time::Duration::from_hours(1));
+
+        register_once(
+            vec![failable_candidate(
+                "fake",
+                Some("v1"),
+                &registrations,
+                &fail,
+            )],
+            Some(&cache),
+        )
+        .await;
+
+        cache.force_stale("fake");
+        fail.store(true, Ordering::SeqCst);
+        register_once(
+            vec![failable_candidate(
+                "fake",
+                Some("v1"),
+                &registrations,
+                &fail,
+            )],
+            Some(&cache),
+        )
+        .await;
+        assert_eq!(registrations.load(Ordering::SeqCst), 2);
+
+        // The failed refresh restarted the entry's time-to-live, so the next
+        // build serves the cached registration without another attempt.
+        let result = register_once(
+            vec![failable_candidate(
+                "fake",
+                Some("v1"),
+                &registrations,
+                &fail,
+            )],
+            Some(&cache),
+        )
+        .await;
+        assert_eq!(result.active_sources.len(), 1);
+        assert!(result.failures.is_empty());
+        assert_eq!(registrations.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn cache_survives_builds_that_select_other_sources() {
+        let registrations = Arc::new(AtomicUsize::new(0));
+        let other_registrations = Arc::new(AtomicUsize::new(0));
+        let cache = RegistrationCache::new();
+
+        register_once(
+            vec![counting_candidate("fake", Some("v1"), &registrations)],
+            Some(&cache),
+        )
+        .await;
+        register_once(
+            vec![counting_candidate(
+                "other",
+                Some("v1"),
+                &other_registrations,
+            )],
+            Some(&cache),
+        )
+        .await;
+        register_once(
+            vec![counting_candidate("fake", Some("v1"), &registrations)],
+            Some(&cache),
+        )
+        .await;
+
+        assert_eq!(registrations.load(Ordering::SeqCst), 1);
+        assert_eq!(other_registrations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn retain_sources_evicts_uninstalled_entries() {
+        let registrations = Arc::new(AtomicUsize::new(0));
+        let cache = RegistrationCache::new();
+
+        register_once(
+            vec![counting_candidate("fake", Some("v1"), &registrations)],
+            Some(&cache),
+        )
+        .await;
+
+        cache.retain_sources(&std::collections::HashSet::from(["other"]));
+        register_once(
+            vec![counting_candidate("fake", Some("v1"), &registrations)],
+            Some(&cache),
+        )
+        .await;
+
+        assert_eq!(registrations.load(Ordering::SeqCst), 2);
+    }
 
     #[test]
     fn reserved_schema_coral_is_rejected() {

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -250,7 +250,19 @@ async fn register_source(
             claim_registration_catalogs(&registration, seen_catalogs)?;
             return Ok(registration);
         }
-        Some(CacheLookup::Stale(registration)) => Some(registration),
+        Some(CacheLookup::Refreshing(registration)) => {
+            tracing::debug!(
+                source = %source.source_name(),
+                "reusing stale cached source registration while refresh is in progress"
+            );
+            claim_registration_schemas(&registration, seen_schemas)?;
+            claim_registration_catalogs(&registration, seen_catalogs)?;
+            return Ok(registration);
+        }
+        Some(CacheLookup::Stale {
+            registration,
+            claim,
+        }) => Some((registration, claim)),
         None => None,
     };
 
@@ -258,11 +270,11 @@ async fn register_source(
         Ok(registration) => registration,
         Err(error) => {
             // Availability over freshness: a source that registered before
-            // keeps serving its last known catalog when a refresh fails, and
-            // `touch` defers the next refresh attempt by one time-to-live so
-            // an unreachable source costs one attempt per window, not one
-            // per query.
-            let Some(registration) = stale else {
+            // keeps serving its last known catalog when a claimed refresh
+            // fails. The cache claim defers the next refresh attempt by one
+            // time-to-live so an unreachable source costs one attempt per
+            // window, not one per query.
+            let Some((registration, claim)) = stale else {
                 return Err(error);
             };
             tracing::warn!(
@@ -271,7 +283,7 @@ async fn register_source(
                 "source registration refresh failed; keeping stale cached registration"
             );
             if let Some(cache) = registration_cache {
-                cache.touch(source.source_name());
+                cache.refresh_failed(&claim);
             }
             claim_registration_schemas(&registration, seen_schemas)?;
             claim_registration_catalogs(&registration, seen_catalogs)?;

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -322,8 +322,28 @@ async fn register_source(
         None => None,
     };
 
-    let registration = match source.register(ctx, registration_context).await {
-        Ok(registration) => registration,
+    match source.register(ctx, registration_context).await {
+        Ok(registration) => {
+            let refresh_claim = stale.map(|(_registration, claim)| claim);
+            if let Err(error) = claim_registration_schemas(&registration, seen_schemas)
+                .and_then(|()| claim_registration_catalogs(&registration, seen_catalogs))
+            {
+                if let (Some(cache), Some(claim)) = (registration_cache, refresh_claim.as_ref()) {
+                    cache.refresh_failed(claim, false);
+                }
+                return Err(error);
+            }
+
+            if let (Some(cache), Some(fingerprint)) = (registration_cache, fingerprint.as_deref()) {
+                if let Some(claim) = refresh_claim {
+                    cache.refresh_succeeded(&claim, &registration);
+                } else {
+                    cache.store(source.source_name(), fingerprint, &registration);
+                }
+            }
+
+            Ok(SourceRegistrationAttempt::Ready(registration))
+        }
         Err(error) => {
             // Availability over freshness: a source that registered before
             // keeps serving its last known catalog when a claimed refresh
@@ -333,20 +353,13 @@ async fn register_source(
             let Some((registration, claim)) = stale else {
                 return Err(error);
             };
-            return Ok(SourceRegistrationAttempt::StaleRefreshFailed {
+            Ok(SourceRegistrationAttempt::StaleRefreshFailed {
                 registration,
                 error,
                 claim,
-            });
+            })
         }
-    };
-    claim_registration_schemas(&registration, seen_schemas)?;
-    claim_registration_catalogs(&registration, seen_catalogs)?;
-    if let (Some(cache), Some(fingerprint)) = (registration_cache, fingerprint.as_deref()) {
-        cache.store(source.source_name(), fingerprint, &registration);
     }
-
-    Ok(SourceRegistrationAttempt::Ready(registration))
 }
 
 fn claim_registration_schemas(
@@ -891,7 +904,7 @@ mod tests {
     async fn failed_refresh_honors_abort_source_failure_policy() {
         let registrations = Arc::new(AtomicUsize::new(0));
         let fail = Arc::new(AtomicBool::new(false));
-        let cache = RegistrationCache::with_ttl(std::time::Duration::ZERO);
+        let cache = RegistrationCache::with_ttl(std::time::Duration::from_hours(1));
 
         register_once(
             vec![failable_candidate(
@@ -904,6 +917,7 @@ mod tests {
         )
         .await;
 
+        cache.force_stale("fake");
         fail.store(true, Ordering::SeqCst);
         let failures = Arc::new(AtomicUsize::new(0));
         let mut source_decorators: Vec<Box<dyn SourceDecorator>> =

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -12,7 +12,9 @@ use crate::backends::{
     BackendSchemaRegistration, CompiledBackendSource, RegisteredSource,
 };
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
-use crate::runtime::registration_cache::{CacheLookup, RegistrationCache};
+use crate::runtime::registration_cache::{
+    CacheLookup, RegistrationCache, RegistrationRefreshClaim,
+};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy};
 
@@ -128,7 +130,7 @@ async fn register_sources_inner(
                 let compiled_source = selected_source.compiled;
                 let source_name = compiled_source.source_name().to_string();
 
-                match register_source(
+                let registration = match register_source(
                     ctx,
                     &registration_context,
                     &mut seen_schemas,
@@ -138,16 +140,51 @@ async fn register_sources_inner(
                 )
                 .await
                 {
-                    Ok(registration) => {
-                        register_backend_registration(
-                            ctx,
-                            catalog.as_ref(),
+                    Ok(SourceRegistrationAttempt::Ready(registration)) => registration,
+                    Ok(SourceRegistrationAttempt::StaleRefreshFailed {
+                        registration,
+                        error,
+                        claim,
+                    }) => {
+                        let core_error = datafusion_to_core(&error, &[]);
+                        let failure_policy = handle_source_registration_failure(
                             source_decorators,
                             query_source,
-                            &source_name,
-                            registration,
-                            &mut result,
-                        )?;
+                            &core_error,
+                        );
+                        if let Some(cache) = registration_cache {
+                            cache.refresh_failed(&claim, matches!(&failure_policy, Ok(false)));
+                        }
+                        if failure_policy? {
+                            return Err(core_error);
+                        }
+                        tracing::warn!(
+                            source = %source_name,
+                            detail = %error,
+                            "source registration refresh failed; keeping stale cached registration"
+                        );
+                        if let Err(error) =
+                            claim_registration_schemas(&registration, &mut seen_schemas).and_then(
+                                |()| claim_registration_catalogs(&registration, &mut seen_catalogs),
+                            )
+                        {
+                            let core_error = datafusion_to_core(&error, &[]);
+                            if handle_source_registration_failure(
+                                source_decorators,
+                                query_source,
+                                &core_error,
+                            )? {
+                                return Err(core_error);
+                            }
+                            push_source_failure(
+                                &mut result,
+                                &source_name,
+                                compiled_source.schema_name(),
+                                core_error.to_string(),
+                            );
+                            continue;
+                        }
+                        registration
                     }
                     Err(error) => {
                         let core_error = datafusion_to_core(&error, &[]);
@@ -164,8 +201,18 @@ async fn register_sources_inner(
                             compiled_source.schema_name(),
                             core_error.to_string(),
                         );
+                        continue;
                     }
-                }
+                };
+                register_backend_registration(
+                    ctx,
+                    catalog.as_ref(),
+                    source_decorators,
+                    query_source,
+                    &source_name,
+                    registration,
+                    &mut result,
+                )?;
             }
             SourceRegistrationCandidate::CompileFailed { source, error } => {
                 if handle_source_registration_failure(source_decorators, &source, &error)? {
@@ -225,6 +272,15 @@ pub(crate) fn register_sources_blocking(
     ))
 }
 
+enum SourceRegistrationAttempt {
+    Ready(BackendRegistration),
+    StaleRefreshFailed {
+        registration: BackendRegistration,
+        error: DataFusionError,
+        claim: RegistrationRefreshClaim,
+    },
+}
+
 async fn register_source(
     ctx: &SessionContext,
     registration_context: &BackendRegistrationContext,
@@ -232,7 +288,7 @@ async fn register_source(
     seen_catalogs: &mut std::collections::HashSet<String>,
     source: &dyn CompiledBackendSource,
     registration_cache: Option<&RegistrationCache>,
-) -> DataFusionResult<BackendRegistration> {
+) -> DataFusionResult<SourceRegistrationAttempt> {
     source.validate_runtime_capabilities()?;
 
     let fingerprint = source.registration_fingerprint();
@@ -248,7 +304,7 @@ async fn register_source(
             );
             claim_registration_schemas(&registration, seen_schemas)?;
             claim_registration_catalogs(&registration, seen_catalogs)?;
-            return Ok(registration);
+            return Ok(SourceRegistrationAttempt::Ready(registration));
         }
         Some(CacheLookup::Refreshing(registration)) => {
             tracing::debug!(
@@ -257,7 +313,7 @@ async fn register_source(
             );
             claim_registration_schemas(&registration, seen_schemas)?;
             claim_registration_catalogs(&registration, seen_catalogs)?;
-            return Ok(registration);
+            return Ok(SourceRegistrationAttempt::Ready(registration));
         }
         Some(CacheLookup::Stale {
             registration,
@@ -277,17 +333,11 @@ async fn register_source(
             let Some((registration, claim)) = stale else {
                 return Err(error);
             };
-            tracing::warn!(
-                source = %source.source_name(),
-                detail = %error,
-                "source registration refresh failed; keeping stale cached registration"
-            );
-            if let Some(cache) = registration_cache {
-                cache.refresh_failed(&claim);
-            }
-            claim_registration_schemas(&registration, seen_schemas)?;
-            claim_registration_catalogs(&registration, seen_catalogs)?;
-            return Ok(registration);
+            return Ok(SourceRegistrationAttempt::StaleRefreshFailed {
+                registration,
+                error,
+                claim,
+            });
         }
     };
     claim_registration_schemas(&registration, seen_schemas)?;
@@ -296,7 +346,7 @@ async fn register_source(
         cache.store(source.source_name(), fingerprint, &registration);
     }
 
-    Ok(registration)
+    Ok(SourceRegistrationAttempt::Ready(registration))
 }
 
 fn claim_registration_schemas(
@@ -535,7 +585,10 @@ mod tests {
         CompiledBackendSource, RegisteredSource,
     };
     use crate::runtime::registration_cache::RegistrationCache;
-    use crate::{CoreError, QuerySource, RuntimeSourcePackage, SourceDecorator};
+    use crate::{
+        CoreError, QuerySource, RuntimeSourcePackage, SourceDecorator, SourceFailurePolicy,
+        SourceTables,
+    };
 
     use super::{
         CompiledQuerySource, SourceRegistrationCandidate, check_reserved_schema, register_sources,
@@ -590,6 +643,33 @@ mod tests {
                 }],
                 catalogs: Vec::new(),
             })
+        }
+    }
+
+    struct AbortOnFailureDecorator {
+        failures: Arc<AtomicUsize>,
+    }
+
+    impl SourceDecorator for AbortOnFailureDecorator {
+        fn name(&self) -> &'static str {
+            "abort_on_failure"
+        }
+
+        fn decorate_source(
+            &mut self,
+            _source: &QuerySource,
+            tables: SourceTables,
+        ) -> Result<SourceTables, crate::SourceDecoratorError> {
+            Ok(tables)
+        }
+
+        fn source_failed(
+            &mut self,
+            _source: &QuerySource,
+            _error: &CoreError,
+        ) -> Result<SourceFailurePolicy, crate::SourceDecoratorError> {
+            self.failures.fetch_add(1, Ordering::SeqCst);
+            Ok(SourceFailurePolicy::Abort)
         }
     }
 
@@ -805,6 +885,71 @@ mod tests {
         assert_eq!(result.active_sources.len(), 1);
         assert!(result.failures.is_empty());
         assert_eq!(registrations.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn failed_refresh_honors_abort_source_failure_policy() {
+        let registrations = Arc::new(AtomicUsize::new(0));
+        let fail = Arc::new(AtomicBool::new(false));
+        let cache = RegistrationCache::with_ttl(std::time::Duration::ZERO);
+
+        register_once(
+            vec![failable_candidate(
+                "fake",
+                Some("v1"),
+                &registrations,
+                &fail,
+            )],
+            Some(&cache),
+        )
+        .await;
+
+        fail.store(true, Ordering::SeqCst);
+        let failures = Arc::new(AtomicUsize::new(0));
+        let mut source_decorators: Vec<Box<dyn SourceDecorator>> =
+            vec![Box::new(AbortOnFailureDecorator {
+                failures: Arc::clone(&failures),
+            })];
+
+        let error = register_sources(
+            &SessionContext::new(),
+            vec![failable_candidate(
+                "fake",
+                Some("v1"),
+                &registrations,
+                &fail,
+            )],
+            source_decorators.as_mut_slice(),
+            Some(&cache),
+        )
+        .await
+        .expect_err("aborting source failure policy should fail runtime registration");
+
+        assert!(
+            error.to_string().contains("simulated registration failure"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(failures.load(Ordering::SeqCst), 1);
+        assert_eq!(registrations.load(Ordering::SeqCst), 2);
+
+        let result = register_once(
+            vec![failable_candidate(
+                "fake",
+                Some("v1"),
+                &registrations,
+                &fail,
+            )],
+            Some(&cache),
+        )
+        .await;
+
+        assert_eq!(result.active_sources.len(), 1);
+        assert!(result.failures.is_empty());
+        assert_eq!(
+            registrations.load(Ordering::SeqCst),
+            3,
+            "abort should clear the refresh claim without deferring the next retry"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Runtime builds happen per query, so backends whose registration performs expensive remote discovery (databases walking the remote catalog) repeated that work on every statement. A process-lifetime RegistrationCache now lives in the app layer, scoped per workspace, and replays registration artifacts when a backend-reported fingerprint (manifest + resolved inputs) matches.

Entries expire after a TTL (5 minutes) so remote DDL surfaces without a restart; a failed refresh serves the stale registration and defers the next attempt by one TTL window so an unreachable database costs one connect attempt per window. Eviction follows the workspace's installed source set, never a per-build selection, so single-source validation cannot evict other sources' entries.

Database and composite sources opt in via registration_fingerprint; HTTP and MCP registration is pure in-memory construction and stays uncached.