### PR TITLE
refactor(engine): centralize HTTP pagination handling

### DIFF
--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -9,8 +9,8 @@ use crate::backends::http::ProviderQueryError;
 use crate::backends::http::client::HttpSourceClient;
 use crate::backends::http::error::{pagination_error, provider_error};
 use crate::backends::http::pagination::{
-    PageState, apply_pagination_body_fields, apply_pagination_query_pairs, page_is_exhausted,
-    pagination_state_values, resolve_page_size,
+    PageAdvance, PageAdvanceContext, advance_pagination_state, apply_pagination_body_fields,
+    apply_pagination_query_pairs, initial_page_state, pagination_state_values, resolve_page_size,
 };
 use crate::backends::http::request::{build_query_pairs, build_request_body};
 use crate::backends::http::target::HttpFetchTarget;
@@ -19,7 +19,7 @@ use crate::backends::http::url::{join_url, normalize_base_url};
 use crate::backends::shared::json_path::get_path_value;
 use crate::backends::shared::response_rows::extract_rows;
 use crate::backends::shared::template::{RenderContext, render_template};
-use coral_spec::ValidatedPaginationMode;
+use coral_spec::{HttpMethod, ValidatedPaginationMode};
 
 const DEFAULT_MAX_PAGES: usize = 10_000;
 
@@ -67,17 +67,10 @@ pub(super) async fn fetch_rows(
 
     let active_request = target.resolved_request();
 
-    let mut state = PageState {
-        page: target.pagination().page_start,
-        offset: match &pagination.mode {
-            ValidatedPaginationMode::Offset(offset) => offset.start,
-            _ => target.pagination().offset_start,
-        },
-        ..PageState::default()
-    };
+    let mut state = initial_page_state(&pagination);
 
     let mut page_count = 0usize;
-    let max_pages = target.pagination().max_pages.unwrap_or(DEFAULT_MAX_PAGES);
+    let max_pages = pagination.max_pages.unwrap_or(DEFAULT_MAX_PAGES);
 
     loop {
         page_count += 1;
@@ -121,7 +114,7 @@ pub(super) async fn fetch_rows(
             (Vec::new(), None)
         } else {
             let mut query_pairs = build_query_pairs(active_request, &render_context)?;
-            apply_pagination_query_pairs(&mut query_pairs, target, &pagination, &state, page_size)
+            apply_pagination_query_pairs(&mut query_pairs, &pagination, &state, page_size)
                 .map_err(|error| {
                     pagination_error(
                         &client.source_schema,
@@ -136,7 +129,6 @@ pub(super) async fn fetch_rows(
             apply_pagination_body_fields(
                 &mut body,
                 &active_request.body,
-                target,
                 &pagination,
                 &state,
                 page_size,
@@ -173,16 +165,14 @@ pub(super) async fn fetch_rows(
                 body_capture: client.body_capture,
                 render_context,
                 allow_404_empty: target.response().allow_404_empty,
-                link_header_require_results: pagination.link_header_require_results,
-                response_cursor_header: target.pagination().response_cursor_header.as_deref(),
-                next_url_header: target.pagination().next_url_header.as_deref(),
             },
         )
         .await?;
 
-        let Some((payload, pagination_hints)) = request else {
+        let Some(response) = request else {
             break;
         };
+        let payload = response.payload;
 
         if !target.response().ok_path.is_empty() {
             let ok = get_path_value(&payload, &target.response().ok_path)
@@ -229,54 +219,41 @@ pub(super) async fn fetch_rows(
             break;
         }
 
-        match &pagination.mode {
-            ValidatedPaginationMode::None => break,
-            ValidatedPaginationMode::CursorQuery | ValidatedPaginationMode::CursorBody => {
-                let next_cursor = pagination_hints.cursor.or_else(|| {
-                    get_path_value(&payload, &target.pagination().response_cursor_path)
-                        .and_then(Value::as_str)
-                        .map(str::trim)
-                        .filter(|s| !s.is_empty())
-                        .map(ToOwned::to_owned)
-                });
-                match next_cursor {
-                    Some(cursor) => state.cursor = Some(cursor),
-                    None => break,
-                }
-            }
-            ValidatedPaginationMode::Page => {
-                if page_is_exhausted(rows_on_page, page_size) {
-                    break;
-                }
-                state.page = state.page.saturating_add(target.pagination().page_step);
-            }
-            ValidatedPaginationMode::Offset(offset) => {
-                if page_is_exhausted(rows_on_page, page_size) {
-                    break;
-                }
-                let step = offset
-                    .resolve_step(page_size, &client.source_schema, target.name())
-                    .map_err(|error| {
-                        provider_error(ProviderQueryError::Pagination {
-                            source_schema: client.source_schema.clone(),
-                            table: target.name().to_string(),
-                            method: None,
-                            url: None,
-                            detail: error.to_string(),
-                        })
-                    })?;
-                state.offset = state.offset.saturating_add(step);
-            }
-            ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto => {
-                match pagination_hints.next_url {
-                    Some(next) => state.next_url = Some(next),
-                    None => break,
-                }
-            }
+        let page_advance = advance_pagination_state(
+            &mut state,
+            &pagination,
+            PageAdvanceContext {
+                payload: &payload,
+                response_headers: &response.headers,
+                request_url: &url,
+                rows_on_page,
+                page_size,
+                source_schema: &client.source_schema,
+                table_name: target.name(),
+            },
+        )
+        .map_err(|error| {
+            pagination_error(
+                &client.source_schema,
+                target.name(),
+                Some(http_method_label(active_request.method)),
+                Some(&url),
+                &error,
+            )
+        })?;
+        if page_advance == PageAdvance::Stop {
+            break;
         }
     }
 
     Ok(all_rows)
+}
+
+fn http_method_label(method: HttpMethod) -> &'static str {
+    match method {
+        HttpMethod::GET => "GET",
+        HttpMethod::POST => "POST",
+    }
 }
 
 fn resolve_fetch_limits(

--- a/crates/coral-engine/src/backends/http/pagination.rs
+++ b/crates/coral-engine/src/backends/http/pagination.rs
@@ -7,7 +7,7 @@ use reqwest::header::{HeaderMap, HeaderName};
 use serde_json::{Map, Value, json};
 
 use crate::backends::http::request::{RequestBody, set_path_value};
-use crate::backends::http::target::HttpFetchTarget;
+use crate::backends::shared::json_path::get_path_value;
 use coral_spec::{BodySpec, PageSizeSpec, ValidatedPagination, ValidatedPaginationMode};
 
 #[derive(Debug, Clone, Default)]
@@ -24,9 +24,36 @@ pub(super) struct ResponsePaginationHints {
     pub(super) cursor: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PageAdvance {
+    Continue,
+    Stop,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct PageAdvanceContext<'a> {
+    pub(super) payload: &'a Value,
+    pub(super) response_headers: &'a HeaderMap,
+    pub(super) request_url: &'a str,
+    pub(super) rows_on_page: usize,
+    pub(super) page_size: Option<usize>,
+    pub(super) source_schema: &'a str,
+    pub(super) table_name: &'a str,
+}
+
+pub(super) fn initial_page_state(pagination: &ValidatedPagination) -> PageState {
+    PageState {
+        page: pagination.page_start,
+        offset: match &pagination.mode {
+            ValidatedPaginationMode::Offset(offset) => offset.start,
+            _ => 0,
+        },
+        ..PageState::default()
+    }
+}
+
 pub(super) fn apply_pagination_query_pairs(
     params: &mut Vec<(String, String)>,
-    target: &HttpFetchTarget,
     pagination: &ValidatedPagination,
     state: &PageState,
     page_size: Option<usize>,
@@ -42,13 +69,13 @@ pub(super) fn apply_pagination_query_pairs(
         | ValidatedPaginationMode::Auto
         | ValidatedPaginationMode::CursorBody => {}
         ValidatedPaginationMode::LinkHeader => {
-            if let Some(name) = &target.pagination().page_param {
+            if let Some(name) = &pagination.page_param {
                 params.push((name.clone(), state.page.to_string()));
             }
         }
         ValidatedPaginationMode::CursorQuery => {
             if let Some(cursor) = &state.cursor {
-                let name = target.pagination().cursor_param.clone().ok_or_else(|| {
+                let name = pagination.cursor_param.clone().ok_or_else(|| {
                     DataFusionError::Execution(
                         "cursor_query pagination requires cursor_param".to_string(),
                     )
@@ -57,7 +84,7 @@ pub(super) fn apply_pagination_query_pairs(
             }
         }
         ValidatedPaginationMode::Page => {
-            let name = target.pagination().page_param.clone().ok_or_else(|| {
+            let name = pagination.page_param.clone().ok_or_else(|| {
                 DataFusionError::Execution("page pagination requires page_param".to_string())
             })?;
             params.push((name, state.page.to_string()));
@@ -73,7 +100,6 @@ pub(super) fn apply_pagination_query_pairs(
 pub(super) fn apply_pagination_body_fields(
     body: &mut Option<RequestBody>,
     body_spec: &BodySpec,
-    target: &HttpFetchTarget,
     pagination: &ValidatedPagination,
     state: &PageState,
     page_size: Option<usize>,
@@ -82,7 +108,7 @@ pub(super) fn apply_pagination_body_fields(
         .zip(pagination.page_size.as_ref())
         .is_some_and(|(_, spec)| !spec.body_path.is_empty());
     let needs_cursor_body = matches!(pagination.mode, ValidatedPaginationMode::CursorBody)
-        && !target.pagination().cursor_body_path.is_empty()
+        && !pagination.cursor_body_path.is_empty()
         && state.cursor.is_some();
 
     if !needs_page_size_body && !needs_cursor_body {
@@ -112,12 +138,12 @@ pub(super) fn apply_pagination_body_fields(
     if matches!(pagination.mode, ValidatedPaginationMode::CursorBody)
         && let Some(cursor) = &state.cursor
     {
-        if target.pagination().cursor_body_path.is_empty() {
+        if pagination.cursor_body_path.is_empty() {
             return Err(DataFusionError::Execution(
                 "cursor_body pagination requires cursor_body_path".to_string(),
             ));
         }
-        set_path_value(root, &target.pagination().cursor_body_path, json!(cursor))?;
+        set_path_value(root, &pagination.cursor_body_path, json!(cursor))?;
     }
 
     Ok(())
@@ -144,6 +170,100 @@ pub(super) fn pagination_state_values(state: &PageState) -> HashMap<String, Stri
         values.insert("cursor".to_string(), cursor.clone());
     }
     values
+}
+
+pub(super) fn advance_pagination_state(
+    state: &mut PageState,
+    pagination: &ValidatedPagination,
+    context: PageAdvanceContext<'_>,
+) -> Result<PageAdvance> {
+    match &pagination.mode {
+        ValidatedPaginationMode::None => Ok(PageAdvance::Stop),
+        ValidatedPaginationMode::CursorQuery | ValidatedPaginationMode::CursorBody => {
+            let hints = extract_response_pagination_hints(
+                context.response_headers,
+                context.request_url,
+                pagination,
+            )?;
+            let next_cursor = hints.cursor.or_else(|| {
+                get_path_value(context.payload, &pagination.response_cursor_path)
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(ToOwned::to_owned)
+            });
+            match next_cursor {
+                Some(cursor) => {
+                    state.cursor = Some(cursor);
+                    Ok(PageAdvance::Continue)
+                }
+                None => Ok(PageAdvance::Stop),
+            }
+        }
+        ValidatedPaginationMode::Page => {
+            if page_is_exhausted(context.rows_on_page, context.page_size) {
+                return Ok(PageAdvance::Stop);
+            }
+            state.page = state.page.saturating_add(pagination.page_step);
+            Ok(PageAdvance::Continue)
+        }
+        ValidatedPaginationMode::Offset(offset) => {
+            if page_is_exhausted(context.rows_on_page, context.page_size) {
+                return Ok(PageAdvance::Stop);
+            }
+            let step = offset
+                .resolve_step(context.page_size, context.source_schema, context.table_name)
+                .map_err(|error| DataFusionError::Execution(error.to_string()))?;
+            state.offset = state.offset.saturating_add(step);
+            Ok(PageAdvance::Continue)
+        }
+        ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto => {
+            let hints = extract_response_pagination_hints(
+                context.response_headers,
+                context.request_url,
+                pagination,
+            )?;
+            match hints.next_url {
+                Some(next) => {
+                    state.next_url = Some(next);
+                    Ok(PageAdvance::Continue)
+                }
+                None => Ok(PageAdvance::Stop),
+            }
+        }
+    }
+}
+
+pub(super) fn extract_response_pagination_hints(
+    headers: &HeaderMap,
+    request_url: &str,
+    pagination: &ValidatedPagination,
+) -> Result<ResponsePaginationHints> {
+    let next_url = match pagination.mode {
+        ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto => {
+            let link_next_url = extract_next_link_url(
+                headers,
+                request_url,
+                pagination.link_header_require_results,
+            )?;
+            let header_next_url = extract_next_url_header(
+                headers,
+                request_url,
+                pagination.next_url_header.as_deref(),
+            )?;
+            link_next_url.or(header_next_url)
+        }
+        _ => None,
+    };
+
+    let cursor = match pagination.mode {
+        ValidatedPaginationMode::CursorQuery | ValidatedPaginationMode::CursorBody => {
+            extract_response_cursor_header(headers, pagination.response_cursor_header.as_deref())?
+        }
+        _ => None,
+    };
+
+    Ok(ResponsePaginationHints { next_url, cursor })
 }
 
 pub(super) fn extract_next_link_url(
@@ -278,11 +398,11 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        PageState, apply_pagination_body_fields, apply_pagination_query_pairs,
-        extract_next_link_url, extract_next_url_header, extract_response_cursor_header,
-        page_is_exhausted,
+        PageAdvance, PageAdvanceContext, PageState, advance_pagination_state,
+        apply_pagination_body_fields, apply_pagination_query_pairs, extract_next_link_url,
+        extract_next_url_header, extract_response_cursor_header, page_is_exhausted,
     };
-    use crate::backends::http::test_support::{test_http_request_target, test_http_table_spec};
+    use crate::backends::http::test_support::test_http_table_spec;
     use coral_spec::{
         BodySpec, HttpMethod, PaginationMode, PaginationSpec, ParsedTemplate, RequestSpec,
         ValidatedPaginationMode, ValueSourceSpec,
@@ -468,17 +588,43 @@ mod tests {
     }
 
     #[test]
-    fn apply_pagination_query_pairs_uses_typed_offset_param() {
-        let table = test_http_table_spec(
-            &json!([]),
-            &RequestSpec {
-                method: HttpMethod::GET,
-                path: ParsedTemplate::parse("/items").expect("template"),
-                query: vec![],
-                body: BodySpec::default(),
-                headers: vec![],
-            },
+    fn advance_cursor_pagination_ignores_unrelated_link_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "link",
+            HeaderValue::from_static("<https://attacker.example/steal>; rel=\"next\""),
         );
+        let pagination = PaginationSpec {
+            mode: PaginationMode::CursorQuery,
+            cursor_param: Some("cursor".to_string()),
+            response_cursor_path: vec!["meta".to_string(), "next_cursor".to_string()],
+            ..PaginationSpec::default()
+        }
+        .validated("demo", "items")
+        .unwrap();
+        let mut state = PageState::default();
+
+        let advance = advance_pagination_state(
+            &mut state,
+            &pagination,
+            PageAdvanceContext {
+                payload: &json!({"meta": {"next_cursor": "cursor-2"}}),
+                response_headers: &headers,
+                request_url: "https://api.example.com/items",
+                rows_on_page: 1,
+                page_size: None,
+                source_schema: "demo",
+                table_name: "items",
+            },
+        )
+        .unwrap();
+
+        assert_eq!(advance, PageAdvance::Continue);
+        assert_eq!(state.cursor.as_deref(), Some("cursor-2"));
+    }
+
+    #[test]
+    fn apply_pagination_query_pairs_uses_typed_offset_param() {
         let pagination = PaginationSpec {
             mode: PaginationMode::Offset,
             page_size: Some(coral_spec::PageSizeSpec {
@@ -500,8 +646,7 @@ mod tests {
             ..PageState::default()
         };
 
-        let target = test_http_request_target(&table);
-        apply_pagination_query_pairs(&mut params, &target, &pagination, &state, Some(25)).unwrap();
+        apply_pagination_query_pairs(&mut params, &pagination, &state, Some(25)).unwrap();
 
         assert_eq!(
             params,
@@ -547,8 +692,7 @@ mod tests {
             ..PageState::default()
         };
 
-        let target = test_http_request_target(&table);
-        apply_pagination_query_pairs(&mut params, &target, &pagination, &state, Some(25)).unwrap();
+        apply_pagination_query_pairs(&mut params, &pagination, &state, Some(25)).unwrap();
 
         assert_eq!(
             params,
@@ -565,16 +709,6 @@ mod tests {
 
     #[test]
     fn apply_pagination_body_fields_rejects_declared_text_body_even_when_absent() {
-        let table = test_http_table_spec(
-            &json!([]),
-            &RequestSpec {
-                method: HttpMethod::GET,
-                path: ParsedTemplate::parse("/items").expect("template"),
-                query: vec![],
-                body: BodySpec::default(),
-                headers: vec![],
-            },
-        );
         let body_spec = BodySpec::Text {
             content: ValueSourceSpec::Filter {
                 key: "sql".to_string(),
@@ -593,12 +727,9 @@ mod tests {
         .validated("demo", "items")
         .unwrap();
         let mut body = None;
-        let target = test_http_request_target(&table);
-
         let error = apply_pagination_body_fields(
             &mut body,
             &body_spec,
-            &target,
             &pagination,
             &PageState::default(),
             Some(25),

--- a/crates/coral-engine/src/backends/http/test_support.rs
+++ b/crates/coral-engine/src/backends/http/test_support.rs
@@ -5,7 +5,6 @@
 use serde::Serialize;
 use serde_json::{Value, json};
 
-use crate::backends::http::target::HttpFetchTarget;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 use coral_spec::{BodySpec, RequestSpec, ValueSourceSpec, parse_source_manifest_value};
 
@@ -38,10 +37,6 @@ pub(super) fn test_http_table_spec(
     .into_iter()
     .next()
     .expect("table should exist")
-}
-
-pub(super) fn test_http_request_target(table: &HttpTableSpec) -> HttpFetchTarget {
-    HttpFetchTarget::from_resolved_table_request(table, table.request.clone())
 }
 
 fn request_json(request: &RequestSpec) -> serde_json::Value {

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -16,11 +16,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 use crate::RequestAuthenticator;
 use crate::backends::http::ProviderQueryError;
 use crate::backends::http::auth::resolve_auth_headers;
-use crate::backends::http::error::{pagination_error, provider_error};
-use crate::backends::http::pagination::{
-    ResponsePaginationHints, extract_next_link_url, extract_next_url_header,
-    extract_response_cursor_header,
-};
+use crate::backends::http::error::provider_error;
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::backends::http::request::RequestBody;
 use crate::backends::http::response::{ResponseDecodeContext, decode_response_body};
@@ -52,9 +48,12 @@ pub(super) struct OutgoingHttpRequest<'a> {
     pub(super) body_capture: HttpBodyCapture,
     pub(super) render_context: RenderContext<'a>,
     pub(super) allow_404_empty: bool,
-    pub(super) link_header_require_results: bool,
-    pub(super) response_cursor_header: Option<&'a str>,
-    pub(super) next_url_header: Option<&'a str>,
+}
+
+#[derive(Debug)]
+pub(super) struct DecodedHttpResponse {
+    pub(super) payload: Value,
+    pub(super) headers: HeaderMap,
 }
 
 #[expect(
@@ -65,9 +64,9 @@ pub(super) async fn execute_request(
     http: &reqwest::Client,
     request_timeout: Duration,
     request: OutgoingHttpRequest<'_>,
-) -> Result<Option<(Value, ResponsePaginationHints)>> {
+) -> Result<Option<DecodedHttpResponse>> {
     enum ResponseOutcome {
-        Done(Result<Option<(Value, ResponsePaginationHints)>>),
+        Done(Result<Option<DecodedHttpResponse>>),
         Retry(Duration),
     }
 
@@ -88,9 +87,6 @@ pub(super) async fn execute_request(
         body_capture,
         render_context,
         allow_404_empty,
-        link_header_require_results,
-        response_cursor_header,
-        next_url_header,
     } = request;
     let mut server_error_retries = 0usize;
     let mut throttle_retries = 0usize;
@@ -305,53 +301,7 @@ pub(super) async fn execute_request(
                 ))));
             }
 
-            let next_url =
-                extract_next_link_url(response.headers(), url, link_header_require_results)
-                    .map_err(|error| {
-                        record_http_processing_error(&request_span, "PAGINATION", &error);
-                        pagination_error(
-                            source_schema,
-                            table_name,
-                            Some(method_label),
-                            Some(&logged_url),
-                            &error,
-                        )
-                    });
-            let next_url = match next_url {
-                Ok(next_url) => next_url,
-                Err(error) => break 'response ResponseOutcome::Done(Err(error)),
-            };
-            let header_next_url = extract_next_url_header(response.headers(), url, next_url_header)
-                .map_err(|error| {
-                    record_http_processing_error(&request_span, "PAGINATION", &error);
-                    pagination_error(
-                        source_schema,
-                        table_name,
-                        Some(method_label),
-                        Some(&logged_url),
-                        &error,
-                    )
-                });
-            let next_url = match header_next_url {
-                Ok(header_next_url) => next_url.or(header_next_url),
-                Err(error) => break 'response ResponseOutcome::Done(Err(error)),
-            };
-            let cursor = extract_response_cursor_header(response.headers(), response_cursor_header)
-                .map_err(|error| {
-                    record_http_processing_error(&request_span, "PAGINATION", &error);
-                    pagination_error(
-                        source_schema,
-                        table_name,
-                        Some(method_label),
-                        Some(&logged_url),
-                        &error,
-                    )
-                });
-            let cursor = match cursor {
-                Ok(cursor) => cursor,
-                Err(error) => break 'response ResponseOutcome::Done(Err(error)),
-            };
-            let pagination = ResponsePaginationHints { next_url, cursor };
+            let response_headers = response.headers().clone();
 
             match decode_response_body(
                 response,
@@ -369,7 +319,10 @@ pub(super) async fn execute_request(
             .instrument(request_span.clone())
             .await
             {
-                Ok(payload) => ResponseOutcome::Done(Ok(Some((payload, pagination)))),
+                Ok(payload) => ResponseOutcome::Done(Ok(Some(DecodedHttpResponse {
+                    payload,
+                    headers: response_headers,
+                }))),
                 Err(mut error) => {
                     // `Decode { retryable }` marks a transient (truncated/EOF) body. Only
                     // idempotent GET requests may be retried or surfaced as retryable.
@@ -547,9 +500,6 @@ mod tests {
                 body_capture: HttpBodyCapture::default(),
                 render_context,
                 allow_404_empty: false,
-                link_header_require_results: false,
-                response_cursor_header: None,
-                next_url_header: None,
             },
         )
         .await

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -737,7 +737,16 @@ impl Default for PaginationSpec {
 pub struct ValidatedPagination {
     pub mode: ValidatedPaginationMode,
     pub page_size: Option<PageSizeSpec>,
+    pub cursor_param: Option<String>,
+    pub cursor_body_path: Vec<String>,
+    pub response_cursor_path: Vec<String>,
+    pub response_cursor_header: Option<String>,
+    pub page_param: Option<String>,
+    pub page_start: i64,
+    pub page_step: i64,
     pub link_header_require_results: bool,
+    pub next_url_header: Option<String>,
+    pub max_pages: Option<usize>,
 }
 
 /// The validated pagination mode selected for one HTTP table.
@@ -774,11 +783,25 @@ impl PaginationSpec {
 
     pub fn validated(&self, schema: &str, table: &str) -> Result<ValidatedPagination> {
         let page_size = self.validated_page_size(schema, table)?;
+        if matches!(self.max_pages, Some(0)) {
+            return Err(ManifestError::validation(format!(
+                "{schema}.{table} pagination.max_pages must be > 0"
+            )));
+        }
         let mode = self.validated_mode(schema, table, page_size.is_some())?;
         Ok(ValidatedPagination {
             mode,
             page_size,
+            cursor_param: self.cursor_param.clone(),
+            cursor_body_path: self.cursor_body_path.clone(),
+            response_cursor_path: self.response_cursor_path.clone(),
+            response_cursor_header: self.response_cursor_header.clone(),
+            page_param: self.page_param.clone(),
+            page_start: self.page_start,
+            page_step: self.page_step,
             link_header_require_results: self.link_header_require_results,
+            next_url_header: self.next_url_header.clone(),
+            max_pages: self.max_pages,
         })
     }
 
@@ -795,6 +818,15 @@ impl PaginationSpec {
         {
             return Err(ManifestError::validation(format!(
                 "{schema}.{table} pagination.response_cursor_header must not be empty"
+            )));
+        }
+        if self
+            .next_url_header
+            .as_deref()
+            .is_some_and(|header| header.trim().is_empty())
+        {
+            return Err(ManifestError::validation(format!(
+                "{schema}.{table} pagination.next_url_header must not be empty"
             )));
         }
 
@@ -1426,6 +1458,20 @@ mod tests {
     }
 
     #[test]
+    fn pagination_max_pages_zero_is_rejected() {
+        let pagination = PaginationSpec {
+            max_pages: Some(0),
+            ..PaginationSpec::default()
+        };
+
+        let err = pagination.validated("demo", "items").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("demo.items pagination.max_pages must be > 0")
+        );
+    }
+
+    #[test]
     fn cursor_query_pagination_rejects_empty_response_cursor_header() {
         let pagination = PaginationSpec {
             mode: PaginationMode::CursorQuery,
@@ -1456,6 +1502,21 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("demo.items pagination.response_cursor_header must not be empty")
+        );
+    }
+
+    #[test]
+    fn link_pagination_rejects_blank_next_url_header() {
+        let pagination = PaginationSpec {
+            mode: PaginationMode::LinkHeader,
+            next_url_header: Some("   ".to_string()),
+            ..PaginationSpec::default()
+        };
+
+        let err = pagination.validated("demo", "items").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("demo.items pagination.next_url_header must not be empty")
         );
     }
 


### PR DESCRIPTION
## Summary

- Remove pagination-specific response extraction from the HTTP transport layer.
- Return decoded HTTP payloads with response headers from transport, then let the pagination module extract Link, cursor-header, next-url-header, and body cursor signals.
- Expand `ValidatedPagination` so fetch/pagination code consumes a validated pagination plan instead of mixing validated mode state with raw target pagination fields.

## Why

Pagination response semantics had leaked into `transport.rs` through `link_header_require_results`, `response_cursor_header`, and `next_url_header`. That made the transport API grow with pagination modes and forced unrelated requests to parse pagination headers too early.

## Impact

Transport is now responsible only for executing and decoding HTTP responses. Pagination owns request mutation, response extraction, state advancement, and stop conditions. This also keeps future response-driven modes, such as an `X-Next-Page` style header, out of `OutgoingHttpRequest`.

## Validation

- `cargo test -p coral-engine backends::http::pagination --lib`
- `cargo test -p coral-spec pagination --lib`
- `cargo test -p coral-engine --test engine pagination_`
- `make rust-checks`