### PR TITLE
perf(spec): reuse v4 projection type index per surface

### DIFF
--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -23,6 +23,8 @@ use super::names::{
 };
 use super::pagination::pagination_query_param_names;
 
+type TypeIndex<'a> = HashMap<&'a str, &'a IrType>;
+
 pub fn generate_projection_catalog(
     manifest: &V4SourceManifest,
     surfaces: &[SemanticIr],
@@ -39,8 +41,10 @@ pub fn generate_projection_catalog(
                     ir.surface_id, manifest.common.name
                 ))
             })?;
+        let type_by_id = type_index(ir);
         for operation in &ir.operations {
-            let projection = generate_projection(ir, namespace, operation, &mut diagnostics);
+            let projection =
+                generate_projection(ir, namespace, &type_by_id, operation, &mut diagnostics);
             projections.push(projection);
         }
         diagnostics.extend(ir.diagnostics.clone());
@@ -62,6 +66,7 @@ pub fn generate_projection_catalog(
 fn generate_projection(
     ir: &SemanticIr,
     namespace: &str,
+    type_by_id: &TypeIndex<'_>,
     operation: &IrOperation,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Projection {
@@ -120,7 +125,7 @@ fn generate_projection(
             }
         })
         .collect::<Vec<_>>();
-    let columns = projection_columns(ir, operation);
+    let columns = projection_columns(type_by_id, operation);
     let name = generated_projection_name(operation, is_search);
     let guide = projection_guide(&kind, &inputs, is_search);
     let projection = Projection {
@@ -292,7 +297,14 @@ fn projection_input_name(
     name
 }
 
-fn projection_columns(ir: &SemanticIr, operation: &IrOperation) -> Vec<ProjectionColumn> {
+fn type_index(ir: &SemanticIr) -> TypeIndex<'_> {
+    ir.types.iter().map(|ty| (ty.id.as_str(), ty)).collect()
+}
+
+fn projection_columns(
+    type_by_id: &TypeIndex<'_>,
+    operation: &IrOperation,
+) -> Vec<ProjectionColumn> {
     if matches!(&operation.execution, IrExecutionAttachment::Mcp(_)) {
         // MCP output schemas drive row cardinality and response extraction, but
         // SQL columns stay opaque until Coral has stable per-tool payload
@@ -314,11 +326,6 @@ fn projection_columns(ir: &SemanticIr, operation: &IrOperation) -> Vec<Projectio
             },
         ];
     }
-    let type_by_id = ir
-        .types
-        .iter()
-        .map(|ty| (ty.id.as_str(), ty))
-        .collect::<HashMap<_, _>>();
     let Some(row_type) = type_by_id.get(operation.output.type_ref.as_str()) else {
         return vec![ProjectionColumn {
             name: "value".to_string(),


### PR DESCRIPTION
## Summary

This changes DSL v4 projection generation to build the `IrType` lookup index once per semantic surface instead of rebuilding it for every operation.

Previously, `projection_columns` rebuilt a `HashMap` over all imported IR types for each operation. On large OpenAPI surfaces this is extremely expensive. The new path builds the type index once in `generate_projection_catalog` and passes it through projection derivation.

## Why

While stress-testing the Microsoft Graph v1.0 OpenAPI spec:

https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/openapi/v1.0/openapi.yaml

the importer produced:

- descriptor size: `37,961,469` bytes
- operations: `16,643`
- IR types: `115,989`

The old projection path rebuilt a ~116k-entry type map for each of the 16.6k operations.

## Perf

Measured with a local full Microsoft Graph OpenAPI stress import.

Before:

```text
projection catalog surface=rest generated 1000/16643 in 47.12s
```

After:

```text
projection catalog type index built surface=rest types=115989 elapsed=44.49ms
projection catalog surface=rest generated 1000/16643 in 57.66ms
projection catalog surface=rest generated 16000/16643 in 300.78ms
projection catalog operation pass done in 309.98ms: projections=16643 diagnostics=18783
projection collision resolution done in 124.90ms: diagnostics=18783
projection generation done in 434.90ms: projections=16643 diagnostics=18783
```

The directly comparable 1,000-operation checkpoint improved from `47.12s` to `57.66ms`, about `817x` faster.

Extrapolating the old rate across the full `16,643`\-operation surface gives a ~13 minute operation pass. After this change, the full operation pass completes in `309.98ms`, and full projection generation including collision resolution completes in `434.90ms`. That is roughly a `1,800-2,500x` improvement for the full projection phase, depending on whether collision resolution is included in the new denominator.

Full materialization completed in `50.24s` in the stress run. The remaining time is now dominated by descriptor fetch/import/normalization and artifact writes, not projection derivation.

## Notes

The full Microsoft Graph stress run required temporarily raising the local descriptor-size cap from 16 MiB to 64 MiB. This PR does not change that cap.

Generated full-Graph artifacts are still large, so this optimization makes large OpenAPI surfaces feasible from a projection-generation perspective, but does not by itself decide the product shape for Microsoft Graph.

## Validation

```bash
cargo build -p coral-cli
```