### PR TITLE
fix(app): allow larger DSL v4 source registration payloads

### DIFF
--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -55,6 +55,12 @@ pub const QUERY_RESPONSE_MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
 /// responses larger than tonic's 4 MB default.
 pub const CATALOG_RESPONSE_MAX_MESSAGE_SIZE: usize = QUERY_RESPONSE_MAX_MESSAGE_SIZE;
 
+/// Maximum gRPC message size for `SourceService` *responses*, in bytes.
+///
+/// Source validation returns source metadata plus all exposed tables. Generated
+/// DSL v4 sources from large OpenAPI documents can exceed tonic's 4 MB default.
+pub const SOURCE_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE_SIZE;
+
 /// Maximum gRPC message size for `SearchService` *responses*, in bytes.
 ///
 /// Universal Search returns bounded metadata hints, but it may include table,

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -58,7 +58,7 @@ pub const CATALOG_RESPONSE_MAX_MESSAGE_SIZE: usize = QUERY_RESPONSE_MAX_MESSAGE_
 /// Maximum gRPC message size for `SourceService` *responses*, in bytes.
 ///
 /// Source validation returns source metadata plus all exposed tables. Generated
-/// DSL v4 sources from large OpenAPI documents can exceed tonic's 4 MB default.
+/// DSL v4 sources from large `OpenAPI` documents can exceed tonic's 4 MB default.
 pub const SOURCE_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE_SIZE;
 
 /// Maximum gRPC message size for `SearchService` *responses*, in bytes.

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -24,7 +24,8 @@ use coral_api::v1::trace_service_server::TraceServiceServer;
 use coral_api::v1::workspace_service_server::WorkspaceServiceServer;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
-    SEARCH_RESPONSE_MAX_MESSAGE_SIZE, TRACE_RESPONSE_MAX_MESSAGE_SIZE,
+    SEARCH_RESPONSE_MAX_MESSAGE_SIZE, SOURCE_RESPONSE_MAX_MESSAGE_SIZE,
+    TRACE_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -449,9 +450,10 @@ async fn start_server(
     let feedback_service = FeedbackService::new(feedback);
     let episode_service = EpisodeService::new(episode_store);
     let mut routes = Routes::default()
-        .add_service(GrpcMethodAnnotatedService::new(SourceServiceServer::new(
-            source_service,
-        )))
+        .add_service(GrpcMethodAnnotatedService::new(
+            SourceServiceServer::new(source_service)
+                .max_encoding_message_size(SOURCE_RESPONSE_MAX_MESSAGE_SIZE),
+        ))
         .add_service(GrpcMethodAnnotatedService::new(
             WorkspaceServiceServer::new(workspace_service),
         ))

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -32,7 +32,7 @@ use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
 
 const DESCRIPTOR_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
-const MAX_DESCRIPTOR_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_DESCRIPTOR_BYTES: u64 = 64 * 1024 * 1024;
 const DESCRIPTOR_USER_AGENT: &str = "coral-dsl-v4-materializer";
 pub(crate) const PROJECTIONS_FILENAME: &str = "projections.yaml";
 pub(crate) const FINGERPRINT_FILENAME: &str = "fingerprint.yaml";

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -10,7 +10,7 @@ use coral_api::v1::source_service_client::SourceServiceClient;
 use coral_api::v1::workspace_service_client::WorkspaceServiceClient;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
-    SEARCH_RESPONSE_MAX_MESSAGE_SIZE,
+    SEARCH_RESPONSE_MAX_MESSAGE_SIZE, SOURCE_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint};
@@ -88,7 +88,8 @@ impl AppClient {
             .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE);
         let grpc_endpoint = GrpcClientEndpoint::from_endpoint_uri(endpoint_uri);
         let channel = endpoint.connect().await?;
-        let source_client = SourceClient::new(grpc_service(channel.clone(), &grpc_endpoint));
+        let source_client = SourceClient::new(grpc_service(channel.clone(), &grpc_endpoint))
+            .max_decoding_message_size(SOURCE_RESPONSE_MAX_MESSAGE_SIZE);
         let workspace_client = WorkspaceClient::new(grpc_service(channel.clone(), &grpc_endpoint));
         let catalog_client = CatalogClient::new(grpc_service(channel.clone(), &grpc_endpoint))
             .max_decoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE);


### PR DESCRIPTION
## Summary

Raise generic size limits hit by large DSL v4 source descriptors and source validation responses.

- increase the remote descriptor fetch cap from 16 MiB to 64 MiB
- add a `SourceService` response size budget matching the existing large catalog/query response budget
- configure source-service server encoding and client decoding to use that larger budget

## Why

Large OpenAPI-backed DSL v4 sources can fail before they are usable for two separate size reasons:

1. the remote OpenAPI descriptor can exceed the current 16 MiB fetch cap
2. source validation/registration can return source metadata and generated table catalogs larger than tonic's default 4 MiB response limit

These limits are not provider-specific. Microsoft Graph is one reproducer, but broad enterprise APIs can hit the same path.

## Validation

- `cargo build -p coral-cli`