### PR TITLE
feat(xtask): add v3 manifest to OpenAPI converter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install ui-build rust-checks perf-check license-check lint-proto lint-sources fix-sources docs-generate docs-check schema-generate schema-check
+.PHONY: install ui-build rust-checks perf-check license-check lint-proto lint-sources fix-sources docs-generate docs-check schema-generate schema-check openapi-export
 
 install: ui-build
 	cargo install --path crates/coral-cli --locked
@@ -94,3 +94,13 @@ schema-generate:
 
 schema-check:
 	cargo run --locked -p xtask -- generate-schemas --check
+
+# ----------------------------------------------------------------------------
+# OpenAPI export (DSL v4 migration)
+# ----------------------------------------------------------------------------
+# Converts v3 HTTP source manifests into OpenAPI 3.0 documents.
+#
+#   make openapi-export    # write target/openapi/<source>.openapi.yaml
+
+openapi-export:
+	cargo run --locked -p xtask -- export-openapi

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,6 +3,9 @@ allow-expect-in-tests = true
 allow-panic-in-tests = true
 allow-dbg-in-tests = true
 
+# Extends (does not replace) clippy's default doc-ident list.
+doc-valid-idents = ["OpenAPI", ".."]
+
 disallowed-methods = [
   { path = "std::env::var", reason = "Read process environment only through crate-owned env modules." },
   { path = "std::env::var_os", reason = "Read process environment only through crate-owned env modules." },

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,6 @@
 //! Developer tooling for Coral repository automation.
 //!
-//! This binary exposes two subcommands that share workspace conventions but
+//! This binary exposes subcommands that share workspace conventions but
 //! serve different workflows:
 //!   - `generate-docs` regenerates the generator-owned Mintlify pages and
 //!     nav from source manifests plus `CHANGELOG.md`.
@@ -8,6 +8,8 @@
 //!     (the regression gate for the SOURCE-465 manifest cleanup).
 //!   - `export-skills` exports installable agent skills from the canonical
 //!     plugin tree into a distribution checkout.
+//!   - `export-openapi` converts v3 HTTP source manifests into OpenAPI
+//!     documents for the DSL v4 migration.
 //!   - `perf-check` runs command-level performance regression checks.
 //!   - `generate-schemas` refreshes checked-in generated JSON schemas.
 //!   - `release-macos-sign-notarize` signs and notarizes macOS release
@@ -28,6 +30,7 @@ use clap::{Parser, Subcommand};
 mod detect;
 mod docs;
 mod env;
+mod openapi;
 mod perf;
 mod release;
 mod schemas;
@@ -52,6 +55,8 @@ enum Command {
     DetectTruncations(DetectArgs),
     /// Export installable skills from plugins/coral/skills.
     ExportSkills(ExportSkillsArgs),
+    /// Convert v3 HTTP source manifests to OpenAPI 3.0 documents.
+    ExportOpenapi(openapi::Args),
     /// Run command-level performance regression checks.
     PerfCheck(perf::Args),
     /// Regenerate checked-in generated JSON schemas.
@@ -104,6 +109,7 @@ fn run(command: &Command) -> Result<bool> {
             detect::run(&paths, args.verbose)
         }
         Command::ExportSkills(args) => skills::export(&args.dest),
+        Command::ExportOpenapi(args) => openapi::run(args),
         Command::PerfCheck(args) => perf::run(args),
         Command::GenerateSchemas(args) => schemas::run(args),
         Command::ReleaseMacosSignNotarize(args) => release::macos_sign_notarize(args),

--- a/xtask/src/openapi/convert.rs
+++ b/xtask/src/openapi/convert.rs
@@ -1,0 +1,1441 @@
+//! Conversion from a validated v3 HTTP source manifest to OpenAPI 3.0.
+//!
+//! [`convert_http_manifest`] turns one manifest into a self-contained
+//! OpenAPI 3.0.3 document: every table, request route, and table function
+//! becomes one operation, filters and function arguments become typed
+//! parameters, declared pagination becomes the request parameters and
+//! response fields the API actually exposes, and declared columns are
+//! folded back into response schemas (see `schema_tree`).
+//!
+//! The emitted document is aimed at the DSL v4 OpenAPI importer: pagination
+//! knowledge is encoded as ordinary OpenAPI facts (parameters, response
+//! headers, cursor properties) that the importer's detection already
+//! understands. Anything the OpenAPI vocabulary cannot express — SQL filter
+//! bindings, runtime-computed values, row strategies — is preserved under
+//! `x-coral*` extensions instead of being dropped, and every lossy or
+//! ambiguous mapping is reported as a warning.
+
+use std::collections::{HashMap, HashSet};
+
+use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec, RateLimitSpec};
+use coral_spec::{
+    AuthSpec, BodySpec, ColumnSpec, DetailHintSpec, FilterMode, FilterSpec, HttpMethod,
+    ManifestDataType, PaginationMode, PaginationSpec, RequestSpec, ResponseBodyFormat,
+    ResponseSpec, RowStrategy, SearchLimitsSpec, SourceTableFunctionKind, SourceTableFunctionSpec,
+    TableFunctionArgSpec, TemplateNamespace, TemplatePart, TemplateToken, ValueSourceSpec,
+};
+use serde_json::{Map, Value, json};
+
+use super::schema_tree::{SchemaTree, row_schema_tree, scalar_schema};
+
+/// One converted manifest: the OpenAPI document plus human-readable
+/// warnings for every construct that could not be mapped faithfully.
+pub(crate) struct ConvertedDocument {
+    pub(crate) document: Value,
+    pub(crate) warnings: Vec<String>,
+}
+
+/// Convert one validated v3 HTTP source manifest into an OpenAPI 3.0.3
+/// document. Infallible by design: unmappable constructs degrade to
+/// warnings plus `x-coral*` extensions rather than errors.
+pub(crate) fn convert_http_manifest(manifest: &HttpSourceManifest) -> ConvertedDocument {
+    Converter {
+        manifest,
+        warnings: Vec::new(),
+    }
+    .convert()
+}
+
+/// Returns true when every request in the manifest targets a GraphQL
+/// endpoint (`/graphql`, `/api/graphql`, `/graphql.json`, ...). OpenAPI
+/// keys operations by path and method, so a GraphQL source would collapse
+/// into a single meaningless operation; callers should skip these instead
+/// of converting them.
+pub(crate) fn is_graphql_source(manifest: &HttpSourceManifest) -> bool {
+    let mut paths = manifest
+        .tables
+        .iter()
+        .flat_map(|table| {
+            std::iter::once(&table.request)
+                .chain(table.requests.iter().map(|route| &route.request))
+        })
+        .chain(manifest.functions.iter().map(|function| &function.request))
+        .map(|request| request.path.raw())
+        .filter(|path| !path.is_empty())
+        .peekable();
+    paths.peek().is_some() && paths.all(|path| path.to_ascii_lowercase().contains("graphql"))
+}
+
+struct Converter<'a> {
+    manifest: &'a HttpSourceManifest,
+    warnings: Vec<String>,
+}
+
+/// One table or function viewed uniformly by the operation builder.
+struct Surface<'a> {
+    kind: &'static str,
+    name: &'a str,
+    description: &'a str,
+    guide: &'a str,
+    filters: &'a [FilterSpec],
+    args: &'a [TableFunctionArgSpec],
+    response: &'a ResponseSpec,
+    pagination: &'a PaginationSpec,
+    columns: &'a [ColumnSpec],
+    function_kind: Option<SourceTableFunctionKind>,
+    search_limits: Option<&'a SearchLimitsSpec>,
+    detail_hints: &'a [DetailHintSpec],
+    fetch_limit_default: Option<usize>,
+}
+
+impl<'a> Surface<'a> {
+    fn from_table(table: &'a HttpTableSpec) -> Self {
+        Self {
+            kind: "table",
+            name: &table.common.name,
+            description: &table.common.description,
+            guide: &table.common.guide,
+            filters: &table.common.filters,
+            args: &[],
+            response: &table.response,
+            pagination: &table.pagination,
+            columns: &table.common.columns,
+            function_kind: None,
+            search_limits: table.common.search_limits.as_ref(),
+            detail_hints: &table.common.detail_hints,
+            fetch_limit_default: table.common.fetch_limit_default,
+        }
+    }
+
+    fn from_function(function: &'a SourceTableFunctionSpec) -> Self {
+        Self {
+            kind: "function",
+            name: &function.name,
+            description: &function.description,
+            guide: "",
+            filters: &[],
+            args: &function.args,
+            response: &function.response,
+            pagination: &function.pagination,
+            columns: &function.columns,
+            function_kind: Some(function.kind),
+            search_limits: function.search_limits.as_ref(),
+            detail_hints: &function.detail_hints,
+            fetch_limit_default: function.fetch_limit_default,
+        }
+    }
+
+    fn label(&self) -> String {
+        format!("{} '{}'", self.kind, self.name)
+    }
+
+    fn filter(&self, key: &str) -> Option<&'a FilterSpec> {
+        self.filters.iter().find(|filter| filter.name == key)
+    }
+
+    /// Resolve a request-side arg key (`from: arg, key: X`) to the declared
+    /// SQL-facing argument bound to it.
+    fn arg(&self, key: &str) -> Option<&'a TableFunctionArgSpec> {
+        self.args.iter().find(|arg| arg.bind.arg == key)
+    }
+}
+
+/// A parameter or body-field description derived from one v3 value source.
+struct ValueSourceDoc {
+    schema: Value,
+    required: bool,
+    description: String,
+    extensions: Vec<(&'static str, Value)>,
+}
+
+/// Everything the declared pagination contributes to one operation.
+#[derive(Default)]
+struct PaginationArtifacts {
+    parameters: Vec<Value>,
+    response_headers: Vec<(String, Value)>,
+    response_cursor_path: Vec<String>,
+    body_properties: Vec<(Vec<String>, Value)>,
+}
+
+/// Document-level accumulators threaded through operation building.
+#[derive(Default)]
+struct DocumentParts {
+    paths: Map<String, Value>,
+    /// Which operation claimed each `(path, method)` slot, for collision
+    /// warnings.
+    slot_owners: HashMap<(String, &'static str), String>,
+    schemas: Map<String, Value>,
+    operation_ids: HashSet<String>,
+}
+
+impl Converter<'_> {
+    fn convert(mut self) -> ConvertedDocument {
+        let mut parts = DocumentParts::default();
+
+        for table in &self.manifest.tables {
+            let surface = Surface::from_table(table);
+            let row_ref = register_row_schema(&surface, &mut parts.schemas);
+            self.add_operation(
+                &mut parts,
+                &surface,
+                surface.name,
+                &table.request,
+                &[],
+                row_ref.as_ref(),
+            );
+            for route in &table.requests {
+                let operation_id = format!("{}_by_{}", surface.name, route.when_filters.join("_"));
+                self.add_operation(
+                    &mut parts,
+                    &surface,
+                    &operation_id,
+                    &route.request,
+                    &route.when_filters,
+                    row_ref.as_ref(),
+                );
+            }
+        }
+        for function in &self.manifest.functions {
+            let surface = Surface::from_function(function);
+            let row_ref = register_row_schema(&surface, &mut parts.schemas);
+            self.add_operation(
+                &mut parts,
+                &surface,
+                surface.name,
+                &function.request,
+                &[],
+                row_ref.as_ref(),
+            );
+        }
+
+        let servers = self.servers_value();
+        let (security_schemes, security) = self.security_values();
+
+        let mut document = Map::new();
+        document.insert("openapi".to_string(), json!("3.0.3"));
+        document.insert(
+            "info".to_string(),
+            json!({
+                "title": self.manifest.common.name,
+                "version": self.manifest.common.version,
+                "description": self.manifest.common.description,
+            }),
+        );
+        document.insert("servers".to_string(), servers);
+        if !security.is_empty() {
+            document.insert("security".to_string(), Value::Array(security));
+        }
+        document.insert("paths".to_string(), Value::Object(parts.paths));
+        let mut components = Map::new();
+        if !parts.schemas.is_empty() {
+            components.insert("schemas".to_string(), Value::Object(parts.schemas));
+        }
+        if !security_schemes.is_empty() {
+            components.insert(
+                "securitySchemes".to_string(),
+                Value::Object(security_schemes),
+            );
+        }
+        if !components.is_empty() {
+            document.insert("components".to_string(), Value::Object(components));
+        }
+        document.insert("x-coral".to_string(), self.document_extension());
+
+        ConvertedDocument {
+            document: Value::Object(document),
+            warnings: self.warnings,
+        }
+    }
+
+    fn warn(&mut self, surface: &Surface<'_>, message: &str) {
+        self.warnings
+            .push(format!("{}: {message}", surface.label()));
+    }
+
+    // ------------------------------------------------------------------
+    // Operations
+    // ------------------------------------------------------------------
+
+    fn add_operation(
+        &mut self,
+        parts: &mut DocumentParts,
+        surface: &Surface<'_>,
+        operation_id: &str,
+        request: &RequestSpec,
+        when_filters: &[String],
+        row_ref: Option<&Value>,
+    ) {
+        let method = method_key(request.method);
+        let (path, mut parameters, mut seen) = self.convert_path(surface, request);
+
+        let slot = (path.clone(), method);
+        if let Some(owner) = parts.slot_owners.get(&slot) {
+            self.warn(
+                surface,
+                &format!(
+                    "operation '{operation_id}' ({} {path}) skipped: slot already \
+                     claimed by operation '{owner}'",
+                    method.to_uppercase()
+                ),
+            );
+            return;
+        }
+
+        for query in &request.query {
+            self.push_parameter(
+                &mut parameters,
+                &mut seen,
+                surface,
+                &query.name,
+                "query",
+                &query.value,
+                when_filters,
+            );
+        }
+        for header in &request.headers {
+            self.push_parameter(
+                &mut parameters,
+                &mut seen,
+                surface,
+                &header.name,
+                "header",
+                &header.value,
+                when_filters,
+            );
+        }
+
+        let artifacts = self.pagination_artifacts(surface, &seen);
+        parameters.extend(artifacts.parameters.iter().cloned());
+
+        let request_body = self.request_body_value(surface, request, when_filters, &artifacts);
+        if request_body.is_some() && request.method == HttpMethod::GET {
+            self.warn(
+                surface,
+                &format!(
+                    "operation '{operation_id}' sends a request body with GET; \
+                     OpenAPI consumers may ignore it"
+                ),
+            );
+        }
+        let responses = self.responses_value(surface, row_ref, &artifacts);
+
+        let mut unique_id = operation_id.to_string();
+        let mut suffix = 2;
+        while !parts.operation_ids.insert(unique_id.clone()) {
+            unique_id = format!("{operation_id}_{suffix}");
+            suffix += 1;
+        }
+        if unique_id != operation_id {
+            self.warn(
+                surface,
+                &format!("operation id '{operation_id}' already taken; renamed to '{unique_id}'"),
+            );
+        }
+
+        let mut operation = Map::new();
+        operation.insert("operationId".to_string(), json!(unique_id));
+        let description = if surface.guide.is_empty() {
+            surface.description.to_string()
+        } else {
+            format!("{}\n\n{}", surface.description, surface.guide)
+        };
+        if !description.is_empty() {
+            operation.insert("description".to_string(), json!(description));
+        }
+        if !parameters.is_empty() {
+            operation.insert("parameters".to_string(), Value::Array(parameters));
+        }
+        if let Some(body) = request_body {
+            operation.insert("requestBody".to_string(), body);
+        }
+        operation.insert("responses".to_string(), responses);
+        operation.insert(
+            "x-coral".to_string(),
+            operation_extension(surface, when_filters),
+        );
+
+        parts.slot_owners.insert(slot, unique_id);
+        let path_item = parts
+            .paths
+            .entry(path)
+            .or_insert_with(|| Value::Object(Map::new()));
+        if let Some(path_item) = path_item.as_object_mut() {
+            path_item.insert(method.to_string(), Value::Object(operation));
+        }
+    }
+
+    /// Convert the v3 path template into an OpenAPI path string plus the
+    /// path parameters implied by its tokens. Returns the parameter list and
+    /// the `(location, name)` pairs already used, so later query/header
+    /// parameters can be deduplicated against it.
+    fn convert_path(
+        &mut self,
+        surface: &Surface<'_>,
+        request: &RequestSpec,
+    ) -> (String, Vec<Value>, HashSet<(String, String)>) {
+        let mut path = String::new();
+        let mut parameters = Vec::new();
+        let mut seen = HashSet::new();
+        for part in request.path.parts() {
+            match part {
+                TemplatePart::Literal(literal) => path.push_str(literal),
+                TemplatePart::Token(token) => {
+                    let name = sanitize_token(token.key());
+                    path.push('{');
+                    path.push_str(&name);
+                    path.push('}');
+                    if !seen.insert(("path".to_string(), name.clone())) {
+                        continue;
+                    }
+                    let doc = self.path_token_doc(surface, token);
+                    parameters.push(parameter_value(&name, "path", true, doc));
+                }
+            }
+        }
+        (path, parameters, seen)
+    }
+
+    fn path_token_doc(&mut self, surface: &Surface<'_>, token: &TemplateToken) -> ValueSourceDoc {
+        let default = token.default_value().map(|value| json!(value));
+        match token.namespace() {
+            TemplateNamespace::Filter => self.filter_doc(FilterDocRequest {
+                surface,
+                key: token.key(),
+                when_filters: &[],
+                schema_override: None,
+                default,
+                note: None,
+            }),
+            TemplateNamespace::Arg => self.arg_doc(surface, token.key(), None, default, None),
+            TemplateNamespace::Input => self.input_doc(token.key()),
+            TemplateNamespace::State => state_doc(token.key()),
+            TemplateNamespace::Expr | TemplateNamespace::Other(_) => {
+                self.warn(
+                    surface,
+                    &format!(
+                        "path template token '{{{{{}}}}}' has an unsupported namespace; \
+                         emitted as an untyped path parameter",
+                        token.raw()
+                    ),
+                );
+                ValueSourceDoc {
+                    schema: json!({"type": "string"}),
+                    required: true,
+                    description: format!("Rendered from the v3 template token `{}`.", token.raw()),
+                    extensions: Vec::new(),
+                }
+            }
+        }
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "One call site per parameter location; grouping would only rename the arguments."
+    )]
+    fn push_parameter(
+        &mut self,
+        parameters: &mut Vec<Value>,
+        seen: &mut HashSet<(String, String)>,
+        surface: &Surface<'_>,
+        wire_name: &str,
+        location: &str,
+        source: &ValueSourceSpec,
+        when_filters: &[String],
+    ) {
+        if !seen.insert((location.to_string(), wire_name.to_string())) {
+            self.warn(
+                surface,
+                &format!("duplicate {location} parameter '{wire_name}' dropped"),
+            );
+            return;
+        }
+        let doc = self.value_source_doc(surface, source, when_filters);
+        let required = doc.required;
+        parameters.push(parameter_value(wire_name, location, required, doc));
+    }
+
+    // ------------------------------------------------------------------
+    // Value sources
+    // ------------------------------------------------------------------
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "One exhaustive match mapping every value-source variant; splitting it \
+                  would smear the variant table across helpers."
+    )]
+    fn value_source_doc(
+        &mut self,
+        surface: &Surface<'_>,
+        source: &ValueSourceSpec,
+        when_filters: &[String],
+    ) -> ValueSourceDoc {
+        match source {
+            ValueSourceSpec::Filter { key, default } => self.filter_doc(FilterDocRequest {
+                surface,
+                key,
+                when_filters,
+                schema_override: None,
+                default: default.clone(),
+                note: None,
+            }),
+            ValueSourceSpec::FilterInt { key, default } => self.filter_doc(FilterDocRequest {
+                surface,
+                key,
+                when_filters,
+                schema_override: Some(json!({"type": "integer"})),
+                default: default.map(|value| json!(value)),
+                note: None,
+            }),
+            ValueSourceSpec::FilterBool { key, default } => self.filter_doc(FilterDocRequest {
+                surface,
+                key,
+                when_filters,
+                schema_override: Some(json!({"type": "boolean"})),
+                default: default.map(|value| json!(value)),
+                note: None,
+            }),
+            ValueSourceSpec::FilterStringArray { key, default } => {
+                self.filter_doc(FilterDocRequest {
+                    surface,
+                    key,
+                    when_filters,
+                    schema_override: Some(json!({"type": "array", "items": {"type": "string"}})),
+                    default: default.clone().map(|values| json!(values)),
+                    note: None,
+                })
+            }
+            ValueSourceSpec::FilterSplit {
+                key,
+                separator,
+                part,
+            } => self.filter_doc(FilterDocRequest {
+                surface,
+                key,
+                when_filters,
+                schema_override: Some(json!({"type": "string"})),
+                default: None,
+                note: Some(split_note(key, separator, *part)),
+            }),
+            ValueSourceSpec::FilterSplitInt {
+                key,
+                separator,
+                part,
+            } => self.filter_doc(FilterDocRequest {
+                surface,
+                key,
+                when_filters,
+                schema_override: Some(json!({"type": "integer"})),
+                default: None,
+                note: Some(split_note(key, separator, *part)),
+            }),
+            ValueSourceSpec::Arg { key, default } => {
+                self.arg_doc(surface, key, None, default.clone(), None)
+            }
+            ValueSourceSpec::ArgInt { key, default } => self.arg_doc(
+                surface,
+                key,
+                Some(json!({"type": "integer"})),
+                default.map(|value| json!(value)),
+                None,
+            ),
+            ValueSourceSpec::ArgBool { key, default } => self.arg_doc(
+                surface,
+                key,
+                Some(json!({"type": "boolean"})),
+                default.map(|value| json!(value)),
+                None,
+            ),
+            ValueSourceSpec::ArgSplit {
+                key,
+                separator,
+                part,
+            } => self.arg_doc(
+                surface,
+                key,
+                Some(json!({"type": "string"})),
+                None,
+                Some(split_note(key, separator, *part)),
+            ),
+            ValueSourceSpec::ArgSplitInt {
+                key,
+                separator,
+                part,
+            } => self.arg_doc(
+                surface,
+                key,
+                Some(json!({"type": "integer"})),
+                None,
+                Some(split_note(key, separator, *part)),
+            ),
+            ValueSourceSpec::Literal { value } => ValueSourceDoc {
+                schema: literal_schema(value),
+                required: false,
+                description: "Fixed value always sent with the request.".to_string(),
+                extensions: vec![("x-coral-constant", json!(true))],
+            },
+            ValueSourceSpec::Template { template } => ValueSourceDoc {
+                schema: json!({"type": "string"}),
+                required: false,
+                description: format!("Rendered from the v3 template `{}`.", template.raw()),
+                extensions: vec![("x-coral-template", json!(template.raw()))],
+            },
+            ValueSourceSpec::OneOf { .. } => ValueSourceDoc {
+                schema: json!({}),
+                required: false,
+                description: "Resolved from the first available of several value sources."
+                    .to_string(),
+                extensions: vec![(
+                    "x-coral-value-source",
+                    serde_json::to_value(source).unwrap_or(Value::Null),
+                )],
+            },
+            ValueSourceSpec::Input { key } | ValueSourceSpec::Bearer { key } => self.input_doc(key),
+            ValueSourceSpec::State { key } => state_doc(key),
+            ValueSourceSpec::NowEpochMinusSeconds { seconds } => ValueSourceDoc {
+                schema: json!({"type": "integer"}),
+                required: false,
+                description: format!(
+                    "Computed at request time as the Unix epoch timestamp {seconds} \
+                     seconds before now."
+                ),
+                extensions: vec![("x-coral-computed", json!("now_epoch_minus_seconds"))],
+            },
+        }
+    }
+
+    fn filter_doc(&mut self, request: FilterDocRequest<'_, '_>) -> ValueSourceDoc {
+        let FilterDocRequest {
+            surface,
+            key,
+            when_filters,
+            schema_override,
+            default,
+            note,
+        } = request;
+        let spec = surface.filter(key);
+        if spec.is_none() {
+            self.warn(
+                surface,
+                &format!("request binds undeclared filter '{key}'; emitted as a string parameter"),
+            );
+        }
+        let mut schema = schema_override.unwrap_or_else(|| {
+            scalar_schema(spec.map_or(ManifestDataType::Utf8, |spec| spec.data_type))
+        });
+        if let (Some(default), Some(object)) = (default, schema.as_object_mut()) {
+            object.insert("default".to_string(), default);
+        }
+        let mut description = spec.map_or(String::new(), |spec| spec.description.clone());
+        match spec.map(|spec| spec.mode) {
+            Some(FilterMode::Contains) => {
+                append_sentence(&mut description, "Matched as a substring.");
+            }
+            Some(FilterMode::Search) => {
+                append_sentence(&mut description, "Free-text search query.");
+            }
+            Some(FilterMode::Equality) | None => {}
+        }
+        if let Some(note) = note {
+            append_sentence(&mut description, &note);
+        }
+        ValueSourceDoc {
+            schema,
+            required: spec.is_some_and(|spec| spec.required)
+                || when_filters.iter().any(|filter| filter == key),
+            description,
+            extensions: vec![("x-coral-filter", json!(key))],
+        }
+    }
+
+    fn arg_doc(
+        &mut self,
+        surface: &Surface<'_>,
+        key: &str,
+        schema_override: Option<Value>,
+        default: Option<Value>,
+        note: Option<String>,
+    ) -> ValueSourceDoc {
+        let spec = surface.arg(key);
+        if spec.is_none() {
+            self.warn(
+                surface,
+                &format!(
+                    "request binds undeclared argument '{key}'; emitted as a string parameter"
+                ),
+            );
+        }
+        let mut schema = schema_override.unwrap_or_else(|| {
+            scalar_schema(spec.map_or(ManifestDataType::Utf8, |spec| spec.data_type))
+        });
+        if let Some(object) = schema.as_object_mut() {
+            if let Some(values) = spec
+                .map(|spec| &spec.values)
+                .filter(|values| !values.is_empty())
+            {
+                object.insert("enum".to_string(), json!(values));
+            }
+            if let Some(default) = default {
+                object.insert("default".to_string(), default);
+            }
+        }
+        let mut description = String::new();
+        if let Some(note) = note {
+            append_sentence(&mut description, &note);
+        }
+        ValueSourceDoc {
+            schema,
+            required: spec.is_some_and(|spec| spec.required),
+            description,
+            extensions: vec![(
+                "x-coral-arg",
+                json!(spec.map_or(key, |spec| spec.name.as_str())),
+            )],
+        }
+    }
+
+    fn input_doc(&mut self, key: &str) -> ValueSourceDoc {
+        let mut schema = json!({"type": "string"});
+        if let (Some(default), Some(object)) = (self.input_default(key), schema.as_object_mut()) {
+            object.insert("default".to_string(), json!(default));
+        }
+        ValueSourceDoc {
+            schema,
+            required: false,
+            description: format!("Resolved from the source input '{key}'."),
+            extensions: vec![("x-coral-input", json!(key))],
+        }
+    }
+
+    fn input_default(&self, key: &str) -> Option<String> {
+        self.manifest
+            .declared_inputs
+            .iter()
+            .find(|input| input.key == key)
+            .map(|input| input.default_value.clone())
+            .filter(|default| !default.is_empty())
+    }
+
+    // ------------------------------------------------------------------
+    // Pagination
+    // ------------------------------------------------------------------
+
+    /// Turn the declared pagination into the request parameters, response
+    /// headers, cursor properties, and body fields the API actually
+    /// exposes, so downstream OpenAPI consumers (including the v4 importer)
+    /// can rediscover the pagination without Coral-specific knowledge.
+    fn pagination_artifacts(
+        &mut self,
+        surface: &Surface<'_>,
+        seen: &HashSet<(String, String)>,
+    ) -> PaginationArtifacts {
+        let pagination = surface.pagination;
+        let mut artifacts = PaginationArtifacts {
+            response_cursor_path: pagination.response_cursor_path.clone(),
+            ..PaginationArtifacts::default()
+        };
+        let mut add_query = |name: &str, schema: Value, description: &str| {
+            if seen.contains(&("query".to_string(), name.to_string())) {
+                return;
+            }
+            artifacts.parameters.push(json!({
+                "name": name,
+                "in": "query",
+                "required": false,
+                "description": description,
+                "schema": schema,
+                "x-coral-pagination": true,
+            }));
+        };
+
+        if let Some(page_size) = &pagination.page_size {
+            let schema = json!({
+                "type": "integer",
+                "default": page_size.default,
+                "maximum": page_size.max,
+            });
+            if let Some(query_param) = &page_size.query_param {
+                add_query(query_param, schema, "Number of results per page.");
+            } else if !page_size.body_path.is_empty() {
+                artifacts.body_properties.push((
+                    page_size.body_path.clone(),
+                    pagination_body_schema(schema, "Number of results per page."),
+                ));
+            }
+        }
+        // Every declared request-side knob becomes a parameter regardless of
+        // the mode: v3 mixes them freely (for example GitHub declares a page
+        // parameter alongside link_header pagination). The mode itself only
+        // shapes the response side and is preserved in `x-coral`.
+        if let Some(page_param) = &pagination.page_param {
+            add_query(
+                page_param,
+                json!({"type": "integer", "default": pagination.page_start}),
+                "Page number.",
+            );
+        }
+        if let Some(offset_param) = &pagination.offset_param {
+            add_query(
+                offset_param,
+                json!({"type": "integer", "default": pagination.offset_start}),
+                "Offset of the first result.",
+            );
+        }
+        if let Some(cursor_param) = &pagination.cursor_param {
+            add_query(
+                cursor_param,
+                json!({"type": "string"}),
+                "Opaque cursor for the next page; omit on the first request.",
+            );
+        }
+        if !pagination.cursor_body_path.is_empty() {
+            artifacts.body_properties.push((
+                pagination.cursor_body_path.clone(),
+                pagination_body_schema(
+                    json!({"type": "string"}),
+                    "Opaque cursor for the next page; omit on the first request.",
+                ),
+            ));
+        }
+        artifacts.response_headers = pagination_response_headers(pagination);
+        if surface.response.row_strategy != RowStrategy::Direct
+            && !artifacts.response_cursor_path.is_empty()
+        {
+            self.warn(
+                surface,
+                "response cursor path on a non-direct row strategy is not represented \
+                 in the response schema",
+            );
+            artifacts.response_cursor_path.clear();
+        }
+        artifacts
+    }
+
+    // ------------------------------------------------------------------
+    // Request bodies
+    // ------------------------------------------------------------------
+
+    fn request_body_value(
+        &mut self,
+        surface: &Surface<'_>,
+        request: &RequestSpec,
+        when_filters: &[String],
+        artifacts: &PaginationArtifacts,
+    ) -> Option<Value> {
+        match &request.body {
+            BodySpec::Json { fields } => {
+                if fields.is_empty() && artifacts.body_properties.is_empty() {
+                    return None;
+                }
+                let mut tree = SchemaTree::new();
+                for field in fields {
+                    let doc = self.value_source_doc(surface, &field.value, when_filters);
+                    let mut description = doc.description.clone();
+                    if let Some(when_arg) = &field.when_arg {
+                        append_sentence(
+                            &mut description,
+                            &format!("Only sent when the '{when_arg}' argument is provided."),
+                        );
+                    }
+                    tree.insert(
+                        &field.path,
+                        SchemaTree::leaf(body_field_schema(doc, &description)),
+                    );
+                }
+                for (path, schema) in &artifacts.body_properties {
+                    tree.insert(path, SchemaTree::leaf(schema.clone()));
+                }
+                Some(json!({
+                    "required": true,
+                    "content": {"application/json": {"schema": tree.into_schema()}},
+                }))
+            }
+            BodySpec::Text { content } => {
+                if !artifacts.body_properties.is_empty() {
+                    self.warn(
+                        surface,
+                        "pagination body fields cannot be represented in a text request body",
+                    );
+                }
+                let doc = self.value_source_doc(surface, content, when_filters);
+                let description = doc.description.clone();
+                let schema = body_field_schema(doc, &description);
+                Some(json!({
+                    "required": true,
+                    "content": {"text/plain": {"schema": schema}},
+                }))
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Responses
+    // ------------------------------------------------------------------
+
+    fn responses_value(
+        &mut self,
+        surface: &Surface<'_>,
+        row_ref: Option<&Value>,
+        artifacts: &PaginationArtifacts,
+    ) -> Value {
+        let row_schema = row_ref.cloned().unwrap_or_else(|| json!({}));
+        let (media_type, schema) = match surface.response.row_strategy {
+            RowStrategy::Direct => self.direct_response_schema(surface, &row_schema, artifacts),
+            RowStrategy::DictEntries => ("application/json", self.dict_response_schema(surface)),
+            RowStrategy::SeriesPointList => {
+                self.warn(
+                    surface,
+                    "series_point_list responses have no faithful OpenAPI schema; \
+                     emitted as an unconstrained object",
+                );
+                ("application/json", json!({}))
+            }
+        };
+
+        let mut ok_response = Map::new();
+        ok_response.insert("description".to_string(), json!("Successful response."));
+        if !artifacts.response_headers.is_empty() {
+            let headers: Map<String, Value> = artifacts
+                .response_headers
+                .iter()
+                .map(|(name, header)| (name.clone(), header.clone()))
+                .collect();
+            ok_response.insert("headers".to_string(), Value::Object(headers));
+        }
+        ok_response.insert(
+            "content".to_string(),
+            json!({media_type: {"schema": schema}}),
+        );
+
+        let mut responses = Map::new();
+        responses.insert("200".to_string(), Value::Object(ok_response));
+        if surface.response.allow_404_empty {
+            responses.insert(
+                "404".to_string(),
+                json!({"description": "Not found; treated as an empty result set."}),
+            );
+        }
+        Value::Object(responses)
+    }
+
+    fn direct_response_schema(
+        &mut self,
+        surface: &Surface<'_>,
+        row_schema: &Value,
+        artifacts: &PaginationArtifacts,
+    ) -> (&'static str, Value) {
+        if surface.response.format == ResponseBodyFormat::JsonEachRow {
+            self.warn(
+                surface,
+                "newline-delimited JSON responses are approximated as an array schema \
+                 under application/x-ndjson",
+            );
+            return (
+                "application/x-ndjson",
+                json!({
+                    "type": "array",
+                    "items": row_schema,
+                    "description": "Newline-delimited JSON; each line is one row.",
+                }),
+            );
+        }
+        let rows = json!({"type": "array", "items": row_schema});
+        if !surface.response.rows_path.is_empty() {
+            let mut wrapper = SchemaTree::new();
+            wrapper.insert(&surface.response.rows_path, SchemaTree::leaf(rows));
+            if !artifacts.response_cursor_path.is_empty() {
+                wrapper.insert(
+                    &artifacts.response_cursor_path,
+                    SchemaTree::leaf(json!({
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Cursor for the next page; absent on the last page.",
+                    })),
+                );
+            }
+            return ("application/json", wrapper.into_schema());
+        }
+        if !artifacts.response_cursor_path.is_empty() {
+            self.warn(
+                surface,
+                "response cursor path declared without rows_path; emitting an object \
+                 schema with the cursor property only",
+            );
+            let mut wrapper = SchemaTree::new();
+            wrapper.insert(
+                &artifacts.response_cursor_path,
+                SchemaTree::leaf(json!({"type": "string", "nullable": true})),
+            );
+            return ("application/json", wrapper.into_schema());
+        }
+        if surface.pagination.mode == PaginationMode::None {
+            self.warn(
+                surface,
+                "response cardinality is ambiguous (no rows_path, no pagination); \
+                 emitted as an array of rows — change to the row object if this \
+                 endpoint returns a single object",
+            );
+        }
+        ("application/json", rows)
+    }
+
+    /// `dict_entries` rows are synthesized from one JSON object: keys become
+    /// the `_key` column and values the remaining columns. The honest
+    /// OpenAPI shape is therefore an object with `additionalProperties`.
+    fn dict_response_schema(&mut self, surface: &Surface<'_>) -> Value {
+        let mut tree = row_schema_tree(surface.columns);
+        drop(tree.remove_child("_key"));
+        let value_tree = tree.remove_child("_value");
+        let additional = match value_tree {
+            Some(value_tree) if tree.is_empty() => value_tree.into_schema(),
+            Some(_) => {
+                self.warn(
+                    surface,
+                    "dict_entries columns mix `_value` with object fields; using the \
+                     object fields for the value schema",
+                );
+                tree.into_schema()
+            }
+            None => tree.into_schema(),
+        };
+        let dict = json!({"type": "object", "additionalProperties": additional});
+        if surface.response.rows_path.is_empty() {
+            return dict;
+        }
+        let mut wrapper = SchemaTree::new();
+        wrapper.insert(&surface.response.rows_path, SchemaTree::leaf(dict));
+        wrapper.into_schema()
+    }
+
+    // ------------------------------------------------------------------
+    // Servers, security, document extension
+    // ------------------------------------------------------------------
+
+    fn servers_value(&mut self) -> Value {
+        let template = &self.manifest.base_url;
+        let mut url = String::new();
+        let mut variables = Map::new();
+        for part in template.parts() {
+            match part {
+                TemplatePart::Literal(literal) => url.push_str(literal),
+                TemplatePart::Token(token) => {
+                    let name = sanitize_token(token.key());
+                    url.push('{');
+                    url.push_str(&name);
+                    url.push('}');
+                    let default = token
+                        .default_value()
+                        .map(str::to_string)
+                        .or_else(|| self.input_default(token.key()))
+                        .unwrap_or_else(|| {
+                            self.warnings
+                                .push(format!("base_url variable '{name}' has no default value"));
+                            String::new()
+                        });
+                    let mut variable = Map::new();
+                    variable.insert("default".to_string(), json!(default));
+                    if let Some(hint) = self
+                        .manifest
+                        .declared_inputs
+                        .iter()
+                        .find(|input| input.key == token.key())
+                        .and_then(|input| input.hint.clone())
+                    {
+                        variable.insert("description".to_string(), json!(hint.trim()));
+                    }
+                    variables.insert(name, Value::Object(variable));
+                }
+            }
+        }
+        let mut server = Map::new();
+        server.insert("url".to_string(), json!(url));
+        if !variables.is_empty() {
+            server.insert("variables".to_string(), Value::Object(variables));
+        }
+        json!([Value::Object(server)])
+    }
+
+    fn security_values(&mut self) -> (Map<String, Value>, Vec<Value>) {
+        let mut schemes = Map::new();
+        let mut security = Vec::new();
+        match &self.manifest.auth {
+            AuthSpec::BasicAuth(_) => {
+                schemes.insert(
+                    "basic_auth".to_string(),
+                    json!({"type": "http", "scheme": "basic"}),
+                );
+                security.push(json!({"basic_auth": []}));
+            }
+            AuthSpec::CustomAuth(spec) => {
+                self.warnings.push(format!(
+                    "custom auth '{}' has no OpenAPI equivalent; auth is only recorded \
+                     under the document's x-coral extension",
+                    spec.authenticator
+                ));
+            }
+            AuthSpec::HeaderAuth(spec) => {
+                let mut per_header_keys: Vec<Vec<String>> = Vec::new();
+                for header in &spec.headers {
+                    let alternatives: Vec<&ValueSourceSpec> = match &header.value {
+                        ValueSourceSpec::OneOf { values } => values.iter().collect(),
+                        other => vec![other],
+                    };
+                    let mut keys = Vec::new();
+                    for alternative in alternatives {
+                        let (key, scheme) = auth_header_scheme(&header.name, alternative);
+                        schemes.entry(key.clone()).or_insert(scheme);
+                        if !keys.contains(&key) {
+                            keys.push(key);
+                        }
+                    }
+                    per_header_keys.push(keys);
+                }
+                if let [keys] = per_header_keys.as_slice() {
+                    // A single auth header with alternatives: each is a valid
+                    // way to authenticate on its own.
+                    security.extend(keys.iter().map(|key| json!({key.as_str(): []})));
+                } else if !per_header_keys.is_empty() {
+                    if per_header_keys.iter().any(|keys| keys.len() > 1) {
+                        self.warnings.push(
+                            "multiple auth headers with alternative sources; only the \
+                             first alternative of each is listed as a security requirement"
+                                .to_string(),
+                        );
+                    }
+                    let requirement: Map<String, Value> = per_header_keys
+                        .iter()
+                        .filter_map(|keys| keys.first())
+                        .map(|key| (key.clone(), json!([])))
+                        .collect();
+                    security.push(Value::Object(requirement));
+                }
+            }
+        }
+        (schemes, security)
+    }
+
+    fn document_extension(&self) -> Value {
+        let mut extension = Map::new();
+        extension.insert("generator".to_string(), json!("coral xtask export-openapi"));
+        extension.insert("source".to_string(), json!(self.manifest.common.name));
+        extension.insert(
+            "source_version".to_string(),
+            json!(self.manifest.common.version),
+        );
+        extension.insert(
+            "dsl_version".to_string(),
+            json!(self.manifest.common.dsl_version),
+        );
+        extension.insert("base_url".to_string(), json!(self.manifest.base_url.raw()));
+        extension.insert(
+            "auth".to_string(),
+            serde_json::to_value(&self.manifest.auth).unwrap_or(Value::Null),
+        );
+        if !self.manifest.request_headers.is_empty() {
+            extension.insert(
+                "request_headers".to_string(),
+                serde_json::to_value(&self.manifest.request_headers).unwrap_or(Value::Null),
+            );
+        }
+        if rate_limit_is_declared(&self.manifest.rate_limit) {
+            extension.insert(
+                "rate_limit".to_string(),
+                serde_json::to_value(&self.manifest.rate_limit).unwrap_or(Value::Null),
+            );
+        }
+        Value::Object(extension)
+    }
+}
+
+/// Arguments for [`Converter::filter_doc`], grouped because filter-bound
+/// value sources vary along several independent axes.
+struct FilterDocRequest<'a, 'b> {
+    surface: &'a Surface<'b>,
+    key: &'a str,
+    when_filters: &'a [String],
+    schema_override: Option<Value>,
+    default: Option<Value>,
+    note: Option<String>,
+}
+
+/// Register the reconstructed row schema for one surface under
+/// `components/schemas` and return a `$ref` to it. Surfaces whose rows are
+/// synthesized rather than read from the payload (`dict_entries`,
+/// `series_point_list`) or whose columns imply no shape get no component.
+///
+/// The component is named exactly after the v3 surface: the v4 importer
+/// takes its entity name from the `$ref` leaf and derives list-projection
+/// names by pluralizing it (a no-op for v3's conventionally plural table
+/// names), so this is what keeps converted catalog names aligned with the
+/// v3 names. A `_row`-style suffix here would leak into every derived name.
+fn register_row_schema(surface: &Surface<'_>, schemas: &mut Map<String, Value>) -> Option<Value> {
+    if surface.response.row_strategy != RowStrategy::Direct {
+        return None;
+    }
+    let tree = row_schema_tree(surface.columns);
+    if tree.is_empty() {
+        return None;
+    }
+    let mut name = sanitize_token(surface.name);
+    let mut suffix = 2;
+    while schemas.contains_key(&name) {
+        name = format!("{}_{suffix}", sanitize_token(surface.name));
+        suffix += 1;
+    }
+    schemas.insert(name.clone(), tree.into_schema());
+    Some(json!({"$ref": format!("#/components/schemas/{name}")}))
+}
+
+fn operation_extension(surface: &Surface<'_>, when_filters: &[String]) -> Value {
+    let mut extension = Map::new();
+    extension.insert("surface".to_string(), json!(surface.kind));
+    extension.insert("name".to_string(), json!(surface.name));
+    if !when_filters.is_empty() {
+        extension.insert("when_filters".to_string(), json!(when_filters));
+    }
+    if surface.function_kind == Some(SourceTableFunctionKind::Search) {
+        extension.insert("function_kind".to_string(), json!("search"));
+    }
+    if let Some(fetch_limit) = surface.fetch_limit_default {
+        extension.insert("fetch_limit_default".to_string(), json!(fetch_limit));
+    }
+    if let Some(search_limits) = surface.search_limits {
+        extension.insert(
+            "search_limits".to_string(),
+            serde_json::to_value(search_limits).unwrap_or(Value::Null),
+        );
+    }
+    if !surface.detail_hints.is_empty() {
+        extension.insert(
+            "detail_hints".to_string(),
+            serde_json::to_value(surface.detail_hints).unwrap_or(Value::Null),
+        );
+    }
+    if response_is_declared(surface.response) {
+        extension.insert(
+            "response".to_string(),
+            serde_json::to_value(surface.response).unwrap_or(Value::Null),
+        );
+    }
+    if pagination_is_declared(surface.pagination) {
+        extension.insert(
+            "pagination".to_string(),
+            serde_json::to_value(surface.pagination).unwrap_or(Value::Null),
+        );
+    }
+    Value::Object(extension)
+}
+
+fn response_is_declared(response: &ResponseSpec) -> bool {
+    !response.rows_path.is_empty()
+        || !response.ok_path.is_empty()
+        || !response.error_path.is_empty()
+        || response.allow_404_empty
+        || response.format != ResponseBodyFormat::Json
+        || response.row_strategy != RowStrategy::Direct
+}
+
+fn pagination_is_declared(pagination: &PaginationSpec) -> bool {
+    pagination.mode != PaginationMode::None
+        || pagination.page_size.is_some()
+        || pagination.next_url_header.is_some()
+        || pagination.response_cursor_header.is_some()
+}
+
+fn rate_limit_is_declared(rate_limit: &RateLimitSpec) -> bool {
+    !rate_limit.extra_statuses.is_empty()
+        || rate_limit.retry_after_header.is_some()
+        || rate_limit.remaining_header.is_some()
+        || rate_limit.reset_header.is_some()
+}
+
+fn parameter_value(name: &str, location: &str, required: bool, doc: ValueSourceDoc) -> Value {
+    let mut parameter = Map::new();
+    parameter.insert("name".to_string(), json!(name));
+    parameter.insert("in".to_string(), json!(location));
+    parameter.insert("required".to_string(), json!(required));
+    if !doc.description.is_empty() {
+        parameter.insert("description".to_string(), json!(doc.description));
+    }
+    parameter.insert("schema".to_string(), doc.schema);
+    for (key, value) in doc.extensions {
+        parameter.insert(key.to_string(), value);
+    }
+    Value::Object(parameter)
+}
+
+/// Fold a value-source doc into a standalone schema object for use inside a
+/// request-body schema, where description and extensions have no parameter
+/// object to live on.
+fn body_field_schema(doc: ValueSourceDoc, description: &str) -> Value {
+    let mut schema = doc.schema;
+    if let Some(object) = schema.as_object_mut() {
+        if !description.is_empty() {
+            object.insert("description".to_string(), json!(description));
+        }
+        for (key, value) in doc.extensions {
+            object.insert(key.to_string(), value);
+        }
+    }
+    schema
+}
+
+/// The response headers the declared pagination promises: RFC 5988 `Link`
+/// headers, cursor headers, and next-page-URL headers.
+fn pagination_response_headers(pagination: &PaginationSpec) -> Vec<(String, Value)> {
+    let mut headers = Vec::new();
+    if pagination.mode == PaginationMode::LinkHeader {
+        headers.push((
+            "Link".to_string(),
+            json!({
+                "description": "RFC 5988 pagination links; rel=\"next\" points at the next page.",
+                "schema": {"type": "string"},
+            }),
+        ));
+    }
+    if let Some(header) = &pagination.response_cursor_header {
+        headers.push((
+            header.clone(),
+            json!({
+                "description": "Cursor for the next page; absent on the last page.",
+                "schema": {"type": "string"},
+            }),
+        ));
+    }
+    if let Some(header) = &pagination.next_url_header {
+        headers.push((
+            header.clone(),
+            json!({
+                "description": "URL of the next page; absent on the last page.",
+                "schema": {"type": "string"},
+            }),
+        ));
+    }
+    headers
+}
+
+fn pagination_body_schema(mut schema: Value, description: &str) -> Value {
+    if let Some(object) = schema.as_object_mut() {
+        object.insert("description".to_string(), json!(description));
+        object.insert("x-coral-pagination".to_string(), json!(true));
+    }
+    schema
+}
+
+fn state_doc(key: &str) -> ValueSourceDoc {
+    ValueSourceDoc {
+        schema: json!({"type": "string"}),
+        required: false,
+        description: "Managed by the Coral runtime (request or pagination state).".to_string(),
+        extensions: vec![("x-coral-state", json!(key))],
+    }
+}
+
+fn literal_schema(value: &Value) -> Value {
+    let mut schema = Map::new();
+    let type_name = match value {
+        Value::String(_) => Some("string"),
+        Value::Bool(_) => Some("boolean"),
+        Value::Number(number) => Some(if number.is_f64() { "number" } else { "integer" }),
+        Value::Null | Value::Array(_) | Value::Object(_) => None,
+    };
+    if let Some(type_name) = type_name {
+        schema.insert("type".to_string(), json!(type_name));
+    }
+    schema.insert("enum".to_string(), json!([value]));
+    schema.insert("default".to_string(), value.clone());
+    Value::Object(schema)
+}
+
+fn split_note(key: &str, separator: &str, part: usize) -> String {
+    format!("Part {part} (0-based) of the '{key}' value split on '{separator}'.")
+}
+
+fn append_sentence(description: &mut String, sentence: &str) {
+    if !description.is_empty() && !description.ends_with(' ') {
+        description.push(' ');
+    }
+    description.push_str(sentence);
+}
+
+fn method_key(method: HttpMethod) -> &'static str {
+    match method {
+        HttpMethod::GET => "get",
+        HttpMethod::POST => "post",
+    }
+}
+
+/// Restrict a template-token or component key to the characters OpenAPI
+/// accepts for path parameter names and component keys.
+fn sanitize_token(raw: &str) -> String {
+    let sanitized: String = raw
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '_' | '.' | '-') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "_".to_string()
+    } else {
+        sanitized
+    }
+}
+
+/// Map one auth header value source to an OpenAPI security scheme.
+fn auth_header_scheme(header_name: &str, source: &ValueSourceSpec) -> (String, Value) {
+    let input_keys = auth_source_input_keys(source);
+    let description = if input_keys.is_empty() {
+        String::new()
+    } else {
+        format!("Provided via source input(s): {}.", input_keys.join(", "))
+    };
+    let is_authorization = header_name.eq_ignore_ascii_case("authorization");
+    let bearer = matches!(source, ValueSourceSpec::Bearer { .. })
+        || matches!(source, ValueSourceSpec::Template { template } if template.raw().starts_with("Bearer "));
+    if is_authorization && bearer {
+        let mut scheme = Map::new();
+        scheme.insert("type".to_string(), json!("http"));
+        scheme.insert("scheme".to_string(), json!("bearer"));
+        if !description.is_empty() {
+            scheme.insert("description".to_string(), json!(description));
+        }
+        return ("bearer_auth".to_string(), Value::Object(scheme));
+    }
+    if is_authorization
+        && matches!(source, ValueSourceSpec::Template { template } if template.raw().starts_with("Basic "))
+    {
+        let mut scheme = Map::new();
+        scheme.insert("type".to_string(), json!("http"));
+        scheme.insert("scheme".to_string(), json!("basic"));
+        if !description.is_empty() {
+            scheme.insert("description".to_string(), json!(description));
+        }
+        return ("basic_auth".to_string(), Value::Object(scheme));
+    }
+    let mut scheme = Map::new();
+    scheme.insert("type".to_string(), json!("apiKey"));
+    scheme.insert("in".to_string(), json!("header"));
+    scheme.insert("name".to_string(), json!(header_name));
+    if !description.is_empty() {
+        scheme.insert("description".to_string(), json!(description));
+    }
+    (
+        sanitize_token(&header_name.to_ascii_lowercase()),
+        Value::Object(scheme),
+    )
+}
+
+fn auth_source_input_keys(source: &ValueSourceSpec) -> Vec<String> {
+    match source {
+        ValueSourceSpec::Template { template } => template
+            .tokens()
+            .flat_map(TemplateToken::input_keys)
+            .map(str::to_string)
+            .collect(),
+        ValueSourceSpec::Input { key } | ValueSourceSpec::Bearer { key } => vec![key.clone()],
+        _ => Vec::new(),
+    }
+}

--- a/xtask/src/openapi/mod.rs
+++ b/xtask/src/openapi/mod.rs
@@ -1,0 +1,136 @@
+//! `export-openapi`: convert v3 HTTP source manifests to OpenAPI documents.
+//!
+//! One document is written per manifest, named `<source>.openapi.yaml`.
+//! Manifests with nothing to describe are skipped with a note: non-HTTP
+//! backends (file, MCP, DSL v4) have no HTTP endpoints, and GraphQL sources
+//! collapse into one meaningless path/method slot. Conversion itself never
+//! fails: any construct OpenAPI cannot express becomes a warning plus an
+//! `x-coral*` extension in the emitted document (see `convert`).
+
+mod convert;
+mod schema_tree;
+
+#[cfg(test)]
+mod tests;
+
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use coral_spec::parse_source_manifest_yaml;
+
+use crate::sources::iter_manifest_files;
+use convert::{convert_http_manifest, is_graphql_source};
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct Args {
+    /// Manifest files or directories to convert. Defaults to `sources/`
+    /// when no paths are given.
+    paths: Vec<PathBuf>,
+
+    /// Directory that receives the generated `<source>.openapi.yaml` files.
+    #[arg(long, default_value = "target/openapi")]
+    out: PathBuf,
+
+    /// Print every conversion warning instead of only per-source counts.
+    #[arg(long)]
+    verbose: bool,
+}
+
+/// Returns `Ok(false)` when any manifest failed to parse or convert; skipped
+/// non-HTTP manifests do not count as failures.
+pub(crate) fn run(args: &Args) -> Result<bool> {
+    let paths = if args.paths.is_empty() {
+        vec![PathBuf::from("sources")]
+    } else {
+        args.paths.clone()
+    };
+    let manifest_files = iter_manifest_files(&paths);
+    if manifest_files.is_empty() {
+        eprintln!("xtask: no manifest.y{{a,}}ml files found under the given paths");
+        return Ok(false);
+    }
+    fs::create_dir_all(&args.out)
+        .with_context(|| format!("creating output directory {}", args.out.display()))?;
+
+    let mut converted = 0usize;
+    let mut skipped = 0usize;
+    let mut failed = 0usize;
+    let mut total_warnings = 0usize;
+    for manifest_path in manifest_files {
+        let raw = match fs::read_to_string(&manifest_path) {
+            Ok(raw) => raw,
+            Err(error) => {
+                eprintln!("xtask: reading {}: {error}", manifest_path.display());
+                failed += 1;
+                continue;
+            }
+        };
+        let manifest = match parse_source_manifest_yaml(&raw) {
+            Ok(manifest) => manifest,
+            Err(error) => {
+                eprintln!("xtask: parsing {}: {error}", manifest_path.display());
+                failed += 1;
+                continue;
+            }
+        };
+        let Some(http) = manifest.as_http() else {
+            println!(
+                "skip  {} ({}, not an HTTP v3 manifest)",
+                manifest.schema_name(),
+                manifest_path.display()
+            );
+            skipped += 1;
+            continue;
+        };
+        if is_graphql_source(http) {
+            println!(
+                "skip  {} ({}, GraphQL source; OpenAPI cannot describe its operations)",
+                manifest.schema_name(),
+                manifest_path.display()
+            );
+            skipped += 1;
+            continue;
+        }
+
+        let conversion = convert_http_manifest(http);
+        let body = serde_yaml::to_string(&conversion.document)
+            .with_context(|| format!("serializing OpenAPI document for {}", http.common.name))?;
+        let out_path = args.out.join(format!("{}.openapi.yaml", http.common.name));
+        fs::write(&out_path, body).with_context(|| format!("writing {}", out_path.display()))?;
+
+        let operations = count_operations(&conversion.document);
+        println!(
+            "write {} ({operations} operations, {} warnings) -> {}",
+            http.common.name,
+            conversion.warnings.len(),
+            out_path.display()
+        );
+        if args.verbose {
+            for warning in &conversion.warnings {
+                println!("      warning: {warning}");
+            }
+        }
+        total_warnings += conversion.warnings.len();
+        converted += 1;
+    }
+
+    println!(
+        "export-openapi: {converted} converted, {skipped} skipped, {failed} failed, \
+         {total_warnings} warnings"
+    );
+    Ok(failed == 0)
+}
+
+fn count_operations(document: &serde_json::Value) -> usize {
+    document
+        .get("paths")
+        .and_then(serde_json::Value::as_object)
+        .map_or(0, |paths| {
+            paths
+                .values()
+                .filter_map(serde_json::Value::as_object)
+                .map(serde_json::Map::len)
+                .sum()
+        })
+}

--- a/xtask/src/openapi/schema_tree.rs
+++ b/xtask/src/openapi/schema_tree.rs
@@ -1,0 +1,405 @@
+//! JSON-schema reconstruction for OpenAPI export.
+//!
+//! A v3 manifest never states the provider's response shape directly; it
+//! declares typed columns whose expressions *address into* the raw response
+//! rows. This module rebuilds the implied JSON shape: each column expression
+//! contributes the fields it reads to a [`SchemaTree`], and the merged tree
+//! renders as one OpenAPI schema object. The merge rules (structure beats
+//! scalar, conflicting scalars widen to the empty schema) live here so the
+//! converter never reasons about shape conflicts.
+
+use coral_spec::{ColumnSpec, ExprSpec, ManifestDataType, TimestampInput};
+use serde_json::{Value, json};
+
+/// A mergeable JSON-schema fragment addressed by response paths.
+///
+/// Leaves are ready-made OpenAPI schema objects; interior nodes are objects
+/// or arrays inferred from the paths and expressions inserted into the tree.
+/// Children keep insertion order, matching column declaration order.
+#[derive(Debug, Default)]
+pub(crate) struct SchemaTree {
+    root: Option<Node>,
+}
+
+#[derive(Debug)]
+enum Node {
+    Leaf(Value),
+    Object(Vec<(String, Node)>),
+    Array(Box<Node>),
+}
+
+impl SchemaTree {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// A tree whose root is the given ready-made schema object.
+    pub(crate) fn leaf(schema: Value) -> Self {
+        Self {
+            root: Some(Node::Leaf(schema)),
+        }
+    }
+
+    /// A tree whose root is an array of the given item tree.
+    pub(crate) fn array_of(items: Self) -> Self {
+        Self {
+            root: Some(Node::Array(Box::new(
+                items.root.unwrap_or(Node::Leaf(json!({}))),
+            ))),
+        }
+    }
+
+    /// Returns true when nothing has been inserted.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.root.is_none()
+    }
+
+    /// Merge `subtree` into this tree at `path`, creating object nodes for
+    /// each path segment. An empty path merges at the root; an empty subtree
+    /// is a no-op.
+    pub(crate) fn insert(&mut self, path: &[String], subtree: Self) {
+        let Some(mut node) = subtree.root else {
+            return;
+        };
+        for segment in path.iter().rev() {
+            node = Node::Object(vec![(segment.clone(), node)]);
+        }
+        self.root = Some(match self.root.take() {
+            Some(existing) => merge(existing, node),
+            None => node,
+        });
+    }
+
+    /// Detach and return the direct child object property named `name`.
+    ///
+    /// Used for `dict_entries` tables, whose synthesized `_key`/`_value`
+    /// columns do not correspond to raw response fields. Returns `None`
+    /// when the root is not an object or has no such property.
+    pub(crate) fn remove_child(&mut self, name: &str) -> Option<Self> {
+        let Some(Node::Object(children)) = &mut self.root else {
+            return None;
+        };
+        let index = children.iter().position(|(key, _)| key == name)?;
+        let (_, child) = children.remove(index);
+        if children.is_empty() {
+            self.root = None;
+        }
+        Some(Self { root: Some(child) })
+    }
+
+    /// Render the tree as one OpenAPI schema object; empty trees render as
+    /// the unconstrained schema `{}`.
+    pub(crate) fn into_schema(self) -> Value {
+        self.root.map_or_else(|| json!({}), render)
+    }
+}
+
+fn render(node: Node) -> Value {
+    match node {
+        Node::Leaf(schema) => schema,
+        Node::Object(children) => {
+            let properties: serde_json::Map<String, Value> = children
+                .into_iter()
+                .map(|(name, child)| (name, render(child)))
+                .collect();
+            json!({"type": "object", "properties": properties})
+        }
+        Node::Array(items) => json!({"type": "array", "items": render(*items)}),
+    }
+}
+
+/// Merge two nodes describing the same location. Structure wins over
+/// scalars (a column may read `labels` as raw JSON text while another
+/// addresses `labels[].name`); conflicting shapes widen to `{}`.
+fn merge(left: Node, right: Node) -> Node {
+    match (left, right) {
+        (Node::Object(mut left_children), Node::Object(right_children)) => {
+            for (name, right_child) in right_children {
+                match left_children
+                    .iter()
+                    .position(|(existing, _)| *existing == name)
+                {
+                    Some(index) => {
+                        let (name, left_child) = left_children.remove(index);
+                        left_children.insert(index, (name, merge(left_child, right_child)));
+                    }
+                    None => left_children.push((name, right_child)),
+                }
+            }
+            Node::Object(left_children)
+        }
+        (Node::Array(left_items), Node::Array(right_items)) => {
+            Node::Array(Box::new(merge(*left_items, *right_items)))
+        }
+        (Node::Leaf(left_schema), Node::Leaf(right_schema)) => {
+            Node::Leaf(merge_leaf_schemas(left_schema, right_schema))
+        }
+        // Structure beats a scalar leaf: keep whichever side is composite.
+        (composite @ (Node::Object(_) | Node::Array(_)), Node::Leaf(_))
+        | (Node::Leaf(_), composite @ (Node::Object(_) | Node::Array(_))) => composite,
+        // Object vs array is a genuine shape conflict: widen to `{}`.
+        (Node::Object(_), Node::Array(_)) | (Node::Array(_), Node::Object(_)) => {
+            Node::Leaf(json!({}))
+        }
+    }
+}
+
+fn merge_leaf_schemas(left: Value, right: Value) -> Value {
+    if is_unconstrained(&left) {
+        return right;
+    }
+    if right == left || is_unconstrained(&right) {
+        return left;
+    }
+    // Same declared type: keep the first (richer descriptions arrive first
+    // because columns contribute in declaration order). Different types:
+    // widen to the unconstrained schema.
+    if left.get("type").is_some() && left.get("type") == right.get("type") {
+        left
+    } else {
+        json!({})
+    }
+}
+
+fn is_unconstrained(schema: &Value) -> bool {
+    schema.as_object().is_some_and(serde_json::Map::is_empty)
+}
+
+/// The OpenAPI schema object for one manifest scalar type.
+pub(crate) fn scalar_schema(data_type: ManifestDataType) -> Value {
+    match data_type {
+        ManifestDataType::Utf8 => json!({"type": "string"}),
+        ManifestDataType::Int64 => json!({"type": "integer", "format": "int64"}),
+        ManifestDataType::Float64 => json!({"type": "number", "format": "double"}),
+        ManifestDataType::Boolean => json!({"type": "boolean"}),
+        ManifestDataType::Timestamp => json!({"type": "string", "format": "date-time"}),
+        ManifestDataType::Json => json!({}),
+    }
+}
+
+/// Rebuild the raw response-row schema implied by a table's declared
+/// columns. Virtual columns and expressions that echo request values
+/// (`from_filter`, `from_arg`, literals) contribute nothing because they do
+/// not read the response payload.
+pub(crate) fn row_schema_tree(columns: &[ColumnSpec]) -> SchemaTree {
+    let mut tree = SchemaTree::new();
+    for column in columns {
+        if column.r#virtual {
+            continue;
+        }
+        let mut leaf = scalar_schema(column.data_type);
+        if let Some(leaf_object) = leaf.as_object_mut() {
+            if column.nullable && !leaf_object.is_empty() {
+                leaf_object.insert("nullable".to_string(), json!(true));
+            }
+            if !column.description.is_empty() {
+                leaf_object.insert("description".to_string(), json!(column.description));
+            }
+        }
+        contribute_expr(&mut tree, &column.resolved_expr(), leaf);
+    }
+    tree
+}
+
+/// Add the raw fields read by `expr` to `tree`. `leaf` is the schema of the
+/// value the expression ultimately produces; transforms substitute the
+/// schema their input must have (for example `base64_decode` reads a
+/// string regardless of the column type).
+fn contribute_expr(tree: &mut SchemaTree, expr: &ExprSpec, leaf: Value) {
+    match expr {
+        ExprSpec::Path { path } => tree.insert(path, SchemaTree::leaf(leaf)),
+        ExprSpec::Coalesce { exprs } => {
+            for sub_expr in exprs {
+                contribute_expr(tree, sub_expr, leaf.clone());
+            }
+        }
+        ExprSpec::JoinArray { path, .. } => {
+            tree.insert(path, SchemaTree::array_of(SchemaTree::leaf(json!({}))));
+        }
+        ExprSpec::JoinArrayPath {
+            path, item_path, ..
+        } => {
+            let mut item = SchemaTree::new();
+            item.insert(item_path, SchemaTree::leaf(json!({})));
+            tree.insert(path, SchemaTree::array_of(item));
+        }
+        ExprSpec::FirstArrayItemPath { path, item_path } => {
+            let mut item = SchemaTree::new();
+            item.insert(item_path, SchemaTree::leaf(leaf));
+            tree.insert(path, SchemaTree::array_of(item));
+        }
+        ExprSpec::TagValue {
+            path,
+            key_field,
+            value_field,
+            ..
+        }
+        | ExprSpec::JoinTagValues {
+            path,
+            key_field,
+            value_field,
+            ..
+        } => {
+            let mut item = SchemaTree::new();
+            item.insert(
+                std::slice::from_ref(key_field),
+                SchemaTree::leaf(json!({"type": "string"})),
+            );
+            item.insert(
+                std::slice::from_ref(value_field),
+                SchemaTree::leaf(json!({})),
+            );
+            tree.insert(path, SchemaTree::array_of(item));
+        }
+        ExprSpec::ObjectFilterPath {
+            path,
+            filter_key,
+            item_path,
+        } => {
+            let mut item = SchemaTree::new();
+            item.insert(
+                std::slice::from_ref(filter_key),
+                SchemaTree::leaf(json!({"type": "string"})),
+            );
+            item.insert(item_path, SchemaTree::leaf(leaf));
+            tree.insert(path, SchemaTree::array_of(item));
+        }
+        ExprSpec::IfPresent { check, .. } => contribute_expr(tree, check, json!({})),
+        ExprSpec::FormatTimestamp { expr, input } => {
+            let input_leaf = match input {
+                TimestampInput::Seconds | TimestampInput::Milliseconds => json!({"type": "number"}),
+                TimestampInput::Iso8601 => json!({"type": "string"}),
+            };
+            contribute_expr(tree, expr, input_leaf);
+        }
+        ExprSpec::Base64Decode { expr } | ExprSpec::Replace { expr, .. } => {
+            contribute_expr(tree, expr, json!({"type": "string"}));
+        }
+        ExprSpec::Template { values, .. } => {
+            for value_expr in values.values() {
+                contribute_expr(tree, value_expr, json!({}));
+            }
+        }
+        // These read request state or constants, not the response payload.
+        ExprSpec::FromFilter { .. }
+        | ExprSpec::FromArg { .. }
+        | ExprSpec::Literal { .. }
+        | ExprSpec::Null
+        | ExprSpec::CurrentRow => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn utf8_column(name: &str, path: &[&str]) -> ColumnSpec {
+        column(name, ManifestDataType::Utf8, path)
+    }
+
+    fn column(name: &str, data_type: ManifestDataType, path: &[&str]) -> ColumnSpec {
+        serde_json::from_value(json!({
+            "name": name,
+            "type": data_type.as_manifest_str(),
+            "nullable": false,
+            "expr": {"kind": "path", "path": path},
+        }))
+        .expect("column spec")
+    }
+
+    #[test]
+    fn nested_paths_reconstruct_objects() {
+        let columns = vec![
+            utf8_column("login", &["user", "login"]),
+            column("id", ManifestDataType::Int64, &["user", "id"]),
+            utf8_column("title", &["title"]),
+        ];
+        assert_eq!(
+            row_schema_tree(&columns).into_schema(),
+            json!({
+                "type": "object",
+                "properties": {
+                    "user": {
+                        "type": "object",
+                        "properties": {
+                            "login": {"type": "string"},
+                            "id": {"type": "integer", "format": "int64"},
+                        }
+                    },
+                    "title": {"type": "string"},
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn structure_wins_over_raw_json_scalar() {
+        let raw: ColumnSpec = serde_json::from_value(json!({
+            "name": "labels",
+            "type": "Json",
+            "expr": {"kind": "path", "path": ["labels"]},
+        }))
+        .expect("column spec");
+        let joined: ColumnSpec = serde_json::from_value(json!({
+            "name": "label_names",
+            "type": "Utf8",
+            "expr": {"kind": "join_array_path", "path": ["labels"], "item_path": ["name"]},
+        }))
+        .expect("column spec");
+
+        assert_eq!(
+            row_schema_tree(&[raw, joined]).into_schema(),
+            json!({
+                "type": "object",
+                "properties": {
+                    "labels": {
+                        "type": "array",
+                        "items": {"type": "object", "properties": {"name": {}}}
+                    }
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn conflicting_scalar_types_widen_to_unconstrained() {
+        let columns = vec![
+            column("count", ManifestDataType::Int64, &["count"]),
+            utf8_column("count_text", &["count"]),
+        ];
+        assert_eq!(
+            row_schema_tree(&columns).into_schema(),
+            json!({"type": "object", "properties": {"count": {}}})
+        );
+    }
+
+    #[test]
+    fn virtual_and_filter_echo_columns_contribute_nothing() {
+        let echo: ColumnSpec = serde_json::from_value(json!({
+            "name": "org",
+            "type": "Utf8",
+            "expr": {"kind": "from_filter", "key": "org"},
+        }))
+        .expect("column spec");
+        let synthetic: ColumnSpec = serde_json::from_value(json!({
+            "name": "synthetic",
+            "type": "Utf8",
+            "virtual": true,
+        }))
+        .expect("column spec");
+        assert!(row_schema_tree(&[echo, synthetic]).is_empty());
+    }
+
+    #[test]
+    fn remove_child_detaches_dict_key() {
+        let mut tree = row_schema_tree(&[
+            utf8_column("key", &["_key"]),
+            utf8_column("status", &["_value"]),
+        ]);
+        assert!(tree.remove_child("_key").is_some());
+        let value = tree.remove_child("_value").expect("value child");
+        assert!(tree.is_empty());
+        assert_eq!(value.into_schema(), json!({"type": "string"}));
+    }
+}

--- a/xtask/src/openapi/snapshots/xtask__openapi__tests__fixture_openapi_document.snap
+++ b/xtask/src/openapi/snapshots/xtask__openapi__tests__fixture_openapi_document.snap
@@ -1,0 +1,451 @@
+---
+source: xtask/src/openapi/tests.rs
+expression: "format!(\"{yaml}\\n--- warnings ---\\n{warnings}\")"
+---
+openapi: 3.0.3
+info:
+  title: demo
+  version: 1.2.3
+  description: Demo issue tracker.
+servers:
+- url: '{DEMO_API_BASE}'
+  variables:
+    DEMO_API_BASE:
+      default: https://api.demo.test
+      description: Base URL of the demo API.
+security:
+- bearer_auth: []
+paths:
+  /projects/{project}/issues:
+    get:
+      operationId: issues
+      description: |-
+        Issues in a project.
+
+        Filter by project for fast lookups.
+      parameters:
+      - name: project
+        in: path
+        required: true
+        description: Project key.
+        schema:
+          type: string
+        x-coral-filter: project
+      - name: q
+        in: query
+        required: false
+        description: Matched as a substring.
+        schema:
+          type: string
+        x-coral-filter: text
+      - name: expand
+        in: query
+        required: false
+        description: Fixed value always sent with the request.
+        schema:
+          type: string
+          enum:
+          - all
+          default: all
+        x-coral-constant: true
+      - name: limit
+        in: query
+        required: false
+        description: Number of results per page.
+        schema:
+          type: integer
+          default: 50
+          maximum: 200
+        x-coral-pagination: true
+      - name: cursor
+        in: query
+        required: false
+        description: Opaque cursor for the next page; omit on the first request.
+        schema:
+          type: string
+        x-coral-pagination: true
+      responses:
+        '200':
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/issues'
+                  meta:
+                    type: object
+                    properties:
+                      next_cursor:
+                        type: string
+                        nullable: true
+                        description: Cursor for the next page; absent on the last page.
+        '404':
+          description: Not found; treated as an empty result set.
+      x-coral:
+        surface: table
+        name: issues
+        fetch_limit_default: 500
+        response:
+          format: json
+          rows_path:
+          - items
+          ok_path: []
+          error_path: []
+          allow_404_empty: true
+          row_strategy: direct
+        pagination:
+          mode: cursor_query
+          page_size:
+            default: 50
+            max: 200
+            query_param: limit
+            body_path: []
+          cursor_param: cursor
+          cursor_body_path: []
+          response_cursor_path:
+          - meta
+          - next_cursor
+          response_cursor_header: null
+          page_param: null
+          page_start: 0
+          page_step: 1
+          offset_param: null
+          offset_start: 0
+          offset_step: null
+          link_header_require_results: false
+          next_url_header: null
+          max_pages: null
+  /projects/{project}/issues/{id}:
+    get:
+      operationId: issues_by_project_id
+      description: |-
+        Issues in a project.
+
+        Filter by project for fast lookups.
+      parameters:
+      - name: project
+        in: path
+        required: true
+        description: Project key.
+        schema:
+          type: string
+        x-coral-filter: project
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        x-coral-filter: id
+      - name: limit
+        in: query
+        required: false
+        description: Number of results per page.
+        schema:
+          type: integer
+          default: 50
+          maximum: 200
+        x-coral-pagination: true
+      - name: cursor
+        in: query
+        required: false
+        description: Opaque cursor for the next page; omit on the first request.
+        schema:
+          type: string
+        x-coral-pagination: true
+      responses:
+        '200':
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/issues'
+                  meta:
+                    type: object
+                    properties:
+                      next_cursor:
+                        type: string
+                        nullable: true
+                        description: Cursor for the next page; absent on the last page.
+        '404':
+          description: Not found; treated as an empty result set.
+      x-coral:
+        surface: table
+        name: issues
+        when_filters:
+        - project
+        - id
+        fetch_limit_default: 500
+        response:
+          format: json
+          rows_path:
+          - items
+          ok_path: []
+          error_path: []
+          allow_404_empty: true
+          row_strategy: direct
+        pagination:
+          mode: cursor_query
+          page_size:
+            default: 50
+            max: 200
+            query_param: limit
+            body_path: []
+          cursor_param: cursor
+          cursor_body_path: []
+          response_cursor_path:
+          - meta
+          - next_cursor
+          response_cursor_header: null
+          page_param: null
+          page_start: 0
+          page_step: 1
+          offset_param: null
+          offset_start: 0
+          offset_step: null
+          link_header_require_results: false
+          next_url_header: null
+          max_pages: null
+  /runs:
+    get:
+      operationId: runs
+      description: Workflow runs.
+      parameters:
+      - name: per_page
+        in: query
+        required: false
+        description: Number of results per page.
+        schema:
+          type: integer
+          default: 30
+          maximum: 100
+        x-coral-pagination: true
+      - name: page
+        in: query
+        required: false
+        description: Page number.
+        schema:
+          type: integer
+          default: 1
+        x-coral-pagination: true
+      responses:
+        '200':
+          description: Successful response.
+          headers:
+            Link:
+              description: RFC 5988 pagination links; rel="next" points at the next page.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/runs'
+      x-coral:
+        surface: table
+        name: runs
+        pagination:
+          mode: link_header
+          page_size:
+            default: 30
+            max: 100
+            query_param: per_page
+            body_path: []
+          cursor_param: null
+          cursor_body_path: []
+          response_cursor_path: []
+          response_cursor_header: null
+          page_param: page
+          page_start: 1
+          page_step: 1
+          offset_param: null
+          offset_start: 0
+          offset_step: null
+          link_header_require_results: false
+          next_url_header: null
+          max_pages: null
+  /statuses:
+    get:
+      operationId: statuses
+      description: Component statuses keyed by component name.
+      responses:
+        '200':
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    status:
+                      type: string
+                      nullable: true
+      x-coral:
+        surface: table
+        name: statuses
+        response:
+          format: json
+          rows_path: []
+          ok_path: []
+          error_path: []
+          allow_404_empty: false
+          row_strategy: dict_entries
+  /meta:
+    get:
+      operationId: meta
+      description: Deployment metadata.
+      responses:
+        '200':
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/meta'
+      x-coral:
+        surface: table
+        name: meta
+  /search/issues:
+    post:
+      operationId: search_issues
+      description: Search issues.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+                  x-coral-arg: q
+                filters:
+                  type: object
+                  properties:
+                    scope:
+                      type: string
+                      enum:
+                      - open
+                      - closed
+                      x-coral-arg: scope
+      responses:
+        '200':
+          description: Successful response.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/search_issues'
+      x-coral:
+        surface: function
+        name: search_issues
+        function_kind: search
+        search_limits:
+          default_top_k: 10
+          max_top_k: 100
+          max_calls_per_query: 2
+        detail_hints:
+        - table: issues
+          search_result_column: id
+          detail_filter: id
+          purpose: Fetch the full issue.
+        response:
+          format: json
+          rows_path:
+          - results
+          ok_path: []
+          error_path: []
+          allow_404_empty: false
+          row_strategy: direct
+components:
+  schemas:
+    issues:
+      type: object
+      properties:
+        id:
+          type: string
+        count:
+          type: integer
+          format: int64
+          nullable: true
+        author:
+          type: object
+          properties:
+            login:
+              type: string
+              nullable: true
+              description: Login of the author.
+        labels:
+          type: array
+          items:
+            type: object
+            properties:
+              name: {}
+    runs:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          nullable: true
+    meta:
+      type: object
+      properties:
+        region:
+          type: string
+          nullable: true
+    search_issues:
+      type: object
+      properties:
+        id:
+          type: string
+          nullable: true
+        score:
+          type: number
+          format: double
+          nullable: true
+  securitySchemes:
+    bearer_auth:
+      type: http
+      scheme: bearer
+      description: 'Provided via source input(s): DEMO_TOKEN.'
+x-coral:
+  generator: coral xtask export-openapi
+  source: demo
+  source_version: 1.2.3
+  dsl_version: 3
+  base_url: '{{input.DEMO_API_BASE}}'
+  auth:
+    type: HeaderAuth
+    headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.DEMO_TOKEN}}
+  request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+  rate_limit:
+    extra_statuses:
+    - 403
+    retry_after_header: null
+    remaining_header: x-ratelimit-remaining
+    reset_header: null
+
+--- warnings ---
+table 'meta': response cardinality is ambiguous (no rows_path, no pagination); emitted as an array of rows — change to the row object if this endpoint returns a single object

--- a/xtask/src/openapi/tests.rs
+++ b/xtask/src/openapi/tests.rs
@@ -1,0 +1,438 @@
+//! Tests for the v3-manifest-to-OpenAPI converter.
+//!
+//! Three layers: a snapshot of one feature-dense fixture (reviews the exact
+//! emitted document), a round trip through the DSL v4 OpenAPI importer
+//! (proves the emitted facts are the ones v4's detection understands), and
+//! a corpus sweep over `sources/` (proves the converter holds up against
+//! every real v3 manifest in the repository).
+
+use std::path::Path;
+
+use coral_spec::backends::http::HttpSourceManifest;
+use coral_spec::parse_source_manifest_yaml;
+use coral_spec::v4::{
+    IrExecutionAttachment, OutputCardinality, SemanticIr, import_openapi_surface,
+};
+use coral_spec::{PaginationMode, ValidatedSourceManifest};
+use serde_json::Value;
+
+use super::convert::{convert_http_manifest, is_graphql_source};
+
+const FIXTURE: &str = r#"
+name: demo
+version: 1.2.3
+dsl_version: 3
+backend: http
+description: Demo issue tracker.
+base_url: "{{input.DEMO_API_BASE}}"
+rate_limit:
+  extra_statuses: [403]
+  remaining_header: x-ratelimit-remaining
+inputs:
+  DEMO_API_BASE:
+    kind: variable
+    default: https://api.demo.test
+    hint: Base URL of the demo API.
+  DEMO_TOKEN:
+    kind: secret
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.DEMO_TOKEN}}
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+tables:
+  - name: issues
+    description: Issues in a project.
+    guide: Filter by project for fast lookups.
+    filters:
+      - name: project
+        required: true
+        description: Project key.
+      - name: text
+        mode: contains
+      - name: id
+    fetch_limit_default: 500
+    request:
+      method: GET
+      path: /projects/{{filter.project}}/issues
+      query:
+        - name: q
+          from: filter
+          key: text
+        - name: expand
+          from: literal
+          value: all
+    requests:
+      - when_filters: [project, id]
+        method: GET
+        path: /projects/{{filter.project}}/issues/{{filter.id}}
+    response:
+      rows_path: [items]
+      allow_404_empty: true
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path: [meta, next_cursor]
+      page_size:
+        default: 50
+        max: 200
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+      - name: count
+        type: Int64
+      - name: author_login
+        type: Utf8
+        description: Login of the author.
+        expr: {kind: path, path: [author, login]}
+      - name: label_names
+        type: Utf8
+        expr:
+          kind: join_array_path
+          path: [labels]
+          item_path: [name]
+      - name: project
+        type: Utf8
+        expr: {kind: from_filter, key: project}
+  - name: runs
+    description: Workflow runs.
+    request:
+      method: GET
+      path: /runs
+    pagination:
+      mode: link_header
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 30
+        max: 100
+        query_param: per_page
+    columns:
+      - name: id
+        type: Int64
+  - name: statuses
+    description: Component statuses keyed by component name.
+    request:
+      method: GET
+      path: /statuses
+    response:
+      row_strategy: dict_entries
+    columns:
+      - name: component
+        type: Utf8
+        expr: {kind: path, path: [_key]}
+      - name: status
+        type: Utf8
+        expr: {kind: path, path: [status]}
+  - name: meta
+    description: Deployment metadata.
+    request:
+      method: GET
+      path: /meta
+    columns:
+      - name: region
+        type: Utf8
+functions:
+  - name: search_issues
+    kind: search
+    description: Search issues.
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 2
+    detail_hints:
+      - table: issues
+        search_result_column: id
+        detail_filter: id
+        purpose: Fetch the full issue.
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+      - name: scope
+        values: [open, closed]
+        bind:
+          arg: scope
+    request:
+      method: POST
+      path: /search/issues
+      body:
+        - path: [query]
+          from: arg
+          key: q
+        - path: [filters, scope]
+          from: arg
+          key: scope
+    response:
+      rows_path: [results]
+    columns:
+      - name: id
+        type: Utf8
+      - name: score
+        type: Float64
+"#;
+
+fn fixture_manifest() -> ValidatedSourceManifest {
+    parse_source_manifest_yaml(FIXTURE).expect("fixture manifest should parse")
+}
+
+fn fixture_http(manifest: &ValidatedSourceManifest) -> &HttpSourceManifest {
+    manifest.as_http().expect("fixture is an HTTP manifest")
+}
+
+fn import_into_v4(document_yaml: &str) -> SemanticIr {
+    let v4_manifest = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/demo.openapi.yaml
+    base_url: https://api.demo.test
+",
+    )
+    .expect("v4 wrapper manifest should parse");
+    let v4 = v4_manifest.as_v4().expect("v4 manifest");
+    let surface = v4.surfaces.first().expect("one surface");
+    import_openapi_surface(v4, surface, document_yaml.as_bytes())
+        .expect("converted document should import into v4")
+}
+
+#[test]
+fn fixture_document_snapshot() {
+    let manifest = fixture_manifest();
+    let conversion = convert_http_manifest(fixture_http(&manifest));
+    let yaml = serde_yaml::to_string(&conversion.document).expect("document serializes");
+    let warnings = conversion.warnings.join("\n");
+    insta::assert_snapshot!(
+        "fixture_openapi_document",
+        format!("{yaml}\n--- warnings ---\n{warnings}")
+    );
+}
+
+#[test]
+fn round_trip_reimports_pagination_and_row_paths() {
+    let manifest = fixture_manifest();
+    let conversion = convert_http_manifest(fixture_http(&manifest));
+    let yaml = serde_yaml::to_string(&conversion.document).expect("document serializes");
+    let ir = import_into_v4(&yaml);
+
+    let operation = |id: &str| {
+        ir.operations
+            .iter()
+            .find(|operation| operation.id == id)
+            .unwrap_or_else(|| panic!("operation '{id}' should be imported"))
+    };
+    let rest = |id: &str| {
+        let IrExecutionAttachment::Rest(rest) = &operation(id).execution else {
+            panic!("operation '{id}' should have a REST attachment");
+        };
+        rest.clone()
+    };
+
+    let issues = rest("issues");
+    assert_eq!(issues.pagination.mode, PaginationMode::CursorQuery);
+    assert_eq!(issues.pagination.cursor_param.as_deref(), Some("cursor"));
+    assert_eq!(
+        issues.pagination.response_cursor_path,
+        vec!["meta".to_string(), "next_cursor".to_string()]
+    );
+    assert_eq!(
+        issues
+            .pagination
+            .page_size
+            .as_ref()
+            .and_then(|page_size| page_size.query_param.as_deref()),
+        Some("limit")
+    );
+    assert_eq!(
+        issues.response.response.rows_path,
+        vec!["items".to_string()]
+    );
+    assert_eq!(
+        operation("issues").output.cardinality,
+        OutputCardinality::WrappedList
+    );
+
+    let runs = rest("runs");
+    assert_eq!(runs.pagination.mode, PaginationMode::LinkHeader);
+    assert_eq!(runs.pagination.page_param.as_deref(), Some("page"));
+
+    let detail = rest("issues_by_project_id");
+    assert_eq!(detail.path_template, "/projects/{project}/issues/{id}");
+    assert!(
+        detail
+            .parameters
+            .iter()
+            .filter(|parameter| ["project", "id"].contains(&parameter.input_name.as_str()))
+            .all(|parameter| parameter.required),
+        "route path parameters should be required"
+    );
+
+    assert!(
+        ir.operations
+            .iter()
+            .any(|operation| operation.id == "search_issues"),
+        "POST function should be imported"
+    );
+}
+
+#[test]
+fn fixture_parameters_reflect_filter_declarations() {
+    let manifest = fixture_manifest();
+    let conversion = convert_http_manifest(fixture_http(&manifest));
+    let parameters = conversion
+        .document
+        .pointer("/paths/~1projects~1{project}~1issues/get/parameters")
+        .and_then(Value::as_array)
+        .expect("issues operation parameters");
+
+    let parameter = |name: &str| {
+        parameters
+            .iter()
+            .find(|parameter| parameter.get("name").and_then(Value::as_str) == Some(name))
+            .unwrap_or_else(|| panic!("parameter '{name}' should exist"))
+    };
+    assert_eq!(
+        parameter("project").get("required"),
+        Some(&Value::Bool(true))
+    );
+    assert_eq!(
+        parameter("project")
+            .get("x-coral-filter")
+            .and_then(Value::as_str),
+        Some("project")
+    );
+    let text = parameter("q");
+    assert_eq!(text.get("required"), Some(&Value::Bool(false)));
+    assert!(
+        text.get("description")
+            .and_then(Value::as_str)
+            .is_some_and(|description| description.contains("substring")),
+        "contains-mode filters should be documented"
+    );
+    let constant = parameter("expand");
+    assert_eq!(
+        constant.pointer("/schema/enum"),
+        Some(&serde_json::json!(["all"]))
+    );
+    assert_eq!(constant.get("x-coral-constant"), Some(&Value::Bool(true)));
+    assert!(
+        parameters
+            .iter()
+            .any(|parameter| parameter.get("x-coral-pagination").is_some()
+                && parameter.get("name").and_then(Value::as_str) == Some("cursor")),
+        "cursor pagination parameter should be synthesized"
+    );
+}
+
+#[test]
+fn fixture_warns_on_ambiguous_cardinality() {
+    let manifest = fixture_manifest();
+    let conversion = convert_http_manifest(fixture_http(&manifest));
+    assert!(
+        conversion
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("meta") && warning.contains("ambiguous")),
+        "expected an ambiguity warning for the meta table, got: {:?}",
+        conversion.warnings
+    );
+}
+
+#[test]
+fn graphql_sources_are_detected() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: gql_demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://api.example.com
+tables:
+  - name: users
+    description: Users via GraphQL.
+    request:
+      method: POST
+      path: /api/graphql
+  - name: teams
+    description: Teams via GraphQL.
+    request:
+      method: POST
+      path: /graphql.json
+",
+    )
+    .expect("GraphQL fixture should parse");
+    assert!(is_graphql_source(
+        manifest.as_http().expect("HTTP manifest")
+    ));
+
+    let rest = fixture_manifest();
+    assert!(!is_graphql_source(fixture_http(&rest)));
+}
+
+/// Every HTTP v3 manifest in the repository must convert without panicking
+/// and produce a document the DSL v4 OpenAPI importer accepts. GraphQL
+/// sources are skipped, exactly as the export command skips them.
+#[test]
+fn corpus_converts_and_imports_into_v4() {
+    let sources_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask has a parent directory")
+        .join("sources");
+    let manifest_files = crate::sources::iter_manifest_files(&[sources_dir]);
+    assert!(
+        manifest_files.len() > 150,
+        "expected the full sources/ corpus, found {} manifests",
+        manifest_files.len()
+    );
+
+    let mut converted = 0usize;
+    let mut graphql_skipped = Vec::new();
+    for manifest_path in manifest_files {
+        let raw = std::fs::read_to_string(&manifest_path).expect("manifest is readable");
+        let manifest = parse_source_manifest_yaml(&raw)
+            .unwrap_or_else(|error| panic!("parsing {}: {error}", manifest_path.display()));
+        let Some(http) = manifest.as_http() else {
+            continue;
+        };
+        if is_graphql_source(http) {
+            graphql_skipped.push(manifest.schema_name().to_string());
+            continue;
+        }
+        let conversion = convert_http_manifest(http);
+        let paths = conversion
+            .document
+            .get("paths")
+            .and_then(Value::as_object)
+            .unwrap_or_else(|| panic!("{}: document has paths", manifest_path.display()));
+        assert!(
+            !paths.is_empty(),
+            "{}: converted document should describe at least one path",
+            manifest_path.display()
+        );
+        let yaml = serde_yaml::to_string(&conversion.document)
+            .unwrap_or_else(|error| panic!("serializing {}: {error}", manifest_path.display()));
+        import_into_v4(&yaml);
+        converted += 1;
+    }
+    assert!(
+        converted > 150,
+        "expected to convert the HTTP corpus, converted {converted}"
+    );
+    for source in ["datahub", "linear", "shopify", "wandb"] {
+        assert!(
+            graphql_skipped.iter().any(|name| name == source),
+            "expected GraphQL source '{source}' to be skipped, skipped: {graphql_skipped:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds `cargo xtask export-openapi` (and `make openapi-export`): converts v3 HTTP source manifests under `sources/` into OpenAPI 3.0.3 documents, as migration bootstrap for the DSL v4 path.

- Every table, request route, and table function becomes one operation; filters/args become typed parameters (required flags, enums, defaults, contains/search modes documented).
- Declared pagination is encoded as the OpenAPI facts the v4 importer's detection already re-derives: page/cursor/offset/page-size query parameters, `Link` response headers, and cursor properties woven into the response wrapper schema.
- Declared columns are folded back into raw response row schemas (`schema_tree`), registered under `components/schemas` and named **exactly after the v3 surface** — the v4 importer derives entity and projection names from the `$ref` leaf, so this keeps converted catalog names aligned with v3 (`pulls` stays `pulls`).
- Anything OpenAPI can't express (SQL filter bindings, runtime state, row strategies, rate limits, raw pagination spec) is preserved under `x-coral*` extensions; every lossy or ambiguous mapping becomes a warning.
- Pure GraphQL sources (`datahub`, `linear`, `shopify`, `wandb`) are skipped with a note — OpenAPI keys operations by path+method, so they'd collapse into one meaningless slot.

Corpus run: **198 converted, 12 skipped, 0 failed, 410 warnings** (220 of those are ambiguous list-vs-singleton cardinality, flagged for curation; the runtime row extraction is shape-tolerant either way).

## Validation against the canonical github_v4

Installed the converted v3 `github` as a v4 source (`source add --file`) next to the checked-in `github_v4` (built from GitHub's canonical OpenAPI URL) and compared materialized projections + live queries:

- 540/546 endpoints join canonical paths exactly; **0** table-vs-function mismatches, **0** required-input mismatches on shared endpoints (the 6 non-joins are v3 param-name choices like `{number}` vs `{issue_number}`, plus endpoints the pinned canonical spec lacks).
- Live queries return identical row sets (`pulls` vs `pulls_list`: 50/50 matching once the canonical spec's `direction: asc` default is pinned).
- Multi-page Link-header pagination and page-mode search functions work end-to-end; ambiguous singletons (e.g. `meta`) query correctly despite the array declaration.
- 267/371 projection names match the v3 names exactly; residual drift is v4's entity pluralization (`meta`→`metas`) — fixing that exactly would need a v4-side naming hook (e.g. operationId-leaf fallback when a doc has no tags, which would also rename `stripe_v4`, so left as a separate decision).

## Tests

- Feature-dense fixture snapshot (insta) covering filters, routes, cursor/link pagination, dict_entries, POST bodies, auth, server variables.
- Round trip through `coral_spec::v4::import_openapi_surface` asserting pagination modes, rows_path, and required path params are re-derived.
- Corpus sweep: every HTTP manifest in the repo converts and re-imports into v4 without errors; asserts the four GraphQL sources are the ones skipped.

Also: `clippy.toml` gains `doc-valid-idents = ["OpenAPI", ".."]`.

## Known limitations

- POST operations with request bodies convert faithfully but v4 flags them `OPENAPI_REQUEST_BODY_UNPUBLISHED` (existing v4 gap; 144 such surfaces in the corpus).
- `pagination.mode: auto` (540 surfaces) has nothing declared to translate; preserved in `x-coral` only.
- Path/method collisions within one source are first-wins with an explicit warning naming the skipped operation.