### PR TITLE
feat(spec): support OAuth credentials in DSL v4

### DIFF
--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -2207,6 +2207,57 @@ tables:
         (manifest, rendered_token_url)
     }
 
+    fn v4_manifest_with_templated_oauth_endpoints(
+        openapi_file: &std::path::Path,
+        token_url: &str,
+        redirect_port: u16,
+    ) -> (String, String) {
+        let token_url_template = token_url.replace("/token", "/{{input.OUTLOOK_TENANT_ID}}/token");
+        let rendered_token_url = token_url.replace("/token", "/organizations/token");
+        let manifest = format!(
+            r#"
+name: secured_messages
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    inputs:
+      API_TOKEN:
+        kind: secret
+        credential:
+          methods:
+            - type: oauth
+              label: Connect
+              description: Use OAuth.
+              oauth:
+                flow:
+                  type: authorization_code
+                  pkce: required
+                redirect_uri: http://127.0.0.1:{redirect_port}/oauth/callback
+                endpoints:
+                  authorization_url: https://provider.example.com/{{{{input.OUTLOOK_TENANT_ID}}}}/oauth/authorize
+                  token_url: {token_url_template}
+                client:
+                  id:
+                    default: default-client
+      OUTLOOK_TENANT_ID:
+        kind: variable
+      API_BASE:
+        kind: variable
+    base_url: "{{{{input.API_BASE}}}}"
+    auth:
+      type: HeaderAuth
+      headers:
+        - name: Authorization
+          from: template
+          template: Bearer {{{{input.API_TOKEN}}}}
+"#,
+            openapi_file.display()
+        );
+        (manifest, rendered_token_url)
+    }
+
     fn oauth_import_bindings_with_tenant() -> SourceBindings {
         SourceBindings {
             variables: vec![
@@ -3249,37 +3300,93 @@ tables:
             },
             event_tx,
         );
-        let callback = async {
-            let event = event_rx
-                .recv()
-                .await
-                .expect("authorization event")
-                .into_event();
-            let ImportSourceWithCredentialsEvent::OAuthAuthorization {
-                input_key,
-                authorization_url,
-                ..
-            } = event
-            else {
-                panic!("unexpected import event");
-            };
-            assert_eq!(input_key, "API_TOKEN");
-            let parsed = Url::parse(&authorization_url).expect("authorization url");
-            assert_eq!(parsed.path(), "/organizations/oauth/authorize");
-            callback(&authorization_url, redirect_port).await;
-            let event = event_rx
-                .recv()
-                .await
-                .expect("completion event")
-                .into_event();
-            let ImportSourceWithCredentialsEvent::OAuthCompleted { input_key, .. } = event else {
-                panic!("unexpected import event");
-            };
-            assert_eq!(input_key, "API_TOKEN");
-        };
+        let callback = authorize_oauth_import(&mut event_rx, redirect_port);
 
         let (source, ()) = tokio::join!(import, callback);
         let source = source.expect("import source with OAuth");
+        assert_eq!(source.secrets, vec!["API_TOKEN"]);
+        let captured = fixture.token_server.await.expect("token server");
+        assert_eq!(
+            captured.form.get("code").map(String::as_str),
+            Some("test-code")
+        );
+        let material = credential_manager
+            .read_material(
+                &default_workspace(),
+                &credential_set_id,
+                CredentialStorageKind::File,
+            )
+            .expect("read material");
+        assert_eq!(
+            material.get("API_TOKEN").map(String::as_str),
+            Some("access-token")
+        );
+        assert_eq!(
+            material
+                .get("__coral_oauth.QVBJX1RPS0VO.method")
+                .map(String::as_str),
+            Some("oauth")
+        );
+        assert_eq!(
+            material
+                .get("__coral_oauth.QVBJX1RPS0VO.token_url")
+                .map(String::as_str),
+            Some(rendered_token_url.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn import_v4_with_oauth_persists_retrieved_material() {
+        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+        let openapi_file = descriptor_temp.path().join("openapi.yaml");
+        std::fs::write(&openapi_file, v4_openapi_fixture()).expect("write descriptor");
+
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager.clone(), layout);
+        let source_name = SourceName::parse("secured_messages").expect("source");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let fixture = OAuthFixture::new();
+        let redirect_port = free_loopback_port();
+        let (manifest_yaml, rendered_token_url) = v4_manifest_with_templated_oauth_endpoints(
+            &openapi_file,
+            &fixture.token_url,
+            redirect_port,
+        );
+        assert!(
+            manifest_yaml
+                .find("      API_TOKEN:")
+                .expect("API_TOKEN input")
+                < manifest_yaml
+                    .find("      OUTLOOK_TENANT_ID:")
+                    .expect("tenant input"),
+            "tenant variable should exercise v4 surface input order after the OAuth secret"
+        );
+        let (event_tx, mut event_rx) = import_event_channel();
+        let workspace_name = default_workspace();
+        let import = manager.import_source_with_credentials(
+            &workspace_name,
+            ImportSourceWithCredentialsCommand {
+                manifest_yaml,
+                bindings: oauth_import_bindings_with_tenant(),
+                oauth_credential_retrievals: vec![SourceOAuthCredentialRetrieval {
+                    input_key: "API_TOKEN".to_string(),
+                    method_index: 0,
+                    credential_inputs: Vec::new(),
+                }],
+            },
+            event_tx,
+        );
+        let callback = authorize_oauth_import(&mut event_rx, redirect_port);
+
+        let (source, ()) = tokio::join!(import, callback);
+        let source = source.expect("import v4 source with OAuth");
         assert_eq!(source.secrets, vec!["API_TOKEN"]);
         let captured = fixture.token_server.await.expect("token server");
         assert_eq!(
@@ -3453,6 +3560,39 @@ tables:
             .expect("callback response")
             .error_for_status()
             .expect("callback success");
+    }
+
+    async fn authorize_oauth_import(
+        event_rx: &mut mpsc::Receiver<PendingImportSourceWithCredentialsEvent>,
+        redirect_port: u16,
+    ) {
+        let event = event_rx
+            .recv()
+            .await
+            .expect("authorization event")
+            .into_event();
+        let ImportSourceWithCredentialsEvent::OAuthAuthorization {
+            input_key,
+            authorization_url,
+            ..
+        } = event
+        else {
+            panic!("unexpected import event");
+        };
+        assert_eq!(input_key, "API_TOKEN");
+        let parsed = Url::parse(&authorization_url).expect("authorization url");
+        assert_eq!(parsed.path(), "/organizations/oauth/authorize");
+        callback(&authorization_url, redirect_port).await;
+
+        let event = event_rx
+            .recv()
+            .await
+            .expect("completion event")
+            .into_event();
+        let ImportSourceWithCredentialsEvent::OAuthCompleted { input_key, .. } = event else {
+            panic!("unexpected import event");
+        };
+        assert_eq!(input_key, "API_TOKEN");
     }
 
     fn import_event_channel() -> (

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -10,6 +10,8 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use url::Url;
 
@@ -255,7 +257,8 @@ fn validate_oauth_url_fragment_policy(
 }
 
 /// Supported loopback redirect URI port binding modes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum ManifestOAuthRedirectUriPortMode {
     /// Bind the exact port authored in `redirect_uri`.
     Fixed,
@@ -291,7 +294,8 @@ pub enum ManifestOAuthFlowKind {
 }
 
 /// Supported PKCE modes for OAuth credential retrieval.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum ManifestOAuthPkceMode {
     /// Require a generated code verifier and S256 challenge.
     Required,
@@ -328,16 +332,19 @@ impl ManifestOAuthClientIdSpec {
 }
 
 /// OAuth client secret retrieval configuration.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct ManifestOAuthClientSecretSpec {
     /// Credential-retrieval input key for the client secret.
+    #[schemars(length(min = 1))]
     pub input: String,
     /// How Coral sends the client secret to the token endpoint.
     pub transport: ManifestOAuthClientSecretTransport,
 }
 
 /// Supported confidential-client secret transport modes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum ManifestOAuthClientSecretTransport {
     /// Send `Authorization: Basic base64(client_id:client_secret)`.
     BasicAuth,
@@ -346,22 +353,30 @@ pub enum ManifestOAuthClientSecretTransport {
 }
 
 /// OAuth 2.0 Dynamic Client Registration configuration.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct ManifestOAuthDynamicClientRegistrationSpec {
     /// OAuth client registration endpoint URL template.
+    #[schemars(length(min = 1))]
     pub registration_url: String,
     /// Optional client display name sent during registration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
     pub client_name: Option<String>,
     /// Requested token endpoint authentication method.
+    #[serde(default)]
     pub token_endpoint_auth_method: ManifestOAuthDynamicClientRegistrationAuthMethod,
     /// Whether Coral requests the `refresh_token` grant type during registration.
+    #[serde(default)]
     pub request_refresh_token_grant: bool,
 }
 
 /// Supported DCR token endpoint authentication method requests.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum ManifestOAuthDynamicClientRegistrationAuthMethod {
     /// Public client; no client authentication at the token endpoint.
+    #[default]
     None,
     /// Confidential client using HTTP Basic authentication at the token endpoint.
     ClientSecretBasic,
@@ -410,23 +425,27 @@ impl ManifestOAuthClientSecretTransport {
 }
 
 /// OAuth scope parameter configuration.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct ManifestOAuthScopesSpec {
     /// The `scope` parameter value definition.
     pub scope: ManifestOAuthScopeSpec,
 }
 
 /// OAuth scope parameter values and delimiter.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct ManifestOAuthScopeSpec {
     /// Delimiter used to join scope values.
     pub delimiter: ManifestOAuthScopeDelimiter,
     /// Authored scope values.
+    #[schemars(length(min = 1), inner(length(min = 1)))]
     pub values: Vec<String>,
 }
 
 /// Supported OAuth scope delimiters.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub enum ManifestOAuthScopeDelimiter {
     /// Join scope values with a single space.
     Space,

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -361,7 +361,7 @@ pub struct ManifestOAuthDynamicClientRegistrationSpec {
     pub registration_url: String,
     /// Optional client display name sent during registration.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(length(min = 1))]
+    #[schemars(required, length(min = 1))]
     pub client_name: Option<String>,
     /// Requested token endpoint authentication method.
     #[serde(default)]

--- a/crates/coral-spec/src/schema/source_manifest_v4.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest_v4.schema.json
@@ -344,7 +344,7 @@
         "redirect_uri_port_mode": {
           "anyOf": [
             {
-              "$ref": "#/$defs/V4OAuthRedirectUriPortModeSchema"
+              "$ref": "#/$defs/ManifestOAuthRedirectUriPortMode"
             },
             {
               "type": "null"
@@ -360,7 +360,7 @@
         "scopes": {
           "anyOf": [
             {
-              "$ref": "#/$defs/V4OAuthScopesSchema"
+              "$ref": "#/$defs/ManifestOAuthScopesSpec"
             },
             {
               "type": "null"
@@ -383,7 +383,7 @@
           "$ref": "#/$defs/V4AuthorizationCodeOAuthFlowTypeSchema"
         },
         "pkce": {
-          "$ref": "#/$defs/V4OAuthPkceModeSchema"
+          "$ref": "#/$defs/ManifestOAuthPkceMode"
         }
       },
       "additionalProperties": false,
@@ -398,18 +398,34 @@
         "authorization_code"
       ]
     },
-    "V4OAuthPkceModeSchema": {
-      "type": "string",
-      "enum": [
-        "required",
-        "disabled"
+    "ManifestOAuthPkceMode": {
+      "description": "Supported PKCE modes for OAuth credential retrieval.",
+      "oneOf": [
+        {
+          "description": "Require a generated code verifier and S256 challenge.",
+          "type": "string",
+          "const": "required"
+        },
+        {
+          "description": "Do not include PKCE parameters.",
+          "type": "string",
+          "const": "disabled"
+        }
       ]
     },
-    "V4OAuthRedirectUriPortModeSchema": {
-      "type": "string",
-      "enum": [
-        "fixed",
-        "random"
+    "ManifestOAuthRedirectUriPortMode": {
+      "description": "Supported loopback redirect URI port binding modes.",
+      "oneOf": [
+        {
+          "description": "Bind the exact port authored in `redirect_uri`.",
+          "type": "string",
+          "const": "fixed"
+        },
+        {
+          "description": "Bind a random free port and use it in OAuth authorization and token exchange.",
+          "type": "string",
+          "const": "random"
+        }
       ]
     },
     "V4AuthorizationCodeOAuthEndpointsSchema": {
@@ -525,7 +541,7 @@
           "$ref": "#/$defs/V4OAuthClientIdWithInputSchema"
         },
         "secret": {
-          "$ref": "#/$defs/V4OAuthClientSecretSchema"
+          "$ref": "#/$defs/ManifestOAuthClientSecretSpec"
         }
       },
       "additionalProperties": false,
@@ -544,15 +560,18 @@
         }
       ]
     },
-    "V4OAuthClientSecretSchema": {
+    "ManifestOAuthClientSecretSpec": {
+      "description": "OAuth client secret retrieval configuration.",
       "type": "object",
       "properties": {
         "input": {
+          "description": "Credential-retrieval input key for the client secret.",
           "type": "string",
           "minLength": 1
         },
         "transport": {
-          "$ref": "#/$defs/V4OAuthClientSecretTransportSchema"
+          "description": "How Coral sends the client secret to the token endpoint.",
+          "$ref": "#/$defs/ManifestOAuthClientSecretTransport"
         }
       },
       "additionalProperties": false,
@@ -561,18 +580,26 @@
         "transport"
       ]
     },
-    "V4OAuthClientSecretTransportSchema": {
-      "type": "string",
-      "enum": [
-        "basic_auth",
-        "request_body"
+    "ManifestOAuthClientSecretTransport": {
+      "description": "Supported confidential-client secret transport modes.",
+      "oneOf": [
+        {
+          "description": "Send `Authorization: Basic base64(client_id:client_secret)`.",
+          "type": "string",
+          "const": "basic_auth"
+        },
+        {
+          "description": "Send `client_secret` in the token request body.",
+          "type": "string",
+          "const": "request_body"
+        }
       ]
     },
     "V4OAuthDynamicClientSchema": {
       "type": "object",
       "properties": {
         "dynamic_registration": {
-          "$ref": "#/$defs/V4OAuthDynamicClientRegistrationSchema"
+          "$ref": "#/$defs/ManifestOAuthDynamicClientRegistrationSpec"
         }
       },
       "additionalProperties": false,
@@ -580,14 +607,17 @@
         "dynamic_registration"
       ]
     },
-    "V4OAuthDynamicClientRegistrationSchema": {
+    "ManifestOAuthDynamicClientRegistrationSpec": {
+      "description": "OAuth 2.0 Dynamic Client Registration configuration.",
       "type": "object",
       "properties": {
         "registration_url": {
+          "description": "OAuth client registration endpoint URL template.",
           "type": "string",
           "minLength": 1
         },
         "client_name": {
+          "description": "Optional client display name sent during registration.",
           "type": [
             "string",
             "null"
@@ -595,20 +625,14 @@
           "minLength": 1
         },
         "token_endpoint_auth_method": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/V4OAuthDynamicClientRegistrationAuthMethodSchema"
-            },
-            {
-              "type": "null"
-            }
-          ]
+          "description": "Requested token endpoint authentication method.",
+          "$ref": "#/$defs/ManifestOAuthDynamicClientRegistrationAuthMethod",
+          "default": "none"
         },
         "request_refresh_token_grant": {
-          "type": [
-            "boolean",
-            "null"
-          ]
+          "description": "Whether Coral requests the `refresh_token` grant type during registration.",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false,
@@ -616,12 +640,24 @@
         "registration_url"
       ]
     },
-    "V4OAuthDynamicClientRegistrationAuthMethodSchema": {
-      "type": "string",
-      "enum": [
-        "none",
-        "client_secret_basic",
-        "client_secret_post"
+    "ManifestOAuthDynamicClientRegistrationAuthMethod": {
+      "description": "Supported DCR token endpoint authentication method requests.",
+      "oneOf": [
+        {
+          "description": "Public client; no client authentication at the token endpoint.",
+          "type": "string",
+          "const": "none"
+        },
+        {
+          "description": "Confidential client using HTTP Basic authentication at the token endpoint.",
+          "type": "string",
+          "const": "client_secret_basic"
+        },
+        {
+          "description": "Confidential client sending the client secret in the token request body.",
+          "type": "string",
+          "const": "client_secret_post"
+        }
       ]
     },
     "V4OAuthPublicDynamicClientSchema": {
@@ -631,7 +667,7 @@
           "$ref": "#/$defs/V4OAuthClientIdSchema"
         },
         "dynamic_registration": {
-          "$ref": "#/$defs/V4OAuthDynamicClientRegistrationSchema"
+          "$ref": "#/$defs/ManifestOAuthDynamicClientRegistrationSpec"
         }
       },
       "additionalProperties": false,
@@ -647,10 +683,10 @@
           "$ref": "#/$defs/V4OAuthClientIdWithInputSchema"
         },
         "secret": {
-          "$ref": "#/$defs/V4OAuthClientSecretSchema"
+          "$ref": "#/$defs/ManifestOAuthClientSecretSpec"
         },
         "dynamic_registration": {
-          "$ref": "#/$defs/V4OAuthDynamicClientRegistrationSchema"
+          "$ref": "#/$defs/ManifestOAuthDynamicClientRegistrationSpec"
         }
       },
       "additionalProperties": false,
@@ -660,11 +696,13 @@
         "dynamic_registration"
       ]
     },
-    "V4OAuthScopesSchema": {
+    "ManifestOAuthScopesSpec": {
+      "description": "OAuth scope parameter configuration.",
       "type": "object",
       "properties": {
         "scope": {
-          "$ref": "#/$defs/V4OAuthScopeSchema"
+          "description": "The `scope` parameter value definition.",
+          "$ref": "#/$defs/ManifestOAuthScopeSpec"
         }
       },
       "additionalProperties": false,
@@ -672,13 +710,16 @@
         "scope"
       ]
     },
-    "V4OAuthScopeSchema": {
+    "ManifestOAuthScopeSpec": {
+      "description": "OAuth scope parameter values and delimiter.",
       "type": "object",
       "properties": {
         "delimiter": {
-          "$ref": "#/$defs/V4OAuthScopeDelimiterSchema"
+          "description": "Delimiter used to join scope values.",
+          "$ref": "#/$defs/ManifestOAuthScopeDelimiter"
         },
         "values": {
+          "description": "Authored scope values.",
           "type": "array",
           "items": {
             "type": "string",
@@ -693,11 +734,19 @@
         "values"
       ]
     },
-    "V4OAuthScopeDelimiterSchema": {
-      "type": "string",
-      "enum": [
-        "space",
-        "comma"
+    "ManifestOAuthScopeDelimiter": {
+      "description": "Supported OAuth scope delimiters.",
+      "oneOf": [
+        {
+          "description": "Join scope values with a single space.",
+          "type": "string",
+          "const": "space"
+        },
+        {
+          "description": "Join scope values with a comma.",
+          "type": "string",
+          "const": "comma"
+        }
       ]
     },
     "V4DeviceCodeOAuthCredentialMethodSchema": {
@@ -722,7 +771,7 @@
         "scopes": {
           "anyOf": [
             {
-              "$ref": "#/$defs/V4OAuthScopesSchema"
+              "$ref": "#/$defs/ManifestOAuthScopesSpec"
             },
             {
               "type": "null"

--- a/crates/coral-spec/src/schema/source_manifest_v4.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest_v4.schema.json
@@ -207,13 +207,19 @@
               ]
             },
             "credential": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/V4CredentialSpecSchema"
-                },
-                {
-                  "type": "null"
+              "type": "object",
+              "properties": {
+                "methods": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/$defs/V4CredentialMethodSchema"
+                  },
+                  "minItems": 1
                 }
+              },
+              "additionalProperties": false,
+              "required": [
+                "methods"
               ]
             },
             "kind": {
@@ -226,22 +232,6 @@
             "kind"
           ]
         }
-      ]
-    },
-    "V4CredentialSpecSchema": {
-      "type": "object",
-      "properties": {
-        "methods": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/V4CredentialMethodSchema"
-          },
-          "minItems": 1
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "methods"
       ]
     },
     "V4CredentialMethodSchema": {
@@ -331,10 +321,7 @@
           "$ref": "#/$defs/V4AuthorizationCodeOAuthFlowSchema"
         },
         "resource": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "minLength": 1
         },
         "redirect_uri": {
@@ -342,12 +329,17 @@
           "minLength": 1
         },
         "redirect_uri_port_mode": {
-          "anyOf": [
+          "description": "Supported loopback redirect URI port binding modes.",
+          "oneOf": [
             {
-              "$ref": "#/$defs/ManifestOAuthRedirectUriPortMode"
+              "description": "Bind the exact port authored in `redirect_uri`.",
+              "type": "string",
+              "const": "fixed"
             },
             {
-              "type": "null"
+              "description": "Bind a random free port and use it in OAuth authorization and token exchange.",
+              "type": "string",
+              "const": "random"
             }
           ]
         },
@@ -358,13 +350,17 @@
           "$ref": "#/$defs/V4OAuthClientSchema"
         },
         "scopes": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ManifestOAuthScopesSpec"
-            },
-            {
-              "type": "null"
+          "description": "OAuth scope parameter configuration.",
+          "type": "object",
+          "properties": {
+            "scope": {
+              "description": "The `scope` parameter value definition.",
+              "$ref": "#/$defs/ManifestOAuthScopeSpec"
             }
+          },
+          "additionalProperties": false,
+          "required": [
+            "scope"
           ]
         }
       },
@@ -410,21 +406,6 @@
           "description": "Do not include PKCE parameters.",
           "type": "string",
           "const": "disabled"
-        }
-      ]
-    },
-    "ManifestOAuthRedirectUriPortMode": {
-      "description": "Supported loopback redirect URI port binding modes.",
-      "oneOf": [
-        {
-          "description": "Bind the exact port authored in `redirect_uri`.",
-          "type": "string",
-          "const": "fixed"
-        },
-        {
-          "description": "Bind a random free port and use it in OAuth authorization and token exchange.",
-          "type": "string",
-          "const": "random"
         }
       ]
     },
@@ -618,10 +599,7 @@
         },
         "client_name": {
           "description": "Optional client display name sent during registration.",
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "minLength": 1
         },
         "token_endpoint_auth_method": {
@@ -696,20 +674,6 @@
         "dynamic_registration"
       ]
     },
-    "ManifestOAuthScopesSpec": {
-      "description": "OAuth scope parameter configuration.",
-      "type": "object",
-      "properties": {
-        "scope": {
-          "description": "The `scope` parameter value definition.",
-          "$ref": "#/$defs/ManifestOAuthScopeSpec"
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "scope"
-      ]
-    },
     "ManifestOAuthScopeSpec": {
       "description": "OAuth scope parameter values and delimiter.",
       "type": "object",
@@ -756,10 +720,7 @@
           "$ref": "#/$defs/V4DeviceCodeOAuthFlowSchema"
         },
         "resource": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": "string",
           "minLength": 1
         },
         "endpoints": {
@@ -769,13 +730,17 @@
           "$ref": "#/$defs/V4DeviceCodeOAuthClientSchema"
         },
         "scopes": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ManifestOAuthScopesSpec"
-            },
-            {
-              "type": "null"
+          "description": "OAuth scope parameter configuration.",
+          "type": "object",
+          "properties": {
+            "scope": {
+              "description": "The `scope` parameter value definition.",
+              "$ref": "#/$defs/ManifestOAuthScopeSpec"
             }
+          },
+          "additionalProperties": false,
+          "required": [
+            "scope"
           ]
         }
       },

--- a/crates/coral-spec/src/schema/source_manifest_v4.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest_v4.schema.json
@@ -206,7 +206,16 @@
                 "null"
               ]
             },
-            "credential": true,
+            "credential": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/V4CredentialSpecSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "kind": {
               "type": "string",
               "const": "secret"
@@ -216,6 +225,580 @@
           "required": [
             "kind"
           ]
+        }
+      ]
+    },
+    "V4CredentialSpecSchema": {
+      "type": "object",
+      "properties": {
+        "methods": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/V4CredentialMethodSchema"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "methods"
+      ]
+    },
+    "V4CredentialMethodSchema": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "hint": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "type": "string",
+              "const": "source_config"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "description": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "hint": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "oauth": {
+              "$ref": "#/$defs/V4OAuthCredentialMethodSchema"
+            },
+            "type": {
+              "type": "string",
+              "const": "oauth"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "oauth"
+          ]
+        }
+      ]
+    },
+    "V4OAuthCredentialMethodSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/V4AuthorizationCodeOAuthCredentialMethodSchema"
+        },
+        {
+          "$ref": "#/$defs/V4DeviceCodeOAuthCredentialMethodSchema"
+        }
+      ]
+    },
+    "V4AuthorizationCodeOAuthCredentialMethodSchema": {
+      "type": "object",
+      "properties": {
+        "flow": {
+          "$ref": "#/$defs/V4AuthorizationCodeOAuthFlowSchema"
+        },
+        "resource": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "redirect_uri": {
+          "type": "string",
+          "minLength": 1
+        },
+        "redirect_uri_port_mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/V4OAuthRedirectUriPortModeSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "endpoints": {
+          "$ref": "#/$defs/V4AuthorizationCodeOAuthEndpointsSchema"
+        },
+        "client": {
+          "$ref": "#/$defs/V4OAuthClientSchema"
+        },
+        "scopes": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/V4OAuthScopesSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "flow",
+        "redirect_uri",
+        "endpoints",
+        "client"
+      ]
+    },
+    "V4AuthorizationCodeOAuthFlowSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/V4AuthorizationCodeOAuthFlowTypeSchema"
+        },
+        "pkce": {
+          "$ref": "#/$defs/V4OAuthPkceModeSchema"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "pkce"
+      ]
+    },
+    "V4AuthorizationCodeOAuthFlowTypeSchema": {
+      "type": "string",
+      "enum": [
+        "authorization_code"
+      ]
+    },
+    "V4OAuthPkceModeSchema": {
+      "type": "string",
+      "enum": [
+        "required",
+        "disabled"
+      ]
+    },
+    "V4OAuthRedirectUriPortModeSchema": {
+      "type": "string",
+      "enum": [
+        "fixed",
+        "random"
+      ]
+    },
+    "V4AuthorizationCodeOAuthEndpointsSchema": {
+      "type": "object",
+      "properties": {
+        "authorization_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "token_url": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "authorization_url",
+        "token_url"
+      ]
+    },
+    "V4OAuthClientSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/V4OAuthPublicClientSchema"
+        },
+        {
+          "$ref": "#/$defs/V4OAuthConfidentialClientSchema"
+        },
+        {
+          "$ref": "#/$defs/V4OAuthDynamicClientSchema"
+        },
+        {
+          "$ref": "#/$defs/V4OAuthPublicDynamicClientSchema"
+        },
+        {
+          "$ref": "#/$defs/V4OAuthConfidentialDynamicClientSchema"
+        }
+      ]
+    },
+    "V4OAuthPublicClientSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/V4OAuthClientIdSchema"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ]
+    },
+    "V4OAuthClientIdSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/V4OAuthClientIdDefaultAndInputSchema"
+        },
+        {
+          "$ref": "#/$defs/V4OAuthClientIdDefaultSchema"
+        },
+        {
+          "$ref": "#/$defs/V4OAuthClientIdInputSchema"
+        }
+      ]
+    },
+    "V4OAuthClientIdDefaultAndInputSchema": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "string",
+          "minLength": 1
+        },
+        "input": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "default",
+        "input"
+      ]
+    },
+    "V4OAuthClientIdDefaultSchema": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "default"
+      ]
+    },
+    "V4OAuthClientIdInputSchema": {
+      "type": "object",
+      "properties": {
+        "input": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "input"
+      ]
+    },
+    "V4OAuthConfidentialClientSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/V4OAuthClientIdWithInputSchema"
+        },
+        "secret": {
+          "$ref": "#/$defs/V4OAuthClientSecretSchema"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "secret"
+      ]
+    },
+    "V4OAuthClientIdWithInputSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/V4OAuthClientIdDefaultAndInputSchema"
+        },
+        {
+          "$ref": "#/$defs/V4OAuthClientIdInputSchema"
+        }
+      ]
+    },
+    "V4OAuthClientSecretSchema": {
+      "type": "object",
+      "properties": {
+        "input": {
+          "type": "string",
+          "minLength": 1
+        },
+        "transport": {
+          "$ref": "#/$defs/V4OAuthClientSecretTransportSchema"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "input",
+        "transport"
+      ]
+    },
+    "V4OAuthClientSecretTransportSchema": {
+      "type": "string",
+      "enum": [
+        "basic_auth",
+        "request_body"
+      ]
+    },
+    "V4OAuthDynamicClientSchema": {
+      "type": "object",
+      "properties": {
+        "dynamic_registration": {
+          "$ref": "#/$defs/V4OAuthDynamicClientRegistrationSchema"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "dynamic_registration"
+      ]
+    },
+    "V4OAuthDynamicClientRegistrationSchema": {
+      "type": "object",
+      "properties": {
+        "registration_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "client_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "token_endpoint_auth_method": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/V4OAuthDynamicClientRegistrationAuthMethodSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "request_refresh_token_grant": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "registration_url"
+      ]
+    },
+    "V4OAuthDynamicClientRegistrationAuthMethodSchema": {
+      "type": "string",
+      "enum": [
+        "none",
+        "client_secret_basic",
+        "client_secret_post"
+      ]
+    },
+    "V4OAuthPublicDynamicClientSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/V4OAuthClientIdSchema"
+        },
+        "dynamic_registration": {
+          "$ref": "#/$defs/V4OAuthDynamicClientRegistrationSchema"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "dynamic_registration"
+      ]
+    },
+    "V4OAuthConfidentialDynamicClientSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/V4OAuthClientIdWithInputSchema"
+        },
+        "secret": {
+          "$ref": "#/$defs/V4OAuthClientSecretSchema"
+        },
+        "dynamic_registration": {
+          "$ref": "#/$defs/V4OAuthDynamicClientRegistrationSchema"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "secret",
+        "dynamic_registration"
+      ]
+    },
+    "V4OAuthScopesSchema": {
+      "type": "object",
+      "properties": {
+        "scope": {
+          "$ref": "#/$defs/V4OAuthScopeSchema"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "scope"
+      ]
+    },
+    "V4OAuthScopeSchema": {
+      "type": "object",
+      "properties": {
+        "delimiter": {
+          "$ref": "#/$defs/V4OAuthScopeDelimiterSchema"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "delimiter",
+        "values"
+      ]
+    },
+    "V4OAuthScopeDelimiterSchema": {
+      "type": "string",
+      "enum": [
+        "space",
+        "comma"
+      ]
+    },
+    "V4DeviceCodeOAuthCredentialMethodSchema": {
+      "type": "object",
+      "properties": {
+        "flow": {
+          "$ref": "#/$defs/V4DeviceCodeOAuthFlowSchema"
+        },
+        "resource": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "endpoints": {
+          "$ref": "#/$defs/V4DeviceCodeOAuthEndpointsSchema"
+        },
+        "client": {
+          "$ref": "#/$defs/V4DeviceCodeOAuthClientSchema"
+        },
+        "scopes": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/V4OAuthScopesSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "flow",
+        "endpoints",
+        "client"
+      ]
+    },
+    "V4DeviceCodeOAuthFlowSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/V4DeviceCodeOAuthFlowTypeSchema"
+        },
+        "pkce": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/V4OAuthDisabledPkceModeSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type"
+      ]
+    },
+    "V4DeviceCodeOAuthFlowTypeSchema": {
+      "type": "string",
+      "enum": [
+        "device_code"
+      ]
+    },
+    "V4OAuthDisabledPkceModeSchema": {
+      "type": "string",
+      "enum": [
+        "disabled"
+      ]
+    },
+    "V4DeviceCodeOAuthEndpointsSchema": {
+      "type": "object",
+      "properties": {
+        "token_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "device_authorization_url": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "token_url",
+        "device_authorization_url"
+      ]
+    },
+    "V4DeviceCodeOAuthClientSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/V4OAuthPublicClientSchema"
+        },
+        {
+          "$ref": "#/$defs/V4OAuthDynamicClientSchema"
+        },
+        {
+          "$ref": "#/$defs/V4OAuthPublicDynamicClientSchema"
         }
       ]
     },

--- a/crates/coral-spec/src/v4/manifest_tests.rs
+++ b/crates/coral-spec/src/v4/manifest_tests.rs
@@ -468,6 +468,11 @@ surfaces:
     };
     assert_eq!(oauth_method.kind, ManifestCredentialMethodKind::OAuth);
     assert_eq!(oauth_method.label.as_deref(), Some("Connect with Demo"));
+    assert_eq!(oauth_method.description.as_deref(), Some("Use OAuth."));
+    assert_eq!(
+        oauth_method.hint.as_deref(),
+        Some("Authorize in your browser.")
+    );
     assert_eq!(
         source_config_method.kind,
         ManifestCredentialMethodKind::SourceConfig

--- a/crates/coral-spec/src/v4/manifest_tests.rs
+++ b/crates/coral-spec/src/v4/manifest_tests.rs
@@ -1,4 +1,8 @@
-use crate::parse_source_manifest_yaml;
+use crate::{
+    ManifestCredentialMethodKind, ManifestOAuthDynamicClientRegistrationAuthMethod,
+    ManifestOAuthFlowKind, ManifestOAuthPkceMode, ManifestOAuthRedirectUriPortMode,
+    ManifestOAuthScopeDelimiter, parse_source_manifest_yaml,
+};
 
 #[test]
 fn parses_v4_manifest_and_unions_surface_inputs() {
@@ -398,4 +402,166 @@ surfaces:
     .expect("v4 manifest");
 
     assert_eq!(manifest.declared_inputs().len(), 2);
+}
+
+#[test]
+fn parses_v4_surface_input_oauth_credential_metadata() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    inputs:
+      TENANT_ID:
+        kind: variable
+        default: organizations
+      ACCESS_TOKEN:
+        kind: secret
+        credential:
+          methods:
+            - type: oauth
+              label: Connect with Demo
+              description: Use OAuth.
+              hint: Authorize in your browser.
+              oauth:
+                flow:
+                  type: authorization_code
+                  pkce: required
+                resource: https://api.example.com/
+                redirect_uri: http://127.0.0.1:0/oauth/callback
+                redirect_uri_port_mode: random
+                endpoints:
+                  authorization_url: https://login.example.com/{{input.TENANT_ID}}/oauth/authorize
+                  token_url: https://login.example.com/{{input.TENANT_ID}}/oauth/token
+                client:
+                  dynamic_registration:
+                    registration_url: https://login.example.com/{{input.TENANT_ID}}/oauth/register
+                    client_name: Coral Demo
+                    token_endpoint_auth_method: client_secret_post
+                    request_refresh_token_grant: true
+                scopes:
+                  scope:
+                    delimiter: comma
+                    values:
+                      - read
+                      - offline_access
+            - type: source_config
+              label: Paste token
+",
+    )
+    .expect("v4 manifest");
+
+    let access_token = manifest
+        .declared_inputs()
+        .iter()
+        .find(|input| input.key == "ACCESS_TOKEN")
+        .expect("ACCESS_TOKEN input");
+    let credential = access_token.credential.as_ref().expect("credential");
+    let [oauth_method, source_config_method] = credential.methods.as_slice() else {
+        panic!(
+            "expected two credential methods, got {:?}",
+            credential.methods
+        );
+    };
+    assert_eq!(oauth_method.kind, ManifestCredentialMethodKind::OAuth);
+    assert_eq!(oauth_method.label.as_deref(), Some("Connect with Demo"));
+    assert_eq!(
+        source_config_method.kind,
+        ManifestCredentialMethodKind::SourceConfig
+    );
+
+    let oauth = oauth_method.oauth.as_ref().expect("oauth");
+    assert_eq!(oauth.flow.kind, ManifestOAuthFlowKind::AuthorizationCode);
+    assert_eq!(oauth.flow.pkce, ManifestOAuthPkceMode::Required);
+    assert_eq!(
+        oauth.redirect_uri_port_mode,
+        ManifestOAuthRedirectUriPortMode::Random
+    );
+    assert_eq!(oauth.resource.as_deref(), Some("https://api.example.com/"));
+    assert_eq!(
+        oauth.authorization_url.as_deref(),
+        Some("https://login.example.com/{{input.TENANT_ID}}/oauth/authorize")
+    );
+    assert_eq!(
+        oauth.token_url,
+        "https://login.example.com/{{input.TENANT_ID}}/oauth/token"
+    );
+    let registration = oauth
+        .client
+        .dynamic_registration
+        .as_ref()
+        .expect("dynamic registration");
+    assert_eq!(
+        registration.token_endpoint_auth_method,
+        ManifestOAuthDynamicClientRegistrationAuthMethod::ClientSecretPost
+    );
+    assert!(registration.request_refresh_token_grant);
+    assert_eq!(
+        oauth.scopes.as_ref().expect("scopes").scope.delimiter,
+        ManifestOAuthScopeDelimiter::Comma
+    );
+}
+
+#[test]
+fn rejects_v4_surfaces_with_incompatible_oauth_input_metadata() {
+    let error = parse_source_manifest_yaml(
+        r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    namespace_suffix: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    inputs:
+      ACCESS_TOKEN:
+        kind: secret
+        credential:
+          methods:
+            - type: oauth
+              oauth:
+                flow:
+                  type: authorization_code
+                  pkce: required
+                redirect_uri: http://127.0.0.1:0/oauth/callback
+                endpoints:
+                  authorization_url: https://login.example.com/oauth/authorize
+                  token_url: https://login.example.com/oauth/token
+                client:
+                  id:
+                    default: rest-client
+  - id: mcp
+    namespace_suffix: mcp
+    type: mcp
+    inputs:
+      ACCESS_TOKEN:
+        kind: secret
+        credential:
+          methods:
+            - type: oauth
+              oauth:
+                flow:
+                  type: device_code
+                endpoints:
+                  device_authorization_url: https://login.example.com/oauth/device
+                  token_url: https://login.example.com/oauth/token
+                client:
+                  id:
+                    default: mcp-client
+    server:
+      transport: stdio
+      command: demo-mcp-server
+",
+    )
+    .expect_err("incompatible duplicate input metadata should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("declare incompatible input 'ACCESS_TOKEN'"),
+        "unexpected error: {error}"
+    );
 }

--- a/crates/coral-spec/src/v4/schema.rs
+++ b/crates/coral-spec/src/v4/schema.rs
@@ -8,7 +8,11 @@ use serde_json::{Value, json};
 
 use crate::backends::http::RateLimitSpec;
 use crate::backends::mcp::McpServerSpec;
-use crate::{AuthSpec, HeaderSpec};
+use crate::{
+    AuthSpec, HeaderSpec, ManifestOAuthClientSecretSpec,
+    ManifestOAuthDynamicClientRegistrationSpec, ManifestOAuthPkceMode,
+    ManifestOAuthRedirectUriPortMode, ManifestOAuthScopesSpec,
+};
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -156,11 +160,11 @@ struct V4AuthorizationCodeOAuthCredentialMethodSchema {
     #[schemars(length(min = 1))]
     redirect: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    redirect_uri_port_mode: Option<V4OAuthRedirectUriPortModeSchema>,
+    redirect_uri_port_mode: Option<ManifestOAuthRedirectUriPortMode>,
     endpoints: V4AuthorizationCodeOAuthEndpointsSchema,
     client: V4OAuthClientSchema,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    scopes: Option<V4OAuthScopesSchema>,
+    scopes: Option<ManifestOAuthScopesSpec>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -173,7 +177,7 @@ struct V4DeviceCodeOAuthCredentialMethodSchema {
     endpoints: V4DeviceCodeOAuthEndpointsSchema,
     client: V4DeviceCodeOAuthClientSchema,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    scopes: Option<V4OAuthScopesSchema>,
+    scopes: Option<ManifestOAuthScopesSpec>,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -181,27 +185,13 @@ struct V4DeviceCodeOAuthCredentialMethodSchema {
 struct V4AuthorizationCodeOAuthFlowSchema {
     #[serde(rename = "type")]
     flow_type: V4AuthorizationCodeOAuthFlowTypeSchema,
-    pkce: V4OAuthPkceModeSchema,
+    pkce: ManifestOAuthPkceMode,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 enum V4AuthorizationCodeOAuthFlowTypeSchema {
     AuthorizationCode,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-enum V4OAuthPkceModeSchema {
-    Required,
-    Disabled,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-enum V4OAuthRedirectUriPortModeSchema {
-    Fixed,
-    Random,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -275,28 +265,28 @@ struct V4OAuthPublicClientSchema {
 #[serde(deny_unknown_fields)]
 struct V4OAuthConfidentialClientSchema {
     id: V4OAuthClientIdWithInputSchema,
-    secret: V4OAuthClientSecretSchema,
+    secret: ManifestOAuthClientSecretSpec,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct V4OAuthDynamicClientSchema {
-    dynamic_registration: V4OAuthDynamicClientRegistrationSchema,
+    dynamic_registration: ManifestOAuthDynamicClientRegistrationSpec,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct V4OAuthPublicDynamicClientSchema {
     id: V4OAuthClientIdSchema,
-    dynamic_registration: V4OAuthDynamicClientRegistrationSchema,
+    dynamic_registration: ManifestOAuthDynamicClientRegistrationSpec,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct V4OAuthConfidentialDynamicClientSchema {
     id: V4OAuthClientIdWithInputSchema,
-    secret: V4OAuthClientSecretSchema,
-    dynamic_registration: V4OAuthDynamicClientRegistrationSchema,
+    secret: ManifestOAuthClientSecretSpec,
+    dynamic_registration: ManifestOAuthDynamicClientRegistrationSpec,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -335,64 +325,6 @@ struct V4OAuthClientIdDefaultSchema {
 struct V4OAuthClientIdInputSchema {
     #[schemars(length(min = 1))]
     input: String,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-struct V4OAuthClientSecretSchema {
-    #[schemars(length(min = 1))]
-    input: String,
-    transport: V4OAuthClientSecretTransportSchema,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-enum V4OAuthClientSecretTransportSchema {
-    BasicAuth,
-    RequestBody,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-struct V4OAuthDynamicClientRegistrationSchema {
-    #[schemars(length(min = 1))]
-    registration_url: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(length(min = 1))]
-    client_name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    token_endpoint_auth_method: Option<V4OAuthDynamicClientRegistrationAuthMethodSchema>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    request_refresh_token_grant: Option<bool>,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-enum V4OAuthDynamicClientRegistrationAuthMethodSchema {
-    None,
-    ClientSecretBasic,
-    ClientSecretPost,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-struct V4OAuthScopesSchema {
-    scope: V4OAuthScopeSchema,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-struct V4OAuthScopeSchema {
-    delimiter: V4OAuthScopeDelimiterSchema,
-    #[schemars(length(min = 1), inner(length(min = 1)))]
-    values: Vec<String>,
-}
-
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-enum V4OAuthScopeDelimiterSchema {
-    Space,
-    Comma,
 }
 
 /// Generate the JSON Schema for authored DSL v4 source manifests.

--- a/crates/coral-spec/src/v4/schema.rs
+++ b/crates/coral-spec/src/v4/schema.rs
@@ -109,6 +109,7 @@ enum V4InputSpecSchema {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         hint: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[schemars(required)]
         credential: Option<V4CredentialSpecSchema>,
     },
 }
@@ -154,16 +155,18 @@ enum V4OAuthCredentialMethodSchema {
 struct V4AuthorizationCodeOAuthCredentialMethodSchema {
     flow: V4AuthorizationCodeOAuthFlowSchema,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(length(min = 1))]
+    #[schemars(required, length(min = 1))]
     resource: Option<String>,
     #[serde(rename = "redirect_uri")]
     #[schemars(length(min = 1))]
     redirect: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(required)]
     redirect_uri_port_mode: Option<ManifestOAuthRedirectUriPortMode>,
     endpoints: V4AuthorizationCodeOAuthEndpointsSchema,
     client: V4OAuthClientSchema,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(required)]
     scopes: Option<ManifestOAuthScopesSpec>,
 }
 
@@ -172,11 +175,12 @@ struct V4AuthorizationCodeOAuthCredentialMethodSchema {
 struct V4DeviceCodeOAuthCredentialMethodSchema {
     flow: V4DeviceCodeOAuthFlowSchema,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(length(min = 1))]
+    #[schemars(required, length(min = 1))]
     resource: Option<String>,
     endpoints: V4DeviceCodeOAuthEndpointsSchema,
     client: V4DeviceCodeOAuthClientSchema,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(required)]
     scopes: Option<ManifestOAuthScopesSpec>,
 }
 
@@ -620,6 +624,80 @@ surfaces:
             "generated schema should reject unknown OAuth fields"
         );
         parse_source_manifest_yaml(raw).expect_err("parser should reject unknown OAuth fields");
+    }
+
+    #[test]
+    fn generated_schema_rejects_explicit_null_oauth_optionals_and_parser_agrees() {
+        let credential_null = r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/openapi.yaml
+    inputs:
+      API_TOKEN:
+        kind: secret
+        credential: null
+";
+        let oauth_manifest = |oauth_extra: &str, registration_extra: &str| {
+            format!(
+                r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/openapi.yaml
+    inputs:
+      API_TOKEN:
+        kind: secret
+        credential:
+          methods:
+            - type: oauth
+              oauth:
+                flow:
+                  type: authorization_code
+                  pkce: required
+                redirect_uri: http://127.0.0.1:0/oauth/callback
+{oauth_extra}                endpoints:
+                  authorization_url: https://login.example.com/oauth/authorize
+                  token_url: https://login.example.com/oauth/token
+                client:
+                  dynamic_registration:
+                    registration_url: https://login.example.com/oauth/register
+{registration_extra}"
+            )
+        };
+        let invalid = [
+            ("credential", credential_null.to_string()),
+            (
+                "resource",
+                oauth_manifest("                resource: null\n", ""),
+            ),
+            (
+                "redirect_uri_port_mode",
+                oauth_manifest("                redirect_uri_port_mode: null\n", ""),
+            ),
+            (
+                "scopes",
+                oauth_manifest("                scopes: null\n", ""),
+            ),
+            (
+                "client_name",
+                oauth_manifest("", "                    client_name: null\n"),
+            ),
+        ];
+
+        let validator = validator();
+        for (field, raw) in invalid {
+            assert!(
+                !validator.is_valid(&manifest_json(&raw)),
+                "generated schema should reject explicit null for {field}"
+            );
+            parse_source_manifest_yaml(&raw)
+                .expect_err("parser should reject explicit null for OAuth optional field");
+        }
     }
 
     #[test]

--- a/crates/coral-spec/src/v4/schema.rs
+++ b/crates/coral-spec/src/v4/schema.rs
@@ -105,8 +105,294 @@ enum V4InputSpecSchema {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         hint: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        credential: Option<Value>,
+        credential: Option<V4CredentialSpecSchema>,
     },
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4CredentialSpecSchema {
+    #[schemars(length(min = 1))]
+    methods: Vec<V4CredentialMethodSchema>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+enum V4CredentialMethodSchema {
+    SourceConfig {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hint: Option<String>,
+    },
+    Oauth {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        label: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hint: Option<String>,
+        oauth: Box<V4OAuthCredentialMethodSchema>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum V4OAuthCredentialMethodSchema {
+    AuthorizationCode(Box<V4AuthorizationCodeOAuthCredentialMethodSchema>),
+    DeviceCode(Box<V4DeviceCodeOAuthCredentialMethodSchema>),
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4AuthorizationCodeOAuthCredentialMethodSchema {
+    flow: V4AuthorizationCodeOAuthFlowSchema,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    resource: Option<String>,
+    #[serde(rename = "redirect_uri")]
+    #[schemars(length(min = 1))]
+    redirect: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    redirect_uri_port_mode: Option<V4OAuthRedirectUriPortModeSchema>,
+    endpoints: V4AuthorizationCodeOAuthEndpointsSchema,
+    client: V4OAuthClientSchema,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    scopes: Option<V4OAuthScopesSchema>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4DeviceCodeOAuthCredentialMethodSchema {
+    flow: V4DeviceCodeOAuthFlowSchema,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    resource: Option<String>,
+    endpoints: V4DeviceCodeOAuthEndpointsSchema,
+    client: V4DeviceCodeOAuthClientSchema,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    scopes: Option<V4OAuthScopesSchema>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4AuthorizationCodeOAuthFlowSchema {
+    #[serde(rename = "type")]
+    flow_type: V4AuthorizationCodeOAuthFlowTypeSchema,
+    pkce: V4OAuthPkceModeSchema,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum V4AuthorizationCodeOAuthFlowTypeSchema {
+    AuthorizationCode,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum V4OAuthPkceModeSchema {
+    Required,
+    Disabled,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum V4OAuthRedirectUriPortModeSchema {
+    Fixed,
+    Random,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4DeviceCodeOAuthFlowSchema {
+    #[serde(rename = "type")]
+    flow_type: V4DeviceCodeOAuthFlowTypeSchema,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pkce: Option<V4OAuthDisabledPkceModeSchema>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum V4DeviceCodeOAuthFlowTypeSchema {
+    DeviceCode,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum V4OAuthDisabledPkceModeSchema {
+    Disabled,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4AuthorizationCodeOAuthEndpointsSchema {
+    #[serde(rename = "authorization_url")]
+    #[schemars(length(min = 1))]
+    authorization: String,
+    #[serde(rename = "token_url")]
+    #[schemars(length(min = 1))]
+    token: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4DeviceCodeOAuthEndpointsSchema {
+    #[serde(rename = "token_url")]
+    #[schemars(length(min = 1))]
+    token: String,
+    #[serde(rename = "device_authorization_url")]
+    #[schemars(length(min = 1))]
+    device_authorization: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum V4OAuthClientSchema {
+    Public(Box<V4OAuthPublicClientSchema>),
+    Confidential(Box<V4OAuthConfidentialClientSchema>),
+    Dynamic(Box<V4OAuthDynamicClientSchema>),
+    PublicDynamic(Box<V4OAuthPublicDynamicClientSchema>),
+    ConfidentialDynamic(Box<V4OAuthConfidentialDynamicClientSchema>),
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum V4DeviceCodeOAuthClientSchema {
+    Public(Box<V4OAuthPublicClientSchema>),
+    Dynamic(Box<V4OAuthDynamicClientSchema>),
+    PublicDynamic(Box<V4OAuthPublicDynamicClientSchema>),
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4OAuthPublicClientSchema {
+    id: V4OAuthClientIdSchema,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4OAuthConfidentialClientSchema {
+    id: V4OAuthClientIdWithInputSchema,
+    secret: V4OAuthClientSecretSchema,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4OAuthDynamicClientSchema {
+    dynamic_registration: V4OAuthDynamicClientRegistrationSchema,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4OAuthPublicDynamicClientSchema {
+    id: V4OAuthClientIdSchema,
+    dynamic_registration: V4OAuthDynamicClientRegistrationSchema,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4OAuthConfidentialDynamicClientSchema {
+    id: V4OAuthClientIdWithInputSchema,
+    secret: V4OAuthClientSecretSchema,
+    dynamic_registration: V4OAuthDynamicClientRegistrationSchema,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum V4OAuthClientIdSchema {
+    DefaultAndInput(V4OAuthClientIdDefaultAndInputSchema),
+    Default(V4OAuthClientIdDefaultSchema),
+    Input(V4OAuthClientIdInputSchema),
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum V4OAuthClientIdWithInputSchema {
+    DefaultAndInput(V4OAuthClientIdDefaultAndInputSchema),
+    Input(V4OAuthClientIdInputSchema),
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4OAuthClientIdDefaultAndInputSchema {
+    #[schemars(length(min = 1))]
+    default: String,
+    #[schemars(length(min = 1))]
+    input: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4OAuthClientIdDefaultSchema {
+    #[schemars(length(min = 1))]
+    default: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4OAuthClientIdInputSchema {
+    #[schemars(length(min = 1))]
+    input: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4OAuthClientSecretSchema {
+    #[schemars(length(min = 1))]
+    input: String,
+    transport: V4OAuthClientSecretTransportSchema,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum V4OAuthClientSecretTransportSchema {
+    BasicAuth,
+    RequestBody,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4OAuthDynamicClientRegistrationSchema {
+    #[schemars(length(min = 1))]
+    registration_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    client_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    token_endpoint_auth_method: Option<V4OAuthDynamicClientRegistrationAuthMethodSchema>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    request_refresh_token_grant: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum V4OAuthDynamicClientRegistrationAuthMethodSchema {
+    None,
+    ClientSecretBasic,
+    ClientSecretPost,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4OAuthScopesSchema {
+    scope: V4OAuthScopeSchema,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4OAuthScopeSchema {
+    delimiter: V4OAuthScopeDelimiterSchema,
+    #[schemars(length(min = 1), inner(length(min = 1)))]
+    values: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum V4OAuthScopeDelimiterSchema {
+    Space,
+    Comma,
 }
 
 /// Generate the JSON Schema for authored DSL v4 source manifests.
@@ -304,6 +590,104 @@ surfaces:
             "generated schema should accept flattened MCP value sources: {errors:?}"
         );
         parse_source_manifest_yaml(raw).expect("parser accepts flattened MCP value sources");
+    }
+
+    #[test]
+    fn generated_schema_accepts_oauth_surface_input_and_parser_agrees() {
+        let raw = r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/openapi.yaml
+    inputs:
+      TENANT_ID:
+        kind: variable
+        default: organizations
+      API_TOKEN:
+        kind: secret
+        credential:
+          methods:
+            - type: oauth
+              label: Connect
+              description: Use OAuth.
+              hint: Authorize in your browser.
+              oauth:
+                flow:
+                  type: authorization_code
+                  pkce: required
+                redirect_uri: http://127.0.0.1:0/oauth/callback
+                redirect_uri_port_mode: random
+                endpoints:
+                  authorization_url: https://login.example.com/{{input.TENANT_ID}}/oauth/authorize
+                  token_url: https://login.example.com/{{input.TENANT_ID}}/oauth/token
+                client:
+                  dynamic_registration:
+                    registration_url: https://login.example.com/{{input.TENANT_ID}}/oauth/register
+                    client_name: Coral Demo
+                    token_endpoint_auth_method: none
+                    request_refresh_token_grant: true
+                scopes:
+                  scope:
+                    delimiter: space
+                    values:
+                      - read
+            - type: source_config
+              label: Paste token
+    base_url: https://api.example.com
+    auth:
+      type: HeaderAuth
+      headers:
+        - name: Authorization
+          from: bearer
+          key: API_TOKEN
+";
+
+        let validator = validator();
+        let manifest = manifest_json(raw);
+        let errors = validation_errors(&validator, &manifest);
+        assert!(
+            errors.is_empty(),
+            "generated schema should accept v4 OAuth surface input: {errors:?}"
+        );
+        parse_source_manifest_yaml(raw).expect("parser accepts v4 OAuth surface input");
+    }
+
+    #[test]
+    fn generated_schema_rejects_unknown_oauth_surface_input_field() {
+        let raw = r"
+name: demo
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    url: https://example.com/openapi.yaml
+    inputs:
+      API_TOKEN:
+        kind: secret
+        credential:
+          methods:
+            - type: oauth
+              oauth:
+                flow:
+                  type: authorization_code
+                  pkce: required
+                redirect_uri: http://127.0.0.1:0/oauth/callback
+                endpoints:
+                  authorization_url: https://login.example.com/oauth/authorize
+                  token_url: https://login.example.com/oauth/token
+                client:
+                  id:
+                    default: demo-client
+                unsupported: true
+";
+
+        assert!(
+            !validator().is_valid(&manifest_json(raw)),
+            "generated schema should reject unknown OAuth fields"
+        );
+        parse_source_manifest_yaml(raw).expect_err("parser should reject unknown OAuth fields");
     }
 
     #[test]

--- a/sources/core-v4/github_v4/manifest.yaml
+++ b/sources/core-v4/github_v4/manifest.yaml
@@ -5,12 +5,41 @@ surfaces:
     type: openapi
     url: https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.yaml
     inputs:
-      GITHUB_TOKEN:
+      GITHUB_TOKEN: &github_token
         kind: secret
         hint: |
           GitHub personal access token used as a bearer token for the live
           GitHub REST API. Set GITHUB_TOKEN when installing this preview
           source.
+        credential:
+          methods:
+            - type: oauth
+              label: Connect with GitHub device code
+              description: Sign in to GitHub with a device code.
+              hint: |
+                Signs you in through GitHub, with no app setup or client
+                secret needed. Requests the `repo`, `read:org`, `read:user`,
+                and `user:email` scopes. To use your own GitHub app instead,
+                set GITHUB_OAUTH_CLIENT_ID to its Client ID and enable device
+                flow on the app.
+              oauth:
+                flow:
+                  type: device_code
+                endpoints:
+                  device_authorization_url: https://github.com/login/device/code
+                  token_url: https://github.com/login/oauth/access_token
+                client:
+                  id:
+                    default: Iv23liJHis6Bs8NO1DAI
+                    input: GITHUB_OAUTH_CLIENT_ID
+                scopes:
+                  scope:
+                    delimiter: space
+                    values:
+                      - repo
+                      - read:org
+                      - read:user
+                      - user:email
     auth:
       type: HeaderAuth
       headers:
@@ -28,12 +57,7 @@ surfaces:
     namespace_suffix: mcp
     type: mcp
     inputs:
-      GITHUB_TOKEN:
-        kind: secret
-        hint: |
-          GitHub personal access token used as a bearer token for the live
-          GitHub REST API. Set GITHUB_TOKEN when installing this preview
-          source.
+      GITHUB_TOKEN: *github_token
     server:
       transport: streamable_http
       url: https://api.githubcopilot.com/mcp/x/all/readonly


### PR DESCRIPTION
## Summary

- Add typed DSL v4 schema support for `credential.methods`, including `source_config` and OAuth methods.
- Model OAuth authorization-code and device-code shapes, client registration, client IDs/secrets, scopes, and generated schema constraints from Rust types.
- Preserve retrieved OAuth material during DSL v4 source import and update the preview GitHub v4 source manifest.

Closes #1495 

## Validation

- `make schema-generate`
- `make schema-check`
- `cargo test -p coral-spec v4::schema`
- `cargo test -p coral-spec v4::manifest_tests`
- `cargo test -p coral-app import_v4_with_oauth_persists_retrieved_material`
- `make rust-checks`