### PR TITLE
feat(source): show OAuth progress during source add

### DIFF
--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -346,6 +346,8 @@ message CreateBundledSourceWithOAuthResponse {
     OAuthCredentialAuthorization oauth_authorization = 2;
     // OAuth credential retrieval completed.
     OAuthCredentialCompleted oauth_completed = 3;
+    // Authorization-code callback was received and token exchange is starting.
+    OAuthCredentialCallbackReceived oauth_callback_received = 4;
   }
 }
 
@@ -373,6 +375,8 @@ message ImportSourceResponse {
     OAuthCredentialAuthorization oauth_authorization = 2;
     // OAuth credential retrieval completed.
     OAuthCredentialCompleted oauth_completed = 3;
+    // Authorization-code callback was received and token exchange is starting.
+    OAuthCredentialCallbackReceived oauth_callback_received = 4;
   }
 }
 
@@ -419,6 +423,12 @@ message OAuthCredentialAuthorization {
   string verification_uri = 5;
   // Device-flow provider verification URL with the user code embedded, when provided.
   string verification_uri_complete = 6;
+}
+
+// OAuth authorization-code callback received by Coral.
+message OAuthCredentialCallbackReceived {
+  // Secret input key being retrieved.
+  string input_key = 1;
 }
 
 // Safe completion metadata emitted after OAuth credential retrieval.

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -255,7 +255,8 @@ impl OAuthCredentialService {
         }
     }
 
-    pub(crate) async fn authorize<F, Fut>(
+    #[cfg(test)]
+    async fn authorize<F, Fut>(
         &self,
         request: StartOAuthCredentialRequest<'_>,
         on_authorization: F,
@@ -263,6 +264,22 @@ impl OAuthCredentialService {
     where
         F: FnOnce(OAuthAuthorization) -> Fut,
         Fut: Future<Output = Result<(), AppError>>,
+    {
+        self.authorize_with_callback(request, on_authorization, || async { Ok(()) })
+            .await
+    }
+
+    pub(crate) async fn authorize_with_callback<F, Fut, C, CallbackFut>(
+        &self,
+        request: StartOAuthCredentialRequest<'_>,
+        on_authorization: F,
+        on_callback_received: C,
+    ) -> Result<OAuthCredentialMaterial, AppError>
+    where
+        F: FnOnce(OAuthAuthorization) -> Fut,
+        Fut: Future<Output = Result<(), AppError>>,
+        C: FnOnce() -> CallbackFut,
+        CallbackFut: Future<Output = Result<(), AppError>>,
     {
         let oauth = request.oauth.clone();
         let endpoints = oauth_endpoint_urls(&oauth, request.source_inputs)?;
@@ -281,6 +298,7 @@ impl OAuthCredentialService {
                         resource,
                     },
                     on_authorization,
+                    on_callback_received,
                 )
                 .await
             }
@@ -301,14 +319,17 @@ impl OAuthCredentialService {
         }
     }
 
-    async fn authorize_authorization_code<F, Fut>(
+    async fn authorize_authorization_code<F, Fut, C, CallbackFut>(
         &self,
         request: OAuthAuthorizationRequest<'_>,
         on_authorization: F,
+        on_callback_received: C,
     ) -> Result<OAuthCredentialMaterial, AppError>
     where
         F: FnOnce(OAuthAuthorization) -> Fut,
         Fut: Future<Output = Result<(), AppError>>,
+        C: FnOnce() -> CallbackFut,
+        CallbackFut: Future<Output = Result<(), AppError>>,
     {
         let OAuthAuthorizationRequest {
             input_key,
@@ -363,7 +384,8 @@ impl OAuthCredentialService {
             verification_uri_complete: None,
         })
         .await?;
-        self.run_authorization_code_session(session).await
+        self.run_authorization_code_session(session, on_callback_received)
+            .await
     }
 
     pub(crate) fn validate_credential_inputs(
@@ -489,14 +511,20 @@ impl OAuthCredentialService {
         self.run_device_code_session(session).await
     }
 
-    async fn run_authorization_code_session(
+    async fn run_authorization_code_session<C, CallbackFut>(
         &self,
         session: AuthorizationCodeSessionConfig,
-    ) -> Result<OAuthCredentialMaterial, AppError> {
+        on_callback_received: C,
+    ) -> Result<OAuthCredentialMaterial, AppError>
+    where
+        C: FnOnce() -> CallbackFut,
+        CallbackFut: Future<Output = Result<(), AppError>>,
+    {
         let deadline = tokio::time::Instant::from_std(session.expires_at);
         let callback = tokio::time::timeout_at(deadline, receive_callback(&session))
             .await
             .map_err(|_elapsed| expired_session_error(&session.common.input_key))??;
+        on_callback_received().await?;
         let token = tokio::time::timeout_at(
             deadline,
             exchange_authorization_code(&self.http, &session, &callback.code),
@@ -1049,7 +1077,9 @@ async fn handle_callback_connection(
     };
     match parse_callback_request(&request, expected_path, expected_state) {
         Ok(CallbackRequestResult::Callback(callback)) => {
-            let page = callback_page("OAuth complete. You can return to Coral.");
+            let page = callback_page(
+                "Authorization received. Coral is finishing sign-in in your terminal.",
+            );
             write_callback_response(stream, "200 OK", &page).await?;
             Ok(CallbackConnectionResult::Callback(callback))
         }

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -83,7 +83,7 @@ pub(crate) struct SourceOAuthCredentialRetrieval {
 }
 
 pub(crate) enum ImportSourceWithCredentialsEvent {
-    OAuthAuthorization {
+    Authorization {
         input_key: String,
         authorization_url: String,
         expires_in_seconds: u64,
@@ -94,7 +94,7 @@ pub(crate) enum ImportSourceWithCredentialsEvent {
     CallbackReceived {
         input_key: String,
     },
-    OAuthCompleted {
+    Completed {
         input_key: String,
         metadata: BTreeMap<String, String>,
     },
@@ -1057,7 +1057,7 @@ impl SourceManager {
                         let events = authorization_events;
                         async move {
                             events
-                                .send(ImportSourceWithCredentialsEvent::OAuthAuthorization {
+                                .send(ImportSourceWithCredentialsEvent::Authorization {
                                     input_key: authorization_input_key,
                                     authorization_url: authorization.authorization_url,
                                     expires_in_seconds: authorization.expires_in_seconds,
@@ -1084,7 +1084,7 @@ impl SourceManager {
                 )
                 .await?;
             events
-                .send(ImportSourceWithCredentialsEvent::OAuthCompleted {
+                .send(ImportSourceWithCredentialsEvent::Completed {
                     input_key: material.input_key.clone(),
                     metadata: material.safe_metadata.clone(),
                 })
@@ -3591,7 +3591,7 @@ surfaces:
             .await
             .expect("authorization event")
             .into_event();
-        let ImportSourceWithCredentialsEvent::OAuthAuthorization {
+        let ImportSourceWithCredentialsEvent::Authorization {
             input_key,
             authorization_url,
             ..
@@ -3607,9 +3607,19 @@ surfaces:
         let event = event_rx
             .recv()
             .await
+            .expect("callback received event")
+            .into_event();
+        let ImportSourceWithCredentialsEvent::CallbackReceived { input_key } = event else {
+            panic!("unexpected import event");
+        };
+        assert_eq!(input_key, "API_TOKEN");
+
+        let event = event_rx
+            .recv()
+            .await
             .expect("completion event")
             .into_event();
-        let ImportSourceWithCredentialsEvent::OAuthCompleted { input_key, .. } = event else {
+        let ImportSourceWithCredentialsEvent::Completed { input_key, .. } = event else {
             panic!("unexpected import event");
         };
         assert_eq!(input_key, "API_TOKEN");

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -91,6 +91,9 @@ pub(crate) enum ImportSourceWithCredentialsEvent {
         verification_uri: Option<String>,
         verification_uri_complete: Option<String>,
     },
+    CallbackReceived {
+        input_key: String,
+    },
     OAuthCompleted {
         input_key: String,
         metadata: BTreeMap<String, String>,
@@ -1039,9 +1042,11 @@ impl SourceManager {
                 .collect();
             let authorization_input_key = input_key.clone();
             let authorization_events = events.clone();
+            let callback_input_key = input_key.clone();
+            let callback_events = events.clone();
             let material = self
                 .oauth_credential_service
-                .authorize(
+                .authorize_with_callback(
                     StartOAuthCredentialRequest {
                         input_key: &input_key,
                         oauth: config.oauth,
@@ -1064,6 +1069,18 @@ impl SourceManager {
                                 .await
                         }
                     },
+                    move || {
+                        let events = callback_events;
+                        async move {
+                            events
+                                .send(ImportSourceWithCredentialsEvent::CallbackReceived {
+                                    input_key: callback_input_key,
+                                })
+                                .await?;
+                            tokio::task::yield_now().await;
+                            Ok(())
+                        }
+                    },
                 )
                 .await?;
             events
@@ -1072,6 +1089,9 @@ impl SourceManager {
                     metadata: material.safe_metadata.clone(),
                 })
                 .await?;
+            // Let the streaming response flush the OAuth completion event before
+            // this task continues into synchronous source installation work.
+            tokio::task::yield_now().await;
             materials.push(material);
         }
         Ok(materials)

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -474,7 +474,7 @@ fn source_secret_from_proto(secret: SourceSecret) -> SourceBinding {
 
 fn import_source_event_to_proto(event: ImportSourceWithCredentialsEvent) -> ImportSourceResponse {
     let event = match event {
-        ImportSourceWithCredentialsEvent::OAuthAuthorization {
+        ImportSourceWithCredentialsEvent::Authorization {
             input_key,
             authorization_url,
             expires_in_seconds,
@@ -494,7 +494,7 @@ fn import_source_event_to_proto(event: ImportSourceWithCredentialsEvent) -> Impo
                 input_key,
             })
         }
-        ImportSourceWithCredentialsEvent::OAuthCompleted {
+        ImportSourceWithCredentialsEvent::Completed {
             input_key,
             metadata,
         } => import_source_response::Event::OauthCompleted(OAuthCredentialCompleted {

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -11,13 +11,13 @@ use coral_api::v1::{
     DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest,
     GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
     ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, OAuthCredentialAuthorization,
-    OAuthCredentialClient, OAuthCredentialClientId, OAuthCredentialClientSecret,
-    OAuthCredentialCompleted, OAuthCredentialEndpoints, OAuthCredentialInput,
-    OAuthCredentialMethod, OAuthCredentialRetrieval, OAuthCredentialScope, OAuthCredentialScopes,
-    OAuthDynamicClientRegistration, OauthCredentialClientSecretTransport, OauthCredentialFlowType,
-    OauthCredentialPkceMode, OauthCredentialRedirectUriPortMode, OauthCredentialScopeDelimiter,
-    OauthDynamicClientRegistrationAuthMethod, Source, SourceConfigCredentialMethod,
-    SourceCredential, SourceCredentialMethod,
+    OAuthCredentialCallbackReceived, OAuthCredentialClient, OAuthCredentialClientId,
+    OAuthCredentialClientSecret, OAuthCredentialCompleted, OAuthCredentialEndpoints,
+    OAuthCredentialInput, OAuthCredentialMethod, OAuthCredentialRetrieval, OAuthCredentialScope,
+    OAuthCredentialScopes, OAuthDynamicClientRegistration, OauthCredentialClientSecretTransport,
+    OauthCredentialFlowType, OauthCredentialPkceMode, OauthCredentialRedirectUriPortMode,
+    OauthCredentialScopeDelimiter, OauthDynamicClientRegistrationAuthMethod, Source,
+    SourceConfigCredentialMethod, SourceCredential, SourceCredentialMethod,
     SourceCredentialStorage as ProtoSourceCredentialStorage, SourceInfo, SourceInputSpec,
     SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceSecretInput, SourceVariable,
     SourceVariableInput, ValidateSourceRequest, ValidateSourceResponse,
@@ -489,6 +489,11 @@ fn import_source_event_to_proto(event: ImportSourceWithCredentialsEvent) -> Impo
             verification_uri: verification_uri.unwrap_or_default(),
             verification_uri_complete: verification_uri_complete.unwrap_or_default(),
         }),
+        ImportSourceWithCredentialsEvent::CallbackReceived { input_key } => {
+            import_source_response::Event::OauthCallbackReceived(OAuthCredentialCallbackReceived {
+                input_key,
+            })
+        }
         ImportSourceWithCredentialsEvent::OAuthCompleted {
             input_key,
             metadata,
@@ -512,6 +517,9 @@ fn create_bundled_source_with_o_auth_response_from_import_response(
         }
         import_source_response::Event::OauthAuthorization(authorization) => {
             create_bundled_source_with_o_auth_response::Event::OauthAuthorization(authorization)
+        }
+        import_source_response::Event::OauthCallbackReceived(callback) => {
+            create_bundled_source_with_o_auth_response::Event::OauthCallbackReceived(callback)
         }
         import_source_response::Event::OauthCompleted(completed) => {
             create_bundled_source_with_o_auth_response::Event::OauthCompleted(completed)

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::thread::JoinHandle;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context as _, bail};
 use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
@@ -298,6 +298,9 @@ enum CredentialStreamEvent {
         authorization_url: String,
         user_code: String,
     },
+    OAuthCallbackReceived {
+        input_key: String,
+    },
     OAuthCompleted,
 }
 
@@ -314,6 +317,11 @@ impl From<create_bundled_source_with_o_auth_response::Event> for CredentialStrea
                 authorization_url: authorization.authorization_url,
                 user_code: authorization.user_code,
             },
+            create_bundled_source_with_o_auth_response::Event::OauthCallbackReceived(callback) => {
+                Self::OAuthCallbackReceived {
+                    input_key: callback.input_key,
+                }
+            }
             create_bundled_source_with_o_auth_response::Event::OauthCompleted(_) => {
                 Self::OAuthCompleted
             }
@@ -330,6 +338,11 @@ impl From<import_source_response::Event> for CredentialStreamEvent {
                     input_key: authorization.input_key,
                     authorization_url: authorization.authorization_url,
                     user_code: authorization.user_code,
+                }
+            }
+            import_source_response::Event::OauthCallbackReceived(callback) => {
+                Self::OAuthCallbackReceived {
+                    input_key: callback.input_key,
                 }
             }
             import_source_response::Event::OauthCompleted(_) => Self::OAuthCompleted,
@@ -365,12 +378,39 @@ fn handle_credential_stream_event(
             }
             None
         }
+        Some(CredentialStreamEvent::OAuthCallbackReceived { input_key }) => {
+            let label = oauth_labels
+                .get(&input_key)
+                .map_or(input_key.as_str(), String::as_str);
+            redirect_prompt.cancel_and_join();
+            redirect_prompt.callback_received_at = Some(Instant::now());
+            println!(
+                "{}",
+                style(format!(
+                    "Authorization received for {label}. Exchanging authorization code for token..."
+                ))
+                .dim()
+            );
+            None
+        }
         Some(CredentialStreamEvent::Source(source)) => {
             redirect_prompt.cancel_and_join();
             Some(source)
         }
         Some(CredentialStreamEvent::OAuthCompleted) => {
             redirect_prompt.cancel_and_join();
+            let elapsed = redirect_prompt
+                .callback_received_at
+                .take()
+                .map(|started| format!(" in {:.1}s", started.elapsed().as_secs_f64()))
+                .unwrap_or_default();
+            println!(
+                "{}",
+                style(format!(
+                    "OAuth token received{elapsed}. Installing source..."
+                ))
+                .dim()
+            );
             None
         }
         None => None,
@@ -830,6 +870,7 @@ pub(crate) async fn validate_and_warn(
     source_name: &str,
     limit: TableDisplayLimit,
 ) -> Result<(), anyhow::Error> {
+    println!("{}", style("Validating source...").dim());
     if let Err(err) = validate_and_print(app, workspace, source_name, limit).await {
         eprintln!("Warning: validation failed: {err}");
     }
@@ -1242,6 +1283,7 @@ fn oauth_error(action: &str, error: &tonic::Status) -> anyhow::Error {
 struct OAuthRedirectPastePrompt {
     cancel: Option<Arc<AtomicBool>>,
     handle: Option<JoinHandle<()>>,
+    callback_received_at: Option<Instant>,
 }
 
 impl OAuthRedirectPastePrompt {
@@ -1249,6 +1291,7 @@ impl OAuthRedirectPastePrompt {
         Self {
             cancel: Some(cancel),
             handle: Some(handle),
+            callback_received_at: None,
         }
     }
 


### PR DESCRIPTION
## Summary

- Add an OAuth callback-received event to source install streams.
- Emit progress when Coral receives the browser callback, starts token exchange, receives the token, installs the source, and begins validation.
- Update the browser callback page so it says authorization was received, rather than implying the whole OAuth flow is already complete.
- Keep the CLI output generic by using the source-defined OAuth method label, so this applies to any OAuth-backed source rather than Microsoft Graph specifically.

## Why

`coral source add --interactive` could look stuck after the browser showed the OAuth success page. At that point Coral had received the authorization code, but the CLI had no event to render until token exchange completed. For slow providers, that made token exchange look like a broken redirect prompt or slow source materialization.

This change does not make provider token exchange faster. It makes the source-add phases visible and distinguishes callback receipt, token exchange, install, and validation.

## Example

Example from recently working on a massive source, instead of just hanging

```
$ CORAL_CONFIG_DIR=$(mktemp -d) ./target/debug/coral source add \
    --file sources/community/microsoft_graph/manifest.yaml --interactive
  Microsoft Entra tenant authority. Use organizations for any work/school account, or a tenant GUID for a specific ten
✔ MS_GRAPH_TENANT_ID [organizations] ·
✔ MS_GRAPH_ACCESS_TOKEN credential · Sign in with Microsoft
  Microsoft Graph delegated access token. Choose Sign in with Microsoft during interactive setup.
✔ MS_GRAPH_OAUTH_CLIENT_ID [source default] ·
Open this URL to connect Sign in with Microsoft:
https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?re..............
If the browser cannot reach the localhost callback, paste the final redirect URL below.
Redirect URL:
Authorization received for Sign in with Microsoft. Exchanging authorization code for token...
OAuth token received in 50.8s. Installing source...
Added source microsoft_graph (secrets: keychain)
Validating source...

  ✓ microsoft_graph connected successfully
  Secrets: keychain

    microsoft_graph (732 tables)
    ├─ admin_admin_admin_admin_getadmin
    ├─ admin_adminmicrosoft365apps_admin_getmicrosoft365apps
    ├─ admin_adminmicrosoft365apps_admin_microsoft365apps_getinstallationoptions
    ├─ admin_adminreportsettings_admin_getreportsettings
    ├─ admin_configurationmanagement_admin_configurationmanagement_listconfigurationdrifts
    ├─ admin_configurationmanagement_admin_configurationmanagement_listconfigurationmonitoringresults
    ├─ admin_configurationmanagement_admin_configurationmanagement_listconfigurationmonitors
    ├─ admin_configurationmanagement_admin_configurationmanagement_listconfigurationsnapshotjobs
    ├─ admin_configurationmanagement_admin_configurationmanagement_listconfigurationsnapshots
    └─ ... and 723 more

```

