### PR TITLE
feat: DSL V4 lookup key inference 

### DIFF
--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -723,7 +723,7 @@ fn write_materialization(
             },
         )));
     }
-    let projections = generate_projection_catalog(manifest, &semantic_irs)
+    let projections = generate_projection_catalog(manifest, &semantic_irs, &BTreeMap::new())
         .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
     diagnostics.extend(projections.diagnostics.clone());
     for ir in &semantic_irs {

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -6,16 +6,14 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use coral_spec::v4::{
-    Diagnostic, DiagnosticSeverity, Fingerprint, FingerprintSurface, GeneratedParameterMetadata,
-    LookupKeysMetadata, MCP_IMPORTER_VERSION, MaterializedSurface, McpToolCatalog,
-    OPENAPI_IMPORTER_VERSION, PROJECTION_GENERATOR_VERSION, ProjectionCatalog,
-    ProjectionPaginationInputSyncMode, SURFACE_IMPORTER_VERSION, SemanticIr, SurfaceType,
-    V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceManifest,
-    apply_parameter_metadata_overrides, generate_projection_catalog, import_mcp_surface,
-    import_openapi_surface, infer_lookup_keys, normalize_mcp_tool_catalog,
-    normalize_source_document, openapi_document_metadata, parse_generated_parameter_metadata_yaml,
-    parse_parameter_metadata_overrides_yaml, sync_projection_pagination_inputs,
-    validate_lookup_keys_for_surface, validate_materialized_source,
+    Diagnostic, DiagnosticSeverity, Fingerprint, FingerprintSurface, MCP_IMPORTER_VERSION,
+    MaterializedSurface, McpToolCatalog, OPENAPI_IMPORTER_VERSION, PROJECTION_GENERATOR_VERSION,
+    ProjectionCatalog, ProjectionPaginationInputSyncMode, SURFACE_IMPORTER_VERSION, SemanticIr,
+    SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceManifest,
+    apply_lookup_key_inference, apply_parameter_metadata_overrides, generate_projection_catalog,
+    import_mcp_surface, import_openapi_surface, normalize_mcp_tool_catalog,
+    normalize_source_document, openapi_document_metadata, parse_parameter_metadata_overrides_yaml,
+    sync_projection_pagination_inputs, validate_materialized_source,
     validate_openapi_base_url_template,
 };
 use coral_spec::{
@@ -189,7 +187,6 @@ pub(crate) fn load_v4_materialization(
     let diagnostics: Vec<Diagnostic> =
         read_artifact_yaml(source_name, "diagnostics", &diagnostics_path)?;
     let mut surfaces = Vec::new();
-    let mut lookup_keys_by_surface = BTreeMap::new();
     for fingerprint_surface in &fingerprint.surfaces {
         let surface = manifest
             .surface(&fingerprint_surface.surface_id)
@@ -211,17 +208,13 @@ pub(crate) fn load_v4_materialization(
         require_file(source_name, &semantic_ir_path)?;
         let mut semantic_ir: SemanticIr =
             read_artifact_yaml(source_name, "semantic IR", &semantic_ir_path)?;
-        let generated_lookup_keys = read_generated_lookup_keys(&surface_dir, &semantic_ir)?;
-        let override_lookup_keys = apply_parameter_metadata_override_file(
+        apply_parameter_metadata_override_file(
             layout,
             workspace_name,
             source_name,
             &surface.id,
             &mut semantic_ir,
         )?;
-        if let Some(lookup_keys) = override_lookup_keys.or(generated_lookup_keys) {
-            lookup_keys_by_surface.insert(surface.id.clone(), lookup_keys);
-        }
         surfaces.push(MaterializedSurface {
             surface_id: surface.id.clone(),
             semantic_ir,
@@ -242,7 +235,6 @@ pub(crate) fn load_v4_materialization(
         surfaces.iter().map(|surface| &surface.semantic_ir),
         &mut projections,
         projection_sync_mode,
-        &lookup_keys_by_surface,
     );
     let materialized = V4MaterializedSource {
         fingerprint,
@@ -445,50 +437,16 @@ fn read_raw_source_document_artifact(
     })
 }
 
-fn read_generated_lookup_keys(
-    surface_dir: &Path,
-    semantic_ir: &SemanticIr,
-) -> Result<Option<LookupKeysMetadata>, AppError> {
-    let path = surface_dir.join(PARAMETER_METADATA_OVERRIDE_FILENAME);
-    if !path.exists() {
-        return Ok(None);
-    }
-    let raw = std::fs::read_to_string(&path).map_err(|error| {
-        AppError::FailedPrecondition(format!(
-            "failed to read DSL v4 parameter metadata '{}': {error}",
-            path.display()
-        ))
-    })?;
-    let metadata = parse_generated_parameter_metadata_yaml(&raw).map_err(|error| {
-        AppError::FailedPrecondition(format!(
-            "failed to parse DSL v4 parameter metadata '{}': {error}",
-            path.display()
-        ))
-    })?;
-    // Materialization writes this file and the semantic IR together, so they
-    // can only disagree after a hand-edit; a typo'd exclude must fail as
-    // loudly here as it does in the override path.
-    if let Some(lookup_keys) = &metadata.lookup_keys {
-        validate_lookup_keys_for_surface(lookup_keys, semantic_ir).map_err(|error| {
-            AppError::FailedPrecondition(format!(
-                "failed to validate DSL v4 parameter metadata '{}': {error}",
-                path.display()
-            ))
-        })?;
-    }
-    Ok(metadata.lookup_keys)
-}
-
 fn apply_parameter_metadata_override_file(
     layout: &AppStateLayout,
     workspace_name: &WorkspaceName,
     source_name: &SourceName,
     surface_id: &str,
     semantic_ir: &mut SemanticIr,
-) -> Result<Option<LookupKeysMetadata>, AppError> {
+) -> Result<(), AppError> {
     let path = layout.v4_parameter_metadata_override_file(workspace_name, source_name, surface_id);
     if !path.exists() {
-        return Ok(None);
+        return Ok(());
     }
 
     let raw = std::fs::read_to_string(&path).map_err(|error| {
@@ -509,7 +467,7 @@ fn apply_parameter_metadata_override_file(
             path.display()
         ))
     })?;
-    Ok(overrides.lookup_keys)
+    Ok(())
 }
 
 fn validate_loaded_materialization(
@@ -701,11 +659,10 @@ fn write_materialization(
     let mut materialized_surfaces = Vec::new();
     let mut semantic_irs = Vec::new();
     let mut fingerprint_surfaces = Vec::new();
-    let mut lookup_keys_by_surface = BTreeMap::new();
     let mut diagnostics = Vec::new();
     let mut first_surface_error = None;
     for surface in &manifest.surfaces {
-        let materialized_surface = match materialize_surface(manifest, surface, inputs) {
+        let mut materialized_surface = match materialize_surface(manifest, surface, inputs) {
             Ok(materialized_surface) => materialized_surface,
             Err(error) => {
                 let message = format!(
@@ -726,10 +683,9 @@ fn write_materialization(
                 continue;
             }
         };
+        apply_lookup_key_inference(&mut materialized_surface.semantic_ir);
         let surface_dir = temp_dir.join("surfaces").join(&surface.id);
-        if let Some(lookup_keys) = write_surface_artifacts(&surface_dir, &materialized_surface)? {
-            lookup_keys_by_surface.insert(surface.id.clone(), lookup_keys);
-        }
+        write_surface_artifacts(&surface_dir, &materialized_surface)?;
         materialized_surfaces.push(MaterializedSurface {
             surface_id: surface.id.clone(),
             semantic_ir: materialized_surface.semantic_ir.clone(),
@@ -757,7 +713,7 @@ fn write_materialization(
             },
         )));
     }
-    let projections = generate_projection_catalog(manifest, &semantic_irs, &lookup_keys_by_surface)
+    let projections = generate_projection_catalog(manifest, &semantic_irs)
         .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
     diagnostics.extend(projections.diagnostics.clone());
     for ir in &semantic_irs {
@@ -797,12 +753,12 @@ struct MaterializedSurfaceBuild {
     semantic_ir: SemanticIr,
 }
 
-/// Writes the per-surface materialized artifacts (source documents, semantic
-/// IR, generated parameter metadata) and returns the inferred lookup keys.
+/// Writes the per-surface materialized artifacts (source documents and
+/// semantic IR).
 fn write_surface_artifacts(
     surface_dir: &Path,
     materialized_surface: &MaterializedSurfaceBuild,
-) -> Result<Option<LookupKeysMetadata>, AppError> {
+) -> Result<(), AppError> {
     fs::ensure_private_dir(surface_dir)?;
     std::fs::write(
         surface_dir.join("source-document.raw"),
@@ -816,16 +772,7 @@ fn write_surface_artifacts(
         &surface_dir.join("semantic-ir.yaml"),
         &materialized_surface.semantic_ir,
     )?;
-    let Some(lookup_keys) = infer_lookup_keys(&materialized_surface.semantic_ir) else {
-        return Ok(None);
-    };
-    write_yaml(
-        &surface_dir.join(PARAMETER_METADATA_OVERRIDE_FILENAME),
-        &GeneratedParameterMetadata {
-            lookup_keys: Some(lookup_keys.clone()),
-        },
-    )?;
-    Ok(Some(lookup_keys))
+    Ok(())
 }
 
 fn materialize_surface(
@@ -1318,6 +1265,10 @@ paths:
   /issues:
     get:
       operationId: issues/list
+      parameters:
+        - {name: order_by, in: query, schema: {type: string}}
+        - {name: q, in: query, schema: {type: string}}
+        - {name: state, in: query, schema: {type: string}}
       responses:
         '200':
           content:
@@ -1507,6 +1458,33 @@ surfaces:
         )
         .expect("write projection override");
         path
+    }
+
+    #[test]
+    fn build_v4_materialization_persists_lookup_key_flags_in_semantic_ir() {
+        let (_state, _descriptor, layout, _manifest_yaml, _manifest) = setup_materialization();
+        let surface_dir = layout.v4_surface_dir(&workspace_name(), &source_name(), "rest");
+        assert!(
+            !surface_dir
+                .join(PARAMETER_METADATA_OVERRIDE_FILENAME)
+                .exists(),
+            "generated lookup key metadata should live in semantic-ir.yaml"
+        );
+
+        let semantic_ir: SemanticIr =
+            read_yaml(&surface_dir.join("semantic-ir.yaml")).expect("read semantic IR");
+        let operation = semantic_ir.operations.first().expect("operation");
+        let input_excluded = |name: &str| {
+            operation
+                .inputs
+                .iter()
+                .find(|input| input.name == name)
+                .expect("input")
+                .exclude_from_lookup_keys
+        };
+        assert!(input_excluded("order_by"));
+        assert!(input_excluded("q"));
+        assert!(!input_excluded("state"));
     }
 
     #[tokio::test]
@@ -1918,6 +1896,9 @@ surfaces:
         std::fs::write(
             &override_path,
             r"
+lookup_keys:
+  enabled: true
+  exclude: [state]
 operation_overrides:
   issues/list:
     pagination:
@@ -1953,6 +1934,17 @@ operation_overrides:
         };
         assert_eq!(rest.pagination.mode, coral_spec::PaginationMode::Page);
         assert_eq!(rest.pagination.page_param.as_deref(), Some("page_number"));
+        let loaded_input_excluded = |name: &str| {
+            operation
+                .inputs
+                .iter()
+                .find(|input| input.name == name)
+                .expect("input")
+                .exclude_from_lookup_keys
+        };
+        assert!(!loaded_input_excluded("order_by"));
+        assert!(!loaded_input_excluded("q"));
+        assert!(loaded_input_excluded("state"));
 
         let semantic_ir_path = layout
             .v4_surface_dir(&workspace_name(), &source_name(), "rest")
@@ -1969,6 +1961,17 @@ operation_overrides:
             artifact_rest.pagination.mode,
             coral_spec::PaginationMode::None
         );
+        let artifact_input_excluded = |name: &str| {
+            artifact_operation
+                .inputs
+                .iter()
+                .find(|input| input.name == name)
+                .expect("input")
+                .exclude_from_lookup_keys
+        };
+        assert!(artifact_input_excluded("order_by"));
+        assert!(artifact_input_excluded("q"));
+        assert!(!artifact_input_excluded("state"));
     }
 
     #[test]

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -10,9 +10,9 @@ use coral_spec::v4::{
     MaterializedSurface, McpToolCatalog, OPENAPI_IMPORTER_VERSION, PROJECTION_GENERATOR_VERSION,
     ProjectionCatalog, ProjectionPaginationInputSyncMode, SURFACE_IMPORTER_VERSION, SemanticIr,
     SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceManifest,
-    apply_lookup_key_inference, apply_parameter_metadata_overrides, generate_projection_catalog,
-    import_mcp_surface, import_openapi_surface, normalize_mcp_tool_catalog,
-    normalize_source_document, openapi_document_metadata, parse_parameter_metadata_overrides_yaml,
+    apply_parameter_metadata_overrides, generate_projection_catalog, import_mcp_surface,
+    import_openapi_surface, normalize_mcp_tool_catalog, normalize_source_document,
+    openapi_document_metadata, parse_parameter_metadata_overrides_yaml,
     sync_projection_pagination_inputs, validate_materialized_source,
     validate_openapi_base_url_template,
 };
@@ -662,7 +662,7 @@ fn write_materialization(
     let mut diagnostics = Vec::new();
     let mut first_surface_error = None;
     for surface in &manifest.surfaces {
-        let mut materialized_surface = match materialize_surface(manifest, surface, inputs) {
+        let materialized_surface = match materialize_surface(manifest, surface, inputs) {
             Ok(materialized_surface) => materialized_surface,
             Err(error) => {
                 let message = format!(
@@ -683,7 +683,6 @@ fn write_materialization(
                 continue;
             }
         };
-        apply_lookup_key_inference(&mut materialized_surface.semantic_ir);
         let surface_dir = temp_dir.join("surfaces").join(&surface.id);
         write_surface_artifacts(&surface_dir, &materialized_surface)?;
         materialized_surfaces.push(MaterializedSurface {

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -6,14 +6,16 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use coral_spec::v4::{
-    Diagnostic, DiagnosticSeverity, Fingerprint, FingerprintSurface, MCP_IMPORTER_VERSION,
-    MaterializedSurface, McpToolCatalog, OPENAPI_IMPORTER_VERSION, PROJECTION_GENERATOR_VERSION,
-    ProjectionCatalog, ProjectionPaginationInputSyncMode, SURFACE_IMPORTER_VERSION, SemanticIr,
-    SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceManifest,
+    Diagnostic, DiagnosticSeverity, Fingerprint, FingerprintSurface, GeneratedParameterMetadata,
+    LookupKeysMetadata, MCP_IMPORTER_VERSION, MaterializedSurface, McpToolCatalog,
+    OPENAPI_IMPORTER_VERSION, PROJECTION_GENERATOR_VERSION, ProjectionCatalog,
+    ProjectionPaginationInputSyncMode, SURFACE_IMPORTER_VERSION, SemanticIr, SurfaceType,
+    V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceManifest,
     apply_parameter_metadata_overrides, generate_projection_catalog, import_mcp_surface,
-    import_openapi_surface, normalize_mcp_tool_catalog, normalize_source_document,
-    openapi_document_metadata, parse_parameter_metadata_overrides_yaml,
-    sync_projection_pagination_inputs, validate_materialized_source,
+    import_openapi_surface, infer_lookup_keys, normalize_mcp_tool_catalog,
+    normalize_source_document, openapi_document_metadata, parse_generated_parameter_metadata_yaml,
+    parse_parameter_metadata_overrides_yaml, sync_projection_pagination_inputs,
+    validate_lookup_keys_for_surface, validate_materialized_source,
     validate_openapi_base_url_template,
 };
 use coral_spec::{
@@ -187,6 +189,7 @@ pub(crate) fn load_v4_materialization(
     let diagnostics: Vec<Diagnostic> =
         read_artifact_yaml(source_name, "diagnostics", &diagnostics_path)?;
     let mut surfaces = Vec::new();
+    let mut lookup_keys_by_surface = BTreeMap::new();
     for fingerprint_surface in &fingerprint.surfaces {
         let surface = manifest
             .surface(&fingerprint_surface.surface_id)
@@ -208,13 +211,17 @@ pub(crate) fn load_v4_materialization(
         require_file(source_name, &semantic_ir_path)?;
         let mut semantic_ir: SemanticIr =
             read_artifact_yaml(source_name, "semantic IR", &semantic_ir_path)?;
-        apply_parameter_metadata_override_file(
+        let generated_lookup_keys = read_generated_lookup_keys(&surface_dir, &semantic_ir)?;
+        let override_lookup_keys = apply_parameter_metadata_override_file(
             layout,
             workspace_name,
             source_name,
             &surface.id,
             &mut semantic_ir,
         )?;
+        if let Some(lookup_keys) = override_lookup_keys.or(generated_lookup_keys) {
+            lookup_keys_by_surface.insert(surface.id.clone(), lookup_keys);
+        }
         surfaces.push(MaterializedSurface {
             surface_id: surface.id.clone(),
             semantic_ir,
@@ -235,6 +242,7 @@ pub(crate) fn load_v4_materialization(
         surfaces.iter().map(|surface| &surface.semantic_ir),
         &mut projections,
         projection_sync_mode,
+        &lookup_keys_by_surface,
     );
     let materialized = V4MaterializedSource {
         fingerprint,
@@ -437,16 +445,50 @@ fn read_raw_source_document_artifact(
     })
 }
 
+fn read_generated_lookup_keys(
+    surface_dir: &Path,
+    semantic_ir: &SemanticIr,
+) -> Result<Option<LookupKeysMetadata>, AppError> {
+    let path = surface_dir.join(PARAMETER_METADATA_OVERRIDE_FILENAME);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(&path).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "failed to read DSL v4 parameter metadata '{}': {error}",
+            path.display()
+        ))
+    })?;
+    let metadata = parse_generated_parameter_metadata_yaml(&raw).map_err(|error| {
+        AppError::FailedPrecondition(format!(
+            "failed to parse DSL v4 parameter metadata '{}': {error}",
+            path.display()
+        ))
+    })?;
+    // Materialization writes this file and the semantic IR together, so they
+    // can only disagree after a hand-edit; a typo'd exclude must fail as
+    // loudly here as it does in the override path.
+    if let Some(lookup_keys) = &metadata.lookup_keys {
+        validate_lookup_keys_for_surface(lookup_keys, semantic_ir).map_err(|error| {
+            AppError::FailedPrecondition(format!(
+                "failed to validate DSL v4 parameter metadata '{}': {error}",
+                path.display()
+            ))
+        })?;
+    }
+    Ok(metadata.lookup_keys)
+}
+
 fn apply_parameter_metadata_override_file(
     layout: &AppStateLayout,
     workspace_name: &WorkspaceName,
     source_name: &SourceName,
     surface_id: &str,
     semantic_ir: &mut SemanticIr,
-) -> Result<(), AppError> {
+) -> Result<Option<LookupKeysMetadata>, AppError> {
     let path = layout.v4_parameter_metadata_override_file(workspace_name, source_name, surface_id);
     if !path.exists() {
-        return Ok(());
+        return Ok(None);
     }
 
     let raw = std::fs::read_to_string(&path).map_err(|error| {
@@ -466,7 +508,8 @@ fn apply_parameter_metadata_override_file(
             "failed to apply DSL v4 parameter metadata override '{}': {error}",
             path.display()
         ))
-    })
+    })?;
+    Ok(overrides.lookup_keys)
 }
 
 fn validate_loaded_materialization(
@@ -658,6 +701,7 @@ fn write_materialization(
     let mut materialized_surfaces = Vec::new();
     let mut semantic_irs = Vec::new();
     let mut fingerprint_surfaces = Vec::new();
+    let mut lookup_keys_by_surface = BTreeMap::new();
     let mut diagnostics = Vec::new();
     let mut first_surface_error = None;
     for surface in &manifest.surfaces {
@@ -683,19 +727,9 @@ fn write_materialization(
             }
         };
         let surface_dir = temp_dir.join("surfaces").join(&surface.id);
-        fs::ensure_private_dir(&surface_dir)?;
-        std::fs::write(
-            surface_dir.join("source-document.raw"),
-            &materialized_surface.raw_document,
-        )?;
-        std::fs::write(
-            surface_dir.join("source-document.yaml"),
-            &materialized_surface.normalized_document,
-        )?;
-        write_yaml(
-            &surface_dir.join("semantic-ir.yaml"),
-            &materialized_surface.semantic_ir,
-        )?;
+        if let Some(lookup_keys) = write_surface_artifacts(&surface_dir, &materialized_surface)? {
+            lookup_keys_by_surface.insert(surface.id.clone(), lookup_keys);
+        }
         materialized_surfaces.push(MaterializedSurface {
             surface_id: surface.id.clone(),
             semantic_ir: materialized_surface.semantic_ir.clone(),
@@ -723,7 +757,7 @@ fn write_materialization(
             },
         )));
     }
-    let projections = generate_projection_catalog(manifest, &semantic_irs, &BTreeMap::new())
+    let projections = generate_projection_catalog(manifest, &semantic_irs, &lookup_keys_by_surface)
         .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
     diagnostics.extend(projections.diagnostics.clone());
     for ir in &semantic_irs {
@@ -761,6 +795,37 @@ struct MaterializedSurfaceBuild {
     normalized_document: Vec<u8>,
     observed_sha256: String,
     semantic_ir: SemanticIr,
+}
+
+/// Writes the per-surface materialized artifacts (source documents, semantic
+/// IR, generated parameter metadata) and returns the inferred lookup keys.
+fn write_surface_artifacts(
+    surface_dir: &Path,
+    materialized_surface: &MaterializedSurfaceBuild,
+) -> Result<Option<LookupKeysMetadata>, AppError> {
+    fs::ensure_private_dir(surface_dir)?;
+    std::fs::write(
+        surface_dir.join("source-document.raw"),
+        &materialized_surface.raw_document,
+    )?;
+    std::fs::write(
+        surface_dir.join("source-document.yaml"),
+        &materialized_surface.normalized_document,
+    )?;
+    write_yaml(
+        &surface_dir.join("semantic-ir.yaml"),
+        &materialized_surface.semantic_ir,
+    )?;
+    let Some(lookup_keys) = infer_lookup_keys(&materialized_surface.semantic_ir) else {
+        return Ok(None);
+    };
+    write_yaml(
+        &surface_dir.join(PARAMETER_METADATA_OVERRIDE_FILENAME),
+        &GeneratedParameterMetadata {
+            lookup_keys: Some(lookup_keys.clone()),
+        },
+    )?;
+    Ok(Some(lookup_keys))
 }
 
 fn materialize_surface(

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -49,6 +49,7 @@ pub struct IrOperationInput {
     pub data_type: IrScalarType,
     pub default_value: Option<String>,
     pub description: String,
+    pub exclude_from_lookup_keys: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -253,7 +254,7 @@ mod tests {
     }
 
     #[test]
-    fn mcp_execution_attachment_uses_v2_artifact_schema() {
+    fn mcp_execution_attachment_uses_current_artifact_schema() {
         let ir = SemanticIr {
             artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
             source_name: "demo".to_string(),
@@ -274,6 +275,7 @@ mod tests {
                     data_type: IrScalarType::String,
                     default_value: None,
                     description: String::new(),
+                    exclude_from_lookup_keys: false,
                 }],
                 output: IrOperationOutput {
                     cardinality: OutputCardinality::List,
@@ -299,8 +301,10 @@ mod tests {
 
         let yaml = serde_yaml::to_string(&ir).expect("serialize MCP semantic IR");
         assert!(
-            yaml.contains("artifact_schema_version: 2"),
-            "MCP execution variants require the v2 artifact schema: {yaml}"
+            yaml.contains(&format!(
+                "artifact_schema_version: {V4_ARTIFACT_SCHEMA_VERSION}"
+            )),
+            "MCP execution variants require the current artifact schema: {yaml}"
         );
         assert!(
             yaml.contains("surface_type: mcp"),
@@ -355,6 +359,7 @@ diagnostics: []
             data_type: IrScalarType::String,
             default_value: None,
             description: String::new(),
+            exclude_from_lookup_keys: false,
         };
 
         let yaml = serde_yaml::to_string(&input).expect("serialize input");

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -49,7 +49,8 @@ pub struct IrOperationInput {
     pub data_type: IrScalarType,
     pub default_value: Option<String>,
     pub description: String,
-    pub exclude_from_lookup_keys: bool,
++    #[serde(default)]
++    pub exclude_from_lookup_keys: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -49,8 +49,8 @@ pub struct IrOperationInput {
     pub data_type: IrScalarType,
     pub default_value: Option<String>,
     pub description: String,
-+    #[serde(default)]
-+    pub exclude_from_lookup_keys: bool,
+    #[serde(default)]
+    pub exclude_from_lookup_keys: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/coral-spec/src/v4/lookup_keys.rs
+++ b/crates/coral-spec/src/v4/lookup_keys.rs
@@ -1,14 +1,17 @@
 //! Heuristic inference of lookup key joinability for REST surfaces.
 //!
-//! At materialization time Coral guesses which query parameters are NOT
+//! During OpenAPI import Coral guesses which REST query parameters are NOT
 //! complete exact lookups and stamps that fact into the semantic IR. Excluded
 //! parameters stay pushdown filters; they just cannot anchor dependent joins
-//! (`FilterSpec.lookup_key` stays false). The heuristic excludes aggressively:
-//! a wrong exclusion only makes a join fall back to the regular plan, while a
-//! wrong inclusion lets the dependent-join optimizer trust incomplete or fuzzy
-//! result sets and produce wrong rows.
+//! (`FilterSpec.lookup_key` stays false). MCP pagination is handled separately
+//! by MCP import/projection code, and MCP inputs do not use lookup-key
+//! exclusions. The heuristic excludes aggressively: a wrong exclusion only
+//! makes a join fall back to the regular plan, while a wrong inclusion lets the
+//! dependent-join optimizer trust incomplete or fuzzy result sets and produce
+//! wrong rows.
 
-use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, SemanticIr};
+use crate::PaginationSpec;
+use crate::v4::ir::{IrInputLocation, IrOperationInput};
 use crate::v4::projections::pagination_query_param_names;
 
 /// Normalized parameter names that only shape response presentation and never
@@ -43,38 +46,22 @@ const SEARCH_NAME_LEXICON: &[&str] = &[
     "filter", "filters", "keyword", "keywords", "q", "query", "search",
 ];
 
-/// Infers per-input lookup key exclusions into the semantic IR. Non-REST
-/// inputs are reset to `false`; projection derivation never treats them as
-/// lookup keys.
-pub fn apply_lookup_key_inference(ir: &mut SemanticIr) {
-    for operation in &mut ir.operations {
-        let pagination_params = match &operation.execution {
-            IrExecutionAttachment::Rest(rest) => {
-                Some(pagination_query_param_names(&rest.pagination))
-            }
-            IrExecutionAttachment::Mcp(_) => None,
-        };
-
-        let Some(pagination_params) = pagination_params else {
-            for input in &mut operation.inputs {
-                input.exclude_from_lookup_keys = false;
-            }
+pub(in crate::v4) fn infer_rest_lookup_key_exclusions(
+    inputs: &mut [IrOperationInput],
+    pagination: &PaginationSpec,
+) {
+    let pagination_params = pagination_query_param_names(pagination);
+    for input in inputs {
+        input.exclude_from_lookup_keys = false;
+        if input.location != IrInputLocation::Query {
             continue;
-        };
-
-        for input in &mut operation.inputs {
-            input.exclude_from_lookup_keys = false;
-            if input.location != IrInputLocation::Query {
-                continue;
-            }
-            // Pagination-owned parameters are internal today, but a later
-            // pagination override can remap the scheme and surface them as
-            // filters. Detection has proven they are windowing, so record that
-            // in the IR instead of relying on their exposure.
-            if pagination_params.contains(input.name.as_str()) || !joinable_param_name(&input.name)
-            {
-                input.exclude_from_lookup_keys = true;
-            }
+        }
+        // Pagination-owned parameters are internal today, but a later
+        // pagination override can remap the scheme and surface them as
+        // filters. Detection has proven they are windowing, so record that
+        // in the IR instead of relying on their exposure.
+        if pagination_params.contains(input.name.as_str()) || !joinable_param_name(&input.name) {
+            input.exclude_from_lookup_keys = true;
         }
     }
 }
@@ -101,16 +88,10 @@ fn normalized_param_name(name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::v4::ir::{
-        HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
-        IrOperationOutput, IrScalarType, McpExecutionAttachment, OutputCardinality,
-        RestExecutionAttachment, RestResponseAttachment, SemanticIr,
-    };
-    use crate::v4::manifest::SurfaceType;
-    use crate::v4::{OPENAPI_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
-    use crate::{PaginationMode, PaginationSpec, ResponseSpec};
+    use crate::v4::ir::{IrInputLocation, IrOperationInput, IrScalarType};
+    use crate::{PaginationMode, PaginationSpec};
 
-    use super::apply_lookup_key_inference;
+    use super::infer_rest_lookup_key_exclusions;
 
     #[test]
     fn infers_exclusions_for_presentation_and_search_params() {
@@ -119,27 +100,17 @@ mod tests {
             page_param: Some("page".to_string()),
             ..PaginationSpec::default()
         };
-        let mut ir = semantic_ir(vec![
-            rest_operation(
-                "widgets_list",
-                &[
-                    "order_by",
-                    "sort ",
-                    "sort_field",
-                    "q",
-                    "search",
-                    "state",
-                    "category",
-                    "page",
-                ],
-                page_pagination,
-            ),
-            rest_operation(
-                "gadgets_list",
-                &["filter", "since"],
-                PaginationSpec::default(),
-            ),
+        let mut widgets = query_inputs(&[
+            "order_by",
+            "sort ",
+            "sort_field",
+            "q",
+            "search",
+            "state",
+            "category",
+            "page",
         ]);
+        let mut gadgets = query_inputs(&["filter", "since"]);
 
         // `order_by`/`sort_field` are exact presentation hits after name
         // normalization, `q`/`search`/`filter` are search-like, and
@@ -147,27 +118,18 @@ mod tests {
         // pagination remap cannot surface it as a lookup key. Padded `sort `
         // is still excluded because no generated side file has to represent
         // the raw padded name. `state`/`category`/`since` remain joinable.
-        apply_lookup_key_inference(&mut ir);
-        assert!(input_excluded(&ir, "widgets_list", "order_by"));
-        assert!(input_excluded(&ir, "widgets_list", "sort "));
-        assert!(input_excluded(&ir, "widgets_list", "sort_field"));
-        assert!(input_excluded(&ir, "widgets_list", "q"));
-        assert!(input_excluded(&ir, "widgets_list", "search"));
-        assert!(input_excluded(&ir, "widgets_list", "page"));
-        assert!(input_excluded(&ir, "gadgets_list", "filter"));
-        assert!(!input_excluded(&ir, "widgets_list", "state"));
-        assert!(!input_excluded(&ir, "widgets_list", "category"));
-        assert!(!input_excluded(&ir, "gadgets_list", "since"));
-    }
-
-    #[test]
-    fn resets_lookup_key_exclusions_for_mcp_inputs() {
-        let mut ir = semantic_ir(vec![mcp_operation("items_search", "query")]);
-        assert!(input_excluded(&ir, "items_search", "query"));
-
-        apply_lookup_key_inference(&mut ir);
-
-        assert!(!input_excluded(&ir, "items_search", "query"));
+        infer_rest_lookup_key_exclusions(&mut widgets, &page_pagination);
+        infer_rest_lookup_key_exclusions(&mut gadgets, &PaginationSpec::default());
+        assert!(input_excluded(&widgets, "order_by"));
+        assert!(input_excluded(&widgets, "sort "));
+        assert!(input_excluded(&widgets, "sort_field"));
+        assert!(input_excluded(&widgets, "q"));
+        assert!(input_excluded(&widgets, "search"));
+        assert!(input_excluded(&widgets, "page"));
+        assert!(input_excluded(&gadgets, "filter"));
+        assert!(!input_excluded(&widgets, "state"));
+        assert!(!input_excluded(&widgets, "category"));
+        assert!(!input_excluded(&gadgets, "since"));
     }
 
     #[test]
@@ -177,32 +139,18 @@ mod tests {
             cursor_param: Some("cursor".to_string()),
             ..PaginationSpec::default()
         };
-        let mut ir = semantic_ir(vec![
-            rest_operation("paginated", &["cursor"], pagination),
-            rest_operation("ordinary", &["cursor"], PaginationSpec::default()),
-        ]);
+        let mut paginated = query_inputs(&["cursor"]);
+        let mut ordinary = query_inputs(&["cursor"]);
 
-        apply_lookup_key_inference(&mut ir);
+        infer_rest_lookup_key_exclusions(&mut paginated, &pagination);
+        infer_rest_lookup_key_exclusions(&mut ordinary, &PaginationSpec::default());
 
-        assert!(input_excluded(&ir, "paginated", "cursor"));
-        assert!(!input_excluded(&ir, "ordinary", "cursor"));
+        assert!(input_excluded(&paginated, "cursor"));
+        assert!(!input_excluded(&ordinary, "cursor"));
     }
 
-    fn semantic_ir(operations: Vec<IrOperation>) -> SemanticIr {
-        SemanticIr {
-            artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
-            source_name: "demo".to_string(),
-            surface_id: "rest".to_string(),
-            surface_type: SurfaceType::OpenApi,
-            importer_version: OPENAPI_IMPORTER_VERSION.to_string(),
-            operations,
-            types: Vec::new(),
-            diagnostics: Vec::new(),
-        }
-    }
-
-    fn rest_operation(id: &str, query_params: &[&str], pagination: PaginationSpec) -> IrOperation {
-        let inputs = query_params
+    fn query_inputs(query_params: &[&str]) -> Vec<IrOperationInput> {
+        query_params
             .iter()
             .map(|name| IrOperationInput {
                 name: (*name).to_string(),
@@ -213,75 +161,11 @@ mod tests {
                 description: String::new(),
                 exclude_from_lookup_keys: false,
             })
-            .collect();
-        IrOperation {
-            id: id.to_string(),
-            method_name: "GET".to_string(),
-            description: String::new(),
-            deprecated: false,
-            read_only: true,
-            naming: None,
-            inputs,
-            output: IrOperationOutput {
-                cardinality: OutputCardinality::List,
-                type_ref: "row".to_string(),
-                row_path: Vec::new(),
-            },
-            entity: None,
-            execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
-                method: HttpMethod::Get,
-                path_template: format!("/{id}"),
-                parameters: Vec::new(),
-                request_body: None,
-                response: RestResponseAttachment {
-                    status_code: 200,
-                    media_type: "application/json".to_string(),
-                    response: ResponseSpec::default(),
-                },
-                pagination,
-            })),
-            diagnostics: Vec::new(),
-        }
+            .collect()
     }
 
-    fn mcp_operation(id: &str, input_name: &str) -> IrOperation {
-        IrOperation {
-            id: id.to_string(),
-            method_name: "tools/call".to_string(),
-            description: String::new(),
-            deprecated: false,
-            read_only: true,
-            naming: None,
-            inputs: vec![IrOperationInput {
-                name: input_name.to_string(),
-                location: IrInputLocation::ToolArg,
-                required: false,
-                data_type: IrScalarType::String,
-                default_value: None,
-                description: String::new(),
-                exclude_from_lookup_keys: true,
-            }],
-            output: IrOperationOutput {
-                cardinality: OutputCardinality::List,
-                type_ref: "row".to_string(),
-                row_path: Vec::new(),
-            },
-            entity: None,
-            execution: IrExecutionAttachment::Mcp(McpExecutionAttachment {
-                tool_name: id.to_string(),
-                pagination: None,
-                offset_pagination: None,
-            }),
-            diagnostics: Vec::new(),
-        }
-    }
-
-    fn input_excluded(ir: &SemanticIr, operation_id: &str, input_name: &str) -> bool {
-        ir.operations
-            .iter()
-            .find(|operation| operation.id == operation_id)
-            .expect("operation")
-            .inputs
+    fn input_excluded(inputs: &[IrOperationInput], input_name: &str) -> bool {
+        inputs
             .iter()
             .find(|input| input.name == input_name)
             .expect("input")

--- a/crates/coral-spec/src/v4/lookup_keys.rs
+++ b/crates/coral-spec/src/v4/lookup_keys.rs
@@ -1,6 +1,6 @@
 //! Heuristic inference of lookup key joinability for REST surfaces.
 //!
-//! During OpenAPI import Coral guesses which REST query parameters are NOT
+//! During `OpenAPI` import Coral guesses which REST query parameters are NOT
 //! complete exact lookups and stamps that fact into the semantic IR. Excluded
 //! parameters stay pushdown filters; they just cannot anchor dependent joins
 //! (`FilterSpec.lookup_key` stays false). MCP pagination is handled separately

--- a/crates/coral-spec/src/v4/lookup_keys.rs
+++ b/crates/coral-spec/src/v4/lookup_keys.rs
@@ -1,18 +1,14 @@
 //! Heuristic inference of lookup key joinability for REST surfaces.
 //!
 //! At materialization time Coral guesses which query parameters are NOT
-//! complete exact lookups and writes them to the `exclude` list of the
-//! generated `parameter_metadata.yaml`. Excluded parameters stay pushdown
-//! filters; they just cannot anchor dependent joins (`FilterSpec.lookup_key`
-//! stays false). The heuristic excludes aggressively: a wrong exclusion only
-//! makes a join fall back to the regular plan, while a wrong inclusion lets
-//! the dependent-join optimizer trust incomplete or fuzzy result sets and
-//! produce wrong rows.
-
-use std::collections::BTreeSet;
+//! complete exact lookups and stamps that fact into the semantic IR. Excluded
+//! parameters stay pushdown filters; they just cannot anchor dependent joins
+//! (`FilterSpec.lookup_key` stays false). The heuristic excludes aggressively:
+//! a wrong exclusion only makes a join fall back to the regular plan, while a
+//! wrong inclusion lets the dependent-join optimizer trust incomplete or fuzzy
+//! result sets and produce wrong rows.
 
 use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, SemanticIr};
-use crate::v4::parameter_metadata::LookupKeysMetadata;
 use crate::v4::projections::pagination_query_param_names;
 
 /// Normalized parameter names that only shape response presentation and never
@@ -47,51 +43,47 @@ const SEARCH_NAME_LEXICON: &[&str] = &[
     "filter", "filters", "keyword", "keywords", "q", "query", "search",
 ];
 
-/// Infers the surface-wide lookup key exclude list from the semantic IR.
-/// Returns `None` for surfaces without REST operations.
-#[must_use]
-pub fn infer_lookup_keys(ir: &SemanticIr) -> Option<LookupKeysMetadata> {
-    let mut has_rest_operations = false;
-    let mut exclude = BTreeSet::new();
+/// Infers per-input lookup key exclusions into the semantic IR. Non-REST
+/// inputs are reset to `false`; projection derivation never treats them as
+/// lookup keys.
+pub fn apply_lookup_key_inference(ir: &mut SemanticIr) {
+    for operation in &mut ir.operations {
+        let pagination_params = match &operation.execution {
+            IrExecutionAttachment::Rest(rest) => {
+                Some(pagination_query_param_names(&rest.pagination))
+            }
+            IrExecutionAttachment::Mcp(_) => None,
+        };
 
-    for operation in &ir.operations {
-        let IrExecutionAttachment::Rest(rest) = &operation.execution else {
+        let Some(pagination_params) = pagination_params else {
+            for input in &mut operation.inputs {
+                input.exclude_from_lookup_keys = false;
+            }
             continue;
         };
-        has_rest_operations = true;
-        let pagination_params = pagination_query_param_names(&rest.pagination);
-        for input in &operation.inputs {
+
+        for input in &mut operation.inputs {
+            input.exclude_from_lookup_keys = false;
             if input.location != IrInputLocation::Query {
-                continue;
-            }
-            // A padded name cannot legally appear in the generated file (the
-            // shape rule rejects it), so skip it rather than emit an invalid
-            // artifact; normalizing pathological specs is the importer's job.
-            if input.name != input.name.trim() {
                 continue;
             }
             // Pagination-owned parameters are internal today, but a later
             // pagination override can remap the scheme and surface them as
-            // filters. Detection has proven they are windowing, so record
-            // that in the artifact instead of relying on their exposure.
+            // filters. Detection has proven they are windowing, so record that
+            // in the IR instead of relying on their exposure.
             if pagination_params.contains(input.name.as_str()) || !joinable_param_name(&input.name)
             {
-                exclude.insert(input.name.clone());
+                input.exclude_from_lookup_keys = true;
             }
         }
     }
-
-    has_rest_operations.then(|| LookupKeysMetadata {
-        enabled: true,
-        exclude: exclude.into_iter().collect(),
-    })
 }
 
 /// Exact lexicon match only: token-level matching (e.g. treating
 /// `sort_field` as presentation) also caught identity keys like `order_id`,
 /// and losing joinability on a foreign key costs more than missing a
-/// presentation alias. Unrecognized names stay joinable; the generated file
-/// is the audit trail for correcting either direction.
+/// presentation alias. Unrecognized names stay joinable; the semantic IR is
+/// the audit trail for correcting either direction.
 fn joinable_param_name(name: &str) -> bool {
     let normalized = normalized_param_name(name);
     !(SEARCH_NAME_LEXICON.contains(&normalized.as_str())
@@ -118,7 +110,7 @@ mod tests {
     use crate::v4::{OPENAPI_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
     use crate::{PaginationMode, PaginationSpec, ResponseSpec};
 
-    use super::infer_lookup_keys;
+    use super::apply_lookup_key_inference;
 
     #[test]
     fn infers_exclusions_for_presentation_and_search_params() {
@@ -127,7 +119,7 @@ mod tests {
             page_param: Some("page".to_string()),
             ..PaginationSpec::default()
         };
-        let ir = semantic_ir(vec![
+        let mut ir = semantic_ir(vec![
             rest_operation(
                 "widgets_list",
                 &[
@@ -149,22 +141,44 @@ mod tests {
             ),
         ]);
 
-        let metadata = infer_lookup_keys(&ir).expect("rest surface metadata");
-
-        assert!(metadata.enabled);
         // `order_by`/`sort_field` are exact presentation hits after name
         // normalization, `q`/`search`/`filter` are search-like, and
         // pagination-owned `page` is recorded as non-joinable so a later
-        // pagination remap cannot surface it as a lookup key. Padded
-        // `sort ` is skipped entirely: the generated file's shape rule
-        // rejects padded values. `state`/`category`/`since` remain joinable.
-        assert_eq!(
-            metadata.exclude,
-            ["filter", "order_by", "page", "q", "search", "sort_field"]
-        );
+        // pagination remap cannot surface it as a lookup key. Padded `sort `
+        // is still excluded because no generated side file has to represent
+        // the raw padded name. `state`/`category`/`since` remain joinable.
+        apply_lookup_key_inference(&mut ir);
+        assert!(input_excluded(&ir, "widgets_list", "order_by"));
+        assert!(input_excluded(&ir, "widgets_list", "sort "));
+        assert!(input_excluded(&ir, "widgets_list", "sort_field"));
+        assert!(input_excluded(&ir, "widgets_list", "q"));
+        assert!(input_excluded(&ir, "widgets_list", "search"));
+        assert!(input_excluded(&ir, "widgets_list", "page"));
+        assert!(input_excluded(&ir, "gadgets_list", "filter"));
+        assert!(!input_excluded(&ir, "widgets_list", "state"));
+        assert!(!input_excluded(&ir, "widgets_list", "category"));
+        assert!(!input_excluded(&ir, "gadgets_list", "since"));
 
-        let mcp_only = semantic_ir(Vec::new());
-        assert!(infer_lookup_keys(&mcp_only).is_none());
+        let mut mcp_only = semantic_ir(Vec::new());
+        apply_lookup_key_inference(&mut mcp_only);
+    }
+
+    #[test]
+    fn pagination_exclusions_are_scoped_to_the_owning_operation() {
+        let pagination = PaginationSpec {
+            mode: PaginationMode::CursorQuery,
+            cursor_param: Some("cursor".to_string()),
+            ..PaginationSpec::default()
+        };
+        let mut ir = semantic_ir(vec![
+            rest_operation("paginated", &["cursor"], pagination),
+            rest_operation("ordinary", &["cursor"], PaginationSpec::default()),
+        ]);
+
+        apply_lookup_key_inference(&mut ir);
+
+        assert!(input_excluded(&ir, "paginated", "cursor"));
+        assert!(!input_excluded(&ir, "ordinary", "cursor"));
     }
 
     fn semantic_ir(operations: Vec<IrOperation>) -> SemanticIr {
@@ -190,6 +204,7 @@ mod tests {
                 data_type: IrScalarType::String,
                 default_value: None,
                 description: String::new(),
+                exclude_from_lookup_keys: false,
             })
             .collect();
         IrOperation {
@@ -220,5 +235,17 @@ mod tests {
             })),
             diagnostics: Vec::new(),
         }
+    }
+
+    fn input_excluded(ir: &SemanticIr, operation_id: &str, input_name: &str) -> bool {
+        ir.operations
+            .iter()
+            .find(|operation| operation.id == operation_id)
+            .expect("operation")
+            .inputs
+            .iter()
+            .find(|input| input.name == input_name)
+            .expect("input")
+            .exclude_from_lookup_keys
     }
 }

--- a/crates/coral-spec/src/v4/lookup_keys.rs
+++ b/crates/coral-spec/src/v4/lookup_keys.rs
@@ -103,8 +103,8 @@ fn normalized_param_name(name: &str) -> String {
 mod tests {
     use crate::v4::ir::{
         HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
-        IrOperationOutput, IrScalarType, OutputCardinality, RestExecutionAttachment,
-        RestResponseAttachment, SemanticIr,
+        IrOperationOutput, IrScalarType, McpExecutionAttachment, OutputCardinality,
+        RestExecutionAttachment, RestResponseAttachment, SemanticIr,
     };
     use crate::v4::manifest::SurfaceType;
     use crate::v4::{OPENAPI_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
@@ -158,9 +158,16 @@ mod tests {
         assert!(!input_excluded(&ir, "widgets_list", "state"));
         assert!(!input_excluded(&ir, "widgets_list", "category"));
         assert!(!input_excluded(&ir, "gadgets_list", "since"));
+    }
 
-        let mut mcp_only = semantic_ir(Vec::new());
-        apply_lookup_key_inference(&mut mcp_only);
+    #[test]
+    fn resets_lookup_key_exclusions_for_mcp_inputs() {
+        let mut ir = semantic_ir(vec![mcp_operation("items_search", "query")]);
+        assert!(input_excluded(&ir, "items_search", "query"));
+
+        apply_lookup_key_inference(&mut ir);
+
+        assert!(!input_excluded(&ir, "items_search", "query"));
     }
 
     #[test]
@@ -233,6 +240,38 @@ mod tests {
                 },
                 pagination,
             })),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn mcp_operation(id: &str, input_name: &str) -> IrOperation {
+        IrOperation {
+            id: id.to_string(),
+            method_name: "tools/call".to_string(),
+            description: String::new(),
+            deprecated: false,
+            read_only: true,
+            naming: None,
+            inputs: vec![IrOperationInput {
+                name: input_name.to_string(),
+                location: IrInputLocation::ToolArg,
+                required: false,
+                data_type: IrScalarType::String,
+                default_value: None,
+                description: String::new(),
+                exclude_from_lookup_keys: true,
+            }],
+            output: IrOperationOutput {
+                cardinality: OutputCardinality::List,
+                type_ref: "row".to_string(),
+                row_path: Vec::new(),
+            },
+            entity: None,
+            execution: IrExecutionAttachment::Mcp(McpExecutionAttachment {
+                tool_name: id.to_string(),
+                pagination: None,
+                offset_pagination: None,
+            }),
             diagnostics: Vec::new(),
         }
     }

--- a/crates/coral-spec/src/v4/lookup_keys.rs
+++ b/crates/coral-spec/src/v4/lookup_keys.rs
@@ -1,0 +1,224 @@
+//! Heuristic inference of lookup key joinability for REST surfaces.
+//!
+//! At materialization time Coral guesses which query parameters are NOT
+//! complete exact lookups and writes them to the `exclude` list of the
+//! generated `parameter_metadata.yaml`. Excluded parameters stay pushdown
+//! filters; they just cannot anchor dependent joins (`FilterSpec.lookup_key`
+//! stays false). The heuristic excludes aggressively: a wrong exclusion only
+//! makes a join fall back to the regular plan, while a wrong inclusion lets
+//! the dependent-join optimizer trust incomplete or fuzzy result sets and
+//! produce wrong rows.
+
+use std::collections::BTreeSet;
+
+use crate::v4::ir::{IrExecutionAttachment, IrInputLocation, SemanticIr};
+use crate::v4::parameter_metadata::LookupKeysMetadata;
+use crate::v4::projections::pagination_query_param_names;
+
+/// Normalized parameter names that only shape response presentation and never
+/// select result candidates; joining on them is meaningless.
+const PRESENTATION_NAME_LEXICON: &[&str] = &[
+    "callback",
+    "direction",
+    "embed",
+    "envelope",
+    "expand",
+    "fields",
+    "format",
+    "include",
+    "order",
+    "orderby",
+    "ordering",
+    "pretty",
+    "select",
+    "sort",
+    "sortby",
+    "sortdir",
+    "sortfield",
+    "sortorder",
+];
+
+/// Normalized names whose values drive fuzzy or expression matching rather
+/// than exact attribute equality (`q=foo` selects search matches, not rows
+/// where `q` equals `foo`). They stay pushdown filters but never become
+/// lookup keys: their virtual columns only echo the request value, so
+/// join-equality enforcement cannot catch the mismatch.
+const SEARCH_NAME_LEXICON: &[&str] = &[
+    "filter", "filters", "keyword", "keywords", "q", "query", "search",
+];
+
+/// Infers the surface-wide lookup key exclude list from the semantic IR.
+/// Returns `None` for surfaces without REST operations.
+#[must_use]
+pub fn infer_lookup_keys(ir: &SemanticIr) -> Option<LookupKeysMetadata> {
+    let mut has_rest_operations = false;
+    let mut exclude = BTreeSet::new();
+
+    for operation in &ir.operations {
+        let IrExecutionAttachment::Rest(rest) = &operation.execution else {
+            continue;
+        };
+        has_rest_operations = true;
+        let pagination_params = pagination_query_param_names(&rest.pagination);
+        for input in &operation.inputs {
+            if input.location != IrInputLocation::Query {
+                continue;
+            }
+            // A padded name cannot legally appear in the generated file (the
+            // shape rule rejects it), so skip it rather than emit an invalid
+            // artifact; normalizing pathological specs is the importer's job.
+            if input.name != input.name.trim() {
+                continue;
+            }
+            // Pagination-owned parameters are internal today, but a later
+            // pagination override can remap the scheme and surface them as
+            // filters. Detection has proven they are windowing, so record
+            // that in the artifact instead of relying on their exposure.
+            if pagination_params.contains(input.name.as_str()) || !joinable_param_name(&input.name)
+            {
+                exclude.insert(input.name.clone());
+            }
+        }
+    }
+
+    has_rest_operations.then(|| LookupKeysMetadata {
+        enabled: true,
+        exclude: exclude.into_iter().collect(),
+    })
+}
+
+/// Exact lexicon match only: token-level matching (e.g. treating
+/// `sort_field` as presentation) also caught identity keys like `order_id`,
+/// and losing joinability on a foreign key costs more than missing a
+/// presentation alias. Unrecognized names stay joinable; the generated file
+/// is the audit trail for correcting either direction.
+fn joinable_param_name(name: &str) -> bool {
+    let normalized = normalized_param_name(name);
+    !(SEARCH_NAME_LEXICON.contains(&normalized.as_str())
+        || PRESENTATION_NAME_LEXICON.contains(&normalized.as_str()))
+}
+
+/// Collapses case and separators so `orderBy`, `order_by`, and `order-by`
+/// all match the lexicon entry `orderby`.
+fn normalized_param_name(name: &str) -> String {
+    name.chars()
+        .filter(char::is_ascii_alphanumeric)
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::v4::ir::{
+        HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, IrOperationInput,
+        IrOperationOutput, IrScalarType, OutputCardinality, RestExecutionAttachment,
+        RestResponseAttachment, SemanticIr,
+    };
+    use crate::v4::manifest::SurfaceType;
+    use crate::v4::{OPENAPI_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
+    use crate::{PaginationMode, PaginationSpec, ResponseSpec};
+
+    use super::infer_lookup_keys;
+
+    #[test]
+    fn infers_exclusions_for_presentation_and_search_params() {
+        let page_pagination = PaginationSpec {
+            mode: PaginationMode::Page,
+            page_param: Some("page".to_string()),
+            ..PaginationSpec::default()
+        };
+        let ir = semantic_ir(vec![
+            rest_operation(
+                "widgets_list",
+                &[
+                    "order_by",
+                    "sort ",
+                    "sort_field",
+                    "q",
+                    "search",
+                    "state",
+                    "category",
+                    "page",
+                ],
+                page_pagination,
+            ),
+            rest_operation(
+                "gadgets_list",
+                &["filter", "since"],
+                PaginationSpec::default(),
+            ),
+        ]);
+
+        let metadata = infer_lookup_keys(&ir).expect("rest surface metadata");
+
+        assert!(metadata.enabled);
+        // `order_by`/`sort_field` are exact presentation hits after name
+        // normalization, `q`/`search`/`filter` are search-like, and
+        // pagination-owned `page` is recorded as non-joinable so a later
+        // pagination remap cannot surface it as a lookup key. Padded
+        // `sort ` is skipped entirely: the generated file's shape rule
+        // rejects padded values. `state`/`category`/`since` remain joinable.
+        assert_eq!(
+            metadata.exclude,
+            ["filter", "order_by", "page", "q", "search", "sort_field"]
+        );
+
+        let mcp_only = semantic_ir(Vec::new());
+        assert!(infer_lookup_keys(&mcp_only).is_none());
+    }
+
+    fn semantic_ir(operations: Vec<IrOperation>) -> SemanticIr {
+        SemanticIr {
+            artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+            source_name: "demo".to_string(),
+            surface_id: "rest".to_string(),
+            surface_type: SurfaceType::OpenApi,
+            importer_version: OPENAPI_IMPORTER_VERSION.to_string(),
+            operations,
+            types: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn rest_operation(id: &str, query_params: &[&str], pagination: PaginationSpec) -> IrOperation {
+        let inputs = query_params
+            .iter()
+            .map(|name| IrOperationInput {
+                name: (*name).to_string(),
+                location: IrInputLocation::Query,
+                required: false,
+                data_type: IrScalarType::String,
+                default_value: None,
+                description: String::new(),
+            })
+            .collect();
+        IrOperation {
+            id: id.to_string(),
+            method_name: "GET".to_string(),
+            description: String::new(),
+            deprecated: false,
+            read_only: true,
+            naming: None,
+            inputs,
+            output: IrOperationOutput {
+                cardinality: OutputCardinality::List,
+                type_ref: "row".to_string(),
+                row_path: Vec::new(),
+            },
+            entity: None,
+            execution: IrExecutionAttachment::Rest(Box::new(RestExecutionAttachment {
+                method: HttpMethod::Get,
+                path_template: format!("/{id}"),
+                parameters: Vec::new(),
+                request_body: None,
+                response: RestResponseAttachment {
+                    status_code: 200,
+                    media_type: "application/json".to_string(),
+                    response: ResponseSpec::default(),
+                },
+                pagination,
+            })),
+            diagnostics: Vec::new(),
+        }
+    }
+}

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -40,7 +40,6 @@ pub use ir::{
     McpExecutionAttachment, OutputCardinality, RestExecutionAttachment, RestParameterBinding,
     RestRequestBody, RestResponseAttachment, SemanticIr,
 };
-pub use lookup_keys::apply_lookup_key_inference;
 pub use manifest::{
     McpRuntimeConfig, OpenApiRuntimeConfig, SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType,
     V4SourceCommon, V4SourceManifest, V4Surface, validate_openapi_base_url_template,

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -7,11 +7,12 @@ pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 2;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v1";
 pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v4";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v1";
-pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v7";
+pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v8";
 
 mod artifacts;
 mod diagnostics;
 mod ir;
+mod lookup_keys;
 mod manifest;
 mod naming;
 mod parameter_metadata;
@@ -39,6 +40,7 @@ pub use ir::{
     McpExecutionAttachment, OutputCardinality, RestExecutionAttachment, RestParameterBinding,
     RestRequestBody, RestResponseAttachment, SemanticIr,
 };
+pub use lookup_keys::infer_lookup_keys;
 pub use manifest::{
     McpRuntimeConfig, OpenApiRuntimeConfig, SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType,
     V4SourceCommon, V4SourceManifest, V4Surface, validate_openapi_base_url_template,

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -45,9 +45,10 @@ pub use manifest::{
 };
 pub use naming::normalize_identifier;
 pub use parameter_metadata::{
-    ParameterMetadataOverrides, ProjectionPaginationInputSyncMode,
-    apply_parameter_metadata_overrides, parse_parameter_metadata_overrides_yaml,
-    sync_projection_pagination_inputs,
+    GeneratedParameterMetadata, LookupKeysMetadata, ParameterMetadataOverrides,
+    ProjectionPaginationInputSyncMode, apply_parameter_metadata_overrides,
+    parse_generated_parameter_metadata_yaml, parse_parameter_metadata_overrides_yaml,
+    sync_projection_pagination_inputs, validate_lookup_keys_for_surface,
 };
 pub use projections::{
     Projection, ProjectionCatalog, ProjectionColumn, ProjectionInput, ProjectionKind,

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -3,7 +3,7 @@
     reason = "DSL v4 contracts are field-heavy artifact models documented in the PRD."
 )]
 
-pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 2;
+pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 3;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v1";
 pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v4";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v1";
@@ -40,16 +40,15 @@ pub use ir::{
     McpExecutionAttachment, OutputCardinality, RestExecutionAttachment, RestParameterBinding,
     RestRequestBody, RestResponseAttachment, SemanticIr,
 };
-pub use lookup_keys::infer_lookup_keys;
+pub use lookup_keys::apply_lookup_key_inference;
 pub use manifest::{
     McpRuntimeConfig, OpenApiRuntimeConfig, SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType,
     V4SourceCommon, V4SourceManifest, V4Surface, validate_openapi_base_url_template,
 };
 pub use naming::normalize_identifier;
 pub use parameter_metadata::{
-    GeneratedParameterMetadata, LookupKeysMetadata, ParameterMetadataOverrides,
-    ProjectionPaginationInputSyncMode, apply_parameter_metadata_overrides,
-    parse_generated_parameter_metadata_yaml, parse_parameter_metadata_overrides_yaml,
+    LookupKeysMetadata, ParameterMetadataOverrides, ProjectionPaginationInputSyncMode,
+    apply_parameter_metadata_overrides, parse_parameter_metadata_overrides_yaml,
     sync_projection_pagination_inputs, validate_lookup_keys_for_surface,
 };
 pub use projections::{

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -171,7 +171,7 @@ components:
     assert_eq!(fallback.group.as_deref(), Some("misc"));
     assert_eq!(fallback.operation.as_deref(), Some("get_fallback"));
 
-    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
     let quotes_projection = catalog
         .projections
         .iter()
@@ -236,7 +236,7 @@ components:
     assert_eq!(operation.output.cardinality, OutputCardinality::WrappedList);
     assert_eq!(operation.output.row_path, vec!["data".to_string()]);
 
-    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
     let projection = catalog
         .projections
         .iter()
@@ -304,7 +304,7 @@ components:
     assert_eq!(operation.output.cardinality, OutputCardinality::WrappedList);
     assert_eq!(operation.output.row_path, vec!["repositories".to_string()]);
 
-    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
     let projection = catalog.projections.first().expect("projection");
     assert_eq!(projection.name, "repository");
     assert!(matches!(
@@ -514,7 +514,7 @@ components:
         operation.diagnostics
     );
 
-    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
     let projection = catalog
         .projections
         .iter()

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -171,7 +171,7 @@ components:
     assert_eq!(fallback.group.as_deref(), Some("misc"));
     assert_eq!(fallback.operation.as_deref(), Some("get_fallback"));
 
-    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
     let quotes_projection = catalog
         .projections
         .iter()
@@ -236,7 +236,7 @@ components:
     assert_eq!(operation.output.cardinality, OutputCardinality::WrappedList);
     assert_eq!(operation.output.row_path, vec!["data".to_string()]);
 
-    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
     let projection = catalog
         .projections
         .iter()
@@ -304,7 +304,7 @@ components:
     assert_eq!(operation.output.cardinality, OutputCardinality::WrappedList);
     assert_eq!(operation.output.row_path, vec!["repositories".to_string()]);
 
-    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
     let projection = catalog.projections.first().expect("projection");
     assert_eq!(projection.name, "repository");
     assert!(matches!(
@@ -514,7 +514,7 @@ components:
         operation.diagnostics
     );
 
-    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
     let projection = catalog
         .projections
         .iter()

--- a/crates/coral-spec/src/v4/parameter_metadata.rs
+++ b/crates/coral-spec/src/v4/parameter_metadata.rs
@@ -816,6 +816,64 @@ pagination:
     }
 
     #[test]
+    fn pagination_override_internalizes_stale_lookup_key_candidate() {
+        let mut ir = semantic_ir(vec![rest_operation(
+            "widgets_list",
+            "/widgets",
+            vec![query_input("cursor"), query_input("state")],
+            PaginationSpec::default(),
+        )]);
+        let overrides = parse_parameter_metadata_overrides_yaml(
+            r"
+pagination:
+  - name: cursor
+    match:
+      operation_ids: [widgets_list]
+    mode: cursor_query
+    cursor_param: cursor
+    response_cursor_path: [next_cursor]
+",
+        )
+        .expect("parse overrides");
+
+        apply_parameter_metadata_overrides(&mut ir, &overrides).expect("apply overrides");
+        assert!(
+            !input_excluded(&ir, "cursor"),
+            "pagination overrides should not rewrite persisted import-time lookup-key metadata"
+        );
+
+        for mode in [
+            ProjectionPaginationInputSyncMode::RecomputeRestInputExposure,
+            ProjectionPaginationInputSyncMode::PreserveExistingExposure,
+        ] {
+            let mut projections = projection_catalog(vec![
+                projection_input("cursor", "cursor", SqlInputExposure::Filter),
+                projection_input("state", "state", SqlInputExposure::Filter),
+            ]);
+            sync_projection_pagination_inputs(std::slice::from_ref(&ir), &mut projections, mode);
+
+            assert_eq!(
+                projection_input_exposure(&projections, "cursor"),
+                SqlInputExposure::Internal,
+                "{mode:?}"
+            );
+            assert!(
+                !projection_input_lookup_key(&projections, "cursor"),
+                "{mode:?}"
+            );
+            assert_eq!(
+                projection_input_exposure(&projections, "state"),
+                SqlInputExposure::Filter,
+                "{mode:?}"
+            );
+            assert!(
+                projection_input_lookup_key(&projections, "state"),
+                "{mode:?}"
+            );
+        }
+    }
+
+    #[test]
     fn sync_projection_inputs_applies_lookup_key_exclusions() {
         let mut ir = semantic_ir(vec![rest_operation(
             "widgets_list",

--- a/crates/coral-spec/src/v4/parameter_metadata.rs
+++ b/crates/coral-spec/src/v4/parameter_metadata.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::v4::ir::{HttpMethod, IrExecutionAttachment, IrInputLocation, IrOperation, SemanticIr};
 use crate::v4::projections::pagination_query_param_names;
@@ -14,8 +14,42 @@ use crate::{ManifestError, PaginationSpec, Result};
 pub struct ParameterMetadataOverrides {
     #[serde(default)]
     pub pagination: Vec<NamedPaginationOverride>,
+    pub lookup_keys: Option<LookupKeysMetadata>,
     #[serde(default)]
     pub operation_overrides: BTreeMap<String, OperationParameterMetadataOverride>,
+}
+
+/// Surface-scoped lookup key joinability: which filter parameters dependent
+/// joins may bind to. `exclude` names wire parameters (as written in the API
+/// description) that are not complete exact lookups; they stay pushdown
+/// filters but never carry `lookup_key: true`. `enabled: false` withholds the
+/// flag from every filter of the surface. Exclusion never changes SQL
+/// exposure.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LookupKeysMetadata {
+    pub enabled: bool,
+    #[serde(default)]
+    pub exclude: Vec<String>,
+}
+
+/// Shape of the generated `parameter_metadata.yaml` artifact written next to
+/// the other materialized surface assets. Mirrors the override file so users
+/// can copy it into `overrides/` and edit.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct GeneratedParameterMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lookup_keys: Option<LookupKeysMetadata>,
+}
+
+impl Default for LookupKeysMetadata {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            exclude: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -52,6 +86,46 @@ pub fn parse_parameter_metadata_overrides_yaml(raw: &str) -> Result<ParameterMet
         serde_yaml::from_str(raw).map_err(ManifestError::parse_yaml)?;
     overrides.validate_shape()?;
     Ok(overrides)
+}
+
+/// Parses the generated `parameter_metadata.yaml` artifact with the same
+/// shape validation as the override file, so a hand-edited generated file
+/// fails as loudly as an invalid override.
+pub fn parse_generated_parameter_metadata_yaml(raw: &str) -> Result<GeneratedParameterMetadata> {
+    let metadata: GeneratedParameterMetadata =
+        serde_yaml::from_str(raw).map_err(ManifestError::parse_yaml)?;
+    if let Some(lookup_keys) = &metadata.lookup_keys {
+        validate_lookup_keys_shape(lookup_keys)?;
+    }
+    Ok(metadata)
+}
+
+/// Checks every exclude entry against the surface's REST input names. A typo
+/// here is not a harmless no-op: the misspelled parameter silently keeps
+/// `lookup_key` and stays joinable, which is exactly what the exclusion tried
+/// to withhold. Non-filter inputs (path parameters, function arguments) are
+/// accepted: derivation treats excluding them as a legal no-op, and the two
+/// layers must agree on the name domain.
+pub fn validate_lookup_keys_for_surface(
+    lookup_keys: &LookupKeysMetadata,
+    ir: &SemanticIr,
+) -> Result<()> {
+    let input_names = ir
+        .operations
+        .iter()
+        .filter(|operation| matches!(operation.execution, IrExecutionAttachment::Rest(_)))
+        .flat_map(|operation| &operation.inputs)
+        .map(|input| input.name.as_str())
+        .collect::<BTreeSet<_>>();
+    for excluded in &lookup_keys.exclude {
+        if !input_names.contains(excluded.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "{} parameter_metadata lookup_keys excludes unknown parameter '{excluded}'",
+                ir.surface_id
+            )));
+        }
+    }
+    Ok(())
 }
 
 pub fn apply_parameter_metadata_overrides(
@@ -152,8 +226,37 @@ pub fn sync_projection_pagination_inputs<'a>(
     }
 }
 
+fn validate_lookup_keys_shape(lookup_keys: &LookupKeysMetadata) -> Result<()> {
+    let mut excluded = BTreeSet::new();
+    for value in &lookup_keys.exclude {
+        if value.trim().is_empty() {
+            return Err(ManifestError::validation(
+                "parameter metadata lookup_keys has an empty exclude value",
+            ));
+        }
+        // A padded value passes the emptiness check but can never match a
+        // wire name in the downstream exact-equality comparison, silently
+        // disabling the exclusion.
+        if value != value.trim() {
+            return Err(ManifestError::validation(format!(
+                "parameter metadata lookup_keys exclude value '{value}' has leading or trailing whitespace"
+            )));
+        }
+        if !excluded.insert(value.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "parameter metadata lookup_keys exclude value '{value}' is repeated"
+            )));
+        }
+    }
+    Ok(())
+}
+
 impl ParameterMetadataOverrides {
     fn validate_shape(&self) -> Result<()> {
+        if let Some(lookup_keys) = &self.lookup_keys {
+            validate_lookup_keys_shape(lookup_keys)?;
+        }
+
         let mut names = BTreeSet::new();
         for strategy in &self.pagination {
             if strategy.name.trim().is_empty() {
@@ -173,6 +276,10 @@ impl ParameterMetadataOverrides {
     }
 
     fn validate_for_surface(&self, ir: &SemanticIr) -> Result<()> {
+        if let Some(lookup_keys) = &self.lookup_keys {
+            validate_lookup_keys_for_surface(lookup_keys, ir)?;
+        }
+
         for strategy in &self.pagination {
             strategy.pagination.validated(
                 &ir.source_name,
@@ -728,6 +835,133 @@ pagination:
     }
 
     #[test]
+    fn lookup_keys_block_parses_and_validates() {
+        let overrides = parse_parameter_metadata_overrides_yaml(
+            r"
+lookup_keys:
+  enabled: true
+  exclude: [order_by, sort, fields]
+",
+        )
+        .expect("parse overrides");
+        let lookup_keys = overrides.lookup_keys.expect("lookup keys block");
+        assert!(lookup_keys.enabled);
+        assert_eq!(lookup_keys.exclude, ["order_by", "sort", "fields"]);
+
+        let absent = parse_parameter_metadata_overrides_yaml("{}").expect("parse overrides");
+        assert!(absent.lookup_keys.is_none());
+        let defaults = super::LookupKeysMetadata::default();
+        assert!(defaults.enabled);
+        assert!(defaults.exclude.is_empty());
+
+        let missing_enabled = parse_parameter_metadata_overrides_yaml(
+            r"
+lookup_keys:
+  exclude: [order_by]
+",
+        )
+        .expect_err("missing enabled should fail");
+        assert!(missing_enabled.to_string().contains("enabled"));
+
+        let empty_value = parse_parameter_metadata_overrides_yaml(
+            r"
+lookup_keys:
+  enabled: true
+  exclude: ['  ']
+",
+        )
+        .expect_err("blank exclude value should fail");
+        assert!(empty_value.to_string().contains("empty exclude value"));
+
+        let repeated_value = parse_parameter_metadata_overrides_yaml(
+            r"
+lookup_keys:
+  enabled: true
+  exclude: [sort, sort]
+",
+        )
+        .expect_err("repeated exclude value should fail");
+        assert!(repeated_value.to_string().contains("'sort' is repeated"));
+
+        let padded_value = parse_parameter_metadata_overrides_yaml(
+            r"
+lookup_keys:
+  enabled: true
+  exclude: [' sort']
+",
+        )
+        .expect_err("padded exclude value should fail");
+        assert!(padded_value.to_string().contains("whitespace"));
+
+        // The generated artifact goes through the same shape validation.
+        let generated = super::parse_generated_parameter_metadata_yaml(
+            r"
+lookup_keys:
+  enabled: true
+  exclude: [sort]
+",
+        )
+        .expect("parse generated metadata");
+        assert_eq!(
+            generated.lookup_keys.expect("lookup keys").exclude,
+            ["sort"]
+        );
+        let invalid_generated = super::parse_generated_parameter_metadata_yaml(
+            r"
+lookup_keys:
+  enabled: true
+  exclude: [sort, sort]
+",
+        )
+        .expect_err("repeated generated exclude value should fail");
+        assert!(invalid_generated.to_string().contains("'sort' is repeated"));
+    }
+
+    #[test]
+    fn rejects_unknown_lookup_key_exclude_target() {
+        let mut ir = semantic_ir(vec![rest_operation(
+            "widgets_list",
+            "/widgets",
+            vec![query_input("sort"), query_input("state")],
+            PaginationSpec::default(),
+        )]);
+        let overrides = parse_parameter_metadata_overrides_yaml(
+            r"
+lookup_keys:
+  enabled: true
+  exclude: [sortt]
+",
+        )
+        .expect("parse overrides");
+
+        let error = apply_parameter_metadata_overrides(&mut ir, &overrides)
+            .expect_err("unknown exclude target should fail");
+        assert!(
+            error.to_string().contains("unknown parameter 'sortt'"),
+            "{error}"
+        );
+
+        // Non-filter inputs are legal excludes: derivation treats them as
+        // no-ops, so validation must accept the same name domain.
+        let mut ir = semantic_ir(vec![rest_operation(
+            "widgets_get",
+            "/widgets/{widget_id}",
+            vec![path_input("widget_id"), query_input("sort")],
+            PaginationSpec::default(),
+        )]);
+        let overrides = parse_parameter_metadata_overrides_yaml(
+            r"
+lookup_keys:
+  enabled: true
+  exclude: [widget_id, sort]
+",
+        )
+        .expect("parse overrides");
+        apply_parameter_metadata_overrides(&mut ir, &overrides)
+            .expect("path parameter exclude is a legal no-op");
+    }
+
+    #[test]
     fn rejects_invalid_override_shapes() {
         let duplicate_name = parse_parameter_metadata_overrides_yaml(
             r"
@@ -870,6 +1104,17 @@ operation_overrides:
             name: name.to_string(),
             location: IrInputLocation::Query,
             required: false,
+            data_type: IrScalarType::String,
+            default_value: None,
+            description: String::new(),
+        }
+    }
+
+    fn path_input(name: &str) -> IrOperationInput {
+        IrOperationInput {
+            name: name.to_string(),
+            location: IrInputLocation::Path,
+            required: true,
             data_type: IrScalarType::String,
             default_value: None,
             description: String::new(),

--- a/crates/coral-spec/src/v4/parameter_metadata.rs
+++ b/crates/coral-spec/src/v4/parameter_metadata.rs
@@ -1170,6 +1170,7 @@ operation_overrides:
             data_type: ManifestDataType::Utf8,
             default_value: None,
             description: String::new(),
+            lookup_key: false,
         }
     }
 

--- a/crates/coral-spec/src/v4/parameter_metadata.rs
+++ b/crates/coral-spec/src/v4/parameter_metadata.rs
@@ -43,12 +43,26 @@ pub struct GeneratedParameterMetadata {
     pub lookup_keys: Option<LookupKeysMetadata>,
 }
 
+/// A surface without lookup key metadata keeps every filter joinable: the
+/// projection generator version gates artifacts, so v8 materializations
+/// always carry generated metadata and this default only covers transitional
+/// states. Both the derivation and sync fallbacks use it, so the two paths
+/// cannot disagree about absent metadata.
 impl Default for LookupKeysMetadata {
     fn default() -> Self {
         Self {
             enabled: true,
             exclude: Vec::new(),
         }
+    }
+}
+
+impl LookupKeysMetadata {
+    /// Shared joinability predicate for write-time derivation and load-time
+    /// sync, so the two paths cannot drift. `wire_name` is the parameter
+    /// name as written in the API description.
+    pub(crate) fn permits_lookup_key(&self, wire_name: &str) -> bool {
+        self.enabled && !self.exclude.iter().any(|excluded| excluded == wire_name)
     }
 }
 
@@ -178,7 +192,9 @@ pub fn sync_projection_pagination_inputs<'a>(
     surfaces: impl IntoIterator<Item = &'a SemanticIr>,
     projections: &mut ProjectionCatalog,
     mode: ProjectionPaginationInputSyncMode,
+    lookup_keys_by_surface: &BTreeMap<String, LookupKeysMetadata>,
 ) {
+    let absent_lookup_keys = LookupKeysMetadata::default();
     let pagination_by_operation = surfaces
         .into_iter()
         .flat_map(|surface| {
@@ -205,6 +221,9 @@ pub fn sync_projection_pagination_inputs<'a>(
             ProjectionKind::Table => SqlInputExposure::Filter,
             ProjectionKind::TableFunction { .. } => SqlInputExposure::FunctionArg,
         };
+        let lookup_keys = lookup_keys_by_surface
+            .get(projection.surface_id.as_str())
+            .unwrap_or(&absent_lookup_keys);
         for input in &mut projection.inputs {
             match mode {
                 ProjectionPaginationInputSyncMode::RecomputeRestInputExposure => {
@@ -222,6 +241,8 @@ pub fn sync_projection_pagination_inputs<'a>(
                     }
                 }
             }
+            input.lookup_key = input.sql_exposure == SqlInputExposure::Filter
+                && lookup_keys.permits_lookup_key(&input.wire_name);
         }
     }
 }
@@ -563,8 +584,10 @@ mod tests {
     use crate::v4::{OPENAPI_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
     use crate::{ManifestDataType, PaginationMode, PaginationSpec, ResponseSpec};
 
+    use std::collections::BTreeMap;
+
     use super::{
-        ProjectionPaginationInputSyncMode, apply_parameter_metadata_overrides,
+        LookupKeysMetadata, ProjectionPaginationInputSyncMode, apply_parameter_metadata_overrides,
         parse_parameter_metadata_overrides_yaml, path_pattern_matches,
         sync_projection_pagination_inputs,
     };
@@ -763,6 +786,7 @@ pagination:
             std::slice::from_ref(&ir),
             &mut projections,
             ProjectionPaginationInputSyncMode::RecomputeRestInputExposure,
+            &BTreeMap::new(),
         );
 
         assert_eq!(
@@ -790,6 +814,7 @@ pagination:
             std::slice::from_ref(&ir),
             &mut overridden_projections,
             ProjectionPaginationInputSyncMode::PreserveExistingExposure,
+            &BTreeMap::new(),
         );
 
         assert_eq!(
@@ -800,6 +825,53 @@ pagination:
             projection_input_exposure(&overridden_projections, "debug"),
             SqlInputExposure::Internal
         );
+    }
+
+    #[test]
+    fn sync_projection_inputs_applies_lookup_key_exclusions() {
+        let ir = semantic_ir(vec![rest_operation(
+            "widgets_list",
+            "/widgets",
+            vec![query_input("state"), query_input("order_by")],
+            PaginationSpec::default(),
+        )]);
+        let lookup_keys = BTreeMap::from([(
+            "rest".to_string(),
+            LookupKeysMetadata {
+                enabled: true,
+                exclude: vec!["order_by".to_string()],
+            },
+        )]);
+
+        for mode in [
+            ProjectionPaginationInputSyncMode::RecomputeRestInputExposure,
+            ProjectionPaginationInputSyncMode::PreserveExistingExposure,
+        ] {
+            let mut projections = projection_catalog(vec![
+                projection_input("state", "state", SqlInputExposure::Filter),
+                projection_input("order_by", "order_by", SqlInputExposure::Filter),
+            ]);
+            sync_projection_pagination_inputs(
+                std::slice::from_ref(&ir),
+                &mut projections,
+                mode,
+                &lookup_keys,
+            );
+            // Exclusion never demotes exposure; it only withholds joinability.
+            assert_eq!(
+                projection_input_exposure(&projections, "order_by"),
+                SqlInputExposure::Filter,
+                "{mode:?}"
+            );
+            assert!(
+                projection_input_lookup_key(&projections, "state"),
+                "{mode:?}"
+            );
+            assert!(
+                !projection_input_lookup_key(&projections, "order_by"),
+                "{mode:?}"
+            );
+        }
     }
 
     #[test]
@@ -1186,6 +1258,18 @@ operation_overrides:
             .iter()
             .find(|input| input.name == input_name)
             .map(|input| input.sql_exposure)
+            .expect("projection input")
+    }
+
+    fn projection_input_lookup_key(catalog: &ProjectionCatalog, input_name: &str) -> bool {
+        catalog
+            .projections
+            .first()
+            .expect("projection")
+            .inputs
+            .iter()
+            .find(|input| input.name == input_name)
+            .map(|input| input.lookup_key)
             .expect("projection input")
     }
 }

--- a/crates/coral-spec/src/v4/parameter_metadata.rs
+++ b/crates/coral-spec/src/v4/parameter_metadata.rs
@@ -33,39 +33,6 @@ pub struct LookupKeysMetadata {
     pub exclude: Vec<String>,
 }
 
-/// Shape of the generated `parameter_metadata.yaml` artifact written next to
-/// the other materialized surface assets. Mirrors the override file so users
-/// can copy it into `overrides/` and edit.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
-pub struct GeneratedParameterMetadata {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub lookup_keys: Option<LookupKeysMetadata>,
-}
-
-/// A surface without lookup key metadata keeps every filter joinable: the
-/// projection generator version gates artifacts, so v8 materializations
-/// always carry generated metadata and this default only covers transitional
-/// states. Both the derivation and sync fallbacks use it, so the two paths
-/// cannot disagree about absent metadata.
-impl Default for LookupKeysMetadata {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            exclude: Vec::new(),
-        }
-    }
-}
-
-impl LookupKeysMetadata {
-    /// Shared joinability predicate for write-time derivation and load-time
-    /// sync, so the two paths cannot drift. `wire_name` is the parameter
-    /// name as written in the API description.
-    pub(crate) fn permits_lookup_key(&self, wire_name: &str) -> bool {
-        self.enabled && !self.exclude.iter().any(|excluded| excluded == wire_name)
-    }
-}
-
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct NamedPaginationOverride {
@@ -102,18 +69,6 @@ pub fn parse_parameter_metadata_overrides_yaml(raw: &str) -> Result<ParameterMet
     Ok(overrides)
 }
 
-/// Parses the generated `parameter_metadata.yaml` artifact with the same
-/// shape validation as the override file, so a hand-edited generated file
-/// fails as loudly as an invalid override.
-pub fn parse_generated_parameter_metadata_yaml(raw: &str) -> Result<GeneratedParameterMetadata> {
-    let metadata: GeneratedParameterMetadata =
-        serde_yaml::from_str(raw).map_err(ManifestError::parse_yaml)?;
-    if let Some(lookup_keys) = &metadata.lookup_keys {
-        validate_lookup_keys_shape(lookup_keys)?;
-    }
-    Ok(metadata)
-}
-
 /// Checks every exclude entry against the surface's REST input names. A typo
 /// here is not a harmless no-op: the misspelled parameter silently keeps
 /// `lookup_key` and stays joinable, which is exactly what the exclusion tried
@@ -129,7 +84,7 @@ pub fn validate_lookup_keys_for_surface(
         .iter()
         .filter(|operation| matches!(operation.execution, IrExecutionAttachment::Rest(_)))
         .flat_map(|operation| &operation.inputs)
-        .map(|input| input.name.as_str())
+        .map(|input| input.name.trim())
         .collect::<BTreeSet<_>>();
     for excluded in &lookup_keys.exclude {
         if !input_names.contains(excluded.as_str()) {
@@ -179,7 +134,28 @@ pub fn apply_parameter_metadata_overrides(
         }
     }
 
+    if let Some(lookup_keys) = &overrides.lookup_keys {
+        apply_lookup_key_overrides(ir, lookup_keys);
+    }
+
     Ok(())
+}
+
+fn apply_lookup_key_overrides(ir: &mut SemanticIr, lookup_keys: &LookupKeysMetadata) {
+    let excluded = lookup_keys
+        .exclude
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    for operation in &mut ir.operations {
+        for input in &mut operation.inputs {
+            input.exclude_from_lookup_keys = if lookup_keys.enabled {
+                excluded.contains(input.name.trim())
+            } else {
+                true
+            };
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -192,26 +168,21 @@ pub fn sync_projection_pagination_inputs<'a>(
     surfaces: impl IntoIterator<Item = &'a SemanticIr>,
     projections: &mut ProjectionCatalog,
     mode: ProjectionPaginationInputSyncMode,
-    lookup_keys_by_surface: &BTreeMap<String, LookupKeysMetadata>,
 ) {
-    let absent_lookup_keys = LookupKeysMetadata::default();
-    let pagination_by_operation = surfaces
+    let operation_by_projection = surfaces
         .into_iter()
         .flat_map(|surface| {
-            surface.operations.iter().filter_map(|operation| {
-                let IrExecutionAttachment::Rest(rest) = &operation.execution else {
-                    return None;
-                };
-                Some((
+            surface.operations.iter().map(|operation| {
+                (
                     (surface.surface_id.as_str(), operation.id.as_str()),
-                    pagination_query_param_names(&rest.pagination),
-                ))
+                    operation,
+                )
             })
         })
         .collect::<BTreeMap<_, _>>();
 
     for projection in &mut projections.projections {
-        let Some(pagination_query_params) = pagination_by_operation.get(&(
+        let Some(operation) = operation_by_projection.get(&(
             projection.surface_id.as_str(),
             projection.operation_id.as_str(),
         )) else {
@@ -221,30 +192,51 @@ pub fn sync_projection_pagination_inputs<'a>(
             ProjectionKind::Table => SqlInputExposure::Filter,
             ProjectionKind::TableFunction { .. } => SqlInputExposure::FunctionArg,
         };
-        let lookup_keys = lookup_keys_by_surface
-            .get(projection.surface_id.as_str())
-            .unwrap_or(&absent_lookup_keys);
+        let pagination_query_params = match &operation.execution {
+            IrExecutionAttachment::Rest(rest) => {
+                Some(pagination_query_param_names(&rest.pagination))
+            }
+            IrExecutionAttachment::Mcp(_) => None,
+        };
         for input in &mut projection.inputs {
-            match mode {
-                ProjectionPaginationInputSyncMode::RecomputeRestInputExposure => {
-                    input.sql_exposure = projection_input_sql_exposure(
-                        input,
-                        default_exposure,
-                        pagination_query_params,
-                    );
-                }
-                ProjectionPaginationInputSyncMode::PreserveExistingExposure => {
-                    if input.source_location == IrInputLocation::Query
-                        && pagination_query_params.contains(input.wire_name.as_str())
-                    {
-                        input.sql_exposure = SqlInputExposure::Internal;
+            if let Some(pagination_query_params) = &pagination_query_params {
+                match mode {
+                    ProjectionPaginationInputSyncMode::RecomputeRestInputExposure => {
+                        input.sql_exposure = projection_input_sql_exposure(
+                            input,
+                            default_exposure,
+                            pagination_query_params,
+                        );
+                    }
+                    ProjectionPaginationInputSyncMode::PreserveExistingExposure => {
+                        if input.source_location == IrInputLocation::Query
+                            && pagination_query_params.contains(input.wire_name.as_str())
+                        {
+                            input.sql_exposure = SqlInputExposure::Internal;
+                        }
                     }
                 }
             }
-            input.lookup_key = input.sql_exposure == SqlInputExposure::Filter
-                && lookup_keys.permits_lookup_key(&input.wire_name);
+            input.lookup_key = projection_input_is_lookup_key(operation, input);
         }
     }
+}
+
+fn projection_input_is_lookup_key(
+    operation: &IrOperation,
+    projection_input: &ProjectionInput,
+) -> bool {
+    if projection_input.sql_exposure != SqlInputExposure::Filter {
+        return false;
+    }
+    if !matches!(operation.execution, IrExecutionAttachment::Rest(_)) {
+        return false;
+    }
+    operation.inputs.iter().any(|input| {
+        input.location == projection_input.source_location
+            && input.name == projection_input.wire_name
+            && !input.exclude_from_lookup_keys
+    })
 }
 
 fn validate_lookup_keys_shape(lookup_keys: &LookupKeysMetadata) -> Result<()> {
@@ -584,10 +576,8 @@ mod tests {
     use crate::v4::{OPENAPI_IMPORTER_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
     use crate::{ManifestDataType, PaginationMode, PaginationSpec, ResponseSpec};
 
-    use std::collections::BTreeMap;
-
     use super::{
-        LookupKeysMetadata, ProjectionPaginationInputSyncMode, apply_parameter_metadata_overrides,
+        ProjectionPaginationInputSyncMode, apply_parameter_metadata_overrides,
         parse_parameter_metadata_overrides_yaml, path_pattern_matches,
         sync_projection_pagination_inputs,
     };
@@ -786,7 +776,6 @@ pagination:
             std::slice::from_ref(&ir),
             &mut projections,
             ProjectionPaginationInputSyncMode::RecomputeRestInputExposure,
-            &BTreeMap::new(),
         );
 
         assert_eq!(
@@ -814,7 +803,6 @@ pagination:
             std::slice::from_ref(&ir),
             &mut overridden_projections,
             ProjectionPaginationInputSyncMode::PreserveExistingExposure,
-            &BTreeMap::new(),
         );
 
         assert_eq!(
@@ -829,19 +817,18 @@ pagination:
 
     #[test]
     fn sync_projection_inputs_applies_lookup_key_exclusions() {
-        let ir = semantic_ir(vec![rest_operation(
+        let mut ir = semantic_ir(vec![rest_operation(
             "widgets_list",
             "/widgets",
             vec![query_input("state"), query_input("order_by")],
             PaginationSpec::default(),
         )]);
-        let lookup_keys = BTreeMap::from([(
-            "rest".to_string(),
-            LookupKeysMetadata {
-                enabled: true,
-                exclude: vec!["order_by".to_string()],
-            },
-        )]);
+        first_operation_mut(&mut ir)
+            .inputs
+            .iter_mut()
+            .find(|input| input.name == "order_by")
+            .expect("order_by")
+            .exclude_from_lookup_keys = true;
 
         for mode in [
             ProjectionPaginationInputSyncMode::RecomputeRestInputExposure,
@@ -851,12 +838,7 @@ pagination:
                 projection_input("state", "state", SqlInputExposure::Filter),
                 projection_input("order_by", "order_by", SqlInputExposure::Filter),
             ]);
-            sync_projection_pagination_inputs(
-                std::slice::from_ref(&ir),
-                &mut projections,
-                mode,
-                &lookup_keys,
-            );
+            sync_projection_pagination_inputs(std::slice::from_ref(&ir), &mut projections, mode);
             // Exclusion never demotes exposure; it only withholds joinability.
             assert_eq!(
                 projection_input_exposure(&projections, "order_by"),
@@ -922,9 +904,6 @@ lookup_keys:
 
         let absent = parse_parameter_metadata_overrides_yaml("{}").expect("parse overrides");
         assert!(absent.lookup_keys.is_none());
-        let defaults = super::LookupKeysMetadata::default();
-        assert!(defaults.enabled);
-        assert!(defaults.exclude.is_empty());
 
         let missing_enabled = parse_parameter_metadata_overrides_yaml(
             r"
@@ -964,29 +943,61 @@ lookup_keys:
         )
         .expect_err("padded exclude value should fail");
         assert!(padded_value.to_string().contains("whitespace"));
+    }
 
-        // The generated artifact goes through the same shape validation.
-        let generated = super::parse_generated_parameter_metadata_yaml(
+    #[test]
+    fn lookup_key_override_replaces_generated_exclusions() {
+        let mut ir = semantic_ir(vec![rest_operation(
+            "widgets_list",
+            "/widgets",
+            vec![
+                query_input("state"),
+                query_input("order_by"),
+                query_input("sort"),
+            ],
+            PaginationSpec::default(),
+        )]);
+        for input in &mut first_operation_mut(&mut ir).inputs {
+            if matches!(input.name.as_str(), "order_by" | "sort") {
+                input.exclude_from_lookup_keys = true;
+            }
+        }
+        let overrides = parse_parameter_metadata_overrides_yaml(
             r"
 lookup_keys:
   enabled: true
-  exclude: [sort]
+  exclude: [order_by]
 ",
         )
-        .expect("parse generated metadata");
-        assert_eq!(
-            generated.lookup_keys.expect("lookup keys").exclude,
-            ["sort"]
-        );
-        let invalid_generated = super::parse_generated_parameter_metadata_yaml(
+        .expect("parse overrides");
+
+        apply_parameter_metadata_overrides(&mut ir, &overrides).expect("apply overrides");
+
+        assert!(!input_excluded(&ir, "state"));
+        assert!(input_excluded(&ir, "order_by"));
+        assert!(!input_excluded(&ir, "sort"));
+    }
+
+    #[test]
+    fn disabled_lookup_key_override_excludes_every_input() {
+        let mut ir = semantic_ir(vec![rest_operation(
+            "widgets_get",
+            "/widgets/{widget_id}",
+            vec![path_input("widget_id"), query_input("state")],
+            PaginationSpec::default(),
+        )]);
+        let overrides = parse_parameter_metadata_overrides_yaml(
             r"
 lookup_keys:
-  enabled: true
-  exclude: [sort, sort]
+  enabled: false
 ",
         )
-        .expect_err("repeated generated exclude value should fail");
-        assert!(invalid_generated.to_string().contains("'sort' is repeated"));
+        .expect("parse overrides");
+
+        apply_parameter_metadata_overrides(&mut ir, &overrides).expect("apply overrides");
+
+        assert!(input_excluded(&ir, "widget_id"));
+        assert!(input_excluded(&ir, "state"));
     }
 
     #[test]
@@ -1179,6 +1190,7 @@ operation_overrides:
             data_type: IrScalarType::String,
             default_value: None,
             description: String::new(),
+            exclude_from_lookup_keys: false,
         }
     }
 
@@ -1190,6 +1202,7 @@ operation_overrides:
             data_type: IrScalarType::String,
             default_value: None,
             description: String::new(),
+            exclude_from_lookup_keys: false,
         }
     }
 
@@ -1202,6 +1215,19 @@ operation_overrides:
 
     fn first_operation(ir: &SemanticIr) -> &IrOperation {
         ir.operations.first().expect("operation")
+    }
+
+    fn first_operation_mut(ir: &mut SemanticIr) -> &mut IrOperation {
+        ir.operations.first_mut().expect("operation")
+    }
+
+    fn input_excluded(ir: &SemanticIr, input_name: &str) -> bool {
+        first_operation(ir)
+            .inputs
+            .iter()
+            .find(|input| input.name == input_name)
+            .expect("input")
+            .exclude_from_lookup_keys
     }
 
     fn projection_catalog(inputs: Vec<ProjectionInput>) -> ProjectionCatalog {

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -29,7 +29,7 @@ surfaces:
     let v4 = manifest.as_v4().expect("v4");
     let surface = v4.surfaces.first().expect("one surface");
     let ir = import_openapi_surface(v4, surface, github_openapi().as_bytes()).expect("import");
-    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
     let published = catalog
         .projections
         .iter()
@@ -39,6 +39,129 @@ surfaces:
     assert!(published.contains(&"issue"), "{published:?}");
     assert!(published.contains(&"search_issues"), "{published:?}");
     assert!(published.contains(&"get_issues"), "{published:?}");
+}
+
+fn items_api_catalog(lookup_keys: Option<(bool, &[&str])>) -> ProjectionCatalog {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: items_api
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let spec = r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      operationId: list_items
+      parameters:
+        - {name: state, in: query, schema: {type: string}}
+        - {name: order_by, in: query, schema: {type: string}}
+      responses: {'200': {content: {application/json: {schema: {type: array, items: {type: object, properties: {id: {type: string}, state: {type: string}}}}}}}}
+  /projects/{project_id}/items:
+    get:
+      operationId: list_project_items
+      parameters:
+        - {name: project_id, in: path, required: true, schema: {type: string}}
+      responses: {'200': {content: {application/json: {schema: {type: array, items: {type: object, properties: {id: {type: string}}}}}}}}
+";
+    let ir = import_openapi_surface(v4, surface, spec.as_bytes()).expect("import");
+    let lookup_keys = lookup_keys
+        .map(|(enabled, exclude)| {
+            BTreeMap::from([(
+                "rest".to_string(),
+                LookupKeysMetadata {
+                    enabled,
+                    exclude: exclude.iter().map(ToString::to_string).collect(),
+                },
+            )])
+        })
+        .unwrap_or_default();
+    generate_projection_catalog(v4, std::slice::from_ref(&ir), &lookup_keys).expect("catalog")
+}
+
+fn exposure(catalog: &ProjectionCatalog, operation_id: &str, input_name: &str) -> SqlInputExposure {
+    catalog
+        .projections
+        .iter()
+        .find(|projection| projection.operation_id == operation_id)
+        .expect("projection")
+        .inputs
+        .iter()
+        .find(|input| input.name == input_name)
+        .expect("input")
+        .sql_exposure
+}
+
+#[test]
+fn lookup_key_exclusions_control_joinability_not_exposure() {
+    let filter_lookup_key = |catalog: &ProjectionCatalog, filter_name: &str| {
+        let list_items = catalog
+            .projections
+            .iter()
+            .find(|projection| projection.operation_id == "list_items")
+            .expect("projection");
+        projection_filter_specs(list_items)
+            .iter()
+            .find(|spec| spec.name == filter_name)
+            .expect("filter spec")
+            .lookup_key
+    };
+
+    let catalog = items_api_catalog(Some((true, &["order_by", "project_id"])));
+
+    // An excluded parameter keeps its exposure and pushdown; it only loses
+    // the dependent-join completeness flag.
+    assert_eq!(
+        exposure(&catalog, "list_items", "order_by"),
+        SqlInputExposure::Filter
+    );
+    assert!(!filter_lookup_key(&catalog, "order_by"));
+    assert_eq!(
+        exposure(&catalog, "list_items", "state"),
+        SqlInputExposure::Filter
+    );
+    assert!(filter_lookup_key(&catalog, "state"));
+
+    // Function arguments never carry the flag, excluded or not.
+    let project_items = catalog
+        .projections
+        .iter()
+        .find(|projection| projection.operation_id == "list_project_items")
+        .expect("projection");
+    assert_eq!(
+        exposure(&catalog, "list_project_items", "project_id"),
+        SqlInputExposure::FunctionArg
+    );
+    assert!(project_items.inputs.iter().all(|input| !input.lookup_key));
+
+    // Disabling lookup keys withholds the flag surface-wide without touching
+    // exposure.
+    let catalog = items_api_catalog(Some((false, &[])));
+    assert_eq!(
+        exposure(&catalog, "list_items", "state"),
+        SqlInputExposure::Filter
+    );
+    assert!(!filter_lookup_key(&catalog, "state"));
+    assert!(!filter_lookup_key(&catalog, "order_by"));
+
+    // Absent metadata makes no completeness claims: without a lookup_keys
+    // entry for the surface, no filter may anchor a dependent join.
+    let catalog = items_api_catalog(None);
+    assert_eq!(
+        exposure(&catalog, "list_items", "state"),
+        SqlInputExposure::Filter
+    );
+    assert!(!filter_lookup_key(&catalog, "state"));
+    assert!(!filter_lookup_key(&catalog, "order_by"));
 }
 
 #[test]
@@ -87,7 +210,7 @@ paths:
     )
     .expect("import");
 
-    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
     let column_types = catalog
         .projections
         .iter()
@@ -263,7 +386,7 @@ components:
         .as_bytes(),
     )
     .expect("import");
-    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
     let names = catalog
         .projections
         .iter()
@@ -313,7 +436,8 @@ surfaces:
     let v4 = manifest.as_v4().expect("v4");
     let surface = v4.surfaces.first().expect("one surface");
     let ir = import_openapi_surface(v4, surface, github_openapi().as_bytes()).expect("import");
-    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
+        .expect("catalog");
     let projection = catalog
         .projections
         .iter()
@@ -442,7 +566,8 @@ paths:
         .as_bytes(),
     )
     .expect("import");
-    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
+        .expect("catalog");
     let projection = catalog
         .projections
         .iter()
@@ -531,7 +656,8 @@ paths:
         .as_bytes(),
     )
     .expect("import");
-    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
+        .expect("catalog");
     let projection = catalog
         .projections
         .iter()
@@ -619,7 +745,8 @@ paths:
         .as_bytes(),
     )
     .expect("import");
-    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
+        .expect("catalog");
     let projection = catalog
         .projections
         .iter()
@@ -734,7 +861,8 @@ components:
         .as_bytes(),
     )
     .expect("import");
-    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
+        .expect("catalog");
     let list_projection = catalog
         .projections
         .iter()
@@ -905,7 +1033,7 @@ components:
         .as_bytes(),
     )
     .expect("import");
-    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
     let names_by_operation = catalog
         .projections
         .iter()
@@ -1121,7 +1249,7 @@ paths:
     let v4 = manifest.as_v4().expect("v4");
     let surface = v4.surfaces.first().expect("surface");
     let ir = import_openapi_surface(v4, surface, openapi.as_bytes()).expect("import");
-    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
     let projection = catalog.projections.first().expect("projection");
     let sql_name_by_wire = projection
         .inputs
@@ -1152,7 +1280,8 @@ fn different_surface_namespaces_keep_colliding_projection_names() {
     let mcp_ir =
         import_mcp_surface(v4, mcp_surface, &search_issues_mcp_catalog()).expect("mcp import");
 
-    let catalog = generate_projection_catalog(v4, &[rest_ir, mcp_ir]).expect("catalog");
+    let catalog =
+        generate_projection_catalog(v4, &[rest_ir, mcp_ir], &BTreeMap::new()).expect("catalog");
     let rest_projection = catalog
         .projections
         .iter()
@@ -1193,7 +1322,7 @@ fn generated_mcp_projection_exposes_current_row_result_columns() {
     let mcp_ir =
         import_mcp_surface(v4, mcp_surface, &search_issues_mcp_catalog()).expect("mcp import");
 
-    let catalog = generate_projection_catalog(v4, &[mcp_ir]).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[mcp_ir], &BTreeMap::new()).expect("catalog");
     let projection = catalog
         .projections
         .iter()
@@ -1273,7 +1402,8 @@ fn generated_mcp_projection_keeps_pagination_cursor_internal() {
     };
     let mcp_ir = import_mcp_surface(v4, mcp_surface, &catalog).expect("mcp import");
 
-    let projections = generate_projection_catalog(v4, &[mcp_ir]).expect("catalog");
+    let projections =
+        generate_projection_catalog(v4, &[mcp_ir], &BTreeMap::new()).expect("catalog");
     let projection = projections
         .projections
         .iter()
@@ -1338,7 +1468,8 @@ fn generated_mcp_projection_with_only_pagination_cursor_is_table() {
     };
     let mcp_ir = import_mcp_surface(v4, mcp_surface, &catalog).expect("mcp import");
 
-    let projections = generate_projection_catalog(v4, &[mcp_ir]).expect("catalog");
+    let projections =
+        generate_projection_catalog(v4, &[mcp_ir], &BTreeMap::new()).expect("catalog");
     let projection = projections
         .projections
         .iter()
@@ -1393,7 +1524,8 @@ fn generated_mcp_projection_snake_cases_camel_input_names() {
     };
     let mcp_ir = import_mcp_surface(v4, mcp_surface, &catalog).expect("mcp import");
 
-    let projections = generate_projection_catalog(v4, &[mcp_ir]).expect("catalog");
+    let projections =
+        generate_projection_catalog(v4, &[mcp_ir], &BTreeMap::new()).expect("catalog");
     let projection = projections
         .projections
         .iter()
@@ -1438,7 +1570,8 @@ fn same_type_surface_namespaces_keep_colliding_projection_names() {
     let secondary_ir = import_openapi_surface(v4, secondary_surface, rest_search_openapi())
         .expect("secondary rest import");
 
-    let catalog = generate_projection_catalog(v4, &[primary_ir, secondary_ir]).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[primary_ir, secondary_ir], &BTreeMap::new())
+        .expect("catalog");
     let primary_projection = catalog
         .projections
         .iter()

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -150,16 +150,15 @@ fn lookup_key_exclusions_control_joinability_not_exposure() {
     assert!(!filter_lookup_key(&catalog, "state"));
     assert!(!filter_lookup_key(&catalog, "order_by"));
 
-    // Absent metadata keeps filters joinable: the generator version gate
-    // ensures v8 artifacts always carry generated metadata, so this default
-    // only covers transitional states.
+    // Generated metadata is present immediately after OpenAPI import, before
+    // app materialization writes the semantic IR artifact.
     let catalog = items_api_catalog(None);
     assert_eq!(
         exposure(&catalog, "list_items", "state"),
         SqlInputExposure::Filter
     );
     assert!(filter_lookup_key(&catalog, "state"));
-    assert!(filter_lookup_key(&catalog, "order_by"));
+    assert!(!filter_lookup_key(&catalog, "order_by"));
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -29,7 +29,7 @@ surfaces:
     let v4 = manifest.as_v4().expect("v4");
     let surface = v4.surfaces.first().expect("one surface");
     let ir = import_openapi_surface(v4, surface, github_openapi().as_bytes()).expect("import");
-    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
     let published = catalog
         .projections
         .iter()
@@ -73,19 +73,16 @@ paths:
         - {name: project_id, in: path, required: true, schema: {type: string}}
       responses: {'200': {content: {application/json: {schema: {type: array, items: {type: object, properties: {id: {type: string}}}}}}}}
 ";
-    let ir = import_openapi_surface(v4, surface, spec.as_bytes()).expect("import");
-    let lookup_keys = lookup_keys
-        .map(|(enabled, exclude)| {
-            BTreeMap::from([(
-                "rest".to_string(),
-                LookupKeysMetadata {
-                    enabled,
-                    exclude: exclude.iter().map(ToString::to_string).collect(),
-                },
-            )])
-        })
-        .unwrap_or_default();
-    generate_projection_catalog(v4, std::slice::from_ref(&ir), &lookup_keys).expect("catalog")
+    let mut ir = import_openapi_surface(v4, surface, spec.as_bytes()).expect("import");
+    if let Some((enabled, exclude)) = lookup_keys {
+        for operation in &mut ir.operations {
+            for input in &mut operation.inputs {
+                input.exclude_from_lookup_keys =
+                    !enabled || exclude.iter().any(|excluded| *excluded == input.name);
+            }
+        }
+    }
+    generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog")
 }
 
 fn exposure(catalog: &ProjectionCatalog, operation_id: &str, input_name: &str) -> SqlInputExposure {
@@ -211,7 +208,7 @@ paths:
     )
     .expect("import");
 
-    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
     let column_types = catalog
         .projections
         .iter()
@@ -387,7 +384,7 @@ components:
         .as_bytes(),
     )
     .expect("import");
-    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
     let names = catalog
         .projections
         .iter()
@@ -437,8 +434,7 @@ surfaces:
     let v4 = manifest.as_v4().expect("v4");
     let surface = v4.surfaces.first().expect("one surface");
     let ir = import_openapi_surface(v4, surface, github_openapi().as_bytes()).expect("import");
-    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
-        .expect("catalog");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
     let projection = catalog
         .projections
         .iter()
@@ -567,8 +563,7 @@ paths:
         .as_bytes(),
     )
     .expect("import");
-    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
-        .expect("catalog");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
     let projection = catalog
         .projections
         .iter()
@@ -657,8 +652,7 @@ paths:
         .as_bytes(),
     )
     .expect("import");
-    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
-        .expect("catalog");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
     let projection = catalog
         .projections
         .iter()
@@ -746,8 +740,7 @@ paths:
         .as_bytes(),
     )
     .expect("import");
-    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
-        .expect("catalog");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
     let projection = catalog
         .projections
         .iter()
@@ -862,8 +855,7 @@ components:
         .as_bytes(),
     )
     .expect("import");
-    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
-        .expect("catalog");
+    let catalog = generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("catalog");
     let list_projection = catalog
         .projections
         .iter()
@@ -1034,7 +1026,7 @@ components:
         .as_bytes(),
     )
     .expect("import");
-    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
     let names_by_operation = catalog
         .projections
         .iter()
@@ -1250,7 +1242,7 @@ paths:
     let v4 = manifest.as_v4().expect("v4");
     let surface = v4.surfaces.first().expect("surface");
     let ir = import_openapi_surface(v4, surface, openapi.as_bytes()).expect("import");
-    let catalog = generate_projection_catalog(v4, &[ir], &BTreeMap::new()).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
     let projection = catalog.projections.first().expect("projection");
     let sql_name_by_wire = projection
         .inputs
@@ -1281,8 +1273,7 @@ fn different_surface_namespaces_keep_colliding_projection_names() {
     let mcp_ir =
         import_mcp_surface(v4, mcp_surface, &search_issues_mcp_catalog()).expect("mcp import");
 
-    let catalog =
-        generate_projection_catalog(v4, &[rest_ir, mcp_ir], &BTreeMap::new()).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[rest_ir, mcp_ir]).expect("catalog");
     let rest_projection = catalog
         .projections
         .iter()
@@ -1323,7 +1314,7 @@ fn generated_mcp_projection_exposes_current_row_result_columns() {
     let mcp_ir =
         import_mcp_surface(v4, mcp_surface, &search_issues_mcp_catalog()).expect("mcp import");
 
-    let catalog = generate_projection_catalog(v4, &[mcp_ir], &BTreeMap::new()).expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[mcp_ir]).expect("catalog");
     let projection = catalog
         .projections
         .iter()
@@ -1403,8 +1394,7 @@ fn generated_mcp_projection_keeps_pagination_cursor_internal() {
     };
     let mcp_ir = import_mcp_surface(v4, mcp_surface, &catalog).expect("mcp import");
 
-    let projections =
-        generate_projection_catalog(v4, &[mcp_ir], &BTreeMap::new()).expect("catalog");
+    let projections = generate_projection_catalog(v4, &[mcp_ir]).expect("catalog");
     let projection = projections
         .projections
         .iter()
@@ -1469,8 +1459,7 @@ fn generated_mcp_projection_with_only_pagination_cursor_is_table() {
     };
     let mcp_ir = import_mcp_surface(v4, mcp_surface, &catalog).expect("mcp import");
 
-    let projections =
-        generate_projection_catalog(v4, &[mcp_ir], &BTreeMap::new()).expect("catalog");
+    let projections = generate_projection_catalog(v4, &[mcp_ir]).expect("catalog");
     let projection = projections
         .projections
         .iter()
@@ -1525,8 +1514,7 @@ fn generated_mcp_projection_snake_cases_camel_input_names() {
     };
     let mcp_ir = import_mcp_surface(v4, mcp_surface, &catalog).expect("mcp import");
 
-    let projections =
-        generate_projection_catalog(v4, &[mcp_ir], &BTreeMap::new()).expect("catalog");
+    let projections = generate_projection_catalog(v4, &[mcp_ir]).expect("catalog");
     let projection = projections
         .projections
         .iter()
@@ -1571,8 +1559,7 @@ fn same_type_surface_namespaces_keep_colliding_projection_names() {
     let secondary_ir = import_openapi_surface(v4, secondary_surface, rest_search_openapi())
         .expect("secondary rest import");
 
-    let catalog = generate_projection_catalog(v4, &[primary_ir, secondary_ir], &BTreeMap::new())
-        .expect("catalog");
+    let catalog = generate_projection_catalog(v4, &[primary_ir, secondary_ir]).expect("catalog");
     let primary_projection = catalog
         .projections
         .iter()

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -153,15 +153,16 @@ fn lookup_key_exclusions_control_joinability_not_exposure() {
     assert!(!filter_lookup_key(&catalog, "state"));
     assert!(!filter_lookup_key(&catalog, "order_by"));
 
-    // Absent metadata makes no completeness claims: without a lookup_keys
-    // entry for the surface, no filter may anchor a dependent join.
+    // Absent metadata keeps filters joinable: the generator version gate
+    // ensures v8 artifacts always carry generated metadata, so this default
+    // only covers transitional states.
     let catalog = items_api_catalog(None);
     assert_eq!(
         exposure(&catalog, "list_items", "state"),
         SqlInputExposure::Filter
     );
-    assert!(!filter_lookup_key(&catalog, "state"));
-    assert!(!filter_lookup_key(&catalog, "order_by"));
+    assert!(filter_lookup_key(&catalog, "state"));
+    assert!(filter_lookup_key(&catalog, "order_by"));
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{
@@ -7,7 +7,6 @@ use crate::v4::ir::{
 };
 use crate::v4::manifest::V4SourceManifest;
 use crate::v4::naming::{normalize_identifier, normalize_sql_identifier, stable_suffix};
-use crate::v4::parameter_metadata::LookupKeysMetadata;
 use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
 use crate::{
     ManifestDataType, ManifestError, PaginationSpec, Result, SearchLimitsSpec,
@@ -29,9 +28,7 @@ type TypeIndex<'a> = HashMap<&'a str, &'a IrType>;
 pub fn generate_projection_catalog(
     manifest: &V4SourceManifest,
     surfaces: &[SemanticIr],
-    lookup_keys_by_surface: &BTreeMap<String, LookupKeysMetadata>,
 ) -> Result<ProjectionCatalog> {
-    let absent_lookup_keys = LookupKeysMetadata::default();
     let mut projections = Vec::new();
     let mut diagnostics = Vec::new();
     for ir in surfaces {
@@ -45,18 +42,9 @@ pub fn generate_projection_catalog(
                 ))
             })?;
         let type_by_id = type_index(ir);
-        let lookup_keys = lookup_keys_by_surface
-            .get(&ir.surface_id)
-            .unwrap_or(&absent_lookup_keys);
         for operation in &ir.operations {
-            let projection = generate_projection(
-                ir,
-                namespace,
-                &type_by_id,
-                operation,
-                lookup_keys,
-                &mut diagnostics,
-            );
+            let projection =
+                generate_projection(ir, namespace, &type_by_id, operation, &mut diagnostics);
             projections.push(projection);
         }
         diagnostics.extend(ir.diagnostics.clone());
@@ -80,7 +68,6 @@ fn generate_projection(
     namespace: &str,
     type_by_id: &TypeIndex<'_>,
     operation: &IrOperation,
-    lookup_keys: &LookupKeysMetadata,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Projection {
     let is_search = is_search_operation(operation);
@@ -135,7 +122,7 @@ fn generate_projection(
                 data_type: input.data_type.lower(),
                 default_value: input.default_value.clone(),
                 description: input.description.clone(),
-                lookup_key: rest_filter_is_lookup_key(rest, input, exposure, lookup_keys),
+                lookup_key: rest_filter_is_lookup_key(rest, input, exposure),
             }
         })
         .collect::<Vec<_>>();
@@ -279,11 +266,8 @@ fn rest_filter_is_lookup_key(
     rest: Option<&RestExecutionAttachment>,
     input: &IrOperationInput,
     exposure: SqlInputExposure,
-    lookup_keys: &LookupKeysMetadata,
 ) -> bool {
-    rest.is_some()
-        && exposure == SqlInputExposure::Filter
-        && lookup_keys.permits_lookup_key(&input.name)
+    rest.is_some() && exposure == SqlInputExposure::Filter && !input.exclude_from_lookup_keys
 }
 
 fn mcp_pagination_owns_input(

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -31,12 +31,7 @@ pub fn generate_projection_catalog(
     surfaces: &[SemanticIr],
     lookup_keys_by_surface: &BTreeMap<String, LookupKeysMetadata>,
 ) -> Result<ProjectionCatalog> {
-    // A surface without lookup key metadata makes no completeness claims:
-    // no filter may anchor a dependent join until metadata says so.
-    let absent_lookup_keys = LookupKeysMetadata {
-        enabled: false,
-        exclude: Vec::new(),
-    };
+    let absent_lookup_keys = LookupKeysMetadata::default();
     let mut projections = Vec::new();
     let mut diagnostics = Vec::new();
     for ir in surfaces {
@@ -288,11 +283,7 @@ fn rest_filter_is_lookup_key(
 ) -> bool {
     rest.is_some()
         && exposure == SqlInputExposure::Filter
-        && lookup_keys.enabled
-        && !lookup_keys
-            .exclude
-            .iter()
-            .any(|excluded| excluded == &input.name)
+        && lookup_keys.permits_lookup_key(&input.name)
 }
 
 fn mcp_pagination_owns_input(

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::{
@@ -7,6 +7,7 @@ use crate::v4::ir::{
 };
 use crate::v4::manifest::V4SourceManifest;
 use crate::v4::naming::{normalize_identifier, normalize_sql_identifier, stable_suffix};
+use crate::v4::parameter_metadata::LookupKeysMetadata;
 use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
 use crate::{
     ManifestDataType, ManifestError, PaginationSpec, Result, SearchLimitsSpec,
@@ -28,7 +29,14 @@ type TypeIndex<'a> = HashMap<&'a str, &'a IrType>;
 pub fn generate_projection_catalog(
     manifest: &V4SourceManifest,
     surfaces: &[SemanticIr],
+    lookup_keys_by_surface: &BTreeMap<String, LookupKeysMetadata>,
 ) -> Result<ProjectionCatalog> {
+    // A surface without lookup key metadata makes no completeness claims:
+    // no filter may anchor a dependent join until metadata says so.
+    let absent_lookup_keys = LookupKeysMetadata {
+        enabled: false,
+        exclude: Vec::new(),
+    };
     let mut projections = Vec::new();
     let mut diagnostics = Vec::new();
     for ir in surfaces {
@@ -42,9 +50,18 @@ pub fn generate_projection_catalog(
                 ))
             })?;
         let type_by_id = type_index(ir);
+        let lookup_keys = lookup_keys_by_surface
+            .get(&ir.surface_id)
+            .unwrap_or(&absent_lookup_keys);
         for operation in &ir.operations {
-            let projection =
-                generate_projection(ir, namespace, &type_by_id, operation, &mut diagnostics);
+            let projection = generate_projection(
+                ir,
+                namespace,
+                &type_by_id,
+                operation,
+                lookup_keys,
+                &mut diagnostics,
+            );
             projections.push(projection);
         }
         diagnostics.extend(ir.diagnostics.clone());
@@ -68,6 +85,7 @@ fn generate_projection(
     namespace: &str,
     type_by_id: &TypeIndex<'_>,
     operation: &IrOperation,
+    lookup_keys: &LookupKeysMetadata,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Projection {
     let is_search = is_search_operation(operation);
@@ -122,6 +140,7 @@ fn generate_projection(
                 data_type: input.data_type.lower(),
                 default_value: input.default_value.clone(),
                 description: input.description.clone(),
+                lookup_key: rest_filter_is_lookup_key(rest, input, exposure, lookup_keys),
             }
         })
         .collect::<Vec<_>>();
@@ -255,6 +274,25 @@ fn rest_input_exposure(
         }
     };
     (exposure, pagination_owned_query_input)
+}
+
+/// A REST filter input is a lookup key (dependent joins may bind to it) when
+/// the surface metadata does not exclude it. Lookup key exclusion never
+/// changes SQL exposure: an excluded input stays a pushdown filter, it just
+/// cannot anchor a join.
+fn rest_filter_is_lookup_key(
+    rest: Option<&RestExecutionAttachment>,
+    input: &IrOperationInput,
+    exposure: SqlInputExposure,
+    lookup_keys: &LookupKeysMetadata,
+) -> bool {
+    rest.is_some()
+        && exposure == SqlInputExposure::Filter
+        && lookup_keys.enabled
+        && !lookup_keys
+            .exclude
+            .iter()
+            .any(|excluded| excluded == &input.name)
 }
 
 fn mcp_pagination_owns_input(

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -58,6 +58,11 @@ pub struct ProjectionInput {
     pub data_type: ManifestDataType,
     pub default_value: Option<String>,
     pub description: String,
+    /// Whether this filter input is a complete exact lookup: the API returns
+    /// every row matching an equality value, so dependent joins may bind to
+    /// it. Meaningless (and false) for non-filter exposures.
+    #[serde(default)]
+    pub lookup_key: bool,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -21,7 +21,7 @@ pub fn projection_filter_specs(projection: &Projection) -> Vec<FilterSpec> {
             required: input.required,
             mode: FilterMode::Equality,
             description: input.description.clone(),
-            lookup_key: false,
+            lookup_key: input.lookup_key,
         })
         .collect()
 }

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -254,6 +254,13 @@ surfaces:
 
         let ir = import_catalog(&catalog);
         let operation = operation(&ir, "search_items");
+        assert!(
+            operation
+                .inputs
+                .iter()
+                .all(|input| !input.exclude_from_lookup_keys),
+            "MCP inputs never participate in REST lookup-key exclusions"
+        );
         let query = operation
             .inputs
             .iter()

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -518,12 +518,9 @@ surfaces:
                 .any(|diagnostic| diagnostic.code == "MCP_INPUT_SCHEMA_REF_NOT_FOUND")
         );
 
-        let projections = generate_projection_catalog(
-            manifest().as_v4().expect("v4"),
-            std::slice::from_ref(&ir),
-            &BTreeMap::new(),
-        )
-        .expect("projections");
+        let projections =
+            generate_projection_catalog(manifest().as_v4().expect("v4"), std::slice::from_ref(&ir))
+                .expect("projections");
         assert_eq!(projections.projections.len(), 0);
     }
 
@@ -852,12 +849,9 @@ surfaces:
                 .any(|diagnostic| diagnostic.code == "MCP_INPUT_SCHEMA_COMPOSITION_UNSUPPORTED")
         );
 
-        let projections = generate_projection_catalog(
-            manifest().as_v4().expect("v4"),
-            std::slice::from_ref(&ir),
-            &BTreeMap::new(),
-        )
-        .expect("projections");
+        let projections =
+            generate_projection_catalog(manifest().as_v4().expect("v4"), std::slice::from_ref(&ir))
+                .expect("projections");
         assert_eq!(projections.projections.len(), 0);
     }
 
@@ -1057,8 +1051,7 @@ surfaces:
         assert_eq!(pagination.offset_start, 0);
 
         let projections =
-            generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
-                .expect("projection catalog");
+            generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("projection catalog");
         let projection = projections
             .projections
             .iter()
@@ -1174,8 +1167,7 @@ surfaces:
         assert!(!operation.read_only);
 
         let projections =
-            generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
-                .expect("projections");
+            generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("projections");
         let projection = projections.projections.first().expect("projection");
         assert_eq!(projection.visibility, ProjectionVisibility::Hidden);
     }

--- a/crates/coral-spec/src/v4/surfaces/mcp/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/import.rs
@@ -518,9 +518,12 @@ surfaces:
                 .any(|diagnostic| diagnostic.code == "MCP_INPUT_SCHEMA_REF_NOT_FOUND")
         );
 
-        let projections =
-            generate_projection_catalog(manifest().as_v4().expect("v4"), std::slice::from_ref(&ir))
-                .expect("projections");
+        let projections = generate_projection_catalog(
+            manifest().as_v4().expect("v4"),
+            std::slice::from_ref(&ir),
+            &BTreeMap::new(),
+        )
+        .expect("projections");
         assert_eq!(projections.projections.len(), 0);
     }
 
@@ -849,9 +852,12 @@ surfaces:
                 .any(|diagnostic| diagnostic.code == "MCP_INPUT_SCHEMA_COMPOSITION_UNSUPPORTED")
         );
 
-        let projections =
-            generate_projection_catalog(manifest().as_v4().expect("v4"), std::slice::from_ref(&ir))
-                .expect("projections");
+        let projections = generate_projection_catalog(
+            manifest().as_v4().expect("v4"),
+            std::slice::from_ref(&ir),
+            &BTreeMap::new(),
+        )
+        .expect("projections");
         assert_eq!(projections.projections.len(), 0);
     }
 
@@ -1051,7 +1057,8 @@ surfaces:
         assert_eq!(pagination.offset_start, 0);
 
         let projections =
-            generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("projection catalog");
+            generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
+                .expect("projection catalog");
         let projection = projections
             .projections
             .iter()
@@ -1167,7 +1174,8 @@ surfaces:
         assert!(!operation.read_only);
 
         let projections =
-            generate_projection_catalog(v4, std::slice::from_ref(&ir)).expect("projections");
+            generate_projection_catalog(v4, std::slice::from_ref(&ir), &BTreeMap::new())
+                .expect("projections");
         let projection = projections.projections.first().expect("projection");
         assert_eq!(projection.visibility, ProjectionVisibility::Hidden);
     }

--- a/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
+++ b/crates/coral-spec/src/v4/surfaces/mcp/input_schema.rs
@@ -66,6 +66,7 @@ impl McpImporter<'_> {
                     data_type,
                     default_value: property.get("default").map(json_schema_default_to_string),
                     description: schema_description(property),
+                    exclude_from_lookup_keys: false,
                 }
             })
             .collect();

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -8,6 +8,7 @@ use crate::v4::ir::{
     IrOperationNaming, IrScalarType, OutputCardinality, RestExecutionAttachment,
     RestParameterBinding, RestRequestBody,
 };
+use crate::v4::lookup_keys::infer_rest_lookup_key_exclusions;
 use crate::v4::naming::normalize_identifier;
 use crate::v4::surfaces::json_schema::{
     json_schema_default_to_string, json_schema_scalar_type_or_string, json_schema_type_contains,
@@ -39,11 +40,15 @@ impl OpenApiImporter<'_> {
         let naming = openapi_operation_naming(op_obj, raw_operation_id, &operation_id);
         let method = parse_http_method(method_name);
         let mut diagnostics = Vec::new();
-        let parameters = self.import_parameters(path_item, op_obj, &operation_id, &mut diagnostics);
+        let mut parameters =
+            self.import_parameters(path_item, op_obj, &operation_id, &mut diagnostics);
         let request_body = self.import_request_body(op_obj, &operation_id, &mut diagnostics);
         let (output, response, entity, pagination_context) =
             self.import_response(path, op_obj, &operation_id, &mut diagnostics);
         let pagination = detect_pagination(&parameters, &pagination_context);
+        // All REST inputs must be present before lookup-key exclusion inference:
+        // the same vector becomes both operation inputs and parameter bindings.
+        infer_rest_lookup_key_exclusions(&mut parameters, &pagination);
         let rest_parameters = parameters
             .iter()
             .map(|input| RestParameterBinding {

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -169,6 +169,7 @@ impl OpenApiImporter<'_> {
                         .and_then(Value::as_str)
                         .unwrap_or_default()
                         .to_string(),
+                    exclude_from_lookup_keys: false,
                 })
             })
             .collect()


### PR DESCRIPTION
**Summary**
- Adds DSL v4 `lookup_keys` parameter metadata, including parsing and validation for generated metadata and user overrides.
- Infers lookup-key exclusions during materialization for pagination, search, and presentation query params, then writes that metadata alongside each REST surface artifact.
- Threads lookup-key metadata through projection generation so REST filter specs can set `lookup_key: true` only when the filter is safe for dependent joins.
- Keeps excluded parameters as normal pushdown filters; exclusion only disables joinability, not SQL exposure.
- Bumps the v4 projection generator to `derive-read-v8` 

Confidence: high.