### PR TITLE
chore: remove Cargo.lock from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,6 @@
 /Makefile @withcoral/core-maintainers
 /rust-toolchain.toml @withcoral/core-maintainers
 /Cargo.toml @withcoral/core-maintainers
-/Cargo.lock @withcoral/core-maintainers
 
 # Project docs.
 /CONTRIBUTING.md @withcoral/core-maintainers


### PR DESCRIPTION
Adding `foo.workspace = true` to a crate's Cargo.toml results in Cargo.lock changing. This happens a lot, and blocks the PR on a review from core-maintainers when it doesn't need to. We really only care if a new dependency is added to the project, and that is covered by having a code owner for the root Cargo.toml.

More generally, we should not declare code owners for generated files.

```
$ git log Cargo.lock | wc -l
      70
$ git log Cargo.toml | wc -l
      50
```