### PR TITLE
fix(spec): remove v4 fallback inflection

### DIFF
--- a/crates/coral-spec/src/v4/naming.rs
+++ b/crates/coral-spec/src/v4/naming.rs
@@ -51,50 +51,6 @@ pub(crate) fn normalize_sql_identifier(value: &str, prefix: &str) -> String {
     }
 }
 
-pub(crate) fn singularize(value: &str) -> String {
-    if let Some(stem) = value.strip_suffix("ies")
-        && !stem.is_empty()
-    {
-        return format!("{stem}y");
-    }
-    for suffix in ["ches", "shes", "xes", "ses"] {
-        if let Some(stem) = value.strip_suffix(suffix)
-            && !stem.is_empty()
-        {
-            return format!("{stem}{}", suffix.trim_end_matches("es"));
-        }
-    }
-    if value.ends_with('s')
-        && !value.ends_with("ss")
-        && !value.ends_with("us")
-        && !value.ends_with("ics")
-        && value != "news"
-    {
-        return value.trim_end_matches('s').to_string();
-    }
-    value.to_string()
-}
-
-pub(crate) fn pluralize(value: &str) -> String {
-    if value.ends_with('s') {
-        value.to_string()
-    } else if let Some(stem) = value.strip_suffix('y') {
-        if stem
-            .chars()
-            .next_back()
-            .is_some_and(|c| !"aeiou".contains(c))
-        {
-            format!("{stem}ies")
-        } else {
-            format!("{value}s")
-        }
-    } else if value.ends_with('x') || value.ends_with("ch") || value.ends_with("sh") {
-        format!("{value}es")
-    } else {
-        format!("{value}s")
-    }
-}
-
 pub(crate) fn stable_suffix(value: &str) -> String {
     let mut hash = 0xcbf2_9ce4_8422_2325_u64;
     for byte in value.as_bytes() {

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -242,7 +242,7 @@ components:
         .iter()
         .find(|projection| projection.operation_id == "listincidents")
         .expect("projection");
-    assert_eq!(projection.name, "incidents");
+    assert_eq!(projection.name, "incident");
     assert!(matches!(
         projection.kind,
         ProjectionKind::TableFunction {
@@ -306,7 +306,7 @@ components:
 
     let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
     let projection = catalog.projections.first().expect("projection");
-    assert_eq!(projection.name, "repositories");
+    assert_eq!(projection.name, "repository");
     assert!(matches!(
         projection.kind,
         ProjectionKind::TableFunction {
@@ -520,7 +520,7 @@ components:
         .iter()
         .find(|projection| projection.operation_id == "issues_list_for_repo")
         .expect("projection");
-    assert_eq!(projection.name, "issues");
+    assert_eq!(projection.name, "issue");
     assert_eq!(projection.visibility, ProjectionVisibility::Published);
     assert!(matches!(
         projection.kind,

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use serde_json::json;
 
-use super::naming::{pluralize, singularize};
 use super::test_support::github_openapi;
 use super::*;
 use crate::{
@@ -37,9 +36,9 @@ surfaces:
         .filter(|projection| projection.visibility == ProjectionVisibility::Published)
         .map(|projection| projection.name.as_str())
         .collect::<Vec<_>>();
-    assert!(published.contains(&"issues"), "{published:?}");
+    assert!(published.contains(&"issue"), "{published:?}");
     assert!(published.contains(&"search_issues"), "{published:?}");
-    assert!(published.contains(&"get_issue"), "{published:?}");
+    assert!(published.contains(&"get_issues"), "{published:?}");
 }
 
 #[test]
@@ -921,19 +920,19 @@ components:
     let issues_list = names_by_operation
         .get("issues_list")
         .expect("issues_list projection");
-    assert_eq!(issues_list.0, "issues");
+    assert_eq!(issues_list.0, "issue");
     let org_issues = names_by_operation
         .get("issues_list_for_org")
         .expect("issues_list_for_org projection");
-    assert_eq!(org_issues.0, "orgs_issues");
+    assert_eq!(org_issues.0, "orgs_issue");
     let repo_issues = names_by_operation
         .get("issues_list_for_repo")
         .expect("issues_list_for_repo projection");
-    assert_eq!(repo_issues.0, "repos_issues");
+    assert_eq!(repo_issues.0, "repos_issue");
     let pulls = names_by_operation
         .get("pulls_list")
         .expect("pulls_list projection");
-    assert_eq!(pulls.0, "pull_requests");
+    assert_eq!(pulls.0, "pull_request");
     assert!(matches!(
         pulls.1,
         ProjectionKind::TableFunction {
@@ -943,11 +942,11 @@ components:
     let commits = names_by_operation
         .get("repos_list_commits")
         .expect("repos_list_commits projection");
-    assert_eq!(commits.0, "commits");
+    assert_eq!(commits.0, "commit");
     let pull_commits = names_by_operation
         .get("pulls_list_commits")
         .expect("pulls_list_commits projection");
-    assert_eq!(pull_commits.0, "repos_pulls_commits");
+    assert_eq!(pull_commits.0, "repos_pulls_commit");
     let pull_commits_projection = catalog
         .projections
         .iter()
@@ -1462,13 +1461,4 @@ fn same_type_surface_namespaces_keep_colliding_projection_names() {
             .iter()
             .any(|diagnostic| diagnostic.code == "PROJECTION_NAME_COLLISION_RESOLVED")
     );
-}
-
-#[test]
-fn projection_names_avoid_obvious_bad_singulars() {
-    assert_eq!(singularize("status"), "status");
-    assert_eq!(singularize("news"), "news");
-    assert_eq!(singularize("analytics"), "analytics");
-    assert_eq!(singularize("addresses"), "address");
-    assert_eq!(pluralize("box"), "boxes");
 }

--- a/crates/coral-spec/src/v4/projections/names.rs
+++ b/crates/coral-spec/src/v4/projections/names.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use crate::v4::diagnostics::{Diagnostic, DiagnosticSeverity};
 use crate::v4::ir::{IrExecutionAttachment, IrOperation, OutputCardinality, SemanticIr};
 use crate::v4::manifest::V4SourceManifest;
-use crate::v4::naming::{normalize_identifier, pluralize, singularize, stable_suffix};
+use crate::v4::naming::{normalize_identifier, stable_suffix};
 
 use super::model::{
     Projection, ProjectionInput, ProjectionKind, ProjectionVisibility, SqlInputExposure,
@@ -248,14 +248,15 @@ fn human_join(items: &[&str]) -> String {
 pub(super) fn projection_name(operation: &IrOperation, is_search: bool) -> String {
     let entity = projection_entity_name(operation, is_search);
     if is_search {
-        return format!("search_{}", pluralize(&entity));
+        return format!("search_{entity}");
     }
     match operation.output.cardinality {
-        OutputCardinality::List | OutputCardinality::WrappedList => pluralize(&entity),
         OutputCardinality::Singleton if operation.inputs.iter().any(|input| input.required) => {
-            format!("get_{}", singularize(&entity))
+            format!("get_{entity}")
         }
-        OutputCardinality::Singleton => singularize(&entity),
+        OutputCardinality::List | OutputCardinality::WrappedList | OutputCardinality::Singleton => {
+            entity
+        }
         OutputCardinality::None | OutputCardinality::Unknown => {
             normalize_identifier(&operation.id, "projection")
         }
@@ -287,7 +288,6 @@ fn search_entity_from_path(operation: &IrOperation) -> Option<String> {
     rest_literal_path_segments(operation)
         .into_iter()
         .next_back()
-        .map(|segment| singularize(&segment))
 }
 
 fn normalize_entity_identifier(raw: &str) -> String {


### PR DESCRIPTION
## Summary

Remove the DSL v4 fallback singularize/pluralize helpers and stop applying English inflection when deriving projection names from normalized entities or path segments.

Fallback projection naming now preserves the normalized token directly while keeping explicit prefixes such as `get_` and `search_`. This avoids heuristic output like `get_analys`, `get_databas`, `get_licens`, and `get_immutable_releas` when operation tag/operationId metadata is unavailable.

## Failure modes observed

I tested this by forcing the GitHub v4 REST importer to ignore tag/operationId-derived names so it had to use the fallback entity/cardinality path, then compared the current inflection helpers against identity functions. The helper path changed 688 projection symbols and exposed several bad stems:

- `get_analyses` became `get_analys`
- `get_databases` became `get_databas`
- `get_licenses` became `get_licens`
- `get_immutable_releases` became `get_immutable_releas`
- `repos_code_scanning_get_analyses` became `repos_code_scanning_get_analys`
- `repos_get_immutable_releases` became `repos_get_immutable_releas`

The helpers improved some ordinary cases such as `issue` to `issues`, but the bad cases are worse than the improvement: deterministic fallback names are preferable to names that sometimes look corrupted.

## Impact

Sources that rely on OpenAPI tag/operationId-derived names, including the current GitHub v4 REST import, keep their primary names. Fallback-only/generated names become deterministic but no longer attempt to pluralize list outputs or singularize singleton outputs.

## Validation

- `cargo fmt --all`
- `cargo test --locked -p coral-spec`