### PR TITLE
feat(engine): lazy-load database catalog metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,6 +1486,7 @@ dependencies = [
  "datafusion-tracing",
  "futures",
  "httpdate",
+ "moka",
  "object_store",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1495,6 +1496,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "strsim",
  "tempfile",
  "thiserror",
@@ -4336,10 +4338,13 @@ version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
+ "async-lock",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
+ "event-listener",
+ "futures-util",
  "parking_lot",
  "portable-atomic",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ keyring-core = { version = "1.0.0", default-features = false }
 apple-native-keyring-store = { version = "1.0.0", default-features = false, features = ["keychain"] }
 windows-native-keyring-store = { version = "1.0.0", default-features = false }
 zbus-secret-service-keyring-store = { version = "1.0.0", default-features = false, features = ["rt-tokio-crypto-rust"] }
+moka = { version = "0.12", features = ["future"] }
 object_store = { version = "0.13.2", features = ["aws"] }
 opentelemetry = "0.31.0"
 opentelemetry-appender-tracing = "0.31.0"

--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -31,7 +31,8 @@ message PaginationResponse {
 message Column {
   // The column name as exposed by the query engine.
   string name = 1;
-  // The DataFusion/Arrow data type rendered as text.
+  // The column data type rendered as text: DataFusion/Arrow form for static
+  // sources, the provider-native type name for database catalogs.
   string data_type = 2;
   // Whether the column can contain null values.
   bool nullable = 3;

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -343,7 +343,7 @@ impl CatalogDiscovery {
         query: ListColumnsQuery<'_>,
         attribution: &QueryAttribution,
     ) -> Result<Option<Page<ColumnSearchResult>>, QueryManagerError> {
-        let table = self
+        let mut matches = self
             .queries
             .list_tables(
                 workspace_name,
@@ -354,8 +354,22 @@ impl CatalogDiscovery {
             )
             .await?
             .into_iter()
-            .find(|table| table_matches_ref(table, query.table_ref));
-        let Some(table) = table else {
+            .filter(|table| table_matches_ref(table, query.table_ref))
+            .collect::<Vec<_>>();
+        // An omitted catalog is a wildcard; refuse to guess when the same
+        // schema.table pair exists in more than one catalog.
+        if matches.len() > 1 {
+            let candidates = matches
+                .iter()
+                .map(|table| format!("`{}`", table_addressable_name(table)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(QueryManagerError::App(AppError::InvalidInput(format!(
+                "table reference `{}.{}` is ambiguous; qualify the catalog: {candidates}",
+                query.table_ref.schema_name, query.table_ref.table_name
+            ))));
+        }
+        let Some(table) = matches.pop() else {
             return Ok(None);
         };
 
@@ -638,9 +652,23 @@ fn table_matches_ref(table: &TableInfo, table_ref: CatalogTableRef<'_>) -> bool 
     table.table_name == table_ref.table_name && table_qualifier_matches(table, table_ref)
 }
 
+/// An omitted catalog is a wildcard, matching the engine's catalog-filter
+/// semantics and `describe_table`'s behavior; a supplied catalog is strict.
+/// A dotted schema with no catalog also matches its `catalog.schema` reading,
+/// so the compound names advertised in miss-hints replay verbatim. Callers
+/// that resolve a single table reject wildcard matches spanning more than one
+/// catalog instead of guessing.
 fn table_qualifier_matches(table: &TableInfo, table_ref: CatalogTableRef<'_>) -> bool {
-    table.catalog_name == table_ref.catalog_name.unwrap_or_default()
-        && table.schema_name == table_ref.schema_name
+    match table_ref.catalog_name {
+        Some(catalog_name) => {
+            table.catalog_name == catalog_name && table.schema_name == table_ref.schema_name
+        }
+        None => {
+            table.schema_name == table_ref.schema_name
+                || (!table.catalog_name.is_empty()
+                    && table_addressable_schema_name(table) == table_ref.schema_name)
+        }
+    }
 }
 
 pub(crate) fn page_items<T>(items: Vec<T>, pagination: Pagination) -> Page<T> {
@@ -731,6 +759,28 @@ mod tests {
             main_table,
             CatalogTableRef::new(Some("coral_db"), "analytics", "users")
         ));
+        assert!(
+            table_matches_ref(main_table, CatalogTableRef::new(None, "main", "users")),
+            "an omitted catalog is a wildcard, matching describe_table"
+        );
+        assert!(
+            table_matches_ref(
+                main_table,
+                CatalogTableRef::new(None, "coral_db.main", "users")
+            ),
+            "advertised compound schema hints must replay verbatim"
+        );
+        assert!(!table_matches_ref(
+            main_table,
+            CatalogTableRef::new(Some("other_db"), "main", "users")
+        ));
+        assert!(
+            !table_matches_ref(
+                main_table,
+                CatalogTableRef::new(Some("coral_db"), "coral_db.main", "users")
+            ),
+            "an explicit catalog keeps the schema comparison strict"
+        );
         assert_eq!(
             table_matched_fields(
                 main_table,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -261,7 +261,10 @@ impl QueryManager {
                         SourceObservationMode::Disabled,
                     )
                     .await?;
-                Ok(runtime.list_tables(catalog_filter, schema_filter, table_filter))
+                runtime
+                    .list_tables(catalog_filter, schema_filter, table_filter)
+                    .await
+                    .map_err(QueryManagerError::Core)
             },
             |tables| Some(u64::try_from(tables.len()).unwrap_or(u64::MAX)),
             |_, _| {},
@@ -314,7 +317,10 @@ impl QueryManager {
                 let runtime_schema_owners =
                     runtime_schema_owners(&source_load.loaded).map_err(QueryManagerError::App)?;
                 Ok(CatalogResolution {
-                    catalog: runtime.list_catalog(catalog_filter, schema_filter),
+                    catalog: runtime
+                        .list_catalog(catalog_filter, schema_filter)
+                        .await
+                        .map_err(QueryManagerError::Core)?,
                     failed_source_names,
                     runtime_schema_owners,
                 })
@@ -364,7 +370,10 @@ impl QueryManager {
                         SourceObservationMode::Disabled,
                     )
                     .await?;
-                Ok(runtime.describe_table(catalog_name, schema_name, table_name))
+                runtime
+                    .describe_table(catalog_name, schema_name, table_name)
+                    .await
+                    .map_err(QueryManagerError::Core)
             },
             |_| None,
             |_, _| {},

--- a/crates/coral-engine/Cargo.toml
+++ b/crates/coral-engine/Cargo.toml
@@ -27,6 +27,7 @@ datafusion-table-providers = { workspace = true, features = [
 datafusion-tracing.workspace = true
 futures.workspace = true
 httpdate.workspace = true
+moka.workspace = true
 object_store.workspace = true
 opentelemetry.workspace = true
 parquet.workspace = true
@@ -34,6 +35,7 @@ reqwest.workspace = true
 rmcp.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -160,6 +160,50 @@ pub(crate) struct BackendSchemaRegistration {
 pub(crate) struct BackendCatalogRegistration {
     pub(crate) catalog: Arc<dyn CatalogProvider>,
     pub(crate) source: RegisteredSource,
+    pub(crate) column_fetcher: Arc<dyn DatabaseColumnFetcher>,
+}
+
+/// Row-set restriction for one lazy database column-metadata fetch.
+///
+/// `None` means "no restriction on this dimension"; `Some` restricts the
+/// remote query to the listed values. An empty list matches nothing.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ColumnInventoryFilter {
+    pub(crate) schemas: Option<Vec<String>>,
+    pub(crate) tables: Option<Vec<String>>,
+}
+
+/// One column described by a remote database's own catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DatabaseColumnRow {
+    pub(crate) schema_name: String,
+    pub(crate) table_name: String,
+    pub(crate) ordinal_position: i32,
+    pub(crate) column_name: String,
+    pub(crate) data_type: String,
+    pub(crate) is_nullable: bool,
+}
+
+/// Query-time source of column metadata for one registered database catalog.
+///
+/// Fetches answer from the remote database's catalog (`information_schema`,
+/// `pragma_table_info`) in one round trip per call, so `coral.columns` cost
+/// scales with source count instead of table count.
+#[async_trait]
+pub(crate) trait DatabaseColumnFetcher: std::fmt::Debug + Send + Sync {
+    async fn fetch_columns(
+        &self,
+        filter: &ColumnInventoryFilter,
+    ) -> datafusion::error::Result<Vec<DatabaseColumnRow>>;
+}
+
+/// Pairs a registered catalog name with its lazy column fetcher.
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogColumnFetcher {
+    pub(crate) catalog_name: String,
+    pub(crate) schema_names: BTreeSet<String>,
+    pub(crate) table_names: BTreeSet<String>,
+    pub(crate) fetcher: Arc<dyn DatabaseColumnFetcher>,
 }
 
 pub(crate) struct BackendCompileRequest<'a> {

--- a/crates/coral-engine/src/backends/database.rs
+++ b/crates/coral-engine/src/backends/database.rs
@@ -262,13 +262,7 @@ SELECT table_schema AS schema_name,
        table_name,
        table_type AS relation_type
 FROM information_schema.tables
-WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
-UNION ALL
-SELECT schemaname AS schema_name,
-       matviewname AS table_name,
-       'MATERIALIZED VIEW' AS relation_type
-FROM pg_matviews
-WHERE schemaname NOT IN ('pg_catalog', 'information_schema')";
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')";
 
 const MYSQL_RELATIONS_SQL: &str = "
 SELECT TABLE_SCHEMA AS schema_name,
@@ -303,10 +297,8 @@ async fn database_catalog<T: 'static, P: 'static>(
     inventory_sql: &str,
 ) -> DataFusionResult<DatabaseCatalog> {
     let relations = load_database_inventory(&pool, inventory_sql).await?;
-    let provider = Arc::new(CoralDatabaseCatalogProvider::new(
-        Arc::clone(&pool),
-        &relations,
-    )) as Arc<dyn CatalogProvider>;
+    let provider =
+        Arc::new(CoralDatabaseCatalogProvider::new(&pool, &relations)) as Arc<dyn CatalogProvider>;
     Ok(DatabaseCatalog {
         provider,
         relations,
@@ -375,7 +367,7 @@ struct CoralDatabaseCatalogProvider {
 }
 
 impl CoralDatabaseCatalogProvider {
-    fn new<T: 'static, P: 'static>(pool: Pool<T, P>, relations: &[DatabaseRelation]) -> Self {
+    fn new<T: 'static, P: 'static>(pool: &Pool<T, P>, relations: &[DatabaseRelation]) -> Self {
         let mut by_schema = BTreeMap::<String, BTreeMap<String, TableType>>::new();
         for relation in relations {
             by_schema
@@ -389,7 +381,7 @@ impl CoralDatabaseCatalogProvider {
                 let provider = CoralDatabaseSchemaProvider {
                     schema_name: schema_name.clone(),
                     tables,
-                    pool: Arc::clone(&pool),
+                    pool: Arc::clone(pool),
                 };
                 (schema_name, Arc::new(provider) as Arc<dyn SchemaProvider>)
             })
@@ -429,7 +421,7 @@ impl<T: 'static, P: 'static> fmt::Debug for CoralDatabaseSchemaProvider<T, P> {
             .debug_struct("CoralDatabaseSchemaProvider")
             .field("schema_name", &self.schema_name)
             .field("tables", &self.tables)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/coral-engine/src/backends/database.rs
+++ b/crates/coral-engine/src/backends/database.rs
@@ -1,6 +1,7 @@
 //! Relational database backend registration through `datafusion-table-providers`.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
@@ -11,28 +12,33 @@ use coral_spec::backends::database::{
     SqliteConnectionSpec,
 };
 use coral_spec::{ParsedTemplate, SourceManifestCommon};
+use datafusion::arrow::array::StringArray;
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::catalog::{CatalogProvider, SchemaProvider};
+use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::logical_expr::TableType;
 use datafusion::prelude::SessionContext;
+use datafusion::sql::TableReference;
 use datafusion_table_providers::UnsupportedTypeAction;
-use datafusion_table_providers::common::DatabaseCatalogProvider;
-use datafusion_table_providers::sql::db_connection_pool::Mode;
+use datafusion_table_providers::sql::db_connection_pool::dbconnection::query_arrow;
 use datafusion_table_providers::sql::db_connection_pool::mysqlpool::MySQLConnectionPool;
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
 use datafusion_table_providers::sql::db_connection_pool::sqlitepool::SqliteConnectionPoolFactory;
+use datafusion_table_providers::sql::db_connection_pool::{DbConnectionPool, Mode};
+use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
 use datafusion_table_providers::util::secrets::to_secret_map;
-use futures::{StreamExt, stream};
+use futures::TryStreamExt as _;
 
 use crate::backends::shared::template::{RenderContext, render_template};
 use crate::backends::{
     BackendCatalogRegistration, BackendCompileRequest, BackendRegistration,
     BackendRegistrationContext, CompiledBackendSource, RegisteredSource, RegisteredTable,
-    SourceQualifiedName, build_registered_inputs, registered_columns_from_schema,
+    SourceQualifiedName, build_registered_inputs,
 };
 
 const REMOTE_DATABASE_REGISTRATION_TIMEOUT: Duration = Duration::from_secs(10);
 const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
-const TABLE_SCHEMA_DISCOVERY_CONCURRENCY: usize = 8;
 
 pub(crate) fn compile_manifest(
     manifest: &DatabaseSourceManifest,
@@ -59,10 +65,8 @@ trait DatabaseCatalogStrategy: Send + Sync {
         Some(REMOTE_DATABASE_REGISTRATION_TIMEOUT)
     }
 
-    async fn build_catalog(
-        &self,
-        context: &RenderContext<'_>,
-    ) -> DataFusionResult<Arc<dyn CatalogProvider>>;
+    async fn build_catalog(&self, context: &RenderContext<'_>)
+    -> DataFusionResult<DatabaseCatalog>;
 }
 
 fn database_strategy(connection: &DatabaseConnectionSpec) -> &dyn DatabaseCatalogStrategy {
@@ -102,19 +106,21 @@ impl CompiledBackendSource for CompiledDatabaseSource {
         let provider_name = strategy.provider_name();
         let registration_timeout = strategy.registration_timeout();
         let registration = async {
-            let catalog = strategy.build_catalog(&context).await?;
+            let database_catalog = strategy.build_catalog(&context).await?;
             let source = registered_source_for_catalog(
                 &self.manifest.common,
                 &self.manifest.declared_inputs,
                 &self.source_secrets,
                 &self.source_variables,
-                Arc::clone(&catalog),
-            )
-            .await?;
+                &database_catalog.relations,
+            );
 
             Ok(BackendRegistration {
                 schemas: Vec::new(),
-                catalogs: vec![BackendCatalogRegistration { catalog, source }],
+                catalogs: vec![BackendCatalogRegistration {
+                    catalog: database_catalog.provider,
+                    source,
+                }],
             })
         };
 
@@ -158,7 +164,7 @@ impl DatabaseCatalogStrategy for PostgresConnectionSpec {
     async fn build_catalog(
         &self,
         context: &RenderContext<'_>,
-    ) -> DataFusionResult<Arc<dyn CatalogProvider>> {
+    ) -> DataFusionResult<DatabaseCatalog> {
         let mut params = render_connection_params(
             [
                 ("host", &self.host),
@@ -177,7 +183,7 @@ impl DatabaseCatalogStrategy for PostgresConnectionSpec {
             .map_err(provider_error)?
             // The MySQL adapter has no equivalent unsupported-type policy.
             .with_unsupported_type_action(UnsupportedTypeAction::String);
-        database_catalog(Arc::new(pool)).await
+        database_catalog(Arc::new(pool), POSTGRES_RELATIONS_SQL).await
     }
 }
 
@@ -190,7 +196,7 @@ impl DatabaseCatalogStrategy for MySqlConnectionSpec {
     async fn build_catalog(
         &self,
         context: &RenderContext<'_>,
-    ) -> DataFusionResult<Arc<dyn CatalogProvider>> {
+    ) -> DataFusionResult<DatabaseCatalog> {
         let mut params = render_connection_params(
             [
                 ("host", &self.host),
@@ -214,7 +220,7 @@ impl DatabaseCatalogStrategy for MySqlConnectionSpec {
         let pool = MySQLConnectionPool::new(to_secret_map(params))
             .await
             .map_err(provider_error)?;
-        database_catalog(Arc::new(pool)).await
+        database_catalog(Arc::new(pool), MYSQL_RELATIONS_SQL).await
     }
 }
 
@@ -241,109 +247,253 @@ impl DatabaseCatalogStrategy for SqliteConnectionSpec {
     async fn build_catalog(
         &self,
         context: &RenderContext<'_>,
-    ) -> DataFusionResult<Arc<dyn CatalogProvider>> {
+    ) -> DataFusionResult<DatabaseCatalog> {
         let path = render_template(&self.path, context)?;
         let pool = SqliteConnectionPoolFactory::new(&path, Mode::File, SQLITE_BUSY_TIMEOUT)
             .build()
             .await
             .map_err(boxed_provider_error)?;
-        database_catalog(Arc::new(pool)).await
+        database_catalog(Arc::new(pool), SQLITE_RELATIONS_SQL).await
     }
 }
 
-async fn database_catalog<T: 'static, P: 'static>(
-    pool: Arc<
-        dyn datafusion_table_providers::sql::db_connection_pool::DbConnectionPool<T, P>
-            + Send
-            + Sync,
-    >,
-) -> DataFusionResult<Arc<dyn CatalogProvider>> {
-    DatabaseCatalogProvider::try_new(pool)
-        .await
-        .map(|catalog| Arc::new(catalog) as Arc<dyn CatalogProvider>)
-        .map_err(boxed_provider_error)
+const POSTGRES_RELATIONS_SQL: &str = "
+SELECT table_schema AS schema_name,
+       table_name,
+       table_type AS relation_type
+FROM information_schema.tables
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+UNION ALL
+SELECT schemaname AS schema_name,
+       matviewname AS table_name,
+       'MATERIALIZED VIEW' AS relation_type
+FROM pg_matviews
+WHERE schemaname NOT IN ('pg_catalog', 'information_schema')";
+
+const MYSQL_RELATIONS_SQL: &str = "
+SELECT TABLE_SCHEMA AS schema_name,
+       TABLE_NAME AS table_name,
+       TABLE_TYPE AS relation_type
+FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')";
+
+const SQLITE_RELATIONS_SQL: &str = "
+SELECT 'main' AS schema_name,
+       name AS table_name,
+       CASE type WHEN 'view' THEN 'VIEW' ELSE 'BASE TABLE' END AS relation_type
+FROM sqlite_master
+WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'";
+
+type Pool<T, P> = Arc<dyn DbConnectionPool<T, P> + Send + Sync>;
+
+struct DatabaseCatalog {
+    provider: Arc<dyn CatalogProvider>,
+    relations: Vec<DatabaseRelation>,
 }
 
-async fn registered_source_for_catalog(
+#[derive(Clone, Debug)]
+struct DatabaseRelation {
+    schema_name: String,
+    table_name: String,
+    table_type: TableType,
+}
+
+async fn database_catalog<T: 'static, P: 'static>(
+    pool: Pool<T, P>,
+    inventory_sql: &str,
+) -> DataFusionResult<DatabaseCatalog> {
+    let relations = load_database_inventory(&pool, inventory_sql).await?;
+    let provider = Arc::new(CoralDatabaseCatalogProvider::new(
+        Arc::clone(&pool),
+        &relations,
+    )) as Arc<dyn CatalogProvider>;
+    Ok(DatabaseCatalog {
+        provider,
+        relations,
+    })
+}
+
+async fn load_database_inventory<T: 'static, P: 'static>(
+    pool: &Pool<T, P>,
+    inventory_sql: &str,
+) -> DataFusionResult<Vec<DatabaseRelation>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("schema_name", DataType::Utf8, false),
+        Field::new("table_name", DataType::Utf8, false),
+        Field::new("relation_type", DataType::Utf8, false),
+    ]));
+    let connection = pool.connect().await.map_err(boxed_provider_error)?;
+    let batches = query_arrow(connection, inventory_sql.to_string(), Some(schema))
+        .await
+        .map_err(provider_error)?
+        .try_collect::<Vec<_>>()
+        .await?;
+    let mut relations = Vec::new();
+    for batch in batches {
+        let schema_names = database_inventory_column(&batch, "schema_name")?;
+        let table_names = database_inventory_column(&batch, "table_name")?;
+        let relation_types = database_inventory_column(&batch, "relation_type")?;
+        for row in 0..batch.num_rows() {
+            relations.push(DatabaseRelation {
+                schema_name: schema_names.value(row).to_string(),
+                table_name: table_names.value(row).to_string(),
+                table_type: relation_table_type(relation_types.value(row)),
+            });
+        }
+    }
+    relations.sort_by(|left, right| {
+        (&left.schema_name, &left.table_name).cmp(&(&right.schema_name, &right.table_name))
+    });
+    relations.dedup_by(|left, right| {
+        left.schema_name == right.schema_name && left.table_name == right.table_name
+    });
+    Ok(relations)
+}
+
+fn database_inventory_column<'a>(
+    batch: &'a datafusion::arrow::record_batch::RecordBatch,
+    name: &str,
+) -> DataFusionResult<&'a StringArray> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref::<StringArray>())
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!("database inventory column '{name}' is not Utf8"))
+        })
+}
+
+fn relation_table_type(value: &str) -> TableType {
+    if value.eq_ignore_ascii_case("VIEW") || value.eq_ignore_ascii_case("MATERIALIZED VIEW") {
+        TableType::View
+    } else {
+        TableType::Base
+    }
+}
+
+struct CoralDatabaseCatalogProvider {
+    schemas: HashMap<String, Arc<dyn SchemaProvider>>,
+}
+
+impl CoralDatabaseCatalogProvider {
+    fn new<T: 'static, P: 'static>(pool: Pool<T, P>, relations: &[DatabaseRelation]) -> Self {
+        let mut by_schema = BTreeMap::<String, BTreeMap<String, TableType>>::new();
+        for relation in relations {
+            by_schema
+                .entry(relation.schema_name.clone())
+                .or_default()
+                .insert(relation.table_name.clone(), relation.table_type);
+        }
+        let schemas = by_schema
+            .into_iter()
+            .map(|(schema_name, tables)| {
+                let provider = CoralDatabaseSchemaProvider {
+                    schema_name: schema_name.clone(),
+                    tables,
+                    pool: Arc::clone(&pool),
+                };
+                (schema_name, Arc::new(provider) as Arc<dyn SchemaProvider>)
+            })
+            .collect();
+        Self { schemas }
+    }
+}
+
+impl fmt::Debug for CoralDatabaseCatalogProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CoralDatabaseCatalogProvider")
+            .field("schemas", &self.schemas.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl CatalogProvider for CoralDatabaseCatalogProvider {
+    fn schema_names(&self) -> Vec<String> {
+        self.schemas.keys().cloned().collect()
+    }
+
+    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        self.schemas.get(name).cloned()
+    }
+}
+
+struct CoralDatabaseSchemaProvider<T: 'static, P: 'static> {
+    schema_name: String,
+    tables: BTreeMap<String, TableType>,
+    pool: Pool<T, P>,
+}
+
+impl<T: 'static, P: 'static> fmt::Debug for CoralDatabaseSchemaProvider<T, P> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CoralDatabaseSchemaProvider")
+            .field("schema_name", &self.schema_name)
+            .field("tables", &self.tables)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl<T: 'static, P: 'static> SchemaProvider for CoralDatabaseSchemaProvider<T, P> {
+    fn table_names(&self) -> Vec<String> {
+        self.tables.keys().cloned().collect()
+    }
+
+    async fn table(&self, name: &str) -> DataFusionResult<Option<Arc<dyn TableProvider>>> {
+        if !self.tables.contains_key(name) {
+            return Ok(None);
+        }
+        SqlTable::new(
+            &self.schema_name,
+            &self.pool,
+            TableReference::partial(self.schema_name.clone(), name.to_string()),
+        )
+        .await
+        .map(|table| Some(Arc::new(table) as Arc<dyn TableProvider>))
+        .map_err(provider_error)
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        self.tables.contains_key(name)
+    }
+
+    async fn table_type(&self, name: &str) -> DataFusionResult<Option<TableType>> {
+        Ok(self.tables.get(name).copied())
+    }
+}
+
+fn registered_source_for_catalog(
     common: &SourceManifestCommon,
     declared_inputs: &[coral_spec::ManifestInputSpec],
     source_secrets: &BTreeMap<String, String>,
     source_variables: &BTreeMap<String, String>,
-    catalog: Arc<dyn CatalogProvider>,
-) -> DataFusionResult<RegisteredSource> {
-    let mut table_discovery = Vec::new();
-    let mut schema_names = catalog.schema_names();
-    schema_names.sort();
-    for schema_name in schema_names {
-        let Some(schema) = catalog.schema(&schema_name) else {
-            continue;
-        };
-        let mut table_names = schema.table_names();
-        table_names.sort();
-        for table_name in table_names {
-            table_discovery.push((schema_name.clone(), table_name, Arc::clone(&schema)));
-        }
-    }
-
-    let source_name: Arc<str> = Arc::from(common.name.as_str());
-    let mut discovery_futures = Vec::with_capacity(table_discovery.len());
-    for (schema_name, table_name, schema) in table_discovery {
-        discovery_futures.push(discover_registered_table(
-            Arc::clone(&source_name),
-            schema_name,
-            table_name,
-            schema,
-        ));
-    }
-    let mut tables = stream::iter(discovery_futures)
-        .buffer_unordered(TABLE_SCHEMA_DISCOVERY_CONCURRENCY)
-        .filter_map(std::future::ready)
-        .collect::<Vec<_>>()
-        .await;
-    tables.sort_by(|left, right| {
-        left.schema_name
-            .cmp(&right.schema_name)
-            .then_with(|| left.table_name.cmp(&right.table_name))
-    });
-
+    relations: &[DatabaseRelation],
+) -> RegisteredSource {
     let secret_keys = source_secrets.keys().cloned().collect::<BTreeSet<_>>();
-    Ok(RegisteredSource {
+    RegisteredSource {
         qualified_name: SourceQualifiedName::Catalog(common.name.clone()),
-        tables,
+        tables: database_relation_inventory(relations),
         table_functions: Vec::new(),
         inputs: build_registered_inputs(declared_inputs, source_variables, &secret_keys),
-    })
+    }
 }
 
-async fn discover_registered_table(
-    source_name: Arc<str>,
-    schema_name: String,
-    table_name: String,
-    schema: Arc<dyn SchemaProvider>,
-) -> Option<RegisteredTable> {
-    match schema.table(&table_name).await {
-        Ok(Some(provider)) => Some(RegisteredTable {
-            schema_name: Some(schema_name),
-            table_name,
+/// Project the Coral-owned relation inventory into public catalog metadata
+/// without constructing table providers or fetching column schemas.
+fn database_relation_inventory(relations: &[DatabaseRelation]) -> Vec<RegisteredTable> {
+    relations
+        .iter()
+        .map(|relation| RegisteredTable {
+            schema_name: Some(relation.schema_name.clone()),
+            table_name: relation.table_name.clone(),
             description: String::new(),
             guide: String::new(),
-            columns: registered_columns_from_schema(&provider.schema(), &[]),
+            columns: Vec::new(),
             filters: Vec::new(),
             required_filters: Vec::new(),
             search_limits: None,
-        }),
-        Ok(None) => None,
-        Err(error) => {
-            tracing::warn!(
-                source = %source_name,
-                schema = %schema_name,
-                table = %table_name,
-                detail = %error,
-                "skipping table that failed schema discovery"
-            );
-            None
-        }
-    }
+        })
+        .collect()
 }
 
 fn provider_error(error: impl std::error::Error + Send + Sync + 'static) -> DataFusionError {

--- a/crates/coral-engine/src/backends/database/columns.rs
+++ b/crates/coral-engine/src/backends/database/columns.rs
@@ -18,13 +18,14 @@ use crate::backends::{ColumnInventoryFilter, DatabaseColumnFetcher, DatabaseColu
 
 /// Normalized inventory queries. Every provider projects the same six Utf8
 /// columns so one Arrow schema and one row parser serve all of them:
-/// `schema_name`, `table_name`, `ordinal_position` (1-based, as text),
+/// `schema_name`, `table_name`, `ordinal_position` (zero-based, as text,
+/// matching the `coral.columns` contract),
 /// `column_name`, `data_type` (provider-native name), `is_nullable`
 /// ('true'/'false').
 pub(super) const POSTGRES_COLUMNS_SQL: &str = "
 SELECT table_schema AS schema_name,
        table_name,
-       CAST(ordinal_position AS TEXT) AS ordinal_position,
+       CAST(ordinal_position - 1 AS TEXT) AS ordinal_position,
        column_name,
        data_type,
        CASE WHEN is_nullable = 'YES' THEN 'true' ELSE 'false' END AS is_nullable
@@ -34,7 +35,7 @@ WHERE table_schema NOT IN ('pg_catalog', 'information_schema')";
 pub(super) const MYSQL_COLUMNS_SQL: &str = "
 SELECT TABLE_SCHEMA AS schema_name,
        TABLE_NAME AS table_name,
-       CAST(ORDINAL_POSITION AS CHAR) AS ordinal_position,
+       CAST(ORDINAL_POSITION - 1 AS CHAR) AS ordinal_position,
        COLUMN_NAME AS column_name,
        DATA_TYPE AS data_type,
        CASE WHEN IS_NULLABLE = 'YES' THEN 'true' ELSE 'false' END AS is_nullable
@@ -44,7 +45,7 @@ WHERE TABLE_SCHEMA NOT IN ('information_schema', 'mysql', 'performance_schema', 
 pub(super) const SQLITE_COLUMNS_SQL: &str = "
 SELECT 'main' AS schema_name,
        m.name AS table_name,
-       CAST(p.cid + 1 AS TEXT) AS ordinal_position,
+       CAST(p.cid AS TEXT) AS ordinal_position,
        p.name AS column_name,
        CASE WHEN p.type = '' THEN 'unknown' ELSE p.type END AS data_type,
        CASE WHEN p.\"notnull\" = 0 THEN 'true' ELSE 'false' END AS is_nullable
@@ -305,14 +306,14 @@ mod tests {
         assert_eq!(
             described,
             [
-                "main.named_users.name:1",
-                "main.orders.order_id:1",
-                "main.orders.user_id:2",
-                "main.orders.note:3",
-                "main.users.id:1",
-                "main.users.name:2",
+                "main.named_users.name:0",
+                "main.orders.order_id:0",
+                "main.orders.user_id:1",
+                "main.orders.note:2",
+                "main.users.id:0",
+                "main.users.name:1",
             ],
-            "inventory should cover tables and views with 1-based ordinals"
+            "inventory should cover tables and views with zero-based ordinals"
         );
 
         let name = rows

--- a/crates/coral-engine/src/backends/database/columns.rs
+++ b/crates/coral-engine/src/backends/database/columns.rs
@@ -1,0 +1,368 @@
+//! Lazy column-metadata inventory for relational database sources.
+//!
+//! Each provider answers column metadata from its own catalog
+//! (`information_schema.columns`, `pragma_table_info`) in a single round
+//! trip, instead of probing every table's Arrow schema individually.
+
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion_table_providers::sql::db_connection_pool::dbconnection::query_arrow;
+use futures::TryStreamExt as _;
+
+use crate::backends::database::{Pool, boxed_provider_error, database_inventory_column};
+use crate::backends::{ColumnInventoryFilter, DatabaseColumnFetcher, DatabaseColumnRow};
+
+/// Normalized inventory queries. Every provider projects the same six Utf8
+/// columns so one Arrow schema and one row parser serve all of them:
+/// `schema_name`, `table_name`, `ordinal_position` (1-based, as text),
+/// `column_name`, `data_type` (provider-native name), `is_nullable`
+/// ('true'/'false').
+pub(super) const POSTGRES_COLUMNS_SQL: &str = "
+SELECT table_schema AS schema_name,
+       table_name,
+       CAST(ordinal_position AS TEXT) AS ordinal_position,
+       column_name,
+       data_type,
+       CASE WHEN is_nullable = 'YES' THEN 'true' ELSE 'false' END AS is_nullable
+FROM information_schema.columns
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')";
+
+pub(super) const MYSQL_COLUMNS_SQL: &str = "
+SELECT TABLE_SCHEMA AS schema_name,
+       TABLE_NAME AS table_name,
+       CAST(ORDINAL_POSITION AS CHAR) AS ordinal_position,
+       COLUMN_NAME AS column_name,
+       DATA_TYPE AS data_type,
+       CASE WHEN IS_NULLABLE = 'YES' THEN 'true' ELSE 'false' END AS is_nullable
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')";
+
+pub(super) const SQLITE_COLUMNS_SQL: &str = "
+SELECT 'main' AS schema_name,
+       m.name AS table_name,
+       CAST(p.cid + 1 AS TEXT) AS ordinal_position,
+       p.name AS column_name,
+       CASE WHEN p.type = '' THEN 'unknown' ELSE p.type END AS data_type,
+       CASE WHEN p.\"notnull\" = 0 THEN 'true' ELSE 'false' END AS is_nullable
+FROM sqlite_master AS m
+JOIN pragma_table_info(m.name) AS p
+WHERE m.type IN ('table', 'view') AND m.name NOT LIKE 'sqlite_%'";
+
+/// [`DatabaseColumnFetcher`] backed by a connection pool and one of the
+/// provider inventory queries above.
+pub(super) struct PooledColumnFetcher<T: 'static, P: 'static> {
+    pool: Pool<T, P>,
+    base_sql: &'static str,
+}
+
+impl<T: 'static, P: 'static> PooledColumnFetcher<T, P> {
+    pub(super) fn new(pool: &Pool<T, P>, base_sql: &'static str) -> Arc<Self> {
+        Arc::new(Self {
+            pool: Arc::clone(pool),
+            base_sql,
+        })
+    }
+}
+
+impl<T: 'static, P: 'static> fmt::Debug for PooledColumnFetcher<T, P> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PooledColumnFetcher")
+            .field("base_sql", &self.base_sql)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl<T: 'static, P: 'static> DatabaseColumnFetcher for PooledColumnFetcher<T, P> {
+    async fn fetch_columns(
+        &self,
+        filter: &ColumnInventoryFilter,
+    ) -> DataFusionResult<Vec<DatabaseColumnRow>> {
+        if filter_matches_nothing(filter) {
+            return Ok(Vec::new());
+        }
+        let sql = compose_columns_sql(self.base_sql, filter);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("schema_name", DataType::Utf8, false),
+            Field::new("table_name", DataType::Utf8, false),
+            Field::new("ordinal_position", DataType::Utf8, false),
+            Field::new("column_name", DataType::Utf8, false),
+            Field::new("data_type", DataType::Utf8, false),
+            Field::new("is_nullable", DataType::Utf8, false),
+        ]));
+        let connection = self.pool.connect().await.map_err(boxed_provider_error)?;
+        let batches = query_arrow(connection, sql, Some(schema))
+            .await
+            .map_err(|error| DataFusionError::External(Box::new(error)))?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let mut rows = Vec::new();
+        for batch in batches {
+            let schema_names = database_inventory_column(&batch, "schema_name")?;
+            let table_names = database_inventory_column(&batch, "table_name")?;
+            let ordinals = database_inventory_column(&batch, "ordinal_position")?;
+            let column_names = database_inventory_column(&batch, "column_name")?;
+            let data_types = database_inventory_column(&batch, "data_type")?;
+            let nullables = database_inventory_column(&batch, "is_nullable")?;
+            for row in 0..batch.num_rows() {
+                rows.push(DatabaseColumnRow {
+                    schema_name: schema_names.value(row).to_string(),
+                    table_name: table_names.value(row).to_string(),
+                    ordinal_position: parse_ordinal(ordinals.value(row))?,
+                    column_name: column_names.value(row).to_string(),
+                    data_type: data_types.value(row).to_string(),
+                    is_nullable: nullables.value(row) == "true",
+                });
+            }
+        }
+        rows.sort_by(|left, right| {
+            (&left.schema_name, &left.table_name, left.ordinal_position).cmp(&(
+                &right.schema_name,
+                &right.table_name,
+                right.ordinal_position,
+            ))
+        });
+        Ok(rows)
+    }
+}
+
+fn parse_ordinal(value: &str) -> DataFusionResult<i32> {
+    value.trim().parse::<i32>().map_err(|_parse_error| {
+        DataFusionError::Execution(format!(
+            "database column inventory returned non-integer ordinal_position '{value}'"
+        ))
+    })
+}
+
+fn filter_matches_nothing(filter: &ColumnInventoryFilter) -> bool {
+    filter.schemas.as_ref().is_some_and(Vec::is_empty)
+        || filter.tables.as_ref().is_some_and(Vec::is_empty)
+}
+
+/// Wraps the base inventory query with the caller's schema/table restriction.
+/// The subquery aliases every provider's columns to a common shape, so the
+/// outer predicates are provider-independent.
+///
+/// Restrictions are pruning-only (the engine re-applies exact predicates
+/// above the scan), so a dimension whose values cannot be embedded verbatim
+/// is fetched unfiltered instead of escaped: dropping a whole restriction
+/// fetches more rows and stays correct, while embedding a hostile value
+/// would hand attacker-controlled SQL to the remote database (`MySQL`'s
+/// default `sql_mode` treats `\` as a string escape, so quote-doubling
+/// alone is not a safe quoting strategy there).
+fn compose_columns_sql(base_sql: &str, filter: &ColumnInventoryFilter) -> String {
+    let mut predicates = Vec::new();
+    if let Some(schemas) = filter.schemas.as_ref()
+        && values_embed_safely(schemas)
+    {
+        predicates.push(format!("schema_name IN ({})", sql_string_list(schemas)));
+    }
+    if let Some(tables) = filter.tables.as_ref()
+        && values_embed_safely(tables)
+    {
+        predicates.push(format!("table_name IN ({})", sql_string_list(tables)));
+    }
+    if predicates.is_empty() {
+        return base_sql.to_string();
+    }
+    format!(
+        "SELECT * FROM ({base_sql}\n) AS columns_inventory WHERE {}",
+        predicates.join(" AND ")
+    )
+}
+
+/// Whether every value can sit inside a single-quoted SQL literal without any
+/// escaping, across all supported providers' string-literal dialects.
+fn values_embed_safely(values: &[String]) -> bool {
+    values
+        .iter()
+        .all(|value| !value.contains('\'') && !value.contains('\\') && !value.contains('\0'))
+}
+
+fn sql_string_list(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|value| format!("'{value}'"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use datafusion_table_providers::sql::db_connection_pool::Mode;
+    use datafusion_table_providers::sql::db_connection_pool::sqlitepool::SqliteConnectionPoolFactory;
+
+    use super::*;
+
+    #[test]
+    fn compose_columns_sql_without_filter_returns_base() {
+        let filter = ColumnInventoryFilter::default();
+        assert_eq!(
+            compose_columns_sql("SELECT 1", &filter),
+            "SELECT 1".to_string()
+        );
+    }
+
+    #[test]
+    fn compose_columns_sql_combines_safe_predicates() {
+        let filter = ColumnInventoryFilter {
+            schemas: Some(vec!["main".to_string()]),
+            tables: Some(vec!["users".to_string(), "orders".to_string()]),
+        };
+        let sql = compose_columns_sql("SELECT 1", &filter);
+        assert_eq!(
+            sql,
+            "SELECT * FROM (SELECT 1\n) AS columns_inventory \
+             WHERE schema_name IN ('main') AND table_name IN ('users', 'orders')"
+        );
+    }
+
+    #[test]
+    fn compose_columns_sql_drops_dimensions_it_cannot_embed_verbatim() {
+        // Values with quote/backslash/NUL never reach the remote SQL text —
+        // the whole dimension falls back to an unfiltered fetch (pruning-only
+        // semantics keep results correct), so injection shapes like a
+        // trailing backslash (MySQL escape) cannot smuggle SQL.
+        for hostile in ["o'brien", "x\\", "x' UNION SELECT 1 --", "x\0"] {
+            let filter = ColumnInventoryFilter {
+                schemas: Some(vec!["main".to_string()]),
+                tables: Some(vec!["users".to_string(), hostile.to_string()]),
+            };
+            let sql = compose_columns_sql("SELECT 1", &filter);
+            assert_eq!(
+                sql,
+                "SELECT * FROM (SELECT 1\n) AS columns_inventory \
+                 WHERE schema_name IN ('main')",
+                "hostile table value {hostile:?} must drop the table restriction"
+            );
+        }
+
+        let filter = ColumnInventoryFilter {
+            schemas: Some(vec!["ma'in".to_string()]),
+            tables: None,
+        };
+        assert_eq!(
+            compose_columns_sql("SELECT 1", &filter),
+            "SELECT 1",
+            "hostile schema value with no other predicate returns the base query"
+        );
+    }
+
+    async fn sqlite_fetcher(db_path: &std::path::Path) -> Arc<dyn DatabaseColumnFetcher> {
+        let pool = SqliteConnectionPoolFactory::new(
+            &db_path.to_string_lossy(),
+            Mode::File,
+            Duration::from_secs(5),
+        )
+        .build()
+        .await
+        .expect("sqlite pool");
+        let pool: Pool<_, _> = Arc::new(pool);
+        PooledColumnFetcher::new(&pool, SQLITE_COLUMNS_SQL)
+    }
+
+    fn sqlite_fixture(dir: &std::path::Path) -> std::path::PathBuf {
+        let db_path = dir.join("columns.sqlite");
+        let conn = rusqlite::Connection::open(&db_path).expect("sqlite db");
+        conn.execute_batch(
+            "
+            CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+            CREATE TABLE orders (order_id INTEGER PRIMARY KEY, user_id INTEGER, note TEXT);
+            CREATE VIEW named_users AS SELECT name FROM users;
+            ",
+        )
+        .expect("sqlite fixture");
+        db_path
+    }
+
+    #[tokio::test]
+    async fn sqlite_inventory_fetches_all_columns_in_one_query() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let fetcher = sqlite_fetcher(&sqlite_fixture(temp.path())).await;
+
+        let rows = fetcher
+            .fetch_columns(&ColumnInventoryFilter::default())
+            .await
+            .expect("fetch all columns");
+
+        let described = rows
+            .iter()
+            .map(|row| {
+                format!(
+                    "{}.{}.{}:{}",
+                    row.schema_name, row.table_name, row.column_name, row.ordinal_position
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            described,
+            [
+                "main.named_users.name:1",
+                "main.orders.order_id:1",
+                "main.orders.user_id:2",
+                "main.orders.note:3",
+                "main.users.id:1",
+                "main.users.name:2",
+            ],
+            "inventory should cover tables and views with 1-based ordinals"
+        );
+
+        let name = rows
+            .iter()
+            .find(|row| row.table_name == "users" && row.column_name == "name")
+            .expect("users.name row");
+        assert_eq!(name.data_type, "TEXT");
+        assert!(!name.is_nullable, "NOT NULL column reports non-nullable");
+        let user_id = rows
+            .iter()
+            .find(|row| row.table_name == "orders" && row.column_name == "user_id")
+            .expect("orders.user_id row");
+        assert!(user_id.is_nullable);
+    }
+
+    #[tokio::test]
+    async fn sqlite_inventory_applies_schema_and_table_filters() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let fetcher = sqlite_fetcher(&sqlite_fixture(temp.path())).await;
+
+        let rows = fetcher
+            .fetch_columns(&ColumnInventoryFilter {
+                schemas: Some(vec!["main".to_string()]),
+                tables: Some(vec!["users".to_string()]),
+            })
+            .await
+            .expect("fetch filtered columns");
+        assert_eq!(
+            rows.iter()
+                .map(|row| row.column_name.as_str())
+                .collect::<Vec<_>>(),
+            ["id", "name"]
+        );
+
+        let rows = fetcher
+            .fetch_columns(&ColumnInventoryFilter {
+                schemas: Some(vec!["other".to_string()]),
+                tables: None,
+            })
+            .await
+            .expect("fetch mismatched schema");
+        assert!(rows.is_empty(), "non-'main' schema filter matches nothing");
+
+        let rows = fetcher
+            .fetch_columns(&ColumnInventoryFilter {
+                schemas: None,
+                tables: Some(Vec::new()),
+            })
+            .await
+            .expect("fetch with empty table list");
+        assert!(rows.is_empty(), "empty restriction short-circuits");
+    }
+}

--- a/crates/coral-engine/src/backends/database/mod.rs
+++ b/crates/coral-engine/src/backends/database/mod.rs
@@ -23,6 +23,7 @@ use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::logical_expr::TableType;
 use datafusion::prelude::SessionContext;
 use datafusion::sql::TableReference;
+use datafusion::sql::unparser::dialect::{Dialect, MySqlDialect, PostgreSqlDialect, SqliteDialect};
 use datafusion_table_providers::UnsupportedTypeAction;
 use datafusion_table_providers::sql::db_connection_pool::dbconnection::query_arrow;
 use datafusion_table_providers::sql::db_connection_pool::mysqlpool::MySQLConnectionPool;
@@ -199,7 +200,14 @@ impl DatabaseCatalogStrategy for PostgresConnectionSpec {
                             .with_unsupported_type_action(UnsupportedTypeAction::String))
                     }
                 },
-                |pool| database_catalog(pool, POSTGRES_RELATIONS_SQL, POSTGRES_COLUMNS_SQL),
+                |pool| {
+                    database_catalog(
+                        pool,
+                        POSTGRES_RELATIONS_SQL,
+                        POSTGRES_COLUMNS_SQL,
+                        Arc::new(PostgreSqlDialect {}),
+                    )
+                },
             )
             .await
     }
@@ -246,7 +254,14 @@ impl DatabaseCatalogStrategy for MySqlConnectionSpec {
                             .map_err(provider_error)
                     }
                 },
-                |pool| database_catalog(pool, MYSQL_RELATIONS_SQL, MYSQL_COLUMNS_SQL),
+                |pool| {
+                    database_catalog(
+                        pool,
+                        MYSQL_RELATIONS_SQL,
+                        MYSQL_COLUMNS_SQL,
+                        Arc::new(MySqlDialect {}),
+                    )
+                },
             )
             .await
     }
@@ -281,7 +296,13 @@ impl DatabaseCatalogStrategy for SqliteConnectionSpec {
             .build()
             .await
             .map_err(boxed_provider_error)?;
-        database_catalog(Arc::new(pool), SQLITE_RELATIONS_SQL, SQLITE_COLUMNS_SQL).await
+        database_catalog(
+            Arc::new(pool),
+            SQLITE_RELATIONS_SQL,
+            SQLITE_COLUMNS_SQL,
+            Arc::new(SqliteDialect {}),
+        )
+        .await
     }
 }
 
@@ -327,14 +348,18 @@ struct DatabaseRelation {
     table_type: TableType,
 }
 
+type SqlDialect = Arc<dyn Dialect + Send + Sync>;
+
 async fn database_catalog<T: 'static, P: 'static>(
     pool: Pool<T, P>,
     inventory_sql: &str,
     columns_sql: &'static str,
+    dialect: SqlDialect,
 ) -> DataFusionResult<DatabaseCatalog> {
     let relations = load_database_inventory(&pool, inventory_sql).await?;
-    let provider =
-        Arc::new(CoralDatabaseCatalogProvider::new(&pool, &relations)) as Arc<dyn CatalogProvider>;
+    let provider = Arc::new(CoralDatabaseCatalogProvider::new(
+        &pool, &relations, &dialect,
+    )) as Arc<dyn CatalogProvider>;
     let column_fetcher = PooledColumnFetcher::new(&pool, columns_sql);
     Ok(DatabaseCatalog {
         provider,
@@ -405,7 +430,11 @@ struct CoralDatabaseCatalogProvider {
 }
 
 impl CoralDatabaseCatalogProvider {
-    fn new<T: 'static, P: 'static>(pool: &Pool<T, P>, relations: &[DatabaseRelation]) -> Self {
+    fn new<T: 'static, P: 'static>(
+        pool: &Pool<T, P>,
+        relations: &[DatabaseRelation],
+        dialect: &SqlDialect,
+    ) -> Self {
         let mut by_schema = BTreeMap::<String, BTreeMap<String, TableType>>::new();
         for relation in relations {
             by_schema
@@ -420,6 +449,7 @@ impl CoralDatabaseCatalogProvider {
                     schema_name: schema_name.clone(),
                     tables,
                     pool: Arc::clone(pool),
+                    dialect: Arc::clone(dialect),
                 };
                 (schema_name, Arc::new(provider) as Arc<dyn SchemaProvider>)
             })
@@ -451,6 +481,7 @@ struct CoralDatabaseSchemaProvider<T: 'static, P: 'static> {
     schema_name: String,
     tables: BTreeMap<String, TableType>,
     pool: Pool<T, P>,
+    dialect: SqlDialect,
 }
 
 impl<T: 'static, P: 'static> fmt::Debug for CoralDatabaseSchemaProvider<T, P> {
@@ -479,7 +510,10 @@ impl<T: 'static, P: 'static> SchemaProvider for CoralDatabaseSchemaProvider<T, P
             TableReference::partial(self.schema_name.clone(), name.to_string()),
         )
         .await
-        .map(|table| Some(Arc::new(table) as Arc<dyn TableProvider>))
+        .map(|table| {
+            let table = table.with_dialect(Arc::clone(&self.dialect));
+            Some(Arc::new(table) as Arc<dyn TableProvider>)
+        })
         .map_err(provider_error)
     }
 

--- a/crates/coral-engine/src/backends/database/mod.rs
+++ b/crates/coral-engine/src/backends/database/mod.rs
@@ -1,5 +1,6 @@
 //! Relational database backend registration through `datafusion-table-providers`.
 
+mod columns;
 mod pool_cache;
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -32,12 +33,15 @@ use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
 use datafusion_table_providers::util::secrets::to_secret_map;
 use futures::TryStreamExt as _;
 
+use self::columns::{
+    MYSQL_COLUMNS_SQL, POSTGRES_COLUMNS_SQL, PooledColumnFetcher, SQLITE_COLUMNS_SQL,
+};
 use self::pool_cache::{PoolCache, PoolKey};
 use crate::backends::shared::template::{RenderContext, render_template};
 use crate::backends::{
     BackendCatalogRegistration, BackendCompileRequest, BackendRegistration,
-    BackendRegistrationContext, CompiledBackendSource, RegisteredSource, RegisteredTable,
-    SourceQualifiedName, build_registered_inputs,
+    BackendRegistrationContext, CompiledBackendSource, DatabaseColumnFetcher, RegisteredSource,
+    RegisteredTable, SourceQualifiedName, build_registered_inputs,
 };
 
 const REMOTE_DATABASE_REGISTRATION_TIMEOUT: Duration = Duration::from_secs(10);
@@ -123,6 +127,7 @@ impl CompiledBackendSource for CompiledDatabaseSource {
                 catalogs: vec![BackendCatalogRegistration {
                     catalog: database_catalog.provider,
                     source,
+                    column_fetcher: database_catalog.column_fetcher,
                 }],
             })
         };
@@ -194,7 +199,7 @@ impl DatabaseCatalogStrategy for PostgresConnectionSpec {
                             .with_unsupported_type_action(UnsupportedTypeAction::String))
                     }
                 },
-                |pool| database_catalog(pool, POSTGRES_RELATIONS_SQL),
+                |pool| database_catalog(pool, POSTGRES_RELATIONS_SQL, POSTGRES_COLUMNS_SQL),
             )
             .await
     }
@@ -241,7 +246,7 @@ impl DatabaseCatalogStrategy for MySqlConnectionSpec {
                             .map_err(provider_error)
                     }
                 },
-                |pool| database_catalog(pool, MYSQL_RELATIONS_SQL),
+                |pool| database_catalog(pool, MYSQL_RELATIONS_SQL, MYSQL_COLUMNS_SQL),
             )
             .await
     }
@@ -276,7 +281,7 @@ impl DatabaseCatalogStrategy for SqliteConnectionSpec {
             .build()
             .await
             .map_err(boxed_provider_error)?;
-        database_catalog(Arc::new(pool), SQLITE_RELATIONS_SQL).await
+        database_catalog(Arc::new(pool), SQLITE_RELATIONS_SQL, SQLITE_COLUMNS_SQL).await
     }
 }
 
@@ -312,6 +317,7 @@ static MYSQL_POOLS: LazyLock<PoolCache<MySQLConnectionPool>> = LazyLock::new(Poo
 struct DatabaseCatalog {
     provider: Arc<dyn CatalogProvider>,
     relations: Vec<DatabaseRelation>,
+    column_fetcher: Arc<dyn DatabaseColumnFetcher>,
 }
 
 #[derive(Clone, Debug)]
@@ -324,13 +330,16 @@ struct DatabaseRelation {
 async fn database_catalog<T: 'static, P: 'static>(
     pool: Pool<T, P>,
     inventory_sql: &str,
+    columns_sql: &'static str,
 ) -> DataFusionResult<DatabaseCatalog> {
     let relations = load_database_inventory(&pool, inventory_sql).await?;
     let provider =
         Arc::new(CoralDatabaseCatalogProvider::new(&pool, &relations)) as Arc<dyn CatalogProvider>;
+    let column_fetcher = PooledColumnFetcher::new(&pool, columns_sql);
     Ok(DatabaseCatalog {
         provider,
         relations,
+        column_fetcher,
     })
 }
 

--- a/crates/coral-engine/src/backends/database/mod.rs
+++ b/crates/coral-engine/src/backends/database/mod.rs
@@ -1,9 +1,11 @@
 //! Relational database backend registration through `datafusion-table-providers`.
 
+mod pool_cache;
+
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -30,6 +32,7 @@ use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
 use datafusion_table_providers::util::secrets::to_secret_map;
 use futures::TryStreamExt as _;
 
+use self::pool_cache::{PoolCache, PoolKey};
 use crate::backends::shared::template::{RenderContext, render_template};
 use crate::backends::{
     BackendCatalogRegistration, BackendCompileRequest, BackendRegistration,
@@ -178,12 +181,22 @@ impl DatabaseCatalogStrategy for PostgresConnectionSpec {
         if let Some(sslmode) = self.sslmode.as_ref() {
             params.insert("sslmode".to_string(), render_template(sslmode, context)?);
         }
-        let pool = PostgresConnectionPool::new(to_secret_map(params))
+        POSTGRES_POOLS
+            .run(
+                PoolKey::new(self.provider_name(), &params),
+                || {
+                    let params = params.clone();
+                    async move {
+                        Ok(PostgresConnectionPool::new(to_secret_map(params))
+                            .await
+                            .map_err(provider_error)?
+                            // The MySQL adapter has no equivalent unsupported-type policy.
+                            .with_unsupported_type_action(UnsupportedTypeAction::String))
+                    }
+                },
+                |pool| database_catalog(pool, POSTGRES_RELATIONS_SQL),
+            )
             .await
-            .map_err(provider_error)?
-            // The MySQL adapter has no equivalent unsupported-type policy.
-            .with_unsupported_type_action(UnsupportedTypeAction::String);
-        database_catalog(Arc::new(pool), POSTGRES_RELATIONS_SQL).await
     }
 }
 
@@ -217,10 +230,20 @@ impl DatabaseCatalogStrategy for MySqlConnectionSpec {
             }
         };
         params.insert("tcp_port".to_string(), tcp_port.to_string());
-        let pool = MySQLConnectionPool::new(to_secret_map(params))
+        MYSQL_POOLS
+            .run(
+                PoolKey::new(self.provider_name(), &params),
+                || {
+                    let params = params.clone();
+                    async move {
+                        MySQLConnectionPool::new(to_secret_map(params))
+                            .await
+                            .map_err(provider_error)
+                    }
+                },
+                |pool| database_catalog(pool, MYSQL_RELATIONS_SQL),
+            )
             .await
-            .map_err(provider_error)?;
-        database_catalog(Arc::new(pool), MYSQL_RELATIONS_SQL).await
     }
 }
 
@@ -279,6 +302,12 @@ FROM sqlite_master
 WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'";
 
 type Pool<T, P> = Arc<dyn DbConnectionPool<T, P> + Send + Sync>;
+
+/// Remote database pools cached across query runtime builds. `SQLite` pools are
+/// deliberately not cached: building one is a local file open, and caching
+/// would pin deleted or replaced database files.
+static POSTGRES_POOLS: LazyLock<PoolCache<PostgresConnectionPool>> = LazyLock::new(PoolCache::new);
+static MYSQL_POOLS: LazyLock<PoolCache<MySQLConnectionPool>> = LazyLock::new(PoolCache::new);
 
 struct DatabaseCatalog {
     provider: Arc<dyn CatalogProvider>,

--- a/crates/coral-engine/src/backends/database/pool_cache.rs
+++ b/crates/coral-engine/src/backends/database/pool_cache.rs
@@ -1,0 +1,319 @@
+//! Cross-query connection pool caching for remote database sources.
+//!
+//! Query runtimes are rebuilt per query, so without caching every query pays
+//! a fresh connection handshake per database source. This module keeps pools
+//! alive across runtime builds, keyed by the resolved connection parameters.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use moka::future::Cache;
+use sha2::{Digest as _, Sha256};
+
+/// How long an unused pool stays cached before its connections are released.
+const POOL_TIME_TO_IDLE: Duration = Duration::from_mins(10);
+
+/// Upper bound on concurrently cached pools per provider.
+const POOL_CAPACITY: u64 = 32;
+
+/// Opaque cache key derived from resolved connection parameters.
+///
+/// Keys hash the parameters instead of storing them so plaintext credentials
+/// never sit in cache state. Changing any parameter (including credentials)
+/// produces a new key, so superseded pools idle out without an explicit
+/// invalidation API.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(super) struct PoolKey([u8; 32]);
+
+impl PoolKey {
+    pub(super) fn new(provider: &str, params: &HashMap<String, String>) -> Self {
+        let mut sorted = params.iter().collect::<Vec<_>>();
+        sorted.sort();
+        let mut hasher = Sha256::new();
+        hash_component(&mut hasher, provider);
+        for (key, value) in sorted {
+            hash_component(&mut hasher, key);
+            hash_component(&mut hasher, value);
+        }
+        Self(hasher.finalize().into())
+    }
+}
+
+/// Length-prefix each component so adjacent values cannot collide
+/// (e.g. `{"ab": "c"}` vs `{"a": "bc"}`).
+fn hash_component(hasher: &mut Sha256, value: &str) {
+    hasher.update((value.len() as u64).to_le_bytes());
+    hasher.update(value.as_bytes());
+}
+
+/// Process-wide cache of connection pools for one database provider.
+pub(super) struct PoolCache<P> {
+    pools: Cache<PoolKey, Arc<P>>,
+}
+
+impl<P: Send + Sync + 'static> PoolCache<P> {
+    pub(super) fn new() -> Self {
+        Self {
+            pools: Cache::builder()
+                .max_capacity(POOL_CAPACITY)
+                .time_to_idle(POOL_TIME_TO_IDLE)
+                .build(),
+        }
+    }
+
+    /// Runs `operation` against the pool cached under `key`, building the
+    /// pool on a miss. Concurrent callers for the same key coalesce into one
+    /// build. If `operation` fails against a pool that predates this call
+    /// (e.g. the database restarted and its connections are dead), the stale
+    /// entry is dropped and the operation retries once against a fresh pool.
+    pub(super) async fn run<F, FutP, Op, FutR, R>(
+        &self,
+        key: PoolKey,
+        build: F,
+        operation: Op,
+    ) -> DataFusionResult<R>
+    where
+        F: Fn() -> FutP,
+        FutP: Future<Output = DataFusionResult<P>>,
+        Op: Fn(Arc<P>) -> FutR,
+        FutR: Future<Output = DataFusionResult<R>>,
+    {
+        let (pool, built_here) = self.get_or_build(&key, &build).await?;
+        match operation(pool).await {
+            Ok(value) => Ok(value),
+            Err(error) if !built_here => {
+                tracing::debug!(
+                    detail = %error,
+                    "cached database pool failed; rebuilding connection pool"
+                );
+                self.pools.invalidate(&key).await;
+                let (pool, _) = self.get_or_build(&key, &build).await?;
+                operation(pool).await
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn get_or_build<F, FutP>(
+        &self,
+        key: &PoolKey,
+        build: &F,
+    ) -> DataFusionResult<(Arc<P>, bool)>
+    where
+        F: Fn() -> FutP,
+        FutP: Future<Output = DataFusionResult<P>>,
+    {
+        let built_here = AtomicBool::new(false);
+        let pool = self
+            .pools
+            .try_get_with(key.clone(), async {
+                built_here.store(true, Ordering::Relaxed);
+                build().await.map(Arc::new)
+            })
+            .await
+            .map_err(unwrap_shared_error)?;
+        Ok((pool, built_here.load(Ordering::Relaxed)))
+    }
+}
+
+/// Moka shares one init error across coalesced waiters; unwrap it when this
+/// caller is the only holder.
+fn unwrap_shared_error(error: Arc<DataFusionError>) -> DataFusionError {
+    Arc::try_unwrap(error).unwrap_or_else(DataFusionError::Shared)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+
+    use super::*;
+
+    fn params(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn pool_key_ignores_parameter_order() {
+        let left = PoolKey::new("postgres", &params(&[("host", "db"), ("user", "coral")]));
+        let right = PoolKey::new("postgres", &params(&[("user", "coral"), ("host", "db")]));
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn pool_key_distinguishes_providers_and_parameters() {
+        let base = PoolKey::new("postgres", &params(&[("host", "db")]));
+        assert_ne!(base, PoolKey::new("mysql", &params(&[("host", "db")])));
+        assert_ne!(
+            base,
+            PoolKey::new("postgres", &params(&[("host", "other")]))
+        );
+        assert_ne!(base, PoolKey::new("postgres", &params(&[("pass", "db")])));
+    }
+
+    #[test]
+    fn pool_key_distinguishes_component_boundaries() {
+        let left = PoolKey::new("postgres", &params(&[("ab", "c")]));
+        let right = PoolKey::new("postgres", &params(&[("a", "bc")]));
+        assert_ne!(left, right);
+    }
+
+    struct FakePool {
+        generation: usize,
+    }
+
+    fn counting_build(
+        builds: &AtomicUsize,
+    ) -> impl Fn() -> std::future::Ready<DataFusionResult<FakePool>> + '_ {
+        move || {
+            std::future::ready(Ok(FakePool {
+                generation: builds.fetch_add(1, Ordering::SeqCst) + 1,
+            }))
+        }
+    }
+
+    fn test_key(name: &str) -> PoolKey {
+        PoolKey::new("test", &params(&[("name", name)]))
+    }
+
+    #[tokio::test]
+    async fn run_reuses_cached_pool_across_calls() {
+        let cache = PoolCache::<FakePool>::new();
+        let builds = AtomicUsize::new(0);
+        for _ in 0..3 {
+            let generation = cache
+                .run(test_key("reuse"), counting_build(&builds), |pool| {
+                    std::future::ready(Ok(pool.generation))
+                })
+                .await
+                .expect("cached run succeeds");
+            assert_eq!(generation, 1);
+        }
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn run_coalesces_concurrent_builds() {
+        let cache = Arc::new(PoolCache::<FakePool>::new());
+        let builds = Arc::new(AtomicUsize::new(0));
+        let tasks = (0..8)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let builds = Arc::clone(&builds);
+                tokio::spawn(async move {
+                    cache
+                        .run(
+                            test_key("coalesce"),
+                            || {
+                                let builds = Arc::clone(&builds);
+                                async move {
+                                    tokio::time::sleep(Duration::from_millis(10)).await;
+                                    Ok(FakePool {
+                                        generation: builds.fetch_add(1, Ordering::SeqCst) + 1,
+                                    })
+                                }
+                            },
+                            |pool| std::future::ready(Ok(pool.generation)),
+                        )
+                        .await
+                })
+            })
+            .collect::<Vec<_>>();
+        for task in tasks {
+            let generation = task.await.expect("join").expect("run succeeds");
+            assert_eq!(generation, 1);
+        }
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn run_retries_once_against_fresh_pool_when_cached_pool_fails() {
+        let cache = PoolCache::<FakePool>::new();
+        let builds = AtomicUsize::new(0);
+
+        cache
+            .run(test_key("stale"), counting_build(&builds), |_pool| {
+                std::future::ready(Ok(()))
+            })
+            .await
+            .expect("first run caches the pool");
+
+        // The cached generation-1 pool now fails; the retry must observe a
+        // freshly built generation-2 pool.
+        let generation = cache
+            .run(test_key("stale"), counting_build(&builds), |pool| {
+                std::future::ready(if pool.generation == 1 {
+                    Err(DataFusionError::Execution("connection reset".to_string()))
+                } else {
+                    Ok(pool.generation)
+                })
+            })
+            .await
+            .expect("retry succeeds against a fresh pool");
+        assert_eq!(generation, 2);
+        assert_eq!(builds.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn run_does_not_retry_when_the_pool_was_built_by_this_call() {
+        let cache = PoolCache::<FakePool>::new();
+        let builds = AtomicUsize::new(0);
+        let operations = AtomicUsize::new(0);
+
+        let error = cache
+            .run(
+                test_key("fresh-failure"),
+                counting_build(&builds),
+                |_pool| {
+                    operations.fetch_add(1, Ordering::SeqCst);
+                    std::future::ready(Err::<(), _>(DataFusionError::Execution(
+                        "authentication failed".to_string(),
+                    )))
+                },
+            )
+            .await
+            .expect_err("fresh pool failure propagates");
+        assert!(error.to_string().contains("authentication failed"));
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
+        assert_eq!(operations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn build_errors_are_not_cached() {
+        let cache = PoolCache::<FakePool>::new();
+        let attempts = AtomicUsize::new(0);
+        let build = || {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            std::future::ready(if attempt == 0 {
+                Err(DataFusionError::Execution("dns failure".to_string()))
+            } else {
+                Ok(FakePool {
+                    generation: attempt,
+                })
+            })
+        };
+
+        let error = cache
+            .run(test_key("build-error"), build, |pool| {
+                std::future::ready(Ok(pool.generation))
+            })
+            .await
+            .expect_err("first build fails");
+        assert!(error.to_string().contains("dns failure"));
+
+        let generation = cache
+            .run(test_key("build-error"), build, |pool| {
+                std::future::ready(Ok(pool.generation))
+            })
+            .await
+            .expect("second build succeeds");
+        assert_eq!(generation, 1);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+}

--- a/crates/coral-engine/src/backends/file/tests.rs
+++ b/crates/coral-engine/src/backends/file/tests.rs
@@ -270,9 +270,13 @@ async fn parquet_provider_exposes_inferred_schema_in_coral_columns() {
 
     let active_sources = register_sources_blocking(&ctx, compile_sources(vec![manifest]))
         .expect("file source should register");
-    catalog::register(&ctx, &active_sources.active_sources, &[])
-        .await
-        .expect("metadata tables should register");
+    catalog::register(
+        &ctx,
+        &active_sources.active_sources,
+        &active_sources.column_fetchers,
+        &[],
+    )
+    .expect("metadata tables should register");
 
     let batches = ctx
         .sql(

--- a/crates/coral-engine/src/backends/file/tests.rs
+++ b/crates/coral-engine/src/backends/file/tests.rs
@@ -271,6 +271,7 @@ async fn parquet_provider_exposes_inferred_schema_in_coral_columns() {
     let active_sources = register_sources_blocking(&ctx, compile_sources(vec![manifest]))
         .expect("file source should register");
     catalog::register(&ctx, &active_sources.active_sources, &[])
+        .await
         .expect("metadata tables should register");
 
     let batches = ctx

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -487,9 +487,13 @@ async fn register_test_sources_with_catalog(
     sources: Vec<CompiledQuerySource>,
 ) {
     let registration = register_sources_blocking(ctx, sources).expect("mcp source should register");
-    catalog::register(ctx, &registration.active_sources, &[])
-        .await
-        .expect("catalog should register");
+    catalog::register(
+        ctx,
+        &registration.active_sources,
+        &registration.column_fetchers,
+        &[],
+    )
+    .expect("catalog should register");
     let source_functions = SourceFunctionRegistry::new(
         registration
             .active_sources

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -482,9 +482,14 @@ fn register_test_sources(ctx: &SessionContext, sources: Vec<CompiledQuerySource>
         .expect("source function planner should register");
 }
 
-fn register_test_sources_with_catalog(ctx: &SessionContext, sources: Vec<CompiledQuerySource>) {
+async fn register_test_sources_with_catalog(
+    ctx: &SessionContext,
+    sources: Vec<CompiledQuerySource>,
+) {
     let registration = register_sources_blocking(ctx, sources).expect("mcp source should register");
-    catalog::register(ctx, &registration.active_sources, &[]).expect("catalog should register");
+    catalog::register(ctx, &registration.active_sources, &[])
+        .await
+        .expect("catalog should register");
     let source_functions = SourceFunctionRegistry::new(
         registration
             .active_sources
@@ -1643,7 +1648,7 @@ async fn mcp_table_appears_in_catalog_metadata() {
     let caller = Arc::new(FakeMcpTableCaller {
         calls: Mutex::new(Vec::new()),
     });
-    register_test_sources_with_catalog(&ctx, compile_sources(mcp_table_manifest(), caller));
+    register_test_sources_with_catalog(&ctx, compile_sources(mcp_table_manifest(), caller)).await;
 
     let batches = ctx
         .sql(

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -81,12 +81,13 @@ pub(crate) mod common;
 mod composite;
 pub(crate) use common::{
     BackendCatalogRegistration, BackendCompileRequest, BackendRegistration,
-    BackendRegistrationContext, BackendSchemaRegistration, CompiledBackendSource, RegisteredInput,
-    RegisteredSource, RegisteredTable, RegisteredTableFunction, RegisteredTableFunctionArgument,
-    SourceFunctionProviderFactory, SourceQualifiedName, build_registered_inputs,
-    build_registered_table, build_registered_table_function, registered_columns_from_schema,
-    registered_columns_from_specs, required_filter_names, schema_from_columns,
-    validate_lookup_key_filter_backend_support,
+    BackendRegistrationContext, BackendSchemaRegistration, CatalogColumnFetcher,
+    ColumnInventoryFilter, CompiledBackendSource, DatabaseColumnFetcher, DatabaseColumnRow,
+    RegisteredInput, RegisteredSource, RegisteredTable, RegisteredTableFunction,
+    RegisteredTableFunctionArgument, SourceFunctionProviderFactory, SourceQualifiedName,
+    build_registered_inputs, build_registered_table, build_registered_table_function,
+    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
+    schema_from_columns, validate_lookup_key_filter_backend_support,
 };
 
 pub(crate) mod database;

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -7,7 +7,8 @@ use coral_spec::{SearchLimitsSpec, SourceTableFunctionKind};
 pub struct ColumnInfo {
     /// Column name.
     pub name: String,
-    /// Data type rendered in `Arrow`/`DataFusion` string form.
+    /// Data type rendered as text: `Arrow`/`DataFusion` string form for
+    /// static sources, the provider-native type name for database catalogs.
     pub data_type: String,
     /// Whether the column can contain null values.
     pub nullable: bool,

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -101,37 +101,52 @@ pub struct PreparedQueryRuntime {
 
 impl PreparedQueryRuntime {
     /// Lists queryable tables from this prepared runtime.
-    #[must_use]
-    pub fn list_tables(
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if live catalog metadata cannot be collected.
+    pub async fn list_tables(
         &self,
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
-    ) -> Vec<TableInfo> {
-        self.inner
-            .list_tables(catalog_filter, schema_filter, table_filter)
+    ) -> Result<Vec<TableInfo>, CoreError> {
+        Box::pin(
+            self.inner
+                .list_tables(catalog_filter, schema_filter, table_filter),
+        )
+        .await
     }
 
     /// Lists queryable catalog metadata from this prepared runtime.
-    #[must_use]
-    pub fn list_catalog(
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if live catalog metadata cannot be collected.
+    pub async fn list_catalog(
         &self,
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
-    ) -> CatalogInfo {
-        self.inner.catalog_info(catalog_filter, schema_filter)
+    ) -> Result<CatalogInfo, CoreError> {
+        Box::pin(self.inner.catalog_info(catalog_filter, schema_filter)).await
     }
 
     /// Describes one table from this prepared runtime.
-    #[must_use]
-    pub fn describe_table(
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if live catalog metadata cannot be collected.
+    pub async fn describe_table(
         &self,
         catalog_name: Option<&str>,
         schema_name: &str,
         table_name: &str,
-    ) -> DescribeTableInfo {
-        self.inner
-            .describe_table(catalog_name, schema_name, table_name)
+    ) -> Result<DescribeTableInfo, CoreError> {
+        Box::pin(
+            self.inner
+                .describe_table(catalog_name, schema_name, table_name),
+        )
+        .await
     }
 
     /// Infers typed signatures for multiple UDFs against this runtime.
@@ -260,11 +275,10 @@ impl CoralQuery {
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, CoreError> {
-        Ok(Self::prepare(sources, runtime).await?.list_tables(
-            catalog_filter,
-            schema_filter,
-            table_filter,
-        ))
+        Self::prepare(sources, runtime)
+            .await?
+            .list_tables(catalog_filter, schema_filter, table_filter)
+            .await
     }
 
     /// Lists queryable catalog metadata from the provided source set.
@@ -285,9 +299,10 @@ impl CoralQuery {
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
     ) -> Result<CatalogInfo, CoreError> {
-        Ok(Self::prepare(sources, runtime)
+        Self::prepare(sources, runtime)
             .await?
-            .list_catalog(catalog_filter, schema_filter))
+            .list_catalog(catalog_filter, schema_filter)
+            .await
     }
 
     /// Describes one table or returns lightweight table metadata for missing-table help.
@@ -307,11 +322,10 @@ impl CoralQuery {
         schema_name: &str,
         table_name: &str,
     ) -> Result<DescribeTableInfo, CoreError> {
-        Ok(Self::prepare(sources, runtime).await?.describe_table(
-            catalog_name,
-            schema_name,
-            table_name,
-        ))
+        Self::prepare(sources, runtime)
+            .await?
+            .describe_table(catalog_name, schema_name, table_name)
+            .await
     }
 
     /// Executes one `SQL` statement over the provided source set.
@@ -464,7 +478,9 @@ impl CoralQuery {
         let source_name = source.source_name();
         let schema_names = source.schema_names();
         let catalog_names = source.catalog_names();
-        let catalog = query_runtime.catalog_info_for_sources(&schema_names, &catalog_names);
+        let catalog = query_runtime
+            .catalog_info_for_sources(&schema_names, &catalog_names)
+            .await?;
         if catalog.tables.is_empty() && catalog.table_functions.is_empty() {
             if let Some(failure) = query_runtime.registration_failure(source_name) {
                 return Err(CoreError::FailedPrecondition(failure.detail.clone()));

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -304,7 +304,7 @@ const COLUMNS_COLUMNS: &[SystemColumnDefinition] = &[
         name: "data_type",
         data_type: "Utf8",
         nullable: false,
-        description: "Column data type rendered in Arrow/DataFusion string form.",
+        description: "Column data type: Arrow/DataFusion string form for static sources; the provider-native type name for database catalogs.",
     },
     SystemColumnDefinition {
         name: "is_nullable",

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use coral_spec::{ManifestInputKind, SearchLimitsSpec, SourceTableFunctionKind};
 use datafusion::arrow::array::{ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
-use datafusion::datasource::MemTable;
+use datafusion::catalog::{MemorySchemaProvider, SchemaProvider};
+use datafusion::datasource::{MemTable, ViewTable};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::prelude::SessionContext;
 use serde::Serialize;
@@ -20,6 +21,7 @@ use crate::{
 
 /// Schema name for source metadata tables such as `coral.tables`.
 pub(crate) const SYSTEM_SCHEMA: &str = "coral";
+const STATIC_COLUMNS_TABLE: &str = "_columns_static";
 
 /// Catalog-only metadata for one SQL table-function surface.
 #[derive(Debug, Clone)]
@@ -54,7 +56,7 @@ pub(crate) struct CatalogTableFunctionResultColumn {
 ///
 /// Returns a `DataFusionError` if the catalog is missing or the metadata
 /// tables cannot be materialized.
-pub(crate) fn register(
+pub(crate) async fn register(
     ctx: &SessionContext,
     active_sources: &[RegisteredSource],
     catalog_only_table_functions: &[CatalogTableFunction],
@@ -69,7 +71,7 @@ pub(crate) fn register(
     let mut meta_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
         HashMap::new();
     meta_tables.insert("tables".to_string(), Arc::new(tables_table));
-    meta_tables.insert("columns".to_string(), Arc::new(columns_table));
+    meta_tables.insert(STATIC_COLUMNS_TABLE.to_string(), Arc::new(columns_table));
     meta_tables.insert("filters".to_string(), Arc::new(filters_table));
     meta_tables.insert("inputs".to_string(), Arc::new(inputs_table));
     meta_tables.insert(
@@ -80,12 +82,65 @@ pub(crate) fn register(
     let catalog = ctx
         .catalog("datafusion")
         .ok_or_else(|| DataFusionError::Plan("catalog 'datafusion' not found".to_string()))?;
+    let planning_schema = Arc::new(MemorySchemaProvider::new());
+    for (name, table) in &meta_tables {
+        planning_schema.register_table(name.clone(), table.clone())?;
+    }
+    catalog.register_schema(SYSTEM_SCHEMA, planning_schema)?;
+
+    let catalog_names = active_sources
+        .iter()
+        .filter_map(|source| source.qualified_name.catalog_name())
+        .collect::<Vec<_>>();
+    let columns_view = view_table_for_sql(ctx, &columns_view_sql(&catalog_names)).await?;
+    meta_tables.insert("columns".to_string(), Arc::new(columns_view));
+
     catalog.register_schema(
         SYSTEM_SCHEMA,
         Arc::new(StaticSchemaProvider::new(meta_tables)),
     )?;
 
     Ok(())
+}
+
+async fn view_table_for_sql(ctx: &SessionContext, sql: &str) -> Result<ViewTable> {
+    let df = ctx.sql(sql).await?;
+    let (_state, plan) = df.into_parts();
+    Ok(ViewTable::new(plan, Some(sql.to_string())))
+}
+
+fn columns_view_sql(catalog_names: &[&str]) -> String {
+    let static_sql = format!(
+        "SELECT schema_name, table_name, ordinal_position, column_name, data_type, \
+         is_nullable, is_virtual, is_required_filter, description, filter_mode, catalog_name \
+         FROM {SYSTEM_SCHEMA}.{STATIC_COLUMNS_TABLE}"
+    );
+    if catalog_names.is_empty() {
+        return static_sql;
+    }
+    format!(
+        "{static_sql} UNION ALL \
+         SELECT table_schema AS schema_name, table_name, \
+         CAST(ordinal_position AS INT) AS ordinal_position, column_name, data_type, \
+         is_nullable = 'YES' AS is_nullable, false AS is_virtual, \
+         false AS is_required_filter, '' AS description, '' AS filter_mode, \
+         table_catalog AS catalog_name \
+         FROM information_schema.columns \
+         WHERE table_catalog IN ({}) AND table_schema <> 'information_schema'",
+        sql_string_list(catalog_names)
+    )
+}
+
+fn sql_string_list(values: &[&str]) -> String {
+    values
+        .iter()
+        .map(|value| sql_string_literal(value))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn sql_string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
 }
 
 fn build_table_functions_table(
@@ -544,9 +599,9 @@ fn system_table_infos() -> Vec<TableInfo> {
         .collect()
 }
 
-/// Collect typed query-visible table metadata for the active source set.
+/// Collect static query-visible table metadata for the active source set.
 #[must_use]
-pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableInfo> {
+pub(crate) fn collect_static_tables(active_sources: &[RegisteredSource]) -> Vec<TableInfo> {
     let mut tables = system_table_infos();
     tables.extend(active_sources.iter().flat_map(|source| {
         source.tables.iter().map(move |table| TableInfo {
@@ -584,6 +639,209 @@ pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableIn
         ))
     });
     tables
+}
+
+/// Collect typed table metadata by querying the public `coral` catalog views.
+pub(crate) async fn collect_tables(
+    ctx: &SessionContext,
+    catalog_filter: Option<&str>,
+    schema_filter: Option<&str>,
+    table_filter: Option<&str>,
+) -> Result<Vec<TableInfo>> {
+    let mut tables = collect_table_metadata(ctx, catalog_filter, schema_filter, table_filter)
+        .await?
+        .into_iter()
+        .map(|table| {
+            (
+                (
+                    table.catalog_name.clone(),
+                    table.schema_name.clone(),
+                    table.table_name.clone(),
+                ),
+                table,
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    let sql = catalog_columns_query(catalog_filter, schema_filter, table_filter);
+    let batches = ctx.sql(&sql).await?.collect().await?;
+    apply_column_infos_from_batches(&mut tables, &batches)?;
+    let mut tables = tables.into_values().collect::<Vec<_>>();
+    sort_tables(&mut tables);
+    for table in &mut tables {
+        table.columns.sort_by_key(|column| column.ordinal_position);
+    }
+    Ok(tables)
+}
+
+/// Collect table metadata without forcing lazy column discovery.
+pub(crate) async fn collect_table_metadata(
+    ctx: &SessionContext,
+    catalog_filter: Option<&str>,
+    schema_filter: Option<&str>,
+    table_filter: Option<&str>,
+) -> Result<Vec<TableInfo>> {
+    let sql = catalog_tables_query(catalog_filter, schema_filter, table_filter);
+    let batches = ctx.sql(&sql).await?.collect().await?;
+    let mut tables = collect_table_infos_from_batches(&batches)?;
+    sort_tables(&mut tables);
+    Ok(tables)
+}
+
+fn catalog_tables_query(
+    catalog_filter: Option<&str>,
+    schema_filter: Option<&str>,
+    table_filter: Option<&str>,
+) -> String {
+    let mut sql = "SELECT catalog_name, schema_name, table_name, description, guide, \
+                   required_filters FROM coral.tables"
+        .to_string();
+    append_catalog_filter(&mut sql, catalog_filter, schema_filter, table_filter);
+    sql
+}
+
+fn catalog_columns_query(
+    catalog_filter: Option<&str>,
+    schema_filter: Option<&str>,
+    table_filter: Option<&str>,
+) -> String {
+    let mut sql = "SELECT catalog_name, schema_name, table_name, ordinal_position, column_name, \
+                   data_type, is_nullable, is_virtual, is_required_filter, description \
+                   FROM coral.columns"
+        .to_string();
+    append_catalog_filter(&mut sql, catalog_filter, schema_filter, table_filter);
+    sql
+}
+
+fn append_catalog_filter(
+    sql: &mut String,
+    catalog_filter: Option<&str>,
+    schema_filter: Option<&str>,
+    table_filter: Option<&str>,
+) {
+    let mut predicates = Vec::new();
+    if let Some(value) = catalog_filter {
+        predicates.push(format!("catalog_name = {}", sql_string_literal(value)));
+    }
+    if let Some(value) = schema_filter {
+        predicates.push(format!("schema_name = {}", sql_string_literal(value)));
+    }
+    if let Some(value) = table_filter {
+        predicates.push(format!("table_name = {}", sql_string_literal(value)));
+    }
+    if !predicates.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&predicates.join(" AND "));
+    }
+}
+
+fn collect_table_infos_from_batches(batches: &[RecordBatch]) -> Result<Vec<TableInfo>> {
+    let mut tables = Vec::new();
+    for batch in batches {
+        let catalog_names = string_array(batch, "catalog_name")?;
+        let schema_names = string_array(batch, "schema_name")?;
+        let table_names = string_array(batch, "table_name")?;
+        let descriptions = string_array(batch, "description")?;
+        let guides = string_array(batch, "guide")?;
+        let required_filters = string_array(batch, "required_filters")?;
+        for row in 0..batch.num_rows() {
+            tables.push(TableInfo {
+                catalog_name: catalog_names.value(row).to_string(),
+                schema_name: schema_names.value(row).to_string(),
+                table_name: table_names.value(row).to_string(),
+                description: descriptions.value(row).to_string(),
+                guide: guides.value(row).to_string(),
+                columns: Vec::new(),
+                required_filters: split_required_filters(required_filters.value(row)),
+            });
+        }
+    }
+    Ok(tables)
+}
+
+type TableInfoByKey = HashMap<(String, String, String), TableInfo>;
+
+fn apply_column_infos_from_batches(
+    tables: &mut TableInfoByKey,
+    batches: &[RecordBatch],
+) -> Result<()> {
+    for batch in batches {
+        let catalog_names = string_array(batch, "catalog_name")?;
+        let schema_names = string_array(batch, "schema_name")?;
+        let table_names = string_array(batch, "table_name")?;
+        let positions = int32_array(batch, "ordinal_position")?;
+        let column_names = string_array(batch, "column_name")?;
+        let data_types = string_array(batch, "data_type")?;
+        let is_nullable = bool_array(batch, "is_nullable")?;
+        let is_virtual = bool_array(batch, "is_virtual")?;
+        let is_required_filter = bool_array(batch, "is_required_filter")?;
+        let descriptions = string_array(batch, "description")?;
+        for row in 0..batch.num_rows() {
+            let key = (
+                catalog_names.value(row).to_string(),
+                schema_names.value(row).to_string(),
+                table_names.value(row).to_string(),
+            );
+            let Some(table) = tables.get_mut(&key) else {
+                continue;
+            };
+            table.columns.push(ColumnInfo {
+                name: column_names.value(row).to_string(),
+                data_type: data_types.value(row).to_string(),
+                nullable: is_nullable.value(row),
+                is_virtual: is_virtual.value(row),
+                is_required_filter: is_required_filter.value(row),
+                description: descriptions.value(row).to_string(),
+                ordinal_position: u32::try_from(positions.value(row)).unwrap_or_default(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn string_array<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref::<StringArray>())
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!("coral catalog column '{name}' is not Utf8"))
+        })
+}
+
+fn int32_array<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a Int32Array> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref::<Int32Array>())
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!("coral catalog column '{name}' is not Int32"))
+        })
+}
+
+fn bool_array<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a BooleanArray> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref::<BooleanArray>())
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!("coral catalog column '{name}' is not Boolean"))
+        })
+}
+
+fn split_required_filters(value: &str) -> Vec<String> {
+    if value.is_empty() {
+        Vec::new()
+    } else {
+        value.split(',').map(ToString::to_string).collect()
+    }
+}
+
+fn sort_tables(tables: &mut [TableInfo]) {
+    tables.sort_by(|left, right| {
+        (&left.catalog_name, &left.schema_name, &left.table_name).cmp(&(
+            &right.catalog_name,
+            &right.schema_name,
+            &right.table_name,
+        ))
+    });
 }
 
 fn registered_table_schema_name(source: &RegisteredSource, table: &RegisteredTable) -> String {
@@ -1165,7 +1423,7 @@ mod tests {
     };
 
     use super::{
-        catalog_filter_rows, catalog_input_rows, collect_table_functions, collect_tables,
+        catalog_filter_rows, catalog_input_rows, collect_static_tables, collect_table_functions,
         source_catalog_column_rows,
     };
 
@@ -1213,7 +1471,7 @@ mod tests {
     fn catalog_source_metadata_keeps_catalog_and_schema_separate() {
         let sources = [catalog_source()];
 
-        let table = collect_tables(&sources)
+        let table = collect_static_tables(&sources)
             .into_iter()
             .find(|table| table.table_name == "orders")
             .expect("catalog table metadata");

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -1,18 +1,26 @@
 //! Registers the `coral` system schema for discoverable source metadata.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use coral_spec::{ManifestInputKind, SearchLimitsSpec, SourceTableFunctionKind};
 use datafusion::arrow::array::{ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray};
-use datafusion::arrow::datatypes::{DataType, Field, Schema};
-use datafusion::catalog::{MemorySchemaProvider, SchemaProvider};
-use datafusion::datasource::{MemTable, ViewTable};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::catalog::Session;
+use datafusion::datasource::{MemTable, TableProvider};
 use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown, TableType};
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
+use futures::future::join_all;
 use serde::Serialize;
 
-use crate::backends::{RegisteredSource, RegisteredTable, SourceQualifiedName};
+use crate::backends::shared::filter_expr::literal_to_string;
+use crate::backends::{
+    CatalogColumnFetcher, ColumnInventoryFilter, DatabaseColumnRow, RegisteredSource,
+    RegisteredTable, SourceQualifiedName,
+};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
     ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
@@ -21,7 +29,6 @@ use crate::{
 
 /// Schema name for source metadata tables such as `coral.tables`.
 pub(crate) const SYSTEM_SCHEMA: &str = "coral";
-const STATIC_COLUMNS_TABLE: &str = "_columns_static";
 
 /// Catalog-only metadata for one SQL table-function surface.
 #[derive(Debug, Clone)]
@@ -56,13 +63,14 @@ pub(crate) struct CatalogTableFunctionResultColumn {
 ///
 /// Returns a `DataFusionError` if the catalog is missing or the metadata
 /// tables cannot be materialized.
-pub(crate) async fn register(
+pub(crate) fn register(
     ctx: &SessionContext,
     active_sources: &[RegisteredSource],
+    column_fetchers: &[CatalogColumnFetcher],
     catalog_only_table_functions: &[CatalogTableFunction],
 ) -> Result<()> {
     let tables_table = build_tables_table(active_sources)?;
-    let columns_table = build_columns_table(active_sources)?;
+    let columns_table = build_columns_table(active_sources, column_fetchers)?;
     let filters_table = build_filters_table(active_sources)?;
     let inputs_table = build_inputs_table(active_sources)?;
     let table_functions_table =
@@ -71,7 +79,7 @@ pub(crate) async fn register(
     let mut meta_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
         HashMap::new();
     meta_tables.insert("tables".to_string(), Arc::new(tables_table));
-    meta_tables.insert(STATIC_COLUMNS_TABLE.to_string(), Arc::new(columns_table));
+    meta_tables.insert("columns".to_string(), Arc::new(columns_table));
     meta_tables.insert("filters".to_string(), Arc::new(filters_table));
     meta_tables.insert("inputs".to_string(), Arc::new(inputs_table));
     meta_tables.insert(
@@ -82,61 +90,12 @@ pub(crate) async fn register(
     let catalog = ctx
         .catalog("datafusion")
         .ok_or_else(|| DataFusionError::Plan("catalog 'datafusion' not found".to_string()))?;
-    let planning_schema = Arc::new(MemorySchemaProvider::new());
-    for (name, table) in &meta_tables {
-        planning_schema.register_table(name.clone(), table.clone())?;
-    }
-    catalog.register_schema(SYSTEM_SCHEMA, planning_schema)?;
-
-    let catalog_names = active_sources
-        .iter()
-        .filter_map(|source| source.qualified_name.catalog_name())
-        .collect::<Vec<_>>();
-    let columns_view = view_table_for_sql(ctx, &columns_view_sql(&catalog_names)).await?;
-    meta_tables.insert("columns".to_string(), Arc::new(columns_view));
-
     catalog.register_schema(
         SYSTEM_SCHEMA,
         Arc::new(StaticSchemaProvider::new(meta_tables)),
     )?;
 
     Ok(())
-}
-
-async fn view_table_for_sql(ctx: &SessionContext, sql: &str) -> Result<ViewTable> {
-    let df = ctx.sql(sql).await?;
-    let (_state, plan) = df.into_parts();
-    Ok(ViewTable::new(plan, Some(sql.to_string())))
-}
-
-fn columns_view_sql(catalog_names: &[&str]) -> String {
-    let static_sql = format!(
-        "SELECT schema_name, table_name, ordinal_position, column_name, data_type, \
-         is_nullable, is_virtual, is_required_filter, description, filter_mode, catalog_name \
-         FROM {SYSTEM_SCHEMA}.{STATIC_COLUMNS_TABLE}"
-    );
-    if catalog_names.is_empty() {
-        return static_sql;
-    }
-    format!(
-        "{static_sql} UNION ALL \
-         SELECT table_schema AS schema_name, table_name, \
-         CAST(ordinal_position AS INT) AS ordinal_position, column_name, data_type, \
-         is_nullable = 'YES' AS is_nullable, false AS is_virtual, \
-         false AS is_required_filter, '' AS description, '' AS filter_mode, \
-         table_catalog AS catalog_name \
-         FROM information_schema.columns \
-         WHERE table_catalog IN ({}) AND table_schema <> 'information_schema'",
-        sql_string_list(catalog_names)
-    )
-}
-
-fn sql_string_list(values: &[&str]) -> String {
-    values
-        .iter()
-        .map(|value| sql_string_literal(value))
-        .collect::<Vec<_>>()
-        .join(", ")
 }
 
 fn sql_string_literal(value: &str) -> String {
@@ -1249,7 +1208,10 @@ struct CatalogColumn {
     ordinal_position: usize,
 }
 
-fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
+fn build_columns_table(
+    active_sources: &[RegisteredSource],
+    column_fetchers: &[CatalogColumnFetcher],
+) -> Result<CoralColumnsTable> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("schema_name", DataType::Utf8, false),
         Field::new("table_name", DataType::Utf8, false),
@@ -1265,9 +1227,231 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
     ]));
 
     let rows = catalog_column_rows(active_sources);
-    let batch = catalog_columns_batch(schema.clone(), &rows)?;
+    let static_batch = catalog_columns_batch(schema.clone(), &rows)?;
 
-    MemTable::try_new(schema, vec![vec![batch]])
+    Ok(CoralColumnsTable {
+        schema,
+        static_batch,
+        fetchers: column_fetchers.to_vec(),
+    })
+}
+
+#[derive(Debug)]
+struct CoralColumnsTable {
+    schema: Arc<Schema>,
+    static_batch: RecordBatch,
+    fetchers: Vec<CatalogColumnFetcher>,
+}
+
+#[async_trait]
+impl TableProvider for CoralColumnsTable {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|filter| {
+                if column_pin(filter).is_some() {
+                    TableProviderFilterPushDown::Inexact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let pins = ColumnPins::from_filters(filters);
+        let inventory_filter = pins.inventory_filter();
+        let relevant = self
+            .fetchers
+            .iter()
+            .filter(|fetcher| {
+                pins.includes_catalog(&fetcher.catalog_name)
+                    && pins.intersects_schemas(&fetcher.schema_names)
+                    && pins.intersects_tables(&fetcher.table_names)
+            })
+            .collect::<Vec<_>>();
+        let outcomes = join_all(
+            relevant
+                .iter()
+                .map(|fetcher| fetcher.fetcher.fetch_columns(&inventory_filter)),
+        )
+        .await;
+
+        let mut batches = vec![self.static_batch.clone()];
+        for (fetcher, outcome) in relevant.iter().zip(outcomes) {
+            match outcome {
+                Ok(rows) => {
+                    let rows = database_catalog_columns(&fetcher.catalog_name, rows);
+                    batches.push(catalog_columns_batch(Arc::clone(&self.schema), &rows)?);
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        catalog = fetcher.catalog_name.as_str(),
+                        detail = %error,
+                        "failed to fetch database column metadata; omitting catalog from coral.columns"
+                    );
+                }
+            }
+        }
+
+        let table = MemTable::try_new(Arc::clone(&self.schema), vec![batches])?;
+        table.scan(state, projection, &[], limit).await
+    }
+}
+
+fn database_catalog_columns(
+    catalog_name: &str,
+    rows: Vec<DatabaseColumnRow>,
+) -> Vec<CatalogColumn> {
+    rows.into_iter()
+        .map(|row| CatalogColumn {
+            catalog_name: catalog_name.to_string(),
+            schema_name: row.schema_name,
+            table_name: row.table_name,
+            column_name: row.column_name,
+            data_type: row.data_type,
+            is_nullable: row.is_nullable,
+            is_virtual: false,
+            is_required_filter: false,
+            filter_mode: None,
+            description: String::new(),
+            ordinal_position: usize::try_from(row.ordinal_position).unwrap_or_default(),
+        })
+        .collect()
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ColumnPins {
+    catalogs: Option<BTreeSet<String>>,
+    schemas: Option<BTreeSet<String>>,
+    tables: Option<BTreeSet<String>>,
+}
+
+impl ColumnPins {
+    fn from_filters(filters: &[Expr]) -> Self {
+        let mut pins = Self::default();
+        for filter in filters {
+            if let Some((column, values)) = column_pin(filter) {
+                pins.restrict(column, values);
+            }
+        }
+        pins
+    }
+
+    fn restrict(&mut self, column: PinColumn, values: BTreeSet<String>) {
+        let slot = match column {
+            PinColumn::Catalog => &mut self.catalogs,
+            PinColumn::Schema => &mut self.schemas,
+            PinColumn::Table => &mut self.tables,
+        };
+        *slot = Some(match slot.take() {
+            None => values,
+            Some(existing) => existing.intersection(&values).cloned().collect(),
+        });
+    }
+
+    fn includes_catalog(&self, catalog_name: &str) -> bool {
+        self.catalogs
+            .as_ref()
+            .is_none_or(|catalogs| catalogs.contains(catalog_name))
+    }
+
+    fn intersects_schemas(&self, known: &BTreeSet<String>) -> bool {
+        Self::pin_intersects(self.schemas.as_ref(), known)
+    }
+
+    fn intersects_tables(&self, known: &BTreeSet<String>) -> bool {
+        Self::pin_intersects(self.tables.as_ref(), known)
+    }
+
+    fn pin_intersects(pinned: Option<&BTreeSet<String>>, known: &BTreeSet<String>) -> bool {
+        pinned.is_none_or(|values| values.iter().any(|value| known.contains(value)))
+    }
+
+    fn inventory_filter(&self) -> ColumnInventoryFilter {
+        ColumnInventoryFilter {
+            schemas: self
+                .schemas
+                .as_ref()
+                .map(|values| values.iter().cloned().collect()),
+            tables: self
+                .tables
+                .as_ref()
+                .map(|values| values.iter().cloned().collect()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PinColumn {
+    Catalog,
+    Schema,
+    Table,
+}
+
+fn pin_column(name: &str) -> Option<PinColumn> {
+    match name {
+        "catalog_name" => Some(PinColumn::Catalog),
+        "schema_name" => Some(PinColumn::Schema),
+        "table_name" => Some(PinColumn::Table),
+        _ => None,
+    }
+}
+
+fn column_pin(expr: &Expr) -> Option<(PinColumn, BTreeSet<String>)> {
+    match expr {
+        Expr::BinaryExpr(binary) if binary.op == Operator::Eq => {
+            let (column, value) = column_equality(binary.left.as_ref(), binary.right.as_ref())
+                .or_else(|| column_equality(binary.right.as_ref(), binary.left.as_ref()))?;
+            Some((column, BTreeSet::from([value])))
+        }
+        Expr::BinaryExpr(binary) if binary.op == Operator::Or => {
+            let (column, mut values) = column_pin(binary.left.as_ref())?;
+            let (right_column, right_values) = column_pin(binary.right.as_ref())?;
+            if column != right_column {
+                return None;
+            }
+            values.extend(right_values);
+            Some((column, values))
+        }
+        Expr::InList(in_list) if !in_list.negated => {
+            let Expr::Column(column) = in_list.expr.as_ref() else {
+                return None;
+            };
+            let column = pin_column(column.name())?;
+            let values = in_list
+                .list
+                .iter()
+                .map(literal_to_string)
+                .collect::<Option<BTreeSet<_>>>()?;
+            Some((column, values))
+        }
+        _ => None,
+    }
+}
+
+fn column_equality(column_side: &Expr, literal_side: &Expr) -> Option<(PinColumn, String)> {
+    let Expr::Column(column) = column_side else {
+        return None;
+    };
+    Some((pin_column(column.name())?, literal_to_string(literal_side)?))
 }
 
 fn catalog_column_rows(active_sources: &[RegisteredSource]) -> Vec<CatalogColumn> {

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -683,7 +683,7 @@ fn append_catalog_filter(
         predicates.push(format!("catalog_name = {}", sql_string_literal(value)));
     }
     if let Some(value) = schema_filter {
-        predicates.push(format!("schema_name = {}", sql_string_literal(value)));
+        predicates.push(schema_filter_predicate(catalog_filter, value));
     }
     if let Some(value) = table_filter {
         predicates.push(format!("table_name = {}", sql_string_literal(value)));
@@ -692,6 +692,17 @@ fn append_catalog_filter(
         sql.push_str(" WHERE ");
         sql.push_str(&predicates.join(" AND "));
     }
+}
+
+fn schema_filter_predicate(catalog_filter: Option<&str>, schema_filter: &str) -> String {
+    let literal = sql_string_literal(schema_filter);
+    if catalog_filter.is_some() || !schema_filter.contains('.') {
+        return format!("schema_name = {literal}");
+    }
+    format!(
+        "(schema_name = {literal} OR (catalog_name <> '' AND \
+         catalog_name || '.' || schema_name = {literal}))"
+    )
 }
 
 fn collect_table_infos_from_batches(batches: &[RecordBatch]) -> Result<Vec<TableInfo>> {

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -71,6 +71,16 @@ pub(crate) fn datafusion_to_core_with_sql_and_table_functions(
     }
 }
 
+pub(crate) fn missing_table_reference(
+    error: &DataFusionError,
+    sql: Option<&str>,
+) -> Option<TableRefParts> {
+    let DataFusionError::Plan(detail) = error.find_root() else {
+        return None;
+    };
+    table_not_found_ref(error, detail, sql)
+}
+
 pub(crate) fn source_decorator_error_to_core(error: &SourceDecoratorError) -> CoreError {
     match error {
         SourceDecoratorError::InvalidInput(detail) => CoreError::InvalidInput(detail.clone()),

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -460,10 +460,14 @@ impl QueryRuntimeAdapter {
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
     ) -> Result<CatalogInfo, CoreError> {
+        // Catalog summaries never surface columns, so skip the coral.columns
+        // expansion (and the remote database inventory fetches behind it).
+        let tables =
+            catalog::collect_table_metadata(&self.ctx, catalog_filter, schema_filter, None)
+                .await
+                .map_err(|err| datafusion_to_core(&err, &self.tables))?;
         Ok(CatalogInfo {
-            tables: self
-                .list_tables(catalog_filter, schema_filter, None)
-                .await?,
+            tables,
             table_functions: if catalog_filter.is_none() {
                 self.list_table_functions(schema_filter, None)
             } else {

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -706,19 +706,13 @@ impl QueryRuntimeAdapter {
         error: &DataFusionError,
         sql: &str,
     ) -> Vec<TableInfo> {
-        let qualifier = missing_table_reference(error, Some(sql))
-            .and_then(|reference| table_context_qualifier(reference.parts.as_slice()));
-        let Some((catalog_name, schema_name)) = qualifier else {
+        let filters = missing_table_reference(error, Some(sql))
+            .map(|reference| table_context_filters(reference.parts.as_slice()))
+            .unwrap_or_default();
+        if filters.is_empty() {
             return self.tables.clone();
-        };
-        match catalog::collect_table_metadata(
-            &self.ctx,
-            catalog_name.as_deref(),
-            Some(&schema_name),
-            None,
-        )
-        .await
-        {
+        }
+        match self.table_metadata_for_error_context(&filters).await {
             Ok(tables) => tables,
             Err(error) => {
                 tracing::debug!(
@@ -728,6 +722,34 @@ impl QueryRuntimeAdapter {
                 self.tables.clone()
             }
         }
+    }
+
+    async fn table_metadata_for_error_context(
+        &self,
+        filters: &TableContextFilters,
+    ) -> Result<Vec<TableInfo>, CoreError> {
+        let mut tables = Vec::new();
+        for (catalog_name, schema_name) in &filters.0 {
+            tables.extend(
+                catalog::collect_table_metadata(
+                    &self.ctx,
+                    catalog_name.as_deref(),
+                    Some(schema_name),
+                    None,
+                )
+                .await
+                .map_err(|error| datafusion_to_core(&error, &self.tables))?,
+            );
+        }
+        let mut seen = HashSet::new();
+        tables.retain(|table| {
+            seen.insert((
+                table.catalog_name.clone(),
+                table.schema_name.clone(),
+                table.table_name.clone(),
+            ))
+        });
+        Ok(tables)
     }
 
     fn observe_query_result(
@@ -1252,17 +1274,30 @@ fn name_to_source_names(sources: &[QuerySource]) -> HashMap<String, String> {
         .collect()
 }
 
-fn table_context_qualifier(parts: &[String]) -> Option<(Option<String>, String)> {
-    let parts = match parts {
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TableContextFilters(Vec<(Option<String>, String)>);
+
+impl TableContextFilters {
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+fn table_context_filters(parts: &[String]) -> TableContextFilters {
+    let body = match parts {
         [catalog, rest @ ..] if catalog == "datafusion" => rest,
         _ => parts,
     };
-    match parts {
-        [schema_name, _table_name] => Some((None, schema_name.clone())),
-        [catalog_name, schema_name, _table_name] => {
-            Some((Some(catalog_name.clone()), schema_name.clone()))
+    match body {
+        [] | [_] => TableContextFilters::default(),
+        [schema_name, _table_name] => TableContextFilters(vec![(None, schema_name.clone())]),
+        [catalog_name, schema @ .., _table_name] => {
+            let schema_name = schema.join(".");
+            TableContextFilters(vec![
+                (None, format!("{catalog_name}.{schema_name}")),
+                (Some(catalog_name.clone()), schema_name),
+            ])
         }
-        _ => None,
     }
 }
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -20,7 +20,7 @@ use tokio::sync::OnceCell;
 use tracing::{Instrument as _, info_span};
 
 use crate::backends::http::ProviderQueryError;
-use crate::backends::{RegisteredSource, compile_query_source};
+use crate::backends::{CatalogColumnFetcher, RegisteredSource, compile_query_source};
 use crate::runtime::catalog;
 use crate::runtime::dependent_join::error::resolver_rows_exceeded;
 use crate::runtime::dependent_join::optimizer;
@@ -58,6 +58,7 @@ pub(crate) struct QueryRuntimeAdapter {
     fallback_runtime: Option<FallbackRuntime>,
     memory: QueryMemoryConfig,
     active_sources: Vec<RegisteredSource>,
+    column_fetchers: Vec<CatalogColumnFetcher>,
     source_function_names: HashSet<ScopedTableFunctionName>,
     udfs_installed: bool,
     tables: Vec<TableInfo>,
@@ -100,6 +101,7 @@ struct FallbackRuntimeConfig {
 struct RegisteredRuntime {
     ctx: Arc<SessionContext>,
     active_sources: Vec<RegisteredSource>,
+    column_fetchers: Vec<CatalogColumnFetcher>,
     source_function_names: HashSet<ScopedTableFunctionName>,
     tables: Vec<TableInfo>,
     table_functions: Vec<TableFunctionInfo>,
@@ -181,6 +183,7 @@ async fn build_runtime_inner(
         fallback_runtime,
         memory,
         active_sources: primary.active_sources,
+        column_fetchers: primary.column_fetchers,
         source_function_names: primary.source_function_names,
         udfs_installed,
         tables: primary.tables,
@@ -212,9 +215,13 @@ async fn build_registered_runtime(
     let source_function_names = source_functions.names();
     let udf_table_functions = published_table_functions(config.udfs, &source_function_names)
         .map_err(|err| datafusion_to_core(&err, &[]))?;
-    catalog::register(&ctx, &registration.active_sources, &udf_table_functions)
-        .await
-        .map_err(|err| datafusion_to_core(&err, &[]))?;
+    catalog::register(
+        &ctx,
+        &registration.active_sources,
+        &registration.column_fetchers,
+        &udf_table_functions,
+    )
+    .map_err(|err| datafusion_to_core(&err, &[]))?;
     let tables = catalog::collect_static_tables(&registration.active_sources);
     let table_functions =
         catalog::collect_table_functions(&registration.active_sources, &udf_table_functions);
@@ -237,6 +244,7 @@ async fn build_registered_runtime(
     Ok(RegisteredRuntime {
         ctx,
         active_sources: registration.active_sources,
+        column_fetchers: registration.column_fetchers,
         source_function_names,
         tables,
         table_functions,
@@ -403,9 +411,13 @@ impl QueryRuntimeAdapter {
         ))
         .await
         .map_err(|err| datafusion_to_core(&err, &self.tables))?;
-        catalog::register(&self.ctx, &self.active_sources, &udf_table_functions)
-            .await
-            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+        catalog::register(
+            &self.ctx,
+            &self.active_sources,
+            &self.column_fetchers,
+            &udf_table_functions,
+        )
+        .map_err(|err| datafusion_to_core(&err, &self.tables))?;
         udf_calls
             .install(&self.ctx)
             .map_err(|err| datafusion_to_core(&err, &self.tables))?;
@@ -1320,15 +1332,14 @@ mod tests {
             inputs: Vec::new(),
         }];
         let ctx = Arc::new(SessionContext::new());
-        catalog::register(&ctx, &active_sources, &[])
-            .await
-            .expect("catalog should register");
+        catalog::register(&ctx, &active_sources, &[], &[]).expect("catalog should register");
         let tables = catalog::collect_static_tables(&active_sources);
         QueryRuntimeAdapter {
             ctx,
             fallback_runtime: None,
             memory: QueryMemoryConfig::default(),
             active_sources,
+            column_fetchers: Vec::new(),
             source_function_names: HashSet::new(),
             udfs_installed: false,
             tables,

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -520,10 +520,21 @@ impl QueryRuntimeAdapter {
         schema_name: &str,
         table_name: &str,
     ) -> Result<DescribeTableInfo, CoreError> {
-        let mut tables = self
+        let matches = self
             .list_tables(catalog_name, Some(schema_name), Some(table_name))
             .await?;
-        if let Some(table) = tables.pop() {
+        if matches.len() > 1 {
+            let candidates = matches
+                .iter()
+                .map(Self::qualified_table_reference)
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(CoreError::InvalidInput(format!(
+                "table reference `{schema_name}.{table_name}` is ambiguous; \
+                 qualify the catalog: {candidates}"
+            )));
+        }
+        if let Some(table) = matches.into_iter().next() {
             return Ok(DescribeTableInfo {
                 table: Some(table),
                 missing_context_tables: Vec::new(),
@@ -540,6 +551,17 @@ impl QueryRuntimeAdapter {
             table: None,
             missing_context_tables,
         })
+    }
+
+    fn qualified_table_reference(table: &TableInfo) -> String {
+        if table.catalog_name.is_empty() {
+            format!("`{}.{}`", table.schema_name, table.table_name)
+        } else {
+            format!(
+                "`{}.{}.{}`",
+                table.catalog_name, table.schema_name, table.table_name
+            )
+        }
     }
 
     pub(crate) fn registration_failure(

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -26,7 +26,7 @@ use crate::runtime::dependent_join::error::resolver_rows_exceeded;
 use crate::runtime::dependent_join::optimizer;
 use crate::runtime::dependent_join::planner::DependentJoinExtensionPlanner;
 use crate::runtime::error::{
-    datafusion_to_core, datafusion_to_core_with_sql_and_table_functions,
+    datafusion_to_core, datafusion_to_core_with_sql_and_table_functions, missing_table_reference,
     query_result_observer_error_to_core,
 };
 use crate::runtime::json::register_json_support;
@@ -127,7 +127,7 @@ pub(crate) async fn build_runtime(
     runtime: QueryRuntimeConfig,
 ) -> Result<QueryRuntimeAdapter, CoreError> {
     let span = info_span!("coral.engine.runtime.build", source.count = sources.len());
-    build_runtime_inner(sources, runtime).instrument(span).await
+    Box::pin(build_runtime_inner(sources, runtime).instrument(span)).await
 }
 
 async fn build_runtime_inner(
@@ -213,8 +213,9 @@ async fn build_registered_runtime(
     let udf_table_functions = published_table_functions(config.udfs, &source_function_names)
         .map_err(|err| datafusion_to_core(&err, &[]))?;
     catalog::register(&ctx, &registration.active_sources, &udf_table_functions)
+        .await
         .map_err(|err| datafusion_to_core(&err, &[]))?;
-    let tables = catalog::collect_tables(&registration.active_sources);
+    let tables = catalog::collect_static_tables(&registration.active_sources);
     let table_functions =
         catalog::collect_table_functions(&registration.active_sources, &udf_table_functions);
     install_table_function_call_planners(
@@ -369,24 +370,6 @@ async fn register_runtime_sources(
     register_sources(ctx, source_candidates, source_decorators).await
 }
 
-fn table_qualifier_matches(
-    table: &TableInfo,
-    catalog_filter: Option<&str>,
-    schema_filter: Option<&str>,
-) -> bool {
-    catalog_filter.is_none_or(|value| table.catalog_name == value)
-        && schema_filter.is_none_or(|value| table.schema_name == value)
-}
-
-fn table_reference_matches(
-    table: &TableInfo,
-    catalog_name: Option<&str>,
-    schema_name: &str,
-) -> bool {
-    table.catalog_name == non_default_catalog_name(catalog_name).unwrap_or_default()
-        && table.schema_name == schema_name
-}
-
 impl QueryRuntimeAdapter {
     pub(crate) async fn install_udfs(
         &mut self,
@@ -421,6 +404,7 @@ impl QueryRuntimeAdapter {
         .await
         .map_err(|err| datafusion_to_core(&err, &self.tables))?;
         catalog::register(&self.ctx, &self.active_sources, &udf_table_functions)
+            .await
             .map_err(|err| datafusion_to_core(&err, &self.tables))?;
         udf_calls
             .install(&self.ctx)
@@ -435,18 +419,15 @@ impl QueryRuntimeAdapter {
         Ok(())
     }
 
-    pub(crate) fn list_tables(
+    pub(crate) async fn list_tables(
         &self,
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
-    ) -> Vec<TableInfo> {
-        self.tables
-            .iter()
-            .filter(|table| table_qualifier_matches(table, catalog_filter, schema_filter))
-            .filter(|table| table_filter.is_none_or(|value| table.table_name == value))
-            .cloned()
-            .collect()
+    ) -> Result<Vec<TableInfo>, CoreError> {
+        catalog::collect_tables(&self.ctx, catalog_filter, schema_filter, table_filter)
+            .await
+            .map_err(|err| datafusion_to_core(&err, &self.tables))
     }
 
     fn list_table_functions(
@@ -462,81 +443,87 @@ impl QueryRuntimeAdapter {
             .collect()
     }
 
-    pub(crate) fn catalog_info(
+    pub(crate) async fn catalog_info(
         &self,
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
-    ) -> CatalogInfo {
-        CatalogInfo {
-            tables: self.list_tables(catalog_filter, schema_filter, None),
+    ) -> Result<CatalogInfo, CoreError> {
+        Ok(CatalogInfo {
+            tables: self
+                .list_tables(catalog_filter, schema_filter, None)
+                .await?,
             table_functions: if catalog_filter.is_none() {
                 self.list_table_functions(schema_filter, None)
             } else {
                 Vec::new()
             },
-        }
+        })
     }
 
     /// Catalog metadata restricted to the sources publishing the given
     /// schema and catalog names. Schema names never match database-internal
     /// schemas, which are addressed through their catalog.
-    pub(crate) fn catalog_info_for_sources(
+    pub(crate) async fn catalog_info_for_sources(
         &self,
         schema_names: &[&str],
         catalog_names: &[&str],
-    ) -> CatalogInfo {
-        CatalogInfo {
-            tables: self
-                .tables
-                .iter()
-                .filter(|table| {
-                    if table.catalog_name.is_empty() {
-                        schema_names.contains(&table.schema_name.as_str())
-                    } else {
-                        catalog_names.contains(&table.catalog_name.as_str())
-                    }
-                })
-                .cloned()
-                .collect(),
+    ) -> Result<CatalogInfo, CoreError> {
+        let mut tables = Vec::new();
+        for schema_name in schema_names {
+            tables.extend(self.list_tables(None, Some(schema_name), None).await?);
+        }
+        for catalog_name in catalog_names {
+            tables.extend(self.list_tables(Some(catalog_name), None, None).await?);
+        }
+        tables.sort_by(|left, right| {
+            (&left.catalog_name, &left.schema_name, &left.table_name).cmp(&(
+                &right.catalog_name,
+                &right.schema_name,
+                &right.table_name,
+            ))
+        });
+        tables.dedup_by(|left, right| {
+            left.catalog_name == right.catalog_name
+                && left.schema_name == right.schema_name
+                && left.table_name == right.table_name
+        });
+        Ok(CatalogInfo {
+            tables,
             table_functions: self
                 .table_functions
                 .iter()
                 .filter(|function| schema_names.contains(&function.schema_name.as_str()))
                 .cloned()
                 .collect(),
-        }
+        })
     }
 
-    pub(crate) fn describe_table(
+    pub(crate) async fn describe_table(
         &self,
         catalog_name: Option<&str>,
         schema_name: &str,
         table_name: &str,
-    ) -> DescribeTableInfo {
-        if let Some(table) = self
-            .tables
-            .iter()
-            .find(|table| {
-                table_reference_matches(table, catalog_name, schema_name)
-                    && table.table_name == table_name
-            })
-            .cloned()
-        {
-            return DescribeTableInfo {
+    ) -> Result<DescribeTableInfo, CoreError> {
+        let mut tables = self
+            .list_tables(catalog_name, Some(schema_name), Some(table_name))
+            .await?;
+        if let Some(table) = tables.pop() {
+            return Ok(DescribeTableInfo {
                 table: Some(table),
                 missing_context_tables: Vec::new(),
-            };
+            });
         }
 
-        let missing_context_tables = self
-            .tables
+        let missing_context_tables = catalog::collect_table_metadata(&self.ctx, None, None, None)
+            .await
+            .map_err(|err| datafusion_to_core(&err, &self.tables))?
             .iter()
             .map(table_metadata_without_columns)
             .collect();
-        DescribeTableInfo {
+        Ok(DescribeTableInfo {
             table: None,
             missing_context_tables,
-        }
+        })
     }
 
     pub(crate) fn registration_failure(
@@ -588,12 +575,12 @@ impl QueryRuntimeAdapter {
                         if is_missing_required_filter_failure(&error) {
                             return Err(cap_core_error);
                         }
-                        let fallback_error = self.sql_execution_failure_to_core(error, sql);
+                        let fallback_error = self.sql_execution_failure_to_core(error, sql).await;
                         Err(fallback_error)
                     }
                 }
             }
-            Err(error) => Err(self.sql_execution_failure_to_core(error, sql)),
+            Err(error) => Err(self.sql_execution_failure_to_core(error, sql).await),
         }
     }
 
@@ -669,12 +656,17 @@ impl QueryRuntimeAdapter {
         Ok(execution)
     }
 
-    fn sql_execution_failure_to_core(&self, error: SqlExecutionFailure, sql: &str) -> CoreError {
+    async fn sql_execution_failure_to_core(
+        &self,
+        error: SqlExecutionFailure,
+        sql: &str,
+    ) -> CoreError {
         match error {
             SqlExecutionFailure::Planning(error) => {
+                let tables = self.table_context_for_planning_error(&error, sql).await;
                 datafusion_to_core_with_sql_and_table_functions(
                     &error,
-                    &self.tables,
+                    &tables,
                     &self.table_functions,
                     Some(sql),
                 )
@@ -691,6 +683,35 @@ impl QueryRuntimeAdapter {
             return error;
         }
         datafusion_to_core(error, &self.tables)
+    }
+
+    async fn table_context_for_planning_error(
+        &self,
+        error: &DataFusionError,
+        sql: &str,
+    ) -> Vec<TableInfo> {
+        let qualifier = missing_table_reference(error, Some(sql))
+            .and_then(|reference| table_context_qualifier(reference.parts.as_slice()));
+        let Some((catalog_name, schema_name)) = qualifier else {
+            return self.tables.clone();
+        };
+        match catalog::collect_table_metadata(
+            &self.ctx,
+            catalog_name.as_deref(),
+            Some(&schema_name),
+            None,
+        )
+        .await
+        {
+            Ok(tables) => tables,
+            Err(error) => {
+                tracing::debug!(
+                    detail = %error,
+                    "failed to collect dynamic table metadata for error context"
+                );
+                self.tables.clone()
+            }
+        }
     }
 
     fn observe_query_result(
@@ -1215,6 +1236,20 @@ fn name_to_source_names(sources: &[QuerySource]) -> HashMap<String, String> {
         .collect()
 }
 
+fn table_context_qualifier(parts: &[String]) -> Option<(Option<String>, String)> {
+    let parts = match parts {
+        [catalog, rest @ ..] if catalog == "datafusion" => rest,
+        _ => parts,
+    };
+    match parts {
+        [schema_name, _table_name] => Some((None, schema_name.clone())),
+        [catalog_name, schema_name, _table_name] => {
+            Some((Some(catalog_name.clone()), schema_name.clone()))
+        }
+        _ => None,
+    }
+}
+
 fn relation_parts(table_reference: &TableReference) -> Option<(&str, &str)> {
     let schema_name = table_reference.schema()?;
     Some((schema_name, table_reference.table()))
@@ -1252,37 +1287,51 @@ mod tests {
     use datafusion::execution::memory_pool::MemoryConsumer;
 
     use super::*;
+    use crate::backends::common::RegisteredColumn;
+    use crate::backends::{RegisteredTable, SourceQualifiedName};
     use crate::{
-        ColumnInfo, DependentJoinConfig, MemorySize, QueryMemoryConfig, QueryRuntimeContext,
+        DependentJoinConfig, MemorySize, QueryMemoryConfig, QueryRuntimeContext,
         UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn,
         UdfRuntimeTableFunctionPublish,
     };
 
-    fn adapter_with_table() -> QueryRuntimeAdapter {
-        QueryRuntimeAdapter {
-            ctx: Arc::new(SessionContext::new()),
-            fallback_runtime: None,
-            memory: QueryMemoryConfig::default(),
-            active_sources: Vec::new(),
-            source_function_names: HashSet::new(),
-            udfs_installed: false,
-            tables: vec![TableInfo {
-                catalog_name: String::new(),
-                schema_name: "demo".to_string(),
+    async fn adapter_with_table() -> QueryRuntimeAdapter {
+        let active_sources = vec![RegisteredSource {
+            qualified_name: SourceQualifiedName::Schema("demo".to_string()),
+            tables: vec![RegisteredTable {
+                schema_name: None,
                 table_name: "events".to_string(),
                 description: "Event rows".to_string(),
                 guide: "Query event rows.".to_string(),
-                columns: vec![ColumnInfo {
+                columns: vec![RegisteredColumn {
                     name: "event_id".to_string(),
                     data_type: "Utf8".to_string(),
                     nullable: false,
                     is_virtual: false,
                     is_required_filter: false,
+                    filter_mode: None,
                     description: "Event ID".to_string(),
-                    ordinal_position: 0,
                 }],
+                filters: Vec::new(),
                 required_filters: vec!["owner".to_string()],
+                search_limits: None,
             }],
+            table_functions: Vec::new(),
+            inputs: Vec::new(),
+        }];
+        let ctx = Arc::new(SessionContext::new());
+        catalog::register(&ctx, &active_sources, &[])
+            .await
+            .expect("catalog should register");
+        let tables = catalog::collect_static_tables(&active_sources);
+        QueryRuntimeAdapter {
+            ctx,
+            fallback_runtime: None,
+            memory: QueryMemoryConfig::default(),
+            active_sources,
+            source_function_names: HashSet::new(),
+            udfs_installed: false,
+            tables,
             table_functions: Vec::new(),
             failures: Vec::new(),
             name_to_source: HashMap::from([("demo".to_string(), "demo".to_string())]),
@@ -1290,24 +1339,32 @@ mod tests {
         }
     }
 
-    #[test]
-    fn describe_table_hit_returns_full_table_without_missing_context() {
-        let result = adapter_with_table().describe_table(None, "demo", "events");
+    #[tokio::test]
+    async fn describe_table_hit_returns_full_table_without_missing_context() {
+        let result = adapter_with_table()
+            .await
+            .describe_table(None, "demo", "events")
+            .await
+            .expect("describe table");
 
         let table = result.table.expect("exact table");
         assert_eq!(table.columns.len(), 1);
         assert!(result.missing_context_tables.is_empty());
     }
 
-    #[test]
-    fn describe_table_miss_returns_columnless_context_tables() {
-        let result = adapter_with_table().describe_table(None, "demo", "missing");
+    #[tokio::test]
+    async fn describe_table_miss_returns_columnless_context_tables() {
+        let result = adapter_with_table()
+            .await
+            .describe_table(None, "demo", "missing")
+            .await
+            .expect("describe table miss");
 
         assert!(result.table.is_none());
-        assert_eq!(result.missing_context_tables.len(), 1);
         let context_table = result
             .missing_context_tables
-            .first()
+            .iter()
+            .find(|table| table.schema_name == "demo" && table.table_name == "events")
             .expect("missing context table");
         assert!(context_table.columns.is_empty());
         assert_eq!(context_table.required_filters, ["owner".to_string()]);

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -9,7 +9,7 @@ use tracing::{Instrument as _, info_span};
 
 use crate::backends::{
     BackendCatalogRegistration, BackendRegistration, BackendRegistrationContext,
-    BackendSchemaRegistration, CompiledBackendSource, RegisteredSource,
+    BackendSchemaRegistration, CatalogColumnFetcher, CompiledBackendSource, RegisteredSource,
 };
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
@@ -57,6 +57,7 @@ pub(crate) struct SourceRegistrationFailure {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SourceRegistrationResult {
     pub(crate) active_sources: Vec<RegisteredSource>,
+    pub(crate) column_fetchers: Vec<CatalogColumnFetcher>,
     pub(crate) failures: Vec<SourceRegistrationFailure>,
 }
 
@@ -313,9 +314,13 @@ fn register_backend_registration(
     let mut staged = Vec::with_capacity(registration.schemas.len());
     let mut catalog_staged = Vec::with_capacity(registration.catalogs.len());
     for catalog_registration in registration.catalogs {
-        let BackendCatalogRegistration { catalog, source } = catalog_registration;
+        let BackendCatalogRegistration {
+            catalog,
+            source,
+            column_fetcher,
+        } = catalog_registration;
         let catalog_name = source.qualified_name.name().to_string();
-        catalog_staged.push((catalog_name, catalog, source));
+        catalog_staged.push((catalog_name, catalog, source, column_fetcher));
     }
 
     for schema_registration in registration.schemas {
@@ -350,14 +355,28 @@ fn register_backend_registration(
         }
     }
 
-    for (catalog_name, registered_catalog, _registered_source) in &catalog_staged {
+    for (catalog_name, registered_catalog, _registered_source, _column_fetcher) in &catalog_staged {
         ctx.register_catalog(catalog_name, Arc::clone(registered_catalog));
     }
 
     for (_schema_name, _decorated_tables, registered_source) in staged {
         result.active_sources.push(registered_source);
     }
-    for (_catalog_name, _registered_catalog, registered_source) in catalog_staged {
+    for (catalog_name, _registered_catalog, registered_source, column_fetcher) in catalog_staged {
+        result.column_fetchers.push(CatalogColumnFetcher {
+            catalog_name,
+            schema_names: registered_source
+                .tables
+                .iter()
+                .filter_map(|table| table.schema_name.clone())
+                .collect(),
+            table_names: registered_source
+                .tables
+                .iter()
+                .map(|table| table.table_name.clone())
+                .collect(),
+            fetcher: column_fetcher,
+        });
         result.active_sources.push(registered_source);
     }
     Ok(())


### PR DESCRIPTION
## Summary
- stop eagerly materializing database tables into Coral registered-source metadata
- expose database catalog metadata through coral.tables and coral.columns union views backed by DataFusion information_schema
- make runtime catalog lookup APIs async while preserving the existing namespace column shape
- attribute three-part database table scans back to their source for query usage tracking

## Validation
- cargo fmt --all -- --check
- cargo test -p coral-engine database --lib
- cargo test -p coral-engine catalog --lib
- cargo test -p coral-engine --test engine catalog
- cargo build -p coral-cli --all-features
- Pickl pg-boss stress: 798 successful Coral SQL queries

Did not run make rust-checks per local instruction for this change.