### PR TITLE
feat(reef): add sources onboarding story

### DIFF
--- a/apps/reef/app/components/onboarding/onboarding-sources-page.css.ts
+++ b/apps/reef/app/components/onboarding/onboarding-sources-page.css.ts
@@ -1,0 +1,125 @@
+import { style } from '@vanilla-extract/css'
+
+import { breakpoints } from '@/styles/theme.css'
+import { theme } from '@/wax/theme/theme.css'
+
+export const root = style({
+  background: theme.surface.mainContent,
+  boxSizing: 'border-box',
+  minHeight: '100dvh',
+  paddingBlock: 32,
+  paddingInline: 32,
+  width: '100%',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      paddingBlock: 24,
+      paddingInline: 16,
+    },
+  },
+})
+
+export const content = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 30,
+  marginInline: 'auto',
+  maxWidth: 960,
+  width: '100%',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      gap: 22,
+    },
+  },
+})
+
+export const header = style({
+  width: '100%',
+})
+
+export const headerText = style({
+  display: 'flex',
+  flex: '1 1 auto',
+  flexDirection: 'column',
+  gap: 6,
+  maxWidth: 640,
+  minWidth: 0,
+})
+
+export const titleRow = style({
+  alignItems: 'center',
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 12,
+  minWidth: 0,
+})
+
+export const stepPill = style({
+  flexShrink: 0,
+})
+
+export const body = style({
+  alignItems: 'start',
+  display: 'grid',
+  gap: 28,
+  gridTemplateColumns: 'minmax(240px, 280px) minmax(0, 720px)',
+  justifyContent: 'center',
+  width: '100%',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      gridTemplateColumns: '1fr',
+    },
+  },
+})
+
+export const explainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 22,
+  paddingBlockStart: 16,
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      paddingBlockStart: 0,
+    },
+  },
+})
+
+export const explainerText = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+})
+
+export const inlineLink = style({
+  color: theme.content.link,
+  textDecoration: 'underline',
+  textUnderlineOffset: 2,
+  selectors: {
+    '&:hover': {
+      color: theme.content.linkHover,
+    },
+    '&:focus-visible': {
+      borderRadius: 2,
+      outline: `1px solid ${theme.stroke.focused}`,
+      outlineOffset: 2,
+    },
+  },
+})
+
+export const catalogFrame = style({
+  alignSelf: 'center',
+  background: theme.surface.mainContent,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 8,
+  boxSizing: 'border-box',
+  height: 'min(620px, calc(100dvh - 204px))',
+  maxWidth: 720,
+  minHeight: 480,
+  overflow: 'hidden',
+  width: '100%',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      height: 'min(600px, calc(100dvh - 236px))',
+      minHeight: 460,
+    },
+  },
+})

--- a/apps/reef/app/components/onboarding/onboarding-sources-page.stories.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sources-page.stories.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { fn } from 'storybook/test'
+
+import type { CatalogEntry } from '@/lib/sources'
+
+import { OnboardingSourcesPage } from './onboarding-sources-page'
+
+const entries: CatalogEntry[] = [
+  {
+    description: 'Sync issues, pull requests, and code from your repositories.',
+    installed: true,
+    name: 'github',
+    origin: 'bundled',
+    version: '1.0.0',
+  },
+  {
+    description: 'Sync merge requests, pipelines, issues, and repository metadata.',
+    installed: false,
+    name: 'gitlab',
+    origin: 'bundled',
+    version: '1.0.0',
+  },
+  {
+    description: 'Inspect errors, releases, issues, and project health.',
+    installed: false,
+    name: 'sentry',
+    origin: 'bundled',
+    version: '1.0.0',
+  },
+  {
+    description: 'Read pages, databases, comments, and workspace content.',
+    installed: false,
+    name: 'notion',
+    origin: 'bundled',
+    version: '1.0.0',
+  },
+  {
+    description: 'Query messages and metadata from Gmail.',
+    installed: false,
+    name: 'gmail',
+    origin: 'bundled',
+    version: '1.0.0',
+  },
+  {
+    description: 'Browse project issues, labels, milestones, and users.',
+    installed: false,
+    name: 'linear',
+    origin: 'bundled',
+    version: '1.0.0',
+  },
+  {
+    description: 'Query incidents, services, and schedules from PagerDuty.',
+    installed: false,
+    name: 'pagerduty',
+    origin: 'bundled',
+    version: '1.0.0',
+  },
+  {
+    description: 'Analyze feature flags, environments, and flag targeting.',
+    installed: false,
+    name: 'launchdarkly',
+    origin: 'bundled',
+    version: '1.0.0',
+  },
+]
+
+const meta = {
+  args: {
+    entries,
+    loadState: 'idle',
+    onContinue: fn(),
+    onRetry: fn(),
+    onSearchChange: fn(),
+    onSourceSelect: fn(),
+    search: '',
+  },
+  component: OnboardingSourcesPage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: (args) => <StatefulPage {...args} />,
+  tags: ['autodocs'],
+  title: 'Components/Onboarding/SourcesPage',
+} satisfies Meta<typeof OnboardingSourcesPage>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const FirstStep: Story = {}
+
+function StatefulPage(args: React.ComponentProps<typeof OnboardingSourcesPage>) {
+  const [search, setSearch] = useState(args.search)
+
+  useEffect(() => {
+    setSearch(args.search)
+  }, [args.search])
+
+  return (
+    <OnboardingSourcesPage
+      {...args}
+      search={search}
+      onSearchChange={(nextSearch) => {
+        setSearch(nextSearch)
+        args.onSearchChange(nextSearch)
+      }}
+    />
+  )
+}

--- a/apps/reef/app/components/onboarding/onboarding-sources-page.stories.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sources-page.stories.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MemoryRouter } from 'react-router'
 
 import { fn } from 'storybook/test'
 
@@ -70,7 +71,6 @@ const meta = {
   args: {
     entries,
     loadState: 'idle',
-    onContinue: fn(),
     onRetry: fn(),
     onSearchChange: fn(),
     onSourceSelect: fn(),
@@ -80,7 +80,11 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
-  render: (args) => <StatefulPage {...args} />,
+  render: (args) => (
+    <MemoryRouter>
+      <StatefulPage {...args} />
+    </MemoryRouter>
+  ),
   tags: ['autodocs'],
   title: 'Components/Onboarding/SourcesPage',
 } satisfies Meta<typeof OnboardingSourcesPage>
@@ -88,7 +92,7 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const FirstStep: Story = {}
+export const Default: Story = {}
 
 function StatefulPage(args: React.ComponentProps<typeof OnboardingSourcesPage>) {
   const [search, setSearch] = useState(args.search)

--- a/apps/reef/app/components/onboarding/onboarding-sources-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sources-page.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router'
+
 import { Button, Typography } from '@/wax/components'
 import { Pill } from '@/wax/components/pill'
 
@@ -12,7 +14,6 @@ export interface OnboardingSourcesPageProps {
   entries: SourceCatalogEntry[]
   errorMessage?: string | null
   loadState?: SourceCatalogLoadState
-  onContinue?: () => void
   onRetry?: () => void
   onSearchChange: (search: string) => void
   onSourceSelect: (entry: SourceCatalogEntry) => void
@@ -26,7 +27,6 @@ export function OnboardingSourcesPage({
   entries,
   errorMessage = null,
   loadState = 'idle',
-  onContinue,
   onRetry,
   onSearchChange,
   onSourceSelect,
@@ -89,7 +89,13 @@ export function OnboardingSourcesPage({
               </Typography.BodyLarge>
             </div>
 
-            <Button.Container disabled={!canContinue} onClick={onContinue} variant="secondary">
+            <Button.Container
+              as={Link}
+              disabled={!canContinue}
+              onClick={canContinue ? undefined : (event) => event.preventDefault()}
+              to="?step=query"
+              variant="secondary"
+            >
               <Button.Text>{continueLabel}</Button.Text>
             </Button.Container>
           </div>

--- a/apps/reef/app/components/onboarding/onboarding-sources-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sources-page.tsx
@@ -1,0 +1,114 @@
+import { Button, Typography } from '@/wax/components'
+import { Pill } from '@/wax/components/pill'
+
+import { SourceCatalogSurface } from '@/components/sources'
+import type { SourceCatalogEntry, SourceCatalogLoadState } from '@/components/sources'
+
+import * as styles from './onboarding-sources-page.css'
+
+export interface OnboardingSourcesPageProps {
+  continueDisabled?: boolean
+  continueLabel?: string
+  entries: SourceCatalogEntry[]
+  errorMessage?: string | null
+  loadState?: SourceCatalogLoadState
+  onContinue?: () => void
+  onRetry?: () => void
+  onSearchChange: (search: string) => void
+  onSourceSelect: (entry: SourceCatalogEntry) => void
+  search: string
+  stepLabel?: string
+}
+
+export function OnboardingSourcesPage({
+  continueDisabled = false,
+  continueLabel = 'I have connected enough sources',
+  entries,
+  errorMessage = null,
+  loadState = 'idle',
+  onContinue,
+  onRetry,
+  onSearchChange,
+  onSourceSelect,
+  search,
+  stepLabel = 'Step 1/3',
+}: OnboardingSourcesPageProps) {
+  const hasConnectedSource = entries.some((entry) => entry.installed)
+  const canContinue = hasConnectedSource && !continueDisabled
+
+  return (
+    <section className={styles.root} aria-label="Onboarding">
+      <div className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <div className={styles.titleRow}>
+              <Typography.HeadingLarge as="h1">Onboarding</Typography.HeadingLarge>
+              <Pill className={styles.stepPill} color="graySubtle">
+                {stepLabel}
+              </Pill>
+            </div>
+          </div>
+        </header>
+
+        <div className={styles.body}>
+          <div className={styles.explainer}>
+            <div className={styles.explainerText}>
+              <Typography.HeadingSmall>Connect sources to Coral</Typography.HeadingSmall>
+              <Typography.BodyLarge>
+                Sources turn APIs, services, and local datasets into tables that Coral can query.
+              </Typography.BodyLarge>
+              <Typography.BodyLarge>
+                Coral ships with{' '}
+                <a
+                  className={styles.inlineLink}
+                  href="https://withcoral.com/docs/reference/bundled-sources"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  core sources
+                </a>
+                , built and maintained by the Coral team. It is also extensible: import{' '}
+                <a
+                  className={styles.inlineLink}
+                  href="https://withcoral.com/docs/reference/community-sources"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  community source specs
+                </a>{' '}
+                or{' '}
+                <a
+                  className={styles.inlineLink}
+                  href="https://withcoral.com/docs/guides/write-a-custom-source"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  write your own spec
+                </a>
+                .
+              </Typography.BodyLarge>
+            </div>
+
+            <Button.Container disabled={!canContinue} onClick={onContinue} variant="secondary">
+              <Button.Text>{continueLabel}</Button.Text>
+            </Button.Container>
+          </div>
+
+          <div className={styles.catalogFrame}>
+            <SourceCatalogSurface
+              entries={entries}
+              errorMessage={errorMessage}
+              loadState={loadState}
+              onPick={onSourceSelect}
+              onRetry={onRetry}
+              onSearchChange={onSearchChange}
+              search={search}
+              showTitle={false}
+              variant="compact"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

Adding the first screen of the onboarding.

Connecting sources is the most important thing, so that's what we'll show people first.
Only when at least a source is connected you'll able to go to the second screen (coming into another PR).

None of this has been wired, just finalising the screens first, and adding the `/onboarding/` router later.

## Test plan

<img width="2092" height="857" alt="image" src="https://github.com/user-attachments/assets/5105d09a-fbc3-41bf-a2ac-3b89fb9f7038" />

