### PR TITLE
fix(spec): report unsupported OpenAPI operation refs

### DIFF
--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1281,6 +1281,16 @@ paths:
 "
     }
 
+    fn unsupported_operation_ref_openapi_fixture() -> &'static str {
+        r"
+openapi: 3.0.3
+paths:
+  /account:
+    get:
+      $ref: resources/account/account_get.yml
+"
+    }
+
     fn json_rpc_result_response(id: Value, result: Value) -> ResponseTemplate {
         let mut body = serde_json::Map::new();
         body.insert("jsonrpc".to_string(), Value::String("2.0".to_string()));
@@ -1643,6 +1653,91 @@ surfaces:
                 .projections
                 .iter()
                 .all(|projection| projection.surface_id == "rest")
+        );
+    }
+
+    #[test]
+    fn build_v4_materialization_reports_unsupported_openapi_operation_refs() {
+        let descriptor_temp = TempDir::new().expect("descriptor temp dir");
+        let openapi_file = descriptor_temp.path().join("openapi.yaml");
+        std::fs::write(&openapi_file, unsupported_operation_ref_openapi_fixture())
+            .expect("write descriptor");
+        let state_temp = TempDir::new().expect("state temp dir");
+        let layout =
+            AppStateLayout::discover(Some(state_temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let manifest_yaml = format!(
+            r"
+name: unsupported_openapi_refs
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: {}
+    base_url: https://api.example.com
+",
+            openapi_file.display()
+        );
+        let manifest = parse_source_manifest_yaml(&manifest_yaml)
+            .expect("parse v4 manifest")
+            .as_v4()
+            .expect("v4")
+            .clone();
+        let source_name = SourceName::parse("unsupported_openapi_refs").expect("source");
+
+        let build = build_v4_materialization_tmp(
+            &layout,
+            &workspace_name(),
+            &source_name,
+            &manifest_yaml,
+            &manifest,
+            &MaterializationInputs::default(),
+            "test",
+        )
+        .expect("unsupported operation refs should materialize with diagnostics");
+
+        let semantic_ir: SemanticIr = read_yaml(
+            &build
+                .temp_dir
+                .join("surfaces")
+                .join("rest")
+                .join("semantic-ir.yaml"),
+        )
+        .expect("read semantic IR");
+        assert!(
+            semantic_ir.operations.is_empty(),
+            "unsupported refs should not import empty operations: {:?}",
+            semantic_ir.operations
+        );
+
+        let projections: ProjectionCatalog =
+            read_yaml(&build.temp_dir.join(PROJECTIONS_FILENAME)).expect("read projections");
+        assert!(
+            projections.projections.is_empty(),
+            "unsupported refs should not create hidden projections: {:?}",
+            projections.projections
+        );
+
+        let diagnostics: Vec<Diagnostic> =
+            read_yaml(&build.temp_dir.join(DIAGNOSTICS_FILENAME)).expect("read diagnostics");
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "OPENAPI_OPERATION_REF_UNSUPPORTED")
+            .expect("unsupported operation ref diagnostic");
+        assert_eq!(diagnostic.surface_id.as_deref(), Some("rest"));
+        assert!(
+            diagnostic
+                .message
+                .contains("resources/account/account_get.yml"),
+            "{}",
+            diagnostic.message
+        );
+        assert!(
+            diagnostic
+                .message
+                .contains("dereferenced or bundled OpenAPI documents"),
+            "{}",
+            diagnostic.message
         );
     }
 

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1722,7 +1722,7 @@ surfaces:
             read_yaml(&build.temp_dir.join(DIAGNOSTICS_FILENAME)).expect("read diagnostics");
         let diagnostic = diagnostics
             .iter()
-            .find(|diagnostic| diagnostic.code == "OPENAPI_OPERATION_REF_UNSUPPORTED")
+            .find(|diagnostic| diagnostic.code == "OPENAPI_EXTERNAL_REF_UNSUPPORTED")
             .expect("unsupported operation ref diagnostic");
         assert_eq!(diagnostic.surface_id.as_deref(), Some("rest"));
         assert!(

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -5,7 +5,7 @@
 
 pub const V4_ARTIFACT_SCHEMA_VERSION: u32 = 3;
 pub const SURFACE_IMPORTER_VERSION: &str = "surface-import-v1";
-pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v4";
+pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v5";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v1";
 pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v8";
 

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -87,7 +87,7 @@ paths:
     let diagnostic = ir
         .diagnostics
         .iter()
-        .find(|diagnostic| diagnostic.code == "OPENAPI_OPERATION_REF_UNSUPPORTED")
+        .find(|diagnostic| diagnostic.code == "OPENAPI_EXTERNAL_REF_UNSUPPORTED")
         .expect("unsupported operation ref diagnostic");
     assert_eq!(diagnostic.surface_id.as_deref(), Some("rest"));
     assert!(diagnostic.operation_id.is_none());

--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -50,6 +50,117 @@ paths: {}
 }
 
 #[test]
+fn importer_warns_and_skips_external_openapi_operation_refs() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: digitalocean_ref_test
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /account:
+    get:
+      $ref: resources/account/account_get.yml
+"
+        .as_bytes(),
+    )
+    .expect("operation ref import should emit diagnostics");
+
+    assert!(
+        ir.operations.is_empty(),
+        "unsupported operation refs should not import empty operations: {:?}",
+        ir.operations
+    );
+    let diagnostic = ir
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "OPENAPI_OPERATION_REF_UNSUPPORTED")
+        .expect("unsupported operation ref diagnostic");
+    assert_eq!(diagnostic.surface_id.as_deref(), Some("rest"));
+    assert!(diagnostic.operation_id.is_none());
+    assert!(
+        diagnostic
+            .message
+            .contains("resources/account/account_get.yml"),
+        "{}",
+        diagnostic.message
+    );
+    assert!(
+        diagnostic
+            .message
+            .contains("dereferenced or bundled OpenAPI documents"),
+        "{}",
+        diagnostic.message
+    );
+}
+
+#[test]
+fn importer_resolves_local_openapi_operation_refs() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: local_ref_test
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.example.com
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /items:
+    get:
+      $ref: '#/x-operations/listItems'
+x-operations:
+  listItems:
+    operationId: items/list
+    responses:
+      '200':
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  id: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("local operation ref import");
+
+    let operation = ir.operations.first().expect("operation");
+    assert_eq!(operation.id, "items_list");
+    assert_eq!(operation.output.cardinality, OutputCardinality::List);
+    assert!(
+        ir.diagnostics.is_empty(),
+        "local operation ref should not produce diagnostics: {:?}",
+        ir.diagnostics
+    );
+}
+
+#[test]
 #[expect(
     clippy::too_many_lines,
     reason = "The OpenAPI fixture keeps related naming metadata cases together."

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -39,6 +39,11 @@ pub(super) struct OpenApiImporter<'a> {
     pub(super) diagnostics: Vec<Diagnostic>,
 }
 
+enum RefDiagnosticContext<'a> {
+    Operation { path: &'a str, method_name: &'a str },
+    OperationId(&'a str),
+}
+
 impl<'a> OpenApiImporter<'a> {
     fn new(manifest: &'a V4SourceManifest, surface: &'a V4Surface, document: &'a Value) -> Self {
         Self {
@@ -72,7 +77,11 @@ impl<'a> OpenApiImporter<'a> {
                     match resolve_local_ref(self.document, operation_value) {
                         Ok(operation_value) => operation_value,
                         Err(error) => {
-                            self.report_operation_ref_error(path, method_name, error);
+                            let diagnostic = self.ref_error_diagnostic(
+                                error,
+                                &RefDiagnosticContext::Operation { path, method_name },
+                            );
+                            self.diagnostics.push(diagnostic);
                             continue;
                         }
                     }
@@ -102,29 +111,6 @@ impl<'a> OpenApiImporter<'a> {
         })
     }
 
-    fn report_operation_ref_error(&mut self, path: &str, method_name: &str, error: RefError<'_>) {
-        match error {
-            RefError::External(reference) => {
-                self.diagnostics.push(Diagnostic::warning(
-                    "OPENAPI_EXTERNAL_REF_UNSUPPORTED",
-                    format!(
-                        "OpenAPI operation {method_name} {path} references external operation '{reference}', but Coral currently requires dereferenced or bundled OpenAPI documents"
-                    ),
-                    self.surface.id.clone(),
-                    None,
-                ));
-            }
-            RefError::NotFound(reference) => {
-                self.diagnostics.push(Diagnostic::warning(
-                    "OPENAPI_REF_NOT_FOUND",
-                    format!("OpenAPI operation {method_name} {path} reference '{reference}' was not found"),
-                    self.surface.id.clone(),
-                    None,
-                ));
-            }
-        }
-    }
-
     pub(super) fn resolve_ref(
         &self,
         value: &Value,
@@ -133,24 +119,44 @@ impl<'a> OpenApiImporter<'a> {
     ) -> Option<Value> {
         match resolve_local_ref(self.document, value) {
             Ok(resolved) => Some(resolved.clone()),
-            Err(RefError::External(reference)) => {
-                diagnostics.push(Diagnostic::warning(
-                    "OPENAPI_EXTERNAL_REF_UNSUPPORTED",
-                    format!("external reference '{reference}' is unsupported"),
-                    self.surface.id.clone(),
-                    Some(operation_id.to_string()),
-                ));
-                None
-            }
-            Err(RefError::NotFound(reference)) => {
-                diagnostics.push(Diagnostic::warning(
-                    "OPENAPI_REF_NOT_FOUND",
-                    format!("reference '{reference}' was not found"),
-                    self.surface.id.clone(),
-                    Some(operation_id.to_string()),
-                ));
+            Err(error) => {
+                diagnostics.push(
+                    self.ref_error_diagnostic(
+                        error,
+                        &RefDiagnosticContext::OperationId(operation_id),
+                    ),
+                );
                 None
             }
         }
+    }
+
+    fn ref_error_diagnostic(
+        &self,
+        error: RefError<'_>,
+        context: &RefDiagnosticContext<'_>,
+    ) -> Diagnostic {
+        let (code, message) = match error {
+            RefError::External(reference) => (
+                "OPENAPI_EXTERNAL_REF_UNSUPPORTED",
+                format!(
+                    "external reference '{reference}' is unsupported; Coral currently requires dereferenced or bundled OpenAPI documents"
+                ),
+            ),
+            RefError::NotFound(reference) => (
+                "OPENAPI_REF_NOT_FOUND",
+                format!("reference '{reference}' was not found"),
+            ),
+        };
+        let (message, operation_id) = match context {
+            RefDiagnosticContext::Operation { path, method_name } => (
+                format!("OpenAPI operation {method_name} {path}: {message}"),
+                None,
+            ),
+            RefDiagnosticContext::OperationId(operation_id) => {
+                (message, Some(operation_id.to_string()))
+            }
+        };
+        Diagnostic::warning(code, message, self.surface.id.clone(), operation_id)
     }
 }

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -106,7 +106,7 @@ impl<'a> OpenApiImporter<'a> {
         match error {
             RefError::External(reference) => {
                 self.diagnostics.push(Diagnostic::warning(
-                    "OPENAPI_OPERATION_REF_UNSUPPORTED",
+                    "OPENAPI_EXTERNAL_REF_UNSUPPORTED",
                     format!(
                         "OpenAPI operation {method_name} {path} references external operation '{reference}', but Coral currently requires dereferenced or bundled OpenAPI documents"
                     ),
@@ -116,7 +116,7 @@ impl<'a> OpenApiImporter<'a> {
             }
             RefError::NotFound(reference) => {
                 self.diagnostics.push(Diagnostic::warning(
-                    "OPENAPI_OPERATION_REF_UNRESOLVED",
+                    "OPENAPI_REF_NOT_FOUND",
                     format!("OpenAPI operation {method_name} {path} reference '{reference}' was not found"),
                     self.surface.id.clone(),
                     None,

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -68,13 +68,19 @@ impl<'a> OpenApiImporter<'a> {
                 let Some(operation_value) = path_item.get(method_name) else {
                     continue;
                 };
-                let Some(operation_value) =
-                    self.resolve_operation_ref(path, method_name, operation_value)
-                else {
-                    continue;
+                let operation_value = if operation_value.get("$ref").is_some() {
+                    match resolve_local_ref(self.document, operation_value) {
+                        Ok(operation_value) => operation_value,
+                        Err(error) => {
+                            self.report_operation_ref_error(path, method_name, error);
+                            continue;
+                        }
+                    }
+                } else {
+                    operation_value
                 };
                 let operation =
-                    self.import_operation(path, path_item, method_name, &operation_value)?;
+                    self.import_operation(path, path_item, method_name, operation_value)?;
                 if !operation_ids.insert(operation.id.clone()) {
                     return Err(ManifestError::validation(format!(
                         "source '{}' surface '{}' imports duplicate operation id '{}'",
@@ -96,18 +102,9 @@ impl<'a> OpenApiImporter<'a> {
         })
     }
 
-    fn resolve_operation_ref(
-        &mut self,
-        path: &str,
-        method_name: &str,
-        operation: &Value,
-    ) -> Option<Value> {
-        let Some(reference) = operation.get("$ref").and_then(Value::as_str) else {
-            return Some(operation.clone());
-        };
-        match resolve_local_ref(self.document, operation) {
-            Ok(resolved) => Some(resolved.clone()),
-            Err(RefError::External(_)) => {
+    fn report_operation_ref_error(&mut self, path: &str, method_name: &str, error: RefError<'_>) {
+        match error {
+            RefError::External(reference) => {
                 self.diagnostics.push(Diagnostic::warning(
                     "OPENAPI_OPERATION_REF_UNSUPPORTED",
                     format!(
@@ -116,16 +113,14 @@ impl<'a> OpenApiImporter<'a> {
                     self.surface.id.clone(),
                     None,
                 ));
-                None
             }
-            Err(RefError::NotFound(_)) => {
+            RefError::NotFound(reference) => {
                 self.diagnostics.push(Diagnostic::warning(
                     "OPENAPI_OPERATION_REF_UNRESOLVED",
                     format!("OpenAPI operation {method_name} {path} reference '{reference}' was not found"),
                     self.surface.id.clone(),
                     None,
                 ));
-                None
             }
         }
     }

--- a/crates/coral-spec/src/v4/surfaces/openapi/import.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/import.rs
@@ -68,8 +68,13 @@ impl<'a> OpenApiImporter<'a> {
                 let Some(operation_value) = path_item.get(method_name) else {
                     continue;
                 };
+                let Some(operation_value) =
+                    self.resolve_operation_ref(path, method_name, operation_value)
+                else {
+                    continue;
+                };
                 let operation =
-                    self.import_operation(path, path_item, method_name, operation_value)?;
+                    self.import_operation(path, path_item, method_name, &operation_value)?;
                 if !operation_ids.insert(operation.id.clone()) {
                     return Err(ManifestError::validation(format!(
                         "source '{}' surface '{}' imports duplicate operation id '{}'",
@@ -89,6 +94,40 @@ impl<'a> OpenApiImporter<'a> {
             types: self.types.values().cloned().collect(),
             diagnostics: self.diagnostics.clone(),
         })
+    }
+
+    fn resolve_operation_ref(
+        &mut self,
+        path: &str,
+        method_name: &str,
+        operation: &Value,
+    ) -> Option<Value> {
+        let Some(reference) = operation.get("$ref").and_then(Value::as_str) else {
+            return Some(operation.clone());
+        };
+        match resolve_local_ref(self.document, operation) {
+            Ok(resolved) => Some(resolved.clone()),
+            Err(RefError::External(_)) => {
+                self.diagnostics.push(Diagnostic::warning(
+                    "OPENAPI_OPERATION_REF_UNSUPPORTED",
+                    format!(
+                        "OpenAPI operation {method_name} {path} references external operation '{reference}', but Coral currently requires dereferenced or bundled OpenAPI documents"
+                    ),
+                    self.surface.id.clone(),
+                    None,
+                ));
+                None
+            }
+            Err(RefError::NotFound(_)) => {
+                self.diagnostics.push(Diagnostic::warning(
+                    "OPENAPI_OPERATION_REF_UNRESOLVED",
+                    format!("OpenAPI operation {method_name} {path} reference '{reference}' was not found"),
+                    self.surface.id.clone(),
+                    None,
+                ));
+                None
+            }
+        }
     }
 
     pub(super) fn resolve_ref(


### PR DESCRIPTION
## Summary

- detect method-level OpenAPI operation `$ref` values before importing operations
- resolve local operation refs and skip unsupported external/relative operation refs with `OPENAPI_OPERATION_REF_UNSUPPORTED`
- prevent unsupported operation refs from producing fake empty `cardinality: none` operations and hidden projections
- bump the OpenAPI importer artifact version so stale materializations are rejected

## Root Cause

DigitalOcean's descriptor uses method-level external refs like `get: { $ref: "resources/account/account_get.yml" }`. Coral previously passed those stub objects directly into operation import, so the operation had no responses, no parameters, and no actionable diagnostic. That produced empty semantic IR/projection output and only failed later as "no runtime components".

This fixes the reporting failure in #1575. Broader external/remote OpenAPI dereferencing remains tracked by #1497.

## Validation

- `cargo test -p coral-spec openapi_operation_refs`
- `cargo test -p coral-app build_v4_materialization_reports_unsupported_openapi_operation_refs`
- `cargo test -p coral-spec openapi`
- `cargo test -p coral-app sources::materialization::tests`
- `make rust-checks`