### PR TITLE
ci(reef): reduce Chromatic snapshot usage

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,10 @@ on:
       - ".github/workflows/chromatic.yml"
       - "apps/reef/**"
 
+concurrency:
+  group: chromatic-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 
@@ -50,6 +54,8 @@ jobs:
         run: npm ci
 
       - name: Run Chromatic
-        run: npm exec -- chromatic
-        env:
-          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        uses: chromaui/action@94713c544284a14195de3b50ef24301579f1877e # v18.0.1
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: apps/reef
+          onlyChanged: true


### PR DESCRIPTION
## Summary

Got an email that we've used 90% of free runs for the month, we can improve things a bit:

- cancel parallel executions (ie if you push to a PR quickly, we'll cancel the first one and save a bit)
- use official chromatic action so we can use `TurboSnap` with `onlyChanged: true`,  to only rebuild snapshot of the stories  we touch in that PR

## Test plan

Branch off this PR, change a single story, check we only run chromatic for that story (#1605)

<img width="379" height="74" alt="image" src="https://github.com/user-attachments/assets/b5ce455b-ea01-4f94-9b8a-298c522359f6" />

```
15:01:45.504 ✔ TurboSnap enabled
             Capturing 2 snapshots, copying 172 TurboSnaps.
15:01:45.505 ✔ Storybook published
             We found 39 components with 174 stories.
             ℹ View your Storybook at https://6a3cfca9530ba1e4c7574952-njnuejtebv.chromatic.com/
15:01:45.505 Started build 206
15:01:45.506 Running 2 tests affected by recent changes (skipping 172 tests)
```