### PR TITLE
refactor(app): clean up workspace catalog cutover names

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -54,7 +54,7 @@ use crate::search::manager::SearchManager;
 use crate::search::service::SearchService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
-use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, cutover_legacy_config};
+use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
@@ -256,7 +256,7 @@ impl ServerBuilder {
         layout.ensure()?;
         let coral_db = init_database(&layout).await?;
         let config_store = ConfigStore::new(layout.clone());
-        cutover_legacy_config(&coral_db, &config_store).await?;
+        run_state_migrations(&coral_db, &config_store).await?;
         let coral_db = Arc::new(coral_db);
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config
@@ -744,9 +744,7 @@ mod tests {
     use crate::query::manager::QueryManager;
     use crate::search::manager::SearchManager;
     use crate::sources::manager::SourceManager;
-    use crate::state::db::{
-        CoralDb, DatabaseConfig, ResolvedDatabaseConfig, cutover_legacy_config,
-    };
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::telemetry::service::TraceService;
     use crate::transport::workspace_to_proto;
@@ -780,9 +778,9 @@ enabled = false
             .await
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
-        cutover_legacy_config(&db, config_store)
+        run_state_migrations(&db, config_store)
             .await
-            .expect("cut over legacy config");
+            .expect("run state migrations");
         Arc::new(db)
     }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -791,9 +791,7 @@ mod tests {
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
     use crate::sources::manager::{ImportSourceCommand, SourceBindings, SourceManager};
     use crate::sources::model::SourceOrigin;
-    use crate::state::db::{
-        CoralDb, DatabaseConfig, ResolvedDatabaseConfig, cutover_legacy_config,
-    };
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
 
     struct QueryManagerFixture {
         _temp: TempDir,
@@ -841,9 +839,9 @@ mod tests {
             .await
             .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
-        cutover_legacy_config(&db, config_store)
+        run_state_migrations(&db, config_store)
             .await
-            .expect("cut over legacy config");
+            .expect("run state migrations");
         Arc::new(db)
     }
 

--- a/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
@@ -169,8 +169,8 @@ tables:
 ";
 
     config_store
-        .create_workspace(&workspace_name)
-        .expect("create workspace");
+        .create_legacy_workspace_entry_for_tests(&workspace_name)
+        .expect("create legacy workspace entry");
     install_imported_source(
         &layout,
         &config_store,
@@ -200,8 +200,8 @@ fn loader_fails_when_installed_manifest_cannot_be_read() {
     let source_name = SourceName::parse("missing").expect("source");
 
     config_store
-        .create_workspace(&workspace_name)
-        .expect("create workspace");
+        .create_legacy_workspace_entry_for_tests(&workspace_name)
+        .expect("create legacy workspace entry");
     config_store
         .upsert_source(
             &workspace_name,
@@ -236,8 +236,8 @@ fn loader_fails_when_v4_source_missing_materialization() {
     let stale_v4_source = SourceName::parse("stale_v4").expect("source");
 
     config_store
-        .create_workspace(&workspace_name)
-        .expect("create workspace");
+        .create_legacy_workspace_entry_for_tests(&workspace_name)
+        .expect("create legacy workspace entry");
     install_imported_source(
         &layout,
         &config_store,

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -20,7 +20,7 @@ impl SearchManager {
         config_store: &ConfigStore,
         workspace_manager: WorkspaceManager,
     ) -> Self {
-        let catalog_loader = CatalogSnapshotLoader::new(config_store, layout.clone());
+        let catalog_loader = CatalogSnapshotLoader::new(config_store.clone(), layout.clone());
         let catalog = CatalogMetadataProvider::new(layout, catalog_loader);
         Self {
             engine: UniversalSearchEngine::new(catalog),

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -20,7 +20,7 @@ impl SearchManager {
         config_store: &ConfigStore,
         workspace_manager: WorkspaceManager,
     ) -> Self {
-        let catalog_loader = CatalogSnapshotLoader::new(config_store.clone(), layout.clone());
+        let catalog_loader = CatalogSnapshotLoader::new(config_store, layout.clone());
         let catalog = CatalogMetadataProvider::new(layout, catalog_loader);
         Self {
             engine: UniversalSearchEngine::new(catalog),

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -35,22 +35,8 @@ impl Default for AppConfig {
 }
 
 impl AppConfig {
-    pub(crate) fn workspaces(&self) -> Vec<WorkspaceRecord> {
+    pub(crate) fn legacy_workspace_records(&self) -> Vec<WorkspaceRecord> {
         self.workspaces.list()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn has_workspace(&self, workspace_name: &WorkspaceName) -> bool {
-        self.workspaces.contains(workspace_name)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn require_workspace(&self, workspace_name: &WorkspaceName) -> Result<(), AppError> {
-        if self.has_workspace(workspace_name) {
-            Ok(())
-        } else {
-            Err(AppError::WorkspaceNotFound(workspace_name.to_string()))
-        }
     }
 
     pub(crate) fn workspace_sources(&self, workspace_name: &WorkspaceName) -> Vec<InstalledSource> {
@@ -251,11 +237,6 @@ impl WorkspaceCatalog {
             .cloned()
             .map(|name| WorkspaceRecord { name })
             .collect()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn contains(&self, workspace_name: &WorkspaceName) -> bool {
-        self.0.contains(workspace_name)
     }
 
     pub(crate) fn insert(&mut self, workspace_name: WorkspaceName) -> bool {
@@ -519,7 +500,7 @@ impl ConfigStore {
     }
 
     #[cfg(test)]
-    pub(crate) fn create_workspace(
+    pub(crate) fn create_legacy_workspace_entry_for_tests(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<WorkspaceRecord, AppError> {
@@ -534,7 +515,7 @@ impl ConfigStore {
         })
     }
 
-    pub(crate) fn delete_workspace(
+    pub(crate) fn remove_workspace_config_entries(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Option<DeletedWorkspace>, AppError> {
@@ -1053,33 +1034,9 @@ mod tests {
         names.iter().map(|name| (*name).to_string()).collect()
     }
 
-    fn assert_workspace_not_found<T>(result: Result<T, AppError>, workspace_name: &WorkspaceName) {
-        match result {
-            Err(AppError::WorkspaceNotFound(actual)) => {
-                assert_eq!(actual, workspace_name.as_str());
-            }
-            Ok(_) => panic!("expected WorkspaceNotFound for '{workspace_name}'"),
-            Err(error) => panic!("expected WorkspaceNotFound for '{workspace_name}', got {error}"),
-        }
-    }
-
     #[test]
     fn default_config_uses_canonical_version() {
         assert_eq!(AppConfig::default().version, 1);
-    }
-
-    #[test]
-    fn require_workspace_rejects_missing_workspace() {
-        let config = AppConfig::default();
-        let missing_workspace = WorkspaceName::parse("missing").expect("workspace");
-
-        config
-            .require_workspace(&default_workspace())
-            .expect("default workspace should exist");
-        assert_workspace_not_found(
-            config.require_workspace(&missing_workspace),
-            &missing_workspace,
-        );
     }
 
     #[test]
@@ -1122,7 +1079,7 @@ mod tests {
     }
 
     #[test]
-    fn loads_empty_workspace_tables() {
+    fn loads_legacy_empty_workspace_tables() {
         let raw = r"
 version = 1
 
@@ -1136,7 +1093,7 @@ version = 1
         )
         .expect("config");
         let names = config
-            .workspaces()
+            .legacy_workspace_records()
             .into_iter()
             .map(|workspace| workspace.name.as_str().to_string())
             .collect::<Vec<_>>();
@@ -1233,22 +1190,22 @@ origin = "bundled"
     }
 
     #[test]
-    fn delete_workspace_returns_removed_sources() {
+    fn remove_workspace_config_entries_returns_removed_sources() {
         let temp = TempDir::new().expect("temp dir");
         let store = ConfigStore::new(test_layout(&temp));
         let workspace_name = WorkspaceName::parse("work").expect("workspace");
 
         store
-            .create_workspace(&workspace_name)
-            .expect("create workspace");
+            .create_legacy_workspace_entry_for_tests(&workspace_name)
+            .expect("create legacy workspace entry");
         store
             .upsert_source(&workspace_name, installed_source("github"))
             .expect("upsert source");
 
         let deleted = store
-            .delete_workspace(&workspace_name)
-            .expect("delete workspace")
-            .expect("workspace should be deleted");
+            .remove_workspace_config_entries(&workspace_name)
+            .expect("remove workspace config entries")
+            .expect("workspace config should be removed");
 
         assert_eq!(deleted.workspace.name, workspace_name);
         assert_eq!(deleted.sources.len(), 1);

--- a/crates/coral-app/src/state/db/import.rs
+++ b/crates/coral-app/src/state/db/import.rs
@@ -9,23 +9,31 @@ use crate::workspaces::WorkspaceRecord;
 const WORKSPACE_CATALOG_CUTOVER_ID: &str = "workspace_catalog_cutover_v1";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct LegacyConfigCutoverReport {
+pub(crate) struct WorkspaceCatalogCutoverReport {
     pub(crate) workspace_count: usize,
     pub(crate) cutover_performed: bool,
 }
 
-pub(crate) async fn cutover_legacy_config(
+pub(crate) async fn run_state_migrations(
     db: &CoralDb,
     config_store: &ConfigStore,
-) -> Result<LegacyConfigCutoverReport, AppError> {
-    cutover_legacy_config_at(db, config_store, now_unix_nanos_i64()?).await
+) -> Result<(), AppError> {
+    cutover_legacy_workspace_catalog(db, config_store).await?;
+    Ok(())
 }
 
-async fn cutover_legacy_config_at(
+async fn cutover_legacy_workspace_catalog(
+    db: &CoralDb,
+    config_store: &ConfigStore,
+) -> Result<WorkspaceCatalogCutoverReport, AppError> {
+    cutover_legacy_workspace_catalog_at(db, config_store, now_unix_nanos_i64()?).await
+}
+
+async fn cutover_legacy_workspace_catalog_at(
     db: &CoralDb,
     config_store: &ConfigStore,
     now_unix_nanos: i64,
-) -> Result<LegacyConfigCutoverReport, AppError> {
+) -> Result<WorkspaceCatalogCutoverReport, AppError> {
     let _state_lock = config_store.state_lock_exclusive()?;
     let mut session = db;
     if session
@@ -33,13 +41,15 @@ async fn cutover_legacy_config_at(
         .has_completed(WORKSPACE_CATALOG_CUTOVER_ID)
         .await?
     {
-        return Ok(LegacyConfigCutoverReport {
+        return Ok(WorkspaceCatalogCutoverReport {
             workspace_count: session.workspaces().list().await?.len(),
             cutover_performed: false,
         });
     }
 
-    let workspaces = config_store.load_config_unlocked()?.workspaces();
+    let workspaces = config_store
+        .load_config_unlocked()?
+        .legacy_workspace_records();
     let workspace_count = workspaces.len();
 
     let mut tx = db.begin().await?;
@@ -51,7 +61,7 @@ async fn cutover_legacy_config_at(
         .await?;
     tx.commit().await?;
 
-    Ok(LegacyConfigCutoverReport {
+    Ok(WorkspaceCatalogCutoverReport {
         workspace_count,
         cutover_performed: true,
     })
@@ -105,8 +115,8 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        LegacyConfigCutoverReport, WORKSPACE_CATALOG_CUTOVER_ID, cutover_legacy_config,
-        cutover_legacy_config_at,
+        WORKSPACE_CATALOG_CUTOVER_ID, WorkspaceCatalogCutoverReport,
+        cutover_legacy_workspace_catalog, cutover_legacy_workspace_catalog_at,
     };
     use crate::state::db::session::DbRepos;
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
@@ -121,17 +131,17 @@ mod tests {
         let config_store = ConfigStore::new(layout.clone());
         let analytics_workspace = WorkspaceName::parse("analytics").expect("workspace");
         config_store
-            .create_workspace(&analytics_workspace)
-            .expect("create workspace");
+            .create_legacy_workspace_entry_for_tests(&analytics_workspace)
+            .expect("create legacy workspace entry");
         let db = open_sqlite(&layout).await;
 
-        let report = cutover_legacy_config_at(&db, &config_store, 11)
+        let report = cutover_legacy_workspace_catalog_at(&db, &config_store, 11)
             .await
-            .expect("cut over legacy config");
+            .expect("cut over legacy workspace catalog");
 
         assert_eq!(
             report,
-            LegacyConfigCutoverReport {
+            WorkspaceCatalogCutoverReport {
                 workspace_count: 2,
                 cutover_performed: true
             }
@@ -168,8 +178,8 @@ mod tests {
         let config_store = ConfigStore::new(layout.clone());
         let analytics_workspace = WorkspaceName::parse("analytics").expect("workspace");
         config_store
-            .create_workspace(&analytics_workspace)
-            .expect("create workspace");
+            .create_legacy_workspace_entry_for_tests(&analytics_workspace)
+            .expect("create legacy workspace entry");
         let db = open_sqlite(&layout).await;
         let mut tx = db.begin().await.expect("begin stale seed tx");
         tx.workspaces()
@@ -178,9 +188,9 @@ mod tests {
             .expect("seed stale workspace");
         tx.commit().await.expect("commit stale seed tx");
 
-        cutover_legacy_config_at(&db, &config_store, 11)
+        cutover_legacy_workspace_catalog_at(&db, &config_store, 11)
             .await
-            .expect("cut over legacy config");
+            .expect("cut over legacy workspace catalog");
 
         let mut session = &db;
         assert_eq!(
@@ -207,18 +217,18 @@ mod tests {
         let config_store = ConfigStore::new(layout.clone());
         let db = open_sqlite(&layout).await;
 
-        cutover_legacy_config_at(&db, &config_store, 11)
+        cutover_legacy_workspace_catalog_at(&db, &config_store, 11)
             .await
             .expect("initial cutover");
         std::fs::write(layout.config_file(), "[[workspaces]\n").expect("corrupt config");
 
-        let report = cutover_legacy_config(&db, &config_store)
+        let report = cutover_legacy_workspace_catalog(&db, &config_store)
             .await
             .expect("marker should skip legacy config reload");
 
         assert_eq!(
             report,
-            LegacyConfigCutoverReport {
+            WorkspaceCatalogCutoverReport {
                 workspace_count: 1,
                 cutover_performed: false
             }

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -16,6 +16,6 @@ pub(crate) use clock::now_unix_nanos_i64;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
-pub(crate) use import::cutover_legacy_config;
+pub(crate) use import::run_state_migrations;
 pub(crate) use session::{DbRepos, DbSession};
 pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -145,7 +145,8 @@ impl WorkspaceManager {
             tx.workspaces().delete(workspace_name.as_str()).await?;
             let deleted = {
                 let _lifecycle_guard = self.lifecycle_lock.lock();
-                self.config_store.delete_workspace(workspace_name)
+                self.config_store
+                    .remove_workspace_config_entries(workspace_name)
             };
             let deleted = match deleted {
                 Ok(deleted) => deleted.unwrap_or_else(|| DeletedWorkspace {
@@ -158,7 +159,7 @@ impl WorkspaceManager {
                     if let Err(rollback_error) = tx.rollback().await {
                         warn!(
                             workspace = %workspace_name,
-                            "legacy config workspace delete failed, and database rollback also failed: {rollback_error}"
+                            "workspace config cleanup failed, and database rollback also failed: {rollback_error}"
                         );
                     }
                     return Err(error);


### PR DESCRIPTION
## Intent

Clean up the workspace catalog cutover follow-up now that the database is the workspace source of truth.

## What it enables

The remaining config APIs are named for their actual roles: legacy workspace snapshot import and source-config cleanup during workspace deletion. This removes stale config-level workspace validation helpers so future workspace work does not accidentally treat config.toml as authoritative again.

## Usage examples

No public command or RPC behavior changes. Workspace lifecycle calls continue to read and write workspace membership through the database; config remains only the legacy upgrade snapshot and source-catalog storage surface.

## Validation

- cargo fmt --all -- --check
- cargo test -p coral-app state::config
- cargo test -p coral-app state::db::import
- cargo test -p coral-app search::catalog::local_snapshot
- cargo test -p coral-app workspaces::manager::tests::delete_workspace_commits_config_then_cleans_artifacts
- cargo test -p coral-app --test grpc workspace_lifecycle_tests
- git diff --check