### PR TITLE
fix(spec): support comma-delimited OpenAPI array query params

### DIFF
--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -917,6 +917,96 @@ paths:
 }
 
 #[test]
+fn importer_exposes_comma_delimited_array_query_parameters_as_strings() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: x
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.x.com/2
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /users:
+    get:
+      operationId: getUsersByIds
+      parameters:
+        - name: ids
+          in: query
+          required: true
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/UserId'
+        - name: user.fields
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
+                        username: {type: string}
+components:
+  schemas:
+    UserId:
+      type: string
+"
+        .as_bytes(),
+    )
+    .expect("array params import");
+
+    let operation = ir.operations.first().expect("operation");
+    let input_types = operation
+        .inputs
+        .iter()
+        .map(|input| (input.name.as_str(), (input.data_type, input.required)))
+        .collect::<BTreeMap<_, _>>();
+
+    assert_eq!(input_types.get("ids"), Some(&(IrScalarType::String, true)));
+    assert_eq!(
+        input_types.get("user.fields"),
+        Some(&(IrScalarType::String, false))
+    );
+    assert!(
+        operation.diagnostics.iter().all(|diagnostic| {
+            !(diagnostic.code == "PROJECTION_INPUT_UNSUPPORTED"
+                && diagnostic
+                    .message
+                    .contains("unsupported schema type 'array'"))
+        }),
+        "unexpected diagnostics: {:#?}",
+        operation.diagnostics
+    );
+}
+
+#[test]
 fn importer_infers_common_query_pagination_modes() {
     let manifest = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -42,6 +42,93 @@ surfaces:
 }
 
 #[test]
+fn comma_delimited_required_query_arrays_become_table_function_args() {
+    let manifest = parse_source_manifest_yaml(
+        r"
+name: x
+dsl_version: 4
+surfaces:
+  - id: rest
+    type: openapi
+    file: /tmp/openapi.yaml
+    base_url: https://api.x.com/2
+",
+    )
+    .expect("manifest");
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = v4.surfaces.first().expect("one surface");
+    let ir = import_openapi_surface(
+        v4,
+        surface,
+        r"
+openapi: 3.0.3
+paths:
+  /users:
+    get:
+      operationId: getUsersByIds
+      parameters:
+        - name: ids
+          in: query
+          required: true
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+        - name: user.fields
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: {type: string}
+                        username: {type: string}
+"
+        .as_bytes(),
+    )
+    .expect("import");
+
+    let catalog = generate_projection_catalog(v4, &[ir]).expect("catalog");
+    let projection = catalog.projections.first().expect("projection");
+
+    assert_eq!(projection.operation_id, "getusersbyids");
+    assert!(matches!(
+        projection.kind,
+        ProjectionKind::TableFunction {
+            function_kind: SourceTableFunctionKind::Table
+        }
+    ));
+    let inputs = projection
+        .inputs
+        .iter()
+        .map(|input| (input.name.as_str(), (input.sql_exposure, input.required)))
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(
+        inputs.get("ids"),
+        Some(&(SqlInputExposure::FunctionArg, true))
+    );
+    assert_eq!(
+        inputs.get("user_fields"),
+        Some(&(SqlInputExposure::FunctionArg, false))
+    );
+}
+
+#[test]
 fn top_level_scalar_rows_use_scalar_projection_types() {
     let manifest = parse_source_manifest_yaml(
         r"

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -156,8 +156,13 @@ impl OpenApiImporter<'_> {
                     .and_then(Value::as_str)
                     .and_then(parse_parameter_location)?;
                 let schema = parameter_obj.get("schema").unwrap_or(&Value::Null);
-                let scalar =
-                    self.import_parameter_scalar(schema, &name, operation_id, diagnostics)?;
+                let scalar = self.import_parameter_scalar(
+                    parameter_obj,
+                    schema,
+                    &name,
+                    operation_id,
+                    diagnostics,
+                )?;
                 Some(IrOperationInput {
                     name,
                     location,
@@ -176,12 +181,20 @@ impl OpenApiImporter<'_> {
 
     fn import_parameter_scalar(
         &mut self,
+        parameter: &Map<String, Value>,
         schema: &Value,
         name: &str,
         operation_id: &str,
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Option<IrScalarType> {
         let resolved = self.resolve_ref(schema, operation_id, diagnostics)?;
+        if parameter_serializes_as_comma_delimited_array(parameter, &resolved) {
+            let items = resolved.get("items")?;
+            let item_schema = self.resolve_ref(items, operation_id, diagnostics)?;
+            if json_schema_scalar_type_or_string(&item_schema).is_some() {
+                return Some(IrScalarType::String);
+            }
+        }
         let Some(scalar) = json_schema_scalar_type_or_string(&resolved) else {
             diagnostics.push(Diagnostic::warning(
                 "PROJECTION_INPUT_UNSUPPORTED",
@@ -232,6 +245,20 @@ impl OpenApiImporter<'_> {
             type_ref,
         })
     }
+}
+
+fn parameter_serializes_as_comma_delimited_array(
+    parameter: &Map<String, Value>,
+    schema: &Value,
+) -> bool {
+    parameter.get("in").and_then(Value::as_str) == Some("query")
+        && parameter
+            .get("style")
+            .and_then(Value::as_str)
+            .unwrap_or("form")
+            == "form"
+        && parameter.get("explode").and_then(Value::as_bool) == Some(false)
+        && json_schema_type_contains(schema, "array")
 }
 
 fn openapi_operation_naming(

--- a/sources/core-v4/x_v4/README.md
+++ b/sources/core-v4/x_v4/README.md
@@ -1,0 +1,42 @@
+# X DSL v4 preview source
+
+This preview source queries posts, users, timelines, mentions, and engagement
+from the X API v2 OpenAPI surface.
+
+## Authentication
+
+Set `X_ACCESS_TOKEN` to an X API bearer token or OAuth 2.0 user-context access
+token with access to the endpoints you query.
+
+```sh
+X_ACCESS_TOKEN=... coral source add --file sources/core-v4/x_v4/manifest.yaml
+```
+
+## Recent search with author metadata
+
+Recent search rows expose post fields such as `author_id`, `username`,
+`created_at`, and `public_metrics`. Request the X field sets you need with the
+comma-separated query arguments generated from `tweet.fields`, `expansions`,
+and `user.fields`:
+
+```sql
+SELECT id, text, author_id, username, created_at, public_metrics
+FROM x_v4.tweets_searchpostsrecent(
+  query => 'from:XDevelopers',
+  tweet_fields => 'author_id,created_at,conversation_id,public_metrics,referenced_tweets,in_reply_to_user_id',
+  expansions => 'author_id',
+  user_fields => 'username,name,public_metrics,verified,verified_type,description'
+)
+LIMIT 5;
+```
+
+For profile metrics or a reliable handle lookup, query users directly:
+
+```sql
+SELECT id, username, name, public_metrics
+FROM x_v4.users_getusersbyusernames(
+  usernames => 'XDevelopers',
+  user_fields => 'username,name,public_metrics,verified,verified_type,description'
+)
+LIMIT 5;
+```

--- a/sources/core-v4/x_v4/manifest.yaml
+++ b/sources/core-v4/x_v4/manifest.yaml
@@ -29,4 +29,19 @@ surfaces:
       reset_header: x-rate-limit-reset
 
 test_queries:
-  - SELECT id, text FROM x_v4.search_recents(query => 'from:XDevelopers', max_results => 10) LIMIT 5
+  - >-
+    SELECT id, text, author_id, username, created_at, public_metrics
+    FROM x_v4.tweets_searchpostsrecent(
+      query => 'from:XDevelopers',
+      tweet_fields => 'author_id,created_at,conversation_id,public_metrics,referenced_tweets,in_reply_to_user_id',
+      expansions => 'author_id',
+      user_fields => 'username,name,public_metrics,verified,verified_type,description'
+    )
+    LIMIT 5
+  - >-
+    SELECT id, username, name, public_metrics
+    FROM x_v4.users_getusersbyusernames(
+      usernames => 'XDevelopers',
+      user_fields => 'username,name,public_metrics,verified,verified_type,description'
+    )
+    LIMIT 5


### PR DESCRIPTION
## Summary
- teach the DSL v4 OpenAPI importer to expose `style: form`, `explode: false` array query parameters as comma-delimited string SQL inputs
- add importer/projection regressions so required array query params become table-function args instead of disappearing
- update `x_v4` test queries and README to use current generated names plus author/profile field arguments

## Why
X recent search and user lookup rely on comma-delimited array query params such as `tweet.fields`, `user.fields`, `expansions`, `ids`, and `usernames`. Before this change, those params were dropped as unsupported arrays, which made `x_v4` bad for author enrichment and left the checked-in test query stale.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p coral-spec`
- `cargo clippy -p coral-spec --all-targets --all-features --locked -- -D warnings`
- `PATH=/Users/kc/.cargo/bin:$PATH make lint-sources`
- `CORAL_CONFIG_DIR=/tmp/coral-x-v4-pr-folded X_ACCESS_TOKEN=fake target/debug/coral source add --file sources/core-v4/x_v4/manifest.yaml` reached the expected X endpoints; validation failed only with expected fake-token 401 auth errors.