### PR TITLE
feat(desktop): publish mac app with updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,9 +318,92 @@ jobs:
             coral-${{ matrix.target }}.zip
             coral-${{ matrix.target }}.tar.gz
 
+  build-desktop-macos:
+    needs:
+      - validate-release-ref
+    environment: release
+    runs-on: macos-latest
+    env:
+      TAG_NAME: ${{ needs.validate-release-ref.outputs.tag-name }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-release-ref.outputs.commit-sha }}
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: apps/desktop/.node-version
+          package-manager-cache: false
+
+      - name: Install desktop dependencies
+        run: npm ci --prefix apps/desktop
+
+      - name: Build, sign, and notarize desktop app
+        shell: bash
+        env:
+          CORAL_DESKTOP_RELEASE: "1"
+          CSC_LINK: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          CSC_NAME: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
+          APPLE_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APPLE_TEAM_ID:-}" ] && [[ "${CSC_NAME:-}" =~ \(([A-Z0-9]{10})\) ]]; then
+            export APPLE_TEAM_ID="${BASH_REMATCH[1]}"
+          fi
+          if [ -z "${APPLE_TEAM_ID:-}" ]; then
+            echo "APPLE_TEAM_ID must be set as a release environment variable or be present in APPLE_CODESIGN_IDENTITY." >&2
+            exit 1
+          fi
+
+          npm run package:mac --prefix apps/desktop
+
+      - name: Verify desktop app signature and notarization
+        shell: bash
+        run: |
+          set -euo pipefail
+          app_bundle="$(find apps/desktop/dist -name 'Coral.app' -type d -prune | head -n 1)"
+          if [ -z "$app_bundle" ]; then
+            echo "Could not find packaged Coral.app under apps/desktop/dist." >&2
+            exit 1
+          fi
+          codesign --verify --deep --strict --verbose=2 "$app_bundle"
+          xcrun stapler validate "$app_bundle"
+          test -s apps/desktop/dist/latest-mac.yml
+
+          shopt -s nullglob
+          dmg_artifacts=(apps/desktop/dist/coral-desktop-*.dmg)
+          zip_artifacts=(apps/desktop/dist/coral-desktop-*.zip)
+          if [ "${#dmg_artifacts[@]}" -ne 1 ] || [ "${#zip_artifacts[@]}" -ne 1 ]; then
+            echo "Expected exactly one desktop DMG and one desktop ZIP artifact." >&2
+            printf 'DMGs: %s\n' "${dmg_artifacts[*]:-<none>}" >&2
+            printf 'ZIPs: %s\n' "${zip_artifacts[*]:-<none>}" >&2
+            exit 1
+          fi
+
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: coral-desktop-macos
+          if-no-files-found: error
+          path: |
+            apps/desktop/dist/coral-desktop-*.dmg
+            apps/desktop/dist/coral-desktop-*.zip
+            apps/desktop/dist/coral-desktop-*.blockmap
+            apps/desktop/dist/latest-mac.yml
+
   checksums:
     needs:
       - build
+      - build-desktop-macos
       - sign-notarize-macos
     runs-on: ubuntu-latest
     steps:
@@ -332,9 +415,15 @@ jobs:
           merge-multiple: true
       - name: Generate checksums
         run: |
+          set -euo pipefail
+          shopt -s nullglob
           cd artifacts
-          sha256sum coral-*.tar.gz > checksums.sha256
-          sha256sum coral-*.zip >> checksums.sha256
+          artifacts=(coral-*.tar.gz coral-*.zip coral-*.dmg)
+          if [ "${#artifacts[@]}" -eq 0 ]; then
+            echo "No Coral release archives found" >&2
+            exit 1
+          fi
+          sha256sum "${artifacts[@]}" > checksums.sha256
           test -s checksums.sha256
       - name: Upload checksums
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -377,7 +466,14 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          artifacts=(artifacts/coral-*.tar.gz artifacts/coral-*.zip artifacts/checksums.sha256)
+          artifacts=(
+            artifacts/coral-*.tar.gz
+            artifacts/coral-*.zip
+            artifacts/coral-*.dmg
+            artifacts/coral-*.blockmap
+            artifacts/latest-mac.yml
+            artifacts/checksums.sha256
+          )
           if [ "${#artifacts[@]}" -lt 2 ]; then
             echo "No Coral release archives found" >&2
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,7 +350,7 @@ jobs:
           CSC_LINK: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_BASE64 }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERTIFICATE_PASSWORD }}
           CSC_NAME: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
-          APPLE_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8_BASE64 }}
+          APP_STORE_CONNECT_API_KEY_P8_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_P8_BASE64 }}
           APPLE_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
@@ -363,6 +363,14 @@ jobs:
             echo "APPLE_TEAM_ID must be set as a release environment variable or be present in APPLE_CODESIGN_IDENTITY." >&2
             exit 1
           fi
+
+          # electron-builder's notarization (@electron/notarize) expects
+          # APPLE_API_KEY to be a *path* to the App Store Connect .p8 key, not
+          # its contents — decode the base64 secret to a file first.
+          APPLE_API_KEY="$RUNNER_TEMP/app-store-connect-api-key.p8"
+          printf '%s' "$APP_STORE_CONNECT_API_KEY_P8_BASE64" | base64 --decode > "$APPLE_API_KEY"
+          test -s "$APPLE_API_KEY"
+          export APPLE_API_KEY
 
           npm run package:mac --prefix apps/desktop
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,11 @@
   `xtask/src/sources.rs`, performance checks live in `xtask/src/perf.rs`, and
   skill export lives in `xtask/src/skills.rs`. Release signing and
   notarization automation lives in `xtask/src/release.rs`.
+- The Electron desktop app version is tied to the CLI release version through
+  release-please. The release workflow builds the macOS desktop app from
+  `apps/desktop`, uploads its DMG/ZIP/update metadata to the same GitHub
+  Release as the CLI artifacts, and the website should link to the
+  `releases/latest/download` DMG rather than storing desktop binaries itself.
 - `make docs-check` intentionally skips the aggregate community source catalog.
   Any PR may leave that generated page stale so unrelated changes do not fail
   on aggregate community catalog drift; keep docs freshness strict for bundled

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -25,7 +25,8 @@ app lifecycle, window and menu, and MCP client configuration.
   Windows target)
 - Coral MCP configuration for Codex and Claude Code — from the Settings page and
   the app menu — via `add-mcp`
-- macOS DMG packaging via `electron-builder`
+- signed, notarized macOS DMG and ZIP packaging via `electron-builder`
+- GitHub Releases update metadata for packaged desktop auto-updates
 - macOS system theme support
 
 ## Development
@@ -63,6 +64,11 @@ npm run package:dir --prefix apps/desktop
 ```
 
 Use `npm run package:dmg --prefix apps/desktop` for the macOS drag-and-drop DMG.
+Use `npm run package:mac --prefix apps/desktop` to build the release-shaped
+universal macOS DMG and ZIP with updater metadata.
+
+Release builds set `CORAL_DESKTOP_RELEASE=1`, which requires Apple signing and
+notarization credentials and fails if the app cannot be signed.
 
 > Run the `--prefix apps/desktop` commands from the repo root. If you are already in
 > `apps/desktop/`, drop the flag (e.g. `npm run package:dir`).

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -1,9 +1,18 @@
 import type { Configuration } from 'electron-builder'
 
+const releaseBuild = process.env.CORAL_DESKTOP_RELEASE === '1'
+
 const config: Configuration = {
   appId: 'com.withcoral.desktop',
   productName: 'Coral',
-  artifactName: 'coral-desktop-${os}-${arch}.${ext}',
+  forceCodeSigning: releaseBuild,
+  publish: [
+    {
+      provider: 'github',
+      owner: 'withcoral',
+      repo: 'coral',
+    },
+  ],
   directories: {
     output: 'dist',
     buildResources: 'resources',
@@ -37,9 +46,14 @@ const config: Configuration = {
     },
   ],
   mac: {
+    artifactName: 'coral-desktop-mac-${arch}.${ext}',
     category: 'public.app-category.developer-tools',
+    entitlements: 'resources/entitlements.mac.plist',
+    entitlementsInherit: 'resources/entitlements.mac.inherit.plist',
+    hardenedRuntime: true,
     icon: 'resources/icons/icon.icns',
-    target: ['dmg'],
+    notarize: releaseBuild,
+    target: ['dmg', 'zip'],
   },
 }
 

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -8,7 +8,8 @@
       "name": "@withcoral/desktop",
       "version": "0.4.4",
       "dependencies": {
-        "add-mcp": "^1.11.0"
+        "add-mcp": "^1.11.0",
+        "electron-updater": "^6.8.9"
       },
       "devDependencies": {
         "@types/node": "^22.19.2",
@@ -2204,7 +2205,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -2500,7 +2500,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2817,6 +2816,34 @@
       "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/electron-vite": {
       "version": "5.0.0",
@@ -3191,7 +3218,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -3442,7 +3468,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -3767,7 +3792,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -3790,7 +3814,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash": {
@@ -3798,6 +3821,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
@@ -3966,7 +4002,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4626,7 +4661,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -4904,6 +4938,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -5008,7 +5048,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,10 +19,13 @@
     "package:dir": "electron-builder --dir --config electron-builder.config.ts",
     "prepackage:dmg": "npm run build",
     "package:dmg": "electron-builder --mac dmg --config electron-builder.config.ts",
+    "prepackage:mac": "CORAL_DESKTOP_UNIVERSAL=1 npm run build",
+    "package:mac": "electron-builder --mac --universal --publish never --config electron-builder.config.ts",
     "stage:coral": "node ./scripts/stage-coral.mjs"
   },
   "dependencies": {
-    "add-mcp": "^1.11.0"
+    "add-mcp": "^1.11.0",
+    "electron-updater": "^6.8.9"
   },
   "devDependencies": {
     "@types/node": "^22.19.2",

--- a/apps/desktop/resources/entitlements.mac.inherit.plist
+++ b/apps/desktop/resources/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/desktop/resources/entitlements.mac.plist
+++ b/apps/desktop/resources/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/desktop/scripts/stage-coral.mjs
+++ b/apps/desktop/scripts/stage-coral.mjs
@@ -7,6 +7,9 @@ const repoRoot = resolve(desktopRoot, '..', '..')
 const outputDir = resolve(desktopRoot, 'resources', 'coral')
 const binaryName = process.platform === 'win32' ? 'coral.exe' : 'coral'
 const targetBinary = resolve(repoRoot, 'target', 'release', binaryName)
+const universalMacBinary = resolve(repoRoot, 'target', 'release', 'coral-universal')
+const universalMac = process.env.CORAL_DESKTOP_UNIVERSAL === '1'
+const macTargets = ['x86_64-apple-darwin', 'aarch64-apple-darwin']
 
 function run(command, args, options = {}) {
   return new Promise((resolveRun, rejectRun) => {
@@ -36,14 +39,38 @@ await run('npm', ['run', 'build', '--prefix', 'apps/reef'], {
     CORAL_DESKTOP_APP: '1',
   },
 })
-await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release'])
+
+async function buildCoralCli() {
+  if (!universalMac) {
+    await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release'])
+    return targetBinary
+  }
+
+  if (process.platform !== 'darwin') {
+    throw new Error('CORAL_DESKTOP_UNIVERSAL=1 is only supported on macOS.')
+  }
+
+  await run('rustup', ['target', 'add', ...macTargets])
+  for (const target of macTargets) {
+    await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release', '--target', target])
+  }
+  await run('lipo', [
+    '-create',
+    ...macTargets.map((target) => resolve(repoRoot, 'target', target, 'release', binaryName)),
+    '-output',
+    universalMacBinary,
+  ])
+  return universalMacBinary
+}
+
+const builtBinary = await buildCoralCli()
 
 await rm(outputDir, { recursive: true, force: true })
 await mkdir(outputDir, { recursive: true })
-await copyFile(targetBinary, join(outputDir, binaryName))
+await copyFile(builtBinary, join(outputDir, binaryName))
 
 if (process.platform !== 'win32') {
   await chmod(join(outputDir, binaryName), 0o755)
 }
 
-console.log(`[stage-coral] staged ${targetBinary} -> ${join(outputDir, binaryName)}`)
+console.log(`[stage-coral] staged ${builtBinary} -> ${join(outputDir, binaryName)}`)

--- a/apps/desktop/src/main/auto-update.ts
+++ b/apps/desktop/src/main/auto-update.ts
@@ -1,0 +1,100 @@
+import { dialog, app } from 'electron'
+import { createRequire } from 'node:module'
+import type { AppUpdater, UpdateCheckResult } from 'electron-updater'
+
+const require = createRequire(import.meta.url)
+const { autoUpdater } = require('electron-updater') as { autoUpdater: AppUpdater }
+
+const STARTUP_UPDATE_CHECK_DELAY_MS = 5000
+
+let installed = false
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+function logUpdateError(context: string, error: unknown): void {
+  console.error(`[coral-updater] ${context}: ${errorMessage(error)}`)
+}
+
+function installUpdateLogging(): void {
+  autoUpdater.on('checking-for-update', () => {
+    console.info('[coral-updater] checking for updates')
+  })
+  autoUpdater.on('update-available', (info) => {
+    console.info(`[coral-updater] update available: ${info.version}`)
+  })
+  autoUpdater.on('update-not-available', (info) => {
+    console.info(`[coral-updater] no update available; latest is ${info.version}`)
+  })
+  autoUpdater.on('download-progress', (progress) => {
+    console.info(`[coral-updater] download ${progress.percent.toFixed(1)}%`)
+  })
+  autoUpdater.on('update-downloaded', (info) => {
+    console.info(`[coral-updater] update downloaded: ${info.version}`)
+  })
+  autoUpdater.on('error', (error) => {
+    logUpdateError('update check failed', error)
+  })
+}
+
+async function showManualResult(result: UpdateCheckResult | null): Promise<void> {
+  if (!result) {
+    await dialog.showMessageBox({
+      type: 'info',
+      message: 'Update checks are unavailable for this build',
+      detail: 'Coral can check for desktop updates only from a packaged release build.',
+    })
+    return
+  }
+
+  if (!result.isUpdateAvailable) {
+    await dialog.showMessageBox({
+      type: 'info',
+      message: 'Coral is up to date',
+      detail: `You are running Coral ${app.getVersion()}.`,
+    })
+    return
+  }
+
+  await dialog.showMessageBox({
+    type: 'info',
+    message: `Coral ${result.updateInfo.version} is downloading`,
+    detail: 'You will be notified when the update is ready. It will install after Coral quits.',
+  })
+}
+
+export function installAutoUpdater(): void {
+  if (!app.isPackaged || installed) return
+
+  installed = true
+  autoUpdater.autoDownload = true
+  autoUpdater.autoInstallOnAppQuit = true
+  installUpdateLogging()
+
+  setTimeout(() => {
+    void checkForDesktopUpdates({ interactive: false })
+  }, STARTUP_UPDATE_CHECK_DELAY_MS)
+}
+
+export async function checkForDesktopUpdates({ interactive }: { interactive: boolean }): Promise<void> {
+  if (!app.isPackaged) {
+    if (interactive) await showManualResult(null)
+    return
+  }
+
+  try {
+    const result = await autoUpdater.checkForUpdatesAndNotify()
+    if (interactive) await showManualResult(result)
+  } catch (error) {
+    logUpdateError('manual update check failed', error)
+    if (interactive) {
+      await dialog.showMessageBox({
+        type: 'error',
+        message: 'Update check failed',
+        detail: errorMessage(error),
+      })
+    }
+  }
+}

--- a/apps/desktop/src/main/auto-update.ts
+++ b/apps/desktop/src/main/auto-update.ts
@@ -6,6 +6,10 @@ const require = createRequire(import.meta.url)
 const { autoUpdater } = require('electron-updater') as { autoUpdater: AppUpdater }
 
 const STARTUP_UPDATE_CHECK_DELAY_MS = 5000
+// Long-running desktop sessions would otherwise only see new releases after a
+// restart; re-check periodically so a release ships to open apps too. The
+// downloaded update still installs on quit.
+const PERIODIC_UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000
 
 let installed = false
 
@@ -76,6 +80,10 @@ export function installAutoUpdater(): void {
   setTimeout(() => {
     void checkForDesktopUpdates({ interactive: false })
   }, STARTUP_UPDATE_CHECK_DELAY_MS)
+  // electron-updater dedupes overlapping checks, so a plain interval is safe.
+  setInterval(() => {
+    void checkForDesktopUpdates({ interactive: false })
+  }, PERIODIC_UPDATE_CHECK_INTERVAL_MS)
 }
 
 export async function checkForDesktopUpdates({ interactive }: { interactive: boolean }): Promise<void> {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -12,6 +12,7 @@ import {
   registerAppSchemePrivileges,
 } from './app-renderer'
 import { killAllTrackedChildren, startCoralSidecar, type CoralSidecar } from './sidecar'
+import { checkForDesktopUpdates, installAutoUpdater } from './auto-update'
 
 const SHUTDOWN_TIMEOUT_MS = 6000
 
@@ -280,6 +281,16 @@ function installMenu() {
           label: 'Configure MCP',
           submenu: mcpSubmenu,
         },
+        ...(app.isPackaged
+          ? ([
+              {
+                label: 'Check for Updates...',
+                click: () => {
+                  void checkForDesktopUpdates({ interactive: true })
+                },
+              },
+            ] satisfies Electron.MenuItemConstructorOptions[])
+          : []),
         { type: 'separator' },
         { role: 'quit' },
       ],
@@ -334,6 +345,7 @@ app.whenReady().then(() => {
   nativeTheme.on('updated', updatePlatformIcon)
   registerIpcHandlers()
   installMenu()
+  installAutoUpdater()
   registerAppProtocol(() => ensureSidecar().then((started) => started.url))
   void ensureSidecar().catch((error: unknown) => {
     const message = error instanceof Error ? error.message : String(error)

--- a/apps/docs/getting-started/installation.mdx
+++ b/apps/docs/getting-started/installation.mdx
@@ -1,19 +1,30 @@
 ---
 title: "Installation"
-description: "Install the Coral CLI"
+description: "Install Coral"
 ---
 
-Coral ships as a single local CLI. Once installed, the same binary is used for source management, SQL queries, and the MCP stdio server.
+Coral ships as a macOS desktop app and a single local CLI. The CLI binary is
+used for source management, SQL queries, and the MCP stdio server; Coral
+Desktop bundles that CLI as its local sidecar.
 
 <Note>
-  Coral publishes macOS, Linux, and x86_64 Windows artifacts. Windows support
-  currently targets native Windows 10/11 on `x86_64-pc-windows-msvc`; ARM64
-  Windows is not released.
+  Coral publishes a macOS desktop app plus macOS, Linux, and x86_64 Windows CLI
+  artifacts. Windows CLI support currently targets native Windows 10/11 on
+  `x86_64-pc-windows-msvc`; ARM64 Windows is not released.
 </Note>
 
 ## Install Coral
 
 <Tabs>
+  <Tab title="Desktop app">
+    Download the signed macOS desktop app:
+
+    [Download Coral Desktop for macOS](https://github.com/withcoral/coral/releases/latest/download/coral-desktop-mac-universal.dmg)
+
+    Coral Desktop bundles the matching Coral CLI sidecar for that release and
+    checks for desktop updates automatically.
+  </Tab>
+
   <Tab title="Homebrew">
     ```shellscript
     brew install withcoral/tap/coral
@@ -134,6 +145,15 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
 ## Upgrade
 
 <Tabs>
+  <Tab title="Desktop app">
+    Coral Desktop checks for updates at startup. To check manually, open
+    **Coral > Check for Updates...** from the app menu.
+
+    You can also download and install the latest DMG again:
+
+    [Download Coral Desktop for macOS](https://github.com/withcoral/coral/releases/latest/download/coral-desktop-mac-universal.dmg)
+  </Tab>
+
   <Tab title="Homebrew">
     ```shellscript
     brew upgrade withcoral/tap/coral
@@ -165,6 +185,14 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
 ## Uninstall
 
 <Tabs>
+  <Tab title="Desktop app">
+    Move Coral from `/Applications` to the Trash. To remove local Coral state:
+
+    ```shellscript
+    rm -rf ~/.config/coral
+    ```
+  </Tab>
+
   <Tab title="Homebrew">
     ```shellscript
     brew uninstall withcoral/tap/coral

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,9 @@
       "package-name": "coral",
       "extra-files": [
         "Cargo.toml",
-        { "type": "json", "path": "apps/desktop/package.json", "jsonpath": "$.version" }
+        { "type": "json", "path": "apps/desktop/package.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "apps/desktop/package-lock.json", "jsonpath": "$.version" },
+        { "type": "json", "path": "apps/desktop/package-lock.json", "jsonpath": "$.packages[\"\"].version" }
       ],
       "exclude-paths": ["sources/community", "sources/core-v4"]
     }


### PR DESCRIPTION
Same commits as #1519 (which stopped receiving GitHub Actions events — no check suites get created for new pushes on that branch while other branches trigger fine; possibly Graphite CI-optimization interference). Fresh branch to restore CI. See #1519 for the full description and review history; supersedes it once green.

https://claude.ai/code/session_01LHpYSWV9NFgBWsgRfF3nkA