### PR TITLE
feat(mcp)!: make feedback opt-out

### DIFF
--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -330,6 +330,7 @@ By default, this server exposes:
 | Tool     | `list_catalog`   | List database tables and table functions with pagination |
 | Tool     | `describe_table` | Show compact metadata for one database table            |
 | Tool     | `list_columns`   | List columns for one database table with pagination     |
+| Tool     | `feedback`       | Submit a blocked-agent feedback report                   |
 | Resource | `coral://guide`  | Database workflow guide for agents                     |
 | Resource | `coral://tables` | JSON summaries of query-visible database tables, including Coral catalog tables and required filters |
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -69,7 +69,7 @@ Feature values must be booleans. Unknown feature keys are preserved in `config.t
 
 | Feature | Default | Description |
 | ------- | ------- | ----------- |
-| `feedback` | `false` | Experimental. Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral. |
+| `feedback` | `true` | Experimental. Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral. |
 
 ## OpenTelemetry
 

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -68,7 +68,7 @@ struct FeatureSpec {
 const FEATURE_SPECS: &[FeatureSpec] = &[FeatureSpec {
     feature: Feature::Feedback,
     key: "feedback",
-    default_enabled: false,
+    default_enabled: true,
     description: "Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral.",
     enable_flag: "enable-feedback",
     disable_flag: "disable-feedback",
@@ -145,6 +145,13 @@ impl Features {
 
     fn from_raw_overrides(raw: &RawFeatureOverrides) -> Self {
         let mut features = Self::default();
+        if raw.container() == RawFeatureContainerState::Unsupported {
+            for spec in FEATURE_SPECS {
+                features.enabled.insert(spec.feature, false);
+            }
+            return features;
+        }
+
         for (key, value) in raw.iter() {
             let Some(spec) = spec_for_key(key) else {
                 warn!(feature = key, "ignoring unknown Coral runtime feature");
@@ -158,8 +165,9 @@ impl Features {
                 RawFeatureValue::UnsupportedType => {
                     warn!(
                         feature = key,
-                        "ignoring unsupported Coral runtime feature value; expected boolean"
+                        "disabling Coral runtime feature with unsupported value; expected boolean"
                     );
+                    features.enabled.insert(spec.feature, false);
                 }
             }
         }
@@ -237,7 +245,7 @@ impl FeatureStore {
         Ok(statuses_from_raw(&raw, &features))
     }
 
-    /// Persists a local opt-in override for a known feature key.
+    /// Persists a local enable override for a known feature key.
     ///
     /// # Errors
     ///
@@ -326,17 +334,18 @@ mod tests {
     }
 
     #[test]
-    fn defaults_disable_feedback() {
+    fn defaults_enable_feedback() {
         let features = Features::default();
 
-        assert!(!features.enabled(Feature::Feedback));
+        assert!(features.enabled(Feature::Feedback));
     }
 
     #[test]
-    fn process_overrides_enable_default_disabled_feature() {
+    fn process_overrides_enable_config_disabled_feature() {
         let mut overrides = FeatureOverrides::default();
         overrides.set(Feature::Feedback, true);
-        let mut features = Features::default();
+        let raw = raw([("feedback", RawFeatureValue::Bool(false))]);
+        let mut features = Features::from_raw_overrides(&raw);
 
         features.apply_overrides(&overrides);
 
@@ -372,15 +381,15 @@ mod tests {
     }
 
     #[test]
-    fn unknown_override_is_ignored() {
-        let raw = raw([("future_flag", RawFeatureValue::Bool(true))]);
+    fn unknown_override_does_not_disable_default_enabled_feedback() {
+        let raw = raw([("future_flag", RawFeatureValue::UnsupportedType)]);
         let features = Features::from_raw_overrides(&raw);
 
-        assert!(!features.enabled(Feature::Feedback));
+        assert!(features.enabled(Feature::Feedback));
     }
 
     #[test]
-    fn unsupported_known_override_is_ignored() {
+    fn unsupported_known_override_fails_closed() {
         let raw = raw([("feedback", RawFeatureValue::UnsupportedType)]);
         let features = Features::from_raw_overrides(&raw);
 

--- a/crates/coral-cli/tests/features.rs
+++ b/crates/coral-cli/tests/features.rs
@@ -89,8 +89,8 @@ fn features_list_shows_feedback_status_without_state_creation() {
         "missing default status: {stdout}"
     );
     assert!(
-        stdout.contains("false"),
-        "missing disabled effective state: {stdout}"
+        stdout.contains("true"),
+        "missing enabled effective state: {stdout}"
     );
     assert!(
         stdout.contains("Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral."),
@@ -103,12 +103,12 @@ fn features_list_shows_feedback_status_without_state_creation() {
 }
 
 #[test]
-fn features_list_applies_global_process_override_without_state_creation() {
+fn features_list_applies_global_disable_override_without_state_creation() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("missing-config");
 
     let assert = coral_cmd(&config_dir)
-        .args(["--enable-feedback", "features", "list"])
+        .args(["--disable-feedback", "features", "list"])
         .assert()
         .success();
 
@@ -122,8 +122,8 @@ fn features_list_applies_global_process_override_without_state_creation() {
         "config status should remain default: {stdout}"
     );
     assert!(
-        stdout.contains("true"),
-        "process override should enable feature in effective state: {stdout}"
+        stdout.contains("false"),
+        "process override should disable feature in effective state: {stdout}"
     );
     assert!(
         !config_dir.exists(),
@@ -149,7 +149,7 @@ fn features_enable_creates_config_with_feedback_enabled() {
     assert!(raw.contains("[features]"), "missing features table: {raw}");
     assert!(
         raw.contains("feedback = true"),
-        "missing feedback opt-in: {raw}"
+        "missing feedback enable override: {raw}"
     );
 }
 
@@ -265,7 +265,7 @@ feedback = true
 }
 
 #[test]
-fn features_list_reports_invalid_known_value_as_default_effective_state() {
+fn features_list_reports_invalid_known_value_and_fails_closed() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
     write_config(
@@ -288,12 +288,12 @@ feedback = "yes"
     );
     assert!(
         stdout.contains("false"),
-        "invalid value should fall back to default disabled state: {stdout}"
+        "invalid value should fail closed: {stdout}"
     );
 }
 
 #[test]
-fn features_list_reports_unsupported_container_as_default_effective_state() {
+fn features_list_reports_unsupported_container_and_fails_closed() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
     write_config(&config_dir, "features = { feedback = true }\n");
@@ -310,7 +310,7 @@ fn features_list_reports_unsupported_container_as_default_effective_state() {
     );
     assert!(
         stdout.contains("false"),
-        "invalid container should fall back to default disabled state: {stdout}"
+        "invalid container should fail closed: {stdout}"
     );
 }
 

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -715,8 +715,16 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             "search",
             "list_catalog",
             "describe_table",
-            "list_columns"
+            "list_columns",
+            "feedback"
         ]
+    );
+    assert!(
+        !server
+            .config_dir()
+            .join("workspaces/default/feedback/reports.jsonl")
+            .exists(),
+        "listing the default-on feedback tool must not submit a report"
     );
     assert!(
         tools[0]
@@ -918,16 +926,9 @@ feedback = false
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn mcp_stdio_disable_feedback_override_overrides_config_enabled()
+async fn mcp_stdio_disable_feedback_flag_removes_default_feedback_tool()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
-    write_config(
-        &server,
-        r"
-[features]
-feedback = true
-",
-    )?;
     let client = start_mcp_client_with_args(&server, &["--disable-feedback"]).await?;
 
     let tools = client.list_all_tools().await?;

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -95,7 +95,7 @@ impl McpQueryExample {
 }
 
 /// Optional MCP surface features.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct McpOptions {
     /// Expose the feedback submission tool.
     pub feedback_enabled: bool,
@@ -107,6 +107,18 @@ pub struct McpOptions {
     pub query_examples: Vec<McpQueryExample>,
     /// Workspace scoped to this MCP server instance.
     pub workspace: Option<coral_api::v1::Workspace>,
+}
+
+impl Default for McpOptions {
+    fn default() -> Self {
+        Self {
+            feedback_enabled: true,
+            trace_parent: None,
+            source_names: Vec::new(),
+            query_examples: Vec::new(),
+            workspace: None,
+        }
+    }
 }
 
 /// Runs the `MCP` stdio server using an existing Coral client.

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -448,7 +448,8 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             "search",
             "list_catalog",
             "describe_table",
-            "list_columns"
+            "list_columns",
+            "feedback"
         ]
     );
     assert!(
@@ -990,14 +991,7 @@ async fn list_catalog_surfaces_table_functions() {
 #[tokio::test]
 async fn mcp_feedback_tool_persists_blocked_agent_report() {
     let temp = TempDir::new().expect("temp dir");
-    let session = start_session_with_options(
-        &temp,
-        McpOptions {
-            feedback_enabled: true,
-            ..McpOptions::default()
-        },
-    )
-    .await;
+    let session = start_session(&temp).await;
     let client = &session.client;
 
     let tools = client.list_all_tools().await.expect("tools");
@@ -1098,11 +1092,45 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
 }
 
 #[tokio::test]
-async fn mcp_feedback_tool_is_disabled_by_default() {
+async fn mcp_feedback_tool_is_enabled_by_default_without_submitting_report() {
     let temp = TempDir::new().expect("temp dir");
     let session = start_session(&temp).await;
     let client = &session.client;
 
+    let tools = client.list_all_tools().await.expect("tools");
+    assert!(
+        tools.iter().any(|tool| tool.name.as_ref() == "feedback"),
+        "feedback should be exposed by default"
+    );
+    assert!(
+        !temp
+            .path()
+            .join("coral-config/workspaces/default/feedback/reports.jsonl")
+            .exists(),
+        "listing the default-on feedback tool must not submit a report"
+    );
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_feedback_tool_can_be_explicitly_disabled() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_session_with_options(
+        &temp,
+        McpOptions {
+            feedback_enabled: false,
+            ..McpOptions::default()
+        },
+    )
+    .await;
+    let client = &session.client;
+
+    let tools = client.list_all_tools().await.expect("tools");
+    assert!(
+        tools.iter().all(|tool| tool.name.as_ref() != "feedback"),
+        "feedback should not be listed when explicitly disabled"
+    );
     let feedback = client
         .call_tool(
             CallToolRequestParams::new("feedback").with_arguments(json_object(&json!({
@@ -1112,7 +1140,7 @@ async fn mcp_feedback_tool_is_disabled_by_default() {
             }))),
         )
         .await
-        .expect_err("feedback should not be exposed by default");
+        .expect_err("feedback should not be exposed when explicitly disabled");
     assert!(feedback.to_string().contains("tool 'feedback' not found"));
     assert!(
         !temp


### PR DESCRIPTION
## Summary

The feedback we collect is completely anonymous; it'd be great to learn more about Coral usage, so making it opt-out by default instead of opt-in.

Users can still easily disable this with flags or persistently with the `feature` cli command