### PR TITLE
refactor(reef): extract reusable query detail UI

### DIFF
--- a/apps/reef/app/components/query-detail/index.ts
+++ b/apps/reef/app/components/query-detail/index.ts
@@ -1,0 +1,8 @@
+export { QueryDetailSummary } from './query-detail-summary'
+export { QueryDetailResults } from './query-detail-results'
+export type { QueryDetailResultsProps } from './query-detail-results'
+export type {
+  QueryDetailStat,
+  QueryDetailStatusTone,
+  QueryDetailSummaryProps,
+} from './query-detail-summary'

--- a/apps/reef/app/components/query-detail/query-detail-results.css.ts
+++ b/apps/reef/app/components/query-detail/query-detail-results.css.ts
@@ -1,0 +1,7 @@
+import { style } from '@vanilla-extract/css'
+
+export const root = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+})

--- a/apps/reef/app/components/query-detail/query-detail-results.stories.tsx
+++ b/apps/reef/app/components/query-detail/query-detail-results.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Table } from '@/wax/components/table'
+
+import { QueryDetailResults } from './query-detail-results'
+
+const meta = {
+  component: QueryDetailResults,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  title: 'Components/QueryDetail/Results',
+} satisfies Meta<typeof QueryDetailResults>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const CatalogRows: Story = {
+  render: (args) => (
+    <QueryDetailResults {...args}>
+      <Table.Wrapper style="compact">
+        <Table.Root>
+          <Table.Head>
+            <Table.Row>
+              <Table.HeaderCell>Schema name</Table.HeaderCell>
+              <Table.HeaderCell align="right">Table count</Table.HeaderCell>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell mono>gitlab</Table.Cell>
+              <Table.Cell align="right" mono>
+                216
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell mono>clickup</Table.Cell>
+              <Table.Cell align="right" mono>
+                46
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell mono>notion</Table.Cell>
+              <Table.Cell align="right" mono>
+                12
+              </Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table.Root>
+      </Table.Wrapper>
+    </QueryDetailResults>
+  ),
+}
+
+export const Empty: Story = {}

--- a/apps/reef/app/components/query-detail/query-detail-results.tsx
+++ b/apps/reef/app/components/query-detail/query-detail-results.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react'
+
+import { Typography } from '@/wax/components/typography'
+
+import * as styles from './query-detail-results.css'
+
+export interface QueryDetailResultsProps {
+  children?: ReactNode
+  emptyMessage?: string
+  title?: ReactNode
+}
+
+export function QueryDetailResults({
+  children,
+  emptyMessage = 'No rows returned.',
+  title = 'Results',
+}: QueryDetailResultsProps) {
+  return (
+    <div className={styles.root}>
+      <Typography.HeadingXSmall as="h2">{title}</Typography.HeadingXSmall>
+      {children ?? <Typography.Body variant="tertiary">{emptyMessage}</Typography.Body>}
+    </div>
+  )
+}

--- a/apps/reef/app/components/query-detail/query-detail-summary.css.ts
+++ b/apps/reef/app/components/query-detail/query-detail-summary.css.ts
@@ -1,0 +1,139 @@
+import { globalStyle, style } from '@vanilla-extract/css'
+
+import { breakpoints } from '@/styles/theme.css'
+import { fontFamily } from '@/wax/theme/font.css'
+import { lightTheme } from '@/wax/theme/theme-light.css'
+import { theme } from '@/wax/theme/theme.css'
+
+export const root = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  minHeight: 0,
+})
+
+export const header = style({
+  alignItems: 'center',
+  borderBlockEnd: `1px solid ${theme.stroke.secondary}`,
+  display: 'flex',
+  flexShrink: 0,
+  height: 56,
+  justifyContent: 'space-between',
+  overflow: 'hidden',
+  paddingBlock: 6,
+  paddingInline: 32,
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      paddingInline: 16,
+    },
+  },
+})
+
+export const headerTitle = style({
+  alignItems: 'center',
+  display: 'flex',
+  flex: 1,
+  gap: 4,
+  minWidth: 0,
+  overflow: 'hidden',
+  paddingInlineEnd: 24,
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+export const headerActions = style({
+  alignItems: 'center',
+  display: 'flex',
+  flexShrink: 0,
+  gap: 4,
+})
+
+export const statusBadge = style({
+  borderRadius: 999,
+  display: 'inline-flex',
+  fontSize: 12,
+  lineHeight: '18px',
+  paddingBlock: 2,
+  paddingInline: 8,
+  selectors: {
+    '&[data-tone="ok"]': {
+      backgroundColor: theme.pill.green.background,
+      color: theme.pill.green.color,
+    },
+    '&[data-tone="error"]': {
+      backgroundColor: theme.pill.red.background,
+      color: theme.pill.red.color,
+    },
+    '&[data-tone="running"]': {
+      backgroundColor: theme.pill.blue.background,
+      color: theme.pill.blue.color,
+    },
+  },
+})
+
+export const scrollBody = style({
+  display: 'flex',
+  flex: 1,
+  minHeight: 0,
+  overflow: 'auto',
+})
+
+export const content = style({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  gap: 16,
+  minHeight: '100%',
+  padding: 16,
+})
+
+export const sqlBlock = style({
+  backgroundColor: theme.surface.main,
+  border: `1px solid ${theme.stroke.primary}`,
+  borderRadius: 8,
+  overflow: 'hidden',
+  position: 'relative',
+})
+
+export const statGrid = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 12,
+})
+
+export const statCard = style({
+  backgroundColor: theme.surface.onMainContent,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 12,
+  display: 'flex',
+  flexDirection: 'column',
+  flexShrink: 0,
+  minWidth: 100,
+  paddingBlock: 12,
+  paddingInline: 16,
+})
+
+globalStyle(`${sqlBlock} pre`, {
+  color: theme.content.primary,
+  fontFamily: fontFamily.dmMono,
+  fontSize: 14,
+  lineHeight: 1.65,
+  margin: 0,
+  overflowX: 'auto',
+  padding: 12,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
+})
+
+globalStyle(`${sqlBlock} .sql-keyword`, { color: '#569CD6', fontWeight: 600 })
+globalStyle(`body.${lightTheme} ${sqlBlock} .sql-keyword`, { color: '#0000FF' })
+globalStyle(`${sqlBlock} .sql-function`, { color: '#4EC9B0' })
+globalStyle(`body.${lightTheme} ${sqlBlock} .sql-function`, { color: '#795E26' })
+globalStyle(`${sqlBlock} .sql-string`, { color: '#CE9178' })
+globalStyle(`body.${lightTheme} ${sqlBlock} .sql-string`, { color: '#A31515' })
+globalStyle(`${sqlBlock} .sql-number`, { color: '#CE9178' })
+globalStyle(`body.${lightTheme} ${sqlBlock} .sql-number`, { color: '#098658' })
+globalStyle(`${sqlBlock} .sql-comment`, { color: '#6A9955', fontStyle: 'italic' })
+globalStyle(`body.${lightTheme} ${sqlBlock} .sql-comment`, { color: '#008000' })
+globalStyle(`${sqlBlock} .sql-identifier`, { color: '#9CDCFE' })
+globalStyle(`body.${lightTheme} ${sqlBlock} .sql-identifier`, { color: '#001080' })

--- a/apps/reef/app/components/query-detail/query-detail-summary.stories.tsx
+++ b/apps/reef/app/components/query-detail/query-detail-summary.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { QueryDetailSummary } from './query-detail-summary'
+
+const meta = {
+  args: {
+    sql: 'SELECT * FROM github.meta LIMIT 1',
+    stats: [
+      { label: 'Duration', value: '42ms' },
+      { label: 'Rows', value: '1' },
+      { label: 'Table scans', value: '1' },
+      { label: 'API requests', value: '2' },
+    ],
+    statusLabel: 'done',
+    statusTone: 'ok',
+    title: 'Query details',
+  },
+  component: QueryDetailSummary,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  title: 'Components/QueryDetail/Summary',
+} satisfies Meta<typeof QueryDetailSummary>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Done: Story = {}
+
+export const Error: Story = {
+  args: {
+    sql: 'SELECT * FROM github.repositories LIMIT 5',
+    stats: [
+      { label: 'Duration', value: '—' },
+      { label: 'Rows', value: '—' },
+      { label: 'Table scans', value: '1' },
+      { label: 'API requests', value: '1' },
+    ],
+    statusLabel: 'error',
+    statusTone: 'error',
+  },
+}

--- a/apps/reef/app/components/query-detail/query-detail-summary.tsx
+++ b/apps/reef/app/components/query-detail/query-detail-summary.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from 'react'
+
+import { highlightSQL } from '@/lib/sql-highlight'
+import { Typography } from '@/wax/components/typography'
+
+import * as styles from './query-detail-summary.css'
+
+export type QueryDetailStatusTone = 'error' | 'ok' | 'running'
+
+export interface QueryDetailStat {
+  label: string
+  value: ReactNode
+}
+
+export interface QueryDetailSummaryProps {
+  actions?: ReactNode
+  children?: ReactNode
+  shortcuts?: ReactNode
+  sql: string
+  stats?: QueryDetailStat[]
+  statusLabel?: ReactNode
+  statusTone?: QueryDetailStatusTone
+  title: ReactNode
+}
+
+export function QueryDetailSummary({
+  actions,
+  children,
+  shortcuts,
+  sql,
+  stats = [],
+  statusLabel,
+  statusTone = 'running',
+  title,
+}: QueryDetailSummaryProps) {
+  const hasHeaderActions = Boolean(statusLabel || actions)
+
+  return (
+    <div className={styles.root}>
+      {shortcuts}
+      <header className={styles.header}>
+        <div className={styles.headerTitle}>
+          {typeof title === 'string' ? (
+            <Typography.BodyStrong as="span" variant="secondary">
+              {title}
+            </Typography.BodyStrong>
+          ) : (
+            title
+          )}
+        </div>
+        {hasHeaderActions ? (
+          <div className={styles.headerActions}>
+            {statusLabel ? (
+              <span className={styles.statusBadge} data-tone={statusTone}>
+                {statusLabel}
+              </span>
+            ) : null}
+            {actions}
+          </div>
+        ) : null}
+      </header>
+      <div className={styles.scrollBody}>
+        <div className={styles.content}>
+          <div className={styles.sqlBlock}>
+            <pre>
+              <QuerySqlCode sql={sql} />
+            </pre>
+          </div>
+          {stats.length > 0 ? (
+            <div className={styles.statGrid}>
+              {stats.map((stat) => (
+                <QueryDetailStatCard key={stat.label} label={stat.label} value={stat.value} />
+              ))}
+            </div>
+          ) : null}
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function QuerySqlCode({ sql }: { sql: string }) {
+  return <code dangerouslySetInnerHTML={{ __html: highlightSQL(sql) }} />
+}
+
+function QueryDetailStatCard({ label, value }: QueryDetailStat) {
+  return (
+    <div className={styles.statCard}>
+      <Typography.Body variant="tertiary">{label}</Typography.Body>
+      <Typography.BodyLargeStrong>{value}</Typography.BodyLargeStrong>
+    </div>
+  )
+}

--- a/apps/reef/app/views/traces/trace-detail.tsx
+++ b/apps/reef/app/views/traces/trace-detail.tsx
@@ -7,12 +7,11 @@ import { Icon } from '@/wax/components/icon'
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
 import { Typography } from '@/wax/components/typography'
 import { EmptyPage } from '@/components/empty-page'
+import { QueryDetailSummary } from '@/components/query-detail'
 import { TraceStatus } from '@/generated/coral/v1/traces_pb'
 
 import * as s from './traces.css'
 import { HttpSpanDetail } from './http-span-detail'
-import { PageHeader } from './page-header'
-import { SqlCode } from './sql-code'
 import { traceLocation } from './trace-location'
 import type { TracesOutletContext } from './traces-index'
 import { useTimelineTree, type TimelineRow } from './use-timeline-tree'
@@ -66,15 +65,6 @@ export interface ExtraDetailTab {
 
 function useProMode() {
   return new URLSearchParams(useLocation().search).has('pro')
-}
-
-function StatCard({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <div className={s.statCard}>
-      <Typography.Body variant="tertiary">{label}</Typography.Body>
-      <Typography.BodyLargeStrong>{value}</Typography.BodyLargeStrong>
-    </div>
-  )
 }
 
 function WaterfallBar({
@@ -807,30 +797,9 @@ function TraceDetailContent({
   const activeExtraTab = resolvedExtraTabs.find((tab) => tab.id === activeTab)
 
   return (
-    <div className={s.detailRoot}>
-      <KeyboardShortcut handler={handlePreviousSpanShortcut} shortcut="ArrowUp" />
-      <KeyboardShortcut handler={handleNextSpanShortcut} shortcut="ArrowDown" />
-      <PageHeader
-        title={
-          <>
-            <Button.TextButton onClick={onClose} size="22" variant="linkSubtle">
-              <Typography.BodyStrong as="span" variant="tertiary">
-                Query stream
-              </Typography.BodyStrong>
-            </Button.TextButton>
-            <Typography.BodyStrong as="span" variant="tertiary">
-              /
-            </Typography.BodyStrong>
-            <Typography.BodyStrong as="span" variant="secondary">
-              Query details
-            </Typography.BodyStrong>
-          </>
-        }
-      >
-        <div className={s.detailHeaderActions}>
-          <span className={s.statusBadge} data-tone={statusTone(summary.status)}>
-            {statusLabel(summary.status)}
-          </span>
+    <QueryDetailSummary
+      actions={
+        <>
           <KeyboardShortcut
             handler={handleNewerTraceShortcut}
             shortcut="$mod+ArrowUp"
@@ -875,38 +844,54 @@ function TraceDetailContent({
               variant="bare"
             />
           </KeyboardShortcut>
-        </div>
-      </PageHeader>
-      <div className={s.scrollBody}>
-        <div className={s.content}>
-          <div className={s.sqlBlock}>
-            <pre>
-              <SqlCode sql={summary.query || 'No SQL recorded for this trace.'} />
-            </pre>
-          </div>
-          <div className={s.statGrid}>
-            <StatCard label="Duration" value={formatDurationFromNanos(summary.durationNanos)} />
-            <StatCard label="Rows" value={formatRows(summary)} />
-            <StatCard label="Table scans" value={detail ? sources.length : '—'} />
-            <StatCard label="API requests" value={detail ? httpSpans.length : '—'} />
-          </div>
-          <DetailTabs activeTab={activeTab} extraTabs={resolvedExtraTabs} onTab={setActiveTab} />
-          <div className={s.tabContent}>
-            {activeTab === 'timeline' &&
-              (detail ? (
-                <TimelineWaterfall
-                  expandedHttpSpanId={expandedHttpSpanId}
-                  onExpandedHttpSpanIdChange={setExpandedHttpSpanId}
-                  onNavigableSpanIdsChange={setNavigableSpanIds}
-                  spans={detail.spans}
-                  summary={summary}
-                />
-              ) : null)}
-            {activeExtraTab?.content}
-          </div>
-        </div>
+        </>
+      }
+      shortcuts={
+        <>
+          <KeyboardShortcut handler={handlePreviousSpanShortcut} shortcut="ArrowUp" />
+          <KeyboardShortcut handler={handleNextSpanShortcut} shortcut="ArrowDown" />
+        </>
+      }
+      sql={summary.query || 'No SQL recorded for this trace.'}
+      stats={[
+        { label: 'Duration', value: formatDurationFromNanos(summary.durationNanos) },
+        { label: 'Rows', value: formatRows(summary) },
+        { label: 'Table scans', value: detail ? sources.length : '—' },
+        { label: 'API requests', value: detail ? httpSpans.length : '—' },
+      ]}
+      statusLabel={statusLabel(summary.status)}
+      statusTone={statusTone(summary.status)}
+      title={
+        <>
+          <Button.TextButton onClick={onClose} size="22" variant="linkSubtle">
+            <Typography.BodyStrong as="span" variant="tertiary">
+              Query stream
+            </Typography.BodyStrong>
+          </Button.TextButton>
+          <Typography.BodyStrong as="span" variant="tertiary">
+            /
+          </Typography.BodyStrong>
+          <Typography.BodyStrong as="span" variant="secondary">
+            Query details
+          </Typography.BodyStrong>
+        </>
+      }
+    >
+      <DetailTabs activeTab={activeTab} extraTabs={resolvedExtraTabs} onTab={setActiveTab} />
+      <div className={s.tabContent}>
+        {activeTab === 'timeline' &&
+          (detail ? (
+            <TimelineWaterfall
+              expandedHttpSpanId={expandedHttpSpanId}
+              onExpandedHttpSpanIdChange={setExpandedHttpSpanId}
+              onNavigableSpanIdsChange={setNavigableSpanIds}
+              spans={detail.spans}
+              summary={summary}
+            />
+          ) : null)}
+        {activeExtraTab?.content}
       </div>
-    </div>
+    </QueryDetailSummary>
   )
 }
 


### PR DESCRIPTION
## Summary

Similar to #1601, extracting a bunch of components so that they can be reused in the onboarding (the second page)

## Test plan

Query details still works

<img width="1100" height="416" alt="image" src="https://github.com/user-attachments/assets/3154be86-a0d5-4ae5-90e1-9130b350aa2f" />
