### PR TITLE
feat(reef): add second onboarding step

### DIFF
--- a/apps/reef/app/components/onboarding/onboarding-page.css.ts
+++ b/apps/reef/app/components/onboarding/onboarding-page.css.ts
@@ -105,7 +105,7 @@ export const inlineLink = style({
   },
 })
 
-export const catalogFrame = style({
+export const mainFrame = style({
   alignSelf: 'center',
   background: theme.surface.mainContent,
   border: `1px solid ${theme.stroke.secondary}`,

--- a/apps/reef/app/components/onboarding/onboarding-page.stories.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-page.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { fn } from 'storybook/test'
+
+import { Typography } from '@/wax/components'
+
+import { OnboardingPage } from './onboarding-page'
+
+const meta = {
+  args: {
+    action: {
+      label: 'Continue',
+      onClick: fn(),
+    },
+    children: (
+      <div
+        style={{ alignItems: 'center', display: 'flex', height: '100%', justifyContent: 'center' }}
+      >
+        <Typography.Body variant="tertiary">Onboarding panel</Typography.Body>
+      </div>
+    ),
+    sideContent: (
+      <>
+        <Typography.BodyLarge>
+          Use this shell for onboarding screens with explanatory copy on the left and the active
+          setup surface on the right.
+        </Typography.BodyLarge>
+      </>
+    ),
+    sideTitle: 'Shared onboarding shell',
+    stepLabel: 'Step 1/2',
+  },
+  component: OnboardingPage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  title: 'Components/Onboarding/Page',
+} satisfies Meta<typeof OnboardingPage>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Basic: Story = {}

--- a/apps/reef/app/components/onboarding/onboarding-page.stories.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-page.stories.tsx
@@ -5,6 +5,7 @@ import { fn } from 'storybook/test'
 import { Typography } from '@/wax/components'
 
 import { OnboardingPage } from './onboarding-page'
+import { getOnboardingStepState } from './onboarding-steps'
 
 const meta = {
   args: {
@@ -28,7 +29,7 @@ const meta = {
       </>
     ),
     sideTitle: 'Shared onboarding shell',
-    stepLabel: 'Step 1/2',
+    step: getOnboardingStepState('sources'),
   },
   component: OnboardingPage,
   parameters: {

--- a/apps/reef/app/components/onboarding/onboarding-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-page.tsx
@@ -1,0 +1,112 @@
+import classNames from 'classnames'
+import type { AnchorHTMLAttributes, ReactNode } from 'react'
+import { Link, type To } from 'react-router'
+
+import { Button, Typography } from '@/wax/components'
+import { Pill } from '@/wax/components/pill'
+
+import * as styles from './onboarding-page.css'
+
+interface OnboardingPageActionBase {
+  disabled?: boolean
+  label: string
+}
+
+interface OnboardingPageButtonAction extends OnboardingPageActionBase {
+  onClick?: () => void
+  to?: never
+}
+
+interface OnboardingPageLinkAction extends OnboardingPageActionBase {
+  onClick?: never
+  to: To
+}
+
+export type OnboardingPageAction = OnboardingPageButtonAction | OnboardingPageLinkAction
+
+export interface OnboardingPageProps {
+  action?: OnboardingPageAction
+  ariaLabel?: string
+  children: ReactNode
+  mainFrameClassName?: string
+  sideContent: ReactNode
+  sideTitle: string
+  stepLabel?: string
+  title?: string
+}
+
+export function OnboardingPage({
+  action,
+  ariaLabel = 'Onboarding',
+  children,
+  mainFrameClassName,
+  sideContent,
+  sideTitle,
+  stepLabel,
+  title = 'Onboarding',
+}: OnboardingPageProps) {
+  return (
+    <section className={styles.root} aria-label={ariaLabel}>
+      <div className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.headerText}>
+            <div className={styles.titleRow}>
+              <Typography.HeadingLarge as="h1">{title}</Typography.HeadingLarge>
+              {stepLabel ? (
+                <Pill className={styles.stepPill} color="graySubtle">
+                  {stepLabel}
+                </Pill>
+              ) : null}
+            </div>
+          </div>
+        </header>
+
+        <div className={styles.body}>
+          <div className={styles.explainer}>
+            <div className={styles.explainerText}>
+              <Typography.HeadingSmall>{sideTitle}</Typography.HeadingSmall>
+              {sideContent}
+            </div>
+
+            {action ? <OnboardingAction action={action} /> : null}
+          </div>
+
+          <div className={classNames(styles.mainFrame, mainFrameClassName)}>{children}</div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function OnboardingAction({ action }: { action: OnboardingPageAction }) {
+  if (action.to !== undefined) {
+    return (
+      <Button.Container
+        as={Link}
+        disabled={action.disabled}
+        onClick={action.disabled ? (event) => event.preventDefault() : undefined}
+        to={action.to}
+        variant="secondary"
+      >
+        <Button.Text>{action.label}</Button.Text>
+      </Button.Container>
+    )
+  }
+
+  return (
+    <Button.Container disabled={action.disabled} onClick={action.onClick} variant="secondary">
+      <Button.Text>{action.label}</Button.Text>
+    </Button.Container>
+  )
+}
+
+export function OnboardingLink({
+  className,
+  rel = 'noopener noreferrer',
+  target = '_blank',
+  ...props
+}: AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return (
+    <a className={classNames(styles.inlineLink, className)} rel={rel} target={target} {...props} />
+  )
+}

--- a/apps/reef/app/components/onboarding/onboarding-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-page.tsx
@@ -6,6 +6,7 @@ import { Button, Typography } from '@/wax/components'
 import { Pill } from '@/wax/components/pill'
 
 import * as styles from './onboarding-page.css'
+import type { OnboardingStepState } from './onboarding-steps'
 
 interface OnboardingPageActionBase {
   disabled?: boolean
@@ -31,7 +32,7 @@ export interface OnboardingPageProps {
   mainFrameClassName?: string
   sideContent: ReactNode
   sideTitle: string
-  stepLabel?: string
+  step: OnboardingStepState
   title?: string
 }
 
@@ -42,7 +43,7 @@ export function OnboardingPage({
   mainFrameClassName,
   sideContent,
   sideTitle,
-  stepLabel,
+  step,
   title = 'Onboarding',
 }: OnboardingPageProps) {
   return (
@@ -52,11 +53,9 @@ export function OnboardingPage({
           <div className={styles.headerText}>
             <div className={styles.titleRow}>
               <Typography.HeadingLarge as="h1">{title}</Typography.HeadingLarge>
-              {stepLabel ? (
-                <Pill className={styles.stepPill} color="graySubtle">
-                  {stepLabel}
-                </Pill>
-              ) : null}
+              <Pill className={styles.stepPill} color="graySubtle">
+                Step {step.current}/{step.total}
+              </Pill>
             </div>
           </div>
         </header>

--- a/apps/reef/app/components/onboarding/onboarding-sample-query-page.css.ts
+++ b/apps/reef/app/components/onboarding/onboarding-sample-query-page.css.ts
@@ -1,0 +1,29 @@
+import { keyframes, style } from '@vanilla-extract/css'
+
+import { theme } from '@/wax/theme/theme.css'
+
+const spin = keyframes({
+  from: { transform: 'rotate(0deg)' },
+  to: { transform: 'rotate(360deg)' },
+})
+
+export const statePanel = style({
+  alignItems: 'center',
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  gap: 12,
+  justifyContent: 'center',
+  minHeight: 240,
+  padding: 24,
+  textAlign: 'center',
+})
+
+export const stateIcon = style({
+  animation: `${spin} 1s linear infinite`,
+})
+
+export const resultTable = style({
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 8,
+})

--- a/apps/reef/app/components/onboarding/onboarding-sample-query-page.stories.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sample-query-page.stories.tsx
@@ -1,4 +1,3 @@
-import { useCallback, useEffect, useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { fn } from 'storybook/test'
@@ -40,7 +39,7 @@ const meta = {
   args: {
     connectedSources,
     onContinue: fn(),
-    onRunSampleQuery: fn(),
+    onRetry: fn(),
     rows,
   },
   component: OnboardingSampleQueryPage,
@@ -81,43 +80,4 @@ export const QueryFailed: Story = {
     loadState: 'error',
     rows: [],
   },
-}
-
-export const InteractiveRun: Story = {
-  args: {
-    loadState: 'idle',
-    rows: [],
-  },
-  render: (args) => <InteractiveSampleQueryPage {...args} />,
-}
-
-function InteractiveSampleQueryPage(args: React.ComponentProps<typeof OnboardingSampleQueryPage>) {
-  const [loadState, setLoadState] = useState(args.loadState ?? 'idle')
-  const [queryRows, setQueryRows] = useState(args.rows ?? [])
-
-  useEffect(() => {
-    setLoadState(args.loadState ?? 'idle')
-    setQueryRows(args.rows ?? [])
-  }, [args.loadState, args.rows])
-
-  const handleRunSampleQuery = useCallback(
-    (sql: string) => {
-      args.onRunSampleQuery?.(sql)
-      setLoadState('loading')
-      window.setTimeout(() => {
-        setQueryRows(rows)
-        setLoadState('success')
-      }, 700)
-    },
-    [args],
-  )
-
-  return (
-    <OnboardingSampleQueryPage
-      {...args}
-      loadState={loadState}
-      onRunSampleQuery={handleRunSampleQuery}
-      rows={queryRows}
-    />
-  )
 }

--- a/apps/reef/app/components/onboarding/onboarding-sample-query-page.stories.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sample-query-page.stories.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { fn } from 'storybook/test'
+
+import type { CatalogEntry } from '@/lib/sources'
+
+import {
+  OnboardingSampleQueryPage,
+  type OnboardingSampleQueryRow,
+} from './onboarding-sample-query-page'
+
+const connectedSources: CatalogEntry[] = [
+  connectedSource('clickup', 'Query tasks, lists, and workspace activity from ClickUp.'),
+  connectedSource('gitlab', 'Query projects, merge requests, pipelines, and more from GitLab.'),
+  connectedSource('linear', 'Query issues, projects, and teams from Linear.'),
+  connectedSource('notion', 'Query pages, databases, and users from Notion.'),
+  connectedSource('slack', 'Query messages and metadata from Slack.'),
+]
+
+const rows: OnboardingSampleQueryRow[] = [
+  { source: 'clickup', tables: 46 },
+  { source: 'gitlab', tables: 216 },
+  { source: 'linear', tables: 10 },
+  { source: 'notion', tables: 12 },
+  { source: 'slack', tables: 2 },
+]
+
+function connectedSource(name: string, description: string): CatalogEntry {
+  return {
+    description,
+    installed: true,
+    name,
+    origin: 'bundled',
+    version: '1.0.0',
+  }
+}
+
+const meta = {
+  args: {
+    connectedSources,
+    onContinue: fn(),
+    onRunSampleQuery: fn(),
+    rows,
+  },
+  component: OnboardingSampleQueryPage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  title: 'Components/Onboarding/SampleQueryPage',
+} satisfies Meta<typeof OnboardingSampleQueryPage>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const QuerySucceeded: Story = {
+  args: {
+    loadState: 'success',
+  },
+}
+
+export const SingleSourceReady: Story = {
+  args: {
+    connectedSources: [connectedSource('slack', 'Query messages and metadata from Slack.')],
+    loadState: 'success',
+    rows: [{ source: 'slack', tables: 2 }],
+  },
+}
+
+export const QueryRunning: Story = {
+  args: {
+    loadState: 'loading',
+    rows: [],
+  },
+}
+
+export const QueryFailed: Story = {
+  args: {
+    errorMessage: 'Coral could not load its source catalog.',
+    loadState: 'error',
+    rows: [],
+  },
+}
+
+export const InteractiveRun: Story = {
+  args: {
+    loadState: 'idle',
+    rows: [],
+  },
+  render: (args) => <InteractiveSampleQueryPage {...args} />,
+}
+
+function InteractiveSampleQueryPage(args: React.ComponentProps<typeof OnboardingSampleQueryPage>) {
+  const [loadState, setLoadState] = useState(args.loadState ?? 'idle')
+  const [queryRows, setQueryRows] = useState(args.rows ?? [])
+
+  useEffect(() => {
+    setLoadState(args.loadState ?? 'idle')
+    setQueryRows(args.rows ?? [])
+  }, [args.loadState, args.rows])
+
+  const handleRunSampleQuery = useCallback(
+    (sql: string) => {
+      args.onRunSampleQuery?.(sql)
+      setLoadState('loading')
+      window.setTimeout(() => {
+        setQueryRows(rows)
+        setLoadState('success')
+      }, 700)
+    },
+    [args],
+  )
+
+  return (
+    <OnboardingSampleQueryPage
+      {...args}
+      loadState={loadState}
+      onRunSampleQuery={handleRunSampleQuery}
+      rows={queryRows}
+    />
+  )
+}

--- a/apps/reef/app/components/onboarding/onboarding-sample-query-page.test.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sample-query-page.test.tsx
@@ -1,10 +1,9 @@
-import { StrictMode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import type { SourceCatalogEntry } from '@/components/sources'
 
-import { ONBOARDING_SAMPLE_QUERY, OnboardingSampleQueryPage } from './onboarding-sample-query-page'
+import { OnboardingSampleQueryPage } from './onboarding-sample-query-page'
 
 const github: SourceCatalogEntry = {
   description: 'Sync issues, pull requests, and code from your repositories.',
@@ -53,38 +52,20 @@ describe('OnboardingSampleQueryPage', () => {
     await expect.element(screen.getByRole('cell', { name: 'slack' })).toBeVisible()
   })
 
-  it('runs the fixed catalog query once when StrictMode replays effects', async () => {
-    const onRunSampleQuery = vi.fn()
-
-    await render(
-      <StrictMode>
-        <OnboardingSampleQueryPage
-          connectedSources={[github]}
-          loadState="idle"
-          onRunSampleQuery={onRunSampleQuery}
-        />
-      </StrictMode>,
-    )
-
-    await expect.poll(() => onRunSampleQuery.mock.calls.length).toBe(1)
-    expect(onRunSampleQuery).toHaveBeenCalledWith(ONBOARDING_SAMPLE_QUERY)
-  })
-
   it('retries a failed catalog query', async () => {
-    const onRunSampleQuery = vi.fn()
+    const onRetry = vi.fn()
     const screen = await render(
       <OnboardingSampleQueryPage
         connectedSources={[github]}
         errorMessage="Catalog unavailable."
         loadState="error"
-        onRunSampleQuery={onRunSampleQuery}
+        onRetry={onRetry}
       />,
     )
 
     await screen.getByRole('button', { name: 'Retry' }).click()
 
-    expect(onRunSampleQuery).toHaveBeenCalledOnce()
-    expect(onRunSampleQuery).toHaveBeenCalledWith(ONBOARDING_SAMPLE_QUERY)
+    expect(onRetry).toHaveBeenCalledOnce()
   })
 
   it('allows setup to finish when the catalog query succeeds without result metadata', async () => {

--- a/apps/reef/app/components/onboarding/onboarding-sample-query-page.test.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sample-query-page.test.tsx
@@ -1,0 +1,130 @@
+import { StrictMode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import type { SourceCatalogEntry } from '@/components/sources'
+
+import { ONBOARDING_SAMPLE_QUERY, OnboardingSampleQueryPage } from './onboarding-sample-query-page'
+
+const github: SourceCatalogEntry = {
+  description: 'Sync issues, pull requests, and code from your repositories.',
+  installed: true,
+  name: 'github',
+  origin: 'bundled',
+  version: '1.0.0',
+}
+
+const slack: SourceCatalogEntry = {
+  description: 'Query messages and metadata from Slack.',
+  installed: true,
+  name: 'slack',
+  origin: 'bundled',
+  version: '1.0.0',
+}
+
+describe('OnboardingSampleQueryPage', () => {
+  it('describes one connected source in the singular', async () => {
+    const screen = await render(
+      <OnboardingSampleQueryPage
+        connectedSources={[github]}
+        loadState="success"
+        rows={[{ source: 'github', tables: 12 }]}
+      />,
+    )
+
+    await expect.element(screen.getByText('Your source is ready')).toBeVisible()
+    await expect.element(screen.getByRole('cell', { name: 'github' })).toBeVisible()
+    await expect.element(screen.getByRole('cell', { name: '12' })).toBeVisible()
+  })
+
+  it('describes multiple connected sources in the plural', async () => {
+    const screen = await render(
+      <OnboardingSampleQueryPage
+        connectedSources={[github, slack]}
+        loadState="success"
+        rows={[
+          { source: 'github', tables: 12 },
+          { source: 'slack', tables: 2 },
+        ]}
+      />,
+    )
+
+    await expect.element(screen.getByText('Your sources are ready')).toBeVisible()
+    await expect.element(screen.getByRole('cell', { name: 'slack' })).toBeVisible()
+  })
+
+  it('runs the fixed catalog query once when StrictMode replays effects', async () => {
+    const onRunSampleQuery = vi.fn()
+
+    await render(
+      <StrictMode>
+        <OnboardingSampleQueryPage
+          connectedSources={[github]}
+          loadState="idle"
+          onRunSampleQuery={onRunSampleQuery}
+        />
+      </StrictMode>,
+    )
+
+    await expect.poll(() => onRunSampleQuery.mock.calls.length).toBe(1)
+    expect(onRunSampleQuery).toHaveBeenCalledWith(ONBOARDING_SAMPLE_QUERY)
+  })
+
+  it('retries a failed catalog query', async () => {
+    const onRunSampleQuery = vi.fn()
+    const screen = await render(
+      <OnboardingSampleQueryPage
+        connectedSources={[github]}
+        errorMessage="Catalog unavailable."
+        loadState="error"
+        onRunSampleQuery={onRunSampleQuery}
+      />,
+    )
+
+    await screen.getByRole('button', { name: 'Retry' }).click()
+
+    expect(onRunSampleQuery).toHaveBeenCalledOnce()
+    expect(onRunSampleQuery).toHaveBeenCalledWith(ONBOARDING_SAMPLE_QUERY)
+  })
+
+  it('allows setup to finish when the catalog query succeeds without result metadata', async () => {
+    const screen = await render(
+      <OnboardingSampleQueryPage connectedSources={[github]} loadState="success" />,
+    )
+
+    await expect.element(screen.getByRole('button', { name: 'Finish setup' })).toBeEnabled()
+    await expect.element(screen.getByText('Results')).toBeVisible()
+    await expect.element(screen.getByText('No rows returned.')).toBeVisible()
+  })
+
+  it('keeps the query visible when the results overflow the panel', async () => {
+    const screen = await render(
+      <OnboardingSampleQueryPage
+        connectedSources={[github]}
+        loadState="success"
+        rows={Array.from({ length: 24 }, (_, index) => ({
+          source: `source-${index}`,
+          tables: index,
+        }))}
+      />,
+    )
+    const queryPre = screen.getByText('SELECT', { exact: true }).element().closest('pre')
+    const queryBlock = queryPre?.parentElement
+
+    if (!queryPre || !queryBlock) throw new Error('Expected the rendered SQL block')
+
+    expect(queryBlock.getBoundingClientRect().height).toBeGreaterThanOrEqual(
+      queryPre.getBoundingClientRect().height,
+    )
+    await expect.element(screen.getByRole('cell', { name: 'source-23' })).toBeInTheDocument()
+  })
+
+  it('keeps setup blocked when no sources are connected', async () => {
+    const screen = await render(
+      <OnboardingSampleQueryPage connectedSources={[]} loadState="success" />,
+    )
+
+    await expect.element(screen.getByRole('button', { name: 'Finish setup' })).toBeDisabled()
+    await expect.element(screen.getByText('No connected sources')).toBeVisible()
+  })
+})

--- a/apps/reef/app/components/onboarding/onboarding-sample-query-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sample-query-page.tsx
@@ -13,6 +13,7 @@ import { Icon } from '@/wax/components/icon'
 
 import { OnboardingPage } from './onboarding-page'
 import * as styles from './onboarding-sample-query-page.css'
+import { getOnboardingStepState } from './onboarding-steps'
 import { pluralise } from '~/utils/pluralise'
 
 export type SampleQueryLoadState = 'error' | 'idle' | 'loading' | 'success'
@@ -36,7 +37,6 @@ export interface OnboardingSampleQueryPageProps {
   onContinue?: () => void
   onRunSampleQuery?: (sql: string) => void
   rows?: OnboardingSampleQueryRow[]
-  stepLabel?: string
 }
 
 export function OnboardingSampleQueryPage({
@@ -48,8 +48,8 @@ export function OnboardingSampleQueryPage({
   onContinue,
   onRunSampleQuery,
   rows = [],
-  stepLabel = 'Step 2/2',
 }: OnboardingSampleQueryPageProps) {
+  const step = getOnboardingStepState('query')
   const sourceCount = connectedSources.length
   const sourceSetKey = connectedSources
     .map((source) => source.name)
@@ -80,7 +80,7 @@ export function OnboardingSampleQueryPage({
         onClick: onContinue,
       }}
       ariaLabel="Confirm connected sources"
-      stepLabel={stepLabel}
+      step={step}
       sideContent={
         <>
           <Typography.BodyLarge>

--- a/apps/reef/app/components/onboarding/onboarding-sample-query-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sample-query-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from 'react'
+import type { ReactNode } from 'react'
 
 import { ErrorBanner } from '@/components/error-banner'
 import {
@@ -35,7 +35,7 @@ export interface OnboardingSampleQueryPageProps {
   errorMessage?: string | null
   loadState?: SampleQueryLoadState
   onContinue?: () => void
-  onRunSampleQuery?: (sql: string) => void
+  onRetry?: () => void
   rows?: OnboardingSampleQueryRow[]
 }
 
@@ -46,31 +46,12 @@ export function OnboardingSampleQueryPage({
   errorMessage = null,
   loadState = 'idle',
   onContinue,
-  onRunSampleQuery,
+  onRetry,
   rows = [],
 }: OnboardingSampleQueryPageProps) {
   const step = getOnboardingStepState('query')
   const sourceCount = connectedSources.length
-  const sourceSetKey = connectedSources
-    .map((source) => source.name)
-    .toSorted()
-    .join('\0')
-  const lastAutoRunSourceSet = useRef<string | null>(null)
   const canContinue = sourceCount > 0 && loadState === 'success' && !continueDisabled
-
-  useEffect(() => {
-    if (
-      !onRunSampleQuery ||
-      !sourceSetKey ||
-      loadState !== 'idle' ||
-      lastAutoRunSourceSet.current === sourceSetKey
-    ) {
-      return
-    }
-
-    lastAutoRunSourceSet.current = sourceSetKey
-    onRunSampleQuery(ONBOARDING_SAMPLE_QUERY)
-  }, [loadState, onRunSampleQuery, sourceSetKey])
 
   return (
     <OnboardingPage
@@ -105,7 +86,7 @@ export function OnboardingSampleQueryPage({
         connectedSources={connectedSources}
         errorMessage={errorMessage}
         loadState={loadState}
-        onRetry={onRunSampleQuery ? () => onRunSampleQuery(ONBOARDING_SAMPLE_QUERY) : undefined}
+        onRetry={onRetry}
         rows={rows}
       />
     </OnboardingPage>

--- a/apps/reef/app/components/onboarding/onboarding-sample-query-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sample-query-page.tsx
@@ -1,0 +1,267 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+
+import { ErrorBanner } from '@/components/error-banner'
+import {
+  QueryDetailResults,
+  QueryDetailSummary,
+  type QueryDetailStatusTone,
+} from '@/components/query-detail'
+import type { SourceCatalogEntry } from '@/components/sources'
+import { formatSQL } from '@/lib/sql-highlight'
+import { Table, Typography } from '@/wax/components'
+import { Icon } from '@/wax/components/icon'
+
+import { OnboardingPage } from './onboarding-page'
+import * as styles from './onboarding-sample-query-page.css'
+import { pluralise } from '~/utils/pluralise'
+
+export type SampleQueryLoadState = 'error' | 'idle' | 'loading' | 'success'
+
+export const ONBOARDING_SAMPLE_QUERY = `SELECT schema_name AS source, COUNT(*) AS tables
+FROM coral.tables
+GROUP BY schema_name
+ORDER BY schema_name`
+
+export interface OnboardingSampleQueryRow {
+  source: string
+  tables: bigint | number | string
+}
+
+export interface OnboardingSampleQueryPageProps {
+  connectedSources: SourceCatalogEntry[]
+  continueDisabled?: boolean
+  continueLabel?: string
+  errorMessage?: string | null
+  loadState?: SampleQueryLoadState
+  onContinue?: () => void
+  onRunSampleQuery?: (sql: string) => void
+  rows?: OnboardingSampleQueryRow[]
+  stepLabel?: string
+}
+
+export function OnboardingSampleQueryPage({
+  connectedSources,
+  continueDisabled = false,
+  continueLabel = 'Finish setup',
+  errorMessage = null,
+  loadState = 'idle',
+  onContinue,
+  onRunSampleQuery,
+  rows = [],
+  stepLabel = 'Step 2/2',
+}: OnboardingSampleQueryPageProps) {
+  const sourceCount = connectedSources.length
+  const sourceSetKey = connectedSources
+    .map((source) => source.name)
+    .toSorted()
+    .join('\0')
+  const lastAutoRunSourceSet = useRef<string | null>(null)
+  const canContinue = sourceCount > 0 && loadState === 'success' && !continueDisabled
+
+  useEffect(() => {
+    if (
+      !onRunSampleQuery ||
+      !sourceSetKey ||
+      loadState !== 'idle' ||
+      lastAutoRunSourceSet.current === sourceSetKey
+    ) {
+      return
+    }
+
+    lastAutoRunSourceSet.current = sourceSetKey
+    onRunSampleQuery(ONBOARDING_SAMPLE_QUERY)
+  }, [loadState, onRunSampleQuery, sourceSetKey])
+
+  return (
+    <OnboardingPage
+      action={{
+        disabled: !canContinue,
+        label: continueLabel,
+        onClick: onContinue,
+      }}
+      ariaLabel="Confirm connected sources"
+      stepLabel={stepLabel}
+      sideContent={
+        <>
+          <Typography.BodyLarge>
+            Coral exposes your connected {pluralise(sourceCount, 'source')} as tables, and converts
+            SQL into what is necessary to retrieve data, whether that's multiple network calls, file
+            reads, and more.
+          </Typography.BodyLarge>
+          <Typography.BodyLarge>
+            Next time you ask a question to your agent, instead of having to learn how to call many
+            different APIs, and how to understand their response format, your agent will only need
+            to know how to write SQL and how to parse tabular data, two things agents are great at.
+          </Typography.BodyLarge>
+        </>
+      }
+      sideTitle={
+        sourceCount === 0
+          ? 'Connect a source to continue'
+          : `Your ${pluralise(sourceCount, 'source is', 'sources are')} ready`
+      }
+    >
+      <QueryPanelBody
+        connectedSources={connectedSources}
+        errorMessage={errorMessage}
+        loadState={loadState}
+        onRetry={onRunSampleQuery ? () => onRunSampleQuery(ONBOARDING_SAMPLE_QUERY) : undefined}
+        rows={rows}
+      />
+    </OnboardingPage>
+  )
+}
+
+function QueryPanelBody({
+  connectedSources,
+  errorMessage,
+  loadState,
+  onRetry,
+  rows,
+}: {
+  connectedSources: SourceCatalogEntry[]
+  errorMessage: string | null
+  loadState: SampleQueryLoadState
+  onRetry?: () => void
+  rows: OnboardingSampleQueryRow[]
+}) {
+  if (connectedSources.length === 0) {
+    return <MissingSourceFallback />
+  }
+
+  const queryState = getQueryState({
+    connectedSourceCount: connectedSources.length,
+    errorMessage,
+    loadState,
+    onRetry,
+    rows,
+  })
+
+  return (
+    <QueryDetailSummary
+      sql={formatSQL(ONBOARDING_SAMPLE_QUERY)}
+      statusLabel={queryState.statusLabel}
+      statusTone={queryState.statusTone}
+      title="Query details"
+    >
+      {queryState.content}
+    </QueryDetailSummary>
+  )
+}
+
+function getQueryState({
+  connectedSourceCount,
+  errorMessage,
+  loadState,
+  onRetry,
+  rows,
+}: {
+  connectedSourceCount: number
+  errorMessage: string | null
+  loadState: SampleQueryLoadState
+  onRetry?: () => void
+  rows: OnboardingSampleQueryRow[]
+}): {
+  content: ReactNode
+  statusLabel: string
+  statusTone: QueryDetailStatusTone
+} {
+  if (loadState === 'loading') {
+    return {
+      content: (
+        <div className={styles.statePanel}>
+          <Icon color="tertiary" name="Loader" size="16" className={styles.stateIcon} />
+          <Typography.BodyLargeStrong>Running query</Typography.BodyLargeStrong>
+          <Typography.Body variant="tertiary">
+            Coral is checking the tables exposed by your connected{' '}
+            {connectedSourceCount === 1 ? 'source' : 'sources'}.
+          </Typography.Body>
+        </div>
+      ),
+      statusLabel: 'running',
+      statusTone: 'running',
+    }
+  }
+
+  if (loadState === 'error') {
+    return {
+      content: (
+        <ErrorBanner
+          title="Couldn't run the catalog query"
+          message={errorMessage ?? 'Check Coral and try again.'}
+          onRetry={onRetry}
+        />
+      ),
+      statusLabel: 'error',
+      statusTone: 'error',
+    }
+  }
+
+  if (loadState === 'success') {
+    return {
+      content: <CatalogQueryResults rows={rows} />,
+      statusLabel: 'done',
+      statusTone: 'ok',
+    }
+  }
+
+  return {
+    content: (
+      <div className={styles.statePanel}>
+        <Icon color="tertiary" name="Play" size="20" />
+        <Typography.BodyLargeStrong>Ready to run</Typography.BodyLargeStrong>
+        <Typography.Body variant="tertiary">
+          Coral will query its catalog for your connected{' '}
+          {connectedSourceCount === 1 ? 'source' : 'sources'}.
+        </Typography.Body>
+      </div>
+    ),
+    statusLabel: 'ready',
+    statusTone: 'running',
+  }
+}
+
+function MissingSourceFallback() {
+  return (
+    <QueryDetailSummary
+      sql={formatSQL(ONBOARDING_SAMPLE_QUERY)}
+      statusLabel="error"
+      statusTone="error"
+      title="Query details"
+    >
+      <ErrorBanner
+        title="No connected sources"
+        message="Connect at least one source before running the catalog query."
+      />
+    </QueryDetailSummary>
+  )
+}
+
+function CatalogQueryResults({ rows }: { rows: OnboardingSampleQueryRow[] }) {
+  return (
+    <QueryDetailResults>
+      {rows.length > 0 ? (
+        <Table.Wrapper className={styles.resultTable} style="compact">
+          <Table.Root>
+            <Table.Head>
+              <Table.Row>
+                <Table.HeaderCell>Source</Table.HeaderCell>
+                <Table.HeaderCell align="right">Tables</Table.HeaderCell>
+              </Table.Row>
+            </Table.Head>
+            <Table.Body>
+              {rows.map((row) => (
+                <Table.Row key={row.source}>
+                  <Table.Cell mono>{row.source}</Table.Cell>
+                  <Table.Cell align="right" mono>
+                    {row.tables.toString()}
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table.Root>
+        </Table.Wrapper>
+      ) : null}
+    </QueryDetailResults>
+  )
+}

--- a/apps/reef/app/components/onboarding/onboarding-sources-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sources-page.tsx
@@ -1,12 +1,9 @@
-import { Link } from 'react-router'
-
-import { Button, Typography } from '@/wax/components'
-import { Pill } from '@/wax/components/pill'
+import { Typography } from '@/wax/components'
 
 import { SourceCatalogSurface } from '@/components/sources'
 import type { SourceCatalogEntry, SourceCatalogLoadState } from '@/components/sources'
 
-import * as styles from './onboarding-sources-page.css'
+import { OnboardingLink, OnboardingPage } from './onboarding-page'
 
 export interface OnboardingSourcesPageProps {
   continueDisabled?: boolean
@@ -31,90 +28,54 @@ export function OnboardingSourcesPage({
   onSearchChange,
   onSourceSelect,
   search,
-  stepLabel = 'Step 1/3',
+  stepLabel = 'Step 1/2',
 }: OnboardingSourcesPageProps) {
   const hasConnectedSource = entries.some((entry) => entry.installed)
   const canContinue = hasConnectedSource && !continueDisabled
 
   return (
-    <section className={styles.root} aria-label="Onboarding">
-      <div className={styles.content}>
-        <header className={styles.header}>
-          <div className={styles.headerText}>
-            <div className={styles.titleRow}>
-              <Typography.HeadingLarge as="h1">Onboarding</Typography.HeadingLarge>
-              <Pill className={styles.stepPill} color="graySubtle">
-                {stepLabel}
-              </Pill>
-            </div>
-          </div>
-        </header>
-
-        <div className={styles.body}>
-          <div className={styles.explainer}>
-            <div className={styles.explainerText}>
-              <Typography.HeadingSmall>Connect sources to Coral</Typography.HeadingSmall>
-              <Typography.BodyLarge>
-                Sources turn APIs, services, and local datasets into tables that Coral can query.
-              </Typography.BodyLarge>
-              <Typography.BodyLarge>
-                Coral ships with{' '}
-                <a
-                  className={styles.inlineLink}
-                  href="https://withcoral.com/docs/reference/bundled-sources"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  core sources
-                </a>
-                , built and maintained by the Coral team. It is also extensible: import{' '}
-                <a
-                  className={styles.inlineLink}
-                  href="https://withcoral.com/docs/reference/community-sources"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  community source specs
-                </a>{' '}
-                or{' '}
-                <a
-                  className={styles.inlineLink}
-                  href="https://withcoral.com/docs/guides/write-a-custom-source"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  write your own spec
-                </a>
-                .
-              </Typography.BodyLarge>
-            </div>
-
-            <Button.Container
-              as={Link}
-              disabled={!canContinue}
-              onClick={canContinue ? undefined : (event) => event.preventDefault()}
-              to="?step=query"
-              variant="secondary"
-            >
-              <Button.Text>{continueLabel}</Button.Text>
-            </Button.Container>
-          </div>
-
-          <div className={styles.catalogFrame}>
-            <SourceCatalogSurface
-              entries={entries}
-              errorMessage={errorMessage}
-              loadState={loadState}
-              onPick={onSourceSelect}
-              onRetry={onRetry}
-              onSearchChange={onSearchChange}
-              search={search}
-              showTitle={false}
-              variant="compact"
-            />
-          </div>
-        </div>
-      </div>
-    </section>
+    <OnboardingPage
+      action={{
+        disabled: !canContinue,
+        label: continueLabel,
+        to: '?step=query',
+      }}
+      stepLabel={stepLabel}
+      sideContent={
+        <>
+          <Typography.BodyLarge>
+            Sources turn APIs, services, and local datasets into tables that Coral can query.
+          </Typography.BodyLarge>
+          <Typography.BodyLarge>
+            Coral ships with{' '}
+            <OnboardingLink href="https://withcoral.com/docs/reference/bundled-sources">
+              core sources
+            </OnboardingLink>
+            , built and maintained by the Coral team. It is also extensible: import{' '}
+            <OnboardingLink href="https://withcoral.com/docs/reference/community-sources">
+              community source specs
+            </OnboardingLink>{' '}
+            or{' '}
+            <OnboardingLink href="https://withcoral.com/docs/guides/write-a-custom-source">
+              write your own spec
+            </OnboardingLink>
+            .
+          </Typography.BodyLarge>
+        </>
+      }
+      sideTitle="Connect sources to Coral"
+    >
+      <SourceCatalogSurface
+        entries={entries}
+        errorMessage={errorMessage}
+        loadState={loadState}
+        onPick={onSourceSelect}
+        onRetry={onRetry}
+        onSearchChange={onSearchChange}
+        search={search}
+        showTitle={false}
+        variant="compact"
+      />
+    </OnboardingPage>
   )
 }

--- a/apps/reef/app/components/onboarding/onboarding-sources-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-sources-page.tsx
@@ -4,6 +4,7 @@ import { SourceCatalogSurface } from '@/components/sources'
 import type { SourceCatalogEntry, SourceCatalogLoadState } from '@/components/sources'
 
 import { OnboardingLink, OnboardingPage } from './onboarding-page'
+import { getOnboardingStepState } from './onboarding-steps'
 
 export interface OnboardingSourcesPageProps {
   continueDisabled?: boolean
@@ -15,7 +16,6 @@ export interface OnboardingSourcesPageProps {
   onSearchChange: (search: string) => void
   onSourceSelect: (entry: SourceCatalogEntry) => void
   search: string
-  stepLabel?: string
 }
 
 export function OnboardingSourcesPage({
@@ -28,19 +28,23 @@ export function OnboardingSourcesPage({
   onSearchChange,
   onSourceSelect,
   search,
-  stepLabel = 'Step 1/2',
 }: OnboardingSourcesPageProps) {
+  const step = getOnboardingStepState('sources')
   const hasConnectedSource = entries.some((entry) => entry.installed)
   const canContinue = hasConnectedSource && !continueDisabled
+
+  if (!step.nextHref) {
+    throw new Error('The onboarding sources step must have a next step')
+  }
 
   return (
     <OnboardingPage
       action={{
         disabled: !canContinue,
         label: continueLabel,
-        to: '?step=query',
+        to: step.nextHref,
       }}
-      stepLabel={stepLabel}
+      step={step}
       sideContent={
         <>
           <Typography.BodyLarge>

--- a/apps/reef/app/components/onboarding/onboarding-steps.test.ts
+++ b/apps/reef/app/components/onboarding/onboarding-steps.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { getOnboardingStepState, ONBOARDING_STEPS } from './onboarding-steps'
+
+describe('onboarding steps', () => {
+  it('derives position and navigation from the ordered step registry', () => {
+    expect(ONBOARDING_STEPS).toEqual(['sources', 'query'])
+    expect(getOnboardingStepState('sources')).toEqual({
+      current: 1,
+      nextHref: '?step=query',
+      nextStep: 'query',
+      step: 'sources',
+      total: 2,
+    })
+    expect(getOnboardingStepState('query')).toEqual({
+      current: 2,
+      nextHref: null,
+      nextStep: null,
+      step: 'query',
+      total: 2,
+    })
+  })
+})

--- a/apps/reef/app/components/onboarding/onboarding-steps.ts
+++ b/apps/reef/app/components/onboarding/onboarding-steps.ts
@@ -1,0 +1,24 @@
+export const ONBOARDING_STEPS = ['sources', 'query'] as const
+
+export type OnboardingStep = (typeof ONBOARDING_STEPS)[number]
+
+export interface OnboardingStepState {
+  current: number
+  nextHref: string | null
+  nextStep: OnboardingStep | null
+  step: OnboardingStep
+  total: number
+}
+
+export function getOnboardingStepState(step: OnboardingStep): OnboardingStepState {
+  const currentIndex = ONBOARDING_STEPS.indexOf(step)
+  const nextStep = ONBOARDING_STEPS[currentIndex + 1] ?? null
+
+  return {
+    current: currentIndex + 1,
+    nextHref: nextStep ? `?step=${nextStep}` : null,
+    nextStep,
+    step,
+    total: ONBOARDING_STEPS.length,
+  }
+}

--- a/apps/reef/app/components/query-detail/query-detail-summary.css.ts
+++ b/apps/reef/app/components/query-detail/query-detail-summary.css.ts
@@ -73,10 +73,8 @@ export const statusBadge = style({
 })
 
 export const scrollBody = style({
-  display: 'flex',
   flex: 1,
   minHeight: 0,
-  overflow: 'auto',
 })
 
 export const content = style({
@@ -92,6 +90,7 @@ export const sqlBlock = style({
   backgroundColor: theme.surface.main,
   border: `1px solid ${theme.stroke.primary}`,
   borderRadius: 8,
+  flexShrink: 0,
   overflow: 'hidden',
   position: 'relative',
 })

--- a/apps/reef/app/components/query-detail/query-detail-summary.tsx
+++ b/apps/reef/app/components/query-detail/query-detail-summary.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 
 import { highlightSQL } from '@/lib/sql-highlight'
+import { Container as ScrollArea } from '@/wax/components/scroll-area'
 import { Typography } from '@/wax/components/typography'
 
 import * as styles from './query-detail-summary.css'
@@ -59,7 +60,7 @@ export function QueryDetailSummary({
           </div>
         ) : null}
       </header>
-      <div className={styles.scrollBody}>
+      <ScrollArea className={styles.scrollBody} constrainWidth fade="none" fillContent>
         <div className={styles.content}>
           <div className={styles.sqlBlock}>
             <pre>
@@ -75,7 +76,7 @@ export function QueryDetailSummary({
           ) : null}
           {children}
         </div>
-      </div>
+      </ScrollArea>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Adding a second step to the onboarding. I wanted to show Coral in action, by running some SQL based on which sources users have connected.
I haven't yet found a neat way of constructing a "ah-ha" query yet, so for now the query will just be against `coral` schema. We can improve this in the future.

## Test plan

<img width="989" height="752" alt="image" src="https://github.com/user-attachments/assets/e869f0f6-197d-4237-a821-fb8336580491" />

- [feat(reef): add second onboarding step](https://github.com/withcoral/coral/pull/1618) <-
- [feat(reef): add onboarding flow](https://github.com/withcoral/coral/pull/1747)
- [feat(reef): add agent setup onboarding step](https://github.com/withcoral/coral/pull/1764)
