### PR TITLE
feat(app): add server bind configuration

### DIFF
--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -7,6 +7,7 @@ mod env;
 mod error;
 mod health;
 mod server;
+mod server_config;
 
 use crate::state::AppStateLayout;
 use crate::telemetry::{

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -114,7 +114,7 @@ impl ServerConfig {
     pub(crate) fn new() -> Self {
         Self {
             config_dir: None,
-            mode: ServerMode::NativeGrpc,
+            mode: ServerMode::EphemeralGrpc,
             engine_extensions_providers: Vec::new(),
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
@@ -160,11 +160,11 @@ impl ServerConfig {
 /// transport or asset-serving knob.
 #[derive(Clone)]
 pub enum ServerMode {
-    /// Native gRPC for CLI, MCP, and local client callers.
-    NativeGrpc,
-    /// Native gRPC bound to an explicit address for the long-running server.
-    RemoteGrpc {
-        /// Address to bind. Non-loopback addresses require authentication.
+    /// Ephemeral native gRPC for CLI, MCP, and local client callers.
+    EphemeralGrpc,
+    /// Native gRPC bound to an explicit address for a standalone server.
+    StandaloneGrpc {
+        /// Address to bind.
         bind: SocketAddr,
     },
     /// Loopback gRPC-Web server that also serves embedded UI assets.
@@ -179,21 +179,10 @@ pub enum ServerMode {
 impl ServerMode {
     fn bind_addr(&self) -> SocketAddr {
         match self {
-            Self::NativeGrpc => SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
-            Self::RemoteGrpc { bind } => *bind,
+            Self::EphemeralGrpc => SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+            Self::StandaloneGrpc { bind } => *bind,
             Self::EmbeddedUi { port, .. } => SocketAddr::from((Ipv4Addr::LOCALHOST, *port)),
         }
-    }
-
-    fn validate_bind(&self) -> Result<(), AppError> {
-        if let Self::RemoteGrpc { bind } = self
-            && !bind.ip().is_loopback()
-        {
-            return Err(AppError::FailedPrecondition(
-                "non-loopback gRPC bind requires configured server authentication".to_string(),
-            ));
-        }
-        Ok(())
     }
 }
 
@@ -205,7 +194,7 @@ pub struct ServerBuilder {
 
 impl ServerBuilder {
     #[must_use]
-    /// Creates a builder for the default native gRPC local server.
+    /// Creates a builder for the default ephemeral native gRPC local server.
     pub fn new() -> Self {
         Self {
             config: ServerConfig::new(),
@@ -213,15 +202,15 @@ impl ServerBuilder {
     }
 
     #[must_use]
-    /// Creates a builder for a native gRPC local server.
-    pub fn native_grpc() -> Self {
-        Self::new().with_mode(ServerMode::NativeGrpc)
+    /// Creates a builder for an ephemeral native gRPC local server.
+    pub fn ephemeral_grpc() -> Self {
+        Self::new().with_mode(ServerMode::EphemeralGrpc)
     }
 
     #[must_use]
-    /// Creates a native gRPC server bound to an explicit address.
-    pub fn remote_grpc(bind: SocketAddr) -> Self {
-        Self::new().with_mode(ServerMode::RemoteGrpc { bind })
+    /// Creates a standalone native gRPC server bound to an explicit address.
+    pub fn standalone_grpc(bind: SocketAddr) -> Self {
+        Self::new().with_mode(ServerMode::StandaloneGrpc { bind })
     }
 
     #[must_use]
@@ -316,7 +305,6 @@ impl ServerBuilder {
     /// required directories cannot be created, the config or credential backends
     /// fail to initialize, or the gRPC server cannot be started.
     pub async fn start(self) -> Result<RunningServer, AppError> {
-        self.config.mode.validate_bind()?;
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir)?;
         layout.ensure()?;
@@ -648,7 +636,7 @@ async fn start_server(
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
     let task = match mode {
-        ServerMode::NativeGrpc | ServerMode::RemoteGrpc { .. } => {
+        ServerMode::EphemeralGrpc | ServerMode::StandaloneGrpc { .. } => {
             start_grpc_server(listener, shutdown_rx, routes)
         }
         ServerMode::EmbeddedUi { assets, .. } => {
@@ -1087,11 +1075,11 @@ enabled = false
     }
 
     #[tokio::test]
-    async fn remote_grpc_binds_the_requested_loopback_address() {
+    async fn standalone_grpc_binds_the_requested_loopback_address() {
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
         disable_internal_tracing(&config_dir);
-        let server = ServerBuilder::remote_grpc(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+        let server = ServerBuilder::standalone_grpc(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
             .with_config_dir(config_dir)
             .start()
             .await
@@ -1102,26 +1090,18 @@ enabled = false
     }
 
     #[tokio::test]
-    async fn remote_grpc_rejects_non_loopback_before_state_creation() {
+    async fn standalone_grpc_binds_the_requested_non_loopback_address() {
         let temp = TempDir::new().expect("temp dir");
-        let config_dir = temp.path().join("must-not-be-created");
-        let result = ServerBuilder::remote_grpc(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
-            .with_config_dir(&config_dir)
+        let config_dir = temp.path().join("coral-config");
+        disable_internal_tracing(&config_dir);
+        let server = ServerBuilder::standalone_grpc(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+            .with_config_dir(config_dir)
             .start()
-            .await;
-        let Err(error) = result else {
-            panic!("unauthenticated non-loopback bind must fail");
-        };
+            .await
+            .expect("start explicit non-loopback server");
 
-        assert!(
-            error
-                .to_string()
-                .contains("requires configured server authentication")
-        );
-        assert!(
-            !config_dir.exists(),
-            "validation must run before state setup"
-        );
+        assert!(server.endpoint_uri().starts_with("http://0.0.0.0:"));
+        server.shutdown().await.expect("shutdown server");
     }
 
     #[tokio::test]
@@ -1466,7 +1446,7 @@ backend = "unsupported"
                 local_trace_store_dir: None,
             },
             Arc::new(SingleUserPrincipalProvider),
-            ServerMode::NativeGrpc,
+            ServerMode::EphemeralGrpc,
         )
         .await
         .expect("start server");
@@ -1535,7 +1515,7 @@ backend = "unsupported"
     }
 
     #[tokio::test]
-    async fn server_builder_applies_injected_provider_to_native_grpc() {
+    async fn server_builder_applies_injected_provider_to_ephemeral_grpc() {
         let temp = TempDir::new().expect("temp dir");
         let server = ServerBuilder::new()
             .with_config_dir(temp.path().join("coral-config"))
@@ -1913,7 +1893,7 @@ tables:
             },
             TraceServerComponents::default(),
             Arc::new(SingleUserPrincipalProvider),
-            ServerMode::NativeGrpc,
+            ServerMode::EphemeralGrpc,
         )
         .await
         .expect("start server");
@@ -2039,7 +2019,7 @@ tables:
             },
             TraceServerComponents::default(),
             Arc::new(SingleUserPrincipalProvider),
-            ServerMode::NativeGrpc,
+            ServerMode::EphemeralGrpc,
         )
         .await
         .expect("start server");
@@ -2165,7 +2145,7 @@ tables:
             },
             TraceServerComponents::default(),
             Arc::new(SingleUserPrincipalProvider),
-            ServerMode::NativeGrpc,
+            ServerMode::EphemeralGrpc,
         )
         .await
         .expect("start server");

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -162,6 +162,11 @@ impl ServerConfig {
 pub enum ServerMode {
     /// Native gRPC for CLI, MCP, and local client callers.
     NativeGrpc,
+    /// Native gRPC bound to an explicit address for the long-running server.
+    RemoteGrpc {
+        /// Address to bind. Non-loopback addresses require authentication.
+        bind: SocketAddr,
+    },
     /// Loopback gRPC-Web server that also serves embedded UI assets.
     EmbeddedUi {
         /// Port to bind on `127.0.0.1`.
@@ -175,8 +180,20 @@ impl ServerMode {
     fn bind_addr(&self) -> SocketAddr {
         match self {
             Self::NativeGrpc => SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+            Self::RemoteGrpc { bind } => *bind,
             Self::EmbeddedUi { port, .. } => SocketAddr::from((Ipv4Addr::LOCALHOST, *port)),
         }
+    }
+
+    fn validate_bind(&self) -> Result<(), AppError> {
+        if let Self::RemoteGrpc { bind } = self
+            && !bind.ip().is_loopback()
+        {
+            return Err(AppError::FailedPrecondition(
+                "non-loopback gRPC bind requires configured server authentication".to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -199,6 +216,12 @@ impl ServerBuilder {
     /// Creates a builder for a native gRPC local server.
     pub fn native_grpc() -> Self {
         Self::new().with_mode(ServerMode::NativeGrpc)
+    }
+
+    #[must_use]
+    /// Creates a native gRPC server bound to an explicit address.
+    pub fn remote_grpc(bind: SocketAddr) -> Self {
+        Self::new().with_mode(ServerMode::RemoteGrpc { bind })
     }
 
     #[must_use]
@@ -293,6 +316,7 @@ impl ServerBuilder {
     /// required directories cannot be created, the config or credential backends
     /// fail to initialize, or the gRPC server cannot be started.
     pub async fn start(self) -> Result<RunningServer, AppError> {
+        self.config.mode.validate_bind()?;
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir)?;
         layout.ensure()?;
@@ -624,7 +648,9 @@ async fn start_server(
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
     let task = match mode {
-        ServerMode::NativeGrpc => start_grpc_server(listener, shutdown_rx, routes),
+        ServerMode::NativeGrpc | ServerMode::RemoteGrpc { .. } => {
+            start_grpc_server(listener, shutdown_rx, routes)
+        }
         ServerMode::EmbeddedUi { assets, .. } => {
             start_grpc_web_server(listener, shutdown_rx, routes, assets)
         }
@@ -843,7 +869,7 @@ mod tests {
     )]
 
     use std::borrow::Cow;
-    use std::net::{Ipv4Addr, TcpListener};
+    use std::net::{Ipv4Addr, SocketAddr, TcpListener};
     use std::path::Path;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
@@ -1057,6 +1083,44 @@ enabled = false
                 .pending_queue_job_count(&workspace)
                 .expect("pending queue depth"),
             0
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_grpc_binds_the_requested_loopback_address() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        disable_internal_tracing(&config_dir);
+        let server = ServerBuilder::remote_grpc(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .with_config_dir(config_dir)
+            .start()
+            .await
+            .expect("start explicit loopback server");
+
+        assert!(server.endpoint_uri().starts_with("http://127.0.0.1:"));
+        server.shutdown().await.expect("shutdown server");
+    }
+
+    #[tokio::test]
+    async fn remote_grpc_rejects_non_loopback_before_state_creation() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("must-not-be-created");
+        let result = ServerBuilder::remote_grpc(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0)))
+            .with_config_dir(&config_dir)
+            .start()
+            .await;
+        let Err(error) = result else {
+            panic!("unauthenticated non-loopback bind must fail");
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("requires configured server authentication")
+        );
+        assert!(
+            !config_dir.exists(),
+            "validation must run before state setup"
         );
     }
 

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -1,0 +1,103 @@
+//! Configuration owned by the long-running Coral server surface.
+
+#![cfg_attr(
+    not(test),
+    expect(dead_code, reason = "consumed by the descendant coral serve command")
+)]
+
+use std::net::{Ipv4Addr, SocketAddr};
+
+use serde::Deserialize;
+
+use super::AppError;
+use crate::state::AppStateLayout;
+
+#[derive(Debug, Default, Deserialize)]
+struct ConfigFile {
+    #[serde(default)]
+    server: ServerSettings,
+}
+
+/// Settings loaded from the top-level `[server]` section of `config.toml`.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub(crate) struct ServerSettings {
+    pub(crate) bind_addr: SocketAddr,
+}
+
+impl Default for ServerSettings {
+    fn default() -> Self {
+        Self {
+            bind_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        }
+    }
+}
+
+impl ServerSettings {
+    /// Loads only the `[server]` section, leaving other config ownership intact.
+    pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, AppError> {
+        if !layout.config_file().try_exists()? {
+            return Ok(Self::default());
+        }
+        let raw = std::fs::read_to_string(layout.config_file())?;
+        Ok(toml::from_str::<ConfigFile>(&raw)?.server)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use tempfile::TempDir;
+
+    use super::ServerSettings;
+    use crate::state::AppStateLayout;
+
+    #[test]
+    fn defaults_to_ephemeral_ipv4_loopback_without_server_section() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+
+        let settings = ServerSettings::load(&layout).expect("server settings");
+
+        assert_eq!(
+            settings.bind_addr,
+            SocketAddr::from((Ipv4Addr::LOCALHOST, 0))
+        );
+    }
+
+    #[test]
+    fn loads_bind_address_without_claiming_other_sections() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[server]\nbind_addr = '127.0.0.2:14555'\n\n[future]\nvalue = true\n",
+        )
+        .expect("config file");
+
+        let settings = ServerSettings::load(&layout).expect("server settings");
+
+        assert_eq!(
+            settings.bind_addr.ip(),
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2))
+        );
+        assert_eq!(settings.bind_addr.port(), 14555);
+    }
+
+    #[test]
+    fn rejects_invalid_bind_address() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[server]\nbind_addr = 'localhost:14555'\n",
+        )
+        .expect("config file");
+
+        ServerSettings::load(&layout).expect_err("bind address must be an IP socket address");
+    }
+}

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -2037,9 +2037,12 @@ headers = "from=config"
 	enabled = false
 	retention_days = 3
 
-	[features]
-	feedback = true
-	future_feature = "not-yet-known"
+[features]
+feedback = true
+future_feature = "not-yet-known"
+
+[server]
+bind_addr = "127.0.0.1:14555"
 
 [engine.dependent_join]
 enabled = false
@@ -2098,6 +2101,14 @@ origin = "bundled"
         assert!(
             raw.contains("future_feature = \"not-yet-known\""),
             "future feature override should be preserved"
+        );
+        assert!(
+            raw.contains("[server]"),
+            "server section should be preserved"
+        );
+        assert!(
+            raw.contains("bind_addr = \"127.0.0.1:14555\""),
+            "server bind address should be preserved"
         );
         assert!(
             raw.contains("[engine.dependent_join]"),


### PR DESCRIPTION
## Intent

Establish app-owned `[server]` configuration and distinguish short-lived embedded gRPC lifecycles from a long-running standalone server without changing Coral's unauthenticated defaults.

## What it enables

- `EphemeralGrpc` binds to `127.0.0.1:0` for short-lived in-process servers.
- `StandaloneGrpc` uses `[server].bind_addr`, including loopback or non-loopback addresses, without requiring server authentication.
- Embedded UI remains loopback-only.

## Usage examples

Configure the standalone bind address in `config.toml`:

```toml
[server]
bind_addr = "127.0.0.1:14555"
```

The descendant CLI layer starts this configured runtime with `coral server`.