### PR TITLE
feat(client): support authenticated remote connections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - `crates/coral-app`: local server composition, state, workspaces, source
   lifecycle, and workspace-scoped catalog discovery behavior.
 - `crates/coral-cli`: terminal adapter.
-- `crates/coral-client`: intentionally thin local transport bootstrap plus
+- `crates/coral-client`: intentionally thin transport bootstrap plus
   Arrow IPC decode/render helpers.
 - `crates/coral-engine`: engine-side backend compilation, runtime registration,
   and query execution.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,14 +1335,16 @@ dependencies = [
  "opentelemetry_sdk",
  "schemars",
  "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tonic",
+  "serde_json",
+  "thiserror",
+  "tokio",
+  "tokio-stream",
+  "tonic",
  "tonic-types",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -5044,6 +5046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6112,9 +6115,11 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "rustls-native-certs",
  "socket2",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 toml = "0.9"
 toml_edit = "0.25.10"
-tonic = "0.14.2"
+tonic = { version = "0.14.2", features = ["tls-native-roots", "tls-ring"] }
 tonic-health = "0.14.2"
 tonic-prost = "0.14.2"
 tonic-types = "0.14.2"

--- a/crates/coral-client/Cargo.toml
+++ b/crates/coral-client/Cargo.toml
@@ -22,6 +22,7 @@ tonic.workspace = true
 tonic-types.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
+url.workspace = true
 
 coral-api.workspace = true
 coral-app.workspace = true
@@ -30,4 +31,5 @@ coral-telemetry.workspace = true
 
 [dev-dependencies]
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
+tokio-stream = { workspace = true, features = ["net"] }
 tracing-subscriber.workspace = true

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -15,7 +15,7 @@ use coral_api::{
 };
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
-use url::{Host, Url};
+use url::Url;
 
 use crate::error::ClientError;
 use crate::grpc::{GrpcClientEndpoint, InstrumentedGrpcService};
@@ -96,9 +96,8 @@ impl AppClient {
     /// Connects to a Coral endpoint and attaches static metadata to every
     /// outgoing request.
     ///
-    /// Trace-context, task-attribution, and gRPC transport keys are reserved. Authorization
-    /// metadata is sent only over HTTPS, except that plaintext HTTP is allowed
-    /// for loopback endpoints used during local development.
+    /// Trace-context, task-attribution, and gRPC transport keys are reserved.
+    /// Authorization metadata is sent only over HTTPS.
     ///
     /// # Errors
     ///
@@ -117,11 +116,10 @@ impl AppClient {
         Self::connect_with_static_metadata(endpoint_uri, static_metadata).await
     }
 
-    /// Connects to a Coral endpoint and attaches bearer authorization metadata
-    /// to every outgoing request.
+    /// Connects to an HTTPS Coral endpoint and attaches bearer authorization
+    /// metadata to every outgoing request.
     ///
-    /// Bearer credentials are sent only over HTTPS, except that plaintext HTTP
-    /// is allowed for loopback endpoints used during local development.
+    /// Bearer credentials are sent only over HTTPS.
     ///
     /// # Errors
     ///
@@ -269,23 +267,11 @@ fn endpoint_allows_authorization(endpoint_uri: &str) -> bool {
     if endpoint_has_credentials(&endpoint) {
         return false;
     }
-    match endpoint.scheme() {
-        "https" => endpoint.host().is_some(),
-        "http" => endpoint.host().as_ref().is_some_and(host_is_loopback),
-        _ => false,
-    }
+    endpoint.scheme() == "https" && endpoint.host().is_some()
 }
 
 fn endpoint_has_credentials(endpoint: &Url) -> bool {
     !endpoint.username().is_empty() || endpoint.password().is_some()
-}
-
-fn host_is_loopback(host: &Host<&str>) -> bool {
-    match host {
-        Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
-        Host::Ipv4(address) => address.is_loopback(),
-        Host::Ipv6(address) => address.is_loopback(),
-    }
 }
 
 fn grpc_service(
@@ -328,9 +314,9 @@ mod tests {
             &self,
             request: tonic::Request<SubmitFeedbackRequest>,
         ) -> Result<tonic::Response<SubmitFeedbackResponse>, tonic::Status> {
-            let authorization = request
+            let route = request
                 .metadata()
-                .get("authorization")
+                .get("x-coral-route")
                 .and_then(|value| value.to_str().ok())
                 .unwrap_or_default()
                 .to_string();
@@ -340,14 +326,14 @@ mod tests {
                 .and_then(|value| value.to_str().ok())
                 .unwrap_or_default()
                 .to_string();
-            *self.capture.0.lock().expect("capture lock") = Some((authorization, traceparent));
+            *self.capture.0.lock().expect("capture lock") = Some((route, traceparent));
 
             Ok(tonic::Response::new(SubmitFeedbackResponse::default()))
         }
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn static_authorization_and_active_traceparent_reach_generated_rpc() {
+    async fn static_metadata_and_active_traceparent_reach_generated_rpc() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind capture server");
@@ -367,12 +353,9 @@ mod tests {
         });
 
         let endpoint = format!("http://{address}");
-        let client = AppClient::connect_with_metadata(
-            &endpoint,
-            [("authorization", "Bearer session-token")],
-        )
-        .await
-        .expect("connect client");
+        let client = AppClient::connect_with_metadata(&endpoint, [("x-coral-route", "primary")])
+            .await
+            .expect("connect client");
         let provider = SdkTracerProvider::builder().build();
         let tracer = provider.tracer("coral-client-metadata-test");
         let subscriber =
@@ -387,13 +370,13 @@ mod tests {
             .await
             .expect("feedback RPC");
 
-        let (authorization, traceparent) = capture
+        let (route, traceparent) = capture
             .0
             .lock()
             .expect("capture lock")
             .clone()
             .expect("captured metadata");
-        assert_eq!(authorization, "Bearer session-token");
+        assert_eq!(route, "primary");
         assert!(traceparent.starts_with("00-"), "{traceparent}");
         assert_eq!(traceparent.len(), 55);
 
@@ -402,19 +385,8 @@ mod tests {
     }
 
     #[test]
-    fn authorization_endpoints_allow_https_and_loopback_http() {
-        for endpoint in [
-            "https://api.example.com",
-            "https://api.example.com:50051",
-            "http://localhost:50051",
-            "http://LOCALHOST",
-            "http://127.0.0.1:50051",
-            "http://127.255.255.254",
-            "http://127.1:50051",
-            "http://2130706433:50051",
-            "http://0x7f000001:50051",
-            "http://[::1]:50051",
-        ] {
+    fn authorization_endpoints_allow_https() {
+        for endpoint in ["https://api.example.com", "https://api.example.com:50051"] {
             assert!(
                 endpoint_allows_authorization(endpoint),
                 "rejected {endpoint}"
@@ -423,10 +395,18 @@ mod tests {
     }
 
     #[test]
-    fn authorization_endpoints_reject_remote_or_ambiguous_plaintext_http() {
+    fn authorization_endpoints_reject_plaintext_http() {
         for endpoint in [
             "http://api.example.com",
             "http://api.example.com:50051",
+            "http://localhost:50051",
+            "http://LOCALHOST",
+            "http://127.0.0.1:50051",
+            "http://127.255.255.254",
+            "http://127.1:50051",
+            "http://2130706433:50051",
+            "http://0x7f000001:50051",
+            "http://[::1]:50051",
             "http://10.0.0.1:50051",
             "http://[2001:db8::1]:50051",
             "http://localhost.example.com:50051",
@@ -457,20 +437,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn authenticated_connect_rejects_remote_http_before_dialing() {
+    async fn authenticated_connect_rejects_http_before_dialing() {
         let Err(error) = AppClient::connect_with_metadata(
-            "http://192.0.2.1:1",
+            "http://127.0.0.1:1",
             [("authorization", "Basic secret")],
         )
         .await
         else {
-            panic!("authorization metadata over remote HTTP must be rejected");
+            panic!("authorization metadata over HTTP must be rejected");
         };
         assert!(matches!(error, ClientError::InsecureAuthorizationEndpoint));
 
         let bearer = BearerToken::new("secret").expect("valid bearer");
-        let Err(error) = AppClient::connect_with_bearer("http://192.0.2.1:1", bearer).await else {
-            panic!("remote HTTP must be rejected");
+        let Err(error) = AppClient::connect_with_bearer("http://127.0.0.1:1", bearer).await else {
+            panic!("HTTP must be rejected");
         };
 
         assert!(matches!(error, ClientError::InsecureAuthorizationEndpoint));

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -14,11 +14,12 @@ use coral_api::{
     SEARCH_RESPONSE_MAX_MESSAGE_SIZE, SOURCE_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tonic::service::interceptor::InterceptedService;
-use tonic::transport::{Channel, Endpoint};
+use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
+use url::{Host, Url};
 
 use crate::error::ClientError;
 use crate::grpc::{GrpcClientEndpoint, InstrumentedGrpcService};
-use crate::propagation::RequestContextInterceptor;
+use crate::propagation::{BearerToken, ClientMetadataInterceptor, StaticClientMetadata};
 
 /// Default workspace used by local Coral clients.
 pub use coral_api::DEFAULT_WORKSPACE_ID;
@@ -37,7 +38,7 @@ pub fn workspace(name: impl Into<String>) -> Workspace {
     Workspace { name: name.into() }
 }
 
-type RawGrpcService = InterceptedService<Channel, RequestContextInterceptor>;
+type RawGrpcService = InterceptedService<Channel, ClientMetadataInterceptor>;
 type GrpcService = InstrumentedGrpcService<RawGrpcService>;
 
 /// Public source-management gRPC client.
@@ -89,23 +90,103 @@ impl AppClient {
     ///
     /// Returns [`ClientError`] if the gRPC clients cannot connect.
     pub async fn connect(endpoint_uri: &str) -> Result<Self, ClientError> {
-        let endpoint = Endpoint::from_shared(endpoint_uri.to_string())?
-            .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE);
+        Self::connect_with_static_metadata(endpoint_uri, StaticClientMetadata::default()).await
+    }
+
+    /// Connects to a Coral endpoint and attaches static metadata to every
+    /// outgoing request.
+    ///
+    /// Trace-context, task-attribution, and gRPC transport keys are reserved. Authorization
+    /// metadata is sent only over HTTPS, except that plaintext HTTP is allowed
+    /// for loopback endpoints used during local development.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError`] if the gRPC clients cannot connect, if supplied
+    /// metadata is invalid, or if authorization would cross plaintext HTTP.
+    pub async fn connect_with_metadata<K, V, I>(
+        endpoint_uri: &str,
+        metadata: I,
+    ) -> Result<Self, ClientError>
+    where
+        K: AsRef<str>,
+        V: AsRef<str>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let static_metadata = StaticClientMetadata::try_from_pairs(metadata)?;
+        Self::connect_with_static_metadata(endpoint_uri, static_metadata).await
+    }
+
+    /// Connects to a Coral endpoint and attaches bearer authorization metadata
+    /// to every outgoing request.
+    ///
+    /// Bearer credentials are sent only over HTTPS, except that plaintext HTTP
+    /// is allowed for loopback endpoints used during local development.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::InsecureAuthorizationEndpoint`] before attempting a
+    /// connection when the endpoint could expose the token over plaintext.
+    /// Returns [`ClientError`] if the gRPC clients otherwise cannot connect.
+    pub async fn connect_with_bearer(
+        endpoint_uri: &str,
+        bearer: BearerToken,
+    ) -> Result<Self, ClientError> {
+        Self::connect_with_metadata(endpoint_uri, [("authorization", bearer.authorization())]).await
+    }
+
+    async fn connect_with_static_metadata(
+        endpoint_uri: &str,
+        static_metadata: StaticClientMetadata,
+    ) -> Result<Self, ClientError> {
+        let endpoint = configured_endpoint(endpoint_uri)?;
+        if static_metadata.contains_authorization() && !endpoint_allows_authorization(endpoint_uri)
+        {
+            return Err(ClientError::InsecureAuthorizationEndpoint);
+        }
         let grpc_endpoint = GrpcClientEndpoint::from_endpoint_uri(endpoint_uri);
         let channel = endpoint.connect().await?;
-        let source_client = SourceClient::new(grpc_service(channel.clone(), &grpc_endpoint))
-            .max_decoding_message_size(SOURCE_RESPONSE_MAX_MESSAGE_SIZE);
-        let workspace_client = WorkspaceClient::new(grpc_service(channel.clone(), &grpc_endpoint));
-        let catalog_client = CatalogClient::new(grpc_service(channel.clone(), &grpc_endpoint))
-            .max_decoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE);
-        let query_client = QueryClient::new(grpc_service(channel.clone(), &grpc_endpoint))
-            .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
-        let search_client = SearchClient::new(grpc_service(channel.clone(), &grpc_endpoint))
-            .max_decoding_message_size(SEARCH_RESPONSE_MAX_MESSAGE_SIZE);
-        let function_client = FunctionClient::new(grpc_service(channel.clone(), &grpc_endpoint))
-            .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
-        let feedback_client = FeedbackClient::new(grpc_service(channel.clone(), &grpc_endpoint));
-        let task_client = TaskClient::new(grpc_service(channel, &grpc_endpoint));
+        let source_client = SourceClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ))
+        .max_decoding_message_size(SOURCE_RESPONSE_MAX_MESSAGE_SIZE);
+        let workspace_client = WorkspaceClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ));
+        let catalog_client = CatalogClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ))
+        .max_decoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE);
+        let query_client = QueryClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ))
+        .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
+        let search_client = SearchClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ))
+        .max_decoding_message_size(SEARCH_RESPONSE_MAX_MESSAGE_SIZE);
+        let function_client = FunctionClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ))
+        .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
+        let feedback_client = FeedbackClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ));
+        let task_client = TaskClient::new(grpc_service(channel, &grpc_endpoint, static_metadata));
         Ok(Self {
             source: source_client,
             workspace: workspace_client,
@@ -167,9 +248,236 @@ impl AppClient {
     }
 }
 
-fn grpc_service(channel: Channel, endpoint: &GrpcClientEndpoint) -> GrpcService {
+fn configured_endpoint(endpoint_uri: &str) -> Result<Endpoint, ClientError> {
+    if Url::parse(endpoint_uri).is_ok_and(|endpoint| endpoint_has_credentials(&endpoint)) {
+        return Err(ClientError::EndpointCredentials);
+    }
+    let endpoint = Endpoint::from_shared(endpoint_uri.to_string())?
+        .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE);
+    if endpoint.uri().scheme_str() == Some("https") {
+        return endpoint
+            .tls_config(ClientTlsConfig::new().with_native_roots())
+            .map_err(Into::into);
+    }
+    Ok(endpoint)
+}
+
+fn endpoint_allows_authorization(endpoint_uri: &str) -> bool {
+    let Ok(endpoint) = Url::parse(endpoint_uri) else {
+        return false;
+    };
+    if endpoint_has_credentials(&endpoint) {
+        return false;
+    }
+    match endpoint.scheme() {
+        "https" => endpoint.host().is_some(),
+        "http" => endpoint.host().as_ref().is_some_and(host_is_loopback),
+        _ => false,
+    }
+}
+
+fn endpoint_has_credentials(endpoint: &Url) -> bool {
+    !endpoint.username().is_empty() || endpoint.password().is_some()
+}
+
+fn host_is_loopback(host: &Host<&str>) -> bool {
+    match host {
+        Host::Domain(host) => host.eq_ignore_ascii_case("localhost"),
+        Host::Ipv4(address) => address.is_loopback(),
+        Host::Ipv6(address) => address.is_loopback(),
+    }
+}
+
+fn grpc_service(
+    channel: Channel,
+    endpoint: &GrpcClientEndpoint,
+    static_metadata: StaticClientMetadata,
+) -> GrpcService {
     InstrumentedGrpcService::new(
-        InterceptedService::new(channel, RequestContextInterceptor),
+        InterceptedService::new(channel, ClientMetadataInterceptor::new(static_metadata)),
         endpoint.clone(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use coral_api::v1::feedback_service_server::{FeedbackService, FeedbackServiceServer};
+    use coral_api::v1::{SubmitFeedbackRequest, SubmitFeedbackResponse};
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::SdkTracerProvider;
+    use tokio::sync::oneshot;
+    use tokio_stream::wrappers::TcpListenerStream;
+    use tracing::Instrument as _;
+    use tracing_subscriber::prelude::*;
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct MetadataCapture(Arc<Mutex<Option<(String, String)>>>);
+
+    #[derive(Clone)]
+    struct CapturingFeedbackService {
+        capture: MetadataCapture,
+    }
+
+    #[tonic::async_trait]
+    impl FeedbackService for CapturingFeedbackService {
+        async fn submit_feedback(
+            &self,
+            request: tonic::Request<SubmitFeedbackRequest>,
+        ) -> Result<tonic::Response<SubmitFeedbackResponse>, tonic::Status> {
+            let authorization = request
+                .metadata()
+                .get("authorization")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_string();
+            let traceparent = request
+                .metadata()
+                .get("traceparent")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default()
+                .to_string();
+            *self.capture.0.lock().expect("capture lock") = Some((authorization, traceparent));
+
+            Ok(tonic::Response::new(SubmitFeedbackResponse::default()))
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn static_authorization_and_active_traceparent_reach_generated_rpc() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind capture server");
+        let address = listener.local_addr().expect("capture server address");
+        let capture = MetadataCapture::default();
+        let service = CapturingFeedbackService {
+            capture: capture.clone(),
+        };
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(FeedbackServiceServer::new(service))
+                .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                    drop(shutdown_rx.await);
+                })
+                .await
+        });
+
+        let endpoint = format!("http://{address}");
+        let client = AppClient::connect_with_metadata(
+            &endpoint,
+            [("authorization", "Bearer session-token")],
+        )
+        .await
+        .expect("connect client");
+        let provider = SdkTracerProvider::builder().build();
+        let tracer = provider.tracer("coral-client-metadata-test");
+        let subscriber =
+            tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+        let span = tracing::info_span!("metadata_rpc_traversal");
+
+        client
+            .feedback_client()
+            .submit_feedback(SubmitFeedbackRequest::default())
+            .instrument(span)
+            .await
+            .expect("feedback RPC");
+
+        let (authorization, traceparent) = capture
+            .0
+            .lock()
+            .expect("capture lock")
+            .clone()
+            .expect("captured metadata");
+        assert_eq!(authorization, "Bearer session-token");
+        assert!(traceparent.starts_with("00-"), "{traceparent}");
+        assert_eq!(traceparent.len(), 55);
+
+        shutdown_tx.send(()).expect("shutdown capture server");
+        server.await.expect("join capture server").expect("server");
+    }
+
+    #[test]
+    fn authorization_endpoints_allow_https_and_loopback_http() {
+        for endpoint in [
+            "https://api.example.com",
+            "https://api.example.com:50051",
+            "http://localhost:50051",
+            "http://LOCALHOST",
+            "http://127.0.0.1:50051",
+            "http://127.255.255.254",
+            "http://127.1:50051",
+            "http://2130706433:50051",
+            "http://0x7f000001:50051",
+            "http://[::1]:50051",
+        ] {
+            assert!(
+                endpoint_allows_authorization(endpoint),
+                "rejected {endpoint}"
+            );
+        }
+    }
+
+    #[test]
+    fn authorization_endpoints_reject_remote_or_ambiguous_plaintext_http() {
+        for endpoint in [
+            "http://api.example.com",
+            "http://api.example.com:50051",
+            "http://10.0.0.1:50051",
+            "http://[2001:db8::1]:50051",
+            "http://localhost.example.com:50051",
+            "http://localhost@api.example.com:50051",
+            "http://user:password@localhost:50051",
+            "ftp://localhost:50051",
+            "localhost:50051",
+        ] {
+            assert!(
+                !endpoint_allows_authorization(endpoint),
+                "accepted {endpoint}"
+            );
+        }
+    }
+
+    #[test]
+    fn configured_endpoints_reject_url_credentials() {
+        for endpoint in [
+            "http://user@localhost:50051",
+            "http://user:password@localhost:50051",
+            "https://%75ser@example.com:50051",
+        ] {
+            assert!(matches!(
+                configured_endpoint(endpoint),
+                Err(ClientError::EndpointCredentials)
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn authenticated_connect_rejects_remote_http_before_dialing() {
+        let Err(error) = AppClient::connect_with_metadata(
+            "http://192.0.2.1:1",
+            [("authorization", "Basic secret")],
+        )
+        .await
+        else {
+            panic!("authorization metadata over remote HTTP must be rejected");
+        };
+        assert!(matches!(error, ClientError::InsecureAuthorizationEndpoint));
+
+        let bearer = BearerToken::new("secret").expect("valid bearer");
+        let Err(error) = AppClient::connect_with_bearer("http://192.0.2.1:1", bearer).await else {
+            panic!("remote HTTP must be rejected");
+        };
+
+        assert!(matches!(error, ClientError::InsecureAuthorizationEndpoint));
+    }
+
+    #[test]
+    fn https_endpoint_builds_with_native_root_tls() {
+        configured_endpoint("https://api.example.com:50051").expect("HTTPS endpoint");
+    }
 }

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -19,7 +19,9 @@ use url::Url;
 
 use crate::error::ClientError;
 use crate::grpc::{GrpcClientEndpoint, InstrumentedGrpcService};
-use crate::propagation::{BearerToken, ClientMetadataInterceptor, StaticClientMetadata};
+use crate::propagation::{
+    AUTHORIZATION_METADATA_KEY, BearerToken, ClientMetadataInterceptor, StaticClientMetadata,
+};
 
 /// Default workspace used by local Coral clients.
 pub use coral_api::DEFAULT_WORKSPACE_ID;
@@ -130,7 +132,11 @@ impl AppClient {
         endpoint_uri: &str,
         bearer: BearerToken,
     ) -> Result<Self, ClientError> {
-        Self::connect_with_metadata(endpoint_uri, [("authorization", bearer.authorization())]).await
+        Self::connect_with_metadata(
+            endpoint_uri,
+            [(AUTHORIZATION_METADATA_KEY, bearer.authorization())],
+        )
+        .await
     }
 
     async fn connect_with_static_metadata(

--- a/crates/coral-client/src/error.rs
+++ b/crates/coral-client/src/error.rs
@@ -7,9 +7,7 @@ pub enum ClientError {
     #[error("invalid bearer token: {0}")]
     InvalidBearerToken(String),
     /// Sending authorization metadata to the endpoint would expose it over plaintext.
-    #[error(
-        "authorization metadata requires an HTTPS endpoint, or an HTTP loopback endpoint for local development"
-    )]
+    #[error("authorization metadata requires an HTTPS endpoint")]
     InsecureAuthorizationEndpoint,
     /// Endpoint credentials could leak through logs or authority handling.
     #[error("endpoint URLs must not include credentials")]

--- a/crates/coral-client/src/error.rs
+++ b/crates/coral-client/src/error.rs
@@ -3,6 +3,20 @@
 /// Errors surfaced while bootstrapping a Coral client.
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
+    /// A bearer token was empty or could not be encoded as gRPC metadata.
+    #[error("invalid bearer token: {0}")]
+    InvalidBearerToken(String),
+    /// Sending authorization metadata to the endpoint would expose it over plaintext.
+    #[error(
+        "authorization metadata requires an HTTPS endpoint, or an HTTP loopback endpoint for local development"
+    )]
+    InsecureAuthorizationEndpoint,
+    /// Endpoint credentials could leak through logs or authority handling.
+    #[error("endpoint URLs must not include credentials")]
+    EndpointCredentials,
+    /// Caller-supplied request metadata was invalid.
+    #[error("invalid client metadata: {0}")]
+    InvalidMetadata(String),
     /// Connecting the generated gRPC client failed.
     #[error(transparent)]
     Transport(#[from] tonic::transport::Error),

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -1,4 +1,4 @@
-//! Thin local transport bootstrap and shared query-result helpers for Coral.
+//! Thin transport bootstrap and shared query-result helpers for Coral.
 //!
 //! `coral-client` intentionally stays narrow today. It owns:
 //!
@@ -45,7 +45,7 @@ pub use client::{
     SearchClient, SourceClient, TaskClient, WorkspaceClient, default_workspace, workspace,
 };
 pub use error::{ClientError, QueryResultError};
-pub use propagation::with_task_metadata;
+pub use propagation::{BearerToken, with_task_metadata};
 pub use search::{
     SearchResponseValue, format_schema_table_equivalent, format_search_response_json,
     format_search_response_text, format_sql_identifier, minimal_table_function_call_example,

--- a/crates/coral-client/src/propagation.rs
+++ b/crates/coral-client/src/propagation.rs
@@ -9,7 +9,7 @@ use tonic::metadata::{Ascii, MetadataKey, MetadataValue};
 
 use crate::error::ClientError;
 
-const AUTHORIZATION_METADATA_KEY: &str = "authorization";
+pub(crate) const AUTHORIZATION_METADATA_KEY: &str = "authorization";
 
 tokio::task_local! {
     static TASK_ID: Option<MetadataValue<Ascii>>;

--- a/crates/coral-client/src/propagation.rs
+++ b/crates/coral-client/src/propagation.rs
@@ -32,11 +32,12 @@ impl BearerToken {
     /// Returns [`ClientError::InvalidBearerToken`] when the token is empty or
     /// cannot be represented as ASCII gRPC metadata.
     pub fn new(token: impl AsRef<str>) -> Result<Self, ClientError> {
-        let token = token.as_ref().trim();
+        let token = token.as_ref().trim_start();
         let token = match token.split_at_checked(7) {
             Some((prefix, token)) if prefix.eq_ignore_ascii_case("bearer ") => token,
             _ => token,
-        };
+        }
+        .trim_end();
         if token.is_empty() || token.chars().any(char::is_whitespace) {
             return Err(ClientError::InvalidBearerToken(
                 "token must be non-empty and contain no whitespace".to_string(),
@@ -226,7 +227,7 @@ mod tests {
 
     #[test]
     fn bearer_token_rejects_empty_and_invalid_metadata() {
-        for token in ["", "  ", "Bearer \nsecret"] {
+        for token in ["", "  ", "Bearer ", "Bearer \nsecret"] {
             assert!(matches!(
                 BearerToken::new(token),
                 Err(ClientError::InvalidBearerToken(_))

--- a/crates/coral-client/src/propagation.rs
+++ b/crates/coral-client/src/propagation.rs
@@ -1,23 +1,67 @@
-//! W3C Trace Context propagation for tonic gRPC clients.
+//! Request metadata propagation for tonic gRPC clients.
 
 use std::future::Future;
+use std::sync::Arc;
 
 use coral_api::CORAL_TASK_ID_METADATA_KEY;
 use opentelemetry::propagation::Injector;
-use tonic::metadata::{Ascii, MetadataValue};
+use tonic::metadata::{Ascii, MetadataKey, MetadataValue};
+
+use crate::error::ClientError;
+
+const AUTHORIZATION_METADATA_KEY: &str = "authorization";
 
 tokio::task_local! {
     static TASK_ID: Option<MetadataValue<Ascii>>;
+}
+
+/// A validated bearer credential for an authenticated Coral connection.
+///
+/// Values may be supplied either as a raw token or with a `Bearer` prefix.
+/// The authorization scheme is normalized before it is attached to requests.
+#[derive(Clone)]
+pub struct BearerToken {
+    authorization: String,
+}
+
+impl BearerToken {
+    /// Validates a bearer token for use as gRPC authorization metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::InvalidBearerToken`] when the token is empty or
+    /// cannot be represented as ASCII gRPC metadata.
+    pub fn new(token: impl AsRef<str>) -> Result<Self, ClientError> {
+        let token = token.as_ref().trim();
+        let token = match token.split_at_checked(7) {
+            Some((prefix, token)) if prefix.eq_ignore_ascii_case("bearer ") => token,
+            _ => token,
+        };
+        if token.is_empty() || token.chars().any(char::is_whitespace) {
+            return Err(ClientError::InvalidBearerToken(
+                "token must be non-empty and contain no whitespace".to_string(),
+            ));
+        }
+
+        let authorization = format!("Bearer {token}");
+        MetadataValue::<Ascii>::try_from(authorization.as_str())
+            .map_err(|error| ClientError::InvalidBearerToken(error.to_string()))?;
+        Ok(Self { authorization })
+    }
+
+    pub(crate) fn authorization(&self) -> &str {
+        &self.authorization
+    }
 }
 
 struct MetadataInjector<'a>(&'a mut tonic::metadata::MetadataMap);
 
 impl Injector for MetadataInjector<'_> {
     fn set(&mut self, key: &str, value: String) {
-        if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes())
-            && let Ok(val) = tonic::metadata::MetadataValue::try_from(&value)
+        if let Ok(key) = MetadataKey::from_bytes(key.as_bytes())
+            && let Ok(value) = MetadataValue::try_from(&value)
         {
-            self.0.insert(key, val);
+            self.0.insert(key, value);
         }
     }
 }
@@ -35,12 +79,83 @@ where
     TASK_ID.scope(task_id, future).await
 }
 
-/// tonic client interceptor that injects request-scoped Coral metadata into
-/// outgoing gRPC request metadata.
-#[derive(Clone)]
-pub struct RequestContextInterceptor;
+#[derive(Clone, Debug, Default)]
+pub(crate) struct StaticClientMetadata {
+    entries: Arc<Vec<(MetadataKey<Ascii>, MetadataValue<Ascii>)>>,
+}
 
-impl tonic::service::Interceptor for RequestContextInterceptor {
+impl StaticClientMetadata {
+    pub(crate) fn try_from_pairs<K, V, I>(metadata: I) -> Result<Self, ClientError>
+    where
+        K: AsRef<str>,
+        V: AsRef<str>,
+        I: IntoIterator<Item = (K, V)>,
+    {
+        let entries = metadata
+            .into_iter()
+            .map(|(key, value)| {
+                let key = MetadataKey::from_bytes(key.as_ref().as_bytes()).map_err(|error| {
+                    ClientError::InvalidMetadata(format!(
+                        "metadata key '{}' is invalid: {error}",
+                        key.as_ref()
+                    ))
+                })?;
+                if is_reserved_static_metadata_key(&key) {
+                    return Err(ClientError::InvalidMetadata(format!(
+                        "metadata key '{}' is reserved for Coral transport",
+                        key.as_str()
+                    )));
+                }
+                let mut value = MetadataValue::try_from(value.as_ref()).map_err(|error| {
+                    ClientError::InvalidMetadata(format!(
+                        "metadata value for '{}' is invalid: {error}",
+                        key.as_str()
+                    ))
+                })?;
+                if key == AUTHORIZATION_METADATA_KEY {
+                    value.set_sensitive(true);
+                }
+                Ok::<_, ClientError>((key, value))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            entries: Arc::new(entries),
+        })
+    }
+
+    pub(crate) fn contains_authorization(&self) -> bool {
+        self.entries
+            .iter()
+            .any(|(key, _)| key == AUTHORIZATION_METADATA_KEY)
+    }
+}
+
+fn is_reserved_static_metadata_key(key: &MetadataKey<Ascii>) -> bool {
+    matches!(
+        key.as_str(),
+        "traceparent"
+            | "tracestate"
+            | "baggage"
+            | CORAL_TASK_ID_METADATA_KEY
+            | "content-type"
+            | "te"
+    ) || key.as_str().starts_with("grpc-")
+}
+
+/// tonic client interceptor that injects the current trace context, scoped
+/// Coral task attribution, and caller-supplied static metadata.
+#[derive(Clone)]
+pub struct ClientMetadataInterceptor {
+    static_metadata: StaticClientMetadata,
+}
+
+impl ClientMetadataInterceptor {
+    pub(crate) fn new(static_metadata: StaticClientMetadata) -> Self {
+        Self { static_metadata }
+    }
+}
+
+impl tonic::service::Interceptor for ClientMetadataInterceptor {
     fn call(
         &mut self,
         mut request: tonic::Request<()>,
@@ -51,25 +166,27 @@ impl tonic::service::Interceptor for RequestContextInterceptor {
                 .metadata_mut()
                 .insert(CORAL_TASK_ID_METADATA_KEY, task_id);
         }
+        for (key, value) in self.static_metadata.entries.iter() {
+            request.metadata_mut().append(key.clone(), value.clone());
+        }
         Ok(request)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use coral_api::CORAL_TASK_ID_METADATA_KEY;
     use tonic::service::Interceptor as _;
 
-    use super::{RequestContextInterceptor, with_task_metadata};
+    use super::*;
 
     #[tokio::test]
-    async fn request_context_interceptor_injects_scoped_task_id() {
+    async fn client_metadata_interceptor_injects_scoped_task_id() {
         let task_id = "550e8400-e29b-41d4-a716-446655440000"
             .parse()
             .expect("metadata value");
 
         let request = with_task_metadata(Some(task_id), async {
-            RequestContextInterceptor
+            ClientMetadataInterceptor::new(StaticClientMetadata::default())
                 .call(tonic::Request::new(()))
                 .expect("interceptor")
         })
@@ -85,11 +202,100 @@ mod tests {
     }
 
     #[test]
-    fn request_context_interceptor_omits_task_id_without_scope() {
-        let request = RequestContextInterceptor
+    fn client_metadata_interceptor_omits_task_id_without_scope() {
+        let request = ClientMetadataInterceptor::new(StaticClientMetadata::default())
             .call(tonic::Request::new(()))
             .expect("interceptor");
 
         assert!(request.metadata().get(CORAL_TASK_ID_METADATA_KEY).is_none());
+    }
+
+    #[test]
+    fn bearer_token_normalizes_raw_and_prefixed_values() {
+        for (token, expected) in [
+            ("secret", "Bearer secret"),
+            ("Bearer secret", "Bearer secret"),
+            ("bearer secret", "Bearer secret"),
+            ("  secret  ", "Bearer secret"),
+            ("bearer", "Bearer bearer"),
+        ] {
+            let bearer = BearerToken::new(token).expect("valid bearer");
+            assert_eq!(bearer.authorization(), expected);
+        }
+    }
+
+    #[test]
+    fn bearer_token_rejects_empty_and_invalid_metadata() {
+        for token in ["", "  ", "Bearer \nsecret"] {
+            assert!(matches!(
+                BearerToken::new(token),
+                Err(ClientError::InvalidBearerToken(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn static_client_metadata_rejects_invalid_and_reserved_keys() {
+        let error = StaticClientMetadata::try_from_pairs([("bad key", "value")])
+            .expect_err("invalid key should fail");
+        assert!(error.to_string().contains("metadata key 'bad key'"));
+
+        for key in [
+            "traceparent",
+            "tracestate",
+            "baggage",
+            CORAL_TASK_ID_METADATA_KEY,
+            "content-type",
+            "te",
+            "grpc-timeout",
+        ] {
+            let error = StaticClientMetadata::try_from_pairs([(key, "value")])
+                .expect_err("reserved key should fail");
+            assert!(error.to_string().contains("is reserved"));
+        }
+    }
+
+    #[tokio::test]
+    async fn interceptor_combines_task_and_repeated_static_metadata() {
+        let metadata = StaticClientMetadata::try_from_pairs([
+            ("x-coral-route", "primary"),
+            ("x-coral-route", "secondary"),
+            (AUTHORIZATION_METADATA_KEY, "Bearer secret"),
+        ])
+        .expect("metadata");
+        assert!(metadata.contains_authorization());
+        let mut interceptor = ClientMetadataInterceptor::new(metadata);
+        let task_id = "550e8400-e29b-41d4-a716-446655440000"
+            .parse()
+            .expect("metadata value");
+
+        let request = with_task_metadata(Some(task_id), async {
+            interceptor
+                .call(tonic::Request::new(()))
+                .expect("interceptor")
+        })
+        .await;
+        let routes = request
+            .metadata()
+            .get_all("x-coral-route")
+            .iter()
+            .map(|value| value.to_str().expect("ASCII metadata"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(routes, vec!["primary", "secondary"]);
+        assert_eq!(
+            request
+                .metadata()
+                .get(CORAL_TASK_ID_METADATA_KEY)
+                .and_then(|value| value.to_str().ok()),
+            Some("550e8400-e29b-41d4-a716-446655440000")
+        );
+        assert!(
+            request
+                .metadata()
+                .get(AUTHORIZATION_METADATA_KEY)
+                .expect("authorization")
+                .is_sensitive()
+        );
     }
 }


### PR DESCRIPTION
## Intent

Allow Coral clients to attach validated outbound gRPC metadata, including bearer authorization, through the typed `AppClient` connection path without changing unauthenticated local connections.

## What it enables

- `AppClient::connect_with_bearer` sends bearer metadata only to public `https://` endpoints.
- `AppClient::connect_with_metadata` supports other validated outbound metadata while preserving repeated values and sensitive authorization handling.
- Public plaintext `http://` endpoints fail before dialing when authorization metadata is present; `AppClient::connect` remains available for unauthenticated local servers.

## Usage examples

Use `AppClient::connect` for an unauthenticated local server. For an authenticated remote server, construct a `BearerToken` and call `AppClient::connect_with_bearer` with an `https://` endpoint.