### PR TITLE
feat(cli): add remote endpoint connectivity

### DIFF
--- a/apps/docs/project/architecture.mdx
+++ b/apps/docs/project/architecture.mdx
@@ -42,7 +42,9 @@ The user-facing command-line interface.
 | Output formatting | Table and JSON via `coral-client` helpers |
 
 Intentionally thin at the binary boundary — `main.rs` is a small wrapper, `bootstrap.rs` owns CLI bootstrap, and `lib.rs` owns shared command parsing and dispatch for Coral binaries. Query/result helpers stay in `coral-client`.
-For black-box CLI tests, contributors can enable the `CORAL_ENDPOINT` bootstrap override with `cargo nextest run --locked -p coral-cli --features cli-test-server`.
+`CORAL_ENDPOINT` is the public CLI override for dialing an existing server. The
+`cli-test-server` feature enables black-box test harnesses that use this same
+connection contract.
 
 ### `coral-client`
 

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -34,6 +34,24 @@ The `--workspace <NAME>` flag overrides `CORAL_WORKSPACE` for that process.
 Coral does not persist a separate active-workspace setting; set
 `CORAL_WORKSPACE` in your shell when you want a default for repeated commands.
 
+## Remote connections
+
+Use the global endpoint and token options to run CLI commands against an
+existing Coral gRPC server instead of starting a local server:
+
+```shellscript
+coral --endpoint https://coral.example.com --token "$TOKEN" sql "select 1"
+CORAL_ENDPOINT=https://coral.example.com CORAL_AUTH_TOKEN="$TOKEN" coral source list
+```
+
+`--endpoint` overrides `CORAL_ENDPOINT`, and `--token` overrides
+`CORAL_AUTH_TOKEN`. A token is optional, so endpoints that do not require
+authentication remain supported. Prefer `CORAL_AUTH_TOKEN` where command-line
+arguments may be visible to other users or process-inspection tools.
+
+Coral sends bearer credentials only over HTTPS. Plaintext HTTP is accepted
+with a token only for loopback endpoints such as `http://127.0.0.1:1457`.
+
 ## `coral sql`
 
 Run one SQL query and exit.

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -2,19 +2,29 @@ use std::sync::Arc;
 
 use coral_app::{AwsEngineExtensionsProvider, features::FeatureOverrides};
 use coral_client::{
-    AppClient, ClientError,
+    AppClient, BearerToken, ClientError,
     local::{LocalServerError, RunningServer as AppRunningServer, ServerBuilder},
 };
 
+use crate::env::ConnectionOptions;
+
 pub(crate) struct Bootstrap {
     pub(crate) app: AppClient,
+    pub(crate) mode: BootstrapMode,
     server: Option<AppRunningServer>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BootstrapMode {
+    Local,
+    Remote,
+}
+
+#[derive(Default)]
 pub(crate) struct BootstrapOptions {
     pub(crate) enable_stderr_logs: bool,
     pub(crate) feature_overrides: FeatureOverrides,
+    pub(crate) connection: ConnectionOptions,
 }
 
 impl Bootstrap {
@@ -36,21 +46,41 @@ pub(crate) enum BootstrapError {
 }
 
 pub(crate) async fn bootstrap(options: BootstrapOptions) -> Result<Bootstrap, BootstrapError> {
-    if let Some(endpoint) = bootstrap_endpoint() {
+    let BootstrapOptions {
+        enable_stderr_logs,
+        feature_overrides,
+        connection,
+    } = options;
+    let bearer = connection
+        .token
+        .as_deref()
+        .map(BearerToken::new)
+        .transpose()?;
+    if let Some(endpoint) = connection.endpoint {
         return Ok(Bootstrap {
-            app: AppClient::connect(&endpoint).await?,
+            app: connect(&endpoint, bearer).await?,
+            mode: BootstrapMode::Remote,
             server: None,
         });
     }
 
-    let server = configure_server_builder(ServerBuilder::new(), options)
-        .start()
-        .await?;
-    let app = AppClient::connect(server.endpoint_uri()).await?;
+    let server =
+        configure_server_builder(ServerBuilder::new(), enable_stderr_logs, feature_overrides)
+            .start()
+            .await?;
+    let app = connect(server.endpoint_uri(), bearer).await?;
     Ok(Bootstrap {
         app,
+        mode: BootstrapMode::Local,
         server: Some(server),
     })
+}
+
+async fn connect(endpoint: &str, bearer: Option<BearerToken>) -> Result<AppClient, ClientError> {
+    match bearer {
+        Some(bearer) => AppClient::connect_with_bearer(endpoint, bearer).await,
+        None => AppClient::connect(endpoint).await,
+    }
 }
 
 #[cfg(feature = "embedded-ui")]
@@ -60,10 +90,8 @@ pub(crate) async fn start_ui_server(
 ) -> Result<AppRunningServer, BootstrapError> {
     let server = configure_server_builder(
         ServerBuilder::embedded_ui_loopback(port, crate::embedded_ui_assets()),
-        BootstrapOptions {
-            feature_overrides,
-            ..BootstrapOptions::default()
-        },
+        false,
+        feature_overrides,
     )
     .start()
     .await?;
@@ -75,27 +103,50 @@ pub(crate) async fn start_standalone_server(
 ) -> Result<crate::serve::RunningServer, BootstrapError> {
     let builder = configure_server_builder(
         ServerBuilder::configured_standalone_grpc(),
-        BootstrapOptions {
-            feature_overrides,
-            ..BootstrapOptions::default()
-        },
+        false,
+        feature_overrides,
     );
     crate::serve::start(builder).await.map_err(Into::into)
 }
 
-fn configure_server_builder(builder: ServerBuilder, options: BootstrapOptions) -> ServerBuilder {
+fn configure_server_builder(
+    builder: ServerBuilder,
+    enable_stderr_logs: bool,
+    feature_overrides: FeatureOverrides,
+) -> ServerBuilder {
     builder
-        .with_stderr_logs(options.enable_stderr_logs)
-        .with_feature_overrides(options.feature_overrides)
+        .with_stderr_logs(enable_stderr_logs)
+        .with_feature_overrides(feature_overrides)
         .add_engine_extensions_provider(Arc::new(AwsEngineExtensionsProvider))
 }
 
-#[cfg(feature = "cli-test-server")]
-fn bootstrap_endpoint() -> Option<String> {
-    crate::env::bootstrap_endpoint()
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[cfg(not(feature = "cli-test-server"))]
-fn bootstrap_endpoint() -> Option<String> {
-    None
+    #[tokio::test(flavor = "multi_thread")]
+    async fn explicit_endpoint_uses_authenticated_remote_bootstrap()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let config_dir = tempfile::tempdir()?;
+        let server = ServerBuilder::new()
+            .with_config_dir(config_dir.path())
+            .with_noop_feedback_uploads()
+            .start()
+            .await?;
+        let bootstrap = bootstrap(BootstrapOptions {
+            connection: ConnectionOptions {
+                endpoint: Some(server.endpoint_uri().to_string()),
+                token: Some("test-token".to_string()),
+            },
+            ..BootstrapOptions::default()
+        })
+        .await?;
+
+        if bootstrap.mode != BootstrapMode::Remote {
+            return Err(std::io::Error::other("explicit endpoint started a local server").into());
+        }
+        bootstrap.shutdown().await;
+        server.shutdown().await?;
+        Ok(())
+    }
 }

--- a/crates/coral-cli/src/env.rs
+++ b/crates/coral-cli/src/env.rs
@@ -3,20 +3,54 @@
 //! `coral-cli` is allowed to read process environment when the CLI surface
 //! explicitly defines an env-backed workflow.
 
-#[cfg(feature = "cli-test-server")]
 const CORAL_ENDPOINT_ENV: &str = "CORAL_ENDPOINT";
+const CORAL_AUTH_TOKEN_ENV: &str = "CORAL_AUTH_TOKEN";
 
-/// Reads the feature-gated endpoint override used by CLI integration tests.
-#[cfg(feature = "cli-test-server")]
+/// Resolved endpoint and bearer credential for one CLI invocation.
+#[derive(Default)]
+pub(crate) struct ConnectionOptions {
+    pub(crate) endpoint: Option<String>,
+    pub(crate) token: Option<String>,
+}
+
+/// Resolves CLI connection flags over their environment fallbacks.
 #[expect(
     clippy::disallowed_methods,
-    reason = "This feature-gated test hook owns the CORAL_ENDPOINT bootstrap override."
+    reason = "CORAL_ENDPOINT and CORAL_AUTH_TOKEN are public CLI connection settings."
 )]
 #[must_use]
-pub fn bootstrap_endpoint() -> Option<String> {
-    std::env::var_os(CORAL_ENDPOINT_ENV)
-        .and_then(|value| value.into_string().ok())
-        .filter(|value| !value.is_empty())
+pub(crate) fn connection_options(
+    cli_endpoint: Option<String>,
+    cli_token: Option<String>,
+) -> ConnectionOptions {
+    resolve_connection_options(cli_endpoint, cli_token, |name| std::env::var(name).ok())
+}
+
+fn resolve_connection_options(
+    cli_endpoint: Option<String>,
+    cli_token: Option<String>,
+    mut read_env: impl FnMut(&str) -> Option<String>,
+) -> ConnectionOptions {
+    ConnectionOptions {
+        endpoint: resolve_value(cli_endpoint, CORAL_ENDPOINT_ENV, &mut read_env),
+        token: resolve_value(cli_token, CORAL_AUTH_TOKEN_ENV, &mut read_env),
+    }
+}
+
+fn resolve_value(
+    cli_value: Option<String>,
+    env_name: &str,
+    read_env: &mut impl FnMut(&str) -> Option<String>,
+) -> Option<String> {
+    match cli_value {
+        Some(value) => non_empty_trimmed(&value),
+        None => read_env(env_name).and_then(|value| non_empty_trimmed(&value)),
+    }
+}
+
+fn non_empty_trimmed(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 const CORAL_TRACE_PARENT_ENV: &str = "CORAL_TRACE_PARENT";
@@ -42,4 +76,42 @@ pub fn workspace() -> Option<String> {
     std::env::var(CORAL_WORKSPACE_ENV)
         .ok()
         .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connection_flags_override_environment() {
+        let options = resolve_connection_options(
+            Some(" https://flag.example ".to_string()),
+            Some(" flag-token ".to_string()),
+            |name| match name {
+                CORAL_ENDPOINT_ENV => Some("https://env.example".to_string()),
+                CORAL_AUTH_TOKEN_ENV => Some("env-token".to_string()),
+                _ => None,
+            },
+        );
+
+        assert_eq!(options.endpoint.as_deref(), Some("https://flag.example"));
+        assert_eq!(options.token.as_deref(), Some("flag-token"));
+    }
+
+    #[test]
+    fn empty_explicit_token_suppresses_environment_token() {
+        let options = resolve_connection_options(None, Some("  ".to_string()), |name| {
+            (name == CORAL_AUTH_TOKEN_ENV).then(|| "env-token".to_string())
+        });
+
+        assert_eq!(options.token, None);
+    }
+
+    #[test]
+    fn whitespace_environment_values_are_unset() {
+        let options = resolve_connection_options(None, None, |_| Some(" \t\n ".to_string()));
+
+        assert_eq!(options.endpoint, None);
+        assert_eq!(options.token, None);
+    }
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -69,11 +69,33 @@ const MAX_SEARCH_LIMIT: u32 = 50;
 /// A local-first SQL interface for APIs, files, and other data sources.
 struct Cli {
     #[command(flatten)]
+    connection: ConnectionArgs,
+    #[command(flatten)]
     feature_overrides: FeatureOverrideArgs,
     #[command(flatten)]
     workspace_selection: WorkspaceSelectionArgs,
     #[command(subcommand)]
     command: Command,
+}
+
+#[derive(Args)]
+struct ConnectionArgs {
+    /// Connect to an existing Coral gRPC endpoint. Overrides `CORAL_ENDPOINT`.
+    #[arg(long, value_name = "URI", global = true)]
+    endpoint: Option<String>,
+    /// Send a bearer token to the Coral endpoint. Overrides `CORAL_AUTH_TOKEN`.
+    #[arg(long, value_name = "TOKEN", global = true)]
+    token: Option<String>,
+}
+
+impl std::fmt::Debug for ConnectionArgs {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ConnectionArgs")
+            .field("endpoint", &self.endpoint)
+            .field("token", &self.token.as_ref().map(|_| "[redacted]"))
+            .finish()
+    }
 }
 
 #[derive(Debug, Subcommand)]
@@ -632,6 +654,7 @@ where
 /// formatting fails.
 pub async fn run_from_env() -> Result<(), CliError> {
     let Cli {
+        connection,
         feature_overrides,
         workspace_selection,
         mut command,
@@ -654,12 +677,21 @@ pub async fn run_from_env() -> Result<(), CliError> {
             let bootstrap = bootstrap::bootstrap(bootstrap::BootstrapOptions {
                 enable_stderr_logs: command.enables_stderr_logs(),
                 feature_overrides: feature_overrides.clone(),
+                connection: env::connection_options(connection.endpoint, connection.token),
             })
             .await
             .map_err(anyhow::Error::from)?;
             let app = bootstrap.app.clone();
             let result = if is_mcp_stdio {
-                run_app_command(app, command, Some(&ctx), &feature_overrides, &workspace).await
+                run_app_command(
+                    app,
+                    command,
+                    Some(&ctx),
+                    &feature_overrides,
+                    &workspace,
+                    bootstrap.mode,
+                )
+                .await
             } else {
                 coral_app::run_with_context(
                     &ctx,
@@ -669,6 +701,7 @@ pub async fn run_from_env() -> Result<(), CliError> {
                         None,
                         &feature_overrides,
                         &workspace,
+                        bootstrap.mode,
                     )),
                 )
                 .await
@@ -857,6 +890,7 @@ async fn run_app_command(
     ctx: Option<&coral_app::RunContext>,
     feature_overrides: &coral_app::features::FeatureOverrides,
     workspace: &Workspace,
+    bootstrap_mode: bootstrap::BootstrapMode,
 ) -> Result<(), CliError> {
     match command {
         Command::Sql(args) => {
@@ -901,7 +935,11 @@ async fn run_app_command(
                     Vec::new()
                 }
             };
-            let (source_names, query_examples) =
+            let (source_names, query_examples) = if bootstrap_mode
+                == bootstrap::BootstrapMode::Remote
+            {
+                (source_names, Vec::new())
+            } else {
                 match coral_app::bootstrap::workspace_mcp_startup_context(
                     &workspace.name,
                     source_names.clone(),
@@ -925,7 +963,8 @@ async fn run_app_command(
                         );
                         (source_names, Vec::new())
                     }
-                };
+                }
+            };
             Box::pin(coral_mcp::run_stdio_with_client(
                 app,
                 coral_mcp::McpOptions {
@@ -1840,6 +1879,41 @@ mod tests {
             Some(function::Runtime::Invalid(_)) | None => panic!("ready function"),
         }
         assert_eq!(function_columns_summary(&function), "-");
+    }
+
+    #[test]
+    fn global_connection_flags_parse_before_or_after_subcommand() {
+        let before = Cli::try_parse_from([
+            "coral",
+            "--endpoint",
+            "https://coral.example.com",
+            "--token",
+            "secret",
+            "source",
+            "list",
+        ])
+        .expect("connection flags before subcommand should parse");
+        assert_eq!(
+            before.connection.endpoint.as_deref(),
+            Some("https://coral.example.com")
+        );
+        assert_eq!(before.connection.token.as_deref(), Some("secret"));
+
+        let after = Cli::try_parse_from([
+            "coral",
+            "source",
+            "list",
+            "--endpoint",
+            "http://127.0.0.1:1457",
+            "--token",
+            "",
+        ])
+        .expect("connection flags after subcommand should parse");
+        assert_eq!(
+            after.connection.endpoint.as_deref(),
+            Some("http://127.0.0.1:1457")
+        );
+        assert_eq!(after.connection.token.as_deref(), Some(""));
     }
 
     #[test]

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -461,7 +461,7 @@ origin = "bundled"
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn mcp_stdio_initialize_includes_trace_backed_query_examples()
+async fn mcp_stdio_remote_initialize_omits_local_query_examples()
 -> Result<(), Box<dyn std::error::Error>> {
     let temp = tempfile::TempDir::new()?;
     let config_dir = temp.path().join("coral-config");
@@ -529,14 +529,12 @@ storage = "file"
         "initialize instructions should include connected source names: {instructions}"
     );
     assert!(
-        instructions.contains("Recent successful Coral SQL examples"),
-        "initialize instructions should include query examples heading: {instructions}"
+        !instructions.contains("Recent successful Coral SQL examples"),
+        "remote initialize instructions must not read local query history: {instructions}"
     );
     assert!(
-        instructions.contains(&format!(
-            "1. sources: local_messages; row_count: 2\n```sql\n{sql}\n```"
-        )),
-        "initialize instructions should include the traced query metadata and SQL: {instructions}"
+        !instructions.contains(sql),
+        "remote initialize instructions must not include local query SQL: {instructions}"
     );
 
     drop(stdin);
@@ -679,14 +677,12 @@ async fn assert_workspace_initialize_instructions(
         "initialize instructions should not use config-store source names: {instructions}"
     );
     assert!(
-        instructions.contains("Recent successful Coral SQL examples"),
-        "non-default workspace initialize instructions should include workspace query history: {instructions}"
+        !instructions.contains("Recent successful Coral SQL examples"),
+        "remote initialize instructions must not read workspace query history: {instructions}"
     );
     assert!(
-        instructions.contains(
-            "1. sources: linear; row_count: 3\n```sql\nSELECT title FROM linear.issues\n```"
-        ),
-        "initialize instructions should include selected workspace query history: {instructions}"
+        !instructions.contains("SELECT title FROM linear.issues"),
+        "remote initialize instructions must not include selected workspace query history: {instructions}"
     );
     assert!(
         !instructions.contains("SELECT title FROM github.issues"),


### PR DESCRIPTION
## Intent
Promote remote endpoint and bearer settings from a test-only hook to a supported CLI connection contract while preserving unauthenticated local and remote operation.

## What it enables
Commands can skip the in-process server and connect to an existing Coral gRPC endpoint, optionally forwarding a validated bearer token. Remote MCP stdio sessions retain server-provided source names without reading local workspace startup state.

## Usage examples
- `coral --endpoint https://coral.example.com --token TOKEN sql "select 1"`
- `CORAL_ENDPOINT=https://coral.example.com CORAL_AUTH_TOKEN=TOKEN coral source list`

## Validation
- `cargo test --locked -p coral-cli --all-features --lib`
- focused remote MCP integration tests
- `cargo clippy --locked -p coral-cli --all-features --all-targets -- -D warnings`
- `make rust-checks`
- `make docs-check`
- `make perf-check` (211 ms mean)