### PR TITLE
feat(cli): add long-running server command

### DIFF
--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -486,6 +486,20 @@ Use `--no-open` to start the same loopback server without launching a browser:
 coral ui --no-open
 ```
 
+## `coral server`
+
+Start a long-running native gRPC server. Coral prints the selected endpoint and
+a `CORAL_ENDPOINT` hint for clients, then runs until you press `Ctrl-C` or send
+`SIGTERM` on Unix.
+
+```shellscript
+coral server
+```
+
+The bind address comes from `[server].bind_addr`. Without a `[server]` section,
+Coral uses an ephemeral port on `127.0.0.1`. See
+[Configuration](/reference/configuration#server).
+
 ## `coral mcp-stdio`
 
 Expose the local Coral runtime as an MCP stdio server.

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -500,6 +500,10 @@ The bind address comes from `[server].bind_addr`. Without a `[server]` section,
 Coral uses an ephemeral port on `127.0.0.1`. See
 [Configuration](/reference/configuration#server).
 
+<Warning>
+  The native gRPC server does not authenticate clients. A non-loopback bind exposes Coral and its configured sources to any client that can reach the port. Protect access with a trusted network boundary or authenticating proxy.
+</Warning>
+
 ## `coral mcp-stdio`
 
 Expose the local Coral runtime as an MCP stdio server.

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -71,6 +71,16 @@ Source specs imported from files and source credential material remain scoped
 to the source installation in a workspace. Reusable global source specs and
 reusable credential references are not config objects today.
 
+## Server
+
+The long-running `coral server` command reads its native gRPC bind address from
+`[server]`:
+
+```toml
+[server]
+bind_addr = "127.0.0.1:14555"
+```
+
 ## Runtime features
 
 Experimental runtime features are configured under `[features]`.

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -81,6 +81,10 @@ The long-running `coral server` command reads its native gRPC bind address from
 bind_addr = "127.0.0.1:14555"
 ```
 
+<Warning>
+  The native gRPC server does not authenticate clients. A non-loopback bind exposes Coral and its configured sources to any client that can reach the port. Protect access with a trusted network boundary or authenticating proxy.
+</Warning>
+
 ## Runtime features
 
 Experimental runtime features are configured under `[features]`.

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -332,6 +332,10 @@ impl ServerBuilder {
     /// Returns [`AppError`] if the config directory cannot be determined,
     /// required directories cannot be created, the config or credential backends
     /// fail to initialize, or the gRPC server cannot be started.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "application bootstrap remains linear"
+    )]
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir.clone())?;

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -3,8 +3,7 @@
 use std::borrow::Cow;
 use std::convert::Infallible;
 use std::future::{Future, Ready};
-use std::net::Ipv4Addr;
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -42,6 +41,7 @@ use tower::{Layer, Service};
 use super::env::AppEnvironment;
 use super::error::AppError;
 use super::health::AggregateHealthService;
+use super::server_config::ServerSettings;
 use crate::EngineExtensionsProvider;
 use crate::catalog::discovery::CatalogDiscovery;
 use crate::catalog::service::CatalogService;
@@ -92,11 +92,17 @@ pub trait StaticAssetsProvider: Send + Sync + 'static {
     fn get(&self, path: &str) -> Option<StaticAsset>;
 }
 
+#[derive(Clone)]
+enum ServerModeSelection {
+    Explicit(ServerMode),
+    ConfiguredStandaloneGrpc,
+}
+
 /// Server-side bootstrap configuration for the Coral server.
 #[derive(Clone)]
 pub(crate) struct ServerConfig {
     config_dir: Option<PathBuf>,
-    mode: ServerMode,
+    mode: ServerModeSelection,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
@@ -114,7 +120,7 @@ impl ServerConfig {
     pub(crate) fn new() -> Self {
         Self {
             config_dir: None,
-            mode: ServerMode::EphemeralGrpc,
+            mode: ServerModeSelection::Explicit(ServerMode::EphemeralGrpc),
             engine_extensions_providers: Vec::new(),
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
@@ -129,8 +135,22 @@ impl ServerConfig {
     }
 
     pub(crate) fn with_mode(mut self, mode: ServerMode) -> Self {
-        self.mode = mode;
+        self.mode = ServerModeSelection::Explicit(mode);
         self
+    }
+
+    pub(crate) fn with_configured_standalone_grpc(mut self) -> Self {
+        self.mode = ServerModeSelection::ConfiguredStandaloneGrpc;
+        self
+    }
+
+    fn resolved_mode(&self, layout: &AppStateLayout) -> Result<ServerMode, AppError> {
+        match &self.mode {
+            ServerModeSelection::Explicit(mode) => Ok(mode.clone()),
+            ServerModeSelection::ConfiguredStandaloneGrpc => Ok(ServerMode::StandaloneGrpc {
+                bind: ServerSettings::load(layout)?.bind_addr,
+            }),
+        }
     }
 
     pub(crate) fn add_engine_extensions_provider(
@@ -211,6 +231,14 @@ impl ServerBuilder {
     /// Creates a standalone native gRPC server bound to an explicit address.
     pub fn standalone_grpc(bind: SocketAddr) -> Self {
         Self::new().with_mode(ServerMode::StandaloneGrpc { bind })
+    }
+
+    #[must_use]
+    /// Creates a standalone gRPC server using `[server].bind_addr`.
+    pub fn configured_standalone_grpc() -> Self {
+        Self {
+            config: ServerConfig::new().with_configured_standalone_grpc(),
+        }
     }
 
     #[must_use]
@@ -306,7 +334,8 @@ impl ServerBuilder {
     /// fail to initialize, or the gRPC server cannot be started.
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
-        let layout = env.app_state_layout(self.config.config_dir)?;
+        let layout = env.app_state_layout(self.config.config_dir.clone())?;
+        let mode = self.config.resolved_mode(&layout)?;
         layout.ensure()?;
         let features = FeatureStore::from_layout(layout.clone())
             .load_with_overrides(&self.config.feature_overrides)?;
@@ -397,7 +426,7 @@ impl ServerBuilder {
             },
             trace_components,
             self.config.user_principal_provider,
-            self.config.mode,
+            mode,
         )
         .await
     }
@@ -1086,6 +1115,55 @@ enabled = false
             .expect("start explicit loopback server");
 
         assert!(server.endpoint_uri().starts_with("http://127.0.0.1:"));
+        server.shutdown().await.expect("shutdown server");
+    }
+
+    #[test]
+    fn configured_standalone_grpc_resolves_configured_bind() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[server]\nbind_addr = '127.0.0.2:14555'\n",
+        )
+        .expect("write config");
+        let layout = AppStateLayout::discover(Some(config_dir)).expect("layout");
+        let builder = ServerBuilder::configured_standalone_grpc();
+
+        let ServerMode::StandaloneGrpc { bind } = builder
+            .config
+            .resolved_mode(&layout)
+            .expect("resolve configured bind")
+        else {
+            panic!("configured server must use standalone gRPC mode");
+        };
+        assert_eq!(bind, SocketAddr::from(([127, 0, 0, 2], 14555)));
+    }
+
+    #[tokio::test]
+    async fn configured_standalone_grpc_starts_with_configured_bind() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        let port = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .expect("reserve loopback port")
+            .local_addr()
+            .expect("reserved address")
+            .port();
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            format!("[server]\nbind_addr = '127.0.0.1:{port}'\n"),
+        )
+        .expect("write config");
+
+        let server = ServerBuilder::configured_standalone_grpc()
+            .with_config_dir(config_dir)
+            .start()
+            .await
+            .expect("start configured standalone server");
+
+        assert_eq!(server.endpoint_uri(), format!("http://127.0.0.1:{port}"));
         server.shutdown().await.expect("shutdown server");
     }
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1194,15 +1194,10 @@ enabled = false
     async fn configured_standalone_grpc_starts_with_configured_bind() {
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
-        let port = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
-            .expect("reserve loopback port")
-            .local_addr()
-            .expect("reserved address")
-            .port();
         std::fs::create_dir_all(&config_dir).expect("create config dir");
         std::fs::write(
             config_dir.join("config.toml"),
-            format!("[server]\nbind_addr = '127.0.0.1:{port}'\n"),
+            "[server]\nbind_addr = '127.0.0.1:0'\n",
         )
         .expect("write config");
 
@@ -1212,7 +1207,14 @@ enabled = false
             .await
             .expect("start configured standalone server");
 
-        assert_eq!(server.endpoint_uri(), format!("http://127.0.0.1:{port}"));
+        let endpoint = server
+            .endpoint_uri()
+            .strip_prefix("http://")
+            .expect("endpoint scheme")
+            .parse::<SocketAddr>()
+            .expect("socket address endpoint");
+        assert!(endpoint.ip().is_loopback());
+        assert_ne!(endpoint.port(), 0);
         server.shutdown().await.expect("shutdown server");
     }
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -28,7 +28,7 @@ use coral_api::{
     TRACE_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tokio::net::TcpListener;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 use tokio::task::{self, JoinHandle};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::codegen::http::header::CONTENT_TYPE;
@@ -485,6 +485,7 @@ pub struct RunningServer {
     search: SearchManager,
     search_observations: Mutex<Option<SearchObservationHandle>>,
     shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    task_finished: watch::Receiver<bool>,
     task: Mutex<Option<JoinHandle<Result<(), tonic::transport::Error>>>>,
 }
 
@@ -504,6 +505,17 @@ impl RunningServer {
     /// trace history is enabled for this process.
     pub fn local_trace_store_dir(&self) -> Option<&std::path::Path> {
         self.local_trace_store_dir.as_deref()
+    }
+
+    /// Waits until the background server task exits.
+    ///
+    /// This method is cancellation-safe and does not initiate shutdown,
+    /// consume the task result, or release server resources. Call
+    /// [`RunningServer::shutdown`] afterward to join the task, surface errors,
+    /// and complete cleanup.
+    pub async fn wait_for_exit(&self) {
+        let mut task_finished = self.task_finished.clone();
+        let _finished = task_finished.wait_for(|finished| *finished).await;
     }
 
     /// Shuts the server down and waits for the background task to finish.
@@ -667,13 +679,14 @@ async fn start_server(
     let listener = TcpListener::bind(mode.bind_addr()).await?;
     let endpoint_uri = format!("http://{}", listener.local_addr()?);
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (task_finished_tx, task_finished) = watch::channel(false);
 
     let task = match mode {
         ServerMode::EphemeralGrpc | ServerMode::StandaloneGrpc { .. } => {
-            start_grpc_server(listener, shutdown_rx, routes)
+            start_grpc_server(listener, shutdown_rx, routes, task_finished_tx)
         }
         ServerMode::EmbeddedUi { assets, .. } => {
-            start_grpc_web_server(listener, shutdown_rx, routes, assets)
+            start_grpc_web_server(listener, shutdown_rx, routes, assets, task_finished_tx)
         }
     };
 
@@ -683,6 +696,7 @@ async fn start_server(
         search,
         search_observations: Mutex::new(search_observations),
         shutdown_tx: Mutex::new(Some(shutdown_tx)),
+        task_finished,
         task: Mutex::new(Some(task)),
     })
 }
@@ -691,15 +705,18 @@ fn start_grpc_server(
     listener: TcpListener,
     shutdown_rx: oneshot::Receiver<()>,
     routes: Routes,
+    task_finished: watch::Sender<bool>,
 ) -> JoinHandle<Result<(), tonic::transport::Error>> {
     tokio::spawn(async move {
-        Server::builder()
+        let result = Server::builder()
             .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE)
             .add_routes(routes)
             .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                 drop(shutdown_rx.await);
             })
-            .await
+            .await;
+        task_finished.send_replace(true);
+        result
     })
 }
 
@@ -708,6 +725,7 @@ fn start_grpc_web_server(
     shutdown_rx: oneshot::Receiver<()>,
     routes: Routes,
     static_assets: Arc<dyn StaticAssetsProvider>,
+    task_finished: watch::Sender<bool>,
 ) -> JoinHandle<Result<(), tonic::transport::Error>> {
     let grpc = routes
         .into_axum_router()
@@ -721,14 +739,16 @@ fn start_grpc_web_server(
     let combined: Routes = app.into();
 
     tokio::spawn(async move {
-        Server::builder()
+        let result = Server::builder()
             .accept_http1(true)
             .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE)
             .add_routes(combined)
             .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                 drop(shutdown_rx.await);
             })
-            .await
+            .await;
+        task_finished.send_replace(true);
+        result
     })
 }
 
@@ -890,9 +910,11 @@ mod tests {
     )]
 
     use std::borrow::Cow;
+    use std::future::Future as _;
     use std::net::{Ipv4Addr, SocketAddr, TcpListener};
     use std::path::Path;
     use std::sync::{Arc, Mutex};
+    use std::task::Poll;
     use std::time::Duration;
 
     use coral_api::v1::query_service_client::QueryServiceClient;
@@ -907,6 +929,7 @@ mod tests {
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
     use tempfile::TempDir;
+    use tokio::sync::{oneshot, watch};
     use tonic::transport::Endpoint;
     use tonic::{Code, Request};
 
@@ -1015,7 +1038,7 @@ enabled = false
     }
 
     #[tokio::test]
-    async fn shutdown_attempts_observed_values_shutdown_after_server_task_error() {
+    async fn wait_for_exit_preserves_task_error_and_shutdown_cleanup() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -1069,9 +1092,13 @@ enabled = false
             )
             .expect("enqueue observed value");
         let search_observations = SearchObservationHandle::new(layout);
-        let task = tokio::spawn(async {
+        let (task_gate_tx, task_gate_rx) = oneshot::channel();
+        let (task_finished_tx, task_finished) = watch::channel(false);
+        let task = tokio::spawn(async move {
+            drop(task_gate_rx.await);
             let should_panic = true;
             assert!(!should_panic, "server task panicked");
+            task_finished_tx.send_replace(true);
             Ok::<(), tonic::transport::Error>(())
         });
         let server = RunningServer {
@@ -1080,12 +1107,30 @@ enabled = false
             search,
             search_observations: Mutex::new(Some(search_observations)),
             shutdown_tx: Mutex::new(None),
+            task_finished,
             task: Mutex::new(Some(task)),
         };
 
+        let mut canceled_wait = Box::pin(server.wait_for_exit());
+        std::future::poll_fn(|cx| {
+            assert!(canceled_wait.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+        drop(canceled_wait);
+        task_gate_tx.send(()).expect("release server task");
+
+        for _ in 0..2 {
+            tokio::time::timeout(Duration::from_secs(1), server.wait_for_exit())
+                .await
+                .expect("server task completion should wake waiters");
+        }
         let result = server.shutdown_inner().await;
 
-        assert!(matches!(result, Err(AppError::TaskJoin(_))));
+        assert!(matches!(
+            result,
+            Err(AppError::TaskJoin(error)) if error.is_panic()
+        ));
         assert!(
             server
                 .search_observations

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -332,10 +332,6 @@ impl ServerBuilder {
     /// Returns [`AppError`] if the config directory cannot be determined,
     /// required directories cannot be created, the config or credential backends
     /// fail to initialize, or the gRPC server cannot be started.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "application bootstrap remains linear"
-    )]
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir.clone())?;
@@ -1038,6 +1034,10 @@ enabled = false
     }
 
     #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "server lifecycle test requires full runtime assembly"
+    )]
     async fn wait_for_exit_preserves_task_error_and_shutdown_cleanup() {
         let temp = TempDir::new().expect("temp dir");
         let layout =

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -1,10 +1,5 @@
 //! Configuration owned by the long-running Coral server surface.
 
-#![cfg_attr(
-    not(test),
-    expect(dead_code, reason = "consumed by the descendant coral serve command")
-)]
-
 use std::net::{Ipv4Addr, SocketAddr};
 
 use serde::Deserialize;

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -68,10 +68,15 @@ pub(crate) async fn start_ui_server(
     Ok(server)
 }
 
-pub(crate) async fn start_standalone_server() -> Result<RunningServer, BootstrapError> {
+pub(crate) async fn start_standalone_server(
+    feature_overrides: FeatureOverrides,
+) -> Result<RunningServer, BootstrapError> {
     let server = configure_server_builder(
         ServerBuilder::configured_standalone_grpc(),
-        BootstrapOptions::default(),
+        BootstrapOptions {
+            feature_overrides,
+            ..BootstrapOptions::default()
+        },
     )
     .start()
     .await?;

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -68,6 +68,16 @@ pub(crate) async fn start_ui_server(
     Ok(server)
 }
 
+pub(crate) async fn start_standalone_server() -> Result<RunningServer, BootstrapError> {
+    let server = configure_server_builder(
+        ServerBuilder::configured_standalone_grpc(),
+        BootstrapOptions::default(),
+    )
+    .start()
+    .await?;
+    Ok(server)
+}
+
 fn configure_server_builder(builder: ServerBuilder, options: BootstrapOptions) -> ServerBuilder {
     builder
         .with_stderr_logs(options.enable_stderr_logs)

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -889,13 +889,7 @@ async fn run_app_command(
             .await
             .map_err(anyhow::Error::from)?;
         }
-        Command::Completion(_) => {
-            unreachable!("no-runtime commands are routed without an app client")
-        }
-        Command::Features(_) => {
-            unreachable!("no-runtime commands are routed without an app client")
-        }
-        Command::Server => {
+        Command::Completion(_) | Command::Features(_) | Command::Server => {
             unreachable!("no-runtime commands are routed without an app client")
         }
         #[cfg(feature = "embedded-ui")]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -737,8 +737,10 @@ async fn run_ui(
     run_until_server_stops(server, tokio::signal::ctrl_c()).await
 }
 
-async fn run_server() -> Result<(), anyhow::Error> {
-    let server = bootstrap::start_standalone_server().await?;
+async fn run_server(
+    feature_overrides: coral_app::features::FeatureOverrides,
+) -> Result<(), anyhow::Error> {
+    let server = bootstrap::start_standalone_server(feature_overrides).await?;
     let endpoint = server.endpoint_uri().to_string();
 
     if !server_endpoint_is_loopback(&endpoint) {
@@ -817,7 +819,9 @@ async fn run_no_runtime_command(
             Ok(())
         }
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
-        Command::Server => run_server().await.map_err(Into::into),
+        Command::Server => run_server(feature_overrides.clone())
+            .await
+            .map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args, feature_overrides.clone())
             .await

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -92,6 +92,8 @@ enum Command {
     Onboard,
     /// Start the MCP server over stdio
     McpStdio(McpStdioArgs),
+    /// Start the long-running gRPC server
+    Server,
     /// Inspect and manage experimental runtime features
     Features(FeaturesArgs),
     #[cfg(feature = "embedded-ui")]
@@ -535,7 +537,9 @@ impl Command {
             | Command::Function(_)
             | Command::Onboard
             | Command::McpStdio(_) => RequiredRuntime::AppClient,
-            Command::Features(_) | Command::Completion(_) => RequiredRuntime::None,
+            Command::Features(_) | Command::Completion(_) | Command::Server => {
+                RequiredRuntime::None
+            }
             #[cfg(feature = "embedded-ui")]
             Command::Ui(_) => RequiredRuntime::None,
         }
@@ -735,6 +739,35 @@ async fn run_ui(
     Ok(())
 }
 
+async fn run_server() -> Result<(), anyhow::Error> {
+    let server = bootstrap::start_standalone_server().await?;
+    let endpoint = server.endpoint_uri().to_string();
+
+    println!("Coral gRPC server listening on {endpoint}");
+    println!("Connect clients with CORAL_ENDPOINT={endpoint}");
+    println!("Press Ctrl-C to stop the server.");
+
+    let signal = wait_for_server_shutdown_signal().await;
+    let shutdown = server.shutdown().await;
+    signal?;
+    shutdown?;
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn wait_for_server_shutdown_signal() -> Result<(), std::io::Error> {
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+    tokio::select! {
+        signal = tokio::signal::ctrl_c() => signal,
+        _ = sigterm.recv() => Ok(()),
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_server_shutdown_signal() -> Result<(), std::io::Error> {
+    tokio::signal::ctrl_c().await
+}
+
 async fn run_no_runtime_command(
     command: Command,
     feature_overrides: &coral_app::features::FeatureOverrides,
@@ -747,6 +780,7 @@ async fn run_no_runtime_command(
             Ok(())
         }
         Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
+        Command::Server => run_server().await.map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args, feature_overrides.clone())
             .await
@@ -859,6 +893,9 @@ async fn run_app_command(
             unreachable!("no-runtime commands are routed without an app client")
         }
         Command::Features(_) => {
+            unreachable!("no-runtime commands are routed without an app client")
+        }
+        Command::Server => {
             unreachable!("no-runtime commands are routed without an app client")
         }
         #[cfg(feature = "embedded-ui")]
@@ -1635,14 +1672,21 @@ mod tests {
     };
 
     #[test]
-    fn server_command_is_not_available() {
-        let error = Cli::try_parse_from(["coral", "server", "--help"])
-            .expect_err("dev server command should not be exposed");
+    fn server_command_requires_no_app_client_runtime() {
+        let cli = Cli::try_parse_from(["coral", "server"]).expect("server should parse");
 
-        assert!(
-            error.to_string().contains("unrecognized subcommand"),
-            "unexpected parse error: {error}"
-        );
+        assert_eq!(cli.command.required_runtime(), RequiredRuntime::None);
+        assert!(matches!(cli.command, super::Command::Server));
+    }
+
+    #[test]
+    fn server_command_rejects_command_line_bind_overrides() {
+        for args in [
+            ["coral", "server", "--bind", "127.0.0.1"],
+            ["coral", "server", "--port", "14555"],
+        ] {
+            Cli::try_parse_from(args).expect_err("server bind overrides should be rejected");
+        }
     }
 
     #[cfg(feature = "embedded-ui")]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -787,7 +787,20 @@ async fn wait_for_server_shutdown_signal() -> Result<(), std::io::Error> {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+async fn wait_for_server_shutdown_signal() -> Result<(), std::io::Error> {
+    let mut ctrl_break = tokio::signal::windows::ctrl_break()?;
+    let mut ctrl_close = tokio::signal::windows::ctrl_close()?;
+    let mut ctrl_shutdown = tokio::signal::windows::ctrl_shutdown()?;
+    tokio::select! {
+        signal = tokio::signal::ctrl_c() => signal,
+        _ = ctrl_break.recv() => Ok(()),
+        _ = ctrl_close.recv() => Ok(()),
+        _ = ctrl_shutdown.recv() => Ok(()),
+    }
+}
+
+#[cfg(all(not(unix), not(windows)))]
 async fn wait_for_server_shutdown_signal() -> Result<(), std::io::Error> {
     tokio::signal::ctrl_c().await
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -19,6 +19,8 @@ mod source_ops;
 
 use std::borrow::Cow;
 use std::fmt::Write as _;
+use std::future::Future;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 #[cfg(feature = "embedded-ui")]
 use std::sync::Arc;
@@ -732,26 +734,48 @@ async fn run_ui(
     }
     println!("Press Ctrl-C to stop the UI.");
 
-    let signal = tokio::signal::ctrl_c().await;
-    let shutdown = server.shutdown().await;
-    signal?;
-    shutdown?;
-    Ok(())
+    run_until_server_stops(server, tokio::signal::ctrl_c()).await
 }
 
 async fn run_server() -> Result<(), anyhow::Error> {
     let server = bootstrap::start_standalone_server().await?;
     let endpoint = server.endpoint_uri().to_string();
 
+    if !server_endpoint_is_loopback(&endpoint) {
+        eprintln!(
+            "Warning: the native gRPC server at {endpoint} does not authenticate clients; \
+             any client that can reach the server can access Coral and its configured sources. \
+             Protect it with a trusted network boundary or authenticating proxy."
+        );
+    }
     println!("Coral gRPC server listening on {endpoint}");
     println!("Connect clients with CORAL_ENDPOINT={endpoint}");
     println!("Press Ctrl-C to stop the server.");
 
-    let signal = wait_for_server_shutdown_signal().await;
+    run_until_server_stops(server, wait_for_server_shutdown_signal()).await
+}
+
+async fn run_until_server_stops(
+    server: coral_app::RunningServer,
+    shutdown_signal: impl Future<Output = Result<(), std::io::Error>>,
+) -> Result<(), anyhow::Error> {
+    let signal = tokio::select! {
+        result = shutdown_signal => Some(result),
+        () = server.wait_for_exit() => None,
+    };
     let shutdown = server.shutdown().await;
-    signal?;
+    if let Some(signal) = signal {
+        signal?;
+    }
     shutdown?;
     Ok(())
+}
+
+fn server_endpoint_is_loopback(endpoint: &str) -> bool {
+    endpoint
+        .strip_prefix("http://")
+        .and_then(|authority| authority.parse::<SocketAddr>().ok())
+        .is_some_and(|address| address.ip().is_loopback())
 }
 
 #[cfg(unix)]
@@ -1662,7 +1686,7 @@ mod tests {
 
     use super::{
         Cli, RequiredRuntime, command_enables_stderr_logs, function_columns_summary,
-        function_status_summary,
+        function_status_summary, server_endpoint_is_loopback,
     };
 
     #[test]
@@ -1680,6 +1704,26 @@ mod tests {
             ["coral", "server", "--port", "14555"],
         ] {
             Cli::try_parse_from(args).expect_err("server bind overrides should be rejected");
+        }
+    }
+
+    #[test]
+    fn server_security_warning_targets_non_loopback_endpoints() {
+        for endpoint in ["http://127.0.0.1:14555", "http://[::1]:14555"] {
+            assert!(
+                server_endpoint_is_loopback(endpoint),
+                "endpoint: {endpoint}"
+            );
+        }
+        for endpoint in [
+            "http://0.0.0.0:14555",
+            "http://[::]:14555",
+            "http://192.168.1.10:14555",
+        ] {
+            assert!(
+                !server_endpoint_is_loopback(endpoint),
+                "endpoint: {endpoint}"
+            );
         }
     }
 


### PR DESCRIPTION
## Intent

Expose Coral's native gRPC runtime as a long-running CLI process for deployments and clients that need a stable server lifecycle. `coral server` reads its bind address exclusively from `[server].bind_addr`; it intentionally provides no command-line host or port overrides.

## What it enables

- Start a standalone native gRPC server that runs until `Ctrl-C` or, on Unix, `SIGTERM`, then shuts down cleanly.
- Print the selected endpoint and a `CORAL_ENDPOINT` hint for connecting clients.
- Listen on loopback or non-loopback addresses selected in configuration. Coral does not gate non-loopback binds on server authentication.
- Fall back to an ephemeral port on `127.0.0.1` when no `[server]` section is configured.

## Usage examples

Configure a fixed endpoint:

```toml
[server]
bind_addr = "127.0.0.1:14555"
```

Start the server:

```shell
coral server
```

Coral reports the selected endpoint:

```text
Coral gRPC server listening on http://127.0.0.1:14555
Connect clients with CORAL_ENDPOINT=http://127.0.0.1:14555
Press Ctrl-C to stop the server.
```

To listen beyond loopback, set a non-loopback address directly in `config.toml`, for example:

```toml
[server]
bind_addr = "0.0.0.0:14555"
```

## Validation

- `cargo test --locked -p coral-app --lib configured_standalone_grpc`
- `cargo test --locked -p coral-app --lib auth`
- `make rust-checks`
- `make docs-check`
- `make perf-check` (226.5 ms mean; 750 ms threshold on the fully restacked branch)
- `git diff --check`
