### PR TITLE
feat(app): enforce static bearer authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.10.9",
  "sqlx",
+ "subtle",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ schemars = "1.2.1"
 sea-query = { version = "1", default-features = false, features = ["backend-postgres", "backend-sqlite", "derive", "thread-safe"] }
 sea-query-sqlx = { version = "0.9", default-features = false, features = ["sqlx-postgres", "sqlx-sqlite"] }
 sha2 = "0.10"
+subtle = "2.6"
 sqlx = { version = "0.9", default-features = false, features = ["macros", "migrate", "postgres", "runtime-tokio", "sqlite", "tls-rustls"] }
 sqlparser = "0.59.0"
 strsim = "0.11"

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -436,7 +436,9 @@ coral server
 ```
 
 The bind address comes from `[server].bind_addr`. Without a `[server]` section,
-Coral uses an ephemeral port on `127.0.0.1`. See
+Coral uses an ephemeral port on `127.0.0.1`. Bearer authentication is optional
+and configured under `[server.auth]`. Coral does not terminate server-side TLS;
+put non-loopback deployments behind a TLS-terminating reverse proxy. See
 [Configuration](/reference/configuration#server).
 
 ## `coral mcp-stdio`

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -79,8 +79,21 @@ The long-running `coral server` command reads its native gRPC bind address from
 ```toml
 [server]
 bind_addr = "127.0.0.1:14555"
+
+[server.auth]
+token_env = "CORAL_SERVER_AUTH_TOKEN"
 ```
 
+The optional `[server.auth]` section requires a nonempty bearer token in
+`token_env`; the environment variable defaults to `CORAL_SERVER_AUTH_TOKEN`.
+If the section is absent, the server accepts unauthenticated requests regardless
+of bind address.
+
+The static token grants full access to Coral's data and control RPCs. The
+standard gRPC health check remains unauthenticated because it reports process
+liveness only. Coral does not terminate server-side TLS yet: put every
+non-loopback deployment behind a TLS-terminating reverse proxy, and do not
+expose its plaintext listener directly.
 ## Runtime features
 
 Experimental runtime features are configured under `[features]`.

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -31,6 +31,7 @@ serde_yaml.workspace = true
 sea-query.workspace = true
 sea-query-sqlx.workspace = true
 sha2.workspace = true
+subtle.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -56,6 +56,7 @@ use crate::functions::service::FunctionService;
 use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
+use crate::request_auth::{AuthValidator, BearerUserPrincipalProvider};
 use crate::search::manager::SearchManager;
 use crate::search::observed::SearchObservationHandle;
 use crate::search::service::SearchService;
@@ -106,6 +107,7 @@ pub(crate) struct ServerConfig {
     user_principal_provider: Arc<dyn UserPrincipalProvider>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
     feature_overrides: FeatureOverrides,
+    auth_validator: Option<Arc<dyn AuthValidator>>,
     enable_stderr_logs: bool,
 }
 
@@ -124,6 +126,7 @@ impl ServerConfig {
             user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
             feature_overrides: FeatureOverrides::default(),
+            auth_validator: None,
             enable_stderr_logs: false,
         }
     }
@@ -143,13 +146,46 @@ impl ServerConfig {
         self
     }
 
-    fn resolved_mode(&self, layout: &AppStateLayout) -> Result<ServerMode, AppError> {
-        match &self.mode {
-            ServerModeSelection::Explicit(mode) => Ok(mode.clone()),
-            ServerModeSelection::ConfiguredStandaloneGrpc => Ok(ServerMode::StandaloneGrpc {
-                bind: ServerSettings::load(layout)?.bind_addr,
-            }),
-        }
+    fn resolved_startup(
+        &self,
+        layout: &AppStateLayout,
+    ) -> Result<(ServerMode, Arc<dyn UserPrincipalProvider>), AppError> {
+        let is_standalone = matches!(
+            &self.mode,
+            ServerModeSelection::Explicit(ServerMode::StandaloneGrpc { .. })
+                | ServerModeSelection::ConfiguredStandaloneGrpc
+        );
+        let settings = is_standalone
+            .then(|| ServerSettings::load(layout))
+            .transpose()?;
+        let mode = match &self.mode {
+            ServerModeSelection::Explicit(mode) => mode.clone(),
+            ServerModeSelection::ConfiguredStandaloneGrpc => ServerMode::StandaloneGrpc {
+                bind: settings
+                    .as_ref()
+                    .expect("configured standalone mode loads settings")
+                    .bind_addr,
+            },
+        };
+        let configured_auth = settings
+            .as_ref()
+            .map(ServerSettings::auth_validator)
+            .transpose()?
+            .flatten();
+        let auth_validator = if matches!(mode, ServerMode::StandaloneGrpc { .. }) {
+            configured_auth.or_else(|| self.auth_validator.clone())
+        } else {
+            None
+        };
+        let user_principal_provider = Arc::clone(&self.user_principal_provider);
+        let user_principal_provider: Arc<dyn UserPrincipalProvider> = match auth_validator {
+            Some(validator) => Arc::new(BearerUserPrincipalProvider::new(
+                validator,
+                user_principal_provider,
+            )),
+            None => user_principal_provider,
+        };
+        Ok((mode, user_principal_provider))
     }
 
     pub(crate) fn add_engine_extensions_provider(
@@ -158,6 +194,11 @@ impl ServerConfig {
     ) -> Self {
         self.engine_extensions_providers
             .push(engine_extensions_provider);
+        self
+    }
+
+    pub(crate) fn with_auth_validator(mut self, validator: Arc<dyn AuthValidator>) -> Self {
+        self.auth_validator = Some(validator);
         self
     }
 
@@ -266,6 +307,16 @@ impl ServerBuilder {
         self
     }
 
+    /// Installs request authentication for explicit remote-server composition.
+    ///
+    /// Native local gRPC and embedded UI modes intentionally ignore this seam.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_auth_validator(mut self, validator: Arc<dyn AuthValidator>) -> Self {
+        self.config = self.config.with_auth_validator(validator);
+        self
+    }
+
     #[must_use]
     /// Adds an engine extensions provider used for query runtime builds.
     ///
@@ -334,7 +385,7 @@ impl ServerBuilder {
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir.clone())?;
-        let mode = self.config.resolved_mode(&layout)?;
+        let (mode, user_principal_provider) = self.config.resolved_startup(&layout)?;
         layout.ensure()?;
         let features = FeatureStore::from_layout(layout.clone())
             .load_with_overrides(&self.config.feature_overrides)?;
@@ -427,7 +478,7 @@ impl ServerBuilder {
                 task: task_manager,
             },
             trace_components,
-            self.config.user_principal_provider,
+            user_principal_provider,
             mode,
         )
         .await
@@ -879,6 +930,7 @@ mod tests {
     use std::borrow::Cow;
     use std::net::{Ipv4Addr, SocketAddr, TcpListener};
     use std::path::Path;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -894,8 +946,11 @@ mod tests {
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
     use tempfile::TempDir;
+    use tonic::metadata::MetadataValue;
     use tonic::transport::Endpoint;
     use tonic::{Code, Request};
+    use tonic_health::pb::HealthCheckRequest;
+    use tonic_health::pb::health_client::HealthClient;
 
     use super::{
         RunningServer, ServerBuilder, ServerDependencies, ServerMode, StaticAsset,
@@ -921,12 +976,26 @@ mod tests {
     use crate::transport::workspace_to_proto;
     use crate::workspaces::{WorkspaceManager, WorkspaceName};
     use crate::{
-        AwsEngineExtensionsProvider, NoopEngineExtensionsProvider, SingleUserPrincipalProvider,
-        UserPrincipal, UserPrincipalProvider, UserPrincipalProviderError,
+        AuthValidator, AwsEngineExtensionsProvider, NoopEngineExtensionsProvider,
+        SingleUserPrincipalProvider, StaticTokenValidator, UserPrincipal, UserPrincipalProvider,
+        UserPrincipalProviderError,
     };
 
     fn default_workspace() -> Workspace {
         workspace_to_proto(&WorkspaceName::default())
+    }
+
+    fn list_sources_request(authorizations: &[&str]) -> Request<ListSourcesRequest> {
+        let mut request = Request::new(ListSourcesRequest {
+            workspace: Some(default_workspace()),
+        });
+        for authorization in authorizations {
+            request.metadata_mut().append(
+                "authorization",
+                MetadataValue::try_from(*authorization).expect("authorization metadata"),
+            );
+        }
+        request
     }
 
     fn disable_internal_tracing(config_dir: &Path) {
@@ -982,6 +1051,19 @@ enabled = false
             Err(UserPrincipalProviderError::unauthenticated(
                 "rejected user principal",
             ))
+        }
+    }
+
+    #[derive(Debug)]
+    struct CountingAuthValidator {
+        inner: StaticTokenValidator,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl AuthValidator for CountingAuthValidator {
+        fn accepts_bearer(&self, token: &str) -> bool {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.inner.accepts_bearer(token)
         }
     }
 
@@ -1089,6 +1171,64 @@ enabled = false
             .expect("start explicit loopback server");
 
         assert!(server.endpoint_uri().starts_with("http://127.0.0.1:"));
+        coral_client::AppClient::connect(server.endpoint_uri())
+            .await
+            .expect("unauthenticated local AppClient")
+            .source_client()
+            .list_sources(list_sources_request(&[]))
+            .await
+            .expect("local request remains unauthenticated");
+        server.shutdown().await.expect("shutdown server");
+    }
+
+    #[tokio::test]
+    async fn standalone_grpc_static_bearer_gates_coral_services_but_not_liveness() {
+        let temp = TempDir::new().expect("temp dir");
+        let validation_calls = Arc::new(AtomicUsize::new(0));
+        let validator = CountingAuthValidator {
+            inner: StaticTokenValidator::new("correct-._~+/=:").expect("token"),
+            calls: Arc::clone(&validation_calls),
+        };
+        let server = ServerBuilder::standalone_grpc(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .with_auth_validator(Arc::new(validator))
+            .with_config_dir(temp.path().join("coral-config"))
+            .start()
+            .await
+            .expect("start authenticated server");
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+        let mut source = SourceServiceClient::new(channel.clone());
+
+        for authorizations in [
+            &[][..],
+            &["Basic correct-._~+/=:"][..],
+            &["Bearer wrong-token"][..],
+            &["Bearer correct-._~+/=:", "Bearer correct-._~+/=:"][..],
+        ] {
+            let status = source
+                .list_sources(list_sources_request(authorizations))
+                .await
+                .expect_err("invalid bearer must fail");
+            assert_eq!(status.code(), Code::Unauthenticated);
+            assert_eq!(status.message(), "unauthenticated: authentication required");
+        }
+
+        source
+            .list_sources(list_sources_request(&["bearer correct-._~+/=:"]))
+            .await
+            .expect("correct bearer reaches service");
+        assert_eq!(validation_calls.load(Ordering::Relaxed), 2);
+
+        HealthClient::new(channel)
+            .check(HealthCheckRequest {
+                service: String::new(),
+            })
+            .await
+            .expect("liveness is intentionally unauthenticated");
+        assert_eq!(validation_calls.load(Ordering::Relaxed), 2);
         server.shutdown().await.expect("shutdown server");
     }
 
@@ -1107,8 +1247,9 @@ enabled = false
 
         let ServerMode::StandaloneGrpc { bind } = builder
             .config
-            .resolved_mode(&layout)
+            .resolved_startup(&layout)
             .expect("resolve configured bind")
+            .0
         else {
             panic!("configured server must use standalone gRPC mode");
         };
@@ -1220,6 +1361,32 @@ enabled = false
 
         assert!(!has_search_observation_handle(&disabled_server));
         disabled_server.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn configured_auth_failure_precedes_state_and_database_setup() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        std::fs::create_dir_all(&config_dir).expect("config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[server.auth]\ntoken_env = 'CORAL_TEST_DEFINITELY_MISSING_SERVER_TOKEN'\n",
+        )
+        .expect("config file");
+
+        let result = ServerBuilder::configured_standalone_grpc()
+            .with_config_dir(&config_dir)
+            .start()
+            .await;
+        let Err(error) = result else {
+            panic!("missing configured token must fail");
+        };
+        assert!(error.to_string().contains("server authentication requires"));
+        let entries = std::fs::read_dir(&config_dir)
+            .expect("read config dir")
+            .map(|entry| entry.expect("entry").file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries, [std::ffi::OsString::from("config.toml")]);
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -1,11 +1,17 @@
 //! Configuration owned by the long-running Coral server surface.
 
 use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
 
 use serde::Deserialize;
+use zeroize::Zeroizing;
 
 use super::AppError;
+use super::env::AppEnvironment;
+use crate::request_auth::{AuthValidator, StaticTokenValidator};
 use crate::state::AppStateLayout;
+
+const DEFAULT_TOKEN_ENV: &str = "CORAL_SERVER_AUTH_TOKEN";
 
 #[derive(Debug, Default, Deserialize)]
 struct ConfigFile {
@@ -18,12 +24,28 @@ struct ConfigFile {
 #[serde(default)]
 pub(crate) struct ServerSettings {
     pub(crate) bind_addr: SocketAddr,
+    auth: Option<ServerAuthSettings>,
 }
 
 impl Default for ServerSettings {
     fn default() -> Self {
         Self {
             bind_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+            auth: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+struct ServerAuthSettings {
+    token_env: String,
+}
+
+impl Default for ServerAuthSettings {
+    fn default() -> Self {
+        Self {
+            token_env: DEFAULT_TOKEN_ENV.to_string(),
         }
     }
 }
@@ -35,8 +57,47 @@ impl ServerSettings {
             return Ok(Self::default());
         }
         let raw = std::fs::read_to_string(layout.config_file())?;
-        Ok(toml::from_str::<ConfigFile>(&raw)?.server)
+        toml::from_str::<ConfigFile>(&raw)
+            .map(|config| config.server)
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!(
+                    "server configuration is invalid: {}",
+                    error.message()
+                ))
+            })
     }
+    pub(crate) fn auth_validator(&self) -> Result<Option<Arc<dyn AuthValidator>>, AppError> {
+        self.auth_validator_with(AppEnvironment::env_var)
+    }
+
+    fn auth_validator_with(
+        &self,
+        read_env: impl FnOnce(&str) -> Result<Option<String>, std::env::VarError>,
+    ) -> Result<Option<Arc<dyn AuthValidator>>, AppError> {
+        let Some(auth) = &self.auth else {
+            return Ok(None);
+        };
+        let token_env = auth.token_env.trim();
+        if token_env.is_empty() || token_env.bytes().any(|byte| matches!(byte, b'=' | b'\0')) {
+            return Err(AppError::FailedPrecondition(
+                "server.auth.token_env must name a valid environment variable".to_string(),
+            ));
+        }
+        let token = Zeroizing::new(
+            read_env(token_env)
+                .map_err(|_error| missing_token_error(token_env))?
+                .ok_or_else(|| missing_token_error(token_env))?,
+        );
+        let validator = StaticTokenValidator::new(token.trim())
+            .ok_or_else(|| missing_token_error(token_env))?;
+        Ok(Some(Arc::new(validator)))
+    }
+}
+
+fn missing_token_error(token_env: &str) -> AppError {
+    AppError::FailedPrecondition(format!(
+        "server authentication requires environment variable `{token_env}` to contain a nonempty printable ASCII token"
+    ))
 }
 
 #[cfg(test)]
@@ -46,7 +107,7 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use super::ServerSettings;
+    use super::{DEFAULT_TOKEN_ENV, ServerSettings};
     use crate::state::AppStateLayout;
 
     #[test]
@@ -94,5 +155,76 @@ mod tests {
         .expect("config file");
 
         ServerSettings::load(&layout).expect_err("bind address must be an IP socket address");
+    }
+    #[test]
+    fn config_decode_errors_do_not_echo_secret_source_lines() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[server.auth]\ntoken = 'must-not-leak'\n",
+        )
+        .expect("config file");
+
+        let error = ServerSettings::load(&layout).expect_err("malformed config must fail");
+        assert!(!error.to_string().contains("must-not-leak"));
+    }
+
+    #[test]
+    fn auth_section_defaults_token_env_and_builds_a_redacted_validator() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(layout.config_file(), "[server.auth]\n").expect("config file");
+        let settings = ServerSettings::load(&layout).expect("server settings");
+
+        let validator = settings
+            .auth_validator_with(|name| {
+                assert_eq!(name, DEFAULT_TOKEN_ENV);
+                Ok(Some("  secret-._~+/=: \t".to_string()))
+            })
+            .expect("auth config")
+            .expect("validator");
+
+        assert!(validator.accepts_bearer("secret-._~+/=:"));
+        assert!(!validator.accepts_bearer("other-value"));
+    }
+
+    #[test]
+    fn invalid_auth_configuration_fails_startup_resolution_without_disclosure() {
+        let settings = ServerSettings {
+            bind_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+            auth: Some(super::ServerAuthSettings {
+                token_env: "  CUSTOM_TOKEN  ".to_string(),
+            }),
+        };
+
+        for token_env in ["", "BAD=NAME", "BAD\0NAME"] {
+            let mut invalid = settings.clone();
+            invalid.auth.as_mut().expect("auth").token_env = token_env.to_string();
+            let Err(error) = invalid.auth_validator_with(|_| panic!("must not read env")) else {
+                panic!("invalid environment name must fail");
+            };
+            assert_eq!(
+                error.to_string(),
+                "failed precondition: server.auth.token_env must name a valid environment variable"
+            );
+        }
+
+        let Err(error) = settings.auth_validator_with(|name| {
+            assert_eq!(name, "CUSTOM_TOKEN");
+            Err(std::env::VarError::NotUnicode("must-not-leak".into()))
+        }) else {
+            panic!("non-UTF8 token must fail");
+        };
+        assert!(!error.to_string().contains("must-not-leak"));
+
+        for token in [" \t ", "two words", "tökén"] {
+            let Err(error) = settings.auth_validator_with(|_| Ok(Some(token.to_string()))) else {
+                panic!("invalid token must fail");
+            };
+            assert!(!error.to_string().contains(token));
+        }
     }
 }

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -51,6 +51,7 @@ mod functions;
 mod hash;
 mod identity;
 mod query;
+mod request_auth;
 mod request_context;
 mod search;
 mod sources;
@@ -71,5 +72,6 @@ pub use identity::{
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };
+pub use request_auth::{AuthValidator, StaticTokenValidator};
 pub use telemetry::{RunContext, RunErrorTelemetry, run_with_context, shutdown_tracing};
 pub use workspaces::DEFAULT_WORKSPACE_ID;

--- a/crates/coral-app/src/request_auth.rs
+++ b/crates/coral-app/src/request_auth.rs
@@ -1,0 +1,152 @@
+//! Request authentication shared by served transport surfaces.
+
+use std::fmt;
+use std::sync::Arc;
+
+use sha2::{Digest as _, Sha256};
+use subtle::ConstantTimeEq as _;
+use tonic::metadata::MetadataMap;
+
+use crate::identity::{UserPrincipal, UserPrincipalProvider, UserPrincipalProviderError};
+
+const AUTHORIZATION_METADATA: &str = "authorization";
+const UNAUTHENTICATED_MESSAGE: &str = "authentication required";
+
+/// Synchronous bearer validator for gRPC and HTTP gates, without principal
+/// or tenant semantics.
+pub trait AuthValidator: Send + Sync + 'static {
+    /// Returns whether `token` grants access to the served API.
+    fn accepts_bearer(&self, token: &str) -> bool;
+}
+
+/// Static bearer validator retaining only a constant-time-compared SHA-256 digest.
+#[derive(Clone)]
+pub struct StaticTokenValidator {
+    expected_digest: [u8; 32],
+}
+
+impl StaticTokenValidator {
+    /// Builds a validator for a printable ASCII token.
+    #[must_use]
+    pub fn new(token: &str) -> Option<Self> {
+        valid_bearer_token(token).then(|| Self {
+            expected_digest: Sha256::digest(token.as_bytes()).into(),
+        })
+    }
+}
+
+impl fmt::Debug for StaticTokenValidator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("StaticTokenValidator").finish()
+    }
+}
+
+impl AuthValidator for StaticTokenValidator {
+    fn accepts_bearer(&self, token: &str) -> bool {
+        let actual_digest: [u8; 32] = Sha256::digest(token.as_bytes()).into();
+        self.expected_digest.ct_eq(&actual_digest).into()
+    }
+}
+
+pub(crate) struct BearerUserPrincipalProvider {
+    validator: Arc<dyn AuthValidator>,
+    inner: Arc<dyn UserPrincipalProvider>,
+}
+
+impl BearerUserPrincipalProvider {
+    pub(crate) fn new(
+        validator: Arc<dyn AuthValidator>,
+        inner: Arc<dyn UserPrincipalProvider>,
+    ) -> Self {
+        Self { validator, inner }
+    }
+}
+
+impl fmt::Debug for BearerUserPrincipalProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BearerUserPrincipalProvider")
+            .finish_non_exhaustive()
+    }
+}
+
+#[tonic::async_trait]
+impl UserPrincipalProvider for BearerUserPrincipalProvider {
+    async fn principal_for_metadata(
+        &self,
+        metadata: &MetadataMap,
+    ) -> Result<UserPrincipal, UserPrincipalProviderError> {
+        authenticate_metadata(metadata, self.validator.as_ref())?;
+        self.inner.principal_for_metadata(metadata).await
+    }
+}
+
+fn authenticate_metadata(
+    metadata: &MetadataMap,
+    validator: &dyn AuthValidator,
+) -> Result<(), UserPrincipalProviderError> {
+    let token = strict_bearer(metadata)?;
+    if !validator.accepts_bearer(token) {
+        return Err(unauthenticated());
+    }
+    Ok(())
+}
+
+fn strict_bearer(metadata: &MetadataMap) -> Result<&str, UserPrincipalProviderError> {
+    let mut values = metadata.get_all(AUTHORIZATION_METADATA).iter();
+    let value = values
+        .next()
+        .filter(|_| values.next().is_none())
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(unauthenticated)?;
+    let (scheme, token) = value.split_once(' ').ok_or_else(unauthenticated)?;
+    if !scheme.eq_ignore_ascii_case("bearer") || !valid_bearer_token(token) {
+        return Err(unauthenticated());
+    }
+    Ok(token)
+}
+
+fn unauthenticated() -> UserPrincipalProviderError {
+    UserPrincipalProviderError::unauthenticated(UNAUTHENTICATED_MESSAGE)
+}
+
+fn valid_bearer_token(token: &str) -> bool {
+    !token.is_empty() && token.bytes().all(|byte| byte.is_ascii_graphic())
+}
+
+#[cfg(test)]
+mod tests {
+    use tonic::Request;
+    use tonic::metadata::MetadataValue;
+
+    use super::{AuthValidator as _, StaticTokenValidator, authenticate_metadata};
+
+    #[test]
+    fn static_validator_accepts_only_the_exact_token_without_debug_disclosure() {
+        let token = "correct-._~+/=:";
+        let validator = StaticTokenValidator::new(token).expect("valid token");
+        assert!(validator.accepts_bearer(token));
+        assert!(!validator.accepts_bearer("wrong-token"));
+        assert!(!format!("{validator:?}").contains(token));
+        for invalid in ["", "two words", "tökén", "line\nbreak"] {
+            assert!(StaticTokenValidator::new(invalid).is_none());
+        }
+    }
+
+    #[test]
+    fn bearer_metadata_is_strict_and_rejections_are_generic() {
+        let validator = StaticTokenValidator::new("correct-token").expect("nonempty token");
+        for value in [None, Some("Basic correct-token"), Some("Bearer wrong")] {
+            let mut request = Request::new(());
+            if let Some(value) = value {
+                request.metadata_mut().insert(
+                    "authorization",
+                    MetadataValue::try_from(value).expect("metadata"),
+                );
+            }
+            let error = authenticate_metadata(request.metadata(), &validator)
+                .expect_err("invalid authentication must fail");
+            assert_eq!(error.client_message(), "authentication required");
+        }
+    }
+}


### PR DESCRIPTION
## Intent
Protect long-running Coral gRPC services with an operator-configured static bearer while preserving unauthenticated local modes.

## What it enables
Allows authenticated non-loopback serving behind a TLS-terminating reverse proxy, with a reusable AuthValidator seam for later session and HTTP gates.

## Usage examples
Configure [server.auth] and provide CORAL_SERVER_AUTH_TOKEN; clients send the token with the Bearer authorization scheme.

## Validation
- make rust-checks
- make perf-check (201 ms mean; 750 ms threshold)
- make docs-check
- focused static-auth, config-secrecy, fail-before-state, and authenticated gRPC tests
- strict coral-app and coral-cli clippy