### PR TITLE
feat(mcp-http): enforce OAuth bearer sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,12 +1413,12 @@ dependencies = [
 name = "coral-mcp"
 version = "0.7.1"
 dependencies = [
- "async-trait",
  "axum",
  "coral-api",
  "coral-app",
  "coral-client",
  "coral-telemetry",
+ "futures",
  "jsonschema",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1431,6 +1431,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tonic-types",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,7 @@ name = "coral-mcp"
 version = "0.7.1"
 dependencies = [
  "axum",
+ "base64",
  "coral-api",
  "coral-app",
  "coral-client",
@@ -1426,6 +1427,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1435,6 +1437,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,8 +1413,8 @@ dependencies = [
 name = "coral-mcp"
 version = "0.7.1"
 dependencies = [
+ "async-trait",
  "axum",
- "base64",
  "coral-api",
  "coral-app",
  "coral-client",

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -11,11 +11,13 @@ workspace = true
 
 [dependencies]
 axum = { workspace = true, features = ["http1", "tokio"] }
+base64.workspace = true
 regex.workspace = true
 rmcp.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tonic.workspace = true
@@ -23,6 +25,7 @@ tower.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
 opentelemetry.workspace = true
+url.workspace = true
 uuid.workspace = true
 
 coral-api.workspace = true

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 workspace = true
 
 [dependencies]
-async-trait.workspace = true
 axum = { workspace = true, features = ["http1", "tokio"] }
+futures.workspace = true
 regex.workspace = true
 rmcp.workspace = true
 schemars.workspace = true
@@ -20,6 +20,7 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 tonic.workspace = true
 tower.workspace = true
 tracing.workspace = true

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 workspace = true
 
 [dependencies]
+async-trait.workspace = true
 axum = { workspace = true, features = ["http1", "tokio"] }
-base64.workspace = true
 regex.workspace = true
 rmcp.workspace = true
 schemars.workspace = true

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -38,5 +38,6 @@ coral-app.workspace = true
 jsonschema.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tonic-types.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -4,7 +4,8 @@
 //! unauthenticated local [`coral_client::AppClient`] across sessions and is not
 //! a safe construction path for a long-running, non-loopback server.
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::error::Error;
 use std::future::Future;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
@@ -12,21 +13,20 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use axum::Router;
 use axum::body::Body;
 use axum::extract::State;
 use axum::http::{HeaderMap, HeaderValue, Method, Request, StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get};
-use base64::Engine as _;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use coral_api::v1::{CatalogItemKind, ListCatalogRequest, PaginationRequest};
 use coral_client::{AppClient, default_workspace};
 use rmcp::model::{ClientJsonRpcMessage, ClientRequest, ProtocolVersion};
 use rmcp::transport::common::http_header::HEADER_MCP_PROTOCOL_VERSION;
 use rmcp::transport::streamable_http_server::{
-    StreamableHttpServerConfig, StreamableHttpService, session::SessionManager,
-    session::local::LocalSessionManager,
+    StreamableHttpServerConfig, StreamableHttpService,
+    session::{SessionManager, local::LocalSessionManager},
 };
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -53,7 +53,68 @@ type Fut<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 type TokenValidator = Arc<dyn Fn(String) -> Fut<Result<(), ()>> + Send + Sync>;
 type SessionClientFactory = Arc<dyn Fn(String) -> Fut<Result<AppClient, ()>> + Send + Sync>;
 type AuthState = Arc<AuthenticatedHttpState>;
-type BoundSessions = Arc<Mutex<BTreeMap<String, BoundSession>>>;
+
+/// Error returned by an authenticated MCP session-binding store.
+pub type SessionBindingStoreError = Box<dyn Error + Send + Sync + 'static>;
+
+/// Bearer-token fingerprint used to bind an MCP session to its authorization context.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct SessionBindingFingerprint([u8; 32]);
+
+impl SessionBindingFingerprint {
+    /// Returns the fingerprint bytes for storage.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+/// Result of authorizing a request against a stored session binding.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum SessionBindingStatus {
+    /// The supplied authorization context owns the session.
+    Authorized,
+    /// No active binding exists for the session.
+    Missing,
+    /// The session belongs to a different authorization context.
+    Mismatch,
+}
+
+/// Storage seam for binding MCP session IDs to authorization contexts.
+///
+/// Implementations must atomically compare and refresh a binding in
+/// [`SessionBindingStore::authorize_and_touch`]. Live MCP handlers remain
+/// process-local and outside this store.
+#[async_trait]
+pub trait SessionBindingStore: Send + Sync + 'static {
+    /// Creates or replaces a session binding.
+    async fn bind(
+        &self,
+        session_id: &str,
+        fingerprint: SessionBindingFingerprint,
+    ) -> Result<(), SessionBindingStoreError>;
+
+    /// Atomically authorizes and refreshes a session binding.
+    async fn authorize_and_touch(
+        &self,
+        session_id: &str,
+        fingerprint: &SessionBindingFingerprint,
+    ) -> Result<SessionBindingStatus, SessionBindingStoreError>;
+
+    /// Removes a session binding.
+    async fn remove(&self, session_id: &str) -> Result<(), SessionBindingStoreError>;
+}
+
+#[derive(Default)]
+struct InMemorySessionBindingStore {
+    bindings: Mutex<HashMap<String, InMemorySessionBinding>>,
+}
+
+struct InMemorySessionBinding {
+    fingerprint: SessionBindingFingerprint,
+    last_seen: Instant,
+}
 
 /// Configuration for the auth-disabled loopback MCP HTTP server.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -147,10 +208,12 @@ pub struct AuthenticatedMcpHttpRuntime {
     session_client_factory: SessionClientFactory,
     options: McpOptions,
     readiness: ReadinessProbe,
+    session_bindings: Arc<dyn SessionBindingStore>,
 }
 
 impl AuthenticatedMcpHttpRuntime {
-    /// Creates a runtime whose client factory MUST forward its bearer.
+    /// Creates a runtime whose client factory must forward the caller's bearer
+    /// token on outbound requests.
     pub fn new<V, VF, F, FF, R, RF>(
         validator: V,
         session_client_factory: F,
@@ -170,7 +233,19 @@ impl AuthenticatedMcpHttpRuntime {
             session_client_factory: Arc::new(move |token| Box::pin(session_client_factory(token))),
             options,
             readiness: ReadinessProbe(Arc::new(move || Box::pin(readiness()))),
+            session_bindings: Arc::new(InMemorySessionBindingStore::default()),
         }
+    }
+
+    /// Configures storage for binding MCP sessions to authorization contexts.
+    ///
+    /// This store protects the authorization association for each MCP session.
+    /// Live MCP handlers remain process-local, so deployments must use
+    /// process-sticky routing.
+    #[must_use]
+    pub fn with_session_binding_store(mut self, store: Arc<dyn SessionBindingStore>) -> Self {
+        self.session_bindings = store;
+        self
     }
 }
 
@@ -374,7 +449,7 @@ pub async fn start_authenticated(
             source,
         })?;
     let local_addr = listener.local_addr().map_err(McpHttpError::Server)?;
-    let (router, state, _bindings) = authenticated_router(config, runtime);
+    let (router, state) = authenticated_router(config, runtime);
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let task = tokio::spawn(async move {
         axum::serve(listener, router)
@@ -471,7 +546,7 @@ async fn mcp(State(state): State<Arc<HttpState>>, request: Request<Body>) -> Res
     };
     serve_mcp_request(
         request,
-        state.factory.clone(),
+        Some(state.factory.clone()),
         state.server.sessions.clone(),
         state.server.config.clone(),
     )
@@ -528,18 +603,18 @@ fn initialize_protocol_header_matches(headers: &HeaderMap, body_protocol: &str) 
 fn authenticated_router(
     config: AuthenticatedMcpHttpConfig,
     runtime: AuthenticatedMcpHttpRuntime,
-) -> (Router, Arc<ServerState>, BoundSessions) {
+) -> (Router, Arc<ServerState>) {
+    let streamable_config =
+        StreamableHttpServerConfig::default().with_allowed_hosts(config.allowed_hosts.clone());
     let server = Arc::new(ServerState {
         sessions: Arc::new(LocalSessionManager::default()),
-        config: StreamableHttpServerConfig::default()
-            .with_allowed_hosts(config.allowed_hosts.clone()),
+        config: streamable_config,
         requests: RwLock::new(()),
     });
     let state = Arc::new(AuthenticatedHttpState {
         config,
         runtime,
         server: server.clone(),
-        bindings: Arc::new(Mutex::new(BTreeMap::new())),
     });
     let router = Router::new()
         .route("/mcp", any(authenticated_mcp))
@@ -548,20 +623,13 @@ fn authenticated_router(
         .route(METADATA_ROOT, get(metadata))
         .route(METADATA_ROUTE, get(metadata))
         .with_state(state.clone());
-    (router, server, state.bindings.clone())
+    (router, server)
 }
 
 struct AuthenticatedHttpState {
     config: AuthenticatedMcpHttpConfig,
     runtime: AuthenticatedMcpHttpRuntime,
     server: Arc<ServerState>,
-    bindings: BoundSessions,
-}
-
-struct BoundSession {
-    token_fingerprint: String,
-    last_seen: Instant,
-    factory: CoralMcpServerFactory,
 }
 
 async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body>) -> Response {
@@ -580,11 +648,12 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
     if validation.is_err() {
         return unauthorized_response(&state.config);
     }
-    let token_fingerprint = fingerprint(&token);
+    let binding_fingerprint = binding_fingerprint(&token);
     let request_session = match session_id(request.headers()) {
         Ok(session) => session.map(str::to_string),
         Err(()) => return StatusCode::BAD_REQUEST.into_response(),
     };
+    let closes_session = request.method() == Method::DELETE;
     let request = if request_session.is_none() {
         tokio::select! {
             biased;
@@ -598,50 +667,104 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
         request
     };
     let factory = if let Some(session_id) = request_session.as_deref() {
-        match bound_factory(&state, session_id, &token_fingerprint).await {
-            Ok(factory) => factory,
+        if let Err(status) = authorize_bound_session(&state, session_id, &binding_fingerprint).await
+        {
+            return status.into_response();
+        }
+        None
+    } else {
+        match create_session_factory(&state, token).await {
+            Ok(factory) => Some(factory),
             Err(status) => return status.into_response(),
         }
-    } else {
-        let client = tokio::select! {
-            biased;
-            () = state.server.config.cancellation_token.cancelled() => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
-            client = (state.runtime.session_client_factory)(token) => client,
-        };
-        match client {
-            Ok(client) => CoralMcpServerFactory::new(client, state.runtime.options.clone()),
-            Err(()) => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
-        }
     };
-    let closes_session = request.method() == Method::DELETE;
     let response = serve_mcp_request(
         request,
-        factory.clone(),
+        factory,
         state.server.sessions.clone(),
         state.server.config.clone(),
     )
     .await;
+    finalize_authenticated_response(
+        &state,
+        request_session.as_deref(),
+        binding_fingerprint,
+        closes_session,
+        response,
+    )
+    .await
+}
+
+async fn finalize_authenticated_response(
+    state: &AuthenticatedHttpState,
+    request_session: Option<&str>,
+    binding_fingerprint: SessionBindingFingerprint,
+    closes_session: bool,
+    response: Response,
+) -> Response {
     if request_session.is_none()
         && response.status().is_success()
         && let Ok(Some(session_id)) = session_id(response.headers())
     {
-        let mut bindings = state.bindings.lock().await;
-        let removed = insert_bound_session(
-            &mut bindings,
-            session_id,
-            token_fingerprint,
-            factory,
-            Instant::now(),
-        );
-        drop(bindings);
-        close_managed_sessions(state.server.sessions.as_ref(), removed).await;
-    } else if closes_session
-        && (response.status().is_success() || response.status() == StatusCode::NOT_FOUND)
+        if let Err(_error) = state
+            .runtime
+            .session_bindings
+            .bind(session_id, binding_fingerprint)
+            .await
+        {
+            remove_managed_session(state.server.as_ref(), session_id).await;
+            let _remove_result = state.runtime.session_bindings.remove(session_id).await;
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    } else if (closes_session && response.status().is_success()
+        || response.status() == StatusCode::NOT_FOUND)
         && let Some(session_id) = request_session
+        && state
+            .runtime
+            .session_bindings
+            .remove(session_id)
+            .await
+            .is_err()
     {
-        state.bindings.lock().await.remove(&session_id);
+        return StatusCode::SERVICE_UNAVAILABLE.into_response();
     }
     response
+}
+
+async fn create_session_factory(
+    state: &AuthenticatedHttpState,
+    token: String,
+) -> Result<CoralMcpServerFactory, StatusCode> {
+    let client = tokio::select! {
+        biased;
+        () = state.server.config.cancellation_token.cancelled() => Err(StatusCode::SERVICE_UNAVAILABLE),
+        client = (state.runtime.session_client_factory)(token) => client.map_err(|()| StatusCode::SERVICE_UNAVAILABLE),
+    }?;
+    Ok(CoralMcpServerFactory::new(
+        client,
+        state.runtime.options.clone(),
+    ))
+}
+
+async fn authorize_bound_session(
+    state: &AuthenticatedHttpState,
+    session_id: &str,
+    fingerprint: &SessionBindingFingerprint,
+) -> Result<(), StatusCode> {
+    let status = state
+        .runtime
+        .session_bindings
+        .authorize_and_touch(session_id, fingerprint)
+        .await
+        .map_err(|_error| StatusCode::SERVICE_UNAVAILABLE)?;
+    if status == SessionBindingStatus::Missing {
+        remove_managed_session(state.server.as_ref(), session_id).await;
+    }
+    match status {
+        SessionBindingStatus::Authorized => Ok(()),
+        SessionBindingStatus::Missing => Err(StatusCode::NOT_FOUND),
+        SessionBindingStatus::Mismatch => Err(StatusCode::FORBIDDEN),
+    }
 }
 
 async fn initialize_request(request: Request<Body>) -> Result<Request<Body>, Response> {
@@ -673,46 +796,8 @@ async fn initialize_request(request: Request<Body>) -> Result<Request<Body>, Res
     Ok(Request::from_parts(parts, Body::from(bytes)))
 }
 
-async fn bound_factory(
-    state: &AuthenticatedHttpState,
-    session_id: &str,
-    token_fingerprint: &str,
-) -> Result<CoralMcpServerFactory, StatusCode> {
-    let (expired, bound_fingerprint) = {
-        let mut bindings = state.bindings.lock().await;
-        let expired = prune_expired_bound_sessions(&mut bindings, Instant::now());
-        let fingerprint = bindings
-            .get(session_id)
-            .map(|binding| binding.token_fingerprint.clone());
-        (expired, fingerprint)
-    };
-    close_managed_sessions(state.server.sessions.as_ref(), expired).await;
-    let Some(bound_fingerprint) = bound_fingerprint else {
-        return Err(StatusCode::NOT_FOUND);
-    };
-    let managed = state
-        .server
-        .sessions
-        .has_session(&Arc::from(session_id))
-        .await
-        .map_err(|_error| StatusCode::INTERNAL_SERVER_ERROR)?;
-    if !managed {
-        state.bindings.lock().await.remove(session_id);
-        return Err(StatusCode::NOT_FOUND);
-    }
-    if bound_fingerprint != token_fingerprint {
-        return Err(StatusCode::FORBIDDEN);
-    }
-    let mut bindings = state.bindings.lock().await;
-    let binding = bindings.get_mut(session_id).ok_or(StatusCode::NOT_FOUND)?;
-    binding.last_seen = Instant::now();
-    Ok(binding.factory.clone())
-}
-
-async fn close_managed_sessions(sessions: &LocalSessionManager, ids: Vec<String>) {
-    for id in ids {
-        let _close_result = sessions.close_session(&Arc::from(id)).await;
-    }
+async fn remove_managed_session(server: &ServerState, id: &str) {
+    let _close_result = server.sessions.close_session(&Arc::from(id)).await;
 }
 
 async fn authenticated_readyz(State(state): State<Arc<AuthenticatedHttpState>>) -> StatusCode {
@@ -777,50 +862,94 @@ fn session_id(headers: &HeaderMap) -> Result<Option<&str>, ()> {
     Ok(Some(value))
 }
 
-fn fingerprint(token: &str) -> String {
-    URL_SAFE_NO_PAD.encode(Sha256::digest(token.as_bytes()))
+fn binding_fingerprint(token: &str) -> SessionBindingFingerprint {
+    SessionBindingFingerprint(Sha256::digest(token.as_bytes()).into())
 }
 
-fn insert_bound_session(
-    sessions: &mut BTreeMap<String, BoundSession>,
+#[async_trait]
+impl SessionBindingStore for InMemorySessionBindingStore {
+    async fn bind(
+        &self,
+        session_id: &str,
+        fingerprint: SessionBindingFingerprint,
+    ) -> Result<(), SessionBindingStoreError> {
+        let mut bindings = self.bindings.lock().await;
+        insert_session_binding(&mut bindings, session_id, fingerprint, Instant::now());
+        Ok(())
+    }
+
+    async fn authorize_and_touch(
+        &self,
+        session_id: &str,
+        fingerprint: &SessionBindingFingerprint,
+    ) -> Result<SessionBindingStatus, SessionBindingStoreError> {
+        let mut bindings = self.bindings.lock().await;
+        Ok(authorize_session_binding(
+            &mut bindings,
+            session_id,
+            fingerprint,
+            Instant::now(),
+        ))
+    }
+
+    async fn remove(&self, session_id: &str) -> Result<(), SessionBindingStoreError> {
+        self.bindings.lock().await.remove(session_id);
+        Ok(())
+    }
+}
+
+fn insert_session_binding(
+    bindings: &mut HashMap<String, InMemorySessionBinding>,
     session_id: &str,
-    token_fingerprint: String,
-    factory: CoralMcpServerFactory,
+    fingerprint: SessionBindingFingerprint,
     now: Instant,
-) -> Vec<String> {
-    let mut removed = prune_expired_bound_sessions(sessions, now);
-    if !sessions.contains_key(session_id)
-        && sessions.len() >= MAX_BOUND_SESSIONS
-        && let Some(oldest) = sessions
+) {
+    prune_expired_session_bindings(bindings, now);
+    if !bindings.contains_key(session_id)
+        && bindings.len() >= MAX_BOUND_SESSIONS
+        && let Some(oldest) = bindings
             .iter()
             .min_by_key(|(_, binding)| binding.last_seen)
             .map(|(session_id, _)| session_id.clone())
     {
-        sessions.remove(&oldest);
-        removed.push(oldest);
+        bindings.remove(&oldest);
     }
-    let binding = BoundSession {
-        token_fingerprint,
+    let binding = InMemorySessionBinding {
+        fingerprint,
         last_seen: now,
-        factory,
     };
-    sessions.insert(session_id.to_string(), binding);
-    removed
+    bindings.insert(session_id.to_string(), binding);
 }
 
-fn prune_expired_bound_sessions(
-    sessions: &mut BTreeMap<String, BoundSession>,
+fn authorize_session_binding(
+    bindings: &mut HashMap<String, InMemorySessionBinding>,
+    session_id: &str,
+    fingerprint: &SessionBindingFingerprint,
     now: Instant,
-) -> Vec<String> {
-    let mut expired = Vec::new();
-    sessions.retain(|session_id, binding| {
-        let active = now.saturating_duration_since(binding.last_seen) <= BOUND_SESSION_IDLE_TIMEOUT;
-        if !active {
-            expired.push(session_id.clone());
-        }
-        active
+) -> SessionBindingStatus {
+    let Some(binding) = bindings.get(session_id) else {
+        return SessionBindingStatus::Missing;
+    };
+    if now.saturating_duration_since(binding.last_seen) > BOUND_SESSION_IDLE_TIMEOUT {
+        bindings.remove(session_id);
+        return SessionBindingStatus::Missing;
+    }
+    if binding.fingerprint != *fingerprint {
+        return SessionBindingStatus::Mismatch;
+    }
+    if let Some(binding) = bindings.get_mut(session_id) {
+        binding.last_seen = now;
+    }
+    SessionBindingStatus::Authorized
+}
+
+fn prune_expired_session_bindings(
+    bindings: &mut HashMap<String, InMemorySessionBinding>,
+    now: Instant,
+) {
+    bindings.retain(|_session_id, binding| {
+        now.saturating_duration_since(binding.last_seen) <= BOUND_SESSION_IDLE_TIMEOUT
     });
-    expired
 }
 
 // The service wrapper is intentionally request-scoped. Auth-required routing
@@ -828,12 +957,21 @@ fn prune_expired_bound_sessions(
 // while later requests reuse the handler already held by `sessions`.
 async fn serve_mcp_request(
     request: Request<Body>,
-    factory: CoralMcpServerFactory,
+    factory: Option<CoralMcpServerFactory>,
     sessions: Arc<LocalSessionManager>,
     config: StreamableHttpServerConfig,
 ) -> Response {
     let cancellation = config.cancellation_token.clone();
-    let service = StreamableHttpService::new(move || Ok(factory.create()), sessions, config);
+    let service = StreamableHttpService::new(
+        move || {
+            factory
+                .as_ref()
+                .map(CoralMcpServerFactory::create)
+                .ok_or_else(|| io::Error::other("MCP session handler factory unavailable"))
+        },
+        sessions,
+        config,
+    );
     tokio::select! {
         biased;
         () = cancellation.cancelled() => StatusCode::SERVICE_UNAVAILABLE.into_response(),

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -5,15 +5,13 @@
 //! a safe construction path for a long-running, non-loopback server.
 
 use std::collections::HashMap;
-use std::error::Error;
 use std::future::Future;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use async_trait::async_trait;
 use axum::Router;
 use axum::body::Body;
 use axum::extract::State;
@@ -22,17 +20,30 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get};
 use coral_api::v1::{CatalogItemKind, ListCatalogRequest, PaginationRequest};
 use coral_client::{AppClient, default_workspace};
-use rmcp::model::{ClientJsonRpcMessage, ClientRequest, ProtocolVersion};
-use rmcp::transport::common::http_header::HEADER_MCP_PROTOCOL_VERSION;
-use rmcp::transport::streamable_http_server::{
-    StreamableHttpServerConfig, StreamableHttpService,
-    session::{SessionManager, local::LocalSessionManager},
+use futures::{Stream, StreamExt as _};
+use rmcp::model::{ClientJsonRpcMessage, ClientRequest, ServerJsonRpcMessage};
+use rmcp::transport::{
+    WorkerTransport,
+    common::{
+        http_header::HEADER_MCP_PROTOCOL_VERSION, server_side_http::session_id as new_session_id,
+    },
+    streamable_http_server::{
+        StreamableHttpServerConfig, StreamableHttpService,
+        session::{
+            ServerSseMessage, SessionId, SessionManager,
+            local::{
+                LocalSessionHandle, LocalSessionManager, LocalSessionManagerError,
+                LocalSessionWorker, SessionConfig, SessionError, create_local_session,
+            },
+        },
+    },
 };
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use tokio::net::TcpListener;
-use tokio::sync::{Mutex, RwLock, oneshot};
+use tokio::sync::{RwLock, oneshot};
 use tokio::task::JoinHandle;
+use tokio_stream::wrappers::ReceiverStream;
 use tonic::Request as GrpcRequest;
 use tower::ServiceExt;
 use url::{Host, Position, Url};
@@ -41,12 +52,10 @@ use crate::{CoralMcpServerFactory, McpOptions};
 
 const READINESS_TIMEOUT: Duration = Duration::from_secs(2);
 const SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_secs(1);
-const MAX_MCP_REQUEST_BODY_SIZE: usize = 1_048_576;
 const SESSION_ID_HEADER: &str = "mcp-session-id";
 const METADATA_ROOT: &str = "/.well-known/oauth-protected-resource";
 const METADATA_ROUTE: &str = "/.well-known/oauth-protected-resource/{*resource_path}";
-const MAX_BOUND_SESSIONS: usize = 4096;
-const BOUND_SESSION_IDLE_TIMEOUT: Duration = Duration::from_hours(1);
+const MAX_MCP_REQUEST_BODY_SIZE: usize = 1_048_576;
 
 type ProbeFuture = Pin<Box<dyn Future<Output = Result<(), tonic::Code>> + Send>>;
 type Fut<T> = Pin<Box<dyn Future<Output = T> + Send>>;
@@ -54,66 +63,210 @@ type TokenValidator = Arc<dyn Fn(String) -> Fut<Result<(), ()>> + Send + Sync>;
 type SessionClientFactory = Arc<dyn Fn(String) -> Fut<Result<AppClient, ()>> + Send + Sync>;
 type AuthState = Arc<AuthenticatedHttpState>;
 
-/// Error returned by an authenticated MCP session-binding store.
-pub type SessionBindingStoreError = Box<dyn Error + Send + Sync + 'static>;
-
-/// Bearer-token fingerprint used to bind an MCP session to its authorization context.
 #[derive(Clone, Copy, Eq, PartialEq)]
-pub struct SessionBindingFingerprint([u8; 32]);
+struct BearerFingerprint([u8; 32]);
 
-impl SessionBindingFingerprint {
-    /// Returns the fingerprint bytes for storage.
-    #[must_use]
-    pub fn as_bytes(&self) -> &[u8; 32] {
-        &self.0
-    }
-}
-
-/// Result of authorizing a request against a stored session binding.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum SessionBindingStatus {
-    /// The supplied authorization context owns the session.
+enum SessionAuthorization {
     Authorized,
-    /// No active binding exists for the session.
     Missing,
-    /// The session belongs to a different authorization context.
     Mismatch,
 }
 
-/// Storage seam for binding MCP session IDs to authorization contexts.
-///
-/// Implementations must atomically compare and refresh a binding in
-/// [`SessionBindingStore::authorize_and_touch`]. Live MCP handlers remain
-/// process-local and outside this store.
-#[async_trait]
-pub trait SessionBindingStore: Send + Sync + 'static {
-    /// Creates or replaces a session binding.
-    async fn bind(
-        &self,
-        session_id: &str,
-        fingerprint: SessionBindingFingerprint,
-    ) -> Result<(), SessionBindingStoreError>;
-
-    /// Atomically authorizes and refreshes a session binding.
-    async fn authorize_and_touch(
-        &self,
-        session_id: &str,
-        fingerprint: &SessionBindingFingerprint,
-    ) -> Result<SessionBindingStatus, SessionBindingStoreError>;
-
-    /// Removes a session binding.
-    async fn remove(&self, session_id: &str) -> Result<(), SessionBindingStoreError>;
+struct AuthenticatedSessions {
+    records: RwLock<HashMap<SessionId, AuthenticatedSession>>,
+    config: SessionConfig,
 }
 
-#[derive(Default)]
-struct InMemorySessionBindingStore {
-    bindings: Mutex<HashMap<String, InMemorySessionBinding>>,
+struct AuthenticatedSession {
+    fingerprint: BearerFingerprint,
+    handle: LocalSessionHandle,
 }
 
-struct InMemorySessionBinding {
-    fingerprint: SessionBindingFingerprint,
-    last_seen: Instant,
+#[derive(Clone)]
+struct AuthenticatedSessionManager {
+    sessions: Arc<AuthenticatedSessions>,
+    fingerprint: BearerFingerprint,
+}
+
+impl AuthenticatedSessions {
+    async fn authorize(
+        &self,
+        session_id: &SessionId,
+        fingerprint: &BearerFingerprint,
+    ) -> SessionAuthorization {
+        let records = self.records.read().await;
+        let Some(session) = records.get(session_id) else {
+            return SessionAuthorization::Missing;
+        };
+        if session.fingerprint == *fingerprint {
+            SessionAuthorization::Authorized
+        } else {
+            SessionAuthorization::Mismatch
+        }
+    }
+
+    async fn close_all(&self) {
+        let handles: Vec<_> = self
+            .records
+            .write()
+            .await
+            .drain()
+            .map(|(_session_id, session)| session.handle)
+            .collect();
+        for handle in handles {
+            let _close_result = close_session_handle(handle).await;
+        }
+    }
+
+    #[cfg(test)]
+    async fn len(&self) -> usize {
+        self.records.read().await.len()
+    }
+}
+
+impl Default for AuthenticatedSessions {
+    fn default() -> Self {
+        Self {
+            records: RwLock::new(HashMap::new()),
+            config: SessionConfig::default(),
+        }
+    }
+}
+
+async fn close_session_handle(handle: LocalSessionHandle) -> Result<(), LocalSessionManagerError> {
+    match handle.close().await {
+        Ok(()) | Err(SessionError::SessionServiceTerminated) => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+impl AuthenticatedSessionManager {
+    async fn session_handle(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<LocalSessionHandle, LocalSessionManagerError> {
+        self.sessions
+            .records
+            .read()
+            .await
+            .get(session_id)
+            .filter(|session| session.fingerprint == self.fingerprint)
+            .map(|session| session.handle.clone())
+            .ok_or_else(|| LocalSessionManagerError::SessionNotFound(session_id.clone()))
+    }
+}
+
+impl SessionManager for AuthenticatedSessionManager {
+    type Error = LocalSessionManagerError;
+    type Transport = WorkerTransport<LocalSessionWorker>;
+
+    async fn create_session(&self) -> Result<(SessionId, Self::Transport), Self::Error> {
+        let mut records = self.sessions.records.write().await;
+        let session_id = new_session_id();
+        let (handle, worker) =
+            create_local_session(session_id.clone(), self.sessions.config.clone());
+        records.insert(
+            session_id.clone(),
+            AuthenticatedSession {
+                fingerprint: self.fingerprint,
+                handle,
+            },
+        );
+        drop(records);
+        Ok((session_id, WorkerTransport::spawn(worker)))
+    }
+
+    async fn initialize_session(
+        &self,
+        session_id: &SessionId,
+        message: ClientJsonRpcMessage,
+    ) -> Result<ServerJsonRpcMessage, Self::Error> {
+        let handle = self.session_handle(session_id).await?;
+        Ok(handle.initialize(message).await?)
+    }
+
+    async fn has_session(&self, session_id: &SessionId) -> Result<bool, Self::Error> {
+        Ok(self
+            .sessions
+            .records
+            .read()
+            .await
+            .get(session_id)
+            .is_some_and(|session| session.fingerprint == self.fingerprint))
+    }
+
+    async fn close_session(&self, session_id: &SessionId) -> Result<(), Self::Error> {
+        let handle = {
+            let mut records = self.sessions.records.write().await;
+            match records.get(session_id) {
+                None => None,
+                Some(session) if session.fingerprint != self.fingerprint => {
+                    return Err(LocalSessionManagerError::SessionNotFound(
+                        session_id.clone(),
+                    ));
+                }
+                Some(_) => records.remove(session_id).map(|session| session.handle),
+            }
+        };
+        match handle {
+            Some(handle) => close_session_handle(handle).await,
+            None => Ok(()),
+        }
+    }
+
+    async fn create_stream(
+        &self,
+        session_id: &SessionId,
+        message: ClientJsonRpcMessage,
+    ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
+        let handle = self.session_handle(session_id).await?;
+        let receiver = handle.establish_request_wise_channel().await?;
+        let request_id = receiver.http_request_id;
+        handle.push_message(message, request_id).await?;
+        let priming = self.sessions.config.sse_retry.map(|retry| {
+            let event_id = request_id.map_or_else(|| "0".to_string(), |id| format!("0/{id}"));
+            ServerSseMessage::priming(event_id, retry)
+        });
+        Ok(futures::stream::iter(priming).chain(ReceiverStream::new(receiver.inner)))
+    }
+
+    async fn accept_message(
+        &self,
+        session_id: &SessionId,
+        message: ClientJsonRpcMessage,
+    ) -> Result<(), Self::Error> {
+        self.session_handle(session_id)
+            .await?
+            .push_message(message, None)
+            .await?;
+        Ok(())
+    }
+
+    async fn create_standalone_stream(
+        &self,
+        session_id: &SessionId,
+    ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
+        let receiver = self
+            .session_handle(session_id)
+            .await?
+            .establish_common_channel()
+            .await?;
+        Ok(ReceiverStream::new(receiver.inner))
+    }
+
+    async fn resume(
+        &self,
+        session_id: &SessionId,
+        last_event_id: String,
+    ) -> Result<impl Stream<Item = ServerSseMessage> + Send + Sync + 'static, Self::Error> {
+        let receiver = self
+            .session_handle(session_id)
+            .await?
+            .resume(last_event_id.parse()?)
+            .await?;
+        Ok(ReceiverStream::new(receiver.inner))
+    }
 }
 
 /// Configuration for the auth-disabled loopback MCP HTTP server.
@@ -146,9 +299,8 @@ impl McpHttpConfig {
 #[derive(Clone, Debug)]
 pub struct AuthenticatedMcpHttpConfig {
     bind_addr: SocketAddr,
-    resource_url: String,
+    public_url: String,
     authorization_server: String,
-    scope: String,
     metadata_path: String,
     challenge: HeaderValue,
     allowed_hosts: Vec<String>,
@@ -156,24 +308,20 @@ pub struct AuthenticatedMcpHttpConfig {
 
 impl AuthenticatedMcpHttpConfig {
     /// # Errors
-    /// Validates OAuth configuration, returning an error for unsafe URLs, scopes, or headers.
+    /// Validates OAuth configuration, returning an error for unsafe URLs or headers.
     pub fn new(
         bind_addr: SocketAddr,
-        resource_url: impl Into<String>,
+        public_url: impl Into<String>,
         authorization_server: impl Into<String>,
-        scope: impl Into<String>,
     ) -> Result<Self, McpHttpError> {
-        let resource = validated_oauth_url(&resource_url.into())?;
+        let resource = validated_oauth_url(&public_url.into())?;
         let authorization_server = validated_oauth_url(&authorization_server.into())?;
-        let scope = scope.into();
-        let valid = scope.bytes().all(|b| matches!(b, 33 | 35..=91 | 93..=126));
-        if scope.is_empty() || !valid {
-            return Err(McpHttpError::InvalidAuthConfig("invalid OAuth scope"));
-        }
         let (metadata_url, metadata_path) = protected_resource_metadata_url(&resource);
-        let challenge = format!("Bearer resource_metadata=\"{metadata_url}\", scope=\"{scope}\"");
+        let challenge = format!("Bearer resource_metadata=\"{metadata_url}\"");
         let challenge = HeaderValue::from_str(&challenge)
             .map_err(|_error| McpHttpError::InvalidAuthConfig("invalid challenge header"))?;
+        let public_url = canonical_oauth_identifier(&resource);
+        let authorization_server = canonical_oauth_identifier(&authorization_server);
         let mut allowed_hosts = vec![
             "localhost".to_string(),
             "127.0.0.1".to_string(),
@@ -191,9 +339,8 @@ impl AuthenticatedMcpHttpConfig {
         }
         Ok(Self {
             bind_addr,
-            resource_url: resource.to_string(),
-            authorization_server: authorization_server.to_string(),
-            scope,
+            public_url,
+            authorization_server,
             metadata_path,
             challenge,
             allowed_hosts,
@@ -208,7 +355,6 @@ pub struct AuthenticatedMcpHttpRuntime {
     session_client_factory: SessionClientFactory,
     options: McpOptions,
     readiness: ReadinessProbe,
-    session_bindings: Arc<dyn SessionBindingStore>,
 }
 
 impl AuthenticatedMcpHttpRuntime {
@@ -233,19 +379,7 @@ impl AuthenticatedMcpHttpRuntime {
             session_client_factory: Arc::new(move |token| Box::pin(session_client_factory(token))),
             options,
             readiness: ReadinessProbe(Arc::new(move || Box::pin(readiness()))),
-            session_bindings: Arc::new(InMemorySessionBindingStore::default()),
         }
-    }
-
-    /// Configures storage for binding MCP sessions to authorization contexts.
-    ///
-    /// This store protects the authorization association for each MCP session.
-    /// Live MCP handlers remain process-local, so deployments must use
-    /// process-sticky routing.
-    #[must_use]
-    pub fn with_session_binding_store(mut self, store: Arc<dyn SessionBindingStore>) -> Self {
-        self.session_bindings = store;
-        self
     }
 }
 
@@ -271,6 +405,13 @@ fn validated_oauth_url(value: &str) -> Result<Url, McpHttpError> {
         ));
     }
     Ok(url)
+}
+
+fn canonical_oauth_identifier(url: &Url) -> String {
+    match url.path() {
+        "/" => url[..Position::BeforePath].to_string(),
+        _ => url.to_string(),
+    }
 }
 
 fn protected_resource_metadata_url(resource: &Url) -> (String, String) {
@@ -359,7 +500,7 @@ impl RunningMcpHttpServer {
         let state = self.state.clone();
         let drain = async {
             let quiescence = state.requests.write().await;
-            close_sessions(state.sessions.as_ref()).await;
+            state.sessions.close_all().await;
             drop(quiescence);
             (&mut self.task).await
         };
@@ -386,13 +527,6 @@ fn join_server(
         .map_err(McpHttpError::Server)
 }
 
-async fn close_sessions(sessions: &LocalSessionManager) {
-    let ids: Vec<_> = sessions.sessions.read().await.keys().cloned().collect();
-    for id in ids {
-        let _close_result = sessions.close_session(&id).await;
-    }
-}
-
 /// Starts the loopback-only, authentication-disabled MCP HTTP server.
 ///
 /// The supplied unauthenticated client is shared across independent MCP
@@ -416,23 +550,12 @@ pub async fn start_auth_disabled(
     let local_addr = listener.local_addr().map_err(McpHttpError::Server)?;
     let readiness = ReadinessProbe::from_app(app.clone());
     let (router, state) = auth_disabled_router(app, options, readiness, local_addr.ip());
-    let (shutdown_tx, shutdown_rx) = oneshot::channel();
-    let task_state = state.clone();
-    let task = tokio::spawn(async move {
-        let result = axum::serve(listener, router)
-            .with_graceful_shutdown(async move {
-                let _shutdown_result = shutdown_rx.await;
-            })
-            .await;
-        close_sessions(task_state.sessions.as_ref()).await;
-        result
-    });
-    Ok(RunningMcpHttpServer {
+    Ok(spawn_http_server(
+        listener,
         local_addr,
-        shutdown: Some(shutdown_tx),
-        task,
-        state,
-    })
+        router,
+        state.server.clone(),
+    ))
 }
 
 /// Starts authenticated serving; fails when the listener cannot bind.
@@ -450,20 +573,37 @@ pub async fn start_authenticated(
         })?;
     let local_addr = listener.local_addr().map_err(McpHttpError::Server)?;
     let (router, state) = authenticated_router(config, runtime);
+    Ok(spawn_http_server(
+        listener,
+        local_addr,
+        router,
+        state.server.clone(),
+    ))
+}
+
+fn spawn_http_server(
+    listener: TcpListener,
+    local_addr: SocketAddr,
+    router: Router,
+    state: Arc<ServerState>,
+) -> RunningMcpHttpServer {
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let task_state = state.clone();
     let task = tokio::spawn(async move {
-        axum::serve(listener, router)
+        let result = axum::serve(listener, router)
             .with_graceful_shutdown(async move {
                 let _shutdown_result = shutdown_rx.await;
             })
-            .await
+            .await;
+        task_state.sessions.close_all().await;
+        result
     });
-    Ok(RunningMcpHttpServer {
+    RunningMcpHttpServer {
         local_addr,
         shutdown: Some(shutdown_tx),
         task,
         state,
-    })
+    }
 }
 
 #[derive(Clone)]
@@ -497,19 +637,20 @@ fn auth_disabled_router(
     options: McpOptions,
     readiness: ReadinessProbe,
     advertised_ip: IpAddr,
-) -> (Router, Arc<ServerState>) {
+) -> (Router, Arc<HttpState>) {
     let factory = CoralMcpServerFactory::new(app, options);
     let config =
         StreamableHttpServerConfig::default().with_allowed_hosts([advertised_ip.to_string()]);
     let sessions = Arc::new(LocalSessionManager::default());
     let server = Arc::new(ServerState {
-        sessions,
+        sessions: SessionOwner::Local(sessions.clone()),
         config,
         requests: RwLock::new(()),
     });
     let state = Arc::new(HttpState {
         factory,
         readiness,
+        sessions,
         server: server.clone(),
     });
     let router = Router::new()
@@ -517,23 +658,46 @@ fn auth_disabled_router(
         .route("/livez", get(livez))
         .route("/readyz", get(readyz))
         .with_state(state.clone());
-    (router, server)
+    (router, state)
 }
 
 struct HttpState {
     factory: CoralMcpServerFactory,
     readiness: ReadinessProbe,
+    sessions: Arc<LocalSessionManager>,
     server: Arc<ServerState>,
 }
 
+enum SessionOwner {
+    Local(Arc<LocalSessionManager>),
+    Authenticated(Arc<AuthenticatedSessions>),
+}
+
+impl SessionOwner {
+    async fn close_all(&self) {
+        match self {
+            Self::Local(sessions) => {
+                let session_ids: Vec<_> = sessions.sessions.read().await.keys().cloned().collect();
+                for session_id in session_ids {
+                    let _close_result = sessions.close_session(&session_id).await;
+                }
+            }
+            Self::Authenticated(sessions) => sessions.close_all().await,
+        }
+    }
+}
+
 struct ServerState {
-    sessions: Arc<LocalSessionManager>,
+    sessions: SessionOwner,
     config: StreamableHttpServerConfig,
     requests: RwLock<()>,
 }
 
 async fn mcp(State(state): State<Arc<HttpState>>, request: Request<Body>) -> Response {
     let _request = state.server.requests.read().await;
+    if request.headers().contains_key(header::ORIGIN) {
+        return StatusCode::FORBIDDEN.into_response();
+    }
     let request = tokio::select! {
         biased;
         () = state.server.config.cancellation_token.cancelled() => {
@@ -547,16 +711,13 @@ async fn mcp(State(state): State<Arc<HttpState>>, request: Request<Body>) -> Res
     serve_mcp_request(
         request,
         Some(state.factory.clone()),
-        state.server.sessions.clone(),
+        state.sessions.clone(),
         state.server.config.clone(),
     )
     .await
 }
 
 async fn validate_mcp_request(request: Request<Body>) -> Result<Request<Body>, Response> {
-    if request.headers().contains_key(header::ORIGIN) {
-        return Err(StatusCode::FORBIDDEN.into_response());
-    }
     if request.method() != Method::POST {
         return Ok(request);
     }
@@ -603,17 +764,19 @@ fn initialize_protocol_header_matches(headers: &HeaderMap, body_protocol: &str) 
 fn authenticated_router(
     config: AuthenticatedMcpHttpConfig,
     runtime: AuthenticatedMcpHttpRuntime,
-) -> (Router, Arc<ServerState>) {
+) -> (Router, AuthState) {
     let streamable_config =
         StreamableHttpServerConfig::default().with_allowed_hosts(config.allowed_hosts.clone());
+    let sessions = Arc::new(AuthenticatedSessions::default());
     let server = Arc::new(ServerState {
-        sessions: Arc::new(LocalSessionManager::default()),
+        sessions: SessionOwner::Authenticated(sessions.clone()),
         config: streamable_config,
         requests: RwLock::new(()),
     });
     let state = Arc::new(AuthenticatedHttpState {
         config,
         runtime,
+        sessions,
         server: server.clone(),
     });
     let router = Router::new()
@@ -623,17 +786,21 @@ fn authenticated_router(
         .route(METADATA_ROOT, get(metadata))
         .route(METADATA_ROUTE, get(metadata))
         .with_state(state.clone());
-    (router, server)
+    (router, state)
 }
 
 struct AuthenticatedHttpState {
     config: AuthenticatedMcpHttpConfig,
     runtime: AuthenticatedMcpHttpRuntime,
+    sessions: Arc<AuthenticatedSessions>,
     server: Arc<ServerState>,
 }
 
 async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body>) -> Response {
     let _request = state.server.requests.read().await;
+    if request.headers().contains_key(header::ORIGIN) {
+        return StatusCode::FORBIDDEN.into_response();
+    }
     if request.method() == Method::OPTIONS {
         return StatusCode::NO_CONTENT.into_response();
     }
@@ -648,87 +815,40 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
     if validation.is_err() {
         return unauthorized_response(&state.config);
     }
+    let request = tokio::select! {
+        biased;
+        () = state.server.config.cancellation_token.cancelled() => {
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+        request = validate_mcp_request(request) => match request {
+            Ok(request) => request,
+            Err(response) => return response,
+        },
+    };
     let binding_fingerprint = binding_fingerprint(&token);
     let request_session = match session_id(request.headers()) {
         Ok(session) => session.map(str::to_string),
         Err(()) => return StatusCode::BAD_REQUEST.into_response(),
     };
-    let closes_session = request.method() == Method::DELETE;
-    let request = if request_session.is_none() {
-        tokio::select! {
-            biased;
-            () = state.server.config.cancellation_token.cancelled() => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
-            request = initialize_request(request) => match request {
-                Ok(request) => request,
-                Err(response) => return response,
-            },
-        }
-    } else {
-        request
-    };
+    let sessions = Arc::new(AuthenticatedSessionManager {
+        sessions: state.sessions.clone(),
+        fingerprint: binding_fingerprint,
+    });
     let factory = if let Some(session_id) = request_session.as_deref() {
         if let Err(status) = authorize_bound_session(&state, session_id, &binding_fingerprint).await
         {
             return status.into_response();
         }
         None
-    } else {
+    } else if request.method() == Method::POST {
         match create_session_factory(&state, token).await {
             Ok(factory) => Some(factory),
             Err(status) => return status.into_response(),
         }
+    } else {
+        None
     };
-    let response = serve_mcp_request(
-        request,
-        factory,
-        state.server.sessions.clone(),
-        state.server.config.clone(),
-    )
-    .await;
-    finalize_authenticated_response(
-        &state,
-        request_session.as_deref(),
-        binding_fingerprint,
-        closes_session,
-        response,
-    )
-    .await
-}
-
-async fn finalize_authenticated_response(
-    state: &AuthenticatedHttpState,
-    request_session: Option<&str>,
-    binding_fingerprint: SessionBindingFingerprint,
-    closes_session: bool,
-    response: Response,
-) -> Response {
-    if request_session.is_none()
-        && response.status().is_success()
-        && let Ok(Some(session_id)) = session_id(response.headers())
-    {
-        if let Err(_error) = state
-            .runtime
-            .session_bindings
-            .bind(session_id, binding_fingerprint)
-            .await
-        {
-            remove_managed_session(state.server.as_ref(), session_id).await;
-            let _remove_result = state.runtime.session_bindings.remove(session_id).await;
-            return StatusCode::SERVICE_UNAVAILABLE.into_response();
-        }
-    } else if (closes_session && response.status().is_success()
-        || response.status() == StatusCode::NOT_FOUND)
-        && let Some(session_id) = request_session
-        && state
-            .runtime
-            .session_bindings
-            .remove(session_id)
-            .await
-            .is_err()
-    {
-        return StatusCode::SERVICE_UNAVAILABLE.into_response();
-    }
-    response
+    serve_mcp_request(request, factory, sessions, state.server.config.clone()).await
 }
 
 async fn create_session_factory(
@@ -749,55 +869,15 @@ async fn create_session_factory(
 async fn authorize_bound_session(
     state: &AuthenticatedHttpState,
     session_id: &str,
-    fingerprint: &SessionBindingFingerprint,
+    fingerprint: &BearerFingerprint,
 ) -> Result<(), StatusCode> {
-    let status = state
-        .runtime
-        .session_bindings
-        .authorize_and_touch(session_id, fingerprint)
-        .await
-        .map_err(|_error| StatusCode::SERVICE_UNAVAILABLE)?;
-    if status == SessionBindingStatus::Missing {
-        remove_managed_session(state.server.as_ref(), session_id).await;
-    }
+    let session_id = Arc::from(session_id);
+    let status = state.sessions.authorize(&session_id, fingerprint).await;
     match status {
-        SessionBindingStatus::Authorized => Ok(()),
-        SessionBindingStatus::Missing => Err(StatusCode::NOT_FOUND),
-        SessionBindingStatus::Mismatch => Err(StatusCode::FORBIDDEN),
+        SessionAuthorization::Authorized => Ok(()),
+        SessionAuthorization::Missing => Err(StatusCode::NOT_FOUND),
+        SessionAuthorization::Mismatch => Err(StatusCode::FORBIDDEN),
     }
-}
-
-async fn initialize_request(request: Request<Body>) -> Result<Request<Body>, Response> {
-    let (parts, body) = request.into_parts();
-    let mut protocols = parts.headers.get_all("mcp-protocol-version").iter();
-    let protocol = protocols.next();
-    let versions = ProtocolVersion::KNOWN_VERSIONS;
-    if protocols.next().is_some()
-        || protocol.is_some_and(|header| !versions.iter().any(|v| header == v.as_str()))
-    {
-        return Err(StatusCode::BAD_REQUEST.into_response());
-    }
-    let bytes = axum::body::to_bytes(body, 1_048_576)
-        .await
-        .map_err(|_error| StatusCode::PAYLOAD_TOO_LARGE.into_response())?;
-    let Ok(ClientJsonRpcMessage::Request(request)) =
-        serde_json::from_slice::<ClientJsonRpcMessage>(&bytes)
-    else {
-        return Err(StatusCode::UNPROCESSABLE_ENTITY.into_response());
-    };
-    let ClientRequest::InitializeRequest(initialize) = request.request else {
-        return Err(StatusCode::UNPROCESSABLE_ENTITY.into_response());
-    };
-    let body_protocol = initialize.params.protocol_version.as_str();
-    let supported = versions.iter().any(|v| v.as_str() == body_protocol);
-    if !supported || protocol.is_some_and(|header| header != body_protocol) {
-        return Err(StatusCode::BAD_REQUEST.into_response());
-    }
-    Ok(Request::from_parts(parts, Body::from(bytes)))
-}
-
-async fn remove_managed_session(server: &ServerState, id: &str) {
-    let _close_result = server.sessions.close_session(&Arc::from(id)).await;
 }
 
 async fn authenticated_readyz(State(state): State<Arc<AuthenticatedHttpState>>) -> StatusCode {
@@ -815,9 +895,8 @@ async fn metadata(State(state): State<AuthState>, uri: Uri) -> Response {
     (
         [(header::CONTENT_TYPE, "application/json")],
         json!({
-            "resource": state.config.resource_url,
+            "resource": state.config.public_url,
             "authorization_servers": [state.config.authorization_server],
-            "scopes_supported": [state.config.scope],
             "bearer_methods_supported": ["header"],
         })
         .to_string(),
@@ -862,105 +941,22 @@ fn session_id(headers: &HeaderMap) -> Result<Option<&str>, ()> {
     Ok(Some(value))
 }
 
-fn binding_fingerprint(token: &str) -> SessionBindingFingerprint {
-    SessionBindingFingerprint(Sha256::digest(token.as_bytes()).into())
-}
-
-#[async_trait]
-impl SessionBindingStore for InMemorySessionBindingStore {
-    async fn bind(
-        &self,
-        session_id: &str,
-        fingerprint: SessionBindingFingerprint,
-    ) -> Result<(), SessionBindingStoreError> {
-        let mut bindings = self.bindings.lock().await;
-        insert_session_binding(&mut bindings, session_id, fingerprint, Instant::now());
-        Ok(())
-    }
-
-    async fn authorize_and_touch(
-        &self,
-        session_id: &str,
-        fingerprint: &SessionBindingFingerprint,
-    ) -> Result<SessionBindingStatus, SessionBindingStoreError> {
-        let mut bindings = self.bindings.lock().await;
-        Ok(authorize_session_binding(
-            &mut bindings,
-            session_id,
-            fingerprint,
-            Instant::now(),
-        ))
-    }
-
-    async fn remove(&self, session_id: &str) -> Result<(), SessionBindingStoreError> {
-        self.bindings.lock().await.remove(session_id);
-        Ok(())
-    }
-}
-
-fn insert_session_binding(
-    bindings: &mut HashMap<String, InMemorySessionBinding>,
-    session_id: &str,
-    fingerprint: SessionBindingFingerprint,
-    now: Instant,
-) {
-    prune_expired_session_bindings(bindings, now);
-    if !bindings.contains_key(session_id)
-        && bindings.len() >= MAX_BOUND_SESSIONS
-        && let Some(oldest) = bindings
-            .iter()
-            .min_by_key(|(_, binding)| binding.last_seen)
-            .map(|(session_id, _)| session_id.clone())
-    {
-        bindings.remove(&oldest);
-    }
-    let binding = InMemorySessionBinding {
-        fingerprint,
-        last_seen: now,
-    };
-    bindings.insert(session_id.to_string(), binding);
-}
-
-fn authorize_session_binding(
-    bindings: &mut HashMap<String, InMemorySessionBinding>,
-    session_id: &str,
-    fingerprint: &SessionBindingFingerprint,
-    now: Instant,
-) -> SessionBindingStatus {
-    let Some(binding) = bindings.get(session_id) else {
-        return SessionBindingStatus::Missing;
-    };
-    if now.saturating_duration_since(binding.last_seen) > BOUND_SESSION_IDLE_TIMEOUT {
-        bindings.remove(session_id);
-        return SessionBindingStatus::Missing;
-    }
-    if binding.fingerprint != *fingerprint {
-        return SessionBindingStatus::Mismatch;
-    }
-    if let Some(binding) = bindings.get_mut(session_id) {
-        binding.last_seen = now;
-    }
-    SessionBindingStatus::Authorized
-}
-
-fn prune_expired_session_bindings(
-    bindings: &mut HashMap<String, InMemorySessionBinding>,
-    now: Instant,
-) {
-    bindings.retain(|_session_id, binding| {
-        now.saturating_duration_since(binding.last_seen) <= BOUND_SESSION_IDLE_TIMEOUT
-    });
+fn binding_fingerprint(token: &str) -> BearerFingerprint {
+    BearerFingerprint(Sha256::digest(token.as_bytes()).into())
 }
 
 // The service wrapper is intentionally request-scoped. Auth-required routing
 // can validate an initialize request and pass its bearer-bound factory here,
 // while later requests reuse the handler already held by `sessions`.
-async fn serve_mcp_request(
+async fn serve_mcp_request<M>(
     request: Request<Body>,
     factory: Option<CoralMcpServerFactory>,
-    sessions: Arc<LocalSessionManager>,
+    sessions: Arc<M>,
     config: StreamableHttpServerConfig,
-) -> Response {
+) -> Response
+where
+    M: SessionManager,
+{
     let cancellation = config.cancellation_token.clone();
     let service = StreamableHttpService::new(
         move || {

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -1,35 +1,41 @@
-//! Loopback Streamable HTTP transport for Coral's MCP surface.
+//! Streamable HTTP transport for Coral's MCP surface.
 //!
 //! [`start_auth_disabled`] is intentionally limited to loopback. It shares an
 //! unauthenticated local [`coral_client::AppClient`] across sessions and is not
 //! a safe construction path for a long-running, non-loopback server.
 
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::Router;
 use axum::body::Body;
 use axum::extract::State;
-use axum::http::{HeaderMap, Method, Request, StatusCode, header};
+use axum::http::{HeaderMap, HeaderValue, Method, Request, StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{any, get};
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use coral_api::v1::{CatalogItemKind, ListCatalogRequest, PaginationRequest};
 use coral_client::{AppClient, default_workspace};
-use rmcp::model::{ClientJsonRpcMessage, ClientRequest};
+use rmcp::model::{ClientJsonRpcMessage, ClientRequest, ProtocolVersion};
 use rmcp::transport::common::http_header::HEADER_MCP_PROTOCOL_VERSION;
 use rmcp::transport::streamable_http_server::{
     StreamableHttpServerConfig, StreamableHttpService, session::SessionManager,
     session::local::LocalSessionManager,
 };
+use serde_json::json;
+use sha2::{Digest, Sha256};
 use tokio::net::TcpListener;
-use tokio::sync::{RwLock, oneshot};
+use tokio::sync::{Mutex, RwLock, oneshot};
 use tokio::task::JoinHandle;
 use tonic::Request as GrpcRequest;
 use tower::ServiceExt;
+use url::{Host, Position, Url};
 
 use crate::{CoralMcpServerFactory, McpOptions};
 
@@ -37,8 +43,17 @@ const READINESS_TIMEOUT: Duration = Duration::from_secs(2);
 const SHUTDOWN_GRACE_PERIOD: Duration = Duration::from_secs(1);
 const MAX_MCP_REQUEST_BODY_SIZE: usize = 1_048_576;
 const SESSION_ID_HEADER: &str = "mcp-session-id";
+const METADATA_ROOT: &str = "/.well-known/oauth-protected-resource";
+const METADATA_ROUTE: &str = "/.well-known/oauth-protected-resource/{*resource_path}";
+const MAX_BOUND_SESSIONS: usize = 4096;
+const BOUND_SESSION_IDLE_TIMEOUT: Duration = Duration::from_hours(1);
 
 type ProbeFuture = Pin<Box<dyn Future<Output = Result<(), tonic::Code>> + Send>>;
+type Fut<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+type TokenValidator = Arc<dyn Fn(String) -> Fut<Result<(), ()>> + Send + Sync>;
+type SessionClientFactory = Arc<dyn Fn(String) -> Fut<Result<AppClient, ()>> + Send + Sync>;
+type AuthState = Arc<AuthenticatedHttpState>;
+type BoundSessions = Arc<Mutex<BTreeMap<String, BoundSession>>>;
 
 /// Configuration for the auth-disabled loopback MCP HTTP server.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -66,6 +81,132 @@ impl McpHttpConfig {
     }
 }
 
+/// Validated OAuth protected-resource configuration.
+#[derive(Clone, Debug)]
+pub struct AuthenticatedMcpHttpConfig {
+    bind_addr: SocketAddr,
+    resource_url: String,
+    authorization_server: String,
+    scope: String,
+    metadata_path: String,
+    challenge: HeaderValue,
+    allowed_hosts: Vec<String>,
+}
+
+impl AuthenticatedMcpHttpConfig {
+    /// # Errors
+    /// Validates OAuth configuration, returning an error for unsafe URLs, scopes, or headers.
+    pub fn new(
+        bind_addr: SocketAddr,
+        resource_url: impl Into<String>,
+        authorization_server: impl Into<String>,
+        scope: impl Into<String>,
+    ) -> Result<Self, McpHttpError> {
+        let resource = validated_oauth_url(&resource_url.into())?;
+        let authorization_server = validated_oauth_url(&authorization_server.into())?;
+        let scope = scope.into();
+        let valid = scope.bytes().all(|b| matches!(b, 33 | 35..=91 | 93..=126));
+        if scope.is_empty() || !valid {
+            return Err(McpHttpError::InvalidAuthConfig("invalid OAuth scope"));
+        }
+        let (metadata_url, metadata_path) = protected_resource_metadata_url(&resource);
+        let challenge = format!("Bearer resource_metadata=\"{metadata_url}\", scope=\"{scope}\"");
+        let challenge = HeaderValue::from_str(&challenge)
+            .map_err(|_error| McpHttpError::InvalidAuthConfig("invalid challenge header"))?;
+        let mut allowed_hosts = vec![
+            "localhost".to_string(),
+            "127.0.0.1".to_string(),
+            "::1".to_string(),
+            bind_addr.ip().to_string(),
+        ];
+        if let Some(host) = resource.host_str() {
+            allowed_hosts.push(host.to_string());
+        }
+        if allowed_hosts
+            .iter()
+            .any(|host| HeaderValue::from_str(host).is_err())
+        {
+            return Err(McpHttpError::InvalidAuthConfig("invalid allowed Host"));
+        }
+        Ok(Self {
+            bind_addr,
+            resource_url: resource.to_string(),
+            authorization_server: authorization_server.to_string(),
+            scope,
+            metadata_path,
+            challenge,
+            allowed_hosts,
+        })
+    }
+}
+
+/// Authenticated callbacks supplied by the composition root.
+#[derive(Clone)]
+pub struct AuthenticatedMcpHttpRuntime {
+    validator: TokenValidator,
+    session_client_factory: SessionClientFactory,
+    options: McpOptions,
+    readiness: ReadinessProbe,
+}
+
+impl AuthenticatedMcpHttpRuntime {
+    /// Creates a runtime whose client factory MUST forward its bearer.
+    pub fn new<V, VF, F, FF, R, RF>(
+        validator: V,
+        session_client_factory: F,
+        options: McpOptions,
+        readiness: R,
+    ) -> Self
+    where
+        V: Fn(String) -> VF + Send + Sync + 'static,
+        VF: Future<Output = Result<(), ()>> + Send + 'static,
+        F: Fn(String) -> FF + Send + Sync + 'static,
+        FF: Future<Output = Result<AppClient, ()>> + Send + 'static,
+        R: Fn() -> RF + Send + Sync + 'static,
+        RF: Future<Output = Result<(), tonic::Code>> + Send + 'static,
+    {
+        Self {
+            validator: Arc::new(move |token| Box::pin(validator(token))),
+            session_client_factory: Arc::new(move |token| Box::pin(session_client_factory(token))),
+            options,
+            readiness: ReadinessProbe(Arc::new(move || Box::pin(readiness()))),
+        }
+    }
+}
+
+fn validated_oauth_url(value: &str) -> Result<Url, McpHttpError> {
+    let url =
+        Url::parse(value).map_err(|_error| McpHttpError::InvalidAuthConfig("invalid OAuth URL"))?;
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.fragment().is_some()
+        || url.query().is_some()
+    {
+        return Err(McpHttpError::InvalidAuthConfig("unsafe OAuth URL"));
+    }
+    let loopback = match url.host() {
+        Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(Host::Ipv6(ip)) => is_loopback(IpAddr::V6(ip)),
+        None => false,
+    };
+    if url.scheme() != "https" && !(url.scheme() == "http" && loopback) {
+        return Err(McpHttpError::InvalidAuthConfig(
+            "OAuth URL must use HTTPS or loopback HTTP",
+        ));
+    }
+    Ok(url)
+}
+
+fn protected_resource_metadata_url(resource: &Url) -> (String, String) {
+    let resource_path = match resource.path() {
+        "/" => "",
+        path => path,
+    };
+    let path = format!("{METADATA_ROOT}{resource_path}");
+    (format!("{}{path}", &resource[..Position::BeforePath]), path)
+}
+
 fn is_loopback(ip: IpAddr) -> bool {
     ip.is_loopback()
         || matches!(ip, IpAddr::V6(ip) if ip.to_ipv4_mapped().is_some_and(|ip| ip.is_loopback()))
@@ -77,6 +218,9 @@ pub enum McpHttpError {
     /// Auth-disabled serving is restricted to the local machine.
     #[error("auth-disabled MCP HTTP bind must be loopback, got {0}")]
     NonLoopbackBind(SocketAddr),
+    /// Authenticated serving configuration is invalid.
+    #[error("invalid authenticated MCP HTTP configuration: {0}")]
+    InvalidAuthConfig(&'static str),
     /// The TCP listener could not bind.
     #[error("failed to bind MCP HTTP server to {address}")]
     Bind {
@@ -97,7 +241,7 @@ pub enum McpHttpError {
     ShutdownTimedOut,
 }
 
-/// Handle for a running auth-disabled MCP HTTP server.
+/// Handle for a running MCP HTTP server.
 ///
 /// Call [`RunningMcpHttpServer::shutdown`] for deterministic teardown. Dropping
 /// this handle cancels active HTTP work and closes sessions asynchronously.
@@ -105,7 +249,7 @@ pub struct RunningMcpHttpServer {
     local_addr: SocketAddr,
     shutdown: Option<oneshot::Sender<()>>,
     task: JoinHandle<Result<(), io::Error>>,
-    state: Arc<HttpState>,
+    state: Arc<ServerState>,
 }
 
 impl RunningMcpHttpServer {
@@ -216,6 +360,37 @@ pub async fn start_auth_disabled(
     })
 }
 
+/// Starts authenticated serving; fails when the listener cannot bind.
+/// # Errors
+/// Returns an error when the listener cannot bind.
+pub async fn start_authenticated(
+    config: AuthenticatedMcpHttpConfig,
+    runtime: AuthenticatedMcpHttpRuntime,
+) -> Result<RunningMcpHttpServer, McpHttpError> {
+    let listener = TcpListener::bind(config.bind_addr)
+        .await
+        .map_err(|source| McpHttpError::Bind {
+            address: config.bind_addr,
+            source,
+        })?;
+    let local_addr = listener.local_addr().map_err(McpHttpError::Server)?;
+    let (router, state, _bindings) = authenticated_router(config, runtime);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async move {
+                let _shutdown_result = shutdown_rx.await;
+            })
+            .await
+    });
+    Ok(RunningMcpHttpServer {
+        local_addr,
+        shutdown: Some(shutdown_tx),
+        task,
+        state,
+    })
+}
+
 #[derive(Clone)]
 struct ReadinessProbe(Arc<dyn Fn() -> ProbeFuture + Send + Sync>);
 
@@ -247,39 +422,46 @@ fn auth_disabled_router(
     options: McpOptions,
     readiness: ReadinessProbe,
     advertised_ip: IpAddr,
-) -> (Router, Arc<HttpState>) {
+) -> (Router, Arc<ServerState>) {
     let factory = CoralMcpServerFactory::new(app, options);
     let config =
         StreamableHttpServerConfig::default().with_allowed_hosts([advertised_ip.to_string()]);
     let sessions = Arc::new(LocalSessionManager::default());
+    let server = Arc::new(ServerState {
+        sessions,
+        config,
+        requests: RwLock::new(()),
+    });
     let state = Arc::new(HttpState {
         factory,
-        sessions: sessions.clone(),
-        config,
         readiness,
-        requests: RwLock::new(()),
+        server: server.clone(),
     });
     let router = Router::new()
         .route("/mcp", any(mcp))
         .route("/livez", get(livez))
         .route("/readyz", get(readyz))
         .with_state(state.clone());
-    (router, state)
+    (router, server)
 }
 
 struct HttpState {
     factory: CoralMcpServerFactory,
+    readiness: ReadinessProbe,
+    server: Arc<ServerState>,
+}
+
+struct ServerState {
     sessions: Arc<LocalSessionManager>,
     config: StreamableHttpServerConfig,
-    readiness: ReadinessProbe,
     requests: RwLock<()>,
 }
 
 async fn mcp(State(state): State<Arc<HttpState>>, request: Request<Body>) -> Response {
-    let _request = state.requests.read().await;
+    let _request = state.server.requests.read().await;
     let request = tokio::select! {
         biased;
-        () = state.config.cancellation_token.cancelled() => {
+        () = state.server.config.cancellation_token.cancelled() => {
             return StatusCode::SERVICE_UNAVAILABLE.into_response();
         }
         request = validate_mcp_request(request) => match request {
@@ -290,8 +472,8 @@ async fn mcp(State(state): State<Arc<HttpState>>, request: Request<Body>) -> Res
     serve_mcp_request(
         request,
         state.factory.clone(),
-        state.sessions.clone(),
-        state.config.clone(),
+        state.server.sessions.clone(),
+        state.server.config.clone(),
     )
     .await
 }
@@ -343,6 +525,304 @@ fn initialize_protocol_header_matches(headers: &HeaderMap, body_protocol: &str) 
         })
 }
 
+fn authenticated_router(
+    config: AuthenticatedMcpHttpConfig,
+    runtime: AuthenticatedMcpHttpRuntime,
+) -> (Router, Arc<ServerState>, BoundSessions) {
+    let server = Arc::new(ServerState {
+        sessions: Arc::new(LocalSessionManager::default()),
+        config: StreamableHttpServerConfig::default()
+            .with_allowed_hosts(config.allowed_hosts.clone()),
+        requests: RwLock::new(()),
+    });
+    let state = Arc::new(AuthenticatedHttpState {
+        config,
+        runtime,
+        server: server.clone(),
+        bindings: Arc::new(Mutex::new(BTreeMap::new())),
+    });
+    let router = Router::new()
+        .route("/mcp", any(authenticated_mcp))
+        .route("/livez", get(livez))
+        .route("/readyz", get(authenticated_readyz))
+        .route(METADATA_ROOT, get(metadata))
+        .route(METADATA_ROUTE, get(metadata))
+        .with_state(state.clone());
+    (router, server, state.bindings.clone())
+}
+
+struct AuthenticatedHttpState {
+    config: AuthenticatedMcpHttpConfig,
+    runtime: AuthenticatedMcpHttpRuntime,
+    server: Arc<ServerState>,
+    bindings: BoundSessions,
+}
+
+struct BoundSession {
+    token_fingerprint: String,
+    last_seen: Instant,
+    factory: CoralMcpServerFactory,
+}
+
+async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body>) -> Response {
+    let _request = state.server.requests.read().await;
+    if request.method() == Method::OPTIONS {
+        return StatusCode::NO_CONTENT.into_response();
+    }
+    let Some(token) = bearer_token(request.headers()) else {
+        return unauthorized_response(&state.config);
+    };
+    let validation = tokio::select! {
+        biased;
+        () = state.server.config.cancellation_token.cancelled() => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
+        validation = (state.runtime.validator)(token.clone()) => validation,
+    };
+    if validation.is_err() {
+        return unauthorized_response(&state.config);
+    }
+    let token_fingerprint = fingerprint(&token);
+    let request_session = match session_id(request.headers()) {
+        Ok(session) => session.map(str::to_string),
+        Err(()) => return StatusCode::BAD_REQUEST.into_response(),
+    };
+    let request = if request_session.is_none() {
+        tokio::select! {
+            biased;
+            () = state.server.config.cancellation_token.cancelled() => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
+            request = initialize_request(request) => match request {
+                Ok(request) => request,
+                Err(response) => return response,
+            },
+        }
+    } else {
+        request
+    };
+    let factory = if let Some(session_id) = request_session.as_deref() {
+        match bound_factory(&state, session_id, &token_fingerprint).await {
+            Ok(factory) => factory,
+            Err(status) => return status.into_response(),
+        }
+    } else {
+        let client = tokio::select! {
+            biased;
+            () = state.server.config.cancellation_token.cancelled() => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
+            client = (state.runtime.session_client_factory)(token) => client,
+        };
+        match client {
+            Ok(client) => CoralMcpServerFactory::new(client, state.runtime.options.clone()),
+            Err(()) => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
+        }
+    };
+    let closes_session = request.method() == Method::DELETE;
+    let response = serve_mcp_request(
+        request,
+        factory.clone(),
+        state.server.sessions.clone(),
+        state.server.config.clone(),
+    )
+    .await;
+    if request_session.is_none()
+        && response.status().is_success()
+        && let Ok(Some(session_id)) = session_id(response.headers())
+    {
+        let mut bindings = state.bindings.lock().await;
+        let removed = insert_bound_session(
+            &mut bindings,
+            session_id,
+            token_fingerprint,
+            factory,
+            Instant::now(),
+        );
+        drop(bindings);
+        close_managed_sessions(state.server.sessions.as_ref(), removed).await;
+    } else if closes_session
+        && (response.status().is_success() || response.status() == StatusCode::NOT_FOUND)
+        && let Some(session_id) = request_session
+    {
+        state.bindings.lock().await.remove(&session_id);
+    }
+    response
+}
+
+async fn initialize_request(request: Request<Body>) -> Result<Request<Body>, Response> {
+    let (parts, body) = request.into_parts();
+    let mut protocols = parts.headers.get_all("mcp-protocol-version").iter();
+    let protocol = protocols.next();
+    let versions = ProtocolVersion::KNOWN_VERSIONS;
+    if protocols.next().is_some()
+        || protocol.is_some_and(|header| !versions.iter().any(|v| header == v.as_str()))
+    {
+        return Err(StatusCode::BAD_REQUEST.into_response());
+    }
+    let bytes = axum::body::to_bytes(body, 1_048_576)
+        .await
+        .map_err(|_error| StatusCode::PAYLOAD_TOO_LARGE.into_response())?;
+    let Ok(ClientJsonRpcMessage::Request(request)) =
+        serde_json::from_slice::<ClientJsonRpcMessage>(&bytes)
+    else {
+        return Err(StatusCode::UNPROCESSABLE_ENTITY.into_response());
+    };
+    let ClientRequest::InitializeRequest(initialize) = request.request else {
+        return Err(StatusCode::UNPROCESSABLE_ENTITY.into_response());
+    };
+    let body_protocol = initialize.params.protocol_version.as_str();
+    let supported = versions.iter().any(|v| v.as_str() == body_protocol);
+    if !supported || protocol.is_some_and(|header| header != body_protocol) {
+        return Err(StatusCode::BAD_REQUEST.into_response());
+    }
+    Ok(Request::from_parts(parts, Body::from(bytes)))
+}
+
+async fn bound_factory(
+    state: &AuthenticatedHttpState,
+    session_id: &str,
+    token_fingerprint: &str,
+) -> Result<CoralMcpServerFactory, StatusCode> {
+    let (expired, bound_fingerprint) = {
+        let mut bindings = state.bindings.lock().await;
+        let expired = prune_expired_bound_sessions(&mut bindings, Instant::now());
+        let fingerprint = bindings
+            .get(session_id)
+            .map(|binding| binding.token_fingerprint.clone());
+        (expired, fingerprint)
+    };
+    close_managed_sessions(state.server.sessions.as_ref(), expired).await;
+    let Some(bound_fingerprint) = bound_fingerprint else {
+        return Err(StatusCode::NOT_FOUND);
+    };
+    let managed = state
+        .server
+        .sessions
+        .has_session(&Arc::from(session_id))
+        .await
+        .map_err(|_error| StatusCode::INTERNAL_SERVER_ERROR)?;
+    if !managed {
+        state.bindings.lock().await.remove(session_id);
+        return Err(StatusCode::NOT_FOUND);
+    }
+    if bound_fingerprint != token_fingerprint {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    let mut bindings = state.bindings.lock().await;
+    let binding = bindings.get_mut(session_id).ok_or(StatusCode::NOT_FOUND)?;
+    binding.last_seen = Instant::now();
+    Ok(binding.factory.clone())
+}
+
+async fn close_managed_sessions(sessions: &LocalSessionManager, ids: Vec<String>) {
+    for id in ids {
+        let _close_result = sessions.close_session(&Arc::from(id)).await;
+    }
+}
+
+async fn authenticated_readyz(State(state): State<Arc<AuthenticatedHttpState>>) -> StatusCode {
+    tokio::select! {
+        biased;
+        () = state.server.config.cancellation_token.cancelled() => StatusCode::SERVICE_UNAVAILABLE,
+        status = readiness_status(&state.runtime.readiness, READINESS_TIMEOUT) => status,
+    }
+}
+
+async fn metadata(State(state): State<AuthState>, uri: Uri) -> Response {
+    if uri.path() != state.config.metadata_path {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    (
+        [(header::CONTENT_TYPE, "application/json")],
+        json!({
+            "resource": state.config.resource_url,
+            "authorization_servers": [state.config.authorization_server],
+            "scopes_supported": [state.config.scope],
+            "bearer_methods_supported": ["header"],
+        })
+        .to_string(),
+    )
+        .into_response()
+}
+
+fn unauthorized_response(config: &AuthenticatedMcpHttpConfig) -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        [(header::WWW_AUTHENTICATE, config.challenge.clone())],
+    )
+        .into_response()
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<String> {
+    let mut values = headers.get_all(header::AUTHORIZATION).iter();
+    let value = values.next()?.to_str().ok()?;
+    if values.next().is_some() || value.trim() != value {
+        return None;
+    }
+    let (scheme, token) = value.split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("Bearer")
+        || token.is_empty()
+        || token.contains(char::is_whitespace)
+    {
+        return None;
+    }
+    Some(token.to_string())
+}
+
+fn session_id(headers: &HeaderMap) -> Result<Option<&str>, ()> {
+    let mut values = headers.get_all(SESSION_ID_HEADER).iter();
+    let Some(value) = values.next() else {
+        return Ok(None);
+    };
+    let value = value.to_str().map_err(|_error| ())?;
+    let valid = !value.is_empty() && value.as_bytes().iter().all(u8::is_ascii_graphic);
+    if values.next().is_some() || !valid {
+        return Err(());
+    }
+    Ok(Some(value))
+}
+
+fn fingerprint(token: &str) -> String {
+    URL_SAFE_NO_PAD.encode(Sha256::digest(token.as_bytes()))
+}
+
+fn insert_bound_session(
+    sessions: &mut BTreeMap<String, BoundSession>,
+    session_id: &str,
+    token_fingerprint: String,
+    factory: CoralMcpServerFactory,
+    now: Instant,
+) -> Vec<String> {
+    let mut removed = prune_expired_bound_sessions(sessions, now);
+    if !sessions.contains_key(session_id)
+        && sessions.len() >= MAX_BOUND_SESSIONS
+        && let Some(oldest) = sessions
+            .iter()
+            .min_by_key(|(_, binding)| binding.last_seen)
+            .map(|(session_id, _)| session_id.clone())
+    {
+        sessions.remove(&oldest);
+        removed.push(oldest);
+    }
+    let binding = BoundSession {
+        token_fingerprint,
+        last_seen: now,
+        factory,
+    };
+    sessions.insert(session_id.to_string(), binding);
+    removed
+}
+
+fn prune_expired_bound_sessions(
+    sessions: &mut BTreeMap<String, BoundSession>,
+    now: Instant,
+) -> Vec<String> {
+    let mut expired = Vec::new();
+    sessions.retain(|session_id, binding| {
+        let active = now.saturating_duration_since(binding.last_seen) <= BOUND_SESSION_IDLE_TIMEOUT;
+        if !active {
+            expired.push(session_id.clone());
+        }
+        active
+    });
+    expired
+}
+
 // The service wrapper is intentionally request-scoped. Auth-required routing
 // can validate an initialize request and pass its bearer-bound factory here,
 // while later requests reuse the handler already held by `sessions`.
@@ -371,7 +851,7 @@ async fn livez() -> StatusCode {
 async fn readyz(State(state): State<Arc<HttpState>>) -> StatusCode {
     tokio::select! {
         biased;
-        () = state.config.cancellation_token.cancelled() => StatusCode::SERVICE_UNAVAILABLE,
+        () = state.server.config.cancellation_token.cancelled() => StatusCode::SERVICE_UNAVAILABLE,
         status = readiness_status(&state.readiness, READINESS_TIMEOUT) => status,
     }
 }

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -32,8 +32,9 @@ use rmcp::transport::{
         session::{
             ServerSseMessage, SessionId, SessionManager,
             local::{
-                LocalSessionHandle, LocalSessionManager, LocalSessionManagerError,
-                LocalSessionWorker, SessionConfig, SessionError, create_local_session,
+                EventIdParseError, LocalSessionHandle, LocalSessionManager,
+                LocalSessionManagerError, LocalSessionWorker, SessionConfig, SessionError,
+                create_local_session,
             },
         },
     },
@@ -41,7 +42,7 @@ use rmcp::transport::{
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use tokio::net::TcpListener;
-use tokio::sync::{RwLock, oneshot};
+use tokio::sync::{Mutex, OwnedSemaphorePermit, RwLock, Semaphore, oneshot};
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Request as GrpcRequest;
@@ -56,6 +57,8 @@ const SESSION_ID_HEADER: &str = "mcp-session-id";
 const METADATA_ROOT: &str = "/.well-known/oauth-protected-resource";
 const METADATA_ROUTE: &str = "/.well-known/oauth-protected-resource/{*resource_path}";
 const MAX_MCP_REQUEST_BODY_SIZE: usize = 1_048_576;
+const MAX_AUTHENTICATED_SESSIONS: usize = 4096;
+const AUTHENTICATED_SESSION_IDLE_TIMEOUT: Duration = Duration::from_hours(1);
 
 type ProbeFuture = Pin<Box<dyn Future<Output = Result<(), tonic::Code>> + Send>>;
 type Fut<T> = Pin<Box<dyn Future<Output = T> + Send>>;
@@ -76,20 +79,48 @@ enum SessionAuthorization {
 struct AuthenticatedSessions {
     records: RwLock<HashMap<SessionId, AuthenticatedSession>>,
     config: SessionConfig,
+    admission: Arc<Semaphore>,
 }
 
 struct AuthenticatedSession {
     fingerprint: BearerFingerprint,
     handle: LocalSessionHandle,
+    _admission_permit: OwnedSemaphorePermit,
 }
 
-#[derive(Clone)]
 struct AuthenticatedSessionManager {
     sessions: Arc<AuthenticatedSessions>,
     fingerprint: BearerFingerprint,
+    admission_permit: Mutex<Option<OwnedSemaphorePermit>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum AuthenticatedSessionManagerError {
+    #[error(transparent)]
+    Local(#[from] LocalSessionManagerError),
+    #[error(transparent)]
+    Session(#[from] SessionError),
+    #[error(transparent)]
+    EventId(#[from] EventIdParseError),
+    #[error("authenticated MCP session admission was not reserved")]
+    AdmissionNotReserved,
 }
 
 impl AuthenticatedSessions {
+    fn new(max_sessions: usize) -> Self {
+        let mut config = SessionConfig::default();
+        config.keep_alive = Some(AUTHENTICATED_SESSION_IDLE_TIMEOUT);
+        Self {
+            records: RwLock::new(HashMap::new()),
+            config,
+            admission: Arc::new(Semaphore::new(max_sessions)),
+        }
+    }
+
+    fn try_admit(&self) -> Option<OwnedSemaphorePermit> {
+        self.admission.clone().try_acquire_owned().ok()
+    }
+
     async fn authorize(
         &self,
         session_id: &SessionId,
@@ -107,14 +138,19 @@ impl AuthenticatedSessions {
     }
 
     async fn close_all(&self) {
-        let handles: Vec<_> = self
+        let sessions: Vec<_> = self
             .records
             .write()
             .await
             .drain()
-            .map(|(_session_id, session)| session.handle)
+            .map(|(_session_id, session)| session)
             .collect();
-        for handle in handles {
+        for AuthenticatedSession {
+            handle,
+            _admission_permit,
+            ..
+        } in sessions
+        {
             let _close_result = close_session_handle(handle).await;
         }
     }
@@ -123,14 +159,16 @@ impl AuthenticatedSessions {
     async fn len(&self) -> usize {
         self.records.read().await.len()
     }
+
+    #[cfg(test)]
+    fn available_permits(&self) -> usize {
+        self.admission.available_permits()
+    }
 }
 
 impl Default for AuthenticatedSessions {
     fn default() -> Self {
-        Self {
-            records: RwLock::new(HashMap::new()),
-            config: SessionConfig::default(),
-        }
+        Self::new(MAX_AUTHENTICATED_SESSIONS)
     }
 }
 
@@ -145,7 +183,7 @@ impl AuthenticatedSessionManager {
     async fn session_handle(
         &self,
         session_id: &SessionId,
-    ) -> Result<LocalSessionHandle, LocalSessionManagerError> {
+    ) -> Result<LocalSessionHandle, AuthenticatedSessionManagerError> {
         self.sessions
             .records
             .read()
@@ -153,16 +191,22 @@ impl AuthenticatedSessionManager {
             .get(session_id)
             .filter(|session| session.fingerprint == self.fingerprint)
             .map(|session| session.handle.clone())
-            .ok_or_else(|| LocalSessionManagerError::SessionNotFound(session_id.clone()))
+            .ok_or_else(|| LocalSessionManagerError::SessionNotFound(session_id.clone()).into())
     }
 }
 
 impl SessionManager for AuthenticatedSessionManager {
-    type Error = LocalSessionManagerError;
+    type Error = AuthenticatedSessionManagerError;
     type Transport = WorkerTransport<LocalSessionWorker>;
 
     async fn create_session(&self) -> Result<(SessionId, Self::Transport), Self::Error> {
         let mut records = self.sessions.records.write().await;
+        let admission_permit = self
+            .admission_permit
+            .try_lock()
+            .map_err(|_error| AuthenticatedSessionManagerError::AdmissionNotReserved)?
+            .take()
+            .ok_or(AuthenticatedSessionManagerError::AdmissionNotReserved)?;
         let session_id = new_session_id();
         let (handle, worker) =
             create_local_session(session_id.clone(), self.sessions.config.clone());
@@ -171,6 +215,7 @@ impl SessionManager for AuthenticatedSessionManager {
             AuthenticatedSession {
                 fingerprint: self.fingerprint,
                 handle,
+                _admission_permit: admission_permit,
             },
         );
         drop(records);
@@ -197,20 +242,24 @@ impl SessionManager for AuthenticatedSessionManager {
     }
 
     async fn close_session(&self, session_id: &SessionId) -> Result<(), Self::Error> {
-        let handle = {
+        let session = {
             let mut records = self.sessions.records.write().await;
             match records.get(session_id) {
                 None => None,
                 Some(session) if session.fingerprint != self.fingerprint => {
-                    return Err(LocalSessionManagerError::SessionNotFound(
-                        session_id.clone(),
-                    ));
+                    return Err(
+                        LocalSessionManagerError::SessionNotFound(session_id.clone()).into(),
+                    );
                 }
-                Some(_) => records.remove(session_id).map(|session| session.handle),
+                Some(_) => records.remove(session_id),
             }
         };
-        match handle {
-            Some(handle) => close_session_handle(handle).await,
+        match session {
+            Some(AuthenticatedSession {
+                handle,
+                _admission_permit,
+                ..
+            }) => Ok(close_session_handle(handle).await?),
             None => Ok(()),
         }
     }
@@ -765,9 +814,16 @@ fn authenticated_router(
     config: AuthenticatedMcpHttpConfig,
     runtime: AuthenticatedMcpHttpRuntime,
 ) -> (Router, AuthState) {
+    authenticated_router_with_sessions(config, runtime, Arc::new(AuthenticatedSessions::default()))
+}
+
+fn authenticated_router_with_sessions(
+    config: AuthenticatedMcpHttpConfig,
+    runtime: AuthenticatedMcpHttpRuntime,
+    sessions: Arc<AuthenticatedSessions>,
+) -> (Router, AuthState) {
     let streamable_config =
         StreamableHttpServerConfig::default().with_allowed_hosts(config.allowed_hosts.clone());
-    let sessions = Arc::new(AuthenticatedSessions::default());
     let server = Arc::new(ServerState {
         sessions: SessionOwner::Authenticated(sessions.clone()),
         config: streamable_config,
@@ -830,24 +886,28 @@ async fn authenticated_mcp(State(state): State<AuthState>, request: Request<Body
         Ok(session) => session.map(str::to_string),
         Err(()) => return StatusCode::BAD_REQUEST.into_response(),
     };
-    let sessions = Arc::new(AuthenticatedSessionManager {
-        sessions: state.sessions.clone(),
-        fingerprint: binding_fingerprint,
-    });
-    let factory = if let Some(session_id) = request_session.as_deref() {
+    let (factory, admission_permit) = if let Some(session_id) = request_session.as_deref() {
         if let Err(status) = authorize_bound_session(&state, session_id, &binding_fingerprint).await
         {
             return status.into_response();
         }
-        None
+        (None, None)
     } else if request.method() == Method::POST {
+        let Some(admission_permit) = state.sessions.try_admit() else {
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        };
         match create_session_factory(&state, token).await {
-            Ok(factory) => Some(factory),
+            Ok(factory) => (Some(factory), Some(admission_permit)),
             Err(status) => return status.into_response(),
         }
     } else {
-        None
+        (None, None)
     };
+    let sessions = Arc::new(AuthenticatedSessionManager {
+        sessions: state.sessions.clone(),
+        fingerprint: binding_fingerprint,
+        admission_permit: Mutex::new(admission_permit),
+    });
     serve_mcp_request(request, factory, sessions, state.server.config.clone()).await
 }
 

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -1,16 +1,24 @@
-use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::Poll;
 use std::time::Duration;
 
-use axum::body::Body;
+use axum::body::{Body, to_bytes};
 use axum::http::{HeaderValue, Method, Request, StatusCode, header};
 use axum::{Router, response::Response};
 use coral_client::{AppClient, local::ServerBuilder};
+use futures::poll;
 use rmcp::ServiceExt as _;
-use rmcp::model::CallToolRequestParams;
-use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::model::{CallToolRequestParams, ClientJsonRpcMessage};
+use rmcp::transport::{
+    StreamableHttpClientTransport,
+    streamable_http_client::StreamableHttpClientTransportConfig,
+    streamable_http_server::session::{
+        SessionManager as _,
+        local::{SessionConfig, create_local_session},
+    },
+};
 use tempfile::TempDir;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::TcpStream;
@@ -19,23 +27,14 @@ use tower::ServiceExt as _;
 use crate::McpOptions;
 
 use super::{
-    AuthenticatedMcpHttpConfig, AuthenticatedMcpHttpRuntime, MAX_MCP_REQUEST_BODY_SIZE,
-    McpHttpConfig, McpHttpError, ReadinessProbe, RunningMcpHttpServer, SESSION_ID_HEADER,
-    SHUTDOWN_GRACE_PERIOD, SessionBindingFingerprint, SessionBindingStatus, SessionBindingStore,
-    SessionBindingStoreError, auth_disabled_router, authenticated_router, readiness_status,
-    start_auth_disabled,
+    AuthenticatedMcpHttpConfig, AuthenticatedMcpHttpRuntime, AuthenticatedSession,
+    AuthenticatedSessionManager, AuthenticatedSessions, MAX_MCP_REQUEST_BODY_SIZE, McpHttpConfig,
+    McpHttpError, ReadinessProbe, RunningMcpHttpServer, SESSION_ID_HEADER, SHUTDOWN_GRACE_PERIOD,
+    SessionOwner, auth_disabled_router, authenticated_router, binding_fingerprint,
+    readiness_status, start_auth_disabled, start_authenticated,
 };
 
-const INITIALIZE: &str = r#"{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "initialize",
-    "params": {
-        "protocolVersion": "2025-03-26",
-        "capabilities": {},
-        "clientInfo": {"name": "raw-test", "version": "1"}
-    }
-}"#;
+const INITIALIZE: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}"#;
 const PING: &str = r#"{"jsonrpc":"2.0","id":2,"method":"ping"}"#;
 
 fn raw_mcp_request(body: impl Into<Body>) -> Request<Body> {
@@ -54,17 +53,20 @@ async fn assert_bad_request_without_session(
     state: &Arc<super::HttpState>,
     request: Request<Body>,
 ) {
-    let response = router.clone().oneshot(request).await.expect("response");
+    let response = send(router, request).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert!(state.server.sessions.sessions.read().await.is_empty());
+    assert!(state.sessions.sessions.read().await.is_empty());
 }
 
 fn authenticated_config() -> AuthenticatedMcpHttpConfig {
+    authenticated_config_at("0.0.0.0:0".parse().unwrap())
+}
+
+fn authenticated_config_at(bind_addr: SocketAddr) -> AuthenticatedMcpHttpConfig {
     AuthenticatedMcpHttpConfig::new(
-        "0.0.0.0:0".parse().unwrap(),
+        bind_addr,
         "https://mcp.example.com/custom%20mcp",
         "https://login.example.com/",
-        "coral:mcp",
     )
     .unwrap()
 }
@@ -85,6 +87,46 @@ fn auth_request(authorization: &str, session: Option<&str>, body: &str) -> Reque
 
 async fn send(router: &Router, request: Request<Body>) -> Response {
     router.clone().oneshot(request).await.expect("response")
+}
+
+async fn assert_sessionless_non_post_requests_rejected(router: &Router) {
+    for (method, expected) in [
+        (Method::GET, StatusCode::BAD_REQUEST),
+        (Method::DELETE, StatusCode::BAD_REQUEST),
+        (Method::PUT, StatusCode::METHOD_NOT_ALLOWED),
+    ] {
+        let mut request = auth_request("Bearer token-a", None, "");
+        *request.method_mut() = method;
+        assert_eq!(send(router, request).await.status(), expected);
+    }
+}
+
+async fn assert_invalid_initialize_protocols_rejected(router: &Router) {
+    let invalid_protocols = [
+        vec![HeaderValue::from_static("2025-06-18")],
+        vec![
+            HeaderValue::from_static("2025-03-26"),
+            HeaderValue::from_static("2025-03-26"),
+        ],
+        vec![
+            HeaderValue::from_static("2025-03-26"),
+            HeaderValue::from_static("2025-06-18"),
+        ],
+        vec![HeaderValue::from_bytes(b"bad\x80version").unwrap()],
+        vec![HeaderValue::from_static("")],
+    ];
+    for protocols in invalid_protocols {
+        let mut invalid = auth_request("Bearer token-a", None, INITIALIZE);
+        for protocol in protocols {
+            invalid
+                .headers_mut()
+                .append("mcp-protocol-version", protocol);
+        }
+        assert_eq!(
+            send(router, invalid).await.status(),
+            StatusCode::BAD_REQUEST
+        );
+    }
 }
 
 async fn local_app() -> (TempDir, coral_client::local::RunningServer, AppClient) {
@@ -124,6 +166,24 @@ async fn open_stalled_request(server: &RunningMcpHttpServer) -> TcpStream {
     .await
     .expect("stalled request was accepted");
     stalled
+}
+
+fn local_sessions(
+    server: &RunningMcpHttpServer,
+) -> std::sync::Weak<rmcp::transport::streamable_http_server::session::local::LocalSessionManager> {
+    match &server.state.sessions {
+        SessionOwner::Local(sessions) => Arc::downgrade(sessions),
+        SessionOwner::Authenticated(_) => panic!("expected local sessions"),
+    }
+}
+
+fn authenticated_sessions(
+    server: &RunningMcpHttpServer,
+) -> std::sync::Weak<super::AuthenticatedSessions> {
+    match &server.state.sessions {
+        SessionOwner::Authenticated(sessions) => Arc::downgrade(sessions),
+        SessionOwner::Local(_) => panic!("expected authenticated sessions"),
+    }
 }
 
 #[test]
@@ -215,8 +275,8 @@ async fn raw_routes_enforce_health_and_host_contracts() {
         .expect("response");
     assert_eq!(response.status(), StatusCode::OK);
 
-    state.config.cancellation_token.cancel();
-    super::close_sessions(state.sessions.as_ref()).await;
+    state.server.config.cancellation_token.cancel();
+    state.server.sessions.close_all().await;
     app_server.shutdown().await.expect("shutdown app server");
 }
 
@@ -304,11 +364,11 @@ async fn mcp_rejects_uninitialized_and_oversized_requests_without_leaking_sessio
         "mcp-protocol-version",
         HeaderValue::from_static("2025-03-26"),
     );
-    let response = router.clone().oneshot(ping).await.expect("response");
+    let response = send(&router, ping).await;
     assert!(response.status().is_success());
 
-    state.config.cancellation_token.cancel();
-    super::close_sessions(state.sessions.as_ref()).await;
+    state.server.config.cancellation_token.cancel();
+    state.server.sessions.close_all().await;
     app_server.shutdown().await.expect("shutdown app server");
 }
 
@@ -391,7 +451,7 @@ async fn streamable_http_executes_tools_and_shutdown_is_bounded() {
         .expect("gRPC rejection is an in-band tool result");
     assert_eq!(rejected.is_error, Some(true));
 
-    let sessions = Arc::downgrade(&server.state.sessions);
+    let sessions = local_sessions(&server);
     let state = Arc::downgrade(&server.state);
     assert_eq!(
         sessions
@@ -472,7 +532,7 @@ async fn dropping_server_cancels_requests_and_releases_state() {
         StreamableHttpClientTransport::from_uri(format!("http://{}/mcp", server.local_addr()));
     let client = ().serve(transport).await.expect("initialize MCP client");
 
-    let sessions = Arc::downgrade(&server.state.sessions);
+    let sessions = local_sessions(&server);
     let state = Arc::downgrade(&server.state);
     assert_eq!(
         sessions
@@ -509,7 +569,7 @@ async fn dropping_server_cancels_requests_and_releases_state() {
 }
 
 #[tokio::test]
-async fn authenticated_sessions_do_not_leak_after_invalid_or_deleted_requests() {
+async fn authenticated_session_lifecycle_is_coherent() {
     let config = authenticated_config();
     let (_temp, app_server, app) = local_app().await;
     let factory_calls = Arc::new(AtomicUsize::new(0));
@@ -524,29 +584,46 @@ async fn authenticated_sessions_do_not_leak_after_invalid_or_deleted_requests() 
         || async { Ok::<_, tonic::Code>(()) },
     );
     let (router, state) = authenticated_router(config, runtime);
-    let _invalid = send(&router, auth_request("Bearer token-a", None, "{}")).await;
-    let unsupported = INITIALIZE.replace("2025-03-26", "2099-01-01");
-    let _unsupported = send(&router, auth_request("Bearer token-a", None, &unsupported)).await;
-    for protocols in [&["2025-06-18"][..], &["2025-03-26", "2025-06-18"][..]] {
-        let mut invalid = auth_request("Bearer token-a", None, INITIALIZE);
-        for protocol in protocols {
-            invalid
-                .headers_mut()
-                .append("mcp-protocol-version", protocol.parse().unwrap());
-        }
-        let _rejected = send(&router, invalid).await;
-    }
-    assert!(state.sessions.sessions.read().await.is_empty());
+
+    let mut browser_request = auth_request("Bearer token-a", None, INITIALIZE);
+    browser_request
+        .headers_mut()
+        .insert(header::ORIGIN, "https://attacker.example".parse().unwrap());
+    assert_eq!(
+        send(&router, browser_request).await.status(),
+        StatusCode::FORBIDDEN
+    );
+    assert_eq!(
+        send(&router, auth_request("Bearer token-a", None, PING))
+            .await
+            .status(),
+        StatusCode::BAD_REQUEST
+    );
+    assert_invalid_initialize_protocols_rejected(&router).await;
+    assert_eq!(state.sessions.len().await, 0);
     assert_eq!(factory_calls.load(Ordering::Relaxed), 0);
-    let response = send(&router, auth_request("Bearer token-a", None, INITIALIZE)).await;
+
+    assert_sessionless_non_post_requests_rejected(&router).await;
+    assert_eq!(state.sessions.len().await, 0);
+    assert_eq!(factory_calls.load(Ordering::Relaxed), 0);
+
+    let mut initialize = auth_request("Bearer token-a", None, INITIALIZE);
+    initialize.headers_mut().insert(
+        "mcp-protocol-version",
+        HeaderValue::from_static("2025-03-26"),
+    );
+    let response = send(&router, initialize).await;
+    assert_eq!(response.status(), StatusCode::OK);
     let session = response.headers()[SESSION_ID_HEADER]
         .to_str()
         .unwrap()
         .to_string();
     assert_eq!(factory_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(state.sessions.len().await, 1);
+
     for invalid in [&b"bad id"[..], &b"bad\tid"[..], &b"bad\x80id"[..]] {
-        let invalid = axum::http::HeaderValue::from_bytes(invalid).unwrap();
-        let mut request = auth_request("Bearer token-a", None, "{}");
+        let invalid = HeaderValue::from_bytes(invalid).unwrap();
+        let mut request = auth_request("Bearer token-a", None, PING);
         request.headers_mut().insert(SESSION_ID_HEADER, invalid);
         let status = send(&router, request).await.status();
         assert_eq!(status, StatusCode::BAD_REQUEST);
@@ -557,6 +634,8 @@ async fn authenticated_sessions_do_not_leak_after_invalid_or_deleted_requests() 
     )
     .await;
     assert_eq!(mismatched.status(), StatusCode::FORBIDDEN);
+    assert_eq!(state.sessions.len().await, 1);
+
     let mut ping = auth_request("Bearer token-a", Some(&session), PING);
     ping.headers_mut()
         .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
@@ -565,6 +644,8 @@ async fn authenticated_sessions_do_not_leak_after_invalid_or_deleted_requests() 
     let mut delete = auth_request("Bearer token-a", Some(&session), "");
     *delete.method_mut() = Method::DELETE;
     assert!(send(&router, delete).await.status().is_success());
+    assert_eq!(state.sessions.len().await, 0);
+
     let missing = send(
         &router,
         auth_request("Bearer token-a", Some(&session), "{}"),
@@ -574,160 +655,293 @@ async fn authenticated_sessions_do_not_leak_after_invalid_or_deleted_requests() 
     app_server.shutdown().await.unwrap();
 }
 
-struct FailingSessionBindingStore {
-    remove_calls: Arc<AtomicUsize>,
-}
-
-#[async_trait::async_trait]
-impl SessionBindingStore for FailingSessionBindingStore {
-    async fn bind(
-        &self,
-        _session_id: &str,
-        _fingerprint: SessionBindingFingerprint,
-    ) -> Result<(), SessionBindingStoreError> {
-        Err(io::Error::other("binding store unavailable").into())
-    }
-
-    async fn authorize_and_touch(
-        &self,
-        _session_id: &str,
-        _fingerprint: &SessionBindingFingerprint,
-    ) -> Result<SessionBindingStatus, SessionBindingStoreError> {
-        Ok(SessionBindingStatus::Missing)
-    }
-
-    async fn remove(&self, _session_id: &str) -> Result<(), SessionBindingStoreError> {
-        self.remove_calls.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-}
-
 #[tokio::test]
-async fn binding_store_failure_closes_new_session() {
+async fn authenticated_requests_are_bounded_before_and_after_initialization() {
     let (_temp, app_server, app) = local_app().await;
-    let remove_calls = Arc::new(AtomicUsize::new(0));
+    let factory_calls = Arc::new(AtomicUsize::new(0));
+    let counted_factory_calls = factory_calls.clone();
     let runtime = AuthenticatedMcpHttpRuntime::new(
         |_| async { Ok::<_, ()>(()) },
-        move |_| std::future::ready(Ok::<_, ()>(app.clone())),
+        move |_| {
+            counted_factory_calls.fetch_add(1, Ordering::Relaxed);
+            std::future::ready(Ok::<_, ()>(app.clone()))
+        },
         McpOptions::default(),
         || async { Ok::<_, tonic::Code>(()) },
-    )
-    .with_session_binding_store(Arc::new(FailingSessionBindingStore {
-        remove_calls: remove_calls.clone(),
-    }));
+    );
     let (router, state) = authenticated_router(authenticated_config(), runtime);
 
-    let response = send(&router, auth_request("Bearer token-a", None, INITIALIZE)).await;
-
-    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
-    assert!(state.sessions.sessions.read().await.is_empty());
-    assert_eq!(remove_calls.load(Ordering::Relaxed), 1);
-    app_server.shutdown().await.unwrap();
-}
-
-struct MissingSessionBindingStore;
-
-#[async_trait::async_trait]
-impl SessionBindingStore for MissingSessionBindingStore {
-    async fn bind(
-        &self,
-        _session_id: &str,
-        _fingerprint: SessionBindingFingerprint,
-    ) -> Result<(), SessionBindingStoreError> {
-        Ok(())
-    }
-
-    async fn authorize_and_touch(
-        &self,
-        _session_id: &str,
-        _fingerprint: &SessionBindingFingerprint,
-    ) -> Result<SessionBindingStatus, SessionBindingStoreError> {
-        Ok(SessionBindingStatus::Missing)
-    }
-
-    async fn remove(&self, _session_id: &str) -> Result<(), SessionBindingStoreError> {
-        Ok(())
-    }
-}
-
-#[tokio::test]
-async fn missing_binding_closes_local_session() {
-    let (_temp, app_server, app) = local_app().await;
-    let runtime = AuthenticatedMcpHttpRuntime::new(
-        |_| async { Ok::<_, ()>(()) },
-        move |_| std::future::ready(Ok::<_, ()>(app.clone())),
-        McpOptions::default(),
-        || async { Ok::<_, tonic::Code>(()) },
+    let mut oversized_initialize = INITIALIZE.to_string();
+    oversized_initialize.extend(std::iter::repeat_n(
+        ' ',
+        MAX_MCP_REQUEST_BODY_SIZE + 1 - oversized_initialize.len(),
+    ));
+    let response = send(
+        &router,
+        auth_request("Bearer token-a", None, &oversized_initialize),
     )
-    .with_session_binding_store(Arc::new(MissingSessionBindingStore));
-    let (router, state) = authenticated_router(authenticated_config(), runtime);
+    .await;
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(factory_calls.load(Ordering::Relaxed), 0);
+    assert_eq!(state.sessions.len().await, 0);
+
     let initialized = send(&router, auth_request("Bearer token-a", None, INITIALIZE)).await;
     let session = initialized.headers()[SESSION_ID_HEADER]
         .to_str()
         .unwrap()
         .to_string();
+    assert_eq!(factory_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(state.sessions.len().await, 1);
 
-    let response = send(
-        &router,
-        auth_request("Bearer token-a", Some(&session), PING),
-    )
-    .await;
+    let mut oversized_ping = PING.to_string();
+    oversized_ping.extend(std::iter::repeat_n(
+        ' ',
+        MAX_MCP_REQUEST_BODY_SIZE + 1 - oversized_ping.len(),
+    ));
+    let mut request = auth_request("Bearer token-a", Some(&session), &oversized_ping);
+    request
+        .headers_mut()
+        .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
+    let response = send(&router, request).await;
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert_eq!(state.sessions.len().await, 1);
 
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert!(state.sessions.sessions.read().await.is_empty());
+    let mut ping = auth_request("Bearer token-a", Some(&session), PING);
+    ping.headers_mut()
+        .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
+    assert!(send(&router, ping).await.status().is_success());
+
+    state.sessions.close_all().await;
     app_server.shutdown().await.unwrap();
 }
 
-struct AuthorizedSessionBindingStore {
-    remove_calls: Arc<AtomicUsize>,
-}
-
-#[async_trait::async_trait]
-impl SessionBindingStore for AuthorizedSessionBindingStore {
-    async fn bind(
-        &self,
-        _session_id: &str,
-        _fingerprint: SessionBindingFingerprint,
-    ) -> Result<(), SessionBindingStoreError> {
-        Ok(())
-    }
-
-    async fn authorize_and_touch(
-        &self,
-        _session_id: &str,
-        _fingerprint: &SessionBindingFingerprint,
-    ) -> Result<SessionBindingStatus, SessionBindingStoreError> {
-        Ok(SessionBindingStatus::Authorized)
-    }
-
-    async fn remove(&self, _session_id: &str) -> Result<(), SessionBindingStoreError> {
-        self.remove_calls.fetch_add(1, Ordering::Relaxed);
-        Ok(())
-    }
-}
-
 #[tokio::test]
-async fn missing_rmcp_session_removes_stale_binding() {
+async fn authenticated_sessions_remain_isolated() {
     let (_temp, app_server, app) = local_app().await;
-    let remove_calls = Arc::new(AtomicUsize::new(0));
     let runtime = AuthenticatedMcpHttpRuntime::new(
         |_| async { Ok::<_, ()>(()) },
         move |_| std::future::ready(Ok::<_, ()>(app.clone())),
         McpOptions::default(),
         || async { Ok::<_, tonic::Code>(()) },
-    )
-    .with_session_binding_store(Arc::new(AuthorizedSessionBindingStore {
-        remove_calls: remove_calls.clone(),
-    }));
-    let (router, _state) = authenticated_router(authenticated_config(), runtime);
+    );
+    let (router, state) = authenticated_router(authenticated_config(), runtime);
+
+    let first = send(&router, auth_request("Bearer token-a", None, INITIALIZE)).await;
+    assert_eq!(first.status(), StatusCode::OK);
+    let first_session = first.headers()[SESSION_ID_HEADER]
+        .to_str()
+        .unwrap()
+        .to_string();
+    let second = send(&router, auth_request("Bearer token-b", None, INITIALIZE)).await;
+    assert_eq!(second.status(), StatusCode::OK);
+    let second_session = second.headers()[SESSION_ID_HEADER]
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(state.sessions.len().await, 2);
 
     let response = send(
         &router,
-        auth_request("Bearer token-a", Some("missing-session"), PING),
+        auth_request("Bearer token-b", Some(&first_session), PING),
     )
     .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(state.sessions.len().await, 2);
 
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_eq!(remove_calls.load(Ordering::Relaxed), 1);
+    for (token, session) in [
+        ("Bearer token-a", &first_session),
+        ("Bearer token-b", &second_session),
+    ] {
+        let mut ping = auth_request(token, Some(session), PING);
+        ping.headers_mut()
+            .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
+        assert!(send(&router, ping).await.status().is_success());
+    }
+
+    state.sessions.close_all().await;
+    app_server.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn authenticated_session_creation_is_cancellation_atomic() {
+    let sessions = Arc::new(AuthenticatedSessions::default());
+    let manager = AuthenticatedSessionManager {
+        sessions: sessions.clone(),
+        fingerprint: binding_fingerprint("token-a"),
+    };
+
+    let records = sessions.records.write().await;
+    let mut blocked_create = Box::pin(manager.create_session());
+    assert!(matches!(poll!(blocked_create.as_mut()), Poll::Pending));
+    drop(blocked_create);
+    drop(records);
+    assert_eq!(sessions.len().await, 0);
+
+    let (session_id, transport) = manager.create_session().await.unwrap();
+    assert_eq!(sessions.len().await, 1);
+    drop(transport);
+    manager.close_session(&session_id).await.unwrap();
+    assert_eq!(sessions.len().await, 0);
+}
+
+#[tokio::test]
+async fn cancelled_authenticated_session_close_removes_the_record() {
+    let sessions = Arc::new(AuthenticatedSessions::default());
+    let session_id: Arc<str> = Arc::from("blocked-close");
+    let fingerprint = binding_fingerprint("token-a");
+    let mut config = SessionConfig::default();
+    config.channel_capacity = 1;
+    let (handle, _worker) = create_local_session(session_id.clone(), config);
+    let message: ClientJsonRpcMessage = serde_json::from_str(PING).unwrap();
+    handle.push_message(message, None).await.unwrap();
+    sessions.records.write().await.insert(
+        session_id.clone(),
+        AuthenticatedSession {
+            fingerprint,
+            handle,
+        },
+    );
+    let manager = AuthenticatedSessionManager {
+        sessions: sessions.clone(),
+        fingerprint,
+    };
+
+    let mut close = Box::pin(manager.close_session(&session_id));
+    assert!(matches!(poll!(close.as_mut()), Poll::Pending));
+    drop(close);
+    assert_eq!(sessions.len().await, 0);
+}
+
+#[test]
+fn authenticated_config_accepts_only_https_or_loopback_http_public_urls() {
+    let bind_addr = "127.0.0.1:0".parse().unwrap();
+    for public_url in ["http://mcp.example.com/mcp", "ftp://mcp.example.com/mcp"] {
+        let error =
+            AuthenticatedMcpHttpConfig::new(bind_addr, public_url, "https://login.example.com/")
+                .unwrap_err();
+        assert!(matches!(
+            error,
+            McpHttpError::InvalidAuthConfig("OAuth URL must use HTTPS or loopback HTTP")
+        ));
+    }
+    for public_url in [
+        "http://localhost/mcp",
+        "http://127.0.0.1/mcp",
+        "http://[::1]/mcp",
+        "https://mcp.example.com/mcp",
+    ] {
+        AuthenticatedMcpHttpConfig::new(bind_addr, public_url, "http://localhost:8080/")
+            .expect("HTTPS and loopback HTTP remain valid");
+    }
+}
+
+#[test]
+fn authenticated_config_omits_scope_and_canonicalizes_root_oauth_identifiers() {
+    let config = AuthenticatedMcpHttpConfig::new(
+        "127.0.0.1:0".parse().unwrap(),
+        "https://mcp.example.com/",
+        "https://login.example.com/",
+    )
+    .unwrap();
+
+    assert_eq!(config.public_url, "https://mcp.example.com");
+    assert_eq!(config.authorization_server, "https://login.example.com");
+    assert_eq!(
+        config.challenge,
+        HeaderValue::from_static(
+            "Bearer resource_metadata=\"https://mcp.example.com/.well-known/oauth-protected-resource\""
+        )
+    );
+}
+
+#[tokio::test]
+async fn authenticated_discovery_and_challenge_do_not_advertise_scopes() {
+    let config = authenticated_config();
+    let metadata_path = config.metadata_path.clone();
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_| async { Ok::<_, ()>(()) },
+        |_| std::future::ready(Err::<AppClient, ()>(())),
+        McpOptions::default(),
+        || async { Ok::<_, tonic::Code>(()) },
+    );
+    let (router, _state) = authenticated_router(config, runtime);
+
+    let unauthorized = send(&router, raw_mcp_request(INITIALIZE)).await;
+    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+    let challenge = unauthorized
+        .headers()
+        .get(header::WWW_AUTHENTICATE)
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(challenge.contains("resource_metadata="));
+    assert!(!challenge.contains("scope="));
+
+    let metadata = send(
+        &router,
+        Request::builder()
+            .method(Method::GET)
+            .uri(metadata_path)
+            .header(header::HOST, "mcp.example.com")
+            .body(Body::empty())
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(metadata.status(), StatusCode::OK);
+    let body = to_bytes(metadata.into_body(), usize::MAX).await.unwrap();
+    let document: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        document
+            .get("resource")
+            .expect("protected-resource metadata must contain resource"),
+        &serde_json::json!("https://mcp.example.com/custom%20mcp")
+    );
+    assert_eq!(
+        document
+            .get("authorization_servers")
+            .expect("protected-resource metadata must contain authorization_servers"),
+        &serde_json::json!(["https://login.example.com"])
+    );
+    assert!(document.get("scopes_supported").is_none());
+}
+
+#[tokio::test]
+async fn dropping_authenticated_server_closes_sessions_and_releases_state() {
+    let (_temp, app_server, app) = local_app().await;
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_| async { Ok::<_, ()>(()) },
+        move |_| std::future::ready(Ok::<_, ()>(app.clone())),
+        McpOptions::default(),
+        || async { Ok::<_, tonic::Code>(()) },
+    );
+    let server = start_authenticated(
+        authenticated_config_at("127.0.0.1:0".parse().unwrap()),
+        runtime,
+    )
+    .await;
+    let server = server.expect("start authenticated MCP HTTP server");
+    let transport = StreamableHttpClientTransport::from_config(
+        StreamableHttpClientTransportConfig::with_uri(format!(
+            "http://{}/mcp",
+            server.local_addr()
+        ))
+        .auth_header("token-a"),
+    );
+    let client = ().serve(transport).await.expect("initialize MCP client");
+    let sessions = authenticated_sessions(&server);
+    let state = Arc::downgrade(&server.state);
+    assert_eq!(sessions.upgrade().expect("sessions").len().await, 1);
+
+    drop(server);
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while sessions.strong_count() != 0 || state.strong_count() != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("authenticated server-owned state must be released");
+
+    let _cancel_result = client.cancel().await;
     app_server.shutdown().await.unwrap();
 }

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -27,11 +27,12 @@ use tower::ServiceExt as _;
 use crate::McpOptions;
 
 use super::{
-    AuthenticatedMcpHttpConfig, AuthenticatedMcpHttpRuntime, AuthenticatedSession,
-    AuthenticatedSessionManager, AuthenticatedSessions, MAX_MCP_REQUEST_BODY_SIZE, McpHttpConfig,
-    McpHttpError, ReadinessProbe, RunningMcpHttpServer, SESSION_ID_HEADER, SHUTDOWN_GRACE_PERIOD,
-    SessionOwner, auth_disabled_router, authenticated_router, binding_fingerprint,
-    readiness_status, start_auth_disabled, start_authenticated,
+    AUTHENTICATED_SESSION_IDLE_TIMEOUT, AuthenticatedMcpHttpConfig, AuthenticatedMcpHttpRuntime,
+    AuthenticatedSession, AuthenticatedSessionManager, AuthenticatedSessions,
+    MAX_AUTHENTICATED_SESSIONS, MAX_MCP_REQUEST_BODY_SIZE, McpHttpConfig, McpHttpError,
+    ReadinessProbe, RunningMcpHttpServer, SESSION_ID_HEADER, SHUTDOWN_GRACE_PERIOD, SessionOwner,
+    auth_disabled_router, authenticated_router, authenticated_router_with_sessions,
+    binding_fingerprint, readiness_status, start_auth_disabled, start_authenticated,
 };
 
 const INITIALIZE: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}"#;
@@ -763,11 +764,108 @@ async fn authenticated_sessions_remain_isolated() {
 }
 
 #[tokio::test]
+async fn authenticated_session_admission_rejects_before_client_creation() {
+    let (_temp, app_server, app) = local_app().await;
+    let factory_calls = Arc::new(AtomicUsize::new(0));
+    let counted_factory_calls = factory_calls.clone();
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_| async { Ok::<_, ()>(()) },
+        move |_| {
+            counted_factory_calls.fetch_add(1, Ordering::Relaxed);
+            std::future::ready(Ok::<_, ()>(app.clone()))
+        },
+        McpOptions::default(),
+        || async { Ok::<_, tonic::Code>(()) },
+    );
+    let sessions = Arc::new(AuthenticatedSessions::new(1));
+    let (router, state) =
+        authenticated_router_with_sessions(authenticated_config(), runtime, sessions);
+
+    let first = send(&router, auth_request("Bearer token-a", None, INITIALIZE)).await;
+    assert_eq!(first.status(), StatusCode::OK);
+    let first_session = first.headers()[SESSION_ID_HEADER]
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(factory_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(state.sessions.len().await, 1);
+    assert_eq!(state.sessions.available_permits(), 0);
+
+    let rejected = send(&router, auth_request("Bearer token-b", None, INITIALIZE)).await;
+    assert_eq!(rejected.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(factory_calls.load(Ordering::Relaxed), 1);
+    assert_eq!(state.sessions.len().await, 1);
+
+    let mut ping = auth_request("Bearer token-a", Some(&first_session), PING);
+    ping.headers_mut()
+        .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
+    assert!(send(&router, ping).await.status().is_success());
+
+    state.sessions.close_all().await;
+    assert_eq!(state.sessions.available_permits(), 1);
+    app_server.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn authenticated_session_honors_the_declared_idle_timeout() {
+    let (_temp, app_server, app) = local_app().await;
+    tokio::time::pause();
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_| async { Ok::<_, ()>(()) },
+        move |_| std::future::ready(Ok::<_, ()>(app.clone())),
+        McpOptions::default(),
+        || async { Ok::<_, tonic::Code>(()) },
+    );
+    let sessions = Arc::new(AuthenticatedSessions::new(1));
+    let (router, state) =
+        authenticated_router_with_sessions(authenticated_config(), runtime, sessions);
+
+    let initialized = send(&router, auth_request("Bearer token-a", None, INITIALIZE)).await;
+    assert_eq!(initialized.status(), StatusCode::OK);
+    let session = initialized.headers()[SESSION_ID_HEADER]
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(state.sessions.available_permits(), 0);
+
+    tokio::task::yield_now().await;
+    tokio::time::advance(SessionConfig::DEFAULT_KEEP_ALIVE + Duration::from_secs(1)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(state.sessions.len().await, 1);
+
+    let mut ping = auth_request("Bearer token-a", Some(&session), PING);
+    ping.headers_mut()
+        .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
+    assert!(send(&router, ping).await.status().is_success());
+
+    tokio::task::yield_now().await;
+    tokio::time::advance(AUTHENTICATED_SESSION_IDLE_TIMEOUT + Duration::from_secs(1)).await;
+    for _ in 0..100 {
+        if state.sessions.len().await == 0 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(state.sessions.len().await, 0);
+    assert_eq!(state.sessions.available_permits(), 1);
+
+    let missing = send(
+        &router,
+        auth_request("Bearer token-a", Some(&session), PING),
+    )
+    .await;
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    app_server.shutdown().await.unwrap();
+}
+
+#[tokio::test]
 async fn authenticated_session_creation_is_cancellation_atomic() {
     let sessions = Arc::new(AuthenticatedSessions::default());
+    let admission_permit = sessions.try_admit().expect("reserve session");
     let manager = AuthenticatedSessionManager {
         sessions: sessions.clone(),
         fingerprint: binding_fingerprint("token-a"),
+        admission_permit: tokio::sync::Mutex::new(Some(admission_permit)),
     };
 
     let records = sessions.records.write().await;
@@ -776,17 +874,20 @@ async fn authenticated_session_creation_is_cancellation_atomic() {
     drop(blocked_create);
     drop(records);
     assert_eq!(sessions.len().await, 0);
+    assert_eq!(sessions.available_permits(), MAX_AUTHENTICATED_SESSIONS - 1);
 
     let (session_id, transport) = manager.create_session().await.unwrap();
     assert_eq!(sessions.len().await, 1);
     drop(transport);
     manager.close_session(&session_id).await.unwrap();
     assert_eq!(sessions.len().await, 0);
+    assert_eq!(sessions.available_permits(), MAX_AUTHENTICATED_SESSIONS);
 }
 
 #[tokio::test]
 async fn cancelled_authenticated_session_close_removes_the_record() {
     let sessions = Arc::new(AuthenticatedSessions::default());
+    let admission_permit = sessions.try_admit().expect("reserve session");
     let session_id: Arc<str> = Arc::from("blocked-close");
     let fingerprint = binding_fingerprint("token-a");
     let mut config = SessionConfig::default();
@@ -799,17 +900,20 @@ async fn cancelled_authenticated_session_close_removes_the_record() {
         AuthenticatedSession {
             fingerprint,
             handle,
+            _admission_permit: admission_permit,
         },
     );
     let manager = AuthenticatedSessionManager {
         sessions: sessions.clone(),
         fingerprint,
+        admission_permit: tokio::sync::Mutex::new(None),
     };
 
     let mut close = Box::pin(manager.close_session(&session_id));
     assert!(matches!(poll!(close.as_mut()), Poll::Pending));
     drop(close);
     assert_eq!(sessions.len().await, 0);
+    assert_eq!(sessions.available_permits(), MAX_AUTHENTICATED_SESSIONS);
 }
 
 #[test]

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -2,9 +2,9 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::Router;
 use axum::body::Body;
 use axum::http::{HeaderValue, Method, Request, StatusCode, header};
+use axum::{Router, response::Response};
 use coral_client::{AppClient, local::ServerBuilder};
 use rmcp::ServiceExt as _;
 use rmcp::model::CallToolRequestParams;
@@ -17,8 +17,9 @@ use tower::ServiceExt as _;
 use crate::McpOptions;
 
 use super::{
-    MAX_MCP_REQUEST_BODY_SIZE, McpHttpConfig, McpHttpError, ReadinessProbe, RunningMcpHttpServer,
-    SESSION_ID_HEADER, SHUTDOWN_GRACE_PERIOD, auth_disabled_router, readiness_status,
+    AuthenticatedMcpHttpConfig, AuthenticatedMcpHttpRuntime, MAX_MCP_REQUEST_BODY_SIZE,
+    McpHttpConfig, McpHttpError, ReadinessProbe, RunningMcpHttpServer, SESSION_ID_HEADER,
+    SHUTDOWN_GRACE_PERIOD, auth_disabled_router, authenticated_router, readiness_status,
     start_auth_disabled,
 };
 
@@ -52,7 +53,25 @@ async fn assert_bad_request_without_session(
 ) {
     let response = router.clone().oneshot(request).await.expect("response");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert!(state.sessions.sessions.read().await.is_empty());
+    assert!(state.server.sessions.sessions.read().await.is_empty());
+}
+
+fn auth_request(authorization: &str, session: Option<&str>, body: &str) -> Request<Body> {
+    let mut request = Request::builder()
+        .method(Method::POST)
+        .uri("/mcp")
+        .header(header::HOST, "mcp.example.com")
+        .header(header::ACCEPT, "application/json, text/event-stream")
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, authorization);
+    if let Some(value) = session {
+        request = request.header(SESSION_ID_HEADER, value);
+    }
+    request.body(Body::from(body.to_string())).expect("request")
+}
+
+async fn send(router: &Router, request: Request<Body>) -> Response {
+    router.clone().oneshot(request).await.expect("response")
 }
 
 async fn local_app() -> (TempDir, coral_client::local::RunningServer, AppClient) {
@@ -474,4 +493,52 @@ async fn dropping_server_cancels_requests_and_releases_state() {
 
     let _cancel_result = client.cancel().await;
     app_server.shutdown().await.expect("shutdown app server");
+}
+
+#[tokio::test]
+async fn authenticated_sessions_do_not_leak_after_invalid_or_deleted_requests() {
+    let config = AuthenticatedMcpHttpConfig::new(
+        "0.0.0.0:0".parse().unwrap(),
+        "https://mcp.example.com/custom%20mcp",
+        "https://login.example.com/",
+        "coral:mcp",
+    )
+    .unwrap();
+    let (_temp, app_server, app) = local_app().await;
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_| async { Ok::<_, ()>(()) },
+        move |_| std::future::ready(Ok::<_, ()>(app.clone())),
+        McpOptions::default(),
+        || async { Ok::<_, tonic::Code>(()) },
+    );
+    let (router, state, bindings) = authenticated_router(config, runtime);
+    let _invalid = send(&router, auth_request("Bearer token-a", None, "{}")).await;
+    let unsupported = INITIALIZE.replace("2025-03-26", "2099-01-01");
+    let _unsupported = send(&router, auth_request("Bearer token-a", None, &unsupported)).await;
+    for protocols in [&["2025-06-18"][..], &["2025-03-26", "2025-06-18"][..]] {
+        let mut invalid = auth_request("Bearer token-a", None, INITIALIZE);
+        for protocol in protocols {
+            invalid
+                .headers_mut()
+                .append("mcp-protocol-version", protocol.parse().unwrap());
+        }
+        let _rejected = send(&router, invalid).await;
+    }
+    assert!(state.sessions.sessions.read().await.is_empty());
+    assert!(bindings.lock().await.is_empty());
+    let response = send(&router, auth_request("Bearer token-a", None, INITIALIZE)).await;
+    let session = response.headers()[SESSION_ID_HEADER].to_str().unwrap();
+    for invalid in [&b"bad id"[..], &b"bad\tid"[..], &b"bad\x80id"[..]] {
+        let invalid = axum::http::HeaderValue::from_bytes(invalid).unwrap();
+        let mut request = auth_request("Bearer token-a", None, "{}");
+        request.headers_mut().insert(SESSION_ID_HEADER, invalid);
+        let status = send(&router, request).await.status();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+    let mut delete = auth_request("Bearer token-a", Some(session), "");
+    *delete.method_mut() = Method::DELETE;
+    assert!(send(&router, delete).await.status().is_success());
+    let missing = send(&router, auth_request("Bearer token-a", Some(session), "{}")).await;
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    app_server.shutdown().await.unwrap();
 }

--- a/crates/coral-mcp/src/http/tests.rs
+++ b/crates/coral-mcp/src/http/tests.rs
@@ -1,5 +1,7 @@
+use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use axum::body::Body;
@@ -19,7 +21,8 @@ use crate::McpOptions;
 use super::{
     AuthenticatedMcpHttpConfig, AuthenticatedMcpHttpRuntime, MAX_MCP_REQUEST_BODY_SIZE,
     McpHttpConfig, McpHttpError, ReadinessProbe, RunningMcpHttpServer, SESSION_ID_HEADER,
-    SHUTDOWN_GRACE_PERIOD, auth_disabled_router, authenticated_router, readiness_status,
+    SHUTDOWN_GRACE_PERIOD, SessionBindingFingerprint, SessionBindingStatus, SessionBindingStore,
+    SessionBindingStoreError, auth_disabled_router, authenticated_router, readiness_status,
     start_auth_disabled,
 };
 
@@ -54,6 +57,16 @@ async fn assert_bad_request_without_session(
     let response = router.clone().oneshot(request).await.expect("response");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert!(state.server.sessions.sessions.read().await.is_empty());
+}
+
+fn authenticated_config() -> AuthenticatedMcpHttpConfig {
+    AuthenticatedMcpHttpConfig::new(
+        "0.0.0.0:0".parse().unwrap(),
+        "https://mcp.example.com/custom%20mcp",
+        "https://login.example.com/",
+        "coral:mcp",
+    )
+    .unwrap()
 }
 
 fn auth_request(authorization: &str, session: Option<&str>, body: &str) -> Request<Body> {
@@ -497,21 +510,20 @@ async fn dropping_server_cancels_requests_and_releases_state() {
 
 #[tokio::test]
 async fn authenticated_sessions_do_not_leak_after_invalid_or_deleted_requests() {
-    let config = AuthenticatedMcpHttpConfig::new(
-        "0.0.0.0:0".parse().unwrap(),
-        "https://mcp.example.com/custom%20mcp",
-        "https://login.example.com/",
-        "coral:mcp",
-    )
-    .unwrap();
+    let config = authenticated_config();
     let (_temp, app_server, app) = local_app().await;
+    let factory_calls = Arc::new(AtomicUsize::new(0));
+    let counted_factory_calls = factory_calls.clone();
     let runtime = AuthenticatedMcpHttpRuntime::new(
         |_| async { Ok::<_, ()>(()) },
-        move |_| std::future::ready(Ok::<_, ()>(app.clone())),
+        move |_| {
+            counted_factory_calls.fetch_add(1, Ordering::Relaxed);
+            std::future::ready(Ok::<_, ()>(app.clone()))
+        },
         McpOptions::default(),
         || async { Ok::<_, tonic::Code>(()) },
     );
-    let (router, state, bindings) = authenticated_router(config, runtime);
+    let (router, state) = authenticated_router(config, runtime);
     let _invalid = send(&router, auth_request("Bearer token-a", None, "{}")).await;
     let unsupported = INITIALIZE.replace("2025-03-26", "2099-01-01");
     let _unsupported = send(&router, auth_request("Bearer token-a", None, &unsupported)).await;
@@ -525,9 +537,13 @@ async fn authenticated_sessions_do_not_leak_after_invalid_or_deleted_requests() 
         let _rejected = send(&router, invalid).await;
     }
     assert!(state.sessions.sessions.read().await.is_empty());
-    assert!(bindings.lock().await.is_empty());
+    assert_eq!(factory_calls.load(Ordering::Relaxed), 0);
     let response = send(&router, auth_request("Bearer token-a", None, INITIALIZE)).await;
-    let session = response.headers()[SESSION_ID_HEADER].to_str().unwrap();
+    let session = response.headers()[SESSION_ID_HEADER]
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(factory_calls.load(Ordering::Relaxed), 1);
     for invalid in [&b"bad id"[..], &b"bad\tid"[..], &b"bad\x80id"[..]] {
         let invalid = axum::http::HeaderValue::from_bytes(invalid).unwrap();
         let mut request = auth_request("Bearer token-a", None, "{}");
@@ -535,10 +551,183 @@ async fn authenticated_sessions_do_not_leak_after_invalid_or_deleted_requests() 
         let status = send(&router, request).await.status();
         assert_eq!(status, StatusCode::BAD_REQUEST);
     }
-    let mut delete = auth_request("Bearer token-a", Some(session), "");
+    let mismatched = send(
+        &router,
+        auth_request("Bearer token-b", Some(&session), PING),
+    )
+    .await;
+    assert_eq!(mismatched.status(), StatusCode::FORBIDDEN);
+    let mut ping = auth_request("Bearer token-a", Some(&session), PING);
+    ping.headers_mut()
+        .insert("mcp-protocol-version", "2025-03-26".parse().unwrap());
+    assert!(send(&router, ping).await.status().is_success());
+    assert_eq!(factory_calls.load(Ordering::Relaxed), 1);
+    let mut delete = auth_request("Bearer token-a", Some(&session), "");
     *delete.method_mut() = Method::DELETE;
     assert!(send(&router, delete).await.status().is_success());
-    let missing = send(&router, auth_request("Bearer token-a", Some(session), "{}")).await;
+    let missing = send(
+        &router,
+        auth_request("Bearer token-a", Some(&session), "{}"),
+    )
+    .await;
     assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    app_server.shutdown().await.unwrap();
+}
+
+struct FailingSessionBindingStore {
+    remove_calls: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl SessionBindingStore for FailingSessionBindingStore {
+    async fn bind(
+        &self,
+        _session_id: &str,
+        _fingerprint: SessionBindingFingerprint,
+    ) -> Result<(), SessionBindingStoreError> {
+        Err(io::Error::other("binding store unavailable").into())
+    }
+
+    async fn authorize_and_touch(
+        &self,
+        _session_id: &str,
+        _fingerprint: &SessionBindingFingerprint,
+    ) -> Result<SessionBindingStatus, SessionBindingStoreError> {
+        Ok(SessionBindingStatus::Missing)
+    }
+
+    async fn remove(&self, _session_id: &str) -> Result<(), SessionBindingStoreError> {
+        self.remove_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn binding_store_failure_closes_new_session() {
+    let (_temp, app_server, app) = local_app().await;
+    let remove_calls = Arc::new(AtomicUsize::new(0));
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_| async { Ok::<_, ()>(()) },
+        move |_| std::future::ready(Ok::<_, ()>(app.clone())),
+        McpOptions::default(),
+        || async { Ok::<_, tonic::Code>(()) },
+    )
+    .with_session_binding_store(Arc::new(FailingSessionBindingStore {
+        remove_calls: remove_calls.clone(),
+    }));
+    let (router, state) = authenticated_router(authenticated_config(), runtime);
+
+    let response = send(&router, auth_request("Bearer token-a", None, INITIALIZE)).await;
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert!(state.sessions.sessions.read().await.is_empty());
+    assert_eq!(remove_calls.load(Ordering::Relaxed), 1);
+    app_server.shutdown().await.unwrap();
+}
+
+struct MissingSessionBindingStore;
+
+#[async_trait::async_trait]
+impl SessionBindingStore for MissingSessionBindingStore {
+    async fn bind(
+        &self,
+        _session_id: &str,
+        _fingerprint: SessionBindingFingerprint,
+    ) -> Result<(), SessionBindingStoreError> {
+        Ok(())
+    }
+
+    async fn authorize_and_touch(
+        &self,
+        _session_id: &str,
+        _fingerprint: &SessionBindingFingerprint,
+    ) -> Result<SessionBindingStatus, SessionBindingStoreError> {
+        Ok(SessionBindingStatus::Missing)
+    }
+
+    async fn remove(&self, _session_id: &str) -> Result<(), SessionBindingStoreError> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn missing_binding_closes_local_session() {
+    let (_temp, app_server, app) = local_app().await;
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_| async { Ok::<_, ()>(()) },
+        move |_| std::future::ready(Ok::<_, ()>(app.clone())),
+        McpOptions::default(),
+        || async { Ok::<_, tonic::Code>(()) },
+    )
+    .with_session_binding_store(Arc::new(MissingSessionBindingStore));
+    let (router, state) = authenticated_router(authenticated_config(), runtime);
+    let initialized = send(&router, auth_request("Bearer token-a", None, INITIALIZE)).await;
+    let session = initialized.headers()[SESSION_ID_HEADER]
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let response = send(
+        &router,
+        auth_request("Bearer token-a", Some(&session), PING),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert!(state.sessions.sessions.read().await.is_empty());
+    app_server.shutdown().await.unwrap();
+}
+
+struct AuthorizedSessionBindingStore {
+    remove_calls: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl SessionBindingStore for AuthorizedSessionBindingStore {
+    async fn bind(
+        &self,
+        _session_id: &str,
+        _fingerprint: SessionBindingFingerprint,
+    ) -> Result<(), SessionBindingStoreError> {
+        Ok(())
+    }
+
+    async fn authorize_and_touch(
+        &self,
+        _session_id: &str,
+        _fingerprint: &SessionBindingFingerprint,
+    ) -> Result<SessionBindingStatus, SessionBindingStoreError> {
+        Ok(SessionBindingStatus::Authorized)
+    }
+
+    async fn remove(&self, _session_id: &str) -> Result<(), SessionBindingStoreError> {
+        self.remove_calls.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn missing_rmcp_session_removes_stale_binding() {
+    let (_temp, app_server, app) = local_app().await;
+    let remove_calls = Arc::new(AtomicUsize::new(0));
+    let runtime = AuthenticatedMcpHttpRuntime::new(
+        |_| async { Ok::<_, ()>(()) },
+        move |_| std::future::ready(Ok::<_, ()>(app.clone())),
+        McpOptions::default(),
+        || async { Ok::<_, tonic::Code>(()) },
+    )
+    .with_session_binding_store(Arc::new(AuthorizedSessionBindingStore {
+        remove_calls: remove_calls.clone(),
+    }));
+    let (router, _state) = authenticated_router(authenticated_config(), runtime);
+
+    let response = send(
+        &router,
+        auth_request("Bearer token-a", Some("missing-session"), PING),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(remove_calls.load(Ordering::Relaxed), 1);
     app_server.shutdown().await.unwrap();
 }


### PR DESCRIPTION
## Stack overview

This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.

## Where this PR fits

The previous PR adds a loopback-only MCP HTTP server with authentication disabled. This PR adds the authenticated transport that later serving code can use. The next PR only exposes the local mode through Coral's server configuration, so this authenticated path is a library capability at this point in the stack.

## Intent

Protect remote MCP HTTP sessions with OAuth bearer tokens without allowing an authenticated request to fall back to Coral's shared unauthenticated client.

## What it enables

The authenticated server:

- publishes OAuth protected-resource metadata;
- requires and validates a bearer token before handling MCP work;
- creates each MCP handler with an `AppClient` that forwards that bearer token to gRPC;
- requires the exact same bearer token on every later request for that MCP session;
- keeps the live handler, token fingerprint, and last-used time in one session record;
- closes a session after one hour of inactivity when it is next accessed; and
- closes both authenticated and authentication-disabled sessions through the same shutdown path.

Only a SHA-256 fingerprint of the bearer is kept with the session; the raw bearer is not stored there.

Live MCP handlers remain in the process that created them. A deployment with more than one replica must route every request for an `Mcp-Session-Id` back to the same replica. This PR does not add shared session persistence or cross-replica handler restoration.

Browser calls remain unsupported, so any request carrying an `Origin` header is rejected.

## Usage examples

```rust
use coral_mcp::{
    McpOptions,
    http::{
        AuthenticatedMcpHttpConfig, AuthenticatedMcpHttpRuntime,
        start_authenticated,
    },
};

let config = AuthenticatedMcpHttpConfig::new(
    "0.0.0.0:14556".parse()?,
    "https://coral.example.com/mcp",
    "https://login.example.com",
    "coral:mcp",
)?;

let runtime = AuthenticatedMcpHttpRuntime::new(
    validate_bearer,
    app_client_for_bearer,
    McpOptions::default(),
    check_grpc_readiness,
);

let server = start_authenticated(config, runtime).await?;
```

`app_client_for_bearer` must return an `AppClient` that forwards the supplied bearer to gRPC. If the server runs behind a load balancer, configure session stickiness using `Mcp-Session-Id`.

## Validation

- `cargo test --locked -p coral-mcp --all-features`
- `cargo clippy --locked -p coral-mcp --all-targets --all-features -- -D warnings`
- `make rust-checks`
- `git diff --check`