### PR TITLE
feat(app): retain validated OIDC provider configuration

### DIFF
--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -92,12 +92,13 @@ impl CoralAuthorizationServer {
                 get(authorization_server_metadata),
             )
             .with_state(state);
-        let listener = TcpListener::bind(bind_addr)
-            .await
-            .map_err(|source| AuthServerError::Bind {
-                address: bind_addr,
-                source,
-            })?;
+        let listener =
+            TcpListener::bind(bind_addr)
+                .await
+                .map_err(|source| AuthServerError::Bind {
+                    address: bind_addr,
+                    source,
+                })?;
         let endpoint_uri = format!(
             "http://{}",
             listener.local_addr().map_err(AuthServerError::LocalAddr)?
@@ -275,7 +276,11 @@ mod tests {
             panic!("expected unsafe bind to be rejected");
         };
 
-        assert!(error.to_string().contains("allow_insecure_remote_http_bind"));
+        assert!(
+            error
+                .to_string()
+                .contains("allow_insecure_remote_http_bind")
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -13,7 +13,7 @@ use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
-use super::config::{AuthSettings, signing_key_env_error};
+use super::config::{AuthSettings, ResolvedAuthSettings, signing_key_env_error};
 use super::error::AuthServerError;
 use super::session::SessionTokenIssuer;
 use super::state_store::{InMemoryStateStore, StateStore};
@@ -22,7 +22,7 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Prepared Coral authorization server with validated settings and runtime dependencies.
 pub struct CoralAuthorizationServer {
-    settings: Arc<AuthSettings>,
+    settings: Arc<ResolvedAuthSettings>,
     session_tokens: SessionTokenIssuer,
     state_store: Arc<dyn StateStore>,
 }
@@ -31,8 +31,9 @@ impl CoralAuthorizationServer {
     /// Builds the Coral authorization server from validated auth settings.
     ///
     /// [`AuthSettings`] can only be produced by [`AuthSettings::from_toml`],
-    /// so the settings arrive already validated and are not rechecked here;
-    /// only runtime readiness (a resolved provider secret) is confirmed.
+    /// so the settings arrive already validated and are not rechecked here.
+    /// This resolves what parsing cannot: the provider secret and the session
+    /// signing key.
     ///
     /// `config_path` is used only to resolve a relative session signing-key
     /// path. Config parsing and the `config.toml` filesystem read remain the
@@ -55,17 +56,19 @@ impl CoralAuthorizationServer {
     }
 
     pub(crate) fn from_resolved_settings(
-        settings: AuthSettings,
+        settings: ResolvedAuthSettings,
         session_tokens: SessionTokenIssuer,
     ) -> Result<Self, AuthServerError> {
-        settings.validate_runtime_ready()?;
         if !settings.matches_session_token_issuer(&session_tokens) {
             return Err(AuthServerError::SessionIssuerMismatch);
         }
         Ok(Self::from_validated_parts(settings, session_tokens))
     }
 
-    fn from_validated_parts(settings: AuthSettings, session_tokens: SessionTokenIssuer) -> Self {
+    fn from_validated_parts(
+        settings: ResolvedAuthSettings,
+        session_tokens: SessionTokenIssuer,
+    ) -> Self {
         Self {
             settings: Arc::new(settings),
             session_tokens,
@@ -173,7 +176,7 @@ impl Drop for RunningCoralAuthorizationServer {
 
 #[derive(Clone)]
 struct AuthorizationServerHttpState {
-    settings: Arc<AuthSettings>,
+    settings: Arc<ResolvedAuthSettings>,
     #[expect(
         dead_code,
         reason = "used by the OAuth token endpoint in a descendant PR"
@@ -288,9 +291,11 @@ mod tests {
         let dir = authorization_server("");
         let config_path = dir.path().join("config.toml");
         let raw = fs::read_to_string(&config_path).expect("config snapshot");
-        let settings = AuthSettings::from_toml(&raw)
+        let (settings, _issuer) = AuthSettings::from_toml(&raw)
             .expect("valid config")
-            .expect("auth settings");
+            .expect("auth settings")
+            .resolve_runtime_dependencies(&config_path, &|_| Ok(None))
+            .expect("resolved runtime dependencies");
         let signing_key = fs::read(dir.path().join("session.key")).expect("session key");
         let session_tokens = super::SessionTokenIssuer::new(
             Some("http://localhost:9999"),

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -270,6 +270,9 @@ mod tests {
             .expect("prepared from snapshot");
     }
 
+    /// `AuthSettings` has no public constructor other than `from_toml`, so the
+    /// unsafe-bind guard cannot be bypassed by building a value directly; the
+    /// parsing boundary is the only place it needs to hold.
     #[test]
     fn rejects_unsafe_bind_at_the_only_construction_site() {
         let raw = format!(

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -31,7 +31,8 @@ impl CoralAuthorizationServer {
     /// Builds the Coral authorization server from validated auth settings.
     ///
     /// [`AuthSettings`] can only be produced by [`AuthSettings::from_toml`],
-    /// so the settings arrive already validated and are not rechecked here.
+    /// so the settings arrive already validated and are not rechecked here;
+    /// only runtime readiness (a resolved provider secret) is confirmed.
     ///
     /// `config_path` is used only to resolve a relative session signing-key
     /// path. Config parsing and the `config.toml` filesystem read remain the
@@ -39,23 +40,25 @@ impl CoralAuthorizationServer {
     ///
     /// # Errors
     ///
-    /// Returns an error when the session signing key cannot be resolved or the
-    /// session-token key material is invalid.
+    /// Returns an error when the settings fail revalidation, the session
+    /// signing key cannot be resolved, or the session-token key material is
+    /// invalid.
     pub fn from_settings(
         config_path: &Path,
         settings: AuthSettings,
     ) -> Result<Self, AuthServerError> {
         let (settings, session_tokens) = settings
-            .resolve_session_token_issuer(config_path, &|name| {
+            .resolve_runtime_dependencies(config_path, &|name| {
                 crate::bootstrap::env_var(name).map_err(|error| signing_key_env_error(&error))
             })?;
         Self::from_resolved_settings(settings, session_tokens)
     }
 
     pub(crate) fn from_resolved_settings(
-        settings: AuthSettings,
+        mut settings: AuthSettings,
         session_tokens: SessionTokenIssuer,
     ) -> Result<Self, AuthServerError> {
+        settings.validate_runtime_ready()?;
         if !settings.matches_session_token_issuer(&session_tokens) {
             return Err(AuthServerError::SessionIssuerMismatch);
         }
@@ -89,13 +92,12 @@ impl CoralAuthorizationServer {
                 get(authorization_server_metadata),
             )
             .with_state(state);
-        let listener =
-            TcpListener::bind(bind_addr)
-                .await
-                .map_err(|source| AuthServerError::Bind {
-                    address: bind_addr,
-                    source,
-                })?;
+        let listener = TcpListener::bind(bind_addr)
+            .await
+            .map_err(|source| AuthServerError::Bind {
+                address: bind_addr,
+                source,
+            })?;
         let endpoint_uri = format!(
             "http://{}",
             listener.local_addr().map_err(AuthServerError::LocalAddr)?
@@ -264,9 +266,6 @@ mod tests {
             .expect("prepared from snapshot");
     }
 
-    /// `AuthSettings` has no public constructor other than `from_toml`, so the
-    /// unsafe-bind guard cannot be bypassed by building a value directly; the
-    /// parsing boundary is the only place it needs to hold.
     #[test]
     fn rejects_unsafe_bind_at_the_only_construction_site() {
         let raw = format!(
@@ -276,11 +275,7 @@ mod tests {
             panic!("expected unsafe bind to be rejected");
         };
 
-        assert!(
-            error
-                .to_string()
-                .contains("allow_insecure_remote_http_bind")
-        );
+        assert!(error.to_string().contains("allow_insecure_remote_http_bind"));
     }
 
     #[test]

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -40,9 +40,9 @@ impl CoralAuthorizationServer {
     ///
     /// # Errors
     ///
-    /// Returns an error when the settings fail revalidation, the session
-    /// signing key cannot be resolved, or the session-token key material is
-    /// invalid.
+    /// Returns an error when the provider secret cannot be resolved from its
+    /// environment variable, the session signing key cannot be resolved, or
+    /// the session-token key material is invalid.
     pub fn from_settings(
         config_path: &Path,
         settings: AuthSettings,
@@ -55,7 +55,7 @@ impl CoralAuthorizationServer {
     }
 
     pub(crate) fn from_resolved_settings(
-        mut settings: AuthSettings,
+        settings: AuthSettings,
         session_tokens: SessionTokenIssuer,
     ) -> Result<Self, AuthServerError> {
         settings.validate_runtime_ready()?;

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -262,6 +262,10 @@ impl AuthorizationServerSettings {
 const DEFAULT_PROVIDER_SCOPES: &[&str] = &["openid", "email", "profile"];
 const RESERVED_PROVIDER_AUTH_PARAMS: &[&str] = &[
     "response_type",
+    // `fragment` and `form_post` both stop the authorization code from ever
+    // reaching the GET callback route, so a login started with either simply
+    // never completes and leaves nothing in this server's logs.
+    "response_mode",
     "client_id",
     "redirect_uri",
     "scope",
@@ -559,10 +563,16 @@ fn provider_claim(field: &str, value: &str, default: &str) -> Result<String, Aut
     Ok(value.to_string())
 }
 
+/// Rejects a key that cannot name a claim or an authorization query parameter.
+///
+/// Interior whitespace matters as much as surrounding whitespace: a claim name
+/// carrying it can never be found in an ID token, and validating it here is
+/// what makes `provider_claim`'s startup guarantee real rather than reporting
+/// it as a missing claim on every login.
 fn validate_provider_key(field: &str, key: &str) -> Result<(), AuthServerError> {
-    if key.is_empty() || key.trim() != key {
+    if key.is_empty() || key.chars().any(char::is_whitespace) {
         return Err(invalid_provider(format!(
-            "{field} keys must be nonempty and have no surrounding whitespace"
+            "{field} keys must be nonempty and contain no whitespace"
         )));
     }
     Ok(())
@@ -820,6 +830,17 @@ mod tests {
         assert!(reject(&reserved).contains("reserved parameter `CLIENT_ID`"));
         let invalid_claim = valid("") + "\n[auth.provider.required_claims]\n' spaced ' = true\n";
         assert!(reject(&invalid_claim).contains("required_claims"));
+        let response_mode =
+            valid("") + "\n[auth.provider.auth_params]\nresponse_mode = 'fragment'\n";
+        assert!(reject(&response_mode).contains("reserved parameter `response_mode`"));
+        let spaced_claim = valid("").replace(
+            "client_id = 'upstream-client'",
+            "client_id = 'upstream-client'\nprincipal_claim = 'user id'",
+        );
+        assert!(
+            reject(&spaced_claim)
+                .contains("principal_claim keys must be nonempty and contain no whitespace")
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -1,5 +1,6 @@
 //! Parsing and validation for Coral authentication settings.
 
+use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -340,11 +341,10 @@ impl OidcProviderSettings {
         }
 
         self.issuer = provider_required("issuer", &self.issuer)?;
-        let issuer = provider_endpoint("issuer", &self.issuer)?;
+        let issuer = provider_issuer_endpoint(&self.issuer)?;
         if issuer.as_url().query().is_some() {
             return Err(invalid_provider("issuer must not include a query"));
         }
-        validate_canonical_issuer(&self.issuer, &issuer)?;
         self.client_id = provider_required("client_id", &self.client_id)?;
         self.redirect_uri = provider_required("redirect_uri", &self.redirect_uri)?;
         let redirect_uri = provider_endpoint("redirect_uri", &self.redirect_uri)?;
@@ -553,27 +553,17 @@ fn provider_endpoint(field: &str, value: &str) -> Result<ConfiguredEndpointUrl, 
         .map_err(|error| invalid_provider(format!("{field} is invalid: {error}")))
 }
 
-/// Rejects a provider issuer the URL parser would rewrite.
-///
-/// The issuer is retained exactly as configured, because an `OpenID` Connect
-/// discovery document's `issuer` must equal the configured one byte for byte.
-/// Providers publish issuers both with a trailing slash and without one, so
-/// both are accepted — the parser appends one only to a root-path URL. Any
-/// other divergence from the parser's canonical serialization (a mixed-case
-/// host, an explicit default port, dot segments, non-canonical percent
-/// encoding) is a form no provider can publish, so accepting it would trade a
-/// startup error for a discovery mismatch on every login.
-fn validate_canonical_issuer(
-    configured: &str,
-    parsed: &ConfiguredEndpointUrl,
-) -> Result<(), AuthServerError> {
-    let canonical = parsed.as_url().as_str();
-    if configured == canonical || format!("{configured}/") == canonical {
-        return Ok(());
+fn provider_issuer_endpoint(value: &str) -> Result<ConfiguredEndpointUrl, AuthServerError> {
+    let syntax_violation = Cell::new(None);
+    let record_violation = |violation| syntax_violation.set(Some(violation));
+    Url::options()
+        .syntax_violation_callback(Some(&record_violation))
+        .parse(value)
+        .map_err(|error| invalid_provider(format!("issuer is invalid: {error}")))?;
+    if let Some(violation) = syntax_violation.get() {
+        return Err(invalid_provider(format!("issuer is invalid: {violation}")));
     }
-    Err(invalid_provider(format!(
-        "issuer must be copied exactly as the provider publishes it; `{configured}` is not a canonical URL (its canonical form is `{canonical}`)"
-    )))
+    provider_endpoint("issuer", value)
 }
 
 fn valid_scope_token(scope: &str) -> bool {
@@ -839,8 +829,8 @@ mod tests {
     }
 
     /// A provider issuer is compared byte for byte against the issuer in the
-    /// discovery document, so every form a provider can publish has to survive
-    /// validation unchanged — including both trailing-slash spellings.
+    /// discovery document, so every valid spelling a provider publishes has to
+    /// survive validation unchanged.
     #[test]
     fn retains_every_issuer_spelling_a_provider_can_publish() {
         for issuer in [
@@ -848,34 +838,12 @@ mod tests {
             "https://accounts.example.test/",
             "https://accounts.example.test/tenant",
             "https://accounts.example.test/tenant/",
+            "https://ACCOUNTS.example.test/tenant",
+            "https://accounts.example.test:443/tenant",
+            "https://accounts.example.test/tenant/../other",
             "http://127.0.0.1:9080/tenant/",
         ] {
             assert_eq!(resolved(&provider_issuer(issuer)).provider().issuer, issuer);
-        }
-    }
-
-    #[test]
-    fn rejects_provider_issuers_no_provider_could_publish() {
-        for (issuer, canonical) in [
-            (
-                "https://ACCOUNTS.example.test/tenant",
-                "https://accounts.example.test/tenant",
-            ),
-            (
-                "https://accounts.example.test:443/tenant",
-                "https://accounts.example.test/tenant",
-            ),
-            (
-                "https://accounts.example.test/tenant/../other",
-                "https://accounts.example.test/other",
-            ),
-        ] {
-            let error = reject(&provider_issuer(issuer));
-            assert!(
-                error.contains("copied exactly as the provider publishes it"),
-                "{error}"
-            );
-            assert!(error.contains(canonical), "{error}");
         }
     }
 
@@ -895,6 +863,18 @@ mod tests {
                     "http://accounts.example.test",
                 ),
                 "issuer is invalid: configured endpoint must use HTTPS",
+            ),
+            (
+                provider_issuer(r"https://accounts.example.test\tenant"),
+                "issuer is invalid: backslash",
+            ),
+            (
+                provider_issuer("https://accounts.example.test/^"),
+                "issuer is invalid: non-URL code point",
+            ),
+            (
+                provider_issuer("https://accounts.example.test/%1"),
+                "issuer is invalid: expected 2 hex digits after %",
             ),
             (
                 valid("").replace(

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -36,9 +36,9 @@ const CONFLICTING_KEY_SOURCES: &str = "configure only one of signing_key_env or 
 /// nothing downstream revalidates. This type performs no `config.toml`
 /// filesystem reads.
 ///
-/// The settings are read through [`ResolvedAuthSettings`], which
-/// [`AuthSettings::resolve_runtime_dependencies`] produces once the secrets
-/// the config only points at have actually been fetched.
+/// The settings are read through the crate-internal `ResolvedAuthSettings`,
+/// which `resolve_runtime_dependencies` produces once the secrets the config
+/// only points at have actually been fetched.
 pub struct AuthSettings(RawAuthSettings);
 
 #[derive(Deserialize)]

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -796,51 +796,75 @@ mod tests {
 
     #[test]
     fn rejects_invalid_provider_fields() {
-        let invalid = [
-            valid("").replace(
-                "issuer = 'https://accounts.example.test'",
-                "type = 'oauth'\nissuer = 'https://accounts.example.test'",
+        let cases = vec![
+            (
+                valid("").replace(
+                    "issuer = 'https://accounts.example.test'",
+                    "type = 'oauth'\nissuer = 'https://accounts.example.test'",
+                ),
+                "type must be `oidc`",
             ),
-            valid("").replace(
-                "https://accounts.example.test",
-                "http://accounts.example.test",
+            (
+                valid("").replace(
+                    "https://accounts.example.test",
+                    "http://accounts.example.test",
+                ),
+                "issuer is invalid: configured endpoint must use HTTPS",
             ),
-            valid("").replace(
-                "https://accounts.example.test",
-                "https://accounts.example.test?q=1",
+            (
+                valid("").replace(
+                    "https://accounts.example.test",
+                    "https://accounts.example.test?q=1",
+                ),
+                "issuer must not include a query",
             ),
-            valid("").replace(
-                "http://localhost:9080/auth/oidc/callback",
-                "http://remote.test/callback",
+            (
+                valid("").replace(
+                    "http://localhost:9080/auth/oidc/callback",
+                    "https://remote.test/callback",
+                ),
+                "must share the origin",
             ),
-            valid("").replace(
-                "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
-                "redirect_uri = 'http://localhost:9080/auth/oidc/callback'\nscopes = ['email']",
+            (
+                valid("").replace(
+                    "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
+                    "redirect_uri = 'http://localhost:9080/auth/oidc/callback'\nscopes = ['email']",
+                ),
+                "scopes must include `openid`",
             ),
-            valid("").replace(
-                "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
-                "redirect_uri = 'http://localhost:9080/auth/oidc/callback'\nscopes = ['openid', 'two scopes']",
+            (
+                valid("").replace(
+                    "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
+                    "redirect_uri = 'http://localhost:9080/auth/oidc/callback'\nscopes = ['openid', 'two scopes']",
+                ),
+                "scopes must contain valid OAuth scope tokens",
+            ),
+            (
+                valid("").replace(
+                    "client_id = 'upstream-client'",
+                    "client_id = 'upstream-client'\nprincipal_claim = 'user id'",
+                ),
+                "principal_claim keys must be nonempty and contain no whitespace",
+            ),
+            (
+                valid("") + "\n[auth.provider.auth_params]\nCLIENT_ID = 'override'\n",
+                "reserved parameter `CLIENT_ID`",
+            ),
+            (
+                valid("") + "\n[auth.provider.auth_params]\nresponse_mode = 'fragment'\n",
+                "reserved parameter `response_mode`",
+            ),
+            (
+                valid("") + "\n[auth.provider.required_claims]\n' spaced ' = true\n",
+                "required_claims keys must be nonempty and contain no whitespace",
             ),
         ];
-        for raw in invalid {
-            assert!(AuthSettings::from_toml(&raw).is_err(), "{raw}");
+        for (raw, expected) in cases {
+            assert!(
+                reject(&raw).contains(expected),
+                "expected `{expected}` for {raw}"
+            );
         }
-
-        let reserved = valid("") + "\n[auth.provider.auth_params]\nCLIENT_ID = 'override'\n";
-        assert!(reject(&reserved).contains("reserved parameter `CLIENT_ID`"));
-        let invalid_claim = valid("") + "\n[auth.provider.required_claims]\n' spaced ' = true\n";
-        assert!(reject(&invalid_claim).contains("required_claims"));
-        let response_mode =
-            valid("") + "\n[auth.provider.auth_params]\nresponse_mode = 'fragment'\n";
-        assert!(reject(&response_mode).contains("reserved parameter `response_mode`"));
-        let spaced_claim = valid("").replace(
-            "client_id = 'upstream-client'",
-            "client_id = 'upstream-client'\nprincipal_claim = 'user id'",
-        );
-        assert!(
-            reject(&spaced_claim)
-                .contains("principal_claim keys must be nonempty and contain no whitespace")
-        );
     }
 
     #[test]

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -308,6 +308,7 @@ impl OidcProviderSettings {
         if issuer.as_url().query().is_some() {
             return Err(invalid_provider("issuer must not include a query"));
         }
+        validate_canonical_issuer(&self.issuer, &issuer)?;
         self.client_id = provider_required("client_id", &self.client_id)?;
         self.redirect_uri = provider_required("redirect_uri", &self.redirect_uri)?;
         let redirect_uri = provider_endpoint("redirect_uri", &self.redirect_uri)?;
@@ -518,6 +519,29 @@ fn provider_endpoint(field: &str, value: &str) -> Result<ConfiguredEndpointUrl, 
         .map_err(|error| invalid_provider(format!("{field} is invalid: {error}")))
 }
 
+/// Rejects a provider issuer the URL parser would rewrite.
+///
+/// The issuer is retained exactly as configured, because an `OpenID` Connect
+/// discovery document's `issuer` must equal the configured one byte for byte.
+/// Providers publish issuers both with a trailing slash and without one, so
+/// both are accepted — the parser appends one only to a root-path URL. Any
+/// other divergence from the parser's canonical serialization (a mixed-case
+/// host, an explicit default port, dot segments, non-canonical percent
+/// encoding) is a form no provider can publish, so accepting it would trade a
+/// startup error for a discovery mismatch on every login.
+fn validate_canonical_issuer(
+    configured: &str,
+    parsed: &ConfiguredEndpointUrl,
+) -> Result<(), AuthServerError> {
+    let canonical = parsed.as_url().as_str();
+    if configured == canonical || format!("{configured}/") == canonical {
+        return Ok(());
+    }
+    Err(invalid_provider(format!(
+        "issuer must be copied exactly as the provider publishes it; `{configured}` is not a canonical URL (its canonical form is `{canonical}`)"
+    )))
+}
+
 fn valid_scope_token(scope: &str) -> bool {
     !scope.is_empty()
         && scope
@@ -610,6 +634,13 @@ mod tests {
 
     fn valid(extra: &str) -> String {
         format!("[auth]\n{SESSION}{AUTHORIZATION_SERVER}{extra}\n{PROVIDER}")
+    }
+
+    fn provider_issuer(issuer: &str) -> String {
+        valid("").replace(
+            "issuer = 'https://accounts.example.test'",
+            &format!("issuer = '{issuer}'"),
+        )
     }
 
     fn reject(raw: &str) -> String {
@@ -707,6 +738,50 @@ mod tests {
         );
         let debug = format!("{provider:?}");
         assert!(!debug.contains("env-secret"));
+    }
+
+    /// A provider issuer is compared byte for byte against the issuer in the
+    /// discovery document, so every form a provider can publish has to survive
+    /// validation unchanged — including both trailing-slash spellings.
+    #[test]
+    fn retains_every_issuer_spelling_a_provider_can_publish() {
+        for issuer in [
+            "https://accounts.example.test",
+            "https://accounts.example.test/",
+            "https://accounts.example.test/tenant",
+            "https://accounts.example.test/tenant/",
+            "http://127.0.0.1:9080/tenant/",
+        ] {
+            let settings = AuthSettings::from_toml(&provider_issuer(issuer))
+                .expect("valid config")
+                .expect("auth settings");
+            assert_eq!(settings.provider().issuer, issuer);
+        }
+    }
+
+    #[test]
+    fn rejects_provider_issuers_no_provider_could_publish() {
+        for (issuer, canonical) in [
+            (
+                "https://ACCOUNTS.example.test/tenant",
+                "https://accounts.example.test/tenant",
+            ),
+            (
+                "https://accounts.example.test:443/tenant",
+                "https://accounts.example.test/tenant",
+            ),
+            (
+                "https://accounts.example.test/tenant/../other",
+                "https://accounts.example.test/other",
+            ),
+        ] {
+            let error = reject(&provider_issuer(issuer));
+            assert!(
+                error.contains("copied exactly as the provider publishes it"),
+                "{error}"
+            );
+            assert!(error.contains(canonical), "{error}");
+        }
     }
 
     #[test]

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -276,7 +276,10 @@ const RESERVED_PROVIDER_AUTH_PARAMS: &[&str] = &[
 ];
 
 /// Validated settings for one upstream OIDC provider.
-#[derive(Clone, Default, Deserialize)]
+///
+/// The derived `Debug` is safe to print: the only secret-bearing field is a
+/// [`ProviderSecret`], which redacts itself.
+#[derive(Clone, Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub(super) struct OidcProviderSettings {
     #[serde(rename = "type")]
@@ -424,25 +427,6 @@ impl OidcProviderSettings {
             .as_ref()
             .expect("runtime-ready provider has a resolved client secret")
             .as_str()
-    }
-}
-
-impl fmt::Debug for OidcProviderSettings {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("OidcProviderSettings")
-            .field("provider_type", &self.provider_type)
-            .field("issuer", &self.issuer)
-            .field("client_id", &self.client_id)
-            .field("client_secret", &self.client_secret)
-            .field("client_secret_env", &self.client_secret_env)
-            .field("redirect_uri", &self.redirect_uri)
-            .field("scopes", &self.scopes)
-            .field("principal_claim", &self.principal_claim)
-            .field("display_name_claim", &self.display_name_claim)
-            .field("auth_params", &self.auth_params)
-            .field("required_claims", &self.required_claims)
-            .finish()
     }
 }
 

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -335,13 +335,13 @@ impl OidcProviderSettings {
         }
 
         if let Some(secret) = &mut self.client_secret {
-            *secret = ProviderSecret::from_trimmed(secret.as_str())?;
+            *secret = ProviderSecret::from_trimmed("client_secret", secret.as_str())?;
         }
         if let Some(env_name) = &mut self.client_secret_env {
             *env_name = env_name.trim().to_string();
             if env_name.is_empty() {
                 return Err(invalid_provider(
-                    "provider secret must be a nonempty string",
+                    "client_secret_env must be a nonempty string",
                 ));
             }
             if env_name.bytes().any(|byte| matches!(byte, b'=' | b'\0')) {
@@ -398,9 +398,9 @@ impl OidcProviderSettings {
         let value = Zeroizing::new(
             get_var(env_name)
                 .map_err(|_error| invalid_provider("client_secret_env could not be read"))?
-                .ok_or_else(|| invalid_provider("client_secret_env is unset or empty"))?,
+                .ok_or_else(|| invalid_provider("client_secret_env names an unset variable"))?,
         );
-        self.client_secret = Some(ProviderSecret::from_trimmed(&value)?);
+        self.client_secret = Some(ProviderSecret::from_trimmed("client_secret_env", &value)?);
         self.client_secret_env = None;
         Ok(())
     }
@@ -450,10 +450,11 @@ impl fmt::Debug for OidcProviderSettings {
 struct ProviderSecret(Arc<Zeroizing<String>>);
 
 impl ProviderSecret {
-    fn from_trimmed(value: &str) -> Result<Self, AuthServerError> {
+    /// Trims a secret read from `field`, which names it in any error.
+    fn from_trimmed(field: &str, value: &str) -> Result<Self, AuthServerError> {
         let value = value.trim();
         if value.is_empty() {
-            Err(invalid_provider("client secret must not be empty"))
+            Err(invalid_provider(format!("{field} must not be empty")))
         } else {
             Ok(Self(Arc::new(Zeroizing::new(value.to_string()))))
         }
@@ -1050,11 +1051,20 @@ mod tests {
 
     #[test]
     fn configuration_errors_do_not_leak_secrets() {
-        for secret in ["client_secret_env = ''", "client_secret = 42"] {
+        for (secret, expected) in [
+            (
+                "client_secret_env = ''",
+                "client_secret_env must be a nonempty string",
+            ),
+            (
+                "client_secret = 42",
+                "provider secret must be a nonempty string",
+            ),
+        ] {
             let raw = valid("").replace("client_secret = 'provider-secret'", secret);
             let error = reject(&raw);
-            assert!(error.contains("provider secret must be a nonempty string"));
-            assert!(!error.contains("42"));
+            assert!(error.contains(expected), "{error}");
+            assert!(!error.contains("42"), "{error}");
         }
         let malformed = "[auth]\nclient_secret = 'SUPER_SECRET' trailing-garbage\n";
         assert!(!reject(malformed).contains("SUPER_SECRET"));

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -290,10 +290,7 @@ pub(super) struct OidcProviderSettings {
 }
 
 impl OidcProviderSettings {
-    fn validate(
-        &mut self,
-        authorization_server_issuer: &str,
-    ) -> Result<(), AuthServerError> {
+    fn validate(&mut self, authorization_server_issuer: &str) -> Result<(), AuthServerError> {
         if self.client_secret.is_some() == self.client_secret_env.is_some() {
             return Err(config_error(
                 "auth.provider must configure exactly one of client_secret or client_secret_env",
@@ -338,7 +335,9 @@ impl OidcProviderSettings {
         if let Some(env_name) = &mut self.client_secret_env {
             *env_name = env_name.trim().to_string();
             if env_name.is_empty() {
-                return Err(invalid_provider("provider secret must be a nonempty string"));
+                return Err(invalid_provider(
+                    "provider secret must be a nonempty string",
+                ));
             }
             if env_name.bytes().any(|byte| matches!(byte, b'=' | b'\0')) {
                 return Err(invalid_provider("client_secret_env is invalid"));
@@ -546,7 +545,9 @@ fn validate_provider_key(field: &str, key: &str) -> Result<(), AuthServerError> 
 }
 
 fn invalid_provider(message: impl fmt::Display) -> AuthServerError {
-    AuthServerError::Config(format!("invalid auth configuration: auth.provider.{message}"))
+    AuthServerError::Config(format!(
+        "invalid auth configuration: auth.provider.{message}"
+    ))
 }
 
 fn validate_issuer(label: &str, raw: &str, root_only: bool) -> Result<String, AuthServerError> {
@@ -742,8 +743,7 @@ mod tests {
 
         let reserved = valid("") + "\n[auth.provider.auth_params]\nCLIENT_ID = 'override'\n";
         assert!(reject(&reserved).contains("reserved parameter `CLIENT_ID`"));
-        let invalid_claim =
-            valid("") + "\n[auth.provider.required_claims]\n' spaced ' = true\n";
+        let invalid_claim = valid("") + "\n[auth.provider.required_claims]\n' spaced ' = true\n";
         assert!(reject(&invalid_claim).contains("required_claims"));
     }
 

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -1,19 +1,24 @@
 //! Parsing and validation for Coral authentication settings.
 
+use std::collections::BTreeMap;
+use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::time::Duration;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer};
-use url::{Host, Url};
+use serde_json::Value;
+use url::Url;
 use zeroize::Zeroizing;
 
 use super::error::AuthServerError;
 use super::session::SessionTokenIssuer;
 use crate::bootstrap::is_loopback_ip;
+use crate::outbound_url_policy::ConfiguredEndpointUrl;
 
 const DEFAULT_BIND_ADDR: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 const DEFAULT_SIGNING_KEY_ENV: &str = "CORAL_SESSION_SIGNING_KEY";
@@ -83,11 +88,20 @@ impl AuthSettings {
         &self.0.authorization_server
     }
 
-    pub(super) fn resolve_session_token_issuer(
-        self,
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used by the OIDC federation descendant")
+    )]
+    pub(super) fn provider(&self) -> &OidcProviderSettings {
+        &self.0.provider
+    }
+
+    pub(super) fn resolve_runtime_dependencies(
+        mut self,
         config_path: &Path,
         get_var: &impl Fn(&str) -> Result<Option<String>, String>,
     ) -> Result<(Self, SessionTokenIssuer), AuthServerError> {
+        self.0.provider.resolve_secret(get_var)?;
         let key = self.0.session.load_signing_key(config_path, get_var)?;
         let issuer = SessionTokenIssuer::new(
             Some(&self.0.authorization_server.issuer),
@@ -96,6 +110,15 @@ impl AuthSettings {
         )
         .map_err(AuthServerError::Config)?;
         Ok((self, issuer))
+    }
+
+    /// Confirms the settings carry everything the running server needs.
+    ///
+    /// Field validation already ran at construction, so this checks only what
+    /// construction cannot: that the provider secret has been resolved from its
+    /// environment variable.
+    pub(super) fn validate_runtime_ready(&self) -> Result<(), AuthServerError> {
+        self.0.provider.require_resolved_secret()
     }
 
     pub(super) fn matches_session_token_issuer(&self, issuer: &SessionTokenIssuer) -> bool {
@@ -236,58 +259,223 @@ impl AuthorizationServerSettings {
     }
 }
 
-#[derive(Default, Deserialize)]
+const DEFAULT_PROVIDER_SCOPES: &[&str] = &["openid", "email", "profile"];
+const RESERVED_PROVIDER_AUTH_PARAMS: &[&str] = &[
+    "response_type",
+    "client_id",
+    "redirect_uri",
+    "scope",
+    "state",
+    "nonce",
+    "code_challenge",
+    "code_challenge_method",
+];
+
+/// Validated settings for one upstream OIDC provider.
+#[derive(Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-struct OidcProviderSettings {
-    issuer: String,
-    client_id: String,
-    redirect_uri: String,
-    client_secret: Option<SecretMarker>,
-    client_secret_env: Option<SecretMarker>,
+pub(super) struct OidcProviderSettings {
+    #[serde(rename = "type")]
+    provider_type: Option<String>,
+    pub(super) issuer: String,
+    pub(super) client_id: String,
+    client_secret: Option<ProviderSecret>,
+    client_secret_env: Option<String>,
+    pub(super) redirect_uri: String,
+    pub(super) scopes: Vec<String>,
+    pub(super) principal_claim: String,
+    pub(super) display_name_claim: String,
+    pub(super) auth_params: BTreeMap<String, String>,
+    pub(super) required_claims: BTreeMap<String, Value>,
 }
 
 impl OidcProviderSettings {
-    fn validate(&mut self, authorization_server_issuer: &str) -> Result<(), AuthServerError> {
+    fn validate(
+        &mut self,
+        authorization_server_issuer: &str,
+    ) -> Result<(), AuthServerError> {
         if self.client_secret.is_some() == self.client_secret_env.is_some() {
             return Err(config_error(
                 "auth.provider must configure exactly one of client_secret or client_secret_env",
             ));
         }
-        self.issuer = required("auth.provider.issuer", &self.issuer)?;
-        self.issuer = validate_issuer("OIDC provider issuer", &self.issuer, false)?;
-        self.client_id = required("auth.provider.client_id", &self.client_id)?;
-        self.redirect_uri = required("auth.provider.redirect_uri", &self.redirect_uri)?;
-        let redirect_uri = validate_endpoint("OIDC provider redirect URI", &self.redirect_uri)?;
+        if let Some(provider_type) = &mut self.provider_type {
+            *provider_type = provider_type.trim().to_string();
+            if provider_type != "oidc" {
+                return Err(invalid_provider("type must be `oidc`"));
+            }
+        }
+
+        self.issuer = provider_required("issuer", &self.issuer)?;
+        let issuer = provider_endpoint("issuer", &self.issuer)?;
+        if issuer.as_url().query().is_some() {
+            return Err(invalid_provider("issuer must not include a query"));
+        }
+        self.client_id = provider_required("client_id", &self.client_id)?;
+        self.redirect_uri = provider_required("redirect_uri", &self.redirect_uri)?;
+        let redirect_uri = provider_endpoint("redirect_uri", &self.redirect_uri)?;
         // The upstream IdP sends the browser back to a callback route under
         // this server's origin, so a redirect URI pointing anywhere else can
         // only fail later, at the IdP or in the browser — far from Coral's own
         // logs.
-        let issuer = Url::parse(authorization_server_issuer).map_err(|error| {
-            config_error(format!(
-                "auth.authorization_server.issuer is not a valid URL: {error}"
-            ))
-        })?;
-        if redirect_uri.origin() != issuer.origin() {
-            return Err(config_error(format!(
-                "auth.provider.redirect_uri must share the origin of auth.authorization_server.issuer ({})",
-                issuer.origin().ascii_serialization()
+        let served_origin = Url::parse(authorization_server_issuer)
+            .map_err(|error| {
+                config_error(format!(
+                    "auth.authorization_server.issuer is not a valid URL: {error}"
+                ))
+            })?
+            .origin();
+        if redirect_uri.as_url().origin() != served_origin {
+            return Err(invalid_provider(format!(
+                "redirect_uri must share the origin of auth.authorization_server.issuer ({})",
+                served_origin.ascii_serialization()
             )));
+        }
+
+        if let Some(secret) = &mut self.client_secret {
+            *secret = ProviderSecret::from_trimmed(secret.as_str())?;
+        }
+        if let Some(env_name) = &mut self.client_secret_env {
+            *env_name = env_name.trim().to_string();
+            if env_name.is_empty() {
+                return Err(invalid_provider("provider secret must be a nonempty string"));
+            }
+            if env_name.bytes().any(|byte| matches!(byte, b'=' | b'\0')) {
+                return Err(invalid_provider("client_secret_env is invalid"));
+            }
+        }
+
+        if self.scopes.is_empty() {
+            self.scopes = DEFAULT_PROVIDER_SCOPES
+                .iter()
+                .map(ToString::to_string)
+                .collect();
+        }
+        if self.scopes.iter().any(|scope| !valid_scope_token(scope)) {
+            return Err(invalid_provider(
+                "scopes must contain valid OAuth scope tokens",
+            ));
+        }
+        if !self.scopes.iter().any(|scope| scope == "openid") {
+            return Err(invalid_provider("scopes must include `openid`"));
+        }
+
+        self.principal_claim = provider_claim("principal_claim", &self.principal_claim, "sub")?;
+        self.display_name_claim =
+            provider_claim("display_name_claim", &self.display_name_claim, "email")?;
+        for key in self.required_claims.keys() {
+            validate_provider_key("required_claims", key)?;
+        }
+        for key in self.auth_params.keys() {
+            validate_provider_key("auth_params", key)?;
+            if RESERVED_PROVIDER_AUTH_PARAMS
+                .iter()
+                .any(|reserved| key.eq_ignore_ascii_case(reserved))
+            {
+                return Err(invalid_provider(format!(
+                    "auth_params must not include reserved parameter `{key}`"
+                )));
+            }
         }
         Ok(())
     }
+
+    fn resolve_secret(
+        &mut self,
+        get_var: &impl Fn(&str) -> Result<Option<String>, String>,
+    ) -> Result<(), AuthServerError> {
+        if self.client_secret.is_some() {
+            return Ok(());
+        }
+        let env_name = self
+            .client_secret_env
+            .as_deref()
+            .expect("validated provider has one secret source");
+        let value = Zeroizing::new(
+            get_var(env_name)
+                .map_err(|_error| invalid_provider("client_secret_env could not be read"))?
+                .ok_or_else(|| invalid_provider("client_secret_env is unset or empty"))?,
+        );
+        self.client_secret = Some(ProviderSecret::from_trimmed(&value)?);
+        self.client_secret_env = None;
+        Ok(())
+    }
+
+    fn require_resolved_secret(&self) -> Result<(), AuthServerError> {
+        if self.client_secret.is_some() && self.client_secret_env.is_none() {
+            Ok(())
+        } else {
+            Err(invalid_provider(
+                "client_secret_env must be resolved before server construction",
+            ))
+        }
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used by the OIDC federation descendant")
+    )]
+    pub(super) fn client_secret(&self) -> &str {
+        self.client_secret
+            .as_ref()
+            .expect("runtime-ready provider has a resolved client secret")
+            .as_str()
+    }
 }
 
-struct SecretMarker;
+impl fmt::Debug for OidcProviderSettings {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("OidcProviderSettings")
+            .field("provider_type", &self.provider_type)
+            .field("issuer", &self.issuer)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &self.client_secret)
+            .field("client_secret_env", &self.client_secret_env)
+            .field("redirect_uri", &self.redirect_uri)
+            .field("scopes", &self.scopes)
+            .field("principal_claim", &self.principal_claim)
+            .field("display_name_claim", &self.display_name_claim)
+            .field("auth_params", &self.auth_params)
+            .field("required_claims", &self.required_claims)
+            .finish()
+    }
+}
 
-impl<'de> Deserialize<'de> for SecretMarker {
+#[derive(Clone)]
+struct ProviderSecret(Arc<Zeroizing<String>>);
+
+impl ProviderSecret {
+    fn from_trimmed(value: &str) -> Result<Self, AuthServerError> {
+        let value = value.trim();
+        if value.is_empty() {
+            Err(invalid_provider("client secret must not be empty"))
+        } else {
+            Ok(Self(Arc::new(Zeroizing::new(value.to_string()))))
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl<'de> Deserialize<'de> for ProviderSecret {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let invalid = || D::Error::custom("provider secret must be a nonempty string");
         let value = String::deserialize(deserializer)
             .map(Zeroizing::new)
             .map_err(|_error| invalid())?;
-        (!value.trim().is_empty())
-            .then_some(Self)
-            .ok_or_else(invalid)
+        if value.trim().is_empty() {
+            return Err(invalid());
+        }
+        Ok(Self(Arc::new(value)))
+    }
+}
+
+impl fmt::Debug for ProviderSecret {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("<redacted>")
     }
 }
 
@@ -317,40 +505,64 @@ fn required(label: &str, value: &str) -> Result<String, AuthServerError> {
     }
 }
 
-fn validate_issuer(label: &str, raw: &str, root_only: bool) -> Result<String, AuthServerError> {
-    let url = validate_endpoint(label, raw)?;
-    if url.query().is_some() {
-        return Err(config_error(format!("{label} must not include a query")));
+fn provider_required(field: &str, value: &str) -> Result<String, AuthServerError> {
+    let value = value.trim();
+    if value.is_empty() {
+        Err(invalid_provider(format!("{field} is required")))
+    } else {
+        Ok(value.to_string())
     }
-    if root_only && !matches!(url.path(), "" | "/") {
-        return Err(config_error(format!("{label} must mount at the root")));
-    }
-    Ok(url.as_str().trim_end_matches('/').to_string())
 }
 
-fn validate_endpoint(label: &str, raw: &str) -> Result<Url, AuthServerError> {
-    let url = Url::parse(raw.trim())
-        .map_err(|error| config_error(format!("{label} is not a valid URL: {error}")))?;
-    if !url.username().is_empty() || url.password().is_some() {
-        return Err(config_error(format!(
-            "{label} must not include credentials"
-        )));
-    }
-    if url.fragment().is_some() {
-        return Err(config_error(format!("{label} must not include a fragment")));
-    }
-    let loopback = match url.host() {
-        Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
-        Some(Host::Ipv4(ip)) => is_loopback_ip(ip.into()),
-        Some(Host::Ipv6(ip)) => is_loopback_ip(ip.into()),
-        None => return Err(config_error(format!("{label} must include a host"))),
+fn provider_endpoint(field: &str, value: &str) -> Result<ConfiguredEndpointUrl, AuthServerError> {
+    ConfiguredEndpointUrl::parse(value)
+        .map_err(|error| invalid_provider(format!("{field} is invalid: {error}")))
+}
+
+fn valid_scope_token(scope: &str) -> bool {
+    !scope.is_empty()
+        && scope
+            .bytes()
+            .all(|byte| matches!(byte, 0x21 | 0x23..=0x5b | 0x5d..=0x7e))
+}
+
+fn provider_claim(field: &str, value: &str, default: &str) -> Result<String, AuthServerError> {
+    let value = if value.trim().is_empty() {
+        default
+    } else {
+        value.trim()
     };
-    if url.scheme() != "https" && !(url.scheme() == "http" && loopback) {
-        return Err(config_error(format!(
-            "{label} requires https or loopback http"
+    validate_provider_key(field, value)?;
+    Ok(value.to_string())
+}
+
+fn validate_provider_key(field: &str, key: &str) -> Result<(), AuthServerError> {
+    if key.is_empty() || key.trim() != key {
+        return Err(invalid_provider(format!(
+            "{field} keys must be nonempty and have no surrounding whitespace"
         )));
     }
-    Ok(url)
+    Ok(())
+}
+
+fn invalid_provider(message: impl fmt::Display) -> AuthServerError {
+    AuthServerError::Config(format!("invalid auth configuration: auth.provider.{message}"))
+}
+
+fn validate_issuer(label: &str, raw: &str, root_only: bool) -> Result<String, AuthServerError> {
+    let url = validate_endpoint(label, raw)?;
+    if url.as_url().query().is_some() {
+        return Err(config_error(format!("{label} must not include a query")));
+    }
+    if root_only && !matches!(url.as_url().path(), "" | "/") {
+        return Err(config_error(format!("{label} must mount at the root")));
+    }
+    Ok(url.as_url().as_str().trim_end_matches('/').to_string())
+}
+
+fn validate_endpoint(label: &str, raw: &str) -> Result<ConfiguredEndpointUrl, AuthServerError> {
+    ConfiguredEndpointUrl::parse(raw.trim())
+        .map_err(|error| config_error(format!("{label} is invalid: {error}")))
 }
 
 fn config_error(message: impl AsRef<str>) -> AuthServerError {
@@ -383,6 +595,7 @@ mod tests {
     use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
     use ring::rand::SystemRandom;
     use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
+    use serde_json::json;
 
     use super::*;
 
@@ -417,6 +630,121 @@ mod tests {
         );
 
         assert!(AuthSettings::from_toml("unowned = true").unwrap().is_none());
+    }
+
+    #[test]
+    fn retains_validated_provider_values_and_secure_defaults() {
+        let raw = valid("")
+            .replace(
+                "issuer = 'https://accounts.example.test'",
+                "issuer = ' https://accounts.example.test/tenant/ '",
+            )
+            .replace("client_id = 'upstream-client'", "client_id = ' client-id '")
+            .replace(
+                "client_secret = 'provider-secret'",
+                "client_secret = ' inline-secret '",
+            )
+            .replace(
+                "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
+                "redirect_uri = ' http://localhost:9080/callback '\nprincipal_claim = ' '\ndisplay_name_claim = ' email '",
+            );
+        let settings = AuthSettings::from_toml(&raw)
+            .expect("valid config")
+            .expect("auth settings");
+        let provider = settings.provider();
+        assert_eq!(provider.issuer, "https://accounts.example.test/tenant/");
+        assert_eq!(provider.client_id, "client-id");
+        assert_eq!(provider.client_secret(), "inline-secret");
+        assert_eq!(provider.redirect_uri, "http://localhost:9080/callback");
+        assert_eq!(provider.scopes, ["openid", "email", "profile"]);
+        assert_eq!(provider.principal_claim, "sub");
+        assert_eq!(provider.display_name_claim, "email");
+        let debug = format!("{provider:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("inline-secret"));
+    }
+
+    #[test]
+    fn resolves_provider_env_secret_and_retains_options() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_path = temp.path().join("config.toml");
+        let key =
+            EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
+                .expect("P-256 signing key");
+        fs::write(temp.path().join("session.key"), key.as_ref()).expect("session key");
+        let raw = valid("")
+            .replace(
+                "client_secret = 'provider-secret'",
+                "client_secret_env = ' PROVIDER_SECRET '",
+            )
+            .replace(
+                "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
+                "redirect_uri = 'http://localhost:9080/auth/oidc/callback'\nscopes = ['openid', 'groups']\nprincipal_claim = 'uid'\ndisplay_name_claim = 'name'",
+            )
+            + "\n[auth.provider.auth_params]\nprompt = 'select_account'\n\
+               [auth.provider.required_claims]\nhd = 'example.test'\n";
+        let settings = AuthSettings::from_toml(&raw)
+            .expect("valid config")
+            .expect("auth settings");
+        let (settings, _issuer) = settings
+            .resolve_runtime_dependencies(&config_path, &|name| {
+                Ok((name == "PROVIDER_SECRET").then(|| " env-secret ".to_string()))
+            })
+            .expect("resolved runtime");
+        let provider = settings.provider();
+        assert_eq!(provider.client_secret(), "env-secret");
+        assert_eq!(provider.scopes, ["openid", "groups"]);
+        assert_eq!(provider.principal_claim, "uid");
+        assert_eq!(provider.display_name_claim, "name");
+        assert_eq!(
+            provider.auth_params.get("prompt").map(String::as_str),
+            Some("select_account")
+        );
+        assert_eq!(
+            provider.required_claims.get("hd"),
+            Some(&json!("example.test"))
+        );
+        let debug = format!("{provider:?}");
+        assert!(!debug.contains("env-secret"));
+    }
+
+    #[test]
+    fn rejects_invalid_provider_fields() {
+        let invalid = [
+            valid("").replace(
+                "issuer = 'https://accounts.example.test'",
+                "type = 'oauth'\nissuer = 'https://accounts.example.test'",
+            ),
+            valid("").replace(
+                "https://accounts.example.test",
+                "http://accounts.example.test",
+            ),
+            valid("").replace(
+                "https://accounts.example.test",
+                "https://accounts.example.test?q=1",
+            ),
+            valid("").replace(
+                "http://localhost:9080/auth/oidc/callback",
+                "http://remote.test/callback",
+            ),
+            valid("").replace(
+                "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
+                "redirect_uri = 'http://localhost:9080/auth/oidc/callback'\nscopes = ['email']",
+            ),
+            valid("").replace(
+                "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
+                "redirect_uri = 'http://localhost:9080/auth/oidc/callback'\nscopes = ['openid', 'two scopes']",
+            ),
+        ];
+        for raw in invalid {
+            assert!(AuthSettings::from_toml(&raw).is_err(), "{raw}");
+        }
+
+        let reserved = valid("") + "\n[auth.provider.auth_params]\nCLIENT_ID = 'override'\n";
+        assert!(reject(&reserved).contains("reserved parameter `CLIENT_ID`"));
+        let invalid_claim =
+            valid("") + "\n[auth.provider.required_claims]\n' spaced ' = true\n";
+        assert!(reject(&invalid_claim).contains("required_claims"));
     }
 
     #[test]
@@ -462,13 +790,13 @@ mod tests {
             ),
             (
                 valid("").replace(
-                    "client_secret_env = 'UNREAD_ENV'",
-                    "client_secret_env = 'UNREAD_ENV'\nclient_secret = 'inline'",
+                    "client_secret = 'provider-secret'",
+                    "client_secret = 'provider-secret'\nclient_secret_env = 'PROVIDER_SECRET'",
                 ),
                 "exactly one",
             ),
             (
-                valid("").replace("client_secret_env = 'UNREAD_ENV'\n", ""),
+                valid("").replace("client_secret = 'provider-secret'\n", ""),
                 "exactly one",
             ),
             (
@@ -506,7 +834,7 @@ mod tests {
             .expect("valid config")
             .expect("auth settings");
         let (settings, issuer) = settings
-            .resolve_session_token_issuer(&config_path, &|_| Ok(None))
+            .resolve_runtime_dependencies(&config_path, &|_| Ok(None))
             .expect("file key");
         assert!(settings.matches_session_token_issuer(&issuer));
         assert_eq!(issuer.issuer, "http://localhost:9080");
@@ -520,7 +848,7 @@ mod tests {
             .expect("valid config")
             .expect("auth settings");
         settings
-            .resolve_session_token_issuer(&config_path, &|name| {
+            .resolve_runtime_dependencies(&config_path, &|name| {
                 Ok((name == "SESSION_KEY").then(|| encoded.clone()))
             })
             .expect("environment key");
@@ -540,7 +868,7 @@ mod tests {
             .expect("valid config")
             .expect("auth settings");
         settings
-            .resolve_session_token_issuer(&config_path, &|name| {
+            .resolve_runtime_dependencies(&config_path, &|name| {
                 Ok((name == DEFAULT_SIGNING_KEY_ENV).then(|| encoded_key.clone()))
             })
             .expect("default environment key");
@@ -569,7 +897,7 @@ mod tests {
         let Err(missing_file) = AuthSettings::from_toml(&valid(""))
             .expect("valid config")
             .expect("auth settings")
-            .resolve_session_token_issuer(&config_path, &|_| Ok(None))
+            .resolve_runtime_dependencies(&config_path, &|_| Ok(None))
         else {
             panic!("expected missing signing key file");
         };
@@ -586,7 +914,7 @@ mod tests {
         let settings = AuthSettings::from_toml(&env_config)
             .expect("valid config")
             .expect("auth settings");
-        let Err(invalid_base64) = settings.resolve_session_token_issuer(&config_path, &|_| {
+        let Err(invalid_base64) = settings.resolve_runtime_dependencies(&config_path, &|_| {
             Ok(Some("visible-secret".to_string()))
         }) else {
             panic!("expected invalid environment key");
@@ -603,7 +931,7 @@ mod tests {
     #[test]
     fn configuration_errors_do_not_leak_secrets() {
         for secret in ["client_secret_env = ''", "client_secret = 42"] {
-            let raw = valid("").replace("client_secret_env = 'UNREAD_ENV'", secret);
+            let raw = valid("").replace("client_secret = 'provider-secret'", secret);
             let error = reject(&raw);
             assert!(error.contains("provider secret must be a nonempty string"));
             assert!(!error.contains("42"));

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -4,7 +4,6 @@ use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -99,7 +98,7 @@ impl AuthSettings {
         config_path: &Path,
         get_var: &impl Fn(&str) -> Result<Option<String>, String>,
     ) -> Result<(ResolvedAuthSettings, SessionTokenIssuer), AuthServerError> {
-        let client_secret = self.0.provider.resolve_secret(get_var)?;
+        let provider = self.0.provider.resolve(get_var)?;
         let key = self.0.session.load_signing_key(config_path, get_var)?;
         let access_token_ttl = Duration::from_secs(self.0.session.access_token_ttl_seconds);
         let session_tokens = SessionTokenIssuer::new(
@@ -113,10 +112,7 @@ impl AuthSettings {
                 http_bind_addr: self.0.http_bind_addr,
                 authorization_server: self.0.authorization_server,
                 access_token_ttl,
-                provider: ResolvedOidcProvider {
-                    client_secret,
-                    settings: self.0.provider,
-                },
+                provider,
             },
             session_tokens,
         ))
@@ -305,25 +301,27 @@ const RESERVED_PROVIDER_AUTH_PARAMS: &[&str] = &[
     "code_challenge_method",
 ];
 
-/// Validated settings for one upstream OIDC provider.
+/// Deserialize-and-validate target for the `[auth.provider]` section.
 ///
-/// The derived `Debug` is safe to print: the only secret-bearing field is a
-/// [`ProviderSecret`], which redacts itself.
-#[derive(Clone, Debug, Default, Deserialize)]
+/// This shape exists only between parsing and
+/// [`resolve`](Self::resolve): it is the one place a client secret and a
+/// name pointing at one coexist, and it does not outlive the resolution that
+/// settles which of them the provider actually uses.
+#[derive(Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-pub(super) struct OidcProviderSettings {
+struct OidcProviderSettings {
     #[serde(rename = "type")]
     provider_type: Option<String>,
-    pub(super) issuer: String,
-    pub(super) client_id: String,
+    issuer: String,
+    client_id: String,
     client_secret: Option<ProviderSecret>,
     client_secret_env: Option<String>,
-    pub(super) redirect_uri: String,
-    pub(super) scopes: Vec<String>,
-    pub(super) principal_claim: String,
-    pub(super) display_name_claim: String,
-    pub(super) auth_params: BTreeMap<String, String>,
-    pub(super) required_claims: BTreeMap<String, Value>,
+    redirect_uri: String,
+    scopes: Vec<String>,
+    principal_claim: String,
+    display_name_claim: String,
+    auth_params: BTreeMap<String, String>,
+    required_claims: BTreeMap<String, Value>,
 }
 
 impl OidcProviderSettings {
@@ -341,13 +339,14 @@ impl OidcProviderSettings {
         }
 
         self.issuer = provider_required("issuer", &self.issuer)?;
-        let issuer = provider_issuer_endpoint(&self.issuer)?;
+        let issuer = provider_literal_endpoint("issuer", &self.issuer)?;
         if issuer.as_url().query().is_some() {
             return Err(invalid_provider("issuer must not include a query"));
         }
+        validate_canonical_issuer(&self.issuer, &issuer)?;
         self.client_id = provider_required("client_id", &self.client_id)?;
         self.redirect_uri = provider_required("redirect_uri", &self.redirect_uri)?;
-        let redirect_uri = provider_endpoint("redirect_uri", &self.redirect_uri)?;
+        let redirect_uri = provider_literal_endpoint("redirect_uri", &self.redirect_uri)?;
         // The upstream IdP sends the browser back to a callback route under
         // this server's origin, so a redirect URI pointing anywhere else can
         // only fail later, at the IdP or in the browser — far from Coral's own
@@ -381,6 +380,10 @@ impl OidcProviderSettings {
             }
         }
 
+        // An omitted `scopes` and an explicit `scopes = []` both land here, and
+        // both take the defaults. Separating them would only let an empty list
+        // report `scopes must include openid` instead, which is the same
+        // startup failure for a request that could never authenticate.
         if self.scopes.is_empty() {
             self.scopes = DEFAULT_PROVIDER_SCOPES
                 .iter()
@@ -399,8 +402,9 @@ impl OidcProviderSettings {
         self.principal_claim = provider_claim("principal_claim", &self.principal_claim, "sub")?;
         self.display_name_claim =
             provider_claim("display_name_claim", &self.display_name_claim, "email")?;
-        for key in self.required_claims.keys() {
+        for (key, value) in &self.required_claims {
             validate_provider_key("required_claims", key)?;
+            validate_required_claim_value(key, value)?;
         }
         for key in self.auth_params.keys() {
             validate_provider_key("auth_params", key)?;
@@ -416,16 +420,20 @@ impl OidcProviderSettings {
         Ok(())
     }
 
-    /// Reads the client secret from whichever source the config names.
-    fn resolve_secret(
-        &self,
+    /// Reads the client secret from whichever source the config names and
+    /// hands the validated fields to the provider that will serve logins.
+    ///
+    /// The fields move rather than copy, so the two ways of naming a secret do
+    /// not survive into the resolved value alongside the secret itself.
+    fn resolve(
+        self,
         get_var: &impl Fn(&str) -> Result<Option<String>, String>,
-    ) -> Result<ProviderSecret, AuthServerError> {
-        match (&self.client_secret, &self.client_secret_env) {
-            (Some(secret), _) => Ok(secret.clone()),
+    ) -> Result<ResolvedOidcProvider, AuthServerError> {
+        let client_secret = match (self.client_secret, self.client_secret_env) {
+            (Some(secret), _) => secret,
             (None, Some(env_name)) => {
                 let value = Zeroizing::new(
-                    get_var(env_name)
+                    get_var(&env_name)
                         .map_err(|_error| invalid_provider("client_secret_env could not be read"))?
                         .ok_or_else(|| {
                             invalid_provider(format!(
@@ -433,27 +441,55 @@ impl OidcProviderSettings {
                             ))
                         })?,
                 );
-                ProviderSecret::from_trimmed("client_secret_env", &value)
+                ProviderSecret::from_trimmed("client_secret_env", &value)?
             }
             // Defense in depth: `validate` requires exactly one source before
             // any call reaches here, so this arm only guards a future caller
             // that skips it.
-            (None, None) => Err(invalid_provider(
-                "client_secret or client_secret_env is required",
-            )),
-        }
+            (None, None) => {
+                return Err(invalid_provider(
+                    "client_secret or client_secret_env is required",
+                ));
+            }
+        };
+        Ok(ResolvedOidcProvider {
+            issuer: self.issuer,
+            client_id: self.client_id,
+            redirect_uri: self.redirect_uri,
+            scopes: self.scopes,
+            principal_claim: self.principal_claim,
+            display_name_claim: self.display_name_claim,
+            auth_params: self.auth_params,
+            required_claims: self.required_claims,
+            client_secret,
+        })
     }
 }
 
-/// Provider settings whose client secret has been read from its source.
+/// One upstream OIDC provider, validated and ready to serve logins.
 ///
-/// [`OidcProviderSettings::resolve_secret`] is the only way to build one, so
-/// holding one is proof the secret is present. The configured fields are
-/// reached through [`Deref`]; only the secret needs an accessor, because it is
-/// the one value the config may merely have pointed at.
+/// [`OidcProviderSettings::resolve`] is the only way to build one, and it moves
+/// the validated fields out of the configured shape, so this type carries no
+/// `client_secret_env` still pointing at a secret and no empty `client_secret`
+/// to disagree with the one it holds. Holding one is therefore proof the secret
+/// was fetched, which is why reading it cannot fail.
+///
+/// The derived `Debug` is safe to print: the only secret-bearing field is a
+/// [`ProviderSecret`], which redacts itself.
 #[derive(Clone, Debug)]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "read by the OIDC federation descendant")
+)]
 pub(super) struct ResolvedOidcProvider {
-    settings: OidcProviderSettings,
+    pub(super) issuer: String,
+    pub(super) client_id: String,
+    pub(super) redirect_uri: String,
+    pub(super) scopes: Vec<String>,
+    pub(super) principal_claim: String,
+    pub(super) display_name_claim: String,
+    pub(super) auth_params: BTreeMap<String, String>,
+    pub(super) required_claims: BTreeMap<String, Value>,
     client_secret: ProviderSecret,
 }
 
@@ -464,14 +500,6 @@ impl ResolvedOidcProvider {
     )]
     pub(super) fn client_secret(&self) -> &str {
         self.client_secret.as_str()
-    }
-}
-
-impl Deref for ResolvedOidcProvider {
-    type Target = OidcProviderSettings;
-
-    fn deref(&self) -> &Self::Target {
-        &self.settings
     }
 }
 
@@ -548,22 +576,55 @@ fn provider_required(field: &str, value: &str) -> Result<String, AuthServerError
     }
 }
 
-fn provider_endpoint(field: &str, value: &str) -> Result<ConfiguredEndpointUrl, AuthServerError> {
-    ConfiguredEndpointUrl::parse(value)
+/// Parses a provider endpoint whose configured spelling is sent verbatim.
+///
+/// `issuer` and `redirect_uri` are both retained as written and later compared
+/// byte for byte — the issuer against the one in the discovery document, the
+/// redirect URI against the registration held by the provider. The parser
+/// silently rewrites a few spellings for a special scheme, so the value that
+/// passes validation is not always the value that goes on the wire:
+/// `.../auth\oidc/callback` parses as if it were written with a slash, and the
+/// backslash then travels to the provider intact. Recording the parser's syntax
+/// violations turns those into a startup error rather than a failed login.
+fn provider_literal_endpoint(
+    field: &str,
+    value: &str,
+) -> Result<ConfiguredEndpointUrl, AuthServerError> {
+    let syntax_violation = Cell::new(None);
+    let record_violation = |violation| syntax_violation.set(Some(violation));
+    let url = Url::options()
+        .syntax_violation_callback(Some(&record_violation))
+        .parse(value)
+        .map_err(|error| invalid_provider(format!("{field} is invalid: {error}")))?;
+    if let Some(violation) = syntax_violation.get() {
+        return Err(invalid_provider(format!("{field} is invalid: {violation}")));
+    }
+    ConfiguredEndpointUrl::from_parsed(url)
         .map_err(|error| invalid_provider(format!("{field} is invalid: {error}")))
 }
 
-fn provider_issuer_endpoint(value: &str) -> Result<ConfiguredEndpointUrl, AuthServerError> {
-    let syntax_violation = Cell::new(None);
-    let record_violation = |violation| syntax_violation.set(Some(violation));
-    Url::options()
-        .syntax_violation_callback(Some(&record_violation))
-        .parse(value)
-        .map_err(|error| invalid_provider(format!("issuer is invalid: {error}")))?;
-    if let Some(violation) = syntax_violation.get() {
-        return Err(invalid_provider(format!("issuer is invalid: {violation}")));
+/// Rejects a provider issuer the URL parser would rewrite.
+///
+/// The issuer is retained exactly as configured, because an `OpenID` Connect
+/// discovery document's `issuer` must equal the configured one byte for byte.
+/// `OpenID` Connect Discovery 1.0 §3 and RFC 8414 §2 both require a published
+/// issuer to be a normalized URL, so a spelling the parser rewrites is one no
+/// compliant provider can publish. Accepting it would not make it work: it
+/// would trade a startup error for a discovery mismatch on every login.
+///
+/// Providers publish issuers both with a trailing slash and without one, so
+/// both are accepted — the parser appends one only to a root-path URL.
+fn validate_canonical_issuer(
+    configured: &str,
+    parsed: &ConfiguredEndpointUrl,
+) -> Result<(), AuthServerError> {
+    let canonical = parsed.as_url().as_str();
+    if configured == canonical || format!("{configured}/") == canonical {
+        return Ok(());
     }
-    provider_endpoint("issuer", value)
+    Err(invalid_provider(format!(
+        "issuer must be copied exactly as the provider publishes it; `{configured}` is not a canonical URL (its canonical form is `{canonical}`)"
+    )))
 }
 
 fn valid_scope_token(scope: &str) -> bool {
@@ -581,6 +642,36 @@ fn provider_claim(field: &str, value: &str, default: &str) -> Result<String, Aut
     };
     validate_provider_key(field, value)?;
     Ok(value.to_string())
+}
+
+/// Rejects a `required_claims` value no ID token could carry.
+///
+/// These values are held as JSON so the check against a decoded ID token is a
+/// plain equality, but they are written in TOML, and the two languages do not
+/// describe the same values. TOML has a datetime that JSON does not, and `toml`
+/// hands one over as an object carrying a private marker key — accepted in
+/// silence today, then unmatchable against every ID token a provider can send.
+/// A date belongs in quotes, where it compares as the string the provider
+/// actually sends.
+///
+/// Numbers are accepted as written and compared as written: `serde_json` holds
+/// integers and floats apart, so `3` does not equal `3.0`. That distinction is
+/// the provider's to make, not something this can settle at startup — the value
+/// has to be spelled the way the ID token spells it.
+fn validate_required_claim_value(key: &str, value: &Value) -> Result<(), AuthServerError> {
+    let is_scalar =
+        |value: &Value| matches!(value, Value::String(_) | Value::Bool(_) | Value::Number(_));
+    let supported = match value {
+        Value::Array(values) => values.iter().all(is_scalar),
+        value => is_scalar(value),
+    };
+    if supported {
+        Ok(())
+    } else {
+        Err(invalid_provider(format!(
+            "required_claims `{key}` must be a string, boolean, number, or an array of those; quote a date or time so it is compared as the string the provider sends"
+        )))
+    }
 }
 
 /// Rejects a key that cannot name a claim or an authorization query parameter.
@@ -773,6 +864,10 @@ mod tests {
                 "client_secret_env = ' PROVIDER_SECRET '",
             )
             .replace(
+                "issuer = 'https://accounts.example.test'",
+                "type = ' oidc '\nissuer = 'https://accounts.example.test'",
+            )
+            .replace(
                 "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
                 "redirect_uri = 'http://localhost:9080/auth/oidc/callback'\nscopes = ['openid', 'groups']\nprincipal_claim = 'uid'\ndisplay_name_claim = 'name'",
             )
@@ -781,6 +876,14 @@ mod tests {
         let (settings, _issuer) = resolve(&raw, &|name| {
             Ok((name == "PROVIDER_SECRET").then(|| " env-secret ".to_string()))
         });
+        // `type` is a validation discriminant that the resolved provider has no
+        // reason to carry, so the accept path is asserted where it survives. A
+        // comparison that never matched would fail here rather than passing
+        // unnoticed beside the reject table.
+        assert_eq!(
+            parse(&raw).0.provider.provider_type.as_deref(),
+            Some("oidc")
+        );
         let provider = settings.provider();
         assert_eq!(provider.client_secret(), "env-secret");
         assert_eq!(provider.scopes, ["openid", "groups"]);
@@ -829,8 +932,8 @@ mod tests {
     }
 
     /// A provider issuer is compared byte for byte against the issuer in the
-    /// discovery document, so every valid spelling a provider publishes has to
-    /// survive validation unchanged.
+    /// discovery document, so every form a provider can publish has to survive
+    /// validation unchanged — including both trailing-slash spellings.
     #[test]
     fn retains_every_issuer_spelling_a_provider_can_publish() {
         for issuer in [
@@ -838,25 +941,57 @@ mod tests {
             "https://accounts.example.test/",
             "https://accounts.example.test/tenant",
             "https://accounts.example.test/tenant/",
-            "https://ACCOUNTS.example.test/tenant",
-            "https://accounts.example.test:443/tenant",
-            "https://accounts.example.test/tenant/../other",
             "http://127.0.0.1:9080/tenant/",
         ] {
             assert_eq!(resolved(&provider_issuer(issuer)).provider().issuer, issuer);
         }
     }
 
+    /// Discovery 1.0 §3 and RFC 8414 §2 require a published issuer to be a
+    /// normalized URL, so these spellings can only ever mismatch the discovery
+    /// document. Rejecting them at startup costs nothing a login would have
+    /// kept.
     #[test]
-    fn rejects_invalid_provider_fields() {
-        let cases = vec![
+    fn rejects_provider_issuers_no_provider_could_publish() {
+        for (issuer, canonical) in [
             (
-                valid("").replace(
-                    "issuer = 'https://accounts.example.test'",
-                    "type = 'oauth'\nissuer = 'https://accounts.example.test'",
-                ),
-                "type must be `oidc`",
+                "https://ACCOUNTS.example.test/tenant",
+                "https://accounts.example.test/tenant",
             ),
+            (
+                "https://accounts.example.test:443/tenant",
+                "https://accounts.example.test/tenant",
+            ),
+            (
+                "https://accounts.example.test/tenant/../other",
+                "https://accounts.example.test/other",
+            ),
+        ] {
+            let error = reject(&provider_issuer(issuer));
+            assert!(
+                error.contains("copied exactly as the provider publishes it"),
+                "{error}"
+            );
+            assert!(error.contains(canonical), "{error}");
+        }
+    }
+
+    fn reject_all(cases: Vec<(String, &str)>) {
+        for (raw, expected) in cases {
+            assert!(
+                reject(&raw).contains(expected),
+                "expected `{expected}` for {raw}"
+            );
+        }
+    }
+
+    /// Both endpoints reach the provider as written — the issuer to be compared
+    /// against the discovery document, the redirect URI against the
+    /// registration — so a spelling the parser would quietly rewrite has to
+    /// fail here rather than on every login.
+    #[test]
+    fn rejects_invalid_provider_endpoints() {
+        reject_all(vec![
             (
                 valid("").replace(
                     "https://accounts.example.test",
@@ -878,6 +1013,27 @@ mod tests {
             ),
             (
                 valid("").replace(
+                    "http://localhost:9080/auth/oidc/callback",
+                    r"http://localhost:9080/auth\oidc/callback",
+                ),
+                "redirect_uri is invalid: backslash",
+            ),
+            (
+                valid("").replace(
+                    "http://localhost:9080/auth/oidc/callback",
+                    "http://localhost:9080/auth/oidc/callback%1",
+                ),
+                "redirect_uri is invalid: expected 2 hex digits after %",
+            ),
+            (
+                valid("").replace(
+                    "http://localhost:9080/auth/oidc/callback",
+                    "http://localhost:9080/auth/oidc/callback^",
+                ),
+                "redirect_uri is invalid: non-URL code point",
+            ),
+            (
+                valid("").replace(
                     "https://accounts.example.test",
                     "https://accounts.example.test?q=1",
                 ),
@@ -889,6 +1045,19 @@ mod tests {
                     "https://remote.test/callback",
                 ),
                 "must share the origin",
+            ),
+        ]);
+    }
+
+    #[test]
+    fn rejects_invalid_provider_fields() {
+        reject_all(vec![
+            (
+                valid("").replace(
+                    "issuer = 'https://accounts.example.test'",
+                    "type = 'oauth'\nissuer = 'https://accounts.example.test'",
+                ),
+                "type must be `oidc`",
             ),
             (
                 valid("").replace(
@@ -923,13 +1092,46 @@ mod tests {
                 valid("") + "\n[auth.provider.required_claims]\n' spaced ' = true\n",
                 "required_claims keys must be nonempty and contain no whitespace",
             ),
-        ];
-        for (raw, expected) in cases {
-            assert!(
-                reject(&raw).contains(expected),
-                "expected `{expected}` for {raw}"
-            );
-        }
+        ]);
+    }
+
+    /// A TOML datetime deserializes into a marker object rather than failing,
+    /// so without this guard `expires = 2030-01-01` starts the server and then
+    /// fails to match on every login.
+    #[test]
+    fn rejects_required_claims_no_id_token_could_carry() {
+        reject_all(vec![
+            (
+                valid("") + "\n[auth.provider.required_claims]\nexpires = 2030-01-01\n",
+                "required_claims `expires` must be a string, boolean, number, or an array",
+            ),
+            (
+                valid("") + "\n[auth.provider.required_claims]\nissued = 09:30:00\n",
+                "required_claims `issued` must be a string, boolean, number, or an array",
+            ),
+            (
+                valid("") + "\n[auth.provider.required_claims]\nnested = { tier = 'gold' }\n",
+                "required_claims `nested` must be a string, boolean, number, or an array",
+            ),
+            (
+                valid("") + "\n[auth.provider.required_claims]\nwindows = [2030-01-01]\n",
+                "required_claims `windows` must be a string, boolean, number, or an array",
+            ),
+        ]);
+    }
+
+    #[test]
+    fn retains_every_required_claim_shape_an_id_token_can_carry() {
+        let raw = valid("")
+            + "\n[auth.provider.required_claims]\nhd = 'example.test'\nverified = true\n\
+               level = 3\nratio = 1.5\ngroups = ['staff', 'admin']\n";
+        let settings = resolved(&raw);
+        let claims = &settings.provider().required_claims;
+        assert_eq!(claims.get("hd"), Some(&json!("example.test")));
+        assert_eq!(claims.get("verified"), Some(&json!(true)));
+        assert_eq!(claims.get("level"), Some(&json!(3)));
+        assert_eq!(claims.get("ratio"), Some(&json!(1.5)));
+        assert_eq!(claims.get("groups"), Some(&json!(["staff", "admin"])));
     }
 
     #[test]

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
@@ -34,6 +35,10 @@ const CONFLICTING_KEY_SOURCES: &str = "configure only one of signing_key_env or 
 /// external callers. Holding one is proof that validation ran, which is why
 /// nothing downstream revalidates. This type performs no `config.toml`
 /// filesystem reads.
+///
+/// The settings are read through [`ResolvedAuthSettings`], which
+/// [`AuthSettings::resolve_runtime_dependencies`] produces once the secrets
+/// the config only points at have actually been fetched.
 pub struct AuthSettings(RawAuthSettings);
 
 #[derive(Deserialize)]
@@ -80,51 +85,75 @@ impl AuthSettings {
         Ok(Some(Self(settings)))
     }
 
+    /// Fetches the secrets the config only points at — the provider client
+    /// secret and the session signing key — and builds the session-token
+    /// issuer keyed by the latter.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AuthServerError::Config`] when a secret source cannot be read
+    /// or the session key material is unusable.
+    pub(super) fn resolve_runtime_dependencies(
+        self,
+        config_path: &Path,
+        get_var: &impl Fn(&str) -> Result<Option<String>, String>,
+    ) -> Result<(ResolvedAuthSettings, SessionTokenIssuer), AuthServerError> {
+        let client_secret = self.0.provider.resolve_secret(get_var)?;
+        let key = self.0.session.load_signing_key(config_path, get_var)?;
+        let access_token_ttl = Duration::from_secs(self.0.session.access_token_ttl_seconds);
+        let session_tokens = SessionTokenIssuer::new(
+            Some(&self.0.authorization_server.issuer),
+            key.as_slice(),
+            access_token_ttl,
+        )
+        .map_err(AuthServerError::Config)?;
+        Ok((
+            ResolvedAuthSettings {
+                http_bind_addr: self.0.http_bind_addr,
+                authorization_server: self.0.authorization_server,
+                access_token_ttl,
+                provider: ResolvedOidcProvider {
+                    client_secret,
+                    settings: self.0.provider,
+                },
+            },
+            session_tokens,
+        ))
+    }
+}
+
+/// Validated auth settings whose runtime dependencies have been resolved.
+///
+/// [`AuthSettings::resolve_runtime_dependencies`] is the only constructor, so
+/// holding one is proof that the provider secret was fetched from its source —
+/// which is why reading it cannot fail and nothing rechecks runtime readiness.
+pub(crate) struct ResolvedAuthSettings {
+    http_bind_addr: SocketAddr,
+    authorization_server: AuthorizationServerSettings,
+    access_token_ttl: Duration,
+    provider: ResolvedOidcProvider,
+}
+
+impl ResolvedAuthSettings {
     pub(crate) fn bind_addr(&self) -> SocketAddr {
-        self.0.http_bind_addr
+        self.http_bind_addr
     }
 
     pub(crate) fn authorization_server(&self) -> &AuthorizationServerSettings {
-        &self.0.authorization_server
+        &self.authorization_server
     }
 
     #[cfg_attr(
         not(test),
         expect(dead_code, reason = "used by the OIDC federation descendant")
     )]
-    pub(super) fn provider(&self) -> &OidcProviderSettings {
-        &self.0.provider
-    }
-
-    pub(super) fn resolve_runtime_dependencies(
-        mut self,
-        config_path: &Path,
-        get_var: &impl Fn(&str) -> Result<Option<String>, String>,
-    ) -> Result<(Self, SessionTokenIssuer), AuthServerError> {
-        self.0.provider.resolve_secret(get_var)?;
-        let key = self.0.session.load_signing_key(config_path, get_var)?;
-        let issuer = SessionTokenIssuer::new(
-            Some(&self.0.authorization_server.issuer),
-            key.as_slice(),
-            Duration::from_secs(self.0.session.access_token_ttl_seconds),
-        )
-        .map_err(AuthServerError::Config)?;
-        Ok((self, issuer))
-    }
-
-    /// Confirms the settings carry everything the running server needs.
-    ///
-    /// Field validation already ran at construction, so this checks only what
-    /// construction cannot: that the provider secret has been resolved from its
-    /// environment variable.
-    pub(super) fn validate_runtime_ready(&self) -> Result<(), AuthServerError> {
-        self.0.provider.require_resolved_secret()
+    pub(super) fn provider(&self) -> &ResolvedOidcProvider {
+        &self.provider
     }
 
     pub(super) fn matches_session_token_issuer(&self, issuer: &SessionTokenIssuer) -> bool {
-        self.0.authorization_server.issuer == issuer.issuer
-            && Duration::from_secs(self.0.session.access_token_ttl_seconds)
-                == issuer.access_token_ttl
+        self.authorization_server.issuer == issuer.issuer
+            && self.access_token_ttl == issuer.access_token_ttl
     }
 }
 
@@ -387,46 +416,62 @@ impl OidcProviderSettings {
         Ok(())
     }
 
+    /// Reads the client secret from whichever source the config names.
     fn resolve_secret(
-        &mut self,
+        &self,
         get_var: &impl Fn(&str) -> Result<Option<String>, String>,
-    ) -> Result<(), AuthServerError> {
-        if self.client_secret.is_some() {
-            return Ok(());
-        }
-        let env_name = self
-            .client_secret_env
-            .as_deref()
-            .expect("validated provider has one secret source");
-        let value = Zeroizing::new(
-            get_var(env_name)
-                .map_err(|_error| invalid_provider("client_secret_env could not be read"))?
-                .ok_or_else(|| invalid_provider("client_secret_env names an unset variable"))?,
-        );
-        self.client_secret = Some(ProviderSecret::from_trimmed("client_secret_env", &value)?);
-        self.client_secret_env = None;
-        Ok(())
-    }
-
-    fn require_resolved_secret(&self) -> Result<(), AuthServerError> {
-        if self.client_secret.is_some() && self.client_secret_env.is_none() {
-            Ok(())
-        } else {
-            Err(invalid_provider(
-                "client_secret_env must be resolved before server construction",
-            ))
+    ) -> Result<ProviderSecret, AuthServerError> {
+        match (&self.client_secret, &self.client_secret_env) {
+            (Some(secret), _) => Ok(secret.clone()),
+            (None, Some(env_name)) => {
+                let value = Zeroizing::new(
+                    get_var(env_name)
+                        .map_err(|_error| invalid_provider("client_secret_env could not be read"))?
+                        .ok_or_else(|| {
+                            invalid_provider(format!(
+                                "client_secret_env names `{env_name}`, which is not set"
+                            ))
+                        })?,
+                );
+                ProviderSecret::from_trimmed("client_secret_env", &value)
+            }
+            // Defense in depth: `validate` requires exactly one source before
+            // any call reaches here, so this arm only guards a future caller
+            // that skips it.
+            (None, None) => Err(invalid_provider(
+                "client_secret or client_secret_env is required",
+            )),
         }
     }
+}
 
+/// Provider settings whose client secret has been read from its source.
+///
+/// [`OidcProviderSettings::resolve_secret`] is the only way to build one, so
+/// holding one is proof the secret is present. The configured fields are
+/// reached through [`Deref`]; only the secret needs an accessor, because it is
+/// the one value the config may merely have pointed at.
+#[derive(Clone, Debug)]
+pub(super) struct ResolvedOidcProvider {
+    settings: OidcProviderSettings,
+    client_secret: ProviderSecret,
+}
+
+impl ResolvedOidcProvider {
     #[cfg_attr(
         not(test),
         expect(dead_code, reason = "used by the OIDC federation descendant")
     )]
     pub(super) fn client_secret(&self) -> &str {
-        self.client_secret
-            .as_ref()
-            .expect("runtime-ready provider has a resolved client secret")
-            .as_str()
+        self.client_secret.as_str()
+    }
+}
+
+impl Deref for ResolvedOidcProvider {
+    type Target = OidcProviderSettings;
+
+    fn deref(&self) -> &Self::Target {
+        &self.settings
     }
 }
 
@@ -645,11 +690,52 @@ mod tests {
         }
     }
 
+    /// A config directory holding the session signing key the fixture names.
+    fn signing_key_dir() -> tempfile::TempDir {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let key =
+            EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
+                .expect("P-256 signing key");
+        fs::write(temp.path().join("session.key"), key.as_ref()).expect("session key");
+        temp
+    }
+
+    fn parse(raw: &str) -> AuthSettings {
+        AuthSettings::from_toml(raw)
+            .expect("valid config")
+            .expect("auth settings")
+    }
+
+    fn resolve(
+        raw: &str,
+        get_var: &impl Fn(&str) -> Result<Option<String>, String>,
+    ) -> (ResolvedAuthSettings, SessionTokenIssuer) {
+        let temp = signing_key_dir();
+        parse(raw)
+            .resolve_runtime_dependencies(&temp.path().join("config.toml"), get_var)
+            .expect("resolved runtime dependencies")
+    }
+
+    fn resolve_error(
+        raw: &str,
+        get_var: &impl Fn(&str) -> Result<Option<String>, String>,
+    ) -> String {
+        let temp = signing_key_dir();
+        let Err(error) =
+            parse(raw).resolve_runtime_dependencies(&temp.path().join("config.toml"), get_var)
+        else {
+            panic!("expected unresolvable runtime dependencies");
+        };
+        error.to_string()
+    }
+
+    fn resolved(raw: &str) -> ResolvedAuthSettings {
+        resolve(raw, &|_| Ok(None)).0
+    }
+
     #[test]
     fn directly_deserializes_and_validates_auth_settings() {
-        let settings = AuthSettings::from_toml(&valid(""))
-            .expect("valid config")
-            .expect("auth settings");
+        let settings = resolved(&valid(""));
         assert_eq!(settings.bind_addr(), DEFAULT_BIND_ADDR);
         assert_eq!(
             settings.authorization_server().issuer,
@@ -675,9 +761,7 @@ mod tests {
                 "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
                 "redirect_uri = ' http://localhost:9080/callback '\nprincipal_claim = ' '\ndisplay_name_claim = ' email '",
             );
-        let settings = AuthSettings::from_toml(&raw)
-            .expect("valid config")
-            .expect("auth settings");
+        let settings = resolved(&raw);
         let provider = settings.provider();
         assert_eq!(provider.issuer, "https://accounts.example.test/tenant/");
         assert_eq!(provider.client_id, "client-id");
@@ -693,12 +777,6 @@ mod tests {
 
     #[test]
     fn resolves_provider_env_secret_and_retains_options() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let config_path = temp.path().join("config.toml");
-        let key =
-            EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
-                .expect("P-256 signing key");
-        fs::write(temp.path().join("session.key"), key.as_ref()).expect("session key");
         let raw = valid("")
             .replace(
                 "client_secret = 'provider-secret'",
@@ -710,14 +788,9 @@ mod tests {
             )
             + "\n[auth.provider.auth_params]\nprompt = 'select_account'\n\
                [auth.provider.required_claims]\nhd = 'example.test'\n";
-        let settings = AuthSettings::from_toml(&raw)
-            .expect("valid config")
-            .expect("auth settings");
-        let (settings, _issuer) = settings
-            .resolve_runtime_dependencies(&config_path, &|name| {
-                Ok((name == "PROVIDER_SECRET").then(|| " env-secret ".to_string()))
-            })
-            .expect("resolved runtime");
+        let (settings, _issuer) = resolve(&raw, &|name| {
+            Ok((name == "PROVIDER_SECRET").then(|| " env-secret ".to_string()))
+        });
         let provider = settings.provider();
         assert_eq!(provider.client_secret(), "env-secret");
         assert_eq!(provider.scopes, ["openid", "groups"]);
@@ -735,6 +808,36 @@ mod tests {
         assert!(!debug.contains("env-secret"));
     }
 
+    #[test]
+    fn reports_provider_secret_sources_that_cannot_be_read() {
+        let env_config = valid("").replace(
+            "client_secret = 'provider-secret'",
+            "client_secret_env = 'PROVIDER_SECRET'",
+        );
+        let unset = resolve_error(&env_config, &|_| Ok(None));
+        assert!(
+            unset.contains("client_secret_env names `PROVIDER_SECRET`, which is not set"),
+            "{unset}"
+        );
+        let blank = resolve_error(&env_config, &|_| Ok(Some("   ".to_string())));
+        assert!(
+            blank.contains("client_secret_env must not be empty"),
+            "{blank}"
+        );
+        let unreadable = resolve_error(&env_config, &|_| Err("host detail".to_string()));
+        assert!(
+            unreadable.contains("client_secret_env could not be read"),
+            "{unreadable}"
+        );
+        assert!(!unreadable.contains("host detail"), "{unreadable}");
+
+        let invalid_name = valid("").replace(
+            "client_secret = 'provider-secret'",
+            "client_secret_env = 'PROVIDER=SECRET'",
+        );
+        assert!(reject(&invalid_name).contains("client_secret_env is invalid"));
+    }
+
     /// A provider issuer is compared byte for byte against the issuer in the
     /// discovery document, so every form a provider can publish has to survive
     /// validation unchanged — including both trailing-slash spellings.
@@ -747,10 +850,7 @@ mod tests {
             "https://accounts.example.test/tenant/",
             "http://127.0.0.1:9080/tenant/",
         ] {
-            let settings = AuthSettings::from_toml(&provider_issuer(issuer))
-                .expect("valid config")
-                .expect("auth settings");
-            assert_eq!(settings.provider().issuer, issuer);
+            assert_eq!(resolved(&provider_issuer(issuer)).provider().issuer, issuer);
         }
     }
 

--- a/crates/coral-app/src/auth/mod.rs
+++ b/crates/coral-app/src/auth/mod.rs
@@ -29,5 +29,5 @@ pub(super) mod test_config {
     pub(crate) const SESSION: &str = "[auth.session]\nsigning_key_file = 'session.key'\n";
     pub(crate) const AUTHORIZATION_SERVER: &str =
         "[auth.authorization_server]\nissuer = 'http://localhost:9080'\n";
-    pub(crate) const PROVIDER: &str = "[auth.provider]\nissuer = 'https://accounts.example.test'\nclient_id = 'upstream-client'\nclient_secret_env = 'UNREAD_ENV'\nredirect_uri = 'http://localhost:9080/auth/oidc/callback'\n";
+    pub(crate) const PROVIDER: &str = "[auth.provider]\nissuer = 'https://accounts.example.test'\nclient_id = 'upstream-client'\nclient_secret = 'provider-secret'\nredirect_uri = 'http://localhost:9080/auth/oidc/callback'\n";
 }

--- a/crates/coral-app/src/outbound_url_policy.rs
+++ b/crates/coral-app/src/outbound_url_policy.rs
@@ -47,7 +47,15 @@ pub(crate) struct ConfiguredEndpointUrl(Url);
 impl ConfiguredEndpointUrl {
     /// Parses an HTTPS endpoint or an explicit loopback HTTP endpoint.
     pub(crate) fn parse(value: &str) -> Result<Self, OutboundUrlPolicyError> {
-        let url = Url::parse(value).map_err(OutboundUrlPolicyError::InvalidUrl)?;
+        Self::from_parsed(Url::parse(value).map_err(OutboundUrlPolicyError::InvalidUrl)?)
+    }
+
+    /// Applies the profile to an already-parsed URL.
+    ///
+    /// The checks are the same ones [`parse`](Self::parse) runs; this entry
+    /// point exists for a caller that already needed the [`Url`] — parsing with
+    /// a syntax-violation callback, say — and would otherwise parse it twice.
+    pub(crate) fn from_parsed(url: Url) -> Result<Self, OutboundUrlPolicyError> {
         if url.host().is_none() {
             return Err(OutboundUrlPolicyError::MissingHost);
         }


### PR DESCRIPTION
## Stack overview

This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.

## Where this PR fits

The previous PR adds safe URL handling for configured endpoints and untrusted metadata. This PR applies that foundation to OpenID Connect provider configuration and keeps the validated values that later discovery, redirect, token exchange, and claim checks will need.

## Intent

Turn the `[auth.provider]` section into complete, runtime-ready OpenID Connect provider settings instead of validating the section and then discarding its useful values.

## What it enables

Coral now retains and validates:

- the provider type, issuer, client ID, and redirect URI;
- exactly one inline or environment-backed client secret;
- requested scopes, which default to `openid`, `email`, and `profile`;
- the claims used for the Coral user ID and display name;
- additional authorization parameters; and
- claims that must have specific values in the provider's ID token.

Environment-backed secrets are read once while runtime dependencies are resolved. Resolving them produces `ResolvedAuthSettings`, whose existence is proof the secret was fetched, so reading it later cannot fail. Resolved secrets are kept in zeroizing storage and replaced with `<redacted>` in debug output. Configuration errors also avoid including secret values.

Provider endpoints use the configured-endpoint URL policy from the previous PR. Reserved OAuth parameters cannot be overridden through `auth_params`, and the requested scopes must include `openid`.

The `issuer` must be written exactly as the provider publishes it, because later discovery compares it byte for byte. OpenID Connect Discovery 1.0 §3 and RFC 8414 §2 both require a published issuer to be a normalized URL, so spellings the URL parser would rewrite — a mixed-case host, an explicit `:443`, dot segments — are ones no compliant provider can publish. Accepting them would not make them work; it would only move the failure from startup to every login, so they are rejected at startup, with the canonical form named in the error. A trailing slash is kept as written, since some providers publish one and some do not.

The `redirect_uri` is retained verbatim for the same reason: OAuth 2.0 compares it against the registration by exact string match, and Coral sends the configured spelling. The URL parser silently rewrites a few spellings for HTTP and HTTPS URLs — `.../auth\oidc/callback` parses as if it were written with a slash — so the value that satisfies validation is not always the value that goes on the wire. Both endpoints therefore reject the parser's syntax violations (a backslash, a non-URL code point, a truncated percent escape) rather than passing them on to the provider.

This PR retains configuration only. It does not perform provider discovery, redirect a user, exchange a code, or validate an ID token.

## Usage examples

```toml
[auth.provider]
type = "oidc"
issuer = "https://login.example.com/tenant"
client_id = "coral"
client_secret_env = "CORAL_OIDC_CLIENT_SECRET"
redirect_uri = "https://coral.example.com/auth/oidc/callback"
scopes = ["openid", "email", "groups"]
principal_claim = "sub"
display_name_claim = "email"

[auth.provider.auth_params]
prompt = "select_account"

[auth.provider.required_claims]
tenant = "example"
```

An inline `client_secret` can be used instead of `client_secret_env`, but configuring both is rejected.

