### PR TITLE
feat(app): resolve MCP HTTP serve configuration

### DIFF
--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -20,9 +20,8 @@ pub(crate) use error::MAX_STATUS_DETAIL_BYTES;
 pub(crate) use error::{app_status, core_status, status_with_bounded_detail};
 
 pub use error::AppError;
-pub use server::{
-    McpHttpServePlan, RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider,
-};
+pub use server::{RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider};
+pub use server_config::McpHttpServeConfig;
 
 pub(crate) fn discover_app_state_layout(
     config_dir_override: Option<PathBuf>,

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -20,7 +20,9 @@ pub(crate) use error::MAX_STATUS_DETAIL_BYTES;
 pub(crate) use error::{app_status, core_status, status_with_bounded_detail};
 
 pub use error::AppError;
-pub use server::{RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider};
+pub use server::{
+    McpHttpServePlan, RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider,
+};
 
 pub(crate) fn discover_app_state_layout(
     config_dir_override: Option<PathBuf>,

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::convert::Infallible;
 use std::future::{Future, Ready};
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -41,7 +41,7 @@ use tower::{Layer, Service};
 use super::env::AppEnvironment;
 use super::error::AppError;
 use super::health::AggregateHealthService;
-use super::server_config::ServerSettings;
+use super::server_config::{ResolvedMcpHttpSettings, ServerSettings};
 use crate::EngineExtensionsProvider;
 use crate::catalog::discovery::CatalogDiscovery;
 use crate::catalog::service::CatalogService;
@@ -90,6 +90,18 @@ pub trait StaticAssetsProvider: Send + Sync + 'static {
     /// Returns the asset stored at `path` (relative, no leading slash), or
     /// `None` if the asset does not exist.
     fn get(&self, path: &str) -> Option<StaticAsset>;
+}
+
+/// Resolved MCP HTTP serving mode.
+#[derive(Clone)]
+pub enum McpHttpServePlan {
+    /// Loopback-only MCP HTTP backed by a shared unauthenticated client.
+    AuthDisabled {
+        /// Address for the MCP HTTP listener.
+        bind_addr: SocketAddr,
+        /// Safe loopback URI for the in-process gRPC client.
+        grpc_endpoint_uri: String,
+    },
 }
 
 #[derive(Clone)]
@@ -144,13 +156,33 @@ impl ServerConfig {
         self
     }
 
-    fn resolved_mode(&self, layout: &AppStateLayout) -> Result<ServerMode, AppError> {
-        match &self.mode {
-            ServerModeSelection::Explicit(mode) => Ok(mode.clone()),
-            ServerModeSelection::ConfiguredStandaloneGrpc => Ok(ServerMode::StandaloneGrpc {
-                bind: ServerSettings::load(layout)?.bind_addr,
-            }),
+    fn resolved_startup(&self, layout: &AppStateLayout) -> Result<ResolvedStartup, AppError> {
+        let is_standalone = matches!(
+            &self.mode,
+            ServerModeSelection::Explicit(ServerMode::StandaloneGrpc { .. })
+                | ServerModeSelection::ConfiguredStandaloneGrpc
+        );
+        let settings = is_standalone
+            .then(|| ServerSettings::load(layout))
+            .transpose()?;
+        let mode = match &self.mode {
+            ServerModeSelection::Explicit(mode) => mode.clone(),
+            ServerModeSelection::ConfiguredStandaloneGrpc => ServerMode::StandaloneGrpc {
+                bind: settings
+                    .as_ref()
+                    .expect("configured standalone mode loads settings")
+                    .bind_addr,
+            },
+        };
+        let mcp_http = settings
+            .as_ref()
+            .map(|settings| settings.mcp_http(false))
+            .transpose()?
+            .flatten();
+        if mcp_http.is_some() {
+            safe_internal_grpc_ip(mode.bind_addr().ip())?;
         }
+        Ok(ResolvedStartup { mode, mcp_http })
     }
 
     pub(crate) fn add_engine_extensions_provider(
@@ -172,6 +204,11 @@ impl ServerConfig {
         self.feature_overrides = feature_overrides;
         self
     }
+}
+
+struct ResolvedStartup {
+    mode: ServerMode,
+    mcp_http: Option<ResolvedMcpHttpSettings>,
 }
 
 /// Concrete local server mode.
@@ -335,7 +372,7 @@ impl ServerBuilder {
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir.clone())?;
-        let mode = self.config.resolved_mode(&layout)?;
+        let ResolvedStartup { mode, mcp_http } = self.config.resolved_startup(&layout)?;
         layout.ensure()?;
         let features = FeatureStore::from_layout(layout.clone())
             .load_with_overrides(&self.config.feature_overrides)?;
@@ -427,6 +464,7 @@ impl ServerBuilder {
             trace_components,
             self.config.principal_provider,
             mode,
+            mcp_http,
         )
         .await
     }
@@ -477,6 +515,7 @@ fn resolve_database_config(layout: &AppStateLayout) -> Result<ResolvedDatabaseCo
 /// does not wait for the task to finish.
 pub struct RunningServer {
     endpoint_uri: String,
+    mcp_http_plan: Option<McpHttpServePlan>,
     local_trace_store_dir: Option<PathBuf>,
     search: SearchManager,
     search_observations: Mutex<Option<SearchObservationHandle>>,
@@ -494,6 +533,12 @@ impl RunningServer {
     /// over server configuration.
     pub fn endpoint_uri(&self) -> &str {
         &self.endpoint_uri
+    }
+
+    /// Returns the configured MCP HTTP companion plan, when enabled.
+    #[must_use]
+    pub fn mcp_http_plan(&self) -> Option<&McpHttpServePlan> {
+        self.mcp_http_plan.as_ref()
     }
 
     #[must_use]
@@ -606,6 +651,7 @@ async fn start_server(
     trace_components: TraceServerComponents,
     principal_provider: Arc<dyn PrincipalProvider>,
     mode: ServerMode,
+    mcp_http: Option<ResolvedMcpHttpSettings>,
 ) -> Result<RunningServer, AppError> {
     let TraceServerComponents {
         service: trace_service,
@@ -672,8 +718,16 @@ async fn start_server(
         AggregateHealthService,
     ));
 
-    let listener = TcpListener::bind(mode.bind_addr()).await?;
-    let endpoint_uri = format!("http://{}", listener.local_addr()?);
+    let grpc_bind_addr = mode.bind_addr();
+    let listener = TcpListener::bind(grpc_bind_addr).await?;
+    let bound_addr = listener.local_addr()?;
+    let endpoint_uri = format!("http://{bound_addr}");
+    let mcp_http_plan = mcp_http
+        .map(|settings| {
+            internal_grpc_endpoint_uri(grpc_bind_addr.ip(), bound_addr.port())
+                .map(|endpoint| mcp_http_plan(settings, endpoint))
+        })
+        .transpose()?;
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let (task_finished_tx, task_finished) = watch::channel(false);
 
@@ -688,6 +742,7 @@ async fn start_server(
 
     Ok(RunningServer {
         endpoint_uri,
+        mcp_http_plan,
         local_trace_store_dir,
         search,
         search_observations: Mutex::new(search_observations),
@@ -695,6 +750,41 @@ async fn start_server(
         task_finished,
         task: Mutex::new(Some(task)),
     })
+}
+
+fn safe_internal_grpc_ip(ip: IpAddr) -> Result<IpAddr, AppError> {
+    match ip {
+        IpAddr::V4(ip) if ip.is_unspecified() => Ok(Ipv4Addr::LOCALHOST.into()),
+        IpAddr::V6(ip) if ip.is_unspecified() => Ok(std::net::Ipv6Addr::LOCALHOST.into()),
+        ip if ip.is_loopback() => Ok(ip),
+        _ => Err(AppError::FailedPrecondition(
+            "server.mcp_http requires a loopback or wildcard gRPC bind for its safe internal plaintext route"
+                .to_string(),
+        )),
+    }
+}
+
+fn internal_grpc_endpoint_uri(bind_ip: IpAddr, bound_port: u16) -> Result<String, AppError> {
+    let address = SocketAddr::new(safe_internal_grpc_ip(bind_ip)?, bound_port);
+    Ok(format!("http://{address}"))
+}
+
+fn mcp_http_plan(settings: ResolvedMcpHttpSettings, grpc_endpoint_uri: String) -> McpHttpServePlan {
+    match settings {
+        ResolvedMcpHttpSettings::AuthDisabled { bind } => McpHttpServePlan::AuthDisabled {
+            bind_addr: bind,
+            grpc_endpoint_uri,
+        },
+        ResolvedMcpHttpSettings::Authenticated {
+            bind,
+            resource_url,
+            authorization_server,
+            scope,
+        } => {
+            drop((bind, resource_url, authorization_server, scope));
+            unreachable!("authenticated MCP is not selected without served authentication")
+        }
+    }
 }
 
 fn start_grpc_server(
@@ -907,7 +997,7 @@ mod tests {
 
     use std::borrow::Cow;
     use std::future::Future as _;
-    use std::net::{Ipv4Addr, SocketAddr, TcpListener};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener};
     use std::path::Path;
     use std::sync::{Arc, Mutex};
     use std::task::Poll;
@@ -930,9 +1020,9 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        RunningServer, ServerBuilder, ServerDependencies, ServerMode, StaticAsset,
-        StaticAssetsProvider, TraceServerComponents, is_grpc_web_content_type,
-        is_native_grpc_content_type, start_server,
+        McpHttpServePlan, RunningServer, ServerBuilder, ServerDependencies, ServerMode,
+        StaticAsset, StaticAssetsProvider, TraceServerComponents, internal_grpc_endpoint_uri,
+        is_grpc_web_content_type, is_native_grpc_content_type, start_server,
     };
     use crate::bootstrap::AppError;
     use crate::catalog::discovery::CatalogDiscovery;
@@ -1103,6 +1193,7 @@ enabled = false
         });
         let server = RunningServer {
             endpoint_uri: "http://127.0.0.1:0".to_string(),
+            mcp_http_plan: None,
             local_trace_store_dir: None,
             search,
             search_observations: Mutex::new(Some(search_observations)),
@@ -1182,12 +1273,59 @@ enabled = false
 
         let ServerMode::StandaloneGrpc { bind } = builder
             .config
-            .resolved_mode(&layout)
+            .resolved_startup(&layout)
             .expect("resolve configured bind")
+            .mode
         else {
             panic!("configured server must use standalone gRPC mode");
         };
         assert_eq!(bind, SocketAddr::from(([127, 0, 0, 2], 14555)));
+    }
+
+    #[test]
+    fn internal_grpc_route_maps_wildcards_to_matching_loopback() {
+        assert_eq!(
+            internal_grpc_endpoint_uri(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 14555)
+                .expect("IPv4 wildcard route"),
+            "http://127.0.0.1:14555"
+        );
+        assert_eq!(
+            internal_grpc_endpoint_uri(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 14555)
+                .expect("IPv6 wildcard route"),
+            "http://[::1]:14555"
+        );
+        assert_eq!(
+            internal_grpc_endpoint_uri(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 14555)
+                .expect("concrete loopback route"),
+            "http://127.0.0.2:14555"
+        );
+        let mapped = IpAddr::V6(Ipv4Addr::LOCALHOST.to_ipv6_mapped());
+        internal_grpc_endpoint_uri(mapped, 14555).expect_err("mapped IPv6 route must fail closed");
+    }
+
+    #[tokio::test]
+    async fn configured_mcp_http_produces_auth_disabled_loopback_plan() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        std::fs::create_dir_all(&config_dir).expect("config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\n",
+        )
+        .expect("config file");
+
+        let server = ServerBuilder::configured_standalone_grpc()
+            .with_config_dir(config_dir)
+            .start()
+            .await
+            .expect("start configured server");
+        let McpHttpServePlan::AuthDisabled {
+            bind_addr,
+            grpc_endpoint_uri,
+        } = server.mcp_http_plan().expect("MCP HTTP plan");
+        assert_eq!(*bind_addr, SocketAddr::from((Ipv4Addr::LOCALHOST, 0)));
+        assert_eq!(grpc_endpoint_uri, server.endpoint_uri());
+        server.shutdown().await.expect("shutdown server");
     }
 
     #[tokio::test]
@@ -1562,6 +1700,7 @@ backend = "unsupported"
             },
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
+            None,
         )
         .await
         .expect("start server");
@@ -2009,6 +2148,7 @@ tables:
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
+            None,
         )
         .await
         .expect("start server");
@@ -2135,6 +2275,7 @@ tables:
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
+            None,
         )
         .await
         .expect("start server");
@@ -2261,6 +2402,7 @@ tables:
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
+            None,
         )
         .await
         .expect("start server");

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::convert::Infallible;
 use std::future::{Future, Ready};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -41,7 +41,7 @@ use tower::{Layer, Service};
 use super::env::AppEnvironment;
 use super::error::AppError;
 use super::health::AggregateHealthService;
-use super::server_config::{ResolvedMcpHttpSettings, ServerSettings};
+use super::server_config::{McpHttpServeConfig, ServerSettings};
 use crate::EngineExtensionsProvider;
 use crate::catalog::discovery::CatalogDiscovery;
 use crate::catalog::service::CatalogService;
@@ -90,18 +90,6 @@ pub trait StaticAssetsProvider: Send + Sync + 'static {
     /// Returns the asset stored at `path` (relative, no leading slash), or
     /// `None` if the asset does not exist.
     fn get(&self, path: &str) -> Option<StaticAsset>;
-}
-
-/// Resolved MCP HTTP serving mode.
-#[derive(Clone)]
-pub enum McpHttpServePlan {
-    /// Loopback-only MCP HTTP backed by a shared unauthenticated client.
-    AuthDisabled {
-        /// Address for the MCP HTTP listener.
-        bind_addr: SocketAddr,
-        /// Safe loopback URI for the in-process gRPC client.
-        grpc_endpoint_uri: String,
-    },
 }
 
 #[derive(Clone)]
@@ -156,33 +144,17 @@ impl ServerConfig {
         self
     }
 
-    fn resolved_startup(&self, layout: &AppStateLayout) -> Result<ResolvedStartup, AppError> {
-        let is_standalone = matches!(
-            &self.mode,
-            ServerModeSelection::Explicit(ServerMode::StandaloneGrpc { .. })
-                | ServerModeSelection::ConfiguredStandaloneGrpc
-        );
-        let settings = is_standalone
-            .then(|| ServerSettings::load(layout))
-            .transpose()?;
-        let mode = match &self.mode {
-            ServerModeSelection::Explicit(mode) => mode.clone(),
-            ServerModeSelection::ConfiguredStandaloneGrpc => ServerMode::StandaloneGrpc {
-                bind: settings
-                    .as_ref()
-                    .expect("configured standalone mode loads settings")
-                    .bind_addr,
-            },
-        };
-        let mcp_http = settings
-            .as_ref()
-            .map(|settings| settings.mcp_http(false))
-            .transpose()?
-            .flatten();
-        if mcp_http.is_some() {
-            safe_internal_grpc_ip(mode.bind_addr().ip())?;
+    fn resolved_mode(&self, layout: &AppStateLayout) -> Result<ServerMode, AppError> {
+        match &self.mode {
+            ServerModeSelection::Explicit(mode @ ServerMode::StandaloneGrpc { .. }) => {
+                ServerSettings::reject_removed_auth(layout)?;
+                Ok(mode.clone())
+            }
+            ServerModeSelection::Explicit(mode) => Ok(mode.clone()),
+            ServerModeSelection::ConfiguredStandaloneGrpc => Ok(ServerMode::StandaloneGrpc {
+                bind: ServerSettings::load(layout)?.bind_addr,
+            }),
         }
-        Ok(ResolvedStartup { mode, mcp_http })
     }
 
     pub(crate) fn add_engine_extensions_provider(
@@ -204,11 +176,6 @@ impl ServerConfig {
         self.feature_overrides = feature_overrides;
         self
     }
-}
-
-struct ResolvedStartup {
-    mode: ServerMode,
-    mcp_http: Option<ResolvedMcpHttpSettings>,
 }
 
 /// Concrete local server mode.
@@ -304,6 +271,21 @@ impl ServerBuilder {
         self
     }
 
+    /// Resolves the configured MCP HTTP listener without starting a server.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the config directory cannot be determined or
+    /// the MCP HTTP configuration cannot use the selected gRPC mode.
+    pub fn resolve_mcp_http_serve_config(&self) -> Result<Option<McpHttpServeConfig>, AppError> {
+        let layout = AppEnvironment::discover().app_state_layout(self.config.config_dir.clone())?;
+        let config = McpHttpServeConfig::load(&layout)?;
+        if config.is_some() {
+            validate_mcp_http_grpc_mode(&self.config.resolved_mode(&layout)?)?;
+        }
+        Ok(config)
+    }
+
     #[must_use]
     /// Adds an engine extensions provider used for query runtime builds.
     ///
@@ -372,7 +354,7 @@ impl ServerBuilder {
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir.clone())?;
-        let ResolvedStartup { mode, mcp_http } = self.config.resolved_startup(&layout)?;
+        let mode = self.config.resolved_mode(&layout)?;
         layout.ensure()?;
         let features = FeatureStore::from_layout(layout.clone())
             .load_with_overrides(&self.config.feature_overrides)?;
@@ -464,9 +446,25 @@ impl ServerBuilder {
             trace_components,
             self.config.principal_provider,
             mode,
-            mcp_http,
         )
         .await
+    }
+}
+
+fn validate_mcp_http_grpc_mode(mode: &ServerMode) -> Result<(), AppError> {
+    match mode {
+        ServerMode::EphemeralGrpc => Ok(()),
+        ServerMode::StandaloneGrpc { bind }
+            if bind.ip().is_loopback() || bind.ip().is_unspecified() =>
+        {
+            Ok(())
+        }
+        ServerMode::StandaloneGrpc { .. } => Err(AppError::FailedPrecondition(
+            "server.mcp_http requires a loopback or wildcard gRPC bind".to_string(),
+        )),
+        ServerMode::EmbeddedUi { .. } => Err(AppError::FailedPrecondition(
+            "server.mcp_http requires a native gRPC server".to_string(),
+        )),
     }
 }
 
@@ -515,7 +513,7 @@ fn resolve_database_config(layout: &AppStateLayout) -> Result<ResolvedDatabaseCo
 /// does not wait for the task to finish.
 pub struct RunningServer {
     endpoint_uri: String,
-    mcp_http_plan: Option<McpHttpServePlan>,
+    local_addr: SocketAddr,
     local_trace_store_dir: Option<PathBuf>,
     search: SearchManager,
     search_observations: Mutex<Option<SearchObservationHandle>>,
@@ -535,10 +533,10 @@ impl RunningServer {
         &self.endpoint_uri
     }
 
-    /// Returns the configured MCP HTTP companion plan, when enabled.
+    /// Returns the address bound by this server.
     #[must_use]
-    pub fn mcp_http_plan(&self) -> Option<&McpHttpServePlan> {
-        self.mcp_http_plan.as_ref()
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
     }
 
     #[must_use]
@@ -651,7 +649,6 @@ async fn start_server(
     trace_components: TraceServerComponents,
     principal_provider: Arc<dyn PrincipalProvider>,
     mode: ServerMode,
-    mcp_http: Option<ResolvedMcpHttpSettings>,
 ) -> Result<RunningServer, AppError> {
     let TraceServerComponents {
         service: trace_service,
@@ -718,16 +715,9 @@ async fn start_server(
         AggregateHealthService,
     ));
 
-    let grpc_bind_addr = mode.bind_addr();
-    let listener = TcpListener::bind(grpc_bind_addr).await?;
-    let bound_addr = listener.local_addr()?;
-    let endpoint_uri = format!("http://{bound_addr}");
-    let mcp_http_plan = mcp_http
-        .map(|settings| {
-            internal_grpc_endpoint_uri(grpc_bind_addr.ip(), bound_addr.port())
-                .map(|endpoint| mcp_http_plan(settings, endpoint))
-        })
-        .transpose()?;
+    let listener = TcpListener::bind(mode.bind_addr()).await?;
+    let local_addr = listener.local_addr()?;
+    let endpoint_uri = format!("http://{local_addr}");
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let (task_finished_tx, task_finished) = watch::channel(false);
 
@@ -742,7 +732,7 @@ async fn start_server(
 
     Ok(RunningServer {
         endpoint_uri,
-        mcp_http_plan,
+        local_addr,
         local_trace_store_dir,
         search,
         search_observations: Mutex::new(search_observations),
@@ -750,41 +740,6 @@ async fn start_server(
         task_finished,
         task: Mutex::new(Some(task)),
     })
-}
-
-fn safe_internal_grpc_ip(ip: IpAddr) -> Result<IpAddr, AppError> {
-    match ip {
-        IpAddr::V4(ip) if ip.is_unspecified() => Ok(Ipv4Addr::LOCALHOST.into()),
-        IpAddr::V6(ip) if ip.is_unspecified() => Ok(std::net::Ipv6Addr::LOCALHOST.into()),
-        ip if ip.is_loopback() => Ok(ip),
-        _ => Err(AppError::FailedPrecondition(
-            "server.mcp_http requires a loopback or wildcard gRPC bind for its safe internal plaintext route"
-                .to_string(),
-        )),
-    }
-}
-
-fn internal_grpc_endpoint_uri(bind_ip: IpAddr, bound_port: u16) -> Result<String, AppError> {
-    let address = SocketAddr::new(safe_internal_grpc_ip(bind_ip)?, bound_port);
-    Ok(format!("http://{address}"))
-}
-
-fn mcp_http_plan(settings: ResolvedMcpHttpSettings, grpc_endpoint_uri: String) -> McpHttpServePlan {
-    match settings {
-        ResolvedMcpHttpSettings::AuthDisabled { bind } => McpHttpServePlan::AuthDisabled {
-            bind_addr: bind,
-            grpc_endpoint_uri,
-        },
-        ResolvedMcpHttpSettings::Authenticated {
-            bind,
-            resource_url,
-            authorization_server,
-            scope,
-        } => {
-            drop((bind, resource_url, authorization_server, scope));
-            unreachable!("authenticated MCP is not selected without served authentication")
-        }
-    }
 }
 
 fn start_grpc_server(
@@ -997,7 +952,7 @@ mod tests {
 
     use std::borrow::Cow;
     use std::future::Future as _;
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener};
+    use std::net::{Ipv4Addr, SocketAddr, TcpListener};
     use std::path::Path;
     use std::sync::{Arc, Mutex};
     use std::task::Poll;
@@ -1020,9 +975,9 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        McpHttpServePlan, RunningServer, ServerBuilder, ServerDependencies, ServerMode,
-        StaticAsset, StaticAssetsProvider, TraceServerComponents, internal_grpc_endpoint_uri,
-        is_grpc_web_content_type, is_native_grpc_content_type, start_server,
+        RunningServer, ServerBuilder, ServerDependencies, ServerMode, StaticAsset,
+        StaticAssetsProvider, TraceServerComponents, is_grpc_web_content_type,
+        is_native_grpc_content_type, start_server,
     };
     use crate::bootstrap::AppError;
     use crate::catalog::discovery::CatalogDiscovery;
@@ -1193,7 +1148,7 @@ enabled = false
         });
         let server = RunningServer {
             endpoint_uri: "http://127.0.0.1:0".to_string(),
-            mcp_http_plan: None,
+            local_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
             local_trace_store_dir: None,
             search,
             search_observations: Mutex::new(Some(search_observations)),
@@ -1273,9 +1228,8 @@ enabled = false
 
         let ServerMode::StandaloneGrpc { bind } = builder
             .config
-            .resolved_startup(&layout)
+            .resolved_mode(&layout)
             .expect("resolve configured bind")
-            .mode
         else {
             panic!("configured server must use standalone gRPC mode");
         };
@@ -1283,49 +1237,100 @@ enabled = false
     }
 
     #[test]
-    fn internal_grpc_route_maps_wildcards_to_matching_loopback() {
-        assert_eq!(
-            internal_grpc_endpoint_uri(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 14555)
-                .expect("IPv4 wildcard route"),
-            "http://127.0.0.1:14555"
-        );
-        assert_eq!(
-            internal_grpc_endpoint_uri(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 14555)
-                .expect("IPv6 wildcard route"),
-            "http://[::1]:14555"
-        );
-        assert_eq!(
-            internal_grpc_endpoint_uri(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 14555)
-                .expect("concrete loopback route"),
-            "http://127.0.0.2:14555"
-        );
-        let mapped = IpAddr::V6(Ipv4Addr::LOCALHOST.to_ipv6_mapped());
-        internal_grpc_endpoint_uri(mapped, 14555).expect_err("mapped IPv6 route must fail closed");
-    }
-
-    #[tokio::test]
-    async fn configured_mcp_http_produces_auth_disabled_loopback_plan() {
+    fn explicit_standalone_grpc_rejects_removed_static_auth_config() {
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
         std::fs::create_dir_all(&config_dir).expect("config dir");
         std::fs::write(
             config_dir.join("config.toml"),
-            "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:0'\n",
+            "[server.auth]\ntoken_env = 'CORAL_SERVER_AUTH_TOKEN'\n",
+        )
+        .expect("config file");
+        let layout = AppStateLayout::discover(Some(config_dir)).expect("layout");
+        let builder =
+            ServerBuilder::standalone_grpc(SocketAddr::from((Ipv4Addr::LOCALHOST, 14555)));
+
+        assert!(
+            builder.config.resolved_mode(&layout).is_err(),
+            "removed standalone auth config must fail closed"
+        );
+    }
+
+    #[test]
+    fn explicit_standalone_grpc_does_not_parse_the_configured_bind() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        std::fs::create_dir_all(&config_dir).expect("config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[server]\nbind_addr = 'not-an-address'\n",
+        )
+        .expect("config file");
+        let layout = AppStateLayout::discover(Some(config_dir)).expect("layout");
+        let explicit_bind = SocketAddr::from((Ipv4Addr::LOCALHOST, 14555));
+        let builder = ServerBuilder::standalone_grpc(explicit_bind);
+
+        let ServerMode::StandaloneGrpc { bind } = builder
+            .config
+            .resolved_mode(&layout)
+            .expect("explicit bind overrides configured bind")
+        else {
+            panic!("explicit standalone mode must remain selected");
+        };
+        assert_eq!(bind, explicit_bind);
+    }
+
+    #[test]
+    fn resolves_mcp_http_config_without_starting_grpc() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        std::fs::create_dir_all(&config_dir).expect("config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[server.mcp_http]\nenabled = true\nbind = '127.0.0.1:14556'\n",
         )
         .expect("config file");
 
-        let server = ServerBuilder::configured_standalone_grpc()
+        let config = ServerBuilder::configured_standalone_grpc()
             .with_config_dir(config_dir)
-            .start()
-            .await
-            .expect("start configured server");
-        let McpHttpServePlan::AuthDisabled {
-            bind_addr,
-            grpc_endpoint_uri,
-        } = server.mcp_http_plan().expect("MCP HTTP plan");
-        assert_eq!(*bind_addr, SocketAddr::from((Ipv4Addr::LOCALHOST, 0)));
-        assert_eq!(grpc_endpoint_uri, server.endpoint_uri());
-        server.shutdown().await.expect("shutdown server");
+            .resolve_mcp_http_serve_config()
+            .expect("resolve MCP HTTP config")
+            .expect("enabled MCP HTTP config");
+
+        assert_eq!(
+            config.bind_addr(),
+            SocketAddr::from((Ipv4Addr::LOCALHOST, 14556))
+        );
+    }
+
+    #[test]
+    fn mcp_http_resolution_accepts_wildcard_and_rejects_public_grpc_binds() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        std::fs::create_dir_all(&config_dir).expect("config dir");
+        std::fs::write(
+            config_dir.join("config.toml"),
+            "[server.mcp_http]\nenabled = true\n",
+        )
+        .expect("config file");
+
+        ServerBuilder::standalone_grpc(SocketAddr::from((Ipv4Addr::UNSPECIFIED, 14555)))
+            .with_config_dir(config_dir.clone())
+            .resolve_mcp_http_serve_config()
+            .expect("wildcard gRPC bind has a safe loopback route");
+
+        let error = ServerBuilder::standalone_grpc(SocketAddr::from(([192, 0, 2, 1], 14555)))
+            .with_config_dir(config_dir.clone())
+            .resolve_mcp_http_serve_config()
+            .expect_err("public gRPC address has no safe local route");
+
+        assert!(error.to_string().contains("loopback or wildcard gRPC bind"));
+
+        let mapped_loopback = SocketAddr::new(Ipv4Addr::LOCALHOST.to_ipv6_mapped().into(), 14555);
+        ServerBuilder::standalone_grpc(mapped_loopback)
+            .with_config_dir(config_dir)
+            .resolve_mcp_http_serve_config()
+            .expect_err("IPv4-mapped IPv6 must fail closed");
     }
 
     #[tokio::test]
@@ -1351,6 +1356,7 @@ enabled = false
             .expect("endpoint scheme")
             .parse::<SocketAddr>()
             .expect("socket address endpoint");
+        assert_eq!(server.local_addr(), endpoint);
         assert!(endpoint.ip().is_loopback());
         assert_ne!(endpoint.port(), 0);
         server.shutdown().await.expect("shutdown server");
@@ -1700,7 +1706,6 @@ backend = "unsupported"
             },
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
-            None,
         )
         .await
         .expect("start server");
@@ -2148,7 +2153,6 @@ tables:
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
-            None,
         )
         .await
         .expect("start server");
@@ -2275,7 +2279,6 @@ tables:
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
-            None,
         )
         .await
         .expect("start server");
@@ -2402,7 +2405,6 @@ tables:
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
-            None,
         )
         .await
         .expect("start server");

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -3,170 +3,140 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use serde::Deserialize;
-use url::{Host, Url};
+use serde::de::DeserializeOwned;
 
 use super::AppError;
 use crate::state::AppStateLayout;
 
-const DEFAULT_MCP_SCOPE: &str = "coral:mcp";
-
 #[derive(Debug, Default, Deserialize)]
-struct ConfigFile {
+struct GrpcConfigFile {
     #[serde(default)]
     server: ServerSettings,
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct McpHttpConfigFile {
+    #[serde(default)]
+    server: McpHttpServerSettings,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RemovedAuthConfigFile {
+    #[serde(default)]
+    server: RemovedAuthServerSettings,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct RemovedAuthServerSettings {
+    #[serde(rename = "auth")]
+    removed_auth: Option<toml::Value>,
+}
+
 /// Settings loaded from the top-level `[server]` section of `config.toml`.
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(default, deny_unknown_fields)]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 pub(crate) struct ServerSettings {
     pub(crate) bind_addr: SocketAddr,
-    mcp_http: ServerMcpHttpSettings,
+    #[serde(rename = "auth")]
+    removed_auth: Option<toml::Value>,
 }
 
 impl Default for ServerSettings {
     fn default() -> Self {
         Self {
             bind_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
-            mcp_http: ServerMcpHttpSettings::default(),
+            removed_auth: None,
         }
     }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct McpHttpServerSettings {
+    mcp_http: RawMcpHttpSettings,
+    #[serde(rename = "auth")]
+    removed_auth: Option<toml::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(default, deny_unknown_fields)]
-struct ServerMcpHttpSettings {
+struct RawMcpHttpSettings {
     enabled: bool,
     bind: SocketAddr,
-    allow_insecure_remote_http_bind: bool,
-    resource_url: Option<String>,
-    authorization_server: Option<String>,
-    scope: String,
 }
 
-impl Default for ServerMcpHttpSettings {
+impl Default for RawMcpHttpSettings {
     fn default() -> Self {
         Self {
             enabled: false,
             bind: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
-            allow_insecure_remote_http_bind: false,
-            resource_url: None,
-            authorization_server: None,
-            scope: DEFAULT_MCP_SCOPE.to_string(),
         }
     }
 }
 
-#[derive(Debug)]
-pub(crate) enum ResolvedMcpHttpSettings {
-    AuthDisabled {
-        bind: SocketAddr,
-    },
-    Authenticated {
-        bind: SocketAddr,
-        resource_url: String,
-        authorization_server: String,
-        scope: String,
-    },
+/// Resolved settings for the auth-disabled MCP HTTP listener.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct McpHttpServeConfig {
+    bind_addr: SocketAddr,
 }
 
-impl ServerSettings {
-    /// Loads only the `[server]` section, leaving other config ownership intact.
-    pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, AppError> {
-        if !layout.config_file().try_exists()? {
-            return Ok(Self::default());
-        }
-        let raw = std::fs::read_to_string(layout.config_file())?;
-        Ok(toml::from_str::<ConfigFile>(&raw)?.server)
+impl McpHttpServeConfig {
+    /// Returns the configured MCP HTTP bind address.
+    #[must_use]
+    pub fn bind_addr(&self) -> SocketAddr {
+        self.bind_addr
     }
 
-    pub(crate) fn mcp_http(
-        &self,
-        authenticated: bool,
-    ) -> Result<Option<ResolvedMcpHttpSettings>, AppError> {
-        if !self.mcp_http.enabled {
+    pub(crate) fn load(layout: &AppStateLayout) -> Result<Option<Self>, AppError> {
+        let settings = load_config::<McpHttpConfigFile>(layout)?.server;
+        reject_removed_auth(settings.removed_auth.as_ref())?;
+        if !settings.mcp_http.enabled {
             return Ok(None);
         }
-
-        let settings = &self.mcp_http;
-        if !authenticated {
-            if !is_loopback(settings.bind.ip()) {
-                return Err(AppError::FailedPrecondition(
-                    "auth-disabled server.mcp_http.bind must be loopback".to_string(),
-                ));
-            }
-            if settings.resource_url.is_some() || settings.authorization_server.is_some() {
-                return Err(AppError::FailedPrecondition(
-                    "auth-disabled server.mcp_http must not advertise OAuth metadata".to_string(),
-                ));
-            }
-            return Ok(Some(ResolvedMcpHttpSettings::AuthDisabled {
-                bind: settings.bind,
-            }));
-        }
-
-        if !is_loopback(settings.bind.ip()) && !settings.allow_insecure_remote_http_bind {
+        if !is_loopback(settings.mcp_http.bind.ip()) {
             return Err(AppError::FailedPrecondition(
-                "non-loopback server.mcp_http.bind serves cleartext authenticated endpoints and requires server.mcp_http.allow_insecure_remote_http_bind = true"
-                    .to_string(),
+                "auth-disabled server.mcp_http.bind must be loopback".to_string(),
             ));
         }
-        let resource_url = required_oauth_url(
-            "server.mcp_http.resource_url",
-            settings.resource_url.as_deref(),
-        )?;
-        let authorization_server = required_oauth_url(
-            "server.mcp_http.authorization_server",
-            settings.authorization_server.as_deref(),
-        )?;
-        let scope = settings.scope.as_str();
-        if scope.is_empty()
-            || !scope
-                .bytes()
-                .all(|byte| matches!(byte, 33 | 35..=91 | 93..=126))
-        {
-            return Err(AppError::FailedPrecondition(
-                "server.mcp_http.scope must be one printable OAuth scope token".to_string(),
-            ));
-        }
-
-        Ok(Some(ResolvedMcpHttpSettings::Authenticated {
-            bind: settings.bind,
-            resource_url,
-            authorization_server,
-            scope: scope.to_string(),
+        Ok(Some(Self {
+            bind_addr: settings.mcp_http.bind,
         }))
     }
 }
 
-fn required_oauth_url(label: &str, value: Option<&str>) -> Result<String, AppError> {
-    let Some(value) = value.filter(|value| !value.is_empty()) else {
-        return Err(AppError::FailedPrecondition(format!(
-            "authenticated MCP HTTP requires {label}"
-        )));
-    };
-    let url = Url::parse(value).map_err(|_error| unsafe_oauth_url(label))?;
-    let loopback = match url.host() {
-        Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
-        Some(Host::Ipv4(ip)) => ip.is_loopback(),
-        Some(Host::Ipv6(ip)) => is_loopback(IpAddr::V6(ip)),
-        None => false,
-    };
-    if !url.username().is_empty()
-        || url.password().is_some()
-        || url.query().is_some()
-        || url.fragment().is_some()
-        || (url.scheme() != "https" && !(url.scheme() == "http" && loopback))
-    {
-        return Err(unsafe_oauth_url(label));
+impl ServerSettings {
+    /// Loads only the gRPC-owned fields from `[server]`.
+    pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, AppError> {
+        let settings = load_config::<GrpcConfigFile>(layout)?.server;
+        reject_removed_auth(settings.removed_auth.as_ref())?;
+        Ok(settings)
     }
-    Ok(url.to_string())
+
+    pub(crate) fn reject_removed_auth(layout: &AppStateLayout) -> Result<(), AppError> {
+        let settings = load_config::<RemovedAuthConfigFile>(layout)?.server;
+        reject_removed_auth(settings.removed_auth.as_ref())
+    }
 }
 
-fn unsafe_oauth_url(label: &str) -> AppError {
-    AppError::FailedPrecondition(format!(
-        "{label} must be an absolute HTTPS or loopback HTTP URL without credentials, query, or fragment"
-    ))
+fn load_config<T>(layout: &AppStateLayout) -> Result<T, AppError>
+where
+    T: DeserializeOwned + Default,
+{
+    if !layout.config_file().try_exists()? {
+        return Ok(T::default());
+    }
+    let raw = std::fs::read_to_string(layout.config_file())?;
+    Ok(toml::from_str(&raw)?)
+}
+
+fn reject_removed_auth(value: Option<&toml::Value>) -> Result<(), AppError> {
+    if value.is_some() {
+        return Err(AppError::FailedPrecondition(
+            "[server.auth] is no longer supported".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn is_loopback(ip: IpAddr) -> bool {
@@ -181,7 +151,7 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use super::{ResolvedMcpHttpSettings, ServerSettings};
+    use super::{McpHttpServeConfig, ServerSettings};
     use crate::state::AppStateLayout;
 
     #[test]
@@ -195,7 +165,11 @@ mod tests {
             settings.bind_addr,
             SocketAddr::from((Ipv4Addr::LOCALHOST, 0))
         );
-        assert!(settings.mcp_http(false).expect("MCP config").is_none());
+        assert!(
+            McpHttpServeConfig::load(&layout)
+                .expect("MCP HTTP config")
+                .is_none()
+        );
     }
 
     #[test]
@@ -205,7 +179,7 @@ mod tests {
         layout.ensure().expect("config dir");
         fs::write(
             layout.config_file(),
-            "[server]\nbind_addr = '127.0.0.2:14555'\n\n[future]\nvalue = true\n",
+            "[server]\nbind_addr = '127.0.0.2:14555'\n\n[server.mcp_http]\nenabled = true\nbind = 'invalid'\n\n[future]\nvalue = true\n",
         )
         .expect("config file");
 
@@ -239,17 +213,18 @@ mod tests {
         layout.ensure().expect("config dir");
         fs::write(
             layout.config_file(),
-            "[server.mcp_http]\nenabled = true\nbind = '[::1]:14556'\n",
+            "[server]\nbind_addr = 'not-an-address'\n\n[server.mcp_http]\nenabled = true\nbind = '[::1]:14556'\n",
         )
         .expect("config file");
 
-        let settings = ServerSettings::load(&layout).expect("server settings");
-        let Some(ResolvedMcpHttpSettings::AuthDisabled { bind }) =
-            settings.mcp_http(false).expect("MCP config")
-        else {
-            panic!("loopback MCP must be explicitly auth-disabled");
-        };
-        assert_eq!(bind, SocketAddr::from((Ipv6Addr::LOCALHOST, 14556)));
+        let settings = McpHttpServeConfig::load(&layout)
+            .expect("MCP HTTP config")
+            .expect("enabled MCP HTTP config");
+
+        assert_eq!(
+            settings.bind_addr(),
+            SocketAddr::from((Ipv6Addr::LOCALHOST, 14556))
+        );
     }
 
     #[test]
@@ -263,100 +238,29 @@ mod tests {
         )
         .expect("config file");
 
-        let settings = ServerSettings::load(&layout).expect("server settings");
-        let error = settings
-            .mcp_http(false)
-            .expect_err("public auth-disabled bind must fail");
+        let error =
+            McpHttpServeConfig::load(&layout).expect_err("public auth-disabled bind must fail");
+
         assert!(error.to_string().contains("must be loopback"));
     }
 
     #[test]
-    fn auth_disabled_mcp_http_rejects_oauth_metadata() {
+    fn auth_disabled_mcp_http_rejects_public_url() {
         let temp = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
         layout.ensure().expect("config dir");
         fs::write(
             layout.config_file(),
-            "[server.mcp_http]\nenabled = true\nresource_url = 'https://coral.example/mcp'\n",
+            "[server.mcp_http]\nenabled = true\npublic_url = 'https://coral.example/mcp'\n",
         )
         .expect("config file");
 
-        let settings = ServerSettings::load(&layout).expect("server settings");
-        let error = settings
-            .mcp_http(false)
-            .expect_err("auth-disabled MCP must not advertise OAuth metadata");
-        assert!(error.to_string().contains("must not advertise"));
+        McpHttpServeConfig::load(&layout)
+            .expect_err("unsupported authenticated MCP public URL must fail");
     }
 
     #[test]
-    fn authenticated_mcp_http_requires_acknowledgement_for_public_bind() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
-        layout.ensure().expect("config dir");
-        fs::write(
-            layout.config_file(),
-            r"
-[server.mcp_http]
-enabled = true
-bind = '0.0.0.0:14556'
-resource_url = 'https://coral.example/mcp'
-authorization_server = 'https://auth.example'
-scope = 'coral:mcp'
-",
-        )
-        .expect("config file");
-
-        let mut settings = ServerSettings::load(&layout).expect("server settings");
-        let error = settings
-            .mcp_http(true)
-            .expect_err("public cleartext bind must require acknowledgement");
-        assert!(
-            error
-                .to_string()
-                .contains("allow_insecure_remote_http_bind")
-        );
-        settings.mcp_http.allow_insecure_remote_http_bind = true;
-        let Some(ResolvedMcpHttpSettings::Authenticated {
-            bind,
-            resource_url,
-            authorization_server,
-            scope,
-        }) = settings.mcp_http(true).expect("MCP config")
-        else {
-            panic!("authenticated MCP settings must resolve");
-        };
-        assert_eq!(bind, SocketAddr::from((Ipv4Addr::UNSPECIFIED, 14556)));
-        assert_eq!(resource_url, "https://coral.example/mcp");
-        assert_eq!(authorization_server, "https://auth.example/");
-        assert_eq!(scope, "coral:mcp");
-    }
-
-    #[test]
-    fn authenticated_mcp_http_rejects_unsafe_metadata_urls_and_scopes() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
-        layout.ensure().expect("config dir");
-        fs::write(
-            layout.config_file(),
-            r"
-[server.mcp_http]
-enabled = true
-resource_url = 'http://coral.example/mcp'
-authorization_server = 'https://auth.example'
-scope = 'two scopes'
-",
-        )
-        .expect("config file");
-
-        let settings = ServerSettings::load(&layout).expect("server settings");
-        let error = settings
-            .mcp_http(true)
-            .expect_err("public HTTP OAuth metadata must fail");
-        assert!(error.to_string().contains("absolute HTTPS"));
-    }
-
-    #[test]
-    fn stale_static_auth_config_is_rejected() {
+    fn stale_static_auth_config_is_rejected_by_both_resolvers() {
         let temp = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
         layout.ensure().expect("config dir");
@@ -366,6 +270,7 @@ scope = 'two scopes'
         )
         .expect("config file");
 
-        ServerSettings::load(&layout).expect_err("removed static auth config must fail closed");
+        ServerSettings::load(&layout).expect_err("removed static auth config must fail");
+        McpHttpServeConfig::load(&layout).expect_err("removed static auth config must fail");
     }
 }

--- a/crates/coral-app/src/bootstrap/server_config.rs
+++ b/crates/coral-app/src/bootstrap/server_config.rs
@@ -1,11 +1,14 @@
 //! Configuration owned by the long-running Coral server surface.
 
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use serde::Deserialize;
+use url::{Host, Url};
 
 use super::AppError;
 use crate::state::AppStateLayout;
+
+const DEFAULT_MCP_SCOPE: &str = "coral:mcp";
 
 #[derive(Debug, Default, Deserialize)]
 struct ConfigFile {
@@ -15,17 +18,56 @@ struct ConfigFile {
 
 /// Settings loaded from the top-level `[server]` section of `config.toml`.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub(crate) struct ServerSettings {
     pub(crate) bind_addr: SocketAddr,
+    mcp_http: ServerMcpHttpSettings,
 }
 
 impl Default for ServerSettings {
     fn default() -> Self {
         Self {
             bind_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+            mcp_http: ServerMcpHttpSettings::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+struct ServerMcpHttpSettings {
+    enabled: bool,
+    bind: SocketAddr,
+    allow_insecure_remote_http_bind: bool,
+    resource_url: Option<String>,
+    authorization_server: Option<String>,
+    scope: String,
+}
+
+impl Default for ServerMcpHttpSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind: SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+            allow_insecure_remote_http_bind: false,
+            resource_url: None,
+            authorization_server: None,
+            scope: DEFAULT_MCP_SCOPE.to_string(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ResolvedMcpHttpSettings {
+    AuthDisabled {
+        bind: SocketAddr,
+    },
+    Authenticated {
+        bind: SocketAddr,
+        resource_url: String,
+        authorization_server: String,
+        scope: String,
+    },
 }
 
 impl ServerSettings {
@@ -37,16 +79,109 @@ impl ServerSettings {
         let raw = std::fs::read_to_string(layout.config_file())?;
         Ok(toml::from_str::<ConfigFile>(&raw)?.server)
     }
+
+    pub(crate) fn mcp_http(
+        &self,
+        authenticated: bool,
+    ) -> Result<Option<ResolvedMcpHttpSettings>, AppError> {
+        if !self.mcp_http.enabled {
+            return Ok(None);
+        }
+
+        let settings = &self.mcp_http;
+        if !authenticated {
+            if !is_loopback(settings.bind.ip()) {
+                return Err(AppError::FailedPrecondition(
+                    "auth-disabled server.mcp_http.bind must be loopback".to_string(),
+                ));
+            }
+            if settings.resource_url.is_some() || settings.authorization_server.is_some() {
+                return Err(AppError::FailedPrecondition(
+                    "auth-disabled server.mcp_http must not advertise OAuth metadata".to_string(),
+                ));
+            }
+            return Ok(Some(ResolvedMcpHttpSettings::AuthDisabled {
+                bind: settings.bind,
+            }));
+        }
+
+        if !is_loopback(settings.bind.ip()) && !settings.allow_insecure_remote_http_bind {
+            return Err(AppError::FailedPrecondition(
+                "non-loopback server.mcp_http.bind serves cleartext authenticated endpoints and requires server.mcp_http.allow_insecure_remote_http_bind = true"
+                    .to_string(),
+            ));
+        }
+        let resource_url = required_oauth_url(
+            "server.mcp_http.resource_url",
+            settings.resource_url.as_deref(),
+        )?;
+        let authorization_server = required_oauth_url(
+            "server.mcp_http.authorization_server",
+            settings.authorization_server.as_deref(),
+        )?;
+        let scope = settings.scope.as_str();
+        if scope.is_empty()
+            || !scope
+                .bytes()
+                .all(|byte| matches!(byte, 33 | 35..=91 | 93..=126))
+        {
+            return Err(AppError::FailedPrecondition(
+                "server.mcp_http.scope must be one printable OAuth scope token".to_string(),
+            ));
+        }
+
+        Ok(Some(ResolvedMcpHttpSettings::Authenticated {
+            bind: settings.bind,
+            resource_url,
+            authorization_server,
+            scope: scope.to_string(),
+        }))
+    }
+}
+
+fn required_oauth_url(label: &str, value: Option<&str>) -> Result<String, AppError> {
+    let Some(value) = value.filter(|value| !value.is_empty()) else {
+        return Err(AppError::FailedPrecondition(format!(
+            "authenticated MCP HTTP requires {label}"
+        )));
+    };
+    let url = Url::parse(value).map_err(|_error| unsafe_oauth_url(label))?;
+    let loopback = match url.host() {
+        Some(Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(Host::Ipv6(ip)) => is_loopback(IpAddr::V6(ip)),
+        None => false,
+    };
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || (url.scheme() != "https" && !(url.scheme() == "http" && loopback))
+    {
+        return Err(unsafe_oauth_url(label));
+    }
+    Ok(url.to_string())
+}
+
+fn unsafe_oauth_url(label: &str) -> AppError {
+    AppError::FailedPrecondition(format!(
+        "{label} must be an absolute HTTPS or loopback HTTP URL without credentials, query, or fragment"
+    ))
+}
+
+fn is_loopback(ip: IpAddr) -> bool {
+    ip.is_loopback()
+        || matches!(ip, IpAddr::V6(ip) if ip.to_ipv4_mapped().is_some_and(|ip| ip.is_loopback()))
 }
 
 #[cfg(test)]
 mod tests {
     use std::fs;
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
     use tempfile::TempDir;
 
-    use super::ServerSettings;
+    use super::{ResolvedMcpHttpSettings, ServerSettings};
     use crate::state::AppStateLayout;
 
     #[test]
@@ -60,6 +195,7 @@ mod tests {
             settings.bind_addr,
             SocketAddr::from((Ipv4Addr::LOCALHOST, 0))
         );
+        assert!(settings.mcp_http(false).expect("MCP config").is_none());
     }
 
     #[test]
@@ -94,5 +230,142 @@ mod tests {
         .expect("config file");
 
         ServerSettings::load(&layout).expect_err("bind address must be an IP socket address");
+    }
+
+    #[test]
+    fn loads_enabled_auth_disabled_mcp_http_on_loopback() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[server.mcp_http]\nenabled = true\nbind = '[::1]:14556'\n",
+        )
+        .expect("config file");
+
+        let settings = ServerSettings::load(&layout).expect("server settings");
+        let Some(ResolvedMcpHttpSettings::AuthDisabled { bind }) =
+            settings.mcp_http(false).expect("MCP config")
+        else {
+            panic!("loopback MCP must be explicitly auth-disabled");
+        };
+        assert_eq!(bind, SocketAddr::from((Ipv6Addr::LOCALHOST, 14556)));
+    }
+
+    #[test]
+    fn auth_disabled_mcp_http_rejects_public_bind() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[server.mcp_http]\nenabled = true\nbind = '0.0.0.0:14556'\n",
+        )
+        .expect("config file");
+
+        let settings = ServerSettings::load(&layout).expect("server settings");
+        let error = settings
+            .mcp_http(false)
+            .expect_err("public auth-disabled bind must fail");
+        assert!(error.to_string().contains("must be loopback"));
+    }
+
+    #[test]
+    fn auth_disabled_mcp_http_rejects_oauth_metadata() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[server.mcp_http]\nenabled = true\nresource_url = 'https://coral.example/mcp'\n",
+        )
+        .expect("config file");
+
+        let settings = ServerSettings::load(&layout).expect("server settings");
+        let error = settings
+            .mcp_http(false)
+            .expect_err("auth-disabled MCP must not advertise OAuth metadata");
+        assert!(error.to_string().contains("must not advertise"));
+    }
+
+    #[test]
+    fn authenticated_mcp_http_requires_acknowledgement_for_public_bind() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            r"
+[server.mcp_http]
+enabled = true
+bind = '0.0.0.0:14556'
+resource_url = 'https://coral.example/mcp'
+authorization_server = 'https://auth.example'
+scope = 'coral:mcp'
+",
+        )
+        .expect("config file");
+
+        let mut settings = ServerSettings::load(&layout).expect("server settings");
+        let error = settings
+            .mcp_http(true)
+            .expect_err("public cleartext bind must require acknowledgement");
+        assert!(
+            error
+                .to_string()
+                .contains("allow_insecure_remote_http_bind")
+        );
+        settings.mcp_http.allow_insecure_remote_http_bind = true;
+        let Some(ResolvedMcpHttpSettings::Authenticated {
+            bind,
+            resource_url,
+            authorization_server,
+            scope,
+        }) = settings.mcp_http(true).expect("MCP config")
+        else {
+            panic!("authenticated MCP settings must resolve");
+        };
+        assert_eq!(bind, SocketAddr::from((Ipv4Addr::UNSPECIFIED, 14556)));
+        assert_eq!(resource_url, "https://coral.example/mcp");
+        assert_eq!(authorization_server, "https://auth.example/");
+        assert_eq!(scope, "coral:mcp");
+    }
+
+    #[test]
+    fn authenticated_mcp_http_rejects_unsafe_metadata_urls_and_scopes() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            r"
+[server.mcp_http]
+enabled = true
+resource_url = 'http://coral.example/mcp'
+authorization_server = 'https://auth.example'
+scope = 'two scopes'
+",
+        )
+        .expect("config file");
+
+        let settings = ServerSettings::load(&layout).expect("server settings");
+        let error = settings
+            .mcp_http(true)
+            .expect_err("public HTTP OAuth metadata must fail");
+        assert!(error.to_string().contains("absolute HTTPS"));
+    }
+
+    #[test]
+    fn stale_static_auth_config_is_rejected() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("config dir");
+        fs::write(
+            layout.config_file(),
+            "[server.auth]\ntoken_env = 'CORAL_SERVER_AUTH_TOKEN'\n",
+        )
+        .expect("config file");
+
+        ServerSettings::load(&layout).expect_err("removed static auth config must fail closed");
     }
 }

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -62,7 +62,8 @@ mod transport;
 mod workspaces;
 
 pub use bootstrap::{
-    AppError, RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider,
+    AppError, McpHttpServePlan, RunningServer, ServerBuilder, ServerMode, StaticAsset,
+    StaticAssetsProvider,
 };
 pub use coral_engine::{EngineExtensions, QuerySource};
 pub use identity::{

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -62,7 +62,7 @@ mod transport;
 mod workspaces;
 
 pub use bootstrap::{
-    AppError, McpHttpServePlan, RunningServer, ServerBuilder, ServerMode, StaticAsset,
+    AppError, McpHttpServeConfig, RunningServer, ServerBuilder, ServerMode, StaticAsset,
     StaticAssetsProvider,
 };
 pub use coral_engine::{EngineExtensions, QuerySource};


### PR DESCRIPTION
## Stack overview

This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.

## Where this PR fits

The previous PR provides the MCP HTTP transport APIs. This PR lets `coral-app` resolve the supported local listener settings without starting that listener or coupling MCP HTTP startup to gRPC startup. The next PR makes the CLI use the resolved settings.

## Intent

Give the process that owns server startup a small, validated configuration object for the optional local MCP HTTP listener.

## What it enables

`ServerBuilder` can now read `[server.mcp_http]` and return an `McpHttpServeConfig` before gRPC starts. MCP HTTP remains disabled by default.

At this point in the stack, configuration supports only the authentication-disabled local mode:

- the MCP bind address must be loopback;
- OAuth metadata fields under `[server.mcp_http]` are rejected rather than ignored;
- the removed `[server.auth]` configuration is rejected;
- the accompanying gRPC server must listen on a loopback or wildcard address so the MCP listener can reach it locally; and
- embedded gRPC-Web mode cannot be paired with this listener.

The running gRPC server also exposes its bound socket address so the CLI can connect the MCP listener to the actual port selected by the operating system.

This PR resolves settings only. It does not start MCP HTTP and does not expose the authenticated transport through configuration.

## Usage examples

Enable the local listener in `config.toml`:

```toml
[server.mcp_http]
enabled = true
bind = "127.0.0.1:14556"
```

A caller can resolve those settings independently of server startup:

```rust
let mcp_http = builder.resolve_mcp_http_serve_config()?;
```

Leaving out `[server.mcp_http]`, or setting `enabled = false`, returns no MCP HTTP configuration.