### PR TITLE
feat(app): add OIDC discovery and code exchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7261,6 +7261,7 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -49,7 +49,7 @@ tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
 uuid.workspace = true
-zeroize.workspace = true
+zeroize = { workspace = true, features = ["serde"] }
 
 coral-api.workspace = true
 coral-auth-aws = { path = "../auth/aws" }

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -15,6 +15,7 @@ use tokio::task::JoinHandle;
 
 use super::config::{AuthSettings, ResolvedAuthSettings, signing_key_env_error};
 use super::error::AuthServerError;
+use super::provider_client::OidcProviderClient;
 use super::session::SessionTokenIssuer;
 use super::state_store::{InMemoryStateStore, StateStore};
 
@@ -88,6 +89,8 @@ impl CoralAuthorizationServer {
             settings: self.settings,
             session_tokens: self.session_tokens,
             state_store: self.state_store,
+            provider_client: OidcProviderClient::new()
+                .map_err(|error| AuthServerError::ProviderClient(error.to_string()))?,
         };
         let router = Router::new()
             .route(
@@ -187,6 +190,8 @@ struct AuthorizationServerHttpState {
         reason = "used by the OAuth authorization endpoint in a descendant PR"
     )]
     state_store: Arc<dyn StateStore>,
+    #[expect(dead_code, reason = "used by OIDC authorization descendants")]
+    provider_client: OidcProviderClient,
 }
 
 async fn authorization_server_metadata(

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -286,7 +286,15 @@ impl AuthorizationServerSettings {
 }
 
 const DEFAULT_PROVIDER_SCOPES: &[&str] = &["openid", "email", "profile"];
-const RESERVED_PROVIDER_AUTH_PARAMS: &[&str] = &[
+
+/// Query parameters reserved to the authorization request.
+///
+/// No outside input may pre-set one. Operator-supplied `auth_params` are
+/// checked against this list here, and the provider client checks the
+/// `authorization_endpoint` it reads out of the discovery document against the
+/// same list, so the two paths cannot drift apart and leave the less trusted
+/// source — the discovery document — the more permissive one.
+pub(super) const RESERVED_PROVIDER_AUTH_PARAMS: &[&str] = &[
     "response_type",
     // `fragment` and `form_post` both stop the authorization code from ever
     // reaching the GET callback route, so a login started with either simply

--- a/crates/coral-app/src/auth/error.rs
+++ b/crates/coral-app/src/auth/error.rs
@@ -20,6 +20,12 @@ pub enum AuthServerError {
     /// resolved from.
     #[error("resolved session-token issuer does not match authorization-server settings")]
     SessionIssuerMismatch,
+    /// The upstream OIDC provider client could not be constructed.
+    ///
+    /// Carries the client's own message rather than its type, which is crate
+    /// internal.
+    #[error("failed to initialize the OIDC provider client: {0}")]
+    ProviderClient(String),
     /// The TCP listener could not bind.
     #[error("failed to bind authorization server to {address}")]
     Bind {

--- a/crates/coral-app/src/auth/mod.rs
+++ b/crates/coral-app/src/auth/mod.rs
@@ -1,6 +1,7 @@
 mod authorization_server;
 mod config;
 mod error;
+mod provider_client;
 #[cfg_attr(
     not(test),
     expect(

--- a/crates/coral-app/src/auth/provider_client.rs
+++ b/crates/coral-app/src/auth/provider_client.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(test), expect(dead_code, reason = "wired by OAuth descendants"))]
 use super::config::ResolvedOidcProvider;
-use crate::outbound_url_policy::{ConfiguredEndpointUrl, read_bounded_body};
+use crate::outbound_url_policy::{ConfiguredEndpointUrl, DiscoveredEndpointUrl, read_bounded_body};
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use reqwest::header::ACCEPT;
@@ -26,14 +26,14 @@ pub(super) struct OidcAuthorizationRequest {
 }
 pub(super) struct OidcCodeExchange {
     id_token: Zeroizing<String>,
-    jwks_uri: ConfiguredEndpointUrl,
+    jwks_uri: DiscoveredEndpointUrl,
     signing_algorithms: Vec<String>,
 }
 impl OidcCodeExchange {
     pub(super) fn id_token(&self) -> &str {
         self.id_token.as_str()
     }
-    pub(super) fn jwks_uri(&self) -> &ConfiguredEndpointUrl {
+    pub(super) fn jwks_uri(&self) -> &DiscoveredEndpointUrl {
         &self.jwks_uri
     }
     pub(super) fn signing_algorithms(&self) -> &[String] {
@@ -144,6 +144,8 @@ impl OidcProviderClient {
         &self,
         provider: &ResolvedOidcProvider,
     ) -> Result<ValidatedDiscovery, OidcProviderClientError> {
+        let issuer = ConfiguredEndpointUrl::parse(&provider.issuer)
+            .map_err(|_error| OidcProviderClientError::Discovery)?;
         let url = discovery_url(&provider.issuer)?;
         let response = self
             .http
@@ -174,17 +176,22 @@ impl OidcProviderClient {
             authorization_endpoint: discovered_endpoint(
                 "authorization_endpoint",
                 &document.authorization_endpoint,
+                &issuer,
             )?,
-            token_endpoint: discovered_endpoint("token_endpoint", &document.token_endpoint)?,
-            jwks_uri: discovered_endpoint("jwks_uri", &document.jwks_uri)?,
+            token_endpoint: discovered_endpoint(
+                "token_endpoint",
+                &document.token_endpoint,
+                &issuer,
+            )?,
+            jwks_uri: discovered_endpoint("jwks_uri", &document.jwks_uri, &issuer)?,
             signing_algorithms: document.id_token_signing_alg_values_supported,
         })
     }
 }
 struct ValidatedDiscovery {
-    authorization_endpoint: ConfiguredEndpointUrl,
-    token_endpoint: ConfiguredEndpointUrl,
-    jwks_uri: ConfiguredEndpointUrl,
+    authorization_endpoint: DiscoveredEndpointUrl,
+    token_endpoint: DiscoveredEndpointUrl,
+    jwks_uri: DiscoveredEndpointUrl,
     signing_algorithms: Vec<String>,
 }
 #[derive(Deserialize)]
@@ -209,11 +216,12 @@ fn discovery_url(issuer: &str) -> Result<ConfiguredEndpointUrl, OidcProviderClie
 fn discovered_endpoint(
     label: &'static str,
     value: &str,
-) -> Result<ConfiguredEndpointUrl, OidcProviderClientError> {
+    issuer: &ConfiguredEndpointUrl,
+) -> Result<DiscoveredEndpointUrl, OidcProviderClientError> {
     if value.trim() != value {
         return Err(OidcProviderClientError::InvalidEndpoint(label));
     }
-    let url = ConfiguredEndpointUrl::parse(value)
+    let url = DiscoveredEndpointUrl::parse(value, issuer)
         .map_err(|_error| OidcProviderClientError::InvalidEndpoint(label))?;
     let reserved = url.as_url().query_pairs().any(|(key, _value)| {
         let key = key.to_ascii_lowercase();
@@ -328,6 +336,22 @@ mod tests {
             &format!("{}/token?tenant=one", server.uri()),
             &format!("{}/jwks", server.uri()),
         )
+    }
+
+    #[test]
+    fn remote_issuer_cannot_discover_loopback_http_endpoints() {
+        let issuer =
+            ConfiguredEndpointUrl::parse("https://accounts.example.test/tenant").expect("issuer");
+        for (label, endpoint) in [
+            ("authorization_endpoint", "http://127.0.0.1:9000/authorize"),
+            ("token_endpoint", "http://127.0.0.1:9000/token"),
+            ("jwks_uri", "http://127.0.0.1:9000/jwks"),
+        ] {
+            assert_eq!(
+                discovered_endpoint(label, endpoint, &issuer).expect_err("loopback downgrade"),
+                OidcProviderClientError::InvalidEndpoint(label)
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/auth/provider_client.rs
+++ b/crates/coral-app/src/auth/provider_client.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(test), expect(dead_code, reason = "wired by OAuth descendants"))]
-use super::config::OidcProviderSettings;
+use super::config::ResolvedOidcProvider;
 use crate::outbound_url_policy::{ConfiguredEndpointUrl, read_bounded_body};
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -69,7 +69,7 @@ impl OidcProviderClient {
 
     pub(super) async fn authorization_request(
         &self,
-        provider: &OidcProviderSettings,
+        provider: &ResolvedOidcProvider,
     ) -> Result<OidcAuthorizationRequest, OidcProviderClientError> {
         let discovery = self.discover(provider).await?;
         let state = random_url_token()?;
@@ -101,7 +101,7 @@ impl OidcProviderClient {
     }
     pub(super) async fn exchange_code(
         &self,
-        provider: &OidcProviderSettings,
+        provider: &ResolvedOidcProvider,
         code: &str,
         code_verifier: &str,
     ) -> Result<OidcCodeExchange, OidcProviderClientError> {
@@ -142,7 +142,7 @@ impl OidcProviderClient {
     }
     async fn discover(
         &self,
-        provider: &OidcProviderSettings,
+        provider: &ResolvedOidcProvider,
     ) -> Result<ValidatedDiscovery, OidcProviderClientError> {
         let url = discovery_url(&provider.issuer)?;
         let response = self
@@ -262,12 +262,16 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+    use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
+    use std::path::Path;
+
     use super::*;
     use crate::auth::config::AuthSettings;
 
     const CLIENT_SECRET: &str = "client-secret-must-not-leak";
 
-    fn provider(issuer: &str) -> OidcProviderSettings {
+    fn provider(issuer: &str) -> ResolvedOidcProvider {
         let settings = AuthSettings::from_toml(&format!(
             "[auth]
              [auth.session]
@@ -284,6 +288,18 @@ mod tests {
         ))
         .expect("valid auth config")
         .expect("auth settings");
+        // A resolved provider is only reachable through runtime resolution, so
+        // the helper supplies the session signing key the same way a running
+        // server would.
+        let signing_key = BASE64_STANDARD.encode(
+            EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
+                .expect("P-256 signing key"),
+        );
+        let (settings, _issuer) = settings
+            .resolve_runtime_dependencies(Path::new("config.toml"), &|name| {
+                Ok((name == "CORAL_SESSION_SIGNING_KEY").then(|| signing_key.clone()))
+            })
+            .expect("resolved runtime dependencies");
         settings.provider().clone()
     }
 

--- a/crates/coral-app/src/auth/provider_client.rs
+++ b/crates/coral-app/src/auth/provider_client.rs
@@ -1,0 +1,586 @@
+#![cfg_attr(not(test), expect(dead_code, reason = "wired by OAuth descendants"))]
+use super::config::OidcProviderSettings;
+use crate::outbound_url_policy::{ConfiguredEndpointUrl, read_bounded_body};
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use reqwest::header::ACCEPT;
+use ring::rand::{SecureRandom as _, SystemRandom};
+use serde::Deserialize;
+use sha2::{Digest as _, Sha256};
+use std::time::Duration;
+use thiserror::Error;
+use url::Url;
+use zeroize::Zeroizing;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const RESPONSE_MAX_BYTES: usize = 64 * 1024;
+#[derive(Clone)]
+pub(super) struct OidcProviderClient {
+    http: reqwest::Client,
+}
+pub(super) struct OidcAuthorizationRequest {
+    pub(super) url: Url,
+    pub(super) state: String,
+    pub(super) nonce: String,
+    pub(super) code_verifier: String,
+}
+pub(super) struct OidcCodeExchange {
+    id_token: Zeroizing<String>,
+    jwks_uri: ConfiguredEndpointUrl,
+    signing_algorithms: Vec<String>,
+}
+impl OidcCodeExchange {
+    pub(super) fn id_token(&self) -> &str {
+        self.id_token.as_str()
+    }
+    pub(super) fn jwks_uri(&self) -> &ConfiguredEndpointUrl {
+        &self.jwks_uri
+    }
+    pub(super) fn signing_algorithms(&self) -> &[String] {
+        &self.signing_algorithms
+    }
+}
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub(super) enum OidcProviderClientError {
+    #[error("failed to initialize OIDC provider HTTP client")]
+    ClientInitialization,
+    #[error("OIDC provider discovery failed")]
+    Discovery,
+    #[error("OIDC provider discovery issuer did not match configured issuer")]
+    IssuerMismatch,
+    #[error("OIDC provider discovery contained an invalid {0}")]
+    InvalidEndpoint(&'static str),
+    #[error("failed to generate OIDC authorization parameters")]
+    Randomness,
+    #[error("OIDC provider token exchange failed")]
+    TokenExchange,
+}
+impl OidcProviderClient {
+    pub(super) fn new() -> Result<Self, OidcProviderClientError> {
+        let http = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .no_proxy()
+            .connect_timeout(CONNECT_TIMEOUT)
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|_error| OidcProviderClientError::ClientInitialization)?;
+        Ok(Self { http })
+    }
+
+    pub(super) async fn authorization_request(
+        &self,
+        provider: &OidcProviderSettings,
+    ) -> Result<OidcAuthorizationRequest, OidcProviderClientError> {
+        let discovery = self.discover(provider).await?;
+        let state = random_url_token()?;
+        let nonce = random_url_token()?;
+        let code_verifier = random_url_token()?;
+        let code_challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(code_verifier.as_bytes()));
+        let mut url = discovery.authorization_endpoint.into_url();
+        {
+            let mut query = url.query_pairs_mut();
+            query
+                .append_pair("response_type", "code")
+                .append_pair("client_id", &provider.client_id)
+                .append_pair("redirect_uri", &provider.redirect_uri)
+                .append_pair("scope", &provider.scopes.join(" "))
+                .append_pair("state", &state)
+                .append_pair("nonce", &nonce)
+                .append_pair("code_challenge", &code_challenge)
+                .append_pair("code_challenge_method", "S256");
+            for (key, value) in &provider.auth_params {
+                query.append_pair(key, value);
+            }
+        }
+        Ok(OidcAuthorizationRequest {
+            url,
+            state,
+            nonce,
+            code_verifier,
+        })
+    }
+    pub(super) async fn exchange_code(
+        &self,
+        provider: &OidcProviderSettings,
+        code: &str,
+        code_verifier: &str,
+    ) -> Result<OidcCodeExchange, OidcProviderClientError> {
+        let discovery = self.discover(provider).await?;
+        let response = self
+            .http
+            .post(discovery.token_endpoint.as_url().clone())
+            .header(ACCEPT, "application/json")
+            .form(&[
+                ("grant_type", "authorization_code"),
+                ("code", code),
+                ("redirect_uri", provider.redirect_uri.as_str()),
+                ("client_id", provider.client_id.as_str()),
+                ("client_secret", provider.client_secret()),
+                ("code_verifier", code_verifier),
+            ])
+            .send()
+            .await
+            .map_err(|_error| OidcProviderClientError::TokenExchange)?;
+        if !response.status().is_success() {
+            return Err(OidcProviderClientError::TokenExchange);
+        }
+        let body = Zeroizing::new(
+            read_bounded_body(response, RESPONSE_MAX_BYTES)
+                .await
+                .map_err(|_error| OidcProviderClientError::TokenExchange)?,
+        );
+        let document: TokenResponse = serde_json::from_slice(&body)
+            .map_err(|_error| OidcProviderClientError::TokenExchange)?;
+        if document.id_token.is_empty() {
+            return Err(OidcProviderClientError::TokenExchange);
+        }
+        Ok(OidcCodeExchange {
+            id_token: document.id_token,
+            jwks_uri: discovery.jwks_uri,
+            signing_algorithms: discovery.signing_algorithms,
+        })
+    }
+    async fn discover(
+        &self,
+        provider: &OidcProviderSettings,
+    ) -> Result<ValidatedDiscovery, OidcProviderClientError> {
+        let url = discovery_url(&provider.issuer)?;
+        let response = self
+            .http
+            .get(url.into_url())
+            .header(ACCEPT, "application/json")
+            .send()
+            .await
+            .map_err(|_error| OidcProviderClientError::Discovery)?;
+        if !response.status().is_success() {
+            return Err(OidcProviderClientError::Discovery);
+        }
+        let body = read_bounded_body(response, RESPONSE_MAX_BYTES)
+            .await
+            .map_err(|_error| OidcProviderClientError::Discovery)?;
+        let document: DiscoveryDocument =
+            serde_json::from_slice(&body).map_err(|_error| OidcProviderClientError::Discovery)?;
+        if document.issuer != provider.issuer {
+            return Err(OidcProviderClientError::IssuerMismatch);
+        }
+        if !document
+            .id_token_signing_alg_values_supported
+            .iter()
+            .any(|algorithm| algorithm == "RS256")
+        {
+            return Err(OidcProviderClientError::Discovery);
+        }
+        Ok(ValidatedDiscovery {
+            authorization_endpoint: discovered_endpoint(
+                "authorization_endpoint",
+                &document.authorization_endpoint,
+            )?,
+            token_endpoint: discovered_endpoint("token_endpoint", &document.token_endpoint)?,
+            jwks_uri: discovered_endpoint("jwks_uri", &document.jwks_uri)?,
+            signing_algorithms: document.id_token_signing_alg_values_supported,
+        })
+    }
+}
+struct ValidatedDiscovery {
+    authorization_endpoint: ConfiguredEndpointUrl,
+    token_endpoint: ConfiguredEndpointUrl,
+    jwks_uri: ConfiguredEndpointUrl,
+    signing_algorithms: Vec<String>,
+}
+#[derive(Deserialize)]
+struct DiscoveryDocument {
+    issuer: String,
+    authorization_endpoint: String,
+    token_endpoint: String,
+    jwks_uri: String,
+    id_token_signing_alg_values_supported: Vec<String>,
+}
+#[derive(Deserialize)]
+struct TokenResponse {
+    id_token: Zeroizing<String>,
+}
+fn discovery_url(issuer: &str) -> Result<ConfiguredEndpointUrl, OidcProviderClientError> {
+    ConfiguredEndpointUrl::parse(&format!(
+        "{}/.well-known/openid-configuration",
+        issuer.trim_end_matches('/')
+    ))
+    .map_err(|_error| OidcProviderClientError::Discovery)
+}
+fn discovered_endpoint(
+    label: &'static str,
+    value: &str,
+) -> Result<ConfiguredEndpointUrl, OidcProviderClientError> {
+    if value.trim() != value {
+        return Err(OidcProviderClientError::InvalidEndpoint(label));
+    }
+    let url = ConfiguredEndpointUrl::parse(value)
+        .map_err(|_error| OidcProviderClientError::InvalidEndpoint(label))?;
+    let reserved = url.as_url().query_pairs().any(|(key, _value)| {
+        let key = key.to_ascii_lowercase();
+        match label {
+            "authorization_endpoint" => matches!(
+                key.as_str(),
+                "response_type"
+                    | "client_id"
+                    | "redirect_uri"
+                    | "scope"
+                    | "state"
+                    | "nonce"
+                    | "code_challenge"
+                    | "code_challenge_method"
+            ),
+            "token_endpoint" => matches!(
+                key.as_str(),
+                "grant_type"
+                    | "code"
+                    | "redirect_uri"
+                    | "client_id"
+                    | "client_secret"
+                    | "code_verifier"
+            ),
+            _ => false,
+        }
+    });
+    (!reserved)
+        .then_some(url)
+        .ok_or(OidcProviderClientError::InvalidEndpoint(label))
+}
+
+fn random_url_token() -> Result<String, OidcProviderClientError> {
+    let mut bytes = Zeroizing::new([0_u8; 32]);
+    SystemRandom::new()
+        .fill(&mut *bytes)
+        .map_err(|_error| OidcProviderClientError::Randomness)?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes.as_slice()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use serde_json::{Value, json};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+    use crate::auth::config::AuthSettings;
+
+    const CLIENT_SECRET: &str = "client-secret-must-not-leak";
+
+    fn provider(issuer: &str) -> OidcProviderSettings {
+        let settings = AuthSettings::from_toml(&format!(
+            "[auth]
+             [auth.session]
+             [auth.authorization_server]
+             issuer = 'http://localhost:9080'
+             [auth.provider]
+             issuer = '{issuer}'
+             client_id = 'provider-client'
+             client_secret = '{CLIENT_SECRET}'
+             redirect_uri = 'http://localhost/callback'
+             scopes = ['openid', 'email']
+             [auth.provider.auth_params]
+             prompt = 'login'"
+        ))
+        .expect("valid auth config")
+        .expect("auth settings");
+        settings.provider().clone()
+    }
+
+    fn discovery(issuer: &str, authorization: &str, token: &str, jwks: &str) -> Value {
+        json!({
+            "issuer": issuer,
+            "authorization_endpoint": authorization,
+            "token_endpoint": token,
+            "jwks_uri": jwks,
+            "id_token_signing_alg_values_supported": ["RS256"],
+        })
+    }
+
+    async fn mount_discovery(server: &MockServer, request_path: &str, body: impl Into<Vec<u8>>) {
+        Mock::given(method("GET"))
+            .and(path(request_path))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+            .mount(server)
+            .await;
+    }
+
+    fn valid_document(server: &MockServer, issuer: &str) -> Value {
+        discovery(
+            issuer,
+            &format!("{}/authorize?tenant=one", server.uri()),
+            &format!("{}/token?tenant=one", server.uri()),
+            &format!("{}/jwks", server.uri()),
+        )
+    }
+
+    #[tokio::test]
+    async fn authorization_request_uses_exact_discovery_and_fresh_pkce_secrets() {
+        let server = MockServer::start().await;
+        let issuer = format!("{}/tenant/", server.uri());
+        mount_discovery(
+            &server,
+            "/tenant/.well-known/openid-configuration",
+            valid_document(&server, &issuer).to_string(),
+        )
+        .await;
+        let request = OidcProviderClient::new()
+            .expect("client")
+            .authorization_request(&provider(&issuer))
+            .await
+            .expect("authorization request");
+        for value in [&request.state, &request.nonce, &request.code_verifier] {
+            assert_eq!(value.len(), 43);
+            assert!(
+                value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+            );
+        }
+        assert_ne!(request.state, request.nonce);
+        assert_ne!(request.nonce, request.code_verifier);
+        let query = request
+            .url
+            .query_pairs()
+            .into_owned()
+            .collect::<BTreeMap<_, _>>();
+        for (key, expected) in [
+            ("tenant", "one"),
+            ("response_type", "code"),
+            ("client_id", "provider-client"),
+            ("redirect_uri", "http://localhost/callback"),
+            ("scope", "openid email"),
+            ("code_challenge_method", "S256"),
+            ("prompt", "login"),
+        ] {
+            assert_eq!(query.get(key).map(String::as_str), Some(expected));
+        }
+        assert_eq!(query.get("state"), Some(&request.state));
+        assert_eq!(query.get("nonce"), Some(&request.nonce));
+        let expected = URL_SAFE_NO_PAD.encode(Sha256::digest(request.code_verifier.as_bytes()));
+        assert_eq!(query.get("code_challenge"), Some(&expected));
+    }
+
+    #[tokio::test]
+    async fn discovery_requires_exact_issuer_and_validates_every_endpoint() {
+        for (field, invalid) in [
+            ("issuer", "http://127.0.0.1:1/"),
+            ("authorization_endpoint", "http://remote.test/authorize"),
+            ("token_endpoint", "https://user:pass@remote.test/token"),
+            ("jwks_uri", "https://remote.test/jwks#secret"),
+            (
+                "authorization_endpoint",
+                "http://localhost:1/authorize?StAtE=evil",
+            ),
+            (
+                "token_endpoint",
+                "http://localhost:1/token?CLIENT_SECRET=evil",
+            ),
+        ] {
+            let server = MockServer::start().await;
+            let issuer = server.uri();
+            let mut document = valid_document(&server, &issuer);
+            *document.get_mut(field).expect("discovery field") = Value::String(invalid.into());
+            mount_discovery(
+                &server,
+                "/.well-known/openid-configuration",
+                document.to_string(),
+            )
+            .await;
+            let error = OidcProviderClient::new()
+                .expect("client")
+                .discover(&provider(&issuer))
+                .await
+                .err()
+                .expect("invalid discovery");
+            let expected = if field == "issuer" {
+                OidcProviderClientError::IssuerMismatch
+            } else {
+                OidcProviderClientError::InvalidEndpoint(field)
+            };
+            assert_eq!(error, expected);
+            assert!(!format!("{error:?} {error}").contains(invalid));
+        }
+
+        let server = MockServer::start().await;
+        let issuer = server.uri();
+        mount_discovery(
+            &server,
+            "/.well-known/openid-configuration",
+            discovery(
+                &issuer,
+                "https://10.0.0.8/authorize",
+                "https://10.0.0.8/token",
+                "https://10.0.0.8/jwks",
+            )
+            .to_string(),
+        )
+        .await;
+        OidcProviderClient::new()
+            .expect("client")
+            .discover(&provider(&issuer))
+            .await
+            .expect("private HTTPS endpoints");
+
+        for algorithms in [json!([]), json!(["ES256", "rs256"])] {
+            let server = MockServer::start().await;
+            let issuer = server.uri();
+            let mut document = valid_document(&server, &issuer);
+            *document
+                .get_mut("id_token_signing_alg_values_supported")
+                .expect("algorithms") = algorithms;
+            mount_discovery(
+                &server,
+                "/.well-known/openid-configuration",
+                document.to_string(),
+            )
+            .await;
+            assert_eq!(
+                OidcProviderClient::new()
+                    .expect("client")
+                    .discover(&provider(&issuer))
+                    .await
+                    .err()
+                    .expect("missing RS256"),
+                OidcProviderClientError::Discovery
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn code_exchange_posts_exact_form_and_returns_redacted_result() {
+        let server = MockServer::start().await;
+        let issuer = server.uri();
+        mount_discovery(
+            &server,
+            "/.well-known/openid-configuration",
+            valid_document(&server, &issuer).to_string(),
+        )
+        .await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"id_token": "header.payload.signature"})),
+            )
+            .mount(&server)
+            .await;
+        let exchange = OidcProviderClient::new()
+            .expect("client")
+            .exchange_code(&provider(&issuer), "provider-code", "pkce-verifier")
+            .await
+            .expect("exchange");
+        assert_eq!(exchange.id_token(), "header.payload.signature");
+        assert_eq!(exchange.jwks_uri().as_url().path(), "/jwks");
+        assert_eq!(exchange.signing_algorithms(), ["RS256"]);
+        let requests = server.received_requests().await.expect("requests");
+        let request = requests
+            .iter()
+            .find(|request| request.url.path() == "/token")
+            .expect("token request");
+        assert_eq!(request.url.query(), Some("tenant=one"));
+        let form = url::form_urlencoded::parse(&request.body)
+            .into_owned()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            form,
+            vec![
+                ("grant_type".into(), "authorization_code".into()),
+                ("code".into(), "provider-code".into()),
+                ("redirect_uri".into(), "http://localhost/callback".into()),
+                ("client_id".into(), "provider-client".into()),
+                ("client_secret".into(), CLIENT_SECRET.into()),
+                ("code_verifier".into(), "pkce-verifier".into()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn token_redirect_is_not_followed_and_errors_never_echo_secrets() {
+        let server = MockServer::start().await;
+        let issuer = server.uri();
+        mount_discovery(
+            &server,
+            "/.well-known/openid-configuration",
+            valid_document(&server, &issuer).to_string(),
+        )
+        .await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(307)
+                    .insert_header("Location", format!("{}/leak", server.uri()))
+                    .set_body_string("upstream-body-secret"),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(path("/leak"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(0)
+            .mount(&server)
+            .await;
+        let error = OidcProviderClient::new()
+            .expect("client")
+            .exchange_code(
+                &provider(&issuer),
+                "secret-provider-code",
+                "secret-verifier",
+            )
+            .await
+            .err()
+            .expect("redirect refused");
+        let rendered = format!("{error:?} {error}");
+        for secret in [
+            CLIENT_SECRET,
+            "secret-provider-code",
+            "secret-verifier",
+            "upstream-body-secret",
+            "/leak",
+        ] {
+            assert!(!rendered.contains(secret));
+        }
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn discovery_and_token_responses_are_bounded() {
+        let server = MockServer::start().await;
+        let issuer = server.uri();
+        mount_discovery(
+            &server,
+            "/.well-known/openid-configuration",
+            vec![b'x'; RESPONSE_MAX_BYTES + 1],
+        )
+        .await;
+        assert_eq!(
+            OidcProviderClient::new()
+                .expect("client")
+                .discover(&provider(&issuer))
+                .await
+                .err()
+                .expect("oversized discovery"),
+            OidcProviderClientError::Discovery
+        );
+        server.reset().await;
+        mount_discovery(
+            &server,
+            "/.well-known/openid-configuration",
+            valid_document(&server, &issuer).to_string(),
+        )
+        .await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_bytes(vec![b'x'; RESPONSE_MAX_BYTES + 1]),
+            )
+            .mount(&server)
+            .await;
+        let error = OidcProviderClient::new()
+            .expect("client")
+            .exchange_code(&provider(&issuer), "code", "verifier")
+            .await
+            .err()
+            .expect("oversized token response");
+        assert_eq!(error, OidcProviderClientError::TokenExchange);
+    }
+}

--- a/crates/coral-app/src/auth/provider_client.rs
+++ b/crates/coral-app/src/auth/provider_client.rs
@@ -1,61 +1,150 @@
+//! Client for the external `OpenID` Connect provider that authenticates users.
+//!
+//! # Trust
+//!
+//! The discovery document is fetched from the operator-configured issuer, but
+//! it is not treated as operator-authored: a provider that is compromised, or
+//! merely misconfigured, can put anything in it. Two checks bound what it can
+//! do. Every endpoint is re-parsed as a [`DiscoveredEndpointUrl`], which refuses
+//! a plain-HTTP downgrade the configured issuer did not already permit; and no
+//! endpoint may pre-set a query parameter this module reserves, so the document
+//! cannot pin `state`, swap `client_id`, or choose a `response_mode` that
+//! strands the authorization code short of the callback route.
+//!
+//! # Errors
+//!
+//! Failures name the stage that failed and nothing else. No status code, body,
+//! or URL from the provider travels in an error, so nothing a provider sends
+//! can reach a log or an HTTP response by that route.
+
 #![cfg_attr(not(test), expect(dead_code, reason = "wired by OAuth descendants"))]
-use super::config::ResolvedOidcProvider;
-use crate::outbound_url_policy::{ConfiguredEndpointUrl, DiscoveredEndpointUrl, read_bounded_body};
+
+use std::time::Duration;
+
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use reqwest::header::ACCEPT;
 use ring::rand::{SecureRandom as _, SystemRandom};
 use serde::Deserialize;
 use sha2::{Digest as _, Sha256};
-use std::time::Duration;
 use thiserror::Error;
 use url::Url;
 use zeroize::Zeroizing;
+
+use super::config::{RESERVED_PROVIDER_AUTH_PARAMS, ResolvedOidcProvider};
+use crate::outbound_url_policy::{ConfiguredEndpointUrl, DiscoveredEndpointUrl, read_bounded_body};
+
+/// Timeout applied to establishing a connection to the provider.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Timeout applied to a complete discovery or token request.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Ceiling on a provider response body, applied while it is read.
 const RESPONSE_MAX_BYTES: usize = 64 * 1024;
+
+/// The token endpoint authentication method this client uses.
+const TOKEN_ENDPOINT_AUTH_METHOD: &str = "client_secret_post";
+
+/// Form parameters the token request supplies for itself.
+///
+/// The authorization endpoint's counterpart is
+/// [`RESERVED_PROVIDER_AUTH_PARAMS`], which is shared with the config
+/// validation that applies the same rule to operator-supplied `auth_params`.
+const RESERVED_TOKEN_PARAMS: &[&str] = &[
+    "grant_type",
+    "code",
+    "redirect_uri",
+    "client_id",
+    "client_secret",
+    "code_verifier",
+];
+
+/// Performs discovery, authorization requests, and code exchange for one
+/// configured provider.
 #[derive(Clone)]
 pub(super) struct OidcProviderClient {
     http: reqwest::Client,
+    random: SystemRandom,
 }
+
+/// An authorization URL and the per-login values that must outlive it.
+///
+/// The three values are held until the callback arrives: `state` and `nonce`
+/// are compared against what the provider echoes back, and `code_verifier` is
+/// sent to the token endpoint to prove this server started the login.
 pub(super) struct OidcAuthorizationRequest {
     pub(super) url: Url,
     pub(super) state: String,
     pub(super) nonce: String,
-    pub(super) code_verifier: String,
+    pub(super) code_verifier: Zeroizing<String>,
 }
+
+/// The result of redeeming an authorization code.
+///
+/// The ID token is unverified at this point; the fields beside it are what a
+/// caller needs to verify it, carried from the same discovery document that
+/// named the token endpoint.
 pub(super) struct OidcCodeExchange {
     id_token: Zeroizing<String>,
     jwks_uri: DiscoveredEndpointUrl,
     signing_algorithms: Vec<String>,
 }
+
 impl OidcCodeExchange {
+    /// Returns the unverified ID token as received from the provider.
     pub(super) fn id_token(&self) -> &str {
         self.id_token.as_str()
     }
+
+    /// Returns the JWKS endpoint that publishes the ID token's verification
+    /// keys.
     pub(super) fn jwks_uri(&self) -> &DiscoveredEndpointUrl {
         &self.jwks_uri
     }
+
+    /// Returns the signing algorithms the provider advertises.
     pub(super) fn signing_algorithms(&self) -> &[String] {
         &self.signing_algorithms
     }
 }
+
+/// A failure talking to the provider, carrying no provider-supplied data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub(super) enum OidcProviderClientError {
+    /// The HTTP client could not be built from this module's settings.
     #[error("failed to initialize OIDC provider HTTP client")]
     ClientInitialization,
+    /// Discovery could not be fetched, parsed, or satisfied.
     #[error("OIDC provider discovery failed")]
     Discovery,
+    /// The document's `issuer` differs from the configured one.
     #[error("OIDC provider discovery issuer did not match configured issuer")]
     IssuerMismatch,
+    /// A discovered endpoint failed the trust policy or pre-set a parameter
+    /// this module reserves. The field names the endpoint, never its value.
     #[error("OIDC provider discovery contained an invalid {0}")]
     InvalidEndpoint(&'static str),
+    /// The provider does not offer the token endpoint authentication method
+    /// this client uses.
+    #[error(
+        "OIDC provider does not offer the client_secret_post token endpoint authentication method"
+    )]
+    UnsupportedTokenEndpointAuth,
+    /// The system random number generator failed.
     #[error("failed to generate OIDC authorization parameters")]
     Randomness,
+    /// The token request failed, or its response was unusable.
     #[error("OIDC provider token exchange failed")]
     TokenExchange,
 }
+
 impl OidcProviderClient {
+    /// Builds a client that refuses redirects and ignores proxy settings.
+    ///
+    /// Refusing redirects keeps a credential-bearing token request from being
+    /// replayed to a destination the discovery document did not name and this
+    /// module never validated.
     pub(super) fn new() -> Result<Self, OidcProviderClientError> {
         let http = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
@@ -64,17 +153,21 @@ impl OidcProviderClient {
             .timeout(REQUEST_TIMEOUT)
             .build()
             .map_err(|_error| OidcProviderClientError::ClientInitialization)?;
-        Ok(Self { http })
+        Ok(Self {
+            http,
+            random: SystemRandom::new(),
+        })
     }
 
+    /// Builds the URL that starts a login, with the secrets it commits to.
     pub(super) async fn authorization_request(
         &self,
         provider: &ResolvedOidcProvider,
     ) -> Result<OidcAuthorizationRequest, OidcProviderClientError> {
         let discovery = self.discover(provider).await?;
-        let state = random_url_token()?;
-        let nonce = random_url_token()?;
-        let code_verifier = random_url_token()?;
+        let state = self.random_url_token()?;
+        let nonce = self.random_url_token()?;
+        let code_verifier = Zeroizing::new(self.random_url_token()?);
         let code_challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(code_verifier.as_bytes()));
         let mut url = discovery.authorization_endpoint.into_url();
         {
@@ -99,6 +192,12 @@ impl OidcProviderClient {
             code_verifier,
         })
     }
+
+    /// Redeems an authorization code for an ID token.
+    ///
+    /// The body is read into a [`Zeroizing`] buffer because it carries the ID
+    /// token; the discovery body read below is not, because a discovery
+    /// document is public.
     pub(super) async fn exchange_code(
         &self,
         provider: &ResolvedOidcProvider,
@@ -140,6 +239,8 @@ impl OidcProviderClient {
             signing_algorithms: discovery.signing_algorithms,
         })
     }
+
+    /// Fetches and validates the provider's discovery document.
     async fn discover(
         &self,
         provider: &ResolvedOidcProvider,
@@ -172,28 +273,45 @@ impl OidcProviderClient {
         {
             return Err(OidcProviderClientError::Discovery);
         }
+        if !document.offers_token_endpoint_auth_method(TOKEN_ENDPOINT_AUTH_METHOD) {
+            return Err(OidcProviderClientError::UnsupportedTokenEndpointAuth);
+        }
+
         Ok(ValidatedDiscovery {
             authorization_endpoint: discovered_endpoint(
-                "authorization_endpoint",
+                DiscoveredEndpoint::Authorization,
                 &document.authorization_endpoint,
                 &issuer,
             )?,
             token_endpoint: discovered_endpoint(
-                "token_endpoint",
+                DiscoveredEndpoint::Token,
                 &document.token_endpoint,
                 &issuer,
             )?,
-            jwks_uri: discovered_endpoint("jwks_uri", &document.jwks_uri, &issuer)?,
+            jwks_uri: discovered_endpoint(DiscoveredEndpoint::Jwks, &document.jwks_uri, &issuer)?,
             signing_algorithms: document.id_token_signing_alg_values_supported,
         })
     }
+
+    /// Returns a fresh URL-safe 256-bit token.
+    fn random_url_token(&self) -> Result<String, OidcProviderClientError> {
+        let mut bytes = Zeroizing::new([0_u8; 32]);
+        self.random
+            .fill(&mut *bytes)
+            .map_err(|_error| OidcProviderClientError::Randomness)?;
+        Ok(URL_SAFE_NO_PAD.encode(bytes.as_slice()))
+    }
 }
+
+/// A discovery document that passed every check in [`OidcProviderClient::discover`].
 struct ValidatedDiscovery {
     authorization_endpoint: DiscoveredEndpointUrl,
     token_endpoint: DiscoveredEndpointUrl,
     jwks_uri: DiscoveredEndpointUrl,
     signing_algorithms: Vec<String>,
 }
+
+/// The fields this module reads from a provider's discovery document.
 #[derive(Deserialize)]
 struct DiscoveryDocument {
     issuer: String,
@@ -201,11 +319,71 @@ struct DiscoveryDocument {
     token_endpoint: String,
     jwks_uri: String,
     id_token_signing_alg_values_supported: Vec<String>,
+    token_endpoint_auth_methods_supported: Option<Vec<String>>,
 }
+
+impl DiscoveryDocument {
+    /// Reports whether the document leaves `method` available at the token
+    /// endpoint.
+    ///
+    /// `OpenID` Connect Discovery 1.0 §3 makes
+    /// `token_endpoint_auth_methods_supported` optional and defaults an omitted
+    /// value to `client_secret_basic`. Applying that default would reject the
+    /// providers that accept `client_secret_post` without advertising it, so an
+    /// omitted list is treated as unknown and left for the token request to
+    /// settle. A list that is present is believed, which surfaces a provider
+    /// this client cannot authenticate to as a named failure before the
+    /// operator's user is sent anywhere, rather than an opaque one after they
+    /// return.
+    fn offers_token_endpoint_auth_method(&self, method: &str) -> bool {
+        self.token_endpoint_auth_methods_supported
+            .as_ref()
+            .is_none_or(|methods| methods.iter().any(|supported| supported == method))
+    }
+}
+
+/// The one field this module reads from a token response.
 #[derive(Deserialize)]
 struct TokenResponse {
     id_token: Zeroizing<String>,
 }
+
+/// An endpoint this module reads out of a discovery document.
+///
+/// Naming the endpoints in a type rather than by string keeps
+/// [`DiscoveredEndpoint::reserved_params`] exhaustive: an endpoint added later
+/// does not compile until it declares which parameters it reserves, instead of
+/// silently reserving none.
+#[derive(Clone, Copy)]
+enum DiscoveredEndpoint {
+    Authorization,
+    Token,
+    Jwks,
+}
+
+impl DiscoveredEndpoint {
+    /// Returns the discovery document field this endpoint is read from.
+    fn label(self) -> &'static str {
+        match self {
+            Self::Authorization => "authorization_endpoint",
+            Self::Token => "token_endpoint",
+            Self::Jwks => "jwks_uri",
+        }
+    }
+
+    /// Returns the parameters this module reserves for its request to the
+    /// endpoint, which a discovery document therefore may not pre-set.
+    fn reserved_params(self) -> &'static [&'static str] {
+        match self {
+            Self::Authorization => RESERVED_PROVIDER_AUTH_PARAMS,
+            Self::Token => RESERVED_TOKEN_PARAMS,
+            // The JWKS endpoint is fetched with no query of this module's own.
+            Self::Jwks => &[],
+        }
+    }
+}
+
+/// Builds the well-known discovery URL for a configured issuer.
 fn discovery_url(issuer: &str) -> Result<ConfiguredEndpointUrl, OidcProviderClientError> {
     ConfiguredEndpointUrl::parse(&format!(
         "{}/.well-known/openid-configuration",
@@ -213,53 +391,32 @@ fn discovery_url(issuer: &str) -> Result<ConfiguredEndpointUrl, OidcProviderClie
     ))
     .map_err(|_error| OidcProviderClientError::Discovery)
 }
+
+/// Validates one endpoint out of a discovery document.
+///
+/// Beyond the transport policy [`DiscoveredEndpointUrl`] applies, the endpoint
+/// may not arrive with surrounding whitespace, nor carry a query parameter this
+/// module reserves for the request to it.
 fn discovered_endpoint(
-    label: &'static str,
+    endpoint: DiscoveredEndpoint,
     value: &str,
     issuer: &ConfiguredEndpointUrl,
 ) -> Result<DiscoveredEndpointUrl, OidcProviderClientError> {
+    let label = endpoint.label();
     if value.trim() != value {
         return Err(OidcProviderClientError::InvalidEndpoint(label));
     }
     let url = DiscoveredEndpointUrl::parse(value, issuer)
         .map_err(|_error| OidcProviderClientError::InvalidEndpoint(label))?;
     let reserved = url.as_url().query_pairs().any(|(key, _value)| {
-        let key = key.to_ascii_lowercase();
-        match label {
-            "authorization_endpoint" => matches!(
-                key.as_str(),
-                "response_type"
-                    | "client_id"
-                    | "redirect_uri"
-                    | "scope"
-                    | "state"
-                    | "nonce"
-                    | "code_challenge"
-                    | "code_challenge_method"
-            ),
-            "token_endpoint" => matches!(
-                key.as_str(),
-                "grant_type"
-                    | "code"
-                    | "redirect_uri"
-                    | "client_id"
-                    | "client_secret"
-                    | "code_verifier"
-            ),
-            _ => false,
-        }
+        endpoint
+            .reserved_params()
+            .iter()
+            .any(|reserved| key.eq_ignore_ascii_case(reserved))
     });
     (!reserved)
         .then_some(url)
         .ok_or(OidcProviderClientError::InvalidEndpoint(label))
-}
-
-fn random_url_token() -> Result<String, OidcProviderClientError> {
-    let mut bytes = Zeroizing::new([0_u8; 32]);
-    SystemRandom::new()
-        .fill(&mut *bytes)
-        .map_err(|_error| OidcProviderClientError::Randomness)?;
-    Ok(URL_SAFE_NO_PAD.encode(bytes.as_slice()))
 }
 
 #[cfg(test)]
@@ -342,14 +499,17 @@ mod tests {
     fn remote_issuer_cannot_discover_loopback_http_endpoints() {
         let issuer =
             ConfiguredEndpointUrl::parse("https://accounts.example.test/tenant").expect("issuer");
-        for (label, endpoint) in [
-            ("authorization_endpoint", "http://127.0.0.1:9000/authorize"),
-            ("token_endpoint", "http://127.0.0.1:9000/token"),
-            ("jwks_uri", "http://127.0.0.1:9000/jwks"),
+        for (endpoint, value) in [
+            (
+                DiscoveredEndpoint::Authorization,
+                "http://127.0.0.1:9000/authorize",
+            ),
+            (DiscoveredEndpoint::Token, "http://127.0.0.1:9000/token"),
+            (DiscoveredEndpoint::Jwks, "http://127.0.0.1:9000/jwks"),
         ] {
             assert_eq!(
-                discovered_endpoint(label, endpoint, &issuer).expect_err("loopback downgrade"),
-                OidcProviderClientError::InvalidEndpoint(label)
+                discovered_endpoint(endpoint, value, &issuer).expect_err("loopback downgrade"),
+                OidcProviderClientError::InvalidEndpoint(endpoint.label())
             );
         }
     }
@@ -369,7 +529,10 @@ mod tests {
             .authorization_request(&provider(&issuer))
             .await
             .expect("authorization request");
-        for value in [&request.state, &request.nonce, &request.code_verifier] {
+        let state = request.state.as_str();
+        let nonce = request.nonce.as_str();
+        let code_verifier = request.code_verifier.as_str();
+        for value in [state, nonce, code_verifier] {
             assert_eq!(value.len(), 43);
             assert!(
                 value
@@ -377,8 +540,9 @@ mod tests {
                     .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
             );
         }
-        assert_ne!(request.state, request.nonce);
-        assert_ne!(request.nonce, request.code_verifier);
+        assert_ne!(state, nonce);
+        assert_ne!(nonce, code_verifier);
+        assert_ne!(state, code_verifier);
         let query = request
             .url
             .query_pairs()
@@ -402,7 +566,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discovery_requires_exact_issuer_and_validates_every_endpoint() {
+    async fn discovery_rejects_mismatched_issuer_and_untrusted_endpoints() {
         for (field, invalid) in [
             ("issuer", "http://127.0.0.1:1/"),
             ("authorization_endpoint", "http://remote.test/authorize"),
@@ -411,6 +575,13 @@ mod tests {
             (
                 "authorization_endpoint",
                 "http://localhost:1/authorize?StAtE=evil",
+            ),
+            // `form_post` and `fragment` both keep the authorization code away
+            // from the GET callback route, so a document that pre-sets either
+            // strands every login it starts.
+            (
+                "authorization_endpoint",
+                "http://localhost:1/authorize?response_mode=form_post",
             ),
             (
                 "token_endpoint",
@@ -441,7 +612,13 @@ mod tests {
             assert_eq!(error, expected);
             assert!(!format!("{error:?} {error}").contains(invalid));
         }
+    }
 
+    /// HTTPS to a private host is accepted: an issuer reachable over HTTPS is
+    /// entitled to name endpoints anywhere, and it is the transport, not the
+    /// destination, that is policed.
+    #[tokio::test]
+    async fn discovery_accepts_private_https_endpoints() {
         let server = MockServer::start().await;
         let issuer = server.uri();
         mount_discovery(
@@ -461,7 +638,10 @@ mod tests {
             .discover(&provider(&issuer))
             .await
             .expect("private HTTPS endpoints");
+    }
 
+    #[tokio::test]
+    async fn discovery_requires_rs256_signing_support() {
         for algorithms in [json!([]), json!(["ES256", "rs256"])] {
             let server = MockServer::start().await;
             let issuer = server.uri();
@@ -484,6 +664,49 @@ mod tests {
                     .expect("missing RS256"),
                 OidcProviderClientError::Discovery
             );
+        }
+    }
+
+    /// An advertised list that excludes `client_secret_post` is believed, and
+    /// an omitted list is not read as the spec's `client_secret_basic` default.
+    #[tokio::test]
+    async fn discovery_believes_an_advertised_token_endpoint_auth_method() {
+        for (methods, expected) in [
+            (Some(json!(["client_secret_basic"])), false),
+            (Some(json!([])), false),
+            (
+                Some(json!(["client_secret_basic", "client_secret_post"])),
+                true,
+            ),
+            (None, true),
+        ] {
+            let server = MockServer::start().await;
+            let issuer = server.uri();
+            let mut document = valid_document(&server, &issuer);
+            if let Some(methods) = methods {
+                document
+                    .as_object_mut()
+                    .expect("discovery object")
+                    .insert("token_endpoint_auth_methods_supported".into(), methods);
+            }
+            mount_discovery(
+                &server,
+                "/.well-known/openid-configuration",
+                document.to_string(),
+            )
+            .await;
+            let result = OidcProviderClient::new()
+                .expect("client")
+                .discover(&provider(&issuer))
+                .await;
+            if expected {
+                result.expect("client_secret_post available");
+            } else {
+                assert_eq!(
+                    result.err().expect("client_secret_post unavailable"),
+                    OidcProviderClientError::UnsupportedTokenEndpointAuth
+                );
+            }
         }
     }
 

--- a/crates/coral-app/src/auth/provider_client.rs
+++ b/crates/coral-app/src/auth/provider_client.rs
@@ -276,7 +276,7 @@ mod tests {
             "[auth]
              [auth.session]
              [auth.authorization_server]
-             issuer = 'http://localhost:9080'
+             issuer = 'http://localhost'
              [auth.provider]
              issuer = '{issuer}'
              client_id = 'provider-client'

--- a/crates/coral-app/src/outbound_url_policy.rs
+++ b/crates/coral-app/src/outbound_url_policy.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 
 use thiserror::Error;
 use url::{Host, Url};
+use zeroize::Zeroizing;
 
 use crate::bootstrap::is_loopback_ip;
 
@@ -238,7 +239,7 @@ pub(crate) async fn read_bounded_body(
         return Err(OutboundUrlPolicyError::BodyTooLarge { limit });
     }
 
-    let mut body = Vec::new();
+    let mut body = Zeroizing::new(Vec::new());
     while let Some(chunk) = response
         .chunk()
         .await
@@ -246,7 +247,7 @@ pub(crate) async fn read_bounded_body(
     {
         append_bounded_chunk(&mut body, &chunk, limit)?;
     }
-    Ok(body)
+    Ok(std::mem::take(&mut *body))
 }
 
 #[derive(Clone)]

--- a/crates/coral-app/src/outbound_url_policy.rs
+++ b/crates/coral-app/src/outbound_url_policy.rs
@@ -1,9 +1,10 @@
-//! Outbound URL policies for configured endpoints and untrusted metadata.
+//! Outbound URL policies for configured endpoints, discovery, and untrusted metadata.
 //!
-//! These policies are intentionally separate. Operator-configured endpoints
-//! may use HTTPS anywhere or plain HTTP on an explicit loopback host. URLs
-//! supplied by an untrusted client must instead identify a public HTTPS
-//! resource and use a DNS resolver that rejects non-public answers.
+//! These policies are intentionally separate. Operator-configured endpoints may
+//! use HTTPS anywhere or plain HTTP on an explicit loopback host. Provider
+//! discovery may use loopback HTTP only when the configured issuer does. URLs
+//! supplied by an untrusted client must instead identify a public HTTPS resource
+//! and use a DNS resolver that rejects non-public answers.
 
 #![cfg_attr(
     not(test),
@@ -34,14 +35,9 @@ pub(crate) const PUBLIC_METADATA_TIMEOUT: Duration = Duration::from_secs(5);
 /// private one, with no check on what the host resolves to. Both are sound only
 /// for a value an operator authored — a config file or environment variable.
 ///
-/// Do not build one from a value a remote party controls. That includes the
-/// endpoints inside an `OpenID` Connect discovery document, which the provider
-/// supplies: a compromised provider answering with
-/// `token_endpoint: "http://127.0.0.1:9999/x"` would be handed the client
-/// secret, authorization code, and PKCE verifier in cleartext, readable by any
-/// local process. Remote-supplied endpoints are a third trust level and need
-/// their own profile — one that requires HTTPS unless the configured issuer is
-/// itself loopback HTTP.
+/// Do not build one from a value a remote party controls. Use
+/// [`DiscoveredEndpointUrl`] for endpoints supplied by an `OpenID` Connect
+/// discovery document.
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct ConfiguredEndpointUrl(Url);
 
@@ -57,15 +53,7 @@ impl ConfiguredEndpointUrl {
     /// point exists for a caller that already needed the [`Url`] — parsing with
     /// a syntax-violation callback, say — and would otherwise parse it twice.
     pub(crate) fn from_parsed(url: Url) -> Result<Self, OutboundUrlPolicyError> {
-        if url.host().is_none() {
-            return Err(OutboundUrlPolicyError::MissingHost);
-        }
-        if !url.username().is_empty() || url.password().is_some() {
-            return Err(OutboundUrlPolicyError::CredentialsNotAllowed);
-        }
-        if url.fragment().is_some() {
-            return Err(OutboundUrlPolicyError::FragmentNotAllowed);
-        }
+        check_endpoint_url(&url)?;
         match url.scheme() {
             "https" => Ok(Self(url)),
             "http" if is_explicit_loopback(&url) => Ok(Self(url)),
@@ -91,6 +79,70 @@ impl fmt::Debug for ConfiguredEndpointUrl {
             .field(&RedactedUrl(&self.0))
             .finish()
     }
+}
+
+/// A remotely discovered provider endpoint safe for credential-bearing requests.
+///
+/// HTTPS may target any host, including a private one. Plain HTTP is restricted
+/// to an explicit loopback endpoint and is accepted only when the
+/// operator-configured issuer also uses loopback HTTP.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct DiscoveredEndpointUrl(Url);
+
+impl DiscoveredEndpointUrl {
+    /// Parses an endpoint under the trust policy established by `issuer`.
+    pub(crate) fn parse(
+        value: &str,
+        issuer: &ConfiguredEndpointUrl,
+    ) -> Result<Self, OutboundUrlPolicyError> {
+        let url = parse_endpoint(value)?;
+        match url.scheme() {
+            "https" => Ok(Self(url)),
+            "http" if issuer.as_url().scheme() == "http" && is_explicit_loopback(&url) => {
+                Ok(Self(url))
+            }
+            _ => Err(OutboundUrlPolicyError::DiscoveredEndpointTransport),
+        }
+    }
+
+    /// Returns the validated URL.
+    pub(crate) fn as_url(&self) -> &Url {
+        &self.0
+    }
+
+    /// Consumes this wrapper and returns the validated URL.
+    pub(crate) fn into_url(self) -> Url {
+        self.0
+    }
+}
+
+impl fmt::Debug for DiscoveredEndpointUrl {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("DiscoveredEndpointUrl")
+            .field(&RedactedUrl(&self.0))
+            .finish()
+    }
+}
+
+fn parse_endpoint(value: &str) -> Result<Url, OutboundUrlPolicyError> {
+    let url = Url::parse(value).map_err(OutboundUrlPolicyError::InvalidUrl)?;
+    check_endpoint_url(&url)?;
+    Ok(url)
+}
+
+/// Rejects an endpoint URL that no profile accepts, whatever its scheme.
+fn check_endpoint_url(url: &Url) -> Result<(), OutboundUrlPolicyError> {
+    if url.host().is_none() {
+        return Err(OutboundUrlPolicyError::MissingHost);
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(OutboundUrlPolicyError::CredentialsNotAllowed);
+    }
+    if url.fragment().is_some() {
+        return Err(OutboundUrlPolicyError::FragmentNotAllowed);
+    }
+    Ok(())
 }
 
 /// An attacker-controlled metadata URL validated for public HTTPS fetching.
@@ -173,6 +225,11 @@ pub(crate) enum OutboundUrlPolicyError {
     /// A configured endpoint used an unsafe transport.
     #[error("configured endpoint must use HTTPS or explicit loopback HTTP")]
     ConfiguredEndpointTransport,
+    /// A discovered endpoint used a transport the configured issuer cannot authorize.
+    #[error(
+        "discovered endpoint must use HTTPS unless the configured issuer uses explicit loopback HTTP"
+    )]
+    DiscoveredEndpointTransport,
     /// Public metadata did not use HTTPS.
     #[error("public metadata URL must use HTTPS")]
     PublicMetadataTransport,
@@ -239,7 +296,7 @@ pub(crate) async fn read_bounded_body(
         return Err(OutboundUrlPolicyError::BodyTooLarge { limit });
     }
 
-    let mut body = Zeroizing::new(Vec::new());
+    let mut body = Zeroizing::new(Vec::with_capacity(limit));
     while let Some(chunk) = response
         .chunk()
         .await
@@ -465,9 +522,9 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::{
-        ConfiguredEndpointUrl, OutboundUrlPolicyError, PublicMetadataUrl, append_bounded_chunk,
-        public_metadata_http_client, public_metadata_ip_is_blocked, read_bounded_body,
-        validate_public_resolution,
+        ConfiguredEndpointUrl, DiscoveredEndpointUrl, OutboundUrlPolicyError, PublicMetadataUrl,
+        append_bounded_chunk, public_metadata_http_client, public_metadata_ip_is_blocked,
+        read_bounded_body, validate_public_resolution,
     };
 
     #[test]
@@ -523,6 +580,40 @@ mod tests {
         assert!(matches!(
             ConfiguredEndpointUrl::parse("https://user:password@login.example.test/oauth"),
             Err(OutboundUrlPolicyError::CredentialsNotAllowed)
+        ));
+    }
+
+    #[test]
+    fn discovered_endpoints_bind_loopback_http_to_loopback_http_issuers() {
+        let remote_issuer =
+            ConfiguredEndpointUrl::parse("https://accounts.example.test/tenant").expect("issuer");
+        let loopback_issuer =
+            ConfiguredEndpointUrl::parse("http://127.0.0.1:9080/tenant").expect("issuer");
+
+        for endpoint in [
+            "http://localhost:14554/authorize",
+            "http://127.42.0.1:14554/token",
+            "http://[::1]:14554/jwks",
+        ] {
+            assert!(matches!(
+                DiscoveredEndpointUrl::parse(endpoint, &remote_issuer),
+                Err(OutboundUrlPolicyError::DiscoveredEndpointTransport)
+            ));
+            DiscoveredEndpointUrl::parse(endpoint, &loopback_issuer)
+                .expect("loopback issuer permits loopback endpoint");
+        }
+
+        for endpoint in [
+            "https://accounts.example.test/authorize",
+            "https://10.0.0.8/token",
+        ] {
+            DiscoveredEndpointUrl::parse(endpoint, &remote_issuer)
+                .expect("HTTPS reaches public or private providers");
+        }
+
+        assert!(matches!(
+            DiscoveredEndpointUrl::parse("http://accounts.example.test/token", &loopback_issuer),
+            Err(OutboundUrlPolicyError::DiscoveredEndpointTransport)
         ));
     }
 
@@ -760,9 +851,11 @@ mod tests {
         let response = reqwest::get(format!("{}/metadata", server.uri()))
             .await
             .expect("response");
-        assert_eq!(
-            read_bounded_body(response, 5).await.expect("body"),
-            b"hello"
+        let body = read_bounded_body(response, 5).await.expect("body");
+        assert_eq!(body, b"hello");
+        assert!(
+            body.capacity() >= 5,
+            "the bounded buffer must reserve its full limit to avoid reallocating secret data"
         );
 
         let response = reqwest::get(format!("{}/metadata", server.uri()))

--- a/crates/coral-app/src/outbound_url_policy.rs
+++ b/crates/coral-app/src/outbound_url_policy.rs
@@ -285,6 +285,20 @@ pub(crate) fn public_metadata_http_client() -> Result<reqwest::Client, OutboundU
 }
 
 /// Reads a response body without buffering more than `limit` bytes.
+///
+/// # Secret handling
+///
+/// The buffer is [`Zeroizing`] while it fills, so the accumulated copy of a
+/// body abandoned part-read — over the limit, or a read error — is wiped rather
+/// than left in the allocator. On success the buffer is *moved* to the caller
+/// by [`std::mem::take`], which is deliberate: zeroizing at that point would
+/// wipe only the empty `Vec` left behind, and the caller is the one that knows
+/// whether the bytes are secret.
+///
+/// Reserving `limit` up front is the guarantee that survives that move: a `Vec`
+/// that grew while filling would strand copies of already-read bytes in freed
+/// allocations, which no later wipe can reach. Keep the reserve, and do not
+/// turn the move into a copy.
 pub(crate) async fn read_bounded_body(
     mut response: reqwest::Response,
     limit: usize,
@@ -851,10 +865,13 @@ mod tests {
         let response = reqwest::get(format!("{}/metadata", server.uri()))
             .await
             .expect("response");
-        let body = read_bounded_body(response, 5).await.expect("body");
+        // The limit sits well above the body so the capacity below can only
+        // come from the reserve, not from the five bytes that were read.
+        let body = read_bounded_body(response, 4096).await.expect("body");
         assert_eq!(body, b"hello");
-        assert!(
-            body.capacity() >= 5,
+        assert_eq!(
+            body.capacity(),
+            4096,
             "the bounded buffer must reserve its full limit to avoid reallocating secret data"
         );
 


### PR DESCRIPTION
## Stack context

**Whole stack:** This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.

**This part of the stack:** PR #1635 keeps the validated provider settings, this PR uses those settings to communicate with the provider, and PR #1639 verifies the identity token returned by the provider.

**This PR:** Adds Coral's internal OpenID Connect client for provider discovery, browser authorization requests, and authorization-code exchange.

## Intent

Coral cannot safely begin an external login from an issuer URL alone. It must discover the provider's exact endpoints, protect the browser round trip, and exchange the returned code without leaking credentials or trusting an unverified identity.

## What it enables

- Downloads the provider's standard discovery document and requires its issuer to exactly match the configured issuer.
- Validates the discovered authorization, token, and signing-key endpoints before using them.
- Creates fresh state, nonce, and PKCE values for every authorization request.
- Builds the upstream authorization URL and exchanges the returned code for an ID token.
- Refuses HTTP redirects, ignores system proxies, limits request time and response size, and returns errors that do not contain provider secrets.
- Passes the still-unverified ID token and signing-key information to the validation layer added by PR #1639.

This PR adds internal provider communication only; it does not expose a new login route by itself.

## Usage examples

When a later authorization route starts a login, it asks this client for:

- the provider URL to redirect the browser to;
- the state and nonce needed to verify the callback; and
- the PKCE verifier needed to exchange the returned code.

When the provider redirects back, the callback passes its code and the stored verifier to this client. The resulting ID token is then verified by the next PR before Coral accepts the user.