### PR TITLE
feat(app): handle OAuth authorization requests

### DIFF
--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -1,5 +1,6 @@
 //! HTTP lifecycle for Coral's authorization server.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -12,12 +13,16 @@ use axum::routing::get;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
+use url::Position;
 
 use super::config::{AuthSettings, ResolvedAuthSettings, signing_key_env_error};
 use super::error::AuthServerError;
 use super::provider_client::OidcProviderClient;
 use super::session::SessionTokenIssuer;
 use super::state_store::{InMemoryStateStore, StateStore};
+use crate::outbound_url_policy::ConfiguredEndpointUrl;
+
+mod authorize;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -26,6 +31,8 @@ pub struct CoralAuthorizationServer {
     settings: Arc<ResolvedAuthSettings>,
     session_tokens: SessionTokenIssuer,
     state_store: Arc<dyn StateStore>,
+    registered_clients: Arc<BTreeMap<String, Vec<String>>>,
+    authorization_resources: BTreeSet<String>,
 }
 
 impl CoralAuthorizationServer {
@@ -74,7 +81,28 @@ impl CoralAuthorizationServer {
             settings: Arc::new(settings),
             session_tokens,
             state_store: Arc::new(InMemoryStateStore::new()),
+            registered_clients: Arc::new(BTreeMap::new()),
+            authorization_resources: BTreeSet::new(),
         }
+    }
+
+    /// Registers a resource identifier that authorization requests may target.
+    ///
+    /// Call this once for each public resource server that shares this
+    /// authorization server.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `resource` is not an HTTPS URL or an explicit
+    /// loopback HTTP URL, or when it contains credentials, a query, or a
+    /// fragment.
+    pub fn with_authorization_resource(
+        mut self,
+        resource: impl AsRef<str>,
+    ) -> Result<Self, String> {
+        self.authorization_resources
+            .insert(canonical_authorization_resource(resource.as_ref())?);
+        Ok(self)
     }
 
     /// Starts the HTTP listener.
@@ -91,12 +119,15 @@ impl CoralAuthorizationServer {
             state_store: self.state_store,
             provider_client: OidcProviderClient::new()
                 .map_err(|error| AuthServerError::ProviderClient(error.to_string()))?,
+            registered_clients: self.registered_clients,
+            authorization_resources: Arc::new(self.authorization_resources),
         };
         let router = Router::new()
             .route(
                 "/.well-known/oauth-authorization-server",
                 get(authorization_server_metadata),
             )
+            .route("/oauth/authorize", get(authorize::oauth_authorize))
             .with_state(state);
         let listener =
             TcpListener::bind(bind_addr)
@@ -180,18 +211,31 @@ impl Drop for RunningCoralAuthorizationServer {
 #[derive(Clone)]
 struct AuthorizationServerHttpState {
     settings: Arc<ResolvedAuthSettings>,
-    #[expect(
-        dead_code,
-        reason = "used by the OAuth token endpoint in a descendant PR"
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "used by the OAuth token endpoint in a descendant PR"
+        )
     )]
     session_tokens: SessionTokenIssuer,
-    #[expect(
-        dead_code,
-        reason = "used by the OAuth authorization endpoint in a descendant PR"
-    )]
     state_store: Arc<dyn StateStore>,
-    #[expect(dead_code, reason = "used by OIDC authorization descendants")]
     provider_client: OidcProviderClient,
+    registered_clients: Arc<BTreeMap<String, Vec<String>>>,
+    authorization_resources: Arc<BTreeSet<String>>,
+}
+
+fn canonical_authorization_resource(value: &str) -> Result<String, String> {
+    let resource = ConfiguredEndpointUrl::parse(value)
+        .map_err(|error| format!("authorization resource is invalid: {error}"))?
+        .into_url();
+    if resource.query().is_some() {
+        return Err("authorization resource must not include a query".to_string());
+    }
+    Ok(match resource.path() {
+        "/" => resource[..Position::BeforePath].to_string(),
+        _ => resource.to_string(),
+    })
 }
 
 async fn authorization_server_metadata(
@@ -321,6 +365,31 @@ mod tests {
                 .to_string()
                 .contains("does not match authorization-server settings")
         );
+    }
+
+    #[test]
+    fn validates_and_canonicalizes_authorization_resources() {
+        let dir = authorization_server("");
+        let prepared = server(&dir)
+            .with_authorization_resource("https://mcp.example.test/")
+            .expect("resource");
+        assert_eq!(
+            prepared.authorization_resources,
+            ["https://mcp.example.test".to_string()].into()
+        );
+
+        for resource in [
+            "http://mcp.example.test",
+            "https://user@mcp.example.test",
+            "https://mcp.example.test?tenant=one",
+            "https://mcp.example.test/#fragment",
+        ] {
+            let error = server(&dir)
+                .with_authorization_resource(resource)
+                .err()
+                .expect("invalid resource");
+            assert!(error.contains("authorization resource"));
+        }
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -20,7 +20,7 @@ use super::error::AuthServerError;
 use super::provider_client::OidcProviderClient;
 use super::session::SessionTokenIssuer;
 use super::state_store::{InMemoryStateStore, StateStore};
-use crate::outbound_url_policy::ConfiguredEndpointUrl;
+use crate::outbound_url_policy::{EndpointUrl, ResourceIdentifier};
 
 mod authorize;
 
@@ -226,7 +226,7 @@ struct AuthorizationServerHttpState {
 }
 
 fn canonical_authorization_resource(value: &str) -> Result<String, String> {
-    let resource = ConfiguredEndpointUrl::parse(value)
+    let resource = EndpointUrl::<ResourceIdentifier>::parse(value)
         .map_err(|error| format!("authorization resource is invalid: {error}"))?
         .into_url();
     if resource.query().is_some() {

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -9,6 +9,7 @@ use super::super::PROVIDER_ID;
 use super::super::provider_client::OidcAuthorizationRequest;
 use super::super::state_store::OAuthAuthorizationSessionRecord;
 use super::{AuthorizationServerHttpState, canonical_authorization_resource};
+use crate::outbound_url_policy::{BrowserRedirect, EndpointUrl};
 
 const MAX_QUERY_BYTES: usize = 8 * 1024;
 const MAX_PARAMETERS: usize = 32;
@@ -149,6 +150,13 @@ fn parse_query(raw: &str) -> Result<AuthorizeQuery, ()> {
     Ok(query)
 }
 
+/// Resolves the registered redirect URI a request names, under
+/// [`BrowserRedirect`].
+///
+/// The registry is remote input once client metadata documents populate it, so
+/// the policy is applied here rather than trusted to have been applied at
+/// registration: a URI the policy rejects resolves to `None`, and the request
+/// fails with a direct error instead of becoming a redirect.
 fn registered_redirect(
     registered_clients: &BTreeMap<String, Vec<String>>,
     client_id: &str,
@@ -158,7 +166,8 @@ fn registered_redirect(
         .get(client_id)?
         .iter()
         .find(|uri| uri.as_str() == redirect_uri)
-        .and_then(|uri| Url::parse(uri).ok())
+        .and_then(|uri| EndpointUrl::<BrowserRedirect>::parse(uri).ok())
+        .map(EndpointUrl::into_url)
 }
 
 fn valid_s256_challenge(value: &str) -> bool {
@@ -405,6 +414,25 @@ mod tests {
         assert!(location(&response).is_none());
         let body = to_bytes(response.into_body(), 4096).await.expect("body");
         assert!(!String::from_utf8_lossy(&body).contains("raw-secret"));
+    }
+
+    #[tokio::test]
+    async fn registered_redirect_outside_browser_policy_never_becomes_a_redirect() {
+        let store = Arc::new(InMemoryStateStore::new());
+        for uri in [
+            "javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "http://client.example.test/callback",
+        ] {
+            let mut auth_state = state("https://provider.invalid", store.clone());
+            auth_state.registered_clients =
+                Arc::new(BTreeMap::from([(CLIENT_ID.into(), vec![uri.into()])]));
+            let mut request_pairs = pairs();
+            replace(&mut request_pairs, "redirect_uri", Some(uri));
+            let response = request(auth_state, &request_pairs).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST, "accepted {uri}");
+            assert!(location(&response).is_none(), "redirected to {uri}");
+        }
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -5,7 +5,6 @@ use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use url::{Url, form_urlencoded};
 
-use super::super::PROVIDER_ID;
 use super::super::provider_client::OidcAuthorizationRequest;
 use super::super::state_store::OAuthAuthorizationSessionRecord;
 use super::{AuthorizationServerHttpState, canonical_authorization_resource};
@@ -85,7 +84,6 @@ pub(super) async fn oauth_authorize(
         code_verifier: oidc_code_verifier,
     } = request;
     let session = OAuthAuthorizationSessionRecord {
-        provider_id: PROVIDER_ID.to_string(),
         client_id: client_id.to_string(),
         redirect_uri: redirect_uri.to_string(),
         client_state: query.state,
@@ -500,7 +498,6 @@ mod tests {
             .await
             .expect("store")
             .expect("stored before redirect");
-        assert_eq!(session.provider_id, PROVIDER_ID);
         assert_eq!(session.client_id, CLIENT_ID);
         assert_eq!(session.redirect_uri, REDIRECT_URI);
         assert_eq!(session.client_state.as_deref(), Some(CLIENT_STATE));
@@ -534,7 +531,6 @@ mod tests {
         provider.reset().await;
         mount_discovery(&provider, 200).await;
         let filler = OAuthAuthorizationSessionRecord {
-            provider_id: PROVIDER_ID.into(),
             client_id: CLIENT_ID.into(),
             redirect_uri: REDIRECT_URI.into(),
             client_state: None,

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -1,0 +1,563 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use axum::extract::{RawQuery, State};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use url::{Url, form_urlencoded};
+
+use super::super::PROVIDER_ID;
+use super::super::provider_client::OidcAuthorizationRequest;
+use super::super::state_store::OAuthAuthorizationSessionRecord;
+use super::{AuthorizationServerHttpState, canonical_authorization_resource};
+
+const MAX_QUERY_BYTES: usize = 8 * 1024;
+const MAX_PARAMETERS: usize = 32;
+const MAX_PARAMETER_NAME_BYTES: usize = 64;
+const MAX_PARAMETER_VALUE_BYTES: usize = 2 * 1024;
+
+pub(super) async fn oauth_authorize(
+    State(state): State<AuthorizationServerHttpState>,
+    RawQuery(raw_query): RawQuery,
+) -> Response {
+    let Ok(query) = parse_query(raw_query.as_deref().unwrap_or_default()) else {
+        return direct_error("invalid_request", "authorization request is malformed");
+    };
+    let (Some(client_id), Some(redirect_uri)) =
+        (query.client_id.as_deref(), query.redirect_uri.as_deref())
+    else {
+        return direct_error("invalid_request", "client_id and redirect_uri are required");
+    };
+    let Some(callback) = registered_redirect(&state.registered_clients, client_id, redirect_uri)
+    else {
+        return direct_error("invalid_request", "client_id or redirect_uri is invalid");
+    };
+    let trusted = TrustedRedirect {
+        url: callback,
+        client_state: query.state.clone(),
+    };
+
+    match query.response_type.as_deref() {
+        Some("code") => {}
+        None => return trusted.error("invalid_request", "response_type is required"),
+        Some(_) => {
+            return trusted.error(
+                "unsupported_response_type",
+                "only response_type=code is supported",
+            );
+        }
+    }
+    let code_challenge = match query.code_challenge.as_deref() {
+        Some(challenge)
+            if query.code_challenge_method.as_deref() == Some("S256")
+                && valid_s256_challenge(challenge) =>
+        {
+            challenge.to_string()
+        }
+        _ => {
+            return trusted.error("invalid_request", "PKCE S256 code_challenge is required");
+        }
+    };
+    if query.scope.is_some() {
+        return trusted.error("invalid_scope", "scope is not supported");
+    }
+    let Some(resource) = query.resource.as_deref() else {
+        return trusted.error("invalid_target", "resource is required");
+    };
+    let Ok(resource) = canonical_authorization_resource(resource) else {
+        return trusted.error("invalid_target", "resource is invalid");
+    };
+    if !state.authorization_resources.contains(&resource) {
+        return trusted.error("invalid_target", "resource does not match this server");
+    }
+    let request = match state
+        .provider_client
+        .authorization_request(state.settings.provider())
+        .await
+    {
+        Ok(request) => request,
+        Err(_error) => return trusted.error("server_error", "authorization failed"),
+    };
+    let OidcAuthorizationRequest {
+        url,
+        state: oidc_state,
+        nonce: oidc_nonce,
+        code_verifier: oidc_code_verifier,
+    } = request;
+    let session = OAuthAuthorizationSessionRecord {
+        provider_id: PROVIDER_ID.to_string(),
+        client_id: client_id.to_string(),
+        redirect_uri: redirect_uri.to_string(),
+        client_state: query.state,
+        code_challenge,
+        resource,
+        oidc_code_verifier,
+        oidc_nonce,
+    };
+    if state
+        .state_store
+        .store_authorization_session(&oidc_state, session)
+        .await
+        .is_err()
+    {
+        return trusted.error("server_error", "authorization failed");
+    }
+    redirect(url.as_str())
+}
+
+#[derive(Default)]
+struct AuthorizeQuery {
+    response_type: Option<String>,
+    client_id: Option<String>,
+    redirect_uri: Option<String>,
+    scope: Option<String>,
+    state: Option<String>,
+    code_challenge: Option<String>,
+    code_challenge_method: Option<String>,
+    resource: Option<String>,
+}
+
+fn parse_query(raw: &str) -> Result<AuthorizeQuery, ()> {
+    if raw.len() > MAX_QUERY_BYTES {
+        return Err(());
+    }
+    let mut query = AuthorizeQuery::default();
+    let mut seen = BTreeSet::new();
+    for (index, (name, value)) in form_urlencoded::parse(raw.as_bytes()).enumerate() {
+        if index >= MAX_PARAMETERS
+            || name.len() > MAX_PARAMETER_NAME_BYTES
+            || value.len() > MAX_PARAMETER_VALUE_BYTES
+        {
+            return Err(());
+        }
+        let name = name.into_owned();
+        if !seen.insert(name.clone()) {
+            return Err(());
+        }
+        let target = match name.as_str() {
+            "response_type" => &mut query.response_type,
+            "client_id" => &mut query.client_id,
+            "redirect_uri" => &mut query.redirect_uri,
+            "scope" => &mut query.scope,
+            "state" => &mut query.state,
+            "code_challenge" => &mut query.code_challenge,
+            "code_challenge_method" => &mut query.code_challenge_method,
+            "resource" => &mut query.resource,
+            _ => continue,
+        };
+        *target = Some(value.into_owned());
+    }
+    Ok(query)
+}
+
+fn registered_redirect(
+    registered_clients: &BTreeMap<String, Vec<String>>,
+    client_id: &str,
+    redirect_uri: &str,
+) -> Option<Url> {
+    registered_clients
+        .get(client_id)?
+        .iter()
+        .find(|uri| uri.as_str() == redirect_uri)
+        .and_then(|uri| Url::parse(uri).ok())
+}
+
+fn valid_s256_challenge(value: &str) -> bool {
+    value.len() == 43
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
+struct TrustedRedirect {
+    url: Url,
+    client_state: Option<String>,
+}
+
+impl TrustedRedirect {
+    fn error(&self, error: &'static str, description: &'static str) -> Response {
+        let mut url = self.url.clone();
+        let mut query = url.query_pairs_mut();
+        query
+            .append_pair("error", error)
+            .append_pair("error_description", description);
+        if let Some(state) = &self.client_state {
+            query.append_pair("state", state);
+        }
+        drop(query);
+        redirect(url.as_str())
+    }
+}
+
+fn direct_error(error: &'static str, description: &'static str) -> Response {
+    let body = serde_json::json!({
+        "error": error,
+        "error_description": description,
+    })
+    .to_string();
+    (
+        StatusCode::BAD_REQUEST,
+        [
+            (header::CONTENT_TYPE, "application/json"),
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+        ],
+        body,
+    )
+        .into_response()
+}
+
+fn redirect(location: &str) -> Response {
+    (
+        StatusCode::FOUND,
+        [
+            (header::LOCATION, location),
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+            (header::REFERRER_POLICY, "no-referrer"),
+        ],
+        "",
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use axum::body::to_bytes;
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD;
+    use ring::rand::SystemRandom;
+    use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::super::{AuthorizationServerHttpState, CoralAuthorizationServer};
+    use super::*;
+    use crate::auth::config::AuthSettings;
+    use crate::auth::config::ResolvedAuthSettings;
+    use crate::auth::provider_client::OidcProviderClient;
+    use crate::auth::session::SessionTokenIssuer;
+    use crate::auth::state_store::{InMemoryStateStore, StateStore};
+
+    const AUTH_ISSUER: &str = "https://auth.example.test";
+    const RESOURCE: &str = "https://api.example.test/mcp";
+    const CLIENT_ID: &str = "https://client.example.test/oauth/client.json";
+    const REDIRECT_URI: &str = "https://client.example.test/callback?tenant=one";
+    const CLIENT_STATE: &str = "client-state&error=injected";
+    const CHALLENGE: &str = "0123456789012345678901234567890123456789012";
+    const PROVIDER_SECRET: &str = "provider-secret-must-not-leak";
+
+    fn settings(issuer: &str) -> ResolvedAuthSettings {
+        let settings = AuthSettings::from_toml(&format!(
+            "[auth]
+             [auth.session]
+             [auth.authorization_server]
+             issuer = '{AUTH_ISSUER}'
+             [auth.provider]
+             issuer = '{issuer}'
+             client_id = 'provider-client'
+             client_secret = '{PROVIDER_SECRET}'
+             redirect_uri = '{AUTH_ISSUER}/auth/oidc/callback'"
+        ))
+        .expect("valid auth config")
+        .expect("auth settings");
+        let signing_key = STANDARD.encode(
+            EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
+                .expect("P-256 signing key"),
+        );
+        let (settings, _issuer) = settings
+            .resolve_runtime_dependencies(Path::new("config.toml"), &|name| {
+                Ok((name == "CORAL_SESSION_SIGNING_KEY").then(|| signing_key.clone()))
+            })
+            .expect("resolved runtime dependencies");
+        settings
+    }
+
+    fn state(issuer: &str, store: Arc<dyn StateStore>) -> AuthorizationServerHttpState {
+        let signing_key =
+            EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
+                .expect("P-256 signing key");
+        let session_tokens = SessionTokenIssuer::new(
+            Some(AUTH_ISSUER),
+            signing_key.as_ref(),
+            Duration::from_mins(5),
+        )
+        .expect("session");
+        AuthorizationServerHttpState {
+            settings: Arc::new(settings(issuer)),
+            session_tokens,
+            state_store: store,
+            provider_client: OidcProviderClient::new().expect("provider client"),
+            registered_clients: Arc::new(BTreeMap::from([(
+                CLIENT_ID.into(),
+                vec![REDIRECT_URI.into()],
+            )])),
+            authorization_resources: Arc::new(BTreeSet::from([RESOURCE.into()])),
+        }
+    }
+
+    fn pairs() -> Vec<(String, String)> {
+        [
+            ("response_type", "code"),
+            ("client_id", CLIENT_ID),
+            ("redirect_uri", REDIRECT_URI),
+            ("state", CLIENT_STATE),
+            ("code_challenge", CHALLENGE),
+            ("code_challenge_method", "S256"),
+            ("resource", RESOURCE),
+        ]
+        .into_iter()
+        .map(|(key, value)| (key.into(), value.into()))
+        .collect()
+    }
+
+    fn encode(pairs: &[(String, String)]) -> String {
+        let mut serializer = form_urlencoded::Serializer::new(String::new());
+        for (key, value) in pairs {
+            serializer.append_pair(key, value);
+        }
+        serializer.finish()
+    }
+
+    fn replace(pairs: &mut Vec<(String, String)>, key: &str, value: Option<&str>) {
+        pairs.retain(|(name, _value)| name != key);
+        if let Some(value) = value {
+            pairs.push((key.into(), value.into()));
+        }
+    }
+
+    async fn request(state: AuthorizationServerHttpState, pairs: &[(String, String)]) -> Response {
+        oauth_authorize(State(state), RawQuery(Some(encode(pairs)))).await
+    }
+
+    fn location(response: &Response) -> Option<&str> {
+        response
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|value| value.to_str().ok())
+    }
+
+    async fn mount_discovery(server: &MockServer, status: u16) {
+        let document = json!({
+            "issuer": server.uri(),
+            "authorization_endpoint": format!("{}/authorize?upstream=one", server.uri()),
+            "token_endpoint": format!("{}/token", server.uri()),
+            "jwks_uri": format!("{}/jwks", server.uri()),
+            "id_token_signing_alg_values_supported": ["RS256"],
+        });
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(status).set_body_json(document))
+            .mount(server)
+            .await;
+    }
+
+    #[test]
+    fn query_parser_bounds_and_rejects_decoded_duplicates() {
+        let encoded = encode(&pairs());
+        let cases = [
+            format!("{encoded}&client%5Fid=duplicate"),
+            "x".repeat(MAX_QUERY_BYTES + 1),
+            format!("{}=value", "n".repeat(MAX_PARAMETER_NAME_BYTES + 1)),
+            format!("value={}", "v".repeat(MAX_PARAMETER_VALUE_BYTES + 1)),
+            (0..=MAX_PARAMETERS)
+                .map(|index| format!("x{index}=1"))
+                .collect::<Vec<_>>()
+                .join("&"),
+        ];
+        for raw in cases {
+            assert!(parse_query(&raw).is_err(), "accepted {raw}");
+        }
+    }
+
+    #[tokio::test]
+    async fn client_and_redirect_must_match_exactly_before_redirecting() {
+        let store = Arc::new(InMemoryStateStore::new());
+        for (field, value) in [
+            (
+                "client_id",
+                "https://client.example.test/oauth/%63lient.json",
+            ),
+            ("redirect_uri", "https://client.example.test/other"),
+        ] {
+            let mut request_pairs = pairs();
+            replace(&mut request_pairs, field, Some(value));
+            let response = request(
+                state("https://provider.invalid", store.clone()),
+                &request_pairs,
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert!(location(&response).is_none());
+        }
+
+        let raw = format!("{}&client%5Fid=raw-secret", encode(&pairs()));
+        let response = oauth_authorize(
+            State(state("https://provider.invalid", store)),
+            RawQuery(Some(raw)),
+        )
+        .await;
+        assert!(location(&response).is_none());
+        let body = to_bytes(response.into_body(), 4096).await.expect("body");
+        assert!(!String::from_utf8_lossy(&body).contains("raw-secret"));
+    }
+
+    #[tokio::test]
+    async fn trusted_protocol_errors_redirect_with_one_encoded_client_state() {
+        let store = Arc::new(InMemoryStateStore::new());
+        for (field, value, expected) in [
+            ("response_type", None, "invalid_request"),
+            ("response_type", Some("token"), "unsupported_response_type"),
+            ("code_challenge", None, "invalid_request"),
+            ("code_challenge", Some("short"), "invalid_request"),
+            ("code_challenge_method", Some("plain"), "invalid_request"),
+            ("scope", Some("coral:access"), "invalid_scope"),
+            ("resource", None, "invalid_target"),
+            ("resource", Some("https://other.test"), "invalid_target"),
+        ] {
+            let mut request_pairs = pairs();
+            replace(&mut request_pairs, field, value);
+            let response = request(
+                state("https://provider.invalid", store.clone()),
+                &request_pairs,
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::FOUND);
+            assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+            assert_eq!(response.headers()[header::REFERRER_POLICY], "no-referrer");
+            let url = Url::parse(location(&response).expect("error redirect")).expect("URL");
+            let query = url.query_pairs().into_owned().collect::<Vec<_>>();
+            assert!(query.contains(&("tenant".into(), "one".into())));
+            assert!(query.contains(&("error".into(), expected.into())));
+            assert_eq!(
+                query.iter().filter(|(key, _value)| key == "state").count(),
+                1
+            );
+            assert!(query.contains(&("state".into(), CLIENT_STATE.into())));
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_resource_allowlist_fails_closed() {
+        let mut auth_state = state(
+            "https://provider.invalid",
+            Arc::new(InMemoryStateStore::new()),
+        );
+        auth_state.authorization_resources = Arc::new(BTreeSet::new());
+        let response = request(auth_state, &pairs()).await;
+        let location = location(&response).expect("trusted error redirect");
+        assert!(location.contains("error=invalid_target"));
+    }
+
+    #[tokio::test]
+    async fn success_stores_single_use_session_before_provider_redirect() {
+        let provider = MockServer::start().await;
+        mount_discovery(&provider, 200).await;
+        let store = Arc::new(InMemoryStateStore::new());
+        let response = request(state(&provider.uri(), store.clone()), &pairs()).await;
+        let provider_url = location(&response).expect("provider redirect");
+        let query = Url::parse(provider_url)
+            .expect("URL")
+            .query_pairs()
+            .into_owned()
+            .collect::<BTreeMap<_, _>>();
+        let oidc_state = query.get("state").expect("OIDC state");
+        let session = store
+            .take_authorization_session(oidc_state)
+            .await
+            .expect("store")
+            .expect("stored before redirect");
+        assert_eq!(session.provider_id, PROVIDER_ID);
+        assert_eq!(session.client_id, CLIENT_ID);
+        assert_eq!(session.redirect_uri, REDIRECT_URI);
+        assert_eq!(session.client_state.as_deref(), Some(CLIENT_STATE));
+        assert_eq!(session.code_challenge, CHALLENGE);
+        assert_eq!(session.resource, RESOURCE);
+        assert_eq!(session.oidc_code_verifier.len(), 43);
+        assert_eq!(session.oidc_nonce.len(), 43);
+        assert!(!query.values().any(|value| value == CLIENT_STATE));
+        for secret in [&session.oidc_code_verifier, PROVIDER_SECRET] {
+            assert!(!provider_url.contains(secret));
+        }
+        assert!(
+            store
+                .take_authorization_session(oidc_state)
+                .await
+                .expect("store")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_and_store_failures_are_generic_trusted_errors() {
+        let provider = MockServer::start().await;
+        mount_discovery(&provider, 500).await;
+        let store = Arc::new(InMemoryStateStore::new());
+        let response = request(state(&provider.uri(), store.clone()), &pairs()).await;
+        let error_location = location(&response).expect("error redirect");
+        assert!(error_location.contains("error=server_error"));
+        assert!(!error_location.contains(PROVIDER_SECRET));
+
+        provider.reset().await;
+        mount_discovery(&provider, 200).await;
+        let filler = OAuthAuthorizationSessionRecord {
+            provider_id: PROVIDER_ID.into(),
+            client_id: CLIENT_ID.into(),
+            redirect_uri: REDIRECT_URI.into(),
+            client_state: None,
+            code_challenge: CHALLENGE.into(),
+            resource: RESOURCE.into(),
+            oidc_code_verifier: "verifier".to_string().into(),
+            oidc_nonce: "nonce".into(),
+        };
+        for index in 0..4096 {
+            store
+                .store_authorization_session(&format!("filler-{index}"), filler.clone())
+                .await
+                .expect("fill store");
+        }
+        let response = request(state(&provider.uri(), store), &pairs()).await;
+        assert!(
+            location(&response)
+                .expect("store error redirect")
+                .contains("error=server_error")
+        );
+    }
+
+    #[tokio::test]
+    async fn listener_exposes_authorize_route() {
+        let provider = MockServer::start().await;
+        mount_discovery(&provider, 200).await;
+        let state = state(&provider.uri(), Arc::new(InMemoryStateStore::new()));
+        let server = CoralAuthorizationServer {
+            settings: state.settings,
+            session_tokens: state.session_tokens,
+            state_store: state.state_store,
+            registered_clients: state.registered_clients,
+            authorization_resources: state.authorization_resources.as_ref().clone(),
+        }
+        .start()
+        .await
+        .expect("start");
+        let client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("client");
+        let response = client
+            .get(format!(
+                "{}/oauth/authorize?{}",
+                server.endpoint_uri(),
+                encode(&pairs())
+            ))
+            .send()
+            .await
+            .expect("request");
+        assert_eq!(response.status(), StatusCode::FOUND);
+        server.shutdown().await.expect("shutdown");
+    }
+}

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -19,7 +19,7 @@ use zeroize::Zeroizing;
 use super::error::AuthServerError;
 use super::session::SessionTokenIssuer;
 use crate::bootstrap::is_loopback_ip;
-use crate::outbound_url_policy::ConfiguredEndpointUrl;
+use crate::outbound_url_policy::{Configured, EndpointUrl};
 
 const DEFAULT_BIND_ADDR: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0);
 const DEFAULT_SIGNING_KEY_ENV: &str = "CORAL_SESSION_SIGNING_KEY";
@@ -593,7 +593,7 @@ fn provider_required(field: &str, value: &str) -> Result<String, AuthServerError
 fn provider_literal_endpoint(
     field: &str,
     value: &str,
-) -> Result<ConfiguredEndpointUrl, AuthServerError> {
+) -> Result<EndpointUrl<Configured>, AuthServerError> {
     let syntax_violation = Cell::new(None);
     let record_violation = |violation| syntax_violation.set(Some(violation));
     let url = Url::options()
@@ -603,7 +603,7 @@ fn provider_literal_endpoint(
     if let Some(violation) = syntax_violation.get() {
         return Err(invalid_provider(format!("{field} is invalid: {violation}")));
     }
-    ConfiguredEndpointUrl::from_parsed(url)
+    EndpointUrl::<Configured>::from_parsed(url)
         .map_err(|error| invalid_provider(format!("{field} is invalid: {error}")))
 }
 
@@ -620,7 +620,7 @@ fn provider_literal_endpoint(
 /// both are accepted — the parser appends one only to a root-path URL.
 fn validate_canonical_issuer(
     configured: &str,
-    parsed: &ConfiguredEndpointUrl,
+    parsed: &EndpointUrl<Configured>,
 ) -> Result<(), AuthServerError> {
     let canonical = parsed.as_url().as_str();
     if configured == canonical || format!("{configured}/") == canonical {
@@ -710,8 +710,8 @@ fn validate_issuer(label: &str, raw: &str, root_only: bool) -> Result<String, Au
     Ok(url.as_url().as_str().trim_end_matches('/').to_string())
 }
 
-fn validate_endpoint(label: &str, raw: &str) -> Result<ConfiguredEndpointUrl, AuthServerError> {
-    ConfiguredEndpointUrl::parse(raw.trim())
+fn validate_endpoint(label: &str, raw: &str) -> Result<EndpointUrl<Configured>, AuthServerError> {
+    EndpointUrl::<Configured>::parse(raw.trim())
         .map_err(|error| config_error(format!("{label} is invalid: {error}")))
 }
 

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -140,10 +140,6 @@ impl ResolvedAuthSettings {
         &self.authorization_server
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "used by the OIDC federation descendant")
-    )]
     pub(super) fn provider(&self) -> &ResolvedOidcProvider {
         &self.provider
     }

--- a/crates/coral-app/src/auth/mod.rs
+++ b/crates/coral-app/src/auth/mod.rs
@@ -21,13 +21,6 @@ pub use authorization_server::{CoralAuthorizationServer, RunningCoralAuthorizati
 pub use config::AuthSettings;
 pub use error::AuthServerError;
 
-/// Identifier recorded for Coral's single configured OIDC provider.
-///
-/// Coral authenticates against exactly one upstream provider, so authorization
-/// state and session tokens carry this constant instead of an operator-chosen
-/// provider name.
-pub(crate) const PROVIDER_ID: &str = "oidc";
-
 /// Minimal `[auth]` TOML sections shared by this module's tests.
 ///
 /// `config` and `authorization_server` both build configs from the same

--- a/crates/coral-app/src/auth/mod.rs
+++ b/crates/coral-app/src/auth/mod.rs
@@ -21,6 +21,13 @@ pub use authorization_server::{CoralAuthorizationServer, RunningCoralAuthorizati
 pub use config::AuthSettings;
 pub use error::AuthServerError;
 
+/// Identifier recorded for Coral's single configured OIDC provider.
+///
+/// Coral authenticates against exactly one upstream provider, so authorization
+/// state and session tokens carry this constant instead of an operator-chosen
+/// provider name.
+pub(crate) const PROVIDER_ID: &str = "oidc";
+
 /// Minimal `[auth]` TOML sections shared by this module's tests.
 ///
 /// `config` and `authorization_server` both build configs from the same

--- a/crates/coral-app/src/auth/provider_client.rs
+++ b/crates/coral-app/src/auth/provider_client.rs
@@ -5,11 +5,11 @@
 //! The discovery document is fetched from the operator-configured issuer, but
 //! it is not treated as operator-authored: a provider that is compromised, or
 //! merely misconfigured, can put anything in it. Two checks bound what it can
-//! do. Every endpoint is re-parsed as a [`DiscoveredEndpointUrl`], which refuses
-//! a plain-HTTP downgrade the configured issuer did not already permit; and no
-//! endpoint may pre-set a query parameter this module reserves, so the document
-//! cannot pin `state`, swap `client_id`, or choose a `response_mode` that
-//! strands the authorization code short of the callback route.
+//! do. Every endpoint is re-parsed under the [`Discovered`] policy, which
+//! refuses a plain-HTTP downgrade the configured issuer did not already permit;
+//! and no endpoint may pre-set a query parameter this module reserves, so the
+//! document cannot pin `state`, swap `client_id`, or choose a `response_mode`
+//! that strands the authorization code short of the callback route.
 //!
 //! # Errors
 //!
@@ -33,7 +33,7 @@ use zeroize::Zeroizing;
 
 use super::config::{RESERVED_PROVIDER_AUTH_PARAMS, ResolvedOidcProvider};
 use super::id_token::{ValidatedOidcIdentity, validate_id_token};
-use crate::outbound_url_policy::{ConfiguredEndpointUrl, DiscoveredEndpointUrl, read_bounded_body};
+use crate::outbound_url_policy::{Configured, Discovered, EndpointUrl, read_bounded_body};
 
 /// Timeout applied to establishing a connection to the provider.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
@@ -88,7 +88,7 @@ pub(super) struct OidcAuthorizationRequest {
 /// named the token endpoint.
 pub(super) struct OidcCodeExchange {
     id_token: Zeroizing<String>,
-    jwks_uri: DiscoveredEndpointUrl,
+    jwks_uri: EndpointUrl<Discovered>,
     signing_algorithms: Vec<String>,
 }
 
@@ -100,7 +100,7 @@ impl OidcCodeExchange {
 
     /// Returns the JWKS endpoint that publishes the ID token's verification
     /// keys.
-    pub(super) fn jwks_uri(&self) -> &DiscoveredEndpointUrl {
+    pub(super) fn jwks_uri(&self) -> &EndpointUrl<Discovered> {
         &self.jwks_uri
     }
 
@@ -208,9 +208,9 @@ impl OidcProviderClient {
         code_verifier: &str,
     ) -> Result<OidcCodeExchange, OidcProviderClientError> {
         let discovery = self.discover(provider).await?;
-        let response = self
-            .http
-            .post(discovery.token_endpoint.as_url().clone())
+        let response = discovery
+            .token_endpoint
+            .post(&self.http)
             .header(ACCEPT, "application/json")
             .form(&[
                 ("grant_type", "authorization_code"),
@@ -254,9 +254,8 @@ impl OidcProviderClient {
             jwks_uri,
             signing_algorithms,
         } = exchange;
-        let response = self
-            .http
-            .get(jwks_uri.into_url())
+        let response = jwks_uri
+            .get(&self.http)
             .header(ACCEPT, "application/json")
             .send()
             .await
@@ -285,12 +284,11 @@ impl OidcProviderClient {
         &self,
         provider: &ResolvedOidcProvider,
     ) -> Result<ValidatedDiscovery, OidcProviderClientError> {
-        let issuer = ConfiguredEndpointUrl::parse(&provider.issuer)
+        let issuer = EndpointUrl::<Configured>::parse(&provider.issuer)
             .map_err(|_error| OidcProviderClientError::Discovery)?;
         let url = discovery_url(&provider.issuer)?;
-        let response = self
-            .http
-            .get(url.into_url())
+        let response = url
+            .get(&self.http)
             .header(ACCEPT, "application/json")
             .send()
             .await
@@ -345,9 +343,9 @@ impl OidcProviderClient {
 
 /// A discovery document that passed every check in [`OidcProviderClient::discover`].
 struct ValidatedDiscovery {
-    authorization_endpoint: DiscoveredEndpointUrl,
-    token_endpoint: DiscoveredEndpointUrl,
-    jwks_uri: DiscoveredEndpointUrl,
+    authorization_endpoint: EndpointUrl<Discovered>,
+    token_endpoint: EndpointUrl<Discovered>,
+    jwks_uri: EndpointUrl<Discovered>,
     signing_algorithms: Vec<String>,
 }
 
@@ -424,8 +422,8 @@ impl DiscoveredEndpoint {
 }
 
 /// Builds the well-known discovery URL for a configured issuer.
-fn discovery_url(issuer: &str) -> Result<ConfiguredEndpointUrl, OidcProviderClientError> {
-    ConfiguredEndpointUrl::parse(&format!(
+fn discovery_url(issuer: &str) -> Result<EndpointUrl<Configured>, OidcProviderClientError> {
+    EndpointUrl::<Configured>::parse(&format!(
         "{}/.well-known/openid-configuration",
         issuer.trim_end_matches('/')
     ))
@@ -434,19 +432,19 @@ fn discovery_url(issuer: &str) -> Result<ConfiguredEndpointUrl, OidcProviderClie
 
 /// Validates one endpoint out of a discovery document.
 ///
-/// Beyond the transport policy [`DiscoveredEndpointUrl`] applies, the endpoint
-/// may not arrive with surrounding whitespace, nor carry a query parameter this
-/// module reserves for the request to it.
+/// Beyond the transport policy [`Discovered`] applies, the endpoint may not
+/// arrive with surrounding whitespace, nor carry a query parameter this module
+/// reserves for the request to it.
 fn discovered_endpoint(
     endpoint: DiscoveredEndpoint,
     value: &str,
-    issuer: &ConfiguredEndpointUrl,
-) -> Result<DiscoveredEndpointUrl, OidcProviderClientError> {
+    issuer: &EndpointUrl<Configured>,
+) -> Result<EndpointUrl<Discovered>, OidcProviderClientError> {
     let label = endpoint.label();
     if value.trim() != value {
         return Err(OidcProviderClientError::InvalidEndpoint(label));
     }
-    let url = DiscoveredEndpointUrl::parse(value, issuer)
+    let url = EndpointUrl::<Discovered>::parse(value, issuer)
         .map_err(|_error| OidcProviderClientError::InvalidEndpoint(label))?;
     let reserved = url.as_url().query_pairs().any(|(key, _value)| {
         endpoint
@@ -538,8 +536,8 @@ mod tests {
 
     #[test]
     fn remote_issuer_cannot_discover_loopback_http_endpoints() {
-        let issuer =
-            ConfiguredEndpointUrl::parse("https://accounts.example.test/tenant").expect("issuer");
+        let issuer = EndpointUrl::<Configured>::parse("https://accounts.example.test/tenant")
+            .expect("issuer");
         for (endpoint, value) in [
             (
                 DiscoveredEndpoint::Authorization,
@@ -556,10 +554,10 @@ mod tests {
     }
 
     fn validation_exchange(server: &MockServer) -> OidcCodeExchange {
-        let issuer = ConfiguredEndpointUrl::parse(&server.uri()).expect("issuer URL");
+        let issuer = EndpointUrl::<Configured>::parse(&server.uri()).expect("issuer URL");
         OidcCodeExchange {
             id_token: Zeroizing::new(id_token(&id_token_claims())),
-            jwks_uri: DiscoveredEndpointUrl::parse(
+            jwks_uri: EndpointUrl::<Discovered>::parse(
                 &format!("{}/jwks?source=url-secret", server.uri()),
                 &issuer,
             )

--- a/crates/coral-app/src/auth/session.rs
+++ b/crates/coral-app/src/auth/session.rs
@@ -489,11 +489,7 @@ mod tests {
         let issuer = test_issuer();
         let verifier = issuer.verifier();
         let access = issuer
-            .issue_access_token(
-                "issuer.example|opaque:subject/123",
-                CLIENT_ID,
-                MCP_AUDIENCE,
-            )
+            .issue_access_token("issuer.example|opaque:subject/123", CLIENT_ID, MCP_AUDIENCE)
             .unwrap();
         let header = decode_header(&access.access_token).unwrap();
         assert_eq!(header.alg, Algorithm::ES256);
@@ -654,8 +650,7 @@ mod tests {
             (CLIENT_ID, ""),
             (CLIENT_ID, "audience "),
         ] {
-            let Err(_error) = issuer.issue_access_token("user-123", client_id, audience)
-            else {
+            let Err(_error) = issuer.issue_access_token("user-123", client_id, audience) else {
                 panic!(
                     "token issuance should reject client_id={client_id:?}, audience={audience:?}"
                 );

--- a/crates/coral-app/src/auth/session.rs
+++ b/crates/coral-app/src/auth/session.rs
@@ -96,13 +96,12 @@ impl SessionTokenIssuer {
 
     pub(crate) fn issue_access_token(
         &self,
-        provider: &str,
         subject: &str,
         client_id: &str,
         audience: &str,
     ) -> Result<IssuedAccessToken, SessionTokenError> {
-        if provider.trim().is_empty() || subject.trim().is_empty() {
-            return Err(config_error("provider and subject must not be empty"));
+        if subject.trim().is_empty() {
+            return Err(config_error("subject must not be empty"));
         }
         if client_id.trim().is_empty()
             || client_id.trim() != client_id
@@ -126,7 +125,6 @@ impl SessionTokenIssuer {
             exp: expires_at,
             iat: issued_at,
             nbf: issued_at,
-            provider: provider.to_string(),
         };
         let mut header = Header::new(SESSION_TOKEN_ALGORITHM);
         header.kid = Some(self.signing_key_id.clone());
@@ -237,7 +235,6 @@ impl SessionTokenVerifier {
             "iss",
             "jti",
             "nbf",
-            "provider",
             "sub",
         ]);
         validation.validate_nbf = true;
@@ -250,23 +247,19 @@ impl SessionTokenVerifier {
             token_id: claims.jti,
             audience: claims.aud,
             client_id: claims.client_id,
-            provider: claims.provider,
             subject: claims.sub,
         })
     }
 
     fn validate_claims(&self, claims: &SessionTokenClaims) -> Result<(), SessionTokenError> {
         let invalid = |message: &str| format!("invalid Coral access token: {message}");
-        if claims.provider.trim().is_empty()
-            || claims.sub.trim().is_empty()
+        if claims.sub.trim().is_empty()
             || claims.client_id.trim().is_empty()
             || claims.client_id.trim() != claims.client_id
             || claims.jti.trim().is_empty()
             || claims.jti.trim() != claims.jti
         {
-            return Err(invalid(
-                "provider, subject, client_id, and jti must be valid",
-            ));
+            return Err(invalid("subject, client_id, and jti must be valid"));
         }
         let now = unix_timestamp()?;
         if claims.iat > now.saturating_add(CLOCK_SKEW.as_secs()) {
@@ -356,7 +349,6 @@ pub(crate) struct ValidatedSession {
     pub(crate) token_id: String,
     pub(crate) audience: String,
     pub(crate) client_id: String,
-    pub(crate) provider: String,
     pub(crate) subject: String,
 }
 
@@ -370,7 +362,6 @@ struct SessionTokenClaims {
     exp: u64,
     iat: u64,
     nbf: u64,
-    provider: String,
 }
 
 fn normalized_or_default<'a>(value: Option<&'a str>, default: &'a str) -> &'a str {
@@ -433,7 +424,6 @@ mod tests {
             exp: now + issuer.access_token_ttl.as_secs(),
             iat: now,
             nbf: now,
-            provider: "oidc".to_string(),
         }
     }
 
@@ -500,7 +490,6 @@ mod tests {
         let verifier = issuer.verifier();
         let access = issuer
             .issue_access_token(
-                "oidc",
                 "issuer.example|opaque:subject/123",
                 CLIENT_ID,
                 MCP_AUDIENCE,
@@ -522,7 +511,6 @@ mod tests {
         assert_eq!(session.token_id, token_id);
         assert_eq!(session.audience, MCP_AUDIENCE);
         assert_eq!(session.client_id, CLIENT_ID);
-        assert_eq!(session.provider, "oidc");
         assert_eq!(session.subject, "issuer.example|opaque:subject/123");
     }
 
@@ -534,7 +522,6 @@ mod tests {
         let invalid = [
             changed(original.clone(), |c| c.iss = "other".into()),
             changed(original.clone(), |c| c.aud = "other".into()),
-            changed(original.clone(), |c| c.provider = " ".into()),
             changed(original.clone(), |c| c.sub = " ".into()),
             changed(original.clone(), |c| c.client_id = " ".into()),
             changed(original.clone(), |c| c.jti = " ".into()),
@@ -634,10 +621,10 @@ mod tests {
         let issuer = test_issuer();
         let verifier = issuer.verifier();
         let mcp = issuer
-            .issue_access_token("oidc", "user-123", "mcp-client", MCP_AUDIENCE)
+            .issue_access_token("user-123", "mcp-client", MCP_AUDIENCE)
             .unwrap();
         let bff = issuer
-            .issue_access_token("oidc", "user-123", "bff-client", BFF_AUDIENCE)
+            .issue_access_token("user-123", "bff-client", BFF_AUDIENCE)
             .unwrap();
 
         verifier
@@ -667,7 +654,7 @@ mod tests {
             (CLIENT_ID, ""),
             (CLIENT_ID, "audience "),
         ] {
-            let Err(_error) = issuer.issue_access_token("oidc", "user-123", client_id, audience)
+            let Err(_error) = issuer.issue_access_token("user-123", client_id, audience)
             else {
                 panic!(
                     "token issuance should reject client_id={client_id:?}, audience={audience:?}"
@@ -680,7 +667,7 @@ mod tests {
     fn public_jwks_support_detached_validation() {
         let issuer = test_issuer();
         let token = issuer
-            .issue_access_token("oidc", "user-123", CLIENT_ID, MCP_AUDIENCE)
+            .issue_access_token("user-123", CLIENT_ID, MCP_AUDIENCE)
             .unwrap();
         let expected = issuer
             .verifier()

--- a/crates/coral-app/src/auth/state_store.rs
+++ b/crates/coral-app/src/auth/state_store.rs
@@ -15,7 +15,6 @@ type SecretHash = [u8; 32];
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct OAuthAuthorizationSessionRecord {
-    pub(crate) provider_id: String,
     pub(crate) client_id: String,
     pub(crate) redirect_uri: String,
     pub(crate) client_state: Option<String>,
@@ -27,7 +26,6 @@ pub(crate) struct OAuthAuthorizationSessionRecord {
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct OAuthAuthorizationCodeRecord {
-    pub(crate) provider_id: String,
     pub(crate) user_id: String,
     pub(crate) client_id: String,
     pub(crate) redirect_uri: String,
@@ -244,7 +242,6 @@ mod tests {
 
     fn session(id: &str) -> OAuthAuthorizationSessionRecord {
         OAuthAuthorizationSessionRecord {
-            provider_id: "oidc".to_string(),
             client_id: "client".to_string(),
             redirect_uri: "http://127.0.0.1/callback".to_string(),
             client_state: Some(id.to_string()),
@@ -257,7 +254,6 @@ mod tests {
 
     fn code(id: &str) -> OAuthAuthorizationCodeRecord {
         OAuthAuthorizationCodeRecord {
-            provider_id: "oidc".to_string(),
             user_id: id.to_string(),
             client_id: "client".to_string(),
             redirect_uri: "http://127.0.0.1/callback".to_string(),

--- a/crates/coral-app/src/outbound_url_policy.rs
+++ b/crates/coral-app/src/outbound_url_policy.rs
@@ -14,12 +14,17 @@
 //! - [`ResourceIdentifier`] — an RFC 8707 `resource`, compared and recorded.
 //! - [`BrowserRedirect`] — an OAuth redirect target, handed to a browser.
 //!
-//! The last two describe URLs Coral never connects to, which is the distinction
-//! [`FetchablePolicy`] carries: they accept the same URLs [`Configured`] does,
-//! but no request can be built from them. That is why a value a remote party
-//! controls may be checked under one of them and must not be checked under
-//! [`Configured`], whose permissiveness about private and loopback hosts is
-//! sound only because an operator chose the value.
+//! The last two describe URLs Coral never connects to. [`FetchablePolicy`] marks
+//! the distinction: the fetch helpers [`EndpointUrl::get`] and
+//! [`EndpointUrl::post`] exist only for the policies whose URLs Coral is meant to
+//! request. That is an intent signal, not a barrier — an [`EndpointUrl<P>`]
+//! certifies its URL passed `P`'s checks; it does not stop a caller from building
+//! a request out of the underlying [`Url`]. What keeps a compared-or-redirected
+//! URL from becoming an outbound request is that no call site fetches one. A
+//! remote party's value may still be checked under one of the non-fetchable
+//! policies but must not be checked under [`Configured`], whose permissiveness
+//! about private and loopback hosts is sound only because an operator chose the
+//! value.
 
 #![cfg_attr(
     not(test),
@@ -331,8 +336,10 @@ impl FetchablePolicy for PublicMetadata {}
 /// What makes that sound is not the permissiveness of the rule but where the
 /// value goes. A canonicalized resource is compared against an allowlist an
 /// operator authored, and only a value proven equal to one of those is stored or
-/// used. Loopback HTTP and private HTTPS therefore never become an outbound
-/// request, and this policy withholds [`FetchablePolicy`] so they cannot.
+/// used. Loopback HTTP and private HTTPS are therefore never fetched — not
+/// because the type forbids it (a [`Url`] can always be requested) but because no
+/// caller fetches a resource identifier. Withholding [`FetchablePolicy`] records
+/// that intent by leaving the fetch helpers absent; it does not enforce it.
 pub(crate) struct ResourceIdentifier;
 
 impl UrlPolicy for ResourceIdentifier {

--- a/crates/coral-app/src/outbound_url_policy.rs
+++ b/crates/coral-app/src/outbound_url_policy.rs
@@ -1,10 +1,25 @@
-//! Outbound URL policies for configured endpoints, discovery, and untrusted metadata.
+//! Outbound URL policies for configured endpoints, discovery, untrusted
+//! metadata, and URLs Coral never fetches.
 //!
-//! These policies are intentionally separate. Operator-configured endpoints may
-//! use HTTPS anywhere or plain HTTP on an explicit loopback host. Provider
-//! discovery may use loopback HTTP only when the configured issuer does. URLs
-//! supplied by an untrusted client must instead identify a public HTTPS resource
-//! and use a DNS resolver that rejects non-public answers.
+//! Every URL here is an [`EndpointUrl<P>`], where `P` names the policy it was
+//! checked under. The policies are intentionally separate, and the type
+//! parameter is what keeps them from being interchanged:
+//!
+//! - [`Configured`] — operator-authored. HTTPS anywhere, or plain HTTP on an
+//!   explicit loopback host.
+//! - [`Discovered`] — from a provider's discovery document. Loopback HTTP only
+//!   when the configured issuer already uses it.
+//! - [`PublicMetadata`] — supplied by an untrusted client and fetched. Public
+//!   HTTPS only, with a DNS resolver that rejects non-public answers.
+//! - [`ResourceIdentifier`] — an RFC 8707 `resource`, compared and recorded.
+//! - [`BrowserRedirect`] — an OAuth redirect target, handed to a browser.
+//!
+//! The last two describe URLs Coral never connects to, which is the distinction
+//! [`FetchablePolicy`] carries: they accept the same URLs [`Configured`] does,
+//! but no request can be built from them. That is why a value a remote party
+//! controls may be checked under one of them and must not be checked under
+//! [`Configured`], whose permissiveness about private and loopback hosts is
+//! sound only because an operator chose the value.
 
 #![cfg_attr(
     not(test),
@@ -15,6 +30,7 @@
 )]
 
 use std::fmt;
+use std::marker::PhantomData;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::Duration;
 
@@ -27,6 +43,139 @@ use crate::bootstrap::is_loopback_ip;
 /// Timeout applied to public metadata connections and complete requests.
 pub(crate) const PUBLIC_METADATA_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// A URL validated under the outbound-URL policy `P`.
+///
+/// The policy is a type parameter rather than a separate wrapper per profile so
+/// that the affordances a policy grants can be gated on the policy itself: only
+/// a [`FetchablePolicy`] can build a request, and only a [`ParsedUrlPolicy`] can
+/// be applied to a URL that has already been through [`Url::parse`]. A caller
+/// that reaches for the wrong one does not compile.
+///
+/// The marker is held as `PhantomData<fn() -> P>` rather than `PhantomData<P>`:
+/// these values are carried across `await` points in spawned request handlers,
+/// and the function-pointer form keeps `EndpointUrl<P>` `Send` and `Sync`
+/// whatever the marker is.
+pub(crate) struct EndpointUrl<P>(Url, PhantomData<fn() -> P>);
+
+/// A named outbound-URL policy.
+pub(crate) trait UrlPolicy {
+    /// The name this policy renders under in [`fmt::Debug`].
+    const NAME: &'static str;
+
+    /// The error a URL of an unacceptable transport is rejected with.
+    ///
+    /// Each policy keeps its own variant so the message names the thing the
+    /// operator or client actually supplied.
+    fn transport_error() -> OutboundUrlPolicyError;
+}
+
+/// A policy that needs no context beyond the URL to decide.
+///
+/// [`Discovered`] is deliberately not one: it can only be applied relative to a
+/// configured issuer, so `EndpointUrl<Discovered>` carries its own `parse`
+/// taking one.
+pub(crate) trait SelfContainedPolicy: UrlPolicy {
+    /// Checks applied to the raw string, before [`Url::parse`] normalizes it.
+    ///
+    /// Accepting everything is the right default: only [`PublicMetadata`] has a
+    /// check the parser would erase before it could run.
+    fn check_raw(_value: &str) -> Result<(), OutboundUrlPolicyError> {
+        Ok(())
+    }
+
+    /// Checks applied to the parsed URL.
+    fn check(url: &Url) -> Result<(), OutboundUrlPolicyError>;
+}
+
+/// A policy whose checks are complete against an already-parsed [`Url`].
+///
+/// [`PublicMetadata`] is deliberately not one. Its traversal checks read the raw
+/// string, because [`Url::parse`] resolves `..` away and leaves nothing to find;
+/// a `from_parsed` entry point for it would silently skip them. Keeping that
+/// entry point on this trait turns the mistake into a compile error rather than
+/// a policy that quietly stops applying.
+pub(crate) trait ParsedUrlPolicy: SelfContainedPolicy {}
+
+/// A policy whose URLs Coral may itself issue a request to.
+///
+/// A profile that both fetches and permits a private or loopback host is sound
+/// only because of where the URL came from. A policy that omits this marker
+/// describes a URL Coral only ever compares, stores, or hands to a browser, and
+/// [`EndpointUrl::get`] and [`EndpointUrl::post`] do not exist for it.
+pub(crate) trait FetchablePolicy: UrlPolicy {}
+
+impl<P: UrlPolicy> EndpointUrl<P> {
+    /// Returns the validated URL.
+    pub(crate) fn as_url(&self) -> &Url {
+        &self.0
+    }
+
+    /// Consumes this wrapper and returns the validated URL.
+    pub(crate) fn into_url(self) -> Url {
+        self.0
+    }
+}
+
+impl<P: SelfContainedPolicy> EndpointUrl<P> {
+    /// Applies the policy to a URL supplied as a string.
+    pub(crate) fn parse(value: &str) -> Result<Self, OutboundUrlPolicyError> {
+        P::check_raw(value)?;
+        let url = Url::parse(value).map_err(OutboundUrlPolicyError::InvalidUrl)?;
+        P::check(&url)?;
+        Ok(Self(url, PhantomData))
+    }
+}
+
+impl<P: ParsedUrlPolicy> EndpointUrl<P> {
+    /// Applies the policy to an already-parsed URL.
+    ///
+    /// The checks are the same ones [`parse`](Self::parse) runs; this entry
+    /// point exists for a caller that already needed the [`Url`] — parsing with
+    /// a syntax-violation callback, say — and would otherwise parse it twice.
+    pub(crate) fn from_parsed(url: Url) -> Result<Self, OutboundUrlPolicyError> {
+        P::check(&url)?;
+        Ok(Self(url, PhantomData))
+    }
+}
+
+impl<P: FetchablePolicy> EndpointUrl<P> {
+    /// Starts a `GET` to this endpoint.
+    pub(crate) fn get(&self, http: &reqwest::Client) -> reqwest::RequestBuilder {
+        http.get(self.0.clone())
+    }
+
+    /// Starts a `POST` to this endpoint.
+    pub(crate) fn post(&self, http: &reqwest::Client) -> reqwest::RequestBuilder {
+        http.post(self.0.clone())
+    }
+}
+
+// `Clone`, `PartialEq`, and `Eq` are written out rather than derived: a derive
+// bounds each impl on `P`, and the markers implement none of these, so no
+// `EndpointUrl` would either.
+impl<P> Clone for EndpointUrl<P> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<P> PartialEq for EndpointUrl<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<P> Eq for EndpointUrl<P> {}
+
+impl<P: UrlPolicy> fmt::Debug for EndpointUrl<P> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple(P::NAME)
+            .field(&RedactedUrl(&self.0))
+            .finish()
+    }
+}
+
 /// A configured endpoint that is safe for credential-bearing requests.
 ///
 /// # Trust
@@ -35,104 +184,74 @@ pub(crate) const PUBLIC_METADATA_TIMEOUT: Duration = Duration::from_secs(5);
 /// private one, with no check on what the host resolves to. Both are sound only
 /// for a value an operator authored — a config file or environment variable.
 ///
-/// Do not build one from a value a remote party controls. Use
-/// [`DiscoveredEndpointUrl`] for endpoints supplied by an `OpenID` Connect
-/// discovery document.
-#[derive(Clone, PartialEq, Eq)]
-pub(crate) struct ConfiguredEndpointUrl(Url);
+/// Do not build one from a value a remote party controls. Use [`Discovered`] for
+/// endpoints supplied by an `OpenID` Connect discovery document,
+/// [`PublicMetadata`] for a client-supplied URL Coral fetches, and
+/// [`ResourceIdentifier`] or [`BrowserRedirect`] for one it never requests.
+pub(crate) struct Configured;
 
-impl ConfiguredEndpointUrl {
-    /// Parses an HTTPS endpoint or an explicit loopback HTTP endpoint.
-    pub(crate) fn parse(value: &str) -> Result<Self, OutboundUrlPolicyError> {
-        Self::from_parsed(Url::parse(value).map_err(OutboundUrlPolicyError::InvalidUrl)?)
-    }
+impl UrlPolicy for Configured {
+    const NAME: &'static str = "EndpointUrl<Configured>";
 
-    /// Applies the profile to an already-parsed URL.
-    ///
-    /// The checks are the same ones [`parse`](Self::parse) runs; this entry
-    /// point exists for a caller that already needed the [`Url`] — parsing with
-    /// a syntax-violation callback, say — and would otherwise parse it twice.
-    pub(crate) fn from_parsed(url: Url) -> Result<Self, OutboundUrlPolicyError> {
-        check_endpoint_url(&url)?;
-        match url.scheme() {
-            "https" => Ok(Self(url)),
-            "http" if is_explicit_loopback(&url) => Ok(Self(url)),
-            _ => Err(OutboundUrlPolicyError::ConfiguredEndpointTransport),
-        }
-    }
-
-    /// Returns the validated URL.
-    pub(crate) fn as_url(&self) -> &Url {
-        &self.0
-    }
-
-    /// Consumes this wrapper and returns the validated URL.
-    pub(crate) fn into_url(self) -> Url {
-        self.0
+    fn transport_error() -> OutboundUrlPolicyError {
+        OutboundUrlPolicyError::ConfiguredEndpointTransport
     }
 }
 
-impl fmt::Debug for ConfiguredEndpointUrl {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_tuple("ConfiguredEndpointUrl")
-            .field(&RedactedUrl(&self.0))
-            .finish()
+impl SelfContainedPolicy for Configured {
+    fn check(url: &Url) -> Result<(), OutboundUrlPolicyError> {
+        check_https_or_explicit_loopback::<Self>(url)
     }
 }
+
+impl ParsedUrlPolicy for Configured {}
+
+impl FetchablePolicy for Configured {}
 
 /// A remotely discovered provider endpoint safe for credential-bearing requests.
 ///
 /// HTTPS may target any host, including a private one. Plain HTTP is restricted
 /// to an explicit loopback endpoint and is accepted only when the
 /// operator-configured issuer also uses loopback HTTP.
-#[derive(Clone, PartialEq, Eq)]
-pub(crate) struct DiscoveredEndpointUrl(Url);
+pub(crate) struct Discovered;
 
-impl DiscoveredEndpointUrl {
+impl UrlPolicy for Discovered {
+    const NAME: &'static str = "EndpointUrl<Discovered>";
+
+    fn transport_error() -> OutboundUrlPolicyError {
+        OutboundUrlPolicyError::DiscoveredEndpointTransport
+    }
+}
+
+impl FetchablePolicy for Discovered {}
+
+impl EndpointUrl<Discovered> {
     /// Parses an endpoint under the trust policy established by `issuer`.
+    ///
+    /// This is an inherent constructor rather than a [`SelfContainedPolicy`]
+    /// impl because the decision needs the issuer. Taking it as an
+    /// [`EndpointUrl<Configured>`] makes "a discovered endpoint is only
+    /// meaningful relative to an operator-configured issuer" a fact the type
+    /// system carries, and adding the trait impl later would collide with this
+    /// method rather than quietly offering a context-free parse.
     pub(crate) fn parse(
         value: &str,
-        issuer: &ConfiguredEndpointUrl,
+        issuer: &EndpointUrl<Configured>,
     ) -> Result<Self, OutboundUrlPolicyError> {
-        let url = parse_endpoint(value)?;
+        let url = Url::parse(value).map_err(OutboundUrlPolicyError::InvalidUrl)?;
+        check_shape(&url)?;
         match url.scheme() {
-            "https" => Ok(Self(url)),
+            "https" => Ok(Self(url, PhantomData)),
             "http" if issuer.as_url().scheme() == "http" && is_explicit_loopback(&url) => {
-                Ok(Self(url))
+                Ok(Self(url, PhantomData))
             }
-            _ => Err(OutboundUrlPolicyError::DiscoveredEndpointTransport),
+            _ => Err(Discovered::transport_error()),
         }
     }
-
-    /// Returns the validated URL.
-    pub(crate) fn as_url(&self) -> &Url {
-        &self.0
-    }
-
-    /// Consumes this wrapper and returns the validated URL.
-    pub(crate) fn into_url(self) -> Url {
-        self.0
-    }
-}
-
-impl fmt::Debug for DiscoveredEndpointUrl {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_tuple("DiscoveredEndpointUrl")
-            .field(&RedactedUrl(&self.0))
-            .finish()
-    }
-}
-
-fn parse_endpoint(value: &str) -> Result<Url, OutboundUrlPolicyError> {
-    let url = Url::parse(value).map_err(OutboundUrlPolicyError::InvalidUrl)?;
-    check_endpoint_url(&url)?;
-    Ok(url)
 }
 
 /// Rejects an endpoint URL that no profile accepts, whatever its scheme.
-fn check_endpoint_url(url: &Url) -> Result<(), OutboundUrlPolicyError> {
+fn check_shape(url: &Url) -> Result<(), OutboundUrlPolicyError> {
     if url.host().is_none() {
         return Err(OutboundUrlPolicyError::MissingHost);
     }
@@ -145,57 +264,123 @@ fn check_endpoint_url(url: &Url) -> Result<(), OutboundUrlPolicyError> {
     Ok(())
 }
 
-/// An attacker-controlled metadata URL validated for public HTTPS fetching.
-#[derive(Clone, PartialEq, Eq)]
-pub(crate) struct PublicMetadataUrl(Url);
+/// The transport rule [`Configured`], [`ResourceIdentifier`], and
+/// [`BrowserRedirect`] share.
+///
+/// HTTPS reaches any host, including a private one; plain HTTP is confined to an
+/// explicit loopback address. The three policies that share it differ in whether
+/// Coral connects to the result, not in which URLs they accept, so the rule is
+/// written once and the rejection is reported under the caller's own policy.
+fn check_https_or_explicit_loopback<P: UrlPolicy>(url: &Url) -> Result<(), OutboundUrlPolicyError> {
+    check_shape(url)?;
+    match url.scheme() {
+        "https" => Ok(()),
+        "http" if is_explicit_loopback(url) => Ok(()),
+        _ => Err(P::transport_error()),
+    }
+}
 
-impl PublicMetadataUrl {
-    /// Parses a public HTTPS metadata URL with a non-root, traversal-free path.
-    pub(crate) fn parse(value: &str) -> Result<Self, OutboundUrlPolicyError> {
+/// An attacker-controlled metadata URL validated for public HTTPS fetching.
+pub(crate) struct PublicMetadata;
+
+impl UrlPolicy for PublicMetadata {
+    const NAME: &'static str = "EndpointUrl<PublicMetadata>";
+
+    fn transport_error() -> OutboundUrlPolicyError {
+        OutboundUrlPolicyError::PublicMetadataTransport
+    }
+}
+
+impl SelfContainedPolicy for PublicMetadata {
+    fn check_raw(value: &str) -> Result<(), OutboundUrlPolicyError> {
         if has_dot_path_segment(value) {
             return Err(OutboundUrlPolicyError::DotPathSegment);
         }
         if has_encoded_path_separator(value) {
             return Err(OutboundUrlPolicyError::EncodedPathSeparator);
         }
-        let url = Url::parse(value).map_err(OutboundUrlPolicyError::InvalidUrl)?;
+        Ok(())
+    }
+
+    fn check(url: &Url) -> Result<(), OutboundUrlPolicyError> {
         if url.scheme() != "https" {
-            return Err(OutboundUrlPolicyError::PublicMetadataTransport);
+            return Err(Self::transport_error());
         }
         if url.path().is_empty() || url.path() == "/" {
             return Err(OutboundUrlPolicyError::MetadataPathRequired);
         }
-        if !url.username().is_empty() || url.password().is_some() {
-            return Err(OutboundUrlPolicyError::CredentialsNotAllowed);
-        }
-        if url.fragment().is_some() {
-            return Err(OutboundUrlPolicyError::FragmentNotAllowed);
-        }
-        if public_metadata_host_is_blocked(&url) {
+        check_shape(url)?;
+        if public_metadata_host_is_blocked(url) {
             return Err(OutboundUrlPolicyError::NonPublicHost);
         }
-        Ok(Self(url))
-    }
-
-    /// Returns the validated URL.
-    pub(crate) fn as_url(&self) -> &Url {
-        &self.0
-    }
-
-    /// Consumes this wrapper and returns the validated URL.
-    pub(crate) fn into_url(self) -> Url {
-        self.0
+        Ok(())
     }
 }
 
-impl fmt::Debug for PublicMetadataUrl {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_tuple("PublicMetadataUrl")
-            .field(&RedactedUrl(&self.0))
-            .finish()
+impl FetchablePolicy for PublicMetadata {}
+
+/// A resource identifier Coral compares and records but never requests.
+///
+/// # Trust
+///
+/// This is the profile for an RFC 8707 `resource` parameter and for the
+/// operator-configured resources it is matched against. Its transport rule is
+/// [`Configured`]'s, but its trust claim is not, and that is the whole point of
+/// separating them: a value under this policy may come from a remote party.
+///
+/// What makes that sound is not the permissiveness of the rule but where the
+/// value goes. A canonicalized resource is compared against an allowlist an
+/// operator authored, and only a value proven equal to one of those is stored or
+/// used. Loopback HTTP and private HTTPS therefore never become an outbound
+/// request, and this policy withholds [`FetchablePolicy`] so they cannot.
+pub(crate) struct ResourceIdentifier;
+
+impl UrlPolicy for ResourceIdentifier {
+    const NAME: &'static str = "EndpointUrl<ResourceIdentifier>";
+
+    fn transport_error() -> OutboundUrlPolicyError {
+        OutboundUrlPolicyError::ResourceIdentifierTransport
     }
 }
+
+impl SelfContainedPolicy for ResourceIdentifier {
+    fn check(url: &Url) -> Result<(), OutboundUrlPolicyError> {
+        check_https_or_explicit_loopback::<Self>(url)
+    }
+}
+
+impl ParsedUrlPolicy for ResourceIdentifier {}
+
+/// A redirect target Coral hands to a browser but never requests itself.
+///
+/// # Trust
+///
+/// A registered OAuth redirect URI arrives from a client's metadata document, so
+/// it is remote input, and it ends up in a `Location` header — the browser
+/// connects to it, Coral does not. HTTPS reaches any host, and plain HTTP is
+/// confined to an explicit loopback address, which is how a native client
+/// receives its callback.
+///
+/// Withholding [`FetchablePolicy`] is what distinguishes this from
+/// [`Configured`]: the two accept the same URLs, but only one of them describes
+/// something Coral will connect to with credentials.
+pub(crate) struct BrowserRedirect;
+
+impl UrlPolicy for BrowserRedirect {
+    const NAME: &'static str = "EndpointUrl<BrowserRedirect>";
+
+    fn transport_error() -> OutboundUrlPolicyError {
+        OutboundUrlPolicyError::BrowserRedirectTransport
+    }
+}
+
+impl SelfContainedPolicy for BrowserRedirect {
+    fn check(url: &Url) -> Result<(), OutboundUrlPolicyError> {
+        check_https_or_explicit_loopback::<Self>(url)
+    }
+}
+
+impl ParsedUrlPolicy for BrowserRedirect {}
 
 struct RedactedUrl<'a>(&'a Url);
 
@@ -233,6 +418,12 @@ pub(crate) enum OutboundUrlPolicyError {
     /// Public metadata did not use HTTPS.
     #[error("public metadata URL must use HTTPS")]
     PublicMetadataTransport,
+    /// A resource identifier did not use HTTPS or explicit loopback HTTP.
+    #[error("resource identifier must use HTTPS or explicit loopback HTTP")]
+    ResourceIdentifierTransport,
+    /// A redirect target used a transport a browser must not be sent to.
+    #[error("redirect URI must use HTTPS or explicit loopback HTTP")]
+    BrowserRedirectTransport,
     /// Public metadata did not identify a document path.
     #[error("public metadata URL must include a non-root path")]
     MetadataPathRequired,
@@ -270,9 +461,10 @@ pub(crate) enum OutboundUrlPolicyError {
 
 /// Builds an HTTP client for attacker-controlled public metadata URLs.
 ///
-/// The caller must still construct requests from [`PublicMetadataUrl`]. The
-/// resolver rejects a hostname if any returned address is non-public, which
-/// prevents mixed-answer DNS rebinding from selecting a private destination.
+/// The caller must still construct requests from an
+/// [`EndpointUrl<PublicMetadata>`]. The resolver rejects a hostname if any
+/// returned address is non-public, which prevents mixed-answer DNS rebinding
+/// from selecting a private destination.
 pub(crate) fn public_metadata_http_client() -> Result<reqwest::Client, OutboundUrlPolicyError> {
     reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
@@ -536,9 +728,9 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::{
-        ConfiguredEndpointUrl, DiscoveredEndpointUrl, OutboundUrlPolicyError, PublicMetadataUrl,
-        append_bounded_chunk, public_metadata_http_client, public_metadata_ip_is_blocked,
-        read_bounded_body, validate_public_resolution,
+        BrowserRedirect, Configured, Discovered, EndpointUrl, OutboundUrlPolicyError,
+        PublicMetadata, ResourceIdentifier, append_bounded_chunk, public_metadata_http_client,
+        public_metadata_ip_is_blocked, read_bounded_body, validate_public_resolution,
     };
 
     #[test]
@@ -554,7 +746,7 @@ mod tests {
             // auth URL validator accepts.
             "http://[::ffff:127.0.0.1]:14554/callback",
         ] {
-            ConfiguredEndpointUrl::parse(endpoint).expect(endpoint);
+            EndpointUrl::<Configured>::parse(endpoint).expect(endpoint);
         }
     }
 
@@ -565,14 +757,14 @@ mod tests {
     #[test]
     fn loopback_name_rules_differ_between_profiles() {
         assert!(matches!(
-            ConfiguredEndpointUrl::parse("http://keycloak.localhost:8080/realms/coral"),
+            EndpointUrl::<Configured>::parse("http://keycloak.localhost:8080/realms/coral"),
             Err(OutboundUrlPolicyError::ConfiguredEndpointTransport)
         ));
-        ConfiguredEndpointUrl::parse("https://keycloak.localhost:8443/realms/coral")
+        EndpointUrl::<Configured>::parse("https://keycloak.localhost:8443/realms/coral")
             .expect("https reaches any host");
 
         assert!(matches!(
-            PublicMetadataUrl::parse("https://keycloak.localhost/oauth/client.json"),
+            EndpointUrl::<PublicMetadata>::parse("https://keycloak.localhost/oauth/client.json"),
             Err(OutboundUrlPolicyError::NonPublicHost)
         ));
     }
@@ -586,23 +778,70 @@ mod tests {
             "ftp://localhost/oauth",
         ] {
             assert!(matches!(
-                ConfiguredEndpointUrl::parse(endpoint),
+                EndpointUrl::<Configured>::parse(endpoint),
                 Err(OutboundUrlPolicyError::ConfiguredEndpointTransport)
             ));
         }
 
         assert!(matches!(
-            ConfiguredEndpointUrl::parse("https://user:password@login.example.test/oauth"),
+            EndpointUrl::<Configured>::parse("https://user:password@login.example.test/oauth"),
             Err(OutboundUrlPolicyError::CredentialsNotAllowed)
         ));
+    }
+
+    /// The two policies Coral never connects to accept exactly what
+    /// [`Configured`] accepts; what separates them is the absence of
+    /// [`FetchablePolicy`], not a narrower set of URLs. Checking all three against
+    /// the same inputs pins that: a later divergence has to break this test
+    /// deliberately.
+    #[test]
+    fn policies_coral_never_fetches_share_the_configured_transport_rule() {
+        for endpoint in [
+            "https://service.example.test/oauth",
+            "https://10.0.0.8/oauth",
+            "http://localhost:14554/callback",
+            "http://[::ffff:127.0.0.1]:14554/callback",
+        ] {
+            EndpointUrl::<Configured>::parse(endpoint).expect(endpoint);
+            EndpointUrl::<ResourceIdentifier>::parse(endpoint).expect(endpoint);
+            EndpointUrl::<BrowserRedirect>::parse(endpoint).expect(endpoint);
+        }
+
+        for endpoint in [
+            "http://service.example.test/oauth",
+            "http://localhost.example.test/oauth",
+            "ftp://localhost/oauth",
+        ] {
+            assert!(matches!(
+                EndpointUrl::<Configured>::parse(endpoint),
+                Err(OutboundUrlPolicyError::ConfiguredEndpointTransport)
+            ));
+            assert!(matches!(
+                EndpointUrl::<ResourceIdentifier>::parse(endpoint),
+                Err(OutboundUrlPolicyError::ResourceIdentifierTransport)
+            ));
+            assert!(matches!(
+                EndpointUrl::<BrowserRedirect>::parse(endpoint),
+                Err(OutboundUrlPolicyError::BrowserRedirectTransport)
+            ));
+        }
+
+        for endpoint in [
+            "https://user:password@login.example.test/oauth",
+            "https://login.example.test/oauth#fragment",
+        ] {
+            EndpointUrl::<ResourceIdentifier>::parse(endpoint).expect_err(endpoint);
+            EndpointUrl::<BrowserRedirect>::parse(endpoint).expect_err(endpoint);
+        }
     }
 
     #[test]
     fn discovered_endpoints_bind_loopback_http_to_loopback_http_issuers() {
         let remote_issuer =
-            ConfiguredEndpointUrl::parse("https://accounts.example.test/tenant").expect("issuer");
+            EndpointUrl::<Configured>::parse("https://accounts.example.test/tenant")
+                .expect("issuer");
         let loopback_issuer =
-            ConfiguredEndpointUrl::parse("http://127.0.0.1:9080/tenant").expect("issuer");
+            EndpointUrl::<Configured>::parse("http://127.0.0.1:9080/tenant").expect("issuer");
 
         for endpoint in [
             "http://localhost:14554/authorize",
@@ -610,10 +849,10 @@ mod tests {
             "http://[::1]:14554/jwks",
         ] {
             assert!(matches!(
-                DiscoveredEndpointUrl::parse(endpoint, &remote_issuer),
+                EndpointUrl::<Discovered>::parse(endpoint, &remote_issuer),
                 Err(OutboundUrlPolicyError::DiscoveredEndpointTransport)
             ));
-            DiscoveredEndpointUrl::parse(endpoint, &loopback_issuer)
+            EndpointUrl::<Discovered>::parse(endpoint, &loopback_issuer)
                 .expect("loopback issuer permits loopback endpoint");
         }
 
@@ -621,38 +860,43 @@ mod tests {
             "https://accounts.example.test/authorize",
             "https://10.0.0.8/token",
         ] {
-            DiscoveredEndpointUrl::parse(endpoint, &remote_issuer)
+            EndpointUrl::<Discovered>::parse(endpoint, &remote_issuer)
                 .expect("HTTPS reaches public or private providers");
         }
 
         assert!(matches!(
-            DiscoveredEndpointUrl::parse("http://accounts.example.test/token", &loopback_issuer),
+            EndpointUrl::<Discovered>::parse(
+                "http://accounts.example.test/token",
+                &loopback_issuer
+            ),
             Err(OutboundUrlPolicyError::DiscoveredEndpointTransport)
         ));
     }
 
     #[test]
     fn validated_wrappers_expose_their_inner_urls() {
-        let configured = ConfiguredEndpointUrl::parse("https://login.example.test/oauth")
+        let configured = EndpointUrl::<Configured>::parse("https://login.example.test/oauth")
             .expect("configured endpoint");
         assert_eq!(configured.as_url().host_str(), Some("login.example.test"));
         assert_eq!(configured.into_url().path(), "/oauth");
 
-        let metadata = PublicMetadataUrl::parse("https://client.example.test/oauth/client.json")
-            .expect("metadata URL");
+        let metadata =
+            EndpointUrl::<PublicMetadata>::parse("https://client.example.test/oauth/client.json")
+                .expect("metadata URL");
         assert_eq!(metadata.as_url().host_str(), Some("client.example.test"));
         assert_eq!(metadata.into_url().path(), "/oauth/client.json");
     }
 
     #[test]
     fn validated_url_debug_output_redacts_paths_and_queries() {
-        let configured = ConfiguredEndpointUrl::parse(
+        let configured = EndpointUrl::<Configured>::parse(
             "https://login.example.test/tenant/secret?client_secret=hidden",
         )
         .expect("configured endpoint");
-        let metadata =
-            PublicMetadataUrl::parse("https://client.example.test/oauth/client.json?token=hidden")
-                .expect("metadata URL");
+        let metadata = EndpointUrl::<PublicMetadata>::parse(
+            "https://client.example.test/oauth/client.json?token=hidden",
+        )
+        .expect("metadata URL");
 
         for rendered in [format!("{configured:?}"), format!("{metadata:?}")] {
             assert!(rendered.contains("/<redacted>"));
@@ -660,12 +904,19 @@ mod tests {
             assert!(!rendered.contains("hidden"));
             assert!(!rendered.contains("client.json"));
         }
+
+        // One generic impl renders every policy, so the rendered name is the only
+        // thing distinguishing them in a log.
+        assert!(format!("{configured:?}").starts_with("EndpointUrl<Configured>"));
+        assert!(format!("{metadata:?}").starts_with("EndpointUrl<PublicMetadata>"));
     }
 
     #[test]
     fn public_metadata_requires_document_shaped_https_url() {
-        PublicMetadataUrl::parse("https://client.example.test/oauth/client.json?version=1")
-            .expect("public metadata URL");
+        EndpointUrl::<PublicMetadata>::parse(
+            "https://client.example.test/oauth/client.json?version=1",
+        )
+        .expect("public metadata URL");
 
         for metadata_url in [
             "http://client.example.test/oauth/client.json",
@@ -677,7 +928,7 @@ mod tests {
             "https://client.example.test/oauth/%2e%2e/client.json",
             "https://client.example.test/oauth\\..\\client.json",
         ] {
-            PublicMetadataUrl::parse(metadata_url).expect_err(metadata_url);
+            EndpointUrl::<PublicMetadata>::parse(metadata_url).expect_err(metadata_url);
         }
     }
 
@@ -696,14 +947,14 @@ mod tests {
         ] {
             assert!(
                 matches!(
-                    PublicMetadataUrl::parse(metadata_url),
+                    EndpointUrl::<PublicMetadata>::parse(metadata_url),
                     Err(OutboundUrlPolicyError::DotPathSegment)
                 ),
                 "{metadata_url}"
             );
         }
 
-        PublicMetadataUrl::parse("https://client.example.test/oauth/client.json")
+        EndpointUrl::<PublicMetadata>::parse("https://client.example.test/oauth/client.json")
             .expect("a traversal-free path is unaffected");
     }
 
@@ -721,7 +972,7 @@ mod tests {
         ] {
             assert!(
                 matches!(
-                    PublicMetadataUrl::parse(metadata_url),
+                    EndpointUrl::<PublicMetadata>::parse(metadata_url),
                     Err(OutboundUrlPolicyError::EncodedPathSeparator)
                 ),
                 "{metadata_url}"
@@ -729,8 +980,10 @@ mod tests {
         }
 
         // An encoded separator past the path delimiter is data, not structure.
-        PublicMetadataUrl::parse("https://client.example.test/oauth/client.json?next=%2fhome")
-            .expect("encoded separator in the query is unaffected");
+        EndpointUrl::<PublicMetadata>::parse(
+            "https://client.example.test/oauth/client.json?next=%2fhome",
+        )
+        .expect("encoded separator in the query is unaffected");
     }
 
     #[test]
@@ -754,7 +1007,7 @@ mod tests {
             "240.0.0.1",
         ] {
             let url = format!("https://{host}/oauth/client.json");
-            PublicMetadataUrl::parse(&url).expect_err(&url);
+            EndpointUrl::<PublicMetadata>::parse(&url).expect_err(&url);
         }
     }
 
@@ -786,7 +1039,7 @@ mod tests {
             "100:0:0:1::1",     // 100:0:0:1::/64 dummy prefix
         ] {
             let url = format!("https://[{host}]/oauth/client.json");
-            PublicMetadataUrl::parse(&url).expect_err(&url);
+            EndpointUrl::<PublicMetadata>::parse(&url).expect_err(&url);
         }
     }
 
@@ -802,7 +1055,7 @@ mod tests {
             "100:0:0:2::1", // just above the dummy prefix
         ] {
             let url = format!("https://[{host}]/oauth/client.json");
-            PublicMetadataUrl::parse(&url).expect(&url);
+            EndpointUrl::<PublicMetadata>::parse(&url).expect(&url);
         }
     }
 
@@ -812,7 +1065,7 @@ mod tests {
             "https://93.184.216.34/oauth/client.json",
             "https://[2606:4700:4700::1111]/oauth/client.json",
         ] {
-            PublicMetadataUrl::parse(url).expect(url);
+            EndpointUrl::<PublicMetadata>::parse(url).expect(url);
         }
     }
 


### PR DESCRIPTION
## Stack context

**Whole stack:** This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.

**This part of the stack:** PR #1639 establishes trusted provider identities, this PR validates the client's initial authorization request and redirects the browser upstream, and PR #1641 handles the provider's callback.

**This PR:** Adds the `GET /oauth/authorize` endpoint and saves the information needed to verify the rest of the login.

## Intent

Before sending a browser to an identity provider, Coral must know that the client and callback are allowed, that the request targets this Coral server, and that the client supplied a valid PKCE proof.

## What it enables

- Bounds the query size, parameter count, names, and values, and rejects duplicate parameters.
- Requires an exact approved client and redirect-URI match before redirecting errors back to the client.
- Supports only the authorization-code flow with PKCE S256.
- Requires a `resource` that names this Coral server.
- Rejects any requested `scope`. This server advertises no `scopes_supported`, so a compliant client omits the parameter.
- Creates the upstream provider request and stores a single-use record containing the client, callback, PKCE challenge, resource, provider, provider nonce, and provider PKCE verifier.
- Redirects the browser upstream only after that record has been saved.

This layer intentionally has no production source of approved clients yet. A later PR connects the endpoint to Client ID Metadata Documents.

## Usage examples

In the completed stack, a web app's backend-for-frontend (BFF) starts login with a request shaped like:

```text
GET /oauth/authorize
  ?response_type=code
  &client_id=https://client.example/oauth-client.json
  &redirect_uri=https://client.example/oauth/callback
  &resource=https://coral.example/mcp
  &code_challenge=<S256 challenge>
  &code_challenge_method=S256
  &state=<client state>
```

At this point in the stack, tests provide the approved client entry. Production client lookup is added later.
