### PR TITLE
feat(app): complete upstream OIDC callbacks

### DIFF
--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -15,6 +15,7 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use url::Position;
 
+use super::OIDC_CALLBACK_PATH;
 use super::config::{AuthSettings, ResolvedAuthSettings, signing_key_env_error};
 use super::error::AuthServerError;
 use super::provider_client::OidcProviderClient;
@@ -129,7 +130,7 @@ impl CoralAuthorizationServer {
                 get(authorization_server_metadata),
             )
             .route("/oauth/authorize", get(authorize::oauth_authorize))
-            .route("/auth/oidc/callback", get(callback::oidc_callback))
+            .route(OIDC_CALLBACK_PATH, get(callback::oidc_callback))
             .with_state(state);
         let listener =
             TcpListener::bind(bind_addr)

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -25,6 +25,8 @@ use crate::outbound_url_policy::{EndpointUrl, ResourceIdentifier};
 
 mod authorize;
 mod callback;
+mod query;
+mod response;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -23,6 +23,7 @@ use super::state_store::{InMemoryStateStore, StateStore};
 use crate::outbound_url_policy::{EndpointUrl, ResourceIdentifier};
 
 mod authorize;
+mod callback;
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -128,6 +129,7 @@ impl CoralAuthorizationServer {
                 get(authorization_server_metadata),
             )
             .route("/oauth/authorize", get(authorize::oauth_authorize))
+            .route("/auth/oidc/callback", get(callback::oidc_callback))
             .with_state(state);
         let listener =
             TcpListener::bind(bind_addr)

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -112,7 +112,10 @@ impl CoralAuthorizationServer {
     /// Starts the HTTP listener.
     ///
     /// The server is intended to run on loopback or behind a TLS-terminating
-    /// reverse proxy.
+    /// reverse proxy that forwards at the origin root. Every endpoint is served
+    /// and advertised relative to `auth.authorization_server.issuer`, which must
+    /// mount at the root, so a proxy that adds a path prefix strands discovery,
+    /// the authorize route, and the OIDC callback.
     /// # Errors
     /// Returns an error when the listener cannot start.
     pub async fn start(self) -> Result<RunningCoralAuthorizationServer, AuthServerError> {

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -1,19 +1,14 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use axum::extract::{RawQuery, State};
-use axum::http::{StatusCode, header};
-use axum::response::{IntoResponse, Response};
-use url::{Url, form_urlencoded};
+use axum::response::Response;
+use url::Url;
 
 use super::super::provider_client::OidcAuthorizationRequest;
 use super::super::state_store::OAuthAuthorizationSessionRecord;
-use super::{AuthorizationServerHttpState, canonical_authorization_resource};
+use super::response::{TrustedRedirect, direct_error, redirect};
+use super::{AuthorizationServerHttpState, canonical_authorization_resource, query};
 use crate::outbound_url_policy::{BrowserRedirect, EndpointUrl};
-
-const MAX_QUERY_BYTES: usize = 8 * 1024;
-const MAX_PARAMETERS: usize = 32;
-const MAX_PARAMETER_NAME_BYTES: usize = 64;
-const MAX_PARAMETER_VALUE_BYTES: usize = 2 * 1024;
 
 pub(super) async fn oauth_authorize(
     State(state): State<AuthorizationServerHttpState>,
@@ -31,10 +26,7 @@ pub(super) async fn oauth_authorize(
     else {
         return direct_error("invalid_request", "client_id or redirect_uri is invalid");
     };
-    let trusted = TrustedRedirect {
-        url: callback,
-        client_state: query.state.clone(),
-    };
+    let trusted = TrustedRedirect::new(callback, query.state.clone());
 
     match query.response_type.as_deref() {
         Some("code") => {}
@@ -116,36 +108,22 @@ struct AuthorizeQuery {
 }
 
 fn parse_query(raw: &str) -> Result<AuthorizeQuery, ()> {
-    if raw.len() > MAX_QUERY_BYTES {
-        return Err(());
-    }
-    let mut query = AuthorizeQuery::default();
-    let mut seen = BTreeSet::new();
-    for (index, (name, value)) in form_urlencoded::parse(raw.as_bytes()).enumerate() {
-        if index >= MAX_PARAMETERS
-            || name.len() > MAX_PARAMETER_NAME_BYTES
-            || value.len() > MAX_PARAMETER_VALUE_BYTES
-        {
-            return Err(());
-        }
-        let name = name.into_owned();
-        if !seen.insert(name.clone()) {
-            return Err(());
-        }
-        let target = match name.as_str() {
-            "response_type" => &mut query.response_type,
-            "client_id" => &mut query.client_id,
-            "redirect_uri" => &mut query.redirect_uri,
-            "scope" => &mut query.scope,
-            "state" => &mut query.state,
-            "code_challenge" => &mut query.code_challenge,
-            "code_challenge_method" => &mut query.code_challenge_method,
-            "resource" => &mut query.resource,
-            _ => continue,
+    let mut parsed = AuthorizeQuery::default();
+    query::scan(raw, |name, value| {
+        let target = match name {
+            "response_type" => &mut parsed.response_type,
+            "client_id" => &mut parsed.client_id,
+            "redirect_uri" => &mut parsed.redirect_uri,
+            "scope" => &mut parsed.scope,
+            "state" => &mut parsed.state,
+            "code_challenge" => &mut parsed.code_challenge,
+            "code_challenge_method" => &mut parsed.code_challenge_method,
+            "resource" => &mut parsed.resource,
+            _ => return,
         };
         *target = Some(value.into_owned());
-    }
-    Ok(query)
+    })?;
+    Ok(parsed)
 }
 
 /// Resolves the registered redirect URI a request names, under
@@ -175,58 +153,6 @@ fn valid_s256_challenge(value: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
-struct TrustedRedirect {
-    url: Url,
-    client_state: Option<String>,
-}
-
-impl TrustedRedirect {
-    fn error(&self, error: &'static str, description: &'static str) -> Response {
-        let mut url = self.url.clone();
-        let mut query = url.query_pairs_mut();
-        query
-            .append_pair("error", error)
-            .append_pair("error_description", description);
-        if let Some(state) = &self.client_state {
-            query.append_pair("state", state);
-        }
-        drop(query);
-        redirect(url.as_str())
-    }
-}
-
-fn direct_error(error: &'static str, description: &'static str) -> Response {
-    let body = serde_json::json!({
-        "error": error,
-        "error_description": description,
-    })
-    .to_string();
-    (
-        StatusCode::BAD_REQUEST,
-        [
-            (header::CONTENT_TYPE, "application/json"),
-            (header::CACHE_CONTROL, "no-store"),
-            (header::PRAGMA, "no-cache"),
-        ],
-        body,
-    )
-        .into_response()
-}
-
-fn redirect(location: &str) -> Response {
-    (
-        StatusCode::FOUND,
-        [
-            (header::LOCATION, location),
-            (header::CACHE_CONTROL, "no-store"),
-            (header::PRAGMA, "no-cache"),
-            (header::REFERRER_POLICY, "no-referrer"),
-        ],
-        "",
-    )
-        .into_response()
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
@@ -235,11 +161,13 @@ mod tests {
     use std::time::Duration;
 
     use axum::body::to_bytes;
+    use axum::http::{StatusCode, header};
     use base64::Engine as _;
     use base64::engine::general_purpose::STANDARD;
     use ring::rand::SystemRandom;
     use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
     use serde_json::json;
+    use url::form_urlencoded;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -364,19 +292,22 @@ mod tests {
             .await;
     }
 
+    /// Asserts the headers every response from this handler carries.
+    ///
+    /// The direct-error path is asserted as well as the redirect path: it is
+    /// the one that shipped without `referrer-policy` while its sibling
+    /// handler set it, and an unasserted header is how that went unnoticed.
+    fn assert_security(response: &Response) {
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+        assert_eq!(response.headers()[header::PRAGMA], "no-cache");
+        assert_eq!(response.headers()[header::REFERRER_POLICY], "no-referrer");
+    }
+
     #[test]
     fn query_parser_bounds_and_rejects_decoded_duplicates() {
         let encoded = encode(&pairs());
-        let cases = [
-            format!("{encoded}&client%5Fid=duplicate"),
-            "x".repeat(MAX_QUERY_BYTES + 1),
-            format!("{}=value", "n".repeat(MAX_PARAMETER_NAME_BYTES + 1)),
-            format!("value={}", "v".repeat(MAX_PARAMETER_VALUE_BYTES + 1)),
-            (0..=MAX_PARAMETERS)
-                .map(|index| format!("x{index}=1"))
-                .collect::<Vec<_>>()
-                .join("&"),
-        ];
+        let mut cases = vec![format!("{encoded}&client%5Fid=duplicate")];
+        cases.extend(query::rejected_queries());
         for raw in cases {
             assert!(parse_query(&raw).is_err(), "accepted {raw}");
         }
@@ -400,6 +331,7 @@ mod tests {
             )
             .await;
             assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert_security(&response);
             assert!(location(&response).is_none());
         }
 
@@ -429,6 +361,7 @@ mod tests {
             replace(&mut request_pairs, "redirect_uri", Some(uri));
             let response = request(auth_state, &request_pairs).await;
             assert_eq!(response.status(), StatusCode::BAD_REQUEST, "accepted {uri}");
+            assert_security(&response);
             assert!(location(&response).is_none(), "redirected to {uri}");
         }
     }
@@ -454,8 +387,7 @@ mod tests {
             )
             .await;
             assert_eq!(response.status(), StatusCode::FOUND);
-            assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
-            assert_eq!(response.headers()[header::REFERRER_POLICY], "no-referrer");
+            assert_security(&response);
             let url = Url::parse(location(&response).expect("error redirect")).expect("URL");
             let query = url.query_pairs().into_owned().collect::<Vec<_>>();
             assert!(query.contains(&("tenant".into(), "one".into())));

--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -1,21 +1,15 @@
-use std::collections::BTreeSet;
-
 use axum::extract::{RawQuery, State};
-use axum::http::{StatusCode, header};
-use axum::response::{IntoResponse, Response};
+use axum::response::Response;
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ring::rand::{SecureRandom as _, SystemRandom};
-use url::{Url, form_urlencoded};
+use url::Url;
 use zeroize::Zeroizing;
 
 use super::super::state_store::{OAuthAuthorizationCodeRecord, OAuthAuthorizationSessionRecord};
 use super::AuthorizationServerHttpState;
-
-const MAX_QUERY_BYTES: usize = 8 * 1024;
-const MAX_PARAMETERS: usize = 32;
-const MAX_PARAMETER_NAME_BYTES: usize = 64;
-const MAX_PARAMETER_VALUE_BYTES: usize = 2 * 1024;
+use super::query;
+use super::response::{TrustedRedirect, direct_error};
 
 pub(super) async fn oidc_callback(
     State(state): State<AuthorizationServerHttpState>,
@@ -37,7 +31,7 @@ pub(super) async fn oidc_callback(
             "OIDC callback state is invalid or expired",
         );
     };
-    let Some(trusted) = TrustedRedirect::new(&session) else {
+    let Some(trusted) = trusted_redirect(&session) else {
         return direct_error("server_error", "authorization failed");
     };
     let provider_code = match classify_result(&query) {
@@ -53,21 +47,30 @@ pub(super) async fn oidc_callback(
         }
     };
     let provider = state.settings.provider();
-    let Ok(exchange) = state
+    let exchange = match state
         .provider_client
         .exchange_code(provider, &provider_code, &session.oidc_code_verifier)
         .await
-    else {
-        return trusted.error("server_error", "authorization failed");
+    {
+        Ok(exchange) => exchange,
+        Err(error) => {
+            tracing::warn!(%error, "OIDC callback could not exchange the provider code");
+            return trusted.error("server_error", "authorization failed");
+        }
     };
-    let Ok(identity) = state
+    let identity = match state
         .provider_client
         .validate_code_exchange(provider, exchange, &session.oidc_nonce)
         .await
-    else {
-        return trusted.error("server_error", "authorization failed");
+    {
+        Ok(identity) => identity,
+        Err(error) => {
+            tracing::warn!(%error, "OIDC callback could not validate the provider identity");
+            return trusted.error("server_error", "authorization failed");
+        }
     };
     let Ok(authorization_code) = random_code() else {
+        tracing::warn!("OIDC callback could not generate an authorization code");
         return trusted.error("server_error", "authorization failed");
     };
     let authorization = OAuthAuthorizationCodeRecord {
@@ -77,12 +80,12 @@ pub(super) async fn oidc_callback(
         code_challenge: session.code_challenge,
         resource: session.resource,
     };
-    if state
+    if let Err(error) = state
         .state_store
         .store_authorization_code(&authorization_code, authorization)
         .await
-        .is_err()
     {
+        tracing::warn!(%error, "OIDC callback could not store the authorization code");
         return trusted.error("server_error", "authorization failed");
     }
     trusted.success(&authorization_code)
@@ -97,31 +100,17 @@ struct CallbackQuery {
 }
 
 fn parse_query(raw: &str) -> Result<CallbackQuery, ()> {
-    if raw.len() > MAX_QUERY_BYTES {
-        return Err(());
-    }
     let mut query = CallbackQuery::default();
-    let mut seen = BTreeSet::new();
-    for (index, (name, value)) in form_urlencoded::parse(raw.as_bytes()).enumerate() {
-        if index >= MAX_PARAMETERS
-            || name.len() > MAX_PARAMETER_NAME_BYTES
-            || value.len() > MAX_PARAMETER_VALUE_BYTES
-        {
-            return Err(());
-        }
-        let name = name.into_owned();
-        if !seen.insert(name.clone()) {
-            return Err(());
-        }
-        let target = match name.as_str() {
+    query::scan(raw, |name, value| {
+        let target = match name {
             "state" => &mut query.state,
             "code" => &mut query.code,
             "error" => &mut query.error,
             "error_description" => &mut query.error_description,
-            _ => continue,
+            _ => return,
         };
         *target = Some(value.into_owned());
-    }
+    })?;
     Ok(query)
 }
 
@@ -150,73 +139,20 @@ fn random_code() -> Result<String, ()> {
     Ok(URL_SAFE_NO_PAD.encode(bytes.as_slice()))
 }
 
-struct TrustedRedirect {
-    url: Url,
-    client_state: Option<String>,
-}
-
-impl TrustedRedirect {
-    fn new(session: &OAuthAuthorizationSessionRecord) -> Option<Self> {
-        Some(Self {
-            url: Url::parse(&session.redirect_uri).ok()?,
-            client_state: session.client_state.clone(),
-        })
-    }
-
-    fn success(&self, code: &str) -> Response {
-        self.redirect("code", code, None)
-    }
-
-    fn error(&self, error: &'static str, description: &'static str) -> Response {
-        self.redirect("error", error, Some(description))
-    }
-
-    fn redirect(&self, key: &str, value: &str, description: Option<&str>) -> Response {
-        let mut url = self.url.clone();
-        let mut query = url.query_pairs_mut();
-        query.append_pair(key, value);
-        if let Some(description) = description {
-            query.append_pair("error_description", description);
-        }
-        if let Some(state) = &self.client_state {
-            query.append_pair("state", state);
-        }
-        drop(query);
-        redirect(url.as_str())
-    }
-}
-
-fn direct_error(error: &'static str, description: &'static str) -> Response {
-    let body = serde_json::json!({
-        "error": error,
-        "error_description": description,
-    })
-    .to_string();
-    (
-        StatusCode::BAD_REQUEST,
-        security_headers(),
-        [(header::CONTENT_TYPE, "application/json")],
-        body,
-    )
-        .into_response()
-}
-
-fn redirect(location: &str) -> Response {
-    (
-        StatusCode::FOUND,
-        security_headers(),
-        [(header::LOCATION, location)],
-        "",
-    )
-        .into_response()
-}
-
-fn security_headers() -> [(header::HeaderName, &'static str); 3] {
-    [
-        (header::CACHE_CONTROL, "no-store"),
-        (header::PRAGMA, "no-cache"),
-        (header::REFERRER_POLICY, "no-referrer"),
-    ]
+/// Rebuilds the client callback this login was started for.
+///
+/// The `None` arm is unreachable. `redirect_uri` is only ever stored after
+/// `authorize`'s `registered_redirect` matched it against a registered URI and
+/// parsed that URI under
+/// [`BrowserRedirect`](crate::outbound_url_policy::BrowserRedirect), so a value
+/// that reaches here has already parsed once. It is checked rather than
+/// unwrapped because the store sits between the two handlers, and a panic in a
+/// callback would be a worse answer than a failed login. Re-applying
+/// `BrowserRedirect` here would not add a check — it would only move where the
+/// same policy was applied.
+fn trusted_redirect(session: &OAuthAuthorizationSessionRecord) -> Option<TrustedRedirect> {
+    let url = Url::parse(&session.redirect_uri).ok()?;
+    Some(TrustedRedirect::new(url, session.client_state.clone()))
 }
 
 #[cfg(test)]
@@ -226,10 +162,12 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use axum::http::{StatusCode, header};
     use base64::engine::general_purpose::STANDARD;
     use ring::rand::SystemRandom;
     use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
     use serde_json::{Value, json};
+    use url::form_urlencoded;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -392,15 +330,7 @@ mod tests {
 
     #[tokio::test]
     async fn malformed_queries_are_bounded_and_do_not_consume_state() {
-        for raw in [
-            "x".repeat(MAX_QUERY_BYTES + 1),
-            format!("{}=x", "n".repeat(MAX_PARAMETER_NAME_BYTES + 1)),
-            format!("x={}", "v".repeat(MAX_PARAMETER_VALUE_BYTES + 1)),
-            (0..=MAX_PARAMETERS)
-                .map(|index| format!("x{index}=1"))
-                .collect::<Vec<_>>()
-                .join("&"),
-        ] {
+        for raw in query::rejected_queries() {
             let Err(()) = parse_query(&raw) else {
                 panic!("malformed callback query must be rejected");
             };

--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -223,9 +223,11 @@ fn security_headers() -> [(header::HeaderName, &'static str); 3] {
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
+    use std::path::Path;
     use std::sync::Arc;
     use std::time::Duration;
 
+    use base64::engine::general_purpose::STANDARD;
     use ring::rand::SystemRandom;
     use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
     use serde_json::{Value, json};
@@ -235,7 +237,7 @@ mod tests {
     use super::super::AuthorizationServerHttpState;
     use super::*;
     use crate::auth::PROVIDER_ID;
-    use crate::auth::config::AuthSettings;
+    use crate::auth::config::{AuthSettings, ResolvedAuthSettings};
     use crate::auth::id_token::tests::{
         claims as id_token_claims, rsa_key, set_claim, token as id_token,
     };
@@ -253,8 +255,8 @@ mod tests {
     const AUTH_ISSUER: &str = "https://auth.example.test";
     const RESOURCE: &str = "https://api.example.test/mcp";
 
-    fn settings(issuer: &str) -> AuthSettings {
-        AuthSettings::from_toml(&format!(
+    fn settings(issuer: &str) -> ResolvedAuthSettings {
+        let settings = AuthSettings::from_toml(&format!(
             "[auth]
              [auth.session]
              [auth.authorization_server]
@@ -266,7 +268,17 @@ mod tests {
              redirect_uri = 'http://localhost/provider-callback'"
         ))
         .expect("valid auth config")
-        .expect("auth settings")
+        .expect("auth settings");
+        let signing_key = STANDARD.encode(
+            EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
+                .expect("P-256 signing key"),
+        );
+        let (settings, _issuer) = settings
+            .resolve_runtime_dependencies(Path::new("config.toml"), &|name| {
+                Ok((name == "CORAL_SESSION_SIGNING_KEY").then(|| signing_key.clone()))
+            })
+            .expect("resolved runtime dependencies");
+        settings
     }
 
     fn state(issuer: &str, state_store: Arc<dyn StateStore>) -> AuthorizationServerHttpState {

--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -265,7 +265,7 @@ mod tests {
              issuer = '{issuer}'
              client_id = 'provider-client'
              client_secret = '{PROVIDER_SECRET}'
-             redirect_uri = 'http://localhost/provider-callback'"
+             redirect_uri = '{AUTH_ISSUER}/auth/oidc/callback'"
         ))
         .expect("valid auth config")
         .expect("auth settings");
@@ -326,10 +326,7 @@ mod tests {
         oidc_callback(State(state), RawQuery(Some(raw))).await
     }
 
-    async fn callback(
-        state: AuthorizationServerHttpState,
-        pairs: &[(&str, &str)],
-    ) -> Response {
+    async fn callback(state: AuthorizationServerHttpState, pairs: &[(&str, &str)]) -> Response {
         callback_raw(state, query(pairs)).await
     }
 

--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -1,0 +1,535 @@
+use std::collections::BTreeSet;
+
+use axum::extract::{RawQuery, State};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use ring::rand::{SecureRandom as _, SystemRandom};
+use url::{Url, form_urlencoded};
+use zeroize::Zeroizing;
+
+use super::super::state_store::{OAuthAuthorizationCodeRecord, OAuthAuthorizationSessionRecord};
+use super::AuthorizationServerHttpState;
+
+const MAX_QUERY_BYTES: usize = 8 * 1024;
+const MAX_PARAMETERS: usize = 32;
+const MAX_PARAMETER_NAME_BYTES: usize = 64;
+const MAX_PARAMETER_VALUE_BYTES: usize = 2 * 1024;
+
+pub(super) async fn oidc_callback(
+    State(state): State<AuthorizationServerHttpState>,
+    RawQuery(raw_query): RawQuery,
+) -> Response {
+    let Ok(query) = parse_query(raw_query.as_deref().unwrap_or_default()) else {
+        return direct_error("invalid_request", "OIDC callback request is malformed");
+    };
+    let Some(oidc_state) = query.state.as_deref().filter(|state| !state.is_empty()) else {
+        return direct_error("invalid_request", "OIDC callback state is required");
+    };
+    let Ok(Some(session)) = state
+        .state_store
+        .take_authorization_session(oidc_state)
+        .await
+    else {
+        return direct_error(
+            "invalid_request",
+            "OIDC callback state is invalid or expired",
+        );
+    };
+    let Some(trusted) = TrustedRedirect::new(&session) else {
+        return direct_error("server_error", "authorization failed");
+    };
+    let provider_code = match classify_result(&query) {
+        Ok(CallbackResult::Code(code)) => code,
+        Ok(CallbackResult::AccessDenied) => {
+            return trusted.error("access_denied", "authorization was denied");
+        }
+        Ok(CallbackResult::ProviderError) => {
+            return trusted.error("server_error", "authorization failed");
+        }
+        Err(()) => {
+            return trusted.error("invalid_request", "OIDC callback response is invalid");
+        }
+    };
+    let provider = state.settings.provider();
+    let Ok(exchange) = state
+        .provider_client
+        .exchange_code(provider, &provider_code, &session.oidc_code_verifier)
+        .await
+    else {
+        return trusted.error("server_error", "authorization failed");
+    };
+    let Ok(identity) = state
+        .provider_client
+        .validate_code_exchange(provider, exchange, &session.oidc_nonce)
+        .await
+    else {
+        return trusted.error("server_error", "authorization failed");
+    };
+    let Ok(authorization_code) = random_code() else {
+        return trusted.error("server_error", "authorization failed");
+    };
+    let authorization = OAuthAuthorizationCodeRecord {
+        provider_id: session.provider_id,
+        user_id: identity.principal,
+        client_id: session.client_id,
+        redirect_uri: session.redirect_uri,
+        code_challenge: session.code_challenge,
+        resource: session.resource,
+    };
+    if state
+        .state_store
+        .store_authorization_code(&authorization_code, authorization)
+        .await
+        .is_err()
+    {
+        return trusted.error("server_error", "authorization failed");
+    }
+    trusted.success(&authorization_code)
+}
+
+#[derive(Default)]
+struct CallbackQuery {
+    state: Option<String>,
+    code: Option<String>,
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+fn parse_query(raw: &str) -> Result<CallbackQuery, ()> {
+    if raw.len() > MAX_QUERY_BYTES {
+        return Err(());
+    }
+    let mut query = CallbackQuery::default();
+    let mut seen = BTreeSet::new();
+    for (index, (name, value)) in form_urlencoded::parse(raw.as_bytes()).enumerate() {
+        if index >= MAX_PARAMETERS
+            || name.len() > MAX_PARAMETER_NAME_BYTES
+            || value.len() > MAX_PARAMETER_VALUE_BYTES
+        {
+            return Err(());
+        }
+        let name = name.into_owned();
+        if !seen.insert(name.clone()) {
+            return Err(());
+        }
+        let target = match name.as_str() {
+            "state" => &mut query.state,
+            "code" => &mut query.code,
+            "error" => &mut query.error,
+            "error_description" => &mut query.error_description,
+            _ => continue,
+        };
+        *target = Some(value.into_owned());
+    }
+    Ok(query)
+}
+
+enum CallbackResult {
+    Code(String),
+    AccessDenied,
+    ProviderError,
+}
+
+fn classify_result(query: &CallbackQuery) -> Result<CallbackResult, ()> {
+    match (
+        query.code.as_deref(),
+        query.error.as_deref(),
+        query.error_description.is_some(),
+    ) {
+        (Some(code), None, false) if !code.is_empty() => Ok(CallbackResult::Code(code.into())),
+        (None, Some("access_denied"), _) => Ok(CallbackResult::AccessDenied),
+        (None, Some(error), _) if !error.is_empty() => Ok(CallbackResult::ProviderError),
+        _ => Err(()),
+    }
+}
+
+fn random_code() -> Result<String, ()> {
+    let mut bytes = Zeroizing::new([0_u8; 32]);
+    SystemRandom::new().fill(&mut *bytes).map_err(|_error| ())?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes.as_slice()))
+}
+
+struct TrustedRedirect {
+    url: Url,
+    client_state: Option<String>,
+}
+
+impl TrustedRedirect {
+    fn new(session: &OAuthAuthorizationSessionRecord) -> Option<Self> {
+        Some(Self {
+            url: Url::parse(&session.redirect_uri).ok()?,
+            client_state: session.client_state.clone(),
+        })
+    }
+
+    fn success(&self, code: &str) -> Response {
+        self.redirect("code", code, None)
+    }
+
+    fn error(&self, error: &'static str, description: &'static str) -> Response {
+        self.redirect("error", error, Some(description))
+    }
+
+    fn redirect(&self, key: &str, value: &str, description: Option<&str>) -> Response {
+        let mut url = self.url.clone();
+        let mut query = url.query_pairs_mut();
+        query.append_pair(key, value);
+        if let Some(description) = description {
+            query.append_pair("error_description", description);
+        }
+        if let Some(state) = &self.client_state {
+            query.append_pair("state", state);
+        }
+        drop(query);
+        redirect(url.as_str())
+    }
+}
+
+fn direct_error(error: &'static str, description: &'static str) -> Response {
+    let body = serde_json::json!({
+        "error": error,
+        "error_description": description,
+    })
+    .to_string();
+    (
+        StatusCode::BAD_REQUEST,
+        security_headers(),
+        [(header::CONTENT_TYPE, "application/json")],
+        body,
+    )
+        .into_response()
+}
+
+fn redirect(location: &str) -> Response {
+    (
+        StatusCode::FOUND,
+        security_headers(),
+        [(header::LOCATION, location)],
+        "",
+    )
+        .into_response()
+}
+
+fn security_headers() -> [(header::HeaderName, &'static str); 3] {
+    [
+        (header::CACHE_CONTROL, "no-store"),
+        (header::PRAGMA, "no-cache"),
+        (header::REFERRER_POLICY, "no-referrer"),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use ring::rand::SystemRandom;
+    use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
+    use serde_json::{Value, json};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::super::AuthorizationServerHttpState;
+    use super::*;
+    use crate::auth::PROVIDER_ID;
+    use crate::auth::config::AuthSettings;
+    use crate::auth::id_token::tests::{
+        claims as id_token_claims, rsa_key, set_claim, token as id_token,
+    };
+    use crate::auth::provider_client::OidcProviderClient;
+    use crate::auth::session::SessionTokenIssuer;
+    use crate::auth::state_store::{InMemoryStateStore, StateStore};
+
+    const OIDC_STATE: &str = "oidc-state";
+    const CLIENT_STATE: &str = "client&error=injected";
+    const REDIRECT_URI: &str = "https://client.example.test/callback?tenant=one";
+    const VERIFIER: &str = "stored-upstream-verifier";
+    const NONCE: &str = "stored-upstream-nonce";
+    const PROVIDER_CODE: &str = "provider-code-secret";
+    const PROVIDER_SECRET: &str = "provider-secret-must-not-leak";
+    const AUTH_ISSUER: &str = "https://auth.example.test";
+    const RESOURCE: &str = "https://api.example.test/mcp";
+
+    fn settings(issuer: &str) -> AuthSettings {
+        AuthSettings::from_toml(&format!(
+            "[auth]
+             [auth.session]
+             [auth.authorization_server]
+             issuer = '{AUTH_ISSUER}'
+             [auth.provider]
+             issuer = '{issuer}'
+             client_id = 'provider-client'
+             client_secret = '{PROVIDER_SECRET}'
+             redirect_uri = 'http://localhost/provider-callback'"
+        ))
+        .expect("valid auth config")
+        .expect("auth settings")
+    }
+
+    fn state(issuer: &str, state_store: Arc<dyn StateStore>) -> AuthorizationServerHttpState {
+        let signing_key =
+            EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
+                .expect("P-256 signing key");
+        let session_tokens = SessionTokenIssuer::new(
+            Some(AUTH_ISSUER),
+            signing_key.as_ref(),
+            Duration::from_mins(5),
+        )
+        .expect("session");
+        AuthorizationServerHttpState {
+            settings: Arc::new(settings(issuer)),
+            session_tokens,
+            state_store,
+            provider_client: OidcProviderClient::new().expect("client"),
+            registered_clients: Arc::new(BTreeMap::new()),
+            authorization_resources: Arc::new(BTreeSet::from([RESOURCE.into()])),
+        }
+    }
+
+    fn session() -> OAuthAuthorizationSessionRecord {
+        OAuthAuthorizationSessionRecord {
+            provider_id: PROVIDER_ID.into(),
+            client_id: "https://client.example.test/oauth/client.json".into(),
+            redirect_uri: REDIRECT_URI.into(),
+            client_state: Some(CLIENT_STATE.into()),
+            code_challenge: "client-code-challenge".into(),
+            resource: RESOURCE.into(),
+            oidc_code_verifier: VERIFIER.to_string().into(),
+            oidc_nonce: NONCE.into(),
+        }
+    }
+
+    fn query(pairs: &[(&str, &str)]) -> String {
+        let mut serializer = form_urlencoded::Serializer::new(String::new());
+        for (key, value) in pairs {
+            serializer.append_pair(key, value);
+        }
+        serializer.finish()
+    }
+
+    async fn callback_raw(state: AuthorizationServerHttpState, raw: String) -> Response {
+        oidc_callback(State(state), RawQuery(Some(raw))).await
+    }
+
+    async fn callback(
+        state: AuthorizationServerHttpState,
+        pairs: &[(&str, &str)],
+    ) -> Response {
+        callback_raw(state, query(pairs)).await
+    }
+
+    async fn seed(store: &dyn StateStore, key: &str) {
+        store
+            .store_authorization_session(key, session())
+            .await
+            .expect("store");
+    }
+
+    async fn take(store: &dyn StateStore, key: &str) -> Option<OAuthAuthorizationSessionRecord> {
+        store.take_authorization_session(key).await.expect("store")
+    }
+
+    fn assert_security(response: &Response) {
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+        assert_eq!(response.headers()[header::PRAGMA], "no-cache");
+        assert_eq!(response.headers()[header::REFERRER_POLICY], "no-referrer");
+    }
+
+    fn redirect_query(response: &Response) -> Vec<(String, String)> {
+        Url::parse(
+            response.headers()[header::LOCATION]
+                .to_str()
+                .expect("location"),
+        )
+        .expect("redirect URL")
+        .query_pairs()
+        .into_owned()
+        .collect()
+    }
+
+    async fn mount_provider(server: &MockServer, token_status: u16, jwks_status: u16, nonce: &str) {
+        let mut claims = id_token_claims();
+        set_claim(&mut claims, "iss", Value::String(server.uri()));
+        set_claim(&mut claims, "nonce", Value::String(nonce.into()));
+        set_claim(&mut claims, "sub", Value::String("raw-principal".into()));
+        let discovery = json!({
+            "issuer": server.uri(),
+            "authorization_endpoint": format!("{}/authorize", server.uri()),
+            "token_endpoint": format!("{}/token", server.uri()),
+            "jwks_uri": format!("{}/jwks", server.uri()),
+            "id_token_signing_alg_values_supported": ["RS256"],
+        });
+        Mock::given(method("GET"))
+            .and(path("/.well-known/openid-configuration"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(discovery))
+            .mount(server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(token_status)
+                    .set_body_json(json!({"id_token": id_token(&claims)})),
+            )
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/jwks"))
+            .respond_with(
+                ResponseTemplate::new(jwks_status).set_body_json(json!({"keys": [rsa_key()]})),
+            )
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn malformed_queries_are_bounded_and_do_not_consume_state() {
+        for raw in [
+            "x".repeat(MAX_QUERY_BYTES + 1),
+            format!("{}=x", "n".repeat(MAX_PARAMETER_NAME_BYTES + 1)),
+            format!("x={}", "v".repeat(MAX_PARAMETER_VALUE_BYTES + 1)),
+            (0..=MAX_PARAMETERS)
+                .map(|index| format!("x{index}=1"))
+                .collect::<Vec<_>>()
+                .join("&"),
+        ] {
+            let Err(()) = parse_query(&raw) else {
+                panic!("malformed callback query must be rejected");
+            };
+        }
+        let store = Arc::new(InMemoryStateStore::new());
+        seed(store.as_ref(), OIDC_STATE).await;
+        let response = callback_raw(
+            state("https://provider.invalid", store.clone()),
+            format!("state={OIDC_STATE}&%73tate=duplicate&code=x"),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(!response.headers().contains_key(header::LOCATION));
+        assert_security(&response);
+        assert!(take(store.as_ref(), OIDC_STATE).await.is_some());
+        let response = callback(
+            state("https://provider.invalid", store),
+            &[("state", "unknown"), ("code", "x")],
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(!response.headers().contains_key(header::LOCATION));
+    }
+
+    #[tokio::test]
+    async fn provider_errors_are_sanitized_and_malformed_results_consume_state() {
+        let store = Arc::new(InMemoryStateStore::new());
+        for (index, suffix, expected) in [
+            (
+                0,
+                "error=access_denied&error_description=secret",
+                "access_denied",
+            ),
+            (
+                1,
+                "error=provider_failure&error_description=secret",
+                "server_error",
+            ),
+        ] {
+            let state_key = format!("state-{index}");
+            seed(store.as_ref(), &state_key).await;
+            let response = callback_raw(
+                state("https://provider.invalid", store.clone()),
+                format!("state={state_key}&{suffix}"),
+            )
+            .await;
+            let values = redirect_query(&response);
+            assert!(values.contains(&("error".into(), expected.into())));
+            assert!(values.contains(&("state".into(), CLIENT_STATE.into())));
+            assert!(!values.iter().any(|(_key, value)| value == "secret"));
+            assert_security(&response);
+        }
+        for (index, suffix) in [
+            (2, "code=x&error=access_denied"),
+            (3, "error="),
+            (4, "error_description=orphan"),
+            (5, ""),
+        ] {
+            let state_key = format!("state-{index}");
+            seed(store.as_ref(), &state_key).await;
+            let response = callback_raw(
+                state("https://provider.invalid", store.clone()),
+                format!("state={state_key}&{suffix}"),
+            )
+            .await;
+            assert!(
+                redirect_query(&response).contains(&("error".into(), "invalid_request".into()))
+            );
+            assert!(take(store.as_ref(), &state_key).await.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn success_is_single_use_and_stores_raw_identity_with_bindings() {
+        let server = MockServer::start().await;
+        mount_provider(&server, 200, 200, NONCE).await;
+        let store = Arc::new(InMemoryStateStore::new());
+        seed(store.as_ref(), OIDC_STATE).await;
+        let app = state(&server.uri(), store.clone());
+        let raw = query(&[("state", OIDC_STATE), ("code", PROVIDER_CODE)]);
+        let (first, second) = tokio::join!(
+            callback_raw(app.clone(), raw.clone()),
+            callback_raw(app, raw)
+        );
+        let (success, replay) = if first.status() == StatusCode::FOUND {
+            (first, second)
+        } else {
+            (second, first)
+        };
+        assert_eq!(replay.status(), StatusCode::BAD_REQUEST);
+        assert_security(&success);
+        let values = redirect_query(&success);
+        assert!(values.contains(&("tenant".into(), "one".into())));
+        assert_eq!(values.iter().filter(|(key, _)| key == "state").count(), 1);
+        assert!(values.contains(&("state".into(), CLIENT_STATE.into())));
+        let code = values
+            .iter()
+            .find(|(key, _value)| key == "code")
+            .expect("authorization code")
+            .1
+            .clone();
+        assert_eq!(code.len(), 43);
+        let authorization = store
+            .take_authorization_code_for_request(
+                &code,
+                &session().client_id,
+                REDIRECT_URI,
+                &session().code_challenge,
+                RESOURCE,
+            )
+            .await
+            .expect("store")
+            .expect("authorization");
+        assert_eq!(authorization.provider_id, PROVIDER_ID);
+        assert_eq!(authorization.user_id, "raw-principal");
+        assert_eq!(authorization.resource, RESOURCE);
+        let requests = server.received_requests().await.expect("requests");
+        let token_requests = requests
+            .iter()
+            .filter(|request| request.url.path() == "/token")
+            .collect::<Vec<_>>();
+        assert_eq!(token_requests.len(), 1);
+        let token_request = token_requests.first().expect("token request");
+        let form = form_urlencoded::parse(&token_request.body)
+            .into_owned()
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(
+            form.get("code_verifier").map(String::as_str),
+            Some(VERIFIER)
+        );
+        let location = success.headers()[header::LOCATION]
+            .to_str()
+            .expect("location");
+        for secret in [VERIFIER, PROVIDER_SECRET, PROVIDER_CODE] {
+            assert!(!location.contains(secret));
+        }
+    }
+}

--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -71,7 +71,6 @@ pub(super) async fn oidc_callback(
         return trusted.error("server_error", "authorization failed");
     };
     let authorization = OAuthAuthorizationCodeRecord {
-        provider_id: session.provider_id,
         user_id: identity.principal,
         client_id: session.client_id,
         redirect_uri: session.redirect_uri,
@@ -236,7 +235,6 @@ mod tests {
 
     use super::super::AuthorizationServerHttpState;
     use super::*;
-    use crate::auth::PROVIDER_ID;
     use crate::auth::config::{AuthSettings, ResolvedAuthSettings};
     use crate::auth::id_token::tests::{
         claims as id_token_claims, rsa_key, set_claim, token as id_token,
@@ -303,7 +301,6 @@ mod tests {
 
     fn session() -> OAuthAuthorizationSessionRecord {
         OAuthAuthorizationSessionRecord {
-            provider_id: PROVIDER_ID.into(),
             client_id: "https://client.example.test/oauth/client.json".into(),
             redirect_uri: REDIRECT_URI.into(),
             client_state: Some(CLIENT_STATE.into()),
@@ -517,7 +514,6 @@ mod tests {
             .await
             .expect("store")
             .expect("authorization");
-        assert_eq!(authorization.provider_id, PROVIDER_ID);
         assert_eq!(authorization.user_id, "raw-principal");
         assert_eq!(authorization.resource, RESOURCE);
         let requests = server.received_requests().await.expect("requests");

--- a/crates/coral-app/src/auth/authorization_server/query.rs
+++ b/crates/coral-app/src/auth/authorization_server/query.rs
@@ -1,0 +1,72 @@
+//! Bounded query-string scanning shared by the authorization-server handlers.
+//!
+//! Every handler here reads its parameters from a browser-supplied query, so
+//! each one needs the same two guarantees: a request cannot grow without bound,
+//! and no parameter may appear twice. Both live here rather than in each
+//! handler because a handler that gets its own copy of the limits is a handler
+//! whose limits can drift from the rest.
+//!
+//! Duplicate rejection is deliberately applied to the *decoded* name, after
+//! percent-decoding, so `%73tate` is caught as a second `state` rather than
+//! slipping past as an unrecognized parameter and shadowing the real one.
+
+use std::borrow::Cow;
+use std::collections::BTreeSet;
+
+use url::form_urlencoded;
+
+const MAX_QUERY_BYTES: usize = 8 * 1024;
+const MAX_PARAMETERS: usize = 32;
+const MAX_PARAMETER_NAME_BYTES: usize = 64;
+const MAX_PARAMETER_VALUE_BYTES: usize = 2 * 1024;
+
+/// Visits each decoded parameter of `raw` once, within this module's limits.
+///
+/// `visit` is called for every parameter, recognized or not; a handler ignores
+/// the names it does not use. Unrecognized names are still counted and still
+/// checked for duplication, so padding a request with junk cannot buy extra
+/// room past the limits.
+///
+/// # Errors
+///
+/// Returns `Err(())` when the query exceeds [`MAX_QUERY_BYTES`], carries more
+/// than [`MAX_PARAMETERS`] parameters, has a name or value over its byte limit,
+/// or repeats a decoded name. The caller turns that into a fixed protocol
+/// error; nothing about which limit tripped reaches the response.
+pub(super) fn scan(raw: &str, mut visit: impl FnMut(&str, Cow<'_, str>)) -> Result<(), ()> {
+    if raw.len() > MAX_QUERY_BYTES {
+        return Err(());
+    }
+    let mut seen = BTreeSet::new();
+    for (index, (name, value)) in form_urlencoded::parse(raw.as_bytes()).enumerate() {
+        if index >= MAX_PARAMETERS
+            || name.len() > MAX_PARAMETER_NAME_BYTES
+            || value.len() > MAX_PARAMETER_VALUE_BYTES
+        {
+            return Err(());
+        }
+        let name = name.into_owned();
+        if !seen.insert(name.clone()) {
+            return Err(());
+        }
+        visit(&name, value);
+    }
+    Ok(())
+}
+
+/// Queries that every handler's limit tests must reject.
+///
+/// The handlers assert against this list rather than each writing its own, so a
+/// limit added here is exercised by every handler that scans a query.
+#[cfg(test)]
+pub(super) fn rejected_queries() -> Vec<String> {
+    vec![
+        "x".repeat(MAX_QUERY_BYTES + 1),
+        format!("{}=x", "n".repeat(MAX_PARAMETER_NAME_BYTES + 1)),
+        format!("x={}", "v".repeat(MAX_PARAMETER_VALUE_BYTES + 1)),
+        (0..=MAX_PARAMETERS)
+            .map(|index| format!("x{index}=1"))
+            .collect::<Vec<_>>()
+            .join("&"),
+    ]
+}

--- a/crates/coral-app/src/auth/authorization_server/response.rs
+++ b/crates/coral-app/src/auth/authorization_server/response.rs
@@ -1,0 +1,119 @@
+//! Responses shared by the authorization-server handlers.
+//!
+//! Every response here carries an authorization code, an error a client acts
+//! on, or a redirect to a browser, so all three share one set of security
+//! headers and one way of building a redirect. Keeping them here means a
+//! handler cannot ship with a weaker header set than its siblings — the state
+//! this module was extracted to end, where one handler set `referrer-policy`
+//! on its direct errors and the other did not.
+//!
+//! # Trust
+//!
+//! Only two kinds of value reach a response body or a `Location` here: a
+//! `&'static str` chosen by the calling handler, and values the client itself
+//! supplied and Coral stored. Nothing an upstream provider sends is passed in,
+//! so a provider cannot steer a redirect or place text in an error.
+
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use url::Url;
+
+/// A redirect target already checked against a client's registration.
+///
+/// The URL is not re-validated here. It reaches this type having passed
+/// [`BrowserRedirect`](crate::outbound_url_policy::BrowserRedirect) at the
+/// point it was matched against the registry, which is the only place with the
+/// registration to match against.
+///
+/// # Known gap
+///
+/// A registered redirect URI may itself carry a `code`, `state`, or
+/// `error` query parameter, and [`Self::redirect`] appends rather than
+/// replaces — so such a URI yields two of that parameter, and a client reading
+/// the first occurrence reads the registered one instead of ours.
+/// `BrowserRedirect` permits any query, so nothing rejects this today. It is
+/// unreachable while the client registry is empty, and rejecting reserved
+/// parameters belongs at registration, where the URI is first accepted; the
+/// client-metadata-document work is where that check goes.
+pub(super) struct TrustedRedirect {
+    url: Url,
+    client_state: Option<String>,
+}
+
+impl TrustedRedirect {
+    /// Binds a checked callback to the `state` its client sent, if any.
+    pub(super) fn new(url: Url, client_state: Option<String>) -> Self {
+        Self { url, client_state }
+    }
+
+    /// Redirects the browser back to the client with an authorization code.
+    pub(super) fn success(&self, code: &str) -> Response {
+        self.redirect("code", code, None)
+    }
+
+    /// Redirects the browser back to the client with a fixed OAuth error.
+    ///
+    /// Both strings are `&'static str` so an error can only ever say what this
+    /// crate wrote, never what a provider or a store reported.
+    pub(super) fn error(&self, error: &'static str, description: &'static str) -> Response {
+        self.redirect("error", error, Some(description))
+    }
+
+    fn redirect(&self, key: &str, value: &str, description: Option<&str>) -> Response {
+        let mut url = self.url.clone();
+        let mut query = url.query_pairs_mut();
+        query.append_pair(key, value);
+        if let Some(description) = description {
+            query.append_pair("error_description", description);
+        }
+        if let Some(state) = &self.client_state {
+            query.append_pair("state", state);
+        }
+        drop(query);
+        redirect(url.as_str())
+    }
+}
+
+/// Reports an OAuth error directly, for a request with no callback to trust.
+///
+/// A request that failed before its redirect URI was checked has nowhere safe
+/// to be sent, so the error is rendered here rather than redirected — a
+/// redirect to an unvalidated URI would make Coral the open redirector.
+pub(super) fn direct_error(error: &'static str, description: &'static str) -> Response {
+    let body = serde_json::json!({
+        "error": error,
+        "error_description": description,
+    })
+    .to_string();
+    (
+        StatusCode::BAD_REQUEST,
+        security_headers(),
+        [(header::CONTENT_TYPE, "application/json")],
+        body,
+    )
+        .into_response()
+}
+
+/// Sends the browser to `location` with no cached copy and no referrer.
+pub(super) fn redirect(location: &str) -> Response {
+    (
+        StatusCode::FOUND,
+        security_headers(),
+        [(header::LOCATION, location)],
+        "",
+    )
+        .into_response()
+}
+
+/// Headers every authorization-server response carries.
+///
+/// Authorization codes travel in URLs, so `no-store`/`no-cache` keep one out of
+/// a shared cache and `no-referrer` keeps one out of the `Referer` a client's
+/// page sends onward.
+fn security_headers() -> [(header::HeaderName, &'static str); 3] {
+    [
+        (header::CACHE_CONTROL, "no-store"),
+        (header::PRAGMA, "no-cache"),
+        (header::REFERRER_POLICY, "no-referrer"),
+    ]
+}

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -16,6 +16,7 @@ use serde_json::Value;
 use url::Url;
 use zeroize::Zeroizing;
 
+use super::OIDC_CALLBACK_PATH;
 use super::error::AuthServerError;
 use super::session::SessionTokenIssuer;
 use crate::bootstrap::is_loopback_ip;
@@ -368,6 +369,19 @@ impl OidcProviderSettings {
                 served_origin.ascii_serialization()
             )));
         }
+        // The origin alone does not make the URI reachable: the router serves
+        // one callback path, so any other path is accepted here and then 404s
+        // once the provider redirects the browser to it. A query is rejected
+        // for the same reason — the provider appends its own `state`, and a
+        // configured one collides with it and fails the callback.
+        if redirect_uri.as_url().path() != OIDC_CALLBACK_PATH {
+            return Err(invalid_provider(format!(
+                "redirect_uri must use the path this server serves ({OIDC_CALLBACK_PATH})"
+            )));
+        }
+        if redirect_uri.as_url().query().is_some() {
+            return Err(invalid_provider("redirect_uri must not include a query"));
+        }
 
         if let Some(secret) = &mut self.client_secret {
             *secret = ProviderSecret::from_trimmed("client_secret", secret.as_str())?;
@@ -481,10 +495,6 @@ impl OidcProviderSettings {
 /// The derived `Debug` is safe to print: the only secret-bearing field is a
 /// [`ProviderSecret`], which redacts itself.
 #[derive(Clone, Debug)]
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "read by the OIDC federation descendant")
-)]
 pub(super) struct ResolvedOidcProvider {
     pub(super) issuer: String,
     pub(super) client_id: String,
@@ -840,14 +850,17 @@ mod tests {
             )
             .replace(
                 "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
-                "redirect_uri = ' http://localhost:9080/callback '\nprincipal_claim = ' '\ndisplay_name_claim = ' email '",
+                "redirect_uri = ' http://localhost:9080/auth/oidc/callback '\nprincipal_claim = ' '\ndisplay_name_claim = ' email '",
             );
         let settings = resolved(&raw);
         let provider = settings.provider();
         assert_eq!(provider.issuer, "https://accounts.example.test/tenant/");
         assert_eq!(provider.client_id, "client-id");
         assert_eq!(provider.client_secret(), "inline-secret");
-        assert_eq!(provider.redirect_uri, "http://localhost:9080/callback");
+        assert_eq!(
+            provider.redirect_uri,
+            "http://localhost:9080/auth/oidc/callback"
+        );
         assert_eq!(provider.scopes, ["openid", "email", "profile"]);
         assert_eq!(provider.principal_claim, "sub");
         assert_eq!(provider.display_name_claim, "email");
@@ -1199,6 +1212,27 @@ mod tests {
                     "redirect_uri = 'http://localhost:9081/auth/oidc/callback'",
                 ),
                 "must share the origin",
+            ),
+            (
+                valid("").replace(
+                    "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
+                    "redirect_uri = 'http://localhost:9080/callback'",
+                ),
+                "must use the path this server serves",
+            ),
+            (
+                valid("").replace(
+                    "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
+                    "redirect_uri = 'http://localhost:9080/'",
+                ),
+                "must use the path this server serves",
+            ),
+            (
+                valid("").replace(
+                    "redirect_uri = 'http://localhost:9080/auth/oidc/callback'",
+                    "redirect_uri = 'http://localhost:9080/auth/oidc/callback?tenant=one'",
+                ),
+                "must not include a query",
             ),
         ];
         for (raw, expected) in cases {

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -498,10 +498,6 @@ pub(super) struct ResolvedOidcProvider {
 }
 
 impl ResolvedOidcProvider {
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "used by the OIDC federation descendant")
-    )]
     pub(super) fn client_secret(&self) -> &str {
         self.client_secret.as_str()
     }

--- a/crates/coral-app/src/auth/config.rs
+++ b/crates/coral-app/src/auth/config.rs
@@ -371,9 +371,11 @@ impl OidcProviderSettings {
         }
         // The origin alone does not make the URI reachable: the router serves
         // one callback path, so any other path is accepted here and then 404s
-        // once the provider redirects the browser to it. A query is rejected
-        // for the same reason — the provider appends its own `state`, and a
-        // configured one collides with it and fails the callback.
+        // once the provider redirects the browser to it. The served path is
+        // always exactly this constant — the issuer is validated `root_only`,
+        // so there is no issuer path prefix to join onto it. A query is
+        // rejected for the same reason — the provider appends its own `state`,
+        // and a configured one collides with it and fails the callback.
         if redirect_uri.as_url().path() != OIDC_CALLBACK_PATH {
             return Err(invalid_provider(format!(
                 "redirect_uri must use the path this server serves ({OIDC_CALLBACK_PATH})"

--- a/crates/coral-app/src/auth/id_token.rs
+++ b/crates/coral-app/src/auth/id_token.rs
@@ -273,7 +273,7 @@ pub(in crate::auth) mod tests {
              issuer = 'http://localhost/issuer'
              client_id = 'provider-client'
              client_secret = 'secret'
-             redirect_uri = 'http://localhost:9080/callback'
+             redirect_uri = 'http://localhost:9080/auth/oidc/callback'
              {extra}"
         ))
         .expect("valid auth config")

--- a/crates/coral-app/src/auth/mod.rs
+++ b/crates/coral-app/src/auth/mod.rs
@@ -21,6 +21,15 @@ pub use authorization_server::{CoralAuthorizationServer, RunningCoralAuthorizati
 pub use config::AuthSettings;
 pub use error::AuthServerError;
 
+/// Path the authorization server answers the upstream provider's callback on.
+///
+/// The router registers exactly this path, and configuration validation pins
+/// `auth.provider.redirect_uri` to it. Both sides read the constant so an
+/// accepted redirect URI is always one this server actually serves: without the
+/// pin, a redirect URI on the right origin but a different path passes startup
+/// and then strands every login on a 404 the provider reports, not Coral.
+pub(crate) const OIDC_CALLBACK_PATH: &str = "/auth/oidc/callback";
+
 /// Minimal `[auth]` TOML sections shared by this module's tests.
 ///
 /// `config` and `authorization_server` both build configs from the same

--- a/crates/coral-app/src/auth/mod.rs
+++ b/crates/coral-app/src/auth/mod.rs
@@ -28,7 +28,7 @@ pub use error::AuthServerError;
 /// accepted redirect URI is always one this server actually serves: without the
 /// pin, a redirect URI on the right origin but a different path passes startup
 /// and then strands every login on a 404 the provider reports, not Coral.
-pub(crate) const OIDC_CALLBACK_PATH: &str = "/auth/oidc/callback";
+pub(in crate::auth) const OIDC_CALLBACK_PATH: &str = "/auth/oidc/callback";
 
 /// Minimal `[auth]` TOML sections shared by this module's tests.
 ///

--- a/crates/coral-app/src/auth/provider_client.rs
+++ b/crates/coral-app/src/auth/provider_client.rs
@@ -485,7 +485,7 @@ mod tests {
              issuer = '{issuer}'
              client_id = 'provider-client'
              client_secret = '{CLIENT_SECRET}'
-             redirect_uri = 'http://localhost/callback'
+             redirect_uri = 'http://localhost/auth/oidc/callback'
              scopes = ['openid', 'email']
              [auth.provider.auth_params]
              prompt = 'login'"
@@ -604,7 +604,7 @@ mod tests {
             ("tenant", "one"),
             ("response_type", "code"),
             ("client_id", "provider-client"),
-            ("redirect_uri", "http://localhost/callback"),
+            ("redirect_uri", "http://localhost/auth/oidc/callback"),
             ("scope", "openid email"),
             ("code_challenge_method", "S256"),
             ("prompt", "login"),
@@ -802,7 +802,10 @@ mod tests {
             vec![
                 ("grant_type".into(), "authorization_code".into()),
                 ("code".into(), "provider-code".into()),
-                ("redirect_uri".into(), "http://localhost/callback".into()),
+                (
+                    "redirect_uri".into(),
+                    "http://localhost/auth/oidc/callback".into(),
+                ),
                 ("client_id".into(), "provider-client".into()),
                 ("client_secret".into(), CLIENT_SECRET.into()),
                 ("code_verifier".into(), "pkce-verifier".into()),


### PR DESCRIPTION
## Stack context

**Whole stack:** This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.

**This part of the stack:** PR #1640 starts the browser login and saves its state, this PR completes the provider callback, and PR #1642 tests the callback's failure handling before token issuance is added.

**This PR:** Adds the provider callback route and converts a verified external login into a single-use Coral authorization code.

## Intent

A provider callback is not proof of identity by itself. Coral must match it to the login it started, exchange the provider code, verify the returned identity, and preserve the original client's security bindings.

## What it enables

- Adds `GET /auth/oidc/callback`. Coral authenticates against exactly one configured provider, so the path is fixed rather than provider-scoped.
- Pins `auth.provider.redirect_uri` to that path during configuration validation, so a redirect URI the config accepts is always one this server answers rather than a startup-clean setting that strands every login on a 404.
- Requires and consumes the stored callback state before making provider requests, preventing reuse.
- Exchanges the provider code using the stored PKCE verifier and validates the ID token using the stored nonce.
- Creates a random, one-time Coral authorization code bound to the user, client ID, exact redirect URI, client PKCE challenge, and resource.
- Redirects only to the callback saved in the original request and preserves the client's state.
- Returns fixed OAuth errors with no-cache and no-referrer headers instead of exposing provider or token details.

The authorization code is created here; PR #1643 adds the endpoint that redeems it for a Coral session token.

## Usage examples

The configured provider redirects the browser to:

```text
/auth/oidc/callback?state=<saved state>&code=<provider code>
```

After successful exchange and identity validation, Coral redirects the browser to the previously approved client callback:

```text
https://client.example/oauth/callback?code=<one-time Coral code>&state=<client state>
```

If the user denies access or validation fails, the same approved callback receives a sanitized OAuth error and no usable code.

