### PR TITLE
test(app): harden OAuth callback failures

### DIFF
--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -179,7 +179,7 @@ mod tests {
     };
     use crate::auth::provider_client::OidcProviderClient;
     use crate::auth::session::SessionTokenIssuer;
-    use crate::auth::state_store::{InMemoryStateStore, StateStore};
+    use crate::auth::state_store::{InMemoryStateStore, StateStore, StateStoreError};
 
     const OIDC_STATE: &str = "oidc-state";
     const CLIENT_STATE: &str = "client&error=injected";
@@ -313,16 +313,17 @@ mod tests {
             .await;
         Mock::given(method("POST"))
             .and(path("/token"))
-            .respond_with(
-                ResponseTemplate::new(token_status)
-                    .set_body_json(json!({"id_token": id_token(&claims)})),
-            )
+            .respond_with(ResponseTemplate::new(token_status).set_body_json(
+                json!({"id_token": id_token(&claims), "detail": "internal-provider-body"}),
+            ))
             .mount(server)
             .await;
         Mock::given(method("GET"))
             .and(path("/jwks"))
             .respond_with(
-                ResponseTemplate::new(jwks_status).set_body_json(json!({"keys": [rsa_key()]})),
+                ResponseTemplate::new(jwks_status).set_body_json(
+                    json!({"keys": [rsa_key()], "detail": "internal-provider-body"}),
+                ),
             )
             .mount(server)
             .await;
@@ -466,5 +467,93 @@ mod tests {
         for secret in [VERIFIER, PROVIDER_SECRET, PROVIDER_CODE] {
             assert!(!location.contains(secret));
         }
+    }
+
+    async fn assert_provider_failure(token_status: u16, jwks_status: u16, nonce: &str) {
+        let server = MockServer::start().await;
+        mount_provider(&server, token_status, jwks_status, nonce).await;
+        let store = Arc::new(InMemoryStateStore::new());
+        seed(store.as_ref(), OIDC_STATE).await;
+        let response = callback(
+            state(&server.uri(), store),
+            &[("state", OIDC_STATE), ("code", PROVIDER_CODE)],
+        )
+        .await;
+        let values = redirect_query(&response);
+        assert!(values.contains(&("error".into(), "server_error".into())));
+        assert!(!values.iter().any(|(key, _value)| key == "code"));
+        assert_security(&response);
+        let location = response.headers()[header::LOCATION]
+            .to_str()
+            .expect("location");
+        for secret in [
+            VERIFIER,
+            PROVIDER_SECRET,
+            PROVIDER_CODE,
+            "internal-provider-body",
+        ] {
+            assert!(!location.contains(secret));
+        }
+    }
+
+    #[tokio::test]
+    async fn exchange_jwks_and_nonce_failures_are_equally_sanitized() {
+        assert_provider_failure(500, 200, NONCE).await;
+        assert_provider_failure(200, 500, NONCE).await;
+        assert_provider_failure(200, 200, "wrong-nonce").await;
+    }
+
+    struct FailCodeStore(InMemoryStateStore);
+
+    #[async_trait::async_trait]
+    impl StateStore for FailCodeStore {
+        async fn store_authorization_session(
+            &self,
+            state: &str,
+            session: OAuthAuthorizationSessionRecord,
+        ) -> Result<(), StateStoreError> {
+            self.0.store_authorization_session(state, session).await
+        }
+        async fn take_authorization_session(
+            &self,
+            state: &str,
+        ) -> Result<Option<OAuthAuthorizationSessionRecord>, StateStoreError> {
+            self.0.take_authorization_session(state).await
+        }
+        async fn store_authorization_code(
+            &self,
+            _code: &str,
+            _authorization: OAuthAuthorizationCodeRecord,
+        ) -> Result<(), StateStoreError> {
+            Err(StateStoreError::CapacityExceeded { max_entries: 0 })
+        }
+        async fn take_authorization_code_for_request(
+            &self,
+            code: &str,
+            client_id: &str,
+            redirect_uri: &str,
+            challenge: &str,
+        ) -> Result<Option<OAuthAuthorizationCodeRecord>, StateStoreError> {
+            self.0
+                .take_authorization_code_for_request(code, client_id, redirect_uri, challenge)
+                .await
+        }
+    }
+
+    #[tokio::test]
+    async fn code_store_capacity_failure_exposes_no_client_code() {
+        let server = MockServer::start().await;
+        mount_provider(&server, 200, 200, NONCE).await;
+        let store = Arc::new(FailCodeStore(InMemoryStateStore::new()));
+        seed(store.as_ref(), OIDC_STATE).await;
+        let response = callback(
+            state(&server.uri(), store),
+            &[("state", OIDC_STATE), ("code", PROVIDER_CODE)],
+        )
+        .await;
+        let values = redirect_query(&response);
+        assert!(values.contains(&("error".into(), "server_error".into())));
+        assert!(!values.iter().any(|(key, _value)| key == "code"));
+        assert_security(&response);
     }
 }

--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -533,9 +533,16 @@ mod tests {
             client_id: &str,
             redirect_uri: &str,
             challenge: &str,
+            resource: &str,
         ) -> Result<Option<OAuthAuthorizationCodeRecord>, StateStoreError> {
             self.0
-                .take_authorization_code_for_request(code, client_id, redirect_uri, challenge)
+                .take_authorization_code_for_request(
+                    code,
+                    client_id,
+                    redirect_uri,
+                    challenge,
+                    resource,
+                )
                 .await
         }
     }


### PR DESCRIPTION
## Stack context

**Whole stack:** This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.

**This part of the stack:** PR #1641 implements the provider callback, this PR exercises its most sensitive failure cases, and PR #1643 adds authorization-code redemption and session-token issuance.

**This PR:** Adds adversarial callback tests without changing production behavior.

## Intent

The callback handles provider codes, ID tokens, signing keys, stored PKCE values, and newly issued Coral codes. Its failure paths need direct tests proving that none of those values escape and that a failed login cannot accidentally produce a usable code.

## What it enables

The new tests prove that:

- a failed provider token exchange;
- a failed public-key fetch;
- an ID-token nonce mismatch; and
- a failure while storing the new Coral authorization code

all produce the same sanitized `server_error`, include no client authorization code, retain the required no-cache and no-referrer headers, and do not expose provider response bodies or secrets.

Production callback logic is unchanged by this PR.

## Usage examples

If a provider's token or signing-key endpoint returns an internal error body, the client sees only:

```text
error=server_error
```

If the stored nonce is wrong or Coral cannot save the one-time authorization code, the client receives the same fixed error and no `code` parameter.