### PR TITLE
feat(cli): manage OAuth authorization server lifecycle

### DIFF
--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -1,6 +1,7 @@
 //! HTTP lifecycle for Coral's authorization server.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -146,10 +147,8 @@ impl CoralAuthorizationServer {
                     address: bind_addr,
                     source,
                 })?;
-        let endpoint_uri = format!(
-            "http://{}",
-            listener.local_addr().map_err(AuthServerError::LocalAddr)?
-        );
+        let local_addr = listener.local_addr().map_err(AuthServerError::LocalAddr)?;
+        let endpoint_uri = format!("http://{local_addr}");
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let task = tokio::spawn(async move {
             axum::serve(listener, router)
@@ -159,6 +158,7 @@ impl CoralAuthorizationServer {
                 .await
         });
         Ok(RunningCoralAuthorizationServer {
+            local_addr,
             endpoint_uri,
             shutdown_tx: Some(shutdown_tx),
             task: Some(task),
@@ -173,12 +173,19 @@ impl CoralAuthorizationServer {
 /// leaves the task detached, so a caller that drops and immediately rebinds the
 /// same fixed address can still lose the race and see `EADDRINUSE`.
 pub struct RunningCoralAuthorizationServer {
+    local_addr: SocketAddr,
     endpoint_uri: String,
     shutdown_tx: Option<oneshot::Sender<()>>,
     task: Option<JoinHandle<std::io::Result<()>>>,
 }
 
 impl RunningCoralAuthorizationServer {
+    /// Returns the listener address, including an OS-assigned port.
+    #[must_use]
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
     /// Returns the cleartext listener endpoint, including an assigned port.
     #[must_use]
     pub fn endpoint_uri(&self) -> &str {
@@ -413,6 +420,7 @@ mod tests {
     #[tokio::test]
     async fn aborts_task_when_shutdown_times_out() {
         let server = RunningCoralAuthorizationServer {
+            local_addr: SocketAddr::from(([127, 0, 0, 1], 0)),
             endpoint_uri: String::new(),
             shutdown_tx: None,
             task: Some(tokio::spawn(std::future::pending::<std::io::Result<()>>())),

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -113,6 +113,11 @@ pub(crate) struct ServerConfig {
     feedback_publisher: Arc<dyn FeedbackPublisher>,
     feature_overrides: FeatureOverrides,
     enable_stderr_logs: bool,
+    // Test seam: a listener the gRPC server adopts instead of binding
+    // `mode.bind_addr()` itself. Lets startup-failure tests hold the reserved
+    // port continuously rather than selecting and releasing it, closing the
+    // race where another process claims the port before the server binds.
+    grpc_listener: Option<Arc<std::net::TcpListener>>,
 }
 
 impl Default for ServerConfig {
@@ -131,6 +136,7 @@ impl ServerConfig {
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
             feature_overrides: FeatureOverrides::default(),
             enable_stderr_logs: false,
+            grpc_listener: None,
         }
     }
 
@@ -353,6 +359,19 @@ impl ServerBuilder {
         self
     }
 
+    /// Adopts an already-bound listener for the gRPC server instead of binding
+    /// the mode's address.
+    ///
+    /// Startup-failure tests use this to reserve a port and hand the live
+    /// listener straight to the server, so the port never lapses between
+    /// selection and bind and a parallel process cannot steal it.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_prebound_grpc_listener(mut self, listener: std::net::TcpListener) -> Self {
+        self.config.grpc_listener = Some(Arc::new(listener));
+        self
+    }
+
     /// Starts the Coral gRPC server on TCP.
     ///
     /// By default, Coral keeps a real local gRPC boundary here so the public
@@ -368,6 +387,7 @@ impl ServerBuilder {
         let layout = env.app_state_layout(self.config.config_dir.clone())?;
         let mode = self.config.resolved_mode(&layout)?;
         let principal_provider = self.config.principal_provider.clone();
+        let grpc_listener = self.config.grpc_listener.clone();
         layout.ensure()?;
         let features = FeatureStore::from_layout(layout.clone())
             .load_with_overrides(&self.config.feature_overrides)?;
@@ -459,6 +479,7 @@ impl ServerBuilder {
             trace_components,
             principal_provider,
             mode,
+            grpc_listener,
         )
         .await
     }
@@ -645,6 +666,7 @@ async fn start_server(
     trace_components: TraceServerComponents,
     principal_provider: Arc<dyn PrincipalProvider>,
     mode: ServerMode,
+    grpc_listener: Option<Arc<std::net::TcpListener>>,
 ) -> Result<RunningServer, AppError> {
     let TraceServerComponents {
         service: trace_service,
@@ -713,7 +735,16 @@ async fn start_server(
         AggregateHealthService::new(EngineReadiness::from_query_manager(health_queries)),
     ));
 
-    let listener = TcpListener::bind(mode.bind_addr()).await?;
+    let listener = match grpc_listener {
+        // A test handed us a live listener; adopt it so the reserved port never
+        // lapses. `from_std` requires the socket be non-blocking.
+        Some(prebound) => {
+            let prebound = prebound.try_clone()?;
+            prebound.set_nonblocking(true)?;
+            TcpListener::from_std(prebound)?
+        }
+        None => TcpListener::bind(mode.bind_addr()).await?,
+    };
     let local_addr = listener.local_addr()?;
     let endpoint_uri = format!("http://{local_addr}");
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -1722,6 +1753,7 @@ backend = "unsupported"
             },
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
+            None,
         )
         .await
         .expect("start server");
@@ -2169,6 +2201,7 @@ tables:
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
+            None,
         )
         .await
         .expect("start server");
@@ -2296,6 +2329,7 @@ tables:
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
+            None,
         )
         .await
         .expect("start server");
@@ -2423,6 +2457,7 @@ tables:
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
             ServerMode::EphemeralGrpc,
+            None,
         )
         .await
         .expect("start server");

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -121,18 +121,21 @@ impl Principal {
     /// provider ids), so anyone holding this value and a candidate list can confirm a
     /// match offline. Nothing deployment-specific enters the preimage either, so
     /// the same subject yields the same id everywhere — two databases join on it
-    /// directly. Keying the derivation is the fix, and doing it before any
-    /// deployment stores `federated-*` rows is free rather than a rekey. No
-    /// running instance can store one at this commit: nothing calls
-    /// `into_authorization_server`, so no token endpoint is served and no session
-    /// token exists to resolve here. That makes this the work of whichever change
-    /// first serves that endpoint.
+    /// directly. That is accepted rather than fixed. The value reaches exactly one
+    /// place, `created_by_principal_id` on `tasks`: it is in no proto, no log and
+    /// no query attribution, so reading it takes database access, and it authorizes
+    /// nothing, since any valid session token already grants full access to the
+    /// instance and every source in it.
     ///
-    /// One trap for whoever does it. The session signing key is the obvious
-    /// keying material and the wrong one: `SessionTokenVerifier` models a
-    /// multi-key `JwkSet` precisely so that key can be rotated, and keying
-    /// principal ids off it would turn a routine JWT rotation into a rekey of
-    /// every user. It needs a salt derived once and never rotated.
+    /// It is also a placeholder. Managing authorization needs a users table — a
+    /// role cannot be granted to someone the instance can neither enumerate nor
+    /// show an admin — and a one-way digest is structurally opposed to that. When
+    /// that table lands the identity becomes a random surrogate key with the
+    /// provider's `sub` in its own column: opaque by construction rather than by
+    /// keeping a key secret, updatable when an upstream subject changes, and
+    /// enumerable, so users can be listed and deleted at all. Getting there is the
+    /// same lazy rekey described above. Do not key this digest in the meantime —
+    /// that swaps one derivation for another and pays that rekey twice.
     pub(crate) fn for_federated(subject: &str) -> Self {
         let mut identity = Vec::with_capacity(subject.len() + 32);
         identity.extend_from_slice(b"coral-federated-user-v1\0");

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -1,7 +1,11 @@
+use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 
-use coral_app::{BearerAuthenticator, McpHttpServeConfig, SessionAuthSettings};
+use coral_app::{
+    BearerAuthenticator, CoralAuthorizationServer, McpHttpServeConfig,
+    RunningCoralAuthorizationServer, SessionAuthSettings,
+};
 use coral_client::{
     AppClient, BearerToken, ClientError,
     local::{
@@ -27,22 +31,83 @@ enum ServeErrorKind {
     Config(#[source] LocalServerError),
     #[error("failed to start gRPC server: {0}")]
     GrpcStart(#[source] LocalServerError),
+    #[error("failed to start OAuth authorization server: {0}")]
+    OAuthStart(#[source] OAuthLifecycleError),
+    #[error("failed to start OAuth authorization server: {oauth}; cleanup also failed: {cleanup}")]
+    OAuthStartCleanup {
+        oauth: OAuthLifecycleError,
+        cleanup: ShutdownFailures,
+    },
     #[error("failed to start MCP HTTP server: {0}")]
     McpStart(#[source] McpStartError),
-    #[error("failed to start MCP HTTP server: {mcp}; gRPC cleanup also failed: {grpc}")]
+    #[error("failed to start MCP HTTP server: {mcp}; cleanup also failed: {cleanup}")]
     McpStartCleanup {
         mcp: McpStartError,
-        grpc: LocalServerError,
+        cleanup: ShutdownFailures,
     },
-    #[error("failed to stop MCP HTTP server: {0}")]
-    McpShutdown(#[source] McpHttpError),
-    #[error("failed to stop gRPC server: {0}")]
-    GrpcShutdown(#[source] LocalServerError),
-    #[error("failed to stop MCP HTTP server: {mcp}; gRPC shutdown also failed: {grpc}")]
-    Shutdown {
-        mcp: McpHttpError,
-        grpc: LocalServerError,
-    },
+    #[error("failed to stop server components: {0}")]
+    Shutdown(ShutdownFailures),
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+struct OAuthLifecycleError(String);
+
+#[derive(Debug)]
+struct ShutdownFailures {
+    mcp: Option<McpHttpError>,
+    oauth: Option<OAuthLifecycleError>,
+    grpc: Option<Box<LocalServerError>>,
+}
+
+impl ShutdownFailures {
+    fn from_results(
+        mcp: Result<(), McpHttpError>,
+        oauth: Result<(), OAuthLifecycleError>,
+        grpc: Result<(), LocalServerError>,
+    ) -> Result<(), Self> {
+        let failures = Self {
+            mcp: mcp.err(),
+            oauth: oauth.err(),
+            grpc: grpc.err().map(Box::new),
+        };
+        if failures.mcp.is_none() && failures.oauth.is_none() && failures.grpc.is_none() {
+            Ok(())
+        } else {
+            Err(failures)
+        }
+    }
+}
+
+impl fmt::Display for ShutdownFailures {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut wrote_failure = false;
+        if let Some(error) = &self.mcp {
+            write_shutdown_failure(formatter, &mut wrote_failure, "MCP HTTP", error)?;
+        }
+        if let Some(error) = &self.oauth {
+            write_shutdown_failure(formatter, &mut wrote_failure, "OAuth", error)?;
+        }
+        if let Some(error) = &self.grpc {
+            write_shutdown_failure(formatter, &mut wrote_failure, "gRPC", error)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for ShutdownFailures {}
+
+fn write_shutdown_failure(
+    formatter: &mut fmt::Formatter<'_>,
+    wrote_failure: &mut bool,
+    component: &str,
+    error: &dyn fmt::Display,
+) -> fmt::Result {
+    if *wrote_failure {
+        formatter.write_str("; ")?;
+    }
+    *wrote_failure = true;
+    write!(formatter, "{component}: {error}")
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -59,6 +124,7 @@ enum McpStartError {
 
 pub(crate) struct RunningServer {
     grpc: GrpcServer,
+    oauth: Option<RunningCoralAuthorizationServer>,
     mcp_http: Option<RunningMcpHttpServer>,
     grpc_authentication_enabled: bool,
 }
@@ -76,6 +142,13 @@ impl RunningServer {
         self.grpc_authentication_enabled
     }
 
+    #[cfg(test)]
+    fn oauth_addr(&self) -> Option<SocketAddr> {
+        self.oauth
+            .as_ref()
+            .map(RunningCoralAuthorizationServer::local_addr)
+    }
+
     pub(crate) async fn wait_for_exit(&self) {
         self.grpc.wait_for_exit().await;
     }
@@ -83,20 +156,13 @@ impl RunningServer {
     pub(crate) async fn shutdown(self) -> Result<(), ServeError> {
         let Self {
             grpc,
+            oauth,
             mcp_http,
             grpc_authentication_enabled: _,
         } = self;
-        let mcp_result = match mcp_http {
-            Some(server) => server.shutdown().await,
-            None => Ok(()),
-        };
-        let grpc_result = grpc.shutdown().await;
-        match (mcp_result, grpc_result) {
-            (Ok(()), Ok(())) => Ok(()),
-            (Err(mcp), Ok(())) => Err(ServeError(ServeErrorKind::McpShutdown(mcp))),
-            (Ok(()), Err(grpc)) => Err(ServeError(ServeErrorKind::GrpcShutdown(grpc))),
-            (Err(mcp), Err(grpc)) => Err(ServeError(ServeErrorKind::Shutdown { mcp, grpc })),
-        }
+        shutdown_components(grpc, oauth, mcp_http)
+            .await
+            .map_err(|failures| ServeError(ServeErrorKind::Shutdown(failures)))
     }
 }
 
@@ -117,24 +183,44 @@ pub(crate) async fn start(
     let grpc_authentication_enabled = session_auth.is_some();
     let (builder, mcp_principal_provider) =
         compose_session_policies(builder, session_auth.as_ref(), mcp_config.as_ref());
+    // Built after the providers, which only borrow the settings; this consumes them.
+    let oauth_server = match session_auth {
+        Some(session_auth) => Some(
+            session_auth
+                .into_authorization_server()
+                .map_err(|error| ServeError(ServeErrorKind::Config(error)))?,
+        ),
+        None => None,
+    };
     let grpc = builder
         .start()
         .await
         .map_err(|error| ServeError(ServeErrorKind::GrpcStart(error)))?;
     let grpc_addr = grpc.local_addr();
+    let oauth = match start_oauth(oauth_server).await {
+        Ok(server) => server,
+        Err(oauth) => {
+            let error = match shutdown_components(grpc, None, None).await {
+                Ok(()) => ServeErrorKind::OAuthStart(oauth),
+                Err(cleanup) => ServeErrorKind::OAuthStartCleanup { oauth, cleanup },
+            };
+            return Err(ServeError(error));
+        }
+    };
     let mcp_http =
         match start_mcp_http(mcp_config, mcp_principal_provider, grpc_addr, mcp_options).await {
             Ok(server) => server,
             Err(mcp) => {
-                let error = match grpc.shutdown().await {
+                let error = match shutdown_components(grpc, oauth, None).await {
                     Ok(()) => ServeErrorKind::McpStart(mcp),
-                    Err(grpc) => ServeErrorKind::McpStartCleanup { mcp, grpc },
+                    Err(cleanup) => ServeErrorKind::McpStartCleanup { mcp, cleanup },
                 };
                 return Err(ServeError(error));
             }
         };
     Ok(RunningServer {
         grpc,
+        oauth,
         mcp_http,
         grpc_authentication_enabled,
     })
@@ -166,6 +252,32 @@ fn compose_session_policies(
         builder.with_principal_provider(private_api),
         mcp_authenticator,
     )
+}
+
+async fn start_oauth(
+    server: Option<CoralAuthorizationServer>,
+) -> Result<Option<RunningCoralAuthorizationServer>, OAuthLifecycleError> {
+    match server {
+        Some(server) => server.start().await.map(Some).map_err(OAuthLifecycleError),
+        None => Ok(None),
+    }
+}
+
+async fn shutdown_components(
+    grpc: GrpcServer,
+    oauth: Option<RunningCoralAuthorizationServer>,
+    mcp_http: Option<RunningMcpHttpServer>,
+) -> Result<(), ShutdownFailures> {
+    let mcp_result = match mcp_http {
+        Some(server) => server.shutdown().await,
+        None => Ok(()),
+    };
+    let oauth_result = match oauth {
+        Some(server) => server.shutdown().await.map_err(OAuthLifecycleError),
+        None => Ok(()),
+    };
+    let grpc_result = grpc.shutdown().await;
+    ShutdownFailures::from_results(mcp_result, oauth_result, grpc_result)
 }
 
 async fn start_mcp_http(

--- a/crates/coral-cli/src/serve.rs
+++ b/crates/coral-cli/src/serve.rs
@@ -3,7 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 
 use coral_app::{
-    BearerAuthenticator, CoralAuthorizationServer, McpHttpServeConfig,
+    AuthServerError, BearerAuthenticator, CoralAuthorizationServer, McpHttpServeConfig,
     RunningCoralAuthorizationServer, SessionAuthSettings,
 };
 use coral_client::{
@@ -32,10 +32,10 @@ enum ServeErrorKind {
     #[error("failed to start gRPC server: {0}")]
     GrpcStart(#[source] LocalServerError),
     #[error("failed to start OAuth authorization server: {0}")]
-    OAuthStart(#[source] OAuthLifecycleError),
+    OAuthStart(#[source] AuthServerError),
     #[error("failed to start OAuth authorization server: {oauth}; cleanup also failed: {cleanup}")]
     OAuthStartCleanup {
-        oauth: OAuthLifecycleError,
+        oauth: AuthServerError,
         cleanup: ShutdownFailures,
     },
     #[error("failed to start MCP HTTP server: {0}")]
@@ -49,21 +49,17 @@ enum ServeErrorKind {
     Shutdown(ShutdownFailures),
 }
 
-#[derive(Debug, thiserror::Error)]
-#[error("{0}")]
-struct OAuthLifecycleError(String);
-
 #[derive(Debug)]
 struct ShutdownFailures {
     mcp: Option<McpHttpError>,
-    oauth: Option<OAuthLifecycleError>,
+    oauth: Option<AuthServerError>,
     grpc: Option<Box<LocalServerError>>,
 }
 
 impl ShutdownFailures {
     fn from_results(
         mcp: Result<(), McpHttpError>,
-        oauth: Result<(), OAuthLifecycleError>,
+        oauth: Result<(), AuthServerError>,
         grpc: Result<(), LocalServerError>,
     ) -> Result<(), Self> {
         let failures = Self {
@@ -256,9 +252,9 @@ fn compose_session_policies(
 
 async fn start_oauth(
     server: Option<CoralAuthorizationServer>,
-) -> Result<Option<RunningCoralAuthorizationServer>, OAuthLifecycleError> {
+) -> Result<Option<RunningCoralAuthorizationServer>, AuthServerError> {
     match server {
-        Some(server) => server.start().await.map(Some).map_err(OAuthLifecycleError),
+        Some(server) => server.start().await.map(Some),
         None => Ok(None),
     }
 }
@@ -273,7 +269,7 @@ async fn shutdown_components(
         None => Ok(()),
     };
     let oauth_result = match oauth {
-        Some(server) => server.shutdown().await.map_err(OAuthLifecycleError),
+        Some(server) => server.shutdown().await,
         None => Ok(()),
     };
     let grpc_result = grpc.shutdown().await;

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -15,9 +15,30 @@ use tonic::Request;
 use super::*;
 
 const INITIALIZE: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}"#;
+const OAUTH_ISSUER: &str = "http://localhost:9080";
+const OAUTH_RESOURCE: &str = "http://localhost:1457";
 
 fn write_config(temp: &TempDir, config: &str) {
     std::fs::write(temp.path().join("config.toml"), config).expect("write config");
+}
+
+fn available_addr() -> SocketAddr {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve address");
+    listener.local_addr().expect("reserved address")
+}
+
+fn write_oauth_config(temp: &TempDir, oauth_bind: SocketAddr, mcp_bind: Option<SocketAddr>) {
+    let signing_key =
+        EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
+            .expect("P-256 signing key");
+    std::fs::write(temp.path().join("session.key"), signing_key.as_ref()).expect("session key");
+    let mcp_bind = mcp_bind.unwrap_or_else(|| SocketAddr::from((Ipv4Addr::LOCALHOST, 0)));
+    write_config(
+        temp,
+        &format!(
+            "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\nbind = '{mcp_bind}'\npublic_url = '{OAUTH_RESOURCE}'\n\n[auth]\nhttp_bind_addr = '{oauth_bind}'\n\n[auth.session]\nsigning_key_file = 'session.key'\n\n[auth.authorization_server]\nissuer = '{OAUTH_ISSUER}'\n\n[auth.provider]\nissuer = 'https://accounts.example.test'\nclient_id = 'upstream-client'\nclient_secret = 'test-secret'\nredirect_uri = '{OAUTH_ISSUER}/auth/oidc/callback'\n"
+        ),
+    );
 }
 
 fn grpc_addr(server: &RunningServer) -> SocketAddr {
@@ -136,6 +157,26 @@ fn loopback_grpc_endpoint_maps_wildcards_and_rejects_public_addresses() {
     .expect_err("IPv4-mapped IPv6 address must be rejected");
 }
 
+#[test]
+fn shutdown_failures_retain_every_component_in_order() {
+    let failures = ShutdownFailures::from_results(
+        Err(McpHttpError::ShutdownTimedOut),
+        Err(OAuthLifecycleError("OAuth test failure".to_string())),
+        Err(LocalServerError::Unavailable(
+            "gRPC test failure".to_string(),
+        )),
+    )
+    .expect_err("all shutdown failures");
+
+    assert!(failures.mcp.is_some());
+    assert!(failures.oauth.is_some());
+    assert!(failures.grpc.is_some());
+    assert_eq!(
+        failures.to_string(),
+        "MCP HTTP: MCP HTTP server shutdown timed out; OAuth: OAuth test failure; gRPC: unavailable: gRPC test failure"
+    );
+}
+
 #[tokio::test]
 async fn auth_disabled_companion_serves_and_shuts_down() {
     let temp = TempDir::new().expect("temp dir");
@@ -154,6 +195,7 @@ async fn auth_disabled_companion_serves_and_shuts_down() {
     let grpc_addr = grpc_addr(&server);
     assert!(!server.grpc_authentication_enabled());
     let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
+    assert!(server.oauth_addr().is_none());
     assert_catalog_tool(format!("http://{mcp_addr}/mcp"), None).await;
     server.shutdown().await.expect("shutdown composite server");
     let grpc_rebound = TcpListener::bind(grpc_addr).expect("gRPC port must be released");
@@ -189,6 +231,69 @@ async fn companion_uses_supplied_mcp_options() {
 /// canonicalization changes (an uppercase host) and mints against whatever the
 /// server advertises.
 #[tokio::test]
+async fn oauth_and_mcp_companions_serve_and_release_all_listeners() {
+    let temp = TempDir::new().expect("temp dir");
+    write_oauth_config(
+        &temp,
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
+        Some(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))),
+    );
+    let server = start(
+        ServerBuilder::configured_standalone_grpc()
+            .with_config_dir(temp.path())
+            .with_noop_feedback_uploads(),
+        McpOptions::default(),
+    )
+    .await
+    .expect("start composite server");
+    let grpc_addr = grpc_addr(&server);
+    let oauth_addr = server.oauth_addr().expect("OAuth endpoint");
+    let mcp_addr = server.mcp_http_addr().expect("MCP HTTP endpoint");
+
+    let response = reqwest::get(format!(
+        "http://{oauth_addr}/.well-known/oauth-authorization-server"
+    ))
+    .await
+    .expect("OAuth metadata response");
+    assert!(response.status().is_success());
+    let metadata = response.text().await.expect("OAuth metadata body");
+    assert!(metadata.contains(&format!(r#""issuer":"{OAUTH_ISSUER}""#)));
+
+    server.shutdown().await.expect("shutdown composite server");
+    let grpc_rebound = TcpListener::bind(grpc_addr).expect("gRPC port must be released");
+    let oauth_rebound = TcpListener::bind(oauth_addr).expect("OAuth port must be released");
+    let mcp_rebound = TcpListener::bind(mcp_addr).expect("MCP port must be released");
+    drop((grpc_rebound, oauth_rebound, mcp_rebound));
+}
+
+#[tokio::test]
+async fn oauth_start_failure_releases_the_started_grpc_listener() {
+    let grpc_addr = available_addr();
+    let occupied_oauth = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("occupy OAuth port");
+    let oauth_addr = occupied_oauth.local_addr().expect("OAuth address");
+    let temp = TempDir::new().expect("temp dir");
+    write_oauth_config(&temp, oauth_addr, None);
+
+    let result = start(
+        ServerBuilder::standalone_grpc(grpc_addr)
+            .with_config_dir(temp.path())
+            .with_noop_feedback_uploads(),
+        McpOptions::default(),
+    )
+    .await;
+    let Err(error) = result else {
+        panic!("occupied OAuth address must fail startup");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("failed to bind authorization server")
+    );
+    let rebound = TcpListener::bind(grpc_addr).expect("gRPC listener must be released");
+    drop((rebound, occupied_oauth));
+}
+
+#[tokio::test]
 async fn session_authenticated_companion_forwards_bearer() {
     let temp = TempDir::new().expect("temp dir");
     let signing_key =
@@ -213,7 +318,6 @@ signing_key_file = 'session.key'
 issuer = 'https://auth.example'
 
 [auth.provider]
-type = 'oidc'
 issuer = 'https://accounts.example'
 client_id = 'upstream-client'
 client_secret = 'test-secret'
@@ -294,19 +398,16 @@ redirect_uri = 'https://auth.example/auth/oidc/callback'
 }
 
 #[tokio::test]
-async fn mcp_start_failure_releases_the_started_grpc_listener() {
+async fn mcp_start_failure_releases_started_oauth_and_grpc_listeners() {
     let grpc_probe = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve gRPC port");
+    let oauth_probe = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve OAuth port");
     let grpc_addr = grpc_probe.local_addr().expect("gRPC address");
-    drop(grpc_probe);
+    let oauth_addr = oauth_probe.local_addr().expect("OAuth address");
+    drop((grpc_probe, oauth_probe));
     let occupied_mcp = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("occupy MCP port");
     let mcp_addr = occupied_mcp.local_addr().expect("MCP address");
     let temp = TempDir::new().expect("temp dir");
-    write_config(
-        &temp,
-        &format!(
-            "[trace_history]\nenabled = false\n\n[server.mcp_http]\nenabled = true\nbind = '{mcp_addr}'\n"
-        ),
-    );
+    write_oauth_config(&temp, oauth_addr, Some(mcp_addr));
 
     let result = start(
         ServerBuilder::standalone_grpc(grpc_addr)
@@ -319,6 +420,7 @@ async fn mcp_start_failure_releases_the_started_grpc_listener() {
         panic!("occupied MCP address must fail startup");
     };
     assert!(error.to_string().contains("failed to bind MCP HTTP server"));
-    let rebound = TcpListener::bind(grpc_addr).expect("gRPC listener must be released");
-    drop(rebound);
+    let grpc_rebound = TcpListener::bind(grpc_addr).expect("gRPC listener must be released");
+    let oauth_rebound = TcpListener::bind(oauth_addr).expect("OAuth listener must be released");
+    drop((grpc_rebound, oauth_rebound, occupied_mcp));
 }

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -22,11 +22,6 @@ fn write_config(temp: &TempDir, config: &str) {
     std::fs::write(temp.path().join("config.toml"), config).expect("write config");
 }
 
-fn available_addr() -> SocketAddr {
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve address");
-    listener.local_addr().expect("reserved address")
-}
-
 fn write_oauth_config(temp: &TempDir, oauth_bind: SocketAddr, mcp_bind: Option<SocketAddr>) {
     let signing_key =
         EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
@@ -268,16 +263,22 @@ async fn oauth_and_mcp_companions_serve_and_release_all_listeners() {
 
 #[tokio::test]
 async fn oauth_start_failure_releases_the_started_grpc_listener() {
-    let grpc_addr = available_addr();
+    let grpc_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve gRPC port");
+    let grpc_addr = grpc_listener.local_addr().expect("gRPC address");
     let occupied_oauth = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("occupy OAuth port");
     let oauth_addr = occupied_oauth.local_addr().expect("OAuth address");
     let temp = TempDir::new().expect("temp dir");
     write_oauth_config(&temp, oauth_addr, None);
 
+    // Hand the live gRPC listener to the server so the reserved port never
+    // lapses between selection and bind: a parallel process cannot claim it, so
+    // startup fails on the occupied OAuth port and must release the gRPC
+    // listener afterward.
     let result = start(
         ServerBuilder::standalone_grpc(grpc_addr)
             .with_config_dir(temp.path())
-            .with_noop_feedback_uploads(),
+            .with_noop_feedback_uploads()
+            .with_prebound_grpc_listener(grpc_listener),
         McpOptions::default(),
     )
     .await;

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -378,6 +378,7 @@ redirect_uri = 'https://auth.example/auth/oidc/callback'
     // HTTP keeps serving must turn the authenticated probe unhealthy.
     let RunningServer {
         grpc,
+        oauth,
         mcp_http,
         grpc_authentication_enabled: _,
     } = server;
@@ -395,6 +396,11 @@ redirect_uri = 'https://auth.example/auth/oidc/callback'
         .shutdown()
         .await
         .expect("shutdown MCP HTTP server");
+    oauth
+        .expect("OAuth server")
+        .shutdown()
+        .await
+        .expect("shutdown OAuth server");
 }
 
 #[tokio::test]

--- a/crates/coral-cli/src/serve/tests.rs
+++ b/crates/coral-cli/src/serve/tests.rs
@@ -161,7 +161,7 @@ fn loopback_grpc_endpoint_maps_wildcards_and_rejects_public_addresses() {
 fn shutdown_failures_retain_every_component_in_order() {
     let failures = ShutdownFailures::from_results(
         Err(McpHttpError::ShutdownTimedOut),
-        Err(OAuthLifecycleError("OAuth test failure".to_string())),
+        Err(AuthServerError::Config("OAuth test failure".to_string())),
         Err(LocalServerError::Unavailable(
             "gRPC test failure".to_string(),
         )),


### PR DESCRIPTION
## Stack context

**Whole stack:** This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.

**This part of the stack:** PR #1645 prepares authenticated gRPC and MCP HTTP services, this PR makes `coral server` manage the OAuth listener with them, and PR #1649 begins adding safe discovery of web-app clients.

**This PR:** Makes the CLI start, track, clean up, and stop the optional OAuth authorization server.

## Intent

The OAuth server can already be constructed from validated settings, but it is not useful until the long-running CLI command owns its lifecycle alongside gRPC and MCP HTTP.

## What it enables

- Starts gRPC first, then OAuth, then MCP HTTP.
- Cleans up already-started components in reverse order if a later component fails to start.
- Stops MCP HTTP, OAuth, and gRPC in reverse order during normal shutdown.
- Preserves and reports cleanup failures instead of hiding one behind another.
- Tracks the OAuth listener as part of the running server and exposes its assigned address for tests.

This PR starts the OAuth listener, but production client-metadata integration still lands later in the stack.

## Usage examples

With session, OAuth, and provider settings configured, run:

```shell
coral server
```

The command now owns all configured listeners as one process. If OAuth cannot bind, gRPC is stopped. If MCP HTTP cannot start, both OAuth and gRPC are stopped before the command returns the error.