### PR TITLE
refactor(app): expose reusable envelope encryption

### DIFF
--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -4,7 +4,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "Credential DB runtime wiring lands in a later stack branch; this branch isolates cryptographic primitives for review."
+        reason = "Credential DB runtime wiring and identity document callers land in later stack branches; this branch isolates cryptographic primitives for review."
     )
 )]
 
@@ -201,6 +201,9 @@ pub(crate) struct EncryptedCredentialDocument {
     pub(crate) aad_version: i64,
 }
 
+/// Shared envelope-encrypted document layout for credential and identity data.
+pub(crate) type EncryptedEnvelopeDocument = EncryptedCredentialDocument;
+
 #[derive(serde::Serialize)]
 struct PlaintextCredentialDocument<'a> {
     version: u32,
@@ -219,43 +222,19 @@ pub(crate) fn encrypt_credential_values(
     values: &BTreeMap<String, String>,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<EncryptedCredentialDocument, CredentialsError> {
-    let kek = key_provider.active_key()?;
-    let dek = Zeroizing::new(random_array::<KEY_LEN>()?);
-    let nonce = random_array::<NONCE_LEN>()?;
-    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
-
     let plaintext = PlaintextCredentialDocument {
         version: CREDENTIAL_DOCUMENT_VERSION,
         values,
     };
-    let mut document_bytes = Zeroizing::new(
+    let document_bytes = Zeroizing::new(
         serde_json::to_vec(&plaintext)
             .map_err(|error| CredentialsError::Parse(error.to_string()))?,
     );
-    seal(
-        &*dek,
-        &nonce,
+    seal_envelope_document(
         credential_document_aad(workspace_name, source_name),
-        &mut document_bytes,
-    )?;
-
-    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
-    seal(
-        &kek.bytes,
-        &wrapped_dek_nonce,
-        credential_dek_aad(kek.key_id()),
-        &mut wrapped_dek,
-    )?;
-
-    Ok(EncryptedCredentialDocument {
-        ciphertext: std::mem::take(&mut *document_bytes),
-        nonce: nonce.to_vec(),
-        wrapped_dek: std::mem::take(&mut *wrapped_dek),
-        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
-        key_id: kek.key_id.clone(),
-        algorithm: CREDENTIAL_DOCUMENT_ALGORITHM.to_string(),
-        aad_version: CREDENTIAL_DOCUMENT_AAD_VERSION,
-    })
+        document_bytes,
+        key_provider,
+    )
 }
 
 pub(crate) fn decrypt_credential_values(
@@ -309,24 +288,7 @@ pub(crate) fn rewrap_credential_document(
             .map(Some);
     }
 
-    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
-    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
-    seal(
-        &active_kek.bytes,
-        &wrapped_dek_nonce,
-        credential_dek_aad(active_kek.key_id()),
-        &mut wrapped_dek,
-    )?;
-
-    Ok(Some(EncryptedCredentialDocument {
-        ciphertext: document.ciphertext.clone(),
-        nonce: document.nonce.clone(),
-        wrapped_dek: std::mem::take(&mut *wrapped_dek),
-        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
-        key_id: active_kek.key_id.clone(),
-        algorithm: document.algorithm.clone(),
-        aad_version: document.aad_version,
-    }))
+    rewrap_dek(document, &active_kek, &dek)
 }
 
 fn decrypt_credential_document_bytes(
@@ -366,14 +328,8 @@ fn unwrap_dek(
     document: &EncryptedCredentialDocument,
     kek: &CredentialEncryptionKey,
 ) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
-    let mut dek = Zeroizing::new(document.wrapped_dek.clone());
-    match open(
-        &kek.bytes,
-        document.wrapped_dek_nonce.as_slice(),
-        credential_dek_aad(&document.key_id),
-        dek.as_mut_slice(),
-    ) {
-        Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
+    match unwrap_current_dek(document, kek) {
+        Ok(dek) => Ok(dek),
         Err(primary_error) => {
             let mut legacy_dek = Zeroizing::new(document.wrapped_dek.clone());
             match open(
@@ -389,6 +345,20 @@ fn unwrap_dek(
     }
 }
 
+fn unwrap_current_dek(
+    document: &EncryptedEnvelopeDocument,
+    kek: &CredentialEncryptionKey,
+) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
+    let mut dek = Zeroizing::new(document.wrapped_dek.clone());
+    open(
+        &kek.bytes,
+        document.wrapped_dek_nonce.as_slice(),
+        credential_dek_aad(&document.key_id),
+        dek.as_mut_slice(),
+    )
+    .and_then(validate_dek_plaintext)
+}
+
 fn validate_dek_plaintext(
     dek_plaintext: &[u8],
 ) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
@@ -401,6 +371,31 @@ fn validate_dek_plaintext(
     let mut dek = [0_u8; KEY_LEN];
     dek.copy_from_slice(dek_plaintext);
     Ok(Zeroizing::new(dek))
+}
+
+fn rewrap_dek(
+    document: &EncryptedEnvelopeDocument,
+    active_kek: &CredentialEncryptionKey,
+    dek: &[u8; KEY_LEN],
+) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
+    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
+    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
+    seal(
+        &active_kek.bytes,
+        &wrapped_dek_nonce,
+        credential_dek_aad(active_kek.key_id()),
+        &mut wrapped_dek,
+    )?;
+
+    Ok(Some(EncryptedCredentialDocument {
+        ciphertext: document.ciphertext.clone(),
+        nonce: document.nonce.clone(),
+        wrapped_dek: std::mem::take(&mut *wrapped_dek),
+        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
+        key_id: active_kek.key_id.clone(),
+        algorithm: document.algorithm.clone(),
+        aad_version: document.aad_version,
+    }))
 }
 
 fn validate_document_metadata(
@@ -419,6 +414,83 @@ fn validate_document_metadata(
         )));
     }
     Ok(())
+}
+
+/// Seal serialized plaintext with a random DEK and wrap that DEK with the active KEK.
+pub(crate) fn seal_envelope_document(
+    document_aad: Vec<u8>,
+    mut document_bytes: Zeroizing<Vec<u8>>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<EncryptedEnvelopeDocument, CredentialsError> {
+    let kek = key_provider.active_key()?;
+    let dek = Zeroizing::new(random_array::<KEY_LEN>()?);
+    let nonce = random_array::<NONCE_LEN>()?;
+    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
+
+    seal(&*dek, &nonce, document_aad, &mut document_bytes)?;
+
+    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
+    seal(
+        &kek.bytes,
+        &wrapped_dek_nonce,
+        credential_dek_aad(kek.key_id()),
+        &mut wrapped_dek,
+    )?;
+
+    Ok(EncryptedCredentialDocument {
+        ciphertext: std::mem::take(&mut *document_bytes),
+        nonce: nonce.to_vec(),
+        wrapped_dek: std::mem::take(&mut *wrapped_dek),
+        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
+        key_id: kek.key_id.clone(),
+        algorithm: CREDENTIAL_DOCUMENT_ALGORITHM.to_string(),
+        aad_version: CREDENTIAL_DOCUMENT_AAD_VERSION,
+    })
+}
+
+/// Open a current-format envelope document with the supplied payload AAD.
+pub(crate) fn open_envelope_document(
+    document: &EncryptedEnvelopeDocument,
+    document_aad: Vec<u8>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
+    validate_document_metadata(document)?;
+    let kek = key_provider.key(&document.key_id)?;
+    let dek = unwrap_current_dek(document, &kek)?;
+
+    let mut ciphertext = Zeroizing::new(document.ciphertext.clone());
+    open(
+        &*dek,
+        document.nonce.as_slice(),
+        document_aad,
+        ciphertext.as_mut_slice(),
+    )
+    .map(|plaintext| Zeroizing::new(plaintext.to_vec()))
+}
+
+/// Rewrap a current-format envelope document when its KEK is stale.
+pub(crate) fn rewrap_envelope_document(
+    document: &EncryptedEnvelopeDocument,
+    document_aad: Vec<u8>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
+    validate_document_metadata(document)?;
+    let old_kek = key_provider.key(&document.key_id)?;
+    let active_kek = key_provider.active_key()?;
+    if old_kek.key_id == active_kek.key_id {
+        return Ok(None);
+    }
+
+    let dek = unwrap_current_dek(document, &old_kek)?;
+    let mut document_probe = Zeroizing::new(document.ciphertext.clone());
+    open(
+        &*dek,
+        document.nonce.as_slice(),
+        document_aad,
+        document_probe.as_mut_slice(),
+    )?;
+
+    rewrap_dek(document, &active_kek, &dek)
 }
 
 fn seal(
@@ -495,7 +567,8 @@ fn legacy_credential_dek_aad(key_id: &str) -> Vec<u8> {
     format!("coral-credential-dek:v{CREDENTIAL_DOCUMENT_AAD_VERSION}:{key_id}").into_bytes()
 }
 
-fn encode_aad_fields(domain: &str, fields: &[&str]) -> Vec<u8> {
+/// Encode an AAD domain and ordered fields using length-prefixed values.
+pub(crate) fn encode_aad_fields(domain: &str, fields: &[&str]) -> Vec<u8> {
     let mut aad = Vec::new();
     aad.extend_from_slice(domain.as_bytes());
     aad.push(0);

--- a/crates/coral-app/src/credentials/encryption_tests.rs
+++ b/crates/coral-app/src/credentials/encryption_tests.rs
@@ -4,12 +4,14 @@ use std::thread;
 
 use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey};
 use tempfile::tempdir;
+use zeroize::Zeroizing;
 
 use super::CredentialsError;
 use super::encryption::{
-    CREDENTIAL_DOCUMENT_AAD_VERSION, CredentialEncryptionKey, CredentialKeyProvider,
-    LocalFileCredentialKeyProvider, decrypt_credential_values, encrypt_credential_values,
-    rewrap_credential_document,
+    CREDENTIAL_DOCUMENT_AAD_VERSION, CREDENTIAL_DOCUMENT_ALGORITHM, CredentialEncryptionKey,
+    CredentialKeyProvider, LocalFileCredentialKeyProvider, decrypt_credential_values,
+    encrypt_credential_values, open_envelope_document, rewrap_credential_document,
+    rewrap_envelope_document, seal_envelope_document,
 };
 use crate::sources::SourceName;
 use crate::state::AppStateLayout;
@@ -305,6 +307,119 @@ fn credential_document_rewrap_changes_kek_without_reencrypting_payload() {
 }
 
 #[test]
+fn credential_document_rewrap_migrates_legacy_payload_aad() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let old_key_bytes = [29; 32];
+    let old_key = CredentialEncryptionKey::from_static_bytes_for_test(old_key_bytes);
+    let new_key = CredentialEncryptionKey::from_static_bytes_for_test([31; 32]);
+    let old_provider = RotatingKeyProvider {
+        active: old_key.clone(),
+        keys: vec![old_key.clone()],
+    };
+    let rotating_provider = RotatingKeyProvider {
+        active: new_key.clone(),
+        keys: vec![old_key, new_key.clone()],
+    };
+    let values = BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]);
+    let mut legacy =
+        encrypt_credential_values(&workspace, &source, &values, &old_provider).expect("encrypt");
+    let key_id = legacy.key_id.clone();
+    let dek: [u8; 32] = open_for_test(
+        &old_key_bytes,
+        legacy.wrapped_dek_nonce.as_slice(),
+        current_dek_aad_for_test(&key_id),
+        &legacy.wrapped_dek,
+    )
+    .try_into()
+    .expect("DEK length");
+    let plaintext = serde_json::to_vec(&serde_json::json!({
+        "version": 1,
+        "values": values,
+    }))
+    .expect("serialize legacy document");
+    let legacy_nonce = [5; 12];
+    legacy.ciphertext = seal_for_test(
+        &dek,
+        legacy_nonce,
+        legacy_document_aad_for_test(&workspace, &source, &key_id),
+        &plaintext,
+    );
+    legacy.nonce = legacy_nonce.to_vec();
+
+    assert_eq!(
+        decrypt_credential_values(&workspace, &source, &legacy, &old_provider)
+            .expect("legacy payload AAD should decrypt"),
+        values
+    );
+    let migrated = rewrap_credential_document(&workspace, &source, &legacy, &rotating_provider)
+        .expect("rewrap legacy document")
+        .expect("stale key should migrate");
+    assert_eq!(migrated.key_id, new_key.key_id());
+    assert_ne!(migrated.ciphertext, legacy.ciphertext);
+    assert_ne!(migrated.nonce, legacy.nonce);
+    assert_eq!(
+        decrypt_credential_values(&workspace, &source, &migrated, &rotating_provider)
+            .expect("decrypt migrated document"),
+        values
+    );
+}
+
+#[test]
+fn shared_envelope_helpers_round_trip_and_rewrap_current_documents() {
+    let old_key = CredentialEncryptionKey::from_static_bytes_for_test([37; 32]);
+    let new_key = CredentialEncryptionKey::from_static_bytes_for_test([41; 32]);
+    let old_provider = RotatingKeyProvider {
+        active: old_key.clone(),
+        keys: vec![old_key.clone()],
+    };
+    let rotating_provider = RotatingKeyProvider {
+        active: new_key.clone(),
+        keys: vec![old_key, new_key.clone()],
+    };
+    let aad = b"test-envelope-aad".to_vec();
+    let plaintext = b"envelope payload".to_vec();
+
+    let encrypted = seal_envelope_document(
+        aad.clone(),
+        Zeroizing::new(plaintext.clone()),
+        &old_provider,
+    )
+    .expect("seal envelope");
+    assert_eq!(
+        open_envelope_document(&encrypted, aad.clone(), &old_provider)
+            .expect("open envelope")
+            .as_slice(),
+        plaintext
+    );
+    assert_open_failed(
+        &open_envelope_document(&encrypted, b"wrong-aad".to_vec(), &old_provider)
+            .expect_err("wrong AAD should fail authentication"),
+    );
+
+    let rewrapped = rewrap_envelope_document(&encrypted, aad.clone(), &rotating_provider)
+        .expect("rewrap envelope")
+        .expect("stale key should rewrap");
+    assert_eq!(rewrapped.key_id, new_key.key_id());
+    assert_eq!(rewrapped.ciphertext, encrypted.ciphertext);
+    assert_eq!(rewrapped.nonce, encrypted.nonce);
+    assert_ne!(rewrapped.wrapped_dek, encrypted.wrapped_dek);
+    assert_ne!(rewrapped.wrapped_dek_nonce, encrypted.wrapped_dek_nonce);
+    assert_eq!(
+        open_envelope_document(&rewrapped, aad.clone(), &rotating_provider)
+            .expect("open rewrapped envelope")
+            .as_slice(),
+        plaintext
+    );
+    assert!(
+        rewrap_envelope_document(&rewrapped, aad, &rotating_provider)
+            .expect("rewrap current envelope")
+            .is_none(),
+        "active KEK should not produce another rewrap"
+    );
+}
+
+#[test]
 fn local_file_key_provider_creates_and_reuses_private_key_file() {
     let temp = tempdir().expect("temp dir");
     let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
@@ -405,6 +520,22 @@ fn current_dek_aad_for_test(key_id: &str) -> Vec<u8> {
 
 fn legacy_dek_aad_for_test(key_id: &str) -> Vec<u8> {
     format!("coral-credential-dek:v{CREDENTIAL_DOCUMENT_AAD_VERSION}:{key_id}").into_bytes()
+}
+
+fn legacy_document_aad_for_test(
+    workspace: &WorkspaceName,
+    source: &SourceName,
+    key_id: &str,
+) -> Vec<u8> {
+    format!(
+        "coral-credential-document:v{}:{}:{}:{}:{}",
+        CREDENTIAL_DOCUMENT_AAD_VERSION,
+        workspace.as_str(),
+        source.as_str(),
+        CREDENTIAL_DOCUMENT_ALGORITHM,
+        key_id
+    )
+    .into_bytes()
 }
 
 fn encode_aad_fields_for_test(domain: &str, fields: &[&str]) -> Vec<u8> {


### PR DESCRIPTION
## Intent

Expose the current envelope-encryption format as a reusable app-internal primitive while keeping credential-specific legacy compatibility isolated.

## What it enables

Identity-spec and identity-instance documents can use the same audited seal, open, rewrap, and AAD encoding implementation without duplicating cryptographic code or widening credential fallback behavior.

## Usage examples

App-owned document code can call seal_envelope_document, open_envelope_document, rewrap_envelope_document, and encode_aad_fields with a domain-specific authenticated context. Existing credential encryption continues through its credential-specific wrappers.