### PR TITLE
feat(app): store OAuth authorization approvals

### DIFF
--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -11,7 +11,7 @@ use super::config::{AuthSettings, ResolvedAuthSettings, signing_key_env_error};
 use super::error::AuthServerError;
 use super::provider_client::OidcProviderClient;
 use super::session::SessionTokenIssuer;
-use super::state_store::{InMemoryStateStore, StateStore};
+use super::state_store::{CodeStore, InMemoryStateStore, SessionStore};
 use crate::oauth_resource::{CanonicalOauthUrl, OauthUrlError};
 use axum::Router;
 use axum::extract::State;
@@ -35,7 +35,7 @@ const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 pub struct CoralAuthorizationServer {
     settings: Arc<ResolvedAuthSettings>,
     session_tokens: SessionTokenIssuer,
-    state_store: Arc<dyn StateStore>,
+    state_store: Arc<InMemoryStateStore>,
     registered_clients: Arc<BTreeMap<String, Vec<String>>>,
     authorization_resources: BTreeSet<String>,
 }
@@ -126,7 +126,8 @@ impl CoralAuthorizationServer {
         let state = AuthorizationServerHttpState {
             settings: self.settings,
             session_tokens: self.session_tokens,
-            state_store: self.state_store,
+            session_store: self.state_store.clone(),
+            code_store: self.state_store,
             provider_client: OidcProviderClient::new()
                 .map_err(|error| AuthServerError::ProviderClient(error.to_string()))?,
             registered_clients: self.registered_clients,
@@ -230,7 +231,8 @@ impl Drop for RunningCoralAuthorizationServer {
 struct AuthorizationServerHttpState {
     settings: Arc<ResolvedAuthSettings>,
     session_tokens: SessionTokenIssuer,
-    state_store: Arc<dyn StateStore>,
+    session_store: Arc<dyn SessionStore>,
+    code_store: Arc<dyn CodeStore>,
     provider_client: OidcProviderClient,
     registered_clients: Arc<BTreeMap<String, Vec<String>>>,
     authorization_resources: Arc<BTreeSet<String>>,

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -85,7 +85,7 @@ pub(super) async fn oauth_authorize(
         oidc_nonce,
     };
     if state
-        .state_store
+        .session_store
         .store_authorization_session(&oidc_state, session)
         .await
         .is_err()
@@ -177,7 +177,7 @@ mod tests {
     use crate::auth::config::ResolvedAuthSettings;
     use crate::auth::provider_client::OidcProviderClient;
     use crate::auth::session::SessionTokenIssuer;
-    use crate::auth::state_store::{InMemoryStateStore, StateStore};
+    use crate::auth::state_store::{InMemoryStateStore, SessionStore};
 
     const AUTH_ISSUER: &str = "https://auth.example.test";
     const RESOURCE: &str = "https://api.example.test/mcp";
@@ -213,7 +213,7 @@ mod tests {
         settings
     }
 
-    fn state(issuer: &str, store: Arc<dyn StateStore>) -> AuthorizationServerHttpState {
+    fn state(issuer: &str, store: Arc<InMemoryStateStore>) -> AuthorizationServerHttpState {
         let signing_key =
             EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
                 .expect("P-256 signing key");
@@ -226,7 +226,8 @@ mod tests {
         AuthorizationServerHttpState {
             settings: Arc::new(settings(issuer)),
             session_tokens,
-            state_store: store,
+            session_store: store.clone(),
+            code_store: store,
             provider_client: OidcProviderClient::new().expect("provider client"),
             registered_clients: Arc::new(BTreeMap::from([(
                 CLIENT_ID.into(),
@@ -489,11 +490,12 @@ mod tests {
     async fn listener_exposes_authorize_route() {
         let provider = MockServer::start().await;
         mount_discovery(&provider, 200).await;
-        let state = state(&provider.uri(), Arc::new(InMemoryStateStore::new()));
+        let store = Arc::new(InMemoryStateStore::new());
+        let state = state(&provider.uri(), Arc::clone(&store));
         let server = CoralAuthorizationServer {
             settings: state.settings,
             session_tokens: state.session_tokens,
-            state_store: state.state_store,
+            state_store: store,
             registered_clients: state.registered_clients,
             authorization_resources: state.authorization_resources.as_ref().clone(),
         }

--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -179,7 +179,10 @@ mod tests {
     };
     use crate::auth::provider_client::OidcProviderClient;
     use crate::auth::session::SessionTokenIssuer;
-    use crate::auth::state_store::{InMemoryStateStore, StateStore, StateStoreError};
+    use crate::auth::state_store::{
+        InMemoryStateStore, OAuthAuthorizationApprovalRecord, OAuthAuthorizationApprovalTicket,
+        StateStore, StateStoreError,
+    };
 
     const OIDC_STATE: &str = "oidc-state";
     const CLIENT_STATE: &str = "client&error=injected";
@@ -507,6 +510,21 @@ mod tests {
 
     #[async_trait::async_trait]
     impl StateStore for FailCodeStore {
+        async fn store_authorization_approval(
+            &self,
+            ticket: &OAuthAuthorizationApprovalTicket,
+            approval: OAuthAuthorizationApprovalRecord,
+        ) -> Result<(), StateStoreError> {
+            self.0.store_authorization_approval(ticket, approval).await
+        }
+
+        async fn take_authorization_approval(
+            &self,
+            ticket: &OAuthAuthorizationApprovalTicket,
+        ) -> Result<Option<OAuthAuthorizationApprovalRecord>, StateStoreError> {
+            self.0.take_authorization_approval(ticket).await
+        }
+
         async fn store_authorization_session(
             &self,
             state: &str,

--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -22,7 +22,7 @@ pub(super) async fn oidc_callback(
         return direct_error("invalid_request", "OIDC callback state is required");
     };
     let Ok(Some(session)) = state
-        .state_store
+        .session_store
         .take_authorization_session(oidc_state)
         .await
     else {
@@ -81,7 +81,7 @@ pub(super) async fn oidc_callback(
         resource: session.resource,
     };
     if let Err(error) = state
-        .state_store
+        .code_store
         .store_authorization_code(&authorization_code, authorization)
         .await
     {
@@ -179,10 +179,7 @@ mod tests {
     };
     use crate::auth::provider_client::OidcProviderClient;
     use crate::auth::session::SessionTokenIssuer;
-    use crate::auth::state_store::{
-        InMemoryStateStore, OAuthAuthorizationApprovalRecord, OAuthAuthorizationApprovalTicket,
-        StateStore, StateStoreError,
-    };
+    use crate::auth::state_store::{CodeStore, InMemoryStateStore, SessionStore, StateStoreError};
 
     const OIDC_STATE: &str = "oidc-state";
     const CLIENT_STATE: &str = "client&error=injected";
@@ -220,7 +217,7 @@ mod tests {
         settings
     }
 
-    fn state(issuer: &str, state_store: Arc<dyn StateStore>) -> AuthorizationServerHttpState {
+    fn state(issuer: &str, store: Arc<InMemoryStateStore>) -> AuthorizationServerHttpState {
         let signing_key =
             EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
                 .expect("P-256 signing key");
@@ -233,7 +230,8 @@ mod tests {
         AuthorizationServerHttpState {
             settings: Arc::new(settings(issuer)),
             session_tokens,
-            state_store,
+            session_store: store.clone(),
+            code_store: store,
             provider_client: OidcProviderClient::new().expect("client"),
             registered_clients: Arc::new(BTreeMap::new()),
             authorization_resources: Arc::new(BTreeSet::from([RESOURCE.into()])),
@@ -268,14 +266,14 @@ mod tests {
         callback_raw(state, query(pairs)).await
     }
 
-    async fn seed(store: &dyn StateStore, key: &str) {
+    async fn seed(store: &dyn SessionStore, key: &str) {
         store
             .store_authorization_session(key, session())
             .await
             .expect("store");
     }
 
-    async fn take(store: &dyn StateStore, key: &str) -> Option<OAuthAuthorizationSessionRecord> {
+    async fn take(store: &dyn SessionStore, key: &str) -> Option<OAuthAuthorizationSessionRecord> {
         store.take_authorization_session(key).await.expect("store")
     }
 
@@ -506,38 +504,11 @@ mod tests {
         assert_provider_failure(200, 200, "wrong-nonce").await;
     }
 
-    struct FailCodeStore(InMemoryStateStore);
+    /// Code store whose writes always fail, standing in for a full store.
+    struct FailCodeStore;
 
     #[async_trait::async_trait]
-    impl StateStore for FailCodeStore {
-        async fn store_authorization_approval(
-            &self,
-            ticket: &OAuthAuthorizationApprovalTicket,
-            approval: OAuthAuthorizationApprovalRecord,
-        ) -> Result<(), StateStoreError> {
-            self.0.store_authorization_approval(ticket, approval).await
-        }
-
-        async fn take_authorization_approval(
-            &self,
-            ticket: &OAuthAuthorizationApprovalTicket,
-        ) -> Result<Option<OAuthAuthorizationApprovalRecord>, StateStoreError> {
-            self.0.take_authorization_approval(ticket).await
-        }
-
-        async fn store_authorization_session(
-            &self,
-            state: &str,
-            session: OAuthAuthorizationSessionRecord,
-        ) -> Result<(), StateStoreError> {
-            self.0.store_authorization_session(state, session).await
-        }
-        async fn take_authorization_session(
-            &self,
-            state: &str,
-        ) -> Result<Option<OAuthAuthorizationSessionRecord>, StateStoreError> {
-            self.0.take_authorization_session(state).await
-        }
+    impl CodeStore for FailCodeStore {
         async fn store_authorization_code(
             &self,
             _code: &str,
@@ -545,23 +516,16 @@ mod tests {
         ) -> Result<(), StateStoreError> {
             Err(StateStoreError::CapacityExceeded { max_entries: 0 })
         }
+
         async fn take_authorization_code_for_request(
             &self,
-            code: &str,
-            client_id: &str,
-            redirect_uri: &str,
-            challenge: &str,
-            resource: &str,
+            _code: &str,
+            _client_id: &str,
+            _redirect_uri: &str,
+            _challenge: &str,
+            _resource: &str,
         ) -> Result<Option<OAuthAuthorizationCodeRecord>, StateStoreError> {
-            self.0
-                .take_authorization_code_for_request(
-                    code,
-                    client_id,
-                    redirect_uri,
-                    challenge,
-                    resource,
-                )
-                .await
+            unreachable!("the OIDC callback issues authorization codes, it never redeems them")
         }
     }
 
@@ -569,13 +533,11 @@ mod tests {
     async fn code_store_capacity_failure_exposes_no_client_code() {
         let server = MockServer::start().await;
         mount_provider(&server, 200, 200, NONCE).await;
-        let store = Arc::new(FailCodeStore(InMemoryStateStore::new()));
+        let store = Arc::new(InMemoryStateStore::new());
         seed(store.as_ref(), OIDC_STATE).await;
-        let response = callback(
-            state(&server.uri(), store),
-            &[("state", OIDC_STATE), ("code", PROVIDER_CODE)],
-        )
-        .await;
+        let mut state = state(&server.uri(), store);
+        state.code_store = Arc::new(FailCodeStore);
+        let response = callback(state, &[("state", OIDC_STATE), ("code", PROVIDER_CODE)]).await;
         let values = redirect_query(&response);
         assert!(values.contains(&("error".into(), "server_error".into())));
         assert!(!values.iter().any(|(key, _value)| key == "code"));

--- a/crates/coral-app/src/auth/authorization_server/token.rs
+++ b/crates/coral-app/src/auth/authorization_server/token.rs
@@ -75,7 +75,7 @@ pub(super) async fn oauth_token(
     }
     let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
     let authorization = match state
-        .state_store
+        .code_store
         .take_authorization_code_for_request(code, client_id, redirect_uri, &challenge, &resource)
         .await
     {
@@ -318,7 +318,7 @@ mod tests {
     use crate::auth::config::AuthSettings;
     use crate::auth::provider_client::OidcProviderClient;
     use crate::auth::session::SessionTokenIssuer;
-    use crate::auth::state_store::{InMemoryStateStore, OAuthAuthorizationCodeRecord, StateStore};
+    use crate::auth::state_store::{CodeStore, InMemoryStateStore, OAuthAuthorizationCodeRecord};
 
     const CLIENT: &str = "https://client.example.test/oauth/client.json";
     const REDIRECT: &str = "http://127.0.0.1:14554/oauth/callback";
@@ -369,7 +369,8 @@ redirect_uri = "{AUTH_ISSUER}/auth/oidc/callback"
         let state = AuthorizationServerHttpState {
             settings: Arc::new(settings),
             session_tokens: session_tokens.clone(),
-            state_store: store.clone(),
+            session_store: store.clone(),
+            code_store: store.clone(),
             provider_client: OidcProviderClient::new().expect("client"),
             registered_clients: Arc::new(BTreeMap::new()),
             authorization_resources: Arc::new(BTreeSet::from([RESOURCE.into()])),
@@ -377,7 +378,7 @@ redirect_uri = "{AUTH_ISSUER}/auth/oidc/callback"
         (state, store, session_tokens)
     }
 
-    async fn seed(store: &dyn StateStore, code: &str, verifier: &str) {
+    async fn seed(store: &dyn CodeStore, code: &str, verifier: &str) {
         store
             .store_authorization_code(
                 code,

--- a/crates/coral-app/src/auth/state_store.rs
+++ b/crates/coral-app/src/auth/state_store.rs
@@ -6,12 +6,44 @@ use std::time::Duration;
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 use tokio::time::Instant;
-use zeroize::Zeroizing;
+use zeroize::{Zeroize as _, Zeroizing};
 
 const OAUTH_STATE_TTL: Duration = Duration::from_mins(5);
 const MAX_OAUTH_STATE_ENTRIES_PER_KIND: usize = 4_096;
 
 type SecretHash = [u8; 32];
+
+pub(crate) struct OAuthAuthorizationApprovalTicket([u8; 32]);
+
+impl OAuthAuthorizationApprovalTicket {
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired by the stacked authorization approval flow")
+    )]
+    pub(super) fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    pub(super) fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl Drop for OAuthAuthorizationApprovalTicket {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct OAuthAuthorizationApprovalRecord {
+    pub(crate) client_id: String,
+    pub(crate) client_name: String,
+    pub(crate) redirect_uri: String,
+    pub(crate) client_state: Option<String>,
+    pub(crate) code_challenge: String,
+    pub(crate) resource: String,
+}
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct OAuthAuthorizationSessionRecord {
@@ -45,6 +77,25 @@ pub(crate) enum StateStoreError {
 
 #[async_trait::async_trait]
 pub(crate) trait StateStore: Send + Sync {
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired by the stacked authorization approval flow")
+    )]
+    async fn store_authorization_approval(
+        &self,
+        ticket: &OAuthAuthorizationApprovalTicket,
+        approval: OAuthAuthorizationApprovalRecord,
+    ) -> Result<(), StateStoreError>;
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "wired by the stacked authorization approval flow")
+    )]
+    async fn take_authorization_approval(
+        &self,
+        ticket: &OAuthAuthorizationApprovalTicket,
+    ) -> Result<Option<OAuthAuthorizationApprovalRecord>, StateStoreError>;
+
     async fn store_authorization_session(
         &self,
         oidc_state: &str,
@@ -105,6 +156,44 @@ impl InMemoryStateStore {
 
 #[async_trait::async_trait]
 impl StateStore for InMemoryStateStore {
+    async fn store_authorization_approval(
+        &self,
+        ticket: &OAuthAuthorizationApprovalTicket,
+        approval: OAuthAuthorizationApprovalRecord,
+    ) -> Result<(), StateStoreError> {
+        let key = opaque_hash(ticket.as_bytes());
+        let mut inner = self.inner.lock().await;
+        let now = Instant::now();
+        let expires_at = self.expires_at(now)?;
+        inner.purge_expired(now);
+        ensure_capacity(
+            inner.approvals.len(),
+            self.max_entries_per_kind,
+            inner.approvals.contains_key(&key),
+        )?;
+        inner.approvals.insert(
+            key,
+            Expiring {
+                value: approval,
+                expires_at,
+            },
+        );
+        Ok(())
+    }
+
+    async fn take_authorization_approval(
+        &self,
+        ticket: &OAuthAuthorizationApprovalTicket,
+    ) -> Result<Option<OAuthAuthorizationApprovalRecord>, StateStoreError> {
+        let key = opaque_hash(ticket.as_bytes());
+        let mut inner = self.inner.lock().await;
+        let now = Instant::now();
+        let entry = inner.approvals.remove(&key);
+        Ok(entry
+            .filter(|entry| entry.expires_at > now)
+            .map(|entry| entry.value))
+    }
+
     async fn store_authorization_session(
         &self,
         oidc_state: &str,
@@ -200,12 +289,14 @@ impl StateStore for InMemoryStateStore {
 
 #[derive(Default)]
 struct StateMaps {
+    approvals: HashMap<SecretHash, Expiring<OAuthAuthorizationApprovalRecord>>,
     sessions: HashMap<SecretHash, Expiring<OAuthAuthorizationSessionRecord>>,
     codes: HashMap<SecretHash, Expiring<OAuthAuthorizationCodeRecord>>,
 }
 
 impl StateMaps {
     fn purge_expired(&mut self, now: Instant) {
+        self.approvals.retain(|_, entry| entry.expires_at > now);
         self.sessions.retain(|_, entry| entry.expires_at > now);
         self.codes.retain(|_, entry| entry.expires_at > now);
     }
@@ -231,14 +322,34 @@ fn secret_hash(secret: &str) -> Result<SecretHash, StateStoreError> {
     if secret.is_empty() {
         return Err(StateStoreError::EmptySecret);
     }
-    Ok(Sha256::digest(secret.as_bytes()).into())
+    Ok(opaque_hash(secret.as_bytes()))
+}
+
+fn opaque_hash(secret: &[u8]) -> SecretHash {
+    Sha256::digest(secret).into()
 }
 
 #[cfg(test)]
 mod tests {
+    use std::future::poll_fn;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::Poll;
+
+    use tokio::sync::Notify;
 
     use super::*;
+
+    fn approval(id: &str) -> OAuthAuthorizationApprovalRecord {
+        OAuthAuthorizationApprovalRecord {
+            client_id: "client".to_string(),
+            client_name: format!("Client {id}"),
+            redirect_uri: "http://127.0.0.1/callback".to_string(),
+            client_state: Some(id.to_string()),
+            code_challenge: "challenge".to_string(),
+            resource: "https://mcp.example.test/mcp".to_string(),
+        }
+    }
 
     fn session(id: &str) -> OAuthAuthorizationSessionRecord {
         OAuthAuthorizationSessionRecord {
@@ -260,6 +371,151 @@ mod tests {
             code_challenge: "challenge".to_string(),
             resource: "https://mcp.example.test/mcp".to_string(),
         }
+    }
+
+    #[tokio::test]
+    async fn authorization_approvals_are_hashed_and_atomically_single_use() {
+        let store = Arc::new(InMemoryStateStore::new());
+        let raw_ticket = [0x5a; 32];
+        let ticket = Arc::new(OAuthAuthorizationApprovalTicket::from_bytes(raw_ticket));
+        store
+            .store_authorization_approval(&ticket, approval("approval"))
+            .await
+            .unwrap();
+        let inner = store.inner.lock().await;
+        let hash = opaque_hash(&raw_ticket);
+        assert!(inner.approvals.contains_key(&hash));
+        assert!(!inner.approvals.contains_key(&raw_ticket));
+
+        let queued_takes = Arc::new(AtomicUsize::new(0));
+        let queued = Arc::new(Notify::new());
+        let first = {
+            let store = Arc::clone(&store);
+            let ticket = Arc::clone(&ticket);
+            let queued_takes = Arc::clone(&queued_takes);
+            let queued = Arc::clone(&queued);
+            tokio::spawn(async move {
+                let mut take = store.take_authorization_approval(&ticket);
+                poll_fn(|context| match take.as_mut().poll(context) {
+                    Poll::Pending => Poll::Ready(()),
+                    Poll::Ready(_) => panic!("take completed while the store lock was held"),
+                })
+                .await;
+                queued_takes.fetch_add(1, Ordering::SeqCst);
+                queued.notify_one();
+                take.await.unwrap()
+            })
+        };
+        let second = {
+            let store = Arc::clone(&store);
+            let ticket = Arc::clone(&ticket);
+            let queued_takes = Arc::clone(&queued_takes);
+            let queued = Arc::clone(&queued);
+            tokio::spawn(async move {
+                let mut take = store.take_authorization_approval(&ticket);
+                poll_fn(|context| match take.as_mut().poll(context) {
+                    Poll::Pending => Poll::Ready(()),
+                    Poll::Ready(_) => panic!("take completed while the store lock was held"),
+                })
+                .await;
+                queued_takes.fetch_add(1, Ordering::SeqCst);
+                queued.notify_one();
+                take.await.unwrap()
+            })
+        };
+        while queued_takes.load(Ordering::SeqCst) < 2 {
+            queued.notified().await;
+        }
+        drop(inner);
+        let (first, second) = tokio::join!(first, second);
+        let first = first.unwrap();
+        let second = second.unwrap();
+        assert_eq!(
+            usize::from(first.is_some()) + usize::from(second.is_some()),
+            1
+        );
+        let winner = first.or(second).expect("one approval winner");
+        assert!(winner == approval("approval"));
+        assert!(
+            store
+                .take_authorization_approval(&ticket)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn authorization_approval_capacity_allows_only_same_ticket_replacement() {
+        let store = InMemoryStateStore::with_options(OAUTH_STATE_TTL, 1);
+        let ticket = OAuthAuthorizationApprovalTicket::from_bytes([1; 32]);
+        let other_ticket = OAuthAuthorizationApprovalTicket::from_bytes([2; 32]);
+        store
+            .store_authorization_approval(&ticket, approval("original"))
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .store_authorization_approval(&other_ticket, approval("other"))
+                .await,
+            Err(StateStoreError::CapacityExceeded { max_entries: 1 })
+        );
+        store
+            .store_authorization_approval(&ticket, approval("replacement"))
+            .await
+            .unwrap();
+        let stored = store
+            .take_authorization_approval(&ticket)
+            .await
+            .unwrap()
+            .expect("replacement approval");
+        assert!(stored == approval("replacement"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn authorization_approvals_expire_and_release_capacity() {
+        let store = InMemoryStateStore::with_options(OAUTH_STATE_TTL, 1);
+        let expired_ticket = OAuthAuthorizationApprovalTicket::from_bytes([1; 32]);
+        let other_ticket = OAuthAuthorizationApprovalTicket::from_bytes([2; 32]);
+        store
+            .store_authorization_approval(&expired_ticket, approval("expired"))
+            .await
+            .unwrap();
+        store
+            .store_authorization_session("session", session("session"))
+            .await
+            .unwrap();
+        store
+            .store_authorization_code("code", code("code"))
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .store_authorization_approval(&other_ticket, approval("other"))
+                .await,
+            Err(StateStoreError::CapacityExceeded { max_entries: 1 })
+        );
+
+        tokio::time::advance(OAUTH_STATE_TTL).await;
+        let replacement_ticket = OAuthAuthorizationApprovalTicket::from_bytes([3; 32]);
+        store
+            .store_authorization_approval(&replacement_ticket, approval("replacement"))
+            .await
+            .unwrap();
+        assert!(
+            store
+                .take_authorization_approval(&expired_ticket)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            store
+                .take_authorization_approval(&replacement_ticket)
+                .await
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/auth/state_store.rs
+++ b/crates/coral-app/src/auth/state_store.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use ring::rand::SecureRandom;
 use sha2::{Digest, Sha256};
 use tokio::sync::Mutex;
 use tokio::time::Instant;
@@ -13,18 +14,39 @@ const MAX_OAUTH_STATE_ENTRIES_PER_KIND: usize = 4_096;
 
 type SecretHash = [u8; 32];
 
+/// Single-use secret naming a stored authorization approval.
+///
+/// Outside tests the only way to build one is [`Self::generate`], which fills
+/// the secret in place from a caller-supplied CSPRNG. The bytes therefore never
+/// exist outside the value that zeroizes them on drop, and no caller can mint a
+/// ticket with attacker-guessable content.
 pub(crate) struct OAuthAuthorizationApprovalTicket([u8; 32]);
 
 impl OAuthAuthorizationApprovalTicket {
+    /// Draws a fresh ticket from `random`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StateStoreError::Randomness`] when `random` cannot fill the
+    /// ticket.
     #[cfg_attr(
         not(test),
         expect(dead_code, reason = "wired by the stacked authorization approval flow")
     )]
-    pub(super) fn from_bytes(bytes: [u8; 32]) -> Self {
+    pub(super) fn generate(random: &dyn SecureRandom) -> Result<Self, StateStoreError> {
+        let mut ticket = Self([0; 32]);
+        random
+            .fill(&mut ticket.0)
+            .map_err(|_error| StateStoreError::Randomness)?;
+        Ok(ticket)
+    }
+
+    #[cfg(test)]
+    fn from_bytes(bytes: [u8; 32]) -> Self {
         Self(bytes)
     }
 
-    pub(super) fn as_bytes(&self) -> &[u8; 32] {
+    fn as_bytes(&self) -> &[u8; 32] {
         &self.0
     }
 }
@@ -73,29 +95,32 @@ pub(crate) enum StateStoreError {
     CapacityExceeded { max_entries: usize },
     #[error("OAuth state expiry exceeds the process clock range")]
     ExpiryOverflow,
+    #[error("OAuth approval ticket generation failed")]
+    Randomness,
 }
 
+/// Storage for approvals awaiting the user's confirmation.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "wired by the stacked authorization approval flow")
+)]
 #[async_trait::async_trait]
-pub(crate) trait StateStore: Send + Sync {
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired by the stacked authorization approval flow")
-    )]
+pub(crate) trait ApprovalStore: Send + Sync {
     async fn store_authorization_approval(
         &self,
         ticket: &OAuthAuthorizationApprovalTicket,
         approval: OAuthAuthorizationApprovalRecord,
     ) -> Result<(), StateStoreError>;
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired by the stacked authorization approval flow")
-    )]
     async fn take_authorization_approval(
         &self,
         ticket: &OAuthAuthorizationApprovalTicket,
     ) -> Result<Option<OAuthAuthorizationApprovalRecord>, StateStoreError>;
+}
 
+/// Storage for handshakes in flight at the identity provider.
+#[async_trait::async_trait]
+pub(crate) trait SessionStore: Send + Sync {
     async fn store_authorization_session(
         &self,
         oidc_state: &str,
@@ -106,7 +131,11 @@ pub(crate) trait StateStore: Send + Sync {
         &self,
         oidc_state: &str,
     ) -> Result<Option<OAuthAuthorizationSessionRecord>, StateStoreError>;
+}
 
+/// Storage for authorization codes awaiting redemption.
+#[async_trait::async_trait]
+pub(crate) trait CodeStore: Send + Sync {
     async fn store_authorization_code(
         &self,
         code: &str,
@@ -155,13 +184,13 @@ impl InMemoryStateStore {
 }
 
 #[async_trait::async_trait]
-impl StateStore for InMemoryStateStore {
+impl ApprovalStore for InMemoryStateStore {
     async fn store_authorization_approval(
         &self,
         ticket: &OAuthAuthorizationApprovalTicket,
         approval: OAuthAuthorizationApprovalRecord,
     ) -> Result<(), StateStoreError> {
-        let key = opaque_hash(ticket.as_bytes());
+        let key = hash_bytes(ticket.as_bytes());
         let mut inner = self.inner.lock().await;
         let now = Instant::now();
         let expires_at = self.expires_at(now)?;
@@ -185,7 +214,7 @@ impl StateStore for InMemoryStateStore {
         &self,
         ticket: &OAuthAuthorizationApprovalTicket,
     ) -> Result<Option<OAuthAuthorizationApprovalRecord>, StateStoreError> {
-        let key = opaque_hash(ticket.as_bytes());
+        let key = hash_bytes(ticket.as_bytes());
         let mut inner = self.inner.lock().await;
         let now = Instant::now();
         let entry = inner.approvals.remove(&key);
@@ -193,7 +222,10 @@ impl StateStore for InMemoryStateStore {
             .filter(|entry| entry.expires_at > now)
             .map(|entry| entry.value))
     }
+}
 
+#[async_trait::async_trait]
+impl SessionStore for InMemoryStateStore {
     async fn store_authorization_session(
         &self,
         oidc_state: &str,
@@ -231,7 +263,10 @@ impl StateStore for InMemoryStateStore {
             .filter(|entry| entry.expires_at > now)
             .map(|entry| entry.value))
     }
+}
 
+#[async_trait::async_trait]
+impl CodeStore for InMemoryStateStore {
     async fn store_authorization_code(
         &self,
         code: &str,
@@ -322,21 +357,23 @@ fn secret_hash(secret: &str) -> Result<SecretHash, StateStoreError> {
     if secret.is_empty() {
         return Err(StateStoreError::EmptySecret);
     }
-    Ok(opaque_hash(secret.as_bytes()))
+    Ok(hash_bytes(secret.as_bytes()))
 }
 
-fn opaque_hash(secret: &[u8]) -> SecretHash {
+fn hash_bytes(secret: &[u8]) -> SecretHash {
     Sha256::digest(secret).into()
 }
 
 #[cfg(test)]
 mod tests {
-    use std::future::poll_fn;
+    use std::future::{Future, poll_fn};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::task::Poll;
 
+    use ring::rand::SystemRandom;
     use tokio::sync::Notify;
+    use tokio::task::JoinHandle;
 
     use super::*;
 
@@ -373,6 +410,46 @@ mod tests {
         }
     }
 
+    /// Parks both takes on the store mutex and returns their join handles.
+    ///
+    /// The caller holds the store lock across this call, so each take is polled
+    /// once, observed to be `Pending`, and left queued on the mutex. Releasing
+    /// the lock afterwards forces the two takes to contend, which `join!` alone
+    /// only manages by luck of the scheduler.
+    async fn park_takes_on_store_lock<T: Send + 'static>(
+        first: impl Future<Output = T> + Send + 'static,
+        second: impl Future<Output = T> + Send + 'static,
+    ) -> (JoinHandle<T>, JoinHandle<T>) {
+        let parked = Arc::new(AtomicUsize::new(0));
+        let notify = Arc::new(Notify::new());
+        let handles = (
+            spawn_parked_take(first, Arc::clone(&parked), Arc::clone(&notify)),
+            spawn_parked_take(second, Arc::clone(&parked), Arc::clone(&notify)),
+        );
+        while parked.load(Ordering::SeqCst) < 2 {
+            notify.notified().await;
+        }
+        handles
+    }
+
+    fn spawn_parked_take<T: Send + 'static>(
+        take: impl Future<Output = T> + Send + 'static,
+        parked: Arc<AtomicUsize>,
+        notify: Arc<Notify>,
+    ) -> JoinHandle<T> {
+        tokio::spawn(async move {
+            let mut take = Box::pin(take);
+            poll_fn(|context| match take.as_mut().poll(context) {
+                Poll::Pending => Poll::Ready(()),
+                Poll::Ready(_) => panic!("take completed while the store lock was held"),
+            })
+            .await;
+            parked.fetch_add(1, Ordering::SeqCst);
+            notify.notify_one();
+            take.await
+        })
+    }
+
     #[tokio::test]
     async fn authorization_approvals_are_hashed_and_atomically_single_use() {
         let store = Arc::new(InMemoryStateStore::new());
@@ -383,53 +460,22 @@ mod tests {
             .await
             .unwrap();
         let inner = store.inner.lock().await;
-        let hash = opaque_hash(&raw_ticket);
+        let hash = hash_bytes(&raw_ticket);
         assert!(inner.approvals.contains_key(&hash));
         assert!(!inner.approvals.contains_key(&raw_ticket));
 
-        let queued_takes = Arc::new(AtomicUsize::new(0));
-        let queued = Arc::new(Notify::new());
-        let first = {
-            let store = Arc::clone(&store);
-            let ticket = Arc::clone(&ticket);
-            let queued_takes = Arc::clone(&queued_takes);
-            let queued = Arc::clone(&queued);
-            tokio::spawn(async move {
-                let mut take = store.take_authorization_approval(&ticket);
-                poll_fn(|context| match take.as_mut().poll(context) {
-                    Poll::Pending => Poll::Ready(()),
-                    Poll::Ready(_) => panic!("take completed while the store lock was held"),
-                })
-                .await;
-                queued_takes.fetch_add(1, Ordering::SeqCst);
-                queued.notify_one();
-                take.await.unwrap()
-            })
+        let take = |store: &Arc<InMemoryStateStore>,
+                    ticket: &Arc<OAuthAuthorizationApprovalTicket>| {
+            let store = Arc::clone(store);
+            let ticket = Arc::clone(ticket);
+            async move { store.take_authorization_approval(&ticket).await }
         };
-        let second = {
-            let store = Arc::clone(&store);
-            let ticket = Arc::clone(&ticket);
-            let queued_takes = Arc::clone(&queued_takes);
-            let queued = Arc::clone(&queued);
-            tokio::spawn(async move {
-                let mut take = store.take_authorization_approval(&ticket);
-                poll_fn(|context| match take.as_mut().poll(context) {
-                    Poll::Pending => Poll::Ready(()),
-                    Poll::Ready(_) => panic!("take completed while the store lock was held"),
-                })
-                .await;
-                queued_takes.fetch_add(1, Ordering::SeqCst);
-                queued.notify_one();
-                take.await.unwrap()
-            })
-        };
-        while queued_takes.load(Ordering::SeqCst) < 2 {
-            queued.notified().await;
-        }
+        let (first, second) =
+            park_takes_on_store_lock(take(&store, &ticket), take(&store, &ticket)).await;
         drop(inner);
         let (first, second) = tokio::join!(first, second);
-        let first = first.unwrap();
-        let second = second.unwrap();
+        let first = first.unwrap().unwrap();
+        let second = second.unwrap().unwrap();
         assert_eq!(
             usize::from(first.is_some()) + usize::from(second.is_some()),
             1
@@ -442,6 +488,35 @@ mod tests {
                 .await
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn generated_tickets_are_unpredictable_and_address_distinct_approvals() {
+        let random = SystemRandom::new();
+        let ticket = OAuthAuthorizationApprovalTicket::generate(&random).expect("ticket");
+        let other = OAuthAuthorizationApprovalTicket::generate(&random).expect("ticket");
+        assert_ne!(ticket.as_bytes(), &[0; 32]);
+        assert_ne!(ticket.as_bytes(), other.as_bytes());
+
+        let store = InMemoryStateStore::new();
+        store
+            .store_authorization_approval(&ticket, approval("generated"))
+            .await
+            .unwrap();
+        assert!(
+            store
+                .take_authorization_approval(&other)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            store
+                .take_authorization_approval(&ticket)
+                .await
+                .unwrap()
+                .is_some()
         );
     }
 
@@ -519,7 +594,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn authorization_sessions_are_hashed_and_single_use() {
+    async fn authorization_sessions_are_hashed_and_atomically_single_use() {
         let store = Arc::new(InMemoryStateStore::new());
         store
             .store_authorization_session("secret-state", session("state"))
@@ -529,15 +604,17 @@ mod tests {
         let hash = secret_hash("secret-state").unwrap();
         assert!(inner.sessions.contains_key(&hash));
         assert_ne!(hash.as_slice(), b"secret-state");
-        drop(inner);
 
-        let first_store = Arc::clone(&store);
-        let second_store = Arc::clone(&store);
-        let first = first_store.take_authorization_session("secret-state");
-        let second = second_store.take_authorization_session("secret-state");
+        let take = |store: &Arc<InMemoryStateStore>| {
+            let store = Arc::clone(store);
+            async move { store.take_authorization_session("secret-state").await }
+        };
+        let (first, second) = park_takes_on_store_lock(take(&store), take(&store)).await;
+        drop(inner);
         let (first, second) = tokio::join!(first, second);
         assert_eq!(
-            usize::from(first.unwrap().is_some()) + usize::from(second.unwrap().is_some()),
+            usize::from(first.unwrap().unwrap().is_some())
+                + usize::from(second.unwrap().unwrap().is_some()),
             1
         );
         assert!(
@@ -546,6 +623,39 @@ mod tests {
                 .await
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn authorization_codes_are_atomically_single_use() {
+        let store = Arc::new(InMemoryStateStore::new());
+        store
+            .store_authorization_code("secret-code", code("user"))
+            .await
+            .unwrap();
+        let inner = store.inner.lock().await;
+
+        let take = |store: &Arc<InMemoryStateStore>| {
+            let store = Arc::clone(store);
+            async move {
+                store
+                    .take_authorization_code_for_request(
+                        "secret-code",
+                        "client",
+                        "http://127.0.0.1/callback",
+                        "challenge",
+                        "https://mcp.example.test/mcp",
+                    )
+                    .await
+            }
+        };
+        let (first, second) = park_takes_on_store_lock(take(&store), take(&store)).await;
+        drop(inner);
+        let (first, second) = tokio::join!(first, second);
+        assert_eq!(
+            usize::from(first.unwrap().unwrap().is_some())
+                + usize::from(second.unwrap().unwrap().is_some()),
+            1
         );
     }
 


### PR DESCRIPTION
> **Stack:** This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.
>
> **This part of the stack:** This section adds a user-confirmation step before Coral sends the browser to the identity provider. The previous PR validates client details, this PR stores the pending request, and the next PR adds the confirmation page.

## Intent

Give the confirmation step a server-side record it can trust. This PR adds short-lived, single-use approval tickets so Coral does not need to accept the client ID, redirect URL, PKCE challenge, or target resource back from the browser.

## What it enables

Coral can store the client name and ID, exact redirect URL, client state, PKCE challenge, and target resource under a random ticket. The ticket is drawn from the system random number generator and filled in place, so its bytes never exist outside the value that wipes them when it goes out of scope. Only a SHA-256 hash of the ticket is kept as the lookup key. A ticket expires after five minutes and can be claimed only once, even when two requests arrive at the same time.

The records live in memory and disappear when Coral restarts. They use the same 4,096-entry limit the rest of the OAuth state uses, counted separately for each record type, so a flood of approval requests cannot crowd out authorization sessions or codes.

This PR also splits the one `StateStore` trait into `ApprovalStore`, `SessionStore`, and `CodeStore`. Each request handler now depends only on the records it touches, and a test double implements only the kind it actually fakes.

This PR adds the storage building block only; it does not add an HTTP endpoint or change the authorization flow yet.

## Usage examples

There is no new command or public API in this PR. The next PR uses this flow: validate the request, mint a ticket, store the record under that ticket, put only the ticket in the confirmation form, and remove the stored record when the user chooses Continue or Cancel.
