### PR TITLE
feat(app): confirm OAuth authorization redirects

### DIFF
--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -11,7 +11,7 @@ use super::config::{AuthSettings, ResolvedAuthSettings, signing_key_env_error};
 use super::error::AuthServerError;
 use super::provider_client::OidcProviderClient;
 use super::session::SessionTokenIssuer;
-use super::state_store::{CodeStore, InMemoryStateStore, SessionStore};
+use super::state_store::{ApprovalStore, CodeStore, InMemoryStateStore, SessionStore};
 use crate::oauth_resource::{CanonicalOauthUrl, OauthUrlError};
 use axum::Router;
 use axum::extract::State;
@@ -36,7 +36,7 @@ pub struct CoralAuthorizationServer {
     settings: Arc<ResolvedAuthSettings>,
     session_tokens: SessionTokenIssuer,
     state_store: Arc<InMemoryStateStore>,
-    registered_clients: Arc<BTreeMap<String, Vec<String>>>,
+    registered_clients: Arc<BTreeMap<String, (String, Vec<String>)>>,
     authorization_resources: BTreeSet<String>,
 }
 
@@ -126,6 +126,7 @@ impl CoralAuthorizationServer {
         let state = AuthorizationServerHttpState {
             settings: self.settings,
             session_tokens: self.session_tokens,
+            approval_store: self.state_store.clone(),
             session_store: self.state_store.clone(),
             code_store: self.state_store,
             provider_client: OidcProviderClient::new()
@@ -138,7 +139,10 @@ impl CoralAuthorizationServer {
                 "/.well-known/oauth-authorization-server",
                 get(authorization_server_metadata),
             )
-            .route("/oauth/authorize", get(authorize::oauth_authorize))
+            .route(
+                "/oauth/authorize",
+                get(authorize::oauth_authorize_get).post(authorize::oauth_authorize_post),
+            )
             .route("/oauth/token", post(token::oauth_token))
             .route(OIDC_CALLBACK_PATH, get(callback::oidc_callback))
             .with_state(state);
@@ -231,10 +235,11 @@ impl Drop for RunningCoralAuthorizationServer {
 struct AuthorizationServerHttpState {
     settings: Arc<ResolvedAuthSettings>,
     session_tokens: SessionTokenIssuer,
+    approval_store: Arc<dyn ApprovalStore>,
     session_store: Arc<dyn SessionStore>,
     code_store: Arc<dyn CodeStore>,
     provider_client: OidcProviderClient,
-    registered_clients: Arc<BTreeMap<String, Vec<String>>>,
+    registered_clients: Arc<BTreeMap<String, (String, Vec<String>)>>,
     authorization_resources: Arc<BTreeSet<String>>,
 }
 

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -1,18 +1,26 @@
 use std::collections::BTreeMap;
 
-use axum::extract::{RawQuery, State};
+use axum::extract::{RawQuery, Request, State};
+use axum::http::HeaderMap;
 use axum::response::Response;
 use url::Url;
 
 use super::super::provider_client::OidcAuthorizationRequest;
-use super::super::state_store::OAuthAuthorizationSessionRecord;
+use super::super::state_store::{
+    OAuthAuthorizationApprovalRecord, OAuthAuthorizationSessionRecord,
+};
 use super::response::{TrustedRedirect, direct_error, redirect};
 use super::{AuthorizationServerHttpState, canonical_authorization_resource, query};
 use crate::outbound_url_policy::{BrowserRedirect, EndpointUrl};
 
-pub(super) async fn oauth_authorize(
+mod confirmation;
+
+use confirmation::ApprovalDecision;
+
+pub(super) async fn oauth_authorize_get(
     State(state): State<AuthorizationServerHttpState>,
     RawQuery(raw_query): RawQuery,
+    headers: HeaderMap,
 ) -> Response {
     let Ok(query) = parse_query(raw_query.as_deref().unwrap_or_default()) else {
         return direct_error("invalid_request", "authorization request is malformed");
@@ -22,11 +30,12 @@ pub(super) async fn oauth_authorize(
     else {
         return direct_error("invalid_request", "client_id and redirect_uri are required");
     };
-    let Some(callback) = registered_redirect(&state.registered_clients, client_id, redirect_uri)
+    let Some((client_name, callback)) =
+        registered_client(&state.registered_clients, client_id, redirect_uri)
     else {
         return direct_error("invalid_request", "client_id or redirect_uri is invalid");
     };
-    let trusted = TrustedRedirect::new(callback, query.state.clone());
+    let trusted = TrustedRedirect::new(callback.clone(), query.state.clone());
 
     match query.response_type.as_deref() {
         Some("code") => {}
@@ -61,6 +70,71 @@ pub(super) async fn oauth_authorize(
     if !state.authorization_resources.contains(&resource) {
         return trusted.error("invalid_target", "resource does not match this server");
     }
+    let approval = OAuthAuthorizationApprovalRecord {
+        client_id: client_id.to_string(),
+        client_name,
+        redirect_uri: redirect_uri.to_string(),
+        client_state: query.state,
+        code_challenge,
+        resource,
+    };
+    let Ok(ticket) = confirmation::new_ticket() else {
+        return trusted.error("server_error", "authorization failed");
+    };
+    let secure_cookie = secure_approval_cookie(&state);
+    let Ok(browser_binding) = confirmation::browser_binding_for_page(&headers, secure_cookie)
+    else {
+        return trusted.error("server_error", "authorization failed");
+    };
+    let Some(page) = confirmation::response(
+        &ticket,
+        &approval.client_name,
+        &approval.client_id,
+        &callback,
+        &browser_binding,
+        secure_cookie,
+    ) else {
+        return trusted.error("server_error", "authorization failed");
+    };
+    if state
+        .approval_store
+        .store_authorization_approval(&ticket, &browser_binding, approval)
+        .await
+        .is_err()
+    {
+        return trusted.error("server_error", "authorization failed");
+    }
+    page
+}
+
+pub(super) async fn oauth_authorize_post(
+    State(state): State<AuthorizationServerHttpState>,
+    request: Request,
+) -> Response {
+    let Ok((ticket, browser_binding, decision)) = confirmation::parse_submission(
+        request,
+        state.settings.authorization_server().issuer(),
+        secure_approval_cookie(&state),
+    )
+    .await
+    else {
+        return approval_error();
+    };
+    let Ok(Some(approval)) = state
+        .approval_store
+        .take_authorization_approval(&ticket, &browser_binding)
+        .await
+    else {
+        return approval_error();
+    };
+    let Some(trusted) =
+        TrustedRedirect::parse(&approval.redirect_uri, approval.client_state.clone())
+    else {
+        return direct_error("server_error", "authorization failed");
+    };
+    if decision == ApprovalDecision::Cancel {
+        return trusted.error("access_denied", "authorization was denied");
+    }
     let request = match state
         .provider_client
         .authorization_request(state.settings.provider())
@@ -76,11 +150,11 @@ pub(super) async fn oauth_authorize(
         code_verifier: oidc_code_verifier,
     } = request;
     let session = OAuthAuthorizationSessionRecord {
-        client_id: client_id.to_string(),
-        redirect_uri: redirect_uri.to_string(),
-        client_state: query.state,
-        code_challenge,
-        resource,
+        client_id: approval.client_id,
+        redirect_uri: approval.redirect_uri,
+        client_state: approval.client_state,
+        code_challenge: approval.code_challenge,
+        resource: approval.resource,
         oidc_code_verifier,
         oidc_nonce,
     };
@@ -93,6 +167,14 @@ pub(super) async fn oauth_authorize(
         return trusted.error("server_error", "authorization failed");
     }
     redirect(url.as_str())
+}
+
+fn secure_approval_cookie(state: &AuthorizationServerHttpState) -> bool {
+    state
+        .settings
+        .authorization_server()
+        .issuer()
+        .starts_with("https://")
 }
 
 #[derive(Default)]
@@ -126,24 +208,25 @@ fn parse_query(raw: &str) -> Result<AuthorizeQuery, ()> {
     Ok(parsed)
 }
 
-/// Resolves the registered redirect URI a request names, under
+/// Resolves the registered client and the redirect URI a request names, under
 /// [`BrowserRedirect`].
 ///
 /// The registry is remote input once client metadata documents populate it, so
 /// the policy is applied here rather than trusted to have been applied at
 /// registration: a URI the policy rejects resolves to `None`, and the request
 /// fails with a direct error instead of becoming a redirect.
-fn registered_redirect(
-    registered_clients: &BTreeMap<String, Vec<String>>,
+fn registered_client(
+    registered_clients: &BTreeMap<String, (String, Vec<String>)>,
     client_id: &str,
     redirect_uri: &str,
-) -> Option<Url> {
-    registered_clients
-        .get(client_id)?
+) -> Option<(String, Url)> {
+    let (client_name, redirect_uris) = registered_clients.get(client_id)?;
+    redirect_uris
         .iter()
         .find(|uri| uri.as_str() == redirect_uri)
         .and_then(|uri| EndpointUrl::<BrowserRedirect>::parse(uri).ok())
         .map(EndpointUrl::into_url)
+        .map(|redirect| (client_name.clone(), redirect))
 }
 
 fn valid_s256_challenge(value: &str) -> bool {
@@ -153,6 +236,13 @@ fn valid_s256_challenge(value: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
+fn approval_error() -> Response {
+    direct_error(
+        "invalid_request",
+        "authorization approval is invalid or expired",
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
@@ -160,13 +250,14 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use axum::body::to_bytes;
+    use axum::body::{Body, to_bytes};
     use axum::http::{StatusCode, header};
     use base64::Engine as _;
-    use base64::engine::general_purpose::STANDARD;
+    use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
     use ring::rand::SystemRandom;
     use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
     use serde_json::json;
+    use tokio::sync::Barrier;
     use url::form_urlencoded;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -176,8 +267,11 @@ mod tests {
     use crate::auth::config::AuthSettings;
     use crate::auth::config::ResolvedAuthSettings;
     use crate::auth::provider_client::OidcProviderClient;
-    use crate::auth::session::SessionTokenIssuer;
-    use crate::auth::state_store::{InMemoryStateStore, SessionStore};
+    use crate::auth::session::{SessionTokenIssuer, test_signing_key};
+    use crate::auth::state_store::{
+        ApprovalStore, InMemoryStateStore, OAuthAuthorizationApprovalBrowserBinding,
+        OAuthAuthorizationApprovalTicket, SessionStore,
+    };
 
     const AUTH_ISSUER: &str = "https://auth.example.test";
     const RESOURCE: &str = "https://api.example.test/mcp";
@@ -186,6 +280,7 @@ mod tests {
     const CLIENT_STATE: &str = "client-state&error=injected";
     const CHALLENGE: &str = "0123456789012345678901234567890123456789012";
     const PROVIDER_SECRET: &str = "provider-secret-must-not-leak";
+    const BROWSER_BINDING: [u8; 32] = [0x42; 32];
 
     fn settings(issuer: &str) -> ResolvedAuthSettings {
         let settings = AuthSettings::from_toml(&format!(
@@ -214,24 +309,22 @@ mod tests {
     }
 
     fn state(issuer: &str, store: Arc<InMemoryStateStore>) -> AuthorizationServerHttpState {
-        let signing_key =
-            EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &SystemRandom::new())
-                .expect("P-256 signing key");
         let session_tokens = SessionTokenIssuer::new(
             Some(AUTH_ISSUER),
-            signing_key.as_ref(),
+            test_signing_key(),
             Duration::from_mins(5),
         )
         .expect("session");
         AuthorizationServerHttpState {
             settings: Arc::new(settings(issuer)),
             session_tokens,
+            approval_store: store.clone(),
             session_store: store.clone(),
             code_store: store,
             provider_client: OidcProviderClient::new().expect("provider client"),
             registered_clients: Arc::new(BTreeMap::from([(
                 CLIENT_ID.into(),
-                vec![REDIRECT_URI.into()],
+                ("Test Client".into(), vec![REDIRECT_URI.into()]),
             )])),
             authorization_resources: Arc::new(BTreeSet::from([RESOURCE.into()])),
         }
@@ -268,7 +361,95 @@ mod tests {
     }
 
     async fn request(state: AuthorizationServerHttpState, pairs: &[(String, String)]) -> Response {
-        oauth_authorize(State(state), RawQuery(Some(encode(pairs)))).await
+        oauth_authorize_get(
+            State(state),
+            RawQuery(Some(encode(pairs))),
+            browser_headers(),
+        )
+        .await
+    }
+
+    fn browser_cookie() -> String {
+        format!(
+            "__Host-coral_oauth_approval={}",
+            URL_SAFE_NO_PAD.encode(BROWSER_BINDING)
+        )
+    }
+
+    fn browser_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::COOKIE,
+            browser_cookie().parse().expect("browser cookie"),
+        );
+        headers
+    }
+
+    fn browser_binding() -> OAuthAuthorizationApprovalBrowserBinding {
+        OAuthAuthorizationApprovalBrowserBinding::from_bytes(BROWSER_BINDING)
+    }
+
+    async fn response_body(response: Response) -> String {
+        String::from_utf8(
+            to_bytes(response.into_body(), 16 * 1024)
+                .await
+                .expect("body")
+                .to_vec(),
+        )
+        .expect("UTF-8 body")
+    }
+
+    fn ticket_from_page(page: &str) -> String {
+        page.split("name=\"ticket\" value=\"")
+            .nth(1)
+            .and_then(|tail| tail.split('"').next())
+            .expect("approval ticket")
+            .to_string()
+    }
+
+    fn set_cookie_pair(response: &Response) -> String {
+        response.headers()[header::SET_COOKIE]
+            .to_str()
+            .expect("approval cookie")
+            .split(';')
+            .next()
+            .expect("cookie pair")
+            .to_string()
+    }
+
+    fn submission_request_with_cookie(
+        ticket: &str,
+        decision: &str,
+        cookie: Option<&str>,
+    ) -> Request {
+        let body = form_urlencoded::Serializer::new(String::new())
+            .extend_pairs([("ticket", ticket), ("decision", decision)])
+            .finish();
+        let mut request = Request::builder()
+            .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .header(header::ORIGIN, AUTH_ISSUER);
+        if let Some(cookie) = cookie {
+            request = request.header(header::COOKIE, cookie);
+        }
+        request.body(Body::from(body)).expect("request")
+    }
+
+    fn submission_request(ticket: &str, decision: &str) -> Request {
+        let cookie = browser_cookie();
+        submission_request_with_cookie(ticket, decision, Some(&cookie))
+    }
+
+    async fn submit(state: AuthorizationServerHttpState, ticket: &str, decision: &str) -> Response {
+        oauth_authorize_post(State(state), submission_request(ticket, decision)).await
+    }
+
+    async fn approval_ticket(
+        state: AuthorizationServerHttpState,
+        pairs: &[(String, String)],
+    ) -> String {
+        let response = request(state, pairs).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        ticket_from_page(&response_body(response).await)
     }
 
     fn location(response: &Response) -> Option<&str> {
@@ -310,7 +491,230 @@ mod tests {
         let mut cases = vec![format!("{encoded}&client%5Fid=duplicate")];
         cases.extend(query::rejected_queries());
         for raw in cases {
-            assert!(parse_query(&raw).is_err(), "accepted {raw}");
+            let Err(()) = parse_query(&raw) else {
+                panic!("accepted malformed authorization query: {raw}");
+            };
+        }
+    }
+
+    #[tokio::test]
+    async fn confirmation_is_secure_and_stores_only_validated_data() {
+        let store = Arc::new(InMemoryStateStore::new());
+        let mut request_pairs = pairs();
+        request_pairs.push(("approved".into(), "true".into()));
+        request_pairs.push(("decision".into(), "continue".into()));
+        let response = request(
+            state("https://provider.invalid", store.clone()),
+            &request_pairs,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        for (name, value) in [
+            (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+            (
+                header::CONTENT_SECURITY_POLICY,
+                "default-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
+            ),
+            (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+            (header::REFERRER_POLICY, "no-referrer"),
+            (header::X_FRAME_OPTIONS, "DENY"),
+        ] {
+            assert_eq!(response.headers()[name], value);
+        }
+        let set_cookie = response.headers()[header::SET_COOKIE]
+            .to_str()
+            .expect("approval cookie")
+            .to_string();
+        let page = response_body(response).await;
+        assert!(page.contains("Client ID hostname</dt><dd><code>client.example.test"));
+        assert!(page.contains("Redirect host and port</dt><dd><code>client.example.test:443"));
+        assert!(page.contains("method=\"post\" action=\"/oauth/authorize\""));
+        assert!(!page.contains(CLIENT_STATE));
+        assert!(!page.contains(CHALLENGE));
+        assert!(!page.contains("<script"));
+        let ticket = ticket_from_page(&page);
+        assert_eq!(
+            set_cookie,
+            format!(
+                "{}; Path=/; Max-Age=300; HttpOnly; Secure; SameSite=Lax",
+                browser_cookie()
+            )
+        );
+        assert!(!set_cookie.contains(&ticket));
+        let ticket = OAuthAuthorizationApprovalTicket::from_bytes(
+            URL_SAFE_NO_PAD
+                .decode(ticket)
+                .expect("ticket")
+                .try_into()
+                .expect("ticket length"),
+        );
+        let approval = store
+            .take_authorization_approval(&ticket, &browser_binding())
+            .await
+            .expect("store")
+            .expect("approval");
+        assert_eq!(approval.client_id, CLIENT_ID);
+        assert_eq!(approval.client_name, "Test Client");
+        assert_eq!(approval.redirect_uri, REDIRECT_URI);
+        assert_eq!(approval.client_state.as_deref(), Some(CLIENT_STATE));
+        assert_eq!(approval.code_challenge, CHALLENGE);
+        assert_eq!(approval.resource, RESOURCE);
+
+        let loopback = confirmation::response(
+            &OAuthAuthorizationApprovalTicket::from_bytes([6; 32]),
+            "Local Test Client",
+            CLIENT_ID,
+            &Url::parse("http://127.0.0.1:14554/oauth/callback").expect("loopback redirect"),
+            &browser_binding(),
+            false,
+        )
+        .expect("page");
+        let loopback_cookie = loopback.headers()[header::SET_COOKIE]
+            .to_str()
+            .expect("loopback approval cookie")
+            .to_string();
+        let page = response_body(loopback).await;
+        assert!(page.contains("<bdi>Local Test Client</bdi>"));
+        assert!(page.contains("127.0.0.1:14554"));
+        assert!(page.contains("Local redirect warning"));
+        assert_eq!(
+            loopback_cookie,
+            format!(
+                "coral_oauth_approval={}; Path=/; Max-Age=300; HttpOnly; SameSite=Lax",
+                URL_SAFE_NO_PAD.encode(BROWSER_BINDING)
+            )
+        );
+        assert!(!loopback_cookie.contains("; Secure"));
+
+        let escaped = confirmation::response(
+            &OAuthAuthorizationApprovalTicket::from_bytes([7; 32]),
+            "</bdi><script>alert(\"x\")</script>&'",
+            CLIENT_ID,
+            &Url::parse(REDIRECT_URI).expect("redirect"),
+            &browser_binding(),
+            true,
+        )
+        .expect("page");
+        let escaped = response_body(escaped).await;
+        assert!(!escaped.contains("</bdi><script>"));
+        assert!(escaped.contains("&lt;/bdi&gt;&lt;script&gt;alert(&quot;x&quot;)"));
+    }
+
+    #[tokio::test]
+    async fn submission_form_is_strict_bounded_and_ignores_no_query_bypass() {
+        let ticket = URL_SAFE_NO_PAD.encode([7; 32]);
+        let malformed = [
+            format!("ticket={ticket}"),
+            format!("ticket={ticket}&decision=continue&extra=x"),
+            format!("ticket={ticket}&ticket={ticket}&decision=continue"),
+            format!("ticket={ticket}&decision=approve"),
+            format!("ticket={ticket}=&decision=continue"),
+            "x".repeat(257),
+        ];
+        for body in malformed {
+            let request = Request::builder()
+                .uri(format!(
+                    "/oauth/authorize?ticket={ticket}&decision=continue"
+                ))
+                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .body(Body::from(body))
+                .expect("request");
+            let Err(()) = confirmation::parse_submission(request, AUTH_ISSUER, true).await else {
+                panic!("accepted malformed approval submission");
+            };
+        }
+        let request = Request::builder()
+            .header(header::CONTENT_TYPE, "text/plain")
+            .body(Body::from(format!("ticket={ticket}&decision=continue")))
+            .expect("request");
+        let Err(()) = confirmation::parse_submission(request, AUTH_ISSUER, true).await else {
+            panic!("accepted approval submission with the wrong content type");
+        };
+    }
+
+    #[tokio::test]
+    async fn submission_requires_same_origin_browser_binding_without_consuming_the_approval() {
+        let auth_state = state(
+            "https://provider.invalid",
+            Arc::new(InMemoryStateStore::new()),
+        );
+        let ticket = approval_ticket(auth_state.clone(), &pairs()).await;
+
+        let missing_cookie = oauth_authorize_post(
+            State(auth_state.clone()),
+            submission_request_with_cookie(&ticket, "cancel", None),
+        )
+        .await;
+        assert_eq!(missing_cookie.status(), StatusCode::BAD_REQUEST);
+
+        let wrong_cookie = format!(
+            "__Host-coral_oauth_approval={}",
+            URL_SAFE_NO_PAD.encode([0x43; 32])
+        );
+        let mismatched_cookie = oauth_authorize_post(
+            State(auth_state.clone()),
+            submission_request_with_cookie(&ticket, "cancel", Some(&wrong_cookie)),
+        )
+        .await;
+        assert_eq!(mismatched_cookie.status(), StatusCode::BAD_REQUEST);
+
+        let mut cross_origin = submission_request(&ticket, "cancel");
+        cross_origin
+            .headers_mut()
+            .insert(header::ORIGIN, "http://127.0.0.1:65535".parse().unwrap());
+        let cross_origin = oauth_authorize_post(State(auth_state.clone()), cross_origin).await;
+        assert_eq!(cross_origin.status(), StatusCode::BAD_REQUEST);
+
+        let mut missing_origin = submission_request(&ticket, "cancel");
+        missing_origin.headers_mut().remove(header::ORIGIN);
+        let missing_origin = oauth_authorize_post(State(auth_state.clone()), missing_origin).await;
+        assert_eq!(missing_origin.status(), StatusCode::BAD_REQUEST);
+
+        let bound_browser = submit(auth_state, &ticket, "cancel").await;
+        assert_eq!(bound_browser.status(), StatusCode::FOUND);
+        assert!(
+            location(&bound_browser).is_some_and(|location| location.contains("access_denied"))
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_consent_pages_reuse_the_binding_and_remain_valid() {
+        let auth_state = state(
+            "https://provider.invalid",
+            Arc::new(InMemoryStateStore::new()),
+        );
+        let first = oauth_authorize_get(
+            State(auth_state.clone()),
+            RawQuery(Some(encode(&pairs()))),
+            HeaderMap::new(),
+        )
+        .await;
+        assert_eq!(first.status(), StatusCode::OK);
+        let cookie = set_cookie_pair(&first);
+        let first_ticket = ticket_from_page(&response_body(first).await);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(header::COOKIE, cookie.parse().expect("browser cookie"));
+        let second = oauth_authorize_get(
+            State(auth_state.clone()),
+            RawQuery(Some(encode(&pairs()))),
+            headers,
+        )
+        .await;
+        assert_eq!(second.status(), StatusCode::OK);
+        assert_eq!(set_cookie_pair(&second), cookie);
+        let second_ticket = ticket_from_page(&response_body(second).await);
+        assert_ne!(first_ticket, second_ticket);
+
+        for ticket in [first_ticket, second_ticket] {
+            let response = oauth_authorize_post(
+                State(auth_state.clone()),
+                submission_request_with_cookie(&ticket, "cancel", Some(&cookie)),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::FOUND);
         }
     }
 
@@ -337,9 +741,10 @@ mod tests {
         }
 
         let raw = format!("{}&client%5Fid=raw-secret", encode(&pairs()));
-        let response = oauth_authorize(
+        let response = oauth_authorize_get(
             State(state("https://provider.invalid", store)),
             RawQuery(Some(raw)),
+            browser_headers(),
         )
         .await;
         assert!(location(&response).is_none());
@@ -356,8 +761,10 @@ mod tests {
             "http://client.example.test/callback",
         ] {
             let mut auth_state = state("https://provider.invalid", store.clone());
-            auth_state.registered_clients =
-                Arc::new(BTreeMap::from([(CLIENT_ID.into(), vec![uri.into()])]));
+            auth_state.registered_clients = Arc::new(BTreeMap::from([(
+                CLIENT_ID.into(),
+                ("Test Client".into(), vec![uri.into()]),
+            )]));
             let mut request_pairs = pairs();
             replace(&mut request_pairs, "redirect_uri", Some(uri));
             let response = request(auth_state, &request_pairs).await;
@@ -414,11 +821,99 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn success_stores_single_use_session_before_provider_redirect() {
+    async fn cancel_is_trusted_once_while_replay_and_restart_are_direct_errors() {
+        let store = Arc::new(InMemoryStateStore::new());
+        let auth_state = state("https://provider.invalid", store);
+        let ticket = approval_ticket(auth_state.clone(), &pairs()).await;
+        let cancelled = submit(auth_state.clone(), &ticket, "cancel").await;
+        let callback = Url::parse(location(&cancelled).expect("client redirect")).expect("URL");
+        let query = callback.query_pairs().into_owned().collect::<Vec<_>>();
+        assert!(query.contains(&("tenant".into(), "one".into())));
+        assert!(query.contains(&("error".into(), "access_denied".into())));
+        assert!(query.contains(&("state".into(), CLIENT_STATE.into())));
+
+        let replay = submit(auth_state, &ticket, "cancel").await;
+        let restarted = submit(
+            state(
+                "https://provider.invalid",
+                Arc::new(InMemoryStateStore::new()),
+            ),
+            &ticket,
+            "continue",
+        )
+        .await;
+        for response in [replay, restarted] {
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert!(location(&response).is_none());
+            let body = response_body(response).await;
+            assert!(body.contains("authorization approval is invalid or expired"));
+            assert!(!body.contains(&ticket));
+            assert!(!body.contains(REDIRECT_URI));
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn expired_approval_is_a_direct_error() {
+        let auth_state = state(
+            "https://provider.invalid",
+            Arc::new(InMemoryStateStore::new()),
+        );
+        let ticket = approval_ticket(auth_state.clone(), &pairs()).await;
+        tokio::time::advance(Duration::from_mins(6)).await;
+        let response = submit(auth_state, &ticket, "continue").await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(location(&response).is_none());
+    }
+
+    #[tokio::test]
+    async fn concurrent_double_submit_has_one_winner() {
+        let provider = MockServer::start().await;
+        mount_discovery(&provider, 200).await;
+        let auth_state = state(&provider.uri(), Arc::new(InMemoryStateStore::new()));
+        let ticket = approval_ticket(auth_state.clone(), &pairs()).await;
+        let barrier = Arc::new(Barrier::new(3));
+        let spawn = |state: AuthorizationServerHttpState| {
+            let barrier = barrier.clone();
+            let ticket = ticket.clone();
+            tokio::spawn(async move {
+                barrier.wait().await;
+                submit(state, &ticket, "continue").await
+            })
+        };
+        let first = spawn(auth_state.clone());
+        let second = spawn(auth_state);
+        barrier.wait().await;
+        let (first, second) = tokio::join!(first, second);
+        let (first, second) = (first.expect("first submit"), second.expect("second submit"));
+        assert!(
+            matches!(
+                (first.status(), second.status()),
+                (StatusCode::FOUND, StatusCode::BAD_REQUEST)
+                    | (StatusCode::BAD_REQUEST, StatusCode::FOUND)
+            ),
+            "one submission must win"
+        );
+        assert_eq!(
+            provider.received_requests().await.expect("requests").len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn continue_stores_single_use_session_before_provider_redirect() {
         let provider = MockServer::start().await;
         mount_discovery(&provider, 200).await;
         let store = Arc::new(InMemoryStateStore::new());
-        let response = request(state(&provider.uri(), store.clone()), &pairs()).await;
+        let auth_state = state(&provider.uri(), store.clone());
+        let ticket = approval_ticket(auth_state.clone(), &pairs()).await;
+        assert!(
+            provider
+                .received_requests()
+                .await
+                .expect("requests")
+                .is_empty()
+        );
+        let response = submit(auth_state, &ticket, "continue").await;
         let provider_url = location(&response).expect("provider redirect");
         let query = Url::parse(provider_url)
             .expect("URL")
@@ -456,27 +951,29 @@ mod tests {
         let provider = MockServer::start().await;
         mount_discovery(&provider, 500).await;
         let store = Arc::new(InMemoryStateStore::new());
-        let response = request(state(&provider.uri(), store.clone()), &pairs()).await;
+        let auth_state = state(&provider.uri(), store.clone());
+        let ticket = approval_ticket(auth_state.clone(), &pairs()).await;
+        let response = submit(auth_state, &ticket, "continue").await;
         let error_location = location(&response).expect("error redirect");
         assert!(error_location.contains("error=server_error"));
         assert!(!error_location.contains(PROVIDER_SECRET));
 
-        provider.reset().await;
-        mount_discovery(&provider, 200).await;
-        let filler = OAuthAuthorizationSessionRecord {
+        let filler = OAuthAuthorizationApprovalRecord {
             client_id: CLIENT_ID.into(),
+            client_name: "Test Client".into(),
             redirect_uri: REDIRECT_URI.into(),
             client_state: None,
             code_challenge: CHALLENGE.into(),
             resource: RESOURCE.into(),
-            oidc_code_verifier: "verifier".to_string().into(),
-            oidc_nonce: "nonce".into(),
         };
-        for index in 0..4096 {
+        for index in 0_u64..4096 {
+            let mut ticket = [0; 32];
+            ticket[..8].copy_from_slice(&index.to_le_bytes());
+            let ticket = OAuthAuthorizationApprovalTicket::from_bytes(ticket);
             store
-                .store_authorization_session(&format!("filler-{index}"), filler.clone())
+                .store_authorization_approval(&ticket, &browser_binding(), filler.clone())
                 .await
-                .expect("fill store");
+                .expect("fill approval store");
         }
         let response = request(state(&provider.uri(), store), &pairs()).await;
         assert!(
@@ -506,6 +1003,7 @@ mod tests {
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("client");
+        let authorize_url = format!("{}/oauth/authorize", server.endpoint_uri());
         let response = client
             .get(format!(
                 "{}/oauth/authorize?{}",
@@ -515,6 +1013,28 @@ mod tests {
             .send()
             .await
             .expect("request");
+        assert_eq!(response.status(), StatusCode::OK);
+        let cookie = response.headers()[header::SET_COOKIE]
+            .to_str()
+            .expect("approval cookie")
+            .split(';')
+            .next()
+            .expect("cookie pair")
+            .to_string();
+        let ticket = ticket_from_page(&response.text().await.expect("page"));
+        let response = client
+            .post(authorize_url)
+            .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .header(header::ORIGIN, AUTH_ISSUER)
+            .header(header::COOKIE, cookie)
+            .body(
+                form_urlencoded::Serializer::new(String::new())
+                    .extend_pairs([("ticket", ticket.as_str()), ("decision", "cancel")])
+                    .finish(),
+            )
+            .send()
+            .await
+            .expect("submit");
         assert_eq!(response.status(), StatusCode::FOUND);
         server.shutdown().await.expect("shutdown");
     }

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -251,7 +251,7 @@ mod tests {
     use std::time::Duration;
 
     use axum::body::{Body, to_bytes};
-    use axum::http::{StatusCode, header};
+    use axum::http::{HeaderValue, StatusCode, header};
     use base64::Engine as _;
     use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
     use ring::rand::SystemRandom;
@@ -531,6 +531,11 @@ mod tests {
         assert!(page.contains("Client ID hostname</dt><dd><code>client.example.test"));
         assert!(page.contains("Redirect host and port</dt><dd><code>client.example.test:443"));
         assert!(page.contains("method=\"post\" action=\"/oauth/authorize\""));
+        assert!(
+            page.find("value=\"cancel\"") < page.find("value=\"continue\""),
+            "Cancel must be the form's first submit button, so a bare Enter key \
+             does not approve access"
+        );
         assert!(!page.contains(CLIENT_STATE));
         assert!(!page.contains(CHALLENGE));
         assert!(!page.contains("<script"));
@@ -561,7 +566,10 @@ mod tests {
         assert_eq!(approval.client_state.as_deref(), Some(CLIENT_STATE));
         assert_eq!(approval.code_challenge, CHALLENGE);
         assert_eq!(approval.resource, RESOURCE);
+    }
 
+    #[tokio::test]
+    async fn confirmation_page_warns_on_loopback_and_escapes_client_text() {
         let loopback = confirmation::response(
             &OAuthAuthorizationApprovalTicket::from_bytes([6; 32]),
             "Local Test Client",
@@ -602,9 +610,29 @@ mod tests {
         assert!(escaped.contains("&lt;/bdi&gt;&lt;script&gt;alert(&quot;x&quot;)"));
     }
 
+    /// Every request here carries the `Origin` and `Cookie` a browser sends,
+    /// because `parse_submission` checks those before it looks at the body: a
+    /// case that omits them is rejected at the origin gate and proves nothing
+    /// about the parser it names. The two accepting cases at the end exist for
+    /// the same reason — they fail if a future guard rejects everything, which
+    /// is how a set of rejection cases goes quietly vacuous.
     #[tokio::test]
     async fn submission_form_is_strict_bounded_and_ignores_no_query_bypass() {
+        const FORM: &str = "application/x-www-form-urlencoded";
+
         let ticket = URL_SAFE_NO_PAD.encode([7; 32]);
+        let submission = |body: String, cookie: HeaderValue, content_type: &'static str| {
+            Request::builder()
+                .uri(format!(
+                    "/oauth/authorize?ticket={ticket}&decision=continue"
+                ))
+                .header(header::CONTENT_TYPE, content_type)
+                .header(header::ORIGIN, AUTH_ISSUER)
+                .header(header::COOKIE, cookie)
+                .body(Body::from(body))
+                .expect("request")
+        };
+        let cookie = || HeaderValue::from_str(&browser_cookie()).expect("cookie");
         let malformed = [
             format!("ticket={ticket}"),
             format!("ticket={ticket}&decision=continue&extra=x"),
@@ -614,24 +642,39 @@ mod tests {
             "x".repeat(257),
         ];
         for body in malformed {
-            let request = Request::builder()
-                .uri(format!(
-                    "/oauth/authorize?ticket={ticket}&decision=continue"
-                ))
-                .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
-                .body(Body::from(body))
-                .expect("request");
+            let request = submission(body, cookie(), FORM);
             let Err(()) = confirmation::parse_submission(request, AUTH_ISSUER, true).await else {
                 panic!("accepted malformed approval submission");
             };
         }
-        let request = Request::builder()
-            .header(header::CONTENT_TYPE, "text/plain")
-            .body(Body::from(format!("ticket={ticket}&decision=continue")))
-            .expect("request");
+        let request = submission(
+            format!("ticket={ticket}&decision=continue"),
+            cookie(),
+            "text/plain",
+        );
         let Err(()) = confirmation::parse_submission(request, AUTH_ISSUER, true).await else {
             panic!("accepted approval submission with the wrong content type");
         };
+
+        // Every request `submission` builds says `decision=continue` in its
+        // query, so a body that parses as `Cancel` is what shows the query
+        // never reaches the decision. The second header is what a non-ASCII
+        // cookie set by anything else on this host would produce; that stray
+        // pair must not hide the binding beside it.
+        let stray = format!("stray=caf\u{e9}; {}", browser_cookie());
+        for cookie in [
+            cookie(),
+            HeaderValue::from_bytes(stray.as_bytes()).expect("cookie"),
+        ] {
+            let request = submission(format!("ticket={ticket}&decision=cancel"), cookie, FORM);
+            let (ticket, browser_binding, decision) =
+                confirmation::parse_submission(request, AUTH_ISSUER, true)
+                    .await
+                    .expect("rejected a well-formed approval submission");
+            assert_eq!(ticket.as_bytes(), &[7; 32]);
+            assert_eq!(browser_binding.as_bytes(), &BROWSER_BINDING);
+            assert!(decision == ApprovalDecision::Cancel);
+        }
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/auth/authorization_server/authorize/confirmation.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize/confirmation.rs
@@ -1,0 +1,263 @@
+//! User confirmation page and submission parsing for OAuth authorization.
+
+use axum::body::to_bytes;
+use axum::extract::Request;
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use ring::rand::{SecureRandom as _, SystemRandom};
+use url::{Host, Url, form_urlencoded};
+use zeroize::Zeroizing;
+
+use super::super::super::state_store::{
+    OAuthAuthorizationApprovalBrowserBinding, OAuthAuthorizationApprovalTicket,
+};
+
+const MAX_FORM_BYTES: usize = 256;
+const TICKET_LENGTH: usize = 43;
+const BROWSER_BINDING_LENGTH: usize = 43;
+const APPROVAL_COOKIE_MAX_AGE_SECONDS: u64 = 5 * 60;
+const SECURE_APPROVAL_COOKIE_NAME: &str = "__Host-coral_oauth_approval";
+const LOOPBACK_APPROVAL_COOKIE_NAME: &str = "coral_oauth_approval";
+const CONTENT_SECURITY_POLICY: &str =
+    "default-src 'none'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'";
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum ApprovalDecision {
+    Continue,
+    Cancel,
+}
+
+pub(super) fn new_ticket() -> Result<OAuthAuthorizationApprovalTicket, ()> {
+    OAuthAuthorizationApprovalTicket::generate(&SystemRandom::new()).map_err(|_error| ())
+}
+
+pub(super) fn browser_binding_for_page(
+    headers: &HeaderMap,
+    secure_cookie: bool,
+) -> Result<OAuthAuthorizationApprovalBrowserBinding, ()> {
+    if let Some(binding) = browser_binding_from_headers(headers, secure_cookie) {
+        return Ok(binding);
+    }
+    let mut binding = Zeroizing::new([0_u8; 32]);
+    SystemRandom::new()
+        .fill(&mut *binding)
+        .map_err(|_error| ())?;
+    Ok(OAuthAuthorizationApprovalBrowserBinding::from_bytes(
+        *binding,
+    ))
+}
+
+pub(super) async fn parse_submission(
+    request: Request,
+    expected_origin: &str,
+    secure_cookie: bool,
+) -> Result<
+    (
+        OAuthAuthorizationApprovalTicket,
+        OAuthAuthorizationApprovalBrowserBinding,
+        ApprovalDecision,
+    ),
+    (),
+> {
+    let (parts, body) = request.into_parts();
+    if !has_exact_origin(&parts.headers, expected_origin) {
+        return Err(());
+    }
+    let browser_binding = browser_binding_from_headers(&parts.headers, secure_cookie).ok_or(())?;
+    let content_type = parts
+        .headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .map(str::trim);
+    if content_type != Some("application/x-www-form-urlencoded") {
+        return Err(());
+    }
+    let body = to_bytes(body, MAX_FORM_BYTES).await.map_err(|_error| ())?;
+    let mut ticket = None;
+    let mut decision = None;
+    for (index, (name, value)) in form_urlencoded::parse(&body).enumerate() {
+        if index >= 2 {
+            return Err(());
+        }
+        match name.as_ref() {
+            "ticket" if ticket.is_none() => ticket = Some(value.into_owned()),
+            "decision" if decision.is_none() => {
+                decision = Some(match value.as_ref() {
+                    "continue" => ApprovalDecision::Continue,
+                    "cancel" => ApprovalDecision::Cancel,
+                    _ => return Err(()),
+                });
+            }
+            _ => return Err(()),
+        }
+    }
+    let encoded = ticket
+        .filter(|ticket| ticket.len() == TICKET_LENGTH)
+        .ok_or(())?;
+    let mut bytes = Zeroizing::new([0_u8; 32]);
+    let decoded = URL_SAFE_NO_PAD
+        .decode_slice(encoded.as_bytes(), &mut *bytes)
+        .map_err(|_error| ())?;
+    if decoded != bytes.len() {
+        return Err(());
+    }
+    let ticket = OAuthAuthorizationApprovalTicket::from_bytes(*bytes);
+    Ok((ticket, browser_binding, decision.ok_or(())?))
+}
+
+pub(super) fn response(
+    ticket: &OAuthAuthorizationApprovalTicket,
+    client_name: &str,
+    client_id: &str,
+    redirect_uri: &Url,
+    browser_binding: &OAuthAuthorizationApprovalBrowserBinding,
+    secure_cookie: bool,
+) -> Option<Response> {
+    let client_host = Url::parse(client_id)
+        .ok()?
+        .host()
+        .as_ref()
+        .map(display_host)?;
+    let redirect_host = redirect_uri.host().as_ref().map(display_host)?;
+    let redirect_destination = format!("{redirect_host}:{}", redirect_uri.port_or_known_default()?);
+    let warning = is_loopback(redirect_uri).then(|| {
+        format!(
+            "<aside role=\"alert\"><h2>Local redirect warning</h2><p>This redirect targets <code>{}</code> on this device. Continue only if you started this sign-in from a trusted local Coral client.</p></aside>",
+            escape_html(&redirect_destination)
+        )
+    });
+    let encoded_ticket = Zeroizing::new(URL_SAFE_NO_PAD.encode(ticket.as_bytes()));
+    let body = format!(
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>Approve Coral access</title></head><body><main><h1>Approve access?</h1><p><bdi>{}</bdi> is requesting access to Coral.</p><dl><dt>Client ID hostname</dt><dd><code>{}</code></dd><dt>Redirect host and port</dt><dd><code>{}</code></dd></dl>{}<form method=\"post\" action=\"/oauth/authorize\" autocomplete=\"off\"><input type=\"hidden\" name=\"ticket\" value=\"{}\"><button type=\"submit\" name=\"decision\" value=\"continue\">Continue</button><button type=\"submit\" name=\"decision\" value=\"cancel\">Cancel</button></form></main></body></html>",
+        escape_html(client_name),
+        escape_html(&client_host),
+        escape_html(&redirect_destination),
+        warning.unwrap_or_default(),
+        escape_html(&encoded_ticket),
+    );
+    let mut response = (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+            (header::CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY),
+            (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+            (header::REFERRER_POLICY, "no-referrer"),
+            (header::X_FRAME_OPTIONS, "DENY"),
+        ],
+        body,
+    )
+        .into_response();
+    response.headers_mut().insert(
+        header::SET_COOKIE,
+        approval_cookie_header(browser_binding, secure_cookie)?,
+    );
+    Some(response)
+}
+
+fn approval_cookie_header(
+    browser_binding: &OAuthAuthorizationApprovalBrowserBinding,
+    secure: bool,
+) -> Option<HeaderValue> {
+    let name = approval_cookie_name(secure);
+    let encoded_binding = Zeroizing::new(URL_SAFE_NO_PAD.encode(browser_binding.as_bytes()));
+    let secure_attribute = if secure { "; Secure" } else { "" };
+    HeaderValue::from_str(&format!(
+        "{name}={}; Path=/; Max-Age={APPROVAL_COOKIE_MAX_AGE_SECONDS}; \
+         HttpOnly{secure_attribute}; SameSite=Lax",
+        encoded_binding.as_str()
+    ))
+    .ok()
+}
+
+fn browser_binding_from_headers(
+    headers: &HeaderMap,
+    secure: bool,
+) -> Option<OAuthAuthorizationApprovalBrowserBinding> {
+    let expected_name = approval_cookie_name(secure);
+    let mut encoded = None;
+    for header_value in headers.get_all(header::COOKIE) {
+        let header_value = header_value.to_str().ok()?;
+        for pair in header_value
+            .split(';')
+            .filter_map(|pair| pair.trim().split_once('='))
+        {
+            if pair.0 != expected_name {
+                continue;
+            }
+            if encoded.is_some() {
+                return None;
+            }
+            encoded = Some(Zeroizing::new(pair.1.to_string()));
+        }
+    }
+    let encoded = encoded.filter(|value| value.len() == BROWSER_BINDING_LENGTH)?;
+    let mut bytes = Zeroizing::new([0_u8; 32]);
+    let decoded = URL_SAFE_NO_PAD
+        .decode_slice(encoded.as_bytes(), &mut *bytes)
+        .ok()?;
+    (decoded == bytes.len()).then(|| OAuthAuthorizationApprovalBrowserBinding::from_bytes(*bytes))
+}
+
+fn has_exact_origin(headers: &HeaderMap, expected_origin: &str) -> bool {
+    let mut origins = headers.get_all(header::ORIGIN).iter();
+    let Some(origin) = origins.next() else {
+        return false;
+    };
+    origins.next().is_none()
+        && origin
+            .to_str()
+            .is_ok_and(|origin| origin == expected_origin)
+}
+
+fn approval_cookie_name(secure: bool) -> &'static str {
+    if secure {
+        SECURE_APPROVAL_COOKIE_NAME
+    } else {
+        LOOPBACK_APPROVAL_COOKIE_NAME
+    }
+}
+
+fn display_host(host: &Host<&str>) -> String {
+    match host {
+        Host::Domain(host) => host.to_string(),
+        Host::Ipv4(host) => host.to_string(),
+        Host::Ipv6(host) => format!("[{host}]"),
+    }
+}
+
+fn is_loopback(url: &Url) -> bool {
+    match url.host() {
+        Some(Host::Domain(host)) => {
+            let host = host.trim_end_matches('.').to_ascii_lowercase();
+            host == "localhost" || host.ends_with(".localhost")
+        }
+        Some(Host::Ipv4(host)) => host.is_loopback(),
+        Some(Host::Ipv6(host)) => {
+            host.is_loopback() || host.to_ipv4_mapped().is_some_and(|host| host.is_loopback())
+        }
+        None => false,
+    }
+}
+
+fn escape_html(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        escaped.push_str(match character {
+            '&' => "&amp;",
+            '<' => "&lt;",
+            '>' => "&gt;",
+            '"' => "&quot;",
+            '\'' => "&#39;",
+            _ => {
+                escaped.push(character);
+                continue;
+            }
+        });
+    }
+    escaped
+}

--- a/crates/coral-app/src/auth/authorization_server/authorize/confirmation.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize/confirmation.rs
@@ -13,6 +13,7 @@ use zeroize::Zeroizing;
 use super::super::super::state_store::{
     OAuthAuthorizationApprovalBrowserBinding, OAuthAuthorizationApprovalTicket,
 };
+use super::super::response::security_headers;
 
 const MAX_FORM_BYTES: usize = 256;
 const TICKET_LENGTH: usize = 43;
@@ -108,6 +109,14 @@ pub(super) async fn parse_submission(
     Ok((ticket, browser_binding, decision.ok_or(())?))
 }
 
+/// Renders the approval page for one pending authorization.
+///
+/// `Cancel` comes before `Continue` in the form because the first submit button
+/// is the one a browser presses for a bare Enter key, and the safe decision is
+/// the better default for a keystroke nobody aimed at either button. Source
+/// order is display order here: the page has no stylesheet, and the policy in
+/// [`CONTENT_SECURITY_POLICY`] has no `style-src`, so it inherits
+/// `default-src 'none'` and no styling could reverse the two.
 pub(super) fn response(
     ticket: &OAuthAuthorizationApprovalTicket,
     client_name: &str,
@@ -131,7 +140,7 @@ pub(super) fn response(
     });
     let encoded_ticket = Zeroizing::new(URL_SAFE_NO_PAD.encode(ticket.as_bytes()));
     let body = format!(
-        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>Approve Coral access</title></head><body><main><h1>Approve access?</h1><p><bdi>{}</bdi> is requesting access to Coral.</p><dl><dt>Client ID hostname</dt><dd><code>{}</code></dd><dt>Redirect host and port</dt><dd><code>{}</code></dd></dl>{}<form method=\"post\" action=\"/oauth/authorize\" autocomplete=\"off\"><input type=\"hidden\" name=\"ticket\" value=\"{}\"><button type=\"submit\" name=\"decision\" value=\"continue\">Continue</button><button type=\"submit\" name=\"decision\" value=\"cancel\">Cancel</button></form></main></body></html>",
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><title>Approve Coral access</title></head><body><main><h1>Approve access?</h1><p><bdi>{}</bdi> is requesting access to Coral.</p><dl><dt>Client ID hostname</dt><dd><code>{}</code></dd><dt>Redirect host and port</dt><dd><code>{}</code></dd></dl>{}<form method=\"post\" action=\"/oauth/authorize\" autocomplete=\"off\"><input type=\"hidden\" name=\"ticket\" value=\"{}\"><button type=\"submit\" name=\"decision\" value=\"cancel\">Cancel</button><button type=\"submit\" name=\"decision\" value=\"continue\">Continue</button></form></main></body></html>",
         escape_html(client_name),
         escape_html(&client_host),
         escape_html(&redirect_destination),
@@ -140,13 +149,10 @@ pub(super) fn response(
     );
     let mut response = (
         StatusCode::OK,
+        security_headers(),
         [
             (header::CONTENT_TYPE, "text/html; charset=utf-8"),
-            (header::CACHE_CONTROL, "no-store"),
-            (header::PRAGMA, "no-cache"),
             (header::CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY),
-            (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
-            (header::REFERRER_POLICY, "no-referrer"),
             (header::X_FRAME_OPTIONS, "DENY"),
         ],
         body,
@@ -174,33 +180,51 @@ fn approval_cookie_header(
     .ok()
 }
 
+/// Recovers the binding this browser was given, from the request's cookies.
+///
+/// The scan works in bytes rather than through `HeaderValue::to_str` because
+/// that rejects every octet outside visible ASCII, and a browser sends a cookie
+/// value however a script set it. Reading the header as text would therefore
+/// let one unrelated cookie on this host decide the answer, and it would fail
+/// in the worst direction: the page handler treats `None` as "no binding yet"
+/// and mints a fresh one, while the submission handler treats it as a rejected
+/// request, so the user loops through the page with no decision ever taking.
+/// Only the value stored under the expected name has to be ASCII, and base64
+/// decoding is already what establishes that.
+///
+/// Returning `None` for a repeated name is what keeps a shadowing cookie from
+/// choosing which binding is read, so every occurrence must be seen, not just
+/// the first.
 fn browser_binding_from_headers(
     headers: &HeaderMap,
     secure: bool,
 ) -> Option<OAuthAuthorizationApprovalBrowserBinding> {
-    let expected_name = approval_cookie_name(secure);
+    let expected_name = approval_cookie_name(secure).as_bytes();
     let mut encoded = None;
     for header_value in headers.get_all(header::COOKIE) {
-        let header_value = header_value.to_str().ok()?;
-        for pair in header_value
-            .split(';')
-            .filter_map(|pair| pair.trim().split_once('='))
-        {
-            if pair.0 != expected_name {
+        for pair in header_value.as_bytes().split(|byte| *byte == b';') {
+            let Some((name, value)) = split_at_byte(pair.trim_ascii(), b'=') else {
+                continue;
+            };
+            if name != expected_name {
                 continue;
             }
             if encoded.is_some() {
                 return None;
             }
-            encoded = Some(Zeroizing::new(pair.1.to_string()));
+            encoded = Some(Zeroizing::new(value.to_vec()));
         }
     }
     let encoded = encoded.filter(|value| value.len() == BROWSER_BINDING_LENGTH)?;
     let mut bytes = Zeroizing::new([0_u8; 32]);
-    let decoded = URL_SAFE_NO_PAD
-        .decode_slice(encoded.as_bytes(), &mut *bytes)
-        .ok()?;
+    let decoded = URL_SAFE_NO_PAD.decode_slice(&**encoded, &mut *bytes).ok()?;
     (decoded == bytes.len()).then(|| OAuthAuthorizationApprovalBrowserBinding::from_bytes(*bytes))
+}
+
+/// Splits `value` at the first occurrence of `byte`, dropping the separator.
+fn split_at_byte(value: &[u8], byte: u8) -> Option<(&[u8], &[u8])> {
+    let mut parts = value.splitn(2, |candidate| *candidate == byte);
+    Some((parts.next()?, parts.next()?))
 }
 
 fn has_exact_origin(headers: &HeaderMap, expected_origin: &str) -> bool {

--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -3,7 +3,6 @@ use axum::response::Response;
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ring::rand::{SecureRandom as _, SystemRandom};
-use url::Url;
 use zeroize::Zeroizing;
 
 use super::super::state_store::{OAuthAuthorizationCodeRecord, OAuthAuthorizationSessionRecord};
@@ -141,18 +140,14 @@ fn random_code() -> Result<String, ()> {
 
 /// Rebuilds the client callback this login was started for.
 ///
-/// The `None` arm is unreachable. `redirect_uri` is only ever stored after
-/// `authorize`'s `registered_redirect` matched it against a registered URI and
-/// parsed that URI under
-/// [`BrowserRedirect`](crate::outbound_url_policy::BrowserRedirect), so a value
-/// that reaches here has already parsed once. It is checked rather than
-/// unwrapped because the store sits between the two handlers, and a panic in a
-/// callback would be a worse answer than a failed login. Re-applying
-/// `BrowserRedirect` here would not add a check — it would only move where the
-/// same policy was applied.
+/// `redirect_uri` is only ever stored after `authorize`'s `registered_client`
+/// matched it against a registered URI and parsed that URI under
+/// [`BrowserRedirect`](crate::outbound_url_policy::BrowserRedirect), so
+/// re-applying `BrowserRedirect` here would not add a check — it would only
+/// move where the same policy was applied. [`TrustedRedirect::parse`] carries
+/// the reason the `None` arm is checked rather than unwrapped.
 fn trusted_redirect(session: &OAuthAuthorizationSessionRecord) -> Option<TrustedRedirect> {
-    let url = Url::parse(&session.redirect_uri).ok()?;
-    Some(TrustedRedirect::new(url, session.client_state.clone()))
+    TrustedRedirect::parse(&session.redirect_uri, session.client_state.clone())
 }
 
 #[cfg(test)]
@@ -167,7 +162,7 @@ mod tests {
     use ring::rand::SystemRandom;
     use ring::signature::{ECDSA_P256_SHA256_FIXED_SIGNING, EcdsaKeyPair};
     use serde_json::{Value, json};
-    use url::form_urlencoded;
+    use url::{Url, form_urlencoded};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -230,6 +225,7 @@ mod tests {
         AuthorizationServerHttpState {
             settings: Arc::new(settings(issuer)),
             session_tokens,
+            approval_store: store.clone(),
             session_store: store.clone(),
             code_store: store,
             provider_client: OidcProviderClient::new().expect("client"),

--- a/crates/coral-app/src/auth/authorization_server/response.rs
+++ b/crates/coral-app/src/auth/authorization_server/response.rs
@@ -46,6 +46,18 @@ impl TrustedRedirect {
         Self { url, client_state }
     }
 
+    /// Rebuilds a callback from a redirect URI a store handed back.
+    ///
+    /// The `None` arm is unreachable in practice: a stored `redirect_uri` was
+    /// string-matched against a registration and parsed under
+    /// [`BrowserRedirect`](crate::outbound_url_policy::BrowserRedirect) before
+    /// it was written, so it has already parsed once. It is checked rather than
+    /// unwrapped because a store sits between the handler that wrote it and the
+    /// one reading it, and a failed authorization beats a panicking handler.
+    pub(super) fn parse(redirect_uri: &str, client_state: Option<String>) -> Option<Self> {
+        Some(Self::new(Url::parse(redirect_uri).ok()?, client_state))
+    }
+
     /// Redirects the browser back to the client with an authorization code.
     pub(super) fn success(&self, code: &str) -> Response {
         self.redirect("code", code, None)
@@ -88,7 +100,10 @@ pub(super) fn direct_error(error: &'static str, description: &'static str) -> Re
     (
         StatusCode::BAD_REQUEST,
         security_headers(),
-        [(header::CONTENT_TYPE, "application/json")],
+        [
+            (header::CONTENT_TYPE, "application/json"),
+            (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+        ],
         body,
     )
         .into_response()

--- a/crates/coral-app/src/auth/authorization_server/response.rs
+++ b/crates/coral-app/src/auth/authorization_server/response.rs
@@ -100,10 +100,7 @@ pub(super) fn direct_error(error: &'static str, description: &'static str) -> Re
     (
         StatusCode::BAD_REQUEST,
         security_headers(),
-        [
-            (header::CONTENT_TYPE, "application/json"),
-            (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
-        ],
+        [(header::CONTENT_TYPE, "application/json")],
         body,
     )
         .into_response()
@@ -120,19 +117,23 @@ pub(super) fn redirect(location: &str) -> Response {
         .into_response()
 }
 
-/// Headers every authorization-server response carries.
+/// Headers every authorization-server response except the discovery document
+/// carries.
 ///
 /// Authorization codes travel in URLs, so `no-store`/`no-cache` keep one out of
 /// a shared cache and `no-referrer` keeps one out of the `Referer` a client's
-/// page sends onward. The token endpoint composes these with its own
-/// `content-type` rather than listing them again, so a header added here
-/// reaches every response that carries a code, a token, or an error. The
-/// discovery metadata document is deliberately not among them: it is public and
-/// meant to be cached.
-pub(super) fn security_headers() -> [(header::HeaderName, &'static str); 3] {
+/// page sends onward. Every response carrying these headers also carries a
+/// `content-type`, so `nosniff` belongs to the shared set rather than to
+/// whichever handler happened to need it first. Handlers compose these with
+/// that `content-type` rather than listing them again, so a header added here
+/// reaches every response that carries a code, a token, an error, or the
+/// approval page. The discovery metadata document is deliberately not among
+/// them: it is public and meant to be cached.
+pub(super) fn security_headers() -> [(header::HeaderName, &'static str); 4] {
     [
         (header::CACHE_CONTROL, "no-store"),
         (header::PRAGMA, "no-cache"),
         (header::REFERRER_POLICY, "no-referrer"),
+        (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
     ]
 }

--- a/crates/coral-app/src/auth/authorization_server/token.rs
+++ b/crates/coral-app/src/auth/authorization_server/token.rs
@@ -369,6 +369,7 @@ redirect_uri = "{AUTH_ISSUER}/auth/oidc/callback"
         let state = AuthorizationServerHttpState {
             settings: Arc::new(settings),
             session_tokens: session_tokens.clone(),
+            approval_store: store.clone(),
             session_store: store.clone(),
             code_store: store.clone(),
             provider_client: OidcProviderClient::new().expect("client"),

--- a/crates/coral-app/src/auth/state_store.rs
+++ b/crates/coral-app/src/auth/state_store.rs
@@ -16,10 +16,10 @@ type SecretHash = [u8; 32];
 
 /// Single-use secret naming a stored authorization approval.
 ///
-/// Outside tests the only way to build one is [`Self::generate`], which fills
-/// the secret in place from a caller-supplied CSPRNG. The bytes therefore never
-/// exist outside the value that zeroizes them on drop, and no caller can mint a
-/// ticket with attacker-guessable content.
+/// New tickets come from [`Self::generate`], which fills the secret in place
+/// from a caller-supplied CSPRNG, so a minted ticket's bytes never exist
+/// outside the value that zeroizes them on drop. [`Self::from_bytes`] exists
+/// only to rebuild a ticket the browser sent back.
 pub(crate) struct OAuthAuthorizationApprovalTicket([u8; 32]);
 
 impl OAuthAuthorizationApprovalTicket {
@@ -29,10 +29,6 @@ impl OAuthAuthorizationApprovalTicket {
     ///
     /// Returns [`StateStoreError::Randomness`] when `random` cannot fill the
     /// ticket.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "wired by the stacked authorization approval flow")
-    )]
     pub(super) fn generate(random: &dyn SecureRandom) -> Result<Self, StateStoreError> {
         let mut ticket = Self([0; 32]);
         random
@@ -41,17 +37,35 @@ impl OAuthAuthorizationApprovalTicket {
         Ok(ticket)
     }
 
-    #[cfg(test)]
-    fn from_bytes(bytes: [u8; 32]) -> Self {
+    /// Rebuilds a ticket from the bytes carried by a confirmation submission.
+    pub(super) fn from_bytes(bytes: [u8; 32]) -> Self {
         Self(bytes)
     }
 
-    fn as_bytes(&self) -> &[u8; 32] {
+    pub(super) fn as_bytes(&self) -> &[u8; 32] {
         &self.0
     }
 }
 
 impl Drop for OAuthAuthorizationApprovalTicket {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+pub(crate) struct OAuthAuthorizationApprovalBrowserBinding([u8; 32]);
+
+impl OAuthAuthorizationApprovalBrowserBinding {
+    pub(super) fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    pub(super) fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl Drop for OAuthAuthorizationApprovalBrowserBinding {
     fn drop(&mut self) {
         self.0.zeroize();
     }
@@ -100,21 +114,19 @@ pub(crate) enum StateStoreError {
 }
 
 /// Storage for approvals awaiting the user's confirmation.
-#[cfg_attr(
-    not(test),
-    expect(dead_code, reason = "wired by the stacked authorization approval flow")
-)]
 #[async_trait::async_trait]
 pub(crate) trait ApprovalStore: Send + Sync {
     async fn store_authorization_approval(
         &self,
         ticket: &OAuthAuthorizationApprovalTicket,
+        browser_binding: &OAuthAuthorizationApprovalBrowserBinding,
         approval: OAuthAuthorizationApprovalRecord,
     ) -> Result<(), StateStoreError>;
 
     async fn take_authorization_approval(
         &self,
         ticket: &OAuthAuthorizationApprovalTicket,
+        browser_binding: &OAuthAuthorizationApprovalBrowserBinding,
     ) -> Result<Option<OAuthAuthorizationApprovalRecord>, StateStoreError>;
 }
 
@@ -188,9 +200,10 @@ impl ApprovalStore for InMemoryStateStore {
     async fn store_authorization_approval(
         &self,
         ticket: &OAuthAuthorizationApprovalTicket,
+        browser_binding: &OAuthAuthorizationApprovalBrowserBinding,
         approval: OAuthAuthorizationApprovalRecord,
     ) -> Result<(), StateStoreError> {
-        let key = hash_bytes(ticket.as_bytes());
+        let key = approval_key(ticket, browser_binding);
         let mut inner = self.inner.lock().await;
         let now = Instant::now();
         let expires_at = self.expires_at(now)?;
@@ -213,8 +226,9 @@ impl ApprovalStore for InMemoryStateStore {
     async fn take_authorization_approval(
         &self,
         ticket: &OAuthAuthorizationApprovalTicket,
+        browser_binding: &OAuthAuthorizationApprovalBrowserBinding,
     ) -> Result<Option<OAuthAuthorizationApprovalRecord>, StateStoreError> {
-        let key = hash_bytes(ticket.as_bytes());
+        let key = approval_key(ticket, browser_binding);
         let mut inner = self.inner.lock().await;
         let now = Instant::now();
         let entry = inner.approvals.remove(&key);
@@ -364,6 +378,17 @@ fn hash_bytes(secret: &[u8]) -> SecretHash {
     Sha256::digest(secret).into()
 }
 
+fn approval_key(
+    ticket: &OAuthAuthorizationApprovalTicket,
+    browser_binding: &OAuthAuthorizationApprovalBrowserBinding,
+) -> SecretHash {
+    let mut hash = Sha256::new();
+    hash.update(b"coral-oauth-browser-bound-approval-v1\0");
+    hash.update(ticket.as_bytes());
+    hash.update(browser_binding.as_bytes());
+    hash.finalize().into()
+}
+
 #[cfg(test)]
 mod tests {
     use std::future::{Future, poll_fn};
@@ -386,6 +411,10 @@ mod tests {
             code_challenge: "challenge".to_string(),
             resource: "https://mcp.example.test/mcp".to_string(),
         }
+    }
+
+    fn browser_binding() -> OAuthAuthorizationApprovalBrowserBinding {
+        OAuthAuthorizationApprovalBrowserBinding::from_bytes([0x42; 32])
     }
 
     fn session(id: &str) -> OAuthAuthorizationSessionRecord {
@@ -455,20 +484,34 @@ mod tests {
         let store = Arc::new(InMemoryStateStore::new());
         let raw_ticket = [0x5a; 32];
         let ticket = Arc::new(OAuthAuthorizationApprovalTicket::from_bytes(raw_ticket));
+        let binding = browser_binding();
         store
-            .store_authorization_approval(&ticket, approval("approval"))
+            .store_authorization_approval(&ticket, &binding, approval("approval"))
             .await
             .unwrap();
         let inner = store.inner.lock().await;
-        let hash = hash_bytes(&raw_ticket);
+        let hash = approval_key(&ticket, &binding);
         assert!(inner.approvals.contains_key(&hash));
         assert!(!inner.approvals.contains_key(&raw_ticket));
+        drop(inner);
+        let wrong_binding = OAuthAuthorizationApprovalBrowserBinding::from_bytes([0x43; 32]);
+        assert!(
+            store
+                .take_authorization_approval(&ticket, &wrong_binding)
+                .await
+                .unwrap()
+                .is_none()
+        );
 
+        let inner = store.inner.lock().await;
         let take = |store: &Arc<InMemoryStateStore>,
                     ticket: &Arc<OAuthAuthorizationApprovalTicket>| {
             let store = Arc::clone(store);
             let ticket = Arc::clone(ticket);
-            async move { store.take_authorization_approval(&ticket).await }
+            async move {
+                let binding = browser_binding();
+                store.take_authorization_approval(&ticket, &binding).await
+            }
         };
         let (first, second) =
             park_takes_on_store_lock(take(&store, &ticket), take(&store, &ticket)).await;
@@ -484,7 +527,7 @@ mod tests {
         assert!(winner == approval("approval"));
         assert!(
             store
-                .take_authorization_approval(&ticket)
+                .take_authorization_approval(&ticket, &binding)
                 .await
                 .unwrap()
                 .is_none()
@@ -500,20 +543,21 @@ mod tests {
         assert_ne!(ticket.as_bytes(), other.as_bytes());
 
         let store = InMemoryStateStore::new();
+        let binding = browser_binding();
         store
-            .store_authorization_approval(&ticket, approval("generated"))
+            .store_authorization_approval(&ticket, &binding, approval("generated"))
             .await
             .unwrap();
         assert!(
             store
-                .take_authorization_approval(&other)
+                .take_authorization_approval(&other, &binding)
                 .await
                 .unwrap()
                 .is_none()
         );
         assert!(
             store
-                .take_authorization_approval(&ticket)
+                .take_authorization_approval(&ticket, &binding)
                 .await
                 .unwrap()
                 .is_some()
@@ -526,21 +570,21 @@ mod tests {
         let ticket = OAuthAuthorizationApprovalTicket::from_bytes([1; 32]);
         let other_ticket = OAuthAuthorizationApprovalTicket::from_bytes([2; 32]);
         store
-            .store_authorization_approval(&ticket, approval("original"))
+            .store_authorization_approval(&ticket, &browser_binding(), approval("original"))
             .await
             .unwrap();
         assert_eq!(
             store
-                .store_authorization_approval(&other_ticket, approval("other"))
+                .store_authorization_approval(&other_ticket, &browser_binding(), approval("other"),)
                 .await,
             Err(StateStoreError::CapacityExceeded { max_entries: 1 })
         );
         store
-            .store_authorization_approval(&ticket, approval("replacement"))
+            .store_authorization_approval(&ticket, &browser_binding(), approval("replacement"))
             .await
             .unwrap();
         let stored = store
-            .take_authorization_approval(&ticket)
+            .take_authorization_approval(&ticket, &browser_binding())
             .await
             .unwrap()
             .expect("replacement approval");
@@ -553,7 +597,7 @@ mod tests {
         let expired_ticket = OAuthAuthorizationApprovalTicket::from_bytes([1; 32]);
         let other_ticket = OAuthAuthorizationApprovalTicket::from_bytes([2; 32]);
         store
-            .store_authorization_approval(&expired_ticket, approval("expired"))
+            .store_authorization_approval(&expired_ticket, &browser_binding(), approval("expired"))
             .await
             .unwrap();
         store
@@ -566,7 +610,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             store
-                .store_authorization_approval(&other_ticket, approval("other"))
+                .store_authorization_approval(&other_ticket, &browser_binding(), approval("other"),)
                 .await,
             Err(StateStoreError::CapacityExceeded { max_entries: 1 })
         );
@@ -574,19 +618,23 @@ mod tests {
         tokio::time::advance(OAUTH_STATE_TTL).await;
         let replacement_ticket = OAuthAuthorizationApprovalTicket::from_bytes([3; 32]);
         store
-            .store_authorization_approval(&replacement_ticket, approval("replacement"))
+            .store_authorization_approval(
+                &replacement_ticket,
+                &browser_binding(),
+                approval("replacement"),
+            )
             .await
             .unwrap();
         assert!(
             store
-                .take_authorization_approval(&expired_ticket)
+                .take_authorization_approval(&expired_ticket, &browser_binding())
                 .await
                 .unwrap()
                 .is_none()
         );
         assert!(
             store
-                .take_authorization_approval(&replacement_ticket)
+                .take_authorization_approval(&replacement_ticket, &browser_binding())
                 .await
                 .unwrap()
                 .is_some()


### PR DESCRIPTION
> **Stack:** This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.
>
> **This part of the stack:** This section adds a user-confirmation step before Coral sends the browser to the identity provider. The previous PR stores each pending request, this PR adds the confirmation page and form, and the next PR connects the flow to client-hosted metadata.

## Intent

Require an explicit Continue or Cancel decision before Coral redirects a user to the external identity provider.

## What it enables

`GET /oauth/authorize` now validates the request, stores the trusted values under a short-lived ticket, and shows a locked-down page with the client name and the redirect host and port. `POST /oauth/authorize` accepts only that ticket and the user's decision.

Continue consumes the ticket and starts the provider login. Cancel consumes it and returns `access_denied` to the previously validated redirect URL. Replayed, expired, malformed, or restart-lost tickets fail directly instead of redirecting anywhere. The form is size-limited, the page escapes client text, and the response disables caching, framing, scripts, and referrer sharing.

This PR supplies the confirmation machinery. The next PR replaces the temporary client lookup used here with the production client-metadata lookup.

## Usage examples

A valid authorization request first returns an “Approve access?” page. Choosing Continue redirects the browser to the configured identity provider once. Choosing Cancel redirects to the validated client callback with `error=access_denied`; submitting the same form again returns a direct error.