### PR TITLE
feat(app): require CIMD for OAuth clients

### DIFF
--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -266,7 +266,7 @@ impl AuthorizationServerHttpState {
             authorization_resources,
             client_metadata_resolver: Arc::new(
                 HttpClientMetadataResolver::new()
-                    .map_err(|error| AuthServerError::ProviderClient(error.to_string()))?,
+                    .map_err(|error| AuthServerError::ClientMetadataResolver(error.to_string()))?,
             ),
         })
     }

--- a/crates/coral-app/src/auth/authorization_server.rs
+++ b/crates/coral-app/src/auth/authorization_server.rs
@@ -1,6 +1,6 @@
 //! HTTP lifecycle for Coral's authorization server.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::sync::Arc;
@@ -29,6 +29,8 @@ mod query;
 mod response;
 mod token;
 
+use self::client_metadata::{ClientMetadataResolver, HttpClientMetadataResolver};
+
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Prepared Coral authorization server with validated settings and runtime dependencies.
@@ -36,7 +38,6 @@ pub struct CoralAuthorizationServer {
     settings: Arc<ResolvedAuthSettings>,
     session_tokens: SessionTokenIssuer,
     state_store: Arc<InMemoryStateStore>,
-    registered_clients: Arc<BTreeMap<String, (String, Vec<String>)>>,
     authorization_resources: BTreeSet<String>,
 }
 
@@ -86,7 +87,6 @@ impl CoralAuthorizationServer {
             settings: Arc::new(settings),
             session_tokens,
             state_store: Arc::new(InMemoryStateStore::new()),
-            registered_clients: Arc::new(BTreeMap::new()),
             authorization_resources: BTreeSet::new(),
         }
     }
@@ -123,53 +123,58 @@ impl CoralAuthorizationServer {
     /// Returns an error when the listener cannot start.
     pub async fn start(self) -> Result<RunningCoralAuthorizationServer, AuthServerError> {
         let bind_addr = self.settings.bind_addr();
-        let state = AuthorizationServerHttpState {
-            settings: self.settings,
-            session_tokens: self.session_tokens,
-            approval_store: self.state_store.clone(),
-            session_store: self.state_store.clone(),
-            code_store: self.state_store,
-            provider_client: OidcProviderClient::new()
-                .map_err(|error| AuthServerError::ProviderClient(error.to_string()))?,
-            registered_clients: self.registered_clients,
-            authorization_resources: Arc::new(self.authorization_resources),
-        };
-        let router = Router::new()
-            .route(
-                "/.well-known/oauth-authorization-server",
-                get(authorization_server_metadata),
-            )
-            .route(
-                "/oauth/authorize",
-                get(authorize::oauth_authorize_get).post(authorize::oauth_authorize_post),
-            )
-            .route("/oauth/token", post(token::oauth_token))
-            .route(OIDC_CALLBACK_PATH, get(callback::oidc_callback))
-            .with_state(state);
-        let listener =
-            TcpListener::bind(bind_addr)
-                .await
-                .map_err(|source| AuthServerError::Bind {
-                    address: bind_addr,
-                    source,
-                })?;
-        let local_addr = listener.local_addr().map_err(AuthServerError::LocalAddr)?;
-        let endpoint_uri = format!("http://{local_addr}");
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let task = tokio::spawn(async move {
-            axum::serve(listener, router)
-                .with_graceful_shutdown(async {
-                    let _result = shutdown_rx.await;
-                })
-                .await
-        });
-        Ok(RunningCoralAuthorizationServer {
-            local_addr,
-            endpoint_uri,
-            shutdown_tx: Some(shutdown_tx),
-            task: Some(task),
-        })
+        let state = AuthorizationServerHttpState::new(
+            self.settings,
+            self.session_tokens,
+            self.state_store,
+            Arc::new(self.authorization_resources),
+        )?;
+        start_listener(bind_addr, state).await
     }
+}
+
+fn auth_router(state: AuthorizationServerHttpState) -> Router {
+    Router::new()
+        .route(
+            "/.well-known/oauth-authorization-server",
+            get(authorization_server_metadata),
+        )
+        .route(
+            "/oauth/authorize",
+            get(authorize::oauth_authorize_get).post(authorize::oauth_authorize_post),
+        )
+        .route("/oauth/token", post(token::oauth_token))
+        .route(OIDC_CALLBACK_PATH, get(callback::oidc_callback))
+        .with_state(state)
+}
+
+async fn start_listener(
+    bind_addr: SocketAddr,
+    state: AuthorizationServerHttpState,
+) -> Result<RunningCoralAuthorizationServer, AuthServerError> {
+    let router = auth_router(state);
+    let listener = TcpListener::bind(bind_addr)
+        .await
+        .map_err(|source| AuthServerError::Bind {
+            address: bind_addr,
+            source,
+        })?;
+    let local_addr = listener.local_addr().map_err(AuthServerError::LocalAddr)?;
+    let endpoint_uri = format!("http://{local_addr}");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async {
+                let _result = shutdown_rx.await;
+            })
+            .await
+    });
+    Ok(RunningCoralAuthorizationServer {
+        local_addr,
+        endpoint_uri,
+        shutdown_tx: Some(shutdown_tx),
+        task: Some(task),
+    })
 }
 
 /// An active Coral authorization-server listener with deterministic graceful shutdown.
@@ -239,8 +244,52 @@ struct AuthorizationServerHttpState {
     session_store: Arc<dyn SessionStore>,
     code_store: Arc<dyn CodeStore>,
     provider_client: OidcProviderClient,
-    registered_clients: Arc<BTreeMap<String, (String, Vec<String>)>>,
     authorization_resources: Arc<BTreeSet<String>>,
+    client_metadata_resolver: Arc<dyn ClientMetadataResolver>,
+}
+
+impl AuthorizationServerHttpState {
+    fn new(
+        settings: Arc<ResolvedAuthSettings>,
+        session_tokens: SessionTokenIssuer,
+        state_store: Arc<InMemoryStateStore>,
+        authorization_resources: Arc<BTreeSet<String>>,
+    ) -> Result<Self, AuthServerError> {
+        Ok(Self {
+            settings,
+            session_tokens,
+            approval_store: state_store.clone(),
+            session_store: state_store.clone(),
+            code_store: state_store,
+            provider_client: OidcProviderClient::new()
+                .map_err(|error| AuthServerError::ProviderClient(error.to_string()))?,
+            authorization_resources,
+            client_metadata_resolver: Arc::new(
+                HttpClientMetadataResolver::new()
+                    .map_err(|error| AuthServerError::ProviderClient(error.to_string()))?,
+            ),
+        })
+    }
+
+    #[cfg(test)]
+    fn with_client_metadata_resolver(
+        settings: Arc<ResolvedAuthSettings>,
+        session_tokens: SessionTokenIssuer,
+        state_store: Arc<InMemoryStateStore>,
+        authorization_resources: Arc<BTreeSet<String>>,
+        client_metadata_resolver: Arc<dyn ClientMetadataResolver>,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            settings,
+            session_tokens,
+            approval_store: state_store.clone(),
+            session_store: state_store.clone(),
+            code_store: state_store,
+            provider_client: OidcProviderClient::new().map_err(|error| error.to_string())?,
+            authorization_resources,
+            client_metadata_resolver,
+        })
+    }
 }
 
 /// Canonicalizes an RFC 8707 `resource` for comparison and recording.
@@ -264,7 +313,7 @@ async fn authorization_server_metadata(
         "grant_types_supported": ["authorization_code"],
         "code_challenge_methods_supported": ["S256"],
         "token_endpoint_auth_methods_supported": ["none"],
-        "client_id_metadata_document_supported": false,
+        "client_id_metadata_document_supported": true,
     }))
 }
 
@@ -405,7 +454,7 @@ mod tests {
                 "grant_types_supported": ["authorization_code"],
                 "code_challenge_methods_supported": ["S256"],
                 "token_endpoint_auth_methods_supported": ["none"],
-                "client_id_metadata_document_supported": false,
+                "client_id_metadata_document_supported": true,
             })
         );
         let response = client

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use axum::extract::{RawQuery, Request, State};
 use axum::http::HeaderMap;
 use axum::response::Response;
@@ -9,6 +7,7 @@ use super::super::provider_client::OidcAuthorizationRequest;
 use super::super::state_store::{
     OAuthAuthorizationApprovalRecord, OAuthAuthorizationSessionRecord,
 };
+use super::client_metadata::OAuthClientRegistration;
 use super::response::{TrustedRedirect, direct_error, redirect};
 use super::{AuthorizationServerHttpState, canonical_authorization_resource, query};
 use crate::outbound_url_policy::{BrowserRedirect, EndpointUrl};
@@ -30,11 +29,13 @@ pub(super) async fn oauth_authorize_get(
     else {
         return direct_error("invalid_request", "client_id and redirect_uri are required");
     };
-    let Some((client_name, callback)) =
-        registered_client(&state.registered_clients, client_id, redirect_uri)
-    else {
+    let Ok(registration) = resolve_client(&state, client_id).await else {
         return direct_error("invalid_request", "client_id or redirect_uri is invalid");
     };
+    let Some(callback) = registered_redirect(&registration.redirect_uris, redirect_uri) else {
+        return direct_error("invalid_request", "client_id or redirect_uri is invalid");
+    };
+    let client_name = registration.client_name;
     let trusted = TrustedRedirect::new(callback.clone(), query.state.clone());
 
     match query.response_type.as_deref() {
@@ -208,25 +209,29 @@ fn parse_query(raw: &str) -> Result<AuthorizeQuery, ()> {
     Ok(parsed)
 }
 
-/// Resolves the registered client and the redirect URI a request names, under
-/// [`BrowserRedirect`].
-///
-/// The registry is remote input once client metadata documents populate it, so
-/// the policy is applied here rather than trusted to have been applied at
-/// registration: a URI the policy rejects resolves to `None`, and the request
-/// fails with a direct error instead of becoming a redirect.
-fn registered_client(
-    registered_clients: &BTreeMap<String, (String, Vec<String>)>,
+async fn resolve_client(
+    state: &AuthorizationServerHttpState,
     client_id: &str,
-    redirect_uri: &str,
-) -> Option<(String, Url)> {
-    let (client_name, redirect_uris) = registered_clients.get(client_id)?;
+) -> Result<OAuthClientRegistration, ()> {
+    state
+        .client_metadata_resolver
+        .resolve(client_id)
+        .await
+        .map_err(|_error| ())
+}
+
+/// Resolves the redirect URI a request names, under [`BrowserRedirect`].
+///
+/// The candidates come from the client's own metadata document, so they are
+/// remote input: the policy is applied here rather than trusted to have been
+/// applied at resolution. A URI the policy rejects resolves to `None`, and the
+/// request fails with a direct error instead of becoming a redirect.
+fn registered_redirect(redirect_uris: &[String], redirect_uri: &str) -> Option<Url> {
     redirect_uris
         .iter()
         .find(|uri| uri.as_str() == redirect_uri)
         .and_then(|uri| EndpointUrl::<BrowserRedirect>::parse(uri).ok())
         .map(EndpointUrl::into_url)
-        .map(|redirect| (client_name.clone(), redirect))
 }
 
 fn valid_s256_challenge(value: &str) -> bool {
@@ -248,6 +253,7 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet};
     use std::path::Path;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use axum::body::{Body, to_bytes};
@@ -262,11 +268,13 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use super::super::{AuthorizationServerHttpState, CoralAuthorizationServer};
+    use super::super::AuthorizationServerHttpState;
+    use super::super::client_metadata::{
+        ClientMetadataError, ClientMetadataResolver, OAuthClientRegistration,
+    };
     use super::*;
     use crate::auth::config::AuthSettings;
     use crate::auth::config::ResolvedAuthSettings;
-    use crate::auth::provider_client::OidcProviderClient;
     use crate::auth::session::{SessionTokenIssuer, test_signing_key};
     use crate::auth::state_store::{
         ApprovalStore, InMemoryStateStore, OAuthAuthorizationApprovalBrowserBinding,
@@ -308,26 +316,66 @@ mod tests {
         settings
     }
 
-    fn state(issuer: &str, store: Arc<InMemoryStateStore>) -> AuthorizationServerHttpState {
+    struct FakeResolver {
+        result: Result<OAuthClientRegistration, ClientMetadataError>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl ClientMetadataResolver for FakeResolver {
+        async fn resolve(
+            &self,
+            _client_id: &str,
+        ) -> Result<OAuthClientRegistration, ClientMetadataError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.result.clone()
+        }
+    }
+
+    fn fake_resolver(
+        result: Result<OAuthClientRegistration, ClientMetadataError>,
+    ) -> (Arc<dyn ClientMetadataResolver>, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        (
+            Arc::new(FakeResolver {
+                result,
+                calls: calls.clone(),
+            }),
+            calls,
+        )
+    }
+
+    fn registration(redirect_uris: &[&str]) -> OAuthClientRegistration {
+        OAuthClientRegistration {
+            redirect_uris: redirect_uris.iter().map(ToString::to_string).collect(),
+            client_name: "Test Client".into(),
+        }
+    }
+
+    fn state_with_resolver(
+        issuer: &str,
+        store: Arc<InMemoryStateStore>,
+        resolver: Arc<dyn ClientMetadataResolver>,
+    ) -> AuthorizationServerHttpState {
         let session_tokens = SessionTokenIssuer::new(
             Some(AUTH_ISSUER),
             test_signing_key(),
             Duration::from_mins(5),
         )
         .expect("session");
-        AuthorizationServerHttpState {
-            settings: Arc::new(settings(issuer)),
+        AuthorizationServerHttpState::with_client_metadata_resolver(
+            Arc::new(settings(issuer)),
             session_tokens,
-            approval_store: store.clone(),
-            session_store: store.clone(),
-            code_store: store,
-            provider_client: OidcProviderClient::new().expect("provider client"),
-            registered_clients: Arc::new(BTreeMap::from([(
-                CLIENT_ID.into(),
-                ("Test Client".into(), vec![REDIRECT_URI.into()]),
-            )])),
-            authorization_resources: Arc::new(BTreeSet::from([RESOURCE.into()])),
-        }
+            store,
+            Arc::new(BTreeSet::from([RESOURCE.into()])),
+            resolver,
+        )
+        .expect("auth state")
+    }
+
+    fn state(issuer: &str, store: Arc<InMemoryStateStore>) -> AuthorizationServerHttpState {
+        let (resolver, _calls) = fake_resolver(Ok(registration(&[REDIRECT_URI])));
+        state_with_resolver(issuer, store, resolver)
     }
 
     fn pairs() -> Vec<(String, String)> {
@@ -762,26 +810,114 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cimd_client_uses_resolved_exact_redirect_once() {
+        let provider = MockServer::start().await;
+        mount_discovery(&provider, 200).await;
+        let (resolver, calls) = fake_resolver(Ok(registration(&[REDIRECT_URI])));
+        let request_pairs = pairs();
+        let auth_state = state_with_resolver(
+            &provider.uri(),
+            Arc::new(InMemoryStateStore::new()),
+            resolver,
+        );
+        let response = request(auth_state.clone(), &request_pairs).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let page = response_body(response).await;
+        assert!(page.contains("<bdi>Test Client</bdi>"));
+        assert!(page.contains("Client ID hostname</dt><dd><code>client.example.test"));
+        let ticket = ticket_from_page(&page);
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert!(
+            provider
+                .received_requests()
+                .await
+                .expect("requests")
+                .is_empty()
+        );
+
+        let response = submit(auth_state, &ticket, "continue").await;
+        assert_eq!(response.status(), StatusCode::FOUND);
+        assert!(location(&response).is_some_and(|url| url.starts_with(&provider.uri())));
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn cimd_undeclared_redirect_is_never_trusted() {
+        let (resolver, calls) = fake_resolver(Ok(registration(&[
+            "https://client.example.test/other-callback",
+        ])));
+        let response = request(
+            state_with_resolver(
+                "https://provider.invalid",
+                Arc::new(InMemoryStateStore::new()),
+                resolver,
+            ),
+            &pairs(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(location(&response).is_none());
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn resolver_failures_are_generic_direct_errors() {
+        let (resolver, calls) = fake_resolver(Err(ClientMetadataError::HttpStatus));
+        let client_id = format!("{CLIENT_ID}?secret=attacker-url-secret");
+        let mut request_pairs = pairs();
+        replace(&mut request_pairs, "client_id", Some(&client_id));
+        let response = request(
+            state_with_resolver(
+                "https://provider.invalid",
+                Arc::new(InMemoryStateStore::new()),
+                resolver,
+            ),
+            &request_pairs,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(location(&response).is_none());
+        let body = to_bytes(response.into_body(), 4096).await.expect("body");
+        let body = String::from_utf8_lossy(&body);
+        assert!(body.contains("invalid_request"));
+        assert!(!body.contains("attacker-url-secret"));
+        assert!(!body.contains("HttpStatus"));
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
     async fn client_and_redirect_must_match_exactly_before_redirecting() {
         let store = Arc::new(InMemoryStateStore::new());
-        for (field, value) in [
-            (
-                "client_id",
-                "https://client.example.test/oauth/%63lient.json",
-            ),
-            ("redirect_uri", "https://client.example.test/other"),
-        ] {
-            let mut request_pairs = pairs();
-            replace(&mut request_pairs, field, Some(value));
-            let response = request(
-                state("https://provider.invalid", store.clone()),
-                &request_pairs,
-            )
-            .await;
-            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-            assert_security(&response);
-            assert!(location(&response).is_none());
-        }
+        let (resolver, _calls) = fake_resolver(Err(ClientMetadataError::InvalidMetadata));
+        let mut wrong_client = pairs();
+        replace(
+            &mut wrong_client,
+            "client_id",
+            Some("https://client.example.test/oauth/%63lient.json"),
+        );
+        let response = request(
+            state_with_resolver("https://provider.invalid", store.clone(), resolver),
+            &wrong_client,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_security(&response);
+        assert!(location(&response).is_none());
+
+        let mut wrong_redirect = pairs();
+        replace(
+            &mut wrong_redirect,
+            "redirect_uri",
+            Some("https://client.example.test/other"),
+        );
+        let response = request(
+            state("https://provider.invalid", store.clone()),
+            &wrong_redirect,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_security(&response);
+        assert!(location(&response).is_none());
 
         let raw = format!("{}&client%5Fid=raw-secret", encode(&pairs()));
         let response = oauth_authorize_get(
@@ -803,11 +939,9 @@ mod tests {
             "data:text/html,<script>alert(1)</script>",
             "http://client.example.test/callback",
         ] {
-            let mut auth_state = state("https://provider.invalid", store.clone());
-            auth_state.registered_clients = Arc::new(BTreeMap::from([(
-                CLIENT_ID.into(),
-                ("Test Client".into(), vec![uri.into()]),
-            )]));
+            let (resolver, _calls) = fake_resolver(Ok(registration(&[uri])));
+            let auth_state =
+                state_with_resolver("https://provider.invalid", store.clone(), resolver);
             let mut request_pairs = pairs();
             replace(&mut request_pairs, "redirect_uri", Some(uri));
             let response = request(auth_state, &request_pairs).await;
@@ -1030,18 +1164,11 @@ mod tests {
     async fn listener_exposes_authorize_route() {
         let provider = MockServer::start().await;
         mount_discovery(&provider, 200).await;
-        let store = Arc::new(InMemoryStateStore::new());
-        let state = state(&provider.uri(), Arc::clone(&store));
-        let server = CoralAuthorizationServer {
-            settings: state.settings,
-            session_tokens: state.session_tokens,
-            state_store: store,
-            registered_clients: state.registered_clients,
-            authorization_resources: state.authorization_resources.as_ref().clone(),
-        }
-        .start()
-        .await
-        .expect("start");
+        let auth_state = state(&provider.uri(), Arc::new(InMemoryStateStore::new()));
+        let bind_addr = auth_state.settings.bind_addr();
+        let server = super::super::start_listener(bind_addr, auth_state)
+            .await
+            .expect("start");
         let client = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
             .build()

--- a/crates/coral-app/src/auth/authorization_server/authorize.rs
+++ b/crates/coral-app/src/auth/authorization_server/authorize.rs
@@ -1135,6 +1135,10 @@ mod tests {
         assert!(error_location.contains("error=server_error"));
         assert!(!error_location.contains(PROVIDER_SECRET));
 
+        // Every filler entry names its own client, because the per-client
+        // bound is what stops one client from reaching the shared budget on
+        // its own. Reaching it at all is the setup for the assertion below,
+        // not the behavior under test.
         let filler = OAuthAuthorizationApprovalRecord {
             client_id: CLIENT_ID.into(),
             client_name: "Test Client".into(),
@@ -1148,7 +1152,14 @@ mod tests {
             ticket[..8].copy_from_slice(&index.to_le_bytes());
             let ticket = OAuthAuthorizationApprovalTicket::from_bytes(ticket);
             store
-                .store_authorization_approval(&ticket, &browser_binding(), filler.clone())
+                .store_authorization_approval(
+                    &ticket,
+                    &browser_binding(),
+                    OAuthAuthorizationApprovalRecord {
+                        client_id: format!("https://filler-{index}.example.test/client.json"),
+                        ..filler.clone()
+                    },
+                )
                 .await
                 .expect("fill approval store");
         }

--- a/crates/coral-app/src/auth/authorization_server/callback.rs
+++ b/crates/coral-app/src/auth/authorization_server/callback.rs
@@ -167,6 +167,7 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::super::AuthorizationServerHttpState;
+    use super::super::client_metadata::HttpClientMetadataResolver;
     use super::*;
     use crate::auth::config::{AuthSettings, ResolvedAuthSettings};
     use crate::auth::id_token::tests::{
@@ -229,8 +230,10 @@ mod tests {
             session_store: store.clone(),
             code_store: store,
             provider_client: OidcProviderClient::new().expect("client"),
-            registered_clients: Arc::new(BTreeMap::new()),
             authorization_resources: Arc::new(BTreeSet::from([RESOURCE.into()])),
+            client_metadata_resolver: Arc::new(
+                HttpClientMetadataResolver::new().expect("client metadata resolver"),
+            ),
         }
     }
 

--- a/crates/coral-app/src/auth/authorization_server/client_metadata.rs
+++ b/crates/coral-app/src/auth/authorization_server/client_metadata.rs
@@ -1,13 +1,5 @@
 //! Client ID Metadata Document fetching and validation.
 
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the authorization-route integration lands in the next stacked PR"
-    )
-)]
-
 use std::fmt;
 use std::sync::Arc;
 
@@ -24,6 +16,7 @@ const CLIENT_METADATA_MAX_BYTES: usize = 5 * 1024;
 const MAX_CLIENT_NAME_BYTES: usize = 255;
 
 /// The client properties needed after a metadata document has been validated.
+#[derive(Clone)]
 pub(super) struct OAuthClientRegistration {
     pub(super) redirect_uris: Vec<String>,
     pub(super) client_name: String,

--- a/crates/coral-app/src/auth/authorization_server/token.rs
+++ b/crates/coral-app/src/auth/authorization_server/token.rs
@@ -301,7 +301,7 @@ fn json_response(status: StatusCode, body: &serde_json::Value) -> Response {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, BTreeSet};
+    use std::collections::BTreeSet;
     use std::path::Path;
     use std::sync::Arc;
 
@@ -313,6 +313,7 @@ mod tests {
     use serde_json::Value;
     use url::form_urlencoded;
 
+    use super::super::client_metadata::HttpClientMetadataResolver;
     use super::super::query;
     use super::*;
     use crate::auth::config::AuthSettings;
@@ -373,8 +374,10 @@ redirect_uri = "{AUTH_ISSUER}/auth/oidc/callback"
             session_store: store.clone(),
             code_store: store.clone(),
             provider_client: OidcProviderClient::new().expect("client"),
-            registered_clients: Arc::new(BTreeMap::new()),
             authorization_resources: Arc::new(BTreeSet::from([RESOURCE.into()])),
+            client_metadata_resolver: Arc::new(
+                HttpClientMetadataResolver::new().expect("client metadata resolver"),
+            ),
         };
         (state, store, session_tokens)
     }

--- a/crates/coral-app/src/auth/error.rs
+++ b/crates/coral-app/src/auth/error.rs
@@ -26,6 +26,14 @@ pub enum AuthServerError {
     /// internal.
     #[error("failed to initialize the OIDC provider client: {0}")]
     ProviderClient(String),
+    /// The OAuth client metadata resolver could not be constructed.
+    ///
+    /// Distinct from [`Self::ProviderClient`] so a failure fetching client
+    /// metadata documents does not point an operator at the upstream provider
+    /// configuration. Carries the resolver's own message rather than its type,
+    /// which is crate internal.
+    #[error("failed to initialize the OAuth client metadata resolver: {0}")]
+    ClientMetadataResolver(String),
     /// The TCP listener could not bind.
     #[error("failed to bind authorization server to {address}")]
     Bind {

--- a/crates/coral-app/src/auth/state_store.rs
+++ b/crates/coral-app/src/auth/state_store.rs
@@ -12,6 +12,24 @@ use zeroize::{Zeroize as _, Zeroizing};
 const OAUTH_STATE_TTL: Duration = Duration::from_mins(5);
 const MAX_OAUTH_STATE_ENTRIES_PER_KIND: usize = 4_096;
 
+/// The most approvals one client may hold awaiting confirmation.
+///
+/// [`MAX_OAUTH_STATE_ENTRIES_PER_KIND`] on its own lets a single client take
+/// the whole approval budget. An approval is written when the confirmation
+/// page is rendered — before the user has done anything and before the
+/// provider is contacted — so anyone holding a resolvable `client_id` and one
+/// of its redirect URIs, both public by construction, mints an entry per
+/// request. Bounding each client separately keeps that inside the client it
+/// came from, and leaves exhausting the shared budget to require a distinct
+/// client metadata document for every block of this many entries — each
+/// document live, or Coral will not resolve it at all.
+///
+/// The bound is per client rather than per browser binding because a caller
+/// that sends no cookie is handed a fresh binding on every request, so a
+/// per-binding limit would bound only the browsers that were never the
+/// problem.
+const MAX_OAUTH_APPROVALS_PER_CLIENT: usize = 64;
+
 type SecretHash = [u8; 32];
 
 /// Single-use secret naming a stored authorization approval.
@@ -107,6 +125,8 @@ pub(crate) enum StateStoreError {
     EmptySecret,
     #[error("OAuth state store has reached its {max_entries}-entry limit")]
     CapacityExceeded { max_entries: usize },
+    #[error("OAuth client has reached its {max_entries}-approval limit")]
+    ClientApprovalsExceeded { max_entries: usize },
     #[error("OAuth state expiry exceeds the process clock range")]
     ExpiryOverflow,
     #[error("OAuth approval ticket generation failed")]
@@ -116,6 +136,16 @@ pub(crate) enum StateStoreError {
 /// Storage for approvals awaiting the user's confirmation.
 #[async_trait::async_trait]
 pub(crate) trait ApprovalStore: Send + Sync {
+    /// Holds `approval` until the browser bound to it confirms or cancels.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StateStoreError::ClientApprovalsExceeded`] once the client
+    /// named by the approval holds too many outstanding entries, and
+    /// [`StateStoreError::CapacityExceeded`] once approvals as a whole do. An
+    /// implementation is expected to bound both: the entry is written before
+    /// the user has acted, so an approval that is never confirmed still costs
+    /// storage until it expires.
     async fn store_authorization_approval(
         &self,
         ticket: &OAuthAuthorizationApprovalTicket,
@@ -168,6 +198,7 @@ pub(crate) struct InMemoryStateStore {
     inner: Mutex<StateMaps>,
     ttl: Duration,
     max_entries_per_kind: usize,
+    max_approvals_per_client: usize,
 }
 
 impl Default for InMemoryStateStore {
@@ -178,14 +209,23 @@ impl Default for InMemoryStateStore {
 
 impl InMemoryStateStore {
     pub(crate) fn new() -> Self {
-        Self::with_options(OAUTH_STATE_TTL, MAX_OAUTH_STATE_ENTRIES_PER_KIND)
+        Self::with_options(
+            OAUTH_STATE_TTL,
+            MAX_OAUTH_STATE_ENTRIES_PER_KIND,
+            MAX_OAUTH_APPROVALS_PER_CLIENT,
+        )
     }
 
-    fn with_options(ttl: Duration, max_entries_per_kind: usize) -> Self {
+    fn with_options(
+        ttl: Duration,
+        max_entries_per_kind: usize,
+        max_approvals_per_client: usize,
+    ) -> Self {
         Self {
             inner: Mutex::new(StateMaps::default()),
             ttl,
             max_entries_per_kind,
+            max_approvals_per_client,
         }
     }
 
@@ -208,11 +248,19 @@ impl ApprovalStore for InMemoryStateStore {
         let now = Instant::now();
         let expires_at = self.expires_at(now)?;
         inner.purge_expired(now);
+        let replaces_existing = inner.approvals.contains_key(&key);
         ensure_capacity(
             inner.approvals.len(),
             self.max_entries_per_kind,
-            inner.approvals.contains_key(&key),
+            replaces_existing,
         )?;
+        if !replaces_existing
+            && inner.approvals_for_client(&approval.client_id) >= self.max_approvals_per_client
+        {
+            return Err(StateStoreError::ClientApprovalsExceeded {
+                max_entries: self.max_approvals_per_client,
+            });
+        }
         inner.approvals.insert(
             key,
             Expiring {
@@ -344,6 +392,18 @@ struct StateMaps {
 }
 
 impl StateMaps {
+    /// Counts the approvals `client_id` is holding.
+    ///
+    /// Walking the map costs no more than the [`Self::purge_expired`] that
+    /// precedes every store, and a count taken from the entries themselves
+    /// cannot drift out of step with them the way a maintained tally can.
+    fn approvals_for_client(&self, client_id: &str) -> usize {
+        self.approvals
+            .values()
+            .filter(|entry| entry.value.client_id == client_id)
+            .count()
+    }
+
     fn purge_expired(&mut self, now: Instant) {
         self.approvals.retain(|_, entry| entry.expires_at > now);
         self.sessions.retain(|_, entry| entry.expires_at > now);
@@ -410,6 +470,13 @@ mod tests {
             client_state: Some(id.to_string()),
             code_challenge: "challenge".to_string(),
             resource: "https://mcp.example.test/mcp".to_string(),
+        }
+    }
+
+    fn client_approval(client_id: &str, id: &str) -> OAuthAuthorizationApprovalRecord {
+        OAuthAuthorizationApprovalRecord {
+            client_id: client_id.to_string(),
+            ..approval(id)
         }
     }
 
@@ -566,7 +633,8 @@ mod tests {
 
     #[tokio::test]
     async fn authorization_approval_capacity_allows_only_same_ticket_replacement() {
-        let store = InMemoryStateStore::with_options(OAUTH_STATE_TTL, 1);
+        let store =
+            InMemoryStateStore::with_options(OAUTH_STATE_TTL, 1, MAX_OAUTH_APPROVALS_PER_CLIENT);
         let ticket = OAuthAuthorizationApprovalTicket::from_bytes([1; 32]);
         let other_ticket = OAuthAuthorizationApprovalTicket::from_bytes([2; 32]);
         store
@@ -591,9 +659,76 @@ mod tests {
         assert!(stored == approval("replacement"));
     }
 
+    /// The shared budget here is eight times the per-client one, so every
+    /// rejection below is the per-client bound and not the budget standing in
+    /// for it.
+    #[tokio::test]
+    async fn approvals_are_bounded_per_client_beneath_the_shared_budget() {
+        const CLIENT: &str = "https://a.example.test/client.json";
+
+        let store = InMemoryStateStore::with_options(OAUTH_STATE_TTL, 16, 2);
+        let ticket = |byte: u8| OAuthAuthorizationApprovalTicket::from_bytes([byte; 32]);
+        for byte in [1, 2] {
+            store
+                .store_authorization_approval(
+                    &ticket(byte),
+                    &browser_binding(),
+                    client_approval(CLIENT, "held"),
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            store
+                .store_authorization_approval(
+                    &ticket(3),
+                    &browser_binding(),
+                    client_approval(CLIENT, "over"),
+                )
+                .await,
+            Err(StateStoreError::ClientApprovalsExceeded { max_entries: 2 })
+        );
+
+        // The cost stays inside the client that caused it.
+        store
+            .store_authorization_approval(
+                &ticket(4),
+                &browser_binding(),
+                client_approval("https://b.example.test/client.json", "other"),
+            )
+            .await
+            .unwrap();
+
+        // A ticket the client already holds is a replacement, not a new entry.
+        store
+            .store_authorization_approval(
+                &ticket(1),
+                &browser_binding(),
+                client_approval(CLIENT, "replacement"),
+            )
+            .await
+            .unwrap();
+
+        // Confirming or cancelling gives the client its slot back.
+        store
+            .take_authorization_approval(&ticket(2), &browser_binding())
+            .await
+            .unwrap()
+            .expect("held approval");
+        store
+            .store_authorization_approval(
+                &ticket(3),
+                &browser_binding(),
+                client_approval(CLIENT, "after release"),
+            )
+            .await
+            .unwrap();
+    }
+
     #[tokio::test(start_paused = true)]
     async fn authorization_approvals_expire_and_release_capacity() {
-        let store = InMemoryStateStore::with_options(OAUTH_STATE_TTL, 1);
+        let store =
+            InMemoryStateStore::with_options(OAUTH_STATE_TTL, 1, MAX_OAUTH_APPROVALS_PER_CLIENT);
         let expired_ticket = OAuthAuthorizationApprovalTicket::from_bytes([1; 32]);
         let other_ticket = OAuthAuthorizationApprovalTicket::from_bytes([2; 32]);
         store
@@ -783,7 +918,8 @@ mod tests {
 
     #[tokio::test]
     async fn expiration_is_lazy_and_capacity_is_bounded_per_record_type() {
-        let expired = InMemoryStateStore::with_options(Duration::ZERO, 1);
+        let expired =
+            InMemoryStateStore::with_options(Duration::ZERO, 1, MAX_OAUTH_APPROVALS_PER_CLIENT);
         expired
             .store_authorization_session("old", session("old"))
             .await
@@ -800,7 +936,8 @@ mod tests {
             .await
             .unwrap();
 
-        let bounded = InMemoryStateStore::with_options(OAUTH_STATE_TTL, 1);
+        let bounded =
+            InMemoryStateStore::with_options(OAUTH_STATE_TTL, 1, MAX_OAUTH_APPROVALS_PER_CLIENT);
         bounded
             .store_authorization_session("one", session("one"))
             .await


### PR DESCRIPTION
> **Stack:** This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.
>
> **This part of the stack:** This section completes client-facing authorization. The previous PR asks the user to confirm a redirect, and this PR makes every client prove its name and allowed callback URLs through a Client ID Metadata Document that the client hosts.

## Intent

Make Client ID Metadata Documents, or CIMD, the only production source of OAuth client identity and redirect information.

## What it enables

When `GET /oauth/authorize` receives a `client_id`, Coral fetches and validates the JSON document at that URL. The requested redirect must exactly match one declared by the document, and the confirmation page shows the validated client name and destination.

Coral fetches the document once, before showing the confirmation page. Continue uses the values already stored with the approval ticket, so a changed document cannot alter an authorization that the user has already reviewed. Coral's authorization-server metadata now advertises CIMD support. There is no hosted client registry or configuration-based bypass.

## Usage examples

A web-app backend can publish a document at `https://client.example/oauth-client.json`, use that exact URL as `client_id`, and declare its callback URL in the document. It then starts Authorization Code with PKCE using that exact callback. Coral validates the document, shows the client name and callback destination, and continues with the stored values if the user approves.