### PR TITLE
feat(app): add identity repository schema

### DIFF
--- a/crates/coral-app/migrations/0010_identity_specs.sql
+++ b/crates/coral-app/migrations/0010_identity_specs.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS identity_specs (
+    scope_kind TEXT NOT NULL,
+    scope_id TEXT NOT NULL,
+    workspace_id TEXT,
+    name TEXT NOT NULL,
+    version TEXT NOT NULL,
+    description TEXT NOT NULL,
+    issuer TEXT NOT NULL,
+    identity_type TEXT NOT NULL,
+    manifest_yaml TEXT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (scope_kind, scope_id, name),
+    CHECK (
+        (
+            scope_kind = 'global'
+            AND scope_id = '__global__'
+            AND workspace_id IS NULL
+        )
+        OR (
+            scope_kind = 'workspace'
+            AND workspace_id IS NOT NULL
+            AND scope_id = workspace_id
+        )
+    ),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS identity_spec_documents (
+    scope_kind TEXT NOT NULL,
+    scope_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    document_version BIGINT NOT NULL,
+    ciphertext BYTEA NOT NULL,
+    nonce BYTEA NOT NULL,
+    wrapped_dek BYTEA NOT NULL,
+    wrapped_dek_nonce BYTEA NOT NULL,
+    key_id TEXT NOT NULL,
+    algorithm TEXT NOT NULL,
+    aad_version BIGINT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (scope_kind, scope_id, name),
+    FOREIGN KEY (scope_kind, scope_id, name) REFERENCES identity_specs(scope_kind, scope_id, name) ON DELETE CASCADE
+);

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -112,6 +112,7 @@ impl From<DbError> for AppError {
             DbError::Config(detail) => {
                 Self::FailedPrecondition(format!("database configuration is invalid: {detail}"))
             }
+            error @ DbError::CorruptData(_) => Self::Database(error.to_string()),
             DbError::MissingDatabaseParent(path) => Self::FailedPrecondition(format!(
                 "database file parent directory is missing for {}",
                 path.display()

--- a/crates/coral-app/src/state/db/error.rs
+++ b/crates/coral-app/src/state/db/error.rs
@@ -4,6 +4,9 @@ use std::path::PathBuf;
 pub(crate) enum DbError {
     #[error("database configuration is invalid: {0}")]
     Config(String),
+    /// A row was read successfully but cannot be decoded into app domain types.
+    #[error("database contains corrupt data: {0}")]
+    CorruptData(String),
     #[error("database file parent directory is missing for {0}")]
     MissingDatabaseParent(PathBuf),
     #[error(transparent)]
@@ -21,6 +24,7 @@ impl DbError {
         match self {
             Self::Sqlx(sqlx::Error::Database(error)) => error.is_unique_violation(),
             Self::Config(_)
+            | Self::CorruptData(_)
             | Self::MissingDatabaseParent(_)
             | Self::Io(_)
             | Self::TomlDecode(_)

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -17,5 +17,10 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
+#[expect(
+    unused_imports,
+    reason = "identity key types land before later repository behavior consumes them"
+)]
+pub(crate) use repositories::identity_specs::{IdentitySpecKey, IdentitySpecScope};
 pub(crate) use session::{DbRepos, DbSession};
 pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/repositories/identity_specs.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs.rs
@@ -1,0 +1,257 @@
+#![expect(
+    dead_code,
+    reason = "identity repositories land before their read and write behavior in the B1 stack"
+)]
+
+use crate::bootstrap::AppError;
+use crate::state::db::{DbError, DbSession};
+use crate::workspaces::WorkspaceName;
+use coral_spec::validate_identity_spec_name;
+
+const GLOBAL_SCOPE_KIND: &str = "global";
+const GLOBAL_SCOPE_ID: &str = "__global__";
+const WORKSPACE_SCOPE_KIND: &str = "workspace";
+
+/// Definition scope for one durable identity spec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum IdentitySpecScope {
+    /// A globally installed identity spec definition.
+    Global,
+    /// An identity spec definition scoped to one workspace.
+    Workspace(WorkspaceName),
+}
+
+impl IdentitySpecScope {
+    /// Build the global identity-spec scope.
+    pub(crate) fn global() -> Self {
+        Self::Global
+    }
+
+    /// Build a workspace identity-spec scope.
+    pub(crate) fn workspace(workspace_name: WorkspaceName) -> Self {
+        Self::Workspace(workspace_name)
+    }
+
+    pub(super) fn kind(&self) -> &'static str {
+        match self {
+            Self::Global => GLOBAL_SCOPE_KIND,
+            Self::Workspace(_workspace_name) => WORKSPACE_SCOPE_KIND,
+        }
+    }
+
+    pub(super) fn scope_id(&self) -> &str {
+        match self {
+            Self::Global => GLOBAL_SCOPE_ID,
+            Self::Workspace(workspace_name) => workspace_name.as_str(),
+        }
+    }
+
+    pub(super) fn workspace_id(&self) -> Option<&str> {
+        match self {
+            Self::Global => None,
+            Self::Workspace(workspace_name) => Some(workspace_name.as_str()),
+        }
+    }
+}
+
+/// Portable primary key for one global or workspace-scoped identity spec.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IdentitySpecKey {
+    /// Scope that owns this identity spec definition.
+    scope: IdentitySpecScope,
+    /// Identity spec name unique within the scope.
+    name: String,
+}
+
+impl IdentitySpecKey {
+    /// Build an identity-spec key from a scope and validated name.
+    pub(crate) fn new(scope: IdentitySpecScope, name: &str) -> Result<Self, AppError> {
+        Ok(Self {
+            scope,
+            name: parse_identity_spec_name(name)?,
+        })
+    }
+
+    /// Build a global identity-spec key.
+    pub(crate) fn global(name: &str) -> Result<Self, AppError> {
+        Self::new(IdentitySpecScope::global(), name)
+    }
+
+    /// Build a workspace-scoped identity-spec key.
+    pub(crate) fn workspace(workspace_name: WorkspaceName, name: &str) -> Result<Self, AppError> {
+        Self::new(IdentitySpecScope::workspace(workspace_name), name)
+    }
+
+    /// Borrow the scope selected for this identity spec.
+    pub(crate) fn scope(&self) -> &IdentitySpecScope {
+        &self.scope
+    }
+
+    /// Borrow the validated identity-spec name.
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(super) fn from_spec_storage_parts(
+        scope_kind: &str,
+        scope_id: &str,
+        workspace_id: Option<&str>,
+        name: &str,
+    ) -> Result<Self, DbError> {
+        let scope = match (scope_kind, workspace_id) {
+            (GLOBAL_SCOPE_KIND, None) if scope_id == GLOBAL_SCOPE_ID => IdentitySpecScope::Global,
+            (GLOBAL_SCOPE_KIND, _) => {
+                return Err(DbError::CorruptData(
+                    "global identity spec row has invalid scope columns".to_string(),
+                ));
+            }
+            (WORKSPACE_SCOPE_KIND, Some(workspace_id)) if scope_id == workspace_id => {
+                IdentitySpecScope::Workspace(parse_workspace_name(workspace_id)?)
+            }
+            (WORKSPACE_SCOPE_KIND, _) => {
+                return Err(DbError::CorruptData(
+                    "workspace identity spec row has invalid scope columns".to_string(),
+                ));
+            }
+            (other, _) => {
+                return Err(DbError::CorruptData(format!(
+                    "identity spec row has invalid scope kind '{other}'"
+                )));
+            }
+        };
+        Ok(Self {
+            scope,
+            name: parse_persisted_identity_spec_name(name)?,
+        })
+    }
+
+    pub(super) fn from_document_storage_parts(
+        scope_kind: &str,
+        scope_id: &str,
+        name: &str,
+    ) -> Result<Self, DbError> {
+        let scope = match scope_kind {
+            GLOBAL_SCOPE_KIND if scope_id == GLOBAL_SCOPE_ID => IdentitySpecScope::Global,
+            GLOBAL_SCOPE_KIND => {
+                return Err(DbError::CorruptData(
+                    "global identity spec document row has invalid scope columns".to_string(),
+                ));
+            }
+            WORKSPACE_SCOPE_KIND => IdentitySpecScope::Workspace(parse_workspace_name(scope_id)?),
+            other => {
+                return Err(DbError::CorruptData(format!(
+                    "identity spec document row has invalid scope kind '{other}'"
+                )));
+            }
+        };
+        Ok(Self {
+            scope,
+            name: parse_persisted_identity_spec_name(name)?,
+        })
+    }
+}
+
+/// Repository shell for durable DSL v4 identity spec definitions.
+pub(crate) struct IdentitySpecsRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> IdentitySpecsRepo<'a, S>
+where
+    S: DbSession,
+{
+    /// Create an identity-spec repository over an existing DB session.
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+}
+
+/// Repository shell for encrypted setup-input documents owned by identity specs.
+pub(crate) struct IdentitySpecDocumentsRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> IdentitySpecDocumentsRepo<'a, S>
+where
+    S: DbSession,
+{
+    /// Create an identity-spec document repository over an existing DB session.
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+}
+
+fn parse_identity_spec_name(name: &str) -> Result<String, AppError> {
+    validate_identity_spec_name(name).map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    Ok(name.to_string())
+}
+
+fn parse_workspace_name(workspace_id: &str) -> Result<WorkspaceName, DbError> {
+    let workspace_name = WorkspaceName::parse(workspace_id).map_err(|error| {
+        DbError::CorruptData(format!("invalid workspace id '{workspace_id}': {error}"))
+    })?;
+    if workspace_name.as_str() != workspace_id {
+        return Err(DbError::CorruptData(format!(
+            "workspace id '{workspace_id}' is not normalized"
+        )));
+    }
+    Ok(workspace_name)
+}
+
+fn parse_persisted_identity_spec_name(name: &str) -> Result<String, DbError> {
+    let parsed = parse_identity_spec_name(name).map_err(|error| {
+        DbError::CorruptData(format!("invalid identity spec name '{name}': {error}"))
+    })?;
+    if parsed != name {
+        return Err(DbError::CorruptData(format!(
+            "identity spec name '{name}' is not normalized"
+        )));
+    }
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IdentitySpecKey;
+    use crate::bootstrap::AppError;
+    use crate::state::db::DbError;
+
+    #[test]
+    fn caller_names_keep_invalid_input_classification() {
+        for name in [
+            "bad/name",
+            "github-oauth",
+            "github oauth",
+            "9github",
+            " github",
+            "github ",
+        ] {
+            assert!(matches!(
+                IdentitySpecKey::global(name),
+                Err(AppError::InvalidInput(_))
+            ));
+        }
+
+        let key = IdentitySpecKey::global("github_oauth2").expect("valid identity spec name");
+        assert_eq!(key.name(), "github_oauth2");
+        assert!(matches!(key.scope(), super::IdentitySpecScope::Global));
+    }
+
+    #[test]
+    fn persisted_scope_keys_reject_non_normalized_identifiers() {
+        for result in [
+            IdentitySpecKey::from_spec_storage_parts("global", "__global__", None, " github"),
+            IdentitySpecKey::from_spec_storage_parts(
+                "workspace",
+                " default",
+                Some(" default"),
+                "github",
+            ),
+            IdentitySpecKey::from_document_storage_parts("global", "__global__", "github "),
+            IdentitySpecKey::from_document_storage_parts("workspace", " default", "github"),
+            IdentitySpecKey::from_spec_storage_parts("global", "__global__", None, "github-oauth"),
+        ] {
+            assert!(matches!(result, Err(DbError::CorruptData(_))));
+        }
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod identity_specs;
 pub(crate) mod state_migrations;
 pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -13,3 +13,45 @@ pub(in crate::state::db) enum AppStateMigrations {
     Id,
     CompletedAtUnixNanos,
 }
+
+#[expect(
+    dead_code,
+    reason = "identity schema lands before repository behavior in the B1 stack"
+)]
+#[derive(Iden)]
+pub(in crate::state::db) enum IdentitySpecs {
+    Table,
+    ScopeKind,
+    ScopeId,
+    WorkspaceId,
+    Name,
+    Version,
+    Description,
+    Issuer,
+    IdentityType,
+    ManifestYaml,
+    CreatedAtUnixNanos,
+    UpdatedAtUnixNanos,
+}
+
+#[expect(
+    dead_code,
+    reason = "identity schema lands before repository behavior in the B1 stack"
+)]
+#[derive(Iden)]
+pub(in crate::state::db) enum IdentitySpecDocuments {
+    Table,
+    ScopeKind,
+    ScopeId,
+    Name,
+    DocumentVersion,
+    Ciphertext,
+    Nonce,
+    WrappedDek,
+    WrappedDekNonce,
+    KeyId,
+    Algorithm,
+    AadVersion,
+    CreatedAtUnixNanos,
+    UpdatedAtUnixNanos,
+}

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -6,6 +6,9 @@ use sqlx::{FromRow, Postgres, Sqlite};
 
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
+use crate::state::db::repositories::identity_specs::{
+    IdentitySpecDocumentsRepo, IdentitySpecsRepo,
+};
 use crate::state::db::repositories::state_migrations::StateMigrationsRepo;
 use crate::state::db::repositories::workspaces::WorkspacesRepo;
 
@@ -34,6 +37,22 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn workspaces(&mut self) -> WorkspacesRepo<'_, Self> {
         WorkspacesRepo::new(self)
+    }
+
+    #[expect(
+        dead_code,
+        reason = "identity repository behavior lands in the next B1 stack units"
+    )]
+    fn identity_specs(&mut self) -> IdentitySpecsRepo<'_, Self> {
+        IdentitySpecsRepo::new(self)
+    }
+
+    #[expect(
+        dead_code,
+        reason = "identity repository behavior lands in the next B1 stack units"
+    )]
+    fn identity_spec_documents(&mut self) -> IdentitySpecDocumentsRepo<'_, Self> {
+        IdentitySpecDocumentsRepo::new(self)
     }
 }
 

--- a/crates/coral-spec/src/identities.rs
+++ b/crates/coral-spec/src/identities.rs
@@ -22,6 +22,11 @@ use crate::{
 /// Current authored identity-spec format version.
 pub const IDENTITY_SPEC_VERSION: u32 = 1;
 
+/// Validate the stable name used by authored and persisted identity specs.
+pub fn validate_identity_spec_name(name: &str) -> Result<()> {
+    validate_identifier(name, "identity spec name")
+}
+
 /// Validated identity manifest.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct IdentityManifest {
@@ -186,7 +191,7 @@ fn validate_identity_manifest(raw: &RawIdentityManifest) -> Result<()> {
             "identity manifest spec_version must be {IDENTITY_SPEC_VERSION}"
         )));
     }
-    validate_identifier(&raw.name, "identity spec name")?;
+    validate_identity_spec_name(&raw.name)?;
     if raw.version.trim().is_empty() {
         return Err(ManifestError::validation(format!(
             "identity '{}' version must not be empty",
@@ -476,7 +481,7 @@ fn optional_string(
 
 #[cfg(test)]
 mod tests {
-    use super::{IdentitySpecConfig, parse_identity_manifest_yaml};
+    use super::{IdentitySpecConfig, parse_identity_manifest_yaml, validate_identity_spec_name};
 
     const OAUTH_BODY: &str = "oauth:\n  method:\n    flow: {type: device_code}\n    endpoints: {device_authorization_url: 'https://provider.example.com/device', token_url: 'https://provider.example.com/token'}\n    client: {id: {default: demo-client}}";
 
@@ -493,6 +498,22 @@ mod tests {
         let fixed =
             parse_identity_manifest_yaml(&identity("fixed_token", "")).expect("fixed token");
         assert!(matches!(fixed.config, IdentitySpecConfig::FixedToken));
+    }
+
+    #[test]
+    fn identity_spec_names_use_the_manifest_identifier_grammar() {
+        for valid in ["github", "github_oauth2", "_internal"] {
+            validate_identity_spec_name(valid).expect(valid);
+        }
+        for invalid in [
+            "",
+            "9github",
+            "github-oauth",
+            "github oauth",
+            "github/oauth",
+        ] {
+            validate_identity_spec_name(invalid).expect_err(invalid);
+        }
     }
 
     #[test]

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -114,7 +114,7 @@ pub use error::{ManifestError, Result};
 pub use identities::{
     IDENTITY_SPEC_VERSION, IdentityManifest, IdentityOAuthMethodSpec, IdentityOAuthSpec,
     IdentitySpecConfig, IdentitySpecType, generated_identity_manifest_schema,
-    parse_identity_manifest_value, parse_identity_manifest_yaml,
+    parse_identity_manifest_value, parse_identity_manifest_yaml, validate_identity_spec_name,
 };
 pub use inputs::{
     ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,


### PR DESCRIPTION
## Intent

Introduce the DB-native schema and repository boundary for dual-scope DSL v4 identity specs directly above immutable PR #1460.

## What it enables

Later identity services can persist global and workspace definitions plus opaque encrypted setup-input documents with exact composite keys, workspace cascades, and explicit corruption handling. Migration 0010 remains isolated from the parallel database stack.

## Usage examples

Database migration creates identity_specs and identity_spec_documents. App database sessions expose typed identity-spec keys and repository accessors; no user-facing identity API is added in this unit.