### PR TITLE
test(app): reject corrupt identity database rows

### DIFF
--- a/crates/coral-app/src/state/db/migration_order_tests.rs
+++ b/crates/coral-app/src/state/db/migration_order_tests.rs
@@ -4,6 +4,7 @@ use tempfile::tempdir;
 use super::{CoralDbBackend, MIGRATOR};
 use crate::bootstrap;
 use crate::state::db::repositories::identity_specs_contract_tests::assert_identity_spec_write_contract;
+use crate::state::db::repositories::identity_specs_negative_contract_tests::assert_identity_spec_negative_contract;
 use crate::state::db::{CoralDb, DbRepos, ResolvedDatabaseConfig};
 
 #[tokio::test]
@@ -53,6 +54,7 @@ async fn postgres_identity_database_contracts() {
     crate::state::db::repositories::identity_specs::tests::assert_identity_spec_read_contract(&db)
         .await;
     assert_identity_spec_write_contract(&db).await;
+    assert_identity_spec_negative_contract(&db).await;
 
     backend.pool.close().await;
     drop(db);

--- a/crates/coral-app/src/state/db/repositories/identity_specs.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs.rs
@@ -861,7 +861,7 @@ pub(in crate::state::db) mod tests {
     use super::{
         IdentitySpecDocumentWrite, IdentitySpecKey, identity_spec_columns, identity_spec_key_where,
     };
-    use crate::bootstrap::{self, AppError};
+    use crate::bootstrap::AppError;
     use crate::state::db::schema::IdentitySpecs;
     use crate::state::db::{CoralDb, DbError, DbRepos, DbSession, ResolvedDatabaseConfig};
     use crate::workspaces::WorkspaceName;
@@ -914,22 +914,6 @@ pub(in crate::state::db) mod tests {
         .await
         .expect("open sqlite");
         db.migrate().await.expect("migrate sqlite");
-        assert_identity_spec_read_contract(&db).await;
-    }
-
-    #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
-    async fn identity_spec_reads_resolve_scopes_against_postgres() {
-        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
-            .expect("read CORAL_TEST_POSTGRES_URL")
-            .filter(|value| !value.is_empty())
-        else {
-            return;
-        };
-        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
-            .await
-            .expect("open postgres");
-        db.migrate().await.expect("migrate postgres");
         assert_identity_spec_read_contract(&db).await;
     }
 

--- a/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
@@ -26,6 +26,7 @@ async fn identity_spec_write_contract_holds_against_sqlite() {
 
 #[expect(clippy::too_many_lines, reason = "shared backend contract fixture")]
 pub(in crate::state::db) async fn assert_identity_spec_write_contract(db: &CoralDb) {
+    assert_ne!(document_aad("workspace"), document_aad("alternate"));
     let suffix = uuid::Uuid::new_v4().simple().to_string();
     let workspace = parsed_workspace(&format!("identity{suffix}"));
     let alternate = parsed_workspace(&format!("alternate{suffix}"));
@@ -76,6 +77,18 @@ pub(in crate::state::db) async fn assert_identity_spec_write_contract(db: &Coral
         assert_pair(db, key, label, now, document_version).await;
     }
     let mut tx = db.begin().await.expect("begin delete tx");
+    let advanced_spec = tx
+        .identity_specs()
+        .upsert(&workspace_key, &spec("workspace"), 21)
+        .await
+        .expect("advance spec timestamp");
+    assert_eq!(
+        (
+            advanced_spec.created_at_unix_nanos,
+            advanced_spec.updated_at_unix_nanos,
+        ),
+        (20, 21)
+    );
     assert!(
         tx.identity_spec_documents()
             .delete(&alternate_key)
@@ -328,7 +341,7 @@ async fn assert_pair(
             wrapped_dek_nonce: format!("wrapped-nonce-{label}").into_bytes(),
             key_id: format!("key-{label}"),
             algorithm: format!("algo-{label}"),
-            aad_version: 99,
+            aad_version: document_aad(label),
             created_at_unix_nanos: now,
             updated_at_unix_nanos: now,
         }
@@ -371,7 +384,7 @@ async fn assert_document_presence<const N: usize>(
     }
 }
 
-fn spec(label: &str) -> IdentitySpecWrite {
+pub(super) fn spec(label: &str) -> IdentitySpecWrite {
     IdentitySpecWrite::new(
         format!("v-{label}"),
         format!("description-{label}"),
@@ -382,7 +395,7 @@ fn spec(label: &str) -> IdentitySpecWrite {
     .expect("valid spec")
 }
 
-fn document(label: &str) -> IdentitySpecDocumentWrite {
+pub(super) fn document(label: &str) -> IdentitySpecDocumentWrite {
     IdentitySpecDocumentWrite::new(
         format!("cipher-{label}").into_bytes(),
         format!("nonce-{label}").into_bytes(),
@@ -390,9 +403,16 @@ fn document(label: &str) -> IdentitySpecDocumentWrite {
         format!("wrapped-nonce-{label}").into_bytes(),
         format!("key-{label}"),
         format!("algo-{label}"),
-        99,
+        document_aad(label),
     )
     .expect("valid opaque document")
+}
+
+fn document_aad(label: &str) -> i64 {
+    label
+        .bytes()
+        .take(3)
+        .fold(0_i64, |aad, byte| aad * 256 + i64::from(byte))
 }
 
 fn document_key_where(key: &IdentitySpecKey) -> sea_query::SimpleExpr {

--- a/crates/coral-app/src/state/db/repositories/identity_specs_negative_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs_negative_contract_tests.rs
@@ -1,0 +1,343 @@
+use sea_query::{Expr, ExprTrait, Query, SimpleExpr, UpdateStatement};
+use tempfile::tempdir;
+
+use super::identity_specs::{IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecWrite};
+use super::identity_specs_contract_tests::{document, spec};
+use crate::bootstrap::AppError;
+use crate::state::db::schema::{IdentitySpecDocuments, IdentitySpecs};
+use crate::state::db::{CoralDb, DbError, DbRepos, ResolvedDatabaseConfig};
+use crate::workspaces::WorkspaceName;
+
+#[tokio::test]
+async fn identity_spec_negative_contract_holds_against_sqlite() {
+    let temp = tempdir().expect("temp dir");
+    let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+        path: temp.path().join("coral.sqlite"),
+    })
+    .await
+    .expect("open sqlite");
+    db.migrate().await.expect("migrate sqlite");
+    assert_identity_spec_negative_contract(&db).await;
+}
+
+#[test]
+fn identity_spec_writes_reject_every_invalid_required_field() {
+    const CIPHERTEXT: &[u8] = b"ciphertext";
+    const NONCE: &[u8] = b"nonce";
+    const WRAPPED_DEK: &[u8] = b"wrapped-dek";
+    const WRAPPED_NONCE: &[u8] = b"wrapped-nonce";
+
+    for (version, issuer, identity_type, manifest_yaml) in [
+        ("", "issuer", "type", "manifest"),
+        (" ", "issuer", "type", "manifest"),
+        ("version", "", "type", "manifest"),
+        ("version", "issuer", "", "manifest"),
+        ("version", "issuer", "type", ""),
+    ] {
+        assert!(matches!(
+            IdentitySpecWrite::new(version, "description", issuer, identity_type, manifest_yaml),
+            Err(AppError::InvalidInput(_))
+        ));
+    }
+    assert_invalid_document(b"", NONCE, WRAPPED_DEK, WRAPPED_NONCE, "key", "algo", 1);
+    assert_invalid_document(
+        CIPHERTEXT,
+        b"",
+        WRAPPED_DEK,
+        WRAPPED_NONCE,
+        "key",
+        "algo",
+        1,
+    );
+    assert_invalid_document(CIPHERTEXT, NONCE, b"", WRAPPED_NONCE, "key", "algo", 1);
+    assert_invalid_document(CIPHERTEXT, NONCE, WRAPPED_DEK, b"", "key", "algo", 1);
+    assert_invalid_document(CIPHERTEXT, NONCE, WRAPPED_DEK, WRAPPED_NONCE, "", "algo", 1);
+    assert_invalid_document(
+        CIPHERTEXT,
+        NONCE,
+        WRAPPED_DEK,
+        WRAPPED_NONCE,
+        " ",
+        "algo",
+        1,
+    );
+    assert_invalid_document(CIPHERTEXT, NONCE, WRAPPED_DEK, WRAPPED_NONCE, "key", "", 1);
+    assert_invalid_document(CIPHERTEXT, NONCE, WRAPPED_DEK, WRAPPED_NONCE, "key", " ", 1);
+    assert_invalid_document(
+        CIPHERTEXT,
+        NONCE,
+        WRAPPED_DEK,
+        WRAPPED_NONCE,
+        "key",
+        "algo",
+        0,
+    );
+}
+
+#[expect(clippy::too_many_lines, reason = "shared backend negative contract")]
+pub(in crate::state::db) async fn assert_identity_spec_negative_contract(db: &CoralDb) {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let workspace = WorkspaceName::parse(&format!("negative{suffix}")).expect("workspace");
+    let key = IdentitySpecKey::workspace(workspace.clone(), &format!("corrupt_{suffix}"))
+        .expect("corrupt key");
+    let constraint_key =
+        IdentitySpecKey::workspace(workspace.clone(), &format!("constraint_{suffix}"))
+            .expect("constraint key");
+
+    let mut tx = db.begin().await.expect("begin seed tx");
+    tx.workspaces()
+        .ensure(workspace.as_str(), 1)
+        .await
+        .expect("ensure workspace");
+    let spec = spec("negative");
+    for key in [&key, &constraint_key] {
+        tx.identity_specs()
+            .upsert(key, &spec, 1)
+            .await
+            .expect("seed spec");
+    }
+    tx.identity_spec_documents()
+        .upsert(&key, &document("negative"), 1)
+        .await
+        .expect("seed document");
+    tx.commit().await.expect("commit seed");
+
+    let document = document("negative");
+    let mut tx = db.begin().await.expect("begin invalid timestamp tx");
+    assert!(matches!(
+        tx.identity_specs().upsert(&key, &spec, -1).await,
+        Err(AppError::InvalidInput(_))
+    ));
+    assert!(matches!(
+        tx.identity_spec_documents()
+            .upsert(&key, &document, -1)
+            .await,
+        Err(AppError::InvalidInput(_))
+    ));
+    tx.rollback().await.expect("rollback invalid timestamps");
+
+    for column in [
+        IdentitySpecs::Version,
+        IdentitySpecs::Issuer,
+        IdentitySpecs::IdentityType,
+        IdentitySpecs::ManifestYaml,
+    ] {
+        assert_corrupt_spec(db, &key, column, Expr::val("")).await;
+    }
+    assert_corrupt_spec(db, &key, IdentitySpecs::Version, Expr::val(" ")).await;
+    assert_corrupt_spec(
+        db,
+        &key,
+        IdentitySpecs::CreatedAtUnixNanos,
+        Expr::val(-1_i64),
+    )
+    .await;
+    assert_corrupt_spec(db, &key, IdentitySpecs::UpdatedAtUnixNanos, zero_i64()).await;
+    assert_corrupt_document(db, &key, IdentitySpecDocuments::DocumentVersion, zero_i64()).await;
+    for column in [
+        IdentitySpecDocuments::Ciphertext,
+        IdentitySpecDocuments::Nonce,
+        IdentitySpecDocuments::WrappedDek,
+        IdentitySpecDocuments::WrappedDekNonce,
+    ] {
+        assert_corrupt_document(db, &key, column, Expr::val(Vec::<u8>::new())).await;
+    }
+    for column in [
+        IdentitySpecDocuments::KeyId,
+        IdentitySpecDocuments::Algorithm,
+    ] {
+        assert_corrupt_document(db, &key, column, Expr::val("")).await;
+    }
+    assert_corrupt_document(db, &key, IdentitySpecDocuments::KeyId, Expr::val(" ")).await;
+    assert_corrupt_document(db, &key, IdentitySpecDocuments::Algorithm, Expr::val(" ")).await;
+    assert_corrupt_document(db, &key, IdentitySpecDocuments::AadVersion, zero_i64()).await;
+    assert_corrupt_document(
+        db,
+        &key,
+        IdentitySpecDocuments::CreatedAtUnixNanos,
+        Expr::val(-1_i64),
+    )
+    .await;
+    assert_corrupt_document(
+        db,
+        &key,
+        IdentitySpecDocuments::UpdatedAtUnixNanos,
+        zero_i64(),
+    )
+    .await;
+    let mut session = db;
+    session
+        .identity_specs()
+        .load_optional(&key)
+        .await
+        .expect("read restored spec")
+        .expect("spec restored");
+    session
+        .identity_spec_documents()
+        .load_optional(&key)
+        .await
+        .expect("read restored document")
+        .expect("document restored");
+
+    assert_violation(
+        db,
+        Query::update()
+            .table(IdentitySpecs::Table)
+            .value(IdentitySpecs::ScopeKind, "global")
+            .and_where(spec_where(&constraint_key))
+            .to_owned(),
+        Violation::Check,
+    )
+    .await;
+    assert_violation(
+        db,
+        Query::update()
+            .table(IdentitySpecs::Table)
+            .value(IdentitySpecs::WorkspaceId, Option::<String>::None)
+            .and_where(spec_where(&constraint_key))
+            .to_owned(),
+        Violation::Check,
+    )
+    .await;
+    let missing_workspace = format!("missing{suffix}");
+    assert_violation(
+        db,
+        Query::update()
+            .table(IdentitySpecs::Table)
+            .value(IdentitySpecs::ScopeId, missing_workspace.clone())
+            .value(IdentitySpecs::WorkspaceId, missing_workspace)
+            .and_where(spec_where(&constraint_key))
+            .to_owned(),
+        Violation::ForeignKey,
+    )
+    .await;
+    assert_violation(
+        db,
+        Query::update()
+            .table(IdentitySpecDocuments::Table)
+            .value(IdentitySpecDocuments::Name, format!("orphan_{suffix}"))
+            .and_where(document_where(&key))
+            .to_owned(),
+        Violation::ForeignKey,
+    )
+    .await;
+
+    let mut tx = db.begin().await.expect("begin cleanup");
+    for key in [&key, &constraint_key] {
+        assert!(tx.identity_specs().delete(key).await.expect("delete spec"));
+    }
+    tx.workspaces()
+        .delete(workspace.as_str())
+        .await
+        .expect("delete workspace");
+    tx.commit().await.expect("commit cleanup");
+}
+
+async fn assert_corrupt_spec(
+    db: &CoralDb,
+    key: &IdentitySpecKey,
+    column: IdentitySpecs,
+    value: SimpleExpr,
+) {
+    let mut tx = db.begin().await.expect("begin corrupt spec tx");
+    tx.execute(
+        Query::update()
+            .table(IdentitySpecs::Table)
+            .value(column, value)
+            .and_where(spec_where(key))
+            .to_owned(),
+    )
+    .await
+    .expect("corrupt spec");
+    assert!(matches!(
+        tx.identity_specs().load_optional(key).await,
+        Err(DbError::CorruptData(_))
+    ));
+    tx.rollback().await.expect("restore spec");
+}
+
+async fn assert_corrupt_document(
+    db: &CoralDb,
+    key: &IdentitySpecKey,
+    column: IdentitySpecDocuments,
+    value: SimpleExpr,
+) {
+    let mut tx = db.begin().await.expect("begin corrupt document tx");
+    tx.execute(
+        Query::update()
+            .table(IdentitySpecDocuments::Table)
+            .value(column, value)
+            .and_where(document_where(key))
+            .to_owned(),
+    )
+    .await
+    .expect("corrupt document");
+    assert!(matches!(
+        tx.identity_spec_documents().load_optional(key).await,
+        Err(DbError::CorruptData(_))
+    ));
+    tx.rollback().await.expect("restore document");
+}
+
+enum Violation {
+    Check,
+    ForeignKey,
+}
+
+async fn assert_violation(db: &CoralDb, statement: UpdateStatement, expected: Violation) {
+    let mut tx = db.begin().await.expect("begin violation tx");
+    let error = tx
+        .execute(statement)
+        .await
+        .expect_err("constraint must reject");
+    let database = match error {
+        DbError::Sqlx(sqlx::Error::Database(database)) => database,
+        other => panic!("expected typed database error, got {other}"),
+    };
+    assert!(match expected {
+        Violation::Check => database.is_check_violation(),
+        Violation::ForeignKey => database.is_foreign_key_violation(),
+    });
+    tx.rollback().await.expect("rollback failed Postgres tx");
+}
+
+fn spec_where(key: &IdentitySpecKey) -> SimpleExpr {
+    Expr::col(IdentitySpecs::ScopeKind)
+        .eq(key.scope().kind())
+        .and(Expr::col(IdentitySpecs::ScopeId).eq(key.scope().scope_id()))
+        .and(Expr::col(IdentitySpecs::Name).eq(key.name()))
+}
+
+fn document_where(key: &IdentitySpecKey) -> SimpleExpr {
+    Expr::col(IdentitySpecDocuments::ScopeKind)
+        .eq(key.scope().kind())
+        .and(Expr::col(IdentitySpecDocuments::ScopeId).eq(key.scope().scope_id()))
+        .and(Expr::col(IdentitySpecDocuments::Name).eq(key.name()))
+}
+
+fn zero_i64() -> SimpleExpr {
+    Expr::val(0_i64)
+}
+
+fn assert_invalid_document(
+    ciphertext: &[u8],
+    nonce: &[u8],
+    wrapped_dek: &[u8],
+    wrapped_dek_nonce: &[u8],
+    key_id: &str,
+    algorithm: &str,
+    aad_version: i64,
+) {
+    assert!(matches!(
+        IdentitySpecDocumentWrite::new(
+            ciphertext.to_vec(),
+            nonce.to_vec(),
+            wrapped_dek.to_vec(),
+            wrapped_dek_nonce.to_vec(),
+            key_id,
+            algorithm,
+            aad_version,
+        ),
+        Err(AppError::InvalidInput(_))
+    ));
+}

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -4,3 +4,5 @@ pub(crate) mod workspaces;
 
 #[cfg(test)]
 pub(super) mod identity_specs_contract_tests;
+#[cfg(test)]
+pub(super) mod identity_specs_negative_contract_tests;


### PR DESCRIPTION
## Intent

Add fail-closed database regressions for corrupt persisted identity rows and invalid scope or foreign-key mutations, while strengthening replacement assertions across every stored field.

## What it enables

Repository decoding cannot silently accept malformed required fields, timestamps, envelope metadata, or document versions. SQLite and Postgres must classify CHECK and foreign-key failures correctly and restore valid rows after negative mutations.

## Usage examples

The focused SQLite contracts run in the normal Rust gate. Run make postgres-tests to execute the same negative matrix inside the isolated Postgres identity and migration aggregator.