### PR TITLE
fix(app): harden private atomic file writes

### DIFF
--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -1770,6 +1770,7 @@ mod tests {
     use crate::sources::materialization::{FINGERPRINT_FILENAME, PROJECTIONS_FILENAME};
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
     use crate::state::{AppStateLayout, ConfigStore};
+    use crate::storage::fs;
     use crate::workspaces::{WorkspaceLifecycleRevision, WorkspaceName};
     use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
@@ -3388,10 +3389,6 @@ surface:
         let refresh_lock = credential_store
             .credential_refresh_lock(&workspace_name, &credential_set_id)
             .expect("hold refresh lock");
-        let config_temp_path = layout
-            .config_file()
-            .with_file_name(format!("config.toml.tmp.{}", std::process::id()));
-        std::fs::create_dir_all(&config_temp_path).expect("block config save temp path");
         let (started_tx, started_rx) = std_mpsc::channel();
         let import_manager = manager.clone();
         let import_workspace = workspace_name.clone();
@@ -3427,12 +3424,12 @@ surface:
                 ]),
             )
             .expect("simulate persisted refresh while lock is held");
+        let _config_write_failure = fs::fail_atomic_write_for_test(layout.config_file());
         drop(refresh_lock);
         import_handle
             .join()
             .expect("import thread")
             .expect_err("blocked config save should fail import");
-        drop(std::fs::remove_dir_all(&config_temp_path));
 
         let material = credential_manager
             .read_material(

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -8,6 +8,41 @@ use std::path::{Path, PathBuf};
 use fs2::FileExt;
 use uuid::Uuid;
 
+#[cfg(test)]
+static BLOCKED_ATOMIC_WRITES: std::sync::Mutex<Vec<PathBuf>> = std::sync::Mutex::new(Vec::new());
+
+#[cfg(test)]
+pub(crate) struct AtomicWriteFailureGuard(PathBuf);
+
+#[cfg(test)]
+pub(crate) fn fail_atomic_write_for_test(path: &Path) -> AtomicWriteFailureGuard {
+    let path = path.to_owned();
+    BLOCKED_ATOMIC_WRITES
+        .lock()
+        .expect("atomic-write failure lock")
+        .push(path.clone());
+    AtomicWriteFailureGuard(path)
+}
+
+#[cfg(test)]
+impl Drop for AtomicWriteFailureGuard {
+    fn drop(&mut self) {
+        BLOCKED_ATOMIC_WRITES
+            .lock()
+            .expect("atomic-write failure lock")
+            .retain(|path| path != &self.0);
+    }
+}
+
+#[cfg(test)]
+fn atomic_write_is_blocked(path: &Path) -> bool {
+    BLOCKED_ATOMIC_WRITES
+        .lock()
+        .expect("atomic-write failure lock")
+        .iter()
+        .any(|blocked| blocked == path)
+}
+
 pub(crate) fn ensure_dir(path: &Path) -> io::Result<()> {
     if path.as_os_str().is_empty() || path == Path::new(".") {
         return Ok(());
@@ -23,7 +58,23 @@ pub(crate) fn ensure_private_dir(path: &Path) -> io::Result<()> {
     if path.as_os_str().is_empty() || path == Path::new(".") {
         return Ok(());
     }
-    fs::create_dir_all(path)?;
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if !metadata.file_type().is_dir() => {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("path exists and is not a directory: {}", path.display()),
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => fs::create_dir_all(path)?,
+        Err(error) => return Err(error),
+    }
+    if !fs::symlink_metadata(path)?.file_type().is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("path exists and is not a directory: {}", path.display()),
+        ));
+    }
     set_dir_permissions_private(path)?;
     Ok(())
 }
@@ -60,11 +111,17 @@ fn ensure_existing_file_private(path: &Path) -> io::Result<()> {
 
 /// Write to a temp file then rename to avoid partial writes on crash.
 pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    #[cfg(test)]
+    if atomic_write_is_blocked(path) {
+        return Err(io::Error::other("atomic write blocked by test"));
+    }
     let temp_path = temp_path_for(path);
-    write_file_private(&temp_path, bytes)?;
-    replace_atomic(&temp_path, path)?;
-    set_file_permissions_private(path)?;
-    Ok(())
+    let result =
+        write_file_private(&temp_path, bytes).and_then(|()| replace_atomic(&temp_path, path));
+    if result.is_err() {
+        drop(fs::remove_file(&temp_path));
+    }
+    result
 }
 
 pub(crate) fn append_file_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
@@ -97,7 +154,7 @@ pub(crate) fn remove_file_if_exists(path: &Path) -> io::Result<()> {
 }
 
 pub(crate) fn replace_atomic(from: &Path, to: &Path) -> io::Result<()> {
-    rename_with_fallback(from, to)?;
+    rename_atomic(from, to)?;
 
     if let Some(parent) = to.parent()
         && let Ok(dir) = fs::File::open(parent)
@@ -177,23 +234,7 @@ impl FileLock {
     }
 }
 
-#[cfg(windows)]
-fn rename_with_fallback(from: &Path, to: &Path) -> io::Result<()> {
-    if let Err(err) = fs::rename(from, to) {
-        if err.kind() == io::ErrorKind::AlreadyExists {
-            if to.exists() {
-                fs::remove_file(to)?;
-            }
-            fs::rename(from, to)?;
-        } else {
-            return Err(err);
-        }
-    }
-    Ok(())
-}
-
-#[cfg(not(windows))]
-fn rename_with_fallback(from: &Path, to: &Path) -> io::Result<()> {
+fn rename_atomic(from: &Path, to: &Path) -> io::Result<()> {
     fs::rename(from, to)
 }
 
@@ -246,7 +287,7 @@ fn temp_path_for(path: &Path) -> PathBuf {
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or("private-file");
-    path.with_file_name(format!("{file_name}.tmp.{}", std::process::id()))
+    path.with_file_name(format!("{file_name}.tmp.{}", Uuid::new_v4()))
 }
 
 #[cfg(unix)]
@@ -257,8 +298,7 @@ fn write_file_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
 
     let mut file = OpenOptions::new()
         .write(true)
-        .create(true)
-        .truncate(true)
+        .create_new(true)
         .mode(0o600)
         .open(path)?;
     file.write_all(bytes)?;
@@ -267,7 +307,9 @@ fn write_file_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
 
 #[cfg(not(unix))]
 fn write_file_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
-    fs::write(path, bytes)
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()
 }
 
 #[cfg(unix)]
@@ -296,7 +338,10 @@ fn set_file_permissions_private(_path: &Path) -> io::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{DirectoryBackup, ensure_file_private, remove_file_if_exists};
+    use super::{
+        DirectoryBackup, ensure_file_private, ensure_private_dir, remove_file_if_exists,
+        write_atomic, write_file_private,
+    };
 
     #[test]
     fn ensure_file_private_rejects_existing_directory() {
@@ -339,6 +384,41 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(target_mode, 0o644);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn private_directory_and_temp_file_creation_reject_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let target_dir = temp.path().join("target-dir");
+        let linked_dir = temp.path().join("private-dir");
+        std::fs::create_dir(&target_dir).expect("target dir");
+        symlink(&target_dir, &linked_dir).expect("dir symlink");
+        ensure_private_dir(&linked_dir).expect_err("directory symlink");
+        let target_file = temp.path().join("target-file");
+        let linked_file = temp.path().join("temp-file");
+        std::fs::write(&target_file, "unchanged").expect("target file");
+        symlink(&target_file, &linked_file).expect("file symlink");
+        write_file_private(&linked_file, b"secret").expect_err("temp symlink");
+        assert_eq!(
+            std::fs::read_to_string(target_file).expect("target"),
+            "unchanged"
+        );
+    }
+
+    #[test]
+    fn atomic_write_cleans_unique_temp_file_when_replace_fails() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let destination = temp.path().join("record");
+        std::fs::create_dir(&destination).expect("blocking directory");
+        write_atomic(&destination, b"secret").expect_err("replace failure");
+        let names = std::fs::read_dir(temp.path())
+            .expect("directory")
+            .map(|entry| entry.expect("entry").file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec![destination.file_name().expect("name")]);
     }
 
     #[test]


### PR DESCRIPTION
> **Stack:** This stack lets a long-running Coral server authenticate users through an external OpenID Connect provider and protect its gRPC and MCP HTTP APIs.
>
> **This part of the stack:** This final section hardens security-sensitive local plumbing. The preceding PR tightens OAuth callback handling; this PR closes file-system safety gaps in Coral's shared private-file writer.

## Intent

Keep an interrupted or competing private-file write from following a symlink, colliding with another writer, leaving sensitive temporary data behind, or replacing a destination through a non-atomic fallback.

## What it enables

Each write now creates a unique temporary file that must not already exist, writes it with private permissions, and removes it if replacement fails. Private directories must be real directories rather than symlinks. The replacement path uses a single rename instead of deleting the destination and retrying.

All existing callers of the shared writer receive these checks without an API change, including configuration, credentials, sources, functions, tasks, and telemetry.

## Usage examples

There is no new command or public surface. Existing app code continues to call:

```rust
write_atomic(path, bytes)?;
```