### PR TITLE
feat(cli): resolve endpoint-bound authentication

### DIFF
--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -44,13 +44,18 @@ coral --endpoint https://coral.example.com --token "$TOKEN" sql "select 1"
 CORAL_ENDPOINT=https://coral.example.com CORAL_AUTH_TOKEN="$TOKEN" coral source list
 ```
 
-`--endpoint` overrides `CORAL_ENDPOINT`, and `--token` overrides
-`CORAL_AUTH_TOKEN`. A token is optional, so endpoints that do not require
-authentication remain supported. Prefer `CORAL_AUTH_TOKEN` where command-line
-arguments may be visible to other users or process-inspection tools.
+`--endpoint` overrides `CORAL_ENDPOINT`. An empty flag or environment value
+selects local mode. For a remote endpoint, `--token` overrides
+`CORAL_AUTH_TOKEN`; when both are absent, Coral uses a stored login only when it
+was issued for that exact canonical endpoint. An empty token flag or environment
+value explicitly disables authentication and suppresses stored-login fallback.
+Unauthenticated remote endpoints remain supported. Prefer `CORAL_AUTH_TOKEN`
+where command-line arguments may be visible to other users or process-inspection
+tools.
 
-Coral sends bearer credentials only over HTTPS. Plaintext HTTP is accepted
-with a token only for loopback endpoints such as `http://127.0.0.1:1457`.
+Remote endpoints must be root HTTPS URLs. Plaintext HTTP is accepted only for
+explicit loopback endpoints such as `http://127.0.0.1:1457`, whether or not a
+token is used.
 
 ## `coral sql`
 

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -1,12 +1,15 @@
 use std::sync::Arc;
 
-use coral_app::{AwsEngineExtensionsProvider, features::FeatureOverrides};
+use coral_app::{
+    AwsEngineExtensionsProvider, CanonicalRemoteEndpoint, OAuthLoginStoreError,
+    RemoteEndpointError, features::FeatureOverrides,
+};
 use coral_client::{
     AppClient, BearerToken, ClientError,
     local::{LocalServerError, RunningServer as AppRunningServer, ServerBuilder},
 };
 
-use crate::env::ConnectionOptions;
+use crate::env::{self, ConnectionEnvError};
 
 pub(crate) struct Bootstrap {
     pub(crate) app: AppClient,
@@ -24,7 +27,21 @@ pub(crate) enum BootstrapMode {
 pub(crate) struct BootstrapOptions {
     pub(crate) enable_stderr_logs: bool,
     pub(crate) feature_overrides: FeatureOverrides,
-    pub(crate) connection: ConnectionOptions,
+    pub(crate) connection: ConnectionOverrides,
+}
+
+#[derive(Default)]
+pub(crate) struct ConnectionOverrides {
+    pub(crate) endpoint: Option<String>,
+    pub(crate) token: Option<String>,
+}
+
+enum ResolvedConnection {
+    Local,
+    Remote {
+        endpoint: CanonicalRemoteEndpoint,
+        bearer: Option<BearerToken>,
+    },
 }
 
 impl Bootstrap {
@@ -37,6 +54,12 @@ impl Bootstrap {
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum BootstrapError {
+    #[error(transparent)]
+    ConnectionEnvironment(#[from] ConnectionEnvError),
+    #[error(transparent)]
+    RemoteEndpoint(#[from] RemoteEndpointError),
+    #[error(transparent)]
+    OAuthLoginStore(#[from] OAuthLoginStoreError),
     #[error(transparent)]
     Startup(#[from] LocalServerError),
     #[error(transparent)]
@@ -51,14 +74,9 @@ pub(crate) async fn bootstrap(options: BootstrapOptions) -> Result<Bootstrap, Bo
         feature_overrides,
         connection,
     } = options;
-    let bearer = connection
-        .token
-        .as_deref()
-        .map(BearerToken::new)
-        .transpose()?;
-    if let Some(endpoint) = connection.endpoint {
+    if let ResolvedConnection::Remote { endpoint, bearer } = resolve_connection(connection)? {
         return Ok(Bootstrap {
-            app: connect(&endpoint, bearer).await?,
+            app: connect(endpoint.as_uri(), bearer).await?,
             mode: BootstrapMode::Remote,
             server: None,
         });
@@ -68,12 +86,64 @@ pub(crate) async fn bootstrap(options: BootstrapOptions) -> Result<Bootstrap, Bo
         configure_server_builder(ServerBuilder::new(), enable_stderr_logs, feature_overrides)
             .start()
             .await?;
-    let app = connect(server.endpoint_uri(), bearer).await?;
+    let app = AppClient::connect(server.endpoint_uri()).await?;
     Ok(Bootstrap {
         app,
         mode: BootstrapMode::Local,
         server: Some(server),
     })
+}
+
+fn resolve_connection(
+    overrides: ConnectionOverrides,
+) -> Result<ResolvedConnection, BootstrapError> {
+    resolve_connection_with(
+        overrides,
+        env::endpoint,
+        env::auth_token,
+        load_stored_bearer,
+    )
+}
+
+fn resolve_connection_with(
+    overrides: ConnectionOverrides,
+    read_endpoint_env: impl FnOnce() -> Result<Option<String>, ConnectionEnvError>,
+    read_token_env: impl FnOnce() -> Result<Option<String>, ConnectionEnvError>,
+    load_stored_bearer: impl FnOnce(
+        &CanonicalRemoteEndpoint,
+    ) -> Result<Option<BearerToken>, BootstrapError>,
+) -> Result<ResolvedConnection, BootstrapError> {
+    let endpoint = select_override(overrides.endpoint, read_endpoint_env)?;
+    let Some(endpoint) = endpoint.filter(|endpoint| !endpoint.is_empty()) else {
+        return Ok(ResolvedConnection::Local);
+    };
+    let endpoint = CanonicalRemoteEndpoint::parse(&endpoint)?;
+    let token = select_override(overrides.token, read_token_env)?;
+    let bearer = match token {
+        Some(token) if token.is_empty() => None,
+        Some(token) => Some(BearerToken::new(token)?),
+        None => load_stored_bearer(&endpoint)?,
+    };
+    Ok(ResolvedConnection::Remote { endpoint, bearer })
+}
+
+fn select_override(
+    value: Option<String>,
+    read_env: impl FnOnce() -> Result<Option<String>, ConnectionEnvError>,
+) -> Result<Option<String>, ConnectionEnvError> {
+    match value {
+        Some(value) => Ok(Some(value)),
+        None => read_env(),
+    }
+}
+
+fn load_stored_bearer(
+    endpoint: &CanonicalRemoteEndpoint,
+) -> Result<Option<BearerToken>, BootstrapError> {
+    let login = coral_app::load_oauth_login(None, endpoint)?;
+    Ok(login
+        .map(|login| BearerToken::new(login.access_token()))
+        .transpose()?)
 }
 
 async fn connect(endpoint: &str, bearer: Option<BearerToken>) -> Result<AppClient, ClientError> {
@@ -124,9 +194,129 @@ fn configure_server_builder(
 mod tests {
     use super::*;
 
+    fn overrides(endpoint: Option<&str>, token: Option<&str>) -> ConnectionOverrides {
+        ConnectionOverrides {
+            endpoint: endpoint.map(str::to_string),
+            token: token.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn endpoint_and_token_flags_win_without_reading_lower_precedence_sources() {
+        let resolved = resolve_connection_with(
+            overrides(Some("https://EXAMPLE.test:443/"), Some("")),
+            || panic!("endpoint flag read endpoint environment"),
+            || panic!("token flag read token environment"),
+            |_| panic!("empty token flag read login store"),
+        )
+        .expect("remote connection");
+
+        let ResolvedConnection::Remote { endpoint, bearer } = resolved else {
+            panic!("remote endpoint selected local mode");
+        };
+        assert_eq!(endpoint.as_uri(), "https://example.test");
+        assert!(bearer.is_none());
+
+        let explicit = resolve_connection_with(
+            overrides(Some("https://example.test"), Some("flag-token")),
+            || panic!("endpoint flag read endpoint environment"),
+            || panic!("token flag read token environment"),
+            |_| panic!("token flag read login store"),
+        )
+        .expect("explicit bearer");
+        assert!(matches!(
+            explicit,
+            ResolvedConnection::Remote {
+                bearer: Some(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn token_environment_is_presence_aware_and_store_receives_canonical_endpoint() {
+        let present = resolve_connection_with(
+            overrides(Some("https://example.test"), None),
+            || panic!("endpoint flag read endpoint environment"),
+            || Ok(Some("environment-token".to_string())),
+            |_| panic!("token environment read login store"),
+        )
+        .expect("environment bearer");
+        assert!(matches!(
+            present,
+            ResolvedConnection::Remote {
+                bearer: Some(_),
+                ..
+            }
+        ));
+
+        let empty = resolve_connection_with(
+            overrides(Some("https://example.test"), None),
+            || panic!("endpoint flag read endpoint environment"),
+            || Ok(Some(String::new())),
+            |_| panic!("empty token environment read login store"),
+        )
+        .expect("remote connection");
+        assert!(matches!(
+            empty,
+            ResolvedConnection::Remote { bearer: None, .. }
+        ));
+
+        let stored = resolve_connection_with(
+            overrides(Some("https://EXAMPLE.test:443/"), None),
+            || panic!("endpoint flag read endpoint environment"),
+            || Ok(None),
+            |endpoint| {
+                assert_eq!(endpoint.as_uri(), "https://example.test");
+                Ok(Some(BearerToken::new("stored-token")?))
+            },
+        )
+        .expect("stored remote connection");
+        assert!(matches!(
+            stored,
+            ResolvedConnection::Remote {
+                bearer: Some(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn invalid_endpoint_fails_before_token_environment_or_login_store() {
+        let Err(error) = resolve_connection_with(
+            overrides(Some(" https://endpoint-secret.example"), None),
+            || panic!("endpoint flag read endpoint environment"),
+            || panic!("invalid endpoint read token environment"),
+            |_| panic!("invalid endpoint read login store"),
+        ) else {
+            panic!("invalid endpoint was accepted");
+        };
+
+        assert!(matches!(error, BootstrapError::RemoteEndpoint(_)));
+        let rendered = format!("{error:?} {error}");
+        assert!(!rendered.contains("endpoint-secret"));
+    }
+
+    #[test]
+    fn invalid_explicit_token_error_is_value_redacted() {
+        let Err(error) = resolve_connection_with(
+            overrides(
+                Some("https://example.test"),
+                Some("token-secret-sentinel with-space"),
+            ),
+            || panic!("endpoint flag read endpoint environment"),
+            || panic!("token flag read token environment"),
+            |_| Ok(None),
+        ) else {
+            panic!("invalid token was accepted");
+        };
+
+        let rendered = format!("{error:?} {error}");
+        assert!(!rendered.contains("token-secret-sentinel"));
+    }
+
     #[tokio::test(flavor = "multi_thread")]
-    async fn explicit_endpoint_uses_authenticated_remote_bootstrap()
-    -> Result<(), Box<dyn std::error::Error>> {
+    async fn explicit_endpoint_uses_remote_bootstrap() -> Result<(), Box<dyn std::error::Error>> {
         let config_dir = tempfile::tempdir()?;
         let server = ServerBuilder::new()
             .with_config_dir(config_dir.path())
@@ -134,10 +324,7 @@ mod tests {
             .start()
             .await?;
         let bootstrap = bootstrap(BootstrapOptions {
-            connection: ConnectionOptions {
-                endpoint: Some(server.endpoint_uri().to_string()),
-                token: Some("test-token".to_string()),
-            },
+            connection: overrides(Some(server.endpoint_uri()), Some("")),
             ..BootstrapOptions::default()
         })
         .await?;

--- a/crates/coral-cli/src/env.rs
+++ b/crates/coral-cli/src/env.rs
@@ -3,54 +3,47 @@
 //! `coral-cli` is allowed to read process environment when the CLI surface
 //! explicitly defines an env-backed workflow.
 
+use std::env::VarError;
+
 const CORAL_ENDPOINT_ENV: &str = "CORAL_ENDPOINT";
 const CORAL_AUTH_TOKEN_ENV: &str = "CORAL_AUTH_TOKEN";
 
-/// Resolved endpoint and bearer credential for one CLI invocation.
-#[derive(Default)]
-pub(crate) struct ConnectionOptions {
-    pub(crate) endpoint: Option<String>,
-    pub(crate) token: Option<String>,
+/// A fixed CLI connection environment variable contained non-Unicode data.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[error("environment variable {name} contains non-Unicode data")]
+pub(crate) struct ConnectionEnvError {
+    name: &'static str,
 }
 
-/// Resolves CLI connection flags over their environment fallbacks.
+/// Reads the optional remote Coral endpoint without collapsing an explicit
+/// empty value into absence.
 #[expect(
     clippy::disallowed_methods,
-    reason = "CORAL_ENDPOINT and CORAL_AUTH_TOKEN are public CLI connection settings."
+    reason = "CORAL_ENDPOINT is a public CLI connection setting."
 )]
-#[must_use]
-pub(crate) fn connection_options(
-    cli_endpoint: Option<String>,
-    cli_token: Option<String>,
-) -> ConnectionOptions {
-    resolve_connection_options(cli_endpoint, cli_token, |name| std::env::var(name).ok())
+pub(crate) fn endpoint() -> Result<Option<String>, ConnectionEnvError> {
+    read_connection_env(CORAL_ENDPOINT_ENV, |name| std::env::var(name))
 }
 
-fn resolve_connection_options(
-    cli_endpoint: Option<String>,
-    cli_token: Option<String>,
-    mut read_env: impl FnMut(&str) -> Option<String>,
-) -> ConnectionOptions {
-    ConnectionOptions {
-        endpoint: resolve_value(cli_endpoint, CORAL_ENDPOINT_ENV, &mut read_env),
-        token: resolve_value(cli_token, CORAL_AUTH_TOKEN_ENV, &mut read_env),
+/// Reads the optional bearer token without collapsing an explicit empty value
+/// into absence.
+#[expect(
+    clippy::disallowed_methods,
+    reason = "CORAL_AUTH_TOKEN is a public CLI connection setting."
+)]
+pub(crate) fn auth_token() -> Result<Option<String>, ConnectionEnvError> {
+    read_connection_env(CORAL_AUTH_TOKEN_ENV, |name| std::env::var(name))
+}
+
+fn read_connection_env(
+    name: &'static str,
+    read_env: impl FnOnce(&str) -> Result<String, VarError>,
+) -> Result<Option<String>, ConnectionEnvError> {
+    match read_env(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(VarError::NotPresent) => Ok(None),
+        Err(VarError::NotUnicode(_value)) => Err(ConnectionEnvError { name }),
     }
-}
-
-fn resolve_value(
-    cli_value: Option<String>,
-    env_name: &str,
-    read_env: &mut impl FnMut(&str) -> Option<String>,
-) -> Option<String> {
-    match cli_value {
-        Some(value) => non_empty_trimmed(&value),
-        None => read_env(env_name).and_then(|value| non_empty_trimmed(&value)),
-    }
-}
-
-fn non_empty_trimmed(value: &str) -> Option<String> {
-    let value = value.trim();
-    (!value.is_empty()).then(|| value.to_string())
 }
 
 const CORAL_TRACE_PARENT_ENV: &str = "CORAL_TRACE_PARENT";
@@ -80,38 +73,38 @@ pub fn workspace() -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsString;
+
     use super::*;
 
     #[test]
-    fn connection_flags_override_environment() {
-        let options = resolve_connection_options(
-            Some(" https://flag.example ".to_string()),
-            Some(" flag-token ".to_string()),
-            |name| match name {
-                CORAL_ENDPOINT_ENV => Some("https://env.example".to_string()),
-                CORAL_AUTH_TOKEN_ENV => Some("env-token".to_string()),
-                _ => None,
-            },
+    fn connection_environment_preserves_missing_empty_and_whitespace_values() {
+        assert_eq!(
+            read_connection_env(CORAL_ENDPOINT_ENV, |_| Err(VarError::NotPresent)),
+            Ok(None)
         );
-
-        assert_eq!(options.endpoint.as_deref(), Some("https://flag.example"));
-        assert_eq!(options.token.as_deref(), Some("flag-token"));
+        assert_eq!(
+            read_connection_env(CORAL_ENDPOINT_ENV, |_| Ok(String::new())),
+            Ok(Some(String::new()))
+        );
+        assert_eq!(
+            read_connection_env(CORAL_ENDPOINT_ENV, |_| Ok(" \t ".to_string())),
+            Ok(Some(" \t ".to_string()))
+        );
     }
 
     #[test]
-    fn empty_explicit_token_suppresses_environment_token() {
-        let options = resolve_connection_options(None, Some("  ".to_string()), |name| {
-            (name == CORAL_AUTH_TOKEN_ENV).then(|| "env-token".to_string())
-        });
+    fn non_unicode_connection_environment_error_is_value_redacted() {
+        let error = read_connection_env(CORAL_AUTH_TOKEN_ENV, |name| {
+            assert_eq!(name, CORAL_AUTH_TOKEN_ENV);
+            Err(VarError::NotUnicode(OsString::from(
+                "token-secret-sentinel",
+            )))
+        })
+        .expect_err("non-Unicode value");
 
-        assert_eq!(options.token, None);
-    }
-
-    #[test]
-    fn whitespace_environment_values_are_unset() {
-        let options = resolve_connection_options(None, None, |_| Some(" \t\n ".to_string()));
-
-        assert_eq!(options.endpoint, None);
-        assert_eq!(options.token, None);
+        let rendered = format!("{error:?} {error}");
+        assert!(rendered.contains(CORAL_AUTH_TOKEN_ENV));
+        assert!(!rendered.contains("token-secret-sentinel"));
     }
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -80,10 +80,10 @@ struct Cli {
 
 #[derive(Args)]
 struct ConnectionArgs {
-    /// Connect to an existing Coral gRPC endpoint. Overrides `CORAL_ENDPOINT`.
+    /// Connect to an existing Coral gRPC endpoint. Overrides `CORAL_ENDPOINT`; empty is local.
     #[arg(long, value_name = "URI", global = true)]
     endpoint: Option<String>,
-    /// Send a bearer token to the Coral endpoint. Overrides `CORAL_AUTH_TOKEN`.
+    /// Send a bearer token. Overrides `CORAL_AUTH_TOKEN` and stored login; empty disables auth.
     #[arg(long, value_name = "TOKEN", global = true)]
     token: Option<String>,
 }
@@ -677,7 +677,10 @@ pub async fn run_from_env() -> Result<(), CliError> {
             let bootstrap = bootstrap::bootstrap(bootstrap::BootstrapOptions {
                 enable_stderr_logs: command.enables_stderr_logs(),
                 feature_overrides: feature_overrides.clone(),
-                connection: env::connection_options(connection.endpoint, connection.token),
+                connection: bootstrap::ConnectionOverrides {
+                    endpoint: connection.endpoint,
+                    token: connection.token,
+                },
             })
             .await
             .map_err(anyhow::Error::from)?;

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-#[cfg(feature = "embedded-ui")]
 use assert_cmd::Command;
 use coral_api::v1::{
     AddFunctionResponse, CatalogRebuildResult, DiscoverSourcesResponse, ExecuteSqlResponse,
@@ -24,6 +23,7 @@ use coral_api::v1::{
     SearchProvider, Source, SourceCredentialStorage, SourceInfo, SourceOrigin, Workspace, function,
     search_clear_target, search_maintenance_result,
 };
+use coral_client::local::ServerBuilder;
 use tempfile::tempdir;
 use tonic::Code;
 
@@ -62,6 +62,152 @@ fn nonempty_lines(output: &str) -> Vec<&str> {
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .collect()
+}
+
+fn write_login_record(config: &std::path::Path, endpoint: &str, token: &str, resource: &str) {
+    let auth_dir = config.join("auth");
+    std::fs::create_dir_all(&auth_dir).expect("auth dir");
+    std::fs::write(
+        auth_dir.join("login.json"),
+        serde_json::json!({
+            "version": 1,
+            "endpoint": endpoint,
+            "issuer": "https://login.example.test",
+            "resource": resource,
+            "access_token": token
+        })
+        .to_string(),
+    )
+    .expect("login record");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stored_login_requires_https_and_empty_token_suppresses_it() {
+    let server_config = tempdir().expect("server config");
+    std::fs::write(server_config.path().join("session.key"), [b'k'; 32]).expect("session key");
+    std::fs::write(
+        server_config.path().join("config.toml"),
+        r#"
+[trace_history]
+enabled = false
+
+[auth.session]
+issuer = "https://login.example.test"
+audience = "https://coral.example.test/mcp"
+signing_key_file = "session.key"
+"#,
+    )
+    .expect("server config");
+    let (server, _companions) = ServerBuilder::configured_standalone_grpc()
+        .with_config_dir(server_config.path())
+        .with_noop_feedback_uploads()
+        .prepare_for_serve()
+        .expect("prepare server");
+    let server = server.start().await.expect("server");
+    let client_config = tempdir().expect("client config");
+    write_login_record(
+        client_config.path(),
+        server.endpoint_uri(),
+        "stored-token",
+        "https://coral.example.test/mcp",
+    );
+
+    let stored = Command::cargo_bin("coral")
+        .expect("cargo bin")
+        .env("CORAL_ENDPOINT", server.endpoint_uri())
+        .env_remove("CORAL_AUTH_TOKEN")
+        .env("CORAL_CONFIG_DIR", client_config.path())
+        .args(["workspace", "list"])
+        .assert()
+        .failure();
+    let stored_stderr = String::from_utf8_lossy(&stored.get_output().stderr);
+    assert!(
+        stored_stderr.contains("authorization metadata requires an HTTPS endpoint"),
+        "unexpected stored-login failure: {stored_stderr}"
+    );
+
+    let suppressed = Command::cargo_bin("coral")
+        .expect("cargo bin")
+        .env("CORAL_ENDPOINT", server.endpoint_uri())
+        .env("CORAL_AUTH_TOKEN", "")
+        .env("CORAL_CONFIG_DIR", client_config.path())
+        .args(["workspace", "list"])
+        .assert()
+        .failure();
+    let suppressed_stderr = String::from_utf8_lossy(&suppressed.get_output().stderr);
+    assert!(
+        suppressed_stderr.contains("unauthenticated: authentication required"),
+        "unexpected empty-token failure: {suppressed_stderr}"
+    );
+
+    server.shutdown().await.expect("shutdown");
+}
+
+#[test]
+fn local_mode_ignores_token_environment_and_login_store() {
+    let config = tempdir().expect("config");
+    let auth_dir = config.path().join("auth");
+    std::fs::create_dir(&auth_dir).expect("auth dir");
+    std::fs::write(auth_dir.join("login.json"), "not-json").expect("corrupt login");
+    #[cfg(unix)]
+    let token = {
+        use std::os::unix::ffi::OsStringExt as _;
+        std::ffi::OsString::from_vec(b"local-token-secret-\xff".to_vec())
+    };
+    #[cfg(not(unix))]
+    let token = std::ffi::OsString::from("invalid token that must be ignored");
+
+    Command::cargo_bin("coral")
+        .expect("cargo bin")
+        .env("CORAL_ENDPOINT", "https://unreachable.example.test")
+        .env("CORAL_AUTH_TOKEN", token)
+        .env("CORAL_CONFIG_DIR", config.path())
+        .args(["--endpoint", "", "workspace", "list"])
+        .assert()
+        .success();
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn remote_environment_and_corrupt_login_fail_redacted_before_rpc() {
+    use std::os::unix::ffi::OsStringExt as _;
+
+    let server = MockServer::start().await;
+    for (name, value, sentinel) in [
+        (
+            "CORAL_ENDPOINT",
+            b"endpoint-secret-\xff".to_vec(),
+            "endpoint-secret",
+        ),
+        (
+            "CORAL_AUTH_TOKEN",
+            b"token-secret-\xff".to_vec(),
+            "token-secret",
+        ),
+    ] {
+        let failed = server
+            .cmd()
+            .env(name, std::ffi::OsString::from_vec(value))
+            .args(["workspace", "list"])
+            .assert()
+            .failure();
+        let stderr = String::from_utf8_lossy(&failed.get_output().stderr);
+        assert!(stderr.contains(name), "missing variable name: {stderr}");
+        assert!(!stderr.contains(sentinel), "secret leaked: {stderr}");
+    }
+
+    write_login_record(
+        server.config_dir(),
+        server.endpoint_uri(),
+        "token-secret-sentinel with-space",
+        "https://resource-secret.example.test/mcp",
+    );
+    let corrupt = server.cmd().args(["workspace", "list"]).assert().failure();
+    let stderr = String::from_utf8_lossy(&corrupt.get_output().stderr);
+    assert!(stderr.contains("invalid or unsupported"), "{stderr}");
+    assert!(!stderr.contains("token-secret") && !stderr.contains("resource-secret"));
+    assert!(server.list_workspaces_requests().is_empty());
+    server.shutdown().await;
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -1537,6 +1537,7 @@ impl MockServer {
     pub(crate) fn cmd(&self) -> Command {
         let mut cmd = Command::cargo_bin("coral").expect("cargo bin");
         cmd.env("CORAL_ENDPOINT", &self.endpoint_uri);
+        cmd.env_remove("CORAL_AUTH_TOKEN");
         cmd.env("CORAL_CONFIG_DIR", self.config_dir.path());
         cmd
     }

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -153,6 +153,7 @@ async fn start_mcp_client_with_args(
             cmd.arg("mcp-stdio")
                 .args(args)
                 .env("CORAL_ENDPOINT", server.endpoint_uri())
+                .env_remove("CORAL_AUTH_TOKEN")
                 .env("CORAL_CONFIG_DIR", server.config_dir());
         }),
     )?;
@@ -388,6 +389,7 @@ origin = "bundled"
     let mut child = Command::new(env!("CARGO_BIN_EXE_coral"))
         .arg("mcp-stdio")
         .env("CORAL_ENDPOINT", server.endpoint_uri())
+        .env_remove("CORAL_AUTH_TOKEN")
         .env("CORAL_CONFIG_DIR", server.config_dir())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -492,6 +494,7 @@ storage = "file"
     let mut child = Command::new(env!("CARGO_BIN_EXE_coral"))
         .arg("mcp-stdio")
         .env("CORAL_ENDPOINT", server.endpoint_uri())
+        .env_remove("CORAL_AUTH_TOKEN")
         .env("CORAL_CONFIG_DIR", &config_dir)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -581,6 +584,7 @@ async fn mcp_stdio_workspace_flag_scopes_server_instance() -> Result<(), Box<dyn
         .arg("mcp-stdio")
         .args(["--workspace", "work"])
         .env("CORAL_ENDPOINT", server.endpoint_uri())
+        .env_remove("CORAL_AUTH_TOKEN")
         .env("CORAL_CONFIG_DIR", server.config_dir())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -1124,6 +1128,7 @@ future_flag = true
     let mut child = Command::new(env!("CARGO_BIN_EXE_coral"))
         .arg("mcp-stdio")
         .env("CORAL_ENDPOINT", server.endpoint_uri())
+        .env_remove("CORAL_AUTH_TOKEN")
         .env("CORAL_CONFIG_DIR", server.config_dir())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())


### PR DESCRIPTION
## Intent

Make CLI remote authentication endpoint-first and presence-aware while preserving Coral's unauthenticated local mode. Local bootstrap now starts and dials its in-process server without reading token environment or persisted login state; remote bootstrap validates one canonical endpoint before selecting a bearer.

## What it enables

- `--endpoint` overrides `CORAL_ENDPOINT`; an explicit empty value selects local mode.
- For remote endpoints, token precedence is `--token` > `CORAL_AUTH_TOKEN` > the login stored for that exact canonical endpoint.
- An explicit empty token flag or environment value suppresses all lower-precedence credentials and connects without a bearer.
- Missing or endpoint-mismatched login state permits unauthenticated remote connections, while malformed matching state fails closed before dialing.
- Non-Unicode connection environment values fail with variable-name-only diagnostics, without exposing the value.

## Usage examples

```shell
coral --endpoint https://coral.example.com --token "$TOKEN" sql "select 1"
CORAL_ENDPOINT=https://coral.example.com coral workspace list
CORAL_ENDPOINT=https://coral.example.com CORAL_AUTH_TOKEN='' coral workspace list
CORAL_ENDPOINT=https://coral.example.com coral --endpoint '' workspace list
```

## Validation

- `make rust-checks`
  - strict workspace formatting and Clippy passed
  - 1,731/1,731 tests passed (2 skipped)
  - strict workspace rustdoc passed
- `cargo test --locked -p coral-cli --all-features --test cli_e2e`: 46/46 passed
- `make docs-check`: passed
- `make perf-check`: 197 ms mean against the 750 ms limit
- Final behavior, security, and simplification reviews: no actionable findings
