### PR TITLE
feat(app): serve identity specs over grpc

### DIFF
--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -33,11 +33,21 @@ For Postgres, store the connection URL in an environment variable and reference 
 [database]
 backend = "postgres"
 url_env = "CORAL_DATABASE_URL"
+
+[credentials]
+encryption_key_env = "CORAL_CREDENTIAL_ENCRYPTION_KEY"
 ```
 
 ```shellscript
 export CORAL_DATABASE_URL="postgres://coral:secret@db.example.com:5432/coral?sslmode=verify-full"
+export CORAL_CREDENTIAL_ENCRYPTION_KEY="v1:$(openssl rand -base64 32)"
 ```
+
+Identity specs with stored inputs on Postgres require one provisioned
+credential encryption key shared by every Coral server connected to that
+database. Preserve the same value across restarts and replicas; replacing or
+losing it makes encrypted identity inputs unreadable. Postgres deployments that
+do not store identity inputs can omit `[credentials].encryption_key_env`.
 
 <Note>
   Remote Postgres URLs must set `sslmode=verify-full` so Coral verifies the server identity. Loopback and local-socket Postgres URLs may omit TLS for local development.

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -16,13 +16,15 @@ use axum::extract::Request as AxumRequest;
 use axum::response::Response as AxumResponse;
 use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
+use coral_api::v1::identity_spec_service_server::IdentitySpecServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::search_service_server::SearchServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
 use coral_api::v1::trace_service_server::TraceServiceServer;
 use coral_api::v1::workspace_service_server::WorkspaceServiceServer;
 use coral_api::{
-    CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
+    CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE,
+    IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
     SEARCH_RESPONSE_MAX_MESSAGE_SIZE, SOURCE_RESPONSE_MAX_MESSAGE_SIZE,
     TRACE_RESPONSE_MAX_MESSAGE_SIZE,
 };
@@ -36,19 +38,26 @@ use tonic::service::Routes;
 use tonic::transport::Server;
 use tonic_web::GrpcWebLayer;
 use tower::{Layer, Service};
+use zeroize::Zeroizing;
 
 use super::env::AppEnvironment;
 use super::error::AppError;
 use crate::EngineExtensionsProvider;
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
-use crate::credentials::{CredentialManager, CredentialStore};
+use crate::credentials::encryption::{
+    CredentialEncryptionKey, CredentialKeyProvider, LocalFileCredentialKeyProvider,
+    configured_key_required,
+};
+use crate::credentials::{CredentialManager, CredentialStore, CredentialsError};
 use crate::feedback::manager::FeedbackManager;
 use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
 };
 use crate::feedback::service::FeedbackService;
 use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
+use crate::identity_specs::IdentitySpecService;
+use crate::identity_specs::manager::IdentitySpecManager;
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::search::manager::SearchManager;
@@ -281,10 +290,17 @@ impl ServerBuilder {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir)?;
         layout.ensure()?;
-        let coral_db = init_database(&layout).await?;
+        let credential_config = CredentialStorageConfig::load(&layout)?;
+        let credential_encryption_key = credential_encryption_key(&credential_config)?;
+        let database_config = resolve_database_config(&layout)?;
+        let (identity_spec_key_provider, postgres_identity_inputs_disabled) =
+            identity_spec_key_provider(&layout, &database_config, credential_encryption_key);
+        let coral_db = init_database(database_config).await?;
         let config_store = ConfigStore::new(layout.clone());
         run_state_migrations(&coral_db, &config_store).await?;
         let coral_db = Arc::new(coral_db);
+        let identity_spec_manager =
+            IdentitySpecManager::new(Arc::clone(&coral_db), identity_spec_key_provider);
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config
             .trace_history
@@ -295,13 +311,20 @@ impl ServerBuilder {
             self.config.enable_stderr_logs,
             internal_trace_store_dir.clone(),
         )?;
+        if postgres_identity_inputs_disabled {
+            tracing::warn!(
+                backend = "postgres",
+                capability = "identity_inputs",
+                remediation = "[credentials].encryption_key_env",
+                "Postgres identity inputs are disabled until a shared credential encryption key is configured"
+            );
+        }
         let active_trace_store = telemetry_config
             .trace_history
             .enabled
             .then_some(installed_trace_store)
             .flatten();
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
-        let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
         let credential_manager = CredentialManager::new(credential_store);
@@ -349,6 +372,7 @@ impl ServerBuilder {
             ServerManagers {
                 source: source_manager,
                 workspace: workspace_manager,
+                identity_spec: identity_spec_manager,
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
@@ -361,11 +385,86 @@ impl ServerBuilder {
     }
 }
 
-async fn init_database(layout: &AppStateLayout) -> Result<CoralDb, AppError> {
-    let database_config = resolve_database_config(layout)?;
+async fn init_database(database_config: ResolvedDatabaseConfig) -> Result<CoralDb, AppError> {
     let coral_db = CoralDb::open(database_config).await?;
     coral_db.migrate().await?;
     Ok(coral_db)
+}
+
+fn identity_spec_key_provider(
+    layout: &AppStateLayout,
+    database_config: &ResolvedDatabaseConfig,
+    configured_key: Option<CredentialEncryptionKey>,
+) -> (Arc<dyn CredentialKeyProvider>, bool) {
+    let configured = configured_key.is_some();
+    let provider: Arc<dyn CredentialKeyProvider> = match database_config {
+        ResolvedDatabaseConfig::Sqlite { .. } => {
+            Arc::new(LocalFileCredentialKeyProvider::new(layout, configured_key))
+        }
+        ResolvedDatabaseConfig::Postgres { .. } => {
+            Arc::new(ReloadingConfiguredKeyProvider(layout.clone()))
+        }
+    };
+    let postgres_identity_inputs_disabled =
+        matches!(database_config, ResolvedDatabaseConfig::Postgres { .. }) && !configured;
+    (provider, postgres_identity_inputs_disabled)
+}
+
+struct ReloadingConfiguredKeyProvider(AppStateLayout);
+
+impl ReloadingConfiguredKeyProvider {
+    fn configured_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        let config = CredentialStorageConfig::load(&self.0)
+            .map_err(|error| CredentialsError::Unavailable(error.to_string()))?;
+        credential_encryption_key(&config)
+            .map_err(|error| CredentialsError::Unavailable(error.to_string()))?
+            .ok_or_else(configured_key_required)
+    }
+}
+
+impl CredentialKeyProvider for ReloadingConfiguredKeyProvider {
+    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        self.configured_key()
+    }
+
+    fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+        let key = self.configured_key()?;
+        if key.key_id() == key_id {
+            Ok(key)
+        } else {
+            Err(CredentialsError::Crypto(format!(
+                "credential encryption key '{key_id}' is unavailable"
+            )))
+        }
+    }
+}
+
+fn credential_encryption_key(
+    config: &CredentialStorageConfig,
+) -> Result<Option<CredentialEncryptionKey>, AppError> {
+    let Some(env_name) = config.encryption_key_env.as_deref() else {
+        return Ok(None);
+    };
+    let raw = Zeroizing::new(
+        AppEnvironment::env_var(env_name)
+            .map_err(|_error| {
+                AppError::FailedPrecondition(format!(
+                    "credential encryption key environment variable `{env_name}` must contain valid UTF-8"
+                ))
+            })?
+            .ok_or_else(|| {
+                AppError::FailedPrecondition(format!(
+                    "credential encryption key environment variable `{env_name}` is not set"
+                ))
+            })?,
+    );
+    CredentialEncryptionKey::from_encoded_material(raw.as_str())
+        .map(Some)
+        .map_err(|error| {
+            AppError::FailedPrecondition(format!(
+                "credential encryption key from environment variable `{env_name}` is invalid: {error}"
+            ))
+        })
 }
 
 fn resolve_database_config(layout: &AppStateLayout) -> Result<ResolvedDatabaseConfig, AppError> {
@@ -475,6 +574,7 @@ struct TraceServerComponents {
 struct ServerManagers {
     source: SourceManager,
     workspace: WorkspaceManager,
+    identity_spec: IdentitySpecManager,
     query: QueryManager,
     search: SearchManager,
     feedback: FeedbackManager,
@@ -493,12 +593,14 @@ async fn start_server(
     let ServerManagers {
         source,
         workspace,
+        identity_spec,
         query,
         search,
         feedback,
     } = managers;
     let source_service = SourceService::new(source, query.clone(), workspace.clone());
     let workspace_service = WorkspaceService::new(workspace);
+    let identity_spec_service = IdentitySpecService::new(identity_spec);
     let catalog_service = CatalogService::new(query.clone());
     let query_service = QueryService::new(query);
     let search_service = SearchService::new(search);
@@ -509,6 +611,10 @@ async fn start_server(
                 .max_encoding_message_size(SOURCE_RESPONSE_MAX_MESSAGE_SIZE),
         )
         .add_service(WorkspaceServiceServer::new(workspace_service))
+        .add_service(
+            IdentitySpecServiceServer::new(identity_spec_service)
+                .max_encoding_message_size(IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE),
+        )
         .add_service(
             CatalogServiceServer::new(catalog_service)
                 .max_encoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE),
@@ -780,8 +886,10 @@ mod tests {
         StaticAssetsProvider, TraceServerComponents, is_grpc_web_content_type,
         is_native_grpc_content_type, start_server,
     };
+    use crate::credentials::encryption::LocalFileCredentialKeyProvider;
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::feedback::manager::FeedbackManager;
+    use crate::identity_specs::manager::IdentitySpecManager;
     use crate::query::manager::QueryManager;
     use crate::search::manager::SearchManager;
     use crate::sources::manager::SourceManager;
@@ -934,6 +1042,16 @@ enabled = false
         Arc::new(db)
     }
 
+    fn test_identity_spec_manager(
+        layout: &AppStateLayout,
+        db: &Arc<CoralDb>,
+    ) -> IdentitySpecManager {
+        IdentitySpecManager::new(
+            Arc::clone(db),
+            Arc::new(LocalFileCredentialKeyProvider::new(layout, None)),
+        )
+    }
+
     #[tokio::test]
     async fn trace_service_is_unregistered_when_local_store_is_disabled() {
         let temp = TempDir::new().expect("temp dir");
@@ -992,6 +1110,7 @@ backend = "unsupported"
             "unsupported database config should abort startup after database cutover"
         );
     }
+
     #[tokio::test]
     async fn trace_service_lists_empty_store() {
         let temp = TempDir::new().expect("temp dir");
@@ -1080,6 +1199,7 @@ backend = "unsupported"
             ServerManagers {
                 source: source_manager,
                 workspace: workspace_manager,
+                identity_spec: test_identity_spec_manager(&layout, &db),
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
@@ -1507,6 +1627,7 @@ tables:
             ServerManagers {
                 source: source_manager,
                 workspace: workspace_manager,
+                identity_spec: test_identity_spec_manager(&layout, &db),
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
@@ -1622,6 +1743,7 @@ tables:
             ServerManagers {
                 source: source_manager,
                 workspace: workspace_manager,
+                identity_spec: test_identity_spec_manager(&layout, &db),
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
@@ -1737,6 +1859,7 @@ tables:
             ServerManagers {
                 source: source_manager,
                 workspace: workspace_manager,
+                identity_spec: test_identity_spec_manager(&layout, &db),
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,

--- a/crates/coral-app/src/credentials/config.rs
+++ b/crates/coral-app/src/credentials/config.rs
@@ -7,9 +7,10 @@ use crate::state::AppStateLayout;
 
 use super::CredentialStoragePreference;
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct CredentialStorageConfig {
     pub(crate) storage: CredentialStoragePreference,
+    pub(crate) encryption_key_env: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -22,6 +23,8 @@ struct CredentialStorageConfigFile {
 struct CredentialStorageConfigSection {
     #[serde(default)]
     storage: CredentialStoragePreference,
+    #[serde(default)]
+    encryption_key_env: Option<String>,
 }
 
 impl CredentialStorageConfig {
@@ -33,6 +36,7 @@ impl CredentialStorageConfig {
         let file = toml::from_str::<CredentialStorageConfigFile>(&raw)?;
         Ok(Self {
             storage: file.credentials.storage,
+            encryption_key_env: file.credentials.encryption_key_env,
         })
     }
 }

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -111,6 +111,7 @@ pub(crate) trait CredentialKeyProvider: Send + Sync {
 pub(crate) struct LocalFileCredentialKeyProvider {
     path: PathBuf,
     provided_key: Option<CredentialEncryptionKey>,
+    allow_local_file_fallback: bool,
 }
 
 impl LocalFileCredentialKeyProvider {
@@ -118,14 +119,30 @@ impl LocalFileCredentialKeyProvider {
         layout: &AppStateLayout,
         provided_key: Option<CredentialEncryptionKey>,
     ) -> Self {
+        Self::from_layout(layout, provided_key, true)
+    }
+
+    pub(crate) fn configured_key_only(
+        layout: &AppStateLayout,
+        provided_key: Option<CredentialEncryptionKey>,
+    ) -> Self {
+        Self::from_layout(layout, provided_key, false)
+    }
+
+    fn from_layout(
+        layout: &AppStateLayout,
+        provided_key: Option<CredentialEncryptionKey>,
+        allow_local_file_fallback: bool,
+    ) -> Self {
         Self {
             path: layout.credential_encryption_key_file(),
             provided_key,
+            allow_local_file_fallback,
         }
     }
 
     fn load_key(&self) -> Result<Option<CredentialEncryptionKey>, CredentialsError> {
-        match std::fs::read_to_string(&self.path) {
+        match storage_fs::read_to_string_private(&self.path) {
             Ok(raw) => {
                 let raw = Zeroizing::new(raw);
                 CredentialEncryptionKey::from_encoded_material(raw.as_str()).map(Some)
@@ -170,7 +187,11 @@ impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
         if let Some(key) = &self.provided_key {
             return Ok(key.clone());
         }
-        self.load_or_create_key()
+        if self.allow_local_file_fallback {
+            self.load_or_create_key()
+        } else {
+            Err(configured_key_required())
+        }
     }
 
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
@@ -179,15 +200,25 @@ impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
         {
             return Ok(key.clone());
         }
-        if let Some(key) = self.load_key()?
-            && key.key_id == key_id
-        {
-            return Ok(key);
+        if self.allow_local_file_fallback {
+            if let Some(key) = self.load_key()?
+                && key.key_id == key_id
+            {
+                return Ok(key);
+            }
+        } else if self.provided_key.is_none() {
+            return Err(configured_key_required());
         }
         Err(CredentialsError::Crypto(format!(
             "credential encryption key '{key_id}' is unavailable"
         )))
     }
+}
+
+pub(crate) fn configured_key_required() -> CredentialsError {
+    CredentialsError::Unavailable(
+        "Postgres identity inputs require [credentials].encryption_key_env to provide a shared credential encryption key".to_string(),
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -168,11 +168,17 @@ impl IdentitySpecManager {
                 .clone()
                 .map(record_to_installed)
                 .transpose()?;
-            let previous_material = decrypt_input_material(
-                &key,
-                snapshot.document.clone(),
-                self.key_provider.as_ref(),
-            )?;
+            let material_key = key.clone();
+            let material_document = snapshot.document.clone();
+            let material_key_provider = Arc::clone(&self.key_provider);
+            let previous_material = run_key_operation(move || {
+                decrypt_input_material(
+                    &material_key,
+                    material_document,
+                    material_key_provider.as_ref(),
+                )
+            })
+            .await?;
             let prepared = prepare_identity_spec_input_material(
                 &key,
                 &manifest,
@@ -180,8 +186,16 @@ impl IdentitySpecManager {
                 &previous_material,
                 &input_values,
             )?;
-            let document =
-                prepare_document_write(&key, &prepared.values, self.key_provider.as_ref())?;
+            let document_key = key.clone();
+            let document_key_provider = Arc::clone(&self.key_provider);
+            let document = run_key_operation(move || {
+                prepare_document_write(
+                    &document_key,
+                    &prepared.values,
+                    document_key_provider.as_ref(),
+                )
+            })
+            .await?;
             let replaced = snapshot.record.is_some();
 
             match self
@@ -318,7 +332,7 @@ impl IdentitySpecManager {
         };
         tx.commit().await?;
         let record = record.ok_or_else(|| spec_not_found(key))?;
-        resolve_record_for_use(record, document, self.key_provider.as_ref())
+        resolve_record_for_use_async(record, document, Arc::clone(&self.key_provider)).await
     }
 
     pub(crate) async fn get_global_for_use(
@@ -396,7 +410,7 @@ impl IdentitySpecManager {
         };
         tx.commit().await?;
         let record = record.ok_or_else(|| spec_not_found(&requested_key))?;
-        resolve_record_for_use(record, document, self.key_provider.as_ref())
+        resolve_record_for_use_async(record, document, Arc::clone(&self.key_provider)).await
     }
 
     /// List the effective specs for a workspace, shadowed and sorted by name.
@@ -525,6 +539,23 @@ fn prepare_document_write(
         document.algorithm,
         document.aad_version,
     )?))
+}
+
+async fn resolve_record_for_use_async(
+    record: IdentitySpecRecord,
+    document: Option<IdentitySpecDocumentRecord>,
+    key_provider: Arc<dyn CredentialKeyProvider>,
+) -> Result<ResolvedIdentitySpec, AppError> {
+    run_key_operation(move || resolve_record_for_use(record, document, key_provider.as_ref())).await
+}
+
+async fn run_key_operation<T, F>(operation: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, AppError> + Send + 'static,
+{
+    let span = tracing::Span::current();
+    tokio::task::spawn_blocking(move || span.in_scope(operation)).await?
 }
 
 fn mutation_retry_exhausted() -> AppError {
@@ -723,7 +754,8 @@ fn scope_label(scope: &IdentitySpecScope) -> String {
 #[cfg(test)]
 pub(crate) mod tests {
     use std::collections::BTreeMap;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex, mpsc};
+    use std::time::Duration;
 
     use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND};
     use coral_spec::parse_identity_manifest_yaml;
@@ -763,6 +795,41 @@ pub(crate) mod tests {
         }};
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn manager_key_provider_wait_keeps_async_runtime_responsive() {
+        let fixture = fixture().await;
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (heartbeat_tx, heartbeat_rx) = mpsc::channel();
+        let manager = IdentitySpecManager::new(
+            Arc::clone(&fixture.db),
+            Arc::new(BlockingKeyProvider {
+                entered: Mutex::new(Some(entered_tx)),
+                release: Mutex::new(release_rx),
+            }),
+        );
+        let watchdog = std::thread::spawn(move || {
+            let progressed = heartbeat_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+            release_tx.send(()).expect("release provider");
+            progressed
+        });
+        let heartbeat = async move {
+            entered_rx.await.expect("provider entry");
+            heartbeat_tx.send(()).expect("heartbeat");
+        };
+        let manifest = oauth_manifest("blocking_key", "blocking");
+        let mutation = manager.add_or_replace_exact(
+            IdentitySpecScope::global(),
+            &manifest,
+            vec![IdentitySpecInputValue::new("CLIENT_SECRET", "secret")],
+        );
+
+        let (result, ()) = tokio::join!(mutation, heartbeat);
+
+        result.expect("identity mutation");
+        assert!(watchdog.join().expect("watchdog"));
+    }
+
     struct Fixture {
         _temp: TempDir,
         db: Arc<CoralDb>,
@@ -787,6 +854,42 @@ pub(crate) mod tests {
                 .find(|key| key.key_id() == key_id)
                 .cloned()
                 .ok_or_else(|| CredentialsError::Crypto("missing test key".to_string()))
+        }
+    }
+
+    struct BlockingKeyProvider {
+        entered: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+        release: Mutex<mpsc::Receiver<()>>,
+    }
+
+    fn coordination_error() -> CredentialsError {
+        CredentialsError::Unavailable("test provider coordination failed".to_string())
+    }
+
+    impl CredentialKeyProvider for BlockingKeyProvider {
+        fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+            if let Some(entered) = self
+                .entered
+                .lock()
+                .map_err(|_error| coordination_error())?
+                .take()
+            {
+                entered.send(()).map_err(|()| coordination_error())?;
+            }
+            self.release
+                .lock()
+                .map_err(|_error| coordination_error())?
+                .recv()
+                .map_err(|_error| coordination_error())?;
+            Ok(CredentialEncryptionKey::from_static_bytes_for_test(
+                [61; 32],
+            ))
+        }
+
+        fn key(&self, _key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+            Err(CredentialsError::Crypto(
+                "unused test key lookup".to_string(),
+            ))
         }
     }
 

--- a/crates/coral-app/src/identity_specs/mod.rs
+++ b/crates/coral-app/src/identity_specs/mod.rs
@@ -1,3 +1,9 @@
 //! Database-backed installed identity-spec management.
-#![cfg_attr(not(test), expect(dead_code, reason = "B2d wires service consumers"))]
+#![cfg_attr(
+    not(test),
+    expect(dead_code, reason = "later identity units consume resolution APIs")
+)]
 pub(crate) mod manager;
+pub(crate) mod service;
+
+pub(crate) use service::IdentitySpecService;

--- a/crates/coral-app/src/identity_specs/service.rs
+++ b/crates/coral-app/src/identity_specs/service.rs
@@ -1,0 +1,152 @@
+//! Implements the gRPC `IdentitySpecService` for installed spec definitions.
+
+use coral_api::v1::identity_spec_service_server::IdentitySpecService as IdentitySpecServiceApi;
+use coral_api::v1::{
+    AddIdentitySpecRequest, AddIdentitySpecResponse, DeleteIdentitySpecRequest,
+    DeleteIdentitySpecResponse, GetIdentitySpecRequest, GetIdentitySpecResponse,
+    IdentitySpec as ProtoIdentitySpec, ListIdentitySpecsRequest, ListIdentitySpecsResponse,
+    Workspace,
+};
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::app_status;
+use crate::identity_specs::manager::{
+    IdentitySpecInputValue, IdentitySpecManager, InstalledIdentitySpec,
+};
+use crate::state::db::{IdentitySpecKey, IdentitySpecScope};
+use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto, workspace_to_proto};
+
+#[derive(Clone)]
+pub(crate) struct IdentitySpecService {
+    specs: IdentitySpecManager,
+}
+
+impl IdentitySpecService {
+    pub(crate) fn new(specs: IdentitySpecManager) -> Self {
+        Self { specs }
+    }
+}
+
+#[tonic::async_trait]
+impl IdentitySpecServiceApi for IdentitySpecService {
+    async fn add_identity_spec(
+        &self,
+        request: Request<AddIdentitySpecRequest>,
+    ) -> Result<Response<AddIdentitySpecResponse>, Status> {
+        let span = grpc_span(&request);
+        let specs = self.specs.clone();
+        instrument_grpc(span, async move {
+            let AddIdentitySpecRequest {
+                manifest_yaml,
+                input_values,
+                workspace,
+            } = request.into_inner();
+            let scope = scope_from_proto(workspace.as_ref())?;
+            let input_values = input_values
+                .into_iter()
+                .map(|input| IdentitySpecInputValue::new(input.key, input.value))
+                .collect();
+            let (identity_spec, replaced) = specs
+                .add_or_replace_exact(scope, &manifest_yaml, input_values)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(AddIdentitySpecResponse {
+                identity_spec: Some(installed_to_proto(identity_spec)),
+                replaced,
+            }))
+        })
+        .await
+    }
+
+    async fn list_identity_specs(
+        &self,
+        request: Request<ListIdentitySpecsRequest>,
+    ) -> Result<Response<ListIdentitySpecsResponse>, Status> {
+        let span = grpc_span(&request);
+        let specs = self.specs.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let scope = scope_from_proto(request.workspace.as_ref())?;
+            let installed = match (&scope, request.include_global) {
+                (IdentitySpecScope::Workspace(workspace), true) => {
+                    specs.list_workspace_with_global(workspace).await
+                }
+                _ => specs.list_exact(&scope).await,
+            }
+            .map_err(app_status)?;
+            Ok(Response::new(ListIdentitySpecsResponse {
+                identity_specs: installed.into_iter().map(installed_to_proto).collect(),
+            }))
+        })
+        .await
+    }
+
+    async fn get_identity_spec(
+        &self,
+        request: Request<GetIdentitySpecRequest>,
+    ) -> Result<Response<GetIdentitySpecResponse>, Status> {
+        let span = grpc_span(&request);
+        let specs = self.specs.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let scope = scope_from_proto(request.workspace.as_ref())?;
+            let key = IdentitySpecKey::new(scope, &request.name).map_err(app_status)?;
+            let identity_spec = specs.get_exact(&key).await.map_err(app_status)?;
+            Ok(Response::new(GetIdentitySpecResponse {
+                identity_spec: Some(installed_to_proto(identity_spec)),
+            }))
+        })
+        .await
+    }
+
+    async fn delete_identity_spec(
+        &self,
+        request: Request<DeleteIdentitySpecRequest>,
+    ) -> Result<Response<DeleteIdentitySpecResponse>, Status> {
+        let span = grpc_span(&request);
+        let specs = self.specs.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let scope = scope_from_proto(request.workspace.as_ref())?;
+            let key = IdentitySpecKey::new(scope, &request.name).map_err(app_status)?;
+            specs.delete_exact(&key).await.map_err(app_status)?;
+
+            // B4 introduces stored identity instances and owns force/orphan semantics.
+            Ok(Response::new(DeleteIdentitySpecResponse {
+                orphaned_identities: 0,
+            }))
+        })
+        .await
+    }
+}
+
+fn scope_from_proto(workspace: Option<&Workspace>) -> Result<IdentitySpecScope, Status> {
+    match workspace {
+        None => Ok(IdentitySpecScope::global()),
+        Some(workspace) => {
+            workspace_name_from_proto(Some(workspace)).map(IdentitySpecScope::workspace)
+        }
+    }
+}
+
+fn installed_to_proto(installed: InstalledIdentitySpec) -> ProtoIdentitySpec {
+    let InstalledIdentitySpec {
+        key,
+        manifest_yaml,
+        manifest,
+    } = installed;
+    let workspace = match key.scope() {
+        IdentitySpecScope::Global => None,
+        IdentitySpecScope::Workspace(workspace) => Some(workspace_to_proto(workspace)),
+    };
+    let identity_type = manifest.identity_type.label().to_string();
+    ProtoIdentitySpec {
+        name: key.name().to_string(),
+        version: manifest.version,
+        description: manifest.description,
+        issuer: manifest.issuer,
+        identity_type,
+        manifest_yaml,
+        workspace,
+    }
+}

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, Write as _};
+use std::io::{self, Read as _, Write as _};
 use std::path::{Path, PathBuf};
 
 use fs2::FileExt;
@@ -46,6 +46,53 @@ pub(crate) fn ensure_file_private(path: &Path) -> io::Result<()> {
         }
         Err(error) => Err(error),
     }
+}
+
+/// Open and read an existing private regular file without following a
+/// pre-existing symlink or trusting a path that changed before open.
+pub(crate) fn read_to_string_private(path: &Path) -> io::Result<String> {
+    if let Some(parent) = path.parent() {
+        ensure_private_dir(parent)?;
+    }
+    let path_metadata = fs::symlink_metadata(path)?;
+    if !path_metadata.file_type().is_file() {
+        return Err(not_regular_file(path));
+    }
+
+    let mut file = File::open(path)?;
+    let opened_metadata = file.metadata()?;
+    if !opened_metadata.file_type().is_file()
+        || !opened_file_matches_path(&path_metadata, &opened_metadata)
+    {
+        return Err(not_regular_file(path));
+    }
+    set_open_file_permissions_private(&file)?;
+
+    let mut raw = String::new();
+    file.read_to_string(&mut raw)?;
+    Ok(raw)
+}
+
+fn not_regular_file(path: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "path is not the same private regular file that was inspected: {}",
+            path.display()
+        ),
+    )
+}
+
+#[cfg(unix)]
+fn opened_file_matches_path(path: &fs::Metadata, opened: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt as _;
+
+    path.dev() == opened.dev() && path.ino() == opened.ino()
+}
+
+#[cfg(not(unix))]
+fn opened_file_matches_path(_path: &fs::Metadata, _opened: &fs::Metadata) -> bool {
+    true
 }
 
 fn ensure_existing_file_private(path: &Path) -> io::Result<()> {
@@ -286,9 +333,80 @@ fn set_file_permissions_private(_path: &Path) -> io::Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn set_open_file_permissions_private(file: &File) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    file.set_permissions(fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn set_open_file_permissions_private(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{DirectoryBackup, ensure_file_private};
+    use super::{DirectoryBackup, ensure_file_private, read_to_string_private};
+
+    #[test]
+    fn read_to_string_private_rejects_non_regular_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("credential-encryption.key");
+        std::fs::create_dir(&path).expect("create directory at key path");
+
+        let error = read_to_string_private(&path).expect_err("directory should be rejected");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("private regular file"));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn read_to_string_private_rejects_symlink_without_chmoding_target() {
+        use std::os::unix::fs::{PermissionsExt as _, symlink};
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let target = temp.path().join("target.key");
+        let link = temp.path().join("credential-encryption.key");
+        std::fs::write(&target, "v1:not-a-real-key\n").expect("write target");
+        std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644))
+            .expect("set target permissions");
+        symlink(&target, &link).expect("create symlink");
+
+        let error = read_to_string_private(&link).expect_err("symlink should be rejected");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        let target_mode = std::fs::metadata(&target)
+            .expect("target metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(target_mode, 0o644);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn read_to_string_private_tightens_opened_file_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = temp.path().join("credential-encryption.key");
+        std::fs::write(&path, "private key\n").expect("write key");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("set permissive mode");
+
+        assert_eq!(
+            read_to_string_private(&path).expect("read key"),
+            "private key\n"
+        );
+        let mode = std::fs::metadata(&path)
+            .expect("key metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
 
     #[test]
     fn ensure_file_private_rejects_existing_directory() {


### PR DESCRIPTION
## Intent

Expose installed identity-spec management through the local native gRPC and gRPC-Web server while keeping setup inputs encrypted and scope behavior exact.

## What it enables

- Add or replace, list, get, and delete global or workspace identity specs through the generated client contract.
- Preserve global/workspace scope identity in responses and opt into global entries only for workspace list requests.
- Keep synchronous KEK work off Tokio workers, validate explicit key configuration before serving, and permanently disable node-local fallback for Postgres identity inputs.
- Preserve existing keyless Postgres startup while emitting a structured capability warning after tracing initializes.

B4 still owns dependent-identity usage checks and force/orphan semantics. B2e, the immediate successor, owns end-to-end native/gRPC-Web lifecycle, restart, configured-key transition, and large-response coverage.

## Usage examples

```rust
let listed = IdentitySpecServiceClient::new(channel)
    .list_identity_specs(ListIdentitySpecsRequest {
        workspace: None,
        include_global: false,
    })
    .await?
    .into_inner();
```

For shared Postgres deployments that store identity inputs, configure the same `credentials.encryption_key_env` value on every replica.

## Validation

- `make rust-checks` — 1,692 passed, 3 skipped; formatting, Clippy, and rustdoc clean
- `make postgres-tests` — repository, migration, and server-startup gates passed
- `make docs-check`
- `make perf-check` — 203.9 ms mean against the 750 ms threshold
- Focused KEK contention, configured-only provider, invalid explicit-key startup, private-file, and service/bootstrap tests
- Structured review swarm with final correctness/tests/operations reruns clean

PR size: 598 changed lines.