### PR TITLE
test(app): cover identity spec service contracts

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -872,8 +872,9 @@ mod tests {
     use coral_api::v1::source_service_client::SourceServiceClient;
     use coral_api::v1::trace_service_client::TraceServiceClient;
     use coral_api::v1::{
-        ExecuteSqlRequest, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
-        ListTracesRequest, SearchRequest, Workspace, import_source_response,
+        ExecuteSqlRequest, ImportSourceRequest, ImportSourceResponse, ListIdentitySpecsRequest,
+        ListIdentitySpecsResponse, ListSourcesRequest, ListTracesRequest, SearchRequest, Workspace,
+        import_source_response,
     };
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
@@ -883,11 +884,13 @@ mod tests {
 
     use super::{
         RunningServer, ServerBuilder, ServerManagers, ServerMode, StaticAsset,
-        StaticAssetsProvider, TraceServerComponents, is_grpc_web_content_type,
-        is_native_grpc_content_type, start_server,
+        StaticAssetsProvider, TraceServerComponents, credential_encryption_key,
+        identity_spec_key_provider, is_grpc_web_content_type, is_native_grpc_content_type,
+        start_server,
     };
+    use crate::credentials::config::CredentialStorageConfig;
     use crate::credentials::encryption::LocalFileCredentialKeyProvider;
-    use crate::credentials::{CredentialManager, CredentialStore};
+    use crate::credentials::{CredentialManager, CredentialStore, CredentialsError};
     use crate::feedback::manager::FeedbackManager;
     use crate::identity_specs::manager::IdentitySpecManager;
     use crate::query::manager::QueryManager;
@@ -1112,6 +1115,95 @@ backend = "unsupported"
     }
 
     #[tokio::test]
+    async fn server_builder_rejects_invalid_explicit_identity_spec_key() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        let missing_env = format!("CORAL_TEST_MISSING_{}", uuid::Uuid::new_v4().simple());
+        std::fs::write(
+            layout.config_file(),
+            format!("[credentials]\nencryption_key_env = \"{missing_env}\"\n"),
+        )
+        .expect("write config");
+
+        let result = ServerBuilder::new()
+            .with_config_dir(config_dir)
+            .start()
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(crate::bootstrap::AppError::FailedPrecondition(_))
+        ));
+        assert!(!layout.database_file().exists());
+        assert!(!layout.credential_encryption_key_file().exists());
+    }
+
+    #[test]
+    fn postgres_identity_spec_key_provider_reloads_config_and_never_falls_back() {
+        const RUN_FLAG: &str = "CORAL_RUN_POSTGRES_KEY_RELOAD_TEST";
+        const KEY_ENV: &str = "CORAL_TEST_POSTGRES_IDENTITY_KEY";
+        const KEY_VALUE: &str = "v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+        if crate::bootstrap::env_var(RUN_FLAG)
+            .expect("read subprocess flag")
+            .is_none()
+        {
+            let status =
+                std::process::Command::new(std::env::current_exe().expect("current test binary"))
+                    .env(RUN_FLAG, "1")
+                    .env(KEY_ENV, KEY_VALUE)
+                    .arg("--exact")
+                    .arg(
+                        "bootstrap::server::tests::postgres_identity_spec_key_provider_reloads_config_and_never_falls_back",
+                    )
+                    .arg("--nocapture")
+                    .status()
+                    .expect("run configured-key subprocess");
+            assert!(status.success(), "configured-key subprocess should pass");
+            return;
+        }
+
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        std::fs::write(
+            layout.config_file(),
+            format!("[credentials]\nencryption_key_env = \"{KEY_ENV}\"\n"),
+        )
+        .expect("write configured key reference");
+        let configured_key = credential_encryption_key(
+            &CredentialStorageConfig::load(&layout).expect("load credential config"),
+        )
+        .expect("resolve configured key")
+        .expect("configured key");
+        let configured_key_id = configured_key.key_id().to_string();
+        let (provider, disabled) = identity_spec_key_provider(
+            &layout,
+            &ResolvedDatabaseConfig::Postgres {
+                url: "postgres://unused".to_string(),
+            },
+            Some(configured_key),
+        );
+
+        assert!(!disabled);
+        let active = provider.active_key().expect("configured active key");
+        assert_eq!(active.key_id(), configured_key_id);
+        std::fs::remove_file(layout.config_file()).expect("remove key configuration");
+        assert!(matches!(
+            provider.active_key(),
+            Err(CredentialsError::Unavailable(_))
+        ));
+        assert!(matches!(
+            provider.key(active.key_id()),
+            Err(CredentialsError::Unavailable(_))
+        ));
+        assert!(!layout.credential_encryption_key_file().exists());
+    }
+
+    #[tokio::test]
     async fn trace_service_lists_empty_store() {
         let temp = TempDir::new().expect("temp dir");
         let server = start_trace_test_server(&temp, Arc::new(SingleUserPrincipalProvider)).await;
@@ -1230,6 +1322,52 @@ backend = "unsupported"
         body
     }
 
+    fn decode_grpc_web_response<T>(body: &[u8]) -> T
+    where
+        T: prost::Message + Default,
+    {
+        assert!(body.len() >= 5, "expected a gRPC-Web data frame");
+        assert_eq!(body[0], 0, "expected first frame to be uncompressed data");
+        let data_len =
+            u32::from_be_bytes(body[1..5].try_into().expect("gRPC-Web data length header"))
+                as usize;
+        let data_end = 5 + data_len;
+        let message = T::decode(body.get(5..data_end).expect("complete gRPC-Web data frame"))
+            .expect("decode gRPC-Web protobuf response");
+
+        assert!(
+            body.len() >= data_end + 5,
+            "expected final gRPC-Web trailer frame"
+        );
+        assert_eq!(
+            body[data_end], 0x80,
+            "expected final frame to be uncompressed trailers"
+        );
+        let trailer_len = u32::from_be_bytes(
+            body[data_end + 1..data_end + 5]
+                .try_into()
+                .expect("gRPC-Web trailer length header"),
+        ) as usize;
+        let trailer_end = data_end + 5 + trailer_len;
+        let trailers = body
+            .get(data_end + 5..trailer_end)
+            .expect("complete gRPC-Web trailer frame");
+        assert_eq!(
+            body.len(),
+            trailer_end,
+            "expected trailers to be the final gRPC-Web frame"
+        );
+        let trailers = std::str::from_utf8(trailers).expect("trailers are UTF-8");
+        assert!(
+            trailers.lines().any(|line| {
+                line.strip_prefix("grpc-status:")
+                    .is_some_and(|status| status.trim() == "0")
+            }),
+            "expected successful gRPC-Web trailer status, got {trailers:?}"
+        );
+        message
+    }
+
     struct StubAssets;
 
     impl StaticAssetsProvider for StubAssets {
@@ -1296,28 +1434,21 @@ backend = "unsupported"
             .await
             .expect("start embedded UI server");
         let endpoint = running.endpoint_uri();
-        let path = format!("{endpoint}/coral.v1.SourceService/ListSources");
+        let path = format!("{endpoint}/coral.v1.IdentitySpecService/ListIdentitySpecs");
         let client = reqwest::Client::new();
 
         let response = client
             .post(&path)
             .header("content-type", "application/grpc-web+proto")
             .header("x-grpc-web", "1")
-            .body(grpc_web_body(&ListSourcesRequest {
-                workspace: Some(default_workspace()),
-            }))
+            .body(grpc_web_body(&ListIdentitySpecsRequest::default()))
             .send()
             .await
             .expect("gRPC-Web request");
         assert_eq!(response.status(), reqwest::StatusCode::OK);
-        assert!(
-            !response
-                .bytes()
-                .await
-                .expect("gRPC-Web response")
-                .is_empty(),
-            "expected framed gRPC-Web response body"
-        );
+        let body = response.bytes().await.expect("gRPC-Web response");
+        let listed = decode_grpc_web_response::<ListIdentitySpecsResponse>(&body);
+        assert!(listed.identity_specs.is_empty());
 
         let native_grpc = client
             .post(&path)
@@ -1379,45 +1510,7 @@ tables:
             .expect("gRPC-Web streaming request");
         assert_eq!(response.status(), reqwest::StatusCode::OK);
         let body = response.bytes().await.expect("gRPC-Web streaming body");
-        let body = body.as_ref();
-        assert!(body.len() >= 5, "expected framed gRPC-Web response body");
-        assert_eq!(body[0], 0, "expected first frame to be a data frame");
-        let len = u32::from_be_bytes([body[1], body[2], body[3], body[4]]) as usize;
-        let frame = body.get(5..5 + len).expect("complete gRPC-Web data frame");
-        let trailer_offset = 5 + len;
-        assert!(
-            body.len() >= trailer_offset + 5,
-            "expected final gRPC-Web trailer frame"
-        );
-        assert_eq!(
-            body[trailer_offset], 0x80,
-            "expected final frame to be uncompressed trailers"
-        );
-        let trailer_len = u32::from_be_bytes([
-            body[trailer_offset + 1],
-            body[trailer_offset + 2],
-            body[trailer_offset + 3],
-            body[trailer_offset + 4],
-        ]) as usize;
-        let trailer_end = trailer_offset + 5 + trailer_len;
-        let trailers = body
-            .get(trailer_offset + 5..trailer_end)
-            .expect("complete gRPC-Web trailer frame");
-        assert_eq!(
-            body.len(),
-            trailer_end,
-            "expected trailers to be the final gRPC-Web frame"
-        );
-        let trailers = std::str::from_utf8(trailers).expect("trailers are UTF-8");
-        assert!(
-            trailers.lines().any(|line| {
-                line.strip_prefix("grpc-status:")
-                    .is_some_and(|status| status.trim() == "0")
-            }),
-            "expected successful gRPC-Web trailer status, got {trailers:?}"
-        );
-        let event = <ImportSourceResponse as prost::Message>::decode(frame)
-            .expect("decode import source response")
+        let event = decode_grpc_web_response::<ImportSourceResponse>(&body)
             .event
             .expect("stream event");
         match event {

--- a/crates/coral-app/src/credentials/config.rs
+++ b/crates/coral-app/src/credentials/config.rs
@@ -62,4 +62,16 @@ storage = "file"
         .expect("config");
         assert_eq!(file.credentials.storage, CredentialStoragePreference::File);
     }
+
+    #[test]
+    fn parses_encryption_key_environment_variable() {
+        let file = toml::from_str::<CredentialStorageConfigFile>(
+            "[credentials]\nencryption_key_env = \"CORAL_CREDENTIAL_KEY\"",
+        )
+        .expect("config");
+        assert_eq!(
+            file.credentials.encryption_key_env.as_deref(),
+            Some("CORAL_CREDENTIAL_KEY")
+        );
+    }
 }

--- a/crates/coral-app/src/credentials/encryption_tests.rs
+++ b/crates/coral-app/src/credentials/encryption_tests.rs
@@ -427,6 +427,16 @@ fn local_file_key_provider_creates_and_reuses_private_key_file() {
     let provider = local_file_key_provider(&layout);
 
     let first = provider.active_key().expect("first key");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        std::fs::set_permissions(
+            layout.credential_encryption_key_file(),
+            std::fs::Permissions::from_mode(0o644),
+        )
+        .expect("make existing key permissive");
+    }
     let second = provider.active_key().expect("second key");
 
     assert_eq!(first, second);
@@ -434,6 +444,43 @@ fn local_file_key_provider_creates_and_reuses_private_key_file() {
         layout.credential_encryption_key_file().exists(),
         "provider should create durable key material outside the DB"
     );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let mode = std::fs::metadata(layout.credential_encryption_key_file())
+            .expect("key metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+}
+
+#[test]
+fn configured_only_key_provider_uses_injected_key_and_fails_closed_without_one() {
+    let temp = tempdir().expect("temp dir");
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+    layout.ensure().expect("ensure layout");
+    let configured_key = CredentialEncryptionKey::from_static_bytes_for_test([7; 32]);
+    let provider =
+        LocalFileCredentialKeyProvider::configured_key_only(&layout, Some(configured_key.clone()));
+
+    let active = provider.active_key().expect("configured active key");
+    assert_eq!(active, configured_key);
+    assert_eq!(provider.key(active.key_id()).expect("key by id"), active);
+    assert!(!layout.credential_encryption_key_file().exists());
+
+    let missing = LocalFileCredentialKeyProvider::configured_key_only(&layout, None);
+    assert!(matches!(
+        missing.active_key(),
+        Err(CredentialsError::Unavailable(_))
+    ));
+    assert!(matches!(
+        missing.key(active.key_id()),
+        Err(CredentialsError::Unavailable(_))
+    ));
+    assert!(!layout.credential_encryption_key_file().exists());
 }
 
 #[test]

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -9,6 +9,8 @@
 mod catalog_discovery_tests;
 #[path = "grpc/harness.rs"]
 mod harness;
+#[path = "grpc/identity_spec_tests.rs"]
+mod identity_spec_tests;
 #[path = "grpc/oauth_refresh_tests.rs"]
 mod oauth_refresh_tests;
 #[path = "grpc/resilience_tests.rs"]

--- a/crates/coral-app/tests/grpc/identity_spec_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_spec_tests.rs
@@ -1,0 +1,276 @@
+use coral_api::v1::{
+    AddIdentitySpecRequest, CreateWorkspaceRequest, DeleteIdentitySpecRequest,
+    GetIdentitySpecRequest, IdentitySpec, IdentitySpecInputValue, ListIdentitySpecsRequest,
+    Workspace,
+};
+use coral_api::{
+    CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND, CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND,
+};
+use coral_client::{
+    AppClient, IdentitySpecClient,
+    local::{RunningServer, ServerBuilder},
+};
+use tempfile::TempDir;
+use tonic::{Code, Request, Status};
+use tonic_types::{ErrorDetail, StatusExt as _};
+
+fn workspace(name: &str) -> Workspace {
+    Workspace {
+        name: name.to_string(),
+    }
+}
+
+fn oauth_manifest(name: &str, label: &str) -> String {
+    format!(
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: {label}\ndescription: OAuth {label}\nissuer: issuer_{label}\ntype: oauth\ninputs:\n  TENANT:\n    kind: variable\n    default: tenant-{label}\n  CLIENT_SECRET:\n    kind: secret\n    required: true\noauth:\n  method:\n    flow:\n      type: authorization_code\n      pkce: disabled\n    redirect_uri: http://127.0.0.1:53682/oauth/callback\n    endpoints:\n      authorization_url: https://provider.example.com/authorize\n      token_url: https://provider.example.com/token\n    client:\n      id:\n        input: TENANT\n      secret:\n        input: CLIENT_SECRET\n        transport: basic_auth\n"
+    )
+}
+
+async fn add_spec(
+    client: &mut IdentitySpecClient,
+    manifest_yaml: String,
+    secret: &str,
+    workspace: Option<Workspace>,
+) -> coral_api::v1::AddIdentitySpecResponse {
+    client
+        .add_identity_spec(Request::new(AddIdentitySpecRequest {
+            manifest_yaml,
+            input_values: vec![IdentitySpecInputValue {
+                key: "CLIENT_SECRET".to_string(),
+                value: secret.to_string(),
+            }],
+            workspace,
+        }))
+        .await
+        .expect("add identity spec")
+        .into_inner()
+}
+
+fn assert_spec(spec: &IdentitySpec, manifest_yaml: &str, label: &str, scope: Option<&str>) {
+    assert_eq!(spec.name, "shared");
+    assert_eq!(spec.version, label);
+    assert_eq!(spec.description, format!("OAuth {label}"));
+    assert_eq!(spec.issuer, format!("issuer_{label}"));
+    assert_eq!(spec.identity_type, "oauth");
+    assert_eq!(spec.manifest_yaml, manifest_yaml);
+    assert_eq!(
+        spec.workspace.as_ref().map(|value| value.name.as_str()),
+        scope
+    );
+}
+
+fn assert_error_reason(status: &Status, expected: &str) {
+    let reason = status
+        .get_error_details_vec()
+        .into_iter()
+        .find_map(|detail| match detail {
+            ErrorDetail::ErrorInfo(info) => Some(info.reason),
+            _ => None,
+        });
+    assert_eq!(reason.as_deref(), Some(expected));
+}
+
+async fn start_server(config_dir: &std::path::Path) -> (RunningServer, AppClient) {
+    let server = ServerBuilder::new()
+        .with_config_dir(config_dir)
+        .start()
+        .await
+        .expect("start server");
+    let app = AppClient::connect(server.endpoint_uri())
+        .await
+        .expect("connect client");
+    (server, app)
+}
+
+async fn seed_scoped_specs(
+    config_dir: &std::path::Path,
+    work: &Workspace,
+    global_v1: &str,
+    workspace_v1: &str,
+) {
+    let (server, app) = start_server(config_dir).await;
+    app.workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(work.clone()),
+        }))
+        .await
+        .expect("create workspace");
+    let global = add_spec(
+        &mut app.identity_spec_client(),
+        global_v1.to_string(),
+        "global-secret",
+        None,
+    )
+    .await;
+    assert!(!global.replaced);
+    assert_spec(
+        global.identity_spec.as_ref().expect("global spec"),
+        global_v1,
+        "global_v1",
+        None,
+    );
+    let scoped = add_spec(
+        &mut app.identity_spec_client(),
+        workspace_v1.to_string(),
+        "workspace-secret",
+        Some(work.clone()),
+    )
+    .await;
+    assert!(!scoped.replaced);
+    assert_spec(
+        scoped.identity_spec.as_ref().expect("workspace spec"),
+        workspace_v1,
+        "workspace_v1",
+        Some("work"),
+    );
+    server.shutdown().await.expect("shutdown first server");
+}
+
+async fn assert_replacement_and_lists(
+    client: &mut IdentitySpecClient,
+    work: &Workspace,
+    global_v2: &str,
+    workspace_v1: &str,
+) {
+    let replaced = add_spec(client, global_v2.to_string(), "  ", None).await;
+    assert!(replaced.replaced);
+    assert_spec(
+        replaced.identity_spec.as_ref().expect("replaced spec"),
+        global_v2,
+        "global_v2",
+        None,
+    );
+
+    let globals = client
+        .list_identity_specs(Request::new(ListIdentitySpecsRequest::default()))
+        .await
+        .expect("list global specs")
+        .into_inner()
+        .identity_specs;
+    assert_eq!(globals.len(), 1);
+    assert_spec(
+        globals.first().expect("one global spec"),
+        global_v2,
+        "global_v2",
+        None,
+    );
+
+    let exact_global = client
+        .get_identity_spec(Request::new(GetIdentitySpecRequest {
+            name: "shared".to_string(),
+            workspace: None,
+        }))
+        .await
+        .expect("get exact global spec")
+        .into_inner()
+        .identity_spec
+        .expect("global spec");
+    assert_spec(&exact_global, global_v2, "global_v2", None);
+
+    let workspace_only = client
+        .list_identity_specs(Request::new(ListIdentitySpecsRequest {
+            workspace: Some(work.clone()),
+            include_global: false,
+        }))
+        .await
+        .expect("list workspace specs")
+        .into_inner()
+        .identity_specs;
+    assert_eq!(workspace_only.len(), 1);
+    assert_spec(
+        workspace_only.first().expect("one workspace spec"),
+        workspace_v1,
+        "workspace_v1",
+        Some("work"),
+    );
+
+    let combined = client
+        .list_identity_specs(Request::new(ListIdentitySpecsRequest {
+            workspace: Some(work.clone()),
+            include_global: true,
+        }))
+        .await
+        .expect("list workspace and global specs")
+        .into_inner()
+        .identity_specs;
+    assert_eq!(combined.len(), 2);
+    assert_spec(
+        combined.first().expect("global entry"),
+        global_v2,
+        "global_v2",
+        None,
+    );
+    assert_spec(
+        combined.get(1).expect("workspace entry"),
+        workspace_v1,
+        "workspace_v1",
+        Some("work"),
+    );
+}
+
+async fn assert_exact_delete_contract(
+    client: &mut IdentitySpecClient,
+    work: &Workspace,
+    workspace_v1: &str,
+) {
+    let exact = client
+        .get_identity_spec(Request::new(GetIdentitySpecRequest {
+            name: "shared".to_string(),
+            workspace: Some(work.clone()),
+        }))
+        .await
+        .expect("get exact workspace spec")
+        .into_inner()
+        .identity_spec
+        .expect("workspace spec");
+    assert_spec(&exact, workspace_v1, "workspace_v1", Some("work"));
+
+    let deleted = client
+        .delete_identity_spec(Request::new(DeleteIdentitySpecRequest {
+            name: "shared".to_string(),
+            workspace: Some(work.clone()),
+            force: false,
+        }))
+        .await
+        .expect("delete workspace spec")
+        .into_inner();
+    assert_eq!(deleted.orphaned_identities, 0);
+
+    let missing_exact = client
+        .get_identity_spec(Request::new(GetIdentitySpecRequest {
+            name: "shared".to_string(),
+            workspace: Some(work.clone()),
+        }))
+        .await
+        .expect_err("workspace lookup must not fall back to global");
+    assert_eq!(missing_exact.code(), Code::NotFound);
+    assert_error_reason(&missing_exact, CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND);
+
+    let missing_workspace = client
+        .list_identity_specs(Request::new(ListIdentitySpecsRequest {
+            workspace: Some(workspace("missing")),
+            include_global: true,
+        }))
+        .await
+        .expect_err("missing workspace should fail");
+    assert_eq!(missing_workspace.code(), Code::NotFound);
+    assert_error_reason(&missing_workspace, CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND);
+}
+
+#[tokio::test]
+async fn identity_spec_service_preserves_exact_scopes_and_inputs_across_restart() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let work = workspace("work");
+    let global_v1 = oauth_manifest("shared", "global_v1");
+    let global_v2 = oauth_manifest("shared", "global_v2");
+    let workspace_v1 = oauth_manifest("shared", "workspace_v1");
+
+    seed_scoped_specs(&config_dir, &work, &global_v1, &workspace_v1).await;
+    let (server, app) = start_server(&config_dir).await;
+    let mut client = app.identity_spec_client();
+    assert_replacement_and_lists(&mut client, &work, &global_v2, &workspace_v1).await;
+    assert_exact_delete_contract(&mut client, &work, &workspace_v1).await;
+
+    server.shutdown().await.expect("shutdown restarted server");
+}

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -8,11 +8,12 @@
 
 use std::fs;
 
-use coral_api::v1::ListSourcesRequest;
+use coral_api::v1::{AddIdentitySpecRequest, ListIdentitySpecsRequest, ListSourcesRequest};
 use coral_client::{
     AppClient, default_workspace,
     local::{LocalServerError, ServerBuilder},
 };
+use prost::Message as _;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use tonic::Request;
@@ -46,6 +47,56 @@ async fn server_lifecycle_can_repeat_within_process() {
 
         server.shutdown().await.expect("shutdown server");
     }
+}
+
+#[tokio::test]
+async fn identity_spec_list_response_above_tonic_default_round_trips_real_route() {
+    const TONIC_DEFAULT_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
+    const DESCRIPTION_SIZE: usize = TONIC_DEFAULT_MESSAGE_SIZE / 4 + 64 * 1024;
+
+    let temp = TempDir::new().expect("temp dir");
+    let server = ServerBuilder::new()
+        .with_config_dir(temp.path().join("coral-config"))
+        .start()
+        .await
+        .expect("start server");
+    let app = AppClient::connect(server.endpoint_uri())
+        .await
+        .expect("connect client");
+    let mut client = app.identity_spec_client();
+
+    for index in 0..2 {
+        let manifest_yaml = format!(
+            "kind: identity\nspec_version: 1\nname: large_{index}\nversion: 0.1.0\ndescription: {}\nissuer: fixture\ntype: fixed_token\n",
+            "x".repeat(DESCRIPTION_SIZE)
+        );
+        let added = client
+            .add_identity_spec(Request::new(AddIdentitySpecRequest {
+                manifest_yaml,
+                input_values: Vec::new(),
+                workspace: None,
+            }))
+            .await
+            .expect("add large identity spec")
+            .into_inner();
+        assert!(
+            added.encoded_len() < TONIC_DEFAULT_MESSAGE_SIZE,
+            "one response should remain below tonic's default limit"
+        );
+    }
+
+    let listed = client
+        .list_identity_specs(Request::new(ListIdentitySpecsRequest::default()))
+        .await
+        .expect("list large identity specs")
+        .into_inner();
+    assert_eq!(listed.identity_specs.len(), 2);
+    assert!(
+        listed.encoded_len() > TONIC_DEFAULT_MESSAGE_SIZE,
+        "real route should return an aggregate response above tonic's default limit"
+    );
+
+    server.shutdown().await.expect("shutdown server");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Intent

Pin the public IdentitySpecService behavior introduced by B2d at real native gRPC and gRPC-Web boundaries, including restart and encryption-key transitions.

## What it enables

- Verifies global, workspace-only, and workspace-plus-global listing while preserving each returned scope.
- Proves exact get/delete behavior never falls back from a deleted workspace spec to a same-name global spec.
- Exercises encrypted setup-input carryover across a deterministic server restart.
- Confirms configured-only KEK providers fail closed after configuration removal without creating a local fallback key.
- Proves aggregate identity-spec responses above the tonic 4 MiB default traverse the configured real route.
- Decodes gRPC-Web data and trailer frames to verify the identity-spec service is mounted and returns grpc-status 0.

## Usage examples

Run the focused service contracts:

```shell
cargo test --locked -p coral-app --all-features --test grpc identity_spec_
cargo test --locked -p coral-app --all-features --lib configured_only_key_provider_fails_closed_after_config_removal
cargo test --locked -p coral-app --all-features --lib embedded_ui_server_accepts_browser_requests_and_rejects_native_grpc
```

## Validation

- `make rust-checks` — 1,695 passed, 3 skipped; formatting, Clippy, and rustdoc clean
- Full app gRPC integration suite — 90 passed
- Focused native lifecycle, restart, large-response, gRPC-Web, and configured-key tests
- Full five-lane review swarm, one accepted P2 test-coverage fix, and clean exact-final correctness/tests/security rerun
- Final supervisor missed-risk sweep found no additional P1/P2 at 0.99 confidence

PR size: 491 changed lines.