### PR TITLE
feat(api): add workspace identity contracts

### DIFF
--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -30,6 +30,12 @@ message Identity {
   IdentityOwner owner = 5;
   // Safe provider metadata, never token material.
   repeated CredentialMetadata metadata = 6;
+  // Workspace that owns this identity. Absent for user-owned identities.
+  Workspace owner_workspace = 7;
+  // Exact workspace scope of the referenced identity spec. Absent when the
+  // identity references a global spec, including workspace-owned identities
+  // that resolved through global fallback.
+  Workspace identity_spec_workspace = 8;
 }
 
 // Creates or replaces one identity owned by the request Coral user principal.
@@ -118,6 +124,78 @@ message DeleteUserOwnedIdentityRequest {
 // Confirms user-owned identity deletion.
 message DeleteUserOwnedIdentityResponse {}
 
+// Creates or replaces one identity owned by a workspace.
+message CreateWorkspaceOwnedIdentityRequest {
+  // Workspace that owns the stored identity material.
+  Workspace workspace = 1;
+  // Stable identity name used by source identity bindings.
+  string name = 2;
+  // Identity spec name resolved from the workspace scope with global fallback.
+  string identity_spec = 3;
+
+  // Type-specific setup material.
+  oneof setup {
+    // Fixed-token identity setup input.
+    FixedTokenWorkspaceOwnedIdentitySetup fixed_token = 4;
+  }
+}
+
+// Setup payload for a workspace-owned fixed-token identity.
+message FixedTokenWorkspaceOwnedIdentitySetup {
+  // Bearer token to store for this identity.
+  string token = 1;
+}
+
+// Streaming event emitted while creating a workspace-owned identity.
+message CreateWorkspaceOwnedIdentityResponse {
+  // Creation progress or completion event.
+  oneof event {
+    // Identity creation completed.
+    Identity identity = 1;
+    // OAuth authorization URL is ready.
+    IdentityOAuthAuthorization oauth_authorization = 2;
+    // OAuth credential retrieval completed.
+    IdentityOAuthCompleted oauth_completed = 3;
+  }
+}
+
+// Lists identities owned by one workspace.
+message ListWorkspaceOwnedIdentitiesRequest {
+  // Workspace that owns the stored identities.
+  Workspace workspace = 1;
+}
+
+// Returns workspace-owned identities sorted by name.
+message ListWorkspaceOwnedIdentitiesResponse {
+  // Stored workspace-owned identities.
+  repeated Identity identities = 1;
+}
+
+// Fetches one identity owned by a workspace.
+message GetWorkspaceOwnedIdentityRequest {
+  // Workspace that owns the stored identity.
+  Workspace workspace = 1;
+  // Stored identity name.
+  string name = 2;
+}
+
+// Returns one workspace-owned identity.
+message GetWorkspaceOwnedIdentityResponse {
+  // Stored identity.
+  Identity identity = 1;
+}
+
+// Deletes one identity owned by a workspace.
+message DeleteWorkspaceOwnedIdentityRequest {
+  // Workspace that owns the stored identity.
+  Workspace workspace = 1;
+  // Stored identity name.
+  string name = 2;
+}
+
+// Confirms workspace-owned identity deletion.
+message DeleteWorkspaceOwnedIdentityResponse {}
+
 // Stored identity APIs.
 service IdentityService {
   // Creates or replaces one identity owned by the request Coral user principal.
@@ -128,4 +206,16 @@ service IdentityService {
   rpc GetUserOwnedIdentity(GetUserOwnedIdentityRequest) returns (GetUserOwnedIdentityResponse);
   // Deletes one user-owned identity.
   rpc DeleteUserOwnedIdentity(DeleteUserOwnedIdentityRequest) returns (DeleteUserOwnedIdentityResponse);
+}
+
+// Workspace-owned stored identity APIs.
+service WorkspaceIdentityService {
+  // Creates or replaces one identity owned by a workspace.
+  rpc CreateWorkspaceOwnedIdentity(CreateWorkspaceOwnedIdentityRequest) returns (stream CreateWorkspaceOwnedIdentityResponse);
+  // Lists identities owned by one workspace.
+  rpc ListWorkspaceOwnedIdentities(ListWorkspaceOwnedIdentitiesRequest) returns (ListWorkspaceOwnedIdentitiesResponse);
+  // Fetches one identity owned by a workspace.
+  rpc GetWorkspaceOwnedIdentity(GetWorkspaceOwnedIdentityRequest) returns (GetWorkspaceOwnedIdentityResponse);
+  // Deletes one identity owned by a workspace.
+  rpc DeleteWorkspaceOwnedIdentity(DeleteWorkspaceOwnedIdentityRequest) returns (DeleteWorkspaceOwnedIdentityResponse);
 }

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -68,6 +68,12 @@ pub const SOURCE_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE
 /// 4 MB default.
 pub const IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE_SIZE;
 
+/// Maximum gRPC message size for stored-identity service *responses*, in bytes.
+///
+/// Identity listing is currently unpaginated and may aggregate safe provider
+/// metadata for many stored identities beyond tonic's 4 MB default.
+pub const IDENTITY_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE_SIZE;
+
 /// Maximum gRPC message size for `SearchService` *responses*, in bytes.
 ///
 /// Universal Search returns bounded metadata hints, but it may include table,
@@ -113,6 +119,9 @@ pub const CORAL_ERROR_REASON_SOURCE_NOT_FOUND: &str = "SOURCE_NOT_FOUND";
 
 /// Machine-readable reason for an installed identity-spec lookup miss.
 pub const CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND: &str = "IDENTITY_SPEC_NOT_FOUND";
+
+/// Machine-readable reason for a stored-identity lookup miss.
+pub const CORAL_ERROR_REASON_IDENTITY_NOT_FOUND: &str = "IDENTITY_NOT_FOUND";
 
 /// Machine-readable reason for a configured workspace lookup miss.
 pub const CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND: &str = "WORKSPACE_NOT_FOUND";

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -8,11 +8,13 @@ use coral_api::v1::identity_spec_service_client::IdentitySpecServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::search_service_client::SearchServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
+use coral_api::v1::workspace_identity_service_client::WorkspaceIdentityServiceClient;
 use coral_api::v1::workspace_service_client::WorkspaceServiceClient;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE,
-    IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
-    SEARCH_RESPONSE_MAX_MESSAGE_SIZE, SOURCE_RESPONSE_MAX_MESSAGE_SIZE,
+    IDENTITY_RESPONSE_MAX_MESSAGE_SIZE, IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE,
+    QUERY_RESPONSE_MAX_MESSAGE_SIZE, SEARCH_RESPONSE_MAX_MESSAGE_SIZE,
+    SOURCE_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint};
@@ -53,6 +55,9 @@ pub type IdentitySpecClient = IdentitySpecServiceClient<GrpcService>;
 /// Public stored-identity gRPC client.
 pub type IdentityClient = IdentityServiceClient<GrpcService>;
 
+/// Public workspace-owned stored-identity gRPC client.
+pub type WorkspaceIdentityClient = WorkspaceIdentityServiceClient<GrpcService>;
+
 /// Public catalog-discovery gRPC client.
 pub type CatalogClient = CatalogServiceClient<GrpcService>;
 
@@ -74,6 +79,7 @@ pub struct AppClient {
     workspace: WorkspaceClient,
     identity_spec: IdentitySpecClient,
     identity: IdentityClient,
+    workspace_identity: WorkspaceIdentityClient,
     catalog: CatalogClient,
     query: QueryClient,
     search: SearchClient,
@@ -100,7 +106,11 @@ impl AppClient {
         let identity_spec_client =
             IdentitySpecClient::new(grpc_service(channel.clone(), &grpc_endpoint))
                 .max_decoding_message_size(IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE);
-        let identity_client = IdentityClient::new(grpc_service(channel.clone(), &grpc_endpoint));
+        let identity_client = IdentityClient::new(grpc_service(channel.clone(), &grpc_endpoint))
+            .max_decoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE);
+        let workspace_identity_client =
+            WorkspaceIdentityClient::new(grpc_service(channel.clone(), &grpc_endpoint))
+                .max_decoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE);
         let catalog_client = CatalogClient::new(grpc_service(channel.clone(), &grpc_endpoint))
             .max_decoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE);
         let query_client = QueryClient::new(grpc_service(channel.clone(), &grpc_endpoint))
@@ -113,6 +123,7 @@ impl AppClient {
             workspace: workspace_client,
             identity_spec: identity_spec_client,
             identity: identity_client,
+            workspace_identity: workspace_identity_client,
             catalog: catalog_client,
             query: query_client,
             search: search_client,
@@ -142,6 +153,12 @@ impl AppClient {
     /// Returns a cloned stored-identity client.
     pub fn identity_client(&self) -> IdentityClient {
         self.identity.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned workspace-owned stored-identity client.
+    pub fn workspace_identity_client(&self) -> WorkspaceIdentityClient {
+        self.workspace_identity.clone()
     }
 
     #[must_use]
@@ -178,15 +195,27 @@ fn grpc_service(channel: Channel, endpoint: &GrpcClientEndpoint) -> GrpcService 
 
 #[cfg(test)]
 mod tests {
-    use coral_api::IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE;
+    use coral_api::v1::identity_service_server::{IdentityService, IdentityServiceServer};
     use coral_api::v1::identity_spec_service_server::{
         IdentitySpecService, IdentitySpecServiceServer,
     };
-    use coral_api::v1::{
-        AddIdentitySpecRequest, AddIdentitySpecResponse, DeleteIdentitySpecRequest,
-        DeleteIdentitySpecResponse, GetIdentitySpecRequest, GetIdentitySpecResponse, IdentitySpec,
-        ListIdentitySpecsRequest, ListIdentitySpecsResponse,
+    use coral_api::v1::workspace_identity_service_server::{
+        WorkspaceIdentityService, WorkspaceIdentityServiceServer,
     };
+    use coral_api::v1::{
+        AddIdentitySpecRequest, AddIdentitySpecResponse, CreateUserOwnedIdentityRequest,
+        CreateUserOwnedIdentityResponse, CreateWorkspaceOwnedIdentityRequest,
+        CreateWorkspaceOwnedIdentityResponse, CredentialMetadata, DeleteIdentitySpecRequest,
+        DeleteIdentitySpecResponse, DeleteUserOwnedIdentityRequest,
+        DeleteUserOwnedIdentityResponse, DeleteWorkspaceOwnedIdentityRequest,
+        DeleteWorkspaceOwnedIdentityResponse, GetIdentitySpecRequest, GetIdentitySpecResponse,
+        GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse,
+        GetWorkspaceOwnedIdentityRequest, GetWorkspaceOwnedIdentityResponse, Identity,
+        IdentitySpec, ListIdentitySpecsRequest, ListIdentitySpecsResponse,
+        ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse,
+        ListWorkspaceOwnedIdentitiesRequest, ListWorkspaceOwnedIdentitiesResponse, Workspace,
+    };
+    use coral_api::{IDENTITY_RESPONSE_MAX_MESSAGE_SIZE, IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE};
     use tokio::net::TcpListener;
     use tokio_stream::wrappers::TcpListenerStream;
     use tonic::transport::Server;
@@ -200,6 +229,9 @@ mod tests {
 
     #[derive(Debug)]
     struct LargeIdentitySpecFixture;
+
+    #[derive(Debug)]
+    struct LargeIdentityFixture;
 
     #[tonic::async_trait]
     impl IdentitySpecService for LargeIdentitySpecFixture {
@@ -237,6 +269,104 @@ mod tests {
         ) -> Result<Response<DeleteIdentitySpecResponse>, Status> {
             Err(Status::unimplemented("fixture only supports listing"))
         }
+    }
+
+    fn large_identities() -> Vec<Identity> {
+        (0..SPEC_COUNT)
+            .map(|index| Identity {
+                name: format!("large-{index}"),
+                metadata: vec![CredentialMetadata {
+                    key: "provider_metadata".to_string(),
+                    value: "x".repeat(MANIFEST_SIZE),
+                }],
+                ..Identity::default()
+            })
+            .collect()
+    }
+
+    #[tonic::async_trait]
+    impl IdentityService for LargeIdentityFixture {
+        type CreateUserOwnedIdentityStream =
+            tokio_stream::Empty<Result<CreateUserOwnedIdentityResponse, Status>>;
+
+        async fn create_user_owned_identity(
+            &self,
+            _request: Request<CreateUserOwnedIdentityRequest>,
+        ) -> Result<Response<Self::CreateUserOwnedIdentityStream>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+
+        async fn list_user_owned_identities(
+            &self,
+            _request: Request<ListUserOwnedIdentitiesRequest>,
+        ) -> Result<Response<ListUserOwnedIdentitiesResponse>, Status> {
+            Ok(Response::new(ListUserOwnedIdentitiesResponse {
+                identities: large_identities(),
+            }))
+        }
+
+        async fn get_user_owned_identity(
+            &self,
+            _request: Request<GetUserOwnedIdentityRequest>,
+        ) -> Result<Response<GetUserOwnedIdentityResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+
+        async fn delete_user_owned_identity(
+            &self,
+            _request: Request<DeleteUserOwnedIdentityRequest>,
+        ) -> Result<Response<DeleteUserOwnedIdentityResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+    }
+
+    #[tonic::async_trait]
+    impl WorkspaceIdentityService for LargeIdentityFixture {
+        type CreateWorkspaceOwnedIdentityStream =
+            tokio_stream::Empty<Result<CreateWorkspaceOwnedIdentityResponse, Status>>;
+
+        async fn create_workspace_owned_identity(
+            &self,
+            _request: Request<CreateWorkspaceOwnedIdentityRequest>,
+        ) -> Result<Response<Self::CreateWorkspaceOwnedIdentityStream>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+
+        async fn list_workspace_owned_identities(
+            &self,
+            _request: Request<ListWorkspaceOwnedIdentitiesRequest>,
+        ) -> Result<Response<ListWorkspaceOwnedIdentitiesResponse>, Status> {
+            Ok(Response::new(ListWorkspaceOwnedIdentitiesResponse {
+                identities: large_identities(),
+            }))
+        }
+
+        async fn get_workspace_owned_identity(
+            &self,
+            _request: Request<GetWorkspaceOwnedIdentityRequest>,
+        ) -> Result<Response<GetWorkspaceOwnedIdentityResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+
+        async fn delete_workspace_owned_identity(
+            &self,
+            _request: Request<DeleteWorkspaceOwnedIdentityRequest>,
+        ) -> Result<Response<DeleteWorkspaceOwnedIdentityResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+    }
+
+    fn assert_large_identity_aggregate(identities: &[Identity]) {
+        assert_eq!(identities.len(), SPEC_COUNT);
+        let metadata_bytes = identities.iter().fold(0, |bytes, identity| {
+            let metadata = identity
+                .metadata
+                .first()
+                .expect("large identity fixture has provider metadata");
+            assert!(metadata.value.len() < TONIC_DEFAULT_MAX_MESSAGE_SIZE);
+            bytes + metadata.value.len()
+        });
+        assert!(metadata_bytes > TONIC_DEFAULT_MAX_MESSAGE_SIZE);
     }
 
     #[tokio::test]
@@ -278,6 +408,52 @@ mod tests {
             .map(|spec| spec.manifest_yaml.len())
             .sum::<usize>();
         assert!(manifest_bytes > TONIC_DEFAULT_MAX_MESSAGE_SIZE);
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn app_client_decodes_large_aggregates_for_both_identity_services() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind identity fixture");
+        let address = listener.local_addr().expect("read fixture address");
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .add_service(
+                    IdentityServiceServer::new(LargeIdentityFixture)
+                        .max_encoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE),
+                )
+                .add_service(
+                    WorkspaceIdentityServiceServer::new(LargeIdentityFixture)
+                        .max_encoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE),
+                )
+                .serve_with_incoming(TcpListenerStream::new(listener))
+                .await
+        });
+
+        let app_client = AppClient::connect(&format!("http://{address}"))
+            .await
+            .expect("connect AppClient to identity fixture");
+        let user_response = app_client
+            .identity_client()
+            .list_user_owned_identities(ListUserOwnedIdentitiesRequest {})
+            .await
+            .expect("decode user identity response through AppClient")
+            .into_inner();
+        assert_large_identity_aggregate(&user_response.identities);
+
+        let workspace_response = app_client
+            .workspace_identity_client()
+            .list_workspace_owned_identities(ListWorkspaceOwnedIdentitiesRequest {
+                workspace: Some(Workspace {
+                    name: "work".to_string(),
+                }),
+            })
+            .await
+            .expect("decode workspace identity response through AppClient")
+            .into_inner();
+        assert_large_identity_aggregate(&workspace_response.identities);
 
         server.abort();
     }

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -43,7 +43,7 @@ use serde_json::Value;
 pub use client::{
     AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, IdentityClient,
     IdentitySpecClient, QueryClient, SearchClient, SourceClient, WorkspaceClient,
-    default_workspace, workspace,
+    WorkspaceIdentityClient, default_workspace, workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use search::{


### PR DESCRIPTION
## Intent

Add the transport contract for workspace-owned identities without changing the existing user-owned identity RPCs. This is the first bounded B4 slice above #1673 and keeps identity ownership and the exact resolved identity-spec scope explicit on the wire.

## What it enables

- A separate `WorkspaceIdentityService` with streaming Create plus List/Get/Delete operations.
- Workspace-owned responses that distinguish the owner workspace from the exact workspace-scoped spec; an absent spec workspace represents a pinned global fallback.
- A generated `WorkspaceIdentityClient` on `AppClient`.
- 64 MiB aggregate-response decoding for both user-owned and workspace-owned identity clients.
- A stable `IDENTITY_NOT_FOUND` error reason for the later service implementation.

This PR is contract/client-only: it does not mount the new service or persist identity material.

## Usage examples

- Obtain the generated client with `AppClient::workspace_identity_client()`.
- Create a fixed-token identity by sending `CreateWorkspaceOwnedIdentityRequest` with the owner workspace, identity name, identity-spec name, and `fixed_token` setup.
- Consume the streaming response using the same identity/OAuth event envelope as the user-owned create RPC.
- List or fetch workspace-owned identities and inspect `owner_workspace`; inspect `identity_spec_workspace` to distinguish a workspace definition from global fallback.

## Validation

- `make lint-proto`
- `cargo test --locked -p coral-api`
- `cargo test --locked -p coral-client client::tests::` — 2 passed
- `make rust-checks` — formatting, Clippy, 1,696/1,696 tests, and rustdoc passed; 3 tests intentionally skipped
- Exact-final review swarm — 0 findings; 5 coverage lanes; 3 credential-flow rows; supervisor missed-risk sweep complete
- Diff size — 291 changed lines

## Draft dependency

Keep this PR and every descendant draft. Before any identity service becomes ready or begins credential-bearing remote operations, the separately owned `AppClient` transport gate must reject non-loopback cleartext endpoints. This PR intentionally does not modify that parallel stack.
