### PR TITLE
feat(app): add identity persistence schema

### DIFF
--- a/crates/coral-app/migrations/0011_identities.sql
+++ b/crates/coral-app/migrations/0011_identities.sql
@@ -1,0 +1,76 @@
+CREATE TABLE IF NOT EXISTS identities (
+    owner_kind TEXT NOT NULL,
+    owner_key TEXT NOT NULL,
+    workspace_id TEXT,
+    name TEXT NOT NULL,
+    identity_spec_scope_kind TEXT NOT NULL,
+    identity_spec_scope_id TEXT NOT NULL,
+    identity_spec_name TEXT NOT NULL,
+    identity_spec_fingerprint TEXT NOT NULL,
+    issuer TEXT NOT NULL,
+    identity_type TEXT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (owner_kind, owner_key, name),
+    CHECK (
+        (
+            owner_kind = 'user'
+            AND workspace_id IS NULL
+        )
+        OR (
+            owner_kind = 'workspace'
+            AND workspace_id IS NOT NULL
+            AND owner_key = workspace_id
+        )
+    ),
+    CHECK (
+        (
+            owner_kind = 'user'
+            AND identity_spec_scope_kind = 'global'
+            AND identity_spec_scope_id = '__global__'
+        )
+        OR (
+            owner_kind = 'workspace'
+            AND (
+                (
+                    identity_spec_scope_kind = 'global'
+                    AND identity_spec_scope_id = '__global__'
+                )
+                OR (
+                    identity_spec_scope_kind = 'workspace'
+                    AND identity_spec_scope_id = workspace_id
+                )
+            )
+        )
+    ),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS identities_workspace_id_idx
+    ON identities (workspace_id);
+
+CREATE INDEX IF NOT EXISTS identities_identity_spec_idx
+    ON identities (
+        identity_spec_scope_kind,
+        identity_spec_scope_id,
+        identity_spec_name,
+        identity_spec_fingerprint
+    );
+
+CREATE TABLE IF NOT EXISTS identity_documents (
+    owner_kind TEXT NOT NULL,
+    owner_key TEXT NOT NULL,
+    name TEXT NOT NULL,
+    document_version BIGINT NOT NULL,
+    ciphertext BYTEA NOT NULL,
+    nonce BYTEA NOT NULL,
+    wrapped_dek BYTEA NOT NULL,
+    wrapped_dek_nonce BYTEA NOT NULL,
+    key_id TEXT NOT NULL,
+    algorithm TEXT NOT NULL,
+    aad_version BIGINT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (owner_kind, owner_key, name),
+    FOREIGN KEY (owner_kind, owner_key, name) REFERENCES identities(owner_kind, owner_key, name) ON DELETE CASCADE
+);

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -1,0 +1,3 @@
+//! App-owned identity instance domain types.
+
+pub(crate) mod model;

--- a/crates/coral-app/src/identities/model.rs
+++ b/crates/coral-app/src/identities/model.rs
@@ -1,0 +1,246 @@
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Identity persistence consumers land in the next stack units."
+    )
+)]
+
+use std::fmt;
+
+use crate::bootstrap::AppError;
+use crate::identity::{UserPrincipal, parse_path_segment};
+use crate::state::db::{IdentitySpecKey, IdentitySpecScope};
+use crate::workspaces::WorkspaceName;
+
+const USER_OWNER_KIND: &str = "user";
+const WORKSPACE_OWNER_KIND: &str = "workspace";
+
+/// Validated name of one identity instance within an owner.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct IdentityName(String);
+
+impl IdentityName {
+    /// Parse and normalize an identity name.
+    pub(crate) fn parse(name: &str) -> Result<Self, AppError> {
+        parse_path_segment("identity", name).map(Self)
+    }
+
+    /// Borrow the normalized identity name.
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for IdentityName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// User or workspace that owns one identity instance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum IdentityOwner {
+    User(UserPrincipal),
+    Workspace(WorkspaceName),
+}
+
+impl IdentityOwner {
+    /// Build a user owner from an already validated request principal.
+    pub(crate) fn for_user(principal: UserPrincipal) -> Self {
+        Self::User(principal)
+    }
+
+    /// Build a workspace owner from an already validated workspace name.
+    pub(crate) fn workspace(workspace: WorkspaceName) -> Self {
+        Self::Workspace(workspace)
+    }
+
+    /// Storage discriminator for this owner.
+    pub(crate) fn kind(&self) -> &'static str {
+        match self {
+            Self::User(_) => USER_OWNER_KIND,
+            Self::Workspace(_) => WORKSPACE_OWNER_KIND,
+        }
+    }
+
+    /// Stable storage key within the owner kind.
+    pub(crate) fn key(&self) -> &str {
+        match self {
+            Self::User(principal) => principal.user_id(),
+            Self::Workspace(workspace) => workspace.as_str(),
+        }
+    }
+
+    /// Workspace foreign-key value, absent for user-owned identities.
+    pub(crate) fn workspace_name(&self) -> Option<&WorkspaceName> {
+        match self {
+            Self::User(_) => None,
+            Self::Workspace(workspace) => Some(workspace),
+        }
+    }
+}
+
+/// Exact identity-spec version selected when an identity is written.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IdentitySpecReference {
+    key: IdentitySpecKey,
+    fingerprint: String,
+    issuer: String,
+    identity_type: String,
+}
+
+impl IdentitySpecReference {
+    /// Validate an exact spec reference against the identity owner.
+    pub(crate) fn new(
+        owner: &IdentityOwner,
+        key: IdentitySpecKey,
+        fingerprint: impl Into<String>,
+        issuer: impl Into<String>,
+        identity_type: impl Into<String>,
+    ) -> Result<Self, AppError> {
+        validate_scope(owner, key.scope())?;
+        let reference = Self {
+            key,
+            fingerprint: fingerprint.into(),
+            issuer: issuer.into(),
+            identity_type: identity_type.into(),
+        };
+        for (field, value) in [
+            ("identity spec fingerprint", reference.fingerprint.as_str()),
+            ("identity spec issuer", reference.issuer.as_str()),
+            ("identity spec type", reference.identity_type.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                return Err(AppError::InvalidInput(format!("missing {field}")));
+            }
+        }
+        Ok(reference)
+    }
+
+    pub(crate) fn key(&self) -> &IdentitySpecKey {
+        &self.key
+    }
+
+    pub(crate) fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    pub(crate) fn issuer(&self) -> &str {
+        &self.issuer
+    }
+
+    pub(crate) fn identity_type(&self) -> &str {
+        &self.identity_type
+    }
+}
+
+fn validate_scope(owner: &IdentityOwner, scope: &IdentitySpecScope) -> Result<(), AppError> {
+    let valid = match (owner, scope) {
+        (_, IdentitySpecScope::Global) => true,
+        (IdentityOwner::Workspace(owner), IdentitySpecScope::Workspace(spec)) => owner == spec,
+        (IdentityOwner::User(_), IdentitySpecScope::Workspace(_)) => false,
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(AppError::InvalidInput(
+            "identity spec scope is incompatible with its owner".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IdentityName, IdentityOwner, IdentitySpecReference};
+    use crate::identity::UserPrincipal;
+    use crate::state::db::IdentitySpecKey;
+    use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn identity_names_are_safe_normalized_and_orderable() {
+        let alpha = IdentityName::parse("  alpha  ").expect("normalized name");
+        let beta = IdentityName::parse("beta").expect("second name");
+        assert_eq!(alpha.as_str(), "alpha");
+        assert_eq!(alpha.to_string(), "alpha");
+        assert!(alpha < beta);
+        for invalid in ["", "  ", ".", "..", "bad/name", r"bad\name"] {
+            assert!(
+                IdentityName::parse(invalid).is_err(),
+                "accepted {invalid:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn owners_expose_stable_storage_values() {
+        let local = IdentityOwner::for_user(UserPrincipal::local());
+        assert_eq!((local.kind(), local.key()), ("user", "local"));
+        assert!(local.workspace_name().is_none());
+
+        let user = IdentityOwner::for_user(UserPrincipal::for_user("member-1").expect("user"));
+        assert_eq!((user.kind(), user.key()), ("user", "member-1"));
+
+        let workspace = WorkspaceName::parse("team-1").expect("workspace");
+        let owner = IdentityOwner::workspace(workspace.clone());
+        assert_eq!((owner.kind(), owner.key()), ("workspace", "team-1"));
+        assert_eq!(owner.workspace_name(), Some(&workspace));
+    }
+
+    #[test]
+    fn spec_references_enforce_the_full_owner_scope_matrix() {
+        let user = IdentityOwner::for_user(UserPrincipal::local());
+        let alpha = WorkspaceName::parse("alpha").expect("alpha");
+        let beta = WorkspaceName::parse("beta").expect("beta");
+        let workspace = IdentityOwner::workspace(alpha.clone());
+        let reference = |owner: &IdentityOwner, key| {
+            IdentitySpecReference::new(owner, key, "fingerprint", "issuer", "fixed_token")
+        };
+
+        reference(&user, IdentitySpecKey::global("token").expect("global"))
+            .expect("user may reference a global spec");
+        reference(
+            &user,
+            IdentitySpecKey::workspace(alpha.clone(), "token").expect("scoped"),
+        )
+        .expect_err("user must not reference a workspace spec");
+        let global = reference(
+            &workspace,
+            IdentitySpecKey::global("token").expect("global"),
+        )
+        .expect("workspace global fallback");
+        assert_eq!(global.key().name(), "token");
+        assert_eq!(global.fingerprint(), "fingerprint");
+        assert_eq!(global.issuer(), "issuer");
+        assert_eq!(global.identity_type(), "fixed_token");
+        reference(
+            &workspace,
+            IdentitySpecKey::workspace(alpha, "token").expect("same workspace"),
+        )
+        .expect("workspace may reference its own spec");
+        reference(
+            &workspace,
+            IdentitySpecKey::workspace(beta, "token").expect("other workspace"),
+        )
+        .expect_err("workspace must not reference another workspace's spec");
+    }
+
+    #[test]
+    fn spec_references_reject_blank_required_fields() {
+        let owner = IdentityOwner::for_user(UserPrincipal::local());
+        for fields in [
+            (" ", "issuer", "fixed_token"),
+            ("fingerprint", "\t", "fixed_token"),
+            ("fingerprint", "issuer", "\n"),
+        ] {
+            IdentitySpecReference::new(
+                &owner,
+                IdentitySpecKey::global("token").expect("key"),
+                fields.0,
+                fields.1,
+                fields.2,
+            )
+            .expect_err("blank required spec-reference field must be rejected");
+        }
+    }
+}

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -47,6 +47,7 @@ mod catalog;
 mod credentials;
 pub mod features;
 mod feedback;
+mod identities;
 mod identity;
 mod identity_specs;
 mod query;

--- a/crates/coral-app/src/state/db/migration_order_tests.rs
+++ b/crates/coral-app/src/state/db/migration_order_tests.rs
@@ -25,6 +25,92 @@ async fn production_migrate_fills_sparse_version_gaps_on_sqlite() {
 }
 
 #[tokio::test]
+async fn sqlite_identity_schema_enforces_owner_and_spec_scope_structure() {
+    let temp = tempdir().expect("temp dir");
+    let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+        path: temp.path().join("identities.sqlite"),
+    })
+    .await
+    .expect("open sqlite");
+    db.migrate().await.expect("migrate sqlite");
+    let CoralDbBackend::Sqlite(backend) = &db.backend else {
+        panic!("expected SQLite backend");
+    };
+    for workspace in ["alpha", "beta"] {
+        sqlx::query("INSERT INTO workspaces (id, created_at_unix_nanos) VALUES (?, 0)")
+            .bind(workspace)
+            .execute(&backend.pool)
+            .await
+            .expect("seed workspace");
+    }
+
+    for row in [
+        ("user", "local", None, "user-global", "global", "__global__"),
+        (
+            "workspace",
+            "alpha",
+            Some("alpha"),
+            "workspace-global",
+            "global",
+            "__global__",
+        ),
+        (
+            "workspace",
+            "alpha",
+            Some("alpha"),
+            "workspace-scoped",
+            "workspace",
+            "alpha",
+        ),
+    ] {
+        insert_identity(&backend.pool, row)
+            .await
+            .expect("valid identity row");
+    }
+    let spec_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM identity_specs")
+        .fetch_one(&backend.pool)
+        .await
+        .expect("count identity specs");
+    let identity_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM identities")
+        .fetch_one(&backend.pool)
+        .await
+        .expect("count identities");
+    assert_eq!((spec_count, identity_count), (0, 3));
+
+    for row in [
+        (
+            "workspace",
+            "alpha",
+            Some("beta"),
+            "owner-mismatch",
+            "global",
+            "__global__",
+        ),
+        (
+            "workspace",
+            "missing",
+            Some("missing"),
+            "missing-workspace",
+            "global",
+            "__global__",
+        ),
+        ("user", "member", None, "user-scoped", "workspace", "alpha"),
+        (
+            "workspace",
+            "alpha",
+            Some("alpha"),
+            "cross-workspace",
+            "workspace",
+            "beta",
+        ),
+    ] {
+        insert_identity(&backend.pool, row)
+            .await
+            .expect_err("invalid identity row must be rejected");
+    }
+}
+
+#[tokio::test]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run the isolated Postgres database contracts"]
 async fn postgres_identity_database_contracts() {
     let base_url = bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
@@ -150,13 +236,13 @@ async fn assert_migration_order_contract(db: &CoralDb) {
         MIGRATOR
             .migrations
             .iter()
-            .filter(|migration| matches!(migration.version, 1 | 10))
+            .filter(|migration| matches!(migration.version, 1 | 10 | 11))
             .cloned()
             .collect(),
     );
-    assert_eq!(migration_versions(&sparse), vec![1, 10]);
+    assert_eq!(migration_versions(&sparse), vec![1, 10, 11]);
     run_migrator(db, &sparse).await;
-    assert_eq!(migration_ledger(db).await, vec![1, 10]);
+    assert_eq!(migration_ledger(db).await, vec![1, 10, 11]);
     let mut session = db;
     let identity_specs = session
         .identity_specs()
@@ -194,6 +280,31 @@ async fn assert_migration_order_contract(db: &CoralDb) {
             .await
             .expect("marker survives idempotent migrate")
     );
+}
+
+type IdentityRow<'a> = (&'a str, &'a str, Option<&'a str>, &'a str, &'a str, &'a str);
+
+async fn insert_identity(
+    pool: &sqlx::SqlitePool,
+    (owner_kind, owner_key, workspace_id, name, scope_kind, scope_id): IdentityRow<'_>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO identities (
+            owner_kind, owner_key, workspace_id, name,
+            identity_spec_scope_kind, identity_spec_scope_id, identity_spec_name,
+            identity_spec_fingerprint, issuer, identity_type,
+            created_at_unix_nanos, updated_at_unix_nanos
+         ) VALUES (?, ?, ?, ?, ?, ?, 'missing-spec', 'fingerprint', 'issuer', 'fixed_token', 1, 1)",
+    )
+    .bind(owner_kind)
+    .bind(owner_key)
+    .bind(workspace_id)
+    .bind(name)
+    .bind(scope_kind)
+    .bind(scope_id)
+    .execute(pool)
+    .await
+    .map(|_| ())
 }
 
 async fn run_migrator(db: &CoralDb, migrator: &Migrator) {

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -47,3 +47,46 @@ pub(in crate::state::db) enum IdentitySpecDocuments {
     CreatedAtUnixNanos,
     UpdatedAtUnixNanos,
 }
+
+#[expect(
+    dead_code,
+    reason = "Identity repository consumers land in the next stack units."
+)]
+#[derive(Iden)]
+pub(in crate::state::db) enum Identities {
+    Table,
+    OwnerKind,
+    OwnerKey,
+    WorkspaceId,
+    Name,
+    IdentitySpecScopeKind,
+    IdentitySpecScopeId,
+    IdentitySpecName,
+    IdentitySpecFingerprint,
+    Issuer,
+    IdentityType,
+    CreatedAtUnixNanos,
+    UpdatedAtUnixNanos,
+}
+
+#[expect(
+    dead_code,
+    reason = "Identity repository consumers land in the next stack units."
+)]
+#[derive(Iden)]
+pub(in crate::state::db) enum IdentityDocuments {
+    Table,
+    OwnerKind,
+    OwnerKey,
+    Name,
+    DocumentVersion,
+    Ciphertext,
+    Nonce,
+    WrappedDek,
+    WrappedDekNonce,
+    KeyId,
+    Algorithm,
+    AadVersion,
+    CreatedAtUnixNanos,
+    UpdatedAtUnixNanos,
+}


### PR DESCRIPTION
## Intent

Define the durable identity ownership, resolved-spec reference, and encrypted-document storage contract before repository or service behavior is added. This is the bounded B4b child of #1674.

## What it enables

- An `identities` table keyed by `owner_kind`, `owner_key`, and identity name.
- Database-enforced user/global, workspace/global-fallback, and workspace/same-workspace scope rules.
- Exact pinned identity-spec identity through scope, name, and fingerprint columns.
- An `identity_documents` envelope table with cascading identity deletion.
- Intentional identity-spec orphan preservation: there is no foreign key from identities to identity specs, so later forced spec deletion can retain the identity and its encrypted material for explicit lifecycle handling.
- App-level `IdentityName`, `IdentityOwner`, and `IdentitySpecReference` invariants for later repository and manager slices.

This PR does not add identity repository CRUD, credential writes, managers, or services.

## Usage examples

Migration `0011_identities.sql` is applied by the existing database migration runner. Later repository code can construct a user owner with `IdentityOwner::for_user`, a workspace owner with `IdentityOwner::workspace`, and validate a pinned spec through `IdentitySpecReference::new`.

## Validation

- Focused identity model tests — 4 passed
- Focused migration-order/schema tests — 2 passed; the Postgres harness remains ignored in the focused local target
- `make postgres-tests` — workspace repository, migration 0011 identity contracts, and Postgres server startup passed
- `make rust-checks` — formatting, Clippy, 1,701/1,701 tests, and rustdoc passed; 3 tests intentionally skipped
- Exact-final review swarm — 0 findings, 0 questions, 5 coverage rows, 1 credential-flow row; supervisor missed-risk sweep rejected any missed P1/P2 concern at 0.97 confidence
- Diff size — 486 changed lines

## Draft dependency

This PR is stacked directly on draft PR #1674 and must remain draft with every mission descendant. The workspace identity service is still contract-only and unmounted at this point in the stack.