### PR TITLE
feat(app): add identity row repository

### DIFF
--- a/crates/coral-app/src/identities/model.rs
+++ b/crates/coral-app/src/identities/model.rs
@@ -1,16 +1,8 @@
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Identity persistence consumers land in the next stack units."
-    )
-)]
-
 use std::fmt;
 
 use crate::bootstrap::AppError;
-use crate::identity::{UserPrincipal, parse_path_segment};
-use crate::state::db::{IdentitySpecKey, IdentitySpecScope};
+use crate::identity::{LOCAL_MEMBER_ID, UserPrincipal, parse_path_segment};
+use crate::state::db::{DbError, IdentitySpecKey, IdentitySpecScope};
 use crate::workspaces::WorkspaceName;
 
 const USER_OWNER_KIND: &str = "user";
@@ -29,6 +21,20 @@ impl IdentityName {
     /// Borrow the normalized identity name.
     pub(crate) fn as_str(&self) -> &str {
         &self.0
+    }
+
+    pub(crate) fn from_storage(value: &str) -> Result<Self, DbError> {
+        let name = Self::parse(value).map_err(|error| {
+            DbError::CorruptData(format!(
+                "invalid persisted identity name '{value}': {error}"
+            ))
+        })?;
+        if name.as_str() != value {
+            return Err(DbError::CorruptData(format!(
+                "persisted identity name '{value}' is not normalized"
+            )));
+        }
+        Ok(name)
     }
 }
 
@@ -77,6 +83,48 @@ impl IdentityOwner {
         match self {
             Self::User(_) => None,
             Self::Workspace(workspace) => Some(workspace),
+        }
+    }
+
+    pub(crate) fn from_storage_parts(
+        owner_kind: &str,
+        owner_key: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<Self, DbError> {
+        match (owner_kind, workspace_id) {
+            (USER_OWNER_KIND, None) => {
+                let principal = if owner_key == LOCAL_MEMBER_ID {
+                    UserPrincipal::local()
+                } else {
+                    UserPrincipal::for_user(owner_key).map_err(|error| {
+                        DbError::CorruptData(format!(
+                            "invalid persisted identity user owner '{owner_key}': {error}"
+                        ))
+                    })?
+                };
+                if principal.user_id() != owner_key {
+                    return Err(DbError::CorruptData(format!(
+                        "persisted identity user owner '{owner_key}' is not normalized"
+                    )));
+                }
+                Ok(Self::for_user(principal))
+            }
+            (WORKSPACE_OWNER_KIND, Some(workspace_id)) if owner_key == workspace_id => {
+                let workspace = WorkspaceName::parse(workspace_id).map_err(|error| {
+                    DbError::CorruptData(format!(
+                        "invalid persisted identity workspace owner '{workspace_id}': {error}"
+                    ))
+                })?;
+                if workspace.as_str() != workspace_id {
+                    return Err(DbError::CorruptData(format!(
+                        "persisted identity workspace owner '{workspace_id}' is not normalized"
+                    )));
+                }
+                Ok(Self::workspace(workspace))
+            }
+            _ => Err(DbError::CorruptData(
+                "persisted identity row has invalid owner columns".to_string(),
+            )),
         }
     }
 }
@@ -132,6 +180,27 @@ impl IdentitySpecReference {
 
     pub(crate) fn identity_type(&self) -> &str {
         &self.identity_type
+    }
+
+    pub(crate) fn validate_for_owner(&self, owner: &IdentityOwner) -> Result<(), AppError> {
+        validate_scope(owner, self.key.scope())
+    }
+
+    pub(crate) fn from_storage_parts(
+        owner: &IdentityOwner,
+        scope_kind: &str,
+        scope_id: &str,
+        name: &str,
+        fingerprint: String,
+        issuer: String,
+        identity_type: String,
+    ) -> Result<Self, DbError> {
+        let key = IdentitySpecKey::from_reference_storage_parts(scope_kind, scope_id, name)?;
+        Self::new(owner, key, fingerprint, issuer, identity_type).map_err(|error| {
+            DbError::CorruptData(format!(
+                "invalid persisted identity spec reference: {error}"
+            ))
+        })
     }
 }
 

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -17,6 +17,8 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
+#[cfg_attr(not(test), expect(unused_imports, reason = "Used by B4f."))]
+pub(crate) use repositories::identities::IdentityRecord;
 pub(crate) use repositories::identity_specs::{
     IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecRecord,
     IdentitySpecScope, IdentitySpecWrite,

--- a/crates/coral-app/src/state/db/repositories/identities.rs
+++ b/crates/coral-app/src/state/db/repositories/identities.rs
@@ -1,0 +1,485 @@
+#![cfg_attr(not(test), expect(dead_code, reason = "Used by B4f."))]
+
+use sea_query::{Alias, Expr, ExprTrait, OnConflict, Order, Query};
+
+use crate::bootstrap::AppError;
+use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+use crate::state::db::schema::Identities;
+use crate::state::db::{CoralTx, DbError, DbSession, IdentitySpecKey};
+
+const IDENTITY_COUNT: &str = "identity_count";
+
+/// Safe persisted fields for one owner-scoped identity instance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IdentityRecord {
+    pub(crate) owner: IdentityOwner,
+    pub(crate) name: IdentityName,
+    pub(crate) spec_reference: IdentitySpecReference,
+    pub(crate) created_at_unix_nanos: i64,
+    pub(crate) updated_at_unix_nanos: i64,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct IdentityRow {
+    owner_kind: String,
+    owner_key: String,
+    workspace_id: Option<String>,
+    name: String,
+    identity_spec_scope_kind: String,
+    identity_spec_scope_id: String,
+    identity_spec_name: String,
+    identity_spec_fingerprint: String,
+    issuer: String,
+    identity_type: String,
+    created_at_unix_nanos: i64,
+    updated_at_unix_nanos: i64,
+}
+
+impl IdentityRow {
+    fn validate(self) -> Result<IdentityRecord, DbError> {
+        if self.created_at_unix_nanos < 0 || self.updated_at_unix_nanos < self.created_at_unix_nanos
+        {
+            return Err(DbError::CorruptData(
+                "identity row has invalid timestamps".to_string(),
+            ));
+        }
+        let owner = IdentityOwner::from_storage_parts(
+            &self.owner_kind,
+            &self.owner_key,
+            self.workspace_id.as_deref(),
+        )?;
+        let name = IdentityName::from_storage(&self.name)?;
+        let spec_reference = IdentitySpecReference::from_storage_parts(
+            &owner,
+            &self.identity_spec_scope_kind,
+            &self.identity_spec_scope_id,
+            &self.identity_spec_name,
+            self.identity_spec_fingerprint,
+            self.issuer,
+            self.identity_type,
+        )?;
+        Ok(IdentityRecord {
+            owner,
+            name,
+            spec_reference,
+            created_at_unix_nanos: self.created_at_unix_nanos,
+            updated_at_unix_nanos: self.updated_at_unix_nanos,
+        })
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct IdentityCountRow {
+    identity_count: i64,
+}
+
+/// Repository shell for durable owner-scoped identity rows.
+pub(crate) struct IdentitiesRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> IdentitiesRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    /// Load one identity by its complete owner and name key.
+    pub(crate) async fn load_optional(
+        &mut self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+    ) -> Result<Option<IdentityRecord>, DbError> {
+        let row: Option<IdentityRow> = self
+            .session
+            .fetch_optional(
+                identity_select()
+                    .and_where(identity_key_where(owner, name))
+                    .to_owned(),
+            )
+            .await?;
+        row.map(IdentityRow::validate).transpose()
+    }
+
+    /// List identities owned by one exact owner in name order.
+    pub(crate) async fn list_for_owner(
+        &mut self,
+        owner: &IdentityOwner,
+    ) -> Result<Vec<IdentityRecord>, DbError> {
+        let rows: Vec<IdentityRow> = self
+            .session
+            .fetch_all(
+                identity_select()
+                    .and_where(identity_owner_where(owner))
+                    .order_by(Identities::Name, Order::Asc)
+                    .to_owned(),
+            )
+            .await?;
+        rows.into_iter().map(IdentityRow::validate).collect()
+    }
+
+    /// Count all identities pinned to one exact spec scope and name.
+    pub(crate) async fn count_dependents(&mut self, key: &IdentitySpecKey) -> Result<u64, DbError> {
+        self.count_where(identity_spec_where(key)).await
+    }
+
+    /// Count identities pinned to one exact spec scope, name, and fingerprint.
+    pub(crate) async fn count_exact_dependents(
+        &mut self,
+        key: &IdentitySpecKey,
+        fingerprint: &str,
+    ) -> Result<u64, DbError> {
+        self.count_where(
+            identity_spec_where(key)
+                .and(Expr::col(Identities::IdentitySpecFingerprint).eq(fingerprint)),
+        )
+        .await
+    }
+
+    async fn count_where(&mut self, predicate: sea_query::SimpleExpr) -> Result<u64, DbError> {
+        let row: IdentityCountRow = self
+            .session
+            .fetch_optional(
+                Query::select()
+                    .expr_as(
+                        Expr::col(Identities::Name).count(),
+                        Alias::new(IDENTITY_COUNT),
+                    )
+                    .from(Identities::Table)
+                    .and_where(predicate)
+                    .to_owned(),
+            )
+            .await?
+            .ok_or_else(|| {
+                DbError::CorruptData("identity count query returned no row".to_string())
+            })?;
+        u64::try_from(row.identity_count).map_err(|error| {
+            DbError::CorruptData(format!(
+                "identity count query returned invalid count {}: {error}",
+                row.identity_count,
+            ))
+        })
+    }
+}
+
+impl IdentitiesRepo<'_, CoralTx<'_>> {
+    /// Insert or replace one identity while preserving its creation time.
+    pub(crate) async fn upsert(
+        &mut self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        spec_reference: &IdentitySpecReference,
+        now_unix_nanos: i64,
+    ) -> Result<IdentityRecord, AppError> {
+        validate_write_timestamp(now_unix_nanos)?;
+        spec_reference.validate_for_owner(owner)?;
+        let current_updated_at = Expr::col((Identities::Table, Identities::UpdatedAtUnixNanos));
+        let key = spec_reference.key();
+        let statement = Query::insert()
+            .into_table(Identities::Table)
+            .columns(identity_columns())
+            .values_panic([
+                Expr::val(owner.kind()),
+                Expr::val(owner.key()),
+                Expr::val(
+                    owner
+                        .workspace_name()
+                        .map(|workspace| workspace.as_str().to_owned()),
+                ),
+                Expr::val(name.as_str()),
+                Expr::val(key.scope().kind()),
+                Expr::val(key.scope().scope_id()),
+                Expr::val(key.name()),
+                Expr::val(spec_reference.fingerprint()),
+                Expr::val(spec_reference.issuer()),
+                Expr::val(spec_reference.identity_type()),
+                Expr::val(now_unix_nanos),
+                Expr::val(now_unix_nanos),
+            ])
+            .on_conflict(
+                OnConflict::columns([
+                    Identities::OwnerKind,
+                    Identities::OwnerKey,
+                    Identities::Name,
+                ])
+                .update_columns([
+                    Identities::IdentitySpecScopeKind,
+                    Identities::IdentitySpecScopeId,
+                    Identities::IdentitySpecName,
+                    Identities::IdentitySpecFingerprint,
+                    Identities::Issuer,
+                    Identities::IdentityType,
+                ])
+                .value(
+                    Identities::UpdatedAtUnixNanos,
+                    Expr::case(
+                        current_updated_at.clone().gt(now_unix_nanos),
+                        current_updated_at,
+                    )
+                    .finally(now_unix_nanos),
+                )
+                .to_owned(),
+            )
+            .to_owned();
+        let rows_affected = self.session.execute_affected(statement).await?;
+        if rows_affected != 1 {
+            return Err(AppError::Database(format!(
+                "identity upsert affected {rows_affected} rows"
+            )));
+        }
+        self.load_optional(owner, name)
+            .await?
+            .ok_or_else(|| AppError::Database("identity disappeared after upsert".to_string()))
+    }
+
+    /// Delete one exact identity row and cascade any encrypted document.
+    pub(crate) async fn delete(
+        &mut self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+    ) -> Result<bool, DbError> {
+        let rows_affected = self
+            .session
+            .execute_affected(
+                Query::delete()
+                    .from_table(Identities::Table)
+                    .and_where(identity_key_where(owner, name))
+                    .to_owned(),
+            )
+            .await?;
+        zero_or_one_affected(rows_affected, "identity delete")
+    }
+}
+
+fn validate_write_timestamp(now_unix_nanos: i64) -> Result<(), AppError> {
+    match now_unix_nanos {
+        0.. => Ok(()),
+        _ => Err(AppError::InvalidInput(
+            "identity timestamp is negative".to_string(),
+        )),
+    }
+}
+
+fn zero_or_one_affected(rows_affected: u64, operation: &str) -> Result<bool, DbError> {
+    match rows_affected {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(DbError::CorruptData(format!(
+            "{operation} affected {rows_affected} rows"
+        ))),
+    }
+}
+
+fn identity_select() -> sea_query::SelectStatement {
+    Query::select()
+        .columns(identity_columns())
+        .from(Identities::Table)
+        .to_owned()
+}
+
+fn identity_columns() -> [Identities; 12] {
+    [
+        Identities::OwnerKind,
+        Identities::OwnerKey,
+        Identities::WorkspaceId,
+        Identities::Name,
+        Identities::IdentitySpecScopeKind,
+        Identities::IdentitySpecScopeId,
+        Identities::IdentitySpecName,
+        Identities::IdentitySpecFingerprint,
+        Identities::Issuer,
+        Identities::IdentityType,
+        Identities::CreatedAtUnixNanos,
+        Identities::UpdatedAtUnixNanos,
+    ]
+}
+
+fn identity_owner_where(owner: &IdentityOwner) -> sea_query::SimpleExpr {
+    Expr::col(Identities::OwnerKind)
+        .eq(owner.kind())
+        .and(Expr::col(Identities::OwnerKey).eq(owner.key()))
+}
+
+fn identity_key_where(owner: &IdentityOwner, name: &IdentityName) -> sea_query::SimpleExpr {
+    identity_owner_where(owner).and(Expr::col(Identities::Name).eq(name.as_str()))
+}
+
+fn identity_spec_where(key: &IdentitySpecKey) -> sea_query::SimpleExpr {
+    Expr::col(Identities::IdentitySpecScopeKind)
+        .eq(key.scope().kind())
+        .and(Expr::col(Identities::IdentitySpecScopeId).eq(key.scope().scope_id()))
+        .and(Expr::col(Identities::IdentitySpecName).eq(key.name()))
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use crate::bootstrap::AppError;
+    use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+    use crate::identity::UserPrincipal;
+    use crate::state::db::{
+        CoralDb, DbRepos, IdentityRecord, IdentitySpecKey, ResolvedDatabaseConfig,
+    };
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    #[expect(clippy::too_many_lines, reason = "Repository contract.")]
+    async fn identity_rows_round_trip_and_count_exact_dependencies() {
+        let temp = tempdir().expect("temp dir");
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+
+        let user = IdentityOwner::for_user(UserPrincipal::local());
+        let workspace = WorkspaceName::parse("local").expect("workspace");
+        let workspace_owner = IdentityOwner::workspace(workspace.clone());
+        let other_owner =
+            IdentityOwner::workspace(WorkspaceName::parse("other").expect("other workspace"));
+        let alpha = IdentityName::parse("alpha").expect("alpha");
+        let bravo = IdentityName::parse("bravo").expect("bravo");
+        let charlie = IdentityName::parse("charlie").expect("charlie");
+        let global_key = IdentitySpecKey::global("github").expect("global key");
+        let workspace_key =
+            IdentitySpecKey::workspace(workspace.clone(), "github").expect("workspace key");
+        let user_f1 = reference(&user, global_key.clone(), "f1");
+        let user_f2 = reference(&user, global_key.clone(), "f2");
+        let workspace_global = reference(&workspace_owner, global_key.clone(), "f1");
+        let workspace_local = reference(&workspace_owner, workspace_key.clone(), "f1");
+        let replacement_key = IdentitySpecKey::global("gitlab").expect("replacement key");
+        let replacement = IdentitySpecReference::new(
+            &user,
+            replacement_key.clone(),
+            "f3",
+            "replacement-issuer",
+            "oauth",
+        )
+        .expect("replacement reference");
+
+        let mut tx = db.begin().await.expect("begin seed tx");
+        tx.workspaces()
+            .ensure(workspace.as_str(), 1)
+            .await
+            .expect("seed workspace");
+        tx.workspaces()
+            .ensure(other_owner.key(), 2)
+            .await
+            .expect("seed other workspace");
+        for (owner, name, spec, now) in [
+            (&user, &alpha, &user_f1, 10),
+            (&user, &bravo, &user_f2, 11),
+            (&workspace_owner, &alpha, &workspace_global, 12),
+            (&workspace_owner, &charlie, &workspace_local, 13),
+        ] {
+            tx.identities()
+                .upsert(owner, name, spec, now)
+                .await
+                .expect("upsert identity");
+        }
+        tx.commit().await.expect("commit seed tx");
+
+        let mut session = &db;
+        let user_rows = session
+            .identities()
+            .list_for_owner(&user)
+            .await
+            .expect("list user rows");
+        assert_eq!(record_names(&user_rows), ["alpha", "bravo"]);
+        let workspace_rows = session
+            .identities()
+            .list_for_owner(&workspace_owner)
+            .await
+            .expect("list workspace rows");
+        assert_eq!(record_names(&workspace_rows), ["alpha", "charlie"]);
+        assert_eq!(dependent_counts(&db, &global_key, "f1").await, (3, 2));
+        assert_eq!(dependent_counts(&db, &workspace_key, "f1").await, (1, 1));
+
+        let mut tx = db.begin().await.expect("begin replacement tx");
+        let replaced = tx
+            .identities()
+            .upsert(&user, &alpha, &replacement, 20)
+            .await
+            .expect("replace all mutable fields");
+        assert_eq!(
+            (
+                replaced.created_at_unix_nanos,
+                replaced.updated_at_unix_nanos
+            ),
+            (10, 20)
+        );
+        assert_eq!(replaced.spec_reference, replacement);
+        let regressed = tx
+            .identities()
+            .upsert(&user, &alpha, &replacement, 5)
+            .await
+            .expect("preserve update time under regressed clock");
+        assert_eq!(regressed.updated_at_unix_nanos, 20);
+        let deleted = tx
+            .identities()
+            .delete(&workspace_owner, &alpha)
+            .await
+            .unwrap();
+        let missing = tx
+            .identities()
+            .delete(&workspace_owner, &alpha)
+            .await
+            .unwrap();
+        assert!(deleted && !missing);
+        let wrong_owner = tx
+            .identities()
+            .upsert(&other_owner, &alpha, &workspace_local, 20)
+            .await
+            .expect_err("cross-workspace reference must fail");
+        assert!(matches!(wrong_owner, AppError::InvalidInput(_)));
+        let negative_time = tx
+            .identities()
+            .upsert(&user, &alpha, &user_f2, -1)
+            .await
+            .expect_err("negative timestamp must fail");
+        assert!(matches!(negative_time, AppError::InvalidInput(_)));
+        tx.commit().await.expect("commit replacement tx");
+
+        let user_row = session
+            .identities()
+            .load_optional(&user, &alpha)
+            .await
+            .unwrap()
+            .expect("reloaded replacement");
+        assert_eq!(user_row, regressed);
+        assert_eq!(dependent_counts(&db, &global_key, "f2").await, (1, 1));
+        assert_eq!(dependent_counts(&db, &replacement_key, "f3").await, (1, 1));
+    }
+
+    fn reference(
+        owner: &IdentityOwner,
+        key: IdentitySpecKey,
+        fingerprint: &str,
+    ) -> IdentitySpecReference {
+        IdentitySpecReference::new(owner, key, fingerprint, "issuer", "fixed_token")
+            .expect("valid reference")
+    }
+
+    fn record_names(records: &[IdentityRecord]) -> Vec<&str> {
+        records.iter().map(|record| record.name.as_str()).collect()
+    }
+
+    async fn dependent_counts(
+        db: &CoralDb,
+        key: &IdentitySpecKey,
+        fingerprint: &str,
+    ) -> (u64, u64) {
+        let mut session = db;
+        let total = session.identities().count_dependents(key).await.unwrap();
+        let exact = session
+            .identities()
+            .count_exact_dependents(key, fingerprint)
+            .await
+            .unwrap();
+        (total, exact)
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/identity_specs.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs.rs
@@ -129,7 +129,7 @@ impl IdentitySpecKey {
         })
     }
 
-    pub(super) fn from_document_storage_parts(
+    pub(crate) fn from_reference_storage_parts(
         scope_kind: &str,
         scope_id: &str,
         name: &str,
@@ -138,13 +138,13 @@ impl IdentitySpecKey {
             GLOBAL_SCOPE_KIND if scope_id == GLOBAL_SCOPE_ID => IdentitySpecScope::Global,
             GLOBAL_SCOPE_KIND => {
                 return Err(DbError::CorruptData(
-                    "global identity spec document row has invalid scope columns".to_string(),
+                    "global identity spec reference has invalid scope columns".to_string(),
                 ));
             }
             WORKSPACE_SCOPE_KIND => IdentitySpecScope::Workspace(parse_workspace_name(scope_id)?),
             other => {
                 return Err(DbError::CorruptData(format!(
-                    "identity spec document row has invalid scope kind '{other}'"
+                    "identity spec reference has invalid scope kind '{other}'"
                 )));
             }
         };
@@ -396,7 +396,7 @@ impl IdentitySpecDocumentRow {
         )
         .map_err(DbError::CorruptData)?;
         Ok(IdentitySpecDocumentRecord {
-            key: IdentitySpecKey::from_document_storage_parts(
+            key: IdentitySpecKey::from_reference_storage_parts(
                 &self.scope_kind,
                 &self.scope_id,
                 &self.name,
@@ -899,8 +899,8 @@ pub(in crate::state::db) mod tests {
                 Some(" default"),
                 "github",
             ),
-            IdentitySpecKey::from_document_storage_parts("global", "__global__", "github "),
-            IdentitySpecKey::from_document_storage_parts("workspace", " default", "github"),
+            IdentitySpecKey::from_reference_storage_parts("global", "__global__", "github "),
+            IdentitySpecKey::from_reference_storage_parts("workspace", " default", "github"),
             IdentitySpecKey::from_spec_storage_parts("global", "__global__", None, "github-oauth"),
         ] {
             assert!(matches!(result, Err(DbError::CorruptData(_))));

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod identities;
 pub(crate) mod identity_specs;
 pub(crate) mod state_migrations;
 pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -48,10 +48,6 @@ pub(in crate::state::db) enum IdentitySpecDocuments {
     UpdatedAtUnixNanos,
 }
 
-#[expect(
-    dead_code,
-    reason = "Identity repository consumers land in the next stack units."
-)]
 #[derive(Iden)]
 pub(in crate::state::db) enum Identities {
     Table,

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -6,6 +6,7 @@ use sqlx::{FromRow, Postgres, Sqlite};
 
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
+use crate::state::db::repositories::identities::IdentitiesRepo;
 use crate::state::db::repositories::identity_specs::{
     IdentitySpecDocumentsRepo, IdentitySpecsRepo,
 };
@@ -41,6 +42,11 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn identity_specs(&mut self) -> IdentitySpecsRepo<'_, Self> {
         IdentitySpecsRepo::new(self)
+    }
+
+    #[cfg_attr(not(test), expect(dead_code, reason = "Used by B4f."))]
+    fn identities(&mut self) -> IdentitiesRepo<'_, Self> {
+        IdentitiesRepo::new(self)
     }
 
     fn identity_spec_documents(&mut self) -> IdentitySpecDocumentsRepo<'_, Self> {


### PR DESCRIPTION
## Intent

Add the relational repository for user-owned and workspace-owned identity rows on top of the schema introduced by #1675. The row stores only safe ownership, pinned identity-spec metadata, and timestamps; credential material is deliberately excluded.

## What it enables

- Owner-isolated point reads and name-sorted lists, including identical identity names across user and workspace owners.
- Transaction-only upsert and delete operations with creation-time preservation and monotonic update timestamps.
- Exact dependent counts by spec scope/name and by full scope/name/fingerprint for later lifecycle enforcement.
- Fail-closed validation of persisted owner, spec-reference, fingerprint, issuer, type, and timestamp invariants.

This is the row-repository seam required by the upcoming document, cross-backend contract, manager/encryption, and lifecycle PRs.

## Usage examples

- Use `IdentitiesRepo::load_optional(owner, name)` for one complete owner/name key.
- Use `IdentitiesRepo::list_for_owner(owner)` for deterministic owner-scoped listing.
- Within a `CoralTx`, use `upsert(owner, name, spec_reference, now_unix_nanos)` or `delete(owner, name)`.
- Use `count_dependents` and `count_exact_dependents` from the same caller-owned session or transaction when enforcing spec lifecycle rules.

## Validation

- `make rust-checks`: 1,702/1,702 tests passed, 3 skipped; formatting, Clippy, and rustdoc passed.
- `PATH=/Users/saul/.cargo/bin:... make postgres-tests`: workspace repository, identity migration contract, and server-startup Postgres tests passed on exact commit `e34fbb726`.
- Focused SQLite identity repository test passed.
- Exact final review bundle: 0 findings, 0 questions, 1 coverage record.
- Scope: 599 changed lines, within the 600-line hard cap.

## Draft stack dependency

Draft PR stacked directly on #1675. Document payload persistence is deferred to B4d; shared SQLite/Postgres corruption and cascade contracts to B4e; fingerprint/manager/encryption work to B4f; lifecycle enforcement to B4g.