### PR TITLE
feat(app): add fixed-token identity manager

### DIFF
--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -2,8 +2,9 @@
 
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_DETAIL, CORAL_ERROR_METADATA_HINT,
-    CORAL_ERROR_METADATA_SUMMARY, CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND,
-    CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND,
+    CORAL_ERROR_METADATA_SUMMARY, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND,
+    CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND, CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+    CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND,
 };
 use coral_engine::{CoreError, StatusCode};
 use tonic::{Code, Status};
@@ -29,6 +30,9 @@ pub enum AppError {
         /// Canonical requested scope (`global` or `workspace:<name>`).
         scope: String,
     },
+    /// A requested owner-scoped identity was not found.
+    #[error("identity '{0}' not found")]
+    IdentityNotFound(String),
     /// A requested workspace was not found in config.
     #[error("workspace '{0}' not found")]
     WorkspaceNotFound(String),
@@ -180,6 +184,7 @@ pub(crate) fn status_with_bounded_detail(code: Code, detail: impl Into<String>) 
 pub(crate) fn app_status(error: AppError) -> Status {
     let not_found_reason = match &error {
         AppError::SourceNotFound(_) => Some(CORAL_ERROR_REASON_SOURCE_NOT_FOUND),
+        AppError::IdentityNotFound(_) => Some(CORAL_ERROR_REASON_IDENTITY_NOT_FOUND),
         AppError::IdentitySpecNotFound { .. } => Some(CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND),
         AppError::WorkspaceNotFound(_) => Some(CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND),
         _ => None,
@@ -268,6 +273,7 @@ fn app_code(error: &AppError) -> Code {
     match error {
         AppError::Unauthenticated(_) => Code::Unauthenticated,
         AppError::SourceNotFound(_)
+        | AppError::IdentityNotFound(_)
         | AppError::IdentitySpecNotFound { .. }
         | AppError::WorkspaceNotFound(_) => Code::NotFound,
         AppError::WorkspaceAlreadyExists(_) => Code::AlreadyExists,
@@ -384,6 +390,23 @@ mod tests {
             "WORKSPACE_NOT_FOUND must not carry unbounded identifier metadata: {:?}",
             info.metadata
         );
+    }
+
+    #[test]
+    fn app_status_attaches_structured_reason_for_identity_not_found() {
+        let status = app_status(AppError::IdentityNotFound("private-name".to_string()));
+        assert_eq!(status.code(), Code::NotFound);
+        let info = status
+            .get_error_details_vec()
+            .into_iter()
+            .find_map(|detail| match detail {
+                ErrorDetail::ErrorInfo(info) => Some(info),
+                _ => None,
+            })
+            .expect("identity-not-found status must carry ErrorInfo");
+        assert_eq!(info.reason, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
+        assert_eq!(info.domain, CORAL_ERROR_DOMAIN);
+        assert!(info.metadata.is_empty());
     }
 
     #[test]

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -1,0 +1,276 @@
+//! Database-backed identity instance management.
+
+#![expect(
+    dead_code,
+    reason = "B4h wires identity managers into public services."
+)]
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use coral_spec::IdentitySpecType;
+
+use crate::bootstrap::AppError;
+use crate::credentials::encryption::{CredentialKeyProvider, EncryptedEnvelopeDocument};
+use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+use crate::identity::{UserPrincipal, encrypt_identity_document, run_key_operation};
+use crate::identity_specs::identity_spec_fingerprint;
+use crate::identity_specs::manager::record_to_installed;
+use crate::state::db::{
+    CoralDb, DbRepos, IdentityDocumentWrite, IdentityRecord, IdentitySpecKey, IdentitySpecRecord,
+    now_unix_nanos_i64,
+};
+
+const FIXED_TOKEN_KEY: &str = "TOKEN";
+const MAX_MUTATION_ATTEMPTS: usize = 8;
+
+/// Database-backed behavior for owner-scoped identity instances.
+#[derive(Clone)]
+pub(crate) struct IdentityManager {
+    db: Arc<CoralDb>,
+    key_provider: Arc<dyn CredentialKeyProvider>,
+}
+
+struct SelectedFixedTokenSpec {
+    record: IdentitySpecRecord,
+    reference: IdentitySpecReference,
+}
+
+impl IdentityManager {
+    pub(crate) fn new(db: Arc<CoralDb>, key_provider: Arc<dyn CredentialKeyProvider>) -> Self {
+        Self { db, key_provider }
+    }
+
+    /// Create or replace a user-owned fixed-token identity from one exact global spec.
+    pub(crate) async fn create_or_replace_user_fixed_token(
+        &self,
+        principal: &UserPrincipal,
+        identity_name: &str,
+        identity_spec_name: &str,
+        token: String,
+    ) -> Result<IdentityRecord, AppError> {
+        let owner = IdentityOwner::for_user(principal.clone());
+        let name = IdentityName::parse(identity_name)?;
+        let spec_key = IdentitySpecKey::global(identity_spec_name)?;
+        let token = token.trim().to_string();
+        if token.is_empty() {
+            return Err(AppError::InvalidInput(
+                "fixed-token identity token must not be blank".to_string(),
+            ));
+        }
+        let mut document = None;
+
+        for _ in 0..MAX_MUTATION_ATTEMPTS {
+            let selected = match self.load_fixed_token_spec(&owner, &spec_key).await {
+                Ok(selected) => selected,
+                Err(AppError::RetryableTransactionConflict) => {
+                    tokio::task::yield_now().await;
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            if document.is_none() {
+                let document_owner = owner.clone();
+                let document_name = name.clone();
+                let document_token = token.clone();
+                let key_provider = Arc::clone(&self.key_provider);
+                document = Some(
+                    run_key_operation(move || {
+                        prepare_fixed_token_document(
+                            &document_owner,
+                            &document_name,
+                            document_token,
+                            key_provider.as_ref(),
+                        )
+                    })
+                    .await?,
+                );
+            }
+            match self
+                .try_write(
+                    &owner,
+                    &name,
+                    &selected,
+                    document.as_ref().expect("document prepared above"),
+                )
+                .await
+            {
+                Ok(Some(record)) => return Ok(record),
+                Ok(None) | Err(AppError::RetryableTransactionConflict) => {
+                    tokio::task::yield_now().await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Err(AppError::RetryableTransactionConflict)
+    }
+
+    /// List safe persisted fields for one exact owner, including orphaned identities.
+    pub(crate) async fn list_for_owner(
+        &self,
+        owner: &IdentityOwner,
+    ) -> Result<Vec<IdentityRecord>, AppError> {
+        let mut db = self.db.as_ref();
+        Ok(db.identities().list_for_owner(owner).await?)
+    }
+
+    /// Get safe persisted fields for one identity, including an orphaned identity.
+    pub(crate) async fn get(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<IdentityRecord, AppError> {
+        let name = IdentityName::parse(identity_name)?;
+        let mut db = self.db.as_ref();
+        db.identities()
+            .load_optional(owner, &name)
+            .await?
+            .ok_or_else(|| identity_not_found(&name))
+    }
+
+    /// Delete one identity and its cascading encrypted document.
+    pub(crate) async fn delete(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<(), AppError> {
+        let name = IdentityName::parse(identity_name)?;
+        for _ in 0..MAX_MUTATION_ATTEMPTS {
+            match self.try_delete(owner, &name).await {
+                Ok(()) => return Ok(()),
+                Err(AppError::RetryableTransactionConflict) => {
+                    tokio::task::yield_now().await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Err(AppError::RetryableTransactionConflict)
+    }
+
+    async fn try_delete(&self, owner: &IdentityOwner, name: &IdentityName) -> Result<(), AppError> {
+        let mut tx = self.db.begin_serializable().await?;
+        let deleted = match tx.identities().delete(owner, name).await {
+            Ok(deleted) => deleted,
+            Err(error) => {
+                tx.rollback().await?;
+                return Err(error.into());
+            }
+        };
+        if !deleted {
+            tx.rollback().await?;
+            return Err(identity_not_found(name));
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn load_fixed_token_spec(
+        &self,
+        owner: &IdentityOwner,
+        key: &IdentitySpecKey,
+    ) -> Result<SelectedFixedTokenSpec, AppError> {
+        let mut tx = self.db.begin_read_snapshot().await?;
+        let record = tx.identity_specs().load_optional(key).await?;
+        tx.commit().await?;
+        let record = record.ok_or_else(|| global_spec_not_found(key))?;
+        let installed = record_to_installed(record.clone())?;
+        if installed.manifest.identity_type != IdentitySpecType::FixedToken {
+            return Err(AppError::InvalidInput(format!(
+                "identity spec '{}' has type '{}', not 'fixed_token'",
+                key.name(),
+                installed.manifest.identity_type.label(),
+            )));
+        }
+        let reference = IdentitySpecReference::new(
+            owner,
+            installed.key,
+            identity_spec_fingerprint(&installed.manifest)?,
+            installed.manifest.issuer,
+            installed.manifest.identity_type.label(),
+        )?;
+        Ok(SelectedFixedTokenSpec { record, reference })
+    }
+
+    async fn try_write(
+        &self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        selected: &SelectedFixedTokenSpec,
+        document: &IdentityDocumentWrite,
+    ) -> Result<Option<IdentityRecord>, AppError> {
+        let mut tx = self.db.begin_serializable().await?;
+        let current = tx
+            .identity_specs()
+            .load_optional(selected.reference.key())
+            .await?;
+        if current.as_ref() != Some(&selected.record) {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+        let now = now_unix_nanos_i64()?;
+        let result = async {
+            let record = tx
+                .identities()
+                .upsert(owner, name, &selected.reference, now)
+                .await?;
+            tx.identity_documents()
+                .upsert(owner, name, document, now)
+                .await?;
+            Ok::<_, AppError>(record)
+        }
+        .await;
+        let record = match result {
+            Ok(record) => record,
+            Err(error) => {
+                tx.rollback().await?;
+                return Err(error);
+            }
+        };
+        tx.commit().await?;
+        Ok(Some(record))
+    }
+}
+
+fn prepare_fixed_token_document(
+    owner: &IdentityOwner,
+    name: &IdentityName,
+    token: String,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<IdentityDocumentWrite, AppError> {
+    let values = BTreeMap::from([(FIXED_TOKEN_KEY.to_string(), token)]);
+    let EncryptedEnvelopeDocument {
+        ciphertext,
+        nonce,
+        wrapped_dek,
+        wrapped_dek_nonce,
+        key_id,
+        algorithm,
+        aad_version,
+    } = encrypt_identity_document(
+        owner.kind(),
+        owner.key(),
+        name.as_str(),
+        &values,
+        key_provider,
+    )?;
+    IdentityDocumentWrite::new(
+        ciphertext,
+        nonce,
+        wrapped_dek,
+        wrapped_dek_nonce,
+        key_id,
+        algorithm,
+        aad_version,
+    )
+}
+
+fn global_spec_not_found(key: &IdentitySpecKey) -> AppError {
+    AppError::IdentitySpecNotFound {
+        name: key.name().to_string(),
+        scope: "global".to_string(),
+    }
+}
+
+fn identity_not_found(name: &IdentityName) -> AppError {
+    AppError::IdentityNotFound(name.to_string())
+}

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -1,3 +1,4 @@
 //! App-owned identity instance domain types.
 
+pub(crate) mod manager;
 pub(crate) mod model;

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -381,6 +381,15 @@ fn validate_identity_document_version(kind: &str, version: u32) -> Result<(), Cr
     Ok(())
 }
 
+pub(crate) async fn run_key_operation<T, F>(operation: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, AppError> + Send + 'static,
+{
+    let span = tracing::Span::current();
+    tokio::task::spawn_blocking(move || span.in_scope(operation)).await?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -10,6 +10,7 @@ use crate::bootstrap::AppError;
 use crate::credentials::encryption::{CredentialKeyProvider, EncryptedEnvelopeDocument};
 use crate::identity::{
     decrypt_identity_spec_document, encrypt_identity_spec_document, parse_path_segment,
+    run_key_operation,
 };
 use crate::state::db::{
     CoralDb, CoralTx, DbRepos, IdentitySpecDocumentRecord, IdentitySpecDocumentWrite,
@@ -549,15 +550,6 @@ async fn resolve_record_for_use_async(
     run_key_operation(move || resolve_record_for_use(record, document, key_provider.as_ref())).await
 }
 
-async fn run_key_operation<T, F>(operation: F) -> Result<T, AppError>
-where
-    T: Send + 'static,
-    F: FnOnce() -> Result<T, AppError> + Send + 'static,
-{
-    let span = tracing::Span::current();
-    tokio::task::spawn_blocking(move || span.in_scope(operation)).await?
-}
-
 fn mutation_retry_exhausted() -> AppError {
     AppError::RetryableTransactionConflict
 }
@@ -692,7 +684,9 @@ fn convert_records(
     records.into_iter().map(record_to_installed).collect()
 }
 
-fn record_to_installed(record: IdentitySpecRecord) -> Result<InstalledIdentitySpec, AppError> {
+pub(crate) fn record_to_installed(
+    record: IdentitySpecRecord,
+) -> Result<InstalledIdentitySpec, AppError> {
     let manifest = parse_identity_manifest_yaml(&record.manifest_yaml).map_err(|error| {
         corrupt_record(&record.key, &format!("manifest cannot be parsed: {error}"))
     })?;

--- a/crates/coral-app/src/identity_specs/mod.rs
+++ b/crates/coral-app/src/identity_specs/mod.rs
@@ -7,6 +7,5 @@ mod fingerprint;
 pub(crate) mod manager;
 pub(crate) mod service;
 
-#[expect(unused_imports, reason = "B4f2 consumes the durable fingerprint API.")]
 pub(crate) use fingerprint::identity_spec_fingerprint;
 pub(crate) use service::IdentitySpecService;

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -706,6 +706,7 @@ fn app_error_type(error: &AppError) -> &'static str {
     match error {
         AppError::Unauthenticated(_) => "UNAUTHENTICATED",
         AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
+        AppError::IdentityNotFound(_) => "IDENTITY_NOT_FOUND",
         AppError::IdentitySpecNotFound { .. } => "IDENTITY_SPEC_NOT_FOUND",
         AppError::WorkspaceNotFound(_) => "WORKSPACE_NOT_FOUND",
         AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -17,7 +17,6 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
-#[cfg_attr(not(test), expect(unused_imports, reason = "Used by B4f."))]
 pub(crate) use repositories::identities::IdentityRecord;
 #[cfg_attr(not(test), expect(unused_imports, reason = "Used by B4f."))]
 pub(crate) use repositories::identity_documents::{IdentityDocumentRecord, IdentityDocumentWrite};

--- a/crates/coral-app/src/state/db/repositories/identity_documents.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_documents.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(not(test), expect(dead_code, reason = "Used by B4f."))]
-
 use sea_query::{Expr, ExprTrait, OnConflict, Query};
 
 use crate::bootstrap::AppError;

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -45,12 +45,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
         IdentitySpecsRepo::new(self)
     }
 
-    #[cfg_attr(not(test), expect(dead_code, reason = "Used by B4f."))]
     fn identities(&mut self) -> IdentitiesRepo<'_, Self> {
         IdentitiesRepo::new(self)
     }
 
-    #[cfg_attr(not(test), expect(dead_code, reason = "Used by B4f."))]
     fn identity_documents(&mut self) -> IdentityDocumentsRepo<'_, Self> {
         IdentityDocumentsRepo::new(self)
     }


### PR DESCRIPTION
## Intent

Add the app-owned, database-backed manager for user-owned fixed-token identities while keeping public CLI and gRPC wiring in later B4 units.

## What it enables

- Validates one exact global `fixed_token` identity spec and persists its canonical manifest fingerprint.
- Encrypts the trimmed token outside the database transaction, then atomically upserts identity metadata and its encrypted document.
- Revalidates the complete raw spec in a short serializable transaction and retries bounded Postgres or SQLite write conflicts.
- Preserves creation timestamps, versions replacement documents, isolates owners, and supports inspectable orphan list/get/delete behavior.
- Adds typed `IDENTITY_NOT_FOUND` application, gRPC status, and telemetry classification.

## Usage examples

This is an internal manager layer. Call `create_or_replace_user_fixed_token` with a `UserPrincipal`, identity name, exact global spec name, and token; use `list_for_owner`, `get`, and `delete` for owner-scoped lifecycle operations. No new CLI command or RPC is mounted in this PR.

## Validation

- `make postgres-tests`: passed the workspace repository, Postgres identity database contract, and Postgres server lifecycle gates.
- `make rust-checks`: 1,716/1,716 tests passed, 3 skipped; formatting, strict workspace Clippy, and rustdoc passed.
- Exact-final review swarm: zero findings and zero questions across correctness, tests, security, architecture, and operations; supervisor found no missed P1/P2 risk.
- 334 changed lines; public service mounting remains in B4h/B4i and production decrypt/rewrap/CAS hardening remains in B4j.
