### PR TITLE
feat(app): add workspace fixed-token identity manager

### DIFF
--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -20,11 +20,12 @@ use crate::credentials::encryption::{CredentialKeyProvider, EncryptedEnvelopeDoc
 use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
 use crate::identity::{UserPrincipal, encrypt_identity_document, run_key_operation};
 use crate::identity_specs::identity_spec_fingerprint;
-use crate::identity_specs::manager::record_to_installed;
+use crate::identity_specs::manager::{record_to_installed, spec_not_found};
 use crate::state::db::{
-    CoralDb, DbRepos, IdentityDocumentWrite, IdentityRecord, IdentitySpecKey, IdentitySpecRecord,
-    now_unix_nanos_i64,
+    CoralDb, CoralTx, DbRepos, IdentityDocumentWrite, IdentityRecord, IdentitySpecKey,
+    IdentitySpecRecord, now_unix_nanos_i64,
 };
+use crate::workspaces::WorkspaceName;
 
 const FIXED_TOKEN_KEY: &str = "TOKEN";
 const MAX_MUTATION_ATTEMPTS: usize = 8;
@@ -38,6 +39,8 @@ pub(crate) struct IdentityManager {
     before_write_gate: Option<BeforeWriteGate>,
     #[cfg(test)]
     before_upsert_gate: Option<BeforeUpsertGate>,
+    #[cfg(test)]
+    before_retry_gate: Option<BeforeWriteGate>,
 }
 
 #[cfg(test)]
@@ -55,6 +58,8 @@ struct BeforeUpsertGate {
 }
 
 struct SelectedFixedTokenSpec {
+    requested_key: IdentitySpecKey,
+    workspace_created_at_unix_nanos: Option<i64>,
     record: IdentitySpecRecord,
     reference: IdentitySpecReference,
 }
@@ -68,6 +73,8 @@ impl IdentityManager {
             before_write_gate: None,
             #[cfg(test)]
             before_upsert_gate: None,
+            #[cfg(test)]
+            before_retry_gate: None,
         }
     }
 
@@ -90,6 +97,19 @@ impl IdentityManager {
         self
     }
 
+    #[cfg(test)]
+    fn with_before_retry_gate(
+        mut self,
+        reached: Arc<tokio::sync::Barrier>,
+        resume: Arc<tokio::sync::Barrier>,
+    ) -> Self {
+        self.before_retry_gate = Some(BeforeWriteGate {
+            selected: reached,
+            resume,
+        });
+        self
+    }
+
     /// Create or replace a user-owned fixed-token identity from one exact global spec.
     pub(crate) async fn create_or_replace_user_fixed_token(
         &self,
@@ -101,6 +121,32 @@ impl IdentityManager {
         let owner = IdentityOwner::for_user(principal.clone());
         let name = IdentityName::parse(identity_name)?;
         let spec_key = IdentitySpecKey::global(identity_spec_name)?;
+        self.create_or_replace_fixed_token(owner, name, spec_key, token)
+            .await
+    }
+
+    /// Create or replace a workspace-owned fixed-token identity using workspace-first resolution.
+    pub(crate) async fn create_or_replace_workspace_fixed_token(
+        &self,
+        workspace: &WorkspaceName,
+        identity_name: &str,
+        identity_spec_name: &str,
+        token: String,
+    ) -> Result<IdentityRecord, AppError> {
+        let owner = IdentityOwner::workspace(workspace.clone());
+        let name = IdentityName::parse(identity_name)?;
+        let spec_key = IdentitySpecKey::workspace(workspace.clone(), identity_spec_name)?;
+        self.create_or_replace_fixed_token(owner, name, spec_key, token)
+            .await
+    }
+
+    async fn create_or_replace_fixed_token(
+        &self,
+        owner: IdentityOwner,
+        name: IdentityName,
+        spec_key: IdentitySpecKey,
+        token: String,
+    ) -> Result<IdentityRecord, AppError> {
         let token = token.trim().to_string();
         if token.is_empty() {
             return Err(AppError::InvalidInput(
@@ -108,11 +154,17 @@ impl IdentityManager {
             ));
         }
         let mut document = None;
+        let mut pinned_workspace_created_at_unix_nanos = None;
         #[cfg(test)]
         let mut before_write_gate = self.before_write_gate.clone();
+        #[cfg(test)]
+        let mut before_retry_gate = self.before_retry_gate.clone();
 
         for _ in 0..MAX_MUTATION_ATTEMPTS {
-            let selected = match self.load_fixed_token_spec(&owner, &spec_key).await {
+            let selected = match self
+                .load_fixed_token_spec(&owner, &spec_key, pinned_workspace_created_at_unix_nanos)
+                .await
+            {
                 Ok(selected) => selected,
                 Err(AppError::RetryableTransactionConflict) => {
                     tokio::task::yield_now().await;
@@ -120,6 +172,9 @@ impl IdentityManager {
                 }
                 Err(error) => return Err(error),
             };
+            if pinned_workspace_created_at_unix_nanos.is_none() {
+                pinned_workspace_created_at_unix_nanos = selected.workspace_created_at_unix_nanos;
+            }
             if document.is_none() {
                 let document_owner = owner.clone();
                 let document_name = name.clone();
@@ -153,6 +208,11 @@ impl IdentityManager {
             {
                 Ok(Some(record)) => return Ok(record),
                 Ok(None) | Err(AppError::RetryableTransactionConflict) => {
+                    #[cfg(test)]
+                    if let Some(gate) = before_retry_gate.take() {
+                        gate.selected.wait().await;
+                        gate.resume.wait().await;
+                    }
                     tokio::task::yield_now().await;
                 }
                 Err(error) => return Err(error),
@@ -224,11 +284,19 @@ impl IdentityManager {
         &self,
         owner: &IdentityOwner,
         key: &IdentitySpecKey,
+        expected_workspace_created_at_unix_nanos: Option<i64>,
     ) -> Result<SelectedFixedTokenSpec, AppError> {
         let mut tx = self.db.begin_read_snapshot().await?;
-        let record = tx.identity_specs().load_optional(key).await?;
+        let workspace_created_at_unix_nanos = owner_workspace_created_at(&mut tx, owner).await?;
+        if expected_workspace_created_at_unix_nanos
+            .is_some_and(|expected| Some(expected) != workspace_created_at_unix_nanos)
+        {
+            tx.rollback().await?;
+            return Err(owner_workspace_not_found(owner));
+        }
+        let record = tx.identity_specs().resolve_optional(key).await?;
         tx.commit().await?;
-        let record = record.ok_or_else(|| global_spec_not_found(key))?;
+        let record = record.ok_or_else(|| spec_not_found(key))?;
         let installed = record_to_installed(record.clone())?;
         if installed.manifest.identity_type != IdentitySpecType::FixedToken {
             return Err(AppError::InvalidInput(format!(
@@ -244,7 +312,12 @@ impl IdentityManager {
             installed.manifest.issuer,
             installed.manifest.identity_type.label(),
         )?;
-        Ok(SelectedFixedTokenSpec { record, reference })
+        Ok(SelectedFixedTokenSpec {
+            requested_key: key.clone(),
+            workspace_created_at_unix_nanos,
+            record,
+            reference,
+        })
     }
 
     async fn try_write(
@@ -255,9 +328,16 @@ impl IdentityManager {
         document: &IdentityDocumentWrite,
     ) -> Result<Option<IdentityRecord>, AppError> {
         let mut tx = self.db.begin_serializable().await?;
+        let workspace_created_at_unix_nanos = owner_workspace_created_at(&mut tx, owner).await?;
+        if workspace_created_at_unix_nanos != selected.workspace_created_at_unix_nanos {
+            // A delete/recreate under the same name is a new owner generation. An in-flight
+            // credential write must not cross that lifecycle boundary.
+            tx.rollback().await?;
+            return Err(owner_workspace_not_found(owner));
+        }
         let current = tx
             .identity_specs()
-            .load_optional(selected.reference.key())
+            .resolve_optional(&selected.requested_key)
             .await?;
         if current.as_ref() != Some(&selected.record) {
             tx.rollback().await?;
@@ -293,6 +373,28 @@ impl IdentityManager {
     }
 }
 
+async fn owner_workspace_created_at(
+    tx: &mut CoralTx<'_>,
+    owner: &IdentityOwner,
+) -> Result<Option<i64>, AppError> {
+    let Some(workspace) = owner.workspace_name() else {
+        return Ok(None);
+    };
+    let record = tx
+        .workspaces()
+        .get(workspace.as_str())
+        .await?
+        .ok_or_else(|| AppError::WorkspaceNotFound(workspace.to_string()))?;
+    Ok(Some(record.created_at_unix_nanos))
+}
+
+fn owner_workspace_not_found(owner: &IdentityOwner) -> AppError {
+    let workspace = owner
+        .workspace_name()
+        .expect("only workspace owners have a persisted workspace generation");
+    AppError::WorkspaceNotFound(workspace.to_string())
+}
+
 fn prepare_fixed_token_document(
     owner: &IdentityOwner,
     name: &IdentityName,
@@ -324,13 +426,6 @@ fn prepare_fixed_token_document(
         algorithm,
         aad_version,
     )
-}
-
-fn global_spec_not_found(key: &IdentitySpecKey) -> AppError {
-    AppError::IdentitySpecNotFound {
-        name: key.name().to_string(),
-        scope: "global".to_string(),
-    }
 }
 
 fn identity_not_found(name: &IdentityName) -> AppError {

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -39,7 +39,7 @@ impl CredentialKeyProvider for TestKeyProvider {
 }
 
 #[tokio::test]
-async fn sqlite_user_global_fixed_token_manager_contract() {
+async fn sqlite_fixed_token_manager_contract() {
     let temp = tempdir().expect("temp dir");
     let db = Arc::new(
         CoralDb::open(ResolvedDatabaseConfig::Sqlite {
@@ -49,14 +49,19 @@ async fn sqlite_user_global_fixed_token_manager_contract() {
         .expect("open sqlite"),
     );
     db.migrate().await.expect("migrate sqlite");
-    assert_user_global_fixed_token_manager_contract(&db).await;
+    Box::pin(assert_fixed_token_manager_contract(&db)).await;
+}
+
+pub(crate) async fn assert_fixed_token_manager_contract(db: &Arc<CoralDb>) {
+    assert_user_global_fixed_token_manager_contract(db).await;
+    assert_workspace_fixed_token_manager_contract(db).await;
 }
 
 #[expect(
     clippy::too_many_lines,
     reason = "shared SQLite/Postgres manager contract"
 )]
-pub(crate) async fn assert_user_global_fixed_token_manager_contract(db: &Arc<CoralDb>) {
+async fn assert_user_global_fixed_token_manager_contract(db: &Arc<CoralDb>) {
     let suffix = uuid::Uuid::new_v4().simple().to_string();
     let spec_a = format!("fixed_a_{suffix}");
     let spec_b = format!("fixed_b_{suffix}");
@@ -66,12 +71,7 @@ pub(crate) async fn assert_user_global_fixed_token_manager_contract(db: &Arc<Cor
     let workspace = WorkspaceName::parse(&format!("work{suffix}")).expect("workspace");
     let workspace_key =
         IdentitySpecKey::workspace(workspace.clone(), &workspace_only).expect("workspace key");
-    let mut tx = db.begin().await.expect("begin seed");
-    tx.workspaces()
-        .ensure(workspace.as_str(), 1)
-        .await
-        .expect("seed workspace");
-    tx.commit().await.expect("commit workspace");
+    put_workspace(db, &workspace).await;
     for (key, yaml) in [
         (
             IdentitySpecKey::global(&spec_a).unwrap(),
@@ -288,6 +288,430 @@ pub(crate) async fn assert_user_global_fixed_token_manager_contract(db: &Arc<Cor
     );
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "shared SQLite/Postgres workspace manager contract"
+)]
+async fn assert_workspace_fixed_token_manager_contract(db: &Arc<CoralDb>) {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let workspace = WorkspaceName::parse(&format!("ws{suffix}")).expect("workspace");
+    let other_workspace = WorkspaceName::parse(&format!("other{suffix}")).expect("other workspace");
+    let deleted_workspace =
+        WorkspaceName::parse(&format!("deleted{suffix}")).expect("deleted workspace");
+    let recreated_workspace =
+        WorkspaceName::parse(&format!("recreated{suffix}")).expect("recreated workspace");
+    let retry_workspace = WorkspaceName::parse(&format!("retry{suffix}")).expect("retry workspace");
+    let missing_workspace =
+        WorkspaceName::parse(&format!("missing{suffix}")).expect("missing workspace");
+    put_workspace(db, &workspace).await;
+    put_workspace(db, &other_workspace).await;
+    put_workspace(db, &deleted_workspace).await;
+    put_workspace(db, &recreated_workspace).await;
+    put_workspace(db, &retry_workspace).await;
+
+    let fallback = format!("fallback_{suffix}");
+    let shadowed = format!("shadowed_{suffix}");
+    let wrong_type = format!("wrong_type_{suffix}");
+    let exact_race = format!("exact_race_{suffix}");
+    let shadow_race = format!("shadow_race_{suffix}");
+    let delete_race = format!("delete_race_{suffix}");
+    let recreate_race = format!("recreate_race_{suffix}");
+    let retry_recreate_race = format!("retry_recreate_race_{suffix}");
+    let retry_recreate_global_key = IdentitySpecKey::global(&retry_recreate_race).unwrap();
+    let retry_recreate_workspace_key =
+        IdentitySpecKey::workspace(retry_workspace.clone(), &retry_recreate_race).unwrap();
+    let fallback_global_key = IdentitySpecKey::global(&fallback).unwrap();
+    let fallback_workspace_key = IdentitySpecKey::workspace(workspace.clone(), &fallback).unwrap();
+    let shadowed_workspace_key = IdentitySpecKey::workspace(workspace.clone(), &shadowed).unwrap();
+    let exact_race_workspace_key =
+        IdentitySpecKey::workspace(workspace.clone(), &exact_race).unwrap();
+    let shadow_race_workspace_key =
+        IdentitySpecKey::workspace(workspace.clone(), &shadow_race).unwrap();
+    for (key, yaml) in [
+        (
+            fallback_global_key.clone(),
+            fixed_manifest(&fallback, "fallback"),
+        ),
+        (
+            IdentitySpecKey::workspace(other_workspace, &fallback).unwrap(),
+            fixed_manifest(&fallback, "other_workspace"),
+        ),
+        (
+            IdentitySpecKey::global(&shadowed).unwrap(),
+            fixed_manifest(&shadowed, "global_shadowed"),
+        ),
+        (
+            shadowed_workspace_key.clone(),
+            fixed_manifest(&shadowed, "workspace_shadowed"),
+        ),
+        (
+            IdentitySpecKey::global(&wrong_type).unwrap(),
+            fixed_manifest(&wrong_type, "global_fixed"),
+        ),
+        (
+            IdentitySpecKey::workspace(workspace.clone(), &wrong_type).unwrap(),
+            oauth_manifest(&wrong_type),
+        ),
+        (
+            exact_race_workspace_key.clone(),
+            fixed_manifest(&exact_race, "before"),
+        ),
+        (
+            IdentitySpecKey::global(&shadow_race).unwrap(),
+            fixed_manifest(&shadow_race, "global_race"),
+        ),
+        (
+            IdentitySpecKey::global(&delete_race).unwrap(),
+            fixed_manifest(&delete_race, "deleted_workspace"),
+        ),
+        (
+            IdentitySpecKey::global(&recreate_race).unwrap(),
+            fixed_manifest(&recreate_race, "recreated_workspace"),
+        ),
+        (
+            retry_recreate_global_key.clone(),
+            fixed_manifest(&retry_recreate_race, "before_retry"),
+        ),
+    ] {
+        put_spec(db, &key, &yaml).await;
+    }
+
+    let key = CredentialEncryptionKey::from_static_bytes_for_test([73; 32]);
+    let provider = Arc::new(TestKeyProvider(vec![key]));
+    let manager = IdentityManager::new(db.clone(), provider.clone());
+    let owner = IdentityOwner::workspace(workspace.clone());
+    assert!(matches!(
+        manager
+            .create_or_replace_workspace_fixed_token(
+                &missing_workspace,
+                "missing-workspace",
+                &fallback,
+                "token".into(),
+            )
+            .await,
+        Err(AppError::WorkspaceNotFound(name)) if name == missing_workspace.as_str()
+    ));
+    assert!(matches!(
+        manager
+            .create_or_replace_workspace_fixed_token(
+                &workspace,
+                "missing-spec",
+                &format!("missing_{suffix}"),
+                "token".into(),
+            )
+            .await,
+        Err(AppError::IdentitySpecNotFound { scope, .. })
+            if scope == format!("workspace:{workspace}")
+    ));
+    assert!(matches!(
+        manager
+            .create_or_replace_workspace_fixed_token(
+                &workspace,
+                "wrong-type",
+                &wrong_type,
+                "token".into(),
+            )
+            .await,
+        Err(AppError::InvalidInput(_))
+    ));
+    assert!(manager.list_for_owner(&owner).await.unwrap().is_empty());
+
+    let fallback_identity = format!("fallback-identity-{suffix}");
+    let fallback_created = manager
+        .create_or_replace_workspace_fixed_token(
+            &workspace,
+            &fallback_identity,
+            &fallback,
+            " fallback-token ".into(),
+        )
+        .await
+        .expect("create global fallback");
+    assert_reference_key(&fallback_created, &fallback_global_key, "fallback");
+    let fallback_pair = load_pair(db, &owner, &fallback_identity).await;
+    assert_eq!(fallback_pair.0.as_ref(), Some(&fallback_created));
+    assert_eq!(fallback_pair.1.as_ref().unwrap().document_version, 1);
+    assert_material(
+        fallback_pair.1.as_ref().unwrap(),
+        &owner,
+        "fallback-token",
+        provider.as_ref(),
+    );
+
+    let shadowed_identity = format!("shadowed-identity-{suffix}");
+    let shadowed_created = manager
+        .create_or_replace_workspace_fixed_token(
+            &workspace,
+            &shadowed_identity,
+            &shadowed,
+            " workspace-token ".into(),
+        )
+        .await
+        .expect("create workspace shadow");
+    assert_reference_key(
+        &shadowed_created,
+        &shadowed_workspace_key,
+        "workspace_shadowed",
+    );
+    let shadowed_pair = load_pair(db, &owner, &shadowed_identity).await;
+    assert_eq!(shadowed_pair.1.as_ref().unwrap().document_version, 1);
+    assert_material(
+        shadowed_pair.1.as_ref().unwrap(),
+        &owner,
+        "workspace-token",
+        provider.as_ref(),
+    );
+
+    put_spec(
+        db,
+        &fallback_workspace_key,
+        &fixed_manifest(&fallback, "late_shadow"),
+    )
+    .await;
+    assert_eq!(
+        manager.get(&owner, &fallback_identity).await.unwrap(),
+        fallback_created
+    );
+
+    let selected = Arc::new(tokio::sync::Barrier::new(2));
+    let resume = Arc::new(tokio::sync::Barrier::new(2));
+    let gated = manager
+        .clone()
+        .with_before_write_gate(selected.clone(), resume.clone());
+    let exact_race_identity = format!("exact-race-identity-{suffix}");
+    let exact_race_result = tokio::time::timeout(Duration::from_secs(10), async {
+        let create = gated.create_or_replace_workspace_fixed_token(
+            &workspace,
+            &exact_race_identity,
+            &exact_race,
+            " exact-race-token ".into(),
+        );
+        let replace = async {
+            selected.wait().await;
+            put_spec(
+                db,
+                &exact_race_workspace_key,
+                &fixed_manifest(&exact_race, "after"),
+            )
+            .await;
+            resume.wait().await;
+        };
+        let (created, ()) = tokio::join!(create, replace);
+        created
+    })
+    .await
+    .expect("workspace spec replacement race must not deadlock")
+    .expect("workspace spec replacement create");
+    assert_reference_key(&exact_race_result, &exact_race_workspace_key, "after");
+    let exact_raced = load_pair(db, &owner, &exact_race_identity).await;
+    assert_eq!(exact_raced.0.as_ref(), Some(&exact_race_result));
+    assert_eq!(exact_raced.1.as_ref().unwrap().document_version, 1);
+    assert_material(
+        exact_raced.1.as_ref().unwrap(),
+        &owner,
+        "exact-race-token",
+        provider.as_ref(),
+    );
+
+    let selected = Arc::new(tokio::sync::Barrier::new(2));
+    let resume = Arc::new(tokio::sync::Barrier::new(2));
+    let gated = manager
+        .clone()
+        .with_before_write_gate(selected.clone(), resume.clone());
+    let shadow_race_identity = format!("shadow-race-identity-{suffix}");
+    let shadow_race_result = tokio::time::timeout(Duration::from_secs(10), async {
+        let create = gated.create_or_replace_workspace_fixed_token(
+            &workspace,
+            &shadow_race_identity,
+            &shadow_race,
+            " shadow-race-token ".into(),
+        );
+        let insert_shadow = async {
+            selected.wait().await;
+            put_spec(
+                db,
+                &shadow_race_workspace_key,
+                &fixed_manifest(&shadow_race, "workspace_race"),
+            )
+            .await;
+            resume.wait().await;
+        };
+        let (created, ()) = tokio::join!(create, insert_shadow);
+        created
+    })
+    .await
+    .expect("workspace shadow race must not deadlock")
+    .expect("workspace shadow race create");
+    assert_reference_key(
+        &shadow_race_result,
+        &shadow_race_workspace_key,
+        "workspace_race",
+    );
+    let shadow_raced = load_pair(db, &owner, &shadow_race_identity).await;
+    assert_eq!(shadow_raced.0.as_ref(), Some(&shadow_race_result));
+    assert_eq!(shadow_raced.1.as_ref().unwrap().document_version, 1);
+    assert_material(
+        shadow_raced.1.as_ref().unwrap(),
+        &owner,
+        "shadow-race-token",
+        provider.as_ref(),
+    );
+
+    let selected = Arc::new(tokio::sync::Barrier::new(2));
+    let resume = Arc::new(tokio::sync::Barrier::new(2));
+    let gated = manager
+        .clone()
+        .with_before_write_gate(selected.clone(), resume.clone());
+    let deleted_identity = format!("deleted-workspace-identity-{suffix}");
+    let deleted_result = tokio::time::timeout(Duration::from_secs(10), async {
+        let create = gated.create_or_replace_workspace_fixed_token(
+            &deleted_workspace,
+            &deleted_identity,
+            &delete_race,
+            " deleted-workspace-token ".into(),
+        );
+        let delete = async {
+            selected.wait().await;
+            delete_workspace(db, &deleted_workspace).await;
+            resume.wait().await;
+        };
+        let (created, ()) = tokio::join!(create, delete);
+        created
+    })
+    .await
+    .expect("workspace deletion race must not deadlock");
+    assert!(matches!(
+        deleted_result,
+        Err(AppError::WorkspaceNotFound(name)) if name == deleted_workspace.as_str()
+    ));
+    let deleted_owner = IdentityOwner::workspace(deleted_workspace);
+    assert_eq!(
+        load_pair(db, &deleted_owner, &deleted_identity).await,
+        (None, None)
+    );
+
+    let selected = Arc::new(tokio::sync::Barrier::new(2));
+    let resume = Arc::new(tokio::sync::Barrier::new(2));
+    let gated = manager
+        .clone()
+        .with_before_write_gate(selected.clone(), resume.clone());
+    let recreated_identity = format!("recreated-workspace-identity-{suffix}");
+    let recreated_result = tokio::time::timeout(Duration::from_secs(10), async {
+        let create = gated.create_or_replace_workspace_fixed_token(
+            &recreated_workspace,
+            &recreated_identity,
+            &recreate_race,
+            " recreated-workspace-token ".into(),
+        );
+        let recreate = async {
+            selected.wait().await;
+            delete_workspace(db, &recreated_workspace).await;
+            put_workspace_at(db, &recreated_workspace, 2).await;
+            resume.wait().await;
+        };
+        let (created, ()) = tokio::join!(create, recreate);
+        created
+    })
+    .await
+    .expect("workspace recreation race must not deadlock");
+    assert!(matches!(
+        recreated_result,
+        Err(AppError::WorkspaceNotFound(name)) if name == recreated_workspace.as_str()
+    ));
+    let recreated_owner = IdentityOwner::workspace(recreated_workspace);
+    assert_eq!(
+        load_pair(db, &recreated_owner, &recreated_identity).await,
+        (None, None)
+    );
+
+    let selected = Arc::new(tokio::sync::Barrier::new(2));
+    let resume_write = Arc::new(tokio::sync::Barrier::new(2));
+    let retry_reached = Arc::new(tokio::sync::Barrier::new(2));
+    let resume_retry = Arc::new(tokio::sync::Barrier::new(2));
+    let gated = manager
+        .clone()
+        .with_before_write_gate(selected.clone(), resume_write.clone())
+        .with_before_retry_gate(retry_reached.clone(), resume_retry.clone());
+    let retry_identity = format!("retry-recreated-workspace-identity-{suffix}");
+    let retry_result = tokio::time::timeout(Duration::from_secs(10), async {
+        let create = gated.create_or_replace_workspace_fixed_token(
+            &retry_workspace,
+            &retry_identity,
+            &retry_recreate_race,
+            " retry-recreated-workspace-token ".into(),
+        );
+        let recreate = async {
+            selected.wait().await;
+            put_spec(
+                db,
+                &retry_recreate_global_key,
+                &fixed_manifest(&retry_recreate_race, "after_retry"),
+            )
+            .await;
+            resume_write.wait().await;
+            retry_reached.wait().await;
+            delete_workspace(db, &retry_workspace).await;
+            put_workspace_at(db, &retry_workspace, 2).await;
+            resume_retry.wait().await;
+        };
+        let (created, ()) = tokio::join!(create, recreate);
+        created
+    })
+    .await
+    .expect("cross-attempt workspace recreation race must not deadlock");
+    assert!(matches!(
+        retry_result,
+        Err(AppError::WorkspaceNotFound(name)) if name == retry_workspace.as_str()
+    ));
+    let retry_owner = IdentityOwner::workspace(retry_workspace.clone());
+    assert_eq!(
+        load_pair(db, &retry_owner, &retry_identity).await,
+        (None, None)
+    );
+    put_spec(
+        db,
+        &retry_recreate_workspace_key,
+        &oauth_manifest(&retry_recreate_race),
+    )
+    .await;
+    assert!(matches!(
+        manager
+            .load_fixed_token_spec(
+                &retry_owner,
+                &retry_recreate_workspace_key,
+                Some(1),
+            )
+            .await,
+        Err(AppError::WorkspaceNotFound(name)) if name == retry_workspace.as_str()
+    ));
+    assert_eq!(manager.list_for_owner(&owner).await.unwrap().len(), 4);
+}
+
+async fn put_workspace(db: &Arc<CoralDb>, workspace: &WorkspaceName) {
+    put_workspace_at(db, workspace, 1).await;
+}
+
+async fn put_workspace_at(
+    db: &Arc<CoralDb>,
+    workspace: &WorkspaceName,
+    created_at_unix_nanos: i64,
+) {
+    let mut tx = db.begin().await.expect("begin workspace write");
+    tx.workspaces()
+        .ensure(workspace.as_str(), created_at_unix_nanos)
+        .await
+        .expect("write workspace");
+    tx.commit().await.expect("commit workspace");
+}
+
+async fn delete_workspace(db: &Arc<CoralDb>, workspace: &WorkspaceName) {
+    let mut tx = db.begin().await.expect("begin workspace delete");
+    tx.workspaces()
+        .delete(workspace.as_str())
+        .await
+        .expect("delete workspace");
+    tx.commit().await.expect("commit workspace delete");
+}
+
 async fn put_spec(db: &Arc<CoralDb>, key: &IdentitySpecKey, yaml: &str) {
     let manifest = parse_identity_manifest_yaml(yaml).expect("valid identity manifest");
     let write = IdentitySpecWrite::new(
@@ -329,11 +753,12 @@ async fn load_pair(
 }
 
 fn assert_reference(record: &IdentityRecord, spec_name: &str, label: &str) {
-    let manifest = parse_identity_manifest_yaml(&fixed_manifest(spec_name, label)).unwrap();
-    assert_eq!(
-        record.spec_reference.key(),
-        &IdentitySpecKey::global(spec_name).unwrap()
-    );
+    assert_reference_key(record, &IdentitySpecKey::global(spec_name).unwrap(), label);
+}
+
+fn assert_reference_key(record: &IdentityRecord, key: &IdentitySpecKey, label: &str) {
+    let manifest = parse_identity_manifest_yaml(&fixed_manifest(key.name(), label)).unwrap();
+    assert_eq!(record.spec_reference.key(), key);
     assert_eq!(
         record.spec_reference.fingerprint(),
         identity_spec_fingerprint(&manifest).unwrap()

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -731,7 +731,7 @@ fn corrupt_record(key: &IdentitySpecKey, detail: &str) -> AppError {
     ))
 }
 
-fn spec_not_found(key: &IdentitySpecKey) -> AppError {
+pub(crate) fn spec_not_found(key: &IdentitySpecKey) -> AppError {
     AppError::IdentitySpecNotFound {
         name: key.name().to_string(),
         scope: scope_label(key.scope()),

--- a/crates/coral-app/src/state/db/migration_order_tests.rs
+++ b/crates/coral-app/src/state/db/migration_order_tests.rs
@@ -155,7 +155,7 @@ async fn postgres_identity_database_contracts() {
     assert_identity_repository_contract(&db).await;
     assert_identity_repository_negative_contract(&db).await;
     crate::identity_specs::manager::tests::assert_identity_spec_mutation_contract(&db).await;
-    crate::identities::manager::tests::assert_user_global_fixed_token_manager_contract(&db).await;
+    Box::pin(crate::identities::manager::tests::assert_fixed_token_manager_contract(&db)).await;
 
     backend.pool.close().await;
     drop(db);


### PR DESCRIPTION
## Intent

Add workspace-owned fixed-token identity creation and replacement with workspace-first identity-spec resolution and safe global fallback.

## What it enables

- Requires the workspace to exist, prefers its exact same-name spec, and otherwise persists the actual selected global fallback reference.
- Re-resolves the requested workspace key inside the serializable write transaction, so exact-spec changes or a newly installed same-workspace shadow cause a clean retry before any identity/document write.
- Pins the first successful workspace-row generation across the complete retry loop and rejects delete/recreate ABA races before observing new-generation spec state or moving encrypted material into the recreated workspace.
- Keeps user and workspace entry points on one private mutation core with the same trimmed-token encryption, active-KEK, owner/name AAD, atomic persistence, and bounded conflict handling.
- Extends one shared SQLite/Postgres contract across workspace preference, global fallback, other-workspace isolation, post-commit reference pinning, exact-spec/shadow races, deletion, direct recreation, and cross-attempt recreation.

## Usage examples

This is an internal manager layer. Call `create_or_replace_workspace_fixed_token` with a validated `WorkspaceName`, identity name, requested spec name, and token. Existing `list_for_owner`, `get`, and `delete` operations accept the resulting workspace owner. Public workspace RPC mounting remains in B4i.

## Validation

- Focused SQLite fixed-token manager contract: 1/1 passed.
- `make postgres-tests`: all 3 required Postgres gates passed, including the shared workspace manager and deterministic race contract.
- `make rust-checks`: 1,717/1,717 tests passed, 3 skipped; formatting, strict workspace Clippy, and rustdoc passed.
- Final exact review swarm: zero findings and zero questions across five lanes, two explicit safe credential flows, and no missed P1/P2 risk at 0.98 supervisor confidence.
- 582 changed lines; no schema, public API, bootstrap, service, OAuth, or production decrypt/rewrap behavior is added.
