### PR TITLE
feat(app): protect identity spec lifecycle

### DIFF
--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -89,7 +89,7 @@ impl IdentityManager {
     }
 
     #[cfg(test)]
-    fn with_before_upsert_gate(mut self, barrier: Arc<tokio::sync::Barrier>) -> Self {
+    pub(crate) fn with_before_upsert_gate(mut self, barrier: Arc<tokio::sync::Barrier>) -> Self {
         self.before_upsert_gate = Some(BeforeUpsertGate {
             barrier,
             used: Arc::new(AtomicBool::new(false)),

--- a/crates/coral-app/src/identity_specs/lifecycle_tests.rs
+++ b/crates/coral-app/src/identity_specs/lifecycle_tests.rs
@@ -1,0 +1,419 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use coral_api::v1::DeleteIdentitySpecRequest;
+use coral_api::v1::identity_spec_service_server::IdentitySpecService as IdentitySpecServiceApi;
+use tempfile::tempdir;
+use tonic::{Code, Request};
+
+use super::tests::TestKeyProvider;
+use super::{IdentitySpecManager, checked_orphan_count, identity_spec_fingerprint};
+use crate::bootstrap::AppError;
+use crate::credentials::encryption::{CredentialEncryptionKey, CredentialKeyProvider};
+use crate::identities::manager::IdentityManager;
+use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+use crate::identity::UserPrincipal;
+use crate::identity_specs::IdentitySpecService;
+use crate::state::db::{
+    CoralDb, DbRepos, IdentitySpecKey, IdentitySpecScope, IdentitySpecWrite, ResolvedDatabaseConfig,
+};
+use crate::workspaces::WorkspaceName;
+
+const RACE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[tokio::test]
+async fn sqlite_identity_spec_lifecycle_contract() {
+    let temp = tempdir().expect("temp dir");
+    let db = Arc::new(
+        CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open SQLite database"),
+    );
+    db.migrate().await.expect("migrate SQLite database");
+
+    Box::pin(assert_identity_spec_lifecycle_contract(&db)).await;
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "shared exact-spec lifecycle contract"
+)]
+pub(crate) async fn assert_identity_spec_lifecycle_contract(db: &Arc<CoralDb>) {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let local_workspace = workspace("local", &suffix);
+    let fallback_workspace = workspace("fallback", &suffix);
+    seed_workspaces(db, [&local_workspace, &fallback_workspace]).await;
+    let key_provider: Arc<dyn CredentialKeyProvider> = Arc::new(TestKeyProvider(vec![
+        CredentialEncryptionKey::from_static_bytes_for_test([73; 32]),
+    ]));
+    let specs = IdentitySpecManager::new(Arc::clone(db), Arc::clone(&key_provider));
+    let identities = IdentityManager::new(Arc::clone(db), Arc::clone(&key_provider));
+    let name = format!("lifecycle_{suffix}");
+    let global_key = IdentitySpecKey::global(&name).expect("global key");
+    let workspace_key =
+        IdentitySpecKey::workspace(local_workspace.clone(), &name).expect("workspace key");
+    let baseline = fixed_manifest(&name, "1.0.0");
+    let equivalent = equivalent_fixed_manifest(&name, "1.0.0");
+    let changed = fixed_manifest(&name, "2.0.0");
+
+    install(&specs, IdentitySpecScope::global(), &baseline)
+        .await
+        .expect("install global spec");
+    install(
+        &specs,
+        IdentitySpecScope::workspace(local_workspace.clone()),
+        &baseline,
+    )
+    .await
+    .expect("install workspace spec");
+    let user_identity = format!("user_{suffix}");
+    let fallback_identity = format!("fallback_{suffix}");
+    let local_identity = format!("local_{suffix}");
+    identities
+        .create_or_replace_user_fixed_token(
+            &UserPrincipal::local(),
+            &user_identity,
+            &name,
+            "user-token".to_string(),
+        )
+        .await
+        .expect("create user identity");
+    identities
+        .create_or_replace_workspace_fixed_token(
+            &fallback_workspace,
+            &fallback_identity,
+            &name,
+            "fallback-token".to_string(),
+        )
+        .await
+        .expect("create global-fallback workspace identity");
+    identities
+        .create_or_replace_workspace_fixed_token(
+            &local_workspace,
+            &local_identity,
+            &name,
+            "workspace-token".to_string(),
+        )
+        .await
+        .expect("create workspace-local identity");
+    let counts = dependent_counts(db, &global_key, &workspace_key).await;
+    assert_eq!(counts, (2, 1));
+
+    assert!(
+        install(&specs, IdentitySpecScope::global(), &equivalent)
+            .await
+            .expect("equivalent replacement")
+            .1
+    );
+    assert_equivalent_rejection(
+        &install(&specs, IdentitySpecScope::global(), &changed)
+            .await
+            .expect_err("changed replacement must reject dependents"),
+        2,
+    );
+
+    let service = IdentitySpecService::new(specs.clone());
+    let guarded =
+        IdentitySpecServiceApi::delete_identity_spec(&service, delete_request(&name, false))
+            .await
+            .expect_err("guarded RPC delete must reject dependents");
+    assert_eq!(guarded.code(), Code::FailedPrecondition);
+    specs.get_global(&name).await.expect("guarded spec remains");
+    assert_eq!(user_identity_pair(db, &user_identity).await, (true, true));
+    let deleted =
+        IdentitySpecServiceApi::delete_identity_spec(&service, delete_request(&name, true))
+            .await
+            .expect("force delete exact spec")
+            .into_inner();
+    assert_eq!(deleted.orphaned_identities, 2);
+    assert_eq!(user_identity_pair(db, &user_identity).await, (true, true));
+    assert!(matches!(
+        specs.get_global(&name).await,
+        Err(AppError::IdentitySpecNotFound { .. })
+    ));
+    assert!(matches!(
+        specs.delete_exact(&global_key, true).await,
+        Err(AppError::IdentitySpecNotFound { .. })
+    ));
+    specs
+        .get_exact(&workspace_key)
+        .await
+        .expect("same-name workspace spec remains installed");
+
+    assert_equivalent_rejection(
+        &install(&specs, IdentitySpecScope::global(), &changed)
+            .await
+            .expect_err("changed re-add must reject orphan dependents"),
+        2,
+    );
+    assert!(
+        !install(&specs, IdentitySpecScope::global(), &equivalent)
+            .await
+            .expect("equivalent re-add heals exact orphans")
+            .1
+    );
+    let stale_write = IdentitySpecWrite::new(
+        "2.0.0",
+        "lifecycle 2.0.0",
+        "lifecycle",
+        "fixed_token",
+        &changed,
+    )
+    .expect("valid stale write");
+    let mut tx = db.begin().await.expect("begin stale write");
+    tx.identity_specs()
+        .upsert(&global_key, &stale_write, 50)
+        .await
+        .unwrap();
+    tx.commit().await.expect("commit stale write");
+    let (_, repaired) = install(&specs, IdentitySpecScope::global(), &equivalent)
+        .await
+        .expect("dependent fingerprints permit stale-row repair");
+    assert!(repaired);
+
+    let owner = IdentityOwner::for_user(UserPrincipal::local());
+    let identity_name = IdentityName::parse(&user_identity).expect("mixed identity name");
+    let mixed = IdentitySpecReference::new(
+        &owner,
+        global_key.clone(),
+        "legacy-mixed-fingerprint",
+        "lifecycle",
+        "fixed_token",
+    )
+    .expect("mixed legacy reference");
+    let mut tx = db.begin().await.expect("begin mixed reference write");
+    tx.identities()
+        .upsert(&owner, &identity_name, &mixed, 51)
+        .await
+        .unwrap();
+    tx.commit().await.expect("commit mixed reference write");
+    assert_equivalent_rejection(
+        &install(&specs, IdentitySpecScope::global(), &equivalent)
+            .await
+            .expect_err("candidate matching only one dependent must reject"),
+        2,
+    );
+    assert_eq!(
+        specs.get_global(&name).await.unwrap().manifest.version,
+        "1.0.0"
+    );
+
+    checked_orphan_count(&global_key, u64::from(u32::MAX) + 1).unwrap_err();
+    assert_changed_replace_create_race(db, Arc::clone(&key_provider), &suffix).await;
+    assert_delete_create_race(db, Arc::clone(&key_provider), &suffix, false).await;
+    assert_delete_create_race(db, key_provider, &suffix, true).await;
+}
+
+async fn assert_changed_replace_create_race(
+    db: &Arc<CoralDb>,
+    key_provider: Arc<dyn CredentialKeyProvider>,
+    suffix: &str,
+) {
+    let name = format!("replace_race_{suffix}");
+    let changed = fixed_manifest(&name, "2.0.0");
+    let specs = IdentitySpecManager::new(Arc::clone(db), Arc::clone(&key_provider));
+    install(
+        &specs,
+        IdentitySpecScope::global(),
+        &fixed_manifest(&name, "1.0.0"),
+    )
+    .await
+    .expect("seed replacement race spec");
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let gated_specs = IdentitySpecManager::new(Arc::clone(db), Arc::clone(&key_provider))
+        .with_before_lifecycle_write(Arc::clone(&barrier));
+    let gated_identities =
+        IdentityManager::new(Arc::clone(db), key_provider).with_before_upsert_gate(barrier);
+    let principal = UserPrincipal::local();
+    let (created, replaced) = tokio::time::timeout(RACE_TIMEOUT, async {
+        tokio::join!(
+            gated_identities.create_or_replace_user_fixed_token(
+                &principal,
+                &name,
+                &name,
+                "race-token".to_string(),
+            ),
+            install(&gated_specs, IdentitySpecScope::global(), &changed),
+        )
+    })
+    .await
+    .expect("changed replacement race must not deadlock");
+    let created = created.expect("identity create must converge on one spec generation");
+    assert_eq!(user_identity_pair(db, &name).await, (true, true));
+    let current = specs.get_global(&name).await.expect("race spec remains");
+    let current_fingerprint =
+        identity_spec_fingerprint(&current.manifest).expect("fingerprint current race spec");
+    assert_eq!(created.spec_reference.fingerprint(), current_fingerprint);
+    match replaced {
+        Ok((_installed, true)) => assert_eq!(current.manifest.version, "2.0.0"),
+        Err(AppError::FailedPrecondition(detail)) => {
+            assert!(detail.contains("equivalent manifest"));
+            assert_eq!(current.manifest.version, "1.0.0");
+        }
+        other => panic!("unexpected changed replacement race result: {other:?}"),
+    }
+}
+
+async fn assert_delete_create_race(
+    db: &Arc<CoralDb>,
+    key_provider: Arc<dyn CredentialKeyProvider>,
+    suffix: &str,
+    force: bool,
+) {
+    let label = if force { "force" } else { "guarded" };
+    let name = format!("delete_{label}_{suffix}");
+    let key = IdentitySpecKey::global(&name).expect("delete race key");
+    let specs = IdentitySpecManager::new(Arc::clone(db), Arc::clone(&key_provider));
+    install(
+        &specs,
+        IdentitySpecScope::global(),
+        &fixed_manifest(&name, "1.0.0"),
+    )
+    .await
+    .expect("seed delete race spec");
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let gated_specs = IdentitySpecManager::new(Arc::clone(db), Arc::clone(&key_provider))
+        .with_before_lifecycle_write(Arc::clone(&barrier));
+    let gated_identities =
+        IdentityManager::new(Arc::clone(db), key_provider).with_before_upsert_gate(barrier);
+    let principal = UserPrincipal::local();
+    let (created, deleted) = tokio::time::timeout(RACE_TIMEOUT, async {
+        tokio::join!(
+            gated_identities.create_or_replace_user_fixed_token(
+                &principal,
+                &name,
+                &name,
+                "race-token".to_string(),
+            ),
+            gated_specs.delete_exact(&key, force),
+        )
+    })
+    .await
+    .expect("delete/create race must not deadlock");
+    let pair_expected = created.is_ok();
+
+    if force {
+        let orphaned = deleted.expect("force delete must converge");
+        match created {
+            Ok(_record) => assert_eq!(orphaned, 1),
+            Err(AppError::IdentitySpecNotFound { .. }) => assert_eq!(orphaned, 0),
+            other => panic!("unexpected force-delete race create result: {other:?}"),
+        }
+        assert!(matches!(
+            specs.get_global(&name).await,
+            Err(AppError::IdentitySpecNotFound { .. })
+        ));
+    } else {
+        match (created, deleted) {
+            (Ok(_record), Err(AppError::FailedPrecondition(detail))) => {
+                assert!(detail.contains("retry with force"));
+                specs
+                    .get_global(&name)
+                    .await
+                    .expect("guarded delete leaves spec installed");
+            }
+            (Err(AppError::IdentitySpecNotFound { .. }), Ok(0)) => assert!(matches!(
+                specs.get_global(&name).await,
+                Err(AppError::IdentitySpecNotFound { .. })
+            )),
+            other => panic!("unexpected guarded-delete race result: {other:?}"),
+        }
+    }
+    assert_eq!(
+        user_identity_pair(db, &name).await,
+        (pair_expected, pair_expected)
+    );
+}
+
+async fn install(
+    manager: &IdentitySpecManager,
+    scope: IdentitySpecScope,
+    manifest: &str,
+) -> Result<(super::InstalledIdentitySpec, bool), AppError> {
+    manager.add_or_replace_exact(scope, manifest, vec![]).await
+}
+
+async fn seed_workspaces<const N: usize>(db: &Arc<CoralDb>, workspaces: [&WorkspaceName; N]) {
+    let mut tx = db.begin().await.expect("begin workspace seed");
+    for (index, workspace) in workspaces.into_iter().enumerate() {
+        tx.workspaces()
+            .ensure(
+                workspace.as_str(),
+                i64::try_from(index + 1).expect("workspace generation"),
+            )
+            .await
+            .expect("seed lifecycle workspace");
+    }
+    tx.commit().await.expect("commit workspace seed");
+}
+
+async fn dependent_counts(
+    db: &Arc<CoralDb>,
+    global: &IdentitySpecKey,
+    workspace: &IdentitySpecKey,
+) -> (u64, u64) {
+    let mut session = db.as_ref();
+    let global = session
+        .identities()
+        .count_dependents(global)
+        .await
+        .expect("count global dependents");
+    let workspace = session
+        .identities()
+        .count_dependents(workspace)
+        .await
+        .expect("count workspace dependents");
+    (global, workspace)
+}
+
+async fn user_identity_pair(db: &Arc<CoralDb>, name: &str) -> (bool, bool) {
+    let owner = IdentityOwner::for_user(UserPrincipal::local());
+    let name = IdentityName::parse(name).expect("valid identity name");
+    let mut session = db.as_ref();
+    let identity = session
+        .identities()
+        .load_optional(&owner, &name)
+        .await
+        .unwrap();
+    let document = session
+        .identity_documents()
+        .load_optional(&owner, &name)
+        .await
+        .unwrap();
+    (identity.is_some(), document.is_some())
+}
+
+fn assert_equivalent_rejection(error: &AppError, count: u64) {
+    assert!(
+        matches!(&error, AppError::FailedPrecondition(detail)
+            if detail.contains(&format!("{count} stored "))
+                && detail.contains("equivalent manifest")),
+        "unexpected dependent replacement error: {error}"
+    );
+}
+
+fn delete_request(name: &str, force: bool) -> Request<DeleteIdentitySpecRequest> {
+    Request::new(DeleteIdentitySpecRequest {
+        name: name.to_string(),
+        workspace: None,
+        force,
+    })
+}
+
+fn workspace(label: &str, suffix: &str) -> WorkspaceName {
+    WorkspaceName::parse(&format!("{label}{suffix}")).expect("valid lifecycle workspace")
+}
+
+fn fixed_manifest(name: &str, version: &str) -> String {
+    format!(
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: {version}\ndescription: lifecycle {version}\nissuer: lifecycle\ntype: fixed_token\n"
+    )
+}
+
+fn equivalent_fixed_manifest(name: &str, version: &str) -> String {
+    format!(
+        "# semantically equivalent reordered YAML\ntype: fixed_token\nissuer: lifecycle\ndescription: lifecycle {version}\nversion: {version}\nname: {name}\nspec_version: 1\nkind: identity\n"
+    )
+}

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -3,6 +3,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use coral_spec::{IdentityManifest, ManifestInputKind, parse_identity_manifest_yaml};
 
@@ -12,6 +14,7 @@ use crate::identity::{
     decrypt_identity_spec_document, encrypt_identity_spec_document, parse_path_segment,
     run_key_operation,
 };
+use crate::identity_specs::identity_spec_fingerprint;
 use crate::state::db::{
     CoralDb, CoralTx, DbRepos, IdentitySpecDocumentRecord, IdentitySpecDocumentWrite,
     IdentitySpecKey, IdentitySpecRecord, IdentitySpecScope, IdentitySpecWrite, now_unix_nanos_i64,
@@ -108,6 +111,15 @@ pub(crate) struct IdentitySpecManager {
     key_provider: Arc<dyn CredentialKeyProvider>,
     #[cfg(test)]
     mutation_barrier: Option<Arc<tokio::sync::Barrier>>,
+    #[cfg(test)]
+    before_lifecycle_write: Option<BeforeLifecycleWrite>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct BeforeLifecycleWrite {
+    barrier: Arc<tokio::sync::Barrier>,
+    used: Arc<AtomicBool>,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -123,12 +135,26 @@ impl IdentitySpecManager {
             key_provider,
             #[cfg(test)]
             mutation_barrier: None,
+            #[cfg(test)]
+            before_lifecycle_write: None,
         }
     }
 
     #[cfg(test)]
     fn with_mutation_barrier(mut self, barrier: Arc<tokio::sync::Barrier>) -> Self {
         self.mutation_barrier = Some(barrier);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_before_lifecycle_write(
+        mut self,
+        barrier: Arc<tokio::sync::Barrier>,
+    ) -> Self {
+        self.before_lifecycle_write = Some(BeforeLifecycleWrite {
+            barrier,
+            used: Arc::new(AtomicBool::new(false)),
+        });
         self
     }
 
@@ -200,7 +226,7 @@ impl IdentitySpecManager {
             let replaced = snapshot.record.is_some();
 
             match self
-                .try_write_mutation(&key, &snapshot, &write, document.as_ref())
+                .try_write_mutation(&key, &snapshot, &manifest, &write, document.as_ref())
                 .await
             {
                 Ok(Some(installed)) => return Ok((installed, replaced)),
@@ -214,10 +240,14 @@ impl IdentitySpecManager {
     }
 
     /// Delete one spec in exactly the selected scope.
-    pub(crate) async fn delete_exact(&self, key: &IdentitySpecKey) -> Result<(), AppError> {
+    pub(crate) async fn delete_exact(
+        &self,
+        key: &IdentitySpecKey,
+        force: bool,
+    ) -> Result<u32, AppError> {
         for _ in 0..MAX_MUTATION_ATTEMPTS {
-            match self.try_delete_exact(key).await {
-                Ok(()) => return Ok(()),
+            match self.try_delete_exact(key, force).await {
+                Ok(orphaned) => return Ok(orphaned),
                 Err(AppError::RetryableTransactionConflict) => {
                     tokio::task::yield_now().await;
                 }
@@ -241,6 +271,7 @@ impl IdentitySpecManager {
         &self,
         key: &IdentitySpecKey,
         expected: &IdentitySpecMutationSnapshot,
+        manifest: &IdentityManifest,
         write: &IdentitySpecWrite,
         document: Option<&IdentitySpecDocumentWrite>,
     ) -> Result<Option<InstalledIdentitySpec>, AppError> {
@@ -250,8 +281,11 @@ impl IdentitySpecManager {
             tx.rollback().await?;
             return Ok(None);
         }
-        let now = now_unix_nanos_i64()?;
         let result = async {
+            require_equivalent_dependents(&mut tx, key, manifest).await?;
+            #[cfg(test)]
+            self.wait_before_lifecycle_write().await;
+            let now = now_unix_nanos_i64()?;
             let record = tx.identity_specs().upsert(key, write, now).await?;
             match document {
                 Some(document) => {
@@ -277,22 +311,45 @@ impl IdentitySpecManager {
         Ok(Some(record))
     }
 
-    async fn try_delete_exact(&self, key: &IdentitySpecKey) -> Result<(), AppError> {
+    async fn try_delete_exact(&self, key: &IdentitySpecKey, force: bool) -> Result<u32, AppError> {
         let mut tx = self.db.begin_serializable().await?;
-        require_scope_workspace(&mut tx, key.scope()).await?;
-        let deleted = match tx.identity_specs().delete(key).await {
-            Ok(deleted) => deleted,
+        let result = async {
+            require_scope_workspace(&mut tx, key.scope()).await?;
+            if tx.identity_specs().load_optional(key).await?.is_none() {
+                return Err(spec_not_found(key));
+            }
+            let orphaned = tx.identities().count_dependents(key).await?;
+            let orphaned = checked_orphan_count(key, orphaned)?;
+            if orphaned > 0 && !force {
+                return Err(spec_delete_requires_force(key, orphaned));
+            }
+            #[cfg(test)]
+            self.wait_before_lifecycle_write().await;
+            let deleted = tx.identity_specs().delete(key).await?;
+            if !deleted {
+                return Err(spec_not_found(key));
+            }
+            Ok(orphaned)
+        }
+        .await;
+        let orphaned = match result {
+            Ok(orphaned) => orphaned,
             Err(error) => {
                 tx.rollback().await?;
-                return Err(error.into());
+                return Err(error);
             }
         };
-        if !deleted {
-            tx.rollback().await?;
-            return Err(spec_not_found(key));
-        }
         tx.commit().await?;
-        Ok(())
+        Ok(orphaned)
+    }
+
+    #[cfg(test)]
+    async fn wait_before_lifecycle_write(&self) {
+        if let Some(gate) = &self.before_lifecycle_write
+            && !gate.used.swap(true, Ordering::SeqCst)
+        {
+            gate.barrier.wait().await;
+        }
     }
 
     /// Fetch one spec in exactly the requested scope, without fallback.
@@ -428,6 +485,59 @@ impl IdentitySpecManager {
         tx.commit().await?;
         convert_records(records)
     }
+}
+
+async fn require_equivalent_dependents(
+    tx: &mut CoralTx<'_>,
+    key: &IdentitySpecKey,
+    manifest: &IdentityManifest,
+) -> Result<(), AppError> {
+    let dependent_count = tx.identities().count_dependents(key).await?;
+    if dependent_count == 0 {
+        return Ok(());
+    }
+    let fingerprint = identity_spec_fingerprint(manifest)?;
+    let equivalent_count = tx
+        .identities()
+        .count_exact_dependents(key, &fingerprint)
+        .await?;
+    if equivalent_count == dependent_count {
+        return Ok(());
+    }
+    Err(AppError::FailedPrecondition(format!(
+        "identity spec '{}' in scope '{}' is used by {dependent_count} stored {} and may only be replaced or re-added with an equivalent manifest",
+        key.name(),
+        scope_label(key.scope()),
+        identity_noun(dependent_count),
+    )))
+}
+
+fn spec_delete_requires_force(key: &IdentitySpecKey, orphaned: u32) -> AppError {
+    AppError::FailedPrecondition(format!(
+        "identity spec '{}' in scope '{}' is used by {orphaned} stored {}; retry with force to orphan {}",
+        key.name(),
+        scope_label(key.scope()),
+        identity_noun(u64::from(orphaned)),
+        identity_pronoun(u64::from(orphaned)),
+    ))
+}
+
+fn checked_orphan_count(key: &IdentitySpecKey, count: u64) -> Result<u32, AppError> {
+    u32::try_from(count).map_err(|_error| {
+        AppError::FailedPrecondition(format!(
+            "identity spec '{}' in scope '{}' has too many dependent identities to report safely",
+            key.name(),
+            scope_label(key.scope()),
+        ))
+    })
+}
+
+fn identity_noun(count: u64) -> &'static str {
+    if count == 1 { "identity" } else { "identities" }
+}
+
+fn identity_pronoun(count: u64) -> &'static str {
+    if count == 1 { "it" } else { "them" }
 }
 
 pub(crate) fn prepare_identity_spec_input_material(
@@ -746,6 +856,10 @@ fn scope_label(scope: &IdentitySpecScope) -> String {
 }
 
 #[cfg(test)]
+#[path = "lifecycle_tests.rs"]
+pub(crate) mod lifecycle_tests;
+
+#[cfg(test)]
 pub(crate) mod tests {
     use std::collections::BTreeMap;
     use std::sync::{Arc, Mutex, mpsc};
@@ -832,7 +946,7 @@ pub(crate) mod tests {
         workspace: WorkspaceName,
     }
 
-    struct TestKeyProvider(Vec<CredentialEncryptionKey>);
+    pub(crate) struct TestKeyProvider(pub(crate) Vec<CredentialEncryptionKey>);
 
     impl CredentialKeyProvider for TestKeyProvider {
         fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
@@ -980,7 +1094,7 @@ pub(crate) mod tests {
 
         let global_before_delete = manager.load_mutation_snapshot(&global_key).await.unwrap();
         manager
-            .delete_exact(&workspace_key)
+            .delete_exact(&workspace_key, false)
             .await
             .expect("delete workspace spec");
         let deleted = manager
@@ -990,7 +1104,7 @@ pub(crate) mod tests {
         assert!(deleted.record.is_none() && deleted.document.is_none());
         assert!(manager.load_mutation_snapshot(&global_key).await.unwrap() == global_before_delete);
         assert!(matches!(
-            manager.delete_exact(&workspace_key).await,
+            manager.delete_exact(&workspace_key, false).await,
             Err(AppError::IdentitySpecNotFound { .. })
         ));
 
@@ -1192,7 +1306,7 @@ pub(crate) mod tests {
             &manifest("alpha", "missing"),
             vec![],
         ));
-        assert_workspace_missing!(fixture.manager.delete_exact(&missing_key));
+        assert_workspace_missing!(fixture.manager.delete_exact(&missing_key, false));
         assert_workspace_missing!(fixture.manager.get_exact(&missing_key));
         assert_workspace_missing!(fixture.manager.get_exact_for_use(&missing_key));
         assert_workspace_missing!(fixture.manager.list_exact(&missing_scope));

--- a/crates/coral-app/src/identity_specs/service.rs
+++ b/crates/coral-app/src/identity_specs/service.rs
@@ -109,11 +109,12 @@ impl IdentitySpecServiceApi for IdentitySpecService {
             let request = request.into_inner();
             let scope = scope_from_proto(request.workspace.as_ref())?;
             let key = IdentitySpecKey::new(scope, &request.name).map_err(app_status)?;
-            specs.delete_exact(&key).await.map_err(app_status)?;
-
-            // B4 introduces stored identity instances and owns force/orphan semantics.
+            let orphaned_identities = specs
+                .delete_exact(&key, request.force)
+                .await
+                .map_err(app_status)?;
             Ok(Response::new(DeleteIdentitySpecResponse {
-                orphaned_identities: 0,
+                orphaned_identities,
             }))
         })
         .await

--- a/crates/coral-app/src/state/db/migration_order_tests.rs
+++ b/crates/coral-app/src/state/db/migration_order_tests.rs
@@ -155,6 +155,12 @@ async fn postgres_identity_database_contracts() {
     assert_identity_repository_contract(&db).await;
     assert_identity_repository_negative_contract(&db).await;
     crate::identity_specs::manager::tests::assert_identity_spec_mutation_contract(&db).await;
+    Box::pin(
+        crate::identity_specs::manager::lifecycle_tests::assert_identity_spec_lifecycle_contract(
+            &db,
+        ),
+    )
+    .await;
     Box::pin(crate::identities::manager::tests::assert_fixed_token_manager_contract(&db)).await;
 
     backend.pool.close().await;

--- a/crates/coral-app/src/state/db/repositories/identities.rs
+++ b/crates/coral-app/src/state/db/repositories/identities.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(not(test), expect(dead_code, reason = "Used by B4f."))]
-
 use sea_query::{Alias, Expr, ExprTrait, OnConflict, Order, Query};
 
 use crate::bootstrap::AppError;


### PR DESCRIPTION
## Intent

Protect exact identity-spec lifecycle once stored identities depend on a canonical scope, name, and manifest fingerprint. Incompatible replacement or accidental deletion must not silently invalidate durable identity references.

## What it enables

- Allows semantically equivalent replacement and re-add when every exact dependent fingerprint matches the candidate manifest.
- Rejects changed manifests while dependents exist, including mixed historical fingerprints, while still permitting stale installed-row repair.
- Rejects non-force deletion, reports the exact orphan count for force deletion, and preserves identity rows and encrypted documents atomically.
- Converges safely under concurrent identity creation versus spec replacement or deletion on SQLite and PostgreSQL.

## Usage examples

`DeleteIdentitySpecRequest { name, workspace, force: false }` returns `FailedPrecondition` when exact dependents exist. Retrying with `force: true` deletes only the spec and returns `orphaned_identities`; the stored identities remain inspectable for later repair or deletion.

Re-adding or replacing a referenced spec succeeds only when its canonical manifest fingerprint is equivalent for every exact dependent identity.

## Validation

- `make postgres-tests`
- `make rust-checks` (1,718/1,718 tests passed; Clippy and rustdoc clean)
- Exact-final five-lane review swarm plus supervisor missed-risk sweep: no findings
