### PR TITLE
feat(sources/community/rclone): add rclone community source

### DIFF
--- a/sources/community/rclone/README.md
+++ b/sources/community/rclone/README.md
@@ -160,7 +160,7 @@ Get the total size and file count for a remote or path, recursively. Pass the pa
 |--------|------|-------------|
 | `bytes` | Int64 | Total size of all files in bytes |
 | `count` | Int64 | Total number of files |
-| `sizeless` | Int64 | Number of files with unknown size |
+| `sizeless` | Int64 | Number of files with unknown size (may not be present on all rclone versions) |
 
 ## Source scope
 

--- a/sources/community/rclone/README.md
+++ b/sources/community/rclone/README.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.1.0
 **Backend:** HTTP
-**Functions:** 2
+**Functions:** 5
 
 Query files, directories, and storage usage across 70+ cloud storage providers through rclone's RC API. Supports Google Drive, Dropbox, S3, OneDrive, MEGA, pCloud, Box, Backblaze B2, and more — all from a single source.
 
@@ -59,6 +59,18 @@ SELECT path, name, size
 FROM rclone.files(fs => 'gdrive:', path => '')
 WHERE size > 10485760
 ORDER BY size DESC;
+
+-- Get info about a specific file
+SELECT path, name, size, mime_type, mod_time
+FROM rclone.stat(fs => 'mega:', path => 'document.pdf');
+
+-- Get recursive size and file count
+SELECT bytes, count
+FROM rclone.size(fs => 'gdrive:', path => 'Photos');
+
+-- Get a public sharing link
+SELECT url
+FROM rclone.publiclink(fs => 'mega:', path => 'report.pdf');
 ```
 
 ## Functions
@@ -108,11 +120,76 @@ Get storage usage for a cloud storage remote. Returns total, used, and free spac
 | `trashed` | Int64 | Space used by trashed files in bytes |
 | `other` | Int64 | Space used by other (non-file) data in bytes |
 
+---
+
+### `rclone.stat`
+
+Get metadata for a single file or directory. Returns the same fields as `files` for one specific path.
+
+**Arguments**
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `fs` | Utf8 | (Required) Remote name with colon |
+| `path` | Utf8 | (Required) Path to the file or directory |
+
+**Result columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `path` | Utf8 | Full path relative to the remote root |
+| `name` | Utf8 | File or directory name |
+| `size` | Int64 | File size in bytes (-1 for directories) |
+| `mime_type` | Utf8 | MIME type of the file |
+| `mod_time` | Utf8 | Last modification time (ISO 8601 with timezone) |
+| `is_dir` | Boolean | Whether the entry is a directory |
+| `id` | Utf8 | Provider-specific file or directory ID |
+
+---
+
+### `rclone.size`
+
+Get the total size and file count for a path, recursively. Use `path => ''` for the entire remote.
+
+**Arguments**
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `fs` | Utf8 | (Required) Remote name with colon |
+| `path` | Utf8 | (Required) Path to measure (use `''` for entire remote) |
+
+**Result columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `bytes` | Int64 | Total size of all files in bytes |
+| `count` | Int64 | Total number of files |
+| `sizeless` | Int64 | Number of files with unknown size |
+
+---
+
+### `rclone.publiclink`
+
+Get a public sharing link for a file or directory. Not all providers support public links.
+
+**Arguments**
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `fs` | Utf8 | (Required) Remote name with colon |
+| `path` | Utf8 | (Required) Path to the file or directory |
+
+**Result columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `url` | Utf8 | Public sharing URL for the file or directory |
+
 ## Source scope
 
 - Targets the rclone RC API (default `http://localhost:5572`). The base URL is configurable via `RCLONE_RC_URL`.
 - No API key required — rclone handles cloud provider authentication through its own config.
-- `files` lists files and directories in any configured remote. `about` returns storage usage.
+- `files` lists files/directories, `about` returns storage usage, `stat` gets single file info, `size` gets recursive count/total, `publiclink` gets sharing URLs.
 - All rclone RC calls use `POST` with JSON body.
 - No pagination — rclone returns the full directory listing per call.
 - Supports any rclone remote: Google Drive, Dropbox, S3, OneDrive, MEGA, pCloud, Box, B2, SFTP, and 60+ more.
@@ -172,6 +249,9 @@ WHERE schema_name = 'rclone';
 +---------------+-------+-----------------------------------------------------------------------------------------+
 | about         | table | [{"name":"fs","required":true,"values":[]}]                                             |
 | files         | table | [{"name":"fs","required":true,"values":[]},{"name":"path","required":true,"values":[]}] |
+| publiclink    | table | [{"name":"fs","required":true,"values":[]},{"name":"path","required":true,"values":[]}] |
+| size          | table | [{"name":"fs","required":true,"values":[]},{"name":"path","required":true,"values":[]}] |
+| stat          | table | [{"name":"fs","required":true,"values":[]},{"name":"path","required":true,"values":[]}] |
 +---------------+-------+-----------------------------------------------------------------------------------------+
 ```
 
@@ -222,4 +302,49 @@ FROM rclone.about(fs => 'mega:');
 +-------------+-------+-------------+
 | 21474836480 | 43054 | 21474793426 |
 +-------------+-------+-------------+
+```
+
+**Live stat proof (MEGA):**
+
+```sql
+SELECT path, name, size, mime_type, is_dir
+FROM rclone.stat(fs => 'mega:', path => '.DS_Store');
+```
+
+```text
++-----------+-----------+-------+--------------------------+--------+
+| path      | name      | size  | mime_type                | is_dir |
++-----------+-----------+-------+--------------------------+--------+
+| .DS_Store | .DS_Store | 10244 | application/octet-stream | false  |
++-----------+-----------+-------+--------------------------+--------+
+```
+
+**Live size proof (MEGA):**
+
+```sql
+SELECT bytes, count, sizeless
+FROM rclone.size(fs => 'mega:', path => '');
+```
+
+```text
++-------+-------+----------+
+| bytes | count | sizeless |
++-------+-------+----------+
+| 10244 | 2     | 0        |
++-------+-------+----------+
+```
+
+**Live publiclink proof (MEGA):**
+
+```sql
+SELECT url
+FROM rclone.publiclink(fs => 'mega:', path => '.DS_Store');
+```
+
+```text
++----------------------------------------------------------------------+
+| url                                                                  |
++----------------------------------------------------------------------+
+| https://mega.co.nz/#!xxxx0000!xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxx |
++----------------------------------------------------------------------+
 ```

--- a/sources/community/rclone/README.md
+++ b/sources/community/rclone/README.md
@@ -170,7 +170,7 @@ Get the total size and file count for a remote or path, recursively. Pass the pa
 - All rclone RC calls use `POST` with JSON body.
 - No pagination — rclone returns the full directory listing per call.
 - Supports any rclone remote: Google Drive, Dropbox, S3, OneDrive, MEGA, pCloud, Box, B2, SFTP, and 60+ more.
-- 1 declared test query (`files`) requires a running rclone daemon and a configured remote.
+- No declared test queries — all functions require a user-specific remote name. Test manually with your configured remote after adding the source.
 
 ## Limitations
 
@@ -205,12 +205,6 @@ $ coral source add --file sources/community/rclone/manifest.yaml
 Added source rclone
 
   ✓ rclone connected successfully
-
-    Query tests
-    1 declared · 1 passed · 0 failed
-
-    ✓ SELECT path, name, size, is_dir FROM rclone.files(fs => 'mega:', path => '') LIMIT 5
-      3 rows
 ```
 
 **Function introspection:**

--- a/sources/community/rclone/README.md
+++ b/sources/community/rclone/README.md
@@ -1,0 +1,225 @@
+# Rclone
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Functions:** 2
+
+Query files, directories, and storage usage across 70+ cloud storage providers through rclone's RC API. Supports Google Drive, Dropbox, S3, OneDrive, MEGA, pCloud, Box, Backblaze B2, and more — all from a single source.
+
+## Installation
+
+1. Install and configure rclone with your cloud storage remotes:
+
+```bash
+brew install rclone    # or see https://rclone.org/install/
+rclone config          # set up remotes (Google Drive, Dropbox, etc.)
+```
+
+2. Start the rclone RC API daemon:
+
+```bash
+rclone rcd --rc-no-auth
+```
+
+3. Install the Coral source:
+
+```bash
+coral source add --file sources/community/rclone/manifest.yaml
+```
+
+## Prerequisites
+
+- [rclone](https://rclone.org/) installed with at least one remote configured
+- rclone RC daemon running (`rclone rcd --rc-no-auth`)
+
+## Quick Start
+
+```sql
+-- List files in a MEGA remote
+SELECT path, name, size, mime_type, is_dir
+FROM rclone.files(fs => 'mega:', path => '')
+LIMIT 10;
+
+-- List files in a Google Drive folder
+SELECT path, name, size, mod_time
+FROM rclone.files(fs => 'gdrive:', path => 'Documents')
+LIMIT 10;
+
+-- Check storage usage for a remote
+SELECT total, used, free
+FROM rclone.about(fs => 'mega:');
+
+-- List only directories
+SELECT path, name
+FROM rclone.files(fs => 'onedrive:', path => '')
+WHERE is_dir = true;
+
+-- Find large files (> 10 MB)
+SELECT path, name, size
+FROM rclone.files(fs => 'gdrive:', path => '')
+WHERE size > 10485760
+ORDER BY size DESC;
+```
+
+## Functions
+
+### `rclone.files`
+
+List files and directories in a cloud storage remote. Returns file metadata including name, size, MIME type, and modification time.
+
+**Arguments**
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `fs` | Utf8 | (Required) Remote name with colon (e.g. `mega:`, `gdrive:`, `s3:bucket`) |
+| `path` | Utf8 | (Required) Path within the remote (use `''` for root) |
+
+**Result columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `path` | Utf8 | Full path relative to the remote root |
+| `name` | Utf8 | File or directory name |
+| `size` | Int64 | File size in bytes (-1 for directories) |
+| `mime_type` | Utf8 | MIME type (e.g. application/pdf, inode/directory) |
+| `mod_time` | Utf8 | Last modification time (ISO 8601 with timezone) |
+| `is_dir` | Boolean | Whether the entry is a directory |
+| `id` | Utf8 | Provider-specific file or directory ID |
+
+---
+
+### `rclone.about`
+
+Get storage usage for a cloud storage remote. Returns total, used, and free space in bytes.
+
+**Arguments**
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `fs` | Utf8 | (Required) Remote name with colon (e.g. `mega:`, `gdrive:`) |
+
+**Result columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `total` | Int64 | Total storage space in bytes |
+| `used` | Int64 | Storage space used in bytes |
+| `free` | Int64 | Free storage space in bytes |
+| `trashed` | Int64 | Space used by trashed files in bytes |
+| `other` | Int64 | Space used by other (non-file) data in bytes |
+
+## Source scope
+
+- Targets the rclone RC API (default `http://localhost:5572`). The base URL is configurable via `RCLONE_RC_URL`.
+- No API key required — rclone handles cloud provider authentication through its own config.
+- `files` lists files and directories in any configured remote. `about` returns storage usage.
+- All rclone RC calls use `POST` with JSON body.
+- No pagination — rclone returns the full directory listing per call.
+- Supports any rclone remote: Google Drive, Dropbox, S3, OneDrive, MEGA, pCloud, Box, B2, SFTP, and 60+ more.
+- 1 declared test query (`files`) requires a running rclone daemon and a configured remote.
+
+## Limitations
+
+- Requires rclone installed and the RC daemon running (`rclone rcd --rc-no-auth`). The source cannot query cloud storage without a running daemon.
+- The `files` function lists a single directory level — it does not recurse into subdirectories. Query subdirectories by changing the `path` argument.
+- No built-in pagination — large directories return all entries in a single response. For directories with thousands of files, this may be slow.
+- `mod_time` is returned as a Utf8 string with timezone (e.g. `2026-07-12T01:37:39+05:30`) — format varies by provider.
+- `size` is `-1` for directories on most providers.
+- Not all providers support `about` (storage usage). Some may return null or error.
+- The default `--rc-no-auth` flag disables authentication on the RC API. For production use, configure `--rc-user` and `--rc-pass`.
+
+## Provider docs
+
+- Rclone installation: https://rclone.org/install/
+- Rclone RC API: https://rclone.org/rc/
+- Supported providers: https://rclone.org/overview/
+- operations/list: https://rclone.org/rc/#operations-list
+- operations/about: https://rclone.org/rc/#operations-about
+
+## Live validation output
+
+Validated against a live rclone RC daemon with a configured MEGA remote.
+
+```bash
+$ coral source lint sources/community/rclone/manifest.yaml
+Manifest is valid
+```
+
+```bash
+$ coral source add --file sources/community/rclone/manifest.yaml
+Added source rclone
+
+  ✓ rclone connected successfully
+
+    Query tests
+    1 declared · 1 passed · 0 failed
+
+    ✓ SELECT path, name, size, is_dir FROM rclone.files(fs => 'mega:', path => '') LIMIT 5
+      3 rows
+```
+
+**Function introspection:**
+
+```sql
+SELECT function_name, kind, arguments_json
+FROM coral.table_functions
+WHERE schema_name = 'rclone';
+```
+
+```text
++---------------+-------+-----------------------------------------------------------------------------------------+
+| function_name | kind  | arguments_json                                                                          |
++---------------+-------+-----------------------------------------------------------------------------------------+
+| about         | table | [{"name":"fs","required":true,"values":[]}]                                             |
+| files         | table | [{"name":"fs","required":true,"values":[]},{"name":"path","required":true,"values":[]}] |
++---------------+-------+-----------------------------------------------------------------------------------------+
+```
+
+**Inputs introspection:**
+
+```sql
+SELECT key, kind, required, is_set
+FROM coral.inputs
+WHERE schema_name = 'rclone';
+```
+
+```text
++---------------+----------+----------+--------+
+| key           | kind     | required | is_set |
++---------------+----------+----------+--------+
+| RCLONE_RC_URL | variable | false    | true   |
++---------------+----------+----------+--------+
+```
+
+**Live files proof (MEGA):**
+
+```sql
+SELECT path, name, size, mime_type, is_dir
+FROM rclone.files(fs => 'mega:', path => '')
+LIMIT 5;
+```
+
+```text
++-----------------+-----------------+-------+---------------------------+--------+
+| path            | name            | size  | mime_type                 | is_dir |
++-----------------+-----------------+-------+---------------------------+--------+
+| .DS_Store       | .DS_Store       | 10244 | application/octet-stream  | false  |
+| ._.DS_Store     | ._.DS_Store     | 0     | application/octet-stream  | false  |
+| untitled folder | untitled folder | -1    | inode/directory           | true   |
++-----------------+-----------------+-------+---------------------------+--------+
+```
+
+**Live about proof (MEGA):**
+
+```sql
+SELECT total, used, free
+FROM rclone.about(fs => 'mega:');
+```
+
+```text
++-------------+-------+-------------+
+| total       | used  | free        |
++-------------+-------+-------------+
+| 21474836480 | 43054 | 21474793426 |
++-------------+-------+-------------+
+```

--- a/sources/community/rclone/README.md
+++ b/sources/community/rclone/README.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.1.0
 **Backend:** HTTP
-**Functions:** 5
+**Functions:** 4
 
 Query files, directories, and storage usage across 70+ cloud storage providers through rclone's RC API. Supports Google Drive, Dropbox, S3, OneDrive, MEGA, pCloud, Box, Backblaze B2, and more — all from a single source.
 
@@ -66,11 +66,8 @@ FROM rclone.stat(fs => 'mega:', path => 'document.pdf');
 
 -- Get recursive size and file count
 SELECT bytes, count
-FROM rclone.size(fs => 'gdrive:', path => 'Photos');
+FROM rclone.size(fs => 'gdrive:Photos');
 
--- Get a public sharing link
-SELECT url
-FROM rclone.publiclink(fs => 'mega:', path => 'report.pdf');
 ```
 
 ## Functions
@@ -149,14 +146,13 @@ Get metadata for a single file or directory. Returns the same fields as `files` 
 
 ### `rclone.size`
 
-Get the total size and file count for a path, recursively. Use `path => ''` for the entire remote.
+Get the total size and file count for a remote or path, recursively. Pass the path in the `fs` argument (e.g. `fs => 'gdrive:Photos'`).
 
 **Arguments**
 
 | Argument | Type | Description |
 |----------|------|-------------|
-| `fs` | Utf8 | (Required) Remote name with colon |
-| `path` | Utf8 | (Required) Path to measure (use `''` for entire remote) |
+| `fs` | Utf8 | (Required) Remote with optional path (e.g. `mega:`, `gdrive:Photos`) |
 
 **Result columns**
 
@@ -166,30 +162,11 @@ Get the total size and file count for a path, recursively. Use `path => ''` for 
 | `count` | Int64 | Total number of files |
 | `sizeless` | Int64 | Number of files with unknown size |
 
----
-
-### `rclone.publiclink`
-
-Get a public sharing link for a file or directory. Not all providers support public links.
-
-**Arguments**
-
-| Argument | Type | Description |
-|----------|------|-------------|
-| `fs` | Utf8 | (Required) Remote name with colon |
-| `path` | Utf8 | (Required) Path to the file or directory |
-
-**Result columns**
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `url` | Utf8 | Public sharing URL for the file or directory |
-
 ## Source scope
 
 - Targets the rclone RC API (default `http://localhost:5572`). The base URL is configurable via `RCLONE_RC_URL`.
 - No API key required — rclone handles cloud provider authentication through its own config.
-- `files` lists files/directories, `about` returns storage usage, `stat` gets single file info, `size` gets recursive count/total, `publiclink` gets sharing URLs.
+- `files` lists files/directories, `about` returns storage usage, `stat` gets single file info, `size` gets recursive count/total.
 - All rclone RC calls use `POST` with JSON body.
 - No pagination — rclone returns the full directory listing per call.
 - Supports any rclone remote: Google Drive, Dropbox, S3, OneDrive, MEGA, pCloud, Box, B2, SFTP, and 60+ more.
@@ -203,7 +180,8 @@ Get a public sharing link for a file or directory. Not all providers support pub
 - `mod_time` is returned as a Utf8 string with timezone (e.g. `2026-07-12T01:37:39+05:30`) — format varies by provider.
 - `size` is `-1` for directories on most providers.
 - Not all providers support `about` (storage usage). Some may return null or error.
-- The default `--rc-no-auth` flag disables authentication on the RC API. For production use, configure `--rc-user` and `--rc-pass`.
+- This source is designed for loopback-only access with `--rc-no-auth`. The rclone RC API is equivalent to shell access — do not expose it on a public network without authentication. For authenticated setups (`--rc-user`/`--rc-pass`), configure auth outside of this source.
+- The `publiclink` endpoint is intentionally excluded because it creates public links (a write operation).
 
 ## Provider docs
 
@@ -249,8 +227,7 @@ WHERE schema_name = 'rclone';
 +---------------+-------+-----------------------------------------------------------------------------------------+
 | about         | table | [{"name":"fs","required":true,"values":[]}]                                             |
 | files         | table | [{"name":"fs","required":true,"values":[]},{"name":"path","required":true,"values":[]}] |
-| publiclink    | table | [{"name":"fs","required":true,"values":[]},{"name":"path","required":true,"values":[]}] |
-| size          | table | [{"name":"fs","required":true,"values":[]},{"name":"path","required":true,"values":[]}] |
+| size          | table | [{"name":"fs","required":true,"values":[]}]                                             |
 | stat          | table | [{"name":"fs","required":true,"values":[]},{"name":"path","required":true,"values":[]}] |
 +---------------+-------+-----------------------------------------------------------------------------------------+
 ```
@@ -323,7 +300,7 @@ FROM rclone.stat(fs => 'mega:', path => '.DS_Store');
 
 ```sql
 SELECT bytes, count, sizeless
-FROM rclone.size(fs => 'mega:', path => '');
+FROM rclone.size(fs => 'mega:');
 ```
 
 ```text
@@ -332,19 +309,4 @@ FROM rclone.size(fs => 'mega:', path => '');
 +-------+-------+----------+
 | 10244 | 2     | 0        |
 +-------+-------+----------+
-```
-
-**Live publiclink proof (MEGA):**
-
-```sql
-SELECT url
-FROM rclone.publiclink(fs => 'mega:', path => '.DS_Store');
-```
-
-```text
-+----------------------------------------------------------------------+
-| url                                                                  |
-+----------------------------------------------------------------------+
-| https://mega.co.nz/#!xxxx0000!xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_xxxx |
-+----------------------------------------------------------------------+
 ```

--- a/sources/community/rclone/manifest.yaml
+++ b/sources/community/rclone/manifest.yaml
@@ -18,9 +18,6 @@ inputs:
       without authentication.
     default: http://localhost:5572
 
-test_queries:
-  - SELECT path, name, size, is_dir FROM rclone.files(fs => 'mega:', path => '') LIMIT 5
-
 functions:
 
   # --------------------------------------------------------------------------

--- a/sources/community/rclone/manifest.yaml
+++ b/sources/community/rclone/manifest.yaml
@@ -17,7 +17,6 @@ inputs:
       --rc-no-auth. Do not expose the RC API on a public network
       without authentication.
     default: http://localhost:5572
-    default: http://localhost:5572
 
 test_queries:
   - SELECT path, name, size, is_dir FROM rclone.files(fs => 'mega:', path => '') LIMIT 5

--- a/sources/community/rclone/manifest.yaml
+++ b/sources/community/rclone/manifest.yaml
@@ -297,6 +297,5 @@ functions:
         description: Total number of files.
       - name: sizeless
         type: Int64
-        nullable: false
-        description: Number of files with unknown size.
-
+        nullable: true
+        description: Number of files with unknown size. May not be present on all rclone versions.

--- a/sources/community/rclone/manifest.yaml
+++ b/sources/community/rclone/manifest.yaml
@@ -1,0 +1,165 @@
+name: rclone
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query files, directories, and storage usage across 70+ cloud storage
+  providers through rclone's RC API. Supports Google Drive, Dropbox,
+  S3, OneDrive, MEGA, pCloud, Box, Backblaze B2, and more.
+base_url: "{{input.RCLONE_RC_URL}}"
+
+inputs:
+  RCLONE_RC_URL:
+    kind: variable
+    hint: >-
+      URL of the rclone RC API. Default: http://localhost:5572.
+      Start rclone with: rclone rcd --rc-no-auth
+    default: http://localhost:5572
+
+test_queries:
+  - SELECT path, name, size, is_dir FROM rclone.files(fs => 'mega:', path => '') LIMIT 5
+
+functions:
+
+  # --------------------------------------------------------------------------
+  # rclone.files — List files and directories in a remote path
+  # POST /operations/list
+  # Array at response.list.
+  # --------------------------------------------------------------------------
+  - name: files
+    kind: table
+    description: >-
+      List files and directories in a cloud storage remote. Pass the
+      remote as `fs => 'remote:'` and the path as `path => 'dir'`.
+      Returns file metadata including name, size, MIME type, and
+      modification time.
+    fetch_limit_default: 100
+    args:
+      - name: fs
+        required: true
+        bind:
+          arg: fs
+      - name: path
+        required: true
+        bind:
+          arg: path
+    request:
+      method: POST
+      path: /operations/list
+      body:
+        - path: [fs]
+          from: arg
+          key: fs
+        - path: [remote]
+          from: arg
+          key: path
+    response:
+      rows_path:
+        - list
+    pagination:
+      mode: none
+    columns:
+      - name: path
+        type: Utf8
+        nullable: false
+        description: Full path relative to the remote root.
+        expr:
+          kind: path
+          path:
+            - Path
+      - name: name
+        type: Utf8
+        nullable: false
+        description: File or directory name.
+        expr:
+          kind: path
+          path:
+            - Name
+      - name: size
+        type: Int64
+        nullable: false
+        description: File size in bytes (-1 for directories).
+        expr:
+          kind: path
+          path:
+            - Size
+      - name: mime_type
+        type: Utf8
+        nullable: true
+        description: MIME type of the file (e.g. application/pdf, inode/directory).
+        expr:
+          kind: path
+          path:
+            - MimeType
+      - name: mod_time
+        type: Utf8
+        nullable: true
+        description: Last modification time (ISO 8601 with timezone).
+        expr:
+          kind: path
+          path:
+            - ModTime
+      - name: is_dir
+        type: Boolean
+        nullable: false
+        description: Whether the entry is a directory.
+        expr:
+          kind: path
+          path:
+            - IsDir
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Provider-specific file or directory ID.
+        expr:
+          kind: path
+          path:
+            - ID
+
+  # --------------------------------------------------------------------------
+  # rclone.about — Storage usage for a remote
+  # POST /operations/about
+  # Single object response.
+  # --------------------------------------------------------------------------
+  - name: about
+    kind: table
+    description: >-
+      Get storage usage for a cloud storage remote. Pass the remote
+      as `fs => 'remote:'`. Returns total, used, and free space in
+      bytes.
+    args:
+      - name: fs
+        required: true
+        bind:
+          arg: fs
+    request:
+      method: POST
+      path: /operations/about
+      body:
+        - path: [fs]
+          from: arg
+          key: fs
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: total
+        type: Int64
+        nullable: true
+        description: Total storage space in bytes.
+      - name: used
+        type: Int64
+        nullable: true
+        description: Storage space used in bytes.
+      - name: free
+        type: Int64
+        nullable: true
+        description: Free storage space in bytes.
+      - name: trashed
+        type: Int64
+        nullable: true
+        description: Space used by trashed files in bytes.
+      - name: other
+        type: Int64
+        nullable: true
+        description: Space used by other (non-file) data in bytes.

--- a/sources/community/rclone/manifest.yaml
+++ b/sources/community/rclone/manifest.yaml
@@ -13,7 +13,10 @@ inputs:
     kind: variable
     hint: >-
       URL of the rclone RC API. Default: http://localhost:5572.
-      Start rclone with: rclone rcd --rc-no-auth
+      This source is designed for loopback-only access with
+      --rc-no-auth. Do not expose the RC API on a public network
+      without authentication.
+    default: http://localhost:5572
     default: http://localhost:5572
 
 test_queries:
@@ -265,18 +268,15 @@ functions:
   - name: size
     kind: table
     description: >-
-      Get the total size and file count for a path, recursively.
-      Pass the remote as `fs => 'remote:'` and the path as
-      `path => 'dir'`. Use `path => ''` for the entire remote.
+      Get the total size and file count for a remote or path,
+      recursively. Pass the remote with path as
+      `fs => 'remote:path/to/dir'` or `fs => 'remote:'` for the
+      entire remote.
     args:
       - name: fs
         required: true
         bind:
           arg: fs
-      - name: path
-        required: true
-        bind:
-          arg: path
     request:
       method: POST
       path: /operations/size
@@ -284,9 +284,6 @@ functions:
         - path: [fs]
           from: arg
           key: fs
-        - path: [remote]
-          from: arg
-          key: path
     response: {}
     pagination:
       mode: none
@@ -304,41 +301,3 @@ functions:
         nullable: false
         description: Number of files with unknown size.
 
-  # --------------------------------------------------------------------------
-  # rclone.publiclink — Get a public sharing link for a file
-  # POST /operations/publiclink
-  # Single object response with url field.
-  # --------------------------------------------------------------------------
-  - name: publiclink
-    kind: table
-    description: >-
-      Get a public sharing link for a file or directory. Pass the
-      remote as `fs => 'remote:'` and the file path as
-      `path => 'file.txt'`. Not all providers support public links.
-    args:
-      - name: fs
-        required: true
-        bind:
-          arg: fs
-      - name: path
-        required: true
-        bind:
-          arg: path
-    request:
-      method: POST
-      path: /operations/publiclink
-      body:
-        - path: [fs]
-          from: arg
-          key: fs
-        - path: [remote]
-          from: arg
-          key: path
-    response: {}
-    pagination:
-      mode: none
-    columns:
-      - name: url
-        type: Utf8
-        nullable: false
-        description: Public sharing URL for the file or directory.

--- a/sources/community/rclone/manifest.yaml
+++ b/sources/community/rclone/manifest.yaml
@@ -163,3 +163,182 @@ functions:
         type: Int64
         nullable: true
         description: Space used by other (non-file) data in bytes.
+
+  # --------------------------------------------------------------------------
+  # rclone.stat — Get info about a single file or directory
+  # POST /operations/stat
+  # Single object response at `item`.
+  # --------------------------------------------------------------------------
+  - name: stat
+    kind: table
+    description: >-
+      Get metadata for a single file or directory. Pass the remote
+      as `fs => 'remote:'` and the file path as `path => 'file.txt'`.
+      Returns name, size, MIME type, modification time, and provider ID.
+    args:
+      - name: fs
+        required: true
+        bind:
+          arg: fs
+      - name: path
+        required: true
+        bind:
+          arg: path
+    request:
+      method: POST
+      path: /operations/stat
+      body:
+        - path: [fs]
+          from: arg
+          key: fs
+        - path: [remote]
+          from: arg
+          key: path
+    response:
+      rows_path:
+        - item
+    pagination:
+      mode: none
+    columns:
+      - name: path
+        type: Utf8
+        nullable: false
+        description: Full path relative to the remote root.
+        expr:
+          kind: path
+          path:
+            - Path
+      - name: name
+        type: Utf8
+        nullable: false
+        description: File or directory name.
+        expr:
+          kind: path
+          path:
+            - Name
+      - name: size
+        type: Int64
+        nullable: false
+        description: File size in bytes (-1 for directories).
+        expr:
+          kind: path
+          path:
+            - Size
+      - name: mime_type
+        type: Utf8
+        nullable: true
+        description: MIME type of the file.
+        expr:
+          kind: path
+          path:
+            - MimeType
+      - name: mod_time
+        type: Utf8
+        nullable: true
+        description: Last modification time (ISO 8601 with timezone).
+        expr:
+          kind: path
+          path:
+            - ModTime
+      - name: is_dir
+        type: Boolean
+        nullable: false
+        description: Whether the entry is a directory.
+        expr:
+          kind: path
+          path:
+            - IsDir
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Provider-specific file or directory ID.
+        expr:
+          kind: path
+          path:
+            - ID
+
+  # --------------------------------------------------------------------------
+  # rclone.size — Recursive count and total size of files
+  # POST /operations/size
+  # Single object response.
+  # --------------------------------------------------------------------------
+  - name: size
+    kind: table
+    description: >-
+      Get the total size and file count for a path, recursively.
+      Pass the remote as `fs => 'remote:'` and the path as
+      `path => 'dir'`. Use `path => ''` for the entire remote.
+    args:
+      - name: fs
+        required: true
+        bind:
+          arg: fs
+      - name: path
+        required: true
+        bind:
+          arg: path
+    request:
+      method: POST
+      path: /operations/size
+      body:
+        - path: [fs]
+          from: arg
+          key: fs
+        - path: [remote]
+          from: arg
+          key: path
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: bytes
+        type: Int64
+        nullable: false
+        description: Total size of all files in bytes.
+      - name: count
+        type: Int64
+        nullable: false
+        description: Total number of files.
+      - name: sizeless
+        type: Int64
+        nullable: false
+        description: Number of files with unknown size.
+
+  # --------------------------------------------------------------------------
+  # rclone.publiclink — Get a public sharing link for a file
+  # POST /operations/publiclink
+  # Single object response with url field.
+  # --------------------------------------------------------------------------
+  - name: publiclink
+    kind: table
+    description: >-
+      Get a public sharing link for a file or directory. Pass the
+      remote as `fs => 'remote:'` and the file path as
+      `path => 'file.txt'`. Not all providers support public links.
+    args:
+      - name: fs
+        required: true
+        bind:
+          arg: fs
+      - name: path
+        required: true
+        bind:
+          arg: path
+    request:
+      method: POST
+      path: /operations/publiclink
+      body:
+        - path: [fs]
+          from: arg
+          key: fs
+        - path: [remote]
+          from: arg
+          key: path
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: url
+        type: Utf8
+        nullable: false
+        description: Public sharing URL for the file or directory.


### PR DESCRIPTION
## Summary

Add an rclone community source so Coral can query files, directories, and storage usage across 70+ cloud storage providers through SQL — Google Drive, Dropbox, S3, OneDrive, MEGA, pCloud, Box, B2, and more from a single source.

## Files contributed

| File | Purpose |
| --- | --- |
| `sources/community/rclone/manifest.yaml` | Coral source manifest defining 4 functions: `files`, `about`, `stat`, `size` |
| `sources/community/rclone/README.md` | Full documentation with prerequisites, functions, queries, and validation |

## Why this source

[Rclone](https://rclone.org/) manages files on 70+ cloud storage providers. Its RC API exposes file listing and storage operations over HTTP. Instead of building separate Coral sources for each cloud provider, a single rclone source covers them all. AI agents can query any configured remote through SQL without provider-specific API keys — rclone handles auth through its own config.

## Provider docs

- Rclone RC API: https://rclone.org/rc/
- operations/list: https://rclone.org/rc/#operations-list
- operations/about: https://rclone.org/rc/#operations-about
- Supported providers: https://rclone.org/overview/

## Source shape

| Function | Required Args | Description |
|----------|--------------|-------------|
| `files` | `fs`, `path` | List files/directories in a remote path — name, size, MIME type, mod time, is_dir, ID (7 columns) |
| `about` | `fs` | Storage usage for a remote — total, used, free, trashed, other (5 columns) |
| `stat` | `fs`, `path` | Single file/dir metadata — name, size, MIME type, mod time, ID (7 columns) |
| `size` | `fs`, `path` | Recursive count and total size of files (3 columns) |

## Source scope

- **Base URL:** Configurable via `RCLONE_RC_URL` (default `http://localhost:5572`)
- **Auth:** No API key — rclone handles cloud provider auth through its own config
- **Prerequisites:** rclone installed + configured remotes + RC daemon running (`rclone rcd --rc-no-auth`)
- **Functions:** `files(fs, path)` for file listing, `about(fs)` for storage usage
- All RC API calls use `POST` with JSON body
- No pagination — rclone returns full directory listing per call
- Read-only access — file upload, delete, copy, and move are out of scope
- No test queries — all functions require a user-specific remote name. Test manually after adding

## Validation

```bash
$ coral source lint sources/community/rclone/manifest.yaml
Manifest is valid
```

```bash
$ coral source add --file sources/community/rclone/manifest.yaml
Added source rclone

  ✓ rclone connected successfully

    Query tests

```

### Live files proof (MEGA)

```sql
SELECT path, name, size, mime_type, is_dir
FROM rclone.files(fs => 'mega:', path => '') LIMIT 5;
```

```text
+-----------------+-----------------+-------+---------------------------+--------+
| path            | name            | size  | mime_type                 | is_dir |
+-----------------+-----------------+-------+---------------------------+--------+
| .DS_Store       | .DS_Store       | 10244 | application/octet-stream  | false  |
| ._.DS_Store     | ._.DS_Store     | 0     | application/octet-stream  | false  |
| untitled folder | untitled folder | -1    | inode/directory           | true   |
+-----------------+-----------------+-------+---------------------------+--------+
```

### Live about proof (MEGA)

```sql
SELECT total, used, free FROM rclone.about(fs => 'mega:');
```

```text
+-------------+-------+-------------+
| total       | used  | free        |
+-------------+-------+-------------+
| 21474836480 | 43054 | 21474793426 |
+-------------+-------+-------------+
```

Closes #1685



