### PR TITLE
feat(app): add user identity service

### DIFF
--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -43,11 +43,12 @@ export CORAL_DATABASE_URL="postgres://coral:secret@db.example.com:5432/coral?ssl
 export CORAL_CREDENTIAL_ENCRYPTION_KEY="v1:$(openssl rand -base64 32)"
 ```
 
-Identity specs with stored inputs on Postgres require one provisioned
-credential encryption key shared by every Coral server connected to that
-database. Preserve the same value across restarts and replicas; replacing or
-losing it makes encrypted identity inputs unreadable. Postgres deployments that
-do not store identity inputs can omit `[credentials].encryption_key_env`.
+Encrypted identity material on Postgres requires one provisioned credential
+encryption key shared by every Coral server connected to that database.
+Preserve the same value across restarts and replicas; replacing or losing it
+makes installed identity-spec inputs and stored identity credentials unreadable.
+Postgres deployments that do not store identity material can omit
+`[credentials].encryption_key_env`.
 
 <Note>
   Remote Postgres URLs must set `sslmode=verify-full` so Coral verifies the server identity. Loopback and local-socket Postgres URLs may omit TLS for local development.

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -16,6 +16,7 @@ use axum::extract::Request as AxumRequest;
 use axum::response::Response as AxumResponse;
 use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
+use coral_api::v1::identity_service_server::IdentityServiceServer;
 use coral_api::v1::identity_spec_service_server::IdentitySpecServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::search_service_server::SearchServiceServer;
@@ -24,9 +25,9 @@ use coral_api::v1::trace_service_server::TraceServiceServer;
 use coral_api::v1::workspace_service_server::WorkspaceServiceServer;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE,
-    IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
-    SEARCH_RESPONSE_MAX_MESSAGE_SIZE, SOURCE_RESPONSE_MAX_MESSAGE_SIZE,
-    TRACE_RESPONSE_MAX_MESSAGE_SIZE,
+    IDENTITY_RESPONSE_MAX_MESSAGE_SIZE, IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE,
+    QUERY_RESPONSE_MAX_MESSAGE_SIZE, SEARCH_RESPONSE_MAX_MESSAGE_SIZE,
+    SOURCE_RESPONSE_MAX_MESSAGE_SIZE, TRACE_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -55,6 +56,8 @@ use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
 };
 use crate::feedback::service::FeedbackService;
+use crate::identities::IdentityService;
+use crate::identities::manager::IdentityManager;
 use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
 use crate::identity_specs::IdentitySpecService;
 use crate::identity_specs::manager::IdentitySpecManager;
@@ -293,14 +296,15 @@ impl ServerBuilder {
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let credential_encryption_key = credential_encryption_key(&credential_config)?;
         let database_config = resolve_database_config(&layout)?;
-        let (identity_spec_key_provider, postgres_identity_inputs_disabled) =
-            identity_spec_key_provider(&layout, &database_config, credential_encryption_key);
+        let (identity_key_provider, postgres_identity_material_disabled) =
+            identity_key_provider(&layout, &database_config, credential_encryption_key);
         let coral_db = init_database(database_config).await?;
         let config_store = ConfigStore::new(layout.clone());
         run_state_migrations(&coral_db, &config_store).await?;
         let coral_db = Arc::new(coral_db);
         let identity_spec_manager =
-            IdentitySpecManager::new(Arc::clone(&coral_db), identity_spec_key_provider);
+            IdentitySpecManager::new(Arc::clone(&coral_db), Arc::clone(&identity_key_provider));
+        let identity_manager = IdentityManager::new(Arc::clone(&coral_db), identity_key_provider);
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config
             .trace_history
@@ -311,12 +315,12 @@ impl ServerBuilder {
             self.config.enable_stderr_logs,
             internal_trace_store_dir.clone(),
         )?;
-        if postgres_identity_inputs_disabled {
+        if postgres_identity_material_disabled {
             tracing::warn!(
                 backend = "postgres",
-                capability = "identity_inputs",
+                capability = "identity_material",
                 remediation = "[credentials].encryption_key_env",
-                "Postgres identity inputs are disabled until a shared credential encryption key is configured"
+                "Postgres identity material is disabled until a shared credential encryption key is configured"
             );
         }
         let active_trace_store = telemetry_config
@@ -373,6 +377,7 @@ impl ServerBuilder {
                 source: source_manager,
                 workspace: workspace_manager,
                 identity_spec: identity_spec_manager,
+                identity: identity_manager,
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
@@ -391,7 +396,7 @@ async fn init_database(database_config: ResolvedDatabaseConfig) -> Result<CoralD
     Ok(coral_db)
 }
 
-fn identity_spec_key_provider(
+fn identity_key_provider(
     layout: &AppStateLayout,
     database_config: &ResolvedDatabaseConfig,
     configured_key: Option<CredentialEncryptionKey>,
@@ -405,9 +410,9 @@ fn identity_spec_key_provider(
             Arc::new(ReloadingConfiguredKeyProvider(layout.clone()))
         }
     };
-    let postgres_identity_inputs_disabled =
+    let postgres_identity_material_disabled =
         matches!(database_config, ResolvedDatabaseConfig::Postgres { .. }) && !configured;
-    (provider, postgres_identity_inputs_disabled)
+    (provider, postgres_identity_material_disabled)
 }
 
 struct ReloadingConfiguredKeyProvider(AppStateLayout);
@@ -575,6 +580,7 @@ struct ServerManagers {
     source: SourceManager,
     workspace: WorkspaceManager,
     identity_spec: IdentitySpecManager,
+    identity: IdentityManager,
     query: QueryManager,
     search: SearchManager,
     feedback: FeedbackManager,
@@ -594,6 +600,7 @@ async fn start_server(
         source,
         workspace,
         identity_spec,
+        identity,
         query,
         search,
         feedback,
@@ -601,6 +608,7 @@ async fn start_server(
     let source_service = SourceService::new(source, query.clone(), workspace.clone());
     let workspace_service = WorkspaceService::new(workspace);
     let identity_spec_service = IdentitySpecService::new(identity_spec);
+    let identity_service = IdentityService::new(identity);
     let catalog_service = CatalogService::new(query.clone());
     let query_service = QueryService::new(query);
     let search_service = SearchService::new(search);
@@ -614,6 +622,10 @@ async fn start_server(
         .add_service(
             IdentitySpecServiceServer::new(identity_spec_service)
                 .max_encoding_message_size(IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE),
+        )
+        .add_service(
+            IdentityServiceServer::new(identity_service)
+                .max_encoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE),
         )
         .add_service(
             CatalogServiceServer::new(catalog_service)
@@ -885,13 +897,13 @@ mod tests {
     use super::{
         RunningServer, ServerBuilder, ServerManagers, ServerMode, StaticAsset,
         StaticAssetsProvider, TraceServerComponents, credential_encryption_key,
-        identity_spec_key_provider, is_grpc_web_content_type, is_native_grpc_content_type,
-        start_server,
+        identity_key_provider, is_grpc_web_content_type, is_native_grpc_content_type, start_server,
     };
     use crate::credentials::config::CredentialStorageConfig;
     use crate::credentials::encryption::LocalFileCredentialKeyProvider;
     use crate::credentials::{CredentialManager, CredentialStore, CredentialsError};
     use crate::feedback::manager::FeedbackManager;
+    use crate::identities::manager::IdentityManager;
     use crate::identity_specs::manager::IdentitySpecManager;
     use crate::query::manager::QueryManager;
     use crate::search::manager::SearchManager;
@@ -1055,6 +1067,13 @@ enabled = false
         )
     }
 
+    fn test_identity_manager(layout: &AppStateLayout, db: &Arc<CoralDb>) -> IdentityManager {
+        IdentityManager::new(
+            Arc::clone(db),
+            Arc::new(LocalFileCredentialKeyProvider::new(layout, None)),
+        )
+    }
+
     #[tokio::test]
     async fn trace_service_is_unregistered_when_local_store_is_disabled() {
         let temp = TempDir::new().expect("temp dir");
@@ -1115,7 +1134,7 @@ backend = "unsupported"
     }
 
     #[tokio::test]
-    async fn server_builder_rejects_invalid_explicit_identity_spec_key() {
+    async fn server_builder_rejects_invalid_explicit_identity_key() {
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
         let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
@@ -1141,7 +1160,7 @@ backend = "unsupported"
     }
 
     #[test]
-    fn postgres_identity_spec_key_provider_reloads_config_and_never_falls_back() {
+    fn postgres_identity_key_provider_reloads_config_and_never_falls_back() {
         const RUN_FLAG: &str = "CORAL_RUN_POSTGRES_KEY_RELOAD_TEST";
         const KEY_ENV: &str = "CORAL_TEST_POSTGRES_IDENTITY_KEY";
         const KEY_VALUE: &str = "v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
@@ -1156,7 +1175,7 @@ backend = "unsupported"
                     .env(KEY_ENV, KEY_VALUE)
                     .arg("--exact")
                     .arg(
-                        "bootstrap::server::tests::postgres_identity_spec_key_provider_reloads_config_and_never_falls_back",
+                        "bootstrap::server::tests::postgres_identity_key_provider_reloads_config_and_never_falls_back",
                     )
                     .arg("--nocapture")
                     .status()
@@ -1180,7 +1199,7 @@ backend = "unsupported"
         .expect("resolve configured key")
         .expect("configured key");
         let configured_key_id = configured_key.key_id().to_string();
-        let (provider, disabled) = identity_spec_key_provider(
+        let (provider, disabled) = identity_key_provider(
             &layout,
             &ResolvedDatabaseConfig::Postgres {
                 url: "postgres://unused".to_string(),
@@ -1292,6 +1311,7 @@ backend = "unsupported"
                 source: source_manager,
                 workspace: workspace_manager,
                 identity_spec: test_identity_spec_manager(&layout, &db),
+                identity: test_identity_manager(&layout, &db),
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
@@ -1721,6 +1741,7 @@ tables:
                 source: source_manager,
                 workspace: workspace_manager,
                 identity_spec: test_identity_spec_manager(&layout, &db),
+                identity: test_identity_manager(&layout, &db),
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
@@ -1837,6 +1858,7 @@ tables:
                 source: source_manager,
                 workspace: workspace_manager,
                 identity_spec: test_identity_spec_manager(&layout, &db),
+                identity: test_identity_manager(&layout, &db),
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,
@@ -1953,6 +1975,7 @@ tables:
                 source: source_manager,
                 workspace: workspace_manager,
                 identity_spec: test_identity_spec_manager(&layout, &db),
+                identity: test_identity_manager(&layout, &db),
                 query: query_manager,
                 search: search_manager,
                 feedback: feedback_manager,

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -217,7 +217,7 @@ impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
 
 pub(crate) fn configured_key_required() -> CredentialsError {
     CredentialsError::Unavailable(
-        "Postgres identity inputs require [credentials].encryption_key_env to provide a shared credential encryption key".to_string(),
+        "Postgres identity material requires [credentials].encryption_key_env to provide a shared credential encryption key".to_string(),
     )
 }
 

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -1,13 +1,5 @@
 //! Database-backed identity instance management.
 
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "B4h wires identity managers into public services."
-    )
-)]
-
 use std::collections::BTreeMap;
 use std::sync::Arc;
 #[cfg(test)]
@@ -126,6 +118,10 @@ impl IdentityManager {
     }
 
     /// Create or replace a workspace-owned fixed-token identity using workspace-first resolution.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "B4i wires the workspace identity service.")
+    )]
     pub(crate) async fn create_or_replace_workspace_fixed_token(
         &self,
         workspace: &WorkspaceName,

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -2,3 +2,6 @@
 
 pub(crate) mod manager;
 pub(crate) mod model;
+pub(crate) mod service;
+
+pub(crate) use service::IdentityService;

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -1,0 +1,170 @@
+//! Implements the gRPC `IdentityService` for user-owned identities.
+
+use std::pin::Pin;
+
+use coral_api::v1::identity_service_server::IdentityService as IdentityServiceApi;
+use coral_api::v1::{
+    CreateUserOwnedIdentityRequest, CreateUserOwnedIdentityResponse,
+    DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse,
+    FixedTokenUserOwnedIdentitySetup, GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse,
+    Identity as ProtoIdentity, IdentityOwner as ProtoIdentityOwner, ListUserOwnedIdentitiesRequest,
+    ListUserOwnedIdentitiesResponse, create_user_owned_identity_request,
+    create_user_owned_identity_response,
+};
+use tokio_stream::Stream;
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::app_status;
+use crate::identities::manager::IdentityManager;
+use crate::identities::model::IdentityOwner;
+use crate::request_context::RequestContext;
+use crate::state::db::{IdentityRecord, IdentitySpecScope};
+use crate::transport::{grpc_span, instrument_grpc, workspace_to_proto};
+
+#[derive(Clone)]
+pub(crate) struct IdentityService {
+    identities: IdentityManager,
+}
+
+impl IdentityService {
+    pub(crate) fn new(identities: IdentityManager) -> Self {
+        Self { identities }
+    }
+}
+
+#[tonic::async_trait]
+impl IdentityServiceApi for IdentityService {
+    type CreateUserOwnedIdentityStream = CreateUserOwnedIdentityResponseStreamBox;
+
+    async fn create_user_owned_identity(
+        &self,
+        request: Request<CreateUserOwnedIdentityRequest>,
+    ) -> Result<Response<Self::CreateUserOwnedIdentityStream>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
+            let CreateUserOwnedIdentityRequest {
+                name,
+                identity_spec,
+                setup,
+            } = request.into_inner();
+            let Some(create_user_owned_identity_request::Setup::FixedToken(
+                FixedTokenUserOwnedIdentitySetup { token },
+            )) = setup
+            else {
+                return Err(Status::unimplemented(
+                    "OAuth identity creation is not enabled by this server",
+                ));
+            };
+            let record = identities
+                .create_or_replace_user_fixed_token(&principal, &name, &identity_spec, token)
+                .await
+                .map_err(app_status)?;
+            let response = CreateUserOwnedIdentityResponse {
+                event: Some(create_user_owned_identity_response::Event::Identity(
+                    identity_to_proto(record),
+                )),
+            };
+            let stream = Box::pin(tokio_stream::iter([Ok(response)]));
+            Ok(Response::new(
+                stream as CreateUserOwnedIdentityResponseStreamBox,
+            ))
+        })
+        .await
+    }
+
+    async fn list_user_owned_identities(
+        &self,
+        request: Request<ListUserOwnedIdentitiesRequest>,
+    ) -> Result<Response<ListUserOwnedIdentitiesResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
+            let _request = request.into_inner();
+            let owner = IdentityOwner::for_user(principal);
+            let records = identities
+                .list_for_owner(&owner)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(ListUserOwnedIdentitiesResponse {
+                identities: records.into_iter().map(identity_to_proto).collect(),
+            }))
+        })
+        .await
+    }
+
+    async fn get_user_owned_identity(
+        &self,
+        request: Request<GetUserOwnedIdentityRequest>,
+    ) -> Result<Response<GetUserOwnedIdentityResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
+            let request = request.into_inner();
+            let owner = IdentityOwner::for_user(principal);
+            let identity = identities
+                .get(&owner, &request.name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(GetUserOwnedIdentityResponse {
+                identity: Some(identity_to_proto(identity)),
+            }))
+        })
+        .await
+    }
+
+    async fn delete_user_owned_identity(
+        &self,
+        request: Request<DeleteUserOwnedIdentityRequest>,
+    ) -> Result<Response<DeleteUserOwnedIdentityResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let principal = RequestContext::from_request(&request)?.principal().clone();
+            let request = request.into_inner();
+            let owner = IdentityOwner::for_user(principal);
+            identities
+                .delete(&owner, &request.name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(DeleteUserOwnedIdentityResponse {}))
+        })
+        .await
+    }
+}
+
+type CreateUserOwnedIdentityResponseStreamBox =
+    Pin<Box<dyn Stream<Item = Result<CreateUserOwnedIdentityResponse, Status>> + Send>>;
+
+pub(super) fn identity_to_proto(record: IdentityRecord) -> ProtoIdentity {
+    let IdentityRecord {
+        owner,
+        name,
+        spec_reference,
+        ..
+    } = record;
+    let (owner, owner_workspace) = match owner {
+        IdentityOwner::User(_) => (ProtoIdentityOwner::User, None),
+        IdentityOwner::Workspace(workspace) => (
+            ProtoIdentityOwner::Workspace,
+            Some(workspace_to_proto(&workspace)),
+        ),
+    };
+    let identity_spec_workspace = match spec_reference.key().scope() {
+        IdentitySpecScope::Global => None,
+        IdentitySpecScope::Workspace(workspace) => Some(workspace_to_proto(workspace)),
+    };
+    ProtoIdentity {
+        name: name.to_string(),
+        identity_spec: spec_reference.key().name().to_string(),
+        issuer: spec_reference.issuer().to_string(),
+        identity_type: spec_reference.identity_type().to_string(),
+        owner: owner as i32,
+        metadata: Vec::new(),
+        owner_workspace,
+        identity_spec_workspace,
+    }
+}

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -11,6 +11,8 @@ mod catalog_discovery_tests;
 mod harness;
 #[path = "grpc/identity_spec_tests.rs"]
 mod identity_spec_tests;
+#[path = "grpc/identity_tests.rs"]
+mod identity_tests;
 #[path = "grpc/oauth_refresh_tests.rs"]
 mod oauth_refresh_tests;
 #[path = "grpc/resilience_tests.rs"]

--- a/crates/coral-app/tests/grpc/identity_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_tests.rs
@@ -1,0 +1,299 @@
+use std::sync::Arc;
+
+use coral_api::v1::{
+    AddIdentitySpecRequest, CreateUserOwnedIdentityRequest, DeleteIdentitySpecRequest,
+    DeleteUserOwnedIdentityRequest, FixedTokenUserOwnedIdentitySetup, GetUserOwnedIdentityRequest,
+    Identity, IdentityOwner, ListUserOwnedIdentitiesRequest, create_user_owned_identity_request,
+    create_user_owned_identity_response,
+};
+use coral_api::{
+    CORAL_ERROR_REASON_IDENTITY_NOT_FOUND, CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND,
+};
+use coral_app::{ServerBuilder, UserPrincipal, UserPrincipalProvider, UserPrincipalProviderError};
+use coral_client::AppClient;
+use tempfile::TempDir;
+use tonic::metadata::MetadataMap;
+use tonic::{Code, Request, Status};
+use tonic_types::{ErrorDetail, StatusExt as _};
+
+const USER_HEADER: &str = "x-test-user";
+
+#[derive(Debug)]
+struct HeaderPrincipalProvider;
+
+#[tonic::async_trait]
+impl UserPrincipalProvider for HeaderPrincipalProvider {
+    async fn principal_for_metadata(
+        &self,
+        metadata: &MetadataMap,
+    ) -> Result<UserPrincipal, UserPrincipalProviderError> {
+        let user = metadata
+            .get(USER_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .ok_or_else(|| UserPrincipalProviderError::unauthenticated("missing test user"))?;
+        UserPrincipal::for_user(user)
+            .map_err(|_error| UserPrincipalProviderError::internal("invalid test user"))
+    }
+}
+
+#[tokio::test]
+async fn user_identity_service_is_scoped_validated_and_restart_safe() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let (server, app) = start(&config_dir).await;
+
+    let missing_principal = app
+        .identity_client()
+        .list_user_owned_identities(Request::new(ListUserOwnedIdentitiesRequest {}))
+        .await
+        .expect_err("missing principal must fail closed");
+    assert_eq!(missing_principal.code(), Code::Unauthenticated);
+
+    add_spec(&app, "alice_spec", "alice", "fixed_token").await;
+    add_spec(&app, "bob_spec", "bob", "fixed_token").await;
+    add_spec(&app, "oauth_spec", "oauth", "oauth").await;
+    assert_create_validation(&app).await;
+
+    let alice = create(&app, "alice", "shared", "alice_spec", "alice-token").await;
+    let bob = create(&app, "bob", "shared", "bob_spec", "bob-token").await;
+    assert_identity(&alice, "alice_spec", "alice");
+    assert_identity(&bob, "bob_spec", "bob");
+    assert_eq!(list(&app, "alice").await, vec![alice.clone()]);
+    assert_eq!(list(&app, "bob").await, vec![bob.clone()]);
+
+    let orphaned = app
+        .identity_spec_client()
+        .delete_identity_spec(for_user(
+            DeleteIdentitySpecRequest {
+                name: "alice_spec".to_string(),
+                workspace: None,
+                force: true,
+            },
+            "alice",
+        ))
+        .await
+        .expect("force delete referenced spec")
+        .into_inner();
+    assert_eq!(orphaned.orphaned_identities, 1);
+    server.shutdown().await.expect("shutdown first server");
+
+    let (server, restarted) = start(&config_dir).await;
+    assert_eq!(get(&restarted, "alice", "shared").await, alice);
+    assert_eq!(get(&restarted, "bob", "shared").await, bob);
+    restarted
+        .identity_client()
+        .delete_user_owned_identity(for_user(
+            DeleteUserOwnedIdentityRequest {
+                name: "shared".to_string(),
+            },
+            "alice",
+        ))
+        .await
+        .expect("delete Alice identity");
+    let missing = restarted
+        .identity_client()
+        .get_user_owned_identity(for_user(
+            GetUserOwnedIdentityRequest {
+                name: "shared".to_string(),
+            },
+            "alice",
+        ))
+        .await
+        .expect_err("Alice identity was deleted");
+    assert_eq!(missing.code(), Code::NotFound);
+    assert_error_reason(&missing, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
+    let missing_delete = restarted
+        .identity_client()
+        .delete_user_owned_identity(for_user(
+            DeleteUserOwnedIdentityRequest {
+                name: "shared".to_string(),
+            },
+            "alice",
+        ))
+        .await
+        .expect_err("repeated delete must remain typed");
+    assert_eq!(missing_delete.code(), Code::NotFound);
+    assert_error_reason(&missing_delete, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
+    assert_eq!(get(&restarted, "bob", "shared").await, bob);
+    server.shutdown().await.expect("shutdown restarted server");
+}
+
+async fn assert_create_validation(app: &AppClient) {
+    let omitted = create_status(
+        app,
+        for_user(
+            CreateUserOwnedIdentityRequest {
+                name: "shared".to_string(),
+                identity_spec: "oauth_spec".to_string(),
+                setup: None,
+            },
+            "alice",
+        ),
+    )
+    .await;
+    assert_eq!(omitted.code(), Code::Unimplemented);
+    assert_eq!(
+        create_status(
+            app,
+            create_request("shared", "oauth_spec", "token", "alice")
+        )
+        .await
+        .code(),
+        Code::InvalidArgument
+    );
+    for request in [
+        create_request("shared", "alice_spec", "  ", "alice"),
+        create_request("bad/name", "alice_spec", "token", "alice"),
+    ] {
+        assert_eq!(
+            create_status(app, request).await.code(),
+            Code::InvalidArgument
+        );
+    }
+    let missing_spec =
+        create_status(app, create_request("shared", "missing", "token", "alice")).await;
+    assert_eq!(missing_spec.code(), Code::NotFound);
+    assert_error_reason(&missing_spec, CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND);
+}
+
+async fn start(config_dir: &std::path::Path) -> (coral_app::RunningServer, AppClient) {
+    let server = ServerBuilder::new()
+        .with_config_dir(config_dir)
+        .with_user_principal_provider(Arc::new(HeaderPrincipalProvider))
+        .start()
+        .await
+        .expect("start server");
+    let app = AppClient::connect(server.endpoint_uri())
+        .await
+        .expect("connect client");
+    (server, app)
+}
+
+async fn add_spec(app: &AppClient, name: &str, issuer: &str, kind: &str) {
+    app.identity_spec_client()
+        .add_identity_spec(for_user(
+            AddIdentitySpecRequest {
+                manifest_yaml: manifest(name, issuer, kind),
+                input_values: Vec::new(),
+                workspace: None,
+            },
+            "alice",
+        ))
+        .await
+        .expect("add identity spec");
+}
+
+async fn create_status(
+    app: &AppClient,
+    request: Request<CreateUserOwnedIdentityRequest>,
+) -> Status {
+    app.identity_client()
+        .create_user_owned_identity(request)
+        .await
+        .expect_err("identity creation must fail")
+}
+
+async fn create(app: &AppClient, user: &str, name: &str, spec: &str, token: &str) -> Identity {
+    let mut stream = app
+        .identity_client()
+        .create_user_owned_identity(create_request(name, spec, token, user))
+        .await
+        .expect("create identity")
+        .into_inner();
+    let response = stream
+        .message()
+        .await
+        .expect("read create stream")
+        .expect("one identity event");
+    assert!(stream.message().await.expect("read stream EOF").is_none());
+    match response.event.expect("identity event") {
+        create_user_owned_identity_response::Event::Identity(identity) => identity,
+        event => panic!("expected identity event, got {event:?}"),
+    }
+}
+
+async fn list(app: &AppClient, user: &str) -> Vec<Identity> {
+    app.identity_client()
+        .list_user_owned_identities(for_user(ListUserOwnedIdentitiesRequest {}, user))
+        .await
+        .expect("list identities")
+        .into_inner()
+        .identities
+}
+
+async fn get(app: &AppClient, user: &str, name: &str) -> Identity {
+    app.identity_client()
+        .get_user_owned_identity(for_user(
+            GetUserOwnedIdentityRequest {
+                name: name.to_string(),
+            },
+            user,
+        ))
+        .await
+        .expect("get identity")
+        .into_inner()
+        .identity
+        .expect("identity response")
+}
+
+fn create_request(
+    name: &str,
+    spec: &str,
+    token: &str,
+    user: &str,
+) -> Request<CreateUserOwnedIdentityRequest> {
+    for_user(
+        CreateUserOwnedIdentityRequest {
+            name: name.to_string(),
+            identity_spec: spec.to_string(),
+            setup: Some(create_user_owned_identity_request::Setup::FixedToken(
+                FixedTokenUserOwnedIdentitySetup {
+                    token: token.to_string(),
+                },
+            )),
+        },
+        user,
+    )
+}
+
+fn for_user<T>(message: T, user: &str) -> Request<T> {
+    let mut request = Request::new(message);
+    request.metadata_mut().insert(
+        USER_HEADER,
+        user.parse().expect("valid user metadata value"),
+    );
+    request
+}
+
+fn assert_identity(identity: &Identity, spec: &str, issuer: &str) {
+    assert_eq!(identity.name, "shared");
+    assert_eq!(identity.identity_spec, spec);
+    assert_eq!(identity.issuer, issuer);
+    assert_eq!(identity.identity_type, "fixed_token");
+    assert_eq!(identity.owner, IdentityOwner::User as i32);
+    assert!(identity.metadata.is_empty());
+    assert!(identity.owner_workspace.is_none());
+    assert!(identity.identity_spec_workspace.is_none());
+}
+
+fn assert_error_reason(status: &Status, expected: &str) {
+    let reason = status
+        .get_error_details_vec()
+        .into_iter()
+        .find_map(|detail| match detail {
+            ErrorDetail::ErrorInfo(info) => Some(info.reason),
+            _ => None,
+        });
+    assert_eq!(reason.as_deref(), Some(expected));
+}
+
+fn manifest(name: &str, issuer: &str, kind: &str) -> String {
+    let oauth = if kind == "oauth" {
+        "oauth:\n  method:\n    flow: {type: authorization_code, pkce: disabled}\n    redirect_uri: http://127.0.0.1:53682/oauth/callback\n    endpoints:\n      authorization_url: https://provider.example.com/authorize\n      token_url: https://provider.example.com/token\n    client:\n      id: {default: client}\n"
+    } else {
+        ""
+    };
+    format!(
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: 1.0.0\ndescription: {issuer} identity\nissuer: {issuer}\ntype: {kind}\n{oauth}"
+    )
+}

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -7,9 +7,11 @@
 
 use std::fs;
 
-use coral_client::local::ServerBuilder;
+use coral_api::v1::ListUserOwnedIdentitiesRequest;
+use coral_client::{AppClient, local::ServerBuilder};
 use sqlx::postgres::PgPoolOptions;
 use tempfile::TempDir;
+use tonic::Request;
 
 #[tokio::test]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run configured Postgres startup coverage"]
@@ -31,6 +33,16 @@ async fn server_lifecycle_can_start_with_postgres_database_config() {
         .start()
         .await
         .expect("start server with Postgres config");
+    let app = AppClient::connect(server.endpoint_uri())
+        .await
+        .expect("connect Postgres-backed client");
+    let identities = app
+        .identity_client()
+        .list_user_owned_identities(Request::new(ListUserOwnedIdentitiesRequest {}))
+        .await
+        .expect("keyless Postgres supports safe identity reads")
+        .into_inner();
+    assert!(identities.identities.is_empty());
     assert_postgres_db_is_migrated(&database_url).await;
 
     server.shutdown().await.expect("shutdown server");


### PR DESCRIPTION
## Intent

Expose the persisted user-owned identity lifecycle through Coral's authenticated app transport while keeping ownership and credential boundaries inside `coral-app`.

## What it enables

- Create or replace fixed-token identities and list, get, or delete them through `IdentityService`.
- Derive user ownership exclusively from the authenticated `RequestContext`, so callers cannot choose another owner.
- Reconstruct safe responses from durable identity rows, preserving orphan inspection and deletion after a forced spec removal or server restart.
- Share one credential key provider across identity-spec and identity managers, while allowing public/keyless Postgres reads that do not decrypt credentials.
- Serve the user identity API on the existing native and gRPC-Web routes with the configured identity response ceiling.

OAuth creation remains explicitly unimplemented until the OAuth slice lands. Workspace-owned lifecycle RPCs remain in the following mission slice.

## Usage examples

- Send `CreateUserOwnedIdentityRequest { name, identity_spec, fixed_token: { token } }`; consume the single completed `Identity` event from the response stream.
- Call `ListUserOwnedIdentities` or `GetUserOwnedIdentity` with the same authenticated principal to read only that principal's identities.
- Call `DeleteUserOwnedIdentity` by name; repeated get/delete requests return the typed `IDENTITY_NOT_FOUND` error.

## Validation

- `make rust-checks` — passed; 1,719 tests passed, 3 skipped, with clean formatting, strict Clippy, and rustdoc.
- `make postgres-tests` — passed, including keyless Postgres identity-list coverage.
- `make docs-check` — passed.
- `make perf-check` — passed at 209.5 ms mean versus the 750 ms ceiling.
- Full native gRPC integration suite — 91/91 passed.
- Focused client aggregate response-ceiling contract — passed.
- Five-lane review swarm plus supervisor sweep — zero findings and zero open questions.
