### PR TITLE
feat(sources/community/twilio): add Twilio community source

### DIFF
--- a/sources/community/twilio/README.md
+++ b/sources/community/twilio/README.md
@@ -1,0 +1,242 @@
+# Twilio
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 3
+
+Query SMS messages, voice calls, and account details from Twilio. Monitor communication history, delivery status, and usage through SQL.
+
+## Installation
+
+Install the source via the CLI:
+
+```bash
+coral source add --file sources/community/twilio/manifest.yaml
+```
+
+## Credentials
+
+To use this source, you need your Twilio Account SID and Auth Token.
+
+1. Log in to the [Twilio Console](https://console.twilio.com).
+2. Copy your **Account SID** (starts with `AC`) and **Auth Token** from the dashboard.
+3. Base64-encode `AccountSID:AuthToken` to create the Basic auth token:
+
+```bash
+printf '%s:%s' YOUR_ACCOUNT_SID YOUR_AUTH_TOKEN | base64
+```
+
+4. Provide all values as environment variables or when prompted by `coral source add`:
+
+```bash
+export TWILIO_ACCOUNT_SID="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+export TWILIO_BASIC_AUTH="QUNiYjdhMjdmMTI0MmE5Mzk4N2U1Y2YwMTM5..."
+```
+
+## Quick Start
+
+```sql
+-- Check account info
+SELECT sid, status, type, friendly_name
+FROM twilio.account;
+
+-- List recent messages
+SELECT sid, direction, "from", "to", body, status
+FROM twilio.messages
+LIMIT 10;
+
+-- List voice calls
+SELECT sid, "from", "to", status, duration, price
+FROM twilio.calls
+LIMIT 10;
+
+-- Filter messages by date
+SELECT sid, "from", "to", body, status
+FROM twilio.messages
+WHERE date_sent_after = '2026-01-01'
+LIMIT 10;
+
+-- Find failed calls
+SELECT sid, "from", "to", status, direction
+FROM twilio.calls
+WHERE status = 'failed';
+```
+
+## Tables
+
+### `account`
+
+Twilio account details including status, type, and friendly name. Returns exactly one row.
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `sid` | Utf8 | Account SID |
+| `friendly_name` | Utf8 | Friendly name of the account |
+| `status` | Utf8 | Account status (active, suspended, closed) |
+| `type` | Utf8 | Account type (Trial, Full) |
+| `date_created` | Utf8 | When the account was created |
+| `date_updated` | Utf8 | When the account was last updated |
+
+---
+
+### `messages`
+
+SMS and MMS messages sent and received through Twilio.
+
+**Filters**
+
+| Filter | Type | Required | Description |
+|--------|------|----------|-------------|
+| `date_sent_after` | Utf8 | | Only messages sent after this date (YYYY-MM-DD) |
+| `date_sent_before` | Utf8 | | Only messages sent before this date (YYYY-MM-DD) |
+| `from_number` | Utf8 | | Filter by sender phone number |
+| `to_number` | Utf8 | | Filter by recipient phone number |
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `sid` | Utf8 | Unique identifier for the message |
+| `direction` | Utf8 | Direction (inbound, outbound-api, outbound-call, outbound-reply) |
+| `from` | Utf8 | Sender phone number or short code |
+| `to` | Utf8 | Recipient phone number |
+| `body` | Utf8 | Text body of the message |
+| `status` | Utf8 | Delivery status (queued, sending, sent, delivered, undelivered, failed, received) |
+| `price` | Utf8 | Cost of the message (negative value) |
+| `price_unit` | Utf8 | Currency (e.g. USD) |
+| `num_segments` | Utf8 | Number of message segments |
+| `error_code` | Utf8 | Error code if the message failed |
+| `error_message` | Utf8 | Error message if the message failed |
+| `date_created` | Utf8 | When the message was created |
+| `date_sent` | Utf8 | When the message was sent |
+
+---
+
+### `calls`
+
+Voice calls made and received through Twilio.
+
+**Filters**
+
+| Filter | Type | Required | Description |
+|--------|------|----------|-------------|
+| `start_time_after` | Utf8 | | Only calls started after this date (YYYY-MM-DD) |
+| `start_time_before` | Utf8 | | Only calls started before this date (YYYY-MM-DD) |
+| `from_number` | Utf8 | | Filter by caller phone number |
+| `to_number` | Utf8 | | Filter by recipient phone number |
+| `status` | Utf8 | | Filter by call status |
+
+**Columns**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `sid` | Utf8 | Unique identifier for the call |
+| `from` | Utf8 | Caller phone number |
+| `to` | Utf8 | Recipient phone number |
+| `status` | Utf8 | Call status (queued, ringing, in-progress, completed, busy, failed, no-answer, canceled) |
+| `direction` | Utf8 | Direction (inbound, outbound-api, outbound-dial) |
+| `duration` | Utf8 | Duration of the call in seconds |
+| `price` | Utf8 | Cost of the call (negative value) |
+| `price_unit` | Utf8 | Currency (e.g. USD) |
+| `start_time` | Utf8 | When the call started |
+| `end_time` | Utf8 | When the call ended |
+| `date_created` | Utf8 | When the call record was created |
+
+## Source scope
+
+- Targets the Twilio REST API at `https://api.twilio.com/2010-04-01/Accounts/{AccountSid}`.
+- Requires `TWILIO_ACCOUNT_SID` (URL path variable) and `TWILIO_BASIC_AUTH` (HTTP Basic auth, base64-encoded `SID:Token`).
+- `messages` supports date range and phone number filters pushed to the API.
+- `calls` supports date range, phone number, and status filters pushed to the API.
+- SQL `LIMIT` is pushed to the API via `PageSize` query param (default 50, max 1000).
+- Twilio timestamps are RFC 2822 format strings (e.g. `Sun, 23 Nov 2025 02:47:12 +0000`), kept as `Utf8`.
+- 1 declared test query (`account`) is source-independent.
+- Provides read-only access. Sending messages, making calls, and other write operations are out of scope.
+
+## Limitations
+
+- The source provides read-only list access only. Sending SMS, making calls, and managing phone numbers are out of scope.
+- Pagination uses Twilio's `PageToken` URL-based cursors. This source uses `mode: none` with `PageSize` (max 1000), so a single query returns at most 1000 items.
+- Twilio timestamps are RFC 2822 strings (not ISO 8601), kept as `Utf8` since Coral's `format_timestamp/iso8601` does not parse RFC 2822.
+- The `price` column is a string — Twilio returns it as a string with negative values (e.g. `-0.08320`).
+- The `incoming_phone_numbers` endpoint is not modeled (trial accounts may have no numbers).
+- Date filters use Twilio's `DateSent>` / `StartTime>` syntax mapped to friendly filter names.
+
+## Provider docs
+
+- Twilio REST API: https://www.twilio.com/docs/usage/api
+- Messages API: https://www.twilio.com/docs/messaging/api/message-resource
+- Calls API: https://www.twilio.com/docs/voice/api/call-resource
+- Console: https://console.twilio.com
+
+## Live validation output
+
+Validated against a live Twilio Trial account with a valid `TWILIO_ACCOUNT_SID` and `TWILIO_BASIC_AUTH`.
+
+```bash
+$ coral source lint sources/community/twilio/manifest.yaml
+Manifest is valid
+```
+
+```bash
+$ coral source add --file sources/community/twilio/manifest.yaml
+Added source twilio
+
+  ✓ twilio connected successfully
+
+    twilio (3 tables)
+    ├─ account
+    ├─ calls
+    └─ messages
+    Query tests
+    1 declared · 1 passed · 0 failed
+
+    ✓ SELECT sid, status, friendly_name FROM twilio.account
+      1 row
+```
+
+**Live account proof:**
+
+```sql
+SELECT sid, status, type, friendly_name FROM twilio.account;
+```
+
+```text
++--------------------------------------+--------+-------+-------------------------+
+| sid                                  | status | type  | friendly_name           |
++--------------------------------------+--------+-------+-------------------------+
+| AC00000000000000000000000000000000c7 | active | Trial | My first Twilio account |
++--------------------------------------+--------+-------+-------------------------+
+```
+
+**Live messages proof:**
+
+```sql
+SELECT sid, direction, status, body FROM twilio.messages LIMIT 3;
+```
+
+```text
++--------------------------------------+--------------+-----------+-------------------------------------------------------+
+| sid                                  | direction    | status    | body                                                  |
++--------------------------------------+--------------+-----------+-------------------------------------------------------+
+| SM00000000000000000000000000000000e3 | outbound-api | delivered | Sent from your Twilio trial account - this is user     |
+| SM00000000000000000000000000000000ea | outbound-api | delivered | Sent from your Twilio trial account - this is user     |
+| MM00000000000000000000000000000000a7 | outbound-api | delivered | Sent from your Twilio trial account - Hi user, great.. |
++--------------------------------------+--------------+-----------+-------------------------------------------------------+
+```
+
+**Live calls proof:**
+
+```sql
+SELECT sid, status, direction, duration FROM twilio.calls LIMIT 3;
+```
+
+```text
++--------------------------------------+--------+-----------+----------+
+| sid                                  | status | direction | duration |
++--------------------------------------+--------+-----------+----------+
+| CA00000000000000000000000000000000a1 | failed | inbound   | 0        |
++--------------------------------------+--------+-----------+----------+
+```

--- a/sources/community/twilio/README.md
+++ b/sources/community/twilio/README.md
@@ -104,7 +104,7 @@ SMS and MMS messages sent and received through Twilio.
 | `to` | Utf8 | Recipient phone number |
 | `body` | Utf8 | Text body of the message |
 | `status` | Utf8 | Delivery status (queued, sending, sent, delivered, undelivered, failed, received) |
-| `price` | Utf8 | Cost of the message (negative value) |
+| `price` | Float64 | Cost of the message (negative value) |
 | `price_unit` | Utf8 | Currency (e.g. USD) |
 | `num_segments` | Utf8 | Number of message segments |
 | `error_code` | Utf8 | Error code if the message failed |
@@ -138,7 +138,7 @@ Voice calls made and received through Twilio.
 | `status` | Utf8 | Call status (queued, ringing, in-progress, completed, busy, failed, no-answer, canceled) |
 | `direction` | Utf8 | Direction (inbound, outbound-api, outbound-dial) |
 | `duration` | Int64 | Duration of the call in seconds |
-| `price` | Utf8 | Cost of the call (negative value) |
+| `price` | Float64 | Cost of the call (negative value) |
 | `price_unit` | Utf8 | Currency (e.g. USD) |
 | `start_time` | Utf8 | When the call started |
 | `end_time` | Utf8 | When the call ended |
@@ -152,7 +152,7 @@ Voice calls made and received through Twilio.
 - `calls` supports date range, phone number, and status filters pushed to the API.
 - SQL `LIMIT` is pushed to the API via `PageSize` query param (default 50, max 1000).
 - Twilio timestamps are RFC 2822 format strings (e.g. `Sun, 23 Nov 2025 02:47:12 +0000`), kept as `Utf8`.
-- 1 declared test query (`account`) is source-independent.
+- 1 declared test query (`account`) requires no filters.
 - Provides read-only access. Sending messages, making calls, and other write operations are out of scope.
 
 ## Limitations
@@ -160,7 +160,7 @@ Voice calls made and received through Twilio.
 - The source provides read-only list access only. Sending SMS, making calls, and managing phone numbers are out of scope.
 - Pagination uses Twilio's `PageToken` URL-based cursors. This source uses `mode: none` with `PageSize` (max 1000), so a single query returns at most 1000 items.
 - Twilio timestamps are RFC 2822 strings (not ISO 8601), kept as `Utf8` since Coral's `format_timestamp/iso8601` does not parse RFC 2822.
-- The `price` column is a string — Twilio returns it as a string with negative values (e.g. `-0.08320`).
+- The `price` column is `Float64` — Twilio returns prices as negative values (e.g. `-0.08320`).
 - The `incoming_phone_numbers` endpoint is not modeled (trial accounts may have no numbers).
 - Date filters use Twilio's `DateSent>` / `StartTime>` syntax mapped to friendly filter names.
 

--- a/sources/community/twilio/README.md
+++ b/sources/community/twilio/README.md
@@ -137,7 +137,7 @@ Voice calls made and received through Twilio.
 | `to` | Utf8 | Recipient phone number |
 | `status` | Utf8 | Call status (queued, ringing, in-progress, completed, busy, failed, no-answer, canceled) |
 | `direction` | Utf8 | Direction (inbound, outbound-api, outbound-dial) |
-| `duration` | Utf8 | Duration of the call in seconds |
+| `duration` | Int64 | Duration of the call in seconds |
 | `price` | Utf8 | Cost of the call (negative value) |
 | `price_unit` | Utf8 | Currency (e.g. USD) |
 | `start_time` | Utf8 | When the call started |

--- a/sources/community/twilio/README.md
+++ b/sources/community/twilio/README.md
@@ -104,7 +104,7 @@ SMS and MMS messages sent and received through Twilio.
 | `to` | Utf8 | Recipient phone number |
 | `body` | Utf8 | Text body of the message |
 | `status` | Utf8 | Delivery status (queued, sending, sent, delivered, undelivered, failed, received) |
-| `price` | Float64 | Cost of the message (negative value) |
+| `price` | Utf8 | Cost of the message as a string (e.g. -0.08320) |
 | `price_unit` | Utf8 | Currency (e.g. USD) |
 | `num_segments` | Utf8 | Number of message segments |
 | `error_code` | Utf8 | Error code if the message failed |
@@ -138,7 +138,7 @@ Voice calls made and received through Twilio.
 | `status` | Utf8 | Call status (queued, ringing, in-progress, completed, busy, failed, no-answer, canceled) |
 | `direction` | Utf8 | Direction (inbound, outbound-api, outbound-dial) |
 | `duration` | Int64 | Duration of the call in seconds |
-| `price` | Float64 | Cost of the call (negative value) |
+| `price` | Utf8 | Cost of the call as a string (e.g. -0.03000) |
 | `price_unit` | Utf8 | Currency (e.g. USD) |
 | `start_time` | Utf8 | When the call started |
 | `end_time` | Utf8 | When the call ended |
@@ -160,7 +160,7 @@ Voice calls made and received through Twilio.
 - The source provides read-only list access only. Sending SMS, making calls, and managing phone numbers are out of scope.
 - Pagination uses Twilio's `PageToken` URL-based cursors. This source uses `mode: none` with `PageSize` (max 1000), so a single query returns at most 1000 items.
 - Twilio timestamps are RFC 2822 strings (not ISO 8601), kept as `Utf8` since Coral's `format_timestamp/iso8601` does not parse RFC 2822.
-- The `price` column is `Float64` — Twilio returns prices as negative values (e.g. `-0.08320`).
+- The `price` column is `Utf8` — Twilio returns prices as strings (e.g. `"-0.08320"`). Cast with `CAST(price AS DOUBLE)` for aggregation.
 - The `incoming_phone_numbers` endpoint is not modeled (trial accounts may have no numbers).
 - Date filters use Twilio's `DateSent>` / `StartTime>` syntax mapped to friendly filter names.
 

--- a/sources/community/twilio/manifest.yaml
+++ b/sources/community/twilio/manifest.yaml
@@ -170,7 +170,7 @@ tables:
         nullable: true
         description: Delivery status (queued, sending, sent, delivered, undelivered, failed, received).
       - name: price
-        type: Utf8
+        type: Float64
         nullable: true
         description: Cost of the message (negative value, in price_unit currency).
       - name: price_unit
@@ -301,7 +301,7 @@ tables:
         nullable: true
         description: Duration of the call in seconds.
       - name: price
-        type: Utf8
+        type: Float64
         nullable: true
         description: Cost of the call (negative value, in price_unit currency).
       - name: price_unit

--- a/sources/community/twilio/manifest.yaml
+++ b/sources/community/twilio/manifest.yaml
@@ -37,6 +37,7 @@ tables:
   # --------------------------------------------------------------------------
   # twilio.account — Account details
   # GET /Accounts/{AccountSid}.json
+  # Path is `.json` because base_url already includes the Account SID.
   # Single object response.
   # --------------------------------------------------------------------------
   - name: account
@@ -104,7 +105,7 @@ tables:
       No required filters. Start with:
         SELECT sid, direction, "from", "to", body, status
         FROM twilio.messages LIMIT 10
-      Filter by direction:
+      Filter by direction (client-side, not pushed to API):
         SELECT sid, "from", "to", body
         FROM twilio.messages
         WHERE direction = 'outbound-api' LIMIT 10
@@ -296,7 +297,7 @@ tables:
         nullable: true
         description: Direction of the call (inbound, outbound-api, outbound-dial).
       - name: duration
-        type: Utf8
+        type: Int64
         nullable: true
         description: Duration of the call in seconds.
       - name: price

--- a/sources/community/twilio/manifest.yaml
+++ b/sources/community/twilio/manifest.yaml
@@ -1,0 +1,337 @@
+name: twilio
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query SMS messages, voice calls, and account details from Twilio.
+  Monitor communication history, delivery status, and usage through SQL.
+base_url: https://api.twilio.com/2010-04-01/Accounts/{{input.TWILIO_ACCOUNT_SID}}
+
+inputs:
+  TWILIO_ACCOUNT_SID:
+    kind: variable
+    hint: >-
+      Twilio Account SID from https://console.twilio.com.
+      Starts with `AC`.
+  TWILIO_BASIC_AUTH:
+    kind: secret
+    hint: >-
+      Base64-encoded "AccountSID:AuthToken" for HTTP Basic auth.
+      Generate from your Account SID and Auth Token (found in
+      the Twilio Console):
+        printf '%s:%s' YOUR_ACCOUNT_SID YOUR_AUTH_TOKEN | base64
+      Paste the full base64 string as the value.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Basic {{input.TWILIO_BASIC_AUTH}}"
+
+test_queries:
+  - SELECT sid, status, friendly_name FROM twilio.account
+
+tables:
+
+  # --------------------------------------------------------------------------
+  # twilio.account — Account details
+  # GET /Accounts/{AccountSid}.json
+  # Single object response.
+  # --------------------------------------------------------------------------
+  - name: account
+    description: >-
+      Twilio account details including status, type, and friendly name.
+      Returns exactly one row.
+    guide: |
+      No required filters. Returns one row:
+        SELECT sid, status, friendly_name, type
+        FROM twilio.account
+    request:
+      method: GET
+      path: .json
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: sid
+        type: Utf8
+        nullable: false
+        description: Account SID.
+      - name: friendly_name
+        type: Utf8
+        nullable: true
+        description: Friendly name of the account.
+        expr:
+          kind: path
+          path:
+            - friendly_name
+      - name: status
+        type: Utf8
+        nullable: false
+        description: Account status (active, suspended, closed).
+      - name: type
+        type: Utf8
+        nullable: false
+        description: Account type (Trial, Full).
+      - name: date_created
+        type: Utf8
+        nullable: false
+        description: When the account was created.
+        expr:
+          kind: path
+          path:
+            - date_created
+      - name: date_updated
+        type: Utf8
+        nullable: false
+        description: When the account was last updated.
+        expr:
+          kind: path
+          path:
+            - date_updated
+
+  # --------------------------------------------------------------------------
+  # twilio.messages — SMS/MMS messages
+  # GET /Accounts/{AccountSid}/Messages.json
+  # Array at response.messages. Paginated.
+  # --------------------------------------------------------------------------
+  - name: messages
+    description: >-
+      SMS and MMS messages sent and received through Twilio. Includes
+      body, sender, recipient, delivery status, price, and timestamps.
+    guide: |
+      No required filters. Start with:
+        SELECT sid, direction, "from", "to", body, status
+        FROM twilio.messages LIMIT 10
+      Filter by direction:
+        SELECT sid, "from", "to", body
+        FROM twilio.messages
+        WHERE direction = 'outbound-api' LIMIT 10
+    filters:
+      - name: date_sent_after
+        description: Only messages sent after this date (YYYY-MM-DD).
+      - name: date_sent_before
+        description: Only messages sent before this date (YYYY-MM-DD).
+      - name: from_number
+        description: Filter by sender phone number.
+      - name: to_number
+        description: Filter by recipient phone number.
+    request:
+      method: GET
+      path: /Messages.json
+      query:
+        - name: "DateSent>"
+          from: filter
+          key: date_sent_after
+        - name: "DateSent<"
+          from: filter
+          key: date_sent_before
+        - name: From
+          from: filter
+          key: from_number
+        - name: To
+          from: filter
+          key: to_number
+    response:
+      rows_path:
+        - messages
+    pagination:
+      mode: none
+      page_size:
+        default: 50
+        max: 1000
+        query_param: PageSize
+    fetch_limit_default: 50
+    columns:
+      - name: sid
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the message.
+      - name: direction
+        type: Utf8
+        nullable: true
+        description: Direction of the message (inbound, outbound-api, outbound-call, outbound-reply).
+      - name: from
+        type: Utf8
+        nullable: true
+        description: Sender phone number or short code.
+      - name: to
+        type: Utf8
+        nullable: true
+        description: Recipient phone number.
+      - name: body
+        type: Utf8
+        nullable: true
+        description: Text body of the message.
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Delivery status (queued, sending, sent, delivered, undelivered, failed, received).
+      - name: price
+        type: Utf8
+        nullable: true
+        description: Cost of the message (negative value, in price_unit currency).
+      - name: price_unit
+        type: Utf8
+        nullable: true
+        description: Currency of the price (e.g. USD).
+        expr:
+          kind: path
+          path:
+            - price_unit
+      - name: num_segments
+        type: Utf8
+        nullable: true
+        description: Number of message segments.
+        expr:
+          kind: path
+          path:
+            - num_segments
+      - name: error_code
+        type: Utf8
+        nullable: true
+        description: Error code if the message failed.
+        expr:
+          kind: path
+          path:
+            - error_code
+      - name: error_message
+        type: Utf8
+        nullable: true
+        description: Error message if the message failed.
+        expr:
+          kind: path
+          path:
+            - error_message
+      - name: date_created
+        type: Utf8
+        nullable: true
+        description: When the message was created.
+        expr:
+          kind: path
+          path:
+            - date_created
+      - name: date_sent
+        type: Utf8
+        nullable: true
+        description: When the message was sent.
+        expr:
+          kind: path
+          path:
+            - date_sent
+
+  # --------------------------------------------------------------------------
+  # twilio.calls — Voice calls
+  # GET /Accounts/{AccountSid}/Calls.json
+  # Array at response.calls. Paginated.
+  # --------------------------------------------------------------------------
+  - name: calls
+    description: >-
+      Voice calls made and received through Twilio. Includes caller,
+      recipient, duration, status, price, and timestamps.
+    guide: |
+      No required filters. Start with:
+        SELECT sid, "from", "to", status, duration, price
+        FROM twilio.calls LIMIT 10
+    filters:
+      - name: start_time_after
+        description: Only calls started after this date (YYYY-MM-DD).
+      - name: start_time_before
+        description: Only calls started before this date (YYYY-MM-DD).
+      - name: from_number
+        description: Filter by caller phone number.
+      - name: to_number
+        description: Filter by recipient phone number.
+      - name: status
+        description: Filter by call status.
+    request:
+      method: GET
+      path: /Calls.json
+      query:
+        - name: "StartTime>"
+          from: filter
+          key: start_time_after
+        - name: "StartTime<"
+          from: filter
+          key: start_time_before
+        - name: From
+          from: filter
+          key: from_number
+        - name: To
+          from: filter
+          key: to_number
+        - name: Status
+          from: filter
+          key: status
+    response:
+      rows_path:
+        - calls
+    pagination:
+      mode: none
+      page_size:
+        default: 50
+        max: 1000
+        query_param: PageSize
+    fetch_limit_default: 50
+    columns:
+      - name: sid
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the call.
+      - name: from
+        type: Utf8
+        nullable: true
+        description: Caller phone number.
+      - name: to
+        type: Utf8
+        nullable: true
+        description: Recipient phone number.
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Call status (queued, ringing, in-progress, completed, busy, failed, no-answer, canceled).
+      - name: direction
+        type: Utf8
+        nullable: true
+        description: Direction of the call (inbound, outbound-api, outbound-dial).
+      - name: duration
+        type: Utf8
+        nullable: true
+        description: Duration of the call in seconds.
+      - name: price
+        type: Utf8
+        nullable: true
+        description: Cost of the call (negative value, in price_unit currency).
+      - name: price_unit
+        type: Utf8
+        nullable: true
+        description: Currency of the price (e.g. USD).
+        expr:
+          kind: path
+          path:
+            - price_unit
+      - name: start_time
+        type: Utf8
+        nullable: true
+        description: When the call started.
+        expr:
+          kind: path
+          path:
+            - start_time
+      - name: end_time
+        type: Utf8
+        nullable: true
+        description: When the call ended.
+        expr:
+          kind: path
+          path:
+            - end_time
+      - name: date_created
+        type: Utf8
+        nullable: true
+        description: When the call record was created.
+        expr:
+          kind: path
+          path:
+            - date_created

--- a/sources/community/twilio/manifest.yaml
+++ b/sources/community/twilio/manifest.yaml
@@ -170,9 +170,9 @@ tables:
         nullable: true
         description: Delivery status (queued, sending, sent, delivered, undelivered, failed, received).
       - name: price
-        type: Float64
+        type: Utf8
         nullable: true
-        description: Cost of the message (negative value, in price_unit currency).
+        description: Cost of the message as a string (e.g. -0.08320, in price_unit currency).
       - name: price_unit
         type: Utf8
         nullable: true
@@ -301,9 +301,9 @@ tables:
         nullable: true
         description: Duration of the call in seconds.
       - name: price
-        type: Float64
+        type: Utf8
         nullable: true
-        description: Cost of the call (negative value, in price_unit currency).
+        description: Cost of the call as a string (e.g. -0.03000, in price_unit currency).
       - name: price_unit
         type: Utf8
         nullable: true


### PR DESCRIPTION
## Summary

Add a Twilio community source so Coral can query SMS messages, voice calls, and account details through SQL.

## Files contributed

| File | Purpose |
| --- | --- |
| `sources/community/twilio/manifest.yaml` | Coral source manifest defining 3 tables: `account`, `messages`, `calls` |
| `sources/community/twilio/README.md` | Full documentation with credentials, tables, queries, and validation |

## Why this source

[Twilio](https://www.twilio.com) is the leading communication API platform. AI agents managing communications need to monitor message delivery, call status, and usage. This source enables querying Twilio communication history through SQL.

## Provider docs

- Twilio REST API: https://www.twilio.com/docs/usage/api
- Messages API: https://www.twilio.com/docs/messaging/api/message-resource
- Calls API: https://www.twilio.com/docs/voice/api/call-resource
- Console: https://console.twilio.com

## Source shape

| Table | Required Filters | Optional Filters | Description |
|-------|-----------------|------------------|-------------|
| `account` | — | — | Account details — SID, status, type, friendly name (6 columns) |
| `messages` | — | `date_sent_after`, `date_sent_before`, `from_number`, `to_number` | SMS/MMS messages — body, direction, status, price (13 columns) |
| `calls` | — | `start_time_after`, `start_time_before`, `from_number`, `to_number`, `status` | Voice calls — direction, duration, status, price (11 columns) |

## Source scope

- **Base URL:** `https://api.twilio.com/2010-04-01/Accounts/{AccountSid}`
- **Auth:** HTTP Basic (`TWILIO_BASIC_AUTH`, base64-encoded `SID:Token`)
- **Tables:** `account`, `messages`, `calls`
- **Pagination:** `mode: none` with PageSize default 50 / max 1000
- `messages` and `calls` support date range and phone number filters pushed to the API
- Twilio timestamps are RFC 2822 strings (kept as Utf8)
- Read-only access — sending messages and making calls are out of scope
- 1 declared test query (`account`) requires no filters

## Validation

```bash
$ coral source lint sources/community/twilio/manifest.yaml
Manifest is valid
```

```bash
$ coral source add --file sources/community/twilio/manifest.yaml
Added source twilio

  ✓ twilio connected successfully

    twilio (3 tables)
    ├─ account
    ├─ calls
    └─ messages
    Query tests
    1 declared · 1 passed · 0 failed

    ✓ SELECT sid, status, friendly_name FROM twilio.account
      1 row
```

### Live account proof

```sql
SELECT sid, status, type, friendly_name FROM twilio.account;
```

```text
+--------------------------------------+--------+-------+-------------------------+
| sid                                  | status | type  | friendly_name           |
+--------------------------------------+--------+-------+-------------------------+
| AC00000000000000000000000000000000c7 | active | Trial | My first Twilio account |
+--------------------------------------+--------+-------+-------------------------+
```

### Live messages proof

```sql
SELECT sid, direction, status, body FROM twilio.messages LIMIT 3;
```

```text
+--------------------------------------+--------------+-----------+-------------------------------------------------------+
| sid                                  | direction    | status    | body                                                  |
+--------------------------------------+--------------+-----------+-------------------------------------------------------+
| SM00000000000000000000000000000000e3 | outbound-api | delivered | Sent from your Twilio trial account - this is user     |
| SM00000000000000000000000000000000ea | outbound-api | delivered | Sent from your Twilio trial account - this is user     |
| MM00000000000000000000000000000000a7 | outbound-api | delivered | Sent from your Twilio trial account - Hi user, great.. |
+--------------------------------------+--------------+-----------+-------------------------------------------------------+
```

### Live calls proof

```sql
SELECT sid, status, direction, duration FROM twilio.calls LIMIT 3;
```

```text
+--------------------------------------+--------+-----------+----------+
| sid                                  | status | direction | duration |
+--------------------------------------+--------+-----------+----------+
| CA00000000000000000000000000000000a1 | failed | inbound   | 0        |
+--------------------------------------+--------+-----------+----------+
```

Closes #1693
