### PR TITLE
feat(app): add workspace identity service

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -22,6 +22,7 @@ use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::search_service_server::SearchServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
 use coral_api::v1::trace_service_server::TraceServiceServer;
+use coral_api::v1::workspace_identity_service_server::WorkspaceIdentityServiceServer;
 use coral_api::v1::workspace_service_server::WorkspaceServiceServer;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE,
@@ -56,8 +57,8 @@ use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
 };
 use crate::feedback::service::FeedbackService;
-use crate::identities::IdentityService;
 use crate::identities::manager::IdentityManager;
+use crate::identities::{IdentityService, WorkspaceIdentityService};
 use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
 use crate::identity_specs::IdentitySpecService;
 use crate::identity_specs::manager::IdentitySpecManager;
@@ -606,9 +607,10 @@ async fn start_server(
         feedback,
     } = managers;
     let source_service = SourceService::new(source, query.clone(), workspace.clone());
-    let workspace_service = WorkspaceService::new(workspace);
+    let workspace_service = WorkspaceService::new(workspace.clone());
     let identity_spec_service = IdentitySpecService::new(identity_spec);
-    let identity_service = IdentityService::new(identity);
+    let identity_service = IdentityService::new(identity.clone());
+    let workspace_identity_service = WorkspaceIdentityService::new(identity, workspace);
     let catalog_service = CatalogService::new(query.clone());
     let query_service = QueryService::new(query);
     let search_service = SearchService::new(search);
@@ -625,6 +627,10 @@ async fn start_server(
         )
         .add_service(
             IdentityServiceServer::new(identity_service)
+                .max_encoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE),
+        )
+        .add_service(
+            WorkspaceIdentityServiceServer::new(workspace_identity_service)
                 .max_encoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE),
         )
         .add_service(

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -118,10 +118,6 @@ impl IdentityManager {
     }
 
     /// Create or replace a workspace-owned fixed-token identity using workspace-first resolution.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "B4i wires the workspace identity service.")
-    )]
     pub(crate) async fn create_or_replace_workspace_fixed_token(
         &self,
         workspace: &WorkspaceName,
@@ -222,8 +218,11 @@ impl IdentityManager {
         &self,
         owner: &IdentityOwner,
     ) -> Result<Vec<IdentityRecord>, AppError> {
-        let mut db = self.db.as_ref();
-        Ok(db.identities().list_for_owner(owner).await?)
+        let mut tx = self.db.begin_read_snapshot().await?;
+        owner_workspace_created_at(&mut tx, owner).await?;
+        let records = tx.identities().list_for_owner(owner).await?;
+        tx.commit().await?;
+        Ok(records)
     }
 
     /// Get safe persisted fields for one identity, including an orphaned identity.
@@ -232,12 +231,15 @@ impl IdentityManager {
         owner: &IdentityOwner,
         identity_name: &str,
     ) -> Result<IdentityRecord, AppError> {
+        if owner.workspace_name().is_none() {
+            IdentityName::parse(identity_name)?;
+        }
+        let mut tx = self.db.begin_read_snapshot().await?;
+        owner_workspace_created_at(&mut tx, owner).await?;
         let name = IdentityName::parse(identity_name)?;
-        let mut db = self.db.as_ref();
-        db.identities()
-            .load_optional(owner, &name)
-            .await?
-            .ok_or_else(|| identity_not_found(&name))
+        let record = tx.identities().load_optional(owner, &name).await?;
+        tx.commit().await?;
+        record.ok_or_else(|| identity_not_found(&name))
     }
 
     /// Delete one identity and its cascading encrypted document.
@@ -246,9 +248,11 @@ impl IdentityManager {
         owner: &IdentityOwner,
         identity_name: &str,
     ) -> Result<(), AppError> {
-        let name = IdentityName::parse(identity_name)?;
+        if owner.workspace_name().is_none() {
+            IdentityName::parse(identity_name)?;
+        }
         for _ in 0..MAX_MUTATION_ATTEMPTS {
-            match self.try_delete(owner, &name).await {
+            match self.try_delete(owner, identity_name).await {
                 Ok(()) => return Ok(()),
                 Err(AppError::RetryableTransactionConflict) => {
                     tokio::task::yield_now().await;
@@ -259,9 +263,11 @@ impl IdentityManager {
         Err(AppError::RetryableTransactionConflict)
     }
 
-    async fn try_delete(&self, owner: &IdentityOwner, name: &IdentityName) -> Result<(), AppError> {
+    async fn try_delete(&self, owner: &IdentityOwner, identity_name: &str) -> Result<(), AppError> {
         let mut tx = self.db.begin_serializable().await?;
-        let deleted = match tx.identities().delete(owner, name).await {
+        owner_workspace_created_at(&mut tx, owner).await?;
+        let name = IdentityName::parse(identity_name)?;
+        let deleted = match tx.identities().delete(owner, &name).await {
             Ok(deleted) => deleted,
             Err(error) => {
                 tx.rollback().await?;
@@ -270,7 +276,7 @@ impl IdentityManager {
         };
         if !deleted {
             tx.rollback().await?;
-            return Err(identity_not_found(name));
+            return Err(identity_not_found(&name));
         }
         tx.commit().await?;
         Ok(())

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -3,5 +3,7 @@
 pub(crate) mod manager;
 pub(crate) mod model;
 pub(crate) mod service;
+pub(crate) mod workspace_service;
 
 pub(crate) use service::IdentityService;
+pub(crate) use workspace_service::WorkspaceIdentityService;

--- a/crates/coral-app/src/identities/workspace_service.rs
+++ b/crates/coral-app/src/identities/workspace_service.rs
@@ -1,0 +1,157 @@
+//! Implements the gRPC `WorkspaceIdentityService` for workspace-owned identities.
+
+use std::pin::Pin;
+
+use coral_api::v1::workspace_identity_service_server::WorkspaceIdentityService as WorkspaceIdentityServiceApi;
+use coral_api::v1::{
+    CreateWorkspaceOwnedIdentityRequest, CreateWorkspaceOwnedIdentityResponse,
+    DeleteWorkspaceOwnedIdentityRequest, DeleteWorkspaceOwnedIdentityResponse,
+    FixedTokenWorkspaceOwnedIdentitySetup, GetWorkspaceOwnedIdentityRequest,
+    GetWorkspaceOwnedIdentityResponse, ListWorkspaceOwnedIdentitiesRequest,
+    ListWorkspaceOwnedIdentitiesResponse, create_workspace_owned_identity_request,
+    create_workspace_owned_identity_response,
+};
+use tokio_stream::Stream;
+use tonic::{Request, Response, Status};
+
+use super::manager::IdentityManager;
+use super::model::IdentityOwner;
+use super::service::identity_to_proto;
+use crate::bootstrap::app_status;
+use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto};
+use crate::workspaces::{WorkspaceManager, WorkspaceName};
+
+#[derive(Clone)]
+pub(crate) struct WorkspaceIdentityService {
+    identities: IdentityManager,
+    workspaces: WorkspaceManager,
+}
+
+impl WorkspaceIdentityService {
+    pub(crate) fn new(identities: IdentityManager, workspaces: WorkspaceManager) -> Self {
+        Self {
+            identities,
+            workspaces,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl WorkspaceIdentityServiceApi for WorkspaceIdentityService {
+    type CreateWorkspaceOwnedIdentityStream = CreateWorkspaceOwnedIdentityResponseStreamBox;
+
+    async fn create_workspace_owned_identity(
+        &self,
+        request: Request<CreateWorkspaceOwnedIdentityRequest>,
+    ) -> Result<Response<Self::CreateWorkspaceOwnedIdentityStream>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        let workspaces = self.workspaces.clone();
+        instrument_grpc(span, async move {
+            let CreateWorkspaceOwnedIdentityRequest {
+                workspace,
+                name,
+                identity_spec,
+                setup,
+            } = request.into_inner();
+            let workspace = workspace_name_from_proto(workspace.as_ref())?;
+            require_workspace(&workspaces, &workspace).await?;
+            let Some(create_workspace_owned_identity_request::Setup::FixedToken(
+                FixedTokenWorkspaceOwnedIdentitySetup { token },
+            )) = setup
+            else {
+                return Err(Status::unimplemented(
+                    "OAuth identity creation is not enabled by this server",
+                ));
+            };
+            let record = identities
+                .create_or_replace_workspace_fixed_token(&workspace, &name, &identity_spec, token)
+                .await
+                .map_err(app_status)?;
+            let response = CreateWorkspaceOwnedIdentityResponse {
+                event: Some(create_workspace_owned_identity_response::Event::Identity(
+                    identity_to_proto(record),
+                )),
+            };
+            let stream = Box::pin(tokio_stream::iter([Ok(response)]));
+            Ok(Response::new(
+                stream as CreateWorkspaceOwnedIdentityResponseStreamBox,
+            ))
+        })
+        .await
+    }
+
+    async fn list_workspace_owned_identities(
+        &self,
+        request: Request<ListWorkspaceOwnedIdentitiesRequest>,
+    ) -> Result<Response<ListWorkspaceOwnedIdentitiesResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
+            let owner = IdentityOwner::workspace(workspace);
+            let records = identities
+                .list_for_owner(&owner)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(ListWorkspaceOwnedIdentitiesResponse {
+                identities: records.into_iter().map(identity_to_proto).collect(),
+            }))
+        })
+        .await
+    }
+
+    async fn get_workspace_owned_identity(
+        &self,
+        request: Request<GetWorkspaceOwnedIdentityRequest>,
+    ) -> Result<Response<GetWorkspaceOwnedIdentityResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
+            let owner = IdentityOwner::workspace(workspace);
+            let identity = identities
+                .get(&owner, &request.name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(GetWorkspaceOwnedIdentityResponse {
+                identity: Some(identity_to_proto(identity)),
+            }))
+        })
+        .await
+    }
+
+    async fn delete_workspace_owned_identity(
+        &self,
+        request: Request<DeleteWorkspaceOwnedIdentityRequest>,
+    ) -> Result<Response<DeleteWorkspaceOwnedIdentityResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
+            let owner = IdentityOwner::workspace(workspace);
+            identities
+                .delete(&owner, &request.name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(DeleteWorkspaceOwnedIdentityResponse {}))
+        })
+        .await
+    }
+}
+
+async fn require_workspace(
+    workspaces: &WorkspaceManager,
+    workspace: &WorkspaceName,
+) -> Result<(), Status> {
+    workspaces
+        .require_workspace(workspace)
+        .await
+        .map_err(app_status)
+}
+
+type CreateWorkspaceOwnedIdentityResponseStreamBox =
+    Pin<Box<dyn Stream<Item = Result<CreateWorkspaceOwnedIdentityResponse, Status>> + Send>>;

--- a/crates/coral-app/tests/grpc/identity_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_tests.rs
@@ -1,13 +1,18 @@
 use std::sync::Arc;
 
 use coral_api::v1::{
-    AddIdentitySpecRequest, CreateUserOwnedIdentityRequest, DeleteIdentitySpecRequest,
-    DeleteUserOwnedIdentityRequest, FixedTokenUserOwnedIdentitySetup, GetUserOwnedIdentityRequest,
-    Identity, IdentityOwner, ListUserOwnedIdentitiesRequest, create_user_owned_identity_request,
-    create_user_owned_identity_response,
+    AddIdentitySpecRequest, CreateUserOwnedIdentityRequest, CreateWorkspaceOwnedIdentityRequest,
+    CreateWorkspaceRequest, DeleteIdentitySpecRequest, DeleteUserOwnedIdentityRequest,
+    DeleteWorkspaceOwnedIdentityRequest, FixedTokenUserOwnedIdentitySetup,
+    FixedTokenWorkspaceOwnedIdentitySetup, GetUserOwnedIdentityRequest,
+    GetWorkspaceOwnedIdentityRequest, Identity, IdentityOwner, ListUserOwnedIdentitiesRequest,
+    ListWorkspaceOwnedIdentitiesRequest, Workspace, create_user_owned_identity_request,
+    create_user_owned_identity_response, create_workspace_owned_identity_request,
+    create_workspace_owned_identity_response,
 };
 use coral_api::{
     CORAL_ERROR_REASON_IDENTITY_NOT_FOUND, CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND,
+    CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND,
 };
 use coral_app::{ServerBuilder, UserPrincipal, UserPrincipalProvider, UserPrincipalProviderError};
 use coral_client::AppClient;
@@ -118,6 +123,156 @@ async fn user_identity_service_is_scoped_validated_and_restart_safe() {
     server.shutdown().await.expect("shutdown restarted server");
 }
 
+#[tokio::test]
+async fn workspace_identity_service_pins_scope_and_isolates_workspaces() {
+    let temp = TempDir::new().expect("temp dir");
+    let (server, app) = start(&temp.path().join("coral-config")).await;
+    let alpha = create_workspace(&app, "alpha").await;
+    let beta = create_workspace(&app, "beta").await;
+
+    add_spec(&app, "shared_spec", "global", "fixed_token").await;
+    add_workspace_spec(&app, &alpha, "shared_spec", "alpha").await;
+    let alpha_identity = create_workspace_identity(
+        &app,
+        "alice",
+        &alpha,
+        "shared",
+        "shared_spec",
+        "alpha-token",
+    )
+    .await;
+    let beta_fallback =
+        create_workspace_identity(&app, "bob", &beta, "shared", "shared_spec", "beta-token").await;
+    assert_workspace_identity(
+        &alpha_identity,
+        &alpha,
+        Some(&alpha),
+        "alpha",
+        "alpha-token",
+    );
+    assert_workspace_identity(&beta_fallback, &beta, None, "global", "beta-token");
+
+    // Workspace ownership is request-selected on the authenticated local-app transport;
+    // it is deliberately independent of the authenticated user principal.
+    assert_eq!(
+        workspace_list(&app, "bob", &alpha).await,
+        vec![alpha_identity.clone()]
+    );
+
+    add_workspace_spec(&app, &beta, "shared_spec", "beta_late").await;
+    assert_eq!(
+        workspace_get(&app, "alice", &beta, "shared").await,
+        beta_fallback
+    );
+    let beta_shadowed = create_workspace_identity(
+        &app,
+        "alice",
+        &beta,
+        "shared",
+        "shared_spec",
+        "beta-replacement-token",
+    )
+    .await;
+    assert_workspace_identity(
+        &beta_shadowed,
+        &beta,
+        Some(&beta),
+        "beta_late",
+        "beta-replacement-token",
+    );
+
+    let orphaned = app
+        .identity_spec_client()
+        .delete_identity_spec(for_user(
+            DeleteIdentitySpecRequest {
+                name: "shared_spec".to_string(),
+                workspace: Some(alpha.clone()),
+                force: true,
+            },
+            "bob",
+        ))
+        .await
+        .expect("force delete exact workspace spec")
+        .into_inner();
+    assert_eq!(orphaned.orphaned_identities, 1);
+    assert_eq!(
+        workspace_get(&app, "bob", &alpha, "shared").await,
+        alpha_identity
+    );
+    delete_workspace_identity(&app, "bob", &alpha, "shared").await;
+    let missing = workspace_get_status(&app, "alice", &alpha, "shared").await;
+    assert_eq!(missing.code(), Code::NotFound);
+    assert_error_reason(&missing, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
+    assert_eq!(
+        workspace_get(&app, "bob", &beta, "shared").await,
+        beta_shadowed
+    );
+    server.shutdown().await.expect("shutdown server");
+}
+
+#[tokio::test]
+async fn workspace_identity_service_validates_workspace_boundaries() {
+    let temp = TempDir::new().expect("temp dir");
+    let (server, app) = start(&temp.path().join("coral-config")).await;
+    let missing = workspace("missing");
+
+    let unauthenticated = app
+        .workspace_identity_client()
+        .list_workspace_owned_identities(Request::new(ListWorkspaceOwnedIdentitiesRequest {
+            workspace: Some(missing.clone()),
+        }))
+        .await
+        .expect_err("missing principal must fail closed");
+    assert_eq!(unauthenticated.code(), Code::Unauthenticated);
+
+    for workspace in [None, Some(workspace("bad/name"))] {
+        let invalid = app
+            .workspace_identity_client()
+            .list_workspace_owned_identities(for_user(
+                ListWorkspaceOwnedIdentitiesRequest { workspace },
+                "alice",
+            ))
+            .await
+            .expect_err("invalid workspace must fail");
+        assert_eq!(invalid.code(), Code::InvalidArgument);
+    }
+
+    let statuses = vec![
+        workspace_create_status(
+            &app,
+            workspace_create_request(&missing, "bad/name", "bad/name", " ", "alice"),
+        )
+        .await,
+        workspace_list_status(&app, "alice", &missing).await,
+        workspace_get_status(&app, "alice", &missing, "bad/name").await,
+        workspace_delete_status(&app, "alice", &missing, "bad/name").await,
+    ];
+    for status in statuses {
+        assert_eq!(status.code(), Code::NotFound);
+        assert_error_reason(&status, CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND);
+    }
+
+    let existing = create_workspace(&app, "existing").await;
+    let missing_identity = workspace_get_status(&app, "alice", &existing, "missing").await;
+    assert_eq!(missing_identity.code(), Code::NotFound);
+    assert_error_reason(&missing_identity, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
+    let omitted = workspace_create_status(
+        &app,
+        for_user(
+            CreateWorkspaceOwnedIdentityRequest {
+                workspace: Some(existing),
+                name: "shared".to_string(),
+                identity_spec: "missing".to_string(),
+                setup: None,
+            },
+            "alice",
+        ),
+    )
+    .await;
+    assert_eq!(omitted.code(), Code::Unimplemented);
+    server.shutdown().await.expect("shutdown server");
+}
+
 async fn assert_create_validation(app: &AppClient) {
     let omitted = create_status(
         app,
@@ -170,17 +325,174 @@ async fn start(config_dir: &std::path::Path) -> (coral_app::RunningServer, AppCl
 }
 
 async fn add_spec(app: &AppClient, name: &str, issuer: &str, kind: &str) {
+    add_scoped_spec(app, None, name, issuer, kind).await;
+}
+
+async fn add_workspace_spec(app: &AppClient, workspace: &Workspace, name: &str, issuer: &str) {
+    add_scoped_spec(app, Some(workspace.clone()), name, issuer, "fixed_token").await;
+}
+
+async fn add_scoped_spec(
+    app: &AppClient,
+    workspace: Option<Workspace>,
+    name: &str,
+    issuer: &str,
+    kind: &str,
+) {
     app.identity_spec_client()
         .add_identity_spec(for_user(
             AddIdentitySpecRequest {
                 manifest_yaml: manifest(name, issuer, kind),
                 input_values: Vec::new(),
-                workspace: None,
+                workspace,
             },
             "alice",
         ))
         .await
         .expect("add identity spec");
+}
+
+async fn create_workspace(app: &AppClient, name: &str) -> Workspace {
+    let workspace = workspace(name);
+    app.workspace_client()
+        .create_workspace(for_user(
+            CreateWorkspaceRequest {
+                workspace: Some(workspace.clone()),
+            },
+            "alice",
+        ))
+        .await
+        .expect("create workspace");
+    workspace
+}
+
+async fn create_workspace_identity(
+    app: &AppClient,
+    user: &str,
+    workspace: &Workspace,
+    name: &str,
+    spec: &str,
+    token: &str,
+) -> Identity {
+    let mut stream = app
+        .workspace_identity_client()
+        .create_workspace_owned_identity(workspace_create_request(
+            workspace, name, spec, token, user,
+        ))
+        .await
+        .expect("create workspace identity")
+        .into_inner();
+    let response = stream
+        .message()
+        .await
+        .expect("read workspace create stream")
+        .expect("one workspace identity event");
+    assert!(stream.message().await.expect("read stream EOF").is_none());
+    match response.event.expect("workspace identity event") {
+        create_workspace_owned_identity_response::Event::Identity(identity) => identity,
+        event => panic!("expected workspace identity event, got {event:?}"),
+    }
+}
+
+async fn workspace_create_status(
+    app: &AppClient,
+    request: Request<CreateWorkspaceOwnedIdentityRequest>,
+) -> Status {
+    app.workspace_identity_client()
+        .create_workspace_owned_identity(request)
+        .await
+        .expect_err("workspace identity creation must fail")
+}
+
+async fn workspace_list(app: &AppClient, user: &str, workspace: &Workspace) -> Vec<Identity> {
+    app.workspace_identity_client()
+        .list_workspace_owned_identities(for_user(
+            ListWorkspaceOwnedIdentitiesRequest {
+                workspace: Some(workspace.clone()),
+            },
+            user,
+        ))
+        .await
+        .expect("list workspace identities")
+        .into_inner()
+        .identities
+}
+
+async fn workspace_list_status(app: &AppClient, user: &str, workspace: &Workspace) -> Status {
+    app.workspace_identity_client()
+        .list_workspace_owned_identities(for_user(
+            ListWorkspaceOwnedIdentitiesRequest {
+                workspace: Some(workspace.clone()),
+            },
+            user,
+        ))
+        .await
+        .expect_err("workspace identity list must fail")
+}
+
+async fn workspace_get(app: &AppClient, user: &str, workspace: &Workspace, name: &str) -> Identity {
+    app.workspace_identity_client()
+        .get_workspace_owned_identity(for_user(
+            GetWorkspaceOwnedIdentityRequest {
+                workspace: Some(workspace.clone()),
+                name: name.to_string(),
+            },
+            user,
+        ))
+        .await
+        .expect("get workspace identity")
+        .into_inner()
+        .identity
+        .expect("workspace identity response")
+}
+
+async fn workspace_get_status(
+    app: &AppClient,
+    user: &str,
+    workspace: &Workspace,
+    name: &str,
+) -> Status {
+    app.workspace_identity_client()
+        .get_workspace_owned_identity(for_user(
+            GetWorkspaceOwnedIdentityRequest {
+                workspace: Some(workspace.clone()),
+                name: name.to_string(),
+            },
+            user,
+        ))
+        .await
+        .expect_err("workspace identity get must fail")
+}
+
+async fn delete_workspace_identity(app: &AppClient, user: &str, workspace: &Workspace, name: &str) {
+    app.workspace_identity_client()
+        .delete_workspace_owned_identity(for_user(
+            DeleteWorkspaceOwnedIdentityRequest {
+                workspace: Some(workspace.clone()),
+                name: name.to_string(),
+            },
+            user,
+        ))
+        .await
+        .expect("delete workspace identity");
+}
+
+async fn workspace_delete_status(
+    app: &AppClient,
+    user: &str,
+    workspace: &Workspace,
+    name: &str,
+) -> Status {
+    app.workspace_identity_client()
+        .delete_workspace_owned_identity(for_user(
+            DeleteWorkspaceOwnedIdentityRequest {
+                workspace: Some(workspace.clone()),
+                name: name.to_string(),
+            },
+            user,
+        ))
+        .await
+        .expect_err("workspace identity delete must fail")
 }
 
 async fn create_status(
@@ -256,6 +568,34 @@ fn create_request(
     )
 }
 
+fn workspace_create_request(
+    workspace: &Workspace,
+    name: &str,
+    spec: &str,
+    token: &str,
+    user: &str,
+) -> Request<CreateWorkspaceOwnedIdentityRequest> {
+    for_user(
+        CreateWorkspaceOwnedIdentityRequest {
+            workspace: Some(workspace.clone()),
+            name: name.to_string(),
+            identity_spec: spec.to_string(),
+            setup: Some(create_workspace_owned_identity_request::Setup::FixedToken(
+                FixedTokenWorkspaceOwnedIdentitySetup {
+                    token: token.to_string(),
+                },
+            )),
+        },
+        user,
+    )
+}
+
+fn workspace(name: &str) -> Workspace {
+    Workspace {
+        name: name.to_string(),
+    }
+}
+
 fn for_user<T>(message: T, user: &str) -> Request<T> {
     let mut request = Request::new(message);
     request.metadata_mut().insert(
@@ -274,6 +614,24 @@ fn assert_identity(identity: &Identity, spec: &str, issuer: &str) {
     assert!(identity.metadata.is_empty());
     assert!(identity.owner_workspace.is_none());
     assert!(identity.identity_spec_workspace.is_none());
+}
+
+fn assert_workspace_identity(
+    identity: &Identity,
+    owner_workspace: &Workspace,
+    spec_workspace: Option<&Workspace>,
+    issuer: &str,
+    token: &str,
+) {
+    assert_eq!(identity.name, "shared");
+    assert_eq!(identity.identity_spec, "shared_spec");
+    assert_eq!(identity.issuer, issuer);
+    assert_eq!(identity.identity_type, "fixed_token");
+    assert_eq!(identity.owner, IdentityOwner::Workspace as i32);
+    assert!(identity.metadata.is_empty());
+    assert_eq!(identity.owner_workspace.as_ref(), Some(owner_workspace));
+    assert_eq!(identity.identity_spec_workspace.as_ref(), spec_workspace);
+    assert!(!format!("{identity:?}").contains(token));
 }
 
 fn assert_error_reason(status: &Status, expected: &str) {

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -7,8 +7,8 @@
 
 use std::fs;
 
-use coral_api::v1::ListUserOwnedIdentitiesRequest;
-use coral_client::{AppClient, local::ServerBuilder};
+use coral_api::v1::{ListUserOwnedIdentitiesRequest, ListWorkspaceOwnedIdentitiesRequest};
+use coral_client::{AppClient, default_workspace, local::ServerBuilder};
 use sqlx::postgres::PgPoolOptions;
 use tempfile::TempDir;
 use tonic::Request;
@@ -43,6 +43,15 @@ async fn server_lifecycle_can_start_with_postgres_database_config() {
         .expect("keyless Postgres supports safe identity reads")
         .into_inner();
     assert!(identities.identities.is_empty());
+    let workspace_identities = app
+        .workspace_identity_client()
+        .list_workspace_owned_identities(Request::new(ListWorkspaceOwnedIdentitiesRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await
+        .expect("keyless Postgres supports safe workspace identity reads")
+        .into_inner();
+    assert!(workspace_identities.identities.is_empty());
     assert_postgres_db_is_migrated(&database_url).await;
 
     server.shutdown().await.expect("shutdown server");


### PR DESCRIPTION
## Intent
Expose workspace-owned fixed-token identity lifecycle over Coral’s existing WorkspaceIdentityService while preserving workspace-first ownership and exact spec pinning.

## What it enables
- Create or replace workspace identities using an exact workspace spec with global fallback.
- List, get, and delete identities safely scoped by workspace through native gRPC and shared gRPC-Web routes.
- Preserve typed WORKSPACE_NOT_FOUND precedence and token-redacted responses.
- Keep workspace existence and reads/deletes atomic across SQLite and Postgres.
- Validate keyless Postgres startup reads.

## Usage examples
- Call CreateWorkspaceOwnedIdentity with a workspace, identity name, spec name, and fixed token.
- Use ListWorkspaceOwnedIdentities, GetWorkspaceOwnedIdentity, and DeleteWorkspaceOwnedIdentity with the same workspace owner.
- Replace the identity explicitly to opt into a later workspace spec shadow.

## Validation
- make rust-checks: all-feature Clippy and rustdoc passed; 1,722 tests passed and 3 skipped.
- The three Postgres contract commands behind make postgres-tests passed against an isolated native Postgres instance; Docker was unavailable because its daemon hung.
- make perf-check: 204.3 ms mean against the 750 ms limit.
- Fresh five-lane review swarm completed with no accepted findings; all four credential flows were classified safe.