### PR TITLE
test(app): cover workspace identity races

### DIFF
--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -40,6 +40,17 @@ pub(crate) struct IdentityManager {
 struct BeforeWriteGate {
     selected: Arc<tokio::sync::Barrier>,
     resume: Arc<tokio::sync::Barrier>,
+    used: Arc<AtomicBool>,
+}
+
+#[cfg(test)]
+impl BeforeWriteGate {
+    async fn wait_once(&self) {
+        if !self.used.swap(true, Ordering::SeqCst) {
+            self.selected.wait().await;
+            self.resume.wait().await;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -76,7 +87,11 @@ impl IdentityManager {
         selected: Arc<tokio::sync::Barrier>,
         resume: Arc<tokio::sync::Barrier>,
     ) -> Self {
-        self.before_write_gate = Some(BeforeWriteGate { selected, resume });
+        self.before_write_gate = Some(BeforeWriteGate {
+            selected,
+            resume,
+            used: Arc::new(AtomicBool::new(false)),
+        });
         self
     }
 
@@ -98,6 +113,7 @@ impl IdentityManager {
         self.before_retry_gate = Some(BeforeWriteGate {
             selected: reached,
             resume,
+            used: Arc::new(AtomicBool::new(false)),
         });
         self
     }
@@ -220,6 +236,10 @@ impl IdentityManager {
     ) -> Result<Vec<IdentityRecord>, AppError> {
         let mut tx = self.db.begin_read_snapshot().await?;
         owner_workspace_created_at(&mut tx, owner).await?;
+        #[cfg(test)]
+        if let Some(gate) = &self.before_write_gate {
+            gate.wait_once().await;
+        }
         let records = tx.identities().list_for_owner(owner).await?;
         tx.commit().await?;
         Ok(records)
@@ -255,6 +275,10 @@ impl IdentityManager {
             match self.try_delete(owner, identity_name).await {
                 Ok(()) => return Ok(()),
                 Err(AppError::RetryableTransactionConflict) => {
+                    #[cfg(test)]
+                    if let Some(gate) = &self.before_retry_gate {
+                        gate.wait_once().await;
+                    }
                     tokio::task::yield_now().await;
                 }
                 Err(error) => return Err(error),
@@ -266,6 +290,10 @@ impl IdentityManager {
     async fn try_delete(&self, owner: &IdentityOwner, identity_name: &str) -> Result<(), AppError> {
         let mut tx = self.db.begin_serializable().await?;
         owner_workspace_created_at(&mut tx, owner).await?;
+        #[cfg(test)]
+        if let Some(gate) = &self.before_write_gate {
+            gate.wait_once().await;
+        }
         let name = IdentityName::parse(identity_name)?;
         let deleted = match tx.identities().delete(owner, &name).await {
             Ok(deleted) => deleted,

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -14,8 +14,8 @@ use crate::identities::model::{IdentityName, IdentityOwner};
 use crate::identity::{UserPrincipal, decrypt_identity_document};
 use crate::identity_specs::identity_spec_fingerprint;
 use crate::state::db::{
-    CoralDb, DbRepos, IdentityDocumentRecord, IdentityRecord, IdentitySpecKey, IdentitySpecWrite,
-    ResolvedDatabaseConfig,
+    CoralDb, DbError, DbRepos, IdentityDocumentRecord, IdentityRecord, IdentitySpecKey,
+    IdentitySpecWrite, ResolvedDatabaseConfig,
 };
 use crate::workspaces::WorkspaceName;
 
@@ -53,8 +53,8 @@ async fn sqlite_fixed_token_manager_contract() {
 }
 
 pub(crate) async fn assert_fixed_token_manager_contract(db: &Arc<CoralDb>) {
-    assert_user_global_fixed_token_manager_contract(db).await;
-    assert_workspace_fixed_token_manager_contract(db).await;
+    Box::pin(assert_user_global_fixed_token_manager_contract(db)).await;
+    Box::pin(assert_workspace_fixed_token_manager_contract(db)).await;
 }
 
 #[expect(
@@ -683,7 +683,110 @@ async fn assert_workspace_fixed_token_manager_contract(db: &Arc<CoralDb>) {
             .await,
         Err(AppError::WorkspaceNotFound(name)) if name == retry_workspace.as_str()
     ));
-    assert_eq!(manager.list_for_owner(&owner).await.unwrap().len(), 4);
+
+    let atomic_delete_name = format!("delete-retry-{suffix}");
+    manager
+        .create_or_replace_workspace_fixed_token(
+            &retry_workspace,
+            &atomic_delete_name,
+            &fallback,
+            "delete-token".into(),
+        )
+        .await
+        .expect("create identity for delete race");
+    assert_workspace_delete_race(db, &manager, &retry_workspace, &atomic_delete_name).await;
+    assert_workspace_list_race(db, &manager, &workspace, &owner).await;
+}
+
+async fn assert_workspace_list_race(
+    db: &Arc<CoralDb>,
+    manager: &IdentityManager,
+    workspace: &WorkspaceName,
+    owner: &IdentityOwner,
+) {
+    let selected = Arc::new(tokio::sync::Barrier::new(2));
+    let resume = Arc::new(tokio::sync::Barrier::new(2));
+    let gated = manager
+        .clone()
+        .with_before_write_gate(selected.clone(), resume.clone());
+    let (listed, ()) = tokio::time::timeout(Duration::from_secs(10), async {
+        tokio::join!(gated.list_for_owner(owner), async {
+            selected.wait().await;
+            let mut tx = db.begin().await.expect("begin concurrent workspace delete");
+            let sqlite = tx
+                .disable_sqlite_busy_wait()
+                .await
+                .expect("configure concurrent workspace delete");
+            tx.workspaces()
+                .delete(workspace.as_str())
+                .await
+                .expect("stage concurrent workspace delete");
+            let commit = tx.commit().await;
+            if sqlite {
+                assert!(matches!(
+                    commit,
+                    Err(DbError::RetryableTransactionConflict(_))
+                ));
+            } else {
+                commit.expect("commit concurrent Postgres workspace delete");
+            }
+            resume.wait().await;
+        })
+    })
+    .await
+    .expect("workspace list/delete race must not deadlock");
+    assert_eq!(listed.expect("list from one workspace snapshot").len(), 4);
+}
+
+async fn assert_workspace_delete_race(
+    db: &Arc<CoralDb>,
+    manager: &IdentityManager,
+    workspace: &WorkspaceName,
+    identity: &str,
+) {
+    let selected = Arc::new(tokio::sync::Barrier::new(2));
+    let resume_write = Arc::new(tokio::sync::Barrier::new(2));
+    let retry_reached = Arc::new(tokio::sync::Barrier::new(2));
+    let resume_retry = Arc::new(tokio::sync::Barrier::new(2));
+    let gated = manager
+        .clone()
+        .with_before_write_gate(selected.clone(), resume_write.clone())
+        .with_before_retry_gate(retry_reached.clone(), resume_retry.clone());
+    let owner = IdentityOwner::workspace(workspace.clone());
+    let (deleted, ()) = tokio::time::timeout(Duration::from_secs(10), async {
+        tokio::join!(gated.delete(&owner, identity), async {
+            selected.wait().await;
+            let mut tx = db.begin().await.expect("begin raced workspace delete");
+            let sqlite = tx
+                .disable_sqlite_busy_wait()
+                .await
+                .expect("configure raced workspace delete");
+            tx.workspaces()
+                .delete(workspace.as_str())
+                .await
+                .expect("stage raced workspace delete");
+            if sqlite {
+                resume_write.wait().await;
+                retry_reached.wait().await;
+                tx.commit()
+                    .await
+                    .expect("commit raced SQLite workspace delete");
+            } else {
+                tx.commit()
+                    .await
+                    .expect("commit raced Postgres workspace delete");
+                resume_write.wait().await;
+                retry_reached.wait().await;
+            }
+            resume_retry.wait().await;
+        })
+    })
+    .await
+    .expect("workspace identity delete race must not deadlock");
+    assert!(matches!(
+        deleted,
+        Err(AppError::WorkspaceNotFound(name)) if name == workspace.as_str()
+    ));
 }
 
 async fn put_workspace(db: &Arc<CoralDb>, workspace: &WorkspaceName) {

--- a/crates/coral-app/src/state/db/transaction.rs
+++ b/crates/coral-app/src/state/db/transaction.rs
@@ -45,6 +45,17 @@ impl<'a> CoralTx<'a> {
         Ok(tx)
     }
 
+    #[cfg(test)]
+    pub(crate) async fn disable_sqlite_busy_wait(&mut self) -> Result<bool, DbError> {
+        let CoralTxBackend::Sqlite(sqlite) = &mut self.backend else {
+            return Ok(false);
+        };
+        sqlx::query("PRAGMA busy_timeout = 0")
+            .execute(&mut **sqlite)
+            .await?;
+        Ok(true)
+    }
+
     pub(crate) async fn commit(self) -> Result<(), DbError> {
         match self.backend {
             CoralTxBackend::Sqlite(tx) => tx.commit().await?,


### PR DESCRIPTION
## Intent
Prove workspace identity List and Delete transaction boundaries deterministically on SQLite and Postgres without changing production behavior.

## What it enables
- Prove SQLite read snapshots block a concurrent workspace-delete commit with BUSY or LOCKED.
- Prove Postgres repeatable-read List survives a committed concurrent workspace delete.
- Prove serializable Delete retries return WORKSPACE_NOT_FOUND after deletion on both backends.
- Keep backend synchronization gates one-shot and cfg(test).

## Usage examples
- Run cargo test --locked -p coral-app --all-features sqlite_fixed_token_manager_contract for the SQLite contract.
- Run the Postgres identity database contract with CORAL_TEST_POSTGRES_URL or through make postgres-tests.

## Validation
- make rust-checks: all-feature Clippy and rustdoc passed; 1,722 tests passed and 3 skipped.
- The focused SQLite manager race contract passed.
- The Postgres identity database contract passed against an isolated native Postgres instance; Docker was unavailable because its daemon hung.
- Fresh final-head five-lane review swarm completed with zero findings or questions; the supervisor missed-risk sweep found no P1 or P2 issue.