### PR TITLE
feat(app): bind identity documents to exact specs

### DIFF
--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -293,7 +293,7 @@ pub(crate) fn rewrap_credential_document(
     document: &EncryptedCredentialDocument,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<Option<EncryptedCredentialDocument>, CredentialsError> {
-    validate_document_metadata(document)?;
+    validate_document_metadata(document, CREDENTIAL_DOCUMENT_AAD_VERSION)?;
     let old_kek = key_provider.key(&document.key_id)?;
     let active_kek = key_provider.active_key()?;
     if old_kek.key_id == active_kek.key_id {
@@ -319,7 +319,7 @@ pub(crate) fn rewrap_credential_document(
             .map(Some);
     }
 
-    rewrap_dek(document, &active_kek, &dek)
+    rewrap_dek(document, &active_kek, &dek, CREDENTIAL_DOCUMENT_AAD_VERSION)
 }
 
 fn decrypt_credential_document_bytes(
@@ -328,7 +328,7 @@ fn decrypt_credential_document_bytes(
     document: &EncryptedCredentialDocument,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
-    validate_document_metadata(document)?;
+    validate_document_metadata(document, CREDENTIAL_DOCUMENT_AAD_VERSION)?;
     let kek = key_provider.key(&document.key_id)?;
     let dek = unwrap_dek(document, &kek)?;
 
@@ -359,7 +359,7 @@ fn unwrap_dek(
     document: &EncryptedCredentialDocument,
     kek: &CredentialEncryptionKey,
 ) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
-    match unwrap_current_dek(document, kek) {
+    match unwrap_current_dek(document, kek, CREDENTIAL_DOCUMENT_AAD_VERSION) {
         Ok(dek) => Ok(dek),
         Err(primary_error) => {
             let mut legacy_dek = Zeroizing::new(document.wrapped_dek.clone());
@@ -379,12 +379,13 @@ fn unwrap_dek(
 fn unwrap_current_dek(
     document: &EncryptedEnvelopeDocument,
     kek: &CredentialEncryptionKey,
+    aad_version: i64,
 ) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
     let mut dek = Zeroizing::new(document.wrapped_dek.clone());
     open(
         &kek.bytes,
         document.wrapped_dek_nonce.as_slice(),
-        credential_dek_aad(&document.key_id),
+        envelope_dek_aad(aad_version, &document.key_id),
         dek.as_mut_slice(),
     )
     .and_then(validate_dek_plaintext)
@@ -408,13 +409,14 @@ fn rewrap_dek(
     document: &EncryptedEnvelopeDocument,
     active_kek: &CredentialEncryptionKey,
     dek: &[u8; KEY_LEN],
+    aad_version: i64,
 ) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
     let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
     let mut wrapped_dek = Zeroizing::new(dek.to_vec());
     seal(
         &active_kek.bytes,
         &wrapped_dek_nonce,
-        credential_dek_aad(active_kek.key_id()),
+        envelope_dek_aad(aad_version, active_kek.key_id()),
         &mut wrapped_dek,
     )?;
 
@@ -431,6 +433,7 @@ fn rewrap_dek(
 
 fn validate_document_metadata(
     document: &EncryptedCredentialDocument,
+    expected_aad_version: i64,
 ) -> Result<(), CredentialsError> {
     if document.algorithm != CREDENTIAL_DOCUMENT_ALGORITHM {
         return Err(CredentialsError::Crypto(format!(
@@ -438,7 +441,7 @@ fn validate_document_metadata(
             document.algorithm
         )));
     }
-    if document.aad_version != CREDENTIAL_DOCUMENT_AAD_VERSION {
+    if document.aad_version != expected_aad_version {
         return Err(CredentialsError::Crypto(format!(
             "unsupported credential AAD version {}",
             document.aad_version
@@ -449,6 +452,21 @@ fn validate_document_metadata(
 
 /// Seal serialized plaintext with a random DEK and wrap that DEK with the active KEK.
 pub(crate) fn seal_envelope_document(
+    document_aad: Vec<u8>,
+    document_bytes: Zeroizing<Vec<u8>>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<EncryptedEnvelopeDocument, CredentialsError> {
+    seal_envelope_document_with_aad_version(
+        CREDENTIAL_DOCUMENT_AAD_VERSION,
+        document_aad,
+        document_bytes,
+        key_provider,
+    )
+}
+
+/// Seal serialized plaintext under a caller-selected envelope AAD version.
+pub(crate) fn seal_envelope_document_with_aad_version(
+    aad_version: i64,
     document_aad: Vec<u8>,
     mut document_bytes: Zeroizing<Vec<u8>>,
     key_provider: &dyn CredentialKeyProvider,
@@ -464,7 +482,7 @@ pub(crate) fn seal_envelope_document(
     seal(
         &kek.bytes,
         &wrapped_dek_nonce,
-        credential_dek_aad(kek.key_id()),
+        envelope_dek_aad(aad_version, kek.key_id()),
         &mut wrapped_dek,
     )?;
 
@@ -475,7 +493,7 @@ pub(crate) fn seal_envelope_document(
         wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
         key_id: kek.key_id.clone(),
         algorithm: CREDENTIAL_DOCUMENT_ALGORITHM.to_string(),
-        aad_version: CREDENTIAL_DOCUMENT_AAD_VERSION,
+        aad_version,
     })
 }
 
@@ -485,9 +503,24 @@ pub(crate) fn open_envelope_document(
     document_aad: Vec<u8>,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
-    validate_document_metadata(document)?;
+    open_envelope_document_with_aad_version(
+        CREDENTIAL_DOCUMENT_AAD_VERSION,
+        document,
+        document_aad,
+        key_provider,
+    )
+}
+
+/// Open an envelope document only when its AAD version matches the caller's expectation.
+pub(crate) fn open_envelope_document_with_aad_version(
+    expected_aad_version: i64,
+    document: &EncryptedEnvelopeDocument,
+    document_aad: Vec<u8>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
+    validate_document_metadata(document, expected_aad_version)?;
     let kek = key_provider.key(&document.key_id)?;
-    let dek = unwrap_current_dek(document, &kek)?;
+    let dek = unwrap_current_dek(document, &kek, expected_aad_version)?;
 
     let mut ciphertext = Zeroizing::new(document.ciphertext.clone());
     open(
@@ -505,14 +538,46 @@ pub(crate) fn rewrap_envelope_document(
     document_aad: Vec<u8>,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
-    validate_document_metadata(document)?;
+    rewrap_envelope_document_inner(
+        CREDENTIAL_DOCUMENT_AAD_VERSION,
+        document,
+        document_aad,
+        key_provider,
+        false,
+    )
+}
+
+/// Rewrap an envelope document only when its AAD version matches the caller's expectation.
+pub(crate) fn rewrap_envelope_document_with_aad_version(
+    expected_aad_version: i64,
+    document: &EncryptedEnvelopeDocument,
+    document_aad: Vec<u8>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
+    rewrap_envelope_document_inner(
+        expected_aad_version,
+        document,
+        document_aad,
+        key_provider,
+        true,
+    )
+}
+
+fn rewrap_envelope_document_inner(
+    expected_aad_version: i64,
+    document: &EncryptedEnvelopeDocument,
+    document_aad: Vec<u8>,
+    key_provider: &dyn CredentialKeyProvider,
+    authenticate_current: bool,
+) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
+    validate_document_metadata(document, expected_aad_version)?;
     let old_kek = key_provider.key(&document.key_id)?;
     let active_kek = key_provider.active_key()?;
-    if old_kek.key_id == active_kek.key_id {
+    if !authenticate_current && old_kek.key_id == active_kek.key_id {
         return Ok(None);
     }
 
-    let dek = unwrap_current_dek(document, &old_kek)?;
+    let dek = unwrap_current_dek(document, &old_kek, expected_aad_version)?;
     let mut document_probe = Zeroizing::new(document.ciphertext.clone());
     open(
         &*dek,
@@ -521,7 +586,11 @@ pub(crate) fn rewrap_envelope_document(
         document_probe.as_mut_slice(),
     )?;
 
-    rewrap_dek(document, &active_kek, &dek)
+    if old_kek.key_id == active_kek.key_id {
+        return Ok(None);
+    }
+
+    rewrap_dek(document, &active_kek, &dek, expected_aad_version)
 }
 
 fn seal(
@@ -589,8 +658,8 @@ fn legacy_credential_document_aad(
     .into_bytes()
 }
 
-fn credential_dek_aad(key_id: &str) -> Vec<u8> {
-    let aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION.to_string();
+fn envelope_dek_aad(aad_version: i64, key_id: &str) -> Vec<u8> {
+    let aad_version = aad_version.to_string();
     encode_aad_fields("coral-credential-dek", &[aad_version.as_str(), key_id])
 }
 

--- a/crates/coral-app/src/credentials/encryption_tests.rs
+++ b/crates/coral-app/src/credentials/encryption_tests.rs
@@ -10,8 +10,10 @@ use super::CredentialsError;
 use super::encryption::{
     CREDENTIAL_DOCUMENT_AAD_VERSION, CREDENTIAL_DOCUMENT_ALGORITHM, CredentialEncryptionKey,
     CredentialKeyProvider, LocalFileCredentialKeyProvider, decrypt_credential_values,
-    encrypt_credential_values, open_envelope_document, rewrap_credential_document,
-    rewrap_envelope_document, seal_envelope_document,
+    encrypt_credential_values, open_envelope_document, open_envelope_document_with_aad_version,
+    rewrap_credential_document, rewrap_envelope_document,
+    rewrap_envelope_document_with_aad_version, seal_envelope_document,
+    seal_envelope_document_with_aad_version,
 };
 use crate::sources::SourceName;
 use crate::state::AppStateLayout;
@@ -416,6 +418,67 @@ fn shared_envelope_helpers_round_trip_and_rewrap_current_documents() {
             .expect("rewrap current envelope")
             .is_none(),
         "active KEK should not produce another rewrap"
+    );
+}
+
+#[test]
+fn versioned_envelope_helpers_require_and_preserve_custom_aad_version() {
+    const AAD_VERSION: i64 = 2;
+    let old_key = CredentialEncryptionKey::from_static_bytes_for_test([43; 32]);
+    let new_key = CredentialEncryptionKey::from_static_bytes_for_test([47; 32]);
+    let old_provider = RotatingKeyProvider {
+        active: old_key.clone(),
+        keys: vec![old_key.clone()],
+    };
+    let rotating_provider = RotatingKeyProvider {
+        active: new_key.clone(),
+        keys: vec![old_key, new_key.clone()],
+    };
+    let aad = b"test-v2-envelope-aad".to_vec();
+    let encrypted = seal_envelope_document_with_aad_version(
+        AAD_VERSION,
+        aad.clone(),
+        Zeroizing::new(b"v2 envelope payload".to_vec()),
+        &old_provider,
+    )
+    .expect("seal v2 envelope");
+
+    open_envelope_document_with_aad_version(
+        CREDENTIAL_DOCUMENT_AAD_VERSION,
+        &encrypted,
+        aad.clone(),
+        &old_provider,
+    )
+    .expect_err("v1 reader must reject v2 envelope");
+    assert_open_failed(
+        &rewrap_envelope_document_with_aad_version(
+            AAD_VERSION,
+            &encrypted,
+            b"wrong-aad".to_vec(),
+            &old_provider,
+        )
+        .expect_err("same-key rewrap must authenticate payload AAD"),
+    );
+
+    let rewrapped = rewrap_envelope_document_with_aad_version(
+        AAD_VERSION,
+        &encrypted,
+        aad.clone(),
+        &rotating_provider,
+    )
+    .expect("rewrap v2 envelope")
+    .expect("stale key should rewrap");
+    assert_eq!(rewrapped.key_id, new_key.key_id());
+    assert_eq!(
+        open_envelope_document_with_aad_version(
+            AAD_VERSION,
+            &rewrapped,
+            aad.clone(),
+            &rotating_provider,
+        )
+        .expect("open rewrapped v2 envelope")
+        .as_slice(),
+        b"v2 envelope payload"
     );
 }
 

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -10,7 +10,9 @@ use coral_spec::IdentitySpecType;
 use crate::bootstrap::AppError;
 use crate::credentials::encryption::{CredentialKeyProvider, EncryptedEnvelopeDocument};
 use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
-use crate::identity::{UserPrincipal, encrypt_identity_document, run_key_operation};
+use crate::identity::{
+    IdentityDocumentBinding, UserPrincipal, encrypt_identity_document, run_key_operation,
+};
 use crate::identity_specs::identity_spec_fingerprint;
 use crate::identity_specs::manager::{record_to_installed, spec_not_found};
 use crate::state::db::{
@@ -161,7 +163,7 @@ impl IdentityManager {
                 "fixed-token identity token must not be blank".to_string(),
             ));
         }
-        let mut document = None;
+        let mut document: Option<(IdentitySpecReference, IdentityDocumentWrite)> = None;
         let mut pinned_workspace_created_at_unix_nanos = None;
         #[cfg(test)]
         let mut before_write_gate = self.before_write_gate.clone();
@@ -183,22 +185,26 @@ impl IdentityManager {
             if pinned_workspace_created_at_unix_nanos.is_none() {
                 pinned_workspace_created_at_unix_nanos = selected.workspace_created_at_unix_nanos;
             }
-            if document.is_none() {
+            if document
+                .as_ref()
+                .is_none_or(|(reference, _document)| reference != &selected.reference)
+            {
                 let document_owner = owner.clone();
                 let document_name = name.clone();
+                let document_reference = selected.reference.clone();
                 let document_token = token.clone();
                 let key_provider = Arc::clone(&self.key_provider);
-                document = Some(
-                    run_key_operation(move || {
-                        prepare_fixed_token_document(
-                            &document_owner,
-                            &document_name,
-                            document_token,
-                            key_provider.as_ref(),
-                        )
-                    })
-                    .await?,
-                );
+                let prepared = run_key_operation(move || {
+                    prepare_fixed_token_document(
+                        &document_owner,
+                        &document_name,
+                        &document_reference,
+                        document_token,
+                        key_provider.as_ref(),
+                    )
+                })
+                .await?;
+                document = Some((selected.reference.clone(), prepared));
             }
             #[cfg(test)]
             if let Some(gate) = before_write_gate.take() {
@@ -210,7 +216,7 @@ impl IdentityManager {
                     &owner,
                     &name,
                     &selected,
-                    document.as_ref().expect("document prepared above"),
+                    &document.as_ref().expect("document prepared above").1,
                 )
                 .await
             {
@@ -428,10 +434,21 @@ fn owner_workspace_not_found(owner: &IdentityOwner) -> AppError {
 fn prepare_fixed_token_document(
     owner: &IdentityOwner,
     name: &IdentityName,
+    reference: &IdentitySpecReference,
     token: String,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<IdentityDocumentWrite, AppError> {
     let values = BTreeMap::from([(FIXED_TOKEN_KEY.to_string(), token)]);
+    let (spec_scope_kind, spec_scope_id, spec_name) = reference.key().document_aad_parts();
+    let binding = IdentityDocumentBinding::new(
+        owner.kind(),
+        owner.key(),
+        name.as_str(),
+        spec_scope_kind,
+        spec_scope_id,
+        spec_name,
+        reference.fingerprint(),
+    );
     let EncryptedEnvelopeDocument {
         ciphertext,
         nonce,
@@ -440,13 +457,7 @@ fn prepare_fixed_token_document(
         key_id,
         algorithm,
         aad_version,
-    } = encrypt_identity_document(
-        owner.kind(),
-        owner.key(),
-        name.as_str(),
-        &values,
-        key_provider,
-    )?;
+    } = encrypt_identity_document(&binding, &values, key_provider)?;
     IdentityDocumentWrite::new(
         ciphertext,
         nonce,

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -11,7 +11,10 @@ use crate::credentials::encryption::{
     CredentialEncryptionKey, CredentialKeyProvider, EncryptedEnvelopeDocument,
 };
 use crate::identities::model::{IdentityName, IdentityOwner};
-use crate::identity::{UserPrincipal, decrypt_identity_document};
+use crate::identity::{
+    IDENTITY_DOCUMENT_AAD_VERSION, IdentityDocumentBinding, UserPrincipal,
+    decrypt_identity_document,
+};
 use crate::identity_specs::identity_spec_fingerprint;
 use crate::state::db::{
     CoralDb, DbError, DbRepos, IdentityDocumentRecord, IdentityRecord, IdentitySpecKey,
@@ -134,14 +137,14 @@ async fn assert_user_global_fixed_token_manager_contract(db: &Arc<CoralDb>) {
     let before_a = load_pair(db, &owner_a, &identity).await;
     let before_b = load_pair(db, &owner_b, &identity).await;
     assert_material(
+        before_a.0.as_ref().unwrap(),
         before_a.1.as_ref().unwrap(),
-        &owner_a,
         "alpha-token",
         old_provider.as_ref(),
     );
     assert_material(
+        before_b.0.as_ref().unwrap(),
         before_b.1.as_ref().unwrap(),
-        &owner_b,
         "beta-token",
         old_provider.as_ref(),
     );
@@ -179,8 +182,8 @@ async fn assert_user_global_fixed_token_manager_contract(db: &Arc<CoralDb>) {
     );
     assert_eq!(after_document.key_id, new_key.key_id());
     assert_material(
+        after_a.0.as_ref().unwrap(),
         after_document,
-        &owner_a,
         "gamma-token",
         rotated_provider.as_ref(),
     );
@@ -223,8 +226,8 @@ async fn assert_user_global_fixed_token_manager_contract(db: &Arc<CoralDb>) {
         name => panic!("unexpected winning spec {name}"),
     };
     assert_material(
+        conflict_record,
         conflict.1.as_ref().unwrap(),
-        &owner_a,
         expected_token,
         rotated_provider.as_ref(),
     );
@@ -278,11 +281,11 @@ async fn assert_user_global_fixed_token_manager_contract(db: &Arc<CoralDb>) {
     .expect("race create");
     assert_reference(&race_result, &race, "after");
     let raced = load_pair(db, &owner_a, &raced_name).await;
-    assert_eq!(raced.0.unwrap(), race_result);
+    assert_eq!(raced.0.as_ref(), Some(&race_result));
     assert_eq!(raced.1.as_ref().unwrap().document_version, 1);
     assert_material(
+        raced.0.as_ref().unwrap(),
         raced.1.as_ref().unwrap(),
-        &owner_a,
         "race-token",
         rotated_provider.as_ref(),
     );
@@ -431,8 +434,8 @@ async fn assert_workspace_fixed_token_manager_contract(db: &Arc<CoralDb>) {
     assert_eq!(fallback_pair.0.as_ref(), Some(&fallback_created));
     assert_eq!(fallback_pair.1.as_ref().unwrap().document_version, 1);
     assert_material(
+        fallback_pair.0.as_ref().unwrap(),
         fallback_pair.1.as_ref().unwrap(),
-        &owner,
         "fallback-token",
         provider.as_ref(),
     );
@@ -455,8 +458,8 @@ async fn assert_workspace_fixed_token_manager_contract(db: &Arc<CoralDb>) {
     let shadowed_pair = load_pair(db, &owner, &shadowed_identity).await;
     assert_eq!(shadowed_pair.1.as_ref().unwrap().document_version, 1);
     assert_material(
+        shadowed_pair.0.as_ref().unwrap(),
         shadowed_pair.1.as_ref().unwrap(),
-        &owner,
         "workspace-token",
         provider.as_ref(),
     );
@@ -506,8 +509,8 @@ async fn assert_workspace_fixed_token_manager_contract(db: &Arc<CoralDb>) {
     assert_eq!(exact_raced.0.as_ref(), Some(&exact_race_result));
     assert_eq!(exact_raced.1.as_ref().unwrap().document_version, 1);
     assert_material(
+        exact_raced.0.as_ref().unwrap(),
         exact_raced.1.as_ref().unwrap(),
-        &owner,
         "exact-race-token",
         provider.as_ref(),
     );
@@ -550,8 +553,8 @@ async fn assert_workspace_fixed_token_manager_contract(db: &Arc<CoralDb>) {
     assert_eq!(shadow_raced.0.as_ref(), Some(&shadow_race_result));
     assert_eq!(shadow_raced.1.as_ref().unwrap().document_version, 1);
     assert_material(
+        shadow_raced.0.as_ref().unwrap(),
         shadow_raced.1.as_ref().unwrap(),
-        &owner,
         "shadow-race-token",
         provider.as_ref(),
     );
@@ -871,11 +874,23 @@ fn assert_reference_key(record: &IdentityRecord, key: &IdentitySpecKey, label: &
 }
 
 fn assert_material(
+    record: &IdentityRecord,
     document: &IdentityDocumentRecord,
-    owner: &IdentityOwner,
     token: &str,
     key_provider: &dyn CredentialKeyProvider,
 ) {
+    assert_eq!(document.aad_version, IDENTITY_DOCUMENT_AAD_VERSION);
+    let reference = &record.spec_reference;
+    let (spec_scope_kind, spec_scope_id, spec_name) = reference.key().document_aad_parts();
+    let binding = IdentityDocumentBinding::new(
+        record.owner.kind(),
+        record.owner.key(),
+        record.name.as_str(),
+        spec_scope_kind,
+        spec_scope_id,
+        spec_name,
+        reference.fingerprint(),
+    );
     let envelope = EncryptedEnvelopeDocument {
         ciphertext: document.ciphertext.clone(),
         nonce: document.nonce.clone(),
@@ -885,14 +900,8 @@ fn assert_material(
         algorithm: document.algorithm.clone(),
         aad_version: document.aad_version,
     };
-    let values = decrypt_identity_document(
-        owner.kind(),
-        owner.key(),
-        document.name.as_str(),
-        &envelope,
-        key_provider,
-    )
-    .expect("decrypt identity material");
+    let values = decrypt_identity_document(&binding, &envelope, key_provider)
+        .expect("decrypt identity material");
     assert_eq!(
         values,
         std::collections::BTreeMap::from([("TOKEN".to_string(), token.to_string())])

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -16,15 +16,19 @@ use zeroize::Zeroizing;
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialsError;
 use crate::credentials::encryption::{
-    CREDENTIAL_DOCUMENT_AAD_VERSION, CREDENTIAL_DOCUMENT_ALGORITHM, CredentialKeyProvider,
-    EncryptedEnvelopeDocument, encode_aad_fields, open_envelope_document, rewrap_envelope_document,
-    seal_envelope_document,
+    CREDENTIAL_DOCUMENT_ALGORITHM, CredentialKeyProvider, EncryptedEnvelopeDocument,
+    encode_aad_fields, open_envelope_document_with_aad_version,
+    rewrap_envelope_document_with_aad_version, seal_envelope_document_with_aad_version,
 };
 
 /// Envelope algorithm identifier for encrypted identity documents.
 pub(crate) const IDENTITY_DOCUMENT_ALGORITHM: &str = CREDENTIAL_DOCUMENT_ALGORITHM;
-/// AAD layout version for encrypted identity documents.
-pub(crate) const IDENTITY_DOCUMENT_AAD_VERSION: i64 = CREDENTIAL_DOCUMENT_AAD_VERSION;
+/// AAD layout version for encrypted identity-spec setup-input documents.
+pub(crate) const IDENTITY_SPEC_DOCUMENT_AAD_VERSION: i64 = 1;
+/// Legacy owner/name-only AAD layout version for encrypted identity instance documents.
+pub(crate) const LEGACY_IDENTITY_DOCUMENT_AAD_VERSION: i64 = 1;
+/// Exact-reference AAD layout version for encrypted identity instance documents.
+pub(crate) const IDENTITY_DOCUMENT_AAD_VERSION: i64 = 2;
 
 const IDENTITY_DOCUMENT_VERSION: u32 = 1;
 
@@ -44,6 +48,40 @@ pub(crate) struct PlaintextIdentityDocument {
     pub(crate) version: u32,
     /// Identity instance values serialized before envelope encryption.
     pub(crate) values: BTreeMap<String, String>,
+}
+
+/// Complete durable binding authenticated by an identity instance document.
+#[derive(Clone, Copy)]
+pub(crate) struct IdentityDocumentBinding<'a> {
+    owner_kind: &'a str,
+    owner_key: &'a str,
+    identity_name: &'a str,
+    spec_scope_kind: &'a str,
+    spec_scope_id: &'a str,
+    spec_name: &'a str,
+    spec_fingerprint: &'a str,
+}
+
+impl<'a> IdentityDocumentBinding<'a> {
+    pub(crate) fn new(
+        owner_kind: &'a str,
+        owner_key: &'a str,
+        identity_name: &'a str,
+        spec_scope_kind: &'a str,
+        spec_scope_id: &'a str,
+        spec_name: &'a str,
+        spec_fingerprint: &'a str,
+    ) -> Self {
+        Self {
+            owner_kind,
+            owner_key,
+            identity_name,
+            spec_scope_kind,
+            spec_scope_id,
+            spec_name,
+            spec_fingerprint,
+        }
+    }
 }
 
 /// Stable local user used by single-user local mode.
@@ -228,7 +266,7 @@ pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppE
 
 /// Build AAD for an encrypted identity-spec setup-input document.
 pub(crate) fn identity_spec_document_aad(scope_kind: &str, scope_id: &str, name: &str) -> Vec<u8> {
-    let aad_version = IDENTITY_DOCUMENT_AAD_VERSION.to_string();
+    let aad_version = IDENTITY_SPEC_DOCUMENT_AAD_VERSION.to_string();
     encode_aad_fields(
         "coral-identity-spec-document",
         &[
@@ -241,16 +279,25 @@ pub(crate) fn identity_spec_document_aad(scope_kind: &str, scope_id: &str, name:
     )
 }
 
-/// Build AAD for an encrypted identity instance document.
-pub(crate) fn identity_document_aad(owner_kind: &str, owner_key: &str, name: &str) -> Vec<u8> {
+/// Return whether persisted identity material uses the legacy owner/name-only AAD.
+pub(crate) fn is_legacy_identity_document_aad_version(aad_version: i64) -> bool {
+    aad_version == LEGACY_IDENTITY_DOCUMENT_AAD_VERSION
+}
+
+/// Build exact-reference AAD for an encrypted identity instance document.
+fn identity_document_aad(binding: IdentityDocumentBinding<'_>) -> Vec<u8> {
     let aad_version = IDENTITY_DOCUMENT_AAD_VERSION.to_string();
     encode_aad_fields(
         "coral-identity-document",
         &[
             aad_version.as_str(),
-            owner_kind,
-            owner_key,
-            name,
+            binding.owner_kind,
+            binding.owner_key,
+            binding.identity_name,
+            binding.spec_scope_kind,
+            binding.spec_scope_id,
+            binding.spec_name,
+            binding.spec_fingerprint,
             IDENTITY_DOCUMENT_ALGORITHM,
         ],
     )
@@ -269,7 +316,8 @@ pub(crate) fn encrypt_identity_spec_document(
         values: values.clone(),
     };
     let document_bytes = serialize_identity_document(&plaintext)?;
-    seal_envelope_document(
+    seal_envelope_document_with_aad_version(
+        IDENTITY_SPEC_DOCUMENT_AAD_VERSION,
         identity_spec_document_aad(scope_kind, scope_id, name),
         document_bytes,
         key_provider,
@@ -284,7 +332,8 @@ pub(crate) fn decrypt_identity_spec_document(
     document: &EncryptedEnvelopeDocument,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<BTreeMap<String, String>, CredentialsError> {
-    let plaintext = open_envelope_document(
+    let plaintext = open_envelope_document_with_aad_version(
+        IDENTITY_SPEC_DOCUMENT_AAD_VERSION,
         document,
         identity_spec_document_aad(scope_kind, scope_id, name),
         key_provider,
@@ -303,7 +352,8 @@ pub(crate) fn rewrap_identity_spec_document(
     document: &EncryptedEnvelopeDocument,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
-    rewrap_envelope_document(
+    rewrap_envelope_document_with_aad_version(
+        IDENTITY_SPEC_DOCUMENT_AAD_VERSION,
         document,
         identity_spec_document_aad(scope_kind, scope_id, name),
         key_provider,
@@ -312,9 +362,7 @@ pub(crate) fn rewrap_identity_spec_document(
 
 /// Encrypt an identity instance document with the shared app KEK.
 pub(crate) fn encrypt_identity_document(
-    owner_kind: &str,
-    owner_key: &str,
-    name: &str,
+    binding: &IdentityDocumentBinding<'_>,
     values: &BTreeMap<String, String>,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<EncryptedEnvelopeDocument, CredentialsError> {
@@ -323,8 +371,9 @@ pub(crate) fn encrypt_identity_document(
         values: values.clone(),
     };
     let document_bytes = serialize_identity_document(&plaintext)?;
-    seal_envelope_document(
-        identity_document_aad(owner_kind, owner_key, name),
+    seal_envelope_document_with_aad_version(
+        IDENTITY_DOCUMENT_AAD_VERSION,
+        identity_document_aad(*binding),
         document_bytes,
         key_provider,
     )
@@ -332,15 +381,14 @@ pub(crate) fn encrypt_identity_document(
 
 /// Decrypt an identity instance document with the shared app KEK.
 pub(crate) fn decrypt_identity_document(
-    owner_kind: &str,
-    owner_key: &str,
-    name: &str,
+    binding: &IdentityDocumentBinding<'_>,
     document: &EncryptedEnvelopeDocument,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<BTreeMap<String, String>, CredentialsError> {
-    let plaintext = open_envelope_document(
+    let plaintext = open_envelope_document_with_aad_version(
+        IDENTITY_DOCUMENT_AAD_VERSION,
         document,
-        identity_document_aad(owner_kind, owner_key, name),
+        identity_document_aad(*binding),
         key_provider,
     )?;
     let decoded: PlaintextIdentityDocument = serde_json::from_slice(&plaintext)
@@ -351,15 +399,14 @@ pub(crate) fn decrypt_identity_document(
 
 /// Rewrap an identity instance document when its KEK is stale.
 pub(crate) fn rewrap_identity_document(
-    owner_kind: &str,
-    owner_key: &str,
-    name: &str,
+    binding: &IdentityDocumentBinding<'_>,
     document: &EncryptedEnvelopeDocument,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
-    rewrap_envelope_document(
+    rewrap_envelope_document_with_aad_version(
+        IDENTITY_DOCUMENT_AAD_VERSION,
         document,
-        identity_document_aad(owner_kind, owner_key, name),
+        identity_document_aad(*binding),
         key_provider,
     )
 }
@@ -398,6 +445,8 @@ mod tests {
     };
     use crate::sources::SourceName;
     use crate::workspaces::WorkspaceName;
+
+    const TEST_SPEC_FINGERPRINT: &str = "identity-manifest-v1:sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     #[derive(Clone)]
     struct StaticKeyProvider {
@@ -505,14 +554,15 @@ mod tests {
     fn identity_documents_round_trip_and_pin_metadata() {
         let provider = static_provider(43);
         let values = secret_values();
+        let binding = user_identity_binding();
         let spec =
             encrypt_identity_spec_document("global", "__global__", "github", &values, &provider)
                 .expect("encrypt identity spec");
-        let identity = encrypt_identity_document("user", "member-1", "github", &values, &provider)
-            .expect("encrypt identity");
+        let identity =
+            encrypt_identity_document(&binding, &values, &provider).expect("encrypt identity");
 
         assert_eq!(spec.algorithm, IDENTITY_DOCUMENT_ALGORITHM);
-        assert_eq!(spec.aad_version, IDENTITY_DOCUMENT_AAD_VERSION);
+        assert_eq!(spec.aad_version, IDENTITY_SPEC_DOCUMENT_AAD_VERSION);
         assert_eq!(identity.algorithm, IDENTITY_DOCUMENT_ALGORITHM);
         assert_eq!(identity.aad_version, IDENTITY_DOCUMENT_AAD_VERSION);
         assert_eq!(
@@ -521,8 +571,7 @@ mod tests {
             values
         );
         assert_eq!(
-            decrypt_identity_document("user", "member-1", "github", &identity, &provider)
-                .expect("decrypt identity"),
+            decrypt_identity_document(&binding, &identity, &provider).expect("decrypt identity"),
             values
         );
     }
@@ -538,15 +587,24 @@ mod tests {
         let spec =
             encrypt_identity_spec_document("workspace", "acme", "github", &values, &provider)
                 .expect("encrypt identity spec");
-        let identity = encrypt_identity_document("workspace", "acme", "github", &values, &provider)
-            .expect("encrypt identity");
+        let binding = IdentityDocumentBinding::new(
+            "workspace",
+            "acme",
+            "github",
+            "workspace",
+            "acme",
+            "github",
+            TEST_SPEC_FINGERPRINT,
+        );
+        let identity =
+            encrypt_identity_document(&binding, &values, &provider).expect("encrypt identity");
 
         assert_open_failed(
             &decrypt_identity_spec_document("workspace", "acme", "github", &credential, &provider)
                 .expect_err("credential must not open as an identity spec"),
         );
         assert_open_failed(
-            &decrypt_identity_document("workspace", "acme", "github", &credential, &provider)
+            &decrypt_identity_document(&binding, &credential, &provider)
                 .expect_err("credential must not open as an identity"),
         );
         assert_open_failed(
@@ -554,7 +612,7 @@ mod tests {
                 .expect_err("identity spec must not open as a credential"),
         );
         assert_open_failed(
-            &decrypt_identity_document("workspace", "acme", "github", &spec, &provider)
+            &decrypt_identity_document(&binding, &spec, &provider)
                 .expect_err("identity spec must not open as an identity"),
         );
         assert_open_failed(
@@ -586,21 +644,52 @@ mod tests {
                 .expect_err("spec name must authenticate"),
         );
 
+        let binding = IdentityDocumentBinding::new(
+            "owner:kind",
+            "owner",
+            "primary",
+            "scope:kind",
+            "scope",
+            "github",
+            TEST_SPEC_FINGERPRINT,
+        );
         let identity =
-            encrypt_identity_document("owner:kind", "owner", "github", &values, &provider)
-                .expect("encrypt identity");
-        assert_open_failed(
-            &decrypt_identity_document("owner", "kind:owner", "github", &identity, &provider)
-                .expect_err("colon-bearing owner fields must stay distinct"),
-        );
-        assert_open_failed(
-            &decrypt_identity_document("owner", "owner:kind", "github", &identity, &provider)
-                .expect_err("owner field order must authenticate"),
-        );
-        assert_open_failed(
-            &decrypt_identity_document("owner:kind", "owner", "gitlab", &identity, &provider)
-                .expect_err("identity name must authenticate"),
-        );
+            encrypt_identity_document(&binding, &values, &provider).expect("encrypt identity");
+        for tampered_binding in [
+            IdentityDocumentBinding {
+                owner_kind: "owner",
+                ..binding
+            },
+            IdentityDocumentBinding {
+                owner_key: "kind:owner",
+                ..binding
+            },
+            IdentityDocumentBinding {
+                identity_name: "secondary",
+                ..binding
+            },
+            IdentityDocumentBinding {
+                spec_scope_kind: "scope",
+                ..binding
+            },
+            IdentityDocumentBinding {
+                spec_scope_id: "kind:scope",
+                ..binding
+            },
+            IdentityDocumentBinding {
+                spec_name: "gitlab",
+                ..binding
+            },
+            IdentityDocumentBinding {
+                spec_fingerprint: "identity-manifest-v1:sha256:tampered",
+                ..binding
+            },
+        ] {
+            assert_open_failed(
+                &decrypt_identity_document(&tampered_binding, &identity, &provider)
+                    .expect_err("every exact-reference AAD field must authenticate"),
+            );
+        }
     }
 
     #[test]
@@ -637,6 +726,37 @@ mod tests {
     }
 
     #[test]
+    fn identity_instance_v1_is_detected_but_never_opened_or_rewrapped() {
+        let old_key = CredentialEncryptionKey::from_static_bytes_for_test([60; 32]);
+        let new_key = CredentialEncryptionKey::from_static_bytes_for_test([62; 32]);
+        let old_provider = StaticKeyProvider {
+            key: old_key.clone(),
+        };
+        let rotating_provider = RotatingKeyProvider {
+            active: new_key.clone(),
+            keys: vec![old_key, new_key],
+        };
+        let legacy = seal_test_document(
+            &PlaintextIdentityDocument {
+                version: IDENTITY_DOCUMENT_VERSION,
+                values: secret_values(),
+            },
+            legacy_identity_document_aad("user", "member-1", "github"),
+            &old_provider,
+        );
+        assert_eq!(legacy.aad_version, LEGACY_IDENTITY_DOCUMENT_AAD_VERSION);
+        assert!(is_legacy_identity_document_aad_version(legacy.aad_version));
+
+        let binding = user_identity_binding();
+        let open_error = decrypt_identity_document(&binding, &legacy, &rotating_provider)
+            .expect_err("v1 identity material must not open through the v2 path");
+        assert_unsupported_aad_version(&open_error, LEGACY_IDENTITY_DOCUMENT_AAD_VERSION);
+        let rewrap_error = rewrap_identity_document(&binding, &legacy, &rotating_provider)
+            .expect_err("v1 identity material must not be rewrapped through the v2 path");
+        assert_unsupported_aad_version(&rewrap_error, LEGACY_IDENTITY_DOCUMENT_AAD_VERSION);
+    }
+
+    #[test]
     fn identity_documents_reject_unknown_plaintext_versions() {
         let provider = static_provider(61);
         let values = secret_values();
@@ -656,15 +776,19 @@ mod tests {
                 .contains("identity spec document version 2")
         );
 
-        let identity = seal_test_document(
-            &PlaintextIdentityDocument {
+        let binding = user_identity_binding();
+        let identity = seal_envelope_document_with_aad_version(
+            IDENTITY_DOCUMENT_AAD_VERSION,
+            identity_document_aad(binding),
+            serialize_identity_document(&PlaintextIdentityDocument {
                 version: IDENTITY_DOCUMENT_VERSION + 1,
                 values,
-            },
-            identity_document_aad("user", "member-1", "github"),
+            })
+            .expect("serialize test document"),
             &provider,
-        );
-        let error = decrypt_identity_document("user", "member-1", "github", &identity, &provider)
+        )
+        .expect("seal test document");
+        let error = decrypt_identity_document(&binding, &identity, &provider)
             .expect_err("unknown identity version must fail");
         assert!(error.to_string().contains("identity document version 2"));
     }
@@ -702,35 +826,30 @@ mod tests {
             values
         );
 
+        let binding = user_identity_binding();
         let identity =
-            encrypt_identity_document("user", "member-1", "github", &values, &old_provider)
-                .expect("encrypt identity");
-        let rewrapped_identity =
-            rewrap_identity_document("user", "member-1", "github", &identity, &rotating_provider)
-                .expect("rewrap identity")
-                .expect("stale identity key must rewrap");
+            encrypt_identity_document(&binding, &values, &old_provider).expect("encrypt identity");
+        let rewrapped_identity = rewrap_identity_document(&binding, &identity, &rotating_provider)
+            .expect("rewrap identity")
+            .expect("stale identity key must rewrap");
         assert_rewrapped_document(&identity, &rewrapped_identity, new_key.key_id());
         assert_eq!(
-            decrypt_identity_document(
-                "user",
-                "member-1",
-                "github",
-                &rewrapped_identity,
-                &rotating_provider,
-            )
-            .expect("decrypt rewrapped identity"),
+            decrypt_identity_document(&binding, &rewrapped_identity, &rotating_provider,)
+                .expect("decrypt rewrapped identity"),
             values
         );
         assert!(
-            rewrap_identity_document(
-                "user",
-                "member-1",
-                "github",
-                &rewrapped_identity,
-                &rotating_provider,
-            )
-            .expect("rewrap current identity")
-            .is_none()
+            rewrap_identity_document(&binding, &rewrapped_identity, &rotating_provider,)
+                .expect("rewrap current identity")
+                .is_none()
+        );
+        let wrong_binding = IdentityDocumentBinding {
+            spec_fingerprint: "identity-manifest-v1:sha256:tampered",
+            ..binding
+        };
+        assert_open_failed(
+            &rewrap_identity_document(&wrong_binding, &rewrapped_identity, &rotating_provider)
+                .expect_err("same-key rewrap must authenticate the exact spec reference"),
         );
         assert_open_failed(
             &rewrap_identity_spec_document(
@@ -754,12 +873,39 @@ mod tests {
         BTreeMap::from([("token".to_string(), "secret".to_string())])
     }
 
+    fn user_identity_binding() -> IdentityDocumentBinding<'static> {
+        IdentityDocumentBinding::new(
+            "user",
+            "member-1",
+            "github",
+            "global",
+            "__global__",
+            "github",
+            TEST_SPEC_FINGERPRINT,
+        )
+    }
+
+    fn legacy_identity_document_aad(owner_kind: &str, owner_key: &str, name: &str) -> Vec<u8> {
+        let aad_version = LEGACY_IDENTITY_DOCUMENT_AAD_VERSION.to_string();
+        encode_aad_fields(
+            "coral-identity-document",
+            &[
+                aad_version.as_str(),
+                owner_kind,
+                owner_key,
+                name,
+                IDENTITY_DOCUMENT_ALGORITHM,
+            ],
+        )
+    }
+
     fn seal_test_document(
         document: &impl serde::Serialize,
         aad: Vec<u8>,
         provider: &StaticKeyProvider,
     ) -> EncryptedEnvelopeDocument {
-        seal_envelope_document(
+        seal_envelope_document_with_aad_version(
+            LEGACY_IDENTITY_DOCUMENT_AAD_VERSION,
             aad,
             serialize_identity_document(document).expect("serialize test document"),
             provider,
@@ -784,6 +930,14 @@ mod tests {
         assert!(error.to_string().contains("unsupported"));
     }
 
+    fn assert_unsupported_aad_version(error: &CredentialsError, aad_version: i64) {
+        let message = error.to_string();
+        assert!(message.contains("unsupported credential AAD version"));
+        assert!(message.contains(&aad_version.to_string()));
+        assert!(!message.contains("secret"));
+        assert!(!message.contains(TEST_SPEC_FINGERPRINT));
+    }
+
     fn assert_rewrapped_document(
         original: &EncryptedEnvelopeDocument,
         rewrapped: &EncryptedEnvelopeDocument,
@@ -797,8 +951,10 @@ mod tests {
     }
 
     fn assert_open_failed(error: &CredentialsError) {
+        let message = error.to_string();
         assert!(
-            error.to_string().contains("open failed"),
+            message.contains("open failed")
+                || message.contains("unsupported credential AAD version"),
             "unexpected error: {error}"
         );
     }


### PR DESCRIPTION
## Intent
Bind every newly written encrypted identity instance document to its owner and exact durable identity-spec reference. This prevents a database row from being rebound to another spec without possessing the KEK, while preserving credential and identity-spec v1 formats.

## What it enables
- New and replaced fixed-token identities use AAD v2 over owner kind, owner key, identity name, exact spec scope kind, scope ID, spec name, canonical fingerprint, algorithm, and version.
- Transaction retries reseal the submitted token whenever the winning exact spec reference changes.
- Legacy v1 identity material is recognized but never silently migrated or blessed under a possibly rebound row.
- Identity-spec and credential persistence remain v1 and independently version-owned.

## Usage examples
No API invocation changes. Creating or replacing a fixed-token identity writes v2 material automatically. List, Get, and Delete remain compatible with legacy rows; the next stacked draft adds coherent for-use resolution and explicit legacy guidance.

## Validation
- make rust-checks: formatting, strict all-feature Clippy, 1,724 of 1,724 tests passed with 3 skipped, and warning-denied rustdoc.
- Focused identity tests: 14 of 14 passed.
- The versioned-envelope regression and SQLite fixed-token manager contract passed.
- Native isolated PostgreSQL equivalents for the repository, identity database, and server-lifecycle contracts passed.
- Fresh final-diff correctness, tests, security, and architecture review lanes found no issues; the supervisor found no missed P1 or P2 risk.
- Pull request size: 596 changed lines.