### PR TITLE
feat(app): resolve identities from coherent snapshots

### DIFF
--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -1,6 +1,12 @@
 //! Database-backed identity instance management.
 
+#![cfg_attr(
+    not(test),
+    expect(dead_code, reason = "Identity use consumers land in B5.")
+)]
+
 use std::collections::BTreeMap;
+use std::fmt;
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -11,18 +17,81 @@ use crate::bootstrap::AppError;
 use crate::credentials::encryption::{CredentialKeyProvider, EncryptedEnvelopeDocument};
 use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
 use crate::identity::{
-    IdentityDocumentBinding, UserPrincipal, encrypt_identity_document, run_key_operation,
+    IdentityDocumentBinding, UserPrincipal, decrypt_identity_document, encrypt_identity_document,
+    is_legacy_identity_document_aad_version, rewrap_identity_document,
+    rewrap_identity_spec_document, run_key_operation,
 };
 use crate::identity_specs::identity_spec_fingerprint;
-use crate::identity_specs::manager::{record_to_installed, spec_not_found};
+use crate::identity_specs::manager::{
+    InstalledIdentitySpec, ResolvedIdentitySpec, record_to_installed, resolve_installed_for_use,
+    spec_not_found,
+};
 use crate::state::db::{
-    CoralDb, CoralTx, DbRepos, IdentityDocumentWrite, IdentityRecord, IdentitySpecKey,
-    IdentitySpecRecord, now_unix_nanos_i64,
+    CoralDb, CoralTx, DbRepos, IdentityDocumentRecord, IdentityDocumentWrite, IdentityRecord,
+    IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecRecord,
+    now_unix_nanos_i64,
 };
 use crate::workspaces::WorkspaceName;
 
 const FIXED_TOKEN_KEY: &str = "TOKEN";
 const MAX_MUTATION_ATTEMPTS: usize = 8;
+
+/// Coherent decrypted identity data prepared for one runtime use.
+pub(crate) struct ResolvedIdentityForUse {
+    pub(crate) identity: IdentityRecord,
+    pub(crate) identity_spec: ResolvedIdentitySpec,
+    material: BTreeMap<String, String>,
+    revision: IdentityForUseRevision,
+}
+
+impl ResolvedIdentityForUse {
+    pub(crate) fn material(&self) -> &BTreeMap<String, String> {
+        &self.material
+    }
+
+    pub(crate) fn revision(&self) -> &IdentityForUseRevision {
+        &self.revision
+    }
+}
+
+impl fmt::Debug for ResolvedIdentityForUse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResolvedIdentityForUse")
+            .field("owner", &self.identity.owner)
+            .field("name", &self.identity.name)
+            .field("identity_spec", &self.identity_spec)
+            .field("material_value_count", &self.material.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Opaque complete database revision paired with resolved identity material.
+pub(crate) struct IdentityForUseRevision {
+    _snapshot: IdentityUseSnapshot,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct IdentityUseSnapshot {
+    workspace_created_at_unix_nanos: Option<i64>,
+    identity: Option<IdentityRecord>,
+    identity_document: Option<IdentityDocumentRecord>,
+    identity_spec: Option<IdentitySpecRecord>,
+    identity_spec_document: Option<IdentitySpecDocumentRecord>,
+}
+
+struct PreparedIdentityForUse {
+    identity: IdentityRecord,
+    identity_spec: ResolvedIdentitySpec,
+    material: BTreeMap<String, String>,
+    identity_rewrap: Option<IdentityDocumentWrite>,
+    identity_spec_rewrap: Option<IdentitySpecDocumentWrite>,
+}
+
+impl PreparedIdentityForUse {
+    fn needs_rewrap(&self) -> bool {
+        self.identity_rewrap.is_some() || self.identity_spec_rewrap.is_some()
+    }
+}
 
 /// Database-backed behavior for owner-scoped identity instances.
 #[derive(Clone)]
@@ -268,6 +337,122 @@ impl IdentityManager {
         record.ok_or_else(|| identity_not_found(&name))
     }
 
+    /// Resolve one identity and its exact installed spec from one coherent snapshot.
+    pub(crate) async fn get_for_use(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<ResolvedIdentityForUse, AppError> {
+        for _ in 0..MAX_MUTATION_ATTEMPTS {
+            let (name, snapshot) = match self.load_for_use_snapshot(owner, identity_name).await {
+                Ok(snapshot) => snapshot,
+                Err(AppError::RetryableTransactionConflict) => {
+                    tokio::task::yield_now().await;
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            let crypto_snapshot = snapshot.clone();
+            let crypto_name = name.clone();
+            let key_provider = Arc::clone(&self.key_provider);
+            let prepared = run_key_operation(move || {
+                prepare_identity_for_use(crypto_snapshot, &crypto_name, key_provider.as_ref())
+            })
+            .await?;
+            let revision = if prepared.needs_rewrap() {
+                match self
+                    .try_rewrap_for_use(owner, &name, &snapshot, &prepared)
+                    .await
+                {
+                    Ok(Some(revision)) => revision,
+                    Ok(None) | Err(AppError::RetryableTransactionConflict) => {
+                        tokio::task::yield_now().await;
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                }
+            } else {
+                snapshot
+            };
+            return Ok(ResolvedIdentityForUse {
+                identity: prepared.identity,
+                identity_spec: prepared.identity_spec,
+                material: prepared.material,
+                revision: IdentityForUseRevision {
+                    _snapshot: revision,
+                },
+            });
+        }
+        Err(AppError::RetryableTransactionConflict)
+    }
+
+    async fn load_for_use_snapshot(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<(IdentityName, IdentityUseSnapshot), AppError> {
+        let mut tx = self.db.begin_read_snapshot().await?;
+        let workspace_created_at_unix_nanos = owner_workspace_created_at(&mut tx, owner).await?;
+        let name = IdentityName::parse(identity_name)?;
+        let snapshot =
+            load_identity_use_snapshot(&mut tx, owner, &name, workspace_created_at_unix_nanos)
+                .await?;
+        tx.commit().await?;
+        Ok((name, snapshot))
+    }
+
+    async fn try_rewrap_for_use(
+        &self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        expected: &IdentityUseSnapshot,
+        prepared: &PreparedIdentityForUse,
+    ) -> Result<Option<IdentityUseSnapshot>, AppError> {
+        let mut tx = self.db.begin_serializable().await?;
+        let workspace_created_at_unix_nanos = owner_workspace_created_at(&mut tx, owner).await?;
+        let mut current =
+            load_identity_use_snapshot(&mut tx, owner, name, workspace_created_at_unix_nanos)
+                .await?;
+        if current != *expected {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+        #[cfg(test)]
+        if let Some(gate) = &self.before_upsert_gate
+            && !gate.used.swap(true, Ordering::SeqCst)
+        {
+            gate.barrier.wait().await;
+        }
+        let now = now_unix_nanos_i64()?;
+        let result = async {
+            if let Some(write) = &prepared.identity_spec_rewrap {
+                let key = current
+                    .identity
+                    .as_ref()
+                    .expect("validated identity snapshot")
+                    .spec_reference
+                    .key();
+                current.identity_spec_document =
+                    Some(tx.identity_spec_documents().upsert(key, write, now).await?);
+            }
+            if let Some(write) = &prepared.identity_rewrap {
+                current.identity_document = Some(
+                    tx.identity_documents()
+                        .upsert(owner, name, write, now)
+                        .await?,
+                );
+            }
+            Ok::<_, AppError>(())
+        }
+        .await;
+        if let Err(error) = result {
+            tx.rollback().await?;
+            return Err(error);
+        }
+        tx.commit().await?;
+        Ok(Some(current))
+    }
+
     /// Delete one identity and its cascading encrypted document.
     pub(crate) async fn delete(
         &self,
@@ -409,6 +594,202 @@ impl IdentityManager {
     }
 }
 
+async fn load_identity_use_snapshot(
+    tx: &mut CoralTx<'_>,
+    owner: &IdentityOwner,
+    name: &IdentityName,
+    workspace_created_at_unix_nanos: Option<i64>,
+) -> Result<IdentityUseSnapshot, AppError> {
+    let identity = tx.identities().load_optional(owner, name).await?;
+    let identity_document = tx.identity_documents().load_optional(owner, name).await?;
+    let (identity_spec, identity_spec_document) = match identity.as_ref() {
+        Some(identity) => {
+            let key = identity.spec_reference.key();
+            (
+                tx.identity_specs().load_optional(key).await?,
+                tx.identity_spec_documents().load_optional(key).await?,
+            )
+        }
+        None => (None, None),
+    };
+    Ok(IdentityUseSnapshot {
+        workspace_created_at_unix_nanos,
+        identity,
+        identity_document,
+        identity_spec,
+        identity_spec_document,
+    })
+}
+
+fn prepare_identity_for_use(
+    snapshot: IdentityUseSnapshot,
+    name: &IdentityName,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<PreparedIdentityForUse, AppError> {
+    let identity = snapshot.identity.ok_or_else(|| identity_not_found(name))?;
+    let identity_document = snapshot
+        .identity_document
+        .ok_or_else(|| recreate_identity(name, "has no encrypted material"))?;
+    if is_legacy_identity_document_aad_version(identity_document.aad_version) {
+        return Err(recreate_identity(
+            name,
+            "uses legacy encrypted material that is not bound to its identity spec",
+        ));
+    }
+    let identity_spec_record = snapshot.identity_spec.ok_or_else(|| {
+        AppError::FailedPrecondition(format!(
+            "identity '{name}' is orphaned because identity spec '{}' is not installed; restore the exact spec or recreate the identity",
+            identity.spec_reference.key().name(),
+        ))
+    })?;
+    let installed = record_to_installed(identity_spec_record)?;
+    validate_identity_reference(&identity, &installed)?;
+    let identity_spec = resolve_installed_for_use(
+        installed,
+        snapshot.identity_spec_document.clone(),
+        key_provider,
+    )?;
+    let binding =
+        identity_document_binding(&identity.owner, &identity.name, &identity.spec_reference);
+    let envelope = identity_envelope(&identity_document);
+    let material = decrypt_identity_document(&binding, &envelope, key_provider)?;
+    if material.len() != 1
+        || material
+            .get(FIXED_TOKEN_KEY)
+            .is_none_or(|token| token.trim().is_empty())
+    {
+        return Err(corrupt_identity_material(&identity));
+    }
+    let identity_rewrap = rewrap_identity_document(&binding, &envelope, key_provider)?
+        .map(identity_document_write)
+        .transpose()?;
+    let identity_spec_rewrap = match snapshot.identity_spec_document.as_ref() {
+        Some(document) => {
+            let envelope = identity_spec_envelope(document);
+            let (scope_kind, scope_id, spec_name) = document.key.document_aad_parts();
+            rewrap_identity_spec_document(scope_kind, scope_id, spec_name, &envelope, key_provider)?
+                .map(identity_spec_document_write)
+                .transpose()?
+        }
+        None => None,
+    };
+    Ok(PreparedIdentityForUse {
+        identity,
+        identity_spec,
+        material,
+        identity_rewrap,
+        identity_spec_rewrap,
+    })
+}
+
+fn validate_identity_reference(
+    identity: &IdentityRecord,
+    installed: &InstalledIdentitySpec,
+) -> Result<(), AppError> {
+    let expected = IdentitySpecReference::new(
+        &identity.owner,
+        installed.key.clone(),
+        identity_spec_fingerprint(&installed.manifest)?,
+        installed.manifest.issuer.clone(),
+        installed.manifest.identity_type.label(),
+    )?;
+    if identity.spec_reference != expected {
+        return Err(recreate_identity(
+            &identity.name,
+            "no longer matches its exact installed identity spec",
+        ));
+    }
+    if installed.manifest.identity_type != IdentitySpecType::FixedToken {
+        return Err(recreate_identity(
+            &identity.name,
+            "does not reference a fixed-token identity spec",
+        ));
+    }
+    Ok(())
+}
+
+fn identity_document_binding<'a>(
+    owner: &'a IdentityOwner,
+    name: &'a IdentityName,
+    reference: &'a IdentitySpecReference,
+) -> IdentityDocumentBinding<'a> {
+    let (spec_scope_kind, spec_scope_id, spec_name) = reference.key().document_aad_parts();
+    IdentityDocumentBinding::new(
+        owner.kind(),
+        owner.key(),
+        name.as_str(),
+        spec_scope_kind,
+        spec_scope_id,
+        spec_name,
+        reference.fingerprint(),
+    )
+}
+
+fn identity_envelope(document: &IdentityDocumentRecord) -> EncryptedEnvelopeDocument {
+    EncryptedEnvelopeDocument {
+        ciphertext: document.ciphertext.clone(),
+        nonce: document.nonce.clone(),
+        wrapped_dek: document.wrapped_dek.clone(),
+        wrapped_dek_nonce: document.wrapped_dek_nonce.clone(),
+        key_id: document.key_id.clone(),
+        algorithm: document.algorithm.clone(),
+        aad_version: document.aad_version,
+    }
+}
+
+fn identity_spec_envelope(document: &IdentitySpecDocumentRecord) -> EncryptedEnvelopeDocument {
+    EncryptedEnvelopeDocument {
+        ciphertext: document.ciphertext.clone(),
+        nonce: document.nonce.clone(),
+        wrapped_dek: document.wrapped_dek.clone(),
+        wrapped_dek_nonce: document.wrapped_dek_nonce.clone(),
+        key_id: document.key_id.clone(),
+        algorithm: document.algorithm.clone(),
+        aad_version: document.aad_version,
+    }
+}
+
+fn identity_document_write(
+    document: EncryptedEnvelopeDocument,
+) -> Result<IdentityDocumentWrite, AppError> {
+    IdentityDocumentWrite::new(
+        document.ciphertext,
+        document.nonce,
+        document.wrapped_dek,
+        document.wrapped_dek_nonce,
+        document.key_id,
+        document.algorithm,
+        document.aad_version,
+    )
+}
+
+fn identity_spec_document_write(
+    document: EncryptedEnvelopeDocument,
+) -> Result<IdentitySpecDocumentWrite, AppError> {
+    IdentitySpecDocumentWrite::new(
+        document.ciphertext,
+        document.nonce,
+        document.wrapped_dek,
+        document.wrapped_dek_nonce,
+        document.key_id,
+        document.algorithm,
+        document.aad_version,
+    )
+}
+
+fn recreate_identity(name: &IdentityName, detail: &str) -> AppError {
+    AppError::FailedPrecondition(format!("identity '{name}' {detail}; recreate the identity"))
+}
+
+fn corrupt_identity_material(identity: &IdentityRecord) -> AppError {
+    AppError::Database(format!(
+        "identity '{}:{}:{}' has invalid encrypted material",
+        identity.owner.kind(),
+        identity.owner.key(),
+        identity.name,
+    ))
+}
+
 async fn owner_workspace_created_at(
     tx: &mut CoralTx<'_>,
     owner: &IdentityOwner,
@@ -439,16 +820,7 @@ fn prepare_fixed_token_document(
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<IdentityDocumentWrite, AppError> {
     let values = BTreeMap::from([(FIXED_TOKEN_KEY.to_string(), token)]);
-    let (spec_scope_kind, spec_scope_id, spec_name) = reference.key().document_aad_parts();
-    let binding = IdentityDocumentBinding::new(
-        owner.kind(),
-        owner.key(),
-        name.as_str(),
-        spec_scope_kind,
-        spec_scope_id,
-        spec_name,
-        reference.fingerprint(),
-    );
+    let binding = identity_document_binding(owner, name, reference);
     let EncryptedEnvelopeDocument {
         ciphertext,
         nonce,

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use coral_spec::parse_identity_manifest_yaml;
+use sea_query::{Alias, Expr, ExprTrait, Query};
 use tempfile::tempdir;
 
 use super::IdentityManager;
@@ -17,7 +18,7 @@ use crate::identity::{
 };
 use crate::identity_specs::identity_spec_fingerprint;
 use crate::state::db::{
-    CoralDb, DbError, DbRepos, IdentityDocumentRecord, IdentityRecord, IdentitySpecKey,
+    CoralDb, DbError, DbRepos, DbSession, IdentityDocumentRecord, IdentityRecord, IdentitySpecKey,
     IdentitySpecWrite, ResolvedDatabaseConfig,
 };
 use crate::workspaces::WorkspaceName;
@@ -29,7 +30,7 @@ impl CredentialKeyProvider for TestKeyProvider {
         self.0
             .last()
             .cloned()
-            .ok_or_else(|| CredentialsError::Crypto("missing test key".to_string()))
+            .ok_or_else(|| CredentialsError::Unavailable("missing test key".to_string()))
     }
 
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
@@ -37,7 +38,7 @@ impl CredentialKeyProvider for TestKeyProvider {
             .iter()
             .find(|key| key.key_id() == key_id)
             .cloned()
-            .ok_or_else(|| CredentialsError::Crypto("missing test key".to_string()))
+            .ok_or_else(|| CredentialsError::Unavailable("missing test key".to_string()))
     }
 }
 
@@ -56,8 +57,108 @@ async fn sqlite_fixed_token_manager_contract() {
 }
 
 pub(crate) async fn assert_fixed_token_manager_contract(db: &Arc<CoralDb>) {
+    Box::pin(assert_fixed_token_for_use_contract(db)).await;
     Box::pin(assert_user_global_fixed_token_manager_contract(db)).await;
     Box::pin(assert_workspace_fixed_token_manager_contract(db)).await;
+}
+
+async fn assert_fixed_token_for_use_contract(db: &Arc<CoralDb>) {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let spec_name = format!("for_use_{suffix}");
+    let identity_name = format!("for-use-{suffix}");
+    let spec_key = IdentitySpecKey::global(&spec_name).unwrap();
+    let principal = UserPrincipal::for_user(&format!("for-use-{suffix}")).unwrap();
+    let owner = IdentityOwner::for_user(principal.clone());
+    let old_key = CredentialEncryptionKey::from_static_bytes_for_test([61; 32]);
+    let old_provider = Arc::new(TestKeyProvider(vec![old_key.clone()]));
+    put_spec(db, &spec_key, &fixed_manifest(&spec_name, "use")).await;
+    let manager = IdentityManager::new(db.clone(), old_provider);
+    let created = manager
+        .create_or_replace_user_fixed_token(
+            &principal,
+            &identity_name,
+            &spec_name,
+            " token-value ".into(),
+        )
+        .await
+        .expect("create identity for use");
+    let before_identity = load_pair(db, &owner, &identity_name).await.1.unwrap();
+
+    let resolved = manager
+        .get_for_use(&owner, &identity_name)
+        .await
+        .expect("resolve identity for use");
+    assert_eq!(resolved.identity, created);
+    assert_eq!(resolved.material().get("TOKEN").unwrap(), "token-value");
+    assert_eq!(resolved.identity_spec.spec.key, spec_key);
+    assert!(resolved.identity_spec.inputs.variables().is_empty());
+    assert!(resolved.identity_spec.inputs.secrets().is_empty());
+    let rendered = format!("{resolved:?}");
+    assert!(!rendered.contains("token-value"));
+    let _revision = resolved.revision();
+    assert_eq!(
+        load_pair(db, &owner, &identity_name).await.1.unwrap(),
+        before_identity
+    );
+
+    let new_key = CredentialEncryptionKey::from_static_bytes_for_test([62; 32]);
+    let rotated = IdentityManager::new(
+        db.clone(),
+        Arc::new(TestKeyProvider(vec![old_key, new_key.clone()])),
+    );
+    let rotated_result = rotated
+        .get_for_use(&owner, &identity_name)
+        .await
+        .expect("resolve and rewrap identity for use");
+    assert_eq!(
+        rotated_result.material().get("TOKEN").unwrap(),
+        "token-value"
+    );
+    let after_identity = load_pair(db, &owner, &identity_name).await.1.unwrap();
+    assert_eq!(after_identity.document_version, 2);
+    assert_eq!(after_identity.key_id, new_key.key_id());
+    assert_eq!(after_identity.ciphertext, before_identity.ciphertext);
+    assert_eq!(after_identity.nonce, before_identity.nonce);
+    let reopened = rotated
+        .get_for_use(&owner, &identity_name)
+        .await
+        .expect("reopen rewrapped identity");
+    assert_eq!(reopened.material().get("TOKEN").unwrap(), "token-value");
+    assert_eq!(
+        load_pair(db, &owner, &identity_name).await.1.unwrap(),
+        after_identity
+    );
+
+    let unavailable = IdentityManager::new(db.clone(), Arc::new(TestKeyProvider(vec![])));
+    assert!(matches!(
+        unavailable.get_for_use(&owner, &identity_name).await,
+        Err(AppError::Credentials(CredentialsError::Unavailable(_)))
+    ));
+    assert_eq!(
+        load_pair(db, &owner, &identity_name).await.1.unwrap(),
+        after_identity
+    );
+
+    set_identity_aad_version(db, &owner, &identity_name, 1).await;
+    assert!(matches!(
+        unavailable.get_for_use(&owner, &identity_name).await,
+        Err(AppError::FailedPrecondition(detail))
+            if detail.contains("legacy") && detail.contains("recreate")
+    ));
+    set_identity_aad_version(db, &owner, &identity_name, IDENTITY_DOCUMENT_AAD_VERSION).await;
+    put_spec(db, &spec_key, &oauth_manifest(&spec_name)).await;
+    assert!(matches!(
+        unavailable.get_for_use(&owner, &identity_name).await,
+        Err(AppError::FailedPrecondition(detail))
+            if detail.contains("no longer matches") && detail.contains("recreate")
+    ));
+    delete_spec(db, &spec_key).await;
+    assert!(matches!(
+        rotated.get_for_use(&owner, &identity_name).await,
+        Err(AppError::FailedPrecondition(detail))
+            if detail.contains("orphaned") && detail.contains("restore")
+    ));
+    assert_eq!(rotated.get(&owner, &identity_name).await.unwrap(), created);
 }
 
 #[expect(
@@ -474,6 +575,15 @@ async fn assert_workspace_fixed_token_manager_contract(db: &Arc<CoralDb>) {
         manager.get(&owner, &fallback_identity).await.unwrap(),
         fallback_created
     );
+    let fallback_for_use = manager
+        .get_for_use(&owner, &fallback_identity)
+        .await
+        .expect("resolve persisted global fallback after late shadow");
+    assert_eq!(fallback_for_use.identity_spec.spec.key, fallback_global_key);
+    assert_eq!(
+        fallback_for_use.material().get("TOKEN").unwrap(),
+        "fallback-token"
+    );
 
     let selected = Arc::new(tokio::sync::Barrier::new(2));
     let resume = Arc::new(tokio::sync::Barrier::new(2));
@@ -840,6 +950,26 @@ async fn delete_spec(db: &Arc<CoralDb>, key: &IdentitySpecKey) {
     let mut tx = db.begin().await.unwrap();
     assert!(tx.identity_specs().delete(key).await.unwrap());
     tx.commit().await.unwrap();
+}
+
+async fn set_identity_aad_version(
+    db: &Arc<CoralDb>,
+    owner: &IdentityOwner,
+    name: &str,
+    aad_version: i64,
+) {
+    let mut db = db.as_ref();
+    db.execute(
+        Query::update()
+            .table(Alias::new("identity_documents"))
+            .value(Alias::new("aad_version"), aad_version)
+            .and_where(Expr::col(Alias::new("owner_kind")).eq(owner.kind()))
+            .and_where(Expr::col(Alias::new("owner_key")).eq(owner.key()))
+            .and_where(Expr::col(Alias::new("name")).eq(name))
+            .to_owned(),
+    )
+    .await
+    .unwrap();
 }
 
 async fn load_pair(

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -1,13 +1,5 @@
 //! Shared validation helpers for app-owned identifiers.
 
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Identity document crypto lands before manager and repository consumers."
-    )
-)]
-
 use std::collections::BTreeMap;
 use std::fmt;
 

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -670,6 +670,14 @@ fn resolve_record_for_use(
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<ResolvedIdentitySpec, AppError> {
     let spec = record_to_installed(record)?;
+    resolve_installed_for_use(spec, document, key_provider)
+}
+
+pub(crate) fn resolve_installed_for_use(
+    spec: InstalledIdentitySpec,
+    document: Option<IdentitySpecDocumentRecord>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<ResolvedIdentitySpec, AppError> {
     let material = decrypt_input_material(&spec.key, document, key_provider)?;
     let inputs = resolve_identity_spec_inputs_for_use(&spec.key, &spec.manifest, &material)?;
     Ok(ResolvedIdentitySpec { spec, inputs })

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -18,7 +18,6 @@ pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
 pub(crate) use repositories::identities::IdentityRecord;
-#[cfg_attr(not(test), expect(unused_imports, reason = "Used by B4f."))]
 pub(crate) use repositories::identity_documents::{IdentityDocumentRecord, IdentityDocumentWrite};
 pub(crate) use repositories::identity_specs::{
     IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecRecord,


### PR DESCRIPTION
## Intent

Resolve an owner-scoped identity and its exact installed identity spec from one coherent database snapshot before runtime credential use. Legacy AAD-v1 material, orphaned or changed specs, wrong identity types, missing configured keys, and malformed token material fail closed without exposing plaintext.

## What it enables

- Gives B5 one crate-private `get_for_use` result containing safe identity metadata, resolved exact-spec inputs, fixed-token material, and an opaque complete revision.
- Revalidates workspace generation plus the full identity/document/spec/spec-document snapshot inside a serializable transaction before any lazy KEK rewrap write.
- Atomically persists provider-capable opportunistic rewraps and retries from a fresh snapshot after conflicts or concurrent changes.
- Keeps B4j3 responsible for the deterministic SQLite/Postgres replacement, delete/recreate, spec-mutation, and rewrap race matrix before B5 consumes this path.

The production `LocalFileCredentialKeyProvider` remains single-key. This PR does not add a keyring or claim a deployable KEK rotation/rollback procedure; a stale document fails closed unless the injected provider can resolve both its old key and the active key.

## Usage examples

This is an internal app seam for the next stack child:

```rust
let resolved = identity_manager.get_for_use(&owner, identity_name).await?;
let token = resolved.material().get("TOKEN");
```

No public CLI, gRPC, or configuration surface changes in this PR.

## Validation

- `make rust-checks` — strict Clippy, 1,724/1,724 nextest tests passed (3 skipped), warning-denied rustdoc
- Shared SQLite fixed-token manager contract
- Isolated Postgres identity database contract, plus workspace repository and server-startup equivalents for `make postgres-tests`
- Fresh review swarm: two accepted test gaps fixed; post-fix tests lane has zero findings/questions; four credential flows reviewed safe; supervisor found no additional P1/P2 risk
