### PR TITLE
feat(app): persist safe identity metadata

### DIFF
--- a/crates/coral-app/migrations/0012_identity_safe_metadata.sql
+++ b/crates/coral-app/migrations/0012_identity_safe_metadata.sql
@@ -1,0 +1,2 @@
+ALTER TABLE identities
+    ADD COLUMN safe_metadata_json TEXT NOT NULL DEFAULT '{}';

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -598,7 +598,7 @@ impl IdentityManager {
         let result = async {
             let record = tx
                 .identities()
-                .upsert(owner, name, &selected.reference, now)
+                .upsert(owner, name, &selected.reference, &BTreeMap::new(), now)
                 .await?;
             tx.identity_documents()
                 .upsert(owner, name, document, now)

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -60,10 +60,75 @@ async fn sqlite_fixed_token_manager_contract() {
 }
 
 pub(crate) async fn assert_fixed_token_manager_contract(db: &Arc<CoralDb>) {
+    Box::pin(assert_safe_metadata_keyless_read_contract(db)).await;
     Box::pin(assert_fixed_token_for_use_contract(db)).await;
     Box::pin(assert_fixed_token_for_use_race_contract(db)).await;
     Box::pin(assert_user_global_fixed_token_manager_contract(db)).await;
     Box::pin(assert_workspace_fixed_token_manager_contract(db)).await;
+}
+
+async fn assert_safe_metadata_keyless_read_contract(db: &Arc<CoralDb>) {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let spec_name = format!("keyless_metadata_{suffix}");
+    let identity_name = format!("keyless-metadata-{suffix}");
+    let principal = UserPrincipal::for_user(&format!("keyless-metadata-{suffix}")).unwrap();
+    let owner = IdentityOwner::for_user(principal.clone());
+    let key = CredentialEncryptionKey::from_static_bytes_for_test([60; 32]);
+    put_spec(
+        db,
+        &IdentitySpecKey::global(&spec_name).unwrap(),
+        &fixed_manifest(&spec_name, "keyless"),
+    )
+    .await;
+    let manager = IdentityManager::new(db.clone(), Arc::new(TestKeyProvider(vec![key])));
+    let created = manager
+        .create_or_replace_user_fixed_token(
+            &principal,
+            &identity_name,
+            &spec_name,
+            "secret-token".into(),
+        )
+        .await
+        .expect("create identity with encrypted material");
+    let expected_metadata = BTreeMap::from([
+        ("scope".to_string(), "repo:read user:email".to_string()),
+        ("token_type".to_string(), "Bearer".to_string()),
+    ]);
+    let name = IdentityName::parse(&identity_name).unwrap();
+    let mut tx = db.begin_serializable().await.expect("begin metadata seed");
+    let seeded = tx
+        .identities()
+        .upsert(
+            &owner,
+            &name,
+            &created.spec_reference,
+            &expected_metadata,
+            created.updated_at_unix_nanos + 1,
+        )
+        .await
+        .expect("persist safe metadata");
+    tx.commit().await.expect("commit safe metadata");
+
+    let unavailable = IdentityManager::new(db.clone(), Arc::new(TestKeyProvider(vec![])));
+    let listed = unavailable
+        .list_for_owner(&owner)
+        .await
+        .expect("list safe metadata without a key");
+    assert_eq!(listed, vec![seeded.clone()]);
+    assert_eq!(
+        listed.first().expect("listed identity").safe_metadata,
+        expected_metadata
+    );
+    let loaded = unavailable
+        .get(&owner, &identity_name)
+        .await
+        .expect("get safe metadata without a key");
+    assert_eq!(loaded, seeded);
+    assert_eq!(loaded.safe_metadata, expected_metadata);
+    assert!(matches!(
+        unavailable.get_for_use(&owner, &identity_name).await,
+        Err(AppError::Credentials(CredentialsError::Unavailable(_)))
+    ));
 }
 
 async fn assert_fixed_token_for_use_contract(db: &Arc<CoralDb>) {
@@ -170,7 +235,10 @@ async fn assert_fixed_token_for_use_race_contract(db: &Arc<CoralDb>) {
     let old_key = CredentialEncryptionKey::from_static_bytes_for_test([63; 32]);
     let new_key = CredentialEncryptionKey::from_static_bytes_for_test([64; 32]);
     Box::pin(assert_use_replacement_race(db, &suffix, &old_key, &new_key)).await;
-    assert_use_delete_recreate_race(db, &suffix, &old_key, &new_key).await;
+    Box::pin(assert_use_delete_recreate_race(
+        db, &suffix, &old_key, &new_key,
+    ))
+    .await;
     assert_use_spec_mutation_race(db, &suffix, &old_key, &new_key).await;
     Box::pin(assert_concurrent_rewrap_race(
         db, &suffix, &old_key, &new_key,

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 
 use coral_api::v1::identity_service_server::IdentityService as IdentityServiceApi;
 use coral_api::v1::{
-    CreateUserOwnedIdentityRequest, CreateUserOwnedIdentityResponse,
+    CreateUserOwnedIdentityRequest, CreateUserOwnedIdentityResponse, CredentialMetadata,
     DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse,
     FixedTokenUserOwnedIdentitySetup, GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse,
     Identity as ProtoIdentity, IdentityOwner as ProtoIdentityOwner, ListUserOwnedIdentitiesRequest,
@@ -144,6 +144,7 @@ pub(super) fn identity_to_proto(record: IdentityRecord) -> ProtoIdentity {
         owner,
         name,
         spec_reference,
+        safe_metadata,
         ..
     } = record;
     let (owner, owner_workspace) = match owner {
@@ -163,8 +164,62 @@ pub(super) fn identity_to_proto(record: IdentityRecord) -> ProtoIdentity {
         issuer: spec_reference.issuer().to_string(),
         identity_type: spec_reference.identity_type().to_string(),
         owner: owner as i32,
-        metadata: Vec::new(),
+        metadata: safe_metadata
+            .into_iter()
+            .map(|(key, value)| CredentialMetadata { key, value })
+            .collect(),
         owner_workspace,
         identity_spec_workspace,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use coral_api::v1::CredentialMetadata;
+
+    use super::identity_to_proto;
+    use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+    use crate::identity::UserPrincipal;
+    use crate::state::db::{IdentityRecord, IdentitySpecKey};
+
+    #[test]
+    fn identity_to_proto_exposes_only_ordered_safe_metadata() {
+        let owner = IdentityOwner::for_user(UserPrincipal::local());
+        let spec_reference = IdentitySpecReference::new(
+            &owner,
+            IdentitySpecKey::global("github_oauth").expect("valid identity spec key"),
+            "fingerprint",
+            "github",
+            "oauth2",
+        )
+        .expect("valid identity spec reference");
+        let safe_metadata = BTreeMap::from([
+            ("token_type".to_string(), "Bearer".to_string()),
+            ("scope".to_string(), "repo user".to_string()),
+        ]);
+        let proto = identity_to_proto(IdentityRecord {
+            owner,
+            name: IdentityName::parse("github").expect("valid identity name"),
+            spec_reference,
+            safe_metadata,
+            created_at_unix_nanos: 1,
+            updated_at_unix_nanos: 1,
+        });
+
+        assert_eq!(
+            proto.metadata,
+            vec![
+                CredentialMetadata {
+                    key: "scope".to_string(),
+                    value: "repo user".to_string(),
+                },
+                CredentialMetadata {
+                    key: "token_type".to_string(),
+                    value: "Bearer".to_string(),
+                },
+            ]
+        );
     }
 }

--- a/crates/coral-app/src/identity_specs/lifecycle_tests.rs
+++ b/crates/coral-app/src/identity_specs/lifecycle_tests.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -185,7 +186,7 @@ pub(crate) async fn assert_identity_spec_lifecycle_contract(db: &Arc<CoralDb>) {
     .expect("mixed legacy reference");
     let mut tx = db.begin().await.expect("begin mixed reference write");
     tx.identities()
-        .upsert(&owner, &identity_name, &mixed, 51)
+        .upsert(&owner, &identity_name, &mixed, &BTreeMap::new(), 51)
         .await
         .unwrap();
     tx.commit().await.expect("commit mixed reference write");

--- a/crates/coral-app/src/state/db/migration_order_tests.rs
+++ b/crates/coral-app/src/state/db/migration_order_tests.rs
@@ -5,6 +5,8 @@ use tempfile::tempdir;
 
 use super::{CoralDbBackend, MIGRATOR};
 use crate::bootstrap;
+use crate::identities::model::{IdentityName, IdentityOwner};
+use crate::identity::UserPrincipal;
 use crate::state::db::repositories::identities_contract_tests::assert_identity_repository_contract;
 use crate::state::db::repositories::identities_negative_contract_tests::assert_identity_repository_negative_contract;
 use crate::state::db::repositories::identity_specs_contract_tests::{
@@ -254,6 +256,7 @@ async fn assert_migration_order_contract(db: &CoralDb) {
     assert_eq!(migration_versions(&sparse), vec![1, 10, 11]);
     run_migrator(db, &sparse).await;
     assert_eq!(migration_ledger(db).await, vec![1, 10, 11]);
+    insert_pre_safe_metadata_identity(db).await;
     let mut session = db;
     let identity_specs = session
         .identity_specs()
@@ -266,6 +269,19 @@ async fn assert_migration_order_contract(db: &CoralDb) {
     let expected = migration_versions(&MIGRATOR);
     assert!(expected.iter().any(|version| 1 < *version && *version < 10));
     assert_eq!(migration_ledger(db).await, expected);
+    let owner = IdentityOwner::for_user(UserPrincipal::local());
+    let name = IdentityName::parse("legacy-metadata-backfill").expect("legacy identity name");
+    let legacy = session
+        .identities()
+        .load_optional(&owner, &name)
+        .await
+        .expect("load migrated identity")
+        .expect("migrated identity");
+    assert!(legacy.safe_metadata.is_empty());
+    assert_eq!(
+        (legacy.created_at_unix_nanos, legacy.updated_at_unix_nanos),
+        (41, 42)
+    );
 
     let marker = format!("b1d-order-{}", uuid::Uuid::new_v4().simple());
     let mut tx = db.begin().await.expect("begin state-migration tx");
@@ -291,6 +307,40 @@ async fn assert_migration_order_contract(db: &CoralDb) {
             .await
             .expect("marker survives idempotent migrate")
     );
+
+    let mut tx = db.begin().await.expect("begin legacy cleanup tx");
+    tx.identities()
+        .delete(&owner, &name)
+        .await
+        .expect("delete migrated identity");
+    tx.commit().await.expect("commit legacy cleanup");
+}
+
+async fn insert_pre_safe_metadata_identity(db: &CoralDb) {
+    let sql = "INSERT INTO identities (
+        owner_kind, owner_key, workspace_id, name,
+        identity_spec_scope_kind, identity_spec_scope_id, identity_spec_name,
+        identity_spec_fingerprint, issuer, identity_type,
+        created_at_unix_nanos, updated_at_unix_nanos
+    ) VALUES (
+        'user', 'local', NULL, 'legacy-metadata-backfill',
+        'global', '__global__', 'legacy_spec',
+        'legacy-fingerprint', 'legacy-issuer', 'fixed_token', 41, 42
+    )";
+    match &db.backend {
+        CoralDbBackend::Sqlite(backend) => {
+            sqlx::query(sql)
+                .execute(&backend.pool)
+                .await
+                .expect("seed pre-0012 SQLite identity");
+        }
+        CoralDbBackend::Postgres(backend) => {
+            sqlx::query(sql)
+                .execute(&backend.pool)
+                .await
+                .expect("seed pre-0012 Postgres identity");
+        }
+    }
 }
 
 type IdentityRow<'a> = (&'a str, &'a str, Option<&'a str>, &'a str, &'a str, &'a str);

--- a/crates/coral-app/src/state/db/repositories/identities.rs
+++ b/crates/coral-app/src/state/db/repositories/identities.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use sea_query::{Alias, Expr, ExprTrait, OnConflict, Order, Query};
 
 use crate::bootstrap::AppError;
@@ -13,6 +15,7 @@ pub(crate) struct IdentityRecord {
     pub(crate) owner: IdentityOwner,
     pub(crate) name: IdentityName,
     pub(crate) spec_reference: IdentitySpecReference,
+    pub(crate) safe_metadata: BTreeMap<String, String>,
     pub(crate) created_at_unix_nanos: i64,
     pub(crate) updated_at_unix_nanos: i64,
 }
@@ -29,6 +32,7 @@ struct IdentityRow {
     identity_spec_fingerprint: String,
     issuer: String,
     identity_type: String,
+    safe_metadata_json: String,
     created_at_unix_nanos: i64,
     updated_at_unix_nanos: i64,
 }
@@ -56,10 +60,12 @@ impl IdentityRow {
             self.issuer,
             self.identity_type,
         )?;
+        let safe_metadata = decode_safe_metadata(&self.safe_metadata_json)?;
         Ok(IdentityRecord {
             owner,
             name,
             spec_reference,
+            safe_metadata,
             created_at_unix_nanos: self.created_at_unix_nanos,
             updated_at_unix_nanos: self.updated_at_unix_nanos,
         })
@@ -169,10 +175,12 @@ impl IdentitiesRepo<'_, CoralTx<'_>> {
         owner: &IdentityOwner,
         name: &IdentityName,
         spec_reference: &IdentitySpecReference,
+        safe_metadata: &BTreeMap<String, String>,
         now_unix_nanos: i64,
     ) -> Result<IdentityRecord, AppError> {
         validate_write_timestamp(now_unix_nanos)?;
         spec_reference.validate_for_owner(owner)?;
+        let safe_metadata_json = serde_json::to_string(safe_metadata)?;
         let current_updated_at = Expr::col((Identities::Table, Identities::UpdatedAtUnixNanos));
         let key = spec_reference.key();
         let statement = Query::insert()
@@ -193,6 +201,7 @@ impl IdentitiesRepo<'_, CoralTx<'_>> {
                 Expr::val(spec_reference.fingerprint()),
                 Expr::val(spec_reference.issuer()),
                 Expr::val(spec_reference.identity_type()),
+                Expr::val(safe_metadata_json),
                 Expr::val(now_unix_nanos),
                 Expr::val(now_unix_nanos),
             ])
@@ -209,6 +218,7 @@ impl IdentitiesRepo<'_, CoralTx<'_>> {
                     Identities::IdentitySpecFingerprint,
                     Identities::Issuer,
                     Identities::IdentityType,
+                    Identities::SafeMetadataJson,
                 ])
                 .value(
                     Identities::UpdatedAtUnixNanos,
@@ -260,6 +270,20 @@ fn validate_write_timestamp(now_unix_nanos: i64) -> Result<(), AppError> {
     }
 }
 
+fn decode_safe_metadata(value: &str) -> Result<BTreeMap<String, String>, DbError> {
+    let metadata: BTreeMap<String, String> =
+        serde_json::from_str(value).map_err(|_error| invalid_safe_metadata())?;
+    let canonical = serde_json::to_string(&metadata).map_err(|_error| invalid_safe_metadata())?;
+    if canonical != value {
+        return Err(invalid_safe_metadata());
+    }
+    Ok(metadata)
+}
+
+fn invalid_safe_metadata() -> DbError {
+    DbError::CorruptData("identity row has invalid safe metadata JSON".to_string())
+}
+
 fn zero_or_one_affected(rows_affected: u64, operation: &str) -> Result<bool, DbError> {
     match rows_affected {
         0 => Ok(false),
@@ -277,7 +301,7 @@ fn identity_select() -> sea_query::SelectStatement {
         .to_owned()
 }
 
-fn identity_columns() -> [Identities; 12] {
+fn identity_columns() -> [Identities; 13] {
     [
         Identities::OwnerKind,
         Identities::OwnerKey,
@@ -289,6 +313,7 @@ fn identity_columns() -> [Identities; 12] {
         Identities::IdentitySpecFingerprint,
         Identities::Issuer,
         Identities::IdentityType,
+        Identities::SafeMetadataJson,
         Identities::CreatedAtUnixNanos,
         Identities::UpdatedAtUnixNanos,
     ]
@@ -313,6 +338,8 @@ fn identity_spec_where(key: &IdentitySpecKey) -> sea_query::SimpleExpr {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use tempfile::tempdir;
 
     use super::IdentityRow;
@@ -337,6 +364,7 @@ mod tests {
             identity_spec_fingerprint: "fingerprint".to_string(),
             issuer: "issuer".to_string(),
             identity_type: "fixed_token".to_string(),
+            safe_metadata_json: "{}".to_string(),
             created_at_unix_nanos: 1,
             updated_at_unix_nanos: 1,
         };
@@ -400,7 +428,7 @@ mod tests {
             (&workspace_owner, &charlie, &workspace_local, 13),
         ] {
             tx.identities()
-                .upsert(owner, name, spec, now)
+                .upsert(owner, name, spec, &BTreeMap::new(), now)
                 .await
                 .expect("upsert identity");
         }
@@ -425,7 +453,7 @@ mod tests {
         let mut tx = db.begin().await.expect("begin replacement tx");
         let replaced = tx
             .identities()
-            .upsert(&user, &alpha, &replacement, 20)
+            .upsert(&user, &alpha, &replacement, &BTreeMap::new(), 20)
             .await
             .expect("replace all mutable fields");
         assert_eq!(
@@ -438,7 +466,7 @@ mod tests {
         assert_eq!(replaced.spec_reference, replacement);
         let regressed = tx
             .identities()
-            .upsert(&user, &alpha, &replacement, 5)
+            .upsert(&user, &alpha, &replacement, &BTreeMap::new(), 5)
             .await
             .expect("preserve update time under regressed clock");
         assert_eq!(regressed.updated_at_unix_nanos, 20);
@@ -455,13 +483,13 @@ mod tests {
         assert!(deleted && !missing);
         let wrong_owner = tx
             .identities()
-            .upsert(&other_owner, &alpha, &workspace_local, 20)
+            .upsert(&other_owner, &alpha, &workspace_local, &BTreeMap::new(), 20)
             .await
             .expect_err("cross-workspace reference must fail");
         assert!(matches!(wrong_owner, AppError::InvalidInput(_)));
         let negative_time = tx
             .identities()
-            .upsert(&user, &alpha, &user_f2, -1)
+            .upsert(&user, &alpha, &user_f2, &BTreeMap::new(), -1)
             .await
             .expect_err("negative timestamp must fail");
         assert!(matches!(negative_time, AppError::InvalidInput(_)));

--- a/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use tempfile::tempdir;
 
 use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
@@ -71,10 +73,30 @@ pub(in crate::state::db) async fn assert_identity_repository_contract(db: &Coral
         .upsert(&replacement_key, &spec("replacement"), 4)
         .await
         .expect("seed replacement spec");
-    let user_row = seed_identity(&mut tx, &user, &shared_name, &user_ref, 10).await;
-    let mut workspace_row =
-        seed_identity(&mut tx, &workspace_owner, &shared_name, &workspace_ref, 11).await;
-    let other_row = seed_identity(&mut tx, &other_owner, &shared_name, &other_ref, 12).await;
+    let user_metadata = metadata([("scope", "user"), ("token_type", "Bearer")]);
+    let workspace_metadata = metadata([("scope", "workspace"), ("token_type", "Bearer")]);
+    let other_metadata = metadata([("scope", "other"), ("token_type", "DPoP")]);
+    let mut user_row =
+        seed_identity_with_metadata(&mut tx, &user, &shared_name, &user_ref, &user_metadata, 10)
+            .await;
+    let mut workspace_row = seed_identity_with_metadata(
+        &mut tx,
+        &workspace_owner,
+        &shared_name,
+        &workspace_ref,
+        &workspace_metadata,
+        11,
+    )
+    .await;
+    let other_row = seed_identity_with_metadata(
+        &mut tx,
+        &other_owner,
+        &shared_name,
+        &other_ref,
+        &other_metadata,
+        12,
+    )
+    .await;
     let fallback_row =
         seed_identity(&mut tx, &workspace_owner, &fallback_name, &fallback_ref, 13).await;
     let user_document = seed_document(&mut tx, &user, &shared_name, "user", 20).await;
@@ -112,10 +134,12 @@ pub(in crate::state::db) async fn assert_identity_repository_contract(db: &Coral
     assert_counts(db, &workspace_key, [("f1", 1)], 1).await;
     assert_counts(db, &replacement_key, [("f3", 0)], 0).await;
 
+    let replacement_metadata = metadata([("token_type", "DPoP")]);
     let expected_replaced_identity = IdentityRecord {
         owner: workspace_owner.clone(),
         name: shared_name.clone(),
         spec_reference: replacement_identity_ref.clone(),
+        safe_metadata: replacement_metadata.clone(),
         created_at_unix_nanos: 11,
         updated_at_unix_nanos: 30,
     };
@@ -126,6 +150,7 @@ pub(in crate::state::db) async fn assert_identity_repository_contract(db: &Coral
             &workspace_owner,
             &shared_name,
             &replacement_identity_ref,
+            &replacement_metadata,
             30,
         )
         .await
@@ -133,7 +158,13 @@ pub(in crate::state::db) async fn assert_identity_repository_contract(db: &Coral
     assert_eq!(replaced_identity, expected_replaced_identity);
     let regressed_identity = tx
         .identities()
-        .upsert(&workspace_owner, &shared_name, &replacement_identity_ref, 5)
+        .upsert(
+            &workspace_owner,
+            &shared_name,
+            &replacement_identity_ref,
+            &replacement_metadata,
+            5,
+        )
         .await
         .expect("replace identity under regressed clock");
     assert_eq!(regressed_identity, expected_replaced_identity);
@@ -159,13 +190,20 @@ pub(in crate::state::db) async fn assert_identity_repository_contract(db: &Coral
     let mut tx = db.begin().await.expect("begin identity restore tx");
     let restored_identity = tx
         .identities()
-        .upsert(&workspace_owner, &shared_name, &workspace_ref, 31)
+        .upsert(
+            &workspace_owner,
+            &shared_name,
+            &workspace_ref,
+            &BTreeMap::new(),
+            31,
+        )
         .await
         .expect("restore workspace identity reference");
     workspace_row = IdentityRecord {
         owner: workspace_owner.clone(),
         name: shared_name.clone(),
         spec_reference: workspace_ref.clone(),
+        safe_metadata: BTreeMap::new(),
         created_at_unix_nanos: 11,
         updated_at_unix_nanos: 31,
     };
@@ -177,7 +215,16 @@ pub(in crate::state::db) async fn assert_identity_repository_contract(db: &Coral
     assert_counts(db, &replacement_key, [("f3", 0)], 0).await;
 
     let replacement_write = document("user-replacement");
+    let updated_user_metadata = metadata([
+        ("access_token_expires_at", "2030-01-02T03:04:05Z"),
+        ("token_type", "Bearer"),
+    ]);
     let mut tx = db.begin().await.expect("begin replacement tx");
+    user_row = tx
+        .identities()
+        .upsert(&user, &shared_name, &user_ref, &updated_user_metadata, 30)
+        .await
+        .expect("replace user safe metadata");
     let replaced = tx
         .identity_documents()
         .upsert(&user, &shared_name, &replacement_write, 30)
@@ -193,6 +240,7 @@ pub(in crate::state::db) async fn assert_identity_repository_contract(db: &Coral
         .await
         .expect("replace under regressed clock");
     tx.commit().await.expect("commit replacement tx");
+    assert_identity(db, &user, &shared_name, &user_row).await;
     assert_eq!(
         replacement,
         expected_document(&user, &shared_name, "user-replacement", 3, 20, 30)
@@ -324,9 +372,20 @@ pub(super) async fn seed_identity(
     reference: &IdentitySpecReference,
     now: i64,
 ) -> IdentityRecord {
+    seed_identity_with_metadata(tx, owner, name, reference, &BTreeMap::new(), now).await
+}
+
+pub(super) async fn seed_identity_with_metadata(
+    tx: &mut CoralTx<'_>,
+    owner: &IdentityOwner,
+    name: &IdentityName,
+    reference: &IdentitySpecReference,
+    safe_metadata: &BTreeMap<String, String>,
+    now: i64,
+) -> IdentityRecord {
     let record = tx
         .identities()
-        .upsert(owner, name, reference, now)
+        .upsert(owner, name, reference, safe_metadata, now)
         .await
         .expect("seed identity");
     assert_eq!(
@@ -335,11 +394,19 @@ pub(super) async fn seed_identity(
             owner: owner.clone(),
             name: name.clone(),
             spec_reference: reference.clone(),
+            safe_metadata: safe_metadata.clone(),
             created_at_unix_nanos: now,
             updated_at_unix_nanos: now,
         }
     );
     record
+}
+
+pub(super) fn metadata<const N: usize>(entries: [(&str, &str); N]) -> BTreeMap<String, String> {
+    entries
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect()
 }
 
 pub(super) async fn seed_document(

--- a/crates/coral-app/src/state/db/repositories/identities_negative_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identities_negative_contract_tests.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use sea_query::{Expr, ExprTrait, Query, SimpleExpr, UpdateStatement};
@@ -5,7 +6,8 @@ use tempfile::tempdir;
 
 use super::identities_contract_tests::{
     assert_document, assert_identity, assert_identity_absent, document, expected_document,
-    identity_name, parsed_workspace, reference, seed_document, seed_identity,
+    identity_name, metadata, parsed_workspace, reference, seed_document, seed_identity,
+    seed_identity_with_metadata,
 };
 use crate::bootstrap::AppError;
 use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
@@ -27,6 +29,7 @@ async fn identity_repository_negative_contract_holds_against_sqlite() {
     assert_identity_repository_negative_contract(&db).await;
 }
 
+#[expect(clippy::too_many_lines, reason = "Shared backend contract fixture.")]
 pub(in crate::state::db) async fn assert_identity_repository_negative_contract(db: &CoralDb) {
     let suffix = uuid::Uuid::new_v4().simple().to_string();
     let workspace = parsed_workspace(&format!("negative{suffix}"));
@@ -43,10 +46,25 @@ pub(in crate::state::db) async fn assert_identity_repository_negative_contract(d
         .ensure(workspace.as_str(), 1)
         .await
         .expect("ensure workspace");
-    let original_identity =
-        seed_identity(&mut tx, &owner, &corrupt_name, &spec_reference, 10).await;
+    let original_identity = seed_identity_with_metadata(
+        &mut tx,
+        &owner,
+        &corrupt_name,
+        &spec_reference,
+        &metadata([("scope", "original"), ("token_type", "Bearer")]),
+        10,
+    )
+    .await;
     seed_identity(&mut tx, &owner, &constraint_name, &spec_reference, 11).await;
-    seed_identity(&mut tx, &owner, &material_name, &spec_reference, 12).await;
+    let original_material_identity = seed_identity_with_metadata(
+        &mut tx,
+        &owner,
+        &material_name,
+        &spec_reference,
+        &metadata([("scope", "material")]),
+        12,
+    )
+    .await;
     let original_document = seed_document(&mut tx, &owner, &material_name, "material", 12).await;
     tx.commit().await.expect("commit seed tx");
 
@@ -101,13 +119,30 @@ pub(in crate::state::db) async fn assert_identity_repository_negative_contract(d
         zero_i64(),
     )
     .await;
+    for value in [
+        "",
+        "[]",
+        "null",
+        r#"{"scope":1}"#,
+        r#"{"scope":"secret\u002dsentinel"}"#,
+        r#"{"token_type":"Bearer", "scope":"secret-sentinel"}"#,
+        r#"{"scope":"secret-sentinel","scope":"secret-sentinel"}"#,
+    ] {
+        assert_corrupt_safe_metadata(db, &owner, &corrupt_name, value).await;
+    }
     assert_identity(db, &owner, &corrupt_name, &original_identity).await;
 
     assert_document_corruption_matrix(db, &owner, &material_name).await;
     assert_document(db, &owner, &material_name, Some(&original_document)).await;
     assert_constraint_violations(db, &suffix, &owner, &constraint_name, &material_name).await;
-    assert_max_version_is_typed_and_nonmutating(db, &owner, &material_name, &original_document)
-        .await;
+    assert_max_version_is_typed_and_nonmutating(
+        db,
+        &owner,
+        &material_name,
+        &original_material_identity,
+        &original_document,
+    )
+    .await;
     let concurrent_name = identity_name(&format!("concurrent{suffix}"));
     assert_concurrent_document_versions(db, &owner, &concurrent_name, &spec_reference).await;
 
@@ -134,7 +169,13 @@ async fn assert_foreign_keys_and_rollback(
     let mut tx = db.begin().await.expect("begin missing workspace tx");
     assert!(matches!(
         tx.identities()
-            .upsert(&missing_owner, &missing_name, &missing_reference, 20)
+            .upsert(
+                &missing_owner,
+                &missing_name,
+                &missing_reference,
+                &BTreeMap::new(),
+                20,
+            )
             .await,
         Err(AppError::Database(_))
     ));
@@ -277,6 +318,38 @@ async fn assert_corrupt_identity_name(
     tx.rollback().await.expect("restore identity name");
 }
 
+async fn assert_corrupt_safe_metadata(
+    db: &CoralDb,
+    owner: &IdentityOwner,
+    name: &IdentityName,
+    value: &str,
+) {
+    let mut tx = db.begin().await.expect("begin corrupt metadata tx");
+    tx.execute(
+        Query::update()
+            .table(Identities::Table)
+            .value(Identities::SafeMetadataJson, value)
+            .and_where(identity_where(owner, name))
+            .to_owned(),
+    )
+    .await
+    .expect("corrupt safe metadata");
+    for error in [
+        tx.identities()
+            .load_optional(owner, name)
+            .await
+            .expect_err("point read must reject corrupt safe metadata"),
+        tx.identities()
+            .list_for_owner(owner)
+            .await
+            .expect_err("list must reject corrupt safe metadata"),
+    ] {
+        assert!(matches!(&error, DbError::CorruptData(_)));
+        assert!(!error.to_string().contains("secret-sentinel"));
+    }
+    tx.rollback().await.expect("restore safe metadata");
+}
+
 async fn assert_corrupt_document(
     db: &CoralDb,
     owner: &IdentityOwner,
@@ -322,6 +395,16 @@ async fn assert_constraint_violations(
         db,
         Query::update()
             .table(Identities::Table)
+            .value(Identities::SafeMetadataJson, Option::<String>::None)
+            .and_where(identity_where(owner, constraint_name))
+            .to_owned(),
+        Violation::NotNull,
+    )
+    .await;
+    assert_violation(
+        db,
+        Query::update()
+            .table(Identities::Table)
             .value(Identities::IdentitySpecScopeId, format!("other{suffix}"))
             .and_where(identity_where(owner, constraint_name))
             .to_owned(),
@@ -357,7 +440,8 @@ async fn assert_max_version_is_typed_and_nonmutating(
     db: &CoralDb,
     owner: &IdentityOwner,
     name: &IdentityName,
-    original: &IdentityDocumentRecord,
+    original_identity: &crate::state::db::IdentityRecord,
+    original_document: &IdentityDocumentRecord,
 ) {
     let mut tx = db.begin().await.expect("begin max-version tx");
     tx.execute(
@@ -375,6 +459,19 @@ async fn assert_max_version_is_typed_and_nonmutating(
         .await
         .expect("load max-version document")
         .expect("max-version document");
+    let changed_metadata = metadata([("scope", "must-roll-back")]);
+    let changed_identity = tx
+        .identities()
+        .upsert(
+            owner,
+            name,
+            &original_identity.spec_reference,
+            &changed_metadata,
+            70,
+        )
+        .await
+        .expect("stage changed safe metadata");
+    assert_eq!(changed_identity.safe_metadata, changed_metadata);
     let error = tx
         .identity_documents()
         .upsert(owner, name, &document("overflow"), 70)
@@ -389,12 +486,14 @@ async fn assert_max_version_is_typed_and_nonmutating(
         .expect("max-version document remains");
     assert_eq!(after, before);
     tx.rollback().await.expect("rollback max version");
-    assert_document(db, owner, name, Some(original)).await;
+    assert_identity(db, owner, name, original_identity).await;
+    assert_document(db, owner, name, Some(original_document)).await;
 }
 
 enum Violation {
     Check,
     ForeignKey,
+    NotNull,
 }
 
 async fn assert_violation(db: &CoralDb, statement: UpdateStatement, expected: Violation) {
@@ -410,6 +509,7 @@ async fn assert_violation(db: &CoralDb, statement: UpdateStatement, expected: Vi
     assert!(match expected {
         Violation::Check => database.is_check_violation(),
         Violation::ForeignKey => database.is_foreign_key_violation(),
+        Violation::NotNull => database.kind() == sqlx::error::ErrorKind::NotNullViolation,
     });
     tx.rollback().await.expect("rollback failed Postgres tx");
 }

--- a/crates/coral-app/src/state/db/repositories/identity_documents.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_documents.rs
@@ -328,6 +328,8 @@ fn identity_document_key_where(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use tempfile::tempdir;
 
     use super::IdentityDocumentRow;
@@ -385,7 +387,7 @@ mod tests {
             .await
             .expect("seed workspace");
         tx.identities()
-            .upsert(&owner, &name, &reference, 2)
+            .upsert(&owner, &name, &reference, &BTreeMap::new(), 2)
             .await
             .expect("seed identity");
         assert!(

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -61,6 +61,7 @@ pub(in crate::state::db) enum Identities {
     IdentitySpecFingerprint,
     Issuer,
     IdentityType,
+    SafeMetadataJson,
     CreatedAtUnixNanos,
     UpdatedAtUnixNanos,
 }

--- a/crates/coral-app/tests/grpc/identity_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_tests.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use coral_api::v1::{
     AddIdentitySpecRequest, CreateUserOwnedIdentityRequest, CreateWorkspaceOwnedIdentityRequest,
-    CreateWorkspaceRequest, DeleteIdentitySpecRequest, DeleteUserOwnedIdentityRequest,
-    DeleteWorkspaceOwnedIdentityRequest, FixedTokenUserOwnedIdentitySetup,
-    FixedTokenWorkspaceOwnedIdentitySetup, GetUserOwnedIdentityRequest,
-    GetWorkspaceOwnedIdentityRequest, Identity, IdentityOwner, ListUserOwnedIdentitiesRequest,
-    ListWorkspaceOwnedIdentitiesRequest, Workspace, create_user_owned_identity_request,
-    create_user_owned_identity_response, create_workspace_owned_identity_request,
-    create_workspace_owned_identity_response,
+    CreateWorkspaceRequest, CredentialMetadata, DeleteIdentitySpecRequest,
+    DeleteUserOwnedIdentityRequest, DeleteWorkspaceOwnedIdentityRequest,
+    FixedTokenUserOwnedIdentitySetup, FixedTokenWorkspaceOwnedIdentitySetup,
+    GetUserOwnedIdentityRequest, GetWorkspaceOwnedIdentityRequest, Identity, IdentityOwner,
+    ListUserOwnedIdentitiesRequest, ListWorkspaceOwnedIdentitiesRequest, Workspace,
+    create_user_owned_identity_request, create_user_owned_identity_response,
+    create_workspace_owned_identity_request, create_workspace_owned_identity_response,
 };
 use coral_api::{
     CORAL_ERROR_REASON_IDENTITY_NOT_FOUND, CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND,
@@ -59,7 +59,7 @@ async fn user_identity_service_is_scoped_validated_and_restart_safe() {
     add_spec(&app, "oauth_spec", "oauth", "oauth").await;
     assert_create_validation(&app).await;
 
-    let alice = create(&app, "alice", "shared", "alice_spec", "alice-token").await;
+    let mut alice = create(&app, "alice", "shared", "alice_spec", "alice-token").await;
     let bob = create(&app, "bob", "shared", "bob_spec", "bob-token").await;
     assert_identity(&alice, "alice_spec", "alice");
     assert_identity(&bob, "bob_spec", "bob");
@@ -82,8 +82,32 @@ async fn user_identity_service_is_scoped_validated_and_restart_safe() {
     assert_eq!(orphaned.orphaned_identities, 1);
     server.shutdown().await.expect("shutdown first server");
 
+    persist_safe_metadata(&config_dir, "alice", "shared").await;
+    let encryption_key = config_dir.join("credentials").join("encryption.key");
+    std::fs::rename(
+        &encryption_key,
+        config_dir
+            .join("credentials")
+            .join("encryption.key.unavailable"),
+    )
+    .expect("make original identity encryption key unavailable");
+    alice.metadata = vec![
+        CredentialMetadata {
+            key: "scope".to_string(),
+            value: "repo user".to_string(),
+        },
+        CredentialMetadata {
+            key: "token_type".to_string(),
+            value: "Bearer".to_string(),
+        },
+    ];
+
     let (server, restarted) = start(&config_dir).await;
-    assert_eq!(get(&restarted, "alice", "shared").await, alice);
+    let listed = list(&restarted, "alice").await;
+    let loaded = get(&restarted, "alice", "shared").await;
+    assert_eq!(listed, vec![alice.clone()]);
+    assert_eq!(loaded, alice);
+    assert!(!format!("{listed:?}{loaded:?}").contains("alice-token"));
     assert_eq!(get(&restarted, "bob", "shared").await, bob);
     restarted
         .identity_client()
@@ -322,6 +346,25 @@ async fn start(config_dir: &std::path::Path) -> (coral_app::RunningServer, AppCl
         .await
         .expect("connect client");
     (server, app)
+}
+
+async fn persist_safe_metadata(config_dir: &std::path::Path, owner_key: &str, name: &str) {
+    let options = sqlx::sqlite::SqliteConnectOptions::new().filename(config_dir.join("coral.db"));
+    let pool = sqlx::SqlitePool::connect_with(options)
+        .await
+        .expect("open identity database for metadata fixture");
+    let result = sqlx::query(
+        "UPDATE identities SET safe_metadata_json = ?
+         WHERE owner_kind = 'user' AND owner_key = ? AND name = ?",
+    )
+    .bind(r#"{"scope":"repo user","token_type":"Bearer"}"#)
+    .bind(owner_key)
+    .bind(name)
+    .execute(&pool)
+    .await
+    .expect("persist canonical safe metadata fixture");
+    assert_eq!(result.rows_affected(), 1);
+    pool.close().await;
 }
 
 async fn add_spec(app: &AppClient, name: &str, issuer: &str, kind: &str) {


### PR DESCRIPTION
## Intent

Persist safe, non-secret identity metadata as canonical data on the identity row so List/Get responses remain available without decrypting credential material and survive server restarts.

## What it enables

- Later OAuth creation and refresh units can atomically commit provider-safe metadata alongside encrypted identity material.
- User- and workspace-owned List/Get responses expose deterministic metadata even when the credential key is unavailable.
- Corrupt or noncanonical metadata fails closed without echoing persisted contents.
- Encrypted identity documents remain the only identity-instance storage for access tokens, refresh tokens, client secrets, and other secret material.

## Usage examples

An OAuth identity can later expose safe fields such as:

```text
metadata:
  scope: repo user:email
  token_type: Bearer
```

Fixed-token identity writes explicitly store an empty metadata map. This PR does not enable OAuth identity creation; that remains in the next B5 units.

## Implementation

- Add migration `0012_identity_safe_metadata.sql` with a canonical empty-map backfill.
- Encode and strictly validate sorted compact string-to-string JSON.
- Replace the whole metadata map atomically with the identity row and encrypted document.
- Project persisted metadata deterministically into `CredentialMetadata`.
- Cover corruption, rollback, migration, owner isolation, keyless reads, and restart behavior on SQLite and Postgres.

## Stack

- Parent: #1705
- This PR remains draft with the rest of the identity-v3 mission.

## Validation

- `cargo test --locked -p coral-app --all-features identity_repository`
- `cargo test --locked -p coral-app --all-features migration_order_tests`
- focused manager, proto, and restart gRPC contracts
- `make postgres-tests`
- `make rust-checks` — 1,734 passed, 3 skipped
- `make perf-check` — 210.1 ms mean against the 750 ms threshold
- exact-final five-lane review: zero findings/questions, four safe credential flows, 0.99 supervisor closure

