### PR TITLE
feat(app): create OAuth identities transactionally

### DIFF
--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -100,6 +100,29 @@ pub(crate) struct OAuthCredentialMaterial {
     pub(crate) safe_metadata: BTreeMap<String, String>,
 }
 
+impl OAuthCredentialMaterial {
+    pub(crate) fn discard_spec_derived_refresh_context(&mut self) {
+        let prefix = oauth_metadata_prefix(&self.input_key);
+        let dynamic_client_registration = OAuthMetadataKey::DynamicClientRegistration
+            .get(&prefix, &self.internal_metadata)
+            == Some("true");
+
+        for key in [OAuthMetadataKey::TokenUrl, OAuthMetadataKey::Resource] {
+            key.remove(&prefix, &mut self.internal_metadata);
+        }
+        if !dynamic_client_registration {
+            for key in [
+                OAuthMetadataKey::ClientId,
+                OAuthMetadataKey::ClientSecretTransport,
+                OAuthMetadataKey::ClientSecret,
+                OAuthMetadataKey::DynamicClientRegistration,
+            ] {
+                key.remove(&prefix, &mut self.internal_metadata);
+            }
+        }
+    }
+}
+
 struct OAuthSessionCommon {
     input_key: String,
     endpoints: ValidatedOAuthEndpoints,
@@ -1571,7 +1594,7 @@ async fn poll_device_token(
                 }
                 "expired_token" => {
                     return Err(AppError::FailedPrecondition(
-                        "OAuth device code expired; rerun `coral source add`".to_string(),
+                        "OAuth device code expired; start a new credential retrieval".to_string(),
                     ));
                 }
                 "access_denied" => {
@@ -1599,7 +1622,7 @@ async fn poll_device_token(
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             return Err(AppError::FailedPrecondition(
-                "OAuth device code expired; rerun `coral source add`".to_string(),
+                "OAuth device code expired; start a new credential retrieval".to_string(),
             ));
         }
         tokio::time::sleep(interval.min(remaining)).await;
@@ -2127,6 +2150,54 @@ mod tests {
 
     fn metadata_key(input_key: &str, key: OAuthMetadataKey) -> String {
         key.key(&oauth_metadata_prefix(input_key))
+    }
+
+    #[test]
+    fn identity_context_pruning_respects_spec_ownership() {
+        use OAuthMetadataKey as Key;
+        let key = |kind| metadata_key("ACCESS_TOKEN", kind);
+        let dcr = key(Key::DynamicClientRegistration);
+        let retained = [
+            Key::Method,
+            Key::AccessTokenExpiresAt,
+            Key::RefreshToken,
+            Key::TokenType,
+        ];
+        let spec_owned = [
+            Key::TokenUrl,
+            Key::Resource,
+            Key::ClientId,
+            Key::ClientSecretTransport,
+            Key::ClientSecret,
+        ];
+        let internal_metadata = retained
+            .into_iter()
+            .chain(spec_owned)
+            .map(|kind| (key(kind), kind.suffix().to_string()))
+            .chain([(dcr.clone(), "true".to_string())])
+            .collect();
+        let mut material = super::OAuthCredentialMaterial {
+            input_key: "ACCESS_TOKEN".to_string(),
+            access_token: "access-token".to_string(),
+            internal_metadata,
+            safe_metadata: BTreeMap::new(),
+        };
+        let mut static_material = material.clone();
+        static_material
+            .internal_metadata
+            .insert(dcr.clone(), "false".into());
+        let mut expected_dcr = material.internal_metadata.clone();
+        for kind in [Key::TokenUrl, Key::Resource] {
+            expected_dcr.remove(&key(kind));
+        }
+        let expected_static: BTreeMap<_, _> = retained
+            .into_iter()
+            .map(|kind| (key(kind), kind.suffix().to_string()))
+            .collect();
+        material.discard_spec_derived_refresh_context();
+        static_material.discard_spec_derived_refresh_context();
+        assert_eq!(material.internal_metadata, expected_dcr);
+        assert_eq!(static_material.internal_metadata, expected_static);
     }
 
     fn assert_public_dcr_metadata(metadata: &BTreeMap<String, String>, input_key: &str) {

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -5,6 +5,8 @@
     expect(dead_code, reason = "Identity use consumers land in B5.")
 )]
 
+mod oauth_create;
+
 use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
@@ -15,6 +17,7 @@ use coral_spec::IdentitySpecType;
 
 use crate::bootstrap::AppError;
 use crate::credentials::encryption::{CredentialKeyProvider, EncryptedEnvelopeDocument};
+use crate::credentials::oauth::{OAuthAuthorization, OAuthCredentialService};
 use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
 use crate::identity::{
     IdentityDocumentBinding, UserPrincipal, decrypt_identity_document, encrypt_identity_document,
@@ -35,6 +38,12 @@ use crate::workspaces::WorkspaceName;
 
 const FIXED_TOKEN_KEY: &str = "TOKEN";
 const MAX_MUTATION_ATTEMPTS: usize = 8;
+
+/// App-private progress emitted before an OAuth identity becomes durable.
+pub(crate) enum IdentityOAuthCreationEvent {
+    Authorization(OAuthAuthorization),
+    Completed(BTreeMap<String, String>),
+}
 
 /// Coherent decrypted identity data prepared for one runtime use.
 pub(crate) struct ResolvedIdentityForUse {
@@ -98,6 +107,7 @@ impl PreparedIdentityForUse {
 pub(crate) struct IdentityManager {
     db: Arc<CoralDb>,
     key_provider: Arc<dyn CredentialKeyProvider>,
+    oauth: OAuthCredentialService,
     #[cfg(test)]
     before_write_gate: Option<BeforeWriteGate>,
     #[cfg(test)]
@@ -145,6 +155,7 @@ impl IdentityManager {
         Self {
             db,
             key_provider,
+            oauth: OAuthCredentialService::new(),
             #[cfg(test)]
             before_write_gate: None,
             #[cfg(test)]

--- a/crates/coral-app/src/identities/manager/oauth_create.rs
+++ b/crates/coral-app/src/identities/manager/oauth_create.rs
@@ -1,0 +1,337 @@
+//! DB-backed OAuth identity creation.
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::sync::Arc;
+
+use coral_spec::{IdentitySpecConfig, IdentitySpecType, ManifestOAuthCredentialSpec};
+
+use crate::bootstrap::AppError;
+use crate::credentials::encryption::CredentialKeyProvider;
+use crate::credentials::oauth::{
+    OAuthCredentialMaterial, OAuthCredentialService, StartOAuthCredentialRequest,
+};
+use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+use crate::identity::{UserPrincipal, encrypt_identity_document, run_key_operation};
+use crate::identity_specs::identity_spec_fingerprint;
+use crate::identity_specs::manager::{
+    record_to_installed, resolve_installed_for_use, spec_not_found,
+};
+use crate::state::db::{
+    CoralTx, DbRepos, IdentityDocumentRecord, IdentityDocumentWrite, IdentityRecord,
+    IdentitySpecDocumentRecord, IdentitySpecKey, IdentitySpecRecord, now_unix_nanos_i64,
+};
+use crate::workspaces::WorkspaceName;
+
+use super::{
+    IdentityManager, IdentityOAuthCreationEvent, MAX_MUTATION_ATTEMPTS, identity_document_binding,
+    identity_document_write, owner_workspace_created_at, owner_workspace_not_found,
+};
+
+const OAUTH_ACCESS_TOKEN_KEY: &str = "ACCESS_TOKEN";
+
+#[derive(Clone, PartialEq, Eq)]
+struct OAuthCreateSnapshot {
+    workspace_created_at_unix_nanos: Option<i64>,
+    identity: Option<IdentityRecord>,
+    identity_document: Option<IdentityDocumentRecord>,
+    identity_spec: Option<IdentitySpecRecord>,
+    identity_spec_document: Option<IdentitySpecDocumentRecord>,
+}
+
+struct SelectedOAuthSpec {
+    requested_key: IdentitySpecKey,
+    snapshot: OAuthCreateSnapshot,
+    reference: IdentitySpecReference,
+    oauth: ManifestOAuthCredentialSpec,
+    source_inputs: BTreeMap<String, String>,
+    credential_inputs: Vec<(String, String)>,
+}
+
+impl IdentityManager {
+    /// Authorize and atomically create or replace one user-owned OAuth identity.
+    pub(crate) async fn create_or_replace_user_oauth<E, EventFut>(
+        &self,
+        principal: &UserPrincipal,
+        identity_name: &str,
+        identity_spec_name: &str,
+        events: E,
+    ) -> Result<IdentityRecord, AppError>
+    where
+        E: Fn(IdentityOAuthCreationEvent) -> EventFut + Clone + Send + Sync,
+        EventFut: Future<Output = Result<(), AppError>> + Send,
+    {
+        let owner = IdentityOwner::for_user(principal.clone());
+        let name = IdentityName::parse(identity_name)?;
+        let requested_key = IdentitySpecKey::global(identity_spec_name)?;
+        self.create_or_replace_oauth(owner, name, requested_key, events)
+            .await
+    }
+
+    /// Authorize and atomically create or replace one workspace-owned OAuth identity.
+    #[expect(dead_code, reason = "mounted by the follow-up service-surface PR")]
+    pub(crate) async fn create_or_replace_workspace_oauth<E, EventFut>(
+        &self,
+        workspace: &WorkspaceName,
+        identity_name: &str,
+        identity_spec_name: &str,
+        events: E,
+    ) -> Result<IdentityRecord, AppError>
+    where
+        E: Fn(IdentityOAuthCreationEvent) -> EventFut + Clone + Send + Sync,
+        EventFut: Future<Output = Result<(), AppError>> + Send,
+    {
+        let owner = IdentityOwner::workspace(workspace.clone());
+        let name = IdentityName::parse(identity_name)?;
+        let requested_key = IdentitySpecKey::workspace(workspace.clone(), identity_spec_name)?;
+        self.create_or_replace_oauth(owner, name, requested_key, events)
+            .await
+    }
+
+    async fn create_or_replace_oauth<E, EventFut>(
+        &self,
+        owner: IdentityOwner,
+        name: IdentityName,
+        requested_key: IdentitySpecKey,
+        events: E,
+    ) -> Result<IdentityRecord, AppError>
+    where
+        E: Fn(IdentityOAuthCreationEvent) -> EventFut + Clone + Send + Sync,
+        EventFut: Future<Output = Result<(), AppError>> + Send,
+    {
+        let selected = self.select_oauth_spec(&owner, &name, requested_key).await?;
+        let authorization_events = events.clone();
+        let mut material = self
+            .oauth
+            .authorize_with_callback(
+                StartOAuthCredentialRequest {
+                    input_key: OAUTH_ACCESS_TOKEN_KEY,
+                    oauth: &selected.oauth,
+                    source_inputs: &selected.source_inputs,
+                    credential_inputs: selected.credential_inputs.clone(),
+                },
+                move |authorization| {
+                    authorization_events(IdentityOAuthCreationEvent::Authorization(authorization))
+                },
+                || async { Ok(()) },
+            )
+            .await?;
+
+        material.discard_spec_derived_refresh_context();
+        let (safe_metadata, values) = oauth_identity_values(material);
+        let document_owner = owner.clone();
+        let document_name = name.clone();
+        let document_reference = selected.reference.clone();
+        let key_provider = Arc::clone(&self.key_provider);
+        let document = run_key_operation(move || {
+            prepare_oauth_document(
+                &document_owner,
+                &document_name,
+                &document_reference,
+                &values,
+                key_provider.as_ref(),
+            )
+        })
+        .await?;
+
+        events(IdentityOAuthCreationEvent::Completed(safe_metadata.clone())).await?;
+
+        for _ in 0..MAX_MUTATION_ATTEMPTS {
+            match self
+                .try_commit_oauth(&owner, &name, &selected, &document, &safe_metadata)
+                .await
+            {
+                Ok(Some(record)) => return Ok(record),
+                Ok(None) => return Err(AppError::RetryableTransactionConflict),
+                Err(AppError::RetryableTransactionConflict) => tokio::task::yield_now().await,
+                Err(error) => return Err(error),
+            }
+        }
+        Err(AppError::RetryableTransactionConflict)
+    }
+
+    async fn select_oauth_spec(
+        &self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        requested_key: IdentitySpecKey,
+    ) -> Result<SelectedOAuthSpec, AppError> {
+        let mut tx = self.db.begin_read_snapshot().await?;
+        let snapshot = load_oauth_create_snapshot(&mut tx, owner, name, &requested_key).await?;
+        tx.commit().await?;
+
+        let record = snapshot
+            .identity_spec
+            .clone()
+            .ok_or_else(|| spec_not_found(&requested_key))?;
+        let installed = record_to_installed(record)?;
+        if installed.manifest.identity_type != IdentitySpecType::OAuth {
+            return Err(AppError::InvalidInput(format!(
+                "identity spec '{}' has type '{}', not 'oauth'",
+                requested_key.name(),
+                installed.manifest.identity_type.label(),
+            )));
+        }
+
+        let key_provider = Arc::clone(&self.key_provider);
+        let document = snapshot.identity_spec_document.clone();
+        let resolved = run_key_operation(move || {
+            resolve_installed_for_use(installed, document, key_provider.as_ref())
+        })
+        .await?;
+        let oauth = match &resolved.spec.manifest.config {
+            IdentitySpecConfig::OAuth(config) => config.method.oauth.clone(),
+            IdentitySpecConfig::FixedToken => {
+                return Err(AppError::InvalidInput(format!(
+                    "identity spec '{}' is not oauth",
+                    requested_key.name(),
+                )));
+            }
+        };
+        let source_inputs = resolved.inputs.variables().clone();
+        let credential_inputs = oauth_client_inputs(&oauth, &resolved.inputs);
+        OAuthCredentialService::validate_credential_inputs(
+            &oauth,
+            &source_inputs,
+            credential_inputs.clone(),
+        )?;
+        let reference = IdentitySpecReference::new(
+            owner,
+            resolved.spec.key,
+            identity_spec_fingerprint(&resolved.spec.manifest)?,
+            resolved.spec.manifest.issuer,
+            resolved.spec.manifest.identity_type.label(),
+        )?;
+
+        Ok(SelectedOAuthSpec {
+            requested_key,
+            snapshot,
+            reference,
+            oauth,
+            source_inputs,
+            credential_inputs,
+        })
+    }
+
+    async fn try_commit_oauth(
+        &self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        selected: &SelectedOAuthSpec,
+        document: &IdentityDocumentWrite,
+        safe_metadata: &BTreeMap<String, String>,
+    ) -> Result<Option<IdentityRecord>, AppError> {
+        let mut tx = self.db.begin_serializable().await?;
+        let current =
+            load_oauth_create_snapshot(&mut tx, owner, name, &selected.requested_key).await?;
+        if current.workspace_created_at_unix_nanos
+            != selected.snapshot.workspace_created_at_unix_nanos
+        {
+            tx.rollback().await?;
+            return Err(owner_workspace_not_found(owner));
+        }
+        if current != selected.snapshot {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+
+        let now = now_unix_nanos_i64()?;
+        let result = async {
+            let record = tx
+                .identities()
+                .upsert(owner, name, &selected.reference, safe_metadata, now)
+                .await?;
+            tx.identity_documents()
+                .upsert(owner, name, document, now)
+                .await?;
+            Ok::<_, AppError>(record)
+        }
+        .await;
+        let record = match result {
+            Ok(record) => record,
+            Err(error) => {
+                tx.rollback().await?;
+                return Err(error);
+            }
+        };
+        tx.commit().await?;
+        Ok(Some(record))
+    }
+}
+
+async fn load_oauth_create_snapshot(
+    tx: &mut CoralTx<'_>,
+    owner: &IdentityOwner,
+    name: &IdentityName,
+    requested_key: &IdentitySpecKey,
+) -> Result<OAuthCreateSnapshot, AppError> {
+    let workspace_created_at_unix_nanos = owner_workspace_created_at(tx, owner).await?;
+    let identity = tx.identities().load_optional(owner, name).await?;
+    let identity_document = tx.identity_documents().load_optional(owner, name).await?;
+    let identity_spec = tx.identity_specs().resolve_optional(requested_key).await?;
+    let identity_spec_document = match identity_spec.as_ref() {
+        Some(record) => {
+            tx.identity_spec_documents()
+                .load_optional(&record.key)
+                .await?
+        }
+        None => None,
+    };
+    Ok(OAuthCreateSnapshot {
+        workspace_created_at_unix_nanos,
+        identity,
+        identity_document,
+        identity_spec,
+        identity_spec_document,
+    })
+}
+
+fn oauth_client_inputs(
+    oauth: &ManifestOAuthCredentialSpec,
+    inputs: &crate::identity_specs::manager::ResolvedIdentitySpecInputs,
+) -> Vec<(String, String)> {
+    let value = |key: &str| {
+        inputs
+            .variables()
+            .get(key)
+            .or_else(|| inputs.secrets().get(key))
+            .cloned()
+    };
+    let mut values = Vec::with_capacity(2);
+    if let Some(key) = oauth.client.id.input.as_deref()
+        && let Some(value) = value(key)
+    {
+        values.push((key.to_string(), value));
+    }
+    if let Some(secret) = oauth.client.secret.as_ref()
+        && let Some(value) = value(&secret.input)
+    {
+        values.push((secret.input.clone(), value));
+    }
+    values
+}
+
+fn oauth_identity_values(
+    material: OAuthCredentialMaterial,
+) -> (BTreeMap<String, String>, BTreeMap<String, String>) {
+    let OAuthCredentialMaterial {
+        access_token,
+        mut internal_metadata,
+        safe_metadata,
+        ..
+    } = material;
+    internal_metadata.insert(OAUTH_ACCESS_TOKEN_KEY.to_string(), access_token);
+    (safe_metadata, internal_metadata)
+}
+
+fn prepare_oauth_document(
+    owner: &IdentityOwner,
+    name: &IdentityName,
+    reference: &IdentitySpecReference,
+    values: &BTreeMap<String, String>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<IdentityDocumentWrite, AppError> {
+    let binding = identity_document_binding(owner, name, reference);
+    let document = encrypt_identity_document(&binding, values, key_provider)?;
+    identity_document_write(document)
+}

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -1,13 +1,15 @@
 use std::collections::BTreeMap;
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use coral_spec::parse_identity_manifest_yaml;
 use sea_query::{Alias, Expr, ExprTrait, Query};
 use tempfile::tempdir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use super::{IdentityManager, ResolvedIdentityForUse};
+use super::{IdentityManager, IdentityOAuthCreationEvent, ResolvedIdentityForUse};
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialsError;
 use crate::credentials::encryption::{
@@ -19,10 +21,11 @@ use crate::identity::{
     decrypt_identity_document, encrypt_identity_spec_document,
 };
 use crate::identity_specs::identity_spec_fingerprint;
+use crate::identity_specs::manager::{IdentitySpecInputValue, IdentitySpecManager};
 use crate::state::db::{
     CoralDb, DbError, DbRepos, DbSession, IdentityDocumentRecord, IdentityRecord,
-    IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecWrite,
-    ResolvedDatabaseConfig,
+    IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecScope,
+    IdentitySpecWrite, ResolvedDatabaseConfig,
 };
 use crate::workspaces::WorkspaceName;
 
@@ -57,6 +60,110 @@ async fn sqlite_fixed_token_manager_contract() {
     );
     db.migrate().await.expect("migrate sqlite");
     Box::pin(assert_fixed_token_manager_contract(&db)).await;
+}
+
+#[tokio::test]
+async fn sqlite_oauth_creation_core_contract() {
+    let temp = tempdir().expect("temp dir");
+    let db = Arc::new(
+        CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite"),
+    );
+    db.migrate().await.expect("migrate sqlite");
+    let provider = device_oauth_provider().await;
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let oauth_spec = format!("oauth_{suffix}");
+    let oauth_key = IdentitySpecKey::global(&oauth_spec).unwrap();
+    let oauth_yaml = device_oauth_manifest(&oauth_spec, &provider.uri());
+    let key_provider = Arc::new(TestKeyProvider(vec![
+        CredentialEncryptionKey::from_static_bytes_for_test([70; 32]),
+    ]));
+    IdentitySpecManager::new(db.clone(), key_provider.clone())
+        .add_or_replace_exact(
+            IdentitySpecScope::global(),
+            &oauth_yaml,
+            vec![IdentitySpecInputValue::new(
+                "OAUTH_CLIENT_ID",
+                "spec-client-id",
+            )],
+        )
+        .await
+        .expect("install OAuth identity spec input");
+    let manager = IdentityManager::new(db.clone(), key_provider.clone());
+    let principal = UserPrincipal::for_user(&format!("oauth-{suffix}")).unwrap();
+    let owner = IdentityOwner::for_user(principal.clone());
+    let identity_name = format!("oauth-{suffix}");
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let captured_events = events.clone();
+    let created = manager
+        .create_or_replace_user_oauth(&principal, &identity_name, &oauth_spec, move |event| {
+            let events = captured_events.clone();
+            async move {
+                events.lock().expect("event lock").push(event);
+                Ok(())
+            }
+        })
+        .await
+        .expect("create user OAuth identity");
+    let expected_safe = BTreeMap::from([
+        ("scope".to_string(), "repo user".to_string()),
+        ("token_type".to_string(), "Bearer".to_string()),
+    ]);
+    assert_eq!(created.spec_reference.key(), &oauth_key);
+    assert_eq!(
+        created.spec_reference.fingerprint(),
+        identity_spec_fingerprint(&parse_identity_manifest_yaml(&oauth_yaml).unwrap()).unwrap()
+    );
+    assert_eq!(created.spec_reference.identity_type(), "oauth");
+    assert_eq!(created.safe_metadata, expected_safe);
+    {
+        let events = events.lock().expect("event lock");
+        assert!(matches!(
+            events.as_slice(),
+            [IdentityOAuthCreationEvent::Authorization(authorization), IdentityOAuthCreationEvent::Completed(metadata)]
+                if authorization.user_code.as_deref() == Some("ABCD-1234")
+                    && authorization.authorization_url == "https://provider.example/device?user_code=ABCD-1234"
+                    && metadata == &expected_safe
+        ));
+    }
+    let (_, document) = load_pair(&db, &owner, &identity_name).await;
+    let material = decrypt_material(
+        &created,
+        document.as_ref().expect("OAuth identity document"),
+        key_provider.as_ref(),
+    );
+    assert_eq!(
+        material.get("ACCESS_TOKEN").map(String::as_str),
+        Some("access-token")
+    );
+    assert!(
+        material
+            .iter()
+            .any(|(key, value)| key.ends_with(".refresh_token") && value == "refresh-token")
+    );
+    assert!(!material.keys().any(|key| {
+        key.ends_with(".client_id")
+            || key.ends_with(".client_secret")
+            || key.ends_with(".token_url")
+    }));
+    assert!(
+        material
+            .values()
+            .all(|value| value != "spec-client-id" && !value.contains(&provider.uri()))
+    );
+    let keyless = IdentityManager::new(db.clone(), Arc::new(TestKeyProvider(vec![])));
+    assert_eq!(keyless.get(&owner, &identity_name).await.unwrap(), created);
+    let requests = provider
+        .received_requests()
+        .await
+        .expect("recorded requests");
+    assert_eq!(requests.len(), 2);
+    assert!(requests.iter().all(|request| {
+        String::from_utf8_lossy(&request.body).contains("client_id=spec-client-id")
+    }));
 }
 
 pub(crate) async fn assert_fixed_token_manager_contract(db: &Arc<CoralDb>) {
@@ -1373,6 +1480,24 @@ fn assert_material(
     token: &str,
     key_provider: &dyn CredentialKeyProvider,
 ) {
+    let values = decrypt_material(record, document, key_provider);
+    assert_eq!(
+        values,
+        std::collections::BTreeMap::from([("TOKEN".to_string(), token.to_string())])
+    );
+    assert!(
+        !document
+            .ciphertext
+            .windows(token.len())
+            .any(|window| window == token.as_bytes())
+    );
+}
+
+fn decrypt_material(
+    record: &IdentityRecord,
+    document: &IdentityDocumentRecord,
+    key_provider: &dyn CredentialKeyProvider,
+) -> BTreeMap<String, String> {
     assert_eq!(document.aad_version, IDENTITY_DOCUMENT_AAD_VERSION);
     let reference = &record.spec_reference;
     let (spec_scope_kind, spec_scope_id, spec_name) = reference.key().document_aad_parts();
@@ -1394,18 +1519,7 @@ fn assert_material(
         algorithm: document.algorithm.clone(),
         aad_version: document.aad_version,
     };
-    let values = decrypt_identity_document(&binding, &envelope, key_provider)
-        .expect("decrypt identity material");
-    assert_eq!(
-        values,
-        std::collections::BTreeMap::from([("TOKEN".to_string(), token.to_string())])
-    );
-    assert!(
-        !document
-            .ciphertext
-            .windows(token.len())
-            .any(|window| window == token.as_bytes())
-    );
+    decrypt_identity_document(&binding, &envelope, key_provider).expect("decrypt identity material")
 }
 
 fn fixed_manifest(name: &str, label: &str) -> String {
@@ -1418,4 +1532,31 @@ fn oauth_manifest(name: &str) -> String {
     format!(
         "kind: identity\nspec_version: 1\nname: {name}\nversion: oauth\ndescription: oauth\nissuer: oauth_issuer\ntype: oauth\noauth:\n  method:\n    flow:\n      type: authorization_code\n      pkce: disabled\n    redirect_uri: http://127.0.0.1:53682/oauth/callback\n    endpoints:\n      authorization_url: https://provider.example.com/authorize\n      token_url: https://provider.example.com/token\n    client:\n      id:\n        default: client\n"
     )
+}
+
+fn device_oauth_manifest(name: &str, base_url: &str) -> String {
+    format!(
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: oauth\ndescription: oauth\nissuer: oauth_issuer\ntype: oauth\ninputs:\n  OAUTH_CLIENT_ID:\n    kind: variable\n    required: true\noauth:\n  method:\n    flow:\n      type: device_code\n    endpoints:\n      device_authorization_url: {base_url}/device\n      token_url: {base_url}/token\n    client:\n      id:\n        input: OAUTH_CLIENT_ID\n"
+    )
+}
+
+async fn device_oauth_provider() -> MockServer {
+    let provider = MockServer::start().await;
+    for (endpoint, response) in [
+        (
+            "/device",
+            r#"{"device_code":"device-code","user_code":"ABCD-1234","verification_uri":"https://provider.example/device","verification_uri_complete":"https://provider.example/device?user_code=ABCD-1234","expires_in":60,"interval":1}"#,
+        ),
+        (
+            "/token",
+            r#"{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","scope":"repo user"}"#,
+        ),
+    ] {
+        Mock::given(method("POST"))
+            .and(path(endpoint))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(response, "application/json"))
+            .mount(&provider)
+            .await;
+    }
+    provider
 }


### PR DESCRIPTION
## Intent

Add the app-owned OAuth identity creation core without holding a database transaction across provider authorization or duplicating exact-spec-owned refresh context in identity material.

## What it enables

- Follow-up service work can stream authorization and safe completion events, then persist an OAuth identity atomically.
- Concurrent workspace, spec, input, identity, or encrypted-document drift fails closed without replaying OAuth or dynamic client registration.
- Identity rows remain keyless-readable while access tokens, refresh tokens, and provider-generated DCR client state remain encrypted.

## Usage examples

This PR intentionally exposes only an app-private manager seam; the follow-up service PR will mount it:

    manager
        .create_or_replace_user_oauth(&principal, "github", "github_oauth", |event| async move {
            acknowledge(event).await
        })
        .await?;

## Implementation

- Resolves and decrypts the effective identity spec and its exact input document in one read snapshot.
- Authorizes exactly once outside every database transaction and acknowledges authorization plus safe completion before persistence.
- Removes spec-derived token URL, resource, and static client context while retaining provider-generated DCR client material.
- Rechecks workspace generation, effective spec row, exact spec document, target identity, and target document in a short serializable transaction.
- Retries only database serialization failures against the same prepared material and atomically upserts safe metadata plus the encrypted document.
- Makes shared device-code expiry guidance caller-neutral for both source and identity flows.

## Stack

- Parent: #1706
- This PR: B5c OAuth creation core
- Follow-up: B5c2 deterministic SQLite/Postgres race schedules

## Validation

- `cargo test --locked -p coral-app --all-features identity_context_pruning_respects_spec_ownership`
- `cargo test --locked -p coral-app --all-features sqlite_oauth_creation_core_contract`
- strict `coral-app` Clippy with warnings denied
- `make rust-checks` — 1,736 passed, 3 skipped; rustdoc clean
- `make postgres-tests` — all three Postgres contracts passed
- `make perf-check` — 210.7 ms mean against the 750 ms ceiling
- fresh five-lane review swarm — 0 findings/questions, 15 credential flows safe, supervisor closure 0.99
