### PR TITLE
test(app): cover OAuth identity creation races

### DIFF
--- a/crates/coral-app/src/identities/manager/oauth_create.rs
+++ b/crates/coral-app/src/identities/manager/oauth_create.rs
@@ -69,7 +69,10 @@ impl IdentityManager {
     }
 
     /// Authorize and atomically create or replace one workspace-owned OAuth identity.
-    #[expect(dead_code, reason = "mounted by the follow-up service-surface PR")]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "mounted by the follow-up service-surface PR")
+    )]
     pub(crate) async fn create_or_replace_workspace_oauth<E, EventFut>(
         &self,
         workspace: &WorkspaceName,
@@ -241,6 +244,10 @@ impl IdentityManager {
                 .identities()
                 .upsert(owner, name, &selected.reference, safe_metadata, now)
                 .await?;
+            #[cfg(test)]
+            if let Some(gate) = &self.before_write_gate {
+                gate.wait_once().await;
+            }
             tx.identity_documents()
                 .upsert(owner, name, document, now)
                 .await?;

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -29,6 +29,10 @@ use crate::state::db::{
 };
 use crate::workspaces::WorkspaceName;
 
+mod oauth_create_races;
+
+pub(crate) use oauth_create_races::assert_oauth_creation_race_contract;
+
 struct TestKeyProvider(Vec<CredentialEncryptionKey>);
 
 impl CredentialKeyProvider for TestKeyProvider {
@@ -520,7 +524,7 @@ async fn assert_concurrent_rewrap_race(
     let race = seed_user_use_race(db, suffix, "rewrap", old_key).await;
     let before_identity = load_pair(db, &race.owner, &race.name).await.1.unwrap();
     let old_provider = TestKeyProvider(vec![old_key.clone()]);
-    let before_spec = put_empty_spec_document(db, &race.key, &old_provider, 1).await;
+    let before_spec = put_spec_document(db, &race.key, &BTreeMap::new(), &old_provider, 1).await;
     let barrier = Arc::new(tokio::sync::Barrier::new(2));
     let base = manager_with_keys(db, vec![old_key.clone(), new_key.clone()]);
     let left = base.clone().with_before_upsert_gate(Arc::clone(&barrier));
@@ -1381,16 +1385,16 @@ async fn delete_spec(db: &Arc<CoralDb>, key: &IdentitySpecKey) {
     tx.commit().await.unwrap();
 }
 
-async fn put_empty_spec_document(
+async fn put_spec_document(
     db: &Arc<CoralDb>,
     key: &IdentitySpecKey,
+    values: &BTreeMap<String, String>,
     key_provider: &dyn CredentialKeyProvider,
     now: i64,
 ) -> IdentitySpecDocumentRecord {
     let (scope_kind, scope_id, name) = key.document_aad_parts();
     let document =
-        encrypt_identity_spec_document(scope_kind, scope_id, name, &BTreeMap::new(), key_provider)
-            .unwrap();
+        encrypt_identity_spec_document(scope_kind, scope_id, name, values, key_provider).unwrap();
     let write = IdentitySpecDocumentWrite::new(
         document.ciphertext,
         document.nonce,

--- a/crates/coral-app/src/identities/manager/tests/oauth_create_races.rs
+++ b/crates/coral-app/src/identities/manager/tests/oauth_create_races.rs
@@ -1,0 +1,563 @@
+use super::*;
+
+use crate::identity::decrypt_identity_spec_document;
+use crate::state::db::IdentitySpecRecord;
+use wiremock::Request;
+
+#[tokio::test]
+async fn sqlite_oauth_creation_race_contract() {
+    let temp = tempdir().expect("temp dir");
+    let db = Arc::new(
+        CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite"),
+    );
+    db.migrate().await.expect("migrate sqlite");
+    Box::pin(assert_oauth_creation_race_contract(&db)).await;
+}
+
+pub(crate) async fn assert_oauth_creation_race_contract(db: &Arc<CoralDb>) {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let key_provider = Arc::new(TestKeyProvider(vec![
+        CredentialEncryptionKey::from_static_bytes_for_test([71; 32]),
+    ]));
+
+    Box::pin(assert_creation_cancellation(db, &key_provider, &suffix)).await;
+    Box::pin(assert_target_replacement(db, &key_provider, &suffix)).await;
+    Box::pin(assert_spec_input_mutation(db, &key_provider, &suffix)).await;
+    Box::pin(assert_fallback_shadow_insertion(db, &key_provider, &suffix)).await;
+    Box::pin(assert_workspace_generation_aba(db, &key_provider, &suffix)).await;
+}
+
+enum OAuthRaceOwner {
+    User(UserPrincipal),
+    Workspace(WorkspaceName),
+}
+
+#[derive(Clone, Copy)]
+enum GatedOAuthEvent {
+    Authorization,
+    Completed,
+}
+
+impl GatedOAuthEvent {
+    fn matches(self, event: &IdentityOAuthCreationEvent) -> bool {
+        match self {
+            Self::Authorization => matches!(event, IdentityOAuthCreationEvent::Authorization(_)),
+            Self::Completed => matches!(event, IdentityOAuthCreationEvent::Completed(_)),
+        }
+    }
+}
+
+async fn assert_creation_cancellation(
+    db: &Arc<CoralDb>,
+    key_provider: &Arc<TestKeyProvider>,
+    suffix: &str,
+) {
+    let provider = device_oauth_provider().await;
+    let spec_name = format!("oauth_cancel_{suffix}");
+    let identity_name = format!("oauth-cancel-{suffix}");
+    let principal = UserPrincipal::for_user(&format!("oauth-cancel-{suffix}")).unwrap();
+    let client_id = format!("cancel-client-{suffix}");
+    let manifest = device_oauth_manifest(&spec_name, &provider.uri());
+    install_oauth_spec(
+        db,
+        key_provider,
+        IdentitySpecScope::global(),
+        &manifest,
+        Some(&client_id),
+    )
+    .await;
+
+    let reached = Arc::new(tokio::sync::Barrier::new(2));
+    let resume = Arc::new(tokio::sync::Barrier::new(2));
+    let manager = IdentityManager::new(db.clone(), key_provider.clone())
+        .with_before_write_gate(reached.clone(), resume);
+    let task_principal = principal.clone();
+    let task_identity_name = identity_name.clone();
+    let task = tokio::spawn(async move {
+        manager
+            .create_or_replace_user_oauth(
+                &task_principal,
+                &task_identity_name,
+                &spec_name,
+                |_| async { Ok(()) },
+            )
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(10), reached.wait())
+        .await
+        .expect("OAuth cancellation must reach the transactional identity upsert");
+    task.abort();
+    let cancelled = tokio::time::timeout(Duration::from_secs(10), task)
+        .await
+        .expect("OAuth cancellation must terminate")
+        .expect_err("OAuth creation must be cancelled");
+    assert!(cancelled.is_cancelled());
+
+    let owner = IdentityOwner::for_user(principal);
+    assert_eq!(load_pair(db, &owner, &identity_name).await, (None, None));
+    assert_static_provider_requests(&provider, &client_id, None).await;
+}
+
+async fn assert_target_replacement(
+    db: &Arc<CoralDb>,
+    key_provider: &Arc<TestKeyProvider>,
+    suffix: &str,
+) {
+    let provider = device_dcr_oauth_provider().await;
+    let oauth_spec = format!("oauth_replace_{suffix}");
+    let oauth_manifest = device_dcr_oauth_manifest(&oauth_spec, &provider.uri());
+    install_oauth_spec(
+        db,
+        key_provider,
+        IdentitySpecScope::global(),
+        &oauth_manifest,
+        None,
+    )
+    .await;
+
+    let first_spec = format!("fixed_replace_first_{suffix}");
+    let winner_spec = format!("fixed_replace_winner_{suffix}");
+    put_spec(
+        db,
+        &IdentitySpecKey::global(&first_spec).unwrap(),
+        &fixed_manifest(&first_spec, "race_first"),
+    )
+    .await;
+    put_spec(
+        db,
+        &IdentitySpecKey::global(&winner_spec).unwrap(),
+        &fixed_manifest(&winner_spec, "race_winner"),
+    )
+    .await;
+
+    let principal = UserPrincipal::for_user(&format!("oauth-replace-{suffix}")).unwrap();
+    let owner = IdentityOwner::for_user(principal.clone());
+    let identity_name = format!("oauth-replace-{suffix}");
+    let manager = IdentityManager::new(db.clone(), key_provider.clone());
+    manager
+        .create_or_replace_user_fixed_token(
+            &principal,
+            &identity_name,
+            &first_spec,
+            "first-token".into(),
+        )
+        .await
+        .expect("seed OAuth replacement target");
+
+    let writer = manager.clone();
+    let (oauth_result, replacement) = Box::pin(race_at_event(
+        manager,
+        OAuthRaceOwner::User(principal.clone()),
+        identity_name.clone(),
+        oauth_spec,
+        GatedOAuthEvent::Completed,
+        || {
+            writer.create_or_replace_user_fixed_token(
+                &principal,
+                &identity_name,
+                &winner_spec,
+                "winner-token".into(),
+            )
+        },
+    ))
+    .await;
+    assert!(matches!(
+        oauth_result,
+        Err(AppError::RetryableTransactionConflict)
+    ));
+    let replacement = replacement.expect("concurrent fixed-token replacement");
+    let (record, document) = load_pair(db, &owner, &identity_name).await;
+    let record = record.expect("replacement identity");
+    let document = document.expect("replacement document");
+    assert_eq!(record, replacement);
+    assert_reference(&record, &winner_spec, "race_winner");
+    assert_eq!(document.document_version, 2);
+    assert_material(&record, &document, "winner-token", key_provider.as_ref());
+    assert_dcr_provider_requests(&provider).await;
+}
+
+async fn assert_spec_input_mutation(
+    db: &Arc<CoralDb>,
+    key_provider: &Arc<TestKeyProvider>,
+    suffix: &str,
+) {
+    let provider = device_oauth_provider().await;
+    let spec_name = format!("oauth_input_{suffix}");
+    let identity_name = format!("oauth-input-{suffix}");
+    let principal = UserPrincipal::for_user(&format!("oauth-input-{suffix}")).unwrap();
+    let owner = IdentityOwner::for_user(principal.clone());
+    let old_client = format!("input-before-{suffix}");
+    let new_client = format!("input-after-{suffix}");
+    let manifest = device_oauth_manifest(&spec_name, &provider.uri());
+    install_oauth_spec(
+        db,
+        key_provider,
+        IdentitySpecScope::global(),
+        &manifest,
+        Some(&old_client),
+    )
+    .await;
+    let key = IdentitySpecKey::global(&spec_name).unwrap();
+    let before_spec = load_exact_spec(db, &key).await;
+    let before_document = load_spec_document(db, &key).await;
+    let next_timestamp = before_document
+        .updated_at_unix_nanos
+        .checked_add(1)
+        .expect("identity spec document timestamp");
+    let changed_values = BTreeMap::from([("OAUTH_CLIENT_ID".to_string(), new_client.clone())]);
+
+    let (oauth_result, changed_document) = Box::pin(race_at_event(
+        IdentityManager::new(db.clone(), key_provider.clone()),
+        OAuthRaceOwner::User(principal),
+        identity_name.clone(),
+        spec_name,
+        GatedOAuthEvent::Authorization,
+        || {
+            put_spec_document(
+                db,
+                &key,
+                &changed_values,
+                key_provider.as_ref(),
+                next_timestamp,
+            )
+        },
+    ))
+    .await;
+    assert!(matches!(
+        oauth_result,
+        Err(AppError::RetryableTransactionConflict)
+    ));
+    assert_eq!(load_exact_spec(db, &key).await, before_spec);
+    assert_eq!(
+        changed_document.document_version,
+        before_document.document_version + 1
+    );
+    assert_eq!(
+        decrypt_spec_values(&key, &changed_document, key_provider.as_ref()),
+        changed_values
+    );
+    assert_eq!(load_pair(db, &owner, &identity_name).await, (None, None));
+    assert_static_provider_requests(&provider, &old_client, Some(&new_client)).await;
+}
+
+async fn assert_fallback_shadow_insertion(
+    db: &Arc<CoralDb>,
+    key_provider: &Arc<TestKeyProvider>,
+    suffix: &str,
+) {
+    let provider = device_oauth_provider().await;
+    let workspace = WorkspaceName::parse(&format!("oauth_shadow_{suffix}")).unwrap();
+    put_workspace(db, &workspace).await;
+    let spec_name = format!("oauth_shadow_{suffix}");
+    let identity_name = format!("oauth-shadow-{suffix}");
+    let owner = IdentityOwner::workspace(workspace.clone());
+    let old_client = format!("shadow-global-{suffix}");
+    let new_client = format!("shadow-workspace-{suffix}");
+    let global_key = IdentitySpecKey::global(&spec_name).unwrap();
+    let global_manifest =
+        device_default_client_oauth_manifest(&spec_name, &provider.uri(), &old_client);
+    put_spec(db, &global_key, &global_manifest).await;
+
+    let workspace_key = IdentitySpecKey::workspace(workspace.clone(), &spec_name).unwrap();
+    let workspace_manifest =
+        device_default_client_oauth_manifest(&spec_name, &provider.uri(), &new_client);
+    let (oauth_result, ()) = Box::pin(race_at_event(
+        IdentityManager::new(db.clone(), key_provider.clone()),
+        OAuthRaceOwner::Workspace(workspace.clone()),
+        identity_name.clone(),
+        spec_name,
+        GatedOAuthEvent::Completed,
+        || put_spec(db, &workspace_key, &workspace_manifest),
+    ))
+    .await;
+    assert!(matches!(
+        oauth_result,
+        Err(AppError::RetryableTransactionConflict)
+    ));
+    assert_eq!(load_exact_spec(db, &workspace_key).await.key, workspace_key);
+    let mut session = db.as_ref();
+    for key in [&global_key, &workspace_key] {
+        assert!(
+            session
+                .identity_spec_documents()
+                .load_optional(key)
+                .await
+                .expect("load absent shadow-race input document")
+                .is_none()
+        );
+    }
+    assert_eq!(load_pair(db, &owner, &identity_name).await, (None, None));
+    assert_static_provider_requests(&provider, &old_client, Some(&new_client)).await;
+}
+
+fn device_default_client_oauth_manifest(name: &str, base_url: &str, client_id: &str) -> String {
+    format!(
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: oauth\ndescription: oauth\nissuer: oauth_issuer\ntype: oauth\noauth:\n  method:\n    flow:\n      type: device_code\n    endpoints:\n      device_authorization_url: {base_url}/device\n      token_url: {base_url}/token\n    client:\n      id:\n        default: {client_id}\n"
+    )
+}
+
+async fn assert_workspace_generation_aba(
+    db: &Arc<CoralDb>,
+    key_provider: &Arc<TestKeyProvider>,
+    suffix: &str,
+) {
+    let provider = device_oauth_provider().await;
+    let workspace = WorkspaceName::parse(&format!("oauth_aba_{suffix}")).unwrap();
+    put_workspace_at(db, &workspace, 1).await;
+    let spec_name = format!("oauth_aba_{suffix}");
+    let identity_name = format!("oauth-aba-{suffix}");
+    let owner = IdentityOwner::workspace(workspace.clone());
+    let client_id = format!("aba-client-{suffix}");
+    let manifest = device_oauth_manifest(&spec_name, &provider.uri());
+    install_oauth_spec(
+        db,
+        key_provider,
+        IdentitySpecScope::global(),
+        &manifest,
+        Some(&client_id),
+    )
+    .await;
+
+    let (oauth_result, ()) = Box::pin(race_at_event(
+        IdentityManager::new(db.clone(), key_provider.clone()),
+        OAuthRaceOwner::Workspace(workspace.clone()),
+        identity_name.clone(),
+        spec_name,
+        GatedOAuthEvent::Completed,
+        || async {
+            delete_workspace(db, &workspace).await;
+            put_workspace_at(db, &workspace, 2).await;
+        },
+    ))
+    .await;
+    assert!(matches!(
+        oauth_result,
+        Err(AppError::WorkspaceNotFound(name)) if name == workspace.as_str()
+    ));
+    let current_workspace = {
+        let mut session = db.as_ref();
+        session
+            .workspaces()
+            .get(workspace.as_str())
+            .await
+            .expect("load recreated workspace")
+            .expect("recreated workspace")
+    };
+    assert_eq!(current_workspace.created_at_unix_nanos, 2);
+    assert_eq!(load_pair(db, &owner, &identity_name).await, (None, None));
+    assert_static_provider_requests(&provider, &client_id, None).await;
+}
+
+async fn create_gated_oauth(
+    manager: IdentityManager,
+    owner: OAuthRaceOwner,
+    identity_name: String,
+    spec_name: String,
+    gated_event: GatedOAuthEvent,
+    reached: Arc<tokio::sync::Barrier>,
+    resume: Arc<tokio::sync::Barrier>,
+) -> Result<IdentityRecord, AppError> {
+    match owner {
+        OAuthRaceOwner::User(principal) => {
+            manager
+                .create_or_replace_user_oauth(
+                    &principal,
+                    &identity_name,
+                    &spec_name,
+                    move |event| {
+                        let reached = reached.clone();
+                        let resume = resume.clone();
+                        async move {
+                            if gated_event.matches(&event) {
+                                reached.wait().await;
+                                resume.wait().await;
+                            }
+                            Ok(())
+                        }
+                    },
+                )
+                .await
+        }
+        OAuthRaceOwner::Workspace(workspace) => {
+            manager
+                .create_or_replace_workspace_oauth(
+                    &workspace,
+                    &identity_name,
+                    &spec_name,
+                    move |event| {
+                        let reached = reached.clone();
+                        let resume = resume.clone();
+                        async move {
+                            if gated_event.matches(&event) {
+                                reached.wait().await;
+                                resume.wait().await;
+                            }
+                            Ok(())
+                        }
+                    },
+                )
+                .await
+        }
+    }
+}
+
+async fn race_at_event<T, F, Fut>(
+    manager: IdentityManager,
+    owner: OAuthRaceOwner,
+    identity_name: String,
+    spec_name: String,
+    gated_event: GatedOAuthEvent,
+    mutate: F,
+) -> (Result<IdentityRecord, AppError>, T)
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = T>,
+{
+    let reached = Arc::new(tokio::sync::Barrier::new(2));
+    let resume = Arc::new(tokio::sync::Barrier::new(2));
+    let creation = create_gated_oauth(
+        manager,
+        owner,
+        identity_name,
+        spec_name,
+        gated_event,
+        reached.clone(),
+        resume.clone(),
+    );
+    tokio::time::timeout(Duration::from_secs(10), async {
+        tokio::join!(creation, async {
+            reached.wait().await;
+            let result = mutate().await;
+            resume.wait().await;
+            result
+        })
+    })
+    .await
+    .expect("OAuth creation race must not deadlock")
+}
+
+async fn install_oauth_spec(
+    db: &Arc<CoralDb>,
+    key_provider: &Arc<TestKeyProvider>,
+    scope: IdentitySpecScope,
+    manifest: &str,
+    client_id: Option<&str>,
+) {
+    let inputs = client_id
+        .into_iter()
+        .map(|value| IdentitySpecInputValue::new("OAUTH_CLIENT_ID", value))
+        .collect();
+    IdentitySpecManager::new(db.clone(), key_provider.clone())
+        .add_or_replace_exact(scope, manifest, inputs)
+        .await
+        .expect("install OAuth race identity spec");
+}
+
+async fn load_exact_spec(db: &Arc<CoralDb>, key: &IdentitySpecKey) -> IdentitySpecRecord {
+    let mut session = db.as_ref();
+    session
+        .identity_specs()
+        .load_optional(key)
+        .await
+        .expect("load exact identity spec")
+        .expect("exact identity spec")
+}
+
+fn decrypt_spec_values(
+    key: &IdentitySpecKey,
+    document: &IdentitySpecDocumentRecord,
+    key_provider: &dyn CredentialKeyProvider,
+) -> BTreeMap<String, String> {
+    let envelope = EncryptedEnvelopeDocument {
+        ciphertext: document.ciphertext.clone(),
+        nonce: document.nonce.clone(),
+        wrapped_dek: document.wrapped_dek.clone(),
+        wrapped_dek_nonce: document.wrapped_dek_nonce.clone(),
+        key_id: document.key_id.clone(),
+        algorithm: document.algorithm.clone(),
+        aad_version: document.aad_version,
+    };
+    let (scope_kind, scope_id, name) = key.document_aad_parts();
+    decrypt_identity_spec_document(scope_kind, scope_id, name, &envelope, key_provider)
+        .expect("decrypt identity spec race inputs")
+}
+
+async fn device_dcr_oauth_provider() -> MockServer {
+    let provider = device_oauth_provider().await;
+    Mock::given(method("POST"))
+        .and(path("/register"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{"client_id":"registered-client","token_endpoint_auth_method":"none"}"#,
+            "application/json",
+        ))
+        .mount(&provider)
+        .await;
+    provider
+}
+
+fn device_dcr_oauth_manifest(name: &str, base_url: &str) -> String {
+    format!(
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: oauth\ndescription: oauth\nissuer: oauth_issuer\ntype: oauth\noauth:\n  method:\n    flow:\n      type: device_code\n    endpoints:\n      device_authorization_url: {base_url}/device\n      token_url: {base_url}/token\n    client:\n      dynamic_registration:\n        registration_url: {base_url}/register\n        token_endpoint_auth_method: none\n"
+    )
+}
+
+async fn assert_static_provider_requests(
+    provider: &MockServer,
+    expected_client: &str,
+    forbidden_client: Option<&str>,
+) {
+    let requests = provider
+        .received_requests()
+        .await
+        .expect("recorded OAuth race requests");
+    assert_request_paths(&requests, &["/device", "/token"]);
+    let expected = format!("client_id={expected_client}");
+    assert!(
+        requests
+            .iter()
+            .all(|request| request_body_contains(request, &expected))
+    );
+    if let Some(forbidden) = forbidden_client {
+        assert!(
+            requests
+                .iter()
+                .all(|request| !request_body_contains(request, forbidden))
+        );
+    }
+}
+
+async fn assert_dcr_provider_requests(provider: &MockServer) {
+    let requests = provider
+        .received_requests()
+        .await
+        .expect("recorded DCR race requests");
+    assert_request_paths(&requests, &["/device", "/register", "/token"]);
+    assert!(
+        requests
+            .iter()
+            .filter(|request| request.url.path() != "/register")
+            .all(|request| request_body_contains(request, "client_id=registered-client"))
+    );
+}
+
+fn assert_request_paths(requests: &[Request], expected: &[&str]) {
+    let mut actual = requests
+        .iter()
+        .map(|request| request.url.path().to_string())
+        .collect::<Vec<_>>();
+    actual.sort();
+    let mut expected = expected
+        .iter()
+        .map(|path| (*path).to_string())
+        .collect::<Vec<_>>();
+    expected.sort();
+    assert_eq!(actual, expected);
+}
+
+fn request_body_contains(request: &Request, expected: &str) -> bool {
+    String::from_utf8_lossy(&request.body).contains(expected)
+}

--- a/crates/coral-app/src/state/db/migration_order_tests.rs
+++ b/crates/coral-app/src/state/db/migration_order_tests.rs
@@ -164,6 +164,7 @@ async fn postgres_identity_database_contracts() {
     )
     .await;
     Box::pin(crate::identities::manager::tests::assert_fixed_token_manager_contract(&db)).await;
+    Box::pin(crate::identities::manager::tests::assert_oauth_creation_race_contract(&db)).await;
 
     backend.pool.close().await;
     drop(db);


### PR DESCRIPTION
## Intent

Prove that OAuth identity creation remains atomic and fail-closed when cancellation or durable state drift occurs after one-shot provider authorization.

## What it enables

This closes the deterministic cross-database race matrix needed before mounting the public OAuth streaming services. Provider OAuth and dynamic client registration remain one-shot, while stale creation attempts cannot overwrite a concurrent durable winner or leave partial identity state.

## Usage examples

Run the focused SQLite contract:

    cargo test --locked -p coral-app --all-features sqlite_oauth_creation_race_contract -- --nocapture

Run the shared PostgreSQL contracts:

    make postgres-tests

## Implementation

- Adds one shared SQLite/PostgreSQL OAuth-creation race contract.
- Cancels creation after the identity-row upsert but before document persistence and proves transaction rollback.
- Replaces the same-name target during authorization and preserves the durable fixed-token winner.
- Mutates the exact identity-spec document after device authorization and before token completion.
- Inserts a same-name workspace shadow while global fallback creation is in flight.
- Deletes and recreates the workspace to exercise generation ABA protection.
- Asserts exact provider request counts and paths so database conflicts never replay OAuth or DCR.
- Verifies every losing schedule leaves either no identity/document pair or the exact concurrent winner.

## Stack

- Parent: #1707
- This PR: B5c2 OAuth-creation cancellation and race contracts
- Next: B5c3 independent identity-document rewrap race, followed by B5d public OAuth streams

## Validation

- Focused SQLite OAuth race contract passed.
- Strict coral-app Clippy passed.
- make postgres-tests passed all workspace, identity, and server-lifecycle gates.
- make rust-checks passed formatting, workspace Clippy, 1,737 tests with 3 skipped, and rustdoc.
- Exact-final five-lane review completed; 18 credential flows were classified safe. One independent document-only rewrap case was accepted as the immediate B5c3 child to preserve the frozen five-schedule contract and the 600-line cap.

This PR is intentionally draft.