### PR TITLE
test(app): cover OAuth creation document rewrap race

### DIFF
--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -31,7 +31,9 @@ use crate::workspaces::WorkspaceName;
 
 mod oauth_create_races;
 
-pub(crate) use oauth_create_races::assert_oauth_creation_race_contract;
+pub(crate) use oauth_create_races::{
+    assert_oauth_creation_document_rewrap_race_contract, assert_oauth_creation_race_contract,
+};
 
 struct TestKeyProvider(Vec<CredentialEncryptionKey>);
 

--- a/crates/coral-app/src/identities/manager/tests/oauth_create_races.rs
+++ b/crates/coral-app/src/identities/manager/tests/oauth_create_races.rs
@@ -18,6 +18,20 @@ async fn sqlite_oauth_creation_race_contract() {
     Box::pin(assert_oauth_creation_race_contract(&db)).await;
 }
 
+#[tokio::test]
+async fn sqlite_oauth_creation_document_rewrap_race_contract() {
+    let temp = tempdir().expect("temp dir");
+    let db = Arc::new(
+        CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite"),
+    );
+    db.migrate().await.expect("migrate sqlite");
+    Box::pin(assert_oauth_creation_document_rewrap_race_contract(&db)).await;
+}
+
 pub(crate) async fn assert_oauth_creation_race_contract(db: &Arc<CoralDb>) {
     let suffix = uuid::Uuid::new_v4().simple().to_string();
     let key_provider = Arc::new(TestKeyProvider(vec![
@@ -29,6 +43,102 @@ pub(crate) async fn assert_oauth_creation_race_contract(db: &Arc<CoralDb>) {
     Box::pin(assert_spec_input_mutation(db, &key_provider, &suffix)).await;
     Box::pin(assert_fallback_shadow_insertion(db, &key_provider, &suffix)).await;
     Box::pin(assert_workspace_generation_aba(db, &key_provider, &suffix)).await;
+}
+
+pub(crate) async fn assert_oauth_creation_document_rewrap_race_contract(db: &Arc<CoralDb>) {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let provider = device_oauth_provider().await;
+    let fixed_spec = format!("fixed_rewrap_{suffix}");
+    let oauth_spec = format!("oauth_rewrap_{suffix}");
+    let identity_name = format!("oauth-rewrap-{suffix}");
+    let principal = UserPrincipal::for_user(&format!("oauth-rewrap-{suffix}")).unwrap();
+    let owner = IdentityOwner::for_user(principal.clone());
+    let client_id = format!("rewrap-client-{suffix}");
+    let fixed_key = IdentitySpecKey::global(&fixed_spec).unwrap();
+    let oauth_key = IdentitySpecKey::global(&oauth_spec).unwrap();
+    let old_key = CredentialEncryptionKey::from_static_bytes_for_test([72; 32]);
+    let new_key = CredentialEncryptionKey::from_static_bytes_for_test([73; 32]);
+
+    put_spec(db, &fixed_key, &fixed_manifest(&fixed_spec, "oauth_rewrap")).await;
+    put_spec(
+        db,
+        &oauth_key,
+        &device_default_client_oauth_manifest(&oauth_spec, &provider.uri(), &client_id),
+    )
+    .await;
+    assert_spec_document_absent(db, &fixed_key).await;
+    assert_spec_document_absent(db, &oauth_key).await;
+
+    let seeded = manager_with_keys(db, vec![old_key.clone()])
+        .create_or_replace_user_fixed_token(
+            &principal,
+            &identity_name,
+            &fixed_spec,
+            "rewrap-token".into(),
+        )
+        .await
+        .expect("seed OAuth document-rewrap target");
+    let (before_record, before_document) = load_pair(db, &owner, &identity_name).await;
+    let before_record = before_record.expect("seeded identity row");
+    let before_document = before_document.expect("seeded identity document");
+    assert_eq!(before_record, seeded);
+    assert_eq!(before_document.document_version, 1);
+    assert_eq!(before_document.key_id, old_key.key_id());
+
+    let rotating = manager_with_keys(db, vec![old_key.clone(), new_key.clone()]);
+    let rewrap_manager = rotating.clone();
+    let (oauth_result, resolved) = Box::pin(race_at_event(
+        rotating,
+        OAuthRaceOwner::User(principal),
+        identity_name.clone(),
+        oauth_spec,
+        GatedOAuthEvent::Completed,
+        || rewrap_manager.get_for_use(&owner, &identity_name),
+    ))
+    .await;
+    assert_use_token(
+        &resolved.expect("rewrap target identity while OAuth is completed"),
+        "rewrap-token",
+    );
+    assert!(matches!(
+        oauth_result,
+        Err(AppError::RetryableTransactionConflict)
+    ));
+
+    let (after_record, after_document) = load_pair(db, &owner, &identity_name).await;
+    let after_record = after_record.expect("identity row after document rewrap");
+    let after_document = after_document.expect("rewrapped identity document");
+    assert_eq!(after_record, before_record);
+    assert_eq!(
+        after_document.document_version,
+        before_document.document_version + 1
+    );
+    assert_eq!(after_document.key_id, new_key.key_id());
+    assert_eq!(after_document.ciphertext, before_document.ciphertext);
+    assert_eq!(after_document.nonce, before_document.nonce);
+    assert_ne!(after_document.wrapped_dek, before_document.wrapped_dek);
+    assert_ne!(
+        after_document.wrapped_dek_nonce,
+        before_document.wrapped_dek_nonce
+    );
+    assert_eq!(after_document.algorithm, before_document.algorithm);
+    assert_eq!(after_document.aad_version, before_document.aad_version);
+    assert_eq!(
+        after_document.created_at_unix_nanos,
+        before_document.created_at_unix_nanos
+    );
+
+    let new_key_only = TestKeyProvider(vec![new_key.clone()]);
+    assert_material(
+        &after_record,
+        &after_document,
+        "rewrap-token",
+        &new_key_only,
+    );
+    assert_reopens_without_repair(db, &owner, &identity_name, &new_key, "rewrap-token").await;
+    assert_spec_document_absent(db, &fixed_key).await;
+    assert_spec_document_absent(db, &oauth_key).await;
+    assert_static_provider_requests(&provider, &client_id, None).await;
 }
 
 enum OAuthRaceOwner {
@@ -465,6 +575,18 @@ async fn load_exact_spec(db: &Arc<CoralDb>, key: &IdentitySpecKey) -> IdentitySp
         .await
         .expect("load exact identity spec")
         .expect("exact identity spec")
+}
+
+async fn assert_spec_document_absent(db: &Arc<CoralDb>, key: &IdentitySpecKey) {
+    let mut session = db.as_ref();
+    assert!(
+        session
+            .identity_spec_documents()
+            .load_optional(key)
+            .await
+            .expect("load absent identity spec document")
+            .is_none()
+    );
 }
 
 fn decrypt_spec_values(

--- a/crates/coral-app/src/state/db/migration_order_tests.rs
+++ b/crates/coral-app/src/state/db/migration_order_tests.rs
@@ -165,6 +165,10 @@ async fn postgres_identity_database_contracts() {
     .await;
     Box::pin(crate::identities::manager::tests::assert_fixed_token_manager_contract(&db)).await;
     Box::pin(crate::identities::manager::tests::assert_oauth_creation_race_contract(&db)).await;
+    Box::pin(
+        crate::identities::manager::tests::assert_oauth_creation_document_rewrap_race_contract(&db),
+    )
+    .await;
 
     backend.pool.close().await;
     drop(db);


### PR DESCRIPTION
## Intent

Close the independent OAuth-creation CAS gap for target identity-document drift by proving that a completed provider authorization cannot overwrite a concurrent KEK rewrap.

## What it enables

This completes the deterministic OAuth-creation race matrix required before mounting B5d public OAuth streams. OAuth creation fails closed without replaying provider requests, while the concurrent rewrapped fixed-token identity remains the exact durable winner.

## Usage examples

Run the dedicated SQLite contract:

    cargo test --locked -p coral-app --all-features sqlite_oauth_creation_document_rewrap_race_contract -- --nocapture

Run the shared PostgreSQL contract:

    make postgres-tests

## Implementation

- Adds a separate test-only contract so B5c2 retains its frozen five schedules.
- Seeds a fixed-token target under an old KEK and installs row-only fixed/OAuth specs, guaranteeing no identity-spec document can change.
- Pauses OAuth replacement at the Completed event after provider side effects but before persistence.
- Runs the real get_for_use path with old and new KEKs, rewrapping only the target identity document.
- Requires OAuth creation to return RetryableTransactionConflict.
- Proves the identity row is byte-for-byte unchanged.
- Proves document version and key ID advance while payload ciphertext, nonce, AAD version, algorithm, creation time, and plaintext token remain preserved.
- Reopens with only the new KEK and verifies no further repair write.
- Requires exactly one device and one token request, proving OAuth is not replayed.
- Runs identically on SQLite and the isolated PostgreSQL schema harness.

## Stack

- Parent: #1708
- This PR: B5c3 target identity-document rewrap race
- Next: B5d authenticated user/workspace OAuth streaming services

## Validation

- Dedicated SQLite document-rewrap race passed.
- Strict all-target coral-app Clippy passed.
- make postgres-tests passed the workspace repository, full identity database contract, and server-lifecycle gates.
- make rust-checks passed formatting, workspace Clippy, 1,738 tests with 3 skipped, and rustdoc.
- Exact-final five-lane review found zero findings or questions.
- Security enumerated five safe credential flows with no unknown sink or guard.
- Mandatory supervisor missed-risk sweep found no additional P1/P2 risk at 0.97 confidence.

This PR is intentionally draft.