### PR TITLE
feat(app): stream OAuth identity creation

### DIFF
--- a/crates/coral-app/src/identities/manager/oauth_create.rs
+++ b/crates/coral-app/src/identities/manager/oauth_create.rs
@@ -69,10 +69,6 @@ impl IdentityManager {
     }
 
     /// Authorize and atomically create or replace one workspace-owned OAuth identity.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "mounted by the follow-up service-surface PR")
-    )]
     pub(crate) async fn create_or_replace_workspace_oauth<E, EventFut>(
         &self,
         workspace: &WorkspaceName,

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -7,7 +7,8 @@ use coral_api::v1::{
     CreateUserOwnedIdentityRequest, CreateUserOwnedIdentityResponse, CredentialMetadata,
     DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse,
     FixedTokenUserOwnedIdentitySetup, GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse,
-    Identity as ProtoIdentity, IdentityOwner as ProtoIdentityOwner, ListUserOwnedIdentitiesRequest,
+    Identity as ProtoIdentity, IdentityOAuthAuthorization, IdentityOAuthCompleted,
+    IdentityOwner as ProtoIdentityOwner, ListUserOwnedIdentitiesRequest,
     ListUserOwnedIdentitiesResponse, create_user_owned_identity_request,
     create_user_owned_identity_response,
 };
@@ -15,11 +16,13 @@ use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
-use crate::identities::manager::IdentityManager;
+use crate::identities::manager::{IdentityManager, IdentityOAuthCreationEvent};
 use crate::identities::model::IdentityOwner;
 use crate::request_context::RequestContext;
 use crate::state::db::{IdentityRecord, IdentitySpecScope};
-use crate::transport::{grpc_span, instrument_grpc, workspace_to_proto};
+use crate::transport::{
+    acknowledged_operation_response_stream, grpc_span, instrument_grpc, workspace_to_proto,
+};
 
 #[derive(Clone)]
 pub(crate) struct IdentityService {
@@ -42,34 +45,56 @@ impl IdentityServiceApi for IdentityService {
     ) -> Result<Response<Self::CreateUserOwnedIdentityStream>, Status> {
         let span = grpc_span(&request);
         let identities = self.identities.clone();
-        instrument_grpc(span, async move {
+        instrument_grpc(span.clone(), async move {
             let principal = RequestContext::from_request(&request)?.principal().clone();
             let CreateUserOwnedIdentityRequest {
                 name,
                 identity_spec,
                 setup,
             } = request.into_inner();
-            let Some(create_user_owned_identity_request::Setup::FixedToken(
-                FixedTokenUserOwnedIdentitySetup { token },
-            )) = setup
-            else {
-                return Err(Status::unimplemented(
-                    "OAuth identity creation is not enabled by this server",
-                ));
-            };
-            let record = identities
-                .create_or_replace_user_fixed_token(&principal, &name, &identity_spec, token)
-                .await
-                .map_err(app_status)?;
-            let response = CreateUserOwnedIdentityResponse {
-                event: Some(create_user_owned_identity_response::Event::Identity(
-                    identity_to_proto(record),
-                )),
-            };
-            let stream = Box::pin(tokio_stream::iter([Ok(response)]));
-            Ok(Response::new(
-                stream as CreateUserOwnedIdentityResponseStreamBox,
-            ))
+            match setup {
+                Some(create_user_owned_identity_request::Setup::FixedToken(
+                    FixedTokenUserOwnedIdentitySetup { token },
+                )) => {
+                    let record = identities
+                        .create_or_replace_user_fixed_token(
+                            &principal,
+                            &name,
+                            &identity_spec,
+                            token,
+                        )
+                        .await
+                        .map_err(app_status)?;
+                    let stream = Box::pin(tokio_stream::iter([Ok(user_identity_response(record))]));
+                    Ok(Response::new(
+                        stream as CreateUserOwnedIdentityResponseStreamBox,
+                    ))
+                }
+                None => {
+                    let stream = acknowledged_operation_response_stream(
+                        "identity OAuth response stream closed before creation completed",
+                        move |event_sender| {
+                            instrument_grpc(span, async move {
+                                identities
+                                    .create_or_replace_user_oauth(
+                                        &principal,
+                                        &name,
+                                        &identity_spec,
+                                        move |event| {
+                                            let event_sender = event_sender.clone();
+                                            async move { event_sender.send(event).await }
+                                        },
+                                    )
+                                    .await
+                                    .map_err(app_status)
+                            })
+                        },
+                        user_oauth_event_response,
+                        user_identity_response,
+                    );
+                    Ok(Response::new(stream))
+                }
+            }
         })
         .await
     }
@@ -139,6 +164,56 @@ impl IdentityServiceApi for IdentityService {
 type CreateUserOwnedIdentityResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<CreateUserOwnedIdentityResponse, Status>> + Send>>;
 
+fn user_oauth_event_response(event: IdentityOAuthCreationEvent) -> CreateUserOwnedIdentityResponse {
+    use create_user_owned_identity_response::Event;
+
+    let event =
+        identity_oauth_event_to_proto(event, Event::OauthAuthorization, Event::OauthCompleted);
+    CreateUserOwnedIdentityResponse { event: Some(event) }
+}
+
+pub(super) fn identity_oauth_event_to_proto<R>(
+    event: IdentityOAuthCreationEvent,
+    authorization_response: impl FnOnce(IdentityOAuthAuthorization) -> R,
+    completed_response: impl FnOnce(IdentityOAuthCompleted) -> R,
+) -> R {
+    match event {
+        IdentityOAuthCreationEvent::Authorization(authorization) => {
+            authorization_response(IdentityOAuthAuthorization {
+                authorization_url: authorization.authorization_url,
+                expires_in_seconds: authorization.expires_in_seconds,
+                user_code: authorization.user_code.unwrap_or_default(),
+                verification_uri: authorization.verification_uri.unwrap_or_default(),
+                verification_uri_complete: authorization
+                    .verification_uri_complete
+                    .unwrap_or_default(),
+            })
+        }
+        IdentityOAuthCreationEvent::Completed(metadata) => {
+            completed_response(IdentityOAuthCompleted {
+                metadata: credential_metadata_to_proto(metadata),
+            })
+        }
+    }
+}
+
+fn user_identity_response(record: IdentityRecord) -> CreateUserOwnedIdentityResponse {
+    CreateUserOwnedIdentityResponse {
+        event: Some(create_user_owned_identity_response::Event::Identity(
+            identity_to_proto(record),
+        )),
+    }
+}
+
+pub(super) fn credential_metadata_to_proto(
+    metadata: impl IntoIterator<Item = (String, String)>,
+) -> Vec<CredentialMetadata> {
+    metadata
+        .into_iter()
+        .map(|(key, value)| CredentialMetadata { key, value })
+        .collect()
+}
+
 pub(super) fn identity_to_proto(record: IdentityRecord) -> ProtoIdentity {
     let IdentityRecord {
         owner,
@@ -164,10 +239,7 @@ pub(super) fn identity_to_proto(record: IdentityRecord) -> ProtoIdentity {
         issuer: spec_reference.issuer().to_string(),
         identity_type: spec_reference.identity_type().to_string(),
         owner: owner as i32,
-        metadata: safe_metadata
-            .into_iter()
-            .map(|(key, value)| CredentialMetadata { key, value })
-            .collect(),
+        metadata: credential_metadata_to_proto(safe_metadata),
         owner_workspace,
         identity_spec_workspace,
     }

--- a/crates/coral-app/src/identities/workspace_service.rs
+++ b/crates/coral-app/src/identities/workspace_service.rs
@@ -14,11 +14,13 @@ use coral_api::v1::{
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
-use super::manager::IdentityManager;
+use super::manager::{IdentityManager, IdentityOAuthCreationEvent};
 use super::model::IdentityOwner;
-use super::service::identity_to_proto;
+use super::service::{identity_oauth_event_to_proto, identity_to_proto};
 use crate::bootstrap::app_status;
-use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto};
+use crate::transport::{
+    acknowledged_operation_response_stream, grpc_span, instrument_grpc, workspace_name_from_proto,
+};
 use crate::workspaces::{WorkspaceManager, WorkspaceName};
 
 #[derive(Clone)]
@@ -47,7 +49,7 @@ impl WorkspaceIdentityServiceApi for WorkspaceIdentityService {
         let span = grpc_span(&request);
         let identities = self.identities.clone();
         let workspaces = self.workspaces.clone();
-        instrument_grpc(span, async move {
+        instrument_grpc(span.clone(), async move {
             let CreateWorkspaceOwnedIdentityRequest {
                 workspace,
                 name,
@@ -56,27 +58,51 @@ impl WorkspaceIdentityServiceApi for WorkspaceIdentityService {
             } = request.into_inner();
             let workspace = workspace_name_from_proto(workspace.as_ref())?;
             require_workspace(&workspaces, &workspace).await?;
-            let Some(create_workspace_owned_identity_request::Setup::FixedToken(
-                FixedTokenWorkspaceOwnedIdentitySetup { token },
-            )) = setup
-            else {
-                return Err(Status::unimplemented(
-                    "OAuth identity creation is not enabled by this server",
-                ));
-            };
-            let record = identities
-                .create_or_replace_workspace_fixed_token(&workspace, &name, &identity_spec, token)
-                .await
-                .map_err(app_status)?;
-            let response = CreateWorkspaceOwnedIdentityResponse {
-                event: Some(create_workspace_owned_identity_response::Event::Identity(
-                    identity_to_proto(record),
-                )),
-            };
-            let stream = Box::pin(tokio_stream::iter([Ok(response)]));
-            Ok(Response::new(
-                stream as CreateWorkspaceOwnedIdentityResponseStreamBox,
-            ))
+            match setup {
+                Some(create_workspace_owned_identity_request::Setup::FixedToken(
+                    FixedTokenWorkspaceOwnedIdentitySetup { token },
+                )) => {
+                    let record = identities
+                        .create_or_replace_workspace_fixed_token(
+                            &workspace,
+                            &name,
+                            &identity_spec,
+                            token,
+                        )
+                        .await
+                        .map_err(app_status)?;
+                    let stream = Box::pin(tokio_stream::iter([Ok(workspace_identity_response(
+                        record,
+                    ))]));
+                    Ok(Response::new(
+                        stream as CreateWorkspaceOwnedIdentityResponseStreamBox,
+                    ))
+                }
+                None => {
+                    let stream = acknowledged_operation_response_stream(
+                        "workspace identity OAuth response stream closed before creation completed",
+                        move |event_sender| {
+                            instrument_grpc(span, async move {
+                                identities
+                                    .create_or_replace_workspace_oauth(
+                                        &workspace,
+                                        &name,
+                                        &identity_spec,
+                                        move |event| {
+                                            let event_sender = event_sender.clone();
+                                            async move { event_sender.send(event).await }
+                                        },
+                                    )
+                                    .await
+                                    .map_err(app_status)
+                            })
+                        },
+                        workspace_oauth_event_response,
+                        workspace_identity_response,
+                    );
+                    Ok(Response::new(stream))
+                }
+            }
         })
         .await
     }
@@ -155,3 +181,23 @@ async fn require_workspace(
 
 type CreateWorkspaceOwnedIdentityResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<CreateWorkspaceOwnedIdentityResponse, Status>> + Send>>;
+
+fn workspace_oauth_event_response(
+    event: IdentityOAuthCreationEvent,
+) -> CreateWorkspaceOwnedIdentityResponse {
+    use create_workspace_owned_identity_response::Event;
+
+    let event =
+        identity_oauth_event_to_proto(event, Event::OauthAuthorization, Event::OauthCompleted);
+    CreateWorkspaceOwnedIdentityResponse { event: Some(event) }
+}
+
+fn workspace_identity_response(
+    record: crate::state::db::IdentityRecord,
+) -> CreateWorkspaceOwnedIdentityResponse {
+    CreateWorkspaceOwnedIdentityResponse {
+        event: Some(create_workspace_owned_identity_response::Event::Identity(
+            identity_to_proto(record),
+        )),
+    }
+}

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -1,5 +1,9 @@
 //! Shared gRPC transport helpers for app-owned services.
 
+mod acknowledged_stream;
+
+pub(crate) use acknowledged_stream::acknowledged_operation_response_stream;
+
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/crates/coral-app/src/transport/acknowledged_stream.rs
+++ b/crates/coral-app/src/transport/acknowledged_stream.rs
@@ -1,0 +1,133 @@
+//! Acknowledged progress-event streams for long-running gRPC operations.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::sync::{mpsc, oneshot};
+use tokio_stream::Stream;
+use tonic::Status;
+
+use crate::bootstrap::AppError;
+
+const EVENT_CHANNEL_CAPACITY: usize = 8;
+
+pub(crate) struct AcknowledgedEventSender<E> {
+    tx: mpsc::Sender<PendingAcknowledgedEvent<E>>,
+    closed_message: &'static str,
+}
+
+impl<E> Clone for AcknowledgedEventSender<E> {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            closed_message: self.closed_message,
+        }
+    }
+}
+
+impl<E: Send> AcknowledgedEventSender<E> {
+    pub(crate) async fn send(&self, event: E) -> Result<(), AppError> {
+        let (delivered, delivered_rx) = oneshot::channel();
+        self.tx
+            .send(PendingAcknowledgedEvent { event, delivered })
+            .await
+            .map_err(|_closed| AppError::FailedPrecondition(self.closed_message.to_string()))?;
+        delivered_rx
+            .await
+            .map_err(|_closed| AppError::FailedPrecondition(self.closed_message.to_string()))
+    }
+}
+
+struct PendingAcknowledgedEvent<E> {
+    event: E,
+    delivered: oneshot::Sender<()>,
+}
+
+impl<E> PendingAcknowledgedEvent<E> {
+    fn into_event(self) -> E {
+        // Acknowledges server dequeue, not network or application-level consumption.
+        let _delivery = self.delivered.send(());
+        self.event
+    }
+}
+
+pub(crate) fn acknowledged_operation_response_stream<E, T, R, F, Fut>(
+    closed_message: &'static str,
+    operation: F,
+    event_to_response: fn(E) -> R,
+    result_to_response: impl FnOnce(T) -> R + Send + 'static,
+) -> Pin<Box<dyn Stream<Item = Result<R, Status>> + Send>>
+where
+    E: Send + 'static,
+    T: 'static,
+    R: Send + Unpin + 'static,
+    F: FnOnce(AcknowledgedEventSender<E>) -> Fut,
+    Fut: Future<Output = Result<T, Status>> + Send + 'static,
+{
+    let (event_tx, event_rx) = mpsc::channel(EVENT_CHANNEL_CAPACITY);
+    let event_sender = AcknowledgedEventSender {
+        tx: event_tx,
+        closed_message,
+    };
+    Box::pin(AcknowledgedOperationResponseStream {
+        events: event_rx,
+        operation: Some((
+            Box::pin(operation(event_sender)),
+            Box::new(result_to_response),
+        )),
+        completion: None,
+        event_to_response,
+    })
+}
+
+struct AcknowledgedOperationResponseStream<E, T, R> {
+    events: mpsc::Receiver<PendingAcknowledgedEvent<E>>,
+    #[expect(clippy::type_complexity, reason = "private one-shot operation slot")]
+    operation: Option<(
+        Pin<Box<dyn Future<Output = Result<T, Status>> + Send>>,
+        Box<dyn FnOnce(T) -> R + Send>,
+    )>,
+    completion: Option<Result<R, Status>>,
+    event_to_response: fn(E) -> R,
+}
+
+impl<E, T, R> AcknowledgedOperationResponseStream<E, T, R> {
+    fn poll_event(&mut self, cx: &mut Context<'_>) -> Poll<Option<R>> {
+        Pin::new(&mut self.events)
+            .poll_recv(cx)
+            .map(|event| event.map(|event| (self.event_to_response)(event.into_event())))
+    }
+}
+
+impl<E, T, R: Unpin> Stream for AcknowledgedOperationResponseStream<E, T, R> {
+    type Item = Result<R, Status>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            if let Poll::Ready(Some(event)) = this.poll_event(cx) {
+                return Poll::Ready(Some(Ok(event)));
+            }
+            if let Some(completion) = this.completion.take() {
+                return Poll::Ready(Some(completion));
+            }
+            let Some((operation, _)) = this.operation.as_mut() else {
+                return Poll::Ready(None);
+            };
+            match operation.as_mut().poll(cx) {
+                Poll::Ready(result) => {
+                    if let Some((_, result_to_response)) = this.operation.take() {
+                        this.completion = Some(result.map(result_to_response));
+                    }
+                }
+                Poll::Pending => {
+                    return match this.poll_event(cx) {
+                        Poll::Ready(Some(event)) => Poll::Ready(Some(Ok(event))),
+                        Poll::Ready(None) | Poll::Pending => Poll::Pending,
+                    };
+                }
+            }
+        }
+    }
+}

--- a/crates/coral-app/tests/grpc/identity_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_tests.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use coral_api::v1::create_user_owned_identity_response::Event as UserCreateEvent;
+use coral_api::v1::create_workspace_owned_identity_response::Event as WorkspaceCreateEvent;
 use coral_api::v1::{
     AddIdentitySpecRequest, CreateUserOwnedIdentityRequest, CreateWorkspaceOwnedIdentityRequest,
     CreateWorkspaceRequest, CredentialMetadata, DeleteIdentitySpecRequest,
@@ -17,11 +19,16 @@ use coral_api::{
 use coral_app::{ServerBuilder, UserPrincipal, UserPrincipalProvider, UserPrincipalProviderError};
 use coral_client::AppClient;
 use tempfile::TempDir;
+use tokio_stream::StreamExt as _;
 use tonic::metadata::MetadataMap;
 use tonic::{Code, Request, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 const USER_HEADER: &str = "x-test-user";
+const DEVICE_RESPONSE: &str = r#"{"device_code":"device-code","user_code":"ABCD-1234","verification_uri":"https://provider.example/device","verification_uri_complete":"https://provider.example/device?user_code=ABCD-1234","expires_in":60,"interval":1}"#;
+const TOKEN_RESPONSE: &str = r#"{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","scope":"repo user"}"#;
 
 #[derive(Debug)]
 struct HeaderPrincipalProvider;
@@ -145,6 +152,105 @@ async fn user_identity_service_is_scoped_validated_and_restart_safe() {
     assert_error_reason(&missing_delete, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
     assert_eq!(get(&restarted, "bob", "shared").await, bob);
     server.shutdown().await.expect("shutdown restarted server");
+}
+
+#[tokio::test]
+async fn oauth_identity_creation_streams_ordered_user_and_workspace_events() {
+    let temp = TempDir::new().expect("temp dir");
+    let (server, app) = start(&temp.path().join("coral-config")).await;
+    let workspace = create_workspace(&app, "oauth_workspace").await;
+    let spec = "shared_oauth";
+    let provider = oauth_fixture(&app, &workspace, spec).await;
+
+    let user_events = app
+        .identity_client()
+        .create_user_owned_identity(user_oauth_request("user-oauth", spec, "alice"))
+        .await
+        .expect("create user OAuth identity")
+        .into_inner()
+        .map(|response| response.expect("OAuth event").event.expect("event"))
+        .collect::<Vec<_>>()
+        .await;
+    let [
+        UserCreateEvent::OauthAuthorization(user_authorization),
+        UserCreateEvent::OauthCompleted(user_completed),
+        UserCreateEvent::Identity(user),
+    ] = user_events.as_slice()
+    else {
+        panic!("expected authorization, completion, identity, and EOF: {user_events:?}");
+    };
+    assert_eq!(user.owner, IdentityOwner::User as i32);
+    assert_eq!(user.issuer, "global_oauth");
+    assert!(user.owner_workspace.is_none());
+    assert!(user.identity_spec_workspace.is_none());
+
+    let workspace_request = workspace_oauth_request(&workspace, "shared-oauth", spec, "bob");
+    let workspace_events = app
+        .workspace_identity_client()
+        .create_workspace_owned_identity(workspace_request)
+        .await
+        .expect("create workspace OAuth identity")
+        .into_inner()
+        .map(|response| response.expect("OAuth event").event.expect("event"))
+        .collect::<Vec<_>>()
+        .await;
+    let [
+        WorkspaceCreateEvent::OauthAuthorization(workspace_authorization),
+        WorkspaceCreateEvent::OauthCompleted(workspace_completed),
+        WorkspaceCreateEvent::Identity(shared),
+    ] = workspace_events.as_slice()
+    else {
+        panic!("expected authorization, completion, identity, and EOF: {workspace_events:?}");
+    };
+    assert_eq!(shared.owner, IdentityOwner::Workspace as i32);
+    assert_eq!(shared.issuer, "workspace_oauth");
+    assert_eq!(shared.owner_workspace.as_ref(), Some(&workspace));
+    assert_eq!(shared.identity_spec_workspace.as_ref(), Some(&workspace));
+
+    assert_eq!(workspace_authorization, user_authorization);
+    assert_eq!(
+        user_authorization.authorization_url,
+        "https://provider.example/device?user_code=ABCD-1234"
+    );
+    assert_eq!(user_authorization.expires_in_seconds, 60);
+    assert_eq!(user_authorization.user_code, "ABCD-1234");
+    assert_eq!(
+        user_authorization.verification_uri,
+        "https://provider.example/device"
+    );
+    assert_eq!(
+        user_authorization.verification_uri_complete,
+        user_authorization.authorization_url
+    );
+    let metadata =
+        [("scope", "repo user"), ("token_type", "Bearer")].map(|(key, value)| CredentialMetadata {
+            key: key.to_string(),
+            value: value.to_string(),
+        });
+    assert_eq!(user_completed.metadata, metadata);
+    assert_eq!(workspace_completed.metadata, metadata);
+    assert_eq!(user.metadata, metadata);
+    assert_eq!(shared.metadata, metadata);
+
+    let requests = provider
+        .received_requests()
+        .await
+        .expect("recorded OAuth requests");
+    for (request, (endpoint, client)) in requests.iter().zip([
+        ("/device", "global-client"),
+        ("/token", "global-client"),
+        ("/device", "workspace-client"),
+        ("/token", "workspace-client"),
+    ]) {
+        assert_eq!(request.url.path(), endpoint);
+        assert!(String::from_utf8_lossy(&request.body).contains(&format!("client_id={client}")));
+    }
+    assert_eq!(requests.len(), 4);
+    let public_responses = format!("{user_events:?}{workspace_events:?}");
+    for secret in ["access-token", "refresh-token", "device-code"] {
+        assert!(!public_responses.contains(secret));
+    }
+    server.shutdown().await.expect("shutdown server");
 }
 
 #[tokio::test]
@@ -280,37 +386,19 @@ async fn workspace_identity_service_validates_workspace_boundaries() {
     let missing_identity = workspace_get_status(&app, "alice", &existing, "missing").await;
     assert_eq!(missing_identity.code(), Code::NotFound);
     assert_error_reason(&missing_identity, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
-    let omitted = workspace_create_status(
+    let omitted = workspace_oauth_status(
         &app,
-        for_user(
-            CreateWorkspaceOwnedIdentityRequest {
-                workspace: Some(existing),
-                name: "shared".to_string(),
-                identity_spec: "missing".to_string(),
-                setup: None,
-            },
-            "alice",
-        ),
+        workspace_oauth_request(&existing, "shared", "missing", "alice"),
     )
     .await;
-    assert_eq!(omitted.code(), Code::Unimplemented);
+    assert_eq!(omitted.code(), Code::NotFound);
+    assert_error_reason(&omitted, CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND);
     server.shutdown().await.expect("shutdown server");
 }
 
 async fn assert_create_validation(app: &AppClient) {
-    let omitted = create_status(
-        app,
-        for_user(
-            CreateUserOwnedIdentityRequest {
-                name: "shared".to_string(),
-                identity_spec: "oauth_spec".to_string(),
-                setup: None,
-            },
-            "alice",
-        ),
-    )
-    .await;
-    assert_eq!(omitted.code(), Code::Unimplemented);
+    let omitted = user_oauth_status(app, user_oauth_request("shared", "alice_spec", "alice")).await;
+    assert_eq!(omitted.code(), Code::InvalidArgument);
     assert_eq!(
         create_status(
             app,
@@ -330,7 +418,7 @@ async fn assert_create_validation(app: &AppClient) {
         );
     }
     let missing_spec =
-        create_status(app, create_request("shared", "missing", "token", "alice")).await;
+        user_oauth_status(app, user_oauth_request("shared", "missing", "alice")).await;
     assert_eq!(missing_spec.code(), Code::NotFound);
     assert_error_reason(&missing_spec, CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND);
 }
@@ -395,6 +483,35 @@ async fn add_scoped_spec(
         .expect("add identity spec");
 }
 
+async fn oauth_fixture(app: &AppClient, workspace: &Workspace, spec: &str) -> MockServer {
+    let provider = MockServer::start().await;
+    for (endpoint, response) in [("/device", DEVICE_RESPONSE), ("/token", TOKEN_RESPONSE)] {
+        Mock::given(method("POST"))
+            .and(path(endpoint))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(response, "application/json"))
+            .mount(&provider)
+            .await;
+    }
+    let workspace_scope = Some(workspace.clone());
+    for (scope, issuer, client) in [
+        (None, "global_oauth", "global-client"),
+        (workspace_scope, "workspace_oauth", "workspace-client"),
+    ] {
+        app.identity_spec_client()
+            .add_identity_spec(for_user(
+                AddIdentitySpecRequest {
+                    manifest_yaml: device_manifest(spec, issuer, &provider.uri(), client),
+                    input_values: Vec::new(),
+                    workspace: scope,
+                },
+                "alice",
+            ))
+            .await
+            .expect("add OAuth identity spec");
+    }
+    provider
+}
+
 async fn create_workspace(app: &AppClient, name: &str) -> Workspace {
     let workspace = workspace(name);
     app.workspace_client()
@@ -445,6 +562,20 @@ async fn workspace_create_status(
         .create_workspace_owned_identity(request)
         .await
         .expect_err("workspace identity creation must fail")
+}
+
+async fn workspace_oauth_status(
+    app: &AppClient,
+    request: Request<CreateWorkspaceOwnedIdentityRequest>,
+) -> Status {
+    app.workspace_identity_client()
+        .create_workspace_owned_identity(request)
+        .await
+        .expect("workspace OAuth stream")
+        .into_inner()
+        .message()
+        .await
+        .expect_err("workspace OAuth stream must fail")
 }
 
 async fn workspace_list(app: &AppClient, user: &str, workspace: &Workspace) -> Vec<Identity> {
@@ -548,6 +679,20 @@ async fn create_status(
         .expect_err("identity creation must fail")
 }
 
+async fn user_oauth_status(
+    app: &AppClient,
+    request: Request<CreateUserOwnedIdentityRequest>,
+) -> Status {
+    app.identity_client()
+        .create_user_owned_identity(request)
+        .await
+        .expect("user OAuth stream")
+        .into_inner()
+        .message()
+        .await
+        .expect_err("user OAuth stream must fail")
+}
+
 async fn create(app: &AppClient, user: &str, name: &str, spec: &str, token: &str) -> Identity {
     let mut stream = app
         .identity_client()
@@ -611,6 +756,21 @@ fn create_request(
     )
 }
 
+fn user_oauth_request(
+    name: &str,
+    spec: &str,
+    user: &str,
+) -> Request<CreateUserOwnedIdentityRequest> {
+    for_user(
+        CreateUserOwnedIdentityRequest {
+            name: name.to_string(),
+            identity_spec: spec.to_string(),
+            setup: None,
+        },
+        user,
+    )
+}
+
 fn workspace_create_request(
     workspace: &Workspace,
     name: &str,
@@ -628,6 +788,23 @@ fn workspace_create_request(
                     token: token.to_string(),
                 },
             )),
+        },
+        user,
+    )
+}
+
+fn workspace_oauth_request(
+    workspace: &Workspace,
+    name: &str,
+    spec: &str,
+    user: &str,
+) -> Request<CreateWorkspaceOwnedIdentityRequest> {
+    for_user(
+        CreateWorkspaceOwnedIdentityRequest {
+            workspace: Some(workspace.clone()),
+            name: name.to_string(),
+            identity_spec: spec.to_string(),
+            setup: None,
         },
         user,
     )
@@ -696,5 +873,11 @@ fn manifest(name: &str, issuer: &str, kind: &str) -> String {
     };
     format!(
         "kind: identity\nspec_version: 1\nname: {name}\nversion: 1.0.0\ndescription: {issuer} identity\nissuer: {issuer}\ntype: {kind}\n{oauth}"
+    )
+}
+
+fn device_manifest(name: &str, issuer: &str, base: &str, client: &str) -> String {
+    format!(
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: 1.0.0\ndescription: {issuer} identity\nissuer: {issuer}\ntype: oauth\noauth:\n  method:\n    flow: {{type: device_code}}\n    endpoints:\n      device_authorization_url: {base}/device\n      token_url: {base}/token\n    client:\n      id: {{default: {client}}}\n"
     )
 }


### PR DESCRIPTION
## Intent

Expose the existing DB-backed OAuth identity-creation core through the authenticated user-owned and workspace-owned streaming RPCs, while preserving fixed-token behavior.

## What it enables

- User-owned OAuth identities created from global identity specs.
- Workspace-owned OAuth identities created from same-workspace specs with global fallback.
- Exact public event ordering: `OAuthAuthorization` -> `OAuthCompleted` -> durable `Identity` -> EOF.
- Typed terminal stream failures without spawning detached OAuth work.

## Usage examples

Send `CreateUserOwnedIdentity` with `name`, `identity_spec`, and no `setup` for OAuth. Send `CreateWorkspaceOwnedIdentity` the same way with a workspace. Fixed-token callers continue to send the existing fixed-token setup and receive one identity event.

## Implementation

Adds one bounded acknowledged-event stream whose operation future remains owned by the response stream, so dropping the stream cancels unfinished work. User and workspace services translate app-private authorization/completion callbacks into dedicated identity OAuth events, share safe metadata conversion, and emit the final identity only after persistence. OAuth tokens, refresh tokens, device codes, and encrypted documents are never projected.

## Stack

Directly based on draft #1709 at `a3dcec71b29b7be3e5b57829b0d949eb04eeaa8f`. This PR remains draft.

The mandatory hardening sequence is:

1. B5d1 draft #1713 bounds and redacts provider responses, callbacks, transport failures, and provider timers.
2. B5d1a directly proves real HTTP 400 `authorization_pending` control flow and hostile-field non-egress.
3. B5d1b adds USER/WORKSPACE shutdown cancellation and pending-operation no-persistence coverage.
4. B5d2 owns the remaining disconnect, post-authorization failure, restart, isolation, raw gRPC-Web framing, response-limit, cardinality, and secret non-egress matrices.

## Validation

- `cargo test --locked -p coral-app --all-features --test grpc identity_tests:: -- --nocapture` — 4 passed.
- `cargo clippy --locked -p coral-app --all-features --all-targets -- -D warnings` — passed.
- `make rust-checks` — formatting, workspace Clippy, 1,739/1,739 tests, and rustdoc passed; 3 tests skipped.
- `make postgres-tests` — repository, identity migration, and Postgres server-startup gates passed.
- Exact 600 changed lines.

## Review

Fresh five-lane exact-diff review completed. Correctness and architecture were clean. Supervisor closure found no additional P1/P2 risk and accepted provider-error disclosure plus active-operation shutdown as mandatory hardening work. Draft #1713 closes the provider-response production defect; B5d1a and B5d1b remain required direct children for protocol control-flow and shutdown/no-persistence proofs. No affected PR will be marked ready before B5d1a, B5d1b, and B5d2 are complete.
