### PR TITLE
fix(app): cancel identity OAuth on shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,6 +1259,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml",
  "toml_edit",
  "tonic",
@@ -6006,6 +6007,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ strsim = "0.11"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["rt"] }
 toml = "0.9"
 toml_edit = "0.25.10"
 tonic = "0.14.2"

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -35,6 +35,7 @@ sqlx.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream = { workspace = true, features = ["net"] }
+tokio-util.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
 tonic.workspace = true

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -34,6 +34,7 @@ use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::TcpListenerStream;
+use tokio_util::sync::CancellationToken;
 use tonic::codegen::http::header::CONTENT_TYPE;
 use tonic::codegen::http::{HeaderValue, Method, Request, Response, StatusCode};
 use tonic::service::Routes;
@@ -501,6 +502,7 @@ fn resolve_database_config(layout: &AppStateLayout) -> Result<ResolvedDatabaseCo
 pub struct RunningServer {
     endpoint_uri: String,
     local_trace_store_dir: Option<PathBuf>,
+    identity_oauth_shutdown: CancellationToken,
     shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
     task: Mutex<Option<JoinHandle<Result<(), tonic::transport::Error>>>>,
 }
@@ -533,18 +535,7 @@ impl RunningServer {
     }
 
     async fn shutdown_inner(&self) -> Result<(), AppError> {
-        if let Some(shutdown_tx) = self
-            .shutdown_tx
-            .lock()
-            .expect("shutdown mutex poisoned")
-            .take()
-        {
-            #[expect(
-                clippy::let_underscore_must_use,
-                reason = "send error means the receiver is already dropped, which is fine during shutdown"
-            )]
-            let _ = shutdown_tx.send(());
-        }
+        self.signal_shutdown();
 
         let task = self.task.lock().expect("task mutex poisoned").take();
         if let Some(task) = task {
@@ -552,10 +543,9 @@ impl RunningServer {
         }
         Ok(())
     }
-}
 
-impl Drop for RunningServer {
-    fn drop(&mut self) {
+    fn signal_shutdown(&self) {
+        self.identity_oauth_shutdown.cancel();
         if let Some(shutdown_tx) = self
             .shutdown_tx
             .lock()
@@ -568,6 +558,12 @@ impl Drop for RunningServer {
             )]
             let _ = shutdown_tx.send(());
         }
+    }
+}
+
+impl Drop for RunningServer {
+    fn drop(&mut self) {
+        self.signal_shutdown();
     }
 }
 
@@ -609,8 +605,11 @@ async fn start_server(
     let source_service = SourceService::new(source, query.clone(), workspace.clone());
     let workspace_service = WorkspaceService::new(workspace.clone());
     let identity_spec_service = IdentitySpecService::new(identity_spec);
-    let identity_service = IdentityService::new(identity.clone());
-    let workspace_identity_service = WorkspaceIdentityService::new(identity, workspace);
+    let identity_oauth_shutdown = CancellationToken::new();
+    let identity_service =
+        IdentityService::new(identity.clone(), identity_oauth_shutdown.child_token());
+    let workspace_identity_service =
+        WorkspaceIdentityService::new(identity, workspace, identity_oauth_shutdown.child_token());
     let catalog_service = CatalogService::new(query.clone());
     let query_service = QueryService::new(query);
     let search_service = SearchService::new(search);
@@ -676,6 +675,7 @@ async fn start_server(
     Ok(RunningServer {
         endpoint_uri,
         local_trace_store_dir,
+        identity_oauth_shutdown,
         shutdown_tx: Mutex::new(Some(shutdown_tx)),
         task: Mutex::new(Some(task)),
     })

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -7,6 +7,8 @@
 
 mod oauth_create;
 
+pub(crate) use oauth_create::IdentityOAuthCommitPhase;
+
 use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;

--- a/crates/coral-app/src/identities/manager/oauth_create.rs
+++ b/crates/coral-app/src/identities/manager/oauth_create.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use coral_spec::{IdentitySpecConfig, IdentitySpecType, ManifestOAuthCredentialSpec};
 
@@ -30,6 +31,19 @@ use super::{
 
 const OAUTH_ACCESS_TOKEN_KEY: &str = "ACCESS_TOKEN";
 
+#[derive(Clone, Default)]
+pub(crate) struct IdentityOAuthCommitPhase(Arc<AtomicBool>);
+
+impl IdentityOAuthCommitPhase {
+    pub(crate) fn mark_started(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn has_started(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
 #[derive(Clone, PartialEq, Eq)]
 struct OAuthCreateSnapshot {
     workspace_created_at_unix_nanos: Option<i64>,
@@ -55,6 +69,7 @@ impl IdentityManager {
         principal: &UserPrincipal,
         identity_name: &str,
         identity_spec_name: &str,
+        commit_phase: IdentityOAuthCommitPhase,
         events: E,
     ) -> Result<IdentityRecord, AppError>
     where
@@ -64,7 +79,7 @@ impl IdentityManager {
         let owner = IdentityOwner::for_user(principal.clone());
         let name = IdentityName::parse(identity_name)?;
         let requested_key = IdentitySpecKey::global(identity_spec_name)?;
-        self.create_or_replace_oauth(owner, name, requested_key, events)
+        self.create_or_replace_oauth(owner, name, requested_key, commit_phase, events)
             .await
     }
 
@@ -74,6 +89,7 @@ impl IdentityManager {
         workspace: &WorkspaceName,
         identity_name: &str,
         identity_spec_name: &str,
+        commit_phase: IdentityOAuthCommitPhase,
         events: E,
     ) -> Result<IdentityRecord, AppError>
     where
@@ -83,7 +99,7 @@ impl IdentityManager {
         let owner = IdentityOwner::workspace(workspace.clone());
         let name = IdentityName::parse(identity_name)?;
         let requested_key = IdentitySpecKey::workspace(workspace.clone(), identity_spec_name)?;
-        self.create_or_replace_oauth(owner, name, requested_key, events)
+        self.create_or_replace_oauth(owner, name, requested_key, commit_phase, events)
             .await
     }
 
@@ -92,6 +108,7 @@ impl IdentityManager {
         owner: IdentityOwner,
         name: IdentityName,
         requested_key: IdentitySpecKey,
+        commit_phase: IdentityOAuthCommitPhase,
         events: E,
     ) -> Result<IdentityRecord, AppError>
     where
@@ -137,7 +154,14 @@ impl IdentityManager {
 
         for _ in 0..MAX_MUTATION_ATTEMPTS {
             match self
-                .try_commit_oauth(&owner, &name, &selected, &document, &safe_metadata)
+                .try_commit_oauth(
+                    &owner,
+                    &name,
+                    &selected,
+                    &commit_phase,
+                    &document,
+                    &safe_metadata,
+                )
                 .await
             {
                 Ok(Some(record)) => return Ok(record),
@@ -217,10 +241,12 @@ impl IdentityManager {
         owner: &IdentityOwner,
         name: &IdentityName,
         selected: &SelectedOAuthSpec,
+        commit_phase: &IdentityOAuthCommitPhase,
         document: &IdentityDocumentWrite,
         safe_metadata: &BTreeMap<String, String>,
     ) -> Result<Option<IdentityRecord>, AppError> {
         let mut tx = self.db.begin_serializable().await?;
+        commit_phase.mark_started();
         let current =
             load_oauth_create_snapshot(&mut tx, owner, name, &selected.requested_key).await?;
         if current.workspace_created_at_unix_nanos

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -9,7 +9,9 @@ use tempfile::tempdir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use super::{IdentityManager, IdentityOAuthCreationEvent, ResolvedIdentityForUse};
+use super::{
+    IdentityManager, IdentityOAuthCommitPhase, IdentityOAuthCreationEvent, ResolvedIdentityForUse,
+};
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialsError;
 use crate::credentials::encryption::{
@@ -69,6 +71,10 @@ async fn sqlite_fixed_token_manager_contract() {
 }
 
 #[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "keeps the complete OAuth creation and encrypted persistence contract together"
+)]
 async fn sqlite_oauth_creation_core_contract() {
     let temp = tempdir().expect("temp dir");
     let db = Arc::new(
@@ -105,13 +111,19 @@ async fn sqlite_oauth_creation_core_contract() {
     let events = Arc::new(Mutex::new(Vec::new()));
     let captured_events = events.clone();
     let created = manager
-        .create_or_replace_user_oauth(&principal, &identity_name, &oauth_spec, move |event| {
-            let events = captured_events.clone();
-            async move {
-                events.lock().expect("event lock").push(event);
-                Ok(())
-            }
-        })
+        .create_or_replace_user_oauth(
+            &principal,
+            &identity_name,
+            &oauth_spec,
+            IdentityOAuthCommitPhase::default(),
+            move |event| {
+                let events = captured_events.clone();
+                async move {
+                    events.lock().expect("event lock").push(event);
+                    Ok(())
+                }
+            },
+        )
         .await
         .expect("create user OAuth identity");
     let expected_safe = BTreeMap::from([

--- a/crates/coral-app/src/identities/manager/tests/oauth_create_races.rs
+++ b/crates/coral-app/src/identities/manager/tests/oauth_create_races.rs
@@ -185,14 +185,18 @@ async fn assert_creation_cancellation(
     let resume = Arc::new(tokio::sync::Barrier::new(2));
     let manager = IdentityManager::new(db.clone(), key_provider.clone())
         .with_before_write_gate(reached.clone(), resume);
+    let commit_phase = IdentityOAuthCommitPhase::default();
     let task_principal = principal.clone();
     let task_identity_name = identity_name.clone();
+    let task_spec_name = spec_name.clone();
+    let task_commit_phase = commit_phase.clone();
     let task = tokio::spawn(async move {
         manager
             .create_or_replace_user_oauth(
                 &task_principal,
                 &task_identity_name,
-                &spec_name,
+                &task_spec_name,
+                task_commit_phase,
                 |_| async { Ok(()) },
             )
             .await
@@ -200,6 +204,7 @@ async fn assert_creation_cancellation(
     tokio::time::timeout(Duration::from_secs(10), reached.wait())
         .await
         .expect("OAuth cancellation must reach the transactional identity upsert");
+    assert!(commit_phase.has_started());
     task.abort();
     let cancelled = tokio::time::timeout(Duration::from_secs(10), task)
         .await
@@ -478,6 +483,7 @@ async fn create_gated_oauth(
                     &principal,
                     &identity_name,
                     &spec_name,
+                    IdentityOAuthCommitPhase::default(),
                     move |event| {
                         let reached = reached.clone();
                         let resume = resume.clone();
@@ -498,6 +504,7 @@ async fn create_gated_oauth(
                     &workspace,
                     &identity_name,
                     &spec_name,
+                    IdentityOAuthCommitPhase::default(),
                     move |event| {
                         let reached = reached.clone();
                         let resume = resume.clone();

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -1,5 +1,6 @@
 //! Implements the gRPC `IdentityService` for user-owned identities.
 
+use std::future::Future;
 use std::pin::Pin;
 
 use coral_api::v1::identity_service_server::IdentityService as IdentityServiceApi;
@@ -13,10 +14,13 @@ use coral_api::v1::{
     create_user_owned_identity_response,
 };
 use tokio_stream::Stream;
+use tokio_util::sync::CancellationToken;
 use tonic::{Request, Response, Status};
 
-use crate::bootstrap::app_status;
-use crate::identities::manager::{IdentityManager, IdentityOAuthCreationEvent};
+use crate::bootstrap::{AppError, app_status};
+use crate::identities::manager::{
+    IdentityManager, IdentityOAuthCommitPhase, IdentityOAuthCreationEvent,
+};
 use crate::identities::model::IdentityOwner;
 use crate::request_context::RequestContext;
 use crate::state::db::{IdentityRecord, IdentitySpecScope};
@@ -27,11 +31,15 @@ use crate::transport::{
 #[derive(Clone)]
 pub(crate) struct IdentityService {
     identities: IdentityManager,
+    oauth_shutdown: CancellationToken,
 }
 
 impl IdentityService {
-    pub(crate) fn new(identities: IdentityManager) -> Self {
-        Self { identities }
+    pub(crate) fn new(identities: IdentityManager, oauth_shutdown: CancellationToken) -> Self {
+        Self {
+            identities,
+            oauth_shutdown,
+        }
     }
 }
 
@@ -45,6 +53,7 @@ impl IdentityServiceApi for IdentityService {
     ) -> Result<Response<Self::CreateUserOwnedIdentityStream>, Status> {
         let span = grpc_span(&request);
         let identities = self.identities.clone();
+        let oauth_shutdown = self.oauth_shutdown.clone();
         instrument_grpc(span.clone(), async move {
             let principal = RequestContext::from_request(&request)?.principal().clone();
             let CreateUserOwnedIdentityRequest {
@@ -71,22 +80,26 @@ impl IdentityServiceApi for IdentityService {
                     ))
                 }
                 None => {
+                    let commit_phase = IdentityOAuthCommitPhase::default();
                     let stream = acknowledged_operation_response_stream(
                         "identity OAuth response stream closed before creation completed",
                         move |event_sender| {
                             instrument_grpc(span, async move {
-                                identities
-                                    .create_or_replace_user_oauth(
+                                run_identity_oauth_until_shutdown(
+                                    oauth_shutdown,
+                                    commit_phase.clone(),
+                                    identities.create_or_replace_user_oauth(
                                         &principal,
                                         &name,
                                         &identity_spec,
+                                        commit_phase,
                                         move |event| {
                                             let event_sender = event_sender.clone();
                                             async move { event_sender.send(event).await }
                                         },
-                                    )
-                                    .await
-                                    .map_err(app_status)
+                                    ),
+                                )
+                                .await
                             })
                         },
                         user_oauth_event_response,
@@ -158,6 +171,25 @@ impl IdentityServiceApi for IdentityService {
             Ok(Response::new(DeleteUserOwnedIdentityResponse {}))
         })
         .await
+    }
+}
+
+pub(super) async fn run_identity_oauth_until_shutdown<T>(
+    oauth_shutdown: CancellationToken,
+    commit_phase: IdentityOAuthCommitPhase,
+    operation: impl Future<Output = Result<T, AppError>>,
+) -> Result<T, Status> {
+    tokio::pin!(operation);
+    tokio::select! {
+        biased;
+        result = operation.as_mut() => result.map_err(app_status),
+        () = oauth_shutdown.cancelled() => {
+            if commit_phase.has_started() {
+                operation.await.map_err(app_status)
+            } else {
+                Err(Status::cancelled("server is shutting down"))
+            }
+        },
     }
 }
 
@@ -248,13 +280,54 @@ pub(super) fn identity_to_proto(record: IdentityRecord) -> ProtoIdentity {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::future::Future as _;
+    use std::task::Poll;
 
     use coral_api::v1::CredentialMetadata;
 
-    use super::identity_to_proto;
+    use super::{identity_to_proto, run_identity_oauth_until_shutdown};
+    use crate::bootstrap::AppError;
+    use crate::identities::manager::IdentityOAuthCommitPhase;
     use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
     use crate::identity::UserPrincipal;
     use crate::state::db::{IdentityRecord, IdentitySpecKey};
+    use tokio_util::sync::CancellationToken;
+
+    #[tokio::test]
+    async fn oauth_shutdown_prefers_ready_manager_result_on_tie() {
+        let shutdown = CancellationToken::new();
+        shutdown.cancel();
+        let result = run_identity_oauth_until_shutdown(
+            shutdown,
+            IdentityOAuthCommitPhase::default(),
+            std::future::ready(Ok::<_, AppError>("manager-result")),
+        )
+        .await;
+        assert_eq!(result.expect("ready manager result wins"), "manager-result");
+    }
+
+    #[tokio::test]
+    async fn oauth_shutdown_waits_for_started_commit() {
+        let shutdown = CancellationToken::new();
+        shutdown.cancel();
+        let commit_phase = IdentityOAuthCommitPhase::default();
+        assert!(!commit_phase.has_started());
+        let operation_phase = commit_phase.clone();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let guarded = run_identity_oauth_until_shutdown(shutdown, commit_phase, async move {
+            operation_phase.mark_started();
+            release_rx.await.expect("release commit");
+            Ok::<_, AppError>("committed")
+        });
+        tokio::pin!(guarded);
+        std::future::poll_fn(|cx| {
+            assert!(guarded.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+        release_tx.send(()).expect("finish commit");
+        assert_eq!(guarded.await.expect("commit result"), "committed");
+    }
 
     #[test]
     fn identity_to_proto_exposes_only_ordered_safe_metadata() {

--- a/crates/coral-app/src/identities/workspace_service.rs
+++ b/crates/coral-app/src/identities/workspace_service.rs
@@ -12,11 +12,14 @@ use coral_api::v1::{
     create_workspace_owned_identity_response,
 };
 use tokio_stream::Stream;
+use tokio_util::sync::CancellationToken;
 use tonic::{Request, Response, Status};
 
-use super::manager::{IdentityManager, IdentityOAuthCreationEvent};
+use super::manager::{IdentityManager, IdentityOAuthCommitPhase, IdentityOAuthCreationEvent};
 use super::model::IdentityOwner;
-use super::service::{identity_oauth_event_to_proto, identity_to_proto};
+use super::service::{
+    identity_oauth_event_to_proto, identity_to_proto, run_identity_oauth_until_shutdown,
+};
 use crate::bootstrap::app_status;
 use crate::transport::{
     acknowledged_operation_response_stream, grpc_span, instrument_grpc, workspace_name_from_proto,
@@ -27,13 +30,19 @@ use crate::workspaces::{WorkspaceManager, WorkspaceName};
 pub(crate) struct WorkspaceIdentityService {
     identities: IdentityManager,
     workspaces: WorkspaceManager,
+    oauth_shutdown: CancellationToken,
 }
 
 impl WorkspaceIdentityService {
-    pub(crate) fn new(identities: IdentityManager, workspaces: WorkspaceManager) -> Self {
+    pub(crate) fn new(
+        identities: IdentityManager,
+        workspaces: WorkspaceManager,
+        oauth_shutdown: CancellationToken,
+    ) -> Self {
         Self {
             identities,
             workspaces,
+            oauth_shutdown,
         }
     }
 }
@@ -49,6 +58,7 @@ impl WorkspaceIdentityServiceApi for WorkspaceIdentityService {
         let span = grpc_span(&request);
         let identities = self.identities.clone();
         let workspaces = self.workspaces.clone();
+        let oauth_shutdown = self.oauth_shutdown.clone();
         instrument_grpc(span.clone(), async move {
             let CreateWorkspaceOwnedIdentityRequest {
                 workspace,
@@ -79,22 +89,26 @@ impl WorkspaceIdentityServiceApi for WorkspaceIdentityService {
                     ))
                 }
                 None => {
+                    let commit_phase = IdentityOAuthCommitPhase::default();
                     let stream = acknowledged_operation_response_stream(
                         "workspace identity OAuth response stream closed before creation completed",
                         move |event_sender| {
                             instrument_grpc(span, async move {
-                                identities
-                                    .create_or_replace_workspace_oauth(
+                                run_identity_oauth_until_shutdown(
+                                    oauth_shutdown,
+                                    commit_phase.clone(),
+                                    identities.create_or_replace_workspace_oauth(
                                         &workspace,
                                         &name,
                                         &identity_spec,
+                                        commit_phase,
                                         move |event| {
                                             let event_sender = event_sender.clone();
                                             async move { event_sender.send(event).await }
                                         },
-                                    )
-                                    .await
-                                    .map_err(app_status)
+                                    ),
+                                )
+                                .await
                             })
                         },
                         workspace_oauth_event_response,

--- a/crates/coral-app/tests/grpc/identity_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_tests.rs
@@ -1,4 +1,7 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use coral_api::v1::create_user_owned_identity_response::Event as UserCreateEvent;
 use coral_api::v1::create_workspace_owned_identity_response::Event as WorkspaceCreateEvent;
@@ -19,6 +22,8 @@ use coral_api::{
 use coral_app::{ServerBuilder, UserPrincipal, UserPrincipalProvider, UserPrincipalProviderError};
 use coral_client::AppClient;
 use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::sync::{Semaphore, mpsc};
 use tokio_stream::StreamExt as _;
 use tonic::metadata::MetadataMap;
 use tonic::{Code, Request, Status};
@@ -29,6 +34,8 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 const USER_HEADER: &str = "x-test-user";
 const DEVICE_RESPONSE: &str = r#"{"device_code":"device-code","user_code":"ABCD-1234","verification_uri":"https://provider.example/device","verification_uri_complete":"https://provider.example/device?user_code=ABCD-1234","expires_in":60,"interval":1}"#;
 const TOKEN_RESPONSE: &str = r#"{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","scope":"repo user"}"#;
+const TEST_PHASE_TIMEOUT: Duration = Duration::from_secs(5);
+const SERVER_SHUTDOWN_CANCELLED_MESSAGE: &str = "server is shutting down";
 
 #[derive(Debug)]
 struct HeaderPrincipalProvider;
@@ -253,6 +260,116 @@ async fn oauth_identity_creation_streams_ordered_user_and_workspace_events() {
     server.shutdown().await.expect("shutdown server");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn server_shutdown_cancels_active_identity_oauth_without_persisting() {
+    const USER_IDENTITY: &str = "shutdown-user-oauth";
+    const WORKSPACE_IDENTITY: &str = "shutdown-workspace-oauth";
+
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let (server, app) = start(&config_dir).await;
+    let workspace = create_workspace(&app, "oauth_shutdown_workspace").await;
+    let mut provider = GatedDeviceOAuthProvider::new().await;
+    add_oauth_specs(
+        &app,
+        &workspace,
+        "shutdown_oauth",
+        &provider.device_url,
+        &provider.token_url,
+    )
+    .await;
+
+    let mut user_client = app.identity_client();
+    let mut workspace_client = app.workspace_identity_client();
+    let (user_stream, workspace_stream) = tokio::time::timeout(TEST_PHASE_TIMEOUT, async {
+        tokio::join!(
+            user_client.create_user_owned_identity(user_oauth_request(
+                USER_IDENTITY,
+                "shutdown_oauth",
+                "alice",
+            )),
+            workspace_client.create_workspace_owned_identity(workspace_oauth_request(
+                &workspace,
+                WORKSPACE_IDENTITY,
+                "shutdown_oauth",
+                "bob",
+            )),
+        )
+    })
+    .await
+    .expect("identity OAuth stream acquisition timed out");
+    let mut user_stream = user_stream.expect("start user OAuth stream").into_inner();
+    let mut workspace_stream = workspace_stream
+        .expect("start workspace OAuth stream")
+        .into_inner();
+
+    let user_event = tokio::time::timeout(TEST_PHASE_TIMEOUT, user_stream.message())
+        .await
+        .expect("user OAuth authorization timed out")
+        .expect("read user OAuth authorization")
+        .expect("user OAuth authorization response")
+        .event
+        .expect("user OAuth authorization event");
+    let UserCreateEvent::OauthAuthorization(user_authorization) = user_event else {
+        panic!("expected user OAuth authorization, got {user_event:?}");
+    };
+    let workspace_event = tokio::time::timeout(TEST_PHASE_TIMEOUT, workspace_stream.message())
+        .await
+        .expect("workspace OAuth authorization timed out")
+        .expect("read workspace OAuth authorization")
+        .expect("workspace OAuth authorization response")
+        .event
+        .expect("workspace OAuth authorization event");
+    let WorkspaceCreateEvent::OauthAuthorization(workspace_authorization) = workspace_event else {
+        panic!("expected workspace OAuth authorization, got {workspace_event:?}");
+    };
+    assert_eq!(workspace_authorization, user_authorization);
+
+    let user_tail = tokio::spawn(terminal_oauth_stream_status(user_stream, "user"));
+    let workspace_tail = tokio::spawn(terminal_oauth_stream_status(workspace_stream, "workspace"));
+    let token_clients = provider.wait_for_token_clients().await;
+    assert_eq!(
+        token_clients,
+        BTreeSet::from(["global-client".to_string(), "workspace-client".to_string()])
+    );
+
+    tokio::time::timeout(Duration::from_secs(2), server.shutdown())
+        .await
+        .expect("server shutdown waited on active identity OAuth streams")
+        .expect("shutdown server");
+    assert_identity_tables_empty(&config_dir).await;
+
+    provider.release_token_responses();
+    let user_status = tokio::time::timeout(TEST_PHASE_TIMEOUT, user_tail)
+        .await
+        .expect("user OAuth stream did not terminate")
+        .expect("join user OAuth stream");
+    let workspace_status = tokio::time::timeout(TEST_PHASE_TIMEOUT, workspace_tail)
+        .await
+        .expect("workspace OAuth stream did not terminate")
+        .expect("join workspace OAuth stream");
+    assert_shutdown_cancelled(&user_status);
+    assert_shutdown_cancelled(&workspace_status);
+    provider.finish().await;
+    assert_identity_tables_empty(&config_dir).await;
+
+    drop(user_client);
+    drop(workspace_client);
+    drop(app);
+    let (restarted_server, restarted) = start(&config_dir).await;
+    let user_missing = user_get_status(&restarted, "alice", USER_IDENTITY).await;
+    assert_eq!(user_missing.code(), Code::NotFound);
+    assert_error_reason(&user_missing, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
+    let workspace_missing =
+        workspace_get_status(&restarted, "bob", &workspace, WORKSPACE_IDENTITY).await;
+    assert_eq!(workspace_missing.code(), Code::NotFound);
+    assert_error_reason(&workspace_missing, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
+    restarted_server
+        .shutdown()
+        .await
+        .expect("shutdown restarted server");
+}
+
 #[tokio::test]
 async fn workspace_identity_service_pins_scope_and_isolates_workspaces() {
     let temp = TempDir::new().expect("temp dir");
@@ -436,6 +553,46 @@ async fn start(config_dir: &std::path::Path) -> (coral_app::RunningServer, AppCl
     (server, app)
 }
 
+async fn terminal_oauth_stream_status<T>(
+    mut stream: tonic::Streaming<T>,
+    label: &'static str,
+) -> Status
+where
+    T: std::fmt::Debug + Send + 'static,
+{
+    match stream.message().await {
+        Ok(Some(response)) => {
+            panic!("{label} OAuth stream emitted an event after shutdown: {response:?}")
+        }
+        Ok(None) => panic!("{label} OAuth stream ended without cancellation status"),
+        Err(status) => status,
+    }
+}
+
+fn assert_shutdown_cancelled(status: &Status) {
+    assert_eq!(status.code(), Code::Cancelled, "{status:?}");
+    assert_eq!(status.message(), SERVER_SHUTDOWN_CANCELLED_MESSAGE);
+}
+
+async fn assert_identity_tables_empty(config_dir: &Path) {
+    let options = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(config_dir.join("coral.db"))
+        .create_if_missing(false);
+    let pool = sqlx::SqlitePool::connect_with(options)
+        .await
+        .expect("open identity database for shutdown assertion");
+    let identity_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM identities")
+        .fetch_one(&pool)
+        .await
+        .expect("count identities after shutdown");
+    let document_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM identity_documents")
+        .fetch_one(&pool)
+        .await
+        .expect("count identity documents after shutdown");
+    pool.close().await;
+    assert_eq!((identity_count, document_count), (0, 0));
+}
+
 async fn persist_safe_metadata(config_dir: &std::path::Path, owner_key: &str, name: &str) {
     let options = sqlx::sqlite::SqliteConnectOptions::new().filename(config_dir.join("coral.db"));
     let pool = sqlx::SqlitePool::connect_with(options)
@@ -492,6 +649,19 @@ async fn oauth_fixture(app: &AppClient, workspace: &Workspace, spec: &str) -> Mo
             .mount(&provider)
             .await;
     }
+    let device_url = format!("{}/device", provider.uri());
+    let token_url = format!("{}/token", provider.uri());
+    add_oauth_specs(app, workspace, spec, &device_url, &token_url).await;
+    provider
+}
+
+async fn add_oauth_specs(
+    app: &AppClient,
+    workspace: &Workspace,
+    spec: &str,
+    device_url: &str,
+    token_url: &str,
+) {
     let workspace_scope = Some(workspace.clone());
     for (scope, issuer, client) in [
         (None, "global_oauth", "global-client"),
@@ -500,7 +670,7 @@ async fn oauth_fixture(app: &AppClient, workspace: &Workspace, spec: &str) -> Mo
         app.identity_spec_client()
             .add_identity_spec(for_user(
                 AddIdentitySpecRequest {
-                    manifest_yaml: device_manifest(spec, issuer, &provider.uri(), client),
+                    manifest_yaml: device_manifest(spec, issuer, device_url, token_url, client),
                     input_values: Vec::new(),
                     workspace: scope,
                 },
@@ -509,7 +679,6 @@ async fn oauth_fixture(app: &AppClient, workspace: &Workspace, spec: &str) -> Mo
             .await
             .expect("add OAuth identity spec");
     }
-    provider
 }
 
 async fn create_workspace(app: &AppClient, name: &str) -> Workspace {
@@ -636,6 +805,18 @@ async fn workspace_get_status(
         ))
         .await
         .expect_err("workspace identity get must fail")
+}
+
+async fn user_get_status(app: &AppClient, user: &str, name: &str) -> Status {
+    app.identity_client()
+        .get_user_owned_identity(for_user(
+            GetUserOwnedIdentityRequest {
+                name: name.to_string(),
+            },
+            user,
+        ))
+        .await
+        .expect_err("user identity get must fail")
 }
 
 async fn delete_workspace_identity(app: &AppClient, user: &str, workspace: &Workspace, name: &str) {
@@ -854,6 +1035,171 @@ fn assert_workspace_identity(
     assert!(!format!("{identity:?}").contains(token));
 }
 
+struct GatedDeviceOAuthProvider {
+    device_url: String,
+    token_url: String,
+    token_requests: mpsc::UnboundedReceiver<BTreeMap<String, String>>,
+    token_release: Arc<Semaphore>,
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl GatedDeviceOAuthProvider {
+    async fn new() -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind gated OAuth provider");
+        let address = listener.local_addr().expect("gated OAuth provider address");
+        let (token_requests_tx, token_requests) = mpsc::unbounded_channel();
+        let token_release = Arc::new(Semaphore::new(0));
+        let task_token_release = Arc::clone(&token_release);
+        let task = tokio::spawn(async move {
+            let mut handlers = tokio::task::JoinSet::new();
+            for _ in 0..4 {
+                let (mut socket, _) = tokio::time::timeout(TEST_PHASE_TIMEOUT, listener.accept())
+                    .await
+                    .expect("OAuth provider accept timed out")
+                    .expect("accept OAuth provider request");
+                let token_requests_tx = token_requests_tx.clone();
+                let token_release = Arc::clone(&task_token_release);
+                handlers.spawn(async move {
+                    let request = read_fixture_request(&mut socket).await;
+                    match request.path.as_str() {
+                        "/device" => write_fixture_json(&mut socket, DEVICE_RESPONSE)
+                            .await
+                            .expect("write device authorization response"),
+                        "/token" => {
+                            token_requests_tx
+                                .send(request.form)
+                                .expect("record in-flight OAuth token request");
+                            let permit = token_release
+                                .acquire_owned()
+                                .await
+                                .expect("token response gate closed");
+                            permit.forget();
+                            let _response = write_fixture_json(&mut socket, TOKEN_RESPONSE).await;
+                        }
+                        path => panic!("unexpected OAuth provider path: {path}"),
+                    }
+                });
+            }
+            drop(token_requests_tx);
+            while let Some(handler) = handlers.join_next().await {
+                handler.expect("OAuth provider handler");
+            }
+        });
+        Self {
+            device_url: format!("http://{address}/device"),
+            token_url: format!("http://{address}/token"),
+            token_requests,
+            token_release,
+            task: Some(task),
+        }
+    }
+
+    async fn wait_for_token_clients(&mut self) -> BTreeSet<String> {
+        let mut clients = BTreeSet::new();
+        for _ in 0..2 {
+            let form = tokio::time::timeout(TEST_PHASE_TIMEOUT, self.token_requests.recv())
+                .await
+                .expect("OAuth token request timed out")
+                .expect("OAuth provider closed before both token requests");
+            assert_eq!(
+                form.get("grant_type").map(String::as_str),
+                Some("urn:ietf:params:oauth:grant-type:device_code")
+            );
+            assert_eq!(
+                form.get("device_code").map(String::as_str),
+                Some("device-code")
+            );
+            clients.insert(
+                form.get("client_id")
+                    .expect("OAuth token client_id")
+                    .clone(),
+            );
+        }
+        clients
+    }
+
+    fn release_token_responses(&self) {
+        self.token_release.add_permits(2);
+    }
+
+    async fn finish(mut self) {
+        let task = self.task.take().expect("OAuth provider task");
+        tokio::time::timeout(TEST_PHASE_TIMEOUT, task)
+            .await
+            .expect("OAuth provider did not finish")
+            .expect("join OAuth provider");
+    }
+}
+
+impl Drop for GatedDeviceOAuthProvider {
+    fn drop(&mut self) {
+        self.token_release.add_permits(2);
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+struct FixtureRequest {
+    path: String,
+    form: BTreeMap<String, String>,
+}
+
+async fn read_fixture_request(socket: &mut tokio::net::TcpStream) -> FixtureRequest {
+    let mut reader = BufReader::new(socket);
+    let mut line = String::new();
+    let read = reader
+        .read_line(&mut line)
+        .await
+        .expect("read OAuth provider request line");
+    assert!(
+        read > 0,
+        "OAuth provider request closed before request line"
+    );
+    let path = line
+        .split_whitespace()
+        .nth(1)
+        .expect("OAuth provider request path")
+        .to_string();
+    let mut content_length = 0;
+    loop {
+        line.clear();
+        let read = reader
+            .read_line(&mut line)
+            .await
+            .expect("read OAuth provider request header");
+        assert!(read > 0, "OAuth provider request closed before headers");
+        if line == "\r\n" {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':')
+            && name.eq_ignore_ascii_case("content-length")
+        {
+            content_length = value.trim().parse().expect("OAuth content-length");
+        }
+    }
+    let mut body = vec![0; content_length];
+    reader
+        .read_exact(&mut body)
+        .await
+        .expect("read OAuth provider request body");
+    FixtureRequest {
+        path,
+        form: url::form_urlencoded::parse(&body).into_owned().collect(),
+    }
+}
+
+async fn write_fixture_json(socket: &mut tokio::net::TcpStream, body: &str) -> std::io::Result<()> {
+    let response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    socket.write_all(response.as_bytes()).await?;
+    socket.shutdown().await
+}
+
 fn assert_error_reason(status: &Status, expected: &str) {
     let reason = status
         .get_error_details_vec()
@@ -876,8 +1222,14 @@ fn manifest(name: &str, issuer: &str, kind: &str) -> String {
     )
 }
 
-fn device_manifest(name: &str, issuer: &str, base: &str, client: &str) -> String {
+fn device_manifest(
+    name: &str,
+    issuer: &str,
+    device_url: &str,
+    token_url: &str,
+    client: &str,
+) -> String {
     format!(
-        "kind: identity\nspec_version: 1\nname: {name}\nversion: 1.0.0\ndescription: {issuer} identity\nissuer: {issuer}\ntype: oauth\noauth:\n  method:\n    flow: {{type: device_code}}\n    endpoints:\n      device_authorization_url: {base}/device\n      token_url: {base}/token\n    client:\n      id: {{default: {client}}}\n"
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: 1.0.0\ndescription: {issuer} identity\nissuer: {issuer}\ntype: oauth\noauth:\n  method:\n    flow: {{type: device_code}}\n    endpoints:\n      device_authorization_url: {device_url}\n      token_url: {token_url}\n    client:\n      id: {{default: {client}}}\n"
     )
 }


### PR DESCRIPTION
## Intent

Cancel active USER and WORKSPACE identity OAuth operations when the local server shuts down, without allowing shutdown to report `Cancelled` after durable credential persistence has begun.

## What it enables

- `RunningServer` owns one root cancellation token and gives each identity service a child token.
- Explicit shutdown and `Drop` signal identity OAuth cancellation before the Tonic server is stopped.
- Pre-transaction cancellation returns a static redacted `Cancelled` status and drops the operation before persistence.
- Once a serializable transaction starts, shutdown awaits the same pinned manager future through its real terminal result, preventing a false cancelled response over committed encrypted credentials.
- USER and WORKSPACE identity OAuth both preserve the same behavior across deterministic restart.

## Usage examples

- If `RunningServer::shutdown().await` begins while an omitted-setup identity OAuth token response is still pending, the client receives `Code::Cancelled` and no identity or identity document is persisted.
- Restarting Coral against the same database after that shutdown returns typed `IDENTITY_NOT_FOUND` for both attempted identities.
- Fixed-token identity creation and source-import OAuth behavior are unchanged.

## Validation

- Focused shutdown-phase, manager-race, and dual-owner gRPC tests passed.
- Strict all-target `coral-app` Clippy passed with `-D warnings`.
- `make postgres-tests` passed all three Docker-backed gates.
- `make perf-check` passed at 209.6 ms mean against the 750 ms threshold.
- Exact final `make rust-checks` passed 1,748/1,748 tests with 3 skipped plus clean fmt, workspace Clippy, and warning-denied rustdoc.
- Final diff: 541 additions and 51 deletions, 592 changed lines.

## Review

The exact-head five-lane review enumerated 17 safe credential flows. It confirmed the prior commit/cancellation P1 is closed, accepted and closed one P2 transition-test gap, and found no additional P1/P2 risk at 0.97 supervisor confidence.

A separate mandatory direct child, B5d1c, will abort owned authorization-code callback workers when their parent operation is dropped. That child remains required before B5d2 and before any affected PR can become ready.

## Stack

Parent: #1714. This PR is intentionally draft and must remain draft.
