### PR TITLE
fix(app): cancel OAuth callback workers

### DIFF
--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -21,7 +21,7 @@ use serde_json::{Value, json};
 use sha2::{Digest as _, Sha256};
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 use tokio::net::TcpListener;
-use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 use url::{Host, Url, form_urlencoded};
 use uuid::Uuid;
 
@@ -1229,31 +1229,32 @@ fn pkce_challenge(verifier: &str) -> String {
 }
 
 async fn receive_callback(session: &AuthorizationCodeSessionConfig) -> Result<Callback, AppError> {
-    let (result_tx, mut result_rx) = mpsc::channel(8);
+    let mut workers = JoinSet::new();
     let deadline = tokio::time::Instant::from_std(session.expires_at);
     loop {
         tokio::select! {
             accepted = session.listener.accept() => {
                 let (mut stream, _peer): (_, SocketAddr) = accepted?;
-                let result_tx = result_tx.clone();
                 let expected_path = session.callback_path.clone();
                 let expected_state = session.state.clone();
-                tokio::spawn(async move {
-                    let result = handle_callback_connection(
+                workers.spawn(async move {
+                    handle_callback_connection(
                         &mut stream,
                         &expected_path,
                         &expected_state,
                         deadline,
                     )
-                    .await;
-                    if result_tx.send(result).await.is_err() {
-                        tracing::debug!(
-                            "OAuth callback receiver closed before connection result was delivered"
-                        );
-                    }
+                    .await
                 });
             }
-            Some(result) = result_rx.recv() => {
+            Some(result) = workers.join_next() => {
+                let result = match result {
+                    Ok(result) => result,
+                    Err(error) => {
+                        tracing::debug!(%error, "OAuth callback connection task failed");
+                        continue;
+                    }
+                };
                 match result? {
                     CallbackConnectionResult::Callback(callback) => return Ok(callback),
                     CallbackConnectionResult::Ignored => {}
@@ -2170,9 +2171,11 @@ mod tests {
     )]
 
     use std::collections::BTreeMap;
-    use std::io::{Read as _, Write as _};
+    use std::future::{Future as _, poll_fn};
+    use std::io::{ErrorKind, Read as _, Write as _};
     use std::net::TcpListener as StdTcpListener;
     use std::sync::LazyLock;
+    use std::task::Poll;
     use std::time::Duration;
 
     use super::{
@@ -4242,6 +4245,97 @@ mod tests {
 
         let (callback, ()) = tokio::join!(receive, send);
         assert_eq!(callback.expect("callback").code, "test-code");
+    }
+
+    #[tokio::test]
+    async fn oauth_callback_drop_aborts_accepted_idle_preconnection() {
+        let redirect_port = free_loopback_port();
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", redirect_port))
+            .await
+            .expect("bind callback listener");
+        let oauth = oauth_spec(
+            "https://provider.example.com/oauth/token",
+            redirect_port,
+            ManifestOAuthPkceMode::Disabled,
+            ManifestOAuthClientSpec {
+                id: ManifestOAuthClientIdSpec {
+                    default: Some("client".to_string()),
+                    input: None,
+                },
+                secret: None,
+                dynamic_registration: None,
+            },
+        );
+        let endpoints = preflight_oauth_endpoints(
+            &oauth,
+            &oauth
+                .endpoint_urls(&EMPTY_SOURCE_INPUTS)
+                .expect("render endpoints"),
+            &EMPTY_SOURCE_INPUTS,
+        )
+        .expect("preflight endpoints");
+        let session = AuthorizationCodeSessionConfig {
+            common: OAuthSessionCommon {
+                input_key: "API_TOKEN".to_string(),
+                endpoints,
+                client: ResolvedOAuthClient {
+                    client_id: "client".to_string(),
+                    client_secret: None,
+                    client_secret_transport: None,
+                    dynamic_client_registration: false,
+                },
+                resource: None,
+            },
+            state: "expected-state".to_string(),
+            code_verifier: None,
+            callback_path: "/oauth/callback".to_string(),
+            provider_redirect_uri: format!("http://127.0.0.1:{redirect_port}/oauth/callback"),
+            listener,
+            expires_at: std::time::Instant::now() + std::time::Duration::from_mins(1),
+        };
+
+        let mut idle = tokio::net::TcpStream::connect(("127.0.0.1", redirect_port))
+            .await
+            .expect("connect idle preconnection");
+        let mut receive = Box::pin(receive_callback(&session));
+        poll_fn(|cx| {
+            assert!(receive.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+        drop(receive);
+        tokio::task::yield_now().await;
+
+        let request = b"GET /oauth/callback?state=expected-state&code=test-code HTTP/1.1\r\nhost: 127.0.0.1\r\n\r\n";
+        let reset = |kind| {
+            matches!(
+                kind,
+                ErrorKind::ConnectionReset
+                    | ErrorKind::ConnectionAborted
+                    | ErrorKind::BrokenPipe
+                    | ErrorKind::NotConnected
+            )
+        };
+        let mut response = Vec::new();
+        match idle.write_all(request).await {
+            Ok(()) => {
+                match tokio::time::timeout(Duration::from_secs(5), idle.read_to_end(&mut response))
+                    .await
+                    .expect("dropped callback receiver closes accepted connection")
+                {
+                    Ok(_) => {}
+                    Err(error) if reset(error.kind()) => {}
+                    Err(error) => panic!("unexpected callback read error: {error}"),
+                }
+            }
+            Err(error) if reset(error.kind()) => {}
+            Err(error) => panic!("unexpected callback write error: {error}"),
+        }
+        assert!(
+            response.is_empty(),
+            "dropped callback receiver emitted a response: {}",
+            String::from_utf8_lossy(&response)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Intent

OAuth loopback callback connections were handled by detached tasks. If the owning OAuth future was dropped by client cancellation, source-import cancellation, timeout, or server shutdown, an already accepted idle connection could remain alive and later emit a stale HTTP 200 after the session no longer had a receiver.

Own every accepted callback worker in the callback receiver so dropping that receiver also aborts its outstanding connections.

## What it enables

- Bounds accepted callback-worker lifetime to the OAuth operation that owns the listener.
- Prevents an idle preconnection from returning callback authority or a stale success response after cancellation.
- Preserves the existing valid, ignored, error, timeout, and worker-failure behavior.
- Applies the same cleanup to identity OAuth and the shared source-import OAuth callback path without adding new public cancellation plumbing.

## Usage examples

There is no new command or API. Existing USER and WORKSPACE OAuth creation streams behave the same while active. If the stream is disconnected or the server shuts down before a callback completes, accepted callback sockets are closed with the operation instead of surviving as detached workers.

The shared source-import authorization-code flow receives the same abort-on-drop cleanup when its owning future is cancelled.

## Validation

- Focused callback, source-import, and server-shutdown regression selection: 6/6 passed.
- Strict all-target coral-app Clippy passed.
- `make rust-checks`: 1,749/1,749 tests passed, 3 skipped; formatting, workspace Clippy, and rustdoc clean.
- The new deterministic regression proves an accepted idle preconnection receives zero response bytes after the callback receiver is dropped.

## Review

- Exact final five-lane review swarm: zero findings and zero questions.
- Eleven credential flows enumerated; all safe, with no unknown transport guards or verdicts.
- Independent supervisor missed-risk sweep found no remaining P1/P2 risk at 0.97 confidence.

## Stack

- Direct draft child of #1715 at exact parent `7017a6abb58981f515439fa4ba9019d0b1781e09`.
- Submitted through an isolated, exact-parent Graphite checkout; pre-submit was one `Create` and post-submit is one `No-op`.
- PR #1460 remains the immutable mission ancestor at `23074065dc7220ee327edbc5cdf13791a6c6b710`.
