### PR TITLE
test(app): cover OAuth transport lifecycle

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -879,6 +879,7 @@ mod tests {
     )]
 
     use std::borrow::Cow;
+    use std::collections::BTreeMap;
     use std::net::{Ipv4Addr, TcpListener};
     use std::path::Path;
     use std::sync::Arc;
@@ -891,7 +892,7 @@ mod tests {
     use coral_api::v1::trace_service_client::TraceServiceClient;
     use coral_api::v1::{
         AddIdentitySpecRequest, AddIdentitySpecResponse, CreateUserOwnedIdentityRequest,
-        CreateUserOwnedIdentityResponse, DeleteUserOwnedIdentityRequest,
+        CreateUserOwnedIdentityResponse, CredentialMetadata, DeleteUserOwnedIdentityRequest,
         DeleteUserOwnedIdentityResponse, ExecuteSqlRequest, FixedTokenUserOwnedIdentitySetup,
         GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse, IdentityOwner,
         ImportSourceRequest, ImportSourceResponse, ListIdentitySpecsRequest,
@@ -905,6 +906,8 @@ mod tests {
     use tempfile::TempDir;
     use tonic::transport::Endpoint;
     use tonic::{Code, Request};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::{
         RunningServer, ServerBuilder, ServerManagers, ServerMode, StaticAsset,
@@ -1394,6 +1397,62 @@ backend = "unsupported"
         response.bytes().await.expect("gRPC-Web response").to_vec()
     }
 
+    fn decode_grpc_web_stream<T>(body: &[u8]) -> (Vec<T>, String)
+    where
+        T: prost::Message + Default,
+    {
+        let mut offset = 0;
+        let mut messages = Vec::new();
+        let mut trailers = None;
+        while offset < body.len() {
+            let header_end = offset.checked_add(5).expect("gRPC-Web header offset");
+            let header = body
+                .get(offset..header_end)
+                .expect("complete gRPC-Web frame header");
+            let frame_len = u32::from_be_bytes(
+                header[1..5]
+                    .try_into()
+                    .expect("gRPC-Web frame length header"),
+            ) as usize;
+            let frame_end = header_end
+                .checked_add(frame_len)
+                .expect("gRPC-Web frame end");
+            let payload = body
+                .get(header_end..frame_end)
+                .expect("complete gRPC-Web frame payload");
+            match header[0] {
+                0 => {
+                    assert!(trailers.is_none(), "data frame followed final trailers");
+                    messages.push(T::decode(payload).expect("decode gRPC-Web protobuf response"));
+                }
+                0x80 => {
+                    assert!(trailers.is_none(), "multiple gRPC-Web trailer frames");
+                    assert_eq!(
+                        frame_end,
+                        body.len(),
+                        "expected trailers to be the final gRPC-Web frame"
+                    );
+                    trailers = Some(
+                        std::str::from_utf8(payload)
+                            .expect("trailers are UTF-8")
+                            .to_string(),
+                    );
+                }
+                flag => panic!("unexpected gRPC-Web frame flag {flag:#x}"),
+            }
+            offset = frame_end;
+        }
+        let trailers = trailers.expect("expected final gRPC-Web trailer frame");
+        assert!(
+            trailers.lines().any(|line| {
+                line.strip_prefix("grpc-status:")
+                    .is_some_and(|status| status.trim() == "0")
+            }),
+            "expected successful gRPC-Web trailer status, got {trailers:?}"
+        );
+        (messages, trailers)
+    }
+
     fn decode_grpc_web_response<T>(body: &[u8]) -> T
     where
         T: prost::Message + Default,
@@ -1636,6 +1695,170 @@ backend = "unsupported"
         .await;
         decode_grpc_web_response::<DeleteUserOwnedIdentityResponse>(&body);
 
+        running.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    #[expect(clippy::too_many_lines, reason = "end-to-end raw OAuth wire contract")]
+    async fn embedded_ui_server_streams_user_oauth_identity_over_grpc_web() {
+        const SPEC: &str = "grpc_web_oauth";
+        const ACCESS_TOKEN: &str = "raw-access-token";
+        const REFRESH_TOKEN: &str = "raw-refresh-token";
+        const DEVICE_CODE: &str = "raw-device-code";
+        let provider = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/device"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "device_code": DEVICE_CODE,
+                "user_code": "RAW-1234",
+                "verification_uri": "https://provider.example/device",
+                "verification_uri_complete": "https://provider.example/device?user_code=RAW-1234",
+                "expires_in": 60,
+                "interval": 1
+            })))
+            .mount(&provider)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": ACCESS_TOKEN,
+                "refresh_token": REFRESH_TOKEN,
+                "token_type": "Bearer",
+                "scope": "repo user",
+                "hostile": "raw-hostile"
+            })))
+            .mount(&provider)
+            .await;
+
+        let temp = TempDir::new().expect("temp dir");
+        let running = ServerBuilder::embedded_ui_loopback(0, Arc::new(StubAssets))
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_user_principal_provider(Arc::new(HeaderUserPrincipalProvider))
+            .start()
+            .await
+            .expect("start embedded UI server");
+        let endpoint = running.endpoint_uri();
+        let client = reqwest::Client::new();
+        let device_url = format!("{}/device", provider.uri());
+        let token_url = format!("{}/token", provider.uri());
+
+        let body = post_grpc_web(
+            &client,
+            endpoint,
+            "coral.v1.IdentitySpecService/AddIdentitySpec",
+            &AddIdentitySpecRequest {
+                manifest_yaml: format!(
+                    r"kind: identity
+spec_version: 1
+name: {SPEC}
+version: 1.0.0
+description: Browser OAuth identity
+issuer: browser_oauth
+type: oauth
+oauth:
+  method:
+    flow: {{type: device_code}}
+    endpoints:
+      device_authorization_url: {device_url}
+      token_url: {token_url}
+    client:
+      id: {{default: raw-client}}
+"
+                ),
+                input_values: Vec::new(),
+                workspace: None,
+            },
+        )
+        .await;
+        decode_grpc_web_response::<AddIdentitySpecResponse>(&body);
+
+        let body = post_grpc_web(
+            &client,
+            endpoint,
+            "coral.v1.IdentityService/CreateUserOwnedIdentity",
+            &CreateUserOwnedIdentityRequest {
+                name: "browser_oauth".to_string(),
+                identity_spec: SPEC.to_string(),
+                setup: None,
+            },
+        )
+        .await;
+        for forbidden in [ACCESS_TOKEN, REFRESH_TOKEN, DEVICE_CODE, "raw-hostile"] {
+            assert!(
+                !body
+                    .windows(forbidden.len())
+                    .any(|window| window == forbidden.as_bytes()),
+                "raw gRPC-Web body leaked {forbidden}"
+            );
+        }
+        let (events, _trailers) = decode_grpc_web_stream::<CreateUserOwnedIdentityResponse>(&body);
+        let [authorization, completed, created] = events.as_slice() else {
+            panic!("expected Authorization, Completed, Identity: {events:?}");
+        };
+        let Some(create_user_owned_identity_response::Event::OauthAuthorization(authorization)) =
+            authorization.event.as_ref()
+        else {
+            panic!("expected OAuth authorization: {authorization:?}");
+        };
+        assert_eq!(authorization.user_code, "RAW-1234");
+        assert_eq!(authorization.expires_in_seconds, 60);
+        assert_eq!(
+            authorization.authorization_url,
+            "https://provider.example/device?user_code=RAW-1234"
+        );
+        let metadata = [("scope", "repo user"), ("token_type", "Bearer")].map(|(key, value)| {
+            CredentialMetadata {
+                key: key.to_string(),
+                value: value.to_string(),
+            }
+        });
+        let Some(create_user_owned_identity_response::Event::OauthCompleted(completed)) =
+            completed.event.as_ref()
+        else {
+            panic!("expected OAuth completion: {completed:?}");
+        };
+        assert_eq!(completed.metadata, metadata);
+        let Some(create_user_owned_identity_response::Event::Identity(identity)) =
+            created.event.as_ref()
+        else {
+            panic!("expected durable identity: {created:?}");
+        };
+        assert_eq!(identity.name, "browser_oauth");
+        assert_eq!(identity.identity_spec, SPEC);
+        assert_eq!(identity.issuer, "browser_oauth");
+        assert_eq!(identity.identity_type, "oauth");
+        assert_eq!(identity.owner, IdentityOwner::User as i32);
+        assert_eq!(identity.metadata, metadata);
+        assert!(identity.owner_workspace.is_none());
+        assert!(identity.identity_spec_workspace.is_none());
+
+        let requests = provider.received_requests().await.expect("OAuth requests");
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].url.path(), "/device");
+        assert_eq!(requests[1].url.path(), "/token");
+        let forms = requests
+            .iter()
+            .map(|request| {
+                url::form_urlencoded::parse(&request.body)
+                    .into_owned()
+                    .collect::<BTreeMap<_, _>>()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            forms[0],
+            BTreeMap::from([("client_id".into(), "raw-client".into())])
+        );
+        assert_eq!(
+            forms[1],
+            BTreeMap::from([
+                ("client_id".into(), "raw-client".into()),
+                ("device_code".into(), DEVICE_CODE.into()),
+                (
+                    "grant_type".into(),
+                    "urn:ietf:params:oauth:grant-type:device_code".into(),
+                ),
+            ])
+        );
         running.shutdown().await.expect("shutdown");
     }
 

--- a/crates/coral-app/tests/grpc/identity_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_tests.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::ErrorKind;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use coral_api::v1::create_user_owned_identity_response::Event as UserCreateEvent;
@@ -162,16 +163,24 @@ async fn user_identity_service_is_scoped_validated_and_restart_safe() {
 }
 
 #[tokio::test]
+#[expect(clippy::too_many_lines, reason = "end-to-end OAuth lifecycle contract")]
 async fn oauth_identity_creation_streams_ordered_user_and_workspace_events() {
     let temp = TempDir::new().expect("temp dir");
-    let (server, app) = start(&temp.path().join("coral-config")).await;
-    let workspace = create_workspace(&app, "oauth_workspace").await;
+    let config_dir = temp.path().join("coral-config");
+    let (server, app) = start(&config_dir).await;
+    let workspace = create_workspace(&app, "oauth_owner").await;
+    let other_workspace = create_workspace(&app, "oauth_other").await;
+    let colliding_owner_key = workspace.name.clone();
+    let identity_name = "same-oauth";
     let spec = "shared_oauth";
     let provider = oauth_fixture(&app, &workspace, spec).await;
-
     let user_events = app
         .identity_client()
-        .create_user_owned_identity(user_oauth_request("user-oauth", spec, "alice"))
+        .create_user_owned_identity(user_oauth_request(
+            identity_name,
+            spec,
+            &colliding_owner_key,
+        ))
         .await
         .expect("create user OAuth identity")
         .into_inner()
@@ -191,7 +200,8 @@ async fn oauth_identity_creation_streams_ordered_user_and_workspace_events() {
     assert!(user.owner_workspace.is_none());
     assert!(user.identity_spec_workspace.is_none());
 
-    let workspace_request = workspace_oauth_request(&workspace, "shared-oauth", spec, "bob");
+    let workspace_request =
+        workspace_oauth_request(&workspace, identity_name, spec, "workspace-caller");
     let workspace_events = app
         .workspace_identity_client()
         .create_workspace_owned_identity(workspace_request)
@@ -258,6 +268,180 @@ async fn oauth_identity_creation_streams_ordered_user_and_workspace_events() {
         assert!(!public_responses.contains(secret));
     }
     server.shutdown().await.expect("shutdown server");
+    drop(app);
+
+    let (server, restarted) = start(&config_dir).await;
+    assert_eq!(
+        get(&restarted, &colliding_owner_key, identity_name).await,
+        *user
+    );
+    assert_eq!(
+        workspace_get(&restarted, "workspace-caller", &workspace, identity_name,).await,
+        *shared
+    );
+    let other_user = user_get_status(&restarted, "other-user", identity_name).await;
+    assert_eq!(other_user.code(), Code::NotFound);
+    assert_error_reason(&other_user, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
+    let other_workspace = workspace_get_status(
+        &restarted,
+        "workspace-caller",
+        &other_workspace,
+        identity_name,
+    )
+    .await;
+    assert_eq!(other_workspace.code(), Code::NotFound);
+    assert_error_reason(&other_workspace, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
+    server.shutdown().await.expect("shutdown restarted server");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn dropping_native_oauth_stream_cancels_before_persistence() {
+    const IDENTITY: &str = "dropped-user-oauth";
+
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let (server, app) = start(&config_dir).await;
+    let workspace = create_workspace(&app, "oauth_drop_workspace").await;
+    let mut provider = GatedDeviceOAuthProvider::new(1).await;
+    add_oauth_specs(
+        &app,
+        &workspace,
+        "drop_oauth",
+        &provider.device_url,
+        &provider.token_url,
+    )
+    .await;
+
+    let mut client = app.identity_client();
+    let mut stream = client
+        .create_user_owned_identity(user_oauth_request(IDENTITY, "drop_oauth", "alice"))
+        .await
+        .expect("start user OAuth stream")
+        .into_inner();
+    let event = tokio::time::timeout(TEST_PHASE_TIMEOUT, stream.message())
+        .await
+        .expect("OAuth authorization timed out")
+        .expect("read OAuth authorization")
+        .expect("OAuth authorization response")
+        .event
+        .expect("OAuth authorization event");
+    assert!(matches!(event, UserCreateEvent::OauthAuthorization(_)));
+    assert_eq!(
+        provider.wait_for_token_clients().await,
+        BTreeSet::from(["global-client".to_string()])
+    );
+
+    drop(stream);
+    drop(client);
+    provider.wait_for_token_disconnect().await;
+    assert_identity_tables_empty(&config_dir).await;
+
+    provider.release_token_responses();
+    let requests = provider.received_requests();
+    provider.finish().await;
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.path.as_str())
+            .collect::<Vec<_>>(),
+        ["/device", "/token"]
+    );
+    assert_identity_tables_empty(&config_dir).await;
+
+    server.shutdown().await.expect("shutdown server");
+    drop(app);
+    let (server, restarted) = start(&config_dir).await;
+    let missing = user_get_status(&restarted, "alice", IDENTITY).await;
+    assert_eq!(missing.code(), Code::NotFound);
+    assert_error_reason(&missing, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
+    server.shutdown().await.expect("shutdown restarted server");
+}
+
+#[tokio::test]
+async fn native_oauth_surfaces_terminal_provider_failure_after_authorization() {
+    const HOSTILE_SECRET: &str = "hostile-access-refresh-device-secret";
+
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let (server, app) = start(&config_dir).await;
+    let workspace = create_workspace(&app, "oauth_failure_workspace").await;
+    let provider = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/device"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(DEVICE_RESPONSE, "application/json"))
+        .expect(1)
+        .mount(&provider)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(500).set_body_raw(
+            format!(r#"{{"error":"server_error","error_description":"{HOSTILE_SECRET}"}}"#),
+            "application/json",
+        ))
+        .expect(1)
+        .mount(&provider)
+        .await;
+    add_oauth_specs(
+        &app,
+        &workspace,
+        "failure_oauth",
+        &format!("{}/device", provider.uri()),
+        &format!("{}/token", provider.uri()),
+    )
+    .await;
+
+    let mut stream = app
+        .identity_client()
+        .create_user_owned_identity(user_oauth_request(
+            "failed-user-oauth",
+            "failure_oauth",
+            "alice",
+        ))
+        .await
+        .expect("start user OAuth stream")
+        .into_inner();
+    let authorization = stream
+        .message()
+        .await
+        .expect("read OAuth authorization")
+        .expect("OAuth authorization response")
+        .event
+        .expect("OAuth authorization event");
+    assert!(matches!(
+        authorization,
+        UserCreateEvent::OauthAuthorization(_)
+    ));
+    let status = stream
+        .message()
+        .await
+        .expect_err("token HTTP failure must terminate the OAuth stream");
+    assert_eq!(status.code(), Code::FailedPrecondition);
+    assert_eq!(
+        status.message(),
+        "failed precondition: OAuth device token request failed with HTTP 500"
+    );
+    assert!(!status.message().contains(HOSTILE_SECRET));
+    assert!(
+        stream
+            .message()
+            .await
+            .expect("read terminal OAuth EOF")
+            .is_none()
+    );
+    provider.verify().await;
+    let requests = provider
+        .received_requests()
+        .await
+        .expect("recorded OAuth requests");
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.url.path())
+            .collect::<Vec<_>>(),
+        ["/device", "/token"]
+    );
+    assert_identity_tables_empty(&config_dir).await;
+    server.shutdown().await.expect("shutdown server");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -269,7 +453,7 @@ async fn server_shutdown_cancels_active_identity_oauth_without_persisting() {
     let config_dir = temp.path().join("coral-config");
     let (server, app) = start(&config_dir).await;
     let workspace = create_workspace(&app, "oauth_shutdown_workspace").await;
-    let mut provider = GatedDeviceOAuthProvider::new().await;
+    let mut provider = GatedDeviceOAuthProvider::new(2).await;
     add_oauth_specs(
         &app,
         &workspace,
@@ -1038,31 +1222,44 @@ fn assert_workspace_identity(
 struct GatedDeviceOAuthProvider {
     device_url: String,
     token_url: String,
+    expected_flows: usize,
     token_requests: mpsc::UnboundedReceiver<BTreeMap<String, String>>,
+    token_disconnects: mpsc::UnboundedReceiver<()>,
     token_release: Arc<Semaphore>,
+    requests: Arc<Mutex<Vec<FixtureRequest>>>,
     task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl GatedDeviceOAuthProvider {
-    async fn new() -> Self {
+    async fn new(expected_flows: usize) -> Self {
+        assert!(expected_flows > 0, "provider must serve at least one flow");
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind gated OAuth provider");
         let address = listener.local_addr().expect("gated OAuth provider address");
         let (token_requests_tx, token_requests) = mpsc::unbounded_channel();
+        let (token_disconnects_tx, token_disconnects) = mpsc::unbounded_channel();
         let token_release = Arc::new(Semaphore::new(0));
+        let requests = Arc::new(Mutex::new(Vec::new()));
         let task_token_release = Arc::clone(&token_release);
+        let task_requests = Arc::clone(&requests);
         let task = tokio::spawn(async move {
             let mut handlers = tokio::task::JoinSet::new();
-            for _ in 0..4 {
+            for _ in 0..expected_flows.saturating_mul(2) {
                 let (mut socket, _) = tokio::time::timeout(TEST_PHASE_TIMEOUT, listener.accept())
                     .await
                     .expect("OAuth provider accept timed out")
                     .expect("accept OAuth provider request");
                 let token_requests_tx = token_requests_tx.clone();
+                let token_disconnects_tx = token_disconnects_tx.clone();
                 let token_release = Arc::clone(&task_token_release);
+                let requests = Arc::clone(&task_requests);
                 handlers.spawn(async move {
                     let request = read_fixture_request(&mut socket).await;
+                    requests
+                        .lock()
+                        .expect("record OAuth provider request")
+                        .push(request.clone());
                     match request.path.as_str() {
                         "/device" => write_fixture_json(&mut socket, DEVICE_RESPONSE)
                             .await
@@ -1071,12 +1268,35 @@ impl GatedDeviceOAuthProvider {
                             token_requests_tx
                                 .send(request.form)
                                 .expect("record in-flight OAuth token request");
-                            let permit = token_release
-                                .acquire_owned()
-                                .await
-                                .expect("token response gate closed");
-                            permit.forget();
-                            let _response = write_fixture_json(&mut socket, TOKEN_RESPONSE).await;
+                            let mut disconnect_probe = [0_u8; 1];
+                            tokio::select! {
+                                permit = token_release.acquire_owned() => {
+                                    permit.expect("token response gate closed").forget();
+                                    let _response =
+                                        write_fixture_json(&mut socket, TOKEN_RESPONSE).await;
+                                }
+                                disconnected = socket.read(&mut disconnect_probe) => {
+                                    match disconnected {
+                                        Ok(0) => {}
+                                        Err(error)
+                                            if matches!(
+                                                error.kind(),
+                                                ErrorKind::ConnectionReset
+                                                    | ErrorKind::ConnectionAborted
+                                                    | ErrorKind::NotConnected
+                                            ) => {}
+                                        Ok(read) => panic!(
+                                            "OAuth client sent {read} unexpected bytes after its request"
+                                        ),
+                                        Err(error) => panic!(
+                                            "unexpected token connection cancellation error: {error}"
+                                        ),
+                                    }
+                                    token_disconnects_tx
+                                        .send(())
+                                        .expect("record token connection cancellation");
+                                }
+                            }
                         }
                         path => panic!("unexpected OAuth provider path: {path}"),
                     }
@@ -1090,15 +1310,18 @@ impl GatedDeviceOAuthProvider {
         Self {
             device_url: format!("http://{address}/device"),
             token_url: format!("http://{address}/token"),
+            expected_flows,
             token_requests,
+            token_disconnects,
             token_release,
+            requests,
             task: Some(task),
         }
     }
 
     async fn wait_for_token_clients(&mut self) -> BTreeSet<String> {
         let mut clients = BTreeSet::new();
-        for _ in 0..2 {
+        for _ in 0..self.expected_flows {
             let form = tokio::time::timeout(TEST_PHASE_TIMEOUT, self.token_requests.recv())
                 .await
                 .expect("OAuth token request timed out")
@@ -1120,8 +1343,22 @@ impl GatedDeviceOAuthProvider {
         clients
     }
 
+    async fn wait_for_token_disconnect(&mut self) {
+        tokio::time::timeout(TEST_PHASE_TIMEOUT, self.token_disconnects.recv())
+            .await
+            .expect("OAuth token connection did not close after stream drop")
+            .expect("OAuth provider closed before observing token connection cancellation");
+    }
+
     fn release_token_responses(&self) {
-        self.token_release.add_permits(2);
+        self.token_release.add_permits(self.expected_flows);
+    }
+
+    fn received_requests(&self) -> Vec<FixtureRequest> {
+        self.requests
+            .lock()
+            .expect("read OAuth provider requests")
+            .clone()
     }
 
     async fn finish(mut self) {
@@ -1135,13 +1372,14 @@ impl GatedDeviceOAuthProvider {
 
 impl Drop for GatedDeviceOAuthProvider {
     fn drop(&mut self) {
-        self.token_release.add_permits(2);
+        self.token_release.add_permits(self.expected_flows);
         if let Some(task) = self.task.take() {
             task.abort();
         }
     }
 }
 
+#[derive(Clone)]
 struct FixtureRequest {
     path: String,
     form: BTreeMap<String, String>,


### PR DESCRIPTION
## Intent

Complete the mandatory B5d2 transport-contract matrix above the hardened OAuth
service stack. The production behavior already exists in the parent chain; this
slice proves that native and raw gRPC-Web clients observe the correct lifecycle,
framing, isolation, and secret-redaction behavior under cancellation and failure.

## What it enables

- Proves dropping a native OAuth response stream while the token POST is in
  flight closes the provider connection and persists no identity material.
- Pins `Authorization` followed by a sanitized terminal provider failure and
  terminal EOF, without emitting `Completed` or `Identity`.
- Proves successful USER and WORKSPACE OAuth identities with colliding raw owner
  keys remain isolated across restart and inaccessible from other owners.
- Decodes raw gRPC-Web server streams with exact ordered data frames and one
  final successful trailer frame.
- Revalidates provider request cardinality, the shared response ceiling, and
  complete public/raw secret non-egress.

## Usage examples

There is no new API. Existing native and gRPC-Web USER/WORKSPACE OAuth creation
streams retain their current request and event contracts. The focused transport
contracts can be run with:

```shell
cargo test --locked -p coral-app --all-features --test grpc identity_tests::
cargo test --locked -p coral-app --all-features --lib embedded_ui_server_streams_user_oauth_identity_over_grpc_web
```

## Validation

- Native identity gRPC module: 7/7 passed.
- Raw gRPC-Web OAuth streaming contract: passed.
- Existing raw unary identity CRUD contract: passed.
- `app_client_decodes_large_aggregates_for_both_identity_services`: passed,
  preserving the shared response ceiling above tonic's 4 MiB default.
- `oauth_provider_response_body_is_bounded_without_echoing_content`: passed.
- Strict all-target coral-app Clippy and workspace formatting passed.
- Exact-final `make rust-checks`: 1,752/1,752 tests passed, 3 skipped;
  formatting, workspace Clippy, and rustdoc clean.

This is test-only transport coverage, so no Postgres or performance gate was
required.

## Review

- Exact frozen five-lane review diff hash:
  `2317ce35781de6b2ce1ad14b84c035f1e124d3872d0c12679bd7de4cf0d66ff7`.
- Zero findings and zero questions across five completed coverage lanes.
- Eighteen credential flows enumerated; every flow is safe, with no unknown
  transport guard or verdict.
- Independent supervisor missed-risk sweep found no remaining P1/P2 risk at
  0.98 confidence.

## Stack

- Direct draft child of #1716 at exact parent
  `2745985b8230ec7c1f70ea76ce2c031b11b89e94`.
- Exact B5d2 head: `7bc4af34d82d7a032ea0f306b2a4ebdd1d1db279`.
- Submitted through an isolated exact-parent Graphite clone; pre-submit was one
  `Create` and post-submit is one `No-op`.
- PR #1460 remains the immutable mission ancestor at
  `23074065dc7220ee327edbc5cdf13791a6c6b710`.
