### PR TITLE
fix(engine): route credential headers directly

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -141,8 +141,9 @@ pub(crate) struct BackendCompileRequest<'a> {
 /// runtime build.
 #[derive(Default)]
 pub(crate) struct BackendRegistrationContext {
-    default_http_client: OnceLock<Result<reqwest::Client, String>>,
-    credential_safe_http_client: OnceLock<Result<reqwest::Client, String>>,
+    default: OnceLock<Result<reqwest::Client, String>>,
+    credential_safe: OnceLock<Result<reqwest::Client, String>>,
+    direct_credential_safe: OnceLock<Result<reqwest::Client, String>>,
 }
 
 impl BackendRegistrationContext {
@@ -152,11 +153,22 @@ impl BackendRegistrationContext {
         build_client: impl FnOnce() -> Result<reqwest::Client, String>,
     ) -> Result<reqwest::Client, String> {
         let cache = if credential_safe {
-            &self.credential_safe_http_client
+            &self.credential_safe
         } else {
-            &self.default_http_client
+            &self.default
         };
         cache
+            .get_or_init(build_client)
+            .as_ref()
+            .cloned()
+            .map_err(Clone::clone)
+    }
+
+    pub(crate) fn direct_credential_safe_http_client(
+        &self,
+        build_client: impl FnOnce() -> Result<reqwest::Client, String>,
+    ) -> Result<reqwest::Client, String> {
+        self.direct_credential_safe
             .get_or_init(build_client)
             .as_ref()
             .cloned()
@@ -469,6 +481,39 @@ mod tests {
             build_count.load(Ordering::SeqCst),
             2,
             "default HTTP clients should not be process-global"
+        );
+    }
+
+    #[test]
+    fn credential_safe_http_clients_have_distinct_registration_scoped_caches() {
+        let build_count = AtomicUsize::new(0);
+        let first_context = BackendRegistrationContext::default();
+
+        for _ in 0..2 {
+            first_context
+                .default_http_client(true, || build_counted_client(&build_count))
+                .expect("proxy-aware credential client");
+            first_context
+                .direct_credential_safe_http_client(|| build_counted_client(&build_count))
+                .expect("direct credential client");
+        }
+        assert_eq!(
+            build_count.load(Ordering::SeqCst),
+            2,
+            "one registration context should build each credential client once"
+        );
+
+        let second_context = BackendRegistrationContext::default();
+        second_context
+            .default_http_client(true, || build_counted_client(&build_count))
+            .expect("new proxy-aware credential client");
+        second_context
+            .direct_credential_safe_http_client(|| build_counted_client(&build_count))
+            .expect("new direct credential client");
+        assert_eq!(
+            build_count.load(Ordering::SeqCst),
+            4,
+            "credential clients should not be process-global"
         );
     }
 

--- a/crates/coral-engine/src/backends/http/auth.rs
+++ b/crates/coral-engine/src/backends/http/auth.rs
@@ -113,7 +113,7 @@ pub(crate) fn resolve_auth_headers(
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     resolved_inputs: &BTreeMap<String, String>,
     require_credential_safe_transport: bool,
-) -> Result<reqwest::Request> {
+) -> Result<(reqwest::Request, bool)> {
     let mut built = request.build().map_err(|error| {
         DataFusionError::Execution(format!("failed to build HTTP request: {error}"))
     })?;
@@ -127,13 +127,14 @@ pub(crate) fn resolve_auth_headers(
                 .map_err(|error| authenticator_error(&spec.authenticator, &error))
         }
     }?;
-    if require_credential_safe_transport && !headers.is_empty() {
+    let has_auth_headers = !headers.is_empty();
+    if require_credential_safe_transport && has_auth_headers {
         ensure_auth_uses_credential_safe_transport(built.url())?;
     }
     for (name, value) in headers {
         built.headers_mut().insert(name, value);
     }
-    Ok(built)
+    Ok((built, has_auth_headers))
 }
 
 pub(super) fn ensure_auth_uses_credential_safe_transport(url: &reqwest::Url) -> Result<()> {
@@ -227,6 +228,7 @@ mod tests {
             &resolved_inputs,
             require_credential_safe_transport,
         )
+        .map(|(request, _)| request)
     }
 
     #[test]
@@ -306,6 +308,35 @@ mod tests {
         assert_eq!(
             built.headers().get(reqwest::header::AUTHORIZATION),
             Some(&HeaderValue::from_static("Bearer secret"))
+        );
+    }
+
+    #[test]
+    fn non_authorization_auth_headers_are_classified_as_credentials() {
+        let http = reqwest::Client::new();
+        let auth = AuthSpec::HeaderAuth(HeaderAuthSpec {
+            headers: vec![HeaderSpec {
+                name: "X-Api-Key".to_string(),
+                value: ValueSourceSpec::Template {
+                    template: ParsedTemplate::parse("{{input.API_TOKEN}}").expect("auth template"),
+                },
+            }],
+        });
+        let resolved_inputs = BTreeMap::from([("API_TOKEN".to_string(), "secret".to_string())]);
+
+        let (request, has_auth_headers) = resolve_auth_headers(
+            &auth,
+            http.get("https://api.example.test/items"),
+            &HashMap::new(),
+            &resolved_inputs,
+            true,
+        )
+        .expect("API key auth request");
+
+        assert!(has_auth_headers);
+        assert_eq!(
+            request.headers().get("x-api-key"),
+            Some(&HeaderValue::from_static("secret"))
         );
     }
 }

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -9,6 +9,7 @@ use opentelemetry::Context as OtelContext;
 use serde_json::Value;
 
 use crate::backends::BackendRegistrationContext;
+use crate::backends::http::auth::ensure_auth_uses_credential_safe_transport;
 use crate::backends::http::fetch::{FetchCompleteness, fetch_rows};
 use crate::backends::http::filter_usage::{HttpRequestFilterUsage, http_request_filter_names};
 use crate::backends::http::registration_checks::validate_source_scoped_http_config;
@@ -24,9 +25,75 @@ use coral_spec::{AuthSpec, HeaderSpec, ParsedTemplate, RequestSpec as ManifestRe
 const DEFAULT_HTTP_REQUEST_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_HTTP_USER_AGENT: &str = concat!("coral/", env!("CARGO_PKG_VERSION"));
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HttpClientRoute {
+    ProxyAware,
+    DirectLoopback,
+}
+
+#[derive(Clone)]
+pub(super) struct HttpClients {
+    proxy_aware: reqwest::Client,
+    direct_loopback: Option<reqwest::Client>,
+}
+
+impl HttpClients {
+    pub(super) fn legacy(http: reqwest::Client) -> Self {
+        Self {
+            proxy_aware: http,
+            direct_loopback: None,
+        }
+    }
+
+    pub(super) fn credential_safe(
+        proxy_aware: reqwest::Client,
+        direct_loopback: reqwest::Client,
+    ) -> Self {
+        Self {
+            proxy_aware,
+            direct_loopback: Some(direct_loopback),
+        }
+    }
+
+    pub(super) fn for_request(
+        &self,
+        url: &reqwest::Url,
+        credential_bearing: bool,
+    ) -> Result<&reqwest::Client> {
+        match self.route_for_request(url, credential_bearing)? {
+            HttpClientRoute::ProxyAware => Ok(&self.proxy_aware),
+            HttpClientRoute::DirectLoopback => self.direct_loopback.as_ref().ok_or_else(|| {
+                DataFusionError::Internal(
+                    "direct HTTP route selected without a direct client".to_string(),
+                )
+            }),
+        }
+    }
+
+    pub(super) fn proxy_aware(&self) -> &reqwest::Client {
+        &self.proxy_aware
+    }
+
+    fn route_for_request(
+        &self,
+        url: &reqwest::Url,
+        credential_bearing: bool,
+    ) -> Result<HttpClientRoute> {
+        if self.direct_loopback.is_none() || !credential_bearing {
+            return Ok(HttpClientRoute::ProxyAware);
+        }
+        ensure_auth_uses_credential_safe_transport(url)?;
+        Ok(if url.scheme() == "http" {
+            HttpClientRoute::DirectLoopback
+        } else {
+            HttpClientRoute::ProxyAware
+        })
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct HttpSourceClient {
-    pub(super) http: reqwest::Client,
+    pub(super) http: HttpClients,
     pub(super) request_timeout: Duration,
     pub(super) source_schema: String,
     pub(super) base_url: ParsedTemplate,
@@ -49,17 +116,17 @@ pub(crate) struct HttpSourceClientRuntime {
     request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
     body_capture_max_bytes: Option<usize>,
     trace_context: Option<OtelContext>,
-    http: reqwest::Client,
+    http: HttpClients,
 }
 
 impl HttpSourceClientRuntime {
-    pub(crate) fn new(
+    pub(super) fn new(
         source_input_resolution_context: SourceInputResolutionContext,
         source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
         request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
         body_capture_max_bytes: Option<usize>,
         trace_context: Option<OtelContext>,
-        http: reqwest::Client,
+        http: HttpClients,
     ) -> Self {
         Self {
             source_input_resolution_context: Some(source_input_resolution_context),
@@ -72,7 +139,16 @@ impl HttpSourceClientRuntime {
     }
 
     #[cfg(test)]
-    fn static_inputs(body_capture_max_bytes: Option<usize>, http: reqwest::Client) -> Self {
+    fn static_inputs(
+        body_capture_max_bytes: Option<usize>,
+        http: reqwest::Client,
+        credential_safe: bool,
+    ) -> Self {
+        let http = if credential_safe {
+            HttpClients::credential_safe(http.clone(), http)
+        } else {
+            HttpClients::legacy(http)
+        };
         Self {
             source_input_resolution_context: None,
             source_input_resolver: None,
@@ -97,16 +173,14 @@ impl std::fmt::Debug for HttpSourceClient {
     }
 }
 
-pub(super) fn default_http_client(
+pub(super) fn default_http_clients(
     registration: &BackendRegistrationContext,
     source_name: &str,
     credential_safe: bool,
-) -> Result<reqwest::Client> {
-    registration
+) -> Result<HttpClients> {
+    let proxy_aware = registration
         .default_http_client(credential_safe, || {
-            let mut builder = reqwest::Client::builder()
-                .timeout(Duration::from_secs(DEFAULT_HTTP_REQUEST_TIMEOUT_SECS))
-                .user_agent(DEFAULT_HTTP_USER_AGENT);
+            let mut builder = default_http_client_builder();
             if credential_safe {
                 builder = builder.redirect(reqwest::redirect::Policy::none());
             }
@@ -116,7 +190,31 @@ pub(super) fn default_http_client(
             DataFusionError::Execution(format!(
                 "failed to build HTTP client for source '{source_name}': {error}"
             ))
+        })?;
+    if !credential_safe {
+        return Ok(HttpClients::legacy(proxy_aware));
+    }
+
+    let direct_loopback = registration
+        .direct_credential_safe_http_client(|| {
+            default_http_client_builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .no_proxy()
+                .build()
+                .map_err(|error| error.to_string())
         })
+        .map_err(|error| {
+            DataFusionError::Execution(format!(
+                "failed to build direct HTTP client for source '{source_name}': {error}"
+            ))
+        })?;
+    Ok(HttpClients::credential_safe(proxy_aware, direct_loopback))
+}
+
+fn default_http_client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(DEFAULT_HTTP_REQUEST_TIMEOUT_SECS))
+        .user_agent(DEFAULT_HTTP_USER_AGENT)
 }
 
 impl HttpSourceClient {
@@ -148,7 +246,11 @@ impl HttpSourceClient {
             source_secrets,
             source_variables,
             request_authenticators,
-            HttpSourceClientRuntime::static_inputs(body_capture_max_bytes, http),
+            HttpSourceClientRuntime::static_inputs(
+                body_capture_max_bytes,
+                http,
+                manifest.common.dsl_version == 4,
+            ),
         )
     }
 
@@ -269,14 +371,78 @@ fn source_input_error(error: SourceInputResolverError) -> DataFusionError {
 
 #[cfg(test)]
 mod tests {
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    use super::default_http_client;
+    use super::{HttpClientRoute, HttpClients, default_http_client_builder, default_http_clients};
     use crate::backends::BackendRegistrationContext;
 
+    #[test]
+    fn credential_safe_client_uses_direct_transport_only_for_loopback_http() {
+        let clients = HttpClients::credential_safe(reqwest::Client::new(), reqwest::Client::new());
+
+        for url in [
+            "http://localhost:8080/items",
+            "http://LOCALHOST/items",
+            "http://127.0.0.1/items",
+            "http://127.255.255.254/items",
+            "http://[::1]/items",
+        ] {
+            let url = reqwest::Url::parse(url).expect("test URL");
+            assert_eq!(
+                clients
+                    .route_for_request(&url, true)
+                    .expect("safe credential URL"),
+                HttpClientRoute::DirectLoopback,
+                "{url}"
+            );
+        }
+        for url in [
+            "https://localhost/items",
+            "https://127.0.0.1/items",
+            "https://api.example.test/items",
+        ] {
+            let url = reqwest::Url::parse(url).expect("test URL");
+            assert_eq!(
+                clients
+                    .route_for_request(&url, true)
+                    .expect("safe credential URL"),
+                HttpClientRoute::ProxyAware,
+                "{url}"
+            );
+        }
+        for url in [
+            "http://localhost.example/items",
+            "http://api.localhost/items",
+            "http://0.0.0.0/items",
+            "http://192.0.2.1/items",
+            "http://[::2]/items",
+            "http://[2001:db8::1]/items",
+        ] {
+            let url = reqwest::Url::parse(url).expect("test URL");
+            clients
+                .route_for_request(&url, true)
+                .expect_err("unsafe credential URL");
+        }
+
+        let loopback = reqwest::Url::parse("http://127.0.0.1/items").expect("test URL");
+        assert_eq!(
+            clients
+                .route_for_request(&loopback, false)
+                .expect("anonymous v4 request"),
+            HttpClientRoute::ProxyAware
+        );
+        let legacy = HttpClients::legacy(reqwest::Client::new());
+        assert_eq!(
+            legacy
+                .route_for_request(&loopback, true)
+                .expect("legacy credential request"),
+            HttpClientRoute::ProxyAware
+        );
+    }
+
     #[tokio::test]
-    async fn credential_safe_client_does_not_follow_redirects() {
+    async fn credential_safe_clients_do_not_follow_redirects() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/start"))
@@ -288,24 +454,96 @@ mod tests {
             .await;
 
         let registration = BackendRegistrationContext::default();
-        let client =
-            default_http_client(&registration, "test", true).expect("credential-safe client");
-        let response = client
-            .get(format!("{}/start", server.uri()))
-            .send()
-            .await
-            .expect("redirect response");
+        let clients =
+            default_http_clients(&registration, "test", true).expect("credential-safe clients");
+        for client in [
+            &clients.proxy_aware,
+            clients.direct_loopback.as_ref().expect("direct client"),
+        ] {
+            let response = client
+                .get(format!("{}/start", server.uri()))
+                .send()
+                .await
+                .expect("redirect response");
 
-        assert_eq!(response.status(), reqwest::StatusCode::FOUND);
-        assert_eq!(response.url().path(), "/start");
+            assert_eq!(response.status(), reqwest::StatusCode::FOUND);
+            assert_eq!(response.url().path(), "/start");
+        }
 
-        let legacy = default_http_client(&registration, "test", false).expect("legacy client");
+        let legacy = default_http_clients(&registration, "test", false).expect("legacy client");
+        let start_url =
+            reqwest::Url::parse(&format!("{}/start", server.uri())).expect("redirect URL");
         let response = legacy
+            .for_request(&start_url, false)
+            .expect("legacy transport")
             .get(format!("{}/start", server.uri()))
             .send()
             .await
             .expect("followed redirect response");
         assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
         assert_eq!(response.url().path(), "/target");
+    }
+
+    #[tokio::test]
+    async fn loopback_credential_client_bypasses_a_hostile_proxy() {
+        let target = MockServer::start().await;
+        let proxy = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/items"))
+            .and(header("authorization", "Bearer runtime-secret"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&target)
+            .await;
+
+        let proxy_aware = default_http_client_builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .proxy(reqwest::Proxy::all(proxy.uri()).expect("proxy URL"))
+            .build()
+            .expect("proxy-aware client");
+        let direct_loopback = default_http_client_builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .no_proxy()
+            .build()
+            .expect("direct client");
+        let clients = HttpClients::credential_safe(proxy_aware, direct_loopback);
+        let url = reqwest::Url::parse(&format!("{}/items", target.uri())).expect("target URL");
+
+        let response = clients
+            .for_request(&url, true)
+            .expect("loopback credential transport")
+            .get(url.clone())
+            .bearer_auth("runtime-secret")
+            .send()
+            .await
+            .expect("loopback request");
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert!(
+            proxy
+                .received_requests()
+                .await
+                .expect("proxy request recording")
+                .is_empty(),
+            "the proxy must receive neither the request nor its bearer token"
+        );
+
+        let response = clients
+            .for_request(&url, false)
+            .expect("anonymous v4 transport")
+            .get(url)
+            .send()
+            .await
+            .expect("proxied anonymous request");
+        assert_eq!(response.status(), reqwest::StatusCode::NOT_FOUND);
+        assert_eq!(
+            proxy
+                .received_requests()
+                .await
+                .expect("proxy request recording")
+                .len(),
+            1,
+            "anonymous loopback traffic should retain proxy-aware behavior"
+        );
     }
 }

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -123,8 +123,11 @@ impl CompiledBackendSource for HttpCompiledSource {
         registration: &BackendRegistrationContext,
     ) -> Result<BackendRegistration> {
         let credential_safe = self.manifest.common.dsl_version == 4;
-        let http =
-            client::default_http_client(registration, &self.manifest.common.name, credential_safe)?;
+        let http = client::default_http_clients(
+            registration,
+            &self.manifest.common.name,
+            credential_safe,
+        )?;
         let runtime = HttpSourceClientRuntime::new(
             self.source_input_resolution.clone(),
             self.source_input_resolver.clone(),

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -18,6 +18,7 @@ use crate::backends::http::auth::{
     ensure_auth_uses_credential_safe_transport, request_requires_credential_safe_transport,
     resolve_auth_headers,
 };
+use crate::backends::http::client::HttpClients;
 use crate::backends::http::error::provider_error;
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::backends::http::request::RequestBody;
@@ -70,7 +71,7 @@ pub(super) struct DecodedHttpResponse {
     reason = "HTTP request execution keeps retry, auth, logging, and response handling in one audited flow"
 )]
 pub(super) async fn execute_request(
-    http: &reqwest::Client,
+    http: &HttpClients,
     request_timeout: Duration,
     request: OutgoingHttpRequest<'_>,
 ) -> Result<Option<DecodedHttpResponse>> {
@@ -104,7 +105,7 @@ pub(super) async fn execute_request(
     let mut decode_retries = 0usize;
     loop {
         let method_label = http_method_label(method);
-        let mut request = build_http_request(http, method, url);
+        let mut request = build_http_request(http.proxy_aware(), method, url);
 
         let mut header_map = HeaderMap::new();
         for header in request_headers.iter().chain(table_headers.iter()) {
@@ -202,7 +203,7 @@ pub(super) async fn execute_request(
         }
 
         body_capture.record_request(&request_span, request_id, body);
-        let mut built = match resolve_auth_headers(
+        let (mut built, has_auth_headers) = match resolve_auth_headers(
             auth,
             request,
             request_authenticators,
@@ -222,6 +223,14 @@ pub(super) async fn execute_request(
             record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
             return Err(error);
         }
+        if require_credential_safe_auth_transport
+            && request_identity_http_authenticator.is_some()
+            && let Err(error) = ensure_auth_uses_credential_safe_transport(built.url())
+        {
+            record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
+            return Err(error);
+        }
+        let mut has_identity_headers = false;
         if let Some(authenticator) = request_identity_http_authenticator {
             let identity_headers = match authenticator(&built, render_context.resolved_inputs).await
             {
@@ -233,8 +242,9 @@ pub(super) async fn execute_request(
                     return Err(error);
                 }
             };
+            has_identity_headers = !identity_headers.is_empty();
             if require_credential_safe_auth_transport
-                && !identity_headers.is_empty()
+                && has_identity_headers
                 && let Err(error) = ensure_auth_uses_credential_safe_transport(built.url())
             {
                 record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
@@ -249,7 +259,21 @@ pub(super) async fn execute_request(
                 built.headers_mut().insert(name, value);
             }
         }
-        let response = match http.execute(built).instrument(request_span.clone()).await {
+        let credential_bearing = has_auth_headers
+            || has_identity_headers
+            || request_requires_credential_safe_transport(&built, has_authored_headers);
+        let request_http = match http.for_request(built.url(), credential_bearing) {
+            Ok(http) => http,
+            Err(error) => {
+                record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
+                return Err(error);
+            }
+        };
+        let response = match request_http
+            .execute(built)
+            .instrument(request_span.clone())
+            .await
+        {
             Ok(response) => response,
             Err(error) => {
                 record_http_processing_error(
@@ -526,14 +550,18 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
     use tokio::task::JoinHandle;
+    use wiremock::MockServer;
 
     use super::{OutgoingHttpRequest as TestOutgoingHttpRequest, execute_request};
     use crate::backends::http::ProviderQueryError;
+    use crate::backends::http::client::HttpClients;
     use crate::backends::http::trace::HttpBodyCapture;
     use crate::backends::shared::template::RenderContext;
     use crate::{BoundRequestIdentityHttpAuthenticator, RequestIdentityHttpAuthenticatorError};
     use coral_spec::backends::http::RateLimitSpec;
-    use coral_spec::{AuthSpec, HeaderSpec, HttpMethod, ResponseBodyFormat, ValueSourceSpec};
+    use coral_spec::{
+        AuthSpec, HeaderAuthSpec, HeaderSpec, HttpMethod, ResponseBodyFormat, ValueSourceSpec,
+    };
 
     async fn spawn_hanging_http_server() -> (String, JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0")
@@ -587,10 +615,12 @@ mod tests {
     async fn execute_request_times_out_when_upstream_stalls() {
         let (base_url, task) = spawn_hanging_http_server().await;
         let request_timeout = Duration::from_millis(100);
-        let http = reqwest::Client::builder()
-            .timeout(request_timeout)
-            .build()
-            .expect("build test client");
+        let http = HttpClients::legacy(
+            reqwest::Client::builder()
+                .timeout(request_timeout)
+                .build()
+                .expect("build test client"),
+        );
         let url = format!("{base_url}/items");
         let query_pairs = vec![("api_key".to_string(), "secret-token".to_string())];
         let filters = HashMap::new();
@@ -662,10 +692,12 @@ mod tests {
     #[tokio::test]
     async fn request_identity_headers_cannot_overwrite_existing_headers() {
         let request_timeout = Duration::from_secs(1);
-        let http = reqwest::Client::builder()
-            .timeout(request_timeout)
-            .build()
-            .expect("build test client");
+        let http = HttpClients::legacy(
+            reqwest::Client::builder()
+                .timeout(request_timeout)
+                .build()
+                .expect("build test client"),
+        );
         let base_url = "https://api.example.test";
         let url = format!("{base_url}/items");
         let filters = HashMap::new();
@@ -733,11 +765,22 @@ mod tests {
     #[tokio::test]
     async fn request_identity_headers_are_injected() {
         let (base_url, task) = spawn_header_recorder(r#"{"ok":true}"#).await;
+        let proxy = MockServer::start().await;
         let request_timeout = Duration::from_secs(1);
-        let http = reqwest::Client::builder()
-            .timeout(request_timeout)
-            .build()
-            .expect("build test client");
+        let http = HttpClients::credential_safe(
+            reqwest::Client::builder()
+                .timeout(request_timeout)
+                .redirect(reqwest::redirect::Policy::none())
+                .proxy(reqwest::Proxy::all(proxy.uri()).expect("proxy URL"))
+                .build()
+                .expect("build proxy-aware client"),
+            reqwest::Client::builder()
+                .timeout(request_timeout)
+                .redirect(reqwest::redirect::Policy::none())
+                .no_proxy()
+                .build()
+                .expect("build direct client"),
+        );
         let url = format!("{base_url}/items");
         let filters = HashMap::new();
         let args = HashMap::new();
@@ -786,6 +829,91 @@ mod tests {
         assert!(
             raw_request.contains("\r\nx-identity-token: identity-token\r\n"),
             "{raw_request}"
+        );
+        assert!(
+            proxy
+                .received_requests()
+                .await
+                .expect("proxy request recording")
+                .is_empty(),
+            "the loopback identity request and token must bypass the proxy"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_authorization_auth_headers_bypass_a_hostile_proxy() {
+        let (base_url, task) = spawn_header_recorder(r#"{"ok":true}"#).await;
+        let proxy = MockServer::start().await;
+        let request_timeout = Duration::from_secs(1);
+        let http = HttpClients::credential_safe(
+            reqwest::Client::builder()
+                .timeout(request_timeout)
+                .redirect(reqwest::redirect::Policy::none())
+                .proxy(reqwest::Proxy::all(proxy.uri()).expect("proxy URL"))
+                .build()
+                .expect("build proxy-aware client"),
+            reqwest::Client::builder()
+                .timeout(request_timeout)
+                .redirect(reqwest::redirect::Policy::none())
+                .no_proxy()
+                .build()
+                .expect("build direct client"),
+        );
+        let url = format!("{base_url}/items");
+        let filters = HashMap::new();
+        let args = HashMap::new();
+        let state = HashMap::new();
+        let resolved_inputs = BTreeMap::new();
+        let render_context = RenderContext::new(&filters, &args, &state, &resolved_inputs);
+        let auth = AuthSpec::HeaderAuth(HeaderAuthSpec {
+            headers: vec![HeaderSpec {
+                name: "X-Api-Key".to_string(),
+                value: ValueSourceSpec::Literal {
+                    value: serde_json::Value::String("runtime-secret".to_string()),
+                },
+            }],
+        });
+
+        let response = execute_request(
+            &http,
+            request_timeout,
+            TestOutgoingHttpRequest {
+                auth: &auth,
+                request_headers: &[],
+                request_authenticators: &HashMap::new(),
+                require_credential_safe_auth_transport: true,
+                request_identity_http_authenticator: None,
+                trace_context: None,
+                table_headers: &[],
+                table_name: "items",
+                method: HttpMethod::GET,
+                url: &url,
+                query_pairs: &[],
+                body: None,
+                response_format: ResponseBodyFormat::default(),
+                source_schema: "demo",
+                rate_limit: &RateLimitSpec::default(),
+                body_capture: HttpBodyCapture::default(),
+                render_context,
+                allow_404_empty: false,
+            },
+        )
+        .await
+        .expect("API-key request should succeed");
+
+        assert!(response.is_some());
+        let raw_request = task.await.expect("header recorder should finish");
+        assert!(
+            raw_request.contains("\r\nx-api-key: runtime-secret\r\n"),
+            "{raw_request}"
+        );
+        assert!(
+            proxy
+                .received_requests()
+                .await
+                .expect("proxy request recording")
+                .is_empty(),
+            "the loopback API-key request and credential must bypass the proxy"
         );
     }
 }

--- a/crates/coral-engine/tests/engine/v4_tests.rs
+++ b/crates/coral-engine/tests/engine/v4_tests.rs
@@ -335,6 +335,14 @@ async fn v4_identity_http_authenticator_rejects_non_loopback_plain_http() {
         "{message}"
     );
     assert!(message.contains("http://api.example.test"), "{message}");
+    assert!(
+        observed
+            .lock()
+            .expect("observed identity lock")
+            .authentications
+            .is_empty(),
+        "unsafe transport must fail before requesting identity headers"
+    );
 }
 #[tokio::test]
 async fn v4_identity_requirements_fail_closed_without_selector() {


### PR DESCRIPTION
## Intent

Establish the engine-side HTTP transport core for DSL v4 credential-bearing headers without changing DSL v3 behavior. Credential-bearing parsed-loopback HTTP must bypass ambient proxies, HTTPS must remain proxy-aware, and v4 credential traffic must never follow redirects.

## What it enables

- Select the executing client after the final rendered or link-pagination URL and header sensitivity are known.
- Route loopback HTTP auth, authored, URL-userinfo, and identity headers through a direct `.no_proxy()` client.
- Keep credential-bearing HTTPS and anonymous v4 traffic proxy-aware with redirects disabled.
- Reject unsafe remote cleartext before invoking the identity authenticator or making a network request.
- Provide the transport seam consumed by immediate child B5e1 (secret URL/query/body provenance) and then B5e2 (app-owned bearer runtime).

## Usage examples

- A DSL v4 request to `http://127.0.0.1:<port>` carrying `Authorization`, `X-Api-Key`, or an identity header reaches the loopback target directly even when `HTTP_PROXY` is hostile.
- The same credential header on `https://api.example.com` retains normal proxy behavior but cannot be redirected.
- A credential-bearing request to `http://api.example.com` fails before authentication or network execution.
- DSL v3 keeps its legacy client and redirect behavior unchanged.

## Validation

- `cargo test --locked -p coral-engine --all-features backends::http::transport::tests::non_authorization_auth_headers_bypass_a_hostile_proxy -- --exact` — passed.
- `make rust-checks` — passed strict fmt, workspace Clippy, rustdoc, and 1,757/1,757 tests with 3 skipped.
- `make perf-check` — passed at 206.5 ms mean versus the 750 ms ceiling.
- Final diff: 505 additions, 52 deletions across 6 files (557 changed lines).

## Review

Fresh five-lane review bundle: `.context/review-swarm/20260712T232614Z-sauldhernandez-dsl-v4-identity-v3-b5e-runtime-transport-local`, frozen/live SHA-256 `6fe6aafa95648a2be91d1c589afcdd69d43b4127c7773556487943a8a470b08d`.

Header, identity, proxy, redirect, retry, pagination, v3 compatibility, architecture, and operations paths were clean. The credential-flow sweep found a separate P1 for secret-backed URL/query/body values; it cannot fit this PR's remaining cap and is assigned to immediate draft child B5e1. This PR and the stack remain draft until that gate is closed.

## Stack

- Parent: #1717 (`test(app): cover OAuth transport lifecycle`)
- This PR: B5e engine credential-header transport core
- Next: B5e1 selected secret-value provenance and contracts
- Then: B5e2 app-owned bearer runtime

All mission PRs remain draft. PR #1460 is the immutable transitive ancestor.
