### PR TITLE
fix(engine): preserve selected-secret provenance

### DIFF
--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -1,6 +1,6 @@
 //! HTTP client orchestration for manifest-driven HTTP sources.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -105,6 +105,7 @@ pub(crate) struct HttpSourceClient {
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
     pub(super) request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
     pub(super) rate_limit: RateLimitSpec,
+    pub(super) secret_input_names: Arc<BTreeSet<String>>,
     pub(super) resolved_inputs: Arc<BTreeMap<String, String>>,
     pub(super) body_capture: HttpBodyCapture,
     pub(super) trace_context: Option<OtelContext>,
@@ -296,6 +297,7 @@ impl HttpSourceClient {
             source_input_resolver: runtime.source_input_resolver,
             request_identity_http_authenticator: runtime.request_identity_http_authenticator,
             rate_limit: manifest.rate_limit.clone(),
+            secret_input_names: Arc::new(manifest.declared_secret_names()),
             resolved_inputs: Arc::new(resolved_inputs),
             body_capture: HttpBodyCapture::new(runtime.body_capture_max_bytes),
             trace_context: runtime.trace_context,

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -14,11 +14,11 @@ use crate::backends::http::pagination::{
 };
 use crate::backends::http::request::{build_query_pairs, build_request_body};
 use crate::backends::http::target::HttpFetchTarget;
-use crate::backends::http::transport::{OutgoingHttpRequest, execute_request};
+use crate::backends::http::transport::{OutgoingHttpRequest, SecretProvenance, execute_request};
 use crate::backends::http::url::{join_url, normalize_base_url};
 use crate::backends::shared::json_path::get_path_value;
 use crate::backends::shared::response_rows::extract_rows;
-use crate::backends::shared::template::{RenderContext, render_template};
+use crate::backends::shared::template::{RenderContext, render_template_with_secret_provenance};
 use coral_spec::{HttpMethod, ValidatedPaginationMode};
 
 const DEFAULT_MAX_PAGES: usize = 10_000;
@@ -68,6 +68,7 @@ pub(super) async fn fetch_rows(
     let active_request = target.resolved_request();
 
     let mut state = initial_page_state(&pagination);
+    let mut next_link_depends_on_secret = false;
 
     let mut page_count = 0usize;
     let max_pages = pagination.max_pages.unwrap_or(DEFAULT_MAX_PAGES);
@@ -92,40 +93,61 @@ pub(super) async fn fetch_rows(
             &state_values,
             resolved_inputs.as_ref(),
         );
-        let base_url = render_template(&client.base_url, &render_context)?;
-        let base_url = normalize_base_url(&base_url);
+        let base_url = render_template_with_secret_provenance(
+            &client.base_url,
+            &render_context,
+            &client.secret_input_names,
+        )?;
+        let normalized_base_url = normalize_base_url(&base_url.value);
         let following_link_header = matches!(
             pagination.mode,
             ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto
         ) && state.next_url.is_some();
 
-        let url = if matches!(
+        let (url, url_depends_on_secret) = if matches!(
             pagination.mode,
             ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto
         ) && let Some(next) = state.next_url.clone()
         {
-            next
+            (next, next_link_depends_on_secret)
         } else {
-            let rendered_path = render_template(&active_request.path, &render_context)?;
-            join_url(&base_url, &rendered_path)?
+            let rendered_path = render_template_with_secret_provenance(
+                &active_request.path,
+                &render_context,
+                &client.secret_input_names,
+            )?;
+            (
+                join_url(&normalized_base_url, &rendered_path.value)?,
+                client.require_credential_safe_auth_transport
+                    && (base_url.depends_on_secret || rendered_path.depends_on_secret),
+            )
         };
 
-        let (query_pairs, body) = if following_link_header {
-            (Vec::new(), None)
+        let (query_pairs, body, contains_secret_value, redact_url) = if following_link_header {
+            (
+                Vec::new(),
+                None,
+                url_depends_on_secret,
+                url_depends_on_secret,
+            )
         } else {
-            let mut query_pairs = build_query_pairs(active_request, &render_context)?;
-            apply_pagination_query_pairs(&mut query_pairs, &pagination, &state, page_size)
+            let mut query_pairs =
+                build_query_pairs(active_request, &render_context, &client.secret_input_names)?;
+            let redact_url = url_depends_on_secret
+                || (client.require_credential_safe_auth_transport && query_pairs.depends_on_secret);
+            apply_pagination_query_pairs(&mut query_pairs.value, &pagination, &state, page_size)
                 .map_err(|error| {
                     pagination_error(
                         &client.source_schema,
                         target.name(),
                         None,
-                        Some(&url),
+                        (!redact_url).then_some(url.as_str()),
                         &error,
                     )
                 })?;
 
-            let mut body = build_request_body(active_request, &render_context)?;
+            let mut body =
+                build_request_body(active_request, &render_context, &client.secret_input_names)?;
             apply_pagination_body_fields(
                 &mut body,
                 &active_request.body,
@@ -138,11 +160,27 @@ pub(super) async fn fetch_rows(
                     &client.source_schema,
                     target.name(),
                     None,
-                    Some(&url),
+                    (!redact_url).then_some(url.as_str()),
                     &error,
                 )
             })?;
-            (query_pairs, body)
+            let contains_secret_value = client.require_credential_safe_auth_transport
+                && (url_depends_on_secret
+                    || query_pairs.depends_on_secret
+                    || body.depends_on_secret());
+            (
+                query_pairs.value,
+                body.value,
+                contains_secret_value,
+                redact_url,
+            )
+        };
+        let secret_provenance = if redact_url {
+            SecretProvenance::Url
+        } else if contains_secret_value {
+            SecretProvenance::Request
+        } else {
+            SecretProvenance::Public
         };
 
         let request = execute_request(
@@ -154,6 +192,7 @@ pub(super) async fn fetch_rows(
                 request_authenticators: &client.request_authenticators,
                 require_credential_safe_auth_transport: client
                     .require_credential_safe_auth_transport,
+                secret_provenance,
                 request_identity_http_authenticator: client
                     .request_identity_http_authenticator
                     .as_ref(),
@@ -238,20 +277,68 @@ pub(super) async fn fetch_rows(
             },
         )
         .map_err(|error| {
+            let error = if contains_secret_value {
+                redacted_pagination_error(&error)
+            } else {
+                error
+            };
             pagination_error(
                 &client.source_schema,
                 target.name(),
                 Some(http_method_label(active_request.method)),
-                Some(&url),
+                (!redact_url).then_some(url.as_str()),
                 &error,
             )
         })?;
         if page_advance == PageAdvance::Stop {
             break;
         }
+        next_link_depends_on_secret = state.next_url.is_some() && contains_secret_value;
     }
 
     Ok(all_rows)
+}
+
+fn redacted_pagination_error(error: &DataFusionError) -> DataFusionError {
+    let detail = error.to_string();
+    let category = [
+        (
+            "next link must stay on origin",
+            "pagination next link must stay on request origin",
+        ),
+        (
+            "next URL header value must stay on origin",
+            "pagination next URL header must stay on request origin",
+        ),
+        (
+            "invalid pagination Link header item",
+            "invalid pagination Link header",
+        ),
+        (
+            "invalid pagination next link",
+            "invalid pagination next link",
+        ),
+        (
+            "invalid pagination next URL header value",
+            "invalid pagination next URL header",
+        ),
+        (
+            "invalid pagination next URL header",
+            "invalid pagination next URL header",
+        ),
+        (
+            "invalid pagination response cursor header",
+            "invalid pagination response cursor header",
+        ),
+        (
+            "invalid request URL for pagination links",
+            "invalid request URL for pagination links",
+        ),
+    ]
+    .into_iter()
+    .find_map(|(needle, category)| detail.contains(needle).then_some(category))
+    .unwrap_or("pagination failed for request with secret-derived URL");
+    DataFusionError::Execution(category.to_string())
 }
 
 fn http_method_label(method: HttpMethod) -> &'static str {

--- a/crates/coral-engine/src/backends/http/pagination.rs
+++ b/crates/coral-engine/src/backends/http/pagination.rs
@@ -6,7 +6,7 @@ use datafusion::error::{DataFusionError, Result};
 use reqwest::header::{HeaderMap, HeaderName};
 use serde_json::{Map, Value, json};
 
-use crate::backends::http::request::{RequestBody, set_path_value};
+use crate::backends::http::request::{RenderedRequestBody, RequestBody, set_path_value};
 use crate::backends::shared::json_path::get_path_value;
 use coral_spec::{BodySpec, PageSizeSpec, ValidatedPagination, ValidatedPaginationMode};
 
@@ -98,7 +98,7 @@ pub(super) fn apply_pagination_query_pairs(
 }
 
 pub(super) fn apply_pagination_body_fields(
-    body: &mut Option<RequestBody>,
+    body: &mut RenderedRequestBody,
     body_spec: &BodySpec,
     pagination: &ValidatedPagination,
     state: &PageState,
@@ -115,16 +115,26 @@ pub(super) fn apply_pagination_body_fields(
         return Ok(());
     }
 
-    if matches!(body_spec, BodySpec::Text { .. }) || matches!(body, Some(RequestBody::Text(_))) {
+    if matches!(body_spec, BodySpec::Text { .. })
+        || matches!(body.value, Some(RequestBody::Text(_)))
+    {
         return Err(DataFusionError::Execution(
             "pagination body fields are not supported with text request bodies".to_string(),
         ));
     }
 
-    if body.is_none() {
-        *body = Some(RequestBody::Json(Value::Object(Map::new())));
+    if body.value.is_none() {
+        body.value = Some(RequestBody::Json(Value::Object(Map::new())));
     }
-    let root = match body.as_mut().expect("body is present") {
+    if let (Some(_), Some(spec)) = (page_size, pagination.page_size.as_ref())
+        && !spec.body_path.is_empty()
+    {
+        body.overwrite_with_public_path(&spec.body_path);
+    }
+    if needs_cursor_body {
+        body.overwrite_with_public_path(&pagination.cursor_body_path);
+    }
+    let root = match body.value.as_mut().expect("body is present") {
         RequestBody::Json(root) => root,
         RequestBody::Text(_) => unreachable!("text body rejected above"),
     };
@@ -402,6 +412,7 @@ mod tests {
         apply_pagination_body_fields, apply_pagination_query_pairs, extract_next_link_url,
         extract_next_url_header, extract_response_cursor_header, page_is_exhausted,
     };
+    use crate::backends::http::request::RenderedRequestBody;
     use crate::backends::http::test_support::test_http_table_spec;
     use coral_spec::{
         BodySpec, HttpMethod, PaginationMode, PaginationSpec, ParsedTemplate, RequestSpec,
@@ -726,7 +737,7 @@ mod tests {
         }
         .validated("demo", "items")
         .unwrap();
-        let mut body = None;
+        let mut body = RenderedRequestBody::default();
         let error = apply_pagination_body_fields(
             &mut body,
             &body_spec,
@@ -741,7 +752,7 @@ mod tests {
                 .to_string()
                 .contains("pagination body fields are not supported with text request bodies")
         );
-        assert!(body.is_none());
+        assert!(body.value.is_none());
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/http/request.rs
+++ b/crates/coral-engine/src/backends/http/request.rs
@@ -1,9 +1,13 @@
 //! Request query and body construction for HTTP-backed sources.
 
+use std::collections::BTreeSet;
+
 use datafusion::error::{DataFusionError, Result};
 use serde_json::{Map, Value};
 
-use crate::backends::shared::template::{RenderContext, resolve_value_source, value_to_string};
+use crate::backends::shared::template::{
+    RenderContext, Resolved, resolve_value_source_with_secret_provenance, value_to_string,
+};
 use coral_spec::BodySpec;
 
 #[derive(Debug, Clone)]
@@ -12,33 +16,74 @@ pub(super) enum RequestBody {
     Text(String),
 }
 
+#[derive(Debug, Clone, Default)]
+pub(super) struct RenderedRequestBody {
+    pub(super) value: Option<RequestBody>,
+    secret_paths: Vec<Vec<String>>,
+    text_depends_on_secret: bool,
+}
+
+impl RenderedRequestBody {
+    pub(super) fn depends_on_secret(&self) -> bool {
+        self.text_depends_on_secret || !self.secret_paths.is_empty()
+    }
+
+    pub(super) fn overwrite_with_public_path(&mut self, path: &[String]) {
+        self.secret_paths
+            .retain(|secret_path| !paths_overlap(secret_path, path));
+    }
+}
+
+fn paths_overlap(left: &[String], right: &[String]) -> bool {
+    for (left, right) in left.iter().zip(right) {
+        match (left.parse::<usize>(), right.parse::<usize>()) {
+            (Ok(left), Ok(right)) if left == right => {}
+            (Err(_), Err(_)) if left == right => {}
+            (Ok(_), Ok(_)) | (Err(_), Err(_)) => return false,
+            (Ok(_), Err(_)) | (Err(_), Ok(_)) => return true,
+        }
+    }
+    true
+}
+
 pub(super) fn build_query_pairs(
     request: &coral_spec::RequestSpec,
     render_context: &RenderContext<'_>,
-) -> Result<Vec<(String, String)>> {
+    secret_input_names: &BTreeSet<String>,
+) -> Result<Resolved<Vec<(String, String)>>> {
     let mut params = Vec::new();
+    let mut depends_on_secret = false;
 
     for param in &request.query {
-        let value = resolve_value_source(&param.value, render_context)?;
-        if let Some(value) = value {
-            params.push((param.name.clone(), value_to_string(&value)));
+        if let Some(resolved) = resolve_value_source_with_secret_provenance(
+            &param.value,
+            render_context,
+            secret_input_names,
+        )? {
+            depends_on_secret |= resolved.depends_on_secret;
+            params.push((param.name.clone(), value_to_string(&resolved.value)));
         }
     }
 
-    Ok(params)
+    Ok(Resolved {
+        value: params,
+        depends_on_secret,
+    })
 }
 
 pub(super) fn build_request_body(
     request: &coral_spec::RequestSpec,
     render_context: &RenderContext<'_>,
-) -> Result<Option<RequestBody>> {
+    secret_input_names: &BTreeSet<String>,
+) -> Result<RenderedRequestBody> {
     match &request.body {
         BodySpec::Json { fields } => {
             if fields.is_empty() {
-                return Ok(None);
+                return Ok(RenderedRequestBody::default());
             }
             let mut root = Value::Object(Map::new());
             let mut rendered_any_field = false;
+            let mut secret_paths = Vec::<Vec<String>>::new();
             for field in fields {
                 if field
                     .when_arg
@@ -47,22 +92,44 @@ pub(super) fn build_request_body(
                 {
                     continue;
                 }
-                if let Some(value) = resolve_value_source(&field.value, render_context)? {
+                if let Some(resolved) = resolve_value_source_with_secret_provenance(
+                    &field.value,
+                    render_context,
+                    secret_input_names,
+                )? {
                     rendered_any_field = true;
-                    set_path_value(&mut root, &field.path, value)?;
+                    secret_paths.retain(|path| !paths_overlap(path, &field.path));
+                    set_path_value(&mut root, &field.path, resolved.value)?;
+                    if resolved.depends_on_secret {
+                        secret_paths.push(field.path.clone());
+                    }
                 }
             }
-            if rendered_any_field {
-                Ok(Some(RequestBody::Json(root)))
+            let value = if rendered_any_field {
+                Some(RequestBody::Json(root))
             } else {
-                Ok(None)
-            }
+                None
+            };
+            Ok(RenderedRequestBody {
+                value,
+                secret_paths,
+                text_depends_on_secret: false,
+            })
         }
         BodySpec::Text { content } => {
-            let Some(value) = resolve_value_source(content, render_context)? else {
-                return Ok(None);
+            let Some(resolved) = resolve_value_source_with_secret_provenance(
+                content,
+                render_context,
+                secret_input_names,
+            )?
+            else {
+                return Ok(RenderedRequestBody::default());
             };
-            Ok(Some(RequestBody::Text(value_to_string(&value))))
+            Ok(RenderedRequestBody {
+                value: Some(RequestBody::Text(value_to_string(&resolved.value))),
+                secret_paths: Vec::new(),
+                text_depends_on_secret: resolved.depends_on_secret,
+            })
         }
     }
 }
@@ -116,14 +183,15 @@ fn set_path_value_at(cursor: &mut Value, path: &[String], value: Value) -> Resul
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
 
     use serde_json::json;
 
-    use super::{RequestBody, build_request_body, set_path_value};
+    use super::{RequestBody, build_query_pairs, build_request_body, set_path_value};
     use crate::backends::shared::template::RenderContext;
     use coral_spec::{
-        BodyFieldSpec, BodySpec, HttpMethod, ParsedTemplate, RequestSpec, ValueSourceSpec,
+        BodyFieldSpec, BodySpec, HttpMethod, ParsedTemplate, QueryParamSpec, RequestSpec,
+        ValueSourceSpec,
     };
 
     #[test]
@@ -150,7 +218,9 @@ mod tests {
         let resolved_inputs = BTreeMap::new();
         let context = RenderContext::new(&filters, &args, &state, &resolved_inputs);
 
-        let body = build_request_body(&request, &context).expect("request body should render");
+        let body = build_request_body(&request, &context, &BTreeSet::new())
+            .expect("request body should render")
+            .value;
 
         assert!(body.is_none());
     }
@@ -179,7 +249,9 @@ mod tests {
         let resolved_inputs = BTreeMap::new();
         let context = RenderContext::new(&filters, &args, &state, &resolved_inputs);
 
-        let body = build_request_body(&request, &context).expect("request body should render");
+        let body = build_request_body(&request, &context, &BTreeSet::new())
+            .expect("request body should render")
+            .value;
 
         assert!(
             matches!(body, Some(RequestBody::Json(value)) if value == json!({"required": "value"}))
@@ -213,13 +285,68 @@ mod tests {
         let resolved_inputs = BTreeMap::new();
         let context = RenderContext::new(&filters, &args, &state, &resolved_inputs);
 
-        let body = build_request_body(&request, &context).expect("request body should render");
+        let body = build_request_body(&request, &context, &BTreeSet::new())
+            .expect("request body should render")
+            .value;
 
         assert!(
             matches!(body, Some(RequestBody::Json(value)) if value == json!({
                 "logStreamNames": ["stream-a", "stream-b"]
             }))
         );
+    }
+
+    #[test]
+    fn request_provenance_tracks_only_emitted_secret_values() {
+        let request = RequestSpec {
+            method: HttpMethod::POST,
+            path: ParsedTemplate::parse("/items").expect("template"),
+            query: vec![QueryParamSpec {
+                name: "token".to_string(),
+                value: ValueSourceSpec::Input {
+                    key: "SECRET".to_string(),
+                },
+            }],
+            body: BodySpec::Json {
+                fields: vec![
+                    BodyFieldSpec {
+                        path: vec!["secret".to_string()],
+                        when_arg: Some("include_secret".to_string()),
+                        value: ValueSourceSpec::Input {
+                            key: "SECRET".to_string(),
+                        },
+                    },
+                    BodyFieldSpec {
+                        path: vec!["public".to_string()],
+                        when_arg: None,
+                        value: ValueSourceSpec::Input {
+                            key: "PUBLIC".to_string(),
+                        },
+                    },
+                ],
+            },
+            headers: vec![],
+        };
+        let inputs = BTreeMap::from([
+            ("SECRET".to_string(), "hidden".to_string()),
+            ("PUBLIC".to_string(), "visible".to_string()),
+        ]);
+        let secret_names = BTreeSet::from(["SECRET".to_string()]);
+        let empty = HashMap::new();
+        let context = RenderContext::new(&empty, &empty, &empty, &inputs);
+
+        let query = build_query_pairs(&request, &context, &secret_names).expect("query");
+        assert!(query.depends_on_secret);
+        let body = build_request_body(&request, &context, &secret_names).expect("body");
+        assert!(
+            !body.depends_on_secret(),
+            "skipped secret field must not taint"
+        );
+
+        let args = HashMap::from([("include_secret".to_string(), "true".to_string())]);
+        let context = RenderContext::new(&empty, &args, &empty, &inputs);
+        let body = build_request_body(&request, &context, &secret_names).expect("body");
+        assert!(body.depends_on_secret());
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -19,7 +19,7 @@ use crate::backends::http::auth::{
     resolve_auth_headers,
 };
 use crate::backends::http::client::HttpClients;
-use crate::backends::http::error::provider_error;
+use crate::backends::http::error::{CredentialTransportError, provider_error};
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::backends::http::request::RequestBody;
 use crate::backends::http::response::{ResponseDecodeContext, decode_response_body};
@@ -37,12 +37,21 @@ use coral_spec::backends::http::RateLimitSpec;
 use coral_spec::{AuthSpec, HeaderSpec, HttpMethod, ResponseBodyFormat};
 
 static NEXT_HTTP_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+const REDACTED_SECRET_URL: &str = "[redacted secret-derived URL]";
+
+#[derive(Clone, Copy)]
+pub(super) enum SecretProvenance {
+    Public,
+    Request,
+    Url,
+}
 
 pub(super) struct OutgoingHttpRequest<'a> {
     pub(super) auth: &'a AuthSpec,
     pub(super) request_headers: &'a [HeaderSpec],
     pub(super) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
     pub(super) require_credential_safe_auth_transport: bool,
+    pub(super) secret_provenance: SecretProvenance,
     pub(super) request_identity_http_authenticator:
         Option<&'a BoundRequestIdentityHttpAuthenticator>,
     pub(super) trace_context: Option<&'a OtelContext>,
@@ -85,6 +94,7 @@ pub(super) async fn execute_request(
         request_headers,
         request_authenticators,
         require_credential_safe_auth_transport,
+        secret_provenance,
         request_identity_http_authenticator,
         trace_context,
         table_headers,
@@ -100,6 +110,10 @@ pub(super) async fn execute_request(
         render_context,
         allow_404_empty,
     } = request;
+    let contains_secret_value = require_credential_safe_auth_transport
+        && !matches!(secret_provenance, SecretProvenance::Public);
+    let redact_url = require_credential_safe_auth_transport
+        && matches!(secret_provenance, SecretProvenance::Url);
     let mut server_error_retries = 0usize;
     let mut throttle_retries = 0usize;
     let mut decode_retries = 0usize;
@@ -135,7 +149,11 @@ pub(super) async fn execute_request(
                 HeaderValue::from_static("text/plain"),
             );
         }
-        let logged_url = build_logged_url(url, query_pairs);
+        let logged_url = if redact_url {
+            REDACTED_SECRET_URL.to_string()
+        } else {
+            build_logged_url(url, query_pairs)
+        };
 
         let request_id = NEXT_HTTP_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
         let attempt = server_error_retries + throttle_retries + decode_retries + 1;
@@ -181,6 +199,12 @@ pub(super) async fn execute_request(
                 "http.request.resend_count",
                 i64::try_from(attempt - 1).unwrap_or(i64::MAX),
             );
+        }
+        if contains_secret_value
+            && let Err(error) = ensure_secret_values_use_credential_safe_transport(url)
+        {
+            record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
+            return Err(error);
         }
 
         inject_trace_context(&request_span, &mut header_map);
@@ -259,7 +283,8 @@ pub(super) async fn execute_request(
                 built.headers_mut().insert(name, value);
             }
         }
-        let credential_bearing = has_auth_headers
+        let credential_bearing = contains_secret_value
+            || has_auth_headers
             || has_identity_headers
             || request_requires_credential_safe_transport(&built, has_authored_headers);
         let request_http = match http.for_request(built.url(), credential_bearing) {
@@ -436,6 +461,19 @@ pub(super) async fn execute_request(
     }
 }
 
+fn ensure_secret_values_use_credential_safe_transport(url: &str) -> Result<()> {
+    let url = reqwest::Url::parse(url).map_err(|_error| {
+        DataFusionError::External(Box::new(CredentialTransportError(
+            "DSL v4 secret values require a valid HTTPS or loopback HTTP URL".to_string(),
+        )))
+    })?;
+    ensure_auth_uses_credential_safe_transport(&url).map_err(|_error| {
+        DataFusionError::External(Box::new(CredentialTransportError(
+            "DSL v4 secret values require HTTPS or loopback HTTP".to_string(),
+        )))
+    })
+}
+
 fn identity_http_authenticator_error(
     source_schema: &str,
     table_name: &str,
@@ -552,7 +590,9 @@ mod tests {
     use tokio::task::JoinHandle;
     use wiremock::MockServer;
 
-    use super::{OutgoingHttpRequest as TestOutgoingHttpRequest, execute_request};
+    use super::{
+        OutgoingHttpRequest as TestOutgoingHttpRequest, SecretProvenance, execute_request,
+    };
     use crate::backends::http::ProviderQueryError;
     use crate::backends::http::client::HttpClients;
     use crate::backends::http::trace::HttpBodyCapture;
@@ -637,6 +677,7 @@ mod tests {
                 request_headers: &[],
                 request_authenticators: &HashMap::new(),
                 require_credential_safe_auth_transport: false,
+                secret_provenance: SecretProvenance::Url,
                 request_identity_http_authenticator: None,
                 trace_context: None,
                 table_headers: &[],
@@ -729,6 +770,7 @@ mod tests {
                 request_headers: &request_headers,
                 request_authenticators: &HashMap::new(),
                 require_credential_safe_auth_transport: true,
+                secret_provenance: SecretProvenance::Public,
                 request_identity_http_authenticator: Some(&identity_authenticator),
                 trace_context: None,
                 table_headers: &[],
@@ -805,6 +847,7 @@ mod tests {
                 request_headers: &[],
                 request_authenticators: &HashMap::new(),
                 require_credential_safe_auth_transport: true,
+                secret_provenance: SecretProvenance::Public,
                 request_identity_http_authenticator: Some(&identity_authenticator),
                 trace_context: None,
                 table_headers: &[],
@@ -882,6 +925,7 @@ mod tests {
                 request_headers: &[],
                 request_authenticators: &HashMap::new(),
                 require_credential_safe_auth_transport: true,
+                secret_provenance: SecretProvenance::Public,
                 request_identity_http_authenticator: None,
                 trace_context: None,
                 table_headers: &[],

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -1,6 +1,6 @@
 //! Backend-agnostic template and value-source rendering.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::LazyLock;
 
 use datafusion::error::{DataFusionError, Result};
@@ -10,6 +10,29 @@ use coral_spec::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken,
 
 /// Shared empty filter/state map for source-scoped rendering.
 pub(crate) static EMPTY_MAP: LazyLock<HashMap<String, String>> = LazyLock::new(HashMap::new);
+static EMPTY_SECRET_INPUT_NAMES: LazyLock<BTreeSet<String>> = LazyLock::new(BTreeSet::new);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Resolved<T> {
+    pub(crate) value: T,
+    pub(crate) depends_on_secret: bool,
+}
+
+impl<T> Resolved<T> {
+    fn public(value: T) -> Self {
+        Self {
+            value,
+            depends_on_secret: false,
+        }
+    }
+
+    fn map<U>(self, map: impl FnOnce(T) -> U) -> Resolved<U> {
+        Resolved {
+            value: map(self.value),
+            depends_on_secret: self.depends_on_secret,
+        }
+    }
+}
 
 /// Runtime values available while rendering one backend request.
 #[derive(Clone, Copy)]
@@ -67,39 +90,61 @@ pub(crate) fn resolve_value_source(
     value: &ValueSourceSpec,
     context: &RenderContext<'_>,
 ) -> Result<Option<Value>> {
+    Ok(
+        resolve_value_source_with_secret_provenance(value, context, &EMPTY_SECRET_INPUT_NAMES)?
+            .map(|resolved| resolved.value),
+    )
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "One exhaustive pass must keep value resolution and secret provenance identical"
+)]
+pub(crate) fn resolve_value_source_with_secret_provenance(
+    value: &ValueSourceSpec,
+    context: &RenderContext<'_>,
+    secret_input_names: &BTreeSet<String>,
+) -> Result<Option<Resolved<Value>>> {
     match value {
         ValueSourceSpec::Template { template } => {
-            let rendered = render_template(template, context)?;
-            Ok(Some(Value::String(rendered)))
+            let rendered =
+                render_template_with_secret_provenance(template, context, secret_input_names)?;
+            Ok(Some(rendered.map(Value::String)))
         }
-        ValueSourceSpec::OneOf { values } => resolve_one_of(values, context),
-        ValueSourceSpec::Literal { value } => Ok(Some(value.clone())),
+        ValueSourceSpec::OneOf { values } => resolve_one_of(values, context, secret_input_names),
+        ValueSourceSpec::Literal { value } => Ok(Some(Resolved::public(value.clone()))),
         ValueSourceSpec::Filter { key, default } => Ok(string_runtime_value(
             context,
             RuntimeValueNamespace::Filter,
             key,
             default.as_ref(),
-        )),
+        )
+        .map(Resolved::public)),
         ValueSourceSpec::Arg { key, default } => Ok(string_runtime_value(
             context,
             RuntimeValueNamespace::FunctionArgument,
             key,
             default.as_ref(),
-        )),
+        )
+        .map(Resolved::public)),
         ValueSourceSpec::FilterInt { key, default } => {
             parse_i64_value(context, RuntimeValueNamespace::Filter, key, *default)
+                .map(|value| value.map(Resolved::public))
         }
         ValueSourceSpec::ArgInt { key, default } => parse_i64_value(
             context,
             RuntimeValueNamespace::FunctionArgument,
             key,
             *default,
-        ),
+        )
+        .map(|value| value.map(Resolved::public)),
         ValueSourceSpec::FilterBool { key, default } => {
             parse_bool_value(context, RuntimeValueNamespace::Filter, key, *default)
+                .map(|value| value.map(Resolved::public))
         }
         ValueSourceSpec::FilterStringArray { key, default } => {
             parse_filter_strings(context, key, default.as_deref())
+                .map(|value| value.map(Resolved::public))
         }
         ValueSourceSpec::FilterSplit {
             key,
@@ -112,7 +157,7 @@ pub(crate) fn resolve_value_source(
             separator,
             *part,
         )
-        .map(|value| value.map(Value::String)),
+        .map(|value| value.map(|value| Resolved::public(Value::String(value)))),
         ValueSourceSpec::FilterSplitInt {
             key,
             separator,
@@ -123,13 +168,15 @@ pub(crate) fn resolve_value_source(
             key,
             separator,
             *part,
-        ),
+        )
+        .map(|value| value.map(Resolved::public)),
         ValueSourceSpec::ArgBool { key, default } => parse_bool_value(
             context,
             RuntimeValueNamespace::FunctionArgument,
             key,
             *default,
-        ),
+        )
+        .map(|value| value.map(Resolved::public)),
         ValueSourceSpec::ArgSplit {
             key,
             separator,
@@ -141,7 +188,7 @@ pub(crate) fn resolve_value_source(
             separator,
             *part,
         )
-        .map(|value| value.map(Value::String)),
+        .map(|value| value.map(|value| Resolved::public(Value::String(value)))),
         ValueSourceSpec::ArgSplitInt {
             key,
             separator,
@@ -152,31 +199,48 @@ pub(crate) fn resolve_value_source(
             key,
             separator,
             *part,
-        ),
+        )
+        .map(|value| value.map(Resolved::public)),
         ValueSourceSpec::Input { key } => {
-            Ok(context.resolved_inputs.get(key).cloned().map(Value::String))
+            Ok(context
+                .resolved_inputs
+                .get(key)
+                .cloned()
+                .map(|value| Resolved {
+                    value: Value::String(value),
+                    depends_on_secret: secret_input_names.contains(key),
+                }))
         }
         ValueSourceSpec::Bearer { key } => Ok(context
             .resolved_inputs
             .get(key)
             .filter(|value| !value.is_empty())
-            .map(|value| Value::String(format!("Bearer {value}")))),
-        ValueSourceSpec::State { key } => {
-            Ok(context.state.get(key).map(|v| Value::String(v.clone())))
+            .map(|value| Resolved {
+                value: Value::String(format!("Bearer {value}")),
+                depends_on_secret: true,
+            })),
+        ValueSourceSpec::State { key } => Ok(context
+            .state
+            .get(key)
+            .map(|value| Resolved::public(Value::String(value.clone())))),
+        ValueSourceSpec::NowEpochMinusSeconds { seconds } => {
+            Ok(Some(Resolved::public(now_minus_seconds(*seconds))))
         }
-        ValueSourceSpec::NowEpochMinusSeconds { seconds } => Ok(Some(now_minus_seconds(*seconds))),
     }
 }
 
 fn resolve_one_of(
     values: &[ValueSourceSpec],
     context: &RenderContext<'_>,
-) -> Result<Option<Value>> {
+    secret_input_names: &BTreeSet<String>,
+) -> Result<Option<Resolved<Value>>> {
     for value in values {
-        let Some(resolved) = resolve_value_source(value, context)? else {
+        let Some(resolved) =
+            resolve_value_source_with_secret_provenance(value, context, secret_input_names)?
+        else {
             continue;
         };
-        if !value_to_string(&resolved).is_empty() {
+        if !value_to_string(&resolved.value).is_empty() {
             return Ok(Some(resolved));
         }
     }
@@ -315,16 +379,31 @@ pub(crate) fn render_template(
     template: &ParsedTemplate,
     context: &RenderContext<'_>,
 ) -> Result<String> {
+    Ok(render_template_with_secret_provenance(template, context, &EMPTY_SECRET_INPUT_NAMES)?.value)
+}
+
+pub(crate) fn render_template_with_secret_provenance(
+    template: &ParsedTemplate,
+    context: &RenderContext<'_>,
+    secret_input_names: &BTreeSet<String>,
+) -> Result<Resolved<String>> {
     let mut out = String::with_capacity(template.raw().len());
+    let mut depends_on_secret = false;
     for part in template.parts() {
         match part {
             TemplatePart::Literal(part) => out.push_str(part),
             TemplatePart::Token(token) => {
                 out.push_str(&resolve_template_token(token, context)?);
+                depends_on_secret |= token.namespace() == &TemplateNamespace::Input
+                    && context.resolved_inputs.contains_key(token.key())
+                    && secret_input_names.contains(token.key());
             }
         }
     }
-    Ok(out)
+    Ok(Resolved {
+        value: out,
+        depends_on_secret,
+    })
 }
 
 fn resolve_template_token(token: &TemplateToken, context: &RenderContext<'_>) -> Result<String> {
@@ -472,12 +551,15 @@ pub(crate) fn validate_value_source_inputs(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-    use coral_spec::ValueSourceSpec;
+    use coral_spec::{ParsedTemplate, ValueSourceSpec};
     use serde_json::json;
 
-    use super::{EMPTY_MAP, RenderContext, resolve_value_source, validate_value_source_inputs};
+    use super::{
+        EMPTY_MAP, RenderContext, render_template_with_secret_provenance, resolve_value_source,
+        resolve_value_source_with_secret_provenance, validate_value_source_inputs,
+    };
 
     fn inputs(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
         pairs
@@ -829,6 +911,83 @@ mod tests {
         .expect("one_of should resolve");
 
         assert_eq!(value, None);
+    }
+
+    #[test]
+    fn one_of_provenance_follows_only_the_selected_branch() {
+        let resolved_inputs = inputs(&[
+            ("EMPTY_SECRET", ""),
+            ("PUBLIC", "visible"),
+            ("OAUTH_TOKEN", "secret"),
+        ]);
+        let secret_names = BTreeSet::from(["EMPTY_SECRET".to_string(), "OAUTH_TOKEN".to_string()]);
+        let context = RenderContext::source_scoped(&resolved_inputs);
+
+        let public = resolve_value_source_with_secret_provenance(
+            &ValueSourceSpec::OneOf {
+                values: vec![
+                    ValueSourceSpec::Input {
+                        key: "EMPTY_SECRET".to_string(),
+                    },
+                    ValueSourceSpec::Input {
+                        key: "PUBLIC".to_string(),
+                    },
+                    ValueSourceSpec::Bearer {
+                        key: "OAUTH_TOKEN".to_string(),
+                    },
+                ],
+            },
+            &context,
+            &secret_names,
+        )
+        .expect("one_of should resolve")
+        .expect("public fallback should be selected");
+        assert_eq!(public.value, json!("visible"));
+        assert!(!public.depends_on_secret);
+
+        let secret = resolve_value_source_with_secret_provenance(
+            &ValueSourceSpec::OneOf {
+                values: vec![
+                    ValueSourceSpec::Input {
+                        key: "MISSING".to_string(),
+                    },
+                    ValueSourceSpec::Bearer {
+                        key: "OAUTH_TOKEN".to_string(),
+                    },
+                ],
+            },
+            &context,
+            &secret_names,
+        )
+        .expect("one_of should resolve")
+        .expect("secret fallback should be selected");
+        assert_eq!(secret.value, json!("Bearer secret"));
+        assert!(secret.depends_on_secret);
+    }
+
+    #[test]
+    fn template_provenance_tracks_rendered_secret_tokens() {
+        let resolved_inputs = inputs(&[("HOST", "api.example.test"), ("PATH", "items")]);
+        let secret_names = BTreeSet::from(["HOST".to_string()]);
+        let context = RenderContext::source_scoped(&resolved_inputs);
+
+        let secret = render_template_with_secret_provenance(
+            &ParsedTemplate::parse("https://{{input.HOST}}/{{input.PATH}}")
+                .expect("secret template"),
+            &context,
+            &secret_names,
+        )
+        .expect("template should render");
+        assert_eq!(secret.value, "https://api.example.test/items");
+        assert!(secret.depends_on_secret);
+
+        let public = render_template_with_secret_provenance(
+            &ParsedTemplate::parse("/{{input.PATH}}").expect("public template"),
+            &context,
+            &secret_names,
+        )
+        .expect("template should render");
+        assert!(!public.depends_on_secret);
     }
 
     #[test]


### PR DESCRIPTION
## Intent

Preserve the sensitivity of actually selected DSL v4 secret input values through request rendering, pagination, transport selection, errors, and telemetry. This closes the boundary where base, path, query, or body secrets could lose their input-kind provenance after resolution and be treated as anonymous traffic.

## What it enables

- Routes selected-secret loopback HTTP through the direct no-proxy, no-redirect client while keeping credential-bearing HTTPS proxy-aware and no-redirect.
- Rejects selected-secret remote cleartext requests before identity authentication or network access.
- Preserves exact ordered `OneOf` selection, final JSON-body ownership after authored or pagination overwrites, and sensitivity across Link/Auto descendants.
- Omits secret-derived URL components from trace endpoint fields, structured errors, and reflected pagination diagnostics.
- Leaves DSL v3 behavior unchanged.

## Usage examples

No new public API is introduced. Existing DSL v4 manifests may resolve `kind: secret` inputs into base URLs, paths, query parameters, or emitted request bodies. Only the selected non-empty value and values surviving final request mutation are treated as credential-bearing; an unused secret fallback does not taint an earlier public `OneOf` winner.

## Validation

- `cargo test --locked -p coral-engine --all-features provenance`
- `cargo test --locked -p coral-engine --all-features pagination`
- `PATH=/Users/saul/.cargo/bin:$PATH make rust-checks` — 1,760/1,760 tests passed, 3 skipped; fmt, strict Clippy, and rustdoc clean.
- `make perf-check` — 209.5 ms mean against the 750 ms threshold.

## Review

The exact 586-line diff received a fresh five-lane structured review with ten safe credential-flow rows and no unresolved production finding. Four accepted executable proof obligations are intentionally assigned to the immediate B5e1a contract child because adding them here would exceed the 600-line PR cap. This PR and B5e1a must remain draft and must not be treated as ready independently.