### PR TITLE
fix(engine): preserve pagination credential taint

### DIFF
--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -4297,6 +4297,7 @@ mod tests {
         let mut idle = tokio::net::TcpStream::connect(("127.0.0.1", redirect_port))
             .await
             .expect("connect idle preconnection");
+        tokio::task::yield_now().await;
         let mut receive = Box::pin(receive_callback(&session));
         poll_fn(|cx| {
             assert!(receive.as_mut().poll(cx).is_pending());

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -150,10 +150,19 @@ impl HttpSourceClientRuntime {
         } else {
             HttpClients::legacy(http)
         };
+        Self::test_with_http_clients(body_capture_max_bytes, http, None)
+    }
+
+    #[cfg(test)]
+    pub(super) fn test_with_http_clients(
+        body_capture_max_bytes: Option<usize>,
+        http: HttpClients,
+        request_identity_http_authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
+    ) -> Self {
         Self {
             source_input_resolution_context: None,
             source_input_resolver: None,
-            request_identity_http_authenticator: None,
+            request_identity_http_authenticator,
             body_capture_max_bytes,
             trace_context: None,
             http,

--- a/crates/coral-engine/src/backends/http/error.rs
+++ b/crates/coral-engine/src/backends/http/error.rs
@@ -16,6 +16,9 @@ const FORBIDDEN: u16 = HttpStatus::FORBIDDEN.as_u16();
 const NOT_FOUND: u16 = HttpStatus::NOT_FOUND.as_u16();
 const TOO_MANY_REQUESTS: u16 = HttpStatus::TOO_MANY_REQUESTS.as_u16();
 
+pub(super) const REDACTED_CREDENTIAL_RESPONSE_DETAIL: &str =
+    "provider returned an error response for credential-bearing request";
+
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
 pub(crate) struct CredentialTransportError(pub(crate) String);

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -7,7 +7,9 @@ use serde_json::Value;
 
 use crate::backends::http::ProviderQueryError;
 use crate::backends::http::client::HttpSourceClient;
-use crate::backends::http::error::{pagination_error, provider_error};
+use crate::backends::http::error::{
+    REDACTED_CREDENTIAL_RESPONSE_DETAIL, pagination_error, provider_error,
+};
 use crate::backends::http::pagination::{
     PageAdvance, PageAdvanceContext, advance_pagination_state, apply_pagination_body_fields,
     apply_pagination_query_pairs, initial_page_state, pagination_state_values, resolve_page_size,
@@ -68,7 +70,7 @@ pub(super) async fn fetch_rows(
     let active_request = target.resolved_request();
 
     let mut state = initial_page_state(&pagination);
-    let mut next_link_depends_on_secret = false;
+    let mut provider_state_is_credential_tainted = false;
 
     let mut page_count = 0usize;
     let max_pages = pagination.max_pages.unwrap_or(DEFAULT_MAX_PAGES);
@@ -109,7 +111,7 @@ pub(super) async fn fetch_rows(
             ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto
         ) && let Some(next) = state.next_url.clone()
         {
-            (next, next_link_depends_on_secret)
+            (next, provider_state_is_credential_tainted)
         } else {
             let rendered_path = render_template_with_secret_provenance(
                 &active_request.path,
@@ -134,6 +136,7 @@ pub(super) async fn fetch_rows(
             let mut query_pairs =
                 build_query_pairs(active_request, &render_context, &client.secret_input_names)?;
             let redact_url = url_depends_on_secret
+                || provider_state_is_credential_tainted
                 || (client.require_credential_safe_auth_transport && query_pairs.depends_on_secret);
             apply_pagination_query_pairs(&mut query_pairs.value, &pagination, &state, page_size)
                 .map_err(|error| {
@@ -166,6 +169,7 @@ pub(super) async fn fetch_rows(
             })?;
             let contains_secret_value = client.require_credential_safe_auth_transport
                 && (url_depends_on_secret
+                    || provider_state_is_credential_tainted
                     || query_pairs.depends_on_secret
                     || body.depends_on_secret());
             (
@@ -216,6 +220,8 @@ pub(super) async fn fetch_rows(
         let Some(response) = request else {
             break;
         };
+        let credential_tainted_response =
+            client.require_credential_safe_auth_transport && response.credential_tainted;
         let payload = response.payload;
 
         if !target.response().ok_path.is_empty() {
@@ -223,7 +229,9 @@ pub(super) async fn fetch_rows(
                 .and_then(Value::as_bool)
                 .unwrap_or(false);
             if !ok {
-                let err = if target.response().error_path.is_empty() {
+                let err = if credential_tainted_response {
+                    REDACTED_CREDENTIAL_RESPONSE_DETAIL.to_string()
+                } else if target.response().error_path.is_empty() {
                     "unknown source API error".to_string()
                 } else {
                     get_path_value(&payload, &target.response().error_path)
@@ -277,7 +285,7 @@ pub(super) async fn fetch_rows(
             },
         )
         .map_err(|error| {
-            let error = if contains_secret_value {
+            let error = if credential_tainted_response {
                 redacted_pagination_error(&error)
             } else {
                 error
@@ -293,7 +301,15 @@ pub(super) async fn fetch_rows(
         if page_advance == PageAdvance::Stop {
             break;
         }
-        next_link_depends_on_secret = state.next_url.is_some() && contains_secret_value;
+        if matches!(
+            pagination.mode,
+            ValidatedPaginationMode::LinkHeader
+                | ValidatedPaginationMode::Auto
+                | ValidatedPaginationMode::CursorQuery
+                | ValidatedPaginationMode::CursorBody
+        ) {
+            provider_state_is_credential_tainted |= credential_tainted_response;
+        }
     }
 
     Ok(all_rows)
@@ -337,7 +353,7 @@ fn redacted_pagination_error(error: &DataFusionError) -> DataFusionError {
     ]
     .into_iter()
     .find_map(|(needle, category)| detail.contains(needle).then_some(category))
-    .unwrap_or("pagination failed for request with secret-derived URL");
+    .unwrap_or("pagination failed for credential-bearing request");
     DataFusionError::Execution(category.to_string())
 }
 
@@ -381,5 +397,362 @@ fn resolve_fetch_limits(
         effective_limit: effective_limit.map(|limit| limit.min(max_candidates)),
         page_size_limit: Some(requested_top_k.min(search_limits.max_top_k)),
         max_search_calls: Some(search_limits.max_calls_per_query),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use datafusion::error::{DataFusionError, Result};
+    use serde_json::{Value, json};
+    use wiremock::matchers::{body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::ProviderQueryError;
+    use crate::BoundRequestIdentityHttpAuthenticator;
+    use crate::backends::http::client::{HttpClients, HttpSourceClient, HttpSourceClientRuntime};
+    use crate::backends::http::target::HttpFetchTarget;
+    use crate::backends::http::test_support::parse_http_manifest;
+    use coral_spec::backends::http::HttpSourceManifest;
+
+    fn materialized_v4_manifest(
+        base_url: &Value,
+        request: &Value,
+        pagination: Option<Value>,
+    ) -> HttpSourceManifest {
+        let mut table = json!({
+            "name": "items",
+            "description": "items",
+            "request": request,
+            "response": { "rows_path": ["data"] },
+            "columns": [{ "name": "id", "type": "Utf8" }]
+        });
+        if let Some(pagination) = pagination {
+            let table = table.as_object_mut().expect("table object");
+            table.insert("pagination".to_string(), pagination);
+        }
+        let mut manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "secret_transport",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": base_url,
+            "inputs": { "SECRET": { "kind": "secret" } },
+            "tables": [table]
+        }));
+        manifest.common.dsl_version = 4;
+        manifest
+    }
+
+    fn credential_safe_clients(proxy: &MockServer) -> HttpClients {
+        let builder = || {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(1))
+                .redirect(reqwest::redirect::Policy::none())
+        };
+        HttpClients::credential_safe(
+            builder()
+                .proxy(reqwest::Proxy::all(proxy.uri()).expect("proxy URL"))
+                .build()
+                .expect("proxy client"),
+            builder().no_proxy().build().expect("direct client"),
+        )
+    }
+
+    async fn fetch_manifest(
+        manifest: &HttpSourceManifest,
+        secret: &str,
+        proxy: &MockServer,
+        authenticator: Option<BoundRequestIdentityHttpAuthenticator>,
+    ) -> Result<Vec<Value>> {
+        let client = HttpSourceClient::from_manifest_with_source_input_resolver(
+            manifest,
+            &BTreeMap::from([("SECRET".to_string(), secret.to_string())]),
+            &BTreeMap::new(),
+            &HashMap::new(),
+            HttpSourceClientRuntime::test_with_http_clients(
+                None,
+                credential_safe_clients(proxy),
+                authenticator,
+            ),
+        )?;
+        let table = manifest.tables.first().expect("table");
+        client
+            .fetch(
+                &HttpFetchTarget::from_resolved_table_request(table, table.request.clone()),
+                &HashMap::new(),
+                &HashMap::new(),
+                None,
+            )
+            .await
+    }
+
+    fn provider_query_error(error: &DataFusionError) -> &ProviderQueryError {
+        let DataFusionError::External(inner) = error else {
+            panic!("expected provider error, got {error:?}");
+        };
+        inner
+            .downcast_ref::<ProviderQueryError>()
+            .expect("provider query error")
+    }
+
+    fn assert_provider_non_egress(error: &DataFusionError, canary: &str) {
+        let provider = provider_query_error(error);
+        let structured = provider.to_structured();
+        assert!(!provider.to_string().contains(canary), "{provider}");
+        assert!(!structured.detail().contains(canary));
+        assert!(
+            structured
+                .metadata()
+                .values()
+                .all(|value| !value.contains(canary))
+        );
+    }
+
+    async fn assert_proxy_empty(proxy: &MockServer) {
+        assert!(
+            proxy
+                .received_requests()
+                .await
+                .expect("proxy requests")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn selected_secret_surfaces_route_direct_while_public_one_of_uses_proxy() {
+        let target = MockServer::start().await;
+        let proxy = MockServer::start().await;
+        let ok = ResponseTemplate::new(200).set_body_json(json!({"data": [{"id": "ok"}]}));
+        Mock::given(method("GET"))
+            .respond_with(ok.clone())
+            .mount(&target)
+            .await;
+        Mock::given(method("POST"))
+            .respond_with(ok.clone())
+            .mount(&target)
+            .await;
+        Mock::given(method("GET"))
+            .respond_with(ok)
+            .mount(&proxy)
+            .await;
+
+        let cases = [
+            (
+                json!("{{input.SECRET}}"),
+                json!({"path": "/base"}),
+                target.uri(),
+            ),
+            (
+                json!(target.uri()),
+                json!({"path": "/{{input.SECRET}}"}),
+                "path-secret".to_string(),
+            ),
+            (
+                json!(target.uri()),
+                json!({"path": "/query", "query": [{"name": "token", "from": "input", "key": "SECRET"}]}),
+                "query-secret".to_string(),
+            ),
+            (
+                json!(target.uri()),
+                json!({"method": "POST", "path": "/body", "body": [{"path": ["token"], "from": "input", "key": "SECRET"}]}),
+                "body-secret".to_string(),
+            ),
+        ];
+        for (base_url, request, secret) in cases {
+            fetch_manifest(
+                &materialized_v4_manifest(&base_url, &request, None),
+                &secret,
+                &proxy,
+                None,
+            )
+            .await
+            .expect("selected secret request");
+        }
+
+        let public_first = materialized_v4_manifest(
+            &json!(target.uri()),
+            &json!({
+                "path": "/public",
+                "query": [{
+                    "name": "selection",
+                    "from": "one_of",
+                    "values": [
+                        {"from": "literal", "value": "public"},
+                        {"from": "input", "key": "SECRET"}
+                    ]
+                }]
+            }),
+            None,
+        );
+        fetch_manifest(&public_first, "unused-secret", &proxy, None)
+            .await
+            .expect("public winner");
+
+        let target_requests = target.received_requests().await.expect("target requests");
+        let proxy_requests = proxy.received_requests().await.expect("proxy requests");
+        assert_eq!((target_requests.len(), proxy_requests.len()), (4, 1));
+        let direct = target_requests
+            .iter()
+            .map(|request| format!("{} {}", request.url, String::from_utf8_lossy(&request.body)))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            ["/base", "/path-secret", "query-secret", "body-secret"]
+                .iter()
+                .all(|expected| direct.contains(expected)),
+            "{direct}"
+        );
+        let proxied = proxy_requests.first().expect("proxy request");
+        let proxied = format!("{} {:?}", proxied.url, proxied.body);
+        assert!(
+            proxied.contains("selection=public") && !proxied.contains("unused-secret"),
+            "{proxied}"
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_cleartext_secret_fails_before_authenticator_or_network() {
+        let proxy = MockServer::start().await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&calls);
+        let authenticator: BoundRequestIdentityHttpAuthenticator = Arc::new(move |_, _| {
+            observed.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Ok(Vec::new()) })
+        });
+        let manifest = materialized_v4_manifest(
+            &json!("http://192.0.2.1"),
+            &json!({"method": "POST", "path": "/items", "body": [{"path": ["token"], "from": "input", "key": "SECRET"}]}),
+            None,
+        );
+
+        let error = fetch_manifest(&manifest, "remote-secret", &proxy, Some(authenticator))
+            .await
+            .expect_err("remote cleartext must fail");
+
+        let public_error = error.to_string();
+        assert!(
+            public_error.contains("DSL v4 secret values require HTTPS or loopback HTTP")
+                && !public_error.contains("remote-secret"),
+            "{public_error}"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert_proxy_empty(&proxy).await;
+    }
+
+    #[tokio::test]
+    async fn link_and_auto_descendants_keep_secret_transport_and_redaction() {
+        for mode in ["link_header", "auto"] {
+            let target = MockServer::start().await;
+            let proxy = MockServer::start().await;
+            let canary = format!("{mode}-descendant-canary");
+            let first_page = if mode == "auto" {
+                json!({"ok": true, "data": [{"id": "first"}]})
+            } else {
+                json!({"data": [{"id": "first"}]})
+            };
+            Mock::given(method("POST"))
+                .and(path("/start"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .insert_header("link", format!("</{canary}>; rel=\"next\""))
+                        .set_body_json(first_page),
+                )
+                .mount(&target)
+                .await;
+            let failure = if mode == "auto" {
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({"ok": false, "error": canary, "data": []}))
+            } else {
+                ResponseTemplate::new(400).set_body_string(canary.clone())
+            };
+            Mock::given(method("POST"))
+                .and(path(format!("/{canary}")))
+                .respond_with(failure)
+                .mount(&target)
+                .await;
+            let mut manifest = materialized_v4_manifest(
+                &json!(target.uri()),
+                &json!({"method": "POST", "path": "/start", "body": [{"path": ["token"], "from": "input", "key": "SECRET"}]}),
+                Some(json!({"mode": mode})),
+            );
+            if mode == "auto" {
+                let response = &mut manifest.tables.first_mut().expect("table").response;
+                response.ok_path = vec!["ok".to_string()];
+                response.error_path = vec!["error".to_string()];
+            }
+
+            let error = fetch_manifest(&manifest, "first-page-secret", &proxy, None)
+                .await
+                .expect_err("page two should fail");
+
+            assert_provider_non_egress(&error, &canary);
+            let requests = target.received_requests().await.expect("target requests");
+            let [first, second] = requests.as_slice() else {
+                panic!("{mode}: {requests:?}");
+            };
+            assert!(
+                first
+                    .body
+                    .windows(17)
+                    .any(|bytes| bytes == b"first-page-secret")
+            );
+            assert!(second.body.is_empty(), "{mode}: {:?}", second.body);
+            assert_proxy_empty(&proxy).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn cursor_body_descendant_from_secret_request_stays_direct() {
+        let target = MockServer::start().await;
+        let proxy = MockServer::start().await;
+        let cursor = "provider-cursor-canary";
+        Mock::given(method("POST"))
+            .and(path("/items"))
+            .and(body_json(json!({"cursor": "first-page-secret"})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": [{"id": "first"}],
+                "meta": {"next_cursor": cursor}
+            })))
+            .mount(&target)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/items"))
+            .and(body_json(json!({"cursor": cursor})))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"data": []})))
+            .mount(&target)
+            .await;
+        let manifest = materialized_v4_manifest(
+            &json!(target.uri()),
+            &json!({
+                "method": "POST",
+                "path": "/items",
+                "body": [{"path": ["cursor"], "from": "input", "key": "SECRET"}]
+            }),
+            Some(json!({
+                "mode": "cursor_body",
+                "cursor_body_path": ["cursor"],
+                "response_cursor_path": ["meta", "next_cursor"]
+            })),
+        );
+
+        let rows = fetch_manifest(&manifest, "first-page-secret", &proxy, None)
+            .await
+            .expect("cursor request");
+
+        assert_eq!(rows, [json!({"id": "first"})]);
+        assert_eq!(
+            target
+                .received_requests()
+                .await
+                .expect("target requests")
+                .len(),
+            2
+        );
+        assert_proxy_empty(&proxy).await;
     }
 }

--- a/crates/coral-engine/src/backends/http/response.rs
+++ b/crates/coral-engine/src/backends/http/response.rs
@@ -39,7 +39,10 @@ pub(super) async fn decode_response_body(
                     table_name,
                     method_label,
                     logged_url,
-                    format!("source API response decoding failed: {error}"),
+                    format!(
+                        "source API response decoding failed: {}",
+                        error.without_url()
+                    ),
                     true,
                 )
             })?;
@@ -65,7 +68,10 @@ pub(super) async fn decode_response_body(
                     table_name,
                     method_label,
                     logged_url,
-                    format!("source API response decoding failed: {error}"),
+                    format!(
+                        "source API response decoding failed: {}",
+                        error.without_url()
+                    ),
                     true,
                 )
             })?;

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -19,7 +19,9 @@ use crate::backends::http::auth::{
     resolve_auth_headers,
 };
 use crate::backends::http::client::HttpClients;
-use crate::backends::http::error::{CredentialTransportError, provider_error};
+use crate::backends::http::error::{
+    CredentialTransportError, REDACTED_CREDENTIAL_RESPONSE_DETAIL, provider_error,
+};
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::backends::http::request::RequestBody;
 use crate::backends::http::response::{ResponseDecodeContext, decode_response_body};
@@ -73,6 +75,7 @@ pub(super) struct OutgoingHttpRequest<'a> {
 pub(super) struct DecodedHttpResponse {
     pub(super) payload: Value,
     pub(super) headers: HeaderMap,
+    pub(super) credential_tainted: bool,
 }
 
 #[expect(
@@ -117,6 +120,7 @@ pub(super) async fn execute_request(
     let mut server_error_retries = 0usize;
     let mut throttle_retries = 0usize;
     let mut decode_retries = 0usize;
+    let mut credential_tainted = false;
     loop {
         let method_label = http_method_label(method);
         let mut request = build_http_request(http.proxy_aware(), method, url);
@@ -287,6 +291,7 @@ pub(super) async fn execute_request(
             || has_auth_headers
             || has_identity_headers
             || request_requires_credential_safe_transport(&built, has_authored_headers);
+        credential_tainted |= credential_bearing;
         let request_http = match http.for_request(built.url(), credential_bearing) {
             Ok(http) => http,
             Err(error) => {
@@ -384,6 +389,11 @@ pub(super) async fn execute_request(
                 );
                 request_span.record("http.response.body.size", body.len());
                 body_capture.record_response(&request_span, request_id, &body);
+                let detail = if credential_tainted {
+                    REDACTED_CREDENTIAL_RESPONSE_DETAIL.to_string()
+                } else {
+                    body
+                };
                 break 'response ResponseOutcome::Done(Err(DataFusionError::External(Box::new(
                     ProviderQueryError::ApiRequest {
                         source_schema: source_schema.to_string(),
@@ -392,7 +402,7 @@ pub(super) async fn execute_request(
                         method: Some(method_label.to_string()),
                         url: Some(logged_url.clone()),
                         filters: render_context.filters.clone(),
-                        detail: body,
+                        detail,
                     },
                 ))));
             }
@@ -418,6 +428,7 @@ pub(super) async fn execute_request(
                 Ok(payload) => ResponseOutcome::Done(Ok(Some(DecodedHttpResponse {
                     payload,
                     headers: response_headers,
+                    credential_tainted,
                 }))),
                 Err(mut error) => {
                     // `Decode { retryable }` marks a transient (truncated/EOF) body. Only
@@ -584,10 +595,13 @@ mod tests {
     use std::time::Duration;
 
     use datafusion::error::DataFusionError;
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
     use reqwest::header::{AUTHORIZATION, HeaderValue};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
     use tokio::task::JoinHandle;
+    use tracing_subscriber::layer::SubscriberExt as _;
     use wiremock::MockServer;
 
     use super::{
@@ -804,6 +818,121 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "auditable retry and non-egress contract"
+    )]
+    async fn credential_tainted_body_read_errors_strip_response_url() {
+        let canary = "credential-read-url-canary";
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind truncated response server");
+        let addr = listener.local_addr().expect("truncated server address");
+        let server = tokio::spawn(async move {
+            for _ in 0..6 {
+                let (mut socket, _) = listener.accept().await.expect("accept request");
+                let mut request = Vec::new();
+                let mut buffer = [0_u8; 1024];
+                loop {
+                    let read = socket.read(&mut buffer).await.expect("read request");
+                    if read == 0 {
+                        break;
+                    }
+                    request.extend(buffer.iter().take(read).copied());
+                    if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+                socket
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 64\r\nconnection: close\r\n\r\n{",
+                    )
+                    .await
+                    .expect("write truncated response");
+            }
+        });
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("decode-url-test")));
+        let _subscriber = tracing::subscriber::set_default(subscriber);
+        let request_timeout = Duration::from_secs(1);
+        let http = HttpClients::credential_safe(
+            reqwest::Client::builder()
+                .timeout(request_timeout)
+                .build()
+                .expect("build proxy-aware client"),
+            reqwest::Client::builder()
+                .timeout(request_timeout)
+                .no_proxy()
+                .build()
+                .expect("build direct client"),
+        );
+        let filters = HashMap::new();
+        let args = HashMap::new();
+        let state = HashMap::new();
+        let resolved_inputs = BTreeMap::new();
+        let url = format!("http://{addr}/{canary}");
+
+        for response_format in [ResponseBodyFormat::Json, ResponseBodyFormat::JsonEachRow] {
+            let render_context = RenderContext::new(&filters, &args, &state, &resolved_inputs);
+            let error = execute_request(
+                &http,
+                request_timeout,
+                TestOutgoingHttpRequest {
+                    auth: &AuthSpec::default(),
+                    request_headers: &[],
+                    request_authenticators: &HashMap::new(),
+                    require_credential_safe_auth_transport: true,
+                    secret_provenance: SecretProvenance::Url,
+                    request_identity_http_authenticator: None,
+                    trace_context: None,
+                    table_headers: &[],
+                    table_name: "items",
+                    method: HttpMethod::GET,
+                    url: &url,
+                    query_pairs: &[],
+                    body: None,
+                    response_format,
+                    source_schema: "demo",
+                    rate_limit: &RateLimitSpec::default(),
+                    body_capture: HttpBodyCapture::default(),
+                    render_context,
+                    allow_404_empty: false,
+                },
+            )
+            .await
+            .expect_err("truncated response must fail after retries");
+
+            let DataFusionError::External(inner) = &error else {
+                panic!("expected provider error, got {error:?}");
+            };
+            let provider_error = inner
+                .downcast_ref::<ProviderQueryError>()
+                .expect("provider decode error");
+            let structured = provider_error.to_structured();
+            assert!(!error.to_string().contains(canary), "{error}");
+            assert!(!structured.detail().contains(canary));
+            assert!(
+                structured
+                    .metadata()
+                    .values()
+                    .all(|value| !value.contains(canary))
+            );
+        }
+
+        server.await.expect("truncated server task");
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        assert_eq!(spans.len(), 6);
+        let span_dump = format!("{spans:#?}");
+        assert!(!span_dump.contains(canary), "{span_dump}");
+        provider.shutdown().expect("shutdown provider");
+    }
+
     #[tokio::test]
     async fn request_identity_headers_are_injected() {
         let (base_url, task) = spawn_header_recorder(r#"{"ok":true}"#).await;
@@ -867,7 +996,7 @@ mod tests {
         .await
         .expect("identity-authenticated request should succeed");
 
-        assert!(response.is_some());
+        assert!(response.expect("decoded response").credential_tainted);
         let raw_request = task.await.expect("header recorder should finish");
         assert!(
             raw_request.contains("\r\nx-identity-token: identity-token\r\n"),
@@ -945,7 +1074,7 @@ mod tests {
         .await
         .expect("API-key request should succeed");
 
-        assert!(response.is_some());
+        assert!(response.expect("decoded response").credential_tainted);
         let raw_request = task.await.expect("header recorder should finish");
         assert!(
             raw_request.contains("\r\nx-api-key: runtime-secret\r\n"),


### PR DESCRIPTION
## Intent

Preserve credential provenance after a credential-bearing DSL v4 response creates retry or pagination work, and keep provider-controlled response data out of public diagnostics and telemetry.

## What it enables

- Direct no-proxy routing remains monotonic for credential-tainted Link, Auto, cursor-query, and cursor-body descendants.
- Credential-tainted provider bodies and response URLs are replaced with bounded, value-free error detail.
- JSON and JSON-each-row body-read failures cannot export credential-derived URLs through errors, metadata, or spans.
- DSL v3 behavior remains unchanged.

## Usage examples

A DSL v4 source may render a selected secret into its base URL, path, query, or body. If the credential-bearing response returns a Link URL or cursor used for the next page, Coral keeps that descendant on the credential-safe client path and redacts the derived URL from public errors and observability.

## Validation

- `cargo nextest run --workspace --all-targets --all-features --locked --no-fail-fast --test-threads=8` — 1,765 passed, 3 skipped
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps --locked`
- Focused HTTP transport, fetch, callback, and dual JSON collector non-egress contracts
- Exact-final structured review: no remaining P1/P2 findings

Two default-concurrency full-suite attempts reproduced only the unrelated five-second device-code fixture timeout; all focused OAuth tests and the exact bounded workspace suite passed.