### PR TITLE
test(engine): lock pagination secret non-egress

### DIFF
--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -408,16 +408,24 @@ mod tests {
     use std::time::Duration;
 
     use datafusion::error::{DataFusionError, Result};
+    use opentelemetry::Value as OtelValue;
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+    use reqwest::header::{HeaderName, HeaderValue};
     use serde_json::{Value, json};
-    use wiremock::matchers::{body_json, method, path};
+    use tracing_subscriber::layer::SubscriberExt as _;
+    use wiremock::matchers::{
+        body_json, header, method, path, query_param, query_param_is_missing,
+    };
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::ProviderQueryError;
-    use crate::BoundRequestIdentityHttpAuthenticator;
     use crate::backends::http::client::{HttpClients, HttpSourceClient, HttpSourceClientRuntime};
     use crate::backends::http::target::HttpFetchTarget;
     use crate::backends::http::test_support::parse_http_manifest;
+    use crate::{BoundRequestIdentityHttpAuthenticator, RequestIdentityHttpAuthenticatorError};
     use coral_spec::backends::http::HttpSourceManifest;
+    use coral_spec::{AuthSpec, HeaderAuthSpec, HeaderSpec, ValueSourceSpec};
 
     fn materialized_v4_manifest(
         base_url: &Value,
@@ -616,6 +624,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pagination_body_overwrites_drive_proxy_selection() {
+        const SECRET: &str = "overwritten-body-secret";
+        let cases = [
+            (
+                "exact public overwrite",
+                json!(["payload", "token"]),
+                json!({"payload": {"token": 25}}),
+                false,
+            ),
+            (
+                "surviving secret sibling",
+                json!(["payload", "limit"]),
+                json!({"payload": {"token": SECRET, "limit": 25}}),
+                true,
+            ),
+        ];
+
+        for (name, page_size_path, expected_body, direct) in cases {
+            let target = MockServer::start().await;
+            let proxy = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(body_json(expected_body))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(json!({"data": [{"id": "ok"}]})),
+                )
+                .expect(1)
+                .mount(if direct { &target } else { &proxy })
+                .await;
+            let manifest = materialized_v4_manifest(
+                &json!(target.uri()),
+                &json!({
+                    "method": "POST",
+                    "path": "/items",
+                    "body": [{"path": ["payload", "token"], "from": "input", "key": "SECRET"}]
+                }),
+                Some(json!({
+                    "page_size": {
+                        "default": 25,
+                        "max": 100,
+                        "body_path": page_size_path
+                    }
+                })),
+            );
+
+            let rows = fetch_manifest(&manifest, SECRET, &proxy, None)
+                .await
+                .expect(name);
+
+            assert_eq!(rows, [json!({"id": "ok"})], "{name}");
+            let target_requests = target.received_requests().await.expect("target requests");
+            let proxy_requests = proxy.received_requests().await.expect("proxy requests");
+            assert_eq!(
+                (target_requests.len(), proxy_requests.len()),
+                if direct { (1, 0) } else { (0, 1) },
+                "{name}"
+            );
+            assert!(proxy_requests.iter().all(|request| {
+                !request.url.as_str().contains(SECRET)
+                    && !String::from_utf8_lossy(&request.body).contains(SECRET)
+            }));
+        }
+    }
+
+    #[tokio::test]
     async fn remote_cleartext_secret_fails_before_authenticator_or_network() {
         let proxy = MockServer::start().await;
         let calls = Arc::new(AtomicUsize::new(0));
@@ -707,6 +779,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn credential_bearing_pagination_failures_use_bounded_categories() {
+        const CANARY: &str = "pagination-error-canary";
+        let cases = [
+            (
+                "cross-origin Link",
+                "link",
+                "<https://other.invalid/pagination-error-canary>; rel=\"next\"",
+                None,
+                "pagination next link must stay on request origin",
+            ),
+            (
+                "malformed Link item",
+                "link",
+                "</pagination-error-canary; rel=\"next\"",
+                None,
+                "invalid pagination Link header",
+            ),
+            (
+                "invalid Link URL",
+                "link",
+                "<http://[pagination-error-canary>; rel=\"next\"",
+                None,
+                "invalid pagination next link",
+            ),
+            (
+                "cross-origin configured header",
+                "x-next-page-url",
+                "https://other.invalid/pagination-error-canary",
+                Some("X-Next-Page-Url"),
+                "pagination next URL header must stay on request origin",
+            ),
+            (
+                "invalid configured header URL",
+                "x-next-page-url",
+                "http://[pagination-error-canary",
+                Some("X-Next-Page-Url"),
+                "invalid pagination next URL header",
+            ),
+        ];
+
+        for (name, response_header, response_value, next_url_header, expected_detail) in cases {
+            let target = MockServer::start().await;
+            let proxy = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/items"))
+                .and(header("x-api-key", CANARY))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .insert_header(response_header, response_value)
+                        .set_body_json(json!({"data": [{"id": "first"}]})),
+                )
+                .expect(1)
+                .mount(&target)
+                .await;
+            let pagination = next_url_header.map_or_else(
+                || json!({"mode": "link_header"}),
+                |header| json!({"mode": "link_header", "next_url_header": header}),
+            );
+            let mut manifest = materialized_v4_manifest(
+                &json!(target.uri()),
+                &json!({"path": "/items"}),
+                Some(pagination),
+            );
+            manifest.auth = AuthSpec::HeaderAuth(HeaderAuthSpec {
+                headers: vec![HeaderSpec {
+                    name: "X-Api-Key".to_string(),
+                    value: ValueSourceSpec::Literal {
+                        value: json!(CANARY),
+                    },
+                }],
+            });
+
+            let error = fetch_manifest(&manifest, "unused", &proxy, None)
+                .await
+                .expect_err(name);
+            let provider = provider_query_error(&error);
+            let ProviderQueryError::Pagination { detail, .. } = provider else {
+                panic!("{name}: expected pagination error, got {provider:?}");
+            };
+            assert_eq!(detail, expected_detail, "{name}");
+            assert_provider_non_egress(&error, CANARY);
+            assert_proxy_empty(&proxy).await;
+        }
+    }
+
+    #[tokio::test]
     async fn cursor_body_descendant_from_secret_request_stays_direct() {
         let target = MockServer::start().await;
         let proxy = MockServer::start().await;
@@ -754,5 +912,138 @@ mod tests {
             2
         );
         assert_proxy_empty(&proxy).await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[expect(
+        clippy::disallowed_methods,
+        clippy::too_many_lines,
+        reason = "auditable exporter contract requires a fresh process for tracing callsite isolation"
+    )]
+    async fn request_identity_cursor_query_redacts_exported_provider_state() {
+        const CHILD_ENV: &str = "CORAL_B5E1B_OTEL_CHILD";
+        const CURSOR: &str = "provider-cursor-canary";
+        const IDENTITY: &str = "runtime-identity-secret";
+        const TEST_NAME: &str = "backends::http::fetch::tests::request_identity_cursor_query_redacts_exported_provider_state";
+        if std::env::var_os(CHILD_ENV).is_none() {
+            // Tracing callsite interest is process-global. Run the exporter assertion in a fresh
+            // process so parallel tests cannot register `http.request` before this local collector.
+            let output = std::process::Command::new(
+                std::env::current_exe().expect("current test executable"),
+            )
+            .arg(TEST_NAME)
+            .arg("--exact")
+            .arg("--nocapture")
+            .env(CHILD_ENV, "1")
+            .output()
+            .expect("run isolated exporter contract");
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(
+                output.status.success()
+                    && stdout.contains(&format!("test {TEST_NAME} ... ok"))
+                    && stdout.contains("1 passed; 0 failed;"),
+                "isolated exporter contract did not run exactly once:\n{stdout}\n{stderr}"
+            );
+            return;
+        }
+        let target = MockServer::start().await;
+        let proxy = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/items"))
+            .and(query_param_is_missing("cursor"))
+            .and(header("x-identity-token", IDENTITY))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": [{"id": "first"}],
+                "meta": {"next_cursor": CURSOR}
+            })))
+            .expect(1)
+            .mount(&target)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/items"))
+            .and(query_param("cursor", CURSOR))
+            .and(header("x-identity-token", IDENTITY))
+            .respond_with(ResponseTemplate::new(400).set_body_string(CURSOR))
+            .expect(1)
+            .mount(&target)
+            .await;
+        let manifest = materialized_v4_manifest(
+            &json!(target.uri()),
+            &json!({"path": "/items"}),
+            Some(json!({
+                "mode": "cursor_query",
+                "cursor_param": "cursor",
+                "response_cursor_path": ["meta", "next_cursor"]
+            })),
+        );
+        let authenticator: BoundRequestIdentityHttpAuthenticator = Arc::new(|_, _| {
+            Box::pin(async {
+                Ok::<_, RequestIdentityHttpAuthenticatorError>(vec![(
+                    HeaderName::from_static("x-identity-token"),
+                    HeaderValue::from_static(IDENTITY),
+                )])
+            })
+        });
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let subscriber = tracing_subscriber::Registry::default().with(
+            tracing_opentelemetry::layer().with_tracer(provider.tracer("cursor-non-egress-test")),
+        );
+        let _subscriber = tracing::subscriber::set_default(subscriber);
+
+        let error = fetch_manifest(&manifest, "unused", &proxy, Some(authenticator))
+            .await
+            .expect_err("credential-tainted page two should fail");
+
+        assert_provider_non_egress(&error, CURSOR);
+        assert_provider_non_egress(&error, IDENTITY);
+        assert_proxy_empty(&proxy).await;
+        assert_eq!(
+            target
+                .received_requests()
+                .await
+                .expect("target requests")
+                .len(),
+            2
+        );
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        assert_eq!(spans.len(), 2, "{spans:#?}");
+        let span_dump = format!("{spans:#?}");
+        assert!(!span_dump.contains(CURSOR), "{span_dump}");
+        assert!(!span_dump.contains(IDENTITY), "{span_dump}");
+        let redacted = spans
+            .iter()
+            .filter(|span| {
+                span.attributes.iter().any(|attribute| {
+                    attribute.key.as_str() == "url.full"
+                        && matches!(
+                            &attribute.value,
+                            OtelValue::String(value)
+                                if value.to_string() == "[redacted secret-derived URL]"
+                        )
+                })
+            })
+            .collect::<Vec<_>>();
+        let [redacted] = redacted.as_slice() else {
+            panic!("expected one redacted descendant span: {spans:#?}");
+        };
+        let endpoint_keys = [
+            "server.address",
+            "server.port",
+            "peer.service",
+            "http.host",
+            "net.peer.name",
+        ];
+        assert!(
+            redacted
+                .attributes
+                .iter()
+                .all(|attribute| { !endpoint_keys.contains(&attribute.key.as_str()) })
+        );
+        provider.shutdown().expect("shutdown provider");
     }
 }

--- a/crates/coral-engine/src/backends/http/pagination.rs
+++ b/crates/coral-engine/src/backends/http/pagination.rs
@@ -404,6 +404,8 @@ fn link_param_matches(item: &str, name: &str, expected: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
+
     use reqwest::header::{HeaderMap, HeaderValue};
     use serde_json::json;
 
@@ -412,12 +414,54 @@ mod tests {
         apply_pagination_body_fields, apply_pagination_query_pairs, extract_next_link_url,
         extract_next_url_header, extract_response_cursor_header, page_is_exhausted,
     };
-    use crate::backends::http::request::RenderedRequestBody;
+    use crate::backends::http::request::{RenderedRequestBody, RequestBody, build_request_body};
     use crate::backends::http::test_support::test_http_table_spec;
+    use crate::backends::shared::template::RenderContext;
     use coral_spec::{
-        BodySpec, HttpMethod, PaginationMode, PaginationSpec, ParsedTemplate, RequestSpec,
-        ValidatedPaginationMode, ValueSourceSpec,
+        BodyFieldSpec, BodySpec, HttpMethod, PageSizeSpec, PaginationMode, PaginationSpec,
+        ParsedTemplate, RequestSpec, ValidatedPaginationMode, ValueSourceSpec,
     };
+
+    #[derive(Clone, Copy)]
+    enum PublicBodyOverwrite {
+        None,
+        PageSize(&'static str),
+        Cursor(&'static str),
+    }
+
+    fn body_path(path: &str) -> Vec<String> {
+        path.split('/').map(ToOwned::to_owned).collect()
+    }
+
+    fn render_secret_body(writes: &[(&str, bool)]) -> RenderedRequestBody {
+        let request = RequestSpec {
+            method: HttpMethod::POST,
+            body: BodySpec::Json {
+                fields: writes
+                    .iter()
+                    .map(|(path, secret)| BodyFieldSpec {
+                        path: body_path(path),
+                        when_arg: None,
+                        value: ValueSourceSpec::Input {
+                            key: if *secret { "SECRET" } else { "PUBLIC" }.to_string(),
+                        },
+                    })
+                    .collect(),
+            },
+            ..RequestSpec::default()
+        };
+        let inputs = BTreeMap::from([
+            ("SECRET".to_string(), "hidden".to_string()),
+            ("PUBLIC".to_string(), "visible".to_string()),
+        ]);
+        let empty = HashMap::new();
+        build_request_body(
+            &request,
+            &RenderContext::new(&empty, &empty, &empty, &inputs),
+            &BTreeSet::from(["SECRET".to_string()]),
+        )
+        .expect("body")
+    }
 
     #[test]
     fn extract_next_link_url_resolves_relative_links_on_same_origin() {
@@ -753,6 +797,148 @@ mod tests {
                 .contains("pagination body fields are not supported with text request bodies")
         );
         assert!(body.value.is_none());
+    }
+
+    #[test]
+    #[expect(clippy::too_many_lines, reason = "auditable test table")]
+    fn final_json_body_provenance_follows_semantic_path_overwrites() {
+        use PublicBodyOverwrite::{Cursor, None as NoOverwrite, PageSize};
+
+        type Case = (
+            &'static [(&'static str, bool)],
+            PublicBodyOverwrite,
+            serde_json::Value,
+            bool,
+        );
+        let cases: Vec<Case> = vec![
+            (
+                &[("slot", true), ("slot", false)],
+                NoOverwrite,
+                json!({"slot": "visible"}),
+                false,
+            ),
+            (
+                &[("slot", false), ("slot", true)],
+                NoOverwrite,
+                json!({"slot": "hidden"}),
+                true,
+            ),
+            (
+                &[("payload/token", true), ("payload", false)],
+                NoOverwrite,
+                json!({"payload": "visible"}),
+                false,
+            ),
+            (
+                &[("payload", true), ("payload/token", false)],
+                NoOverwrite,
+                json!({"payload": {"token": "visible"}}),
+                false,
+            ),
+            (
+                &[("payload/token", true), ("payload/public", false)],
+                NoOverwrite,
+                json!({"payload": {"token": "hidden", "public": "visible"}}),
+                true,
+            ),
+            (
+                &[("payload/token", true), ("payload/0", false)],
+                NoOverwrite,
+                json!({"payload": ["visible"]}),
+                false,
+            ),
+            (
+                &[("payload/token", true)],
+                PageSize("payload/token"),
+                json!({"payload": {"token": 25}}),
+                false,
+            ),
+            (
+                &[("payload", true)],
+                PageSize("payload/limit"),
+                json!({"payload": {"limit": 25}}),
+                false,
+            ),
+            (
+                &[("items/0/token", true)],
+                PageSize("items/1/token"),
+                json!({"items": [{"token": "hidden"}, {"token": 25}]}),
+                true,
+            ),
+            (
+                &[("items/00/token", true)],
+                PageSize("items/0/token"),
+                json!({"items": [{"token": 25}]}),
+                false,
+            ),
+            (
+                &[("payload/0", true)],
+                PageSize("payload/limit"),
+                json!({"payload": {"limit": 25}}),
+                false,
+            ),
+            (
+                &[("payload/cursor", true)],
+                Cursor("payload/cursor"),
+                json!({"payload": {"cursor": "cursor-2"}}),
+                false,
+            ),
+        ];
+
+        for (case, (writes, overwrite, expected, depends_on_secret)) in
+            cases.into_iter().enumerate()
+        {
+            let mut body = render_secret_body(writes);
+            let (pagination, state, page_size) = match overwrite {
+                PublicBodyOverwrite::None => {
+                    (PaginationSpec::default(), PageState::default(), None)
+                }
+                PublicBodyOverwrite::PageSize(path) => (
+                    PaginationSpec {
+                        page_size: Some(PageSizeSpec {
+                            default: 25,
+                            max: 100,
+                            query_param: None,
+                            body_path: body_path(path),
+                        }),
+                        ..PaginationSpec::default()
+                    },
+                    PageState::default(),
+                    Some(25),
+                ),
+                PublicBodyOverwrite::Cursor(path) => (
+                    PaginationSpec {
+                        mode: PaginationMode::CursorBody,
+                        cursor_body_path: body_path(path),
+                        response_cursor_path: body_path("meta/next_cursor"),
+                        ..PaginationSpec::default()
+                    },
+                    PageState {
+                        cursor: Some("cursor-2".to_string()),
+                        ..PageState::default()
+                    },
+                    None,
+                ),
+            };
+            let pagination = pagination.validated("demo", "items").expect("pagination");
+            apply_pagination_body_fields(
+                &mut body,
+                &BodySpec::default(),
+                &pagination,
+                &state,
+                page_size,
+            )
+            .expect("pagination body");
+
+            assert!(
+                matches!(&body.value, Some(RequestBody::Json(value)) if value == &expected),
+                "case {case}: {:?}",
+                body.value
+            );
+            // This is body-local final-value provenance; fetch separately preserves monotonic
+            // credential taint when a credential-bearing response creates later pagination state.
+            assert_eq!(body.depends_on_secret(), depends_on_secret, "case {case}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Intent

Lock the credential non-egress boundary where semantic JSON-body overwrites and provider-issued pagination state determine whether a DSL v4 request is anonymous or credential-bearing.

## What it enables

- Final-value body provenance is covered across exact, ancestor, descendant, sibling, object/array, numeric-alias, page-size, and cursor overwrites.
- Fetch-level coverage proves a public overwrite uses the proxy while a surviving secret sibling routes directly and never reaches the proxy.
- Credential-bearing cross-origin, malformed, and invalid Link/configured-next-header failures expose only stable bounded categories.
- Request-identity cursor descendants remain direct and exclude identity/cursor canaries from public errors, metadata, and every exported span.

## Usage examples

A source may author a secret JSON body field and then configure pagination to write a public page size into that body. If pagination overwrites the exact secret path, the final request is anonymous and remains proxy-aware. If the secret survives at a sibling path, Coral treats the final body as credential-bearing and uses the direct loopback client.

## Validation

- `cargo test --locked -p coral-engine --all-features backends::http::` — 77/77 passed
- Complete `coral-engine` unit, integration, and doctest suites passed
- `cargo nextest run --workspace --all-targets --all-features --locked --no-fail-fast --test-threads=8` — 1,769/1,769 passed, 3 skipped
- Workspace formatting, strict all-target Clippy, and `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps --locked` passed
- Exact-final five-lane review: zero findings/questions, ten safe credential flows, 0.98 supervisor closure

Default-concurrency `make rust-checks` reproduced only five unrelated five-second device-code fixture timeouts: 1,764 passed, 5 timed out, and 3 skipped. The bounded exact workspace run above passed all 1,769 tests.