### PR TITLE
feat(app): add identity bearer runtime

### DIFF
--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -38,7 +38,8 @@ use crate::state::db::{
 };
 use crate::workspaces::WorkspaceName;
 
-const FIXED_TOKEN_KEY: &str = "TOKEN";
+pub(super) const FIXED_TOKEN_KEY: &str = "TOKEN";
+pub(super) const OAUTH_ACCESS_TOKEN_KEY: &str = "ACCESS_TOKEN";
 const MAX_MUTATION_ATTEMPTS: usize = 8;
 
 /// App-private progress emitted before an OAuth identity becomes durable.
@@ -690,11 +691,18 @@ fn prepare_identity_for_use(
         identity_document_binding(&identity.owner, &identity.name, &identity.spec_reference);
     let envelope = identity_envelope(&identity_document);
     let material = decrypt_identity_document(&binding, &envelope, key_provider)?;
-    if material.len() != 1
-        || material
-            .get(FIXED_TOKEN_KEY)
-            .is_none_or(|token| token.trim().is_empty())
-    {
+    let material_is_valid = match identity_spec.spec.manifest.identity_type {
+        IdentitySpecType::FixedToken => {
+            material.len() == 1
+                && material
+                    .get(FIXED_TOKEN_KEY)
+                    .is_some_and(|token| !token.trim().is_empty())
+        }
+        IdentitySpecType::OAuth => material
+            .get(OAUTH_ACCESS_TOKEN_KEY)
+            .is_some_and(|token| !token.trim().is_empty()),
+    };
+    if !material_is_valid {
         return Err(corrupt_identity_material(&identity));
     }
     let identity_rewrap = rewrap_identity_document(&binding, &envelope, key_provider)?
@@ -734,12 +742,6 @@ fn validate_identity_reference(
         return Err(recreate_identity(
             &identity.name,
             "no longer matches its exact installed identity spec",
-        ));
-    }
-    if installed.manifest.identity_type != IdentitySpecType::FixedToken {
-        return Err(recreate_identity(
-            &identity.name,
-            "does not reference a fixed-token identity spec",
         ));
     }
     Ok(())

--- a/crates/coral-app/src/identities/manager/oauth_create.rs
+++ b/crates/coral-app/src/identities/manager/oauth_create.rs
@@ -25,11 +25,10 @@ use crate::state::db::{
 use crate::workspaces::WorkspaceName;
 
 use super::{
-    IdentityManager, IdentityOAuthCreationEvent, MAX_MUTATION_ATTEMPTS, identity_document_binding,
-    identity_document_write, owner_workspace_created_at, owner_workspace_not_found,
+    IdentityManager, IdentityOAuthCreationEvent, MAX_MUTATION_ATTEMPTS, OAUTH_ACCESS_TOKEN_KEY,
+    identity_document_binding, identity_document_write, owner_workspace_created_at,
+    owner_workspace_not_found,
 };
-
-const OAUTH_ACCESS_TOKEN_KEY: &str = "ACCESS_TOKEN";
 
 #[derive(Clone, Default)]
 pub(crate) struct IdentityOAuthCommitPhase(Arc<AtomicBool>);

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -3,7 +3,9 @@ use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use coral_engine::SelectedRequestIdentity;
 use coral_spec::parse_identity_manifest_yaml;
+use reqwest::header::{AUTHORIZATION, HeaderValue};
 use sea_query::{Alias, Expr, ExprTrait, Query};
 use tempfile::tempdir;
 use wiremock::matchers::{method, path};
@@ -89,7 +91,10 @@ async fn sqlite_oauth_creation_core_contract() {
     let suffix = uuid::Uuid::new_v4().simple().to_string();
     let oauth_spec = format!("oauth_{suffix}");
     let oauth_key = IdentitySpecKey::global(&oauth_spec).unwrap();
-    let oauth_yaml = device_oauth_manifest(&oauth_spec, &provider.uri());
+    let oauth_yaml = device_oauth_manifest(&oauth_spec, &provider.uri()).replace(
+        "type: oauth\n",
+        "type: oauth\naudience:\n  host: api.example.test\n  tenant:\n    id: 7\n",
+    );
     let key_provider = Arc::new(TestKeyProvider(vec![
         CredentialEncryptionKey::from_static_bytes_for_test([70; 32]),
     ]));
@@ -147,7 +152,8 @@ async fn sqlite_oauth_creation_core_contract() {
                     && metadata == &expected_safe
         ));
     }
-    let (_, document) = load_pair(&db, &owner, &identity_name).await;
+    let pair_before_use = load_pair(&db, &owner, &identity_name).await;
+    let document = &pair_before_use.1;
     let material = decrypt_material(
         &created,
         document.as_ref().expect("OAuth identity document"),
@@ -171,6 +177,71 @@ async fn sqlite_oauth_creation_core_contract() {
         material
             .values()
             .all(|value| value != "spec-client-id" && !value.contains(&provider.uri()))
+    );
+    let prepared = manager
+        .prepare_bearer_for_use(&owner, &identity_name)
+        .await
+        .expect("prepare OAuth identity for request use");
+    let selected = prepared.selected_identity();
+    assert!(selected.identity_id().starts_with("request-identity-"));
+    assert_eq!(selected.identity_spec_id(), oauth_spec);
+    assert_eq!(
+        selected.audience(),
+        &BTreeMap::from([
+            ("host".to_string(), serde_json::json!("api.example.test")),
+            ("tenant".to_string(), serde_json::json!({"id": 7})),
+        ])
+    );
+    let bound = prepared
+        .bind(&selected)
+        .expect("bind exact OAuth selection");
+    let request = reqwest::Request::new(
+        reqwest::Method::GET,
+        "https://api.example.test/user".parse().unwrap(),
+    );
+    let resolved_inputs = BTreeMap::new();
+    let headers = bound(&request, &resolved_inputs)
+        .await
+        .expect("OAuth bearer header");
+    let [(name, value)] = headers.as_slice() else {
+        panic!("OAuth identity must produce exactly one header");
+    };
+    assert_eq!(name, AUTHORIZATION);
+    assert_eq!(value, HeaderValue::from_static("Bearer access-token"));
+    assert!(value.is_sensitive());
+    let resolved = prepared.resolved_for_refresh();
+    assert_eq!(resolved.identity.safe_metadata, expected_safe);
+    assert_eq!(resolved.material(), &material);
+    let _full_revision = resolved.revision();
+    let rendered = format!("{prepared:?}");
+    for canary in ["access-token", "refresh-token", "spec-client-id"] {
+        assert!(!rendered.contains(canary));
+    }
+    for substituted in [
+        SelectedRequestIdentity::new(
+            "substituted-runtime-identity",
+            selected.identity_spec_id().to_string(),
+            selected.audience().clone(),
+        ),
+        SelectedRequestIdentity::new(
+            selected.identity_id().to_string(),
+            "other_spec",
+            selected.audience().clone(),
+        ),
+        SelectedRequestIdentity::new(
+            selected.identity_id().to_string(),
+            selected.identity_spec_id().to_string(),
+            BTreeMap::from([("host".to_string(), serde_json::json!("api.example.test"))]),
+        ),
+    ] {
+        let Err(error) = prepared.bind(&substituted) else {
+            panic!("substituted selection must not bind");
+        };
+        assert!(!error.to_string().contains("access-token"));
+    }
+    assert_eq!(
+        load_pair(&db, &owner, &identity_name).await,
+        pair_before_use
     );
     let keyless = IdentityManager::new(db.clone(), Arc::new(TestKeyProvider(vec![])));
     assert_eq!(keyless.get(&owner, &identity_name).await.unwrap(), created);
@@ -265,7 +336,11 @@ async fn assert_fixed_token_for_use_contract(db: &Arc<CoralDb>) {
     let owner = IdentityOwner::for_user(principal.clone());
     let old_key = CredentialEncryptionKey::from_static_bytes_for_test([61; 32]);
     let old_provider = Arc::new(TestKeyProvider(vec![old_key.clone()]));
-    put_spec(db, &spec_key, &fixed_manifest(&spec_name, "use")).await;
+    let manifest = fixed_manifest(&spec_name, "use").replace(
+        "type: fixed_token\n",
+        "type: fixed_token\naudience:\n  host: api.example.test\n",
+    );
+    put_spec(db, &spec_key, &manifest).await;
     let manager = IdentityManager::new(db.clone(), old_provider);
     let created = manager
         .create_or_replace_user_fixed_token(
@@ -294,6 +369,7 @@ async fn assert_fixed_token_for_use_contract(db: &Arc<CoralDb>) {
         load_pair(db, &owner, &identity_name).await.1.unwrap(),
         before_identity
     );
+    assert_fixed_bearer_runtime(&manager, &owner, &principal, &identity_name, &spec_name).await;
 
     let new_key = CredentialEncryptionKey::from_static_bytes_for_test([62; 32]);
     let rotated = IdentityManager::new(
@@ -353,6 +429,107 @@ async fn assert_fixed_token_for_use_contract(db: &Arc<CoralDb>) {
             if detail.contains("orphaned") && detail.contains("restore")
     ));
     assert_eq!(rotated.get(&owner, &identity_name).await.unwrap(), created);
+}
+
+async fn assert_fixed_bearer_runtime(
+    manager: &IdentityManager,
+    owner: &IdentityOwner,
+    principal: &UserPrincipal,
+    identity_name: &str,
+    spec_name: &str,
+) {
+    let prepared = manager
+        .prepare_bearer_for_use(owner, identity_name)
+        .await
+        .expect("prepare fixed-token identity for request use");
+    let bound = prepared
+        .bind(&prepared.selected_identity())
+        .expect("bind fixed-token identity");
+    let request = reqwest::Request::new(
+        reqwest::Method::GET,
+        "https://api.example.test/repos".parse().unwrap(),
+    );
+    let headers = bound(&request, &BTreeMap::new())
+        .await
+        .expect("fixed bearer header");
+    let [(_, value)] = headers.as_slice() else {
+        panic!("fixed identity must produce exactly one header");
+    };
+    assert_eq!(value, HeaderValue::from_static("Bearer token-value"));
+    let mut existing_authorization = reqwest::Request::new(
+        reqwest::Method::GET,
+        "https://api.example.test/repos".parse().unwrap(),
+    );
+    existing_authorization.headers_mut().insert(
+        AUTHORIZATION,
+        HeaderValue::from_static("Basic existing-credential"),
+    );
+    for unsafe_request in [
+        reqwest::Request::new(
+            reqwest::Method::GET,
+            "https://attacker.example.test/repos".parse().unwrap(),
+        ),
+        reqwest::Request::new(
+            reqwest::Method::GET,
+            "http://api.example.test/repos".parse().unwrap(),
+        ),
+        existing_authorization,
+    ] {
+        let error = bound(&unsafe_request, &BTreeMap::new())
+            .await
+            .expect_err("unsafe request must not receive a bearer header");
+        assert!(!error.to_string().contains("token-value"));
+    }
+
+    let other_name = format!("{identity_name}-other");
+    manager
+        .create_or_replace_user_fixed_token(principal, &other_name, spec_name, "other-token".into())
+        .await
+        .expect("create same-spec identity");
+    let other = manager
+        .prepare_bearer_for_use(owner, &other_name)
+        .await
+        .expect("prepare same-spec identity");
+    assert_ne!(
+        prepared.selected_identity().identity_id(),
+        other.selected_identity().identity_id()
+    );
+    assert!(prepared.bind(&other.selected_identity()).is_err());
+    let other_bound = other
+        .bind(&other.selected_identity())
+        .expect("bind same-spec identity snapshot");
+    manager
+        .create_or_replace_user_fixed_token(
+            principal,
+            &other_name,
+            spec_name,
+            "replacement-token".into(),
+        )
+        .await
+        .expect("replace prepared identity");
+    let replacement = manager
+        .prepare_bearer_for_use(owner, &other_name)
+        .await
+        .expect("prepare replacement identity");
+    let replacement_bound = replacement
+        .bind(&replacement.selected_identity())
+        .expect("bind replacement identity snapshot");
+    for (authenticator, expected) in [
+        (&other_bound, "Bearer other-token"),
+        (&replacement_bound, "Bearer replacement-token"),
+    ] {
+        let request = reqwest::Request::new(
+            reqwest::Method::GET,
+            "https://api.example.test/repos".parse().unwrap(),
+        );
+        let headers = authenticator(&request, &BTreeMap::new())
+            .await
+            .expect("snapshot bearer header");
+        let [(_, value)] = headers.as_slice() else {
+            panic!("snapshot identity must produce exactly one header");
+        };
+        assert_eq!(value.to_str().unwrap(), expected);
+    }
 }
 
 async fn assert_fixed_token_for_use_race_contract(db: &Arc<CoralDb>) {

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod manager;
 pub(crate) mod model;
+pub(crate) mod runtime;
 pub(crate) mod service;
 pub(crate) mod workspace_service;
 

--- a/crates/coral-app/src/identities/runtime.rs
+++ b/crates/coral-app/src/identities/runtime.rs
@@ -1,0 +1,359 @@
+//! Prepared request authentication for coherent stored identities.
+
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "B5e2 prepares the app-owned adapter that B7 wires into query runtimes"
+    )
+)]
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use coral_engine::{
+    BoundRequestIdentityHttpAuthenticator, RequestIdentityHttpAuthenticatorError,
+    SelectedRequestIdentity,
+};
+use coral_spec::IdentitySpecType;
+use reqwest::header::{AUTHORIZATION, HeaderValue};
+use serde_json::Value;
+use url::{Host, Url};
+
+use crate::bootstrap::AppError;
+use crate::identities::manager::{
+    FIXED_TOKEN_KEY, IdentityManager, OAUTH_ACCESS_TOKEN_KEY, ResolvedIdentityForUse,
+};
+use crate::identities::model::IdentityOwner;
+
+/// One coherent identity snapshot prepared for the engine's synchronous factory handoff.
+pub(crate) struct PreparedBearerIdentity {
+    selected: SelectedRequestIdentity,
+    resolved: ResolvedIdentityForUse,
+    material_key: &'static str,
+}
+
+impl PreparedBearerIdentity {
+    fn new(resolved: ResolvedIdentityForUse) -> Arc<Self> {
+        let manifest = &resolved.identity_spec.spec.manifest;
+        let material_key = match manifest.identity_type {
+            IdentitySpecType::FixedToken => FIXED_TOKEN_KEY,
+            IdentitySpecType::OAuth => OAUTH_ACCESS_TOKEN_KEY,
+        };
+        let selected = SelectedRequestIdentity::new(
+            format!("request-identity-{}", uuid::Uuid::new_v4().simple()),
+            manifest.name.clone(),
+            manifest.audience.clone(),
+        );
+        Arc::new(Self {
+            selected,
+            resolved,
+            material_key,
+        })
+    }
+
+    /// Returns the exact selection B7 will hand to the engine.
+    pub(crate) fn selected_identity(&self) -> SelectedRequestIdentity {
+        self.selected.clone()
+    }
+
+    /// Retains the complete material and revision needed by B5f refresh CAS.
+    pub(crate) fn resolved_for_refresh(&self) -> &ResolvedIdentityForUse {
+        &self.resolved
+    }
+
+    /// Binds the exact engine selection to this prepared coherent snapshot.
+    pub(crate) fn bind(
+        self: &Arc<Self>,
+        selected: &SelectedRequestIdentity,
+    ) -> Result<BoundRequestIdentityHttpAuthenticator, RequestIdentityHttpAuthenticatorError> {
+        if selected != &self.selected {
+            return Err(RequestIdentityHttpAuthenticatorError::failed_precondition(
+                "selected identity does not match the prepared identity snapshot",
+            ));
+        }
+        let prepared = Arc::clone(self);
+        Ok(Arc::new(move |request, _resolved_inputs| {
+            let prepared = Arc::clone(&prepared);
+            Box::pin(async move { prepared.headers_for_request(request) })
+        }))
+    }
+
+    fn headers_for_request(
+        &self,
+        request: &reqwest::Request,
+    ) -> Result<
+        Vec<(reqwest::header::HeaderName, HeaderValue)>,
+        RequestIdentityHttpAuthenticatorError,
+    > {
+        validate_request(request, self.selected.audience())?;
+        let token = self
+            .resolved
+            .material()
+            .get(self.material_key)
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                RequestIdentityHttpAuthenticatorError::failed_precondition(
+                    "prepared identity is missing bearer credential material",
+                )
+            })?;
+        Ok(vec![(AUTHORIZATION, bearer_header(token)?)])
+    }
+}
+
+impl fmt::Debug for PreparedBearerIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PreparedBearerIdentity")
+            .field("material_value_count", &self.resolved.material().len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl IdentityManager {
+    /// Resolves and prepares one fixed-token or OAuth bearer identity without refreshing it.
+    pub(crate) async fn prepare_bearer_for_use(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<Arc<PreparedBearerIdentity>, AppError> {
+        Ok(PreparedBearerIdentity::new(
+            self.get_for_use(owner, identity_name).await?,
+        ))
+    }
+}
+
+fn validate_request_url(
+    url: &Url,
+    audience: &BTreeMap<String, Value>,
+) -> Result<(), RequestIdentityHttpAuthenticatorError> {
+    if !url.username().is_empty() || url.password().is_some() || url_has_userinfo(url) {
+        return Err(RequestIdentityHttpAuthenticatorError::failed_precondition(
+            "identity authentication requires a request URL without user information",
+        ));
+    }
+    if url.fragment().is_some() {
+        return Err(RequestIdentityHttpAuthenticatorError::failed_precondition(
+            "identity authentication requires a request URL without a fragment",
+        ));
+    }
+    let request_host = url.host().ok_or_else(|| {
+        RequestIdentityHttpAuthenticatorError::failed_precondition(
+            "identity authentication requires a request URL with a host",
+        )
+    })?;
+    let transport_is_safe = match (url.scheme(), &request_host) {
+        ("https", _) => true,
+        ("http", Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        ("http", Host::Ipv4(address)) => address.is_loopback(),
+        ("http", Host::Ipv6(address)) => address.is_loopback(),
+        _ => false,
+    };
+    if !transport_is_safe {
+        return Err(RequestIdentityHttpAuthenticatorError::failed_precondition(
+            "identity authentication requires HTTPS or exact loopback HTTP",
+        ));
+    }
+
+    let audience_host = audience
+        .get("host")
+        .and_then(Value::as_str)
+        .filter(|host| !host.trim().is_empty())
+        .ok_or_else(|| {
+            RequestIdentityHttpAuthenticatorError::failed_precondition(
+                "identity audience.host must be a non-empty string",
+            )
+        })?;
+    let audience_host = Host::parse(audience_host).map_err(|_error| {
+        RequestIdentityHttpAuthenticatorError::failed_precondition(
+            "identity audience.host must be a valid typed host",
+        )
+    })?;
+    if audience_host != request_host {
+        return Err(RequestIdentityHttpAuthenticatorError::failed_precondition(
+            "identity audience host does not match the request host",
+        ));
+    }
+
+    if let Some(port) = audience.get("port") {
+        let expected_port = port
+            .as_u64()
+            .and_then(|port| u16::try_from(port).ok())
+            .filter(|port| *port != 0)
+            .ok_or_else(|| {
+                RequestIdentityHttpAuthenticatorError::failed_precondition(
+                    "identity audience.port must be an integer from 1 through 65535",
+                )
+            })?;
+        if url.port_or_known_default() != Some(expected_port) {
+            return Err(RequestIdentityHttpAuthenticatorError::failed_precondition(
+                "identity audience port does not match the effective request port",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_request(
+    request: &reqwest::Request,
+    audience: &BTreeMap<String, Value>,
+) -> Result<(), RequestIdentityHttpAuthenticatorError> {
+    validate_request_url(request.url(), audience)?;
+    if request.headers().contains_key(AUTHORIZATION) {
+        return Err(RequestIdentityHttpAuthenticatorError::failed_precondition(
+            "identity authentication cannot replace an existing Authorization header",
+        ));
+    }
+    Ok(())
+}
+
+fn bearer_header(token: &str) -> Result<HeaderValue, RequestIdentityHttpAuthenticatorError> {
+    let mut value = HeaderValue::from_str(&format!("Bearer {token}")).map_err(|_error| {
+        RequestIdentityHttpAuthenticatorError::failed_precondition(
+            "prepared identity bearer credential cannot be encoded as an HTTP header",
+        )
+    })?;
+    value.set_sensitive(true);
+    Ok(value)
+}
+
+fn url_has_userinfo(url: &Url) -> bool {
+    let Some(authority) = url
+        .as_str()
+        .split_once("://")
+        .map(|(_, remainder)| remainder.split(['/', '?', '#']).next().unwrap_or_default())
+    else {
+        return false;
+    };
+    authority.contains('@')
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use reqwest::header::{AUTHORIZATION, HeaderValue};
+    use serde_json::{Value, json};
+
+    use super::{bearer_header, validate_request, validate_request_url};
+
+    fn request(url: &str) -> reqwest::Request {
+        reqwest::Request::new(reqwest::Method::GET, url.parse().expect("test URL"))
+    }
+
+    fn audience(host: Value, port: Option<Value>) -> BTreeMap<String, Value> {
+        let mut audience = BTreeMap::from([
+            ("host".to_string(), host),
+            ("tenant".to_string(), json!({"id": 7})),
+        ]);
+        if let Some(port) = port {
+            audience.insert("port".to_string(), port);
+        }
+        audience
+    }
+
+    #[test]
+    fn request_audience_accepts_exact_typed_hosts_and_effective_ports() {
+        for (url, host, port) in [
+            (
+                "https://api.example.test/path",
+                json!("api.example.test"),
+                None,
+            ),
+            (
+                "https://api.example.test/path",
+                json!("api.example.test"),
+                Some(json!(443)),
+            ),
+            (
+                "https://api.example.test:443/path",
+                json!("api.example.test"),
+                Some(json!(443)),
+            ),
+            ("https://127.0.0.1/path", json!("127.0.0.1"), None),
+            ("https://[::1]/path", json!("[::1]"), None),
+            ("http://localhost/path", json!("localhost"), Some(json!(80))),
+            ("http://127.0.0.1/path", json!("127.0.0.1"), None),
+            ("http://[::1]/path", json!("[::1]"), None),
+        ] {
+            validate_request_url(request(url).url(), &audience(host, port))
+                .unwrap_or_else(|error| panic!("{url} should pass: {error}"));
+        }
+    }
+
+    #[test]
+    fn request_audience_rejects_host_and_port_substitution() {
+        for (url, host, port) in [
+            ("https://api.example.test", json!("example.test"), None),
+            ("https://example.test", json!("api.example.test"), None),
+            ("https://example.test.attacker", json!("example.test"), None),
+            ("https://127.0.0.1", json!("localhost"), None),
+            (
+                "https://example.test",
+                json!("example.test"),
+                Some(json!(444)),
+            ),
+            (
+                "https://example.test",
+                json!("example.test"),
+                Some(json!("443")),
+            ),
+            (
+                "https://example.test",
+                json!("example.test"),
+                Some(json!(443.0)),
+            ),
+            (
+                "https://example.test",
+                json!("example.test"),
+                Some(json!(0)),
+            ),
+            (
+                "https://example.test",
+                json!("example.test"),
+                Some(json!(65536)),
+            ),
+        ] {
+            assert!(
+                validate_request_url(request(url).url(), &audience(host, port)).is_err(),
+                "{url} should reject the supplied audience"
+            );
+        }
+    }
+
+    #[test]
+    fn request_audience_rejects_malformed_host_and_unsafe_urls() {
+        let valid = audience(json!("example.test"), None);
+        for url in [
+            "http://example.test/path",
+            "ftp://example.test/path",
+            "https://user@example.test/path",
+            "https://example.test/path#fragment",
+        ] {
+            assert!(
+                validate_request_url(request(url).url(), &valid).is_err(),
+                "{url} should be unsafe"
+            );
+        }
+        for host in [Value::Null, json!(7), json!(""), json!("bad host")] {
+            assert!(
+                validate_request_url(request("https://example.test").url(), &audience(host, None),)
+                    .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn existing_authorization_and_invalid_bearer_values_fail_closed() {
+        let mut existing = request("https://example.test");
+        existing
+            .headers_mut()
+            .insert(AUTHORIZATION, HeaderValue::from_static("Basic existing"));
+        assert!(validate_request(&existing, &audience(json!("example.test"), None)).is_err());
+
+        let canary = "token-canary\r\ninjected: value";
+        let error = bearer_header(canary).expect_err("CRLF token must fail");
+        assert!(!error.to_string().contains(canary));
+    }
+}


### PR DESCRIPTION
## Intent

Turn coherently resolved fixed-token and OAuth identity snapshots into app-owned bearer authenticators without exposing credential material.

## What it enables

- Exact opaque identity, installed spec, and complete audience binding before credential use.
- HTTPS or loopback-HTTP enforcement with typed host and optional effective-port checks.
- Snapshot-preserving request authentication for fixed-token and OAuth access-token material.
- The app-owned bearer seam required by the later B5f refresh/CAS and B7 query-wiring slices.

## Usage examples

This is an internal runtime seam. Resolve with `IdentityManager::prepare_bearer_for_use`, carry `prepared.selected_identity()` through request selection, then call `prepared.bind(&selected)` to obtain the HTTP request authenticator. Query/bootstrap wiring follows in B7.

## Validation

- Workspace formatting and Clippy passed.
- Bounded workspace suite: 1,773/1,773 passed, with 3 intentionally skipped.
- Default-concurrency `make rust-checks`: 1,768 passed; only five known timing-sensitive device-code fixture tests timed out.
- `make postgres-tests` passed repository, migration-order, and server-startup contracts.
- Rustdoc passed with warnings denied.
- Exact-final five-lane review found no accepted issue and enumerated nine safe credential flows.