### PR TITLE
feat(app): add durable identity refresh claims

### DIFF
--- a/crates/coral-app/migrations/0013_identity_oauth_refresh_claim.sql
+++ b/crates/coral-app/migrations/0013_identity_oauth_refresh_claim.sql
@@ -1,0 +1,17 @@
+ALTER TABLE identities
+    ADD COLUMN oauth_refresh_claim_id TEXT;
+
+ALTER TABLE identities
+    ADD COLUMN oauth_refresh_claim_deadline_unix_nanos BIGINT
+    CHECK (
+        (oauth_refresh_claim_id IS NULL) =
+        (oauth_refresh_claim_deadline_unix_nanos IS NULL)
+    )
+    CHECK (
+        oauth_refresh_claim_id IS NULL
+        OR LENGTH(oauth_refresh_claim_id) > 0
+    )
+    CHECK (
+        oauth_refresh_claim_deadline_unix_nanos IS NULL
+        OR oauth_refresh_claim_deadline_unix_nanos >= 0
+    );

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -32,9 +32,9 @@ use crate::identity_specs::manager::{
     spec_not_found,
 };
 use crate::state::db::{
-    CoralDb, CoralTx, DbRepos, IdentityDocumentRecord, IdentityDocumentWrite, IdentityRecord,
-    IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecRecord,
-    now_unix_nanos_i64,
+    CoralDb, CoralTx, DbRepos, IdentityDocumentRecord, IdentityDocumentWrite,
+    IdentityOAuthRefreshClaim, IdentityRecord, IdentitySpecDocumentRecord,
+    IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecRecord, now_unix_nanos_i64,
 };
 use crate::workspaces::WorkspaceName;
 
@@ -89,6 +89,7 @@ struct IdentityUseSnapshot {
     identity_document: Option<IdentityDocumentRecord>,
     identity_spec: Option<IdentitySpecRecord>,
     identity_spec_document: Option<IdentitySpecDocumentRecord>,
+    oauth_refresh_claim: Option<IdentityOAuthRefreshClaim>,
 }
 
 struct PreparedIdentityForUse {
@@ -397,7 +398,7 @@ impl IdentityManager {
             {
                 gate.wait_once().await;
             }
-            let revision = if prepared.needs_rewrap() {
+            let revision = if prepared.needs_rewrap() && snapshot.oauth_refresh_claim.is_none() {
                 match self
                     .try_rewrap_for_use(owner, &name, &snapshot, &prepared)
                     .await
@@ -455,6 +456,23 @@ impl IdentityManager {
             tx.rollback().await?;
             return Ok(None);
         }
+        let spec_rewrap_blocked = if prepared.identity_spec_rewrap.is_some() {
+            let key = current
+                .identity
+                .as_ref()
+                .expect("validated identity snapshot")
+                .spec_reference
+                .key();
+            tx.identities()
+                .has_oauth_refresh_claimed_dependents(key)
+                .await?
+        } else {
+            false
+        };
+        if spec_rewrap_blocked && prepared.identity_rewrap.is_none() {
+            tx.rollback().await?;
+            return Ok(Some(current));
+        }
         #[cfg(test)]
         if let Some(gate) = &self.before_upsert_gate
             && !gate.used.swap(true, Ordering::SeqCst)
@@ -463,7 +481,9 @@ impl IdentityManager {
         }
         let now = now_unix_nanos_i64()?;
         let result = async {
-            if let Some(write) = &prepared.identity_spec_rewrap {
+            if let Some(write) = &prepared.identity_spec_rewrap
+                && !spec_rewrap_blocked
+            {
                 let key = current
                     .identity
                     .as_ref()
@@ -639,6 +659,10 @@ async fn load_identity_use_snapshot(
     workspace_created_at_unix_nanos: Option<i64>,
 ) -> Result<IdentityUseSnapshot, AppError> {
     let identity = tx.identities().load_optional(owner, name).await?;
+    let oauth_refresh_claim = tx
+        .identities()
+        .load_oauth_refresh_claim(owner, name)
+        .await?;
     let identity_document = tx.identity_documents().load_optional(owner, name).await?;
     let (identity_spec, identity_spec_document) = match identity.as_ref() {
         Some(identity) => {
@@ -656,6 +680,7 @@ async fn load_identity_use_snapshot(
         identity_document,
         identity_spec,
         identity_spec_document,
+        oauth_refresh_claim,
     })
 }
 

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -27,9 +27,9 @@ use crate::identity::{
 use crate::identity_specs::identity_spec_fingerprint;
 use crate::identity_specs::manager::{IdentitySpecInputValue, IdentitySpecManager};
 use crate::state::db::{
-    CoralDb, DbError, DbRepos, DbSession, IdentityDocumentRecord, IdentityRecord,
-    IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecScope,
-    IdentitySpecWrite, ResolvedDatabaseConfig,
+    CoralDb, DbError, DbRepos, DbSession, IdentityDocumentRecord, IdentityOAuthRefreshClaim,
+    IdentityRecord, IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey,
+    IdentitySpecScope, IdentitySpecWrite, ResolvedDatabaseConfig,
 };
 use crate::workspaces::WorkspaceName;
 
@@ -372,32 +372,16 @@ async fn assert_fixed_token_for_use_contract(db: &Arc<CoralDb>) {
     assert_fixed_bearer_runtime(&manager, &owner, &principal, &identity_name, &spec_name).await;
 
     let new_key = CredentialEncryptionKey::from_static_bytes_for_test([62; 32]);
-    let rotated = IdentityManager::new(
-        db.clone(),
-        Arc::new(TestKeyProvider(vec![old_key, new_key.clone()])),
-    );
-    let rotated_result = rotated
-        .get_for_use(&owner, &identity_name)
-        .await
-        .expect("resolve and rewrap identity for use");
-    assert_eq!(
-        rotated_result.material().get("TOKEN").unwrap(),
-        "token-value"
-    );
-    let after_identity = load_pair(db, &owner, &identity_name).await.1.unwrap();
-    assert_eq!(after_identity.document_version, 2);
-    assert_eq!(after_identity.key_id, new_key.key_id());
-    assert_eq!(after_identity.ciphertext, before_identity.ciphertext);
-    assert_eq!(after_identity.nonce, before_identity.nonce);
-    let reopened = rotated
-        .get_for_use(&owner, &identity_name)
-        .await
-        .expect("reopen rewrapped identity");
-    assert_eq!(reopened.material().get("TOKEN").unwrap(), "token-value");
-    assert_eq!(
-        load_pair(db, &owner, &identity_name).await.1.unwrap(),
-        after_identity
-    );
+    let (rotated, after_identity) = Box::pin(assert_refresh_claim_fences_rewrap(
+        db,
+        &owner,
+        &identity_name,
+        &created,
+        &before_identity,
+        &old_key,
+        &new_key,
+    ))
+    .await;
 
     let unavailable = IdentityManager::new(db.clone(), Arc::new(TestKeyProvider(vec![])));
     assert!(matches!(
@@ -429,6 +413,75 @@ async fn assert_fixed_token_for_use_contract(db: &Arc<CoralDb>) {
             if detail.contains("orphaned") && detail.contains("restore")
     ));
     assert_eq!(rotated.get(&owner, &identity_name).await.unwrap(), created);
+}
+
+async fn assert_refresh_claim_fences_rewrap(
+    db: &Arc<CoralDb>,
+    owner: &IdentityOwner,
+    identity_name: &str,
+    created: &IdentityRecord,
+    before_document: &IdentityDocumentRecord,
+    old_key: &CredentialEncryptionKey,
+    new_key: &CredentialEncryptionKey,
+) -> (IdentityManager, IdentityDocumentRecord) {
+    let name = IdentityName::parse(identity_name).unwrap();
+    let claim = IdentityOAuthRefreshClaim::new(uuid::Uuid::new_v4(), i64::MAX)
+        .expect("valid refresh claim");
+    let mut tx = db.begin_serializable().await.expect("begin claim tx");
+    assert!(
+        tx.identities()
+            .try_claim_oauth_refresh(owner, &name, &claim)
+            .await
+            .expect("claim identity refresh")
+    );
+    tx.commit().await.expect("commit refresh claim");
+
+    let rotated = manager_with_keys(db, vec![old_key.clone(), new_key.clone()]);
+    let claimed_result = rotated
+        .get_for_use(owner, identity_name)
+        .await
+        .expect("resolve claimed identity without rewrap");
+    assert_use_token(&claimed_result, "token-value");
+    assert_eq!(
+        load_pair(db, owner, identity_name).await.1.as_ref(),
+        Some(before_document),
+        "active refresh claim must fence opportunistic rewrap"
+    );
+    let mut tx = db.begin_serializable().await.expect("begin replacement tx");
+    let cleared = tx
+        .identities()
+        .upsert(
+            owner,
+            &name,
+            &created.spec_reference,
+            &created.safe_metadata,
+            created.updated_at_unix_nanos,
+        )
+        .await
+        .expect("same-value replacement clears claim");
+    assert_eq!(&cleared, created);
+    tx.commit().await.expect("commit replacement");
+
+    let rotated_result = rotated
+        .get_for_use(owner, identity_name)
+        .await
+        .expect("resolve and rewrap identity for use");
+    assert_use_token(&rotated_result, "token-value");
+    let after_document = load_pair(db, owner, identity_name).await.1.unwrap();
+    assert_eq!(after_document.document_version, 2);
+    assert_eq!(after_document.key_id, new_key.key_id());
+    assert_eq!(after_document.ciphertext, before_document.ciphertext);
+    assert_eq!(after_document.nonce, before_document.nonce);
+    let reopened = rotated
+        .get_for_use(owner, identity_name)
+        .await
+        .expect("reopen rewrapped identity");
+    assert_use_token(&reopened, "token-value");
+    assert_eq!(
+        load_pair(db, owner, identity_name).await.1.unwrap(),
+        after_document
+    );
+    (rotated, after_document)
 }
 
 async fn assert_fixed_bearer_runtime(
@@ -655,7 +708,7 @@ async fn assert_use_delete_recreate_race(
 ) {
     let race = seed_user_use_race(db, suffix, "recreate", old_key).await;
     let writer = manager_with_keys(db, vec![old_key.clone()]);
-    let (resolved, recreated) = race_before_use_cas(
+    let (resolved, recreated) = Box::pin(race_before_use_cas(
         manager_with_keys(db, vec![old_key.clone(), new_key.clone()]),
         &race.owner,
         &race.name,
@@ -670,7 +723,7 @@ async fn assert_use_delete_recreate_race(
                 )
                 .await
         },
-    )
+    ))
     .await;
     recreated.expect("concurrent delete/recreate");
     assert_use_token(&resolved.expect("ABA race resolution"), "winner-token");

--- a/crates/coral-app/src/state/db/migration_order_tests.rs
+++ b/crates/coral-app/src/state/db/migration_order_tests.rs
@@ -283,6 +283,14 @@ async fn assert_migration_order_contract(db: &CoralDb) {
         .expect("load migrated identity")
         .expect("migrated identity");
     assert!(legacy.safe_metadata.is_empty());
+    assert!(
+        session
+            .identities()
+            .load_oauth_refresh_claim(&owner, &name)
+            .await
+            .expect("load migrated refresh claim")
+            .is_none()
+    );
     assert_eq!(
         (legacy.created_at_unix_nanos, legacy.updated_at_unix_nanos),
         (41, 42)

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
-pub(crate) use repositories::identities::IdentityRecord;
+pub(crate) use repositories::identities::{IdentityOAuthRefreshClaim, IdentityRecord};
 pub(crate) use repositories::identity_documents::{IdentityDocumentRecord, IdentityDocumentWrite};
 pub(crate) use repositories::identity_specs::{
     IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecRecord,

--- a/crates/coral-app/src/state/db/repositories/identities.rs
+++ b/crates/coral-app/src/state/db/repositories/identities.rs
@@ -9,6 +9,51 @@ use crate::state::db::{CoralTx, DbError, DbSession, IdentitySpecKey};
 
 const IDENTITY_COUNT: &str = "identity_count";
 
+/// Internal cross-process ownership of one in-flight identity OAuth refresh.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct IdentityOAuthRefreshClaim {
+    id: String,
+    deadline_unix_nanos: i64,
+}
+
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "OAuth refresh claim construction and ownership land in B5f"
+    )
+)]
+impl IdentityOAuthRefreshClaim {
+    pub(crate) fn new(id: uuid::Uuid, deadline_unix_nanos: i64) -> Result<Self, AppError> {
+        if deadline_unix_nanos < 0 {
+            return Err(AppError::InvalidInput(
+                "identity OAuth refresh claim deadline is negative".to_string(),
+            ));
+        }
+        Ok(Self {
+            id: id.simple().to_string(),
+            deadline_unix_nanos,
+        })
+    }
+
+    pub(crate) fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub(crate) fn deadline_unix_nanos(&self) -> i64 {
+        self.deadline_unix_nanos
+    }
+}
+
+impl std::fmt::Debug for IdentityOAuthRefreshClaim {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IdentityOAuthRefreshClaim")
+            .field("id", &"<opaque>")
+            .field("deadline_unix_nanos", &self.deadline_unix_nanos)
+            .finish()
+    }
+}
+
 /// Safe persisted fields for one owner-scoped identity instance.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct IdentityRecord {
@@ -77,6 +122,33 @@ struct IdentityCountRow {
     identity_count: i64,
 }
 
+#[derive(sqlx::FromRow)]
+struct IdentityOAuthRefreshClaimRow {
+    oauth_refresh_claim_id: Option<String>,
+    oauth_refresh_claim_deadline_unix_nanos: Option<i64>,
+}
+
+impl IdentityOAuthRefreshClaimRow {
+    fn validate(self) -> Result<Option<IdentityOAuthRefreshClaim>, DbError> {
+        let (id, deadline_unix_nanos) = match (
+            self.oauth_refresh_claim_id,
+            self.oauth_refresh_claim_deadline_unix_nanos,
+        ) {
+            (None, None) => return Ok(None),
+            (Some(id), Some(deadline_unix_nanos)) => (id, deadline_unix_nanos),
+            _ => return Err(invalid_oauth_refresh_claim()),
+        };
+        let parsed = uuid::Uuid::parse_str(&id).map_err(|_error| invalid_oauth_refresh_claim())?;
+        if parsed.simple().to_string() != id || deadline_unix_nanos < 0 {
+            return Err(invalid_oauth_refresh_claim());
+        }
+        Ok(Some(IdentityOAuthRefreshClaim {
+            id,
+            deadline_unix_nanos,
+        }))
+    }
+}
+
 /// Repository shell for durable owner-scoped identity rows.
 pub(crate) struct IdentitiesRepo<'a, S> {
     session: &'a mut S,
@@ -124,6 +196,30 @@ where
         rows.into_iter().map(IdentityRow::validate).collect()
     }
 
+    /// Load internal OAuth refresh coordination without widening public identity fields.
+    pub(crate) async fn load_oauth_refresh_claim(
+        &mut self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+    ) -> Result<Option<IdentityOAuthRefreshClaim>, DbError> {
+        let row: Option<IdentityOAuthRefreshClaimRow> = self
+            .session
+            .fetch_optional(
+                Query::select()
+                    .columns([
+                        Identities::OauthRefreshClaimId,
+                        Identities::OauthRefreshClaimDeadlineUnixNanos,
+                    ])
+                    .from(Identities::Table)
+                    .and_where(identity_key_where(owner, name))
+                    .to_owned(),
+            )
+            .await?;
+        row.map(IdentityOAuthRefreshClaimRow::validate)
+            .transpose()
+            .map(Option::flatten)
+    }
+
     /// Count all identities pinned to one exact spec scope and name.
     pub(crate) async fn count_dependents(&mut self, key: &IdentitySpecKey) -> Result<u64, DbError> {
         self.count_where(identity_spec_where(key)).await
@@ -140,6 +236,18 @@ where
                 .and(Expr::col(Identities::IdentitySpecFingerprint).eq(fingerprint)),
         )
         .await
+    }
+
+    /// Report whether any exact dependent currently owns an OAuth refresh claim.
+    pub(crate) async fn has_oauth_refresh_claimed_dependents(
+        &mut self,
+        key: &IdentitySpecKey,
+    ) -> Result<bool, DbError> {
+        self.count_where(
+            identity_spec_where(key).and(Expr::col(Identities::OauthRefreshClaimId).is_not_null()),
+        )
+        .await
+        .map(|count| count != 0)
     }
 
     async fn count_where(&mut self, predicate: sea_query::SimpleExpr) -> Result<u64, DbError> {
@@ -169,6 +277,67 @@ where
 }
 
 impl IdentitiesRepo<'_, CoralTx<'_>> {
+    /// Acquire an unclaimed identity refresh slot without stealing stale claims.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "OAuth refresh claim acquisition lands in B5f")
+    )]
+    pub(crate) async fn try_claim_oauth_refresh(
+        &mut self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        claim: &IdentityOAuthRefreshClaim,
+    ) -> Result<bool, DbError> {
+        let rows_affected = self
+            .session
+            .execute_affected(
+                Query::update()
+                    .table(Identities::Table)
+                    .value(Identities::OauthRefreshClaimId, claim.id.clone())
+                    .value(
+                        Identities::OauthRefreshClaimDeadlineUnixNanos,
+                        claim.deadline_unix_nanos,
+                    )
+                    .and_where(identity_key_where(owner, name))
+                    .and_where(Expr::col(Identities::OauthRefreshClaimId).is_null())
+                    .and_where(Expr::col(Identities::OauthRefreshClaimDeadlineUnixNanos).is_null())
+                    .to_owned(),
+            )
+            .await?;
+        zero_or_one_affected(rows_affected, "identity OAuth refresh claim")
+    }
+
+    /// Make a matching claim immediately fail closed without releasing ownership.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "OAuth refresh failure handling lands in B5f")
+    )]
+    pub(crate) async fn expire_oauth_refresh_claim(
+        &mut self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        claim_id: &str,
+        now_unix_nanos: i64,
+    ) -> Result<bool, AppError> {
+        validate_write_timestamp(now_unix_nanos)?;
+        let rows_affected = self
+            .session
+            .execute_affected(
+                Query::update()
+                    .table(Identities::Table)
+                    .value(
+                        Identities::OauthRefreshClaimDeadlineUnixNanos,
+                        now_unix_nanos,
+                    )
+                    .and_where(identity_key_where(owner, name))
+                    .and_where(Expr::col(Identities::OauthRefreshClaimId).eq(claim_id))
+                    .to_owned(),
+            )
+            .await?;
+        zero_or_one_affected(rows_affected, "identity OAuth refresh claim expiry")
+            .map_err(Into::into)
+    }
+
     /// Insert or replace one identity while preserving its creation time.
     pub(crate) async fn upsert(
         &mut self,
@@ -220,6 +389,14 @@ impl IdentitiesRepo<'_, CoralTx<'_>> {
                     Identities::IdentityType,
                     Identities::SafeMetadataJson,
                 ])
+                .value(
+                    Identities::OauthRefreshClaimId,
+                    Expr::val(Option::<String>::None),
+                )
+                .value(
+                    Identities::OauthRefreshClaimDeadlineUnixNanos,
+                    Expr::val(Option::<i64>::None),
+                )
                 .value(
                     Identities::UpdatedAtUnixNanos,
                     Expr::case(
@@ -282,6 +459,10 @@ fn decode_safe_metadata(value: &str) -> Result<BTreeMap<String, String>, DbError
 
 fn invalid_safe_metadata() -> DbError {
     DbError::CorruptData("identity row has invalid safe metadata JSON".to_string())
+}
+
+fn invalid_oauth_refresh_claim() -> DbError {
+    DbError::CorruptData("identity row has invalid OAuth refresh claim".to_string())
 }
 
 fn zero_or_one_affected(rows_affected: u64, operation: &str) -> Result<bool, DbError> {

--- a/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
@@ -5,8 +5,9 @@ use tempfile::tempdir;
 use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
 use crate::identity::UserPrincipal;
 use crate::state::db::{
-    CoralDb, CoralTx, DbRepos, IdentityDocumentRecord, IdentityDocumentWrite, IdentityRecord,
-    IdentitySpecKey, IdentitySpecWrite, ResolvedDatabaseConfig,
+    CoralDb, CoralTx, DbRepos, IdentityDocumentRecord, IdentityDocumentWrite,
+    IdentityOAuthRefreshClaim, IdentityRecord, IdentitySpecKey, IdentitySpecWrite,
+    ResolvedDatabaseConfig,
 };
 use crate::workspaces::WorkspaceName;
 
@@ -134,6 +135,64 @@ pub(in crate::state::db) async fn assert_identity_repository_contract(db: &Coral
     assert_counts(db, &workspace_key, [("f1", 1)], 1).await;
     assert_counts(db, &replacement_key, [("f3", 0)], 0).await;
 
+    let claim = IdentityOAuthRefreshClaim::new(uuid::Uuid::new_v4(), 40)
+        .expect("valid OAuth refresh claim");
+    let competing_claim =
+        IdentityOAuthRefreshClaim::new(uuid::Uuid::new_v4(), 41).expect("valid competing claim");
+    let mut tx = db.begin().await.expect("begin refresh claim tx");
+    assert!(
+        tx.identities()
+            .try_claim_oauth_refresh(&workspace_owner, &shared_name, &claim)
+            .await
+            .expect("claim identity OAuth refresh")
+    );
+    assert!(
+        !tx.identities()
+            .try_claim_oauth_refresh(&workspace_owner, &shared_name, &competing_claim)
+            .await
+            .expect("do not replace a live claim")
+    );
+    assert!(
+        tx.identities()
+            .has_oauth_refresh_claimed_dependents(&workspace_key)
+            .await
+            .expect("count claimed dependents")
+    );
+    tx.commit().await.expect("commit refresh claim");
+    assert_eq!(
+        load_refresh_claim(db, &workspace_owner, &shared_name).await,
+        Some(claim.clone())
+    );
+    assert_eq!(load_refresh_claim(db, &user, &shared_name).await, None);
+
+    let mut tx = db.begin().await.expect("begin refresh claim expiry tx");
+    assert!(
+        !tx.identities()
+            .expire_oauth_refresh_claim(&workspace_owner, &shared_name, competing_claim.id(), 14,)
+            .await
+            .expect("wrong claimant cannot expire")
+    );
+    assert!(
+        tx.identities()
+            .expire_oauth_refresh_claim(&workspace_owner, &shared_name, claim.id(), 14)
+            .await
+            .expect("claimant expires its claim")
+    );
+    assert!(
+        !tx.identities()
+            .try_claim_oauth_refresh(&workspace_owner, &shared_name, &competing_claim)
+            .await
+            .expect("expired claims are never stolen")
+    );
+    tx.commit().await.expect("commit refresh claim expiry");
+    assert_eq!(
+        load_refresh_claim(db, &workspace_owner, &shared_name)
+            .await
+            .expect("expired claim remains durable")
+            .deadline_unix_nanos(),
+        14
+    );
+
     let replacement_metadata = metadata([("token_type", "DPoP")]);
     let expected_replaced_identity = IdentityRecord {
         owner: workspace_owner.clone(),
@@ -169,6 +228,11 @@ pub(in crate::state::db) async fn assert_identity_repository_contract(db: &Coral
         .expect("replace identity under regressed clock");
     assert_eq!(regressed_identity, expected_replaced_identity);
     tx.commit().await.expect("commit identity replacement tx");
+    assert_eq!(
+        load_refresh_claim(db, &workspace_owner, &shared_name).await,
+        None,
+        "explicit replacement must clear refresh coordination"
+    );
     assert_identity(
         db,
         &workspace_owner,
@@ -465,6 +529,19 @@ pub(super) async fn assert_identity(
             .as_ref(),
         Some(expected)
     );
+}
+
+async fn load_refresh_claim(
+    db: &CoralDb,
+    owner: &IdentityOwner,
+    name: &IdentityName,
+) -> Option<IdentityOAuthRefreshClaim> {
+    let mut session = db;
+    session
+        .identities()
+        .load_oauth_refresh_claim(owner, name)
+        .await
+        .expect("load identity OAuth refresh claim")
 }
 
 pub(super) async fn assert_identity_absent(

--- a/crates/coral-app/src/state/db/repositories/identities_negative_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identities_negative_contract_tests.rs
@@ -130,6 +130,7 @@ pub(in crate::state::db) async fn assert_identity_repository_negative_contract(d
     ] {
         assert_corrupt_safe_metadata(db, &owner, &corrupt_name, value).await;
     }
+    assert_corrupt_oauth_refresh_claim(db, &owner, &corrupt_name).await;
     assert_identity(db, &owner, &corrupt_name, &original_identity).await;
 
     assert_document_corruption_matrix(db, &owner, &material_name).await;
@@ -350,6 +351,32 @@ async fn assert_corrupt_safe_metadata(
     tx.rollback().await.expect("restore safe metadata");
 }
 
+async fn assert_corrupt_oauth_refresh_claim(
+    db: &CoralDb,
+    owner: &IdentityOwner,
+    name: &IdentityName,
+) {
+    let mut tx = db.begin().await.expect("begin corrupt refresh claim tx");
+    tx.execute(
+        Query::update()
+            .table(Identities::Table)
+            .value(Identities::OauthRefreshClaimId, "not-a-uuid")
+            .value(Identities::OauthRefreshClaimDeadlineUnixNanos, 50_i64)
+            .and_where(identity_where(owner, name))
+            .to_owned(),
+    )
+    .await
+    .expect("seed structurally valid corrupt claim");
+    let error = tx
+        .identities()
+        .load_oauth_refresh_claim(owner, name)
+        .await
+        .expect_err("runtime claim read must reject noncanonical IDs");
+    assert!(matches!(error, DbError::CorruptData(_)));
+    assert!(!error.to_string().contains("not-a-uuid"));
+    tx.rollback().await.expect("restore refresh claim");
+}
+
 async fn assert_corrupt_document(
     db: &CoralDb,
     owner: &IdentityOwner,
@@ -399,6 +426,33 @@ async fn assert_constraint_violations(
             .and_where(identity_where(owner, constraint_name))
             .to_owned(),
         Violation::NotNull,
+    )
+    .await;
+    assert_violation(
+        db,
+        Query::update()
+            .table(Identities::Table)
+            .value(
+                Identities::OauthRefreshClaimId,
+                uuid::Uuid::new_v4().simple().to_string(),
+            )
+            .and_where(identity_where(owner, constraint_name))
+            .to_owned(),
+        Violation::Check,
+    )
+    .await;
+    assert_violation(
+        db,
+        Query::update()
+            .table(Identities::Table)
+            .value(
+                Identities::OauthRefreshClaimId,
+                uuid::Uuid::new_v4().simple().to_string(),
+            )
+            .value(Identities::OauthRefreshClaimDeadlineUnixNanos, -1_i64)
+            .and_where(identity_where(owner, constraint_name))
+            .to_owned(),
+        Violation::Check,
     )
     .await;
     assert_violation(

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -62,6 +62,8 @@ pub(in crate::state::db) enum Identities {
     Issuer,
     IdentityType,
     SafeMetadataJson,
+    OauthRefreshClaimId,
+    OauthRefreshClaimDeadlineUnixNanos,
     CreatedAtUnixNanos,
     UpdatedAtUnixNanos,
 }


### PR DESCRIPTION
## Intent

Add durable, fail-closed coordination state for OAuth refresh so the later refresh runtime can guarantee one cross-process claimant without making provider requests inside database transactions.

## What it enables

- Atomic owner/name refresh-claim acquisition across SQLite and Postgres.
- Non-stealable waiter deadlines, exact-claim expiry, and explicit replacement/deletion recovery.
- Coherent identity-use revisions that fence opportunistic identity and shared-spec KEK rewrap while a claim is outstanding.
- A private persistence foundation for B5f's one-shot provider call and exact-claim/full-revision finalization, without exposing claim state through public List/Get.

## Usage examples

This is an internal foundation and adds no public command. B5f will acquire the claim inside a serializable transaction, execute the provider request after that transaction commits, and finalize refreshed encrypted material only when both the claim and full persisted revision still match.

## Validation

- Focused SQLite repository, manager, and sparse-migration contracts passed (9/9).
- Strict all-target `coral-app` Clippy passed with warnings denied.
- `make postgres-tests` passed repository, migration-order, and server-startup contracts (3/3).
- Workspace formatting and Clippy passed; the bounded workspace suite passed 1,773/1,773 with 3 intentionally skipped.
- Default-concurrency `make rust-checks` reproduced only five known timing-sensitive device-code fixture timeouts (1,768 passed, 5 timed out, 3 skipped).
- Rustdoc passed with warnings denied.
- `make perf-check` passed the CLI startup/catalog latency budget.
- Exact-final five-lane review enumerated five safe credential flows, rejected four out-of-slice or semantics-conflicting findings, and found no additional P1/P2 risk.
