### PR TITLE
feat(reef): prevent workspace context loss across local data views

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -342,22 +342,23 @@ describe('Architectural Tests', () => {
       )
       expect(routeConfig).toContain("layout('routes/app-shell.tsx', [")
       expect(routeConfig).toContain("index('routes/index.tsx')")
-      expect(routeConfig).toContain("route('sources', 'routes/sources.tsx', [")
+      expect(routeConfig).toContain(
+        "route(routePattern('workspaceSources'), 'routes/sources.tsx', [",
+      )
       expect(routeConfig).toContain("route(':sourceName', 'routes/source-detail.tsx')")
       // Schema is a layout with nested table-detail routes.
-      expect(routeConfig).toContain("route('schema', 'routes/schema.tsx', [")
+      expect(routeConfig).toContain("route(routePattern('workspaceSchema'), 'routes/schema.tsx', [")
       expect(routeConfig).toContain("index('routes/schema-empty.tsx')")
       expect(routeConfig).toContain("route(':schemaName/:tableName', 'routes/schema-table.tsx')")
-      expect(routeConfig).toContain("route('traces', 'routes/traces.tsx', [")
+      expect(routeConfig).toContain("route(routePattern('workspaceTraces'), 'routes/traces.tsx', [")
       expect(routeConfig).toContain("route(':traceId', 'routes/trace-detail.tsx')")
       // Settings is gated to the desktop build, but the route entry is still present.
-      expect(routeConfig).toContain("route('settings', 'routes/settings.tsx')")
+      expect(routeConfig).toContain("route(routePattern('settings'), 'routes/settings.tsx')")
 
       // Structural check: the OAuth streaming resource route stays outside the
-      // app shell, while rendered app pages are nested inside it and settings
-      // keeps its desktop-only conditional spread.
+      // app shell, while canonical workspace routes and settings stay inside it.
       expect(routeConfig).toMatch(
-        /export default \[\s*(?:\/\/[^\n]*\n\s*)*route\('sources\/:sourceName\/oauth-install', 'routes\/source-oauth-install\.ts'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[\s*index\('routes\/index\.tsx'\),\s*route\('sources', 'routes\/sources\.tsx',\s*\[\s*route\(':sourceName', 'routes\/source-detail\.tsx'\),?\s*\]\),\s*route\('schema', 'routes\/schema\.tsx', \[\s*index\('routes\/schema-empty\.tsx'\),\s*route\(':schemaName\/:tableName', 'routes\/schema-table\.tsx'\),?\s*\]\),\s*route\('traces', 'routes\/traces\.tsx',\s*\[\s*route\(':traceId', 'routes\/trace-detail\.tsx'\),?\s*\]\),\s*\.\.\.\(\s*isDesktopApp\s*\?\s*\[route\('settings', 'routes\/settings\.tsx'\)\]\s*:\s*\[\]\),?\s*\]\s*\)/,
+        /export default \[\s*(?:\/\/[^\n]*\n\s*)*route\('sources\/:sourceName\/oauth-install', 'routes\/source-oauth-install\.ts'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\] satisfies RouteConfig/,
       )
     })
 

--- a/apps/reef/app/components/sidebar/sidebar.test.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.test.tsx
@@ -5,16 +5,33 @@ import { render } from 'vitest-browser-react'
 
 import { Sidebar } from './sidebar'
 import { SIDEBAR_COOKIE_NAME } from './sidebar-state'
+import { routePath, routePattern } from '@/routing/routemap'
 
-async function renderSidebar(initialIsMinimized: boolean) {
+async function renderSidebar(initialIsMinimized: boolean, initialEntry = routePath('home')) {
   const router = createMemoryRouter(
     [
       {
         element: <Sidebar initialIsMinimized={initialIsMinimized} />,
-        path: '/',
+        path: '/workspaces/:workspaceId/sources/:sourceName?',
+      },
+      {
+        element: <Sidebar initialIsMinimized={initialIsMinimized} />,
+        path: routePattern('workspaceSchemaTable'),
+      },
+      {
+        element: <Sidebar initialIsMinimized={initialIsMinimized} />,
+        path: routePattern('workspaceSchema'),
+      },
+      {
+        element: <Sidebar initialIsMinimized={initialIsMinimized} />,
+        path: '/workspaces/:workspaceId/traces/:traceId?',
+      },
+      {
+        element: <Sidebar initialIsMinimized={initialIsMinimized} />,
+        path: '*',
       },
     ],
-    { initialEntries: ['/'] },
+    { initialEntries: [initialEntry] },
   )
 
   return render(<RouterProvider router={router} />)
@@ -80,5 +97,36 @@ describe('Sidebar', () => {
 
     await expect.element(sidebar).toHaveAttribute('data-sidebar-minimized', 'false')
     await expect.element(screen.getByRole('button', { name: 'Collapse sidebar' })).toBeVisible()
+  })
+
+  it('keeps source navigation in the active workspace', async () => {
+    const screen = await renderSidebar(false, '/workspaces/analytics/sources/github')
+
+    await expect
+      .element(screen.getByRole('link', { name: 'Sources' }))
+      .toHaveAttribute('href', '/workspaces/analytics/sources')
+  })
+
+  it('keeps trace navigation in the active workspace', async () => {
+    const screen = await renderSidebar(false, '/workspaces/analytics/traces/trace-1')
+
+    await expect
+      .element(screen.getByRole('link', { name: 'Traces' }))
+      .toHaveAttribute('href', '/workspaces/analytics/traces')
+  })
+
+  it('keeps schema navigation in the active workspace', async () => {
+    const screen = await renderSidebar(
+      false,
+      routePath('workspaceSchemaTable', {
+        schemaName: 'github',
+        tableName: 'issues',
+        workspaceId: 'analytics',
+      }),
+    )
+
+    await expect
+      .element(screen.getByRole('link', { name: 'Schema' }))
+      .toHaveAttribute('href', routePath('workspaceSchema', { workspaceId: 'analytics' }))
   })
 })

--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { NavLink, useLocation } from 'react-router'
+import { NavLink, useLocation, useParams } from 'react-router'
 
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
 import { IconButton } from '@/wax/components/button'
@@ -9,6 +9,7 @@ import { Tooltip } from '@/wax/components/tooltip'
 import { Typography } from '@/wax/components/typography'
 import type { IconName } from '@/wax/components/icon'
 import { isCoralDesktopBuild } from '@/lib/coral-desktop'
+import { routePath } from '@/routing/routemap'
 
 import * as styles from './sidebar.css'
 import { useSidebarState } from './use-sidebar-state'
@@ -17,17 +18,23 @@ interface SidebarProps {
   initialIsMinimized: boolean
 }
 
-const NAV_ITEMS = [
-  { icon: 'Plug', label: 'Sources', paths: ['/', '/sources'], to: '/sources' },
-  { icon: 'Database', label: 'Schema', paths: ['/schema'], to: '/schema' },
-  { icon: 'Activity', label: 'Traces', paths: ['/traces'], to: '/traces' },
-] satisfies Array<{ icon: IconName; label: string; paths: string[]; to: string }>
-
 export function Sidebar({ initialIsMinimized }: SidebarProps) {
   const location = useLocation()
+  const { workspaceId } = useParams()
   const { isMinimized, toggleSidebar } = useSidebarState(initialIsMinimized)
+  const sourcesPath = workspaceId
+    ? routePath('workspaceSources', { workspaceId })
+    : routePath('home')
+  const schemaPath = workspaceId ? routePath('workspaceSchema', { workspaceId }) : routePath('home')
+  const tracesPath = workspaceId ? routePath('workspaceTraces', { workspaceId }) : routePath('home')
+  const navItems = [
+    { icon: 'Plug', label: 'Sources', paths: [routePath('home'), sourcesPath], to: sourcesPath },
+    { icon: 'Database', label: 'Schema', paths: [schemaPath], to: schemaPath },
+    { icon: 'Activity', label: 'Traces', paths: [tracesPath], to: tracesPath },
+  ] satisfies Array<{ icon: IconName; label: string; paths: string[]; to: string }>
   const isSettingsActive =
-    location.pathname === '/settings' || location.pathname.startsWith('/settings/')
+    location.pathname === routePath('settings') ||
+    location.pathname.startsWith(`${routePath('settings')}/`)
   // Keep the desktop-only settings link stable across SSR and hydration. The
   // actual bridge can only be detected on the client, but the route is included
   // at build time for Electron and omitted from the web build.
@@ -40,7 +47,7 @@ export function Sidebar({ initialIsMinimized }: SidebarProps) {
       icon="Settings"
       isActive={isSettingsActive}
       isMinimized={isMinimized}
-      to="/settings"
+      to={routePath('settings')}
     >
       Settings
     </SidebarButton>
@@ -105,8 +112,10 @@ export function Sidebar({ initialIsMinimized }: SidebarProps) {
       </div>
 
       <div className={styles.nav}>
-        {NAV_ITEMS.map((item) => {
-          const isActive = item.paths.includes(location.pathname)
+        {navItems.map((item) => {
+          const isActive = item.paths.some(
+            (path) => location.pathname === path || location.pathname.startsWith(`${path}/`),
+          )
           const button = (
             <SidebarButton
               aria-label={item.label}

--- a/apps/reef/app/lib/constants.ts
+++ b/apps/reef/app/lib/constants.ts
@@ -1,3 +1,2 @@
 export const DEFAULT_DEV_CORAL_ENDPOINT = 'http://127.0.0.1:1457'
 export const DEFAULT_DEV_CORAL_PORT = '1457'
-export const WORKSPACE = { name: 'default' } as const

--- a/apps/reef/app/lib/coral-request.server.ts
+++ b/apps/reef/app/lib/coral-request.server.ts
@@ -4,15 +4,17 @@ import { createGrpcWebTransport } from '@connectrpc/connect-web'
 import { CatalogService } from '@/generated/coral/v1/catalog_pb'
 import { SourceService } from '@/generated/coral/v1/sources_pb'
 import { TraceService } from '@/generated/coral/v1/traces_pb'
+import { WorkspaceService } from '@/generated/coral/v1/workspaces_pb'
 
 import { DEFAULT_DEV_CORAL_ENDPOINT } from './constants'
 import { isLocalDevOrigin, trimTrailingSlash } from './utils'
 
 export function sourceClientForRequest(request: Request) {
-  return createClient(
-    SourceService,
-    createGrpcWebTransport({ baseUrl: coralEndpointForRequest(request) }),
-  )
+  return createClient(SourceService, coralTransportForRequest(request))
+}
+
+export function workspaceClientForRequest(request: Request) {
+  return createClient(WorkspaceService, coralTransportForRequest(request))
 }
 
 export function catalogClientForRequest(request: Request) {
@@ -23,10 +25,7 @@ export function catalogClientForRequest(request: Request) {
 }
 
 export function traceClientForRequest(request: Request) {
-  return createClient(
-    TraceService,
-    createGrpcWebTransport({ baseUrl: coralEndpointForRequest(request) }),
-  )
+  return createClient(TraceService, coralTransportForRequest(request))
 }
 
 export function coralEndpointForRequest(request: Request): string {
@@ -40,4 +39,8 @@ export function coralEndpointForRequest(request: Request): string {
   const url = new URL(request.url)
   if (isLocalDevOrigin(url)) return DEFAULT_DEV_CORAL_ENDPOINT
   return url.origin
+}
+
+function coralTransportForRequest(request: Request) {
+  return createGrpcWebTransport({ baseUrl: coralEndpointForRequest(request) })
 }

--- a/apps/reef/app/lib/schema-explorer.ts
+++ b/apps/reef/app/lib/schema-explorer.ts
@@ -9,8 +9,7 @@ import {
   type ListColumnsResponse,
   type TableSummary,
 } from '@/generated/coral/v1/catalog_pb'
-
-import { WORKSPACE } from './constants'
+import type { Workspace } from '@/generated/coral/v1/resources_pb'
 
 export type CatalogClient = Client<typeof CatalogService>
 
@@ -46,9 +45,10 @@ const COLUMN_PAGE_CONCURRENCY = 6
 
 export async function fetchSchemaFromCoral(
   catalogClient: CatalogClient,
+  workspace: Workspace,
   signal?: AbortSignal,
 ): Promise<SchemaResponse> {
-  const tableSummaries = await listTables(catalogClient, signal)
+  const tableSummaries = await listTables(catalogClient, workspace, signal)
   if (tableSummaries.length === 0) return { connectors: [] }
 
   const schemaMap = new Map<string, TableDef[]>()
@@ -78,12 +78,13 @@ export async function fetchSchemaFromCoral(
 
 async function listTables(
   catalogClient: CatalogClient,
+  workspace: Workspace,
   signal?: AbortSignal,
 ): Promise<TableSummary[]> {
   const response = await catalogClient.listCatalog(
     create(ListCatalogRequestSchema, {
       kind: CatalogItemKind.TABLE,
-      workspace: WORKSPACE,
+      workspace,
     }),
     { signal },
   )
@@ -93,11 +94,19 @@ async function listTables(
 
 export async function fetchTableColumnsFromCoral(
   catalogClient: CatalogClient,
+  workspace: Workspace,
   schemaName: string,
   tableName: string,
   signal?: AbortSignal,
 ): Promise<ColumnDef[]> {
-  const firstPage = await listColumnsPage(catalogClient, schemaName, tableName, 0, signal)
+  const firstPage = await listColumnsPage(
+    catalogClient,
+    workspace,
+    schemaName,
+    tableName,
+    0,
+    signal,
+  )
   const columns = columnsFromResponse(firstPage)
   const pagination = firstPage.pagination
   if (!pagination?.hasMore) return columns
@@ -107,14 +116,21 @@ export async function fetchTableColumnsFromCoral(
     const remainingPages = await mapWithConcurrency(
       pageOffsets(nextOffset, pagination.totalCount, COLUMN_PAGE_LIMIT),
       COLUMN_PAGE_CONCURRENCY,
-      (offset) => listColumnsPage(catalogClient, schemaName, tableName, offset, signal),
+      (offset) => listColumnsPage(catalogClient, workspace, schemaName, tableName, offset, signal),
     )
     return columns.concat(remainingPages.flatMap(columnsFromResponse))
   }
 
   let offset = pagination.nextOffset
   while (offset > 0) {
-    const page = await listColumnsPage(catalogClient, schemaName, tableName, offset, signal)
+    const page = await listColumnsPage(
+      catalogClient,
+      workspace,
+      schemaName,
+      tableName,
+      offset,
+      signal,
+    )
     columns.push(...columnsFromResponse(page))
     if (!page.pagination?.hasMore) break
     offset = page.pagination.nextOffset
@@ -124,6 +140,7 @@ export async function fetchTableColumnsFromCoral(
 
 async function listColumnsPage(
   catalogClient: CatalogClient,
+  workspace: Workspace,
   schemaName: string,
   tableName: string,
   offset: number,
@@ -137,7 +154,7 @@ async function listColumnsPage(
       },
       schemaName,
       tableName,
-      workspace: WORKSPACE,
+      workspace,
     }),
     { signal },
   )

--- a/apps/reef/app/lib/workspace-redirect.server.test.ts
+++ b/apps/reef/app/lib/workspace-redirect.server.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { firstWorkspaceForRequest } = vi.hoisted(() => ({
+  firstWorkspaceForRequest: vi.fn(),
+}))
+
+vi.mock('@/lib/workspaces.server', () => ({ firstWorkspaceForRequest }))
+
+import { redirectToFirstWorkspaceSources } from './workspace-redirect.server'
+
+describe('redirectToFirstWorkspaceSources', () => {
+  beforeEach(() => {
+    firstWorkspaceForRequest.mockReset()
+    firstWorkspaceForRequest.mockResolvedValue({ name: 'team alpha' })
+  })
+
+  it('redirects the app index to the first workspace sources and preserves its query', async () => {
+    const response = await redirectToFirstWorkspaceSources(
+      new Request('http://localhost/?from=index'),
+    )
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('/workspaces/team%20alpha/sources?from=index')
+  })
+})

--- a/apps/reef/app/lib/workspace-redirect.server.ts
+++ b/apps/reef/app/lib/workspace-redirect.server.ts
@@ -1,0 +1,10 @@
+import { redirect } from 'react-router'
+
+import { firstWorkspaceForRequest } from '@/lib/workspaces.server'
+import { routePath } from '@/routing/routemap'
+
+export async function redirectToFirstWorkspaceSources(request: Request): Promise<Response> {
+  const workspace = await firstWorkspaceForRequest(request)
+  const search = new URL(request.url).search
+  return redirect(`${routePath('workspaceSources', { workspaceId: workspace.name })}${search}`)
+}

--- a/apps/reef/app/lib/workspace-routing.test.ts
+++ b/apps/reef/app/lib/workspace-routing.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+
+import { workspaceFromParams } from './workspace-routing'
+
+describe('workspace routing', () => {
+  it('treats the workspace route parameter as the local workspace name', () => {
+    expect(workspaceFromParams({ workspaceId: 'analytics' }).name).toBe('analytics')
+  })
+})

--- a/apps/reef/app/lib/workspace-routing.ts
+++ b/apps/reef/app/lib/workspace-routing.ts
@@ -1,0 +1,14 @@
+import { create } from '@bufbuild/protobuf'
+
+import { WorkspaceSchema, type Workspace } from '@/generated/coral/v1/resources_pb'
+
+export function workspaceFromParams(params: { workspaceId?: string }): Workspace {
+  const workspaceId = params.workspaceId
+  if (!workspaceId) {
+    throw new Response('Missing workspace route parameter.', {
+      status: 400,
+      statusText: 'Invalid Workspace',
+    })
+  }
+  return create(WorkspaceSchema, { name: workspaceId })
+}

--- a/apps/reef/app/lib/workspaces.server.test.ts
+++ b/apps/reef/app/lib/workspaces.server.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { listWorkspaces, workspaceClientForRequest } = vi.hoisted(() => ({
+  listWorkspaces: vi.fn(),
+  workspaceClientForRequest: vi.fn(),
+}))
+
+vi.mock('@/lib/coral-request.server', () => ({ workspaceClientForRequest }))
+
+import { firstWorkspaceForRequest, listWorkspacesForRequest } from './workspaces.server'
+
+describe('local workspaces', () => {
+  beforeEach(() => {
+    listWorkspaces.mockReset()
+    workspaceClientForRequest.mockReset()
+    workspaceClientForRequest.mockReturnValue({ listWorkspaces })
+  })
+
+  it('lists workspaces through the local WorkspaceService and selects the first', async () => {
+    const request = new Request('http://localhost/')
+    listWorkspaces.mockResolvedValue({
+      workspaces: [{ name: 'default' }, { name: 'analytics' }],
+    })
+
+    await expect(listWorkspacesForRequest(request)).resolves.toEqual([
+      { name: 'default' },
+      { name: 'analytics' },
+    ])
+    await expect(firstWorkspaceForRequest(request)).resolves.toEqual({ name: 'default' })
+    expect(workspaceClientForRequest).toHaveBeenCalledWith(request)
+  })
+
+  it('returns a clear route error when no local workspace exists', async () => {
+    listWorkspaces.mockResolvedValue({ workspaces: [] })
+
+    await expect(firstWorkspaceForRequest(new Request('http://localhost/'))).rejects.toMatchObject({
+      status: 404,
+      statusText: 'Workspace Not Found',
+    })
+  })
+})

--- a/apps/reef/app/lib/workspaces.server.ts
+++ b/apps/reef/app/lib/workspaces.server.ts
@@ -1,0 +1,17 @@
+import type { Workspace } from '@/generated/coral/v1/resources_pb'
+import { workspaceClientForRequest } from '@/lib/coral-request.server'
+
+export async function listWorkspacesForRequest(request: Request): Promise<Workspace[]> {
+  const response = await workspaceClientForRequest(request).listWorkspaces({})
+  return response.workspaces
+}
+
+export async function firstWorkspaceForRequest(request: Request): Promise<Workspace> {
+  const [workspace] = await listWorkspacesForRequest(request)
+  if (workspace) return workspace
+
+  throw new Response('No Coral workspace is configured.', {
+    status: 404,
+    statusText: 'Workspace Not Found',
+  })
+}

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -1,5 +1,7 @@
 import { type RouteConfig, index, layout, route } from '@react-router/dev/routes'
 
+import { routePattern } from './routing/routemap'
+
 // Settings is a desktop-only surface (it drives the Electron MCP bridge); the
 // web build omits it so browser users don't hit a dead "bridge unavailable" page.
 const isDesktopApp = process.env.CORAL_DESKTOP_APP === '1'
@@ -11,12 +13,16 @@ export default [
   route('sources/:sourceName/oauth-install', 'routes/source-oauth-install.ts'),
   layout('routes/app-shell.tsx', [
     index('routes/index.tsx'),
-    route('sources', 'routes/sources.tsx', [route(':sourceName', 'routes/source-detail.tsx')]),
-    route('schema', 'routes/schema.tsx', [
+    route(routePattern('workspaceSources'), 'routes/sources.tsx', [
+      route(':sourceName', 'routes/source-detail.tsx'),
+    ]),
+    route(routePattern('workspaceSchema'), 'routes/schema.tsx', [
       index('routes/schema-empty.tsx'),
       route(':schemaName/:tableName', 'routes/schema-table.tsx'),
     ]),
-    route('traces', 'routes/traces.tsx', [route(':traceId', 'routes/trace-detail.tsx')]),
-    ...(isDesktopApp ? [route('settings', 'routes/settings.tsx')] : []),
+    route(routePattern('workspaceTraces'), 'routes/traces.tsx', [
+      route(':traceId', 'routes/trace-detail.tsx'),
+    ]),
+    ...(isDesktopApp ? [route(routePattern('settings'), 'routes/settings.tsx')] : []),
   ]),
 ] satisfies RouteConfig

--- a/apps/reef/app/routes/index.tsx
+++ b/apps/reef/app/routes/index.tsx
@@ -1,10 +1,11 @@
 import type { Route } from './+types/index'
 
-import { SourcesIndex } from '@/views/sources/sources-index'
+import { redirectToFirstWorkspaceSources } from '@/lib/workspace-redirect.server'
 
-export { action } from './sources-action'
-export { loader } from './sources-loader'
+export async function loader({ request }: Route.LoaderArgs) {
+  return redirectToFirstWorkspaceSources(request)
+}
 
-export default function AppIndex({ loaderData }: Route.ComponentProps) {
-  return <SourcesIndex entries={loaderData.entries} loadError={loaderData.loadError} />
+export default function AppIndex() {
+  return null
 }

--- a/apps/reef/app/routes/schema-loaders.server.test.ts
+++ b/apps/reef/app/routes/schema-loaders.server.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { catalogClientForRequest, fetchSchemaFromCoral, fetchTableColumnsFromCoral } = vi.hoisted(
+  () => ({
+    catalogClientForRequest: vi.fn(),
+    fetchSchemaFromCoral: vi.fn(),
+    fetchTableColumnsFromCoral: vi.fn(),
+  }),
+)
+
+vi.mock('@/lib/coral-request.server', () => ({ catalogClientForRequest }))
+vi.mock('@/lib/schema-explorer', () => ({ fetchSchemaFromCoral, fetchTableColumnsFromCoral }))
+
+import { loader as schemaLoader } from './schema'
+import { loader as schemaTableLoader } from './schema-table'
+
+describe('schema loaders', () => {
+  const catalogClient = { name: 'catalog-client' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    catalogClientForRequest.mockReturnValue(catalogClient)
+  })
+
+  it('lists catalog tables for the workspace route parameter', async () => {
+    const request = new Request('http://reef.test/workspaces/analytics/schema')
+    const schema = { connectors: [] }
+    fetchSchemaFromCoral.mockResolvedValue(schema)
+
+    await expect(
+      schemaLoader({ params: { workspaceId: 'analytics' }, request } as Parameters<
+        typeof schemaLoader
+      >[0]),
+    ).resolves.toEqual({ schema })
+    expect(fetchSchemaFromCoral).toHaveBeenCalledWith(
+      catalogClient,
+      expect.objectContaining({ name: 'analytics' }),
+      request.signal,
+    )
+  })
+
+  it('lists table columns for the workspace route parameter', async () => {
+    const request = new Request('http://reef.test/workspaces/analytics/schema/github/issues')
+    fetchTableColumnsFromCoral.mockResolvedValue([])
+
+    await expect(
+      schemaTableLoader({
+        params: {
+          schemaName: 'github',
+          tableName: 'issues',
+          workspaceId: 'analytics',
+        },
+        request,
+      } as Parameters<typeof schemaTableLoader>[0]),
+    ).resolves.toEqual({ columns: [] })
+    expect(fetchTableColumnsFromCoral).toHaveBeenCalledWith(
+      catalogClient,
+      expect.objectContaining({ name: 'analytics' }),
+      'github',
+      'issues',
+      request.signal,
+    )
+  })
+})

--- a/apps/reef/app/routes/schema-table.tsx
+++ b/apps/reef/app/routes/schema-table.tsx
@@ -1,5 +1,6 @@
 import { fetchTableColumnsFromCoral } from '@/lib/schema-explorer'
 import { catalogClientForRequest } from '@/lib/coral-request.server'
+import { workspaceFromParams } from '@/lib/workspace-routing'
 import { SchemaTableError, SchemaTableView } from '@/views/schema-explorer/schema-table'
 
 import type { Route } from './+types/schema-table'
@@ -12,9 +13,11 @@ import type { Route } from './+types/schema-table'
 // ListColumns calls, so switching tables quickly would otherwise pile up
 // orphaned requests.
 export async function loader({ params, request }: Route.LoaderArgs) {
+  const workspace = workspaceFromParams(params)
   return {
     columns: await fetchTableColumnsFromCoral(
       catalogClientForRequest(request),
+      workspace,
       params.schemaName,
       params.tableName,
       request.signal,

--- a/apps/reef/app/routes/schema.tsx
+++ b/apps/reef/app/routes/schema.tsx
@@ -1,5 +1,6 @@
 import { fetchSchemaFromCoral } from '@/lib/schema-explorer'
 import { catalogClientForRequest } from '@/lib/coral-request.server'
+import { workspaceFromParams } from '@/lib/workspace-routing'
 import { SchemaExplorer, SchemaExplorerError } from '@/views/schema-explorer/schema'
 
 import type { Route } from './+types/schema'
@@ -8,12 +9,15 @@ import type { Route } from './+types/schema'
 // global navigation progress bar is the pending UI and a failure lands in the
 // route ErrorBoundary. The abort signal cancels the catalog request when the
 // navigation is superseded.
-export async function loader({ request }: Route.LoaderArgs) {
-  return { schema: await fetchSchemaFromCoral(catalogClientForRequest(request), request.signal) }
+export async function loader({ params, request }: Route.LoaderArgs) {
+  const workspace = workspaceFromParams(params)
+  return {
+    schema: await fetchSchemaFromCoral(catalogClientForRequest(request), workspace, request.signal),
+  }
 }
 
-export default function SchemaRoute({ loaderData }: Route.ComponentProps) {
-  return <SchemaExplorer schema={loaderData.schema} />
+export default function SchemaRoute({ loaderData, params }: Route.ComponentProps) {
+  return <SchemaExplorer schema={loaderData.schema} workspaceId={params.workspaceId} />
 }
 
 export { SchemaExplorerError as ErrorBoundary }

--- a/apps/reef/app/routes/source-detail.tsx
+++ b/apps/reef/app/routes/source-detail.tsx
@@ -9,9 +9,9 @@ import {
   type Source,
   type SourceInfo,
 } from '@/generated/coral/v1/sources_pb'
+import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { SourceDetailView } from '@/views/sources/source-detail'
 import { sourceClientForRequest } from '@/lib/coral-request.server'
-import { WORKSPACE } from '@/lib/constants'
 import {
   originLabel,
   toCatalogSource,
@@ -19,6 +19,8 @@ import {
   type CatalogEntry,
 } from '@/lib/sources'
 import { errorMessage } from '@/lib/utils'
+import { workspaceFromParams } from '@/lib/workspace-routing'
+import { routePath } from '@/routing/routemap'
 
 interface SourceDetailRouteData {
   entry: CatalogEntry
@@ -30,6 +32,7 @@ export async function loader({
   request,
 }: Route.LoaderArgs): Promise<SourceDetailRouteData> {
   const name = params.sourceName
+  const workspace = workspaceFromParams(params)
   if (!name) {
     return {
       entry: sourceDetailEntry('', null, null),
@@ -39,8 +42,8 @@ export async function loader({
 
   const sourceClient = sourceClientForRequest(request)
   const [sourceResult, infoResult] = await Promise.allSettled([
-    getInstalledSource(sourceClient, name),
-    getSourceInfo(sourceClient, name),
+    getInstalledSource(sourceClient, workspace, name),
+    getSourceInfo(sourceClient, workspace, name),
   ])
   const info = infoResult.status === 'fulfilled' ? infoResult.value : null
 
@@ -60,16 +63,27 @@ export async function action(args: Route.ActionArgs): Promise<SourcesActionData 
   return sourcesAction(args)
 }
 
-export default function SourceDetailRoute({ actionData, loaderData }: Route.ComponentProps) {
-  return <SourceDetailView actionData={actionData} loaderData={loaderData} />
+export default function SourceDetailRoute({
+  actionData,
+  loaderData,
+  params,
+}: Route.ComponentProps) {
+  return (
+    <SourceDetailView
+      actionData={actionData}
+      loaderData={loaderData}
+      sourcesPath={routePath('workspaceSources', { workspaceId: params.workspaceId })}
+    />
+  )
 }
 
 async function getSourceInfo(
   sourceClient: ReturnType<typeof sourceClientForRequest>,
+  workspace: Workspace,
   name: string,
 ): Promise<SourceInfo> {
   const response = await sourceClient.getSourceInfo(
-    create(GetSourceInfoRequestSchema, { name, workspace: WORKSPACE }),
+    create(GetSourceInfoRequestSchema, { name, workspace }),
   )
   if (!response.sourceInfo) throw new Error(`Source info for ${name} was not found`)
   return response.sourceInfo
@@ -77,11 +91,10 @@ async function getSourceInfo(
 
 async function getInstalledSource(
   sourceClient: ReturnType<typeof sourceClientForRequest>,
+  workspace: Workspace,
   name: string,
 ): Promise<Source> {
-  const response = await sourceClient.getSource(
-    create(GetSourceRequestSchema, { name, workspace: WORKSPACE }),
-  )
+  const response = await sourceClient.getSource(create(GetSourceRequestSchema, { name, workspace }))
   if (!response.source) throw new Error(`Source ${name} was not found`)
   return response.source
 }

--- a/apps/reef/app/routes/source-oauth-install.ts
+++ b/apps/reef/app/routes/source-oauth-install.ts
@@ -8,8 +8,8 @@ import {
   type CreateBundledSourceWithOAuthResponse,
   type SourceInfo,
 } from '@/generated/coral/v1/sources_pb'
+import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { sourceClientForRequest } from '@/lib/coral-request.server'
-import { WORKSPACE } from '@/lib/constants'
 import {
   firstMissingRequiredInput,
   firstOAuthMethodInput,
@@ -19,6 +19,7 @@ import {
   splitInstallBindings,
 } from '@/lib/source-install-form'
 import { originLabel } from '@/lib/sources'
+import { firstWorkspaceForRequest } from '@/lib/workspaces.server'
 import {
   oauthInstallEventToNdjson,
   type OAuthInstallStreamEvent,
@@ -47,7 +48,8 @@ export async function action({ params, request }: Route.ActionArgs): Promise<Res
 
   const sourceClient = sourceClientForRequest(request)
   try {
-    const info = await getSourceInfo(sourceClient, name)
+    const workspace = await firstWorkspaceForRequest(request)
+    const info = await getSourceInfo(sourceClient, name, workspace)
     if (info.installed && originLabel(info.origin) !== 'bundled') {
       return ndjsonErrorResponse("Imported sources can't be installed here yet", 400)
     }
@@ -77,7 +79,7 @@ export async function action({ params, request }: Route.ActionArgs): Promise<Res
         oauthCredentialRetrievals,
         secrets,
         variables,
-        workspace: WORKSPACE,
+        workspace,
       }),
       { signal: request.signal },
     )
@@ -176,9 +178,10 @@ function resolveSourceName(paramName: string | undefined, formData: FormData): s
 async function getSourceInfo(
   sourceClient: ReturnType<typeof sourceClientForRequest>,
   name: string,
+  workspace: Workspace,
 ): Promise<SourceInfo> {
   const response = await sourceClient.getSourceInfo(
-    create(GetSourceInfoRequestSchema, { name, workspace: WORKSPACE }),
+    create(GetSourceInfoRequestSchema, { name, workspace }),
   )
   if (!response.sourceInfo) throw new Error(`Source info for ${name} was not found`)
   return response.sourceInfo

--- a/apps/reef/app/routes/sources-action.server.test.ts
+++ b/apps/reef/app/routes/sources-action.server.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { deleteSource } = vi.hoisted(() => ({ deleteSource: vi.fn() }))
+
+vi.mock('@/lib/coral-request.server', () => ({
+  sourceClientForRequest: () => ({ deleteSource }),
+}))
+
+import { action } from './sources-action'
+
+describe('sources action workspace routing', () => {
+  beforeEach(() => {
+    deleteSource.mockReset()
+    deleteSource.mockResolvedValue({})
+  })
+
+  it('deletes from and redirects back to the route workspace', async () => {
+    const request = new Request('http://localhost/workspaces/analytics/sources/github', {
+      body: new URLSearchParams({ _intent: 'delete', name: 'github' }),
+      method: 'POST',
+    })
+
+    const response = await action({ params: { workspaceId: 'analytics' }, request })
+
+    expect(deleteSource).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'github',
+        workspace: expect.objectContaining({ name: 'analytics' }),
+      }),
+    )
+    expect(response).toBeInstanceOf(Response)
+    expect((response as Response).headers.get('location')).toBe('/workspaces/analytics/sources')
+  })
+})

--- a/apps/reef/app/routes/sources-action.ts
+++ b/apps/reef/app/routes/sources-action.ts
@@ -7,8 +7,8 @@ import {
   GetSourceInfoRequestSchema,
   GetSourceRequestSchema,
 } from '@/generated/coral/v1/sources_pb'
+import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { sourceClientForRequest } from '@/lib/coral-request.server'
-import { WORKSPACE } from '@/lib/constants'
 import {
   editBindingsFromForm,
   firstMissingRequiredInput,
@@ -20,6 +20,8 @@ import {
 } from '@/lib/source-install-form'
 import { originLabel } from '@/lib/sources'
 import { errorMessage } from '@/lib/utils'
+import { workspaceFromParams } from '@/lib/workspace-routing'
+import { routePath } from '@/routing/routemap'
 
 export {
   editBindingsFromForm,
@@ -41,20 +43,25 @@ export type SourcesActionData =
     }
   | undefined
 
-export async function action({
-  request,
-}: {
+interface SourcesActionArgs {
+  params: { workspaceId?: string }
   request: Request
-}): Promise<SourcesActionData | Response> {
+}
+
+export async function action({
+  params,
+  request,
+}: SourcesActionArgs): Promise<SourcesActionData | Response> {
   const formData = await request.formData()
   const intent = formValue(formData, '_intent')
   const name = formValue(formData, 'name')
   if (!name) return actionError('install', '', 'Missing source name')
 
+  const workspace = workspaceFromParams(params)
   const sourceClient = sourceClientForRequest(request)
   try {
     if (intent === 'install') {
-      const info = await getSourceInfo(sourceClient, name)
+      const info = await getSourceInfo(sourceClient, workspace, name)
       if (info.installed && originLabel(info.origin) !== 'bundled') {
         return actionError('install', name, "Imported sources can't be installed here yet")
       }
@@ -63,23 +70,31 @@ export async function action({
       }
       const missing = firstMissingRequiredInput(info, formData)
       if (missing) return actionError('install', name, `${missing} is required`)
-      await createBundledSource(sourceClient, name, installBindingsFromForm(info, formData))
-      return redirect('/sources')
+      await createBundledSource(
+        sourceClient,
+        workspace,
+        name,
+        installBindingsFromForm(info, formData),
+      )
+      return redirect(routePath('workspaceSources', { workspaceId: workspace.name }))
     }
     if (intent === 'edit') {
-      const source = await getInstalledSource(sourceClient, name)
+      const source = await getInstalledSource(sourceClient, workspace, name)
       if (originLabel(source.origin) !== 'bundled') {
         return actionError('edit', name, "Imported sources can't be edited here yet")
       }
-      const info = await getSourceInfo(sourceClient, name).catch(() => null)
-      await createBundledSource(sourceClient, name, editBindingsFromForm(source, info, formData))
-      return redirect('/sources')
+      const info = await getSourceInfo(sourceClient, workspace, name).catch(() => null)
+      await createBundledSource(
+        sourceClient,
+        workspace,
+        name,
+        editBindingsFromForm(source, info, formData),
+      )
+      return redirect(routePath('workspaceSources', { workspaceId: workspace.name }))
     }
     if (intent === 'delete') {
-      await sourceClient.deleteSource(
-        create(DeleteSourceRequestSchema, { name, workspace: WORKSPACE }),
-      )
-      return redirect('/sources')
+      await sourceClient.deleteSource(create(DeleteSourceRequestSchema, { name, workspace }))
+      return redirect(routePath('workspaceSources', { workspaceId: workspace.name }))
     }
     return actionError('install', name, 'Unknown source action')
   } catch (error) {
@@ -93,10 +108,11 @@ export async function action({
 
 async function getSourceInfo(
   sourceClient: ReturnType<typeof sourceClientForRequest>,
+  workspace: Workspace,
   name: string,
 ) {
   const response = await sourceClient.getSourceInfo(
-    create(GetSourceInfoRequestSchema, { name, workspace: WORKSPACE }),
+    create(GetSourceInfoRequestSchema, { name, workspace }),
   )
   if (!response.sourceInfo) throw new Error(`Source info for ${name} was not found`)
   return response.sourceInfo
@@ -104,17 +120,17 @@ async function getSourceInfo(
 
 async function getInstalledSource(
   sourceClient: ReturnType<typeof sourceClientForRequest>,
+  workspace: Workspace,
   name: string,
 ) {
-  const response = await sourceClient.getSource(
-    create(GetSourceRequestSchema, { name, workspace: WORKSPACE }),
-  )
+  const response = await sourceClient.getSource(create(GetSourceRequestSchema, { name, workspace }))
   if (!response.source) throw new Error(`Source ${name} was not found`)
   return response.source
 }
 
 async function createBundledSource(
   sourceClient: ReturnType<typeof sourceClientForRequest>,
+  workspace: Workspace,
   name: string,
   bindings: InstallInput[],
 ) {
@@ -122,7 +138,7 @@ async function createBundledSource(
   const response = await sourceClient.createBundledSource(
     create(CreateBundledSourceRequestSchema, {
       name,
-      workspace: WORKSPACE,
+      workspace,
       variables,
       secrets,
     }),

--- a/apps/reef/app/routes/sources-loader.ts
+++ b/apps/reef/app/routes/sources-loader.ts
@@ -6,33 +6,40 @@ import {
   DiscoverSourcesRequestSchema,
   ListSourcesRequestSchema,
 } from '@/generated/coral/v1/sources_pb'
-import { WORKSPACE } from '@/lib/constants'
+import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { sourceClientForRequest } from '@/lib/coral-request.server'
 import { catalogEntries, type CatalogEntry } from '@/lib/sources'
 import { errorMessage } from '@/lib/utils'
+import { workspaceFromParams } from '@/lib/workspace-routing'
 
 export interface SourcesRouteData {
   entries: CatalogEntry[]
   loadError: string | null
 }
 
-export async function loader({ request }: Route.LoaderArgs): Promise<SourcesRouteData> {
-  return loadSourcesRouteData(request)
+export async function loader({ params, request }: Route.LoaderArgs): Promise<SourcesRouteData> {
+  return loadSourcesRouteData(request, workspaceFromParams(params))
 }
 
-export async function loadSourcesRouteData(request: Request): Promise<SourcesRouteData> {
+export async function loadSourcesRouteData(
+  request: Request,
+  workspace: Workspace,
+): Promise<SourcesRouteData> {
   try {
-    return { entries: await listCatalogForRequest(request), loadError: null }
+    return { entries: await listCatalogForRequest(request, workspace), loadError: null }
   } catch (error) {
     return { entries: [], loadError: errorMessage(error) }
   }
 }
 
-export async function listCatalogForRequest(request: Request): Promise<CatalogEntry[]> {
+export async function listCatalogForRequest(
+  request: Request,
+  workspace: Workspace,
+): Promise<CatalogEntry[]> {
   const sourceClient = sourceClientForRequest(request)
   const [discovered, installed] = await Promise.all([
-    sourceClient.discoverSources(create(DiscoverSourcesRequestSchema, { workspace: WORKSPACE })),
-    sourceClient.listSources(create(ListSourcesRequestSchema, { workspace: WORKSPACE })),
+    sourceClient.discoverSources(create(DiscoverSourcesRequestSchema, { workspace })),
+    sourceClient.listSources(create(ListSourcesRequestSchema, { workspace })),
   ])
   return catalogEntries(discovered.sources, installed.sources)
 }

--- a/apps/reef/app/routes/sources.test.ts
+++ b/apps/reef/app/routes/sources.test.ts
@@ -8,10 +8,10 @@ function revalidationArgs(
 ): ShouldRevalidateFunctionArgs {
   return {
     currentParams: {},
-    currentUrl: new URL('http://localhost/sources'),
+    currentUrl: new URL('http://localhost/workspaces/default/sources'),
     defaultShouldRevalidate: true,
     nextParams: {},
-    nextUrl: new URL('http://localhost/sources/github'),
+    nextUrl: new URL('http://localhost/workspaces/default/sources/github'),
     ...overrides,
   }
 }
@@ -21,22 +21,34 @@ describe('sources shouldRevalidate', () => {
     expect(
       shouldRevalidate(
         revalidationArgs({
-          currentUrl: new URL('http://localhost/sources'),
+          currentUrl: new URL('http://localhost/workspaces/default/sources'),
           defaultShouldRevalidate: true,
-          nextUrl: new URL('http://localhost/sources/github'),
+          nextUrl: new URL('http://localhost/workspaces/default/sources/github'),
         }),
       ),
     ).toBe(false)
   })
 
-  it('revalidates the catalog after source mutations even when the action redirects to /sources', () => {
+  it('revalidates the catalog after source mutations', () => {
     expect(
       shouldRevalidate(
         revalidationArgs({
-          currentUrl: new URL('http://localhost/sources/github'),
+          currentUrl: new URL('http://localhost/workspaces/default/sources/github'),
           defaultShouldRevalidate: false,
           formMethod: 'POST',
-          nextUrl: new URL('http://localhost/sources'),
+          nextUrl: new URL('http://localhost/workspaces/default/sources'),
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('revalidates when navigating between workspaces', () => {
+    expect(
+      shouldRevalidate(
+        revalidationArgs({
+          currentUrl: new URL('http://localhost/workspaces/default/sources/github'),
+          defaultShouldRevalidate: true,
+          nextUrl: new URL('http://localhost/workspaces/analytics/sources/github'),
         }),
       ),
     ).toBe(true)

--- a/apps/reef/app/routes/sources.tsx
+++ b/apps/reef/app/routes/sources.tsx
@@ -1,8 +1,9 @@
-import { Outlet, type ShouldRevalidateFunctionArgs } from 'react-router'
+import { matchPath, Outlet, type ShouldRevalidateFunctionArgs } from 'react-router'
 
 import type { Route } from './+types/sources'
 
 import { SourcesIndex } from '@/views/sources/sources-index'
+import { routePattern } from '@/routing/routemap'
 
 export { action } from './sources-action'
 export { loader } from './sources-loader'
@@ -24,17 +25,26 @@ export function shouldRevalidate({
 }
 
 function isSourcesDetailNavigation(currentPath: string, nextPath: string) {
-  const sourcesPath = '/sources'
-  const sourceDetailPath = /^\/sources\/[^/]+$/
-  const currentIsSources = currentPath === sourcesPath || sourceDetailPath.test(currentPath)
-  const nextIsSources = nextPath === sourcesPath || sourceDetailPath.test(nextPath)
-  return currentIsSources && nextIsSources
+  const currentWorkspace = sourcesWorkspaceId(currentPath)
+  const nextWorkspace = sourcesWorkspaceId(nextPath)
+  return currentWorkspace !== undefined && currentWorkspace === nextWorkspace
 }
 
-export default function SourcesRoute({ loaderData }: Route.ComponentProps) {
+function sourcesWorkspaceId(pathname: string): string | undefined {
+  return (
+    matchPath(routePattern('workspaceSource'), pathname) ??
+    matchPath(routePattern('workspaceSources'), pathname)
+  )?.params.workspaceId
+}
+
+export default function SourcesRoute({ loaderData, params }: Route.ComponentProps) {
   return (
     <>
-      <SourcesIndex entries={loaderData.entries} loadError={loaderData.loadError} />
+      <SourcesIndex
+        entries={loaderData.entries}
+        loadError={loaderData.loadError}
+        workspaceId={params.workspaceId}
+      />
       <Outlet />
     </>
   )

--- a/apps/reef/app/routes/trace-detail-loader.server.test.ts
+++ b/apps/reef/app/routes/trace-detail-loader.server.test.ts
@@ -24,7 +24,7 @@ function detail(traceId: string): TraceDetailData {
 }
 
 describe('trace detail loader', () => {
-  const request = new Request('http://reef.test/traces/trace-07')
+  const request = new Request('http://reef.test/workspaces/analytics/traces/trace-07')
 
   it('loads the URL-selected trace without decoding it again', async () => {
     const getTrace = vi.fn().mockResolvedValue(detail('trace/with?reserved'))

--- a/apps/reef/app/routes/traces-loader.server.test.ts
+++ b/apps/reef/app/routes/traces-loader.server.test.ts
@@ -21,7 +21,7 @@ function summary(traceId: string, query = `select '${traceId}'`): TraceSummaryDa
 }
 
 describe('traces list loader', () => {
-  const request = new Request('http://reef.test/traces')
+  const request = new Request('http://reef.test/workspaces/analytics/traces')
 
   it('filters query traces and returns a deterministic endpoint label', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(123_456)

--- a/apps/reef/app/routes/traces-middleware.server.test.ts
+++ b/apps/reef/app/routes/traces-middleware.server.test.ts
@@ -1,4 +1,4 @@
-import { createRequestHandler, type ServerBuild } from 'react-router'
+import { createRequestHandler, type LoaderFunctionArgs, type ServerBuild } from 'react-router'
 import { describe, expect, it } from 'vitest'
 
 import { middleware } from './traces'
@@ -38,7 +38,7 @@ const build = {
       id: 'routes/trace-detail',
       module: {
         default: routeComponent,
-        loader: ({ params }) => ({ traceId: params.traceId }),
+        loader: ({ params }: LoaderFunctionArgs) => ({ traceId: params.traceId }),
       },
       parentId: 'routes/traces',
       path: ':traceId',
@@ -51,14 +51,14 @@ const build = {
         middleware,
       },
       parentId: 'root',
-      path: 'traces',
+      path: 'workspaces/:workspaceId/traces',
     },
   },
   ssr: true,
-} as ServerBuild
+} as unknown as ServerBuild
 
 describe('traces response cache policy', () => {
-  it.each(['/traces.data', '/traces/example.data'])(
+  it.each(['/workspaces/analytics/traces.data', '/workspaces/analytics/traces/example.data'])(
     'marks the final %s response as private and non-cacheable',
     async (pathname) => {
       const handleRequest = createRequestHandler(build, 'test')

--- a/apps/reef/app/routes/traces.test.tsx
+++ b/apps/reef/app/routes/traces.test.tsx
@@ -12,6 +12,10 @@ import { render } from 'vitest-browser-react'
 
 import { shouldRevalidate } from './traces'
 import { traceLocation } from '@/views/traces/trace-location'
+import { routePath } from '@/routing/routemap'
+
+const WORKSPACE_ID = 'analytics'
+const TRACES_PATH = routePath('workspaceTraces', { workspaceId: WORKSPACE_ID })
 
 function revalidationArgs(
   currentPath: string,
@@ -21,10 +25,16 @@ function revalidationArgs(
   overrides: Partial<ShouldRevalidateFunctionArgs> = {},
 ): ShouldRevalidateFunctionArgs {
   return {
-    currentParams: currentTraceId === undefined ? {} : { traceId: currentTraceId },
+    currentParams: {
+      workspaceId: WORKSPACE_ID,
+      ...(currentTraceId === undefined ? {} : { traceId: currentTraceId }),
+    },
     currentUrl: new URL(`http://localhost${currentPath}`),
     defaultShouldRevalidate: true,
-    nextParams: nextTraceId === undefined ? {} : { traceId: nextTraceId },
+    nextParams: {
+      workspaceId: WORKSPACE_ID,
+      ...(nextTraceId === undefined ? {} : { traceId: nextTraceId }),
+    },
     nextUrl: new URL(`http://localhost${nextPath}`),
     ...overrides,
   }
@@ -32,8 +42,8 @@ function revalidationArgs(
 
 describe('traces shouldRevalidate', () => {
   it.each([
-    ['/traces', '/traces/trace-a', undefined, 'trace-a'],
-    ['/traces/trace-a', '/traces/trace-b', 'trace-a', 'trace-b'],
+    [TRACES_PATH, `${TRACES_PATH}/trace-a`, undefined, 'trace-a'],
+    [`${TRACES_PATH}/trace-a`, `${TRACES_PATH}/trace-b`, 'trace-a', 'trace-b'],
   ])(
     'skips the parent loader for %s -> %s',
     (currentPath, nextPath, currentTraceId, nextTraceId) => {
@@ -46,7 +56,7 @@ describe('traces shouldRevalidate', () => {
   it('revalidates the parent loader when returning from detail to the list', () => {
     expect(
       shouldRevalidate(
-        revalidationArgs('/traces/trace-b', '/traces', 'trace-b', undefined, {
+        revalidationArgs(`${TRACES_PATH}/trace-b`, TRACES_PATH, 'trace-b', undefined, {
           defaultShouldRevalidate: false,
         }),
       ),
@@ -56,14 +66,14 @@ describe('traces shouldRevalidate', () => {
   it('delegates same-URL and unrelated navigation to React Router', () => {
     expect(
       shouldRevalidate(
-        revalidationArgs('/traces', '/traces', undefined, undefined, {
+        revalidationArgs(TRACES_PATH, TRACES_PATH, undefined, undefined, {
           defaultShouldRevalidate: false,
         }),
       ),
     ).toBe(false)
     expect(
       shouldRevalidate(
-        revalidationArgs('/traces', '/sources', undefined, undefined, {
+        revalidationArgs(TRACES_PATH, '/workspaces/analytics/sources', undefined, undefined, {
           defaultShouldRevalidate: true,
         }),
       ),
@@ -71,8 +81,23 @@ describe('traces shouldRevalidate', () => {
     expect(
       shouldRevalidate(
         revalidationArgs(
-          '/traces/trace-a?search=one',
-          '/traces/trace-a?search=two',
+          `${TRACES_PATH}/trace-a`,
+          '/workspaces/other/traces/trace-a',
+          'trace-a',
+          'trace-a',
+          {
+            currentParams: { traceId: 'trace-a', workspaceId: WORKSPACE_ID },
+            defaultShouldRevalidate: false,
+            nextParams: { traceId: 'trace-a', workspaceId: 'other' },
+          },
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      shouldRevalidate(
+        revalidationArgs(
+          `${TRACES_PATH}/trace-a?search=one`,
+          `${TRACES_PATH}/trace-a?search=two`,
           'trace-a',
           'trace-a',
           {
@@ -86,7 +111,7 @@ describe('traces shouldRevalidate', () => {
   it('never suppresses non-GET revalidation', () => {
     expect(
       shouldRevalidate(
-        revalidationArgs('/traces/trace-a', '/traces', 'trace-a', undefined, {
+        revalidationArgs(`${TRACES_PATH}/trace-a`, TRACES_PATH, 'trace-a', undefined, {
           defaultShouldRevalidate: false,
           formMethod: 'POST',
         }),
@@ -100,7 +125,10 @@ function ParentRoute() {
   return (
     <div>
       {data.traces.map((traceId) => (
-        <Link key={traceId} to={`/traces/${traceId}`}>
+        <Link
+          key={traceId}
+          to={routePath('workspaceTrace', { traceId, workspaceId: WORKSPACE_ID })}
+        >
           {traceId}
         </Link>
       ))}
@@ -115,7 +143,7 @@ function DetailRoute() {
   return (
     <div>
       <span>detail {traceId}</span>
-      <button onClick={() => navigate('/traces')} type="button">
+      <button onClick={() => navigate(TRACES_PATH)} type="button">
         Close
       </button>
     </div>
@@ -124,8 +152,8 @@ function DetailRoute() {
 
 describe('nested traces data routing', () => {
   it('preserves search and pro state in encoded adjacent trace locations', () => {
-    expect(traceLocation('trace/with?reserved', '?search=playwright&pro')).toEqual({
-      pathname: '/traces/trace%2Fwith%3Freserved',
+    expect(traceLocation(WORKSPACE_ID, 'trace/with?reserved', '?search=playwright&pro')).toEqual({
+      pathname: '/workspaces/analytics/traces/trace%2Fwith%3Freserved',
       search: '?search=playwright&pro',
     })
   })
@@ -144,11 +172,11 @@ describe('nested traces data routing', () => {
           ],
           element: <ParentRoute />,
           loader: parentLoader,
-          path: '/traces',
+          path: TRACES_PATH,
           shouldRevalidate,
         },
       ],
-      { initialEntries: ['/traces'] },
+      { initialEntries: [TRACES_PATH] },
     )
     const screen = await render(<RouterProvider router={router} />)
 
@@ -159,7 +187,7 @@ describe('nested traces data routing', () => {
     expect(parentLoader).toHaveBeenCalledOnce()
     await screen.getByRole('button', { name: 'Close' }).click()
 
-    expect(router.state.location.pathname).toBe('/traces')
+    expect(router.state.location.pathname).toBe(TRACES_PATH)
     expect(parentLoader).toHaveBeenCalledTimes(2)
     expect(childLoader).toHaveBeenCalledTimes(2)
   })
@@ -177,17 +205,17 @@ describe('nested traces data routing', () => {
           ],
           element: <ParentRoute />,
           loader: () => ({ traces: ['trace-a'] }),
-          path: '/traces',
+          path: TRACES_PATH,
           shouldRevalidate,
         },
       ],
-      { initialEntries: ['/traces', '/traces/trace-a'], initialIndex: 1 },
+      { initialEntries: [TRACES_PATH, `${TRACES_PATH}/trace-a`], initialIndex: 1 },
     )
     const screen = await render(<RouterProvider router={router} />)
 
     await expect.element(screen.getByText('detail trace-a')).toBeVisible()
     await router.navigate(-1)
-    expect(router.state.location.pathname).toBe('/traces')
+    expect(router.state.location.pathname).toBe(TRACES_PATH)
     await expect.element(screen.getByRole('link', { name: 'trace-a' })).toBeVisible()
   })
 })

--- a/apps/reef/app/routes/traces.tsx
+++ b/apps/reef/app/routes/traces.tsx
@@ -21,10 +21,11 @@ export function shouldRevalidate({
   nextParams,
 }: ShouldRevalidateFunctionArgs) {
   if (formMethod && formMethod.toUpperCase() !== 'GET') return true
+  if (currentParams.workspaceId !== nextParams.workspaceId) return true
   if (currentParams.traceId !== nextParams.traceId) return nextParams.traceId === undefined
   return defaultShouldRevalidate
 }
 
-export default function TracesRoute({ loaderData }: Route.ComponentProps) {
-  return <TracesIndex {...loaderData} />
+export default function TracesRoute({ loaderData, params }: Route.ComponentProps) {
+  return <TracesIndex {...loaderData} workspaceId={params.workspaceId} />
 }

--- a/apps/reef/app/views/schema-explorer/schema.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema.test.tsx
@@ -1,0 +1,48 @@
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import type { SchemaResponse } from '@/lib/schema-explorer'
+import { routePath, routePattern } from '@/routing/routemap'
+
+import { SchemaExplorer } from './schema'
+
+const SCHEMA = {
+  connectors: [
+    {
+      name: 'github?api',
+      tables: [
+        {
+          columns: [],
+          columnsLoaded: false,
+          name: 'issues/closed',
+          requiredFilters: [],
+        },
+      ],
+    },
+  ],
+} satisfies SchemaResponse
+
+it('links tables within the active workspace schema route', async () => {
+  const workspaceId = 'team alpha'
+  const router = createMemoryRouter(
+    [
+      {
+        element: <SchemaExplorer schema={SCHEMA} workspaceId={workspaceId} />,
+        path: routePattern('workspaceSchema'),
+      },
+    ],
+    { initialEntries: [routePath('workspaceSchema', { workspaceId })] },
+  )
+  const screen = await render(<RouterProvider router={router} />)
+
+  await screen.getByRole('button', { name: /github\?api/ }).click()
+  await expect.element(screen.getByRole('link', { name: 'issues/closed' })).toHaveAttribute(
+    'href',
+    routePath('workspaceSchemaTable', {
+      schemaName: 'github?api',
+      tableName: 'issues/closed',
+      workspaceId,
+    }),
+  )
+})

--- a/apps/reef/app/views/schema-explorer/schema.tsx
+++ b/apps/reef/app/views/schema-explorer/schema.tsx
@@ -3,6 +3,7 @@ import { NavLink, Outlet, useParams, useRouteError } from 'react-router'
 
 import { ErrorBanner } from '@/components/error-banner'
 import type { SchemaGroup, SchemaResponse, TableDef } from '@/lib/schema-explorer'
+import { routePath } from '@/routing/routemap'
 import { PageHeader } from '@/views/traces/page-header'
 import { Container as ButtonContainer } from '@/wax/components/button'
 import { Icon } from '@/wax/components/icon'
@@ -47,8 +48,8 @@ function visibleTablesForSchema(schema: SchemaGroup, search: string) {
   return schema.tables.filter((table) => tableMatchesSearch(table, search))
 }
 
-function tablePath(schemaName: string, tableName: string) {
-  return `/schema/${encodeURIComponent(schemaName)}/${encodeURIComponent(tableName)}`
+function tablePath(workspaceId: string, schemaName: string, tableName: string) {
+  return routePath('workspaceSchemaTable', { schemaName, tableName, workspaceId })
 }
 
 // Header + two-panel scaffold for the error state so it looks like the loaded page.
@@ -61,8 +62,9 @@ function Frame({ children }: { children: React.ReactNode }) {
   )
 }
 
-// Route ErrorBoundary for /schema: the schema is this page's critical data, so
-// a failed load errors the whole page (re-exported by the route module).
+// Route ErrorBoundary for /workspaces/:workspaceId/schema: the schema is this
+// page's critical data, so a failed load errors the whole page (re-exported by
+// the route module).
 export function SchemaExplorerError() {
   const error = useRouteError()
   const retry = useRouteRetry()
@@ -89,7 +91,13 @@ export function SchemaExplorerError() {
 // The schema is awaited in the server loader (critical data): the global
 // navigation progress bar is the pending UI and failures land in the route
 // ErrorBoundary, so this view only renders the loaded state.
-export function SchemaExplorer({ schema }: { schema: SchemaResponse }) {
+export function SchemaExplorer({
+  schema,
+  workspaceId,
+}: {
+  schema: SchemaResponse
+  workspaceId: string
+}) {
   const activeTable = useParams()
   const [search, setSearch] = useState('')
   // Collapsed by default so the initial render is one row per schema, not one per
@@ -202,9 +210,9 @@ export function SchemaExplorer({ schema }: { schema: SchemaResponse }) {
                                   activeTable.schemaName === connector.name &&
                                   activeTable.tableName === table.name
                                 }
-                                key={tablePath(connector.name, table.name)}
+                                key={tablePath(workspaceId, connector.name, table.name)}
                                 size="22"
-                                to={tablePath(connector.name, table.name)}
+                                to={tablePath(workspaceId, connector.name, table.name)}
                                 variant="bare"
                               >
                                 <Icon color="secondary" name="Table2" size="14" />

--- a/apps/reef/app/views/sources/source-detail.test.tsx
+++ b/apps/reef/app/views/sources/source-detail.test.tsx
@@ -22,12 +22,13 @@ describe('SourceDetailView', () => {
                 },
                 loadError: null,
               }}
+              sourcesPath="/workspaces/default/sources"
             />
           ),
-          path: '/sources/:sourceName',
+          path: '/workspaces/:workspaceId/sources/:sourceName',
         },
       ],
-      { initialEntries: ['/sources/github'] },
+      { initialEntries: ['/workspaces/default/sources/github'] },
     )
 
     const screen = await render(<RouterProvider router={router} />)

--- a/apps/reef/app/views/sources/source-detail.tsx
+++ b/apps/reef/app/views/sources/source-detail.tsx
@@ -30,12 +30,14 @@ const IMPORTED_EDIT_NOTICE =
 export function SourceDetailView({
   actionData,
   loaderData,
+  sourcesPath,
 }: {
   actionData: SourcesActionData | undefined
   loaderData: {
     entry: CatalogEntry
     loadError: string | null
   }
+  sourcesPath: string
 }) {
   const navigate = useNavigate()
   const navigation = useNavigation()
@@ -55,7 +57,7 @@ export function SourceDetailView({
         entry={entry}
         open
         onOpenChange={(open) => {
-          if (!open) navigate('/sources')
+          if (!open) navigate(sourcesPath)
         }}
         submitting={pendingName === entry.name && pendingIntent === 'install'}
       />
@@ -68,7 +70,7 @@ export function SourceDetailView({
       loadError={loaderData.loadError}
       open
       onOpenChange={(open) => {
-        if (!open) navigate('/sources')
+        if (!open) navigate(sourcesPath)
       }}
     />
   )

--- a/apps/reef/app/views/sources/sources-index.test.tsx
+++ b/apps/reef/app/views/sources/sources-index.test.tsx
@@ -10,7 +10,7 @@ function renderSourcesIndex(entries: CatalogEntry[]) {
   const router = createMemoryRouter(
     [
       {
-        element: <SourcesIndex entries={entries} />,
+        element: <SourcesIndex entries={entries} workspaceId="team alpha" />,
         path: '/',
       },
     ],
@@ -34,7 +34,7 @@ describe('SourcesIndex', () => {
 
     await expect
       .element(screen.getByRole('link', { name: /github/i }))
-      .toHaveAttribute('href', '/sources/github')
+      .toHaveAttribute('href', '/workspaces/team%20alpha/sources/github')
   })
 
   it('encodes source names before routing through the source detail route', async () => {
@@ -50,6 +50,6 @@ describe('SourcesIndex', () => {
 
     await expect
       .element(screen.getByRole('link', { name: /foo\?bar/i }))
-      .toHaveAttribute('href', '/sources/foo%3Fbar')
+      .toHaveAttribute('href', '/workspaces/team%20alpha/sources/foo%3Fbar')
   })
 })

--- a/apps/reef/app/views/sources/sources-index.tsx
+++ b/apps/reef/app/views/sources/sources-index.tsx
@@ -3,13 +3,16 @@ import { useRevalidator } from 'react-router'
 
 import { SourceCatalogSurface } from '@/components/sources'
 import type { CatalogEntry } from '@/lib/sources'
+import { routePath } from '@/routing/routemap'
 
 export function SourcesIndex({
   entries,
   loadError = null,
+  workspaceId,
 }: {
   entries: CatalogEntry[]
   loadError?: string | null
+  workspaceId: string
 }) {
   const [search, setSearch] = useState('')
   const searchInputRef = useRef<HTMLInputElement>(null)
@@ -35,7 +38,7 @@ export function SourcesIndex({
     <SourceCatalogSurface
       entries={entries}
       errorMessage={loadError}
-      getEntryTo={(entry) => `/sources/${encodeURIComponent(entry.name)}`}
+      getEntryTo={(entry) => routePath('workspaceSource', { sourceName: entry.name, workspaceId })}
       loadState={loadError ? 'error' : loading ? 'loading' : 'idle'}
       onRetry={() => revalidator.revalidate()}
       onSearchChange={setSearch}

--- a/apps/reef/app/views/traces/trace-detail.test.tsx
+++ b/apps/reef/app/views/traces/trace-detail.test.tsx
@@ -7,6 +7,9 @@ import { render } from 'vitest-browser-react'
 import type { TraceDetailData, TraceSpanData } from './trace-utils'
 import { TraceDetail } from './trace-detail'
 
+const WORKSPACE_ID = 'analytics'
+const TRACES_PATH = `/workspaces/${WORKSPACE_ID}/traces`
+
 function detail(): TraceDetailData {
   return {
     spans: [],
@@ -111,11 +114,11 @@ function renderDetail(
             path: ':traceId',
           },
         ],
-        element: <Outlet context={{ traces }} />,
-        path: '/traces',
+        element: <Outlet context={{ traces, workspaceId: WORKSPACE_ID }} />,
+        path: TRACES_PATH,
       },
     ],
-    { initialEntries: ['/traces/trace-07?pro'] },
+    { initialEntries: [`${TRACES_PATH}/trace-07?pro`] },
   )
   return { router, screen: render(<RouterProvider router={router} />) }
 }
@@ -150,7 +153,7 @@ describe('TraceDetail', () => {
 
     await expect.element(rendered.getByText('Tracing unavailable')).toBeVisible()
     await rendered.getByRole('button', { name: 'Back to query stream' }).click()
-    expect(router.state.location.pathname).toBe('/traces')
+    expect(router.state.location.pathname).toBe(TRACES_PATH)
     expect(router.state.location.search).toBe('?pro')
   })
 
@@ -191,18 +194,18 @@ describe('TraceDetail', () => {
       traceId,
     }))
     const { router } = renderDetail(null, detail(), traces)
-    await router.navigate('/traces/trace-07?search=playwright&pro')
+    await router.navigate(`${TRACES_PATH}/trace-07?search=playwright&pro`)
 
     dispatchModArrow('ArrowDown')
-    await expect.poll(() => router.state.location.pathname).toBe('/traces/older')
+    await expect.poll(() => router.state.location.pathname).toBe(`${TRACES_PATH}/older`)
     expect(router.state.location.search).toBe('?search=playwright&pro')
 
-    await router.navigate('/traces/trace-07?search=playwright&pro')
+    await router.navigate(`${TRACES_PATH}/trace-07?search=playwright&pro`)
     dispatchModArrow('ArrowUp')
-    await expect.poll(() => router.state.location.pathname).toBe('/traces/newer')
+    await expect.poll(() => router.state.location.pathname).toBe(`${TRACES_PATH}/newer`)
 
     await userEvent.keyboard('{Escape}')
-    await expect.poll(() => router.state.location.pathname).toBe('/traces')
+    await expect.poll(() => router.state.location.pathname).toBe(TRACES_PATH)
     expect(router.state.location.search).toBe('?search=playwright&pro')
   })
 
@@ -211,6 +214,6 @@ describe('TraceDetail', () => {
     const rendered = await screen
     await expect.element(rendered.getByText('No spans for this trace')).toBeVisible()
     await rendered.getByRole('button', { name: 'Back to query stream' }).click()
-    expect(router.state.location.pathname).toBe('/traces')
+    expect(router.state.location.pathname).toBe(TRACES_PATH)
   })
 })

--- a/apps/reef/app/views/traces/trace-detail.tsx
+++ b/apps/reef/app/views/traces/trace-detail.tsx
@@ -14,6 +14,7 @@ import * as s from './traces.css'
 import { HttpSpanDetail } from './http-span-detail'
 import { traceLocation } from './trace-location'
 import type { TracesOutletContext } from './traces-index'
+import { routePath } from '@/routing/routemap'
 import { useTimelineTree, type TimelineRow } from './use-timeline-tree'
 import {
   formatDuration,
@@ -906,7 +907,7 @@ export function TraceDetail({
   loadError: string | null
   traceId: string
 }) {
-  const { traces } = useOutletContext<TracesOutletContext>()
+  const { traces, workspaceId } = useOutletContext<TracesOutletContext>()
   const location = useLocation()
   const navigate = useNavigate()
   const selectedIndex = traces.findIndex((trace) => trace.traceId === traceId)
@@ -926,8 +927,15 @@ export function TraceDetail({
         loadError={loadError}
         newerTraceId={newerTraceId}
         olderTraceId={olderTraceId}
-        onClose={() => navigate({ pathname: '/traces', search: location.search })}
-        onSelectTrace={(nextTraceId) => navigate(traceLocation(nextTraceId, location.search))}
+        onClose={() =>
+          navigate({
+            pathname: routePath('workspaceTraces', { workspaceId }),
+            search: location.search,
+          })
+        }
+        onSelectTrace={(nextTraceId) =>
+          navigate(traceLocation(workspaceId, nextTraceId, location.search))
+        }
         traceId={traceId}
       />
     </div>

--- a/apps/reef/app/views/traces/trace-list.server.test.tsx
+++ b/apps/reef/app/views/traces/trace-list.server.test.tsx
@@ -22,8 +22,8 @@ const trace: TraceSummaryData = {
 
 function renderList() {
   return renderToString(
-    <MemoryRouter initialEntries={['/traces']}>
-      <TraceList referenceTimeMs={1_700_000_030_000} traces={[trace]} />
+    <MemoryRouter initialEntries={['/workspaces/analytics/traces']}>
+      <TraceList referenceTimeMs={1_700_000_030_000} traces={[trace]} workspaceId="analytics" />
     </MemoryRouter>,
   )
 }

--- a/apps/reef/app/views/traces/trace-list.test.tsx
+++ b/apps/reef/app/views/traces/trace-list.test.tsx
@@ -28,19 +28,23 @@ describe('TraceList', () => {
       [
         {
           element: (
-            <TraceList referenceTimeMs={2_000_000} traces={[summary('trace/with?reserved')]} />
+            <TraceList
+              referenceTimeMs={2_000_000}
+              traces={[summary('trace/with?reserved')]}
+              workspaceId="analytics"
+            />
           ),
-          path: '/traces',
+          path: '/workspaces/:workspaceId/traces',
         },
       ],
-      { initialEntries: ['/traces?pro'] },
+      { initialEntries: ['/workspaces/analytics/traces?pro'] },
     )
 
     const screen = await render(<RouterProvider router={router} />)
 
     await expect
       .element(screen.getByRole('link', { name: /select 'trace\/with\?reserved'/i }))
-      .toHaveAttribute('href', '/traces/trace%2Fwith%3Freserved?pro')
+      .toHaveAttribute('href', '/workspaces/analytics/traces/trace%2Fwith%3Freserved?pro')
   })
 
   it('marks the URL-selected row current independently from keyboard highlighting', async () => {
@@ -53,12 +57,13 @@ describe('TraceList', () => {
               activeTraceId="keyboard-active"
               referenceTimeMs={2_000_000}
               traces={[summary('selected'), summary('keyboard-active')]}
+              workspaceId="analytics"
             />
           ),
-          path: '/traces',
+          path: '/workspaces/:workspaceId/traces',
         },
       ],
-      { initialEntries: ['/traces/selected'] },
+      { initialEntries: ['/workspaces/analytics/traces/selected'] },
     )
 
     const screen = await render(<RouterProvider router={router} />)

--- a/apps/reef/app/views/traces/trace-list.tsx
+++ b/apps/reef/app/views/traces/trace-list.tsx
@@ -3,6 +3,7 @@ import { NavLink, useLocation } from 'react-router'
 
 import { Tooltip } from '@/wax/components/tooltip'
 import { Typography } from '@/wax/components/typography'
+import { routePath } from '@/routing/routemap'
 
 import * as s from './traces.css'
 import { SqlCode } from './sql-code'
@@ -21,18 +22,23 @@ function TraceRow({
   referenceTimeMs,
   search,
   trace,
+  workspaceId,
 }: {
   active: boolean
   referenceTimeMs: number
   search: string
   trace: TraceSummaryData
+  workspaceId: string
 }) {
   return (
     <NavLink
       className={s.fullRow}
       data-active={active || undefined}
       data-trace-row-id={trace.traceId}
-      to={{ pathname: `/traces/${encodeURIComponent(trace.traceId)}`, search }}
+      to={{
+        pathname: routePath('workspaceTrace', { traceId: trace.traceId, workspaceId }),
+        search,
+      }}
     >
       <span className={s.statusDot} data-tone={statusTone(trace.status)} />
       <div className={classNames(s.cell, s.cellTimestamp)}>
@@ -62,10 +68,12 @@ export function TraceList({
   activeTraceId,
   referenceTimeMs,
   traces,
+  workspaceId,
 }: {
   activeTraceId?: string | null
   referenceTimeMs: number
   traces: TraceSummaryData[]
+  workspaceId: string
 }) {
   const location = useLocation()
   return (
@@ -77,6 +85,7 @@ export function TraceList({
           referenceTimeMs={referenceTimeMs}
           search={location.search}
           trace={trace}
+          workspaceId={workspaceId}
         />
       ))}
     </div>

--- a/apps/reef/app/views/traces/trace-location.ts
+++ b/apps/reef/app/views/traces/trace-location.ts
@@ -1,3 +1,5 @@
-export function traceLocation(traceId: string, search: string) {
-  return { pathname: `/traces/${encodeURIComponent(traceId)}`, search }
+import { routePath } from '@/routing/routemap'
+
+export function traceLocation(workspaceId: string, traceId: string, search: string) {
+  return { pathname: routePath('workspaceTrace', { traceId, workspaceId }), search }
 }

--- a/apps/reef/app/views/traces/traces-index.test.tsx
+++ b/apps/reef/app/views/traces/traces-index.test.tsx
@@ -10,6 +10,7 @@ import { userEvent } from 'vitest/browser'
 import { render } from 'vitest-browser-react'
 
 import { shouldRevalidate } from '@/routes/traces'
+import { routePath } from '@/routing/routemap'
 
 import { TracesIndex } from './traces-index'
 import type { TraceSummaryData } from './trace-utils'
@@ -20,6 +21,9 @@ interface Data {
   referenceTimeMs: number
   traces: TraceSummaryData[]
 }
+
+const WORKSPACE_ID = 'analytics'
+const TRACES_PATH = routePath('workspaceTraces', { workspaceId: WORKSPACE_ID })
 
 function summary(traceId: string): TraceSummaryData {
   return {
@@ -38,17 +42,17 @@ function summary(traceId: string): TraceSummaryData {
 }
 
 function IndexRoute() {
-  return <TracesIndex {...(useLoaderData() as Data)} />
+  return <TracesIndex {...(useLoaderData() as Data)} workspaceId={WORKSPACE_ID} />
 }
 
-function renderIndex(loader: LoaderFunction, initialEntry = '/traces?pro') {
+function renderIndex(loader: LoaderFunction, initialEntry = `${TRACES_PATH}?pro`) {
   const router = createMemoryRouter(
     [
       {
         children: [{ element: <div>Trace detail</div>, path: ':traceId' }],
         element: <IndexRoute />,
         loader,
-        path: '/traces',
+        path: TRACES_PATH,
         shouldRevalidate,
       },
     ],
@@ -114,7 +118,7 @@ describe('TracesIndex route behavior', () => {
     releaseRefresh?.()
     await vi.runAllTicks()
 
-    await router.navigate('/traces/a?pro')
+    await router.navigate(`${TRACES_PATH}/a?pro`)
     await vi.advanceTimersByTimeAsync(60_000)
     expect(loader).toHaveBeenCalledTimes(2)
   })
@@ -175,7 +179,7 @@ describe('TracesIndex route behavior', () => {
       .toHaveAttribute('data-active', 'true')
     expect(scrollIntoView).toHaveBeenCalled()
     await userEvent.keyboard('{Enter}')
-    expect(router.state.location.pathname).toBe('/traces/alpha')
+    expect(router.state.location.pathname).toBe(`${TRACES_PATH}/alpha`)
     expect(router.state.location.search).toBe('?pro')
     HTMLElement.prototype.scrollIntoView = original
   })

--- a/apps/reef/app/views/traces/traces-index.tsx
+++ b/apps/reef/app/views/traces/traces-index.tsx
@@ -6,6 +6,7 @@ import { TextInput } from '@/wax/components/inputs/text'
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
 import { Typography } from '@/wax/components/typography'
 import { EmptyPage } from '@/components/empty-page'
+import { routePath } from '@/routing/routemap'
 
 import * as s from './traces.css'
 import { PageHeader } from './page-header'
@@ -17,6 +18,7 @@ const TRACE_LIST_REFRESH_MS = 30_000
 
 export interface TracesOutletContext {
   traces: TraceSummaryData[]
+  workspaceId: string
 }
 
 function HeaderActions({
@@ -93,11 +95,13 @@ export function TracesIndex({
   loadError,
   referenceTimeMs: loadedReferenceTimeMs,
   traces: loadedTraces,
+  workspaceId,
 }: {
   endpointLabel: string
   loadError: string | null
   referenceTimeMs: number
   traces: TraceSummaryData[]
+  workspaceId: string
 }) {
   const location = useLocation()
   const navigate = useNavigate()
@@ -120,7 +124,8 @@ export function TracesIndex({
   const [searchOpen, setSearchOpen] = useState(false)
   const [activeIndex, setActiveIndex] = useState<number | null>(null)
   const searchVisible = searchOpen || searchText.trim().length > 0
-  const listIsActive = location.pathname === '/traces'
+  const tracesPath = routePath('workspaceTraces', { workspaceId })
+  const listIsActive = location.pathname === tracesPath
 
   const filtered = traces.filter((trace) => {
     const needle = searchText.trim().toLowerCase()
@@ -156,14 +161,17 @@ export function TracesIndex({
           return
         event.preventDefault()
         navigate({
-          pathname: `/traces/${encodeURIComponent(filtered[activeIndex].traceId)}`,
+          pathname: routePath('workspaceTrace', {
+            traceId: filtered[activeIndex].traceId,
+            workspaceId,
+          }),
           search: location.search,
         })
       }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [activeIndex, filtered, listIsActive, location.search, navigate])
+  }, [activeIndex, filtered, listIsActive, location.search, navigate, workspaceId])
 
   useEffect(() => {
     if (activeIndex === null) return
@@ -227,6 +235,7 @@ export function TracesIndex({
             activeTraceId={activeIndex !== null ? filtered[activeIndex]?.traceId : null}
             referenceTimeMs={referenceTimeMs}
             traces={filtered}
+            workspaceId={workspaceId}
           />
         </div>
       )}
@@ -236,7 +245,7 @@ export function TracesIndex({
         endpointLabel={endpointLabel}
         totalCount={traces.length}
       />
-      <Outlet context={{ traces: filtered } satisfies TracesOutletContext} />
+      <Outlet context={{ traces: filtered, workspaceId } satisfies TracesOutletContext} />
     </section>
   )
 }

--- a/apps/reef/buf.gen.yaml
+++ b/apps/reef/buf.gen.yaml
@@ -13,3 +13,4 @@ inputs:
       - ../../crates/coral-api/proto/coral/v1/query.proto
       - ../../crates/coral-api/proto/coral/v1/sources.proto
       - ../../crates/coral-api/proto/coral/v1/traces.proto
+      - ../../crates/coral-api/proto/coral/v1/workspaces.proto


### PR DESCRIPTION
TL/DR from human: routes are workspace aware, and we default to 1st workspace if necessary  
  
\-----

Canonical workspace routes now drive source and trace requests. Legacy URLs resolve through the first local workspace, while trace reads filter by the recorded workspace attribute before pagination and detail access.

Constraint: Local Workspace.name is the route identifier; trace ownership comes from the workspace span attribute.
Rejected: Keep TraceService global | query history would cross workspace boundaries.
Rejected: Add Coral Cloud auth or session plumbing | local Reef already uses the local WorkspaceService.
Confidence: high
Scope-risk: moderate
Directive: Keep source and trace RPCs aligned with /workspaces/:workspaceId routes.
Tested: npm Reef check, typecheck, 246 tests, and build; cargo fmt check; workspace Clippy with -D warnings; cargo test workspace all targets and features.
Not-tested: cargo-nextest runner unavailable; ignored Postgres tests; manual browser interaction against a live sidecar.