### PR TITLE
feat(reef): workspace selector

### DIFF
--- a/apps/reef/app/components/sidebar/sidebar.css.ts
+++ b/apps/reef/app/components/sidebar/sidebar.css.ts
@@ -1,7 +1,8 @@
 import { style } from '@vanilla-extract/css'
+import { recipe } from '@vanilla-extract/recipes'
 
 import { breakpoints } from '@/styles/theme.css'
-import { theme, zIndex } from '@/wax/theme/theme.css'
+import { animation, theme, zIndex } from '@/wax/theme/theme.css'
 
 const MAIN_CONTENT_PADDING = 12
 const SIDEBAR_COLLAPSED_WIDTH = 34
@@ -36,26 +37,39 @@ export const header = style({
   paddingBlockStart: '10px',
 })
 
-export const brandRow = style({
+export const workspaceSelectorRow = style({
   alignItems: 'center',
   display: 'flex',
   gap: '4px',
   minWidth: 0,
 })
 
-export const brandMark = style({
+export const workspaceSelector = style({
   alignItems: 'center',
+  background: 'transparent',
+  border: 'none',
   borderRadius: '8px',
-  backgroundColor: theme.surface.main,
   color: theme.content.primary,
   display: 'flex',
-  flexShrink: 0,
-  height: '32px',
-  justifyContent: 'center',
-  width: '32px',
+  flex: '1 1 auto',
+  gap: '8px',
+  minHeight: '32px',
+  minWidth: 0,
+  overflow: 'hidden',
+  paddingInline: '8px',
+  transition: animation.colorTransition,
+  selectors: {
+    '&[data-popup-open], &:hover': {
+      backgroundColor: theme.surface.onMainContent,
+    },
+    '&:focus-visible': {
+      outline: `1px solid ${theme.button.primary.focus}`,
+      outlineOffset: '2px',
+    },
+  },
 })
 
-export const brandLabel = style({
+export const workspaceSelectorLabel = style({
   '@media': {
     [`screen and (max-width: ${breakpoints.mobile})`]: {
       display: 'none',
@@ -66,6 +80,30 @@ export const brandLabel = style({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
+})
+
+export const workspaceSelectorChevron = style({
+  display: 'flex',
+  flexShrink: 0,
+  marginInlineStart: 'auto',
+})
+
+export const workspaceSelectorMark = recipe({
+  base: {
+    alignItems: 'center',
+    borderRadius: '8px',
+    display: 'flex',
+    flexShrink: 0,
+    height: '20px',
+    justifyContent: 'center',
+    transition: animation.colorTransition,
+    width: '20px',
+  },
+  variants: {
+    color: {
+      ...theme.avatarFallback,
+    },
+  },
 })
 
 export const toggleButton = style({

--- a/apps/reef/app/components/sidebar/sidebar.stories.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.stories.tsx
@@ -54,11 +54,13 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   args: {
     initialIsMinimized: false,
+    workspaces: [{ name: 'default' }, { name: 'analytics' }],
   },
 }
 
 export const Minimized: Story = {
   args: {
     initialIsMinimized: true,
+    workspaces: [{ name: 'default' }, { name: 'analytics' }],
   },
 }

--- a/apps/reef/app/components/sidebar/sidebar.test.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.test.tsx
@@ -7,27 +7,41 @@ import { Sidebar } from './sidebar'
 import { SIDEBAR_COOKIE_NAME } from './sidebar-state'
 import { routePath, routePattern } from '@/routing/routemap'
 
-async function renderSidebar(initialIsMinimized: boolean, initialEntry = routePath('home')) {
+const WORKSPACES = [{ name: 'default' }, { name: 'analytics' }]
+
+async function renderSidebar(
+  initialIsMinimized: boolean,
+  initialEntry = routePath('home'),
+  workspaces: Array<{ name: string }> = [],
+) {
   const router = createMemoryRouter(
     [
       {
-        element: <Sidebar initialIsMinimized={initialIsMinimized} />,
-        path: '/workspaces/:workspaceId/sources/:sourceName?',
+        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        path: routePattern('workspaceSource'),
       },
       {
-        element: <Sidebar initialIsMinimized={initialIsMinimized} />,
+        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        path: routePattern('workspaceSources'),
+      },
+      {
+        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
         path: routePattern('workspaceSchemaTable'),
       },
       {
-        element: <Sidebar initialIsMinimized={initialIsMinimized} />,
+        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
         path: routePattern('workspaceSchema'),
       },
       {
-        element: <Sidebar initialIsMinimized={initialIsMinimized} />,
-        path: '/workspaces/:workspaceId/traces/:traceId?',
+        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        path: routePattern('workspaceTrace'),
       },
       {
-        element: <Sidebar initialIsMinimized={initialIsMinimized} />,
+        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        path: routePattern('workspaceTraces'),
+      },
+      {
+        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
         path: '*',
       },
     ],
@@ -100,7 +114,7 @@ describe('Sidebar', () => {
   })
 
   it('keeps source navigation in the active workspace', async () => {
-    const screen = await renderSidebar(false, '/workspaces/analytics/sources/github')
+    const screen = await renderSidebar(false, '/workspaces/analytics/sources/github', WORKSPACES)
 
     await expect
       .element(screen.getByRole('link', { name: 'Sources' }))
@@ -108,7 +122,7 @@ describe('Sidebar', () => {
   })
 
   it('keeps trace navigation in the active workspace', async () => {
-    const screen = await renderSidebar(false, '/workspaces/analytics/traces/trace-1')
+    const screen = await renderSidebar(false, '/workspaces/analytics/traces/trace-1', WORKSPACES)
 
     await expect
       .element(screen.getByRole('link', { name: 'Traces' }))
@@ -123,10 +137,90 @@ describe('Sidebar', () => {
         tableName: 'issues',
         workspaceId: 'analytics',
       }),
+      WORKSPACES,
     )
 
     await expect
       .element(screen.getByRole('link', { name: 'Schema' }))
       .toHaveAttribute('href', routePath('workspaceSchema', { workspaceId: 'analytics' }))
+  })
+
+  it('shows the active workspace and lists every local workspace', async () => {
+    const screen = await renderSidebar(false, '/workspaces/analytics/sources', WORKSPACES)
+
+    await expect.element(screen.getByText('analytics', { exact: true })).toBeVisible()
+    await screen.getByRole('button', { name: 'Open workspace menu' }).click()
+    const defaultWorkspace = screen.getByRole('menuitemradio', { name: 'default' })
+    const activeWorkspace = screen.getByRole('menuitemradio', { name: 'analytics' })
+
+    await expect.element(defaultWorkspace).toBeVisible()
+    await expect.element(defaultWorkspace).toHaveAttribute('aria-checked', 'false')
+    await expect.element(activeWorkspace).toBeVisible()
+    await expect.element(activeWorkspace).toHaveAttribute('aria-checked', 'true')
+    expect(defaultWorkspace.element().querySelector('svg')).toBeNull()
+    expect(activeWorkspace.element().querySelector('svg')).not.toBeNull()
+  })
+
+  it.each([
+    [
+      routePath('workspaceSources', { workspaceId: 'analytics' }),
+      routePath('workspaceSources', { workspaceId: 'default' }),
+    ],
+    [
+      routePath('workspaceSource', { sourceName: 'github', workspaceId: 'analytics' }),
+      routePath('workspaceSources', { workspaceId: 'default' }),
+    ],
+    [
+      routePath('workspaceSchema', { workspaceId: 'analytics' }),
+      routePath('workspaceSchema', { workspaceId: 'default' }),
+    ],
+    [
+      routePath('workspaceSchemaTable', {
+        schemaName: 'github',
+        tableName: 'issues',
+        workspaceId: 'analytics',
+      }),
+      routePath('workspaceSchema', { workspaceId: 'default' }),
+    ],
+    [
+      routePath('workspaceTrace', { traceId: 'trace-1', workspaceId: 'analytics' }),
+      routePath('workspaceTraces', { workspaceId: 'default' }),
+    ],
+  ])('switches workspaces within the current section from %s', async (currentPath, targetPath) => {
+    const screen = await renderSidebar(false, currentPath, WORKSPACES)
+
+    await screen.getByRole('button', { name: 'Open workspace menu' }).click()
+    await expect
+      .element(screen.getByRole('menuitemradio', { name: 'default' }))
+      .toHaveAttribute('href', targetPath)
+  })
+
+  it('falls back to the first workspace outside a canonical workspace route', async () => {
+    const screen = await renderSidebar(false, routePath('settings'), WORKSPACES)
+
+    await expect.element(screen.getByText('default', { exact: true })).toBeVisible()
+    await expect
+      .element(screen.getByRole('link', { name: 'Sources' }))
+      .toHaveAttribute('href', '/workspaces/default/sources')
+    await expect
+      .element(screen.getByRole('link', { name: 'Schema' }))
+      .toHaveAttribute('href', routePath('workspaceSchema', { workspaceId: 'default' }))
+  })
+
+  it('falls back to Coral and an empty menu when no workspace exists', async () => {
+    const screen = await renderSidebar(false)
+
+    await expect.element(screen.getByText('Coral', { exact: true })).toBeVisible()
+    await screen.getByRole('button', { name: 'Open workspace menu' }).click()
+    await expect.element(screen.getByRole('menuitem', { name: 'No workspaces' })).toBeVisible()
+  })
+
+  it('keeps collapsed navigation labels available through tooltips', async () => {
+    const screen = await renderSidebar(true, '/workspaces/analytics/sources', WORKSPACES)
+
+    await screen.getByRole('link', { name: 'Sources' }).hover()
+    await expect
+      .poll(() => document.querySelector('[data-base-ui-portal]')?.textContent)
+      .toContain('Sources')
   })
 })

--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { NavLink, useLocation, useParams } from 'react-router'
+import { Link, NavLink, useLocation, useParams } from 'react-router'
 
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
 import { IconButton } from '@/wax/components/button'
@@ -8,7 +8,11 @@ import { SidebarButton } from '@/wax/components/sidebar-button/sidebar-button'
 import { Tooltip } from '@/wax/components/tooltip'
 import { Typography } from '@/wax/components/typography'
 import type { IconName } from '@/wax/components/icon'
+import * as Menu from '@/wax/components/menu'
+import { getAvatarColorFromSeed } from '@/wax/components/avatar/utils/get-avatar-color'
+import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { isCoralDesktopBuild } from '@/lib/coral-desktop'
+import { workspacePathForCurrentSection } from '@/lib/workspace-routing'
 import { routePath } from '@/routing/routemap'
 
 import * as styles from './sidebar.css'
@@ -16,17 +20,26 @@ import { useSidebarState } from './use-sidebar-state'
 
 interface SidebarProps {
   initialIsMinimized: boolean
+  workspaces: ReadonlyArray<Pick<Workspace, 'name'>>
 }
 
-export function Sidebar({ initialIsMinimized }: SidebarProps) {
+export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
   const location = useLocation()
   const { workspaceId } = useParams()
   const { isMinimized, toggleSidebar } = useSidebarState(initialIsMinimized)
-  const sourcesPath = workspaceId
-    ? routePath('workspaceSources', { workspaceId })
+  const currentWorkspace = workspaces.find((workspace) => workspace.name === workspaceId)
+  const workspaceNavTarget = currentWorkspace ?? workspaces[0]
+  const workspaceSelectorLabel = workspaceNavTarget?.name ?? 'Coral'
+  const workspaceSelectorMarkColor = getAvatarColorFromSeed(workspaceSelectorLabel)
+  const sourcesPath = workspaceNavTarget
+    ? routePath('workspaceSources', { workspaceId: workspaceNavTarget.name })
     : routePath('home')
-  const schemaPath = workspaceId ? routePath('workspaceSchema', { workspaceId }) : routePath('home')
-  const tracesPath = workspaceId ? routePath('workspaceTraces', { workspaceId }) : routePath('home')
+  const schemaPath = workspaceNavTarget
+    ? routePath('workspaceSchema', { workspaceId: workspaceNavTarget.name })
+    : routePath('home')
+  const tracesPath = workspaceNavTarget
+    ? routePath('workspaceTraces', { workspaceId: workspaceNavTarget.name })
+    : routePath('home')
   const navItems = [
     { icon: 'Plug', label: 'Sources', paths: [routePath('home'), sourcesPath], to: sourcesPath },
     { icon: 'Database', label: 'Schema', paths: [schemaPath], to: schemaPath },
@@ -84,11 +97,50 @@ export function Sidebar({ initialIsMinimized }: SidebarProps) {
           </div>
         )}
 
-        <div className={styles.brandRow}>
-          <div className={styles.brandMark}>
-            <Icon color="inherit" name="Coral" size="18" />
-          </div>
-          {!isMinimized && <Typography.Body className={styles.brandLabel}>Coral</Typography.Body>}
+        <div className={styles.workspaceSelectorRow}>
+          <Menu.Container>
+            <Menu.Trigger
+              className={styles.workspaceSelector}
+              render={<button aria-label="Open workspace menu" type="button" />}
+            >
+              <span className={styles.workspaceSelectorMark({ color: workspaceSelectorMarkColor })}>
+                <Icon color="inherit" name="Coral" size="18" />
+              </span>
+              {!isMinimized && (
+                <>
+                  <Tooltip content={workspaceSelectorLabel} showOnlyWhenTruncated side="bottom">
+                    <span className={styles.workspaceSelectorLabel}>
+                      <Typography.Body>{workspaceSelectorLabel}</Typography.Body>
+                    </span>
+                  </Tooltip>
+                  <span className={styles.workspaceSelectorChevron}>
+                    <Icon color="tertiary" name="ChevronDown" size="16" />
+                  </span>
+                </>
+              )}
+            </Menu.Trigger>
+            <Menu.Content align="start" side="bottom" sideOffset={6}>
+              <Menu.Group>
+                <Menu.GroupLabel>Workspaces</Menu.GroupLabel>
+                {workspaces.length === 0 ? (
+                  <Menu.Item disabled>No workspaces</Menu.Item>
+                ) : (
+                  <Menu.RadioGroup value={workspaceNavTarget?.name}>
+                    {workspaces.map((workspace) => (
+                      <Menu.RadioItem
+                        as={Link}
+                        key={workspace.name}
+                        to={workspacePathForCurrentSection(workspace.name, location.pathname)}
+                        value={workspace.name}
+                      >
+                        {workspace.name}
+                      </Menu.RadioItem>
+                    ))}
+                  </Menu.RadioGroup>
+                )}
+              </Menu.Group>
+            </Menu.Content>
+          </Menu.Container>
 
           {!isMinimized && (
             <div className={styles.toggleButton}>

--- a/apps/reef/app/lib/workspace-routing.test.ts
+++ b/apps/reef/app/lib/workspace-routing.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, it } from 'vitest'
 
-import { workspaceFromParams } from './workspace-routing'
+import { workspaceFromParams, workspacePathForCurrentSection } from './workspace-routing'
 
 describe('workspace routing', () => {
   it('treats the workspace route parameter as the local workspace name', () => {
     expect(workspaceFromParams({ workspaceId: 'analytics' }).name).toBe('analytics')
+  })
+
+  it.each([
+    ['/workspaces/default/sources/github', '/workspaces/team%20alpha/sources'],
+    ['/workspaces/default/schema', '/workspaces/team%20alpha/schema'],
+    ['/workspaces/default/schema/github/issues', '/workspaces/team%20alpha/schema'],
+    ['/workspaces/default/traces/trace-1', '/workspaces/team%20alpha/traces'],
+    ['/settings', '/workspaces/team%20alpha/sources'],
+  ])('targets the corresponding section for %s', (pathname, expectedPath) => {
+    expect(workspacePathForCurrentSection('team alpha', pathname)).toBe(expectedPath)
   })
 })

--- a/apps/reef/app/lib/workspace-routing.ts
+++ b/apps/reef/app/lib/workspace-routing.ts
@@ -1,6 +1,8 @@
 import { create } from '@bufbuild/protobuf'
+import { matchPath } from 'react-router'
 
 import { WorkspaceSchema, type Workspace } from '@/generated/coral/v1/resources_pb'
+import { routePath, routePattern } from '@/routing/routemap'
 
 export function workspaceFromParams(params: { workspaceId?: string }): Workspace {
   const workspaceId = params.workspaceId
@@ -11,4 +13,14 @@ export function workspaceFromParams(params: { workspaceId?: string }): Workspace
     })
   }
   return create(WorkspaceSchema, { name: workspaceId })
+}
+
+export function workspacePathForCurrentSection(workspaceId: string, pathname: string): string {
+  const isSchemaSection = matchPath({ end: false, path: routePattern('workspaceSchema') }, pathname)
+  if (isSchemaSection) return routePath('workspaceSchema', { workspaceId })
+
+  const isTracesSection = matchPath({ end: false, path: routePattern('workspaceTraces') }, pathname)
+  return isTracesSection
+    ? routePath('workspaceTraces', { workspaceId })
+    : routePath('workspaceSources', { workspaceId })
 }

--- a/apps/reef/app/routes/app-shell.server.test.ts
+++ b/apps/reef/app/routes/app-shell.server.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { listWorkspacesForRequest } = vi.hoisted(() => ({
+  listWorkspacesForRequest: vi.fn(),
+}))
+
+vi.mock('@/lib/workspaces.server', () => ({ listWorkspacesForRequest }))
+
+import { routePath } from '@/routing/routemap'
+
+import { loader } from './app-shell'
+
+describe('app shell loader', () => {
+  beforeEach(() => {
+    listWorkspacesForRequest.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('loads the local workspace list once for the sidebar', async () => {
+    const request = new Request('http://reef.test/workspaces/default/sources')
+    const workspaces = [{ name: 'default' }, { name: 'analytics' }]
+    listWorkspacesForRequest.mockResolvedValue(workspaces)
+
+    await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toEqual({
+      workspaces,
+    })
+    expect(listWorkspacesForRequest).toHaveBeenCalledOnce()
+    expect(listWorkspacesForRequest).toHaveBeenCalledWith(request)
+  })
+
+  it('leaves workspace lookup to the index redirect loader', async () => {
+    await expect(
+      loader({
+        request: new Request(`http://reef.test${routePath('home')}`),
+      } as Parameters<typeof loader>[0]),
+    ).resolves.toEqual({ workspaces: [] })
+    expect(listWorkspacesForRequest).not.toHaveBeenCalled()
+  })
+
+  it('falls back to an empty sidebar when workspace loading fails', async () => {
+    const error = new Error('sidecar unavailable')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    listWorkspacesForRequest.mockRejectedValue(error)
+
+    await expect(
+      loader({
+        request: new Request('http://reef.test/workspaces/default/sources'),
+      } as Parameters<typeof loader>[0]),
+    ).resolves.toEqual({ workspaces: [] })
+    expect(consoleError).toHaveBeenCalledWith('Failed to load sidebar workspaces:', error)
+  })
+})

--- a/apps/reef/app/routes/app-shell.tsx
+++ b/apps/reef/app/routes/app-shell.tsx
@@ -1,7 +1,11 @@
 import { Outlet, useRouteLoaderData } from 'react-router'
 
+import type { Route } from './+types/app-shell'
+
 import { ContentContainer } from '@/components/content-container'
 import { Sidebar } from '@/components/sidebar'
+import { listWorkspacesForRequest } from '@/lib/workspaces.server'
+import { routePath } from '@/routing/routemap'
 import { ToastContainer } from '@/wax/components/toast'
 
 import * as styles from './app-shell.css'
@@ -10,12 +14,30 @@ interface RootLoaderData {
   sidebarIsMinimized: boolean
 }
 
-export default function AppShell() {
+export async function loader({ request }: Route.LoaderArgs) {
+  if (isWorkspaceRedirectRoute(request)) return { workspaces: [] }
+
+  try {
+    return { workspaces: await listWorkspacesForRequest(request) }
+  } catch (error) {
+    console.error('Failed to load sidebar workspaces:', error)
+    return { workspaces: [] }
+  }
+}
+
+function isWorkspaceRedirectRoute(request: Request): boolean {
+  return new URL(request.url).pathname === routePath('home')
+}
+
+export default function AppShell({ loaderData }: Route.ComponentProps) {
   const rootData = useRouteLoaderData('root') as RootLoaderData | undefined
 
   return (
     <div className={styles.layout}>
-      <Sidebar initialIsMinimized={rootData?.sidebarIsMinimized ?? false} />
+      <Sidebar
+        initialIsMinimized={rootData?.sidebarIsMinimized ?? false}
+        workspaces={loaderData.workspaces}
+      />
       <ContentContainer>
         <ToastContainer />
         <Outlet />

--- a/apps/reef/app/wax/components/menu/radio-item.tsx
+++ b/apps/reef/app/wax/components/menu/radio-item.tsx
@@ -1,5 +1,6 @@
 import { Menu as BaseMenu } from '@base-ui/react/menu'
 import classNames from 'classnames'
+import React, { type ElementType } from 'react'
 
 import { Icon } from '@/wax/components/icon'
 import type { IconColor, IconName } from '@/wax/components/icon'
@@ -7,7 +8,7 @@ import { Tooltip } from '@/wax/components/tooltip'
 
 import * as styles from './menu.css'
 
-export interface RadioItemProps {
+interface RadioItemBaseProps {
   children: React.ReactNode
   className?: string
   closeOnClick?: boolean
@@ -17,22 +18,26 @@ export interface RadioItemProps {
   value: string
 }
 
-export function RadioItem({
-  children,
-  className,
-  closeOnClick = true,
-  disabled = false,
-  iconColor = 'tertiary',
-  iconName,
-  value,
-}: RadioItemProps) {
-  return (
-    <BaseMenu.RadioItem
-      className={classNames(styles.item, className)}
-      closeOnClick={closeOnClick}
-      disabled={disabled}
-      value={value}
-    >
+export type RadioItemProps<T extends ElementType = 'div'> = RadioItemBaseProps &
+  Omit<React.ComponentPropsWithoutRef<T>, 'as' | keyof RadioItemBaseProps> & {
+    as?: T
+  }
+
+export function RadioItem<T extends ElementType = 'div'>(props: RadioItemProps<T>) {
+  const {
+    as,
+    children,
+    className,
+    closeOnClick = true,
+    disabled = false,
+    iconColor = 'tertiary',
+    iconName,
+    value,
+    ...rest
+  } = props
+  const render = as ? React.createElement(as, rest) : undefined
+  const content = (
+    <>
       {iconName && <Icon color={iconColor} name={iconName} size="18" />}
       <div className={styles.itemContent}>
         <Tooltip content={children} showOnlyWhenTruncated>
@@ -42,6 +47,18 @@ export function RadioItem({
       <BaseMenu.RadioItemIndicator className={styles.radioIndicator}>
         <Icon color="secondary" name="Check" size="16" />
       </BaseMenu.RadioItemIndicator>
+    </>
+  )
+
+  return (
+    <BaseMenu.RadioItem
+      className={classNames(styles.item, className)}
+      closeOnClick={closeOnClick}
+      disabled={disabled}
+      render={render}
+      value={value}
+    >
+      {content}
     </BaseMenu.RadioItem>
   )
 }


### PR DESCRIPTION
![image.png](https://app.graphite.com/user-attachments/assets/85408b88-d13b-45df-850c-4b460072e29c.png)



![image.png](https://app.graphite.com/user-attachments/assets/fefc7561-f3ae-4bcb-9f7a-aaa77f208e15.png)

![image.png](https://app.graphite.com/user-attachments/assets/8eaf1ac0-950a-4ce5-9e68-18e4f8f7805f.png)



  
  
Load local workspaces at the app-shell boundary and expose a WAX sidebar selector that keeps users in sources or traces when changing workspace.

Constraint: Local Workspace.name remains the route identifier; creation and settings management belong to later workspace parts.
Rejected: Fetch workspaces inside Sidebar | route loaders should own server data and avoid duplicate service calls.
Rejected: Preserve source detail across workspace switches | the selected workspace may not contain that source.
Confidence: high
Scope-risk: narrow
Directive: Keep workspace mutations out of the sidebar until the dedicated create-workspace action is added.
Tested: npm --prefix apps/reef run check; npm --prefix apps/reef run typecheck; 25 focused sidebar, routing, and app-shell tests.
Not-tested: Manual interaction against a live Coral sidecar.