### PR TITLE
feat(app): refresh OAuth identities

### DIFF
--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -39,7 +39,6 @@ const REFRESH_EXPIRY_SKEW_SECONDS: i64 = 60;
 const TOKEN_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Duration used for the durable claim that fences one provider refresh.
-#[expect(dead_code, reason = "consumed by B5f")]
 pub(crate) fn oauth_refresh_claim_duration() -> Duration {
     TOKEN_REQUEST_TIMEOUT
 }
@@ -97,7 +96,6 @@ impl<'a> RefreshOAuthCredentialRequest<'a> {
         }
     }
 
-    #[cfg_attr(not(test), expect(dead_code, reason = "consumed by B5f"))]
     pub(crate) fn for_identity(
         identity_name: &str,
         access_token_material_key: &'a str,

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -6,11 +6,15 @@
 )]
 
 mod oauth_create;
+mod oauth_refresh;
 
 pub(crate) use oauth_create::IdentityOAuthCommitPhase;
+use oauth_refresh::IdentityOAuthRefreshOutcome;
 
 use std::collections::BTreeMap;
 use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -371,7 +375,15 @@ impl IdentityManager {
     }
 
     /// Resolve one identity and its exact installed spec from one coherent snapshot.
-    pub(crate) async fn get_for_use(
+    pub(crate) fn get_for_use<'a>(
+        &'a self,
+        owner: &'a IdentityOwner,
+        identity_name: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<ResolvedIdentityForUse, AppError>> + Send + 'a>> {
+        Box::pin(self.get_for_use_inner(owner, identity_name))
+    }
+
+    async fn get_for_use_inner(
         &self,
         owner: &IdentityOwner,
         identity_name: &str,
@@ -392,6 +404,17 @@ impl IdentityManager {
                 prepare_identity_for_use(crypto_snapshot, &crypto_name, key_provider.as_ref())
             })
             .await?;
+            let (snapshot, prepared) = match self
+                .refresh_prepared_identity(owner, &name, snapshot, prepared)
+                .await?
+            {
+                IdentityOAuthRefreshOutcome::Unchanged(state) => *state,
+                IdentityOAuthRefreshOutcome::Retry => {
+                    tokio::task::yield_now().await;
+                    continue;
+                }
+                IdentityOAuthRefreshOutcome::Refreshed(resolved) => return Ok(*resolved),
+            };
             #[cfg(test)]
             if prepared.needs_rewrap()
                 && let Some(gate) = &self.before_use_cas_gate

--- a/crates/coral-app/src/identities/manager/oauth_create.rs
+++ b/crates/coral-app/src/identities/manager/oauth_create.rs
@@ -314,7 +314,7 @@ async fn load_oauth_create_snapshot(
     })
 }
 
-fn oauth_client_inputs(
+pub(super) fn oauth_client_inputs(
     oauth: &ManifestOAuthCredentialSpec,
     inputs: &crate::identity_specs::manager::ResolvedIdentitySpecInputs,
 ) -> Vec<(String, String)> {
@@ -352,7 +352,7 @@ fn oauth_identity_values(
     (safe_metadata, internal_metadata)
 }
 
-fn prepare_oauth_document(
+pub(super) fn prepare_oauth_document(
     owner: &IdentityOwner,
     name: &IdentityName,
     reference: &IdentitySpecReference,

--- a/crates/coral-app/src/identities/manager/oauth_refresh.rs
+++ b/crates/coral-app/src/identities/manager/oauth_refresh.rs
@@ -1,0 +1,285 @@
+use std::time::Duration;
+
+use coral_spec::{IdentitySpecConfig, IdentitySpecType};
+
+use super::oauth_create::{oauth_client_inputs, prepare_oauth_document};
+use super::{
+    IdentityForUseRevision, IdentityManager, IdentityUseSnapshot, MAX_MUTATION_ATTEMPTS,
+    OAUTH_ACCESS_TOKEN_KEY, PreparedIdentityForUse, ResolvedIdentityForUse,
+    load_identity_use_snapshot, owner_workspace_created_at,
+};
+use crate::bootstrap::AppError;
+use crate::credentials::oauth::{
+    OAuthCredentialService, PreparedOAuthRefresh, RefreshOAuthCredentialRequest,
+    oauth_refresh_claim_duration,
+};
+use crate::identities::model::{IdentityName, IdentityOwner};
+use crate::identity::run_key_operation;
+use crate::state::db::{
+    DbRepos, IdentityDocumentWrite, IdentityOAuthRefreshClaim, now_unix_nanos_i64,
+};
+
+const REFRESH_CLAIM_POLL_INTERVAL: Duration = Duration::from_millis(50);
+pub(super) enum IdentityOAuthRefreshOutcome {
+    Unchanged(Box<(IdentityUseSnapshot, PreparedIdentityForUse)>),
+    Retry,
+    Refreshed(Box<ResolvedIdentityForUse>),
+}
+
+impl IdentityManager {
+    pub(super) async fn refresh_prepared_identity(
+        &self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        snapshot: IdentityUseSnapshot,
+        prepared: PreparedIdentityForUse,
+    ) -> Result<IdentityOAuthRefreshOutcome, AppError> {
+        use IdentityOAuthRefreshOutcome::{Refreshed, Retry, Unchanged};
+
+        let refresh = Self::prepare_identity_oauth_refresh(name, &prepared)?;
+        if prepared.identity_spec.spec.manifest.identity_type == IdentitySpecType::OAuth
+            && let Some(claim) = snapshot.oauth_refresh_claim.as_ref()
+        {
+            return match self.await_existing_oauth_refresh(owner, name, claim).await {
+                Ok(()) | Err(AppError::RetryableTransactionConflict) => Ok(Retry),
+                Err(error) => Err(error),
+            };
+        }
+        let Some(refresh) = refresh else {
+            return Ok(Unchanged(Box::new((snapshot, prepared))));
+        };
+        let claim = new_refresh_claim()?;
+        let claimed_revision = match self
+            .try_claim_oauth_refresh_revision(owner, name, &snapshot, &claim)
+            .await
+        {
+            Ok(Some(revision)) => revision,
+            Ok(None) | Err(AppError::RetryableTransactionConflict) => return Ok(Retry),
+            Err(error) => return Err(error),
+        };
+        let result = async {
+            let (material, safe_metadata) = self.oauth.execute_refresh(refresh).await?.into_parts();
+            let crypto_owner = owner.clone();
+            let crypto_name = name.clone();
+            let reference = prepared.identity.spec_reference.clone();
+            let key_provider = self.key_provider.clone();
+            let (document, material) = run_key_operation(move || {
+                let document = prepare_oauth_document(
+                    &crypto_owner,
+                    &crypto_name,
+                    &reference,
+                    &material,
+                    key_provider.as_ref(),
+                )?;
+                Ok::<_, AppError>((document, material))
+            })
+            .await?;
+            let revision = self
+                .finish_claimed_oauth_refresh(
+                    owner,
+                    name,
+                    &claim,
+                    &claimed_revision,
+                    &document,
+                    &safe_metadata,
+                )
+                .await?;
+            let identity = revision
+                .identity
+                .clone()
+                .expect("finalized refresh retains the identity");
+            Ok::<_, AppError>(ResolvedIdentityForUse {
+                identity,
+                identity_spec: prepared.identity_spec,
+                material,
+                revision: IdentityForUseRevision {
+                    _snapshot: revision,
+                },
+            })
+        }
+        .await;
+        match result {
+            Ok(resolved) => Ok(Refreshed(Box::new(resolved))),
+            Err(error) => {
+                tracing::warn!(%error, "OAuth identity refresh failed after claim");
+                self.expire_owned_oauth_refresh_claim(owner, name, &claim)
+                    .await;
+                Err(oauth_refresh_reconnect(name))
+            }
+        }
+    }
+
+    fn prepare_identity_oauth_refresh(
+        name: &IdentityName,
+        prepared: &PreparedIdentityForUse,
+    ) -> Result<Option<PreparedOAuthRefresh>, AppError> {
+        if prepared.identity_spec.spec.manifest.identity_type != IdentitySpecType::OAuth {
+            return Ok(None);
+        }
+        let IdentitySpecConfig::OAuth(config) = &prepared.identity_spec.spec.manifest.config else {
+            return Err(oauth_refresh_reconnect(name));
+        };
+        let oauth = &config.method.oauth;
+        let request = RefreshOAuthCredentialRequest::for_identity(
+            name.as_str(),
+            OAUTH_ACCESS_TOKEN_KEY,
+            oauth,
+            prepared.identity_spec.inputs.variables(),
+            oauth_client_inputs(oauth, &prepared.identity_spec.inputs),
+        )?;
+        OAuthCredentialService::prepare_refresh(request, &prepared.material)
+    }
+
+    async fn await_existing_oauth_refresh(
+        &self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        expected: &IdentityOAuthRefreshClaim,
+    ) -> Result<(), AppError> {
+        loop {
+            let now = now_unix_nanos_i64()?;
+            let remaining = expected.deadline_unix_nanos().saturating_sub(now);
+            let expired = remaining <= 0;
+            if !expired {
+                let sleep = Duration::from_nanos(u64::try_from(remaining).unwrap_or(u64::MAX))
+                    .min(REFRESH_CLAIM_POLL_INTERVAL);
+                tokio::time::sleep(sleep).await;
+            }
+            let mut db = self.db.as_ref();
+            let current = db
+                .identities()
+                .load_oauth_refresh_claim(owner, name)
+                .await?;
+            if current.as_ref() != Some(expected) {
+                return Ok(());
+            }
+            if expired {
+                return Err(oauth_refresh_reconnect(name));
+            }
+        }
+    }
+
+    async fn try_claim_oauth_refresh_revision(
+        &self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        expected: &IdentityUseSnapshot,
+        claim: &IdentityOAuthRefreshClaim,
+    ) -> Result<Option<IdentityUseSnapshot>, AppError> {
+        let mut tx = self.db.begin_serializable().await?;
+        let workspace_created_at_unix_nanos = owner_workspace_created_at(&mut tx, owner).await?;
+        let mut current =
+            load_identity_use_snapshot(&mut tx, owner, name, workspace_created_at_unix_nanos)
+                .await?;
+        if current != *expected
+            || !tx
+                .identities()
+                .try_claim_oauth_refresh(owner, name, claim)
+                .await?
+        {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+        current.oauth_refresh_claim = Some(claim.clone());
+        tx.commit().await?;
+        Ok(Some(current))
+    }
+
+    pub(super) async fn finish_claimed_oauth_refresh(
+        &self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        claim: &IdentityOAuthRefreshClaim,
+        expected: &IdentityUseSnapshot,
+        document: &IdentityDocumentWrite,
+        safe_metadata: &std::collections::BTreeMap<String, String>,
+    ) -> Result<IdentityUseSnapshot, AppError> {
+        for _ in 0..MAX_MUTATION_ATTEMPTS {
+            let result = async {
+                let mut tx = self.db.begin_serializable().await?;
+                let workspace_created_at_unix_nanos =
+                    owner_workspace_created_at(&mut tx, owner).await?;
+                let mut current = load_identity_use_snapshot(
+                    &mut tx,
+                    owner,
+                    name,
+                    workspace_created_at_unix_nanos,
+                )
+                .await?;
+                if current != *expected || current.oauth_refresh_claim.as_ref() != Some(claim) {
+                    tx.rollback().await?;
+                    return Ok(None);
+                }
+                let now = now_unix_nanos_i64()?;
+                let reference = &current
+                    .identity
+                    .as_ref()
+                    .expect("refresh identity")
+                    .spec_reference;
+                let identity = tx
+                    .identities()
+                    .upsert(owner, name, reference, safe_metadata, now)
+                    .await?;
+                let identity_document = tx
+                    .identity_documents()
+                    .upsert(owner, name, document, now)
+                    .await?;
+                current.identity = Some(identity);
+                current.identity_document = Some(identity_document);
+                current.oauth_refresh_claim = None;
+                tx.commit().await?;
+                Ok(Some(current))
+            }
+            .await;
+            match result {
+                Ok(Some(revision)) => return Ok(revision),
+                Ok(None) => return Err(oauth_refresh_reconnect(name)),
+                Err(AppError::RetryableTransactionConflict) => tokio::task::yield_now().await,
+                Err(error) => return Err(error),
+            }
+        }
+        Err(oauth_refresh_reconnect(name))
+    }
+
+    async fn expire_owned_oauth_refresh_claim(
+        &self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        claim: &IdentityOAuthRefreshClaim,
+    ) {
+        for _ in 0..MAX_MUTATION_ATTEMPTS {
+            let result: Result<(), AppError> = async {
+                let mut tx = self.db.begin_serializable().await?;
+                let now = now_unix_nanos_i64()?;
+                tx.identities()
+                    .expire_oauth_refresh_claim(owner, name, claim.id(), now)
+                    .await?;
+                tx.commit().await?;
+                Ok(())
+            }
+            .await;
+            match result {
+                Ok(()) => return,
+                Err(AppError::RetryableTransactionConflict) => tokio::task::yield_now().await,
+                Err(error) => return tracing::warn!(%error, "OAuth refresh claim cleanup failed"),
+            }
+        }
+        tracing::warn!("OAuth refresh claim cleanup exhausted transaction retries");
+    }
+}
+
+fn new_refresh_claim() -> Result<IdentityOAuthRefreshClaim, AppError> {
+    let duration = i64::try_from(oauth_refresh_claim_duration().as_nanos()).map_err(|_error| {
+        AppError::Database("OAuth refresh claim duration is not representable".to_string())
+    })?;
+    let deadline = now_unix_nanos_i64()?
+        .checked_add(duration)
+        .ok_or_else(|| AppError::Database("OAuth refresh claim deadline overflowed".to_string()))?;
+    IdentityOAuthRefreshClaim::new(uuid::Uuid::new_v4(), deadline)
+}
+
+fn oauth_refresh_reconnect(name: &IdentityName) -> AppError {
+    AppError::FailedPrecondition(format!(
+        "identity '{name}' OAuth refresh could not be completed safely; reconnect the identity"
+    ))
+}

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -12,7 +12,8 @@ use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use super::{
-    IdentityManager, IdentityOAuthCommitPhase, IdentityOAuthCreationEvent, ResolvedIdentityForUse,
+    IdentityManager, IdentityOAuthCommitPhase, IdentityOAuthCreationEvent, IdentityUseSnapshot,
+    ResolvedIdentityForUse, identity_document_write, identity_envelope, load_identity_use_snapshot,
 };
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialsError;
@@ -27,9 +28,10 @@ use crate::identity::{
 use crate::identity_specs::identity_spec_fingerprint;
 use crate::identity_specs::manager::{IdentitySpecInputValue, IdentitySpecManager};
 use crate::state::db::{
-    CoralDb, DbError, DbRepos, DbSession, IdentityDocumentRecord, IdentityOAuthRefreshClaim,
-    IdentityRecord, IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey,
-    IdentitySpecScope, IdentitySpecWrite, ResolvedDatabaseConfig,
+    CoralDb, DbError, DbRepos, DbSession, IdentityDocumentRecord, IdentityDocumentWrite,
+    IdentityOAuthRefreshClaim, IdentityRecord, IdentitySpecDocumentRecord,
+    IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecScope, IdentitySpecWrite,
+    ResolvedDatabaseConfig, now_unix_nanos_i64,
 };
 use crate::workspaces::WorkspaceName;
 
@@ -59,7 +61,7 @@ impl CredentialKeyProvider for TestKeyProvider {
 }
 
 #[tokio::test]
-async fn sqlite_fixed_token_manager_contract() {
+async fn sqlite_identity_manager_contracts() {
     let temp = tempdir().expect("temp dir");
     let db = Arc::new(
         CoralDb::open(ResolvedDatabaseConfig::Sqlite {
@@ -70,6 +72,7 @@ async fn sqlite_fixed_token_manager_contract() {
     );
     db.migrate().await.expect("migrate sqlite");
     Box::pin(assert_fixed_token_manager_contract(&db)).await;
+    Box::pin(assert_oauth_refresh_manager_contract(&db)).await;
 }
 
 #[tokio::test]
@@ -255,6 +258,233 @@ async fn sqlite_oauth_creation_core_contract() {
     assert!(requests.iter().all(|request| {
         String::from_utf8_lossy(&request.body).contains("client_id=spec-client-id")
     }));
+}
+
+struct RefreshManagerFixture {
+    provider: MockServer,
+    manager: IdentityManager,
+    owner: IdentityOwner,
+    name: IdentityName,
+    keys: Arc<TestKeyProvider>,
+}
+
+#[expect(clippy::too_many_lines, reason = "shared refresh manager contract")]
+#[expect(clippy::used_underscore_binding, reason = "opaque revision contract")]
+pub(crate) async fn assert_oauth_refresh_manager_contract(db: &Arc<CoralDb>) {
+    let success = create_refresh_manager_fixture(db, false).await;
+    let before = load_pair(db, &success.owner, success.name.as_str()).await;
+    let prepared = success
+        .manager
+        .prepare_bearer_for_use(&success.owner, success.name.as_str())
+        .await
+        .expect("refresh expired OAuth identity");
+    assert_eq!(
+        prepared.resolved_for_refresh().material()["ACCESS_TOKEN"],
+        "refreshed-token"
+    );
+    let (Some(record), Some(document)) = load_pair(db, &success.owner, success.name.as_str()).await
+    else {
+        panic!("refreshed identity pair must remain durable");
+    };
+    let expected_safe = BTreeMap::from([
+        ("scope".to_string(), "repo refreshed".to_string()),
+        ("token_type".to_string(), "Bearer".to_string()),
+    ]);
+    assert_eq!(record.safe_metadata, expected_safe);
+    assert_eq!(
+        document.document_version,
+        before.1.as_ref().unwrap().document_version + 1
+    );
+    let material = decrypt_material(&record, &document, success.keys.as_ref());
+    assert!(matches!(material.get("ACCESS_TOKEN"), Some(token) if token == "refreshed-token"));
+    assert!(
+        material
+            .keys()
+            .all(|key| !key.ends_with(".access_token_expires_at"))
+    );
+    let committed = load_use_snapshot(db, &success.owner, &success.name).await;
+    assert_eq!(prepared.resolved_for_refresh().identity, record);
+    assert!(prepared.resolved_for_refresh().revision()._snapshot == committed);
+    assert!(committed.oauth_refresh_claim.is_none());
+    success
+        .manager
+        .prepare_bearer_for_use(&success.owner, success.name.as_str())
+        .await
+        .expect("reopen without a second refresh");
+    let requests = success.provider.received_requests().await.unwrap();
+    let refresh_request = |request: &&wiremock::Request| {
+        String::from_utf8_lossy(&request.body).contains("grant_type=refresh_token")
+    };
+    assert_eq!(requests.iter().filter(refresh_request).count(), 1);
+    assert!(requests.iter().filter(refresh_request).all(|request| {
+        String::from_utf8_lossy(&request.body).contains("client_id=spec-client-id")
+    }));
+
+    let failed = create_refresh_manager_fixture(db, true).await;
+    let before = load_pair(db, &failed.owner, failed.name.as_str()).await;
+    let error = failed
+        .manager
+        .prepare_bearer_for_use(&failed.owner, failed.name.as_str())
+        .await
+        .expect_err("provider failure must fail closed");
+    let detail = error.to_string();
+    for canary in ["provider-secret-canary", "access-token", "refresh-token"] {
+        assert!(!detail.contains(canary), "diagnostic leaked {canary}");
+    }
+    assert_eq!(
+        load_pair(db, &failed.owner, failed.name.as_str()).await,
+        before
+    );
+    let failed_snapshot = load_use_snapshot(db, &failed.owner, &failed.name).await;
+    let failed_claim = failed_snapshot.oauth_refresh_claim.clone().unwrap();
+    assert!(failed_claim.deadline_unix_nanos() <= now_unix_nanos_i64().unwrap());
+    let candidate = identity_document_write(identity_envelope(
+        failed_snapshot.identity_document.as_ref().unwrap(),
+    ))
+    .unwrap();
+    let candidate_safe = BTreeMap::from([("scope".to_string(), "candidate".to_string())]);
+    let finalized = finish_refresh_candidate(
+        &failed,
+        &failed_claim,
+        &failed_snapshot,
+        &candidate,
+        &candidate_safe,
+    )
+    .await
+    .expect("matching claimant may finalize after its deadline");
+    assert!(finalized.oauth_refresh_claim.is_none());
+    assert_eq!(finalized.identity.unwrap().safe_metadata, candidate_safe);
+
+    let expected = claim_refresh_snapshot(db, &failed.owner, &failed.name).await;
+    let claim = expected.oauth_refresh_claim.clone().unwrap();
+    let wrong_claim = IdentityOAuthRefreshClaim::new(uuid::Uuid::new_v4(), i64::MAX).unwrap();
+    assert!(
+        finish_refresh_candidate(
+            &failed,
+            &wrong_claim,
+            &expected,
+            &candidate,
+            &candidate_safe
+        )
+        .await
+        .is_err()
+    );
+    assert!(load_use_snapshot(db, &failed.owner, &failed.name).await == expected);
+    let mut tx = db.begin_serializable().await.unwrap();
+    tx.identity_documents()
+        .upsert(
+            &failed.owner,
+            &failed.name,
+            &candidate,
+            now_unix_nanos_i64().unwrap(),
+        )
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    let changed = load_use_snapshot(db, &failed.owner, &failed.name).await;
+    assert!(changed != expected);
+    assert!(
+        finish_refresh_candidate(&failed, &claim, &expected, &candidate, &candidate_safe)
+            .await
+            .is_err()
+    );
+    assert!(load_use_snapshot(db, &failed.owner, &failed.name).await == changed);
+}
+
+async fn create_refresh_manager_fixture(
+    db: &Arc<CoralDb>,
+    fail_refresh: bool,
+) -> RefreshManagerFixture {
+    let provider = refresh_device_oauth_provider(fail_refresh).await;
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let spec_name = format!("refresh_{suffix}");
+    let name = IdentityName::parse(&format!("refresh-{suffix}")).unwrap();
+    let key = CredentialEncryptionKey::from_static_bytes_for_test([71; 32]);
+    let keys = Arc::new(TestKeyProvider(vec![key.clone()]));
+    IdentitySpecManager::new(db.clone(), keys.clone())
+        .add_or_replace_exact(
+            IdentitySpecScope::global(),
+            &device_oauth_manifest(&spec_name, &provider.uri()),
+            vec![IdentitySpecInputValue::new(
+                "OAUTH_CLIENT_ID",
+                "spec-client-id",
+            )],
+        )
+        .await
+        .unwrap();
+    let manager = IdentityManager::new(db.clone(), keys.clone());
+    let principal = UserPrincipal::for_user(&format!("refresh-{suffix}")).unwrap();
+    manager
+        .create_or_replace_user_oauth(
+            &principal,
+            name.as_str(),
+            &spec_name,
+            IdentityOAuthCommitPhase::default(),
+            |_event| async { Ok(()) },
+        )
+        .await
+        .unwrap();
+    RefreshManagerFixture {
+        provider,
+        manager,
+        owner: IdentityOwner::for_user(principal),
+        name,
+        keys,
+    }
+}
+
+async fn load_use_snapshot(
+    db: &Arc<CoralDb>,
+    owner: &IdentityOwner,
+    name: &IdentityName,
+) -> IdentityUseSnapshot {
+    let mut tx = db.begin_read_snapshot().await.unwrap();
+    let snapshot = load_identity_use_snapshot(&mut tx, owner, name, None)
+        .await
+        .unwrap();
+    tx.commit().await.unwrap();
+    snapshot
+}
+
+async fn claim_refresh_snapshot(
+    db: &Arc<CoralDb>,
+    owner: &IdentityOwner,
+    name: &IdentityName,
+) -> IdentityUseSnapshot {
+    let claim = IdentityOAuthRefreshClaim::new(uuid::Uuid::new_v4(), i64::MAX).unwrap();
+    let mut tx = db.begin_serializable().await.unwrap();
+    let mut snapshot = load_identity_use_snapshot(&mut tx, owner, name, None)
+        .await
+        .unwrap();
+    assert!(
+        tx.identities()
+            .try_claim_oauth_refresh(owner, name, &claim)
+            .await
+            .unwrap()
+    );
+    snapshot.oauth_refresh_claim = Some(claim);
+    tx.commit().await.unwrap();
+    snapshot
+}
+
+async fn finish_refresh_candidate(
+    fixture: &RefreshManagerFixture,
+    claim: &IdentityOAuthRefreshClaim,
+    expected: &IdentityUseSnapshot,
+    document: &IdentityDocumentWrite,
+    safe_metadata: &BTreeMap<String, String>,
+) -> Result<IdentityUseSnapshot, AppError> {
+    fixture
+        .manager
+        .finish_claimed_oauth_refresh(
+            &fixture.owner,
+            &fixture.name,
+            claim,
+            expected,
+            document,
+            safe_metadata,
+        )
+        .await
 }
 
 pub(crate) async fn assert_fixed_token_manager_contract(db: &Arc<CoralDb>) {
@@ -1808,5 +2038,31 @@ async fn device_oauth_provider() -> MockServer {
             .mount(&provider)
             .await;
     }
+    provider
+}
+
+async fn refresh_device_oauth_provider(fail_refresh: bool) -> MockServer {
+    let provider = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(move |request: &wiremock::Request| {
+            if request.url.path() == "/device" {
+                return ResponseTemplate::new(200).set_body_raw(
+                    r#"{"device_code":"device-code","user_code":"ABCD-1234","verification_uri":"https://provider.example/device","verification_uri_complete":"https://provider.example/device?user_code=ABCD-1234","expires_in":60,"interval":1}"#,
+                    "application/json",
+                );
+            }
+            let refresh = String::from_utf8_lossy(&request.body).contains("grant_type=refresh_token");
+            if refresh && fail_refresh {
+                return ResponseTemplate::new(500).set_body_string("provider-secret-canary");
+            }
+            let response = if refresh {
+                r#"{"access_token":"refreshed-token","refresh_token":"rotated-refresh-token","scope":"repo refreshed"}"#
+            } else {
+                r#"{"access_token":"access-token","refresh_token":"refresh-token","token_type":"Bearer","scope":"repo user","expires_in":-300}"#
+            };
+            ResponseTemplate::new(200).set_body_raw(response, "application/json")
+        })
+        .mount(&provider)
+        .await;
     provider
 }

--- a/crates/coral-app/src/identities/runtime.rs
+++ b/crates/coral-app/src/identities/runtime.rs
@@ -112,7 +112,7 @@ impl fmt::Debug for PreparedBearerIdentity {
 }
 
 impl IdentityManager {
-    /// Resolves and prepares one fixed-token or OAuth bearer identity without refreshing it.
+    /// Resolves and prepares one fixed-token or OAuth bearer identity, refreshing when necessary.
     pub(crate) async fn prepare_bearer_for_use(
         &self,
         owner: &IdentityOwner,

--- a/crates/coral-app/src/state/db/migration_order_tests.rs
+++ b/crates/coral-app/src/state/db/migration_order_tests.rs
@@ -164,6 +164,7 @@ async fn postgres_identity_database_contracts() {
     )
     .await;
     Box::pin(crate::identities::manager::tests::assert_fixed_token_manager_contract(&db)).await;
+    Box::pin(crate::identities::manager::tests::assert_oauth_refresh_manager_contract(&db)).await;
     Box::pin(crate::identities::manager::tests::assert_oauth_creation_race_contract(&db)).await;
     Box::pin(
         crate::identities::manager::tests::assert_oauth_creation_document_rewrap_race_contract(&db),

--- a/crates/coral-app/src/state/db/repositories/identities.rs
+++ b/crates/coral-app/src/state/db/repositories/identities.rs
@@ -16,13 +16,6 @@ pub(crate) struct IdentityOAuthRefreshClaim {
     deadline_unix_nanos: i64,
 }
 
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "OAuth refresh claim construction and ownership land in B5f"
-    )
-)]
 impl IdentityOAuthRefreshClaim {
     pub(crate) fn new(id: uuid::Uuid, deadline_unix_nanos: i64) -> Result<Self, AppError> {
         if deadline_unix_nanos < 0 {
@@ -278,10 +271,6 @@ where
 
 impl IdentitiesRepo<'_, CoralTx<'_>> {
     /// Acquire an unclaimed identity refresh slot without stealing stale claims.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "OAuth refresh claim acquisition lands in B5f")
-    )]
     pub(crate) async fn try_claim_oauth_refresh(
         &mut self,
         owner: &IdentityOwner,
@@ -308,10 +297,6 @@ impl IdentitiesRepo<'_, CoralTx<'_>> {
     }
 
     /// Make a matching claim immediately fail closed without releasing ownership.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "OAuth refresh failure handling lands in B5f")
-    )]
     pub(crate) async fn expire_oauth_refresh_claim(
         &mut self,
         owner: &IdentityOwner,


### PR DESCRIPTION
## Intent

Refresh expired OAuth identity credentials at request time without performing provider I/O inside database transactions or returning a bearer token before the refreshed material is durable.

## What it enables

- Coordinates refresh across processes with one durable, non-stealable per-identity claim.
- Executes exactly one prepared provider request outside the transaction, then encrypts and atomically commits safe metadata, the credential document, and claim clearing against the complete expected revision.
- Fails closed on binding drift, stale revisions, crypto/provider/database errors, and cleanup exhaustion while keeping the caller-facing reconnect error generic and retaining redacted server-side diagnostics.

## Usage examples

No new CLI or API surface is introduced. Existing queries transparently use the refreshed identity:

```sh
coral sql "select * from github.issues limit 1"
```

If the selected OAuth access token is expired, Coral coordinates and persists its refresh before issuing the authenticated request. If refresh cannot be completed safely, the query tells the user to reconnect the identity.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo nextest run --workspace --all-targets --all-features --locked --no-fail-fast -j 8` — 1,779/1,779 passed; 3 skipped
- `make postgres-tests` — repository, shared identity-manager, and server lifecycle contracts passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- `make perf-check` — 210.9 ms mean versus 750 ms limit
- Exact-head five-lane review — zero findings/questions, seven safe credential flows, supervisor missed-risk closure at 0.99 confidence
