### PR TITLE
feat(desktop): release-shaped universal mac packaging

### DIFF
--- a/.github/workflows/build-timings.yml
+++ b/.github/workflows/build-timings.yml
@@ -25,7 +25,7 @@ jobs:
         run: rustup show
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/ui/.node-version
           cache: npm

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -37,14 +37,14 @@ jobs:
 
       - name: Setup Node
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/reef/.node-version
           package-manager-cache: false
 
       - name: Setup Node with trusted npm cache
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/reef/.node-version
           cache: npm

--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -1,0 +1,75 @@
+name: Desktop macOS package
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: desktop-package-macos-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  package:
+    name: Build unsigned package
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: coral-desktop-macos-universal
+          cache-on-failure: true
+          save-if: ${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Set up Node without npm cache
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: apps/desktop/.node-version
+          package-manager-cache: false
+
+      - name: Set up Node with trusted npm cache
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: apps/desktop/.node-version
+          cache: npm
+          cache-dependency-path: apps/desktop/package-lock.json
+
+      - name: Install desktop dependencies
+        run: npm ci --prefix apps/desktop
+
+      - name: Package desktop app
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: npm run package:mac --prefix apps/desktop
+
+      - name: Verify desktop package artifacts
+        run: node apps/desktop/scripts/verify-dist.mjs apps/desktop/dist
+
+      # PR and manual builds are available for inspection for one week.
+      - name: Upload desktop package artifact
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: coral-desktop-macos-unsigned
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            apps/desktop/dist/coral-desktop-*.dmg
+            apps/desktop/dist/coral-desktop-*.zip
+            apps/desktop/dist/coral-desktop-*.blockmap
+            apps/desktop/dist/latest-mac.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           fi
       - name: Set up Node
         if: steps.detect-ui.outputs.has-ui == 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/ui/.node-version
           package-manager-cache: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,6 +40,7 @@ jobs:
       ui-tests: ${{ steps.filter.outputs.ui-tests }}
       reef-checks: ${{ steps.filter.outputs.reef-checks }}
       desktop-checks: ${{ steps.filter.outputs.desktop-checks }}
+      desktop-package-macos: ${{ steps.filter.outputs.desktop-package-macos }}
       proto-lint: ${{ steps.filter.outputs.proto-lint }}
       source-lint: ${{ steps.filter.outputs.source-lint }}
       docs-freshness: ${{ steps.filter.outputs.docs-freshness }}
@@ -96,6 +97,15 @@ jobs:
             desktop-checks:
               - '.github/workflows/validate.yml'
               - 'apps/desktop/**'
+            desktop-package-macos:
+              - '.github/workflows/validate.yml'
+              - '.github/workflows/release.yml'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/**'
+              - 'apps/desktop/**'
+              - 'apps/reef/**'
+              - 'apps/ui/**'
             proto-lint:
               - '.github/workflows/validate.yml'
               - 'Makefile'
@@ -507,6 +517,77 @@ jobs:
       - name: Type-check desktop
         run: npm run check --prefix apps/desktop
 
+  desktop-package-macos:
+    name: Desktop macOS package
+    runs-on: macos-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.desktop-package-macos == 'true' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Set up Node
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: apps/desktop/.node-version
+          package-manager-cache: false
+
+      - name: Set up Node with trusted npm cache
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: apps/desktop/.node-version
+          cache: npm
+          cache-dependency-path: apps/desktop/package-lock.json
+
+      - name: Install desktop dependencies
+        run: npm ci --prefix apps/desktop
+
+      - name: Package desktop app
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: npm run package:mac --prefix apps/desktop
+
+      - name: Verify desktop package artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -s apps/desktop/dist/latest-mac.yml
+
+          shopt -s nullglob
+          dmg_artifacts=(apps/desktop/dist/coral-desktop-*.dmg)
+          zip_artifacts=(apps/desktop/dist/coral-desktop-*.zip)
+          blockmap_artifacts=(apps/desktop/dist/coral-desktop-*.blockmap)
+          if [ "${#dmg_artifacts[@]}" -ne 1 ] || [ "${#zip_artifacts[@]}" -ne 1 ]; then
+            echo "Expected exactly one desktop DMG and one desktop ZIP artifact." >&2
+            printf 'DMGs: %s\n' "${dmg_artifacts[*]:-<none>}" >&2
+            printf 'ZIPs: %s\n' "${zip_artifacts[*]:-<none>}" >&2
+            exit 1
+          fi
+          if [ "${#blockmap_artifacts[@]}" -eq 0 ]; then
+            echo "Expected at least one desktop blockmap artifact." >&2
+            exit 1
+          fi
+          grep -q "$(basename "${zip_artifacts[0]}")" apps/desktop/dist/latest-mac.yml
+
+      # Unsigned build for manual inspection; the run page serves it for a week.
+      - name: Upload desktop package artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: coral-desktop-macos-unsigned
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            apps/desktop/dist/coral-desktop-*.dmg
+            apps/desktop/dist/coral-desktop-*.zip
+            apps/desktop/dist/coral-desktop-*.blockmap
+            apps/desktop/dist/latest-mac.yml
+
   proto-lint:
     name: Lint protobuf API
     runs-on: ubuntu-latest
@@ -732,6 +813,7 @@ jobs:
         ui-tests,
         reef-checks,
         desktop-checks,
+        desktop-package-macos,
         proto-lint,
         gha-security-audit-pr,
         gha-security-audit-sarif,
@@ -755,6 +837,7 @@ jobs:
           UI_TESTS_RESULT: ${{ needs.ui-tests.result }}
           REEF_CHECKS_RESULT: ${{ needs.reef-checks.result }}
           DESKTOP_CHECKS_RESULT: ${{ needs.desktop-checks.result }}
+          DESKTOP_PACKAGE_MACOS_RESULT: ${{ needs.desktop-package-macos.result }}
           PROTO_LINT_RESULT: ${{ needs.proto-lint.result }}
           GHA_SECURITY_AUDIT_PR_RESULT: ${{ needs.gha-security-audit-pr.result }}
           GHA_SECURITY_AUDIT_SARIF_RESULT: ${{ needs.gha-security-audit-sarif.result }}
@@ -773,6 +856,7 @@ jobs:
             "ui-tests:$UI_TESTS_RESULT"
             "reef-checks:$REEF_CHECKS_RESULT"
             "desktop-checks:$DESKTOP_CHECKS_RESULT"
+            "desktop-package-macos:$DESKTOP_PACKAGE_MACOS_RESULT"
             "proto-lint:$PROTO_LINT_RESULT"
             "gha-security-audit-pr:$GHA_SECURITY_AUDIT_PR_RESULT"
             "gha-security-audit-sarif:$GHA_SECURITY_AUDIT_SARIF_RESULT"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -100,14 +100,15 @@ jobs:
             desktop-package-macos:
               - '.github/workflows/validate.yml'
               - '.github/workflows/release.yml'
+              - '.github/workflows/desktop-package.yml'
+              - '.cargo/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
               - 'rust-toolchain'
-              - 'crates/**'
+              - 'crates/**/Cargo.toml'
+              - 'crates/**/build.rs'
               - 'apps/desktop/**'
-              - 'apps/reef/**'
-              - 'apps/ui/**'
             proto-lint:
               - '.github/workflows/validate.yml'
               - 'Makefile'
@@ -364,14 +365,14 @@ jobs:
 
       - name: Set up Node
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/ui/.node-version
           package-manager-cache: false
 
       - name: Set up Node with trusted npm cache
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/ui/.node-version
           cache: npm
@@ -408,14 +409,14 @@ jobs:
 
       - name: Set up Node
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/ui/.node-version
           package-manager-cache: false
 
       - name: Set up Node with trusted npm cache
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/ui/.node-version
           cache: npm
@@ -455,14 +456,14 @@ jobs:
 
       - name: Set up Node
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/reef/.node-version
           package-manager-cache: false
 
       - name: Set up Node with trusted npm cache
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/reef/.node-version
           cache: npm
@@ -498,14 +499,14 @@ jobs:
 
       - name: Set up Node
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/desktop/.node-version
           package-manager-cache: false
 
       - name: Set up Node with trusted npm cache
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/desktop/.node-version
           cache: npm
@@ -521,55 +522,11 @@ jobs:
 
   desktop-package-macos:
     name: Desktop macOS package
-    runs-on: macos-latest
     needs: changes
-    if: ${{ needs.changes.outputs.desktop-package-macos == 'true' }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Install Rust toolchain
-        run: rustup show
-
-      - name: Set up Node
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: apps/desktop/.node-version
-          package-manager-cache: false
-
-      - name: Set up Node with trusted npm cache
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version-file: apps/desktop/.node-version
-          cache: npm
-          cache-dependency-path: apps/desktop/package-lock.json
-
-      - name: Install desktop dependencies
-        run: npm ci --prefix apps/desktop
-
-      - name: Package desktop app
-        env:
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
-        run: npm run package:mac --prefix apps/desktop
-
-      - name: Verify desktop package artifacts
-        run: node apps/desktop/scripts/verify-dist.mjs apps/desktop/dist
-
-      # Unsigned build for manual inspection; the run page serves it for a week.
-      - name: Upload desktop package artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: coral-desktop-macos-unsigned
-          if-no-files-found: error
-          retention-days: 7
-          path: |
-            apps/desktop/dist/coral-desktop-*.dmg
-            apps/desktop/dist/coral-desktop-*.zip
-            apps/desktop/dist/coral-desktop-*.blockmap
-            apps/desktop/dist/latest-mac.yml
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.desktop-package-macos == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/desktop-package.yml
 
   proto-lint:
     name: Lint protobuf API
@@ -682,7 +639,7 @@ jobs:
         run: make docs-check
 
       - name: Set up Node for Mintlify validation
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/ui/.node-version
           package-manager-cache: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -556,26 +556,7 @@ jobs:
         run: npm run package:mac --prefix apps/desktop
 
       - name: Verify desktop package artifacts
-        shell: bash
-        run: |
-          set -euo pipefail
-          test -s apps/desktop/dist/latest-mac.yml
-
-          shopt -s nullglob
-          dmg_artifacts=(apps/desktop/dist/coral-desktop-*.dmg)
-          zip_artifacts=(apps/desktop/dist/coral-desktop-*.zip)
-          blockmap_artifacts=(apps/desktop/dist/coral-desktop-*.blockmap)
-          if [ "${#dmg_artifacts[@]}" -ne 1 ] || [ "${#zip_artifacts[@]}" -ne 1 ]; then
-            echo "Expected exactly one desktop DMG and one desktop ZIP artifact." >&2
-            printf 'DMGs: %s\n' "${dmg_artifacts[*]:-<none>}" >&2
-            printf 'ZIPs: %s\n' "${zip_artifacts[*]:-<none>}" >&2
-            exit 1
-          fi
-          if [ "${#blockmap_artifacts[@]}" -eq 0 ]; then
-            echo "Expected at least one desktop blockmap artifact." >&2
-            exit 1
-          fi
-          grep -q "$(basename "${zip_artifacts[0]}")" apps/desktop/dist/latest-mac.yml
+        run: node apps/desktop/scripts/verify-dist.mjs apps/desktop/dist
 
       # Unsigned build for manual inspection; the run page serves it for a week.
       - name: Upload desktop package artifact

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -102,6 +102,8 @@ jobs:
               - '.github/workflows/release.yml'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'rust-toolchain'
               - 'crates/**'
               - 'apps/desktop/**'
               - 'apps/reef/**'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,10 +49,15 @@
   latency. CI installs the bundled `github` source with fake credentials and
   fails when release `coral sql "select * from coral.tables"` has a hyperfine
   mean above 750 ms.
-- Desktop distribution changes must exercise the release-shaped macOS package
-  path, not only the desktop type-check. The Validate workflow runs the
-  `Desktop macOS package` job for desktop, Reef, UI, Rust, and release-workflow
-  inputs so PRs catch missing DMG/ZIP/update metadata before the release job.
+- Desktop distribution-sensitive PRs must exercise the release-shaped macOS
+  package path, not only the desktop type-check. Validate calls the reusable
+  desktop packaging workflow for desktop, packaging-workflow, release-workflow,
+  Cargo workspace/toolchain, crate-manifest, and build-script changes. Ordinary
+  Rust, Reef, and UI changes use their existing checks. Use manual dispatch as
+  an unsigned packaging preflight for distribution-sensitive changes outside
+  the automatic paths. Validation artifacts stay unsigned and must not be
+  reused for a release; desktop release publishing must rebuild from a clean
+  checkout with signing and notarization.
 - The `Validate` workflow intentionally skips draft pull request runs, starts
   again on `ready_for_review`, and still triggers on `converted_to_draft` so the
   replacement skipped run cancels any in-progress validation for the PR branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,10 @@
   latency. CI installs the bundled `github` source with fake credentials and
   fails when release `coral sql "select * from coral.tables"` has a hyperfine
   mean above 750 ms.
+- Desktop distribution changes must exercise the release-shaped macOS package
+  path, not only the desktop type-check. The Validate workflow runs the
+  `Desktop macOS package` job for desktop, Reef, UI, Rust, and release-workflow
+  inputs so PRs catch missing DMG/ZIP/update metadata before the release job.
 - The `Validate` workflow intentionally skips draft pull request runs, starts
   again on `ready_for_review`, and still triggers on `converted_to_draft` so the
   replacement skipped run cancels any in-progress validation for the PR branch.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -31,7 +31,8 @@ uses `CORAL_ENDPOINT` to reach the supervised sidecar.
   Windows target)
 - Coral MCP configuration for Codex and Claude Code — from the Settings page and
   the app menu — via `add-mcp`
-- macOS DMG packaging via `electron-builder`
+- macOS DMG and ZIP packaging via `electron-builder`
+- GitHub Releases update metadata for packaged desktop builds
 - macOS system theme support
 
 ## Development
@@ -74,6 +75,8 @@ npm run package:dir --prefix apps/desktop
 ```
 
 Use `npm run package:dmg --prefix apps/desktop` for the macOS drag-and-drop DMG.
+Use `npm run package:mac --prefix apps/desktop` to build the release-shaped
+universal macOS DMG and ZIP with updater metadata.
 
 > Run the `--prefix apps/desktop` commands from the repo root. If you are already in
 > `apps/desktop/`, drop the flag (e.g. `npm run package:dir`).

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -3,6 +3,7 @@ import type { Configuration } from 'electron-builder'
 const config: Configuration = {
   appId: 'com.withcoral.desktop',
   productName: 'Coral',
+  artifactName: 'coral-desktop-${os}-${arch}.${ext}',
   publish: [
     {
       provider: 'github',
@@ -43,7 +44,6 @@ const config: Configuration = {
     },
   ],
   mac: {
-    artifactName: 'coral-desktop-mac-${arch}.${ext}',
     category: 'public.app-category.developer-tools',
     icon: 'resources/icons/icon.icns',
     target: ['dmg', 'zip'],

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -3,7 +3,13 @@ import type { Configuration } from 'electron-builder'
 const config: Configuration = {
   appId: 'com.withcoral.desktop',
   productName: 'Coral',
-  artifactName: 'coral-desktop-${os}-${arch}.${ext}',
+  publish: [
+    {
+      provider: 'github',
+      owner: 'withcoral',
+      repo: 'coral',
+    },
+  ],
   directories: {
     output: 'dist',
     buildResources: 'resources',
@@ -37,9 +43,10 @@ const config: Configuration = {
     },
   ],
   mac: {
+    artifactName: 'coral-desktop-mac-${arch}.${ext}',
     category: 'public.app-category.developer-tools',
     icon: 'resources/icons/icon.icns',
-    target: ['dmg'],
+    target: ['dmg', 'zip'],
   },
 }
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,8 @@
     "package:dir": "electron-builder --dir --config electron-builder.config.ts",
     "prepackage:dmg": "npm run build",
     "package:dmg": "electron-builder --mac dmg --config electron-builder.config.ts",
+    "prepackage:mac": "CORAL_DESKTOP_UNIVERSAL=1 npm run build",
+    "package:mac": "electron-builder --mac --universal --publish never --config electron-builder.config.ts",
     "stage:coral": "node ./scripts/stage-coral.mjs"
   },
   "dependencies": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,11 +15,11 @@
     "type-check": "tsc --noEmit",
     "check": "npm run type-check",
     "prepackage": "npm run build",
-    "package": "electron-builder --config electron-builder.config.ts",
+    "package": "electron-builder --publish never --config electron-builder.config.ts",
     "prepackage:dir": "npm run build",
     "package:dir": "electron-builder --dir --config electron-builder.config.ts",
     "prepackage:dmg": "npm run build",
-    "package:dmg": "electron-builder --mac dmg --config electron-builder.config.ts",
+    "package:dmg": "electron-builder --mac dmg --publish never --config electron-builder.config.ts",
     "prepackage:mac": "CORAL_DESKTOP_UNIVERSAL=1 npm run build",
     "package:mac": "electron-builder --mac --universal --publish never --config electron-builder.config.ts",
     "stage:coral": "node ./scripts/stage-coral.mjs"

--- a/apps/desktop/scripts/stage-coral.mjs
+++ b/apps/desktop/scripts/stage-coral.mjs
@@ -7,6 +7,9 @@ const repoRoot = resolve(desktopRoot, '..', '..')
 const outputDir = resolve(desktopRoot, 'resources', 'coral')
 const binaryName = process.platform === 'win32' ? 'coral.exe' : 'coral'
 const targetBinary = resolve(repoRoot, 'target', 'release', binaryName)
+const universalMacBinary = resolve(repoRoot, 'target', 'release', 'coral-universal')
+const universalMac = process.env.CORAL_DESKTOP_UNIVERSAL === '1'
+const macTargets = ['x86_64-apple-darwin', 'aarch64-apple-darwin']
 
 function run(command, args, options = {}) {
   return new Promise((resolveRun, rejectRun) => {
@@ -37,14 +40,38 @@ await run('npm', ['run', 'build', '--prefix', 'apps/reef'], {
     VITE_CORAL_DESKTOP_APP: '1',
   },
 })
-await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release'])
+
+async function buildCoralCli() {
+  if (!universalMac) {
+    await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release'])
+    return targetBinary
+  }
+
+  if (process.platform !== 'darwin') {
+    throw new Error('CORAL_DESKTOP_UNIVERSAL=1 is only supported on macOS.')
+  }
+
+  await run('rustup', ['target', 'add', ...macTargets])
+  for (const target of macTargets) {
+    await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release', '--target', target])
+  }
+  await run('lipo', [
+    '-create',
+    ...macTargets.map((target) => resolve(repoRoot, 'target', target, 'release', binaryName)),
+    '-output',
+    universalMacBinary,
+  ])
+  return universalMacBinary
+}
+
+const builtBinary = await buildCoralCli()
 
 await rm(outputDir, { recursive: true, force: true })
 await mkdir(outputDir, { recursive: true })
-await copyFile(targetBinary, join(outputDir, binaryName))
+await copyFile(builtBinary, join(outputDir, binaryName))
 
 if (process.platform !== 'win32') {
   await chmod(join(outputDir, binaryName), 0o755)
 }
 
-console.log(`[stage-coral] staged ${targetBinary} -> ${join(outputDir, binaryName)}`)
+console.log(`[stage-coral] staged ${builtBinary} -> ${join(outputDir, binaryName)}`)

--- a/apps/desktop/scripts/verify-dist.mjs
+++ b/apps/desktop/scripts/verify-dist.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Verifies a release-shaped desktop dist directory. Shared by the Validate
+// workflow's Desktop macOS package job and the release workflow so the two
+// checks cannot drift: exactly one DMG and one ZIP, non-empty update
+// metadata, every file latest-mac.yml references present, and a blockmap
+// next to the ZIP (electron-updater fetches <file>.blockmap for
+// differential updates).
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const distDir = resolve(process.argv[2] ?? 'apps/desktop/dist')
+
+function fail(message) {
+  console.error(`[verify-dist] ${message}`)
+  process.exit(1)
+}
+
+if (!existsSync(distDir)) fail(`missing dist directory: ${distDir}`)
+const entries = readdirSync(distDir)
+
+const dmgs = entries.filter((f) => f.startsWith('coral-desktop-') && f.endsWith('.dmg'))
+const zips = entries.filter((f) => f.startsWith('coral-desktop-') && f.endsWith('.zip'))
+if (dmgs.length !== 1 || zips.length !== 1) {
+  fail(
+    `expected exactly one desktop DMG and one desktop ZIP, got DMGs: [${dmgs}] ZIPs: [${zips}]`,
+  )
+}
+
+const metadataPath = join(distDir, 'latest-mac.yml')
+if (!existsSync(metadataPath)) fail('missing latest-mac.yml')
+const metadata = readFileSync(metadataPath, 'utf8')
+if (!metadata.trim()) fail('latest-mac.yml is empty')
+
+// latest-mac.yml lists its update assets as `url:` entries plus a legacy
+// top-level `path:`; a file the metadata references but the dist lacks would
+// 404 for every updater in the wild.
+const referenced = [
+  ...new Set(
+    [...metadata.matchAll(/^\s*(?:-\s*)?(?:url|path):\s*(\S+)\s*$/gm)].map((match) => match[1]),
+  ),
+]
+if (referenced.length === 0) fail('latest-mac.yml references no update assets')
+if (!referenced.includes(zips[0])) fail(`latest-mac.yml does not reference ${zips[0]}`)
+for (const file of referenced) {
+  if (!entries.includes(file)) fail(`latest-mac.yml references a missing file: ${file}`)
+}
+
+const zipBlockmap = `${zips[0]}.blockmap`
+if (!entries.includes(zipBlockmap)) {
+  fail(`missing ${zipBlockmap}; differential updates need the ZIP blockmap`)
+}
+
+console.log(
+  `[verify-dist] ok: ${dmgs[0]}, ${zips[0]} (+${zipBlockmap}), latest-mac.yml references ${referenced.join(', ')}`,
+)


### PR DESCRIPTION
Part 1/4 of splitting #1519 into reviewable pieces. This PR establishes the local and CI packaging path; it does not ship a desktop release.

- `npm run package:mac` builds a **universal** (arm64 + x86_64) macOS app: `CORAL_DESKTOP_UNIVERSAL=1` makes `stage-coral.mjs` compile the Coral sidecar for both targets and combine them with `lipo`.
- electron-builder produces **DMG + ZIP** with version-less `coral-desktop-mac-*` names, so a future `releases/latest/download` link can remain stable across releases.
- The `github` publish provider generates `latest-mac.yml` update metadata and embeds `app-update.yml`; nothing consumes them yet (the updater lands in part 4).
- Unsigned packaging and artifact verification live in the reusable `.github/workflows/desktop-package.yml`. Validate calls it only for distribution-sensitive PRs: desktop files, packaging/validation/release workflow changes, Cargo workspace or toolchain configuration, and crate manifests or build scripts. Ordinary Rust, Reef, and UI changes continue to use their existing checks.
- The reusable workflow also runs nightly on `main` and by manual dispatch as an unsigned packaging preflight. Every run verifies the DMG, ZIP, blockmaps, and `latest-mac.yml`; PR and manual runs retain the roughly 700 MB artifact for seven days, while nightly runs verify it without uploading it.
- PRs may restore the trusted desktop Rust cache, but only nightly and manual runs can update it. The stale `actions/setup-node` pins are also refreshed so the workflow security audit recognizes the current immutable revision.
- Contributor guidance now distinguishes distribution-sensitive PRs from ordinary Rust/Reef/UI validation and records nightly integrated-package coverage.

The validation artifact is unsigned and is never a release input. Signing/notarization and desktop release publishing remain in stacked follow-ups #1732 and #1735; that release path will rebuild the desktop package from a clean checkout.

Based on the paths changed by the 50 most recently created PRs that later merged (created July 7–17, 2026), the narrowed filter is expected to reduce this expensive PR job from roughly 84% of PRs to roughly 6%, while retaining packaging coverage on sensitive changes and nightly integration coverage.

Stack: this → #1732 signing → #1735 release publish → #1736 auto-update. Release remains ordered before the updater deliberately: the first release verifies signing/notarization/upload end to end, and the release after #1736 verifies the update flow against it.