### PR TITLE
docs(search): document catalog search

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -78,6 +78,7 @@
         "group": "Guides",
         "pages": [
           "guides/use-coral-over-mcp",
+          "guides/search-the-catalog",
           "guides/write-a-custom-source",
           "guides/observe-with-opentelemetry"
         ]

--- a/apps/docs/guides/search-the-catalog.mdx
+++ b/apps/docs/guides/search-the-catalog.mdx
@@ -7,7 +7,7 @@ Use catalog search when you know what data you need but not which table or table
 
 Catalog search helps you find where data can be queried. It does not retrieve rows from GitHub, Slack, or another connected source.
 
-## Find the right table or table function
+## Use catalog search from the CLI
 
 ```shellscript
 coral search github issues assigned to me

--- a/apps/docs/guides/search-the-catalog.mdx
+++ b/apps/docs/guides/search-the-catalog.mdx
@@ -3,9 +3,11 @@ title: "Search the catalog"
 description: "Find relevant tables, table functions, columns, and filters before you write SQL."
 ---
 
-Use catalog search when you know what data you need but not which table or table function exposes it. Enter a natural language query and Coral ranks matching tables, table functions, columns, and filters from the sources installed in your current workspace.
+Catalog search helps you find the right table or table function when you know what you want to query but not where to start. Enter a natural language description, and Coral ranks matching tables, table functions, columns, and filters in your current workspace.
 
-Catalog search helps you find where data can be queried. It does not retrieve rows from GitHub, Slack, or another connected source.
+<Note>
+Catalog search looks only at Coral's catalog metadata. It does not query connected sources or return source rows.
+</Note>
 
 ## Use catalog search from the CLI
 
@@ -26,7 +28,7 @@ Results
 
 The `SQL` line gives you the table reference. For a table function, `SQL reference` identifies the function and `Call` shows its required arguments.
 
-Catalog search only identifies these queryable surfaces; it does not execute them or retrieve rows. To fetch rows, use the returned `SQL` reference or `Call` example with `coral sql`. See [Query your data](/getting-started/quickstart#3-query-your-data) for a complete example.
+To fetch rows, use the result's `SQL` reference or `Call` example in a query with `coral sql`. See [Query your data](/getting-started/quickstart#3-query-your-data) for a complete example.
 
 By default, Coral returns up to 10 results. Use `--limit` to request between 1 and 50. See the complete [`coral search` reference](/reference/cli-reference#coral-search).
 

--- a/apps/docs/guides/search-the-catalog.mdx
+++ b/apps/docs/guides/search-the-catalog.mdx
@@ -1,0 +1,46 @@
+---
+title: "Search the catalog"
+description: "Find relevant tables, table functions, columns, and filters before you write SQL."
+---
+
+Use catalog search when you know what data you need but not which table or table function exposes it. Enter a natural language query and Coral ranks matching tables, table functions, columns, and filters from the sources installed in your current workspace.
+
+Catalog search helps you find where data can be queried. It does not retrieve rows from GitHub, Slack, or another connected source.
+
+## Find the right table or table function
+
+```shellscript
+coral search github issues assigned to me
+```
+
+Among the ranked results, you might see:
+
+```text
+Results
+1. [catalog_metadata] table github.issues
+   SQL: github.issues
+```
+
+The `SQL` line gives you the table reference. When a result is a table function, Coral also shows a `Call` example with its arguments.
+
+Catalog search only identifies these queryable surfaces; it does not execute them or retrieve rows. To fetch rows, use the returned `SQL` reference or `Call` example with `coral sql`. See [Query your data](/getting-started/quickstart#3-query-your-data) for a complete example.
+
+## Use catalog search over MCP
+
+Coral exposes catalog search to connected agents through its read-only `search` MCP tool. An agent can use it to find the relevant table or table function before querying your data.
+
+> "Use Coral to show the open GitHub issues assigned to me."
+
+Ask for the result you want; you do not need to mention the `search` tool. The agent can decide when catalog search is needed.
+
+[Set up Coral over MCP](/guides/use-coral-over-mcp).
+
+## Search options
+
+By default, Coral returns up to 10 results. Use `--limit` to request between 1 and 50:
+
+```shellscript
+coral search --limit 5 slack messages text
+```
+
+Use `--json` when a script or another program needs the structured response. See [`coral search` in the CLI reference](/reference/cli-reference#coral-search) for the complete response fields and provider-status details.

--- a/apps/docs/guides/search-the-catalog.mdx
+++ b/apps/docs/guides/search-the-catalog.mdx
@@ -19,11 +19,16 @@ Among the ranked results, you might see:
 Results
 1. [catalog_metadata] table github.issues
    SQL: github.issues
+2. [catalog_metadata] table function github.search_issues
+   SQL reference: github.search_issues
+   Call: github.search_issues(q => '<value>')
 ```
 
-The `SQL` line gives you the table reference. When a result is a table function, Coral also shows a `Call` example with its arguments.
+The `SQL` line gives you the table reference. For a table function, `SQL reference` identifies the function and `Call` shows its required arguments.
 
 Catalog search only identifies these queryable surfaces; it does not execute them or retrieve rows. To fetch rows, use the returned `SQL` reference or `Call` example with `coral sql`. See [Query your data](/getting-started/quickstart#3-query-your-data) for a complete example.
+
+By default, Coral returns up to 10 results. Use `--limit` to request between 1 and 50. See the complete [`coral search` reference](/reference/cli-reference#coral-search).
 
 ## Use catalog search over MCP
 
@@ -34,13 +39,3 @@ Coral exposes catalog search to connected agents through its read-only `search` 
 Ask for the result you want; you do not need to mention the `search` tool. The agent can decide when catalog search is needed.
 
 [Set up Coral over MCP](/guides/use-coral-over-mcp).
-
-## Search options
-
-By default, Coral returns up to 10 results. Use `--limit` to request between 1 and 50:
-
-```shellscript
-coral search --limit 5 slack messages text
-```
-
-Use `--json` when a script or another program needs the structured response. See [`coral search` in the CLI reference](/reference/cli-reference#coral-search) for the complete response fields and provider-status details.

--- a/apps/docs/guides/use-coral-over-mcp.mdx
+++ b/apps/docs/guides/use-coral-over-mcp.mdx
@@ -211,7 +211,7 @@ When your agent has many tools available, name Coral explicitly:
 
 > "Use Coral. Search the catalog for the relevant table or table function, then query the best match."
 
-When the right table or table function is not obvious, ask the agent to search the catalog before querying. You do not need to know the MCP tool names; Coral exposes both catalog search and read-only SQL through MCP. Catalog search identifies queryable surfaces but does not retrieve source rows. For a CLI walkthrough, see [Search the catalog](/guides/search-the-catalog). If an answer needs data from multiple connected sources, ask the agent to combine the data in Coral when possible.
+When the right table or table function is not obvious, ask the agent to [search the catalog](/guides/search-the-catalog) first. For questions that span connected sources, ask it to combine the data in Coral when possible.
 
 ## Workspaces
 

--- a/apps/docs/guides/use-coral-over-mcp.mdx
+++ b/apps/docs/guides/use-coral-over-mcp.mdx
@@ -209,9 +209,9 @@ When your agent has many tools available, name Coral explicitly:
 
 > "Use Coral to compare recent deploy errors in Datadog with related Slack messages."
 
-> "Use Coral. First inspect the catalog, then query the right tables."
+> "Use Coral. Search the catalog for the relevant table or table function, then query the best match."
 
-Good agents will inspect Coral's catalog before writing SQL, then answer from query results. If an answer needs data from multiple connected sources, ask the agent to combine the data in Coral when possible.
+When the right table or table function is not obvious, ask the agent to search the catalog before querying. You do not need to know the MCP tool names; Coral exposes both catalog search and read-only SQL through MCP. Catalog search identifies queryable surfaces but does not retrieve source rows. For a CLI walkthrough, see [Search the catalog](/guides/search-the-catalog). If an answer needs data from multiple connected sources, ask the agent to combine the data in Coral when possible.
 
 ## Workspaces
 

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -9,6 +9,8 @@ Agents are able to make fewer, more precise tool calls with Coral than they do w
 
 Coral supports a number of [popular data sources](/reference/bundled-sources) bundled in, plus [community source specs](/reference/community-sources) you can import with `coral source add --file`. You can also extend it to accommodate others by writing your own [source specs](/reference/source-spec-reference). You can run SQL from the [CLI](/reference/cli-reference) or through [MCP](/guides/use-coral-over-mcp). And everything is local; your data, credentials and usage history never leave your machine.
 
+When you know what data you need but not which table or table function exposes it, [search Coral's catalog](/guides/search-the-catalog) with a natural language query before you write SQL.
+
 ## Get started
 
 <Steps titleSize="h3">
@@ -120,6 +122,9 @@ For the full internals, crates, gRPC transport, DataFusion integration, see the 
 ## Quick links
 
 <CardGroup cols={2}>
+  <Card title="Search the catalog" href="/guides/search-the-catalog">
+    Find the right table, table function, column, or filter before you write SQL
+  </Card>
   <Card title="Use Coral over MCP" href="/guides/use-coral-over-mcp">
     Set up MCP for Claude Code, Cursor, and other agents
   </Card>

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -9,8 +9,6 @@ Agents are able to make fewer, more precise tool calls with Coral than they do w
 
 Coral supports a number of [popular data sources](/reference/bundled-sources) bundled in, plus [community source specs](/reference/community-sources) you can import with `coral source add --file`. You can also extend it to accommodate others by writing your own [source specs](/reference/source-spec-reference). You can run SQL from the [CLI](/reference/cli-reference) or through [MCP](/guides/use-coral-over-mcp). And everything is local; your data, credentials and usage history never leave your machine.
 
-When you know what data you need but not which table or table function exposes it, [search Coral's catalog](/guides/search-the-catalog) with a natural language query before you write SQL.
-
 ## Get started
 
 <Steps titleSize="h3">
@@ -122,11 +120,11 @@ For the full internals, crates, gRPC transport, DataFusion integration, see the 
 ## Quick links
 
 <CardGroup cols={2}>
-  <Card title="Search the catalog" href="/guides/search-the-catalog">
-    Find the right table, table function, column, or filter before you write SQL
-  </Card>
   <Card title="Use Coral over MCP" href="/guides/use-coral-over-mcp">
     Set up MCP for Claude Code, Cursor, and other agents
+  </Card>
+  <Card title="Search the catalog" href="/guides/search-the-catalog">
+    Find the right table, table function, column, or filter before you write SQL
   </Card>
   <Card title="Write a custom source" href="/guides/write-a-custom-source">
     Connect any API or dataset to Coral

--- a/apps/docs/project/roadmap.mdx
+++ b/apps/docs/project/roadmap.mdx
@@ -7,6 +7,7 @@ description: "What Coral supports today, what is coming next, and where the proj
 
 - One SQL interface across APIs, local files, and live systems
 - Use Coral from the CLI or over MCP
+- Natural language search for tables, table functions, columns, and filters in your Coral catalog
 - Data, credentials, and query history stay local
 - Bundled sources for GitHub, Slack, Datadog, Linear, Sentry, Stripe, and more
 - Bring your own sources with source specs
@@ -18,6 +19,7 @@ description: "What Coral supports today, what is coming next, and where the proj
 - Explore schemas, query traces, and source health in a local UI
 - Source actions as table functions
 - Table and column level access policies
+- Search over values Coral has observed while querying connected sources
 - Semantic search predicates that push down to source-native search
 
 ## Future

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -81,6 +81,12 @@ answer the question by itself; use the returned `sql_reference` or
 | `--json`  | flag    | `false` | Render the shared machine-readable JSON response          |
 | `--limit` | integer | `10`    | Maximum results to return, from 1 to 50                   |
 
+### JSON response
+
+With `--json`, the response separates `results`, `provider_statuses`, and `truncation`. Table results include `sql_reference`. Table-function results include `sql_reference` and `sql_call_example`. Field-level results include `surface_sql_reference`, identifying the table or table function that owns the matching column, filter, argument, or result column.
+
+For catalog search, the `catalog_metadata` provider status reports whether search found matches, completed with no matches, returned partial coverage, or failed. `truncation` reports when more matches were available than returned.
+
 ## `coral source`
 
 Manage configured sources, either the bundled ones, or your custom source specs.


### PR DESCRIPTION
## Summary

- add a human-first **Search the catalog** guide focused on catalog discovery, with a real output excerpt and a handoff to the existing query tutorial
- link catalog search from the docs homepage and place it after **Use Coral over MCP** in Guides navigation
- explain catalog search over MCP without requiring users to name the `search` tool in their prompts
- document machine-readable search fields and provider statuses in the CLI reference
- list catalog search under **Now** and search over observed values under **Next** on the roadmap

## Why

Catalog search shipped through the CLI and MCP in #1462, but the public documentation did not make it discoverable or explain its boundaries. This documents the released capability as **catalog search**: it finds tables, table functions, columns, filters, arguments, and result columns, but does not retrieve source rows or present the future observed-value and source-native search providers as currently available.

## Validation

- `make docs-check`
- `npx --yes mint validate`
- `npx --yes mint broken-links --check-anchors --check-redirects`
- `git diff --check main...HEAD`
