### PR TITLE
feat(app): add request principal boundary

### DIFF
--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -15,6 +15,9 @@ use crate::state::db::DbError;
 /// Errors surfaced by the local application layer.
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
+    /// The request did not present valid authentication.
+    #[error("unauthenticated: {0}")]
+    Unauthenticated(String),
     /// A requested source was not found in config.
     #[error("source '{0}' not found")]
     SourceNotFound(String),
@@ -143,6 +146,10 @@ fn truncate_status_detail(detail: String) -> String {
     format!("{truncated}{MARKER}")
 }
 
+pub(crate) fn status_with_bounded_detail(code: Code, detail: impl Into<String>) -> Status {
+    Status::new(code, truncate_status_detail(detail.into()))
+}
+
 #[expect(
     clippy::needless_pass_by_value,
     reason = "used directly as a map_err adapter across tonic service handlers"
@@ -167,7 +174,7 @@ pub(crate) fn app_status(error: AppError) -> Status {
             details,
         );
     }
-    Status::new(app_code(&error), truncate_status_detail(error.to_string()))
+    status_with_bounded_detail(app_code(&error), error.to_string())
 }
 
 pub(crate) fn core_status(error: CoreError) -> Status {
@@ -235,6 +242,7 @@ fn grpc_code(status: StatusCode) -> Code {
 
 fn app_code(error: &AppError) -> Code {
     match error {
+        AppError::Unauthenticated(_) => Code::Unauthenticated,
         AppError::SourceNotFound(_) | AppError::WorkspaceNotFound(_) => Code::NotFound,
         AppError::WorkspaceAlreadyExists(_) => Code::AlreadyExists,
         AppError::InvalidInput(_) => Code::InvalidArgument,
@@ -277,6 +285,15 @@ mod tests {
         let out = truncate_status_detail(detail);
         assert!(out.len() <= MAX_STATUS_DETAIL_BYTES);
         assert!(out.ends_with("… (truncated)"), "missing marker: {out:?}");
+    }
+
+    #[test]
+    fn app_status_maps_unauthenticated_and_truncates_detail() {
+        let status = app_status(AppError::Unauthenticated("x".repeat(20 * 1024)));
+
+        assert_eq!(status.code(), Code::Unauthenticated);
+        assert!(status.message().len() <= MAX_STATUS_DETAIL_BYTES);
+        assert!(status.message().ends_with("… (truncated)"));
     }
 
     #[test]

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -15,7 +15,7 @@ use crate::workspaces::WorkspaceName;
 
 #[cfg(test)]
 pub(crate) use error::MAX_STATUS_DETAIL_BYTES;
-pub(crate) use error::{app_status, core_status};
+pub(crate) use error::{app_status, core_status, status_with_bounded_detail};
 
 pub use error::AppError;
 pub use server::{RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider};

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -48,6 +48,7 @@ use crate::feedback::publisher::{
     FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
 };
 use crate::feedback::service::FeedbackService;
+use crate::identity::{SingleUserPrincipalProvider, UserPrincipalProvider};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::search::manager::SearchManager;
@@ -58,7 +59,7 @@ use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_stat
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
-use crate::transport::GrpcMethodAnnotatedService;
+use crate::transport::GrpcRequestContextLayer;
 use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceManager, WorkspaceService};
 
 /// A static asset (e.g., a built SPA file) served on the same port as
@@ -86,6 +87,7 @@ pub(crate) struct ServerConfig {
     config_dir: Option<PathBuf>,
     mode: ServerMode,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
     feedback_publisher: Arc<dyn FeedbackPublisher>,
     enable_stderr_logs: bool,
 }
@@ -102,6 +104,7 @@ impl ServerConfig {
             config_dir: None,
             mode: ServerMode::NativeGrpc,
             engine_extensions_providers: Vec::new(),
+            user_principal_provider: Arc::new(SingleUserPrincipalProvider),
             feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
             enable_stderr_logs: false,
         }
@@ -222,6 +225,20 @@ impl ServerBuilder {
     }
 
     #[must_use]
+    /// Sets the server-side user principal provider.
+    ///
+    /// The default provider returns the local single-user principal for every
+    /// request. Product runtimes can authenticate inbound metadata and select a
+    /// user by installing their own provider.
+    pub fn with_user_principal_provider(
+        mut self,
+        user_principal_provider: Arc<dyn UserPrincipalProvider>,
+    ) -> Self {
+        self.config.user_principal_provider = user_principal_provider;
+        self
+    }
+
+    #[must_use]
     /// Enables or disables local stderr log rendering for this server.
     ///
     /// `MCP` stdio adapters can enable this for diagnostics while keeping
@@ -327,6 +344,7 @@ impl ServerBuilder {
                 feedback: feedback_manager,
             },
             trace_components,
+            self.config.user_principal_provider,
             self.config.mode,
         )
         .await
@@ -455,6 +473,7 @@ struct ServerManagers {
 async fn start_server(
     managers: ServerManagers,
     trace_components: TraceServerComponents,
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
     mode: ServerMode,
 ) -> Result<RunningServer, AppError> {
     let TraceServerComponents {
@@ -475,34 +494,34 @@ async fn start_server(
     let search_service = SearchService::new(search);
     let feedback_service = FeedbackService::new(feedback);
     let mut routes = Routes::default()
-        .add_service(GrpcMethodAnnotatedService::new(
+        .add_service(
             SourceServiceServer::new(source_service)
                 .max_encoding_message_size(SOURCE_RESPONSE_MAX_MESSAGE_SIZE),
-        ))
-        .add_service(GrpcMethodAnnotatedService::new(
-            WorkspaceServiceServer::new(workspace_service),
-        ))
-        .add_service(GrpcMethodAnnotatedService::new(
+        )
+        .add_service(WorkspaceServiceServer::new(workspace_service))
+        .add_service(
             CatalogServiceServer::new(catalog_service)
                 .max_encoding_message_size(CATALOG_RESPONSE_MAX_MESSAGE_SIZE),
-        ))
-        .add_service(GrpcMethodAnnotatedService::new(FeedbackServiceServer::new(
-            feedback_service,
-        )))
-        .add_service(GrpcMethodAnnotatedService::new(
+        )
+        .add_service(FeedbackServiceServer::new(feedback_service))
+        .add_service(
             QueryServiceServer::new(query_service)
                 .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
-        ))
-        .add_service(GrpcMethodAnnotatedService::new(
+        )
+        .add_service(
             SearchServiceServer::new(search_service)
                 .max_encoding_message_size(SEARCH_RESPONSE_MAX_MESSAGE_SIZE),
-        ));
+        );
     if let Some(trace_service) = trace_service {
-        routes = routes.add_service(GrpcMethodAnnotatedService::new(
+        routes = routes.add_service(
             TraceServiceServer::new(trace_service)
                 .max_encoding_message_size(TRACE_RESPONSE_MAX_MESSAGE_SIZE),
-        ));
+        );
     }
+    let routes = routes
+        .into_axum_router()
+        .layer(GrpcRequestContextLayer::new(user_principal_provider))
+        .into();
 
     let listener = TcpListener::bind(mode.bind_addr()).await?;
     let endpoint_uri = format!("http://{}", listener.local_addr()?);
@@ -749,7 +768,10 @@ mod tests {
     use crate::telemetry::service::TraceService;
     use crate::transport::workspace_to_proto;
     use crate::workspaces::{WorkspaceManager, WorkspaceName};
-    use crate::{AwsEngineExtensionsProvider, NoopEngineExtensionsProvider};
+    use crate::{
+        AwsEngineExtensionsProvider, NoopEngineExtensionsProvider, SingleUserPrincipalProvider,
+        UserPrincipal, UserPrincipalProvider, UserPrincipalProviderError,
+    };
 
     fn default_workspace() -> Workspace {
         workspace_to_proto(&WorkspaceName::default())
@@ -767,6 +789,21 @@ enabled = false
 ",
         )
         .expect("write telemetry config");
+    }
+
+    #[derive(Debug)]
+    struct RejectingUserPrincipalProvider;
+
+    #[tonic::async_trait]
+    impl UserPrincipalProvider for RejectingUserPrincipalProvider {
+        async fn principal_for_metadata(
+            &self,
+            _metadata: &tonic::metadata::MetadataMap,
+        ) -> Result<UserPrincipal, UserPrincipalProviderError> {
+            Err(UserPrincipalProviderError::unauthenticated(
+                "rejected user principal",
+            ))
+        }
     }
 
     async fn test_db(layout: &AppStateLayout, config_store: &ConfigStore) -> Arc<CoralDb> {
@@ -889,6 +926,7 @@ backend = "unsupported"
                 service: Some(trace_service),
                 local_trace_store_dir: None,
             },
+            Arc::new(SingleUserPrincipalProvider),
             ServerMode::NativeGrpc,
         )
         .await
@@ -954,6 +992,32 @@ backend = "unsupported"
         let _builder = ServerBuilder::new()
             .add_engine_extensions_provider(Arc::new(AwsEngineExtensionsProvider))
             .add_engine_extensions_provider(Arc::new(NoopEngineExtensionsProvider));
+    }
+
+    #[tokio::test]
+    async fn server_builder_applies_injected_provider_to_native_grpc() {
+        let temp = TempDir::new().expect("temp dir");
+        let server = ServerBuilder::new()
+            .with_config_dir(temp.path().join("coral-config"))
+            .with_user_principal_provider(Arc::new(RejectingUserPrincipalProvider))
+            .start()
+            .await
+            .expect("start server");
+        let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
+            .expect("endpoint")
+            .connect()
+            .await
+            .expect("connect");
+
+        let status = SourceServiceClient::new(channel)
+            .list_sources(Request::new(ListSourcesRequest {
+                workspace: Some(default_workspace()),
+            }))
+            .await
+            .expect_err("request should be rejected");
+
+        assert_eq!(status.code(), Code::Unauthenticated);
+        server.shutdown().await.expect("shutdown");
     }
 
     #[test]
@@ -1130,10 +1194,11 @@ tables:
     }
 
     #[tokio::test]
-    async fn embedded_ui_server_serves_static_assets_alongside_grpc_web() {
+    async fn embedded_ui_authenticates_grpc_web_without_gating_static_assets() {
         let temp = TempDir::new().expect("temp dir");
         let running = ServerBuilder::embedded_ui_loopback(0, Arc::new(StubAssets))
             .with_config_dir(temp.path().join("coral-config"))
+            .with_user_principal_provider(Arc::new(RejectingUserPrincipalProvider))
             .start()
             .await
             .expect("start embedded UI server");
@@ -1182,7 +1247,7 @@ tables:
             Some("text/html; charset=utf-8")
         );
 
-        // gRPC-Web still works on the same port
+        // Registered gRPC-Web routes still pass through the principal gate.
         let grpc_path = format!("{endpoint}/coral.v1.SourceService/ListSources");
         let response = client
             .post(&grpc_path)
@@ -1195,6 +1260,19 @@ tables:
             .await
             .expect("gRPC-Web request");
         assert_eq!(response.status(), reqwest::StatusCode::OK);
+        let grpc_status = response
+            .headers()
+            .get("grpc-status")
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned);
+        let body = String::from_utf8_lossy(&response.bytes().await.expect("gRPC-Web response"))
+            .into_owned();
+        assert!(
+            grpc_status.as_deref() == Some("16")
+                || body.contains("grpc-status: 16")
+                || body.contains("grpc-status:16"),
+            "expected unauthenticated gRPC-Web status, got header {grpc_status:?} and body {body:?}"
+        );
 
         let unknown_grpc = client
             .post(format!("{endpoint}/unknown.Service/Method"))
@@ -1283,6 +1361,7 @@ tables:
                 feedback: feedback_manager,
             },
             TraceServerComponents::default(),
+            Arc::new(SingleUserPrincipalProvider),
             ServerMode::NativeGrpc,
         )
         .await
@@ -1397,6 +1476,7 @@ tables:
                 feedback: feedback_manager,
             },
             TraceServerComponents::default(),
+            Arc::new(SingleUserPrincipalProvider),
             ServerMode::NativeGrpc,
         )
         .await
@@ -1511,6 +1591,7 @@ tables:
                 feedback: feedback_manager,
             },
             TraceServerComponents::default(),
+            Arc::new(SingleUserPrincipalProvider),
             ServerMode::NativeGrpc,
         )
         .await

--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -1,6 +1,170 @@
 //! Shared validation helpers for app-owned identifiers.
 
+use std::fmt;
+
 use crate::bootstrap::AppError;
+
+/// Stable local user used by single-user local mode.
+pub(crate) const LOCAL_MEMBER_ID: &str = "local";
+
+/// Request-scoped user principal selected by the app transport layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserPrincipal {
+    user_id: String,
+}
+
+impl UserPrincipal {
+    /// Builds the default single-user local principal.
+    #[must_use]
+    pub fn local() -> Self {
+        Self {
+            user_id: LOCAL_MEMBER_ID.to_string(),
+        }
+    }
+
+    /// Builds a principal for a validated user id.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the user id is empty, contains whitespace,
+    /// contains path separators, or aliases the reserved local single-user
+    /// sentinel.
+    pub fn for_user(user_id: &str) -> Result<Self, AppError> {
+        if user_id.chars().any(char::is_whitespace) {
+            return Err(AppError::InvalidInput(
+                "user id must not contain whitespace".to_string(),
+            ));
+        }
+        let user_id = parse_path_segment("user", user_id)?;
+        if user_id == LOCAL_MEMBER_ID {
+            return Err(AppError::InvalidInput(format!(
+                "user id '{LOCAL_MEMBER_ID}' is reserved for single-user local mode"
+            )));
+        }
+        Ok(Self { user_id })
+    }
+
+    /// Returns the validated user id.
+    #[must_use]
+    pub fn user_id(&self) -> &str {
+        &self.user_id
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UserPrincipalProviderErrorKind {
+    Unauthenticated,
+    Unavailable,
+    Internal,
+}
+
+/// Client-safe failure reported by a request principal provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UserPrincipalProviderError {
+    kind: UserPrincipalProviderErrorKind,
+    client_message: String,
+}
+
+impl UserPrincipalProviderError {
+    fn new(
+        kind: UserPrincipalProviderErrorKind,
+        client_message: impl Into<String>,
+        default_message: &str,
+    ) -> Self {
+        let client_message = client_message.into();
+        let client_message = if client_message.trim().is_empty() {
+            default_message.to_string()
+        } else {
+            client_message
+        };
+        Self {
+            kind,
+            client_message,
+        }
+    }
+
+    /// Builds a provider error with a client-safe message.
+    #[must_use]
+    pub fn unauthenticated(client_message: impl Into<String>) -> Self {
+        Self::new(
+            UserPrincipalProviderErrorKind::Unauthenticated,
+            client_message,
+            "unauthenticated request",
+        )
+    }
+
+    /// Builds a transient provider failure with a client-safe message.
+    #[must_use]
+    pub fn unavailable(client_message: impl Into<String>) -> Self {
+        Self::new(
+            UserPrincipalProviderErrorKind::Unavailable,
+            client_message,
+            "user principal provider unavailable",
+        )
+    }
+
+    /// Builds an unexpected provider failure with a client-safe message.
+    #[must_use]
+    pub fn internal(client_message: impl Into<String>) -> Self {
+        Self::new(
+            UserPrincipalProviderErrorKind::Internal,
+            client_message,
+            "user principal provider failed",
+        )
+    }
+
+    pub(crate) fn kind(&self) -> UserPrincipalProviderErrorKind {
+        self.kind
+    }
+
+    /// Returns the client-safe failure message.
+    #[must_use]
+    pub fn client_message(&self) -> &str {
+        &self.client_message
+    }
+}
+
+impl fmt::Display for UserPrincipalProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.client_message)
+    }
+}
+
+impl std::error::Error for UserPrincipalProviderError {}
+
+/// Server-side provider for request user principals.
+///
+/// The OSS provider always returns [`UserPrincipal::local`]. Product runtimes
+/// can install a provider that authenticates inbound metadata and returns the
+/// corresponding user principal.
+#[tonic::async_trait]
+pub trait UserPrincipalProvider: Send + Sync + std::fmt::Debug {
+    /// Returns the user principal for one inbound gRPC request.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UserPrincipalProviderError`] when transport metadata is
+    /// malformed, the provider cannot authenticate the request, or principal
+    /// selection fails.
+    async fn principal_for_metadata(
+        &self,
+        metadata: &tonic::metadata::MetadataMap,
+    ) -> Result<UserPrincipal, UserPrincipalProviderError>;
+}
+
+/// Default OSS principal provider for single-user local mode.
+#[derive(Debug, Default)]
+pub struct SingleUserPrincipalProvider;
+
+#[tonic::async_trait]
+impl UserPrincipalProvider for SingleUserPrincipalProvider {
+    async fn principal_for_metadata(
+        &self,
+        _metadata: &tonic::metadata::MetadataMap,
+    ) -> Result<UserPrincipal, UserPrincipalProviderError> {
+        Ok(UserPrincipal::local())
+    }
+}
 
 pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppError> {
     let trimmed = value.trim();
@@ -22,7 +186,9 @@ pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppE
 
 #[cfg(test)]
 mod tests {
-    use super::parse_path_segment;
+    use super::{
+        SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider, parse_path_segment,
+    };
 
     #[test]
     fn rejects_empty_names() {
@@ -48,5 +214,42 @@ mod tests {
                 .to_string()
                 .contains("source name must not be '.' or '..'")
         );
+    }
+
+    #[test]
+    fn user_principal_rejects_whitespace_anywhere() {
+        for invalid in [" saul", "saul ", "alice bob", "alice\tbob", "alice\nbob"] {
+            let error = UserPrincipal::for_user(invalid).expect_err("whitespace should fail");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("user id must not contain whitespace")
+            );
+        }
+    }
+
+    #[test]
+    fn user_principal_rejects_path_segments_and_reserved_local_id() {
+        for invalid in ["team/saul", r"team\saul", ".", "..", "local"] {
+            UserPrincipal::for_user(invalid).expect_err("invalid user id should fail");
+        }
+    }
+
+    #[test]
+    fn user_principal_preserves_valid_id() {
+        let principal = UserPrincipal::for_user("saul").expect("valid user");
+
+        assert_eq!(principal.user_id(), "saul");
+    }
+
+    #[tokio::test]
+    async fn single_user_provider_returns_local_principal() {
+        let principal = SingleUserPrincipalProvider
+            .principal_for_metadata(&tonic::metadata::MetadataMap::new())
+            .await
+            .expect("local principal");
+
+        assert_eq!(principal, UserPrincipal::local());
     }
 }

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -49,6 +49,7 @@ pub mod features;
 mod feedback;
 mod identity;
 mod query;
+mod request_context;
 mod search;
 mod sources;
 mod state;
@@ -62,6 +63,9 @@ pub use bootstrap::{
     AppError, RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider,
 };
 pub use coral_engine::{EngineExtensions, QuerySource};
+pub use identity::{
+    SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider, UserPrincipalProviderError,
+};
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -701,6 +701,7 @@ fn query_error_message(error: &QueryManagerError) -> String {
 
 fn app_error_type(error: &AppError) -> &'static str {
     match error {
+        AppError::Unauthenticated(_) => "UNAUTHENTICATED",
         AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
         AppError::WorkspaceNotFound(_) => "WORKSPACE_NOT_FOUND",
         AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",

--- a/crates/coral-app/src/request_context.rs
+++ b/crates/coral-app/src/request_context.rs
@@ -1,8 +1,5 @@
 //! Request-scoped app context selected at the transport boundary.
 
-use tonic::{Request, Status};
-
-use crate::bootstrap::{AppError, app_status};
 use crate::identity::UserPrincipal;
 
 /// Request-scoped data that domain services may need after authentication.
@@ -20,29 +17,11 @@ impl RequestContext {
         Self { principal }
     }
 
-    // Installed server-wide by the immediate P1a child and consumed at service
-    // boundaries by P1b.
     #[cfg_attr(
         not(test),
         expect(
             dead_code,
-            reason = "installed server-wide by P1a and consumed at service boundaries by P1b"
-        )
-    )]
-    pub(crate) fn from_request<T>(request: &Request<T>) -> Result<Self, Status> {
-        request.extensions().get::<Self>().cloned().ok_or_else(|| {
-            app_status(AppError::Unauthenticated(
-                "missing request principal".to_string(),
-            ))
-        })
-    }
-
-    // Consumed by the QueryContext introduced in the immediate P1b child.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "consumed by the QueryContext introduced in the P1b child"
+            reason = "request principals stay encapsulated for downstream authorization and attribution"
         )
     )]
     pub(crate) fn principal(&self) -> &UserPrincipal {
@@ -60,13 +39,5 @@ mod tests {
         let context = RequestContext::new(principal.clone());
 
         assert_eq!(context.principal(), &principal);
-    }
-
-    #[test]
-    fn rejects_requests_without_a_principal() {
-        let status = RequestContext::from_request(&Request::new(()))
-            .expect_err("missing context should fail closed");
-
-        assert_eq!(status.code(), tonic::Code::Unauthenticated);
     }
 }

--- a/crates/coral-app/src/request_context.rs
+++ b/crates/coral-app/src/request_context.rs
@@ -1,0 +1,72 @@
+//! Request-scoped app context selected at the transport boundary.
+
+use tonic::{Request, Status};
+
+use crate::bootstrap::{AppError, app_status};
+use crate::identity::UserPrincipal;
+
+/// Request-scoped data that domain services may need after authentication.
+///
+/// This intentionally starts narrow. Query attribution still flows through its
+/// existing path today, but can move here later without widening every
+/// principal-aware call signature again.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RequestContext {
+    principal: UserPrincipal,
+}
+
+impl RequestContext {
+    pub(crate) fn new(principal: UserPrincipal) -> Self {
+        Self { principal }
+    }
+
+    // Installed server-wide by the immediate P1a child and consumed at service
+    // boundaries by P1b.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "installed server-wide by P1a and consumed at service boundaries by P1b"
+        )
+    )]
+    pub(crate) fn from_request<T>(request: &Request<T>) -> Result<Self, Status> {
+        request.extensions().get::<Self>().cloned().ok_or_else(|| {
+            app_status(AppError::Unauthenticated(
+                "missing request principal".to_string(),
+            ))
+        })
+    }
+
+    // Consumed by the QueryContext introduced in the immediate P1b child.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "consumed by the QueryContext introduced in the P1b child"
+        )
+    )]
+    pub(crate) fn principal(&self) -> &UserPrincipal {
+        &self.principal
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exposes_request_principal() {
+        let principal = UserPrincipal::for_user("saul").expect("valid user");
+        let context = RequestContext::new(principal.clone());
+
+        assert_eq!(context.principal(), &principal);
+    }
+
+    #[test]
+    fn rejects_requests_without_a_principal() {
+        let status = RequestContext::from_request(&Request::new(()))
+            .expect_err("missing context should fail closed");
+
+        assert_eq!(status.code(), tonic::Code::Unauthenticated);
+    }
+}

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -33,8 +33,7 @@ use crate::catalog::discovery::{
     ColumnSearchResult, DescribeTableResult,
 };
 use crate::identity::{
-    SingleUserPrincipalProvider, UserPrincipalProvider, UserPrincipalProviderError,
-    UserPrincipalProviderErrorKind,
+    UserPrincipalProvider, UserPrincipalProviderError, UserPrincipalProviderErrorKind,
 };
 use crate::query::manager::QueryManagerError;
 use crate::request_context::RequestContext;
@@ -62,53 +61,6 @@ impl Extractor for MetadataExtractor<'_> {
             })
             .collect()
     }
-}
-
-/// Compatibility wrapper used until the next stack unit installs one layer
-/// around the complete route tree.
-#[derive(Clone)]
-pub(crate) struct GrpcMethodAnnotatedService<S> {
-    inner: GrpcRequestContextService<S>,
-}
-
-impl<S> GrpcMethodAnnotatedService<S> {
-    pub(crate) fn new(inner: S) -> Self {
-        let layer = GrpcRequestContextLayer::new(Arc::new(SingleUserPrincipalProvider));
-        Self {
-            inner: layer.layer(inner),
-        }
-    }
-}
-
-impl<S, B, ResBody> Service<http::Request<B>> for GrpcMethodAnnotatedService<S>
-where
-    S: Service<http::Request<B>, Response = http::Response<ResBody>> + Clone + Send + 'static,
-    S::Future: Send + 'static,
-    S::Error: Send + 'static,
-    B: Send + 'static,
-    ResBody: Default + Send + 'static,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
-
-    fn poll_ready(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, request: http::Request<B>) -> Self::Future {
-        self.inner.call(request)
-    }
-}
-
-impl<S> tonic::server::NamedService for GrpcMethodAnnotatedService<S>
-where
-    S: tonic::server::NamedService,
-{
-    const NAME: &'static str = S::NAME;
 }
 
 /// Tower layer that installs Coral request context for gRPC route trees.
@@ -653,18 +605,14 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        GrpcMethodMetadata, GrpcRequestContextLayer, GrpcServerMethod, grpc_method, query_status,
+        GrpcMethodMetadata, GrpcServerMethod, grpc_method, query_status,
         query_test_result_to_proto, table_function_to_proto, table_summary_to_proto,
         table_to_proto, user_principal_provider_status, workspace_name_from_proto,
         workspace_to_proto,
     };
     use crate::bootstrap::AppError;
-    use crate::identity::{
-        SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider,
-        UserPrincipalProviderError,
-    };
+    use crate::identity::UserPrincipalProviderError;
     use crate::query::manager::QueryManagerError;
-    use crate::request_context::RequestContext;
     use crate::workspaces::WorkspaceName;
     use coral_engine::{
         ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableFunctionInfo,
@@ -755,74 +703,6 @@ mod tests {
             grpc_method(&request),
             GrpcMethodMetadata::new("coral.v1.QueryService", "ExecuteSql")
         );
-    }
-
-    #[derive(Debug)]
-    struct FixedUserPrincipalProvider {
-        principal: UserPrincipal,
-    }
-
-    #[tonic::async_trait]
-    impl UserPrincipalProvider for FixedUserPrincipalProvider {
-        async fn principal_for_metadata(
-            &self,
-            _metadata: &tonic::metadata::MetadataMap,
-        ) -> Result<UserPrincipal, UserPrincipalProviderError> {
-            Ok(self.principal.clone())
-        }
-    }
-
-    async fn principal_inserted_by(
-        provider: std::sync::Arc<dyn UserPrincipalProvider>,
-    ) -> UserPrincipal {
-        use std::sync::{Arc, Mutex};
-        use tonic::codegen::http;
-        use tower::{Layer as _, Service as _};
-
-        let observed_context = Arc::new(Mutex::new(None));
-        let observed_context_for_service = Arc::clone(&observed_context);
-        let service = tower::service_fn(move |request: http::Request<()>| {
-            let observed_context = Arc::clone(&observed_context_for_service);
-            async move {
-                *observed_context.lock().expect("observed context lock") =
-                    request.extensions().get::<RequestContext>().cloned();
-                Ok::<_, std::convert::Infallible>(http::Response::new(()))
-            }
-        });
-        let mut service = GrpcRequestContextLayer::new(provider).layer(service);
-        let request = http::Request::builder()
-            .uri("/coral.v1.QueryService/ExecuteSql")
-            .body(())
-            .expect("http request");
-
-        service.call(request).await.expect("service response");
-
-        observed_context
-            .lock()
-            .expect("observed context lock")
-            .clone()
-            .expect("request context")
-            .principal()
-            .clone()
-    }
-
-    #[tokio::test]
-    async fn request_context_layer_inserts_local_principal() {
-        let principal =
-            principal_inserted_by(std::sync::Arc::new(SingleUserPrincipalProvider)).await;
-
-        assert_eq!(principal, UserPrincipal::local());
-    }
-
-    #[tokio::test]
-    async fn request_context_layer_honors_injected_provider() {
-        let expected_principal = UserPrincipal::for_user("saul").expect("valid user");
-        let principal = principal_inserted_by(std::sync::Arc::new(FixedUserPrincipalProvider {
-            principal: expected_principal.clone(),
-        }))
-        .await;
-
-        assert_eq!(principal, expected_principal);
     }
 
     #[test]

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -1,6 +1,9 @@
 //! Shared gRPC transport helpers for app-owned services.
 
 use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
 
 use coral_api::{
     CORAL_ERROR_DOMAIN, grpc_response_status_code,
@@ -17,20 +20,32 @@ use coral_spec::{SearchLimitsSpec, SourceTableFunctionKind};
 use opentelemetry::propagation::Extractor;
 use opentelemetry::trace::Status as OtelStatus;
 use tonic::codegen::{Service, http};
+use tonic::metadata::MetadataMap;
 use tonic::{Code, Request, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
+use tower::Layer;
 use tracing::{Instrument as _, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
-use crate::bootstrap::{AppError, app_status, core_status};
+use crate::bootstrap::{AppError, app_status, core_status, status_with_bounded_detail};
 use crate::catalog::discovery::{
     CatalogItem, CatalogMetadataField, CatalogSearchResult, ColumnMetadataField,
     ColumnSearchResult, DescribeTableResult,
 };
+use crate::identity::{
+    SingleUserPrincipalProvider, UserPrincipalProvider, UserPrincipalProviderError,
+    UserPrincipalProviderErrorKind,
+};
 use crate::query::manager::QueryManagerError;
+use crate::request_context::RequestContext;
 use crate::workspaces::WorkspaceName;
 
 struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
+
+const USER_PRINCIPAL_PROVIDER_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Clone)]
+struct GrpcServerSpan(tracing::Span);
 
 impl Extractor for MetadataExtractor<'_> {
     fn get(&self, key: &str) -> Option<&str> {
@@ -49,31 +64,33 @@ impl Extractor for MetadataExtractor<'_> {
     }
 }
 
-/// Wraps a generated tonic service and stores inbound request context on the request.
-///
-/// Tonic preserves `http::Request` extensions when it decodes the protobuf
-/// message into a `tonic::Request`, but generated server wrappers do not insert
-/// `tonic::GrpcMethod` the way generated clients do. This keeps the method
-/// data and Coral request metadata at the transport boundary and lets handlers
-/// read typed context from the request.
+/// Compatibility wrapper used until the next stack unit installs one layer
+/// around the complete route tree.
 #[derive(Clone)]
 pub(crate) struct GrpcMethodAnnotatedService<S> {
-    inner: S,
+    inner: GrpcRequestContextService<S>,
 }
 
 impl<S> GrpcMethodAnnotatedService<S> {
     pub(crate) fn new(inner: S) -> Self {
-        Self { inner }
+        let layer = GrpcRequestContextLayer::new(Arc::new(SingleUserPrincipalProvider));
+        Self {
+            inner: layer.layer(inner),
+        }
     }
 }
 
-impl<S, B> Service<http::Request<B>> for GrpcMethodAnnotatedService<S>
+impl<S, B, ResBody> Service<http::Request<B>> for GrpcMethodAnnotatedService<S>
 where
-    S: Service<http::Request<B>>,
+    S: Service<http::Request<B>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    B: Send + 'static,
+    ResBody: Default + Send + 'static,
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = S::Future;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(
         &mut self,
@@ -82,8 +99,7 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, mut request: http::Request<B>) -> Self::Future {
-        annotate_request_context(&mut request);
+    fn call(&mut self, request: http::Request<B>) -> Self::Future {
         self.inner.call(request)
     }
 }
@@ -95,9 +111,155 @@ where
     const NAME: &'static str = S::NAME;
 }
 
+/// Tower layer that installs Coral request context for gRPC route trees.
+///
+/// Tonic preserves `http::Request` extensions when it decodes the protobuf
+/// message into a `tonic::Request`, but generated server wrappers do not insert
+/// `tonic::GrpcMethod` the way generated clients do. This keeps the method
+/// data and Coral request metadata at the transport boundary and lets handlers
+/// read typed context from the request.
+///
+/// The wrapper also authenticates the inbound metadata once before dispatching
+/// to a service handler, so every registered gRPC route is covered by the same
+/// principal-selection path.
+#[derive(Clone)]
+pub(crate) struct GrpcRequestContextLayer {
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+}
+
+impl GrpcRequestContextLayer {
+    pub(crate) fn new(user_principal_provider: Arc<dyn UserPrincipalProvider>) -> Self {
+        Self {
+            user_principal_provider,
+        }
+    }
+}
+
+impl<S> Layer<S> for GrpcRequestContextLayer {
+    type Service = GrpcRequestContextService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        GrpcRequestContextService {
+            inner,
+            user_principal_provider: Arc::clone(&self.user_principal_provider),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct GrpcRequestContextService<S> {
+    inner: S,
+    user_principal_provider: Arc<dyn UserPrincipalProvider>,
+}
+
+impl<S, B, ResBody> Service<http::Request<B>> for GrpcRequestContextService<S>
+where
+    S: Service<http::Request<B>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+    B: Send + 'static,
+    ResBody: Default + Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: http::Request<B>) -> Self::Future {
+        annotate_request_context(&mut request);
+        let method_metadata = request.extensions().get::<GrpcServerMethod>().map_or_else(
+            || GrpcMethodMetadata::new("coral.v1.UnknownService", "Unknown"),
+            |method| GrpcMethodMetadata::new(method.service.as_str(), method.method.as_str()),
+        );
+        let request_metadata = MetadataMap::from_headers(request.headers().clone());
+        let user_principal_provider = Arc::clone(&self.user_principal_provider);
+        let span = grpc_span_for_metadata(&method_metadata, &request_metadata);
+        request
+            .extensions_mut()
+            .insert(GrpcServerSpan(span.clone()));
+
+        let mut inner = self.inner.clone();
+        std::mem::swap(&mut self.inner, &mut inner);
+
+        let instrumented_span = span.clone();
+        Box::pin(
+            async move {
+                match principal_for_request(
+                    user_principal_provider.as_ref(),
+                    &request_metadata,
+                    USER_PRINCIPAL_PROVIDER_TIMEOUT,
+                )
+                .await
+                {
+                    Ok(principal) => {
+                        request
+                            .extensions_mut()
+                            .insert(RequestContext::new(principal));
+                        inner.call(request).await
+                    }
+                    Err(error) => {
+                        let status = user_principal_provider_status(&error);
+                        record_grpc_status(&span, status.code(), Some(&status));
+                        Ok(status.into_http())
+                    }
+                }
+            }
+            .instrument(instrumented_span),
+        )
+    }
+}
+
+async fn principal_for_request(
+    provider: &dyn UserPrincipalProvider,
+    metadata: &MetadataMap,
+    timeout: Duration,
+) -> Result<crate::identity::UserPrincipal, UserPrincipalProviderError> {
+    tokio::time::timeout(timeout, provider.principal_for_metadata(metadata))
+        .await
+        .unwrap_or_else(|_| {
+            Err(UserPrincipalProviderError::unavailable(
+                "user principal provider timed out",
+            ))
+        })
+}
+
+fn user_principal_provider_status(error: &UserPrincipalProviderError) -> Status {
+    let (code, prefix) = match error.kind() {
+        UserPrincipalProviderErrorKind::Unauthenticated => {
+            (Code::Unauthenticated, "unauthenticated")
+        }
+        UserPrincipalProviderErrorKind::Unavailable => (Code::Unavailable, "unavailable"),
+        UserPrincipalProviderErrorKind::Internal => (Code::Internal, "internal"),
+    };
+    status_with_bounded_detail(code, format!("{prefix}: {}", error.client_message()))
+}
+
+impl<S> tonic::server::NamedService for GrpcRequestContextService<S>
+where
+    S: tonic::server::NamedService,
+{
+    const NAME: &'static str = S::NAME;
+}
+
 /// Creates a span parented to the trace context extracted from a gRPC request.
 pub(crate) fn grpc_span<T>(request: &Request<T>) -> tracing::Span {
+    if let Some(span) = request.extensions().get::<GrpcServerSpan>() {
+        return span.0.clone();
+    }
     let metadata = grpc_method(request);
+    grpc_span_for_metadata(&metadata, request.metadata())
+}
+
+fn grpc_span_for_metadata(
+    metadata: &GrpcMethodMetadata,
+    request_metadata: &MetadataMap,
+) -> tracing::Span {
     let span_name = format!("{}/{}", metadata.service, metadata.method);
     let span = tracing::info_span!(
         "grpc",
@@ -115,7 +277,7 @@ pub(crate) fn grpc_span<T>(request: &Request<T>) -> tracing::Span {
         grpc.code = tracing::field::Empty,
         status = tracing::field::Empty,
     );
-    coral_telemetry::set_parent_from_extractor(&span, &MetadataExtractor(request.metadata()));
+    coral_telemetry::set_parent_from_extractor(&span, &MetadataExtractor(request_metadata));
     span
 }
 
@@ -491,12 +653,18 @@ mod tests {
     use tonic::{Code, Request};
 
     use super::{
-        GrpcMethodMetadata, GrpcServerMethod, grpc_method, query_status,
+        GrpcMethodMetadata, GrpcRequestContextLayer, GrpcServerMethod, grpc_method, query_status,
         query_test_result_to_proto, table_function_to_proto, table_summary_to_proto,
-        table_to_proto, workspace_name_from_proto, workspace_to_proto,
+        table_to_proto, user_principal_provider_status, workspace_name_from_proto,
+        workspace_to_proto,
     };
     use crate::bootstrap::AppError;
+    use crate::identity::{
+        SingleUserPrincipalProvider, UserPrincipal, UserPrincipalProvider,
+        UserPrincipalProviderError,
+    };
     use crate::query::manager::QueryManagerError;
+    use crate::request_context::RequestContext;
     use crate::workspaces::WorkspaceName;
     use coral_engine::{
         ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableFunctionInfo,
@@ -535,6 +703,32 @@ mod tests {
     }
 
     #[test]
+    fn user_principal_provider_status_preserves_failure_class() {
+        let cases = [
+            (
+                UserPrincipalProviderError::unauthenticated("bad token"),
+                Code::Unauthenticated,
+                "unauthenticated: bad token",
+            ),
+            (
+                UserPrincipalProviderError::unavailable("key service offline"),
+                Code::Unavailable,
+                "unavailable: key service offline",
+            ),
+            (
+                UserPrincipalProviderError::internal("invalid principal selection"),
+                Code::Internal,
+                "internal: invalid principal selection",
+            ),
+        ];
+        for (error, code, message) in cases {
+            let status = user_principal_provider_status(&error);
+            assert_eq!(status.code(), code);
+            assert_eq!(status.message(), message);
+        }
+    }
+
+    #[test]
     fn grpc_server_method_derives_from_uri_path() {
         assert_eq!(
             GrpcServerMethod::from_path("/coral.v1.QueryService/ExecuteSql"),
@@ -561,6 +755,74 @@ mod tests {
             grpc_method(&request),
             GrpcMethodMetadata::new("coral.v1.QueryService", "ExecuteSql")
         );
+    }
+
+    #[derive(Debug)]
+    struct FixedUserPrincipalProvider {
+        principal: UserPrincipal,
+    }
+
+    #[tonic::async_trait]
+    impl UserPrincipalProvider for FixedUserPrincipalProvider {
+        async fn principal_for_metadata(
+            &self,
+            _metadata: &tonic::metadata::MetadataMap,
+        ) -> Result<UserPrincipal, UserPrincipalProviderError> {
+            Ok(self.principal.clone())
+        }
+    }
+
+    async fn principal_inserted_by(
+        provider: std::sync::Arc<dyn UserPrincipalProvider>,
+    ) -> UserPrincipal {
+        use std::sync::{Arc, Mutex};
+        use tonic::codegen::http;
+        use tower::{Layer as _, Service as _};
+
+        let observed_context = Arc::new(Mutex::new(None));
+        let observed_context_for_service = Arc::clone(&observed_context);
+        let service = tower::service_fn(move |request: http::Request<()>| {
+            let observed_context = Arc::clone(&observed_context_for_service);
+            async move {
+                *observed_context.lock().expect("observed context lock") =
+                    request.extensions().get::<RequestContext>().cloned();
+                Ok::<_, std::convert::Infallible>(http::Response::new(()))
+            }
+        });
+        let mut service = GrpcRequestContextLayer::new(provider).layer(service);
+        let request = http::Request::builder()
+            .uri("/coral.v1.QueryService/ExecuteSql")
+            .body(())
+            .expect("http request");
+
+        service.call(request).await.expect("service response");
+
+        observed_context
+            .lock()
+            .expect("observed context lock")
+            .clone()
+            .expect("request context")
+            .principal()
+            .clone()
+    }
+
+    #[tokio::test]
+    async fn request_context_layer_inserts_local_principal() {
+        let principal =
+            principal_inserted_by(std::sync::Arc::new(SingleUserPrincipalProvider)).await;
+
+        assert_eq!(principal, UserPrincipal::local());
+    }
+
+    #[tokio::test]
+    async fn request_context_layer_honors_injected_provider() {
+        let expected_principal = UserPrincipal::for_user("saul").expect("valid user");
+        let principal = principal_inserted_by(std::sync::Arc::new(FixedUserPrincipalProvider {
+            principal: expected_principal.clone(),
+        }))
+        .await;
+
+        assert_eq!(principal, expected_principal);
     }
 
     #[test]


### PR DESCRIPTION
## Intent

Establish the app-owned request-principal boundary needed for multi-user identity while preserving existing local single-user behavior. This is a standalone, `main`-based replacement for #1505 so later identity work can depend on it without inheriting the earlier stack history.

## What it enables

- A validated `UserPrincipal` model and provider abstraction.
- A configurable `UserPrincipalProvider` composition seam on `ServerBuilder`, with the reserved local principal as the default.
- One authentication and request-context layer across every registered native gRPC and gRPC-Web route.
- Fail-closed gRPC status mapping for unauthenticated, unavailable, and internal provider failures.
- Request-scoped principal access for app-owned domain services while static UI assets remain outside the authentication gate.

## Usage examples

Existing local-server callers require no changes. The default provider selects the reserved local principal and installs it into `RequestContext` before dispatching each registered gRPC request.

Product runtimes can install a metadata-aware provider without rebuilding individual services:

```rust
let server = ServerBuilder::new()
    .with_user_principal_provider(Arc::new(MyPrincipalProvider))
    .start()
    .await?;
```

## Validation

- `make rust-checks` — passed: formatting, workspace-wide Clippy with warnings denied, 1,598 tests passed (2 skipped), and Rust documentation built.
- Focused native gRPC coverage proves that `ServerBuilder` installs and enforces a custom rejecting provider.
- Focused gRPC-Web coverage proves registered routes are authenticated while HTML, asset, SPA, and unknown-route fallbacks remain ungated.
- 529 additions and 38 deletions across 8 files (567 changed lines), within the repository's 600-line PR hard cap.