### PR TITLE
fix(app): preserve installed DSL v4 sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,12 @@
   manifests, materialized fingerprints, semantic IR, or projection catalogs.
 - For DSL v4 materialization, the user owns when a source is generated or
   regenerated. Coral materializes at source add, queries only from the
-  installed materialized package, never silently refreshes descriptors or
-  projections, and should fail loudly on missing or incompatible artifacts with
-  guidance to re-add the source.
+  installed materialized package, and never silently refreshes descriptors,
+  projections, or persisted artifacts. Treat fingerprints and producer
+  versions as advisory provenance, preserve schema-v3 IR and projection YAML
+  through explicit file-to-runtime migrations, and load every compatible
+  surface. An unusable surface must not disable compatible sibling surfaces;
+  an unusable source must not disable other installed sources.
 - Keep cross-crate W3C trace-context propagation helpers in
   `coral-telemetry`; do not make `coral-app`, `coral-client`, `coral-engine`,
   or `coral-mcp` depend on each other just to share telemetry carrier logic.

--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -54,10 +54,13 @@ root.
   IR, projections, and package fingerprints belong in materialized artifacts
   or runtime package assembly, not in persisted `manifest.yaml`.
 - Treat DSL v4 materialization as a user-chosen lifecycle event: generate at
-  source add, never re-fetch descriptors or recompute projections implicitly
-  during query/list/validate, and fail with re-add guidance when artifacts are
-  missing or incompatible. RDBMS migration machinery must preserve that
-  explicit lifecycle instead of silently refreshing artifacts.
+  source add and never re-fetch descriptors, recompute projections, or rewrite
+  artifacts implicitly during query/list/validate. Fingerprints and producer
+  versions are diagnostics rather than runtime gates. Load persisted IR and
+  projections through explicit compatibility mappings, degrade per surface,
+  and isolate source-local failures while preserving that explicit lifecycle.
+  RDBMS migration machinery must not turn load-time compatibility into silent
+  regeneration.
 - User-facing runtime feature semantics belong in `coral_app::features`; raw
   config-file persistence, locking, and TOML extraction stay in `state/`.
 - Bundled installs persist source identity plus configured variables and

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -30,6 +30,14 @@ pub enum AppError {
     /// The request requires additional setup before it can succeed.
     #[error("failed precondition: {0}")]
     FailedPrecondition(String),
+    /// One installed source is missing required configured inputs.
+    #[error("failed precondition: source '{source_name}' is missing {detail}")]
+    MissingSourceInputs {
+        /// Source whose required input is absent.
+        source_name: String,
+        /// Human-readable description of the missing input or inputs.
+        detail: String,
+    },
     /// A DSL v4 source has missing or stale generated runtime artifacts.
     #[error(
         "failed precondition: source '{source_name}' has missing or incompatible DSL v4 materialized artifacts: {detail}. Re-add the source to regenerate them."
@@ -239,6 +247,7 @@ fn app_code(error: &AppError) -> Code {
         AppError::WorkspaceAlreadyExists(_) => Code::AlreadyExists,
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
+        | AppError::MissingSourceInputs { .. }
         | AppError::MissingOrIncompatibleV4Materialization { .. }
         | AppError::InvalidV4ProjectionOverride { .. }
         | AppError::CredentialRefresh(_)

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -53,6 +53,7 @@ use crate::query::service::QueryService;
 use crate::search::manager::SearchManager;
 use crate::search::service::SearchService;
 use crate::sources::manager::SourceManager;
+use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::sources::service::SourceService;
 use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
 use crate::state::{AppStateLayout, ConfigStore};
@@ -279,11 +280,13 @@ impl ServerBuilder {
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
         let credential_manager = CredentialManager::new(credential_store);
         let workspace_lifecycle_lock = WorkspaceLifecycleLock::default();
-        let source_manager = SourceManager::new(
+        let diagnostic_reporter = SourceDiagnosticReporter::default();
+        let source_manager = SourceManager::with_diagnostic_reporter(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
             workspace_lifecycle_lock.clone(),
+            diagnostic_reporter.clone(),
         );
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
@@ -302,15 +305,21 @@ impl ServerBuilder {
             .query_runtime_context()
             .with_body_capture_max_bytes(body_capture_max_bytes);
 
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::with_diagnostic_reporter(
             config_store.clone(),
             workspace_manager.clone(),
             credential_manager,
             query_runtime_context,
             layout.clone(),
             self.config.engine_extensions_providers,
+            diagnostic_reporter.clone(),
         );
-        let search_manager = SearchManager::new(layout, &config_store, workspace_manager.clone());
+        let search_manager = SearchManager::with_diagnostic_reporter(
+            layout,
+            &config_store,
+            workspace_manager.clone(),
+            diagnostic_reporter,
+        );
         let trace_components =
             active_trace_store.map_or_else(TraceServerComponents::default, |store| {
                 TraceServerComponents {

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -311,7 +311,7 @@ impl QueryManager {
         self.require_workspace(workspace_name).await?;
         let _state_lock = self.config_store.state_lock_shared()?;
         let config = self.config_store.load_config_unlocked()?;
-        let sources = self.load_query_sources_from_config(workspace_name, &config);
+        let sources = self.load_query_sources_from_config(workspace_name, &config)?;
         Ok((sources, config))
     }
 
@@ -325,7 +325,7 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         config: &AppConfig,
-    ) -> Vec<LoadedQuerySource> {
+    ) -> Result<Vec<LoadedQuerySource>, AppError> {
         let span = tracing::info_span!(
             "coral.app.query_sources.load",
             workspace = tracing::field::Empty,
@@ -340,7 +340,10 @@ impl QueryManager {
                     clear_source_load_failure(workspace_name, &source.name);
                     loaded_sources.push(loaded_source);
                 }
-                Err(error) => {
+                Err(
+                    error @ (AppError::MissingOrIncompatibleV4Materialization { .. }
+                    | AppError::InvalidV4ProjectionOverride { .. }),
+                ) => {
                     report_source_load_failure(
                         workspace_name,
                         &source.name,
@@ -348,10 +351,11 @@ impl QueryManager {
                         &error.to_string(),
                     );
                 }
+                Err(error) => return Err(error),
             }
         }
         span.record("source.count", loaded_sources.len());
-        loaded_sources
+        Ok(loaded_sources)
     }
 
     fn load_query_source(
@@ -787,7 +791,9 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
-    use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
+    use crate::credentials::{
+        CredentialStorageKind, CredentialStoragePreference, CredentialStore, CredentialsError,
+    };
     use crate::sources::manager::{ImportSourceCommand, SourceBindings, SourceManager};
     use crate::sources::model::SourceOrigin;
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
@@ -1376,7 +1382,7 @@ surfaces:
     }
 
     #[tokio::test]
-    async fn load_query_sources_skips_unavailable_keychain_source() {
+    async fn load_query_sources_fails_closed_for_unavailable_keychain_source() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -1418,12 +1424,24 @@ surfaces:
             layout,
             Vec::new(),
         );
-        let (sources, _) = manager
+        let error = manager
             .load_query_sources(&workspace_name)
             .await
-            .expect("unavailable keychain source should be isolated");
+            .expect_err("unavailable keychain should fail closed");
 
-        assert!(sources.is_empty());
+        assert!(
+            matches!(
+                error,
+                AppError::Credentials(CredentialsError::Unavailable(_))
+            ),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("configured for keychain storage"),
+            "keychain-routed query failure should name the routed backend: {error}"
+        );
     }
 
     #[derive(Debug)]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -17,7 +17,7 @@ use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::AppError;
-use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
+use crate::credentials::{CredentialManager, CredentialSetId};
 use crate::query::QueryAttribution;
 use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_providers};
 use crate::query::input_resolver::{
@@ -26,7 +26,8 @@ use crate::query::input_resolver::{
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::materialization::{
-    incompatible_materialization_error, load_v4_materialization,
+    clear_source_load_failure, incompatible_materialization_error, load_v4_materialization,
+    report_source_load_failure,
 };
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::runtime_components_for_v4_source;
@@ -310,7 +311,7 @@ impl QueryManager {
         self.require_workspace(workspace_name).await?;
         let _state_lock = self.config_store.state_lock_shared()?;
         let config = self.config_store.load_config_unlocked()?;
-        let sources = self.load_query_sources_from_config(workspace_name, &config)?;
+        let sources = self.load_query_sources_from_config(workspace_name, &config);
         Ok((sources, config))
     }
 
@@ -324,7 +325,7 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         config: &AppConfig,
-    ) -> Result<Vec<LoadedQuerySource>, AppError> {
+    ) -> Vec<LoadedQuerySource> {
         let span = tracing::info_span!(
             "coral.app.query_sources.load",
             workspace = tracing::field::Empty,
@@ -335,25 +336,22 @@ impl QueryManager {
         let mut loaded_sources = Vec::new();
         for source in config.workspace_sources(workspace_name) {
             match self.load_query_source(workspace_name, &source) {
-                Ok((loaded_source, _version)) => loaded_sources.push(loaded_source),
-                Err(
-                    error @ (AppError::Credentials(CredentialsError::Unavailable(_))
-                    | AppError::MissingOrIncompatibleV4Materialization { .. }
-                    | AppError::InvalidV4ProjectionOverride { .. }),
-                ) => {
-                    return Err(error);
+                Ok((loaded_source, _version)) => {
+                    clear_source_load_failure(workspace_name, &source.name);
+                    loaded_sources.push(loaded_source);
                 }
                 Err(error) => {
-                    tracing::warn!(
-                        source = %source.name,
-                        detail = %error,
-                        "skipping source during query-source load"
+                    report_source_load_failure(
+                        workspace_name,
+                        &source.name,
+                        "SOURCE_LOAD_FAILED",
+                        &error.to_string(),
                     );
                 }
             }
         }
         span.record("source.count", loaded_sources.len());
-        Ok(loaded_sources)
+        loaded_sources
     }
 
     fn load_query_source(
@@ -372,7 +370,8 @@ impl QueryManager {
                 v4,
             )?;
             Some(
-                runtime_components_for_v4_source(v4, &materialized).map_err(|error| {
+                runtime_components_for_v4_source(workspace_name, &source.name, v4, &materialized)
+                    .map_err(|error| {
                     incompatible_materialization_error(
                         &source.name,
                         format!("failed to assemble runtime package: {error}"),
@@ -1328,7 +1327,7 @@ pagination:
     }
 
     #[tokio::test]
-    async fn load_query_sources_fails_closed_for_missing_v4_materialization() {
+    async fn load_query_sources_skips_missing_v4_materialization() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new()).await;
         fixture.manager.layout.ensure().expect("ensure layout");
         let workspace_name = WorkspaceName::default();
@@ -1367,23 +1366,17 @@ surfaces:
             )
             .expect("persist source");
 
-        let error = fixture
+        let (sources, _) = fixture
             .manager
             .load_query_sources(&workspace_name)
             .await
-            .expect_err("missing materialization should fail closed");
+            .expect("missing materialization should be isolated");
 
-        assert!(
-            matches!(
-                error,
-                AppError::MissingOrIncompatibleV4Materialization { .. }
-            ),
-            "unexpected error: {error:#}"
-        );
+        assert!(sources.is_empty());
     }
 
     #[tokio::test]
-    async fn load_query_sources_fails_closed_for_unavailable_keychain_source() {
+    async fn load_query_sources_skips_unavailable_keychain_source() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -1425,24 +1418,12 @@ surfaces:
             layout,
             Vec::new(),
         );
-        let error = manager
+        let (sources, _) = manager
             .load_query_sources(&workspace_name)
             .await
-            .expect_err("unavailable keychain should fail closed");
+            .expect("unavailable keychain source should be isolated");
 
-        assert!(
-            matches!(
-                error,
-                AppError::Credentials(CredentialsError::Unavailable(_))
-            ),
-            "unexpected error: {error:#}"
-        );
-        assert!(
-            error
-                .to_string()
-                .contains("configured for keychain storage"),
-            "keychain-routed query failure should name the routed backend: {error}"
-        );
+        assert!(sources.is_empty());
     }
 
     #[derive(Debug)]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -26,8 +26,7 @@ use crate::query::input_resolver::{
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::materialization::{
-    clear_source_load_failure, incompatible_materialization_error, load_v4_materialization,
-    report_source_load_failure,
+    SourceDiagnosticReporter, incompatible_materialization_error, load_v4_materialization,
 };
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::runtime_components_for_v4_source;
@@ -67,9 +66,11 @@ pub(crate) struct QueryManager {
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    diagnostic_reporter: SourceDiagnosticReporter,
 }
 
 impl QueryManager {
+    #[cfg(test)]
     pub(crate) fn new(
         config_store: ConfigStore,
         workspace_manager: WorkspaceManager,
@@ -78,6 +79,26 @@ impl QueryManager {
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
+        Self::with_diagnostic_reporter(
+            config_store,
+            workspace_manager,
+            credential_manager,
+            runtime_context,
+            layout,
+            engine_extensions_providers,
+            SourceDiagnosticReporter::default(),
+        )
+    }
+
+    pub(crate) fn with_diagnostic_reporter(
+        config_store: ConfigStore,
+        workspace_manager: WorkspaceManager,
+        credential_manager: CredentialManager,
+        runtime_context: QueryRuntimeContext,
+        layout: AppStateLayout,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        diagnostic_reporter: SourceDiagnosticReporter,
+    ) -> Self {
         Self {
             config_store,
             workspace_manager: Arc::new(workspace_manager),
@@ -85,6 +106,7 @@ impl QueryManager {
             runtime_context,
             layout,
             engine_extensions_providers,
+            diagnostic_reporter,
         }
     }
 
@@ -337,14 +359,15 @@ impl QueryManager {
         for source in config.workspace_sources(workspace_name) {
             match self.load_query_source(workspace_name, &source) {
                 Ok((loaded_source, _version)) => {
-                    clear_source_load_failure(workspace_name, &source.name);
+                    self.diagnostic_reporter
+                        .clear_source_load_failure(workspace_name, &source.name);
                     loaded_sources.push(loaded_source);
                 }
                 Err(
                     error @ (AppError::MissingOrIncompatibleV4Materialization { .. }
                     | AppError::InvalidV4ProjectionOverride { .. }),
                 ) => {
-                    report_source_load_failure(
+                    self.diagnostic_reporter.report_source_load_failure(
                         workspace_name,
                         &source.name,
                         "SOURCE_LOAD_FAILED",
@@ -372,10 +395,17 @@ impl QueryManager {
                 &source.name,
                 &installed.manifest_yaml,
                 v4,
+                &self.diagnostic_reporter,
             )?;
             Some(
-                runtime_components_for_v4_source(workspace_name, &source.name, v4, &materialized)
-                    .map_err(|error| {
+                runtime_components_for_v4_source(
+                    workspace_name,
+                    &source.name,
+                    v4,
+                    &materialized,
+                    &self.diagnostic_reporter,
+                )
+                .map_err(|error| {
                     incompatible_materialization_error(
                         &source.name,
                         format!("failed to assemble runtime package: {error}"),

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -17,7 +17,7 @@ use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::AppError;
-use crate::credentials::{CredentialManager, CredentialSetId};
+use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::query::QueryAttribution;
 use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_providers};
 use crate::query::input_resolver::{
@@ -49,6 +49,16 @@ pub(crate) struct ValidatedSource {
 enum CredentialResolutionMode {
     Refreshing,
     StoredOnly,
+}
+
+fn is_source_scoped_load_failure(error: &AppError) -> bool {
+    matches!(
+        error,
+        AppError::MissingSourceInputs { .. }
+            | AppError::MissingOrIncompatibleV4Materialization { .. }
+            | AppError::InvalidV4ProjectionOverride { .. }
+            | AppError::Credentials(CredentialsError::Io(_) | CredentialsError::Parse(_))
+    )
 }
 
 #[derive(Debug, Clone)]
@@ -363,10 +373,7 @@ impl QueryManager {
                         .clear_source_load_failure(workspace_name, &source.name);
                     loaded_sources.push(loaded_source);
                 }
-                Err(
-                    error @ (AppError::MissingOrIncompatibleV4Materialization { .. }
-                    | AppError::InvalidV4ProjectionOverride { .. }),
-                ) => {
+                Err(error) if is_source_scoped_load_failure(&error) => {
                     self.diagnostic_reporter.report_source_load_failure(
                         workspace_name,
                         &source.name,
@@ -439,10 +446,10 @@ impl QueryManager {
             } else {
                 format!("secret '{first}' and {} other(s)", rest.len())
             };
-            return Err(AppError::FailedPrecondition(format!(
-                "source '{}' is missing {detail}",
-                source.name
-            )));
+            return Err(AppError::MissingSourceInputs {
+                source_name: source.name.to_string(),
+                detail,
+            });
         }
         for secret_name in source_spec.declared_secret_names() {
             if let Some(value) = stored_secrets.get(&secret_name) {
@@ -739,6 +746,7 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",
         AppError::InvalidInput(_) => "INVALID_INPUT",
         AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
+        AppError::MissingSourceInputs { .. } => "MISSING_SOURCE_INPUTS",
         AppError::MissingOrIncompatibleV4Materialization { .. } => {
             "MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION"
         }
@@ -794,10 +802,10 @@ fn validate_required_variables(
         } else {
             format!("variable '{}' and {} other(s)", first.key, rest.len())
         };
-        return Err(AppError::FailedPrecondition(format!(
-            "source '{}' is missing {detail}",
-            source.name
-        )));
+        return Err(AppError::MissingSourceInputs {
+            source_name: source.name.to_string(),
+            detail,
+        });
     }
     Ok(())
 }
@@ -1409,6 +1417,32 @@ surfaces:
             .expect("missing materialization should be isolated");
 
         assert!(sources.is_empty());
+    }
+
+    #[test]
+    fn source_load_isolation_excludes_backend_wide_credential_failures() {
+        let missing_file = AppError::Credentials(CredentialsError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "missing source credential file",
+        )));
+        let corrupt_file =
+            AppError::Credentials(CredentialsError::Parse("invalid source credentials".into()));
+        let missing_inputs = AppError::MissingSourceInputs {
+            source_name: "demo".into(),
+            detail: "secret 'TOKEN'".into(),
+        };
+        let unavailable_backend =
+            AppError::Credentials(CredentialsError::Unavailable("keychain unavailable".into()));
+        let snapshot_mismatch = AppError::Credentials(CredentialsError::SnapshotStorageMismatch {
+            snapshot: "file",
+            requested: "keychain",
+        });
+
+        assert!(is_source_scoped_load_failure(&missing_file));
+        assert!(is_source_scoped_load_failure(&corrupt_file));
+        assert!(is_source_scoped_load_failure(&missing_inputs));
+        assert!(!is_source_scoped_load_failure(&unavailable_backend));
+        assert!(!is_source_scoped_load_failure(&snapshot_mismatch));
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/search/catalog/local_snapshot.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot.rs
@@ -19,8 +19,7 @@ use coral_spec::{
 use crate::bootstrap::AppError;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::materialization::{
-    clear_source_load_failure, incompatible_materialization_error, load_v4_materialization,
-    report_source_load_failure,
+    SourceDiagnosticReporter, incompatible_materialization_error, load_v4_materialization,
 };
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::runtime_components_for_v4_source;
@@ -38,13 +37,23 @@ use crate::workspaces::WorkspaceName;
 pub(crate) struct CatalogSnapshotLoader {
     config_store: ConfigStore,
     layout: AppStateLayout,
+    diagnostic_reporter: SourceDiagnosticReporter,
 }
 
 impl CatalogSnapshotLoader {
     pub(crate) fn new(config_store: ConfigStore, layout: AppStateLayout) -> Self {
+        Self::with_diagnostic_reporter(config_store, layout, SourceDiagnosticReporter::default())
+    }
+
+    pub(crate) fn with_diagnostic_reporter(
+        config_store: ConfigStore,
+        layout: AppStateLayout,
+        diagnostic_reporter: SourceDiagnosticReporter,
+    ) -> Self {
         Self {
             config_store,
             layout,
+            diagnostic_reporter,
         }
     }
 
@@ -70,7 +79,8 @@ impl CatalogSnapshotLoader {
         for source in config.workspace_sources(workspace_name) {
             match self.load_source_catalog(workspace_name, &source) {
                 Ok(source_catalog) => {
-                    clear_source_load_failure(workspace_name, &source.name);
+                    self.diagnostic_reporter
+                        .clear_source_load_failure(workspace_name, &source.name);
                     catalog.tables.extend(source_catalog.tables);
                     catalog
                         .table_functions
@@ -80,7 +90,7 @@ impl CatalogSnapshotLoader {
                     error @ (AppError::MissingOrIncompatibleV4Materialization { .. }
                     | AppError::InvalidV4ProjectionOverride { .. }),
                 ) => {
-                    report_source_load_failure(
+                    self.diagnostic_reporter.report_source_load_failure(
                         workspace_name,
                         &source.name,
                         "SOURCE_LOAD_FAILED",
@@ -118,14 +128,21 @@ impl CatalogSnapshotLoader {
                 &source.name,
                 &installed.manifest_yaml,
                 v4,
+                &self.diagnostic_reporter,
             )?;
-            runtime_components_for_v4_source(workspace_name, &source.name, v4, &materialized)
-                .map_err(|error| {
-                    incompatible_materialization_error(
-                        &source.name,
-                        format!("failed to assemble runtime package: {error}"),
-                    )
-                })
+            runtime_components_for_v4_source(
+                workspace_name,
+                &source.name,
+                v4,
+                &materialized,
+                &self.diagnostic_reporter,
+            )
+            .map_err(|error| {
+                incompatible_materialization_error(
+                    &source.name,
+                    format!("failed to assemble runtime package: {error}"),
+                )
+            })
         } else {
             Ok(runtime_components_from_manifest(&source_spec))
         }

--- a/crates/coral-app/src/search/catalog/local_snapshot.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot.rs
@@ -19,7 +19,8 @@ use coral_spec::{
 use crate::bootstrap::AppError;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::materialization::{
-    incompatible_materialization_error, load_v4_materialization,
+    clear_source_load_failure, incompatible_materialization_error, load_v4_materialization,
+    report_source_load_failure,
 };
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::runtime_components_for_v4_source;
@@ -53,29 +54,39 @@ impl CatalogSnapshotLoader {
     ) -> Result<CatalogInfo, AppError> {
         let _state_lock = self.config_store.state_lock_shared()?;
         let config = self.config_store.load_config_unlocked()?;
-        self.load_catalog_from_config(workspace_name, &config)
+        Ok(self.load_catalog_from_config(workspace_name, &config))
     }
 
     fn load_catalog_from_config(
         &self,
         workspace_name: &WorkspaceName,
         config: &AppConfig,
-    ) -> Result<CatalogInfo, AppError> {
+    ) -> CatalogInfo {
         let mut catalog = CatalogInfo {
             tables: Vec::new(),
             table_functions: Vec::new(),
         };
 
         for source in config.workspace_sources(workspace_name) {
-            let source_catalog = self.load_source_catalog(workspace_name, &source)?;
-            catalog.tables.extend(source_catalog.tables);
-            catalog
-                .table_functions
-                .extend(source_catalog.table_functions);
+            match self.load_source_catalog(workspace_name, &source) {
+                Ok(source_catalog) => {
+                    clear_source_load_failure(workspace_name, &source.name);
+                    catalog.tables.extend(source_catalog.tables);
+                    catalog
+                        .table_functions
+                        .extend(source_catalog.table_functions);
+                }
+                Err(error) => report_source_load_failure(
+                    workspace_name,
+                    &source.name,
+                    "SOURCE_LOAD_FAILED",
+                    &error.to_string(),
+                ),
+            }
         }
 
         sort_catalog(&mut catalog);
-        Ok(catalog)
+        catalog
     }
 
     fn load_source_catalog(
@@ -102,12 +113,13 @@ impl CatalogSnapshotLoader {
                 &installed.manifest_yaml,
                 v4,
             )?;
-            runtime_components_for_v4_source(v4, &materialized).map_err(|error| {
-                incompatible_materialization_error(
-                    &source.name,
-                    format!("failed to assemble runtime package: {error}"),
-                )
-            })
+            runtime_components_for_v4_source(workspace_name, &source.name, v4, &materialized)
+                .map_err(|error| {
+                    incompatible_materialization_error(
+                        &source.name,
+                        format!("failed to assemble runtime package: {error}"),
+                    )
+                })
         } else {
             Ok(runtime_components_from_manifest(&source_spec))
         }

--- a/crates/coral-app/src/search/catalog/local_snapshot.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot.rs
@@ -54,14 +54,14 @@ impl CatalogSnapshotLoader {
     ) -> Result<CatalogInfo, AppError> {
         let _state_lock = self.config_store.state_lock_shared()?;
         let config = self.config_store.load_config_unlocked()?;
-        Ok(self.load_catalog_from_config(workspace_name, &config))
+        self.load_catalog_from_config(workspace_name, &config)
     }
 
     fn load_catalog_from_config(
         &self,
         workspace_name: &WorkspaceName,
         config: &AppConfig,
-    ) -> CatalogInfo {
+    ) -> Result<CatalogInfo, AppError> {
         let mut catalog = CatalogInfo {
             tables: Vec::new(),
             table_functions: Vec::new(),
@@ -76,17 +76,23 @@ impl CatalogSnapshotLoader {
                         .table_functions
                         .extend(source_catalog.table_functions);
                 }
-                Err(error) => report_source_load_failure(
-                    workspace_name,
-                    &source.name,
-                    "SOURCE_LOAD_FAILED",
-                    &error.to_string(),
-                ),
+                Err(
+                    error @ (AppError::MissingOrIncompatibleV4Materialization { .. }
+                    | AppError::InvalidV4ProjectionOverride { .. }),
+                ) => {
+                    report_source_load_failure(
+                        workspace_name,
+                        &source.name,
+                        "SOURCE_LOAD_FAILED",
+                        &error.to_string(),
+                    );
+                }
+                Err(error) => return Err(error),
             }
         }
 
         sort_catalog(&mut catalog);
-        catalog
+        Ok(catalog)
     }
 
     fn load_source_catalog(

--- a/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
@@ -6,7 +6,6 @@ use tempfile::tempdir;
 use super::{
     CatalogSnapshotLoader, catalog_info_from_components, runtime_components_from_manifest,
 };
-use crate::bootstrap::AppError;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore};
@@ -192,7 +191,7 @@ tables:
 }
 
 #[test]
-fn loader_fails_when_installed_manifest_cannot_be_read() {
+fn loader_skips_installed_source_whose_manifest_cannot_be_read() {
     let temp = tempdir().expect("tempdir");
     let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
     let config_store = ConfigStore::new(layout.clone());
@@ -216,18 +215,16 @@ fn loader_fails_when_installed_manifest_cannot_be_read() {
         )
         .expect("upsert source");
 
-    let error = CatalogSnapshotLoader::new(config_store, layout)
+    let catalog = CatalogSnapshotLoader::new(config_store, layout)
         .load_catalog(&workspace_name)
-        .expect_err("missing installed manifest should fail catalog load");
+        .expect("missing installed manifest should be isolated");
 
-    assert!(
-        matches!(error, AppError::Io(ref io_error) if io_error.kind() == std::io::ErrorKind::NotFound),
-        "unexpected error: {error}"
-    );
+    assert!(catalog.tables.is_empty());
+    assert!(catalog.table_functions.is_empty());
 }
 
 #[test]
-fn loader_fails_when_v4_source_missing_materialization() {
+fn loader_keeps_healthy_source_when_v4_source_is_missing_materialization() {
     let temp = tempdir().expect("tempdir");
     let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
     let config_store = ConfigStore::new(layout.clone());
@@ -275,16 +272,13 @@ surfaces:
 ",
     );
 
-    let error = CatalogSnapshotLoader::new(config_store, layout)
+    let catalog = CatalogSnapshotLoader::new(config_store, layout)
         .load_catalog(&workspace_name)
-        .expect_err("missing v4 materialization should fail catalog load");
+        .expect("missing v4 materialization should be isolated");
 
-    match error {
-        AppError::MissingOrIncompatibleV4Materialization { source_name, .. } => {
-            assert_eq!(source_name, stale_v4_source.as_str());
-        }
-        other => panic!("unexpected error: {other}"),
-    }
+    assert!(catalog.tables.iter().any(|table| {
+        table.schema_name == healthy_source.as_str() && table.table_name == "messages"
+    }));
 }
 
 fn install_imported_source(

--- a/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
@@ -6,6 +6,7 @@ use tempfile::tempdir;
 use super::{
     CatalogSnapshotLoader, catalog_info_from_components, runtime_components_from_manifest,
 };
+use crate::bootstrap::AppError;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore};
@@ -191,7 +192,7 @@ tables:
 }
 
 #[test]
-fn loader_skips_installed_source_whose_manifest_cannot_be_read() {
+fn loader_fails_closed_when_installed_manifest_cannot_be_read() {
     let temp = tempdir().expect("tempdir");
     let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
     let config_store = ConfigStore::new(layout.clone());
@@ -215,12 +216,14 @@ fn loader_skips_installed_source_whose_manifest_cannot_be_read() {
         )
         .expect("upsert source");
 
-    let catalog = CatalogSnapshotLoader::new(config_store, layout)
+    let error = CatalogSnapshotLoader::new(config_store, layout)
         .load_catalog(&workspace_name)
-        .expect("missing installed manifest should be isolated");
+        .expect_err("missing installed manifest should fail closed");
 
-    assert!(catalog.tables.is_empty());
-    assert!(catalog.table_functions.is_empty());
+    assert!(
+        matches!(error, AppError::Io(_)),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]

--- a/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
+++ b/crates/coral-app/src/search/catalog/local_snapshot/tests.rs
@@ -192,6 +192,84 @@ tables:
 }
 
 #[test]
+fn loader_builds_catalog_from_schema_v3_materialization_fixture_bytes() {
+    let temp = tempdir().expect("tempdir");
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+    let config_store = ConfigStore::new(layout.clone());
+    let workspace_name = WorkspaceName::parse("work").expect("workspace");
+    let source_name = SourceName::parse("compatibility_fixture").expect("source");
+    let manifest_yaml = r"
+name: compatibility_fixture
+dsl_version: 4
+surfaces:
+  - id: rest
+    namespace_suffix: rest
+    type: openapi
+    file: /tmp/schema-v3-openapi.yaml
+    base_url: https://api.example.com
+  - id: mcp
+    namespace_suffix: mcp
+    type: mcp
+    server:
+      transport: stdio
+      command: schema-v3-mcp-server
+";
+
+    config_store
+        .create_legacy_workspace_entry_for_tests(&workspace_name)
+        .expect("create legacy workspace entry");
+    install_imported_source(
+        &layout,
+        &config_store,
+        &workspace_name,
+        &source_name,
+        manifest_yaml,
+    );
+
+    let materialized_dir = layout.v4_materialized_dir(&workspace_name, &source_name);
+    let rest_dir = materialized_dir.join("surfaces").join("rest");
+    let mcp_dir = materialized_dir.join("surfaces").join("mcp");
+    std::fs::create_dir_all(&rest_dir).expect("create REST artifact dir");
+    std::fs::create_dir_all(&mcp_dir).expect("create MCP artifact dir");
+    std::fs::write(
+        materialized_dir.join("projections.yaml"),
+        include_str!("../../../../../coral-spec/src/v4/fixtures/v3/projections.yaml"),
+    )
+    .expect("write schema-v3 projections");
+    std::fs::write(
+        rest_dir.join("semantic-ir.yaml"),
+        include_str!("../../../../../coral-spec/src/v4/fixtures/v3/semantic-ir.yaml"),
+    )
+    .expect("write schema-v3 REST semantic IR");
+    std::fs::write(
+        mcp_dir.join("semantic-ir.yaml"),
+        include_str!("../../../../../coral-spec/src/v4/fixtures/v3/mcp-semantic-ir.yaml"),
+    )
+    .expect("write schema-v3 MCP semantic IR");
+
+    let catalog = CatalogSnapshotLoader::new(config_store, layout)
+        .load_catalog(&workspace_name)
+        .expect("load catalog from schema-v3 materialization");
+
+    let table = catalog
+        .tables
+        .iter()
+        .find(|table| {
+            table.schema_name == "compatibility_fixture_rest" && table.table_name == "items"
+        })
+        .expect("legacy projection without a namespace should produce the items table");
+    assert_eq!(
+        table
+            .columns
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>(),
+        ["id", "state", "owner"]
+    );
+    assert_eq!(table.required_filters, ["owner"]);
+}
+
+#[test]
 fn loader_fails_closed_when_installed_manifest_cannot_be_read() {
     let temp = tempdir().expect("tempdir");
     let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -5,6 +5,7 @@ use crate::search::catalog::local_snapshot::CatalogSnapshotLoader;
 use crate::search::catalog::provider::CatalogMetadataProvider;
 use crate::search::engine::UniversalSearchEngine;
 use crate::search::result::{SearchManagerError, SearchRequest, SearchResponse};
+use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::WorkspaceManager;
 
@@ -15,12 +16,31 @@ pub(crate) struct SearchManager {
 }
 
 impl SearchManager {
+    #[cfg(test)]
     pub(crate) fn new(
         layout: AppStateLayout,
         config_store: &ConfigStore,
         workspace_manager: WorkspaceManager,
     ) -> Self {
-        let catalog_loader = CatalogSnapshotLoader::new(config_store.clone(), layout.clone());
+        Self::with_diagnostic_reporter(
+            layout,
+            config_store,
+            workspace_manager,
+            SourceDiagnosticReporter::default(),
+        )
+    }
+
+    pub(crate) fn with_diagnostic_reporter(
+        layout: AppStateLayout,
+        config_store: &ConfigStore,
+        workspace_manager: WorkspaceManager,
+        diagnostic_reporter: SourceDiagnosticReporter,
+    ) -> Self {
+        let catalog_loader = CatalogSnapshotLoader::with_diagnostic_reporter(
+            config_store.clone(),
+            layout.clone(),
+            diagnostic_reporter,
+        );
         let catalog = CatalogMetadataProvider::new(layout, catalog_loader);
         Self {
             engine: UniversalSearchEngine::new(catalog),

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -21,9 +21,10 @@ use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
 };
 use crate::sources::materialization::{
-    MaterializationBuild, MaterializationInputs, build_v4_materialization_tmp,
-    canonicalize_file_descriptor, cleanup_materialization_backup, cleanup_materialization_tmp,
-    new_materialization_suffix, replace_v4_materialization, restore_materialization_backup,
+    MaterializationBuild, MaterializationInputs, SourceDiagnosticReporter,
+    build_v4_materialization_tmp, canonicalize_file_descriptor, cleanup_materialization_backup,
+    cleanup_materialization_tmp, new_materialization_suffix, replace_v4_materialization,
+    restore_materialization_backup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore};
@@ -41,6 +42,7 @@ pub(crate) struct SourceManager {
     oauth_credential_service: OAuthCredentialService,
     layout: AppStateLayout,
     lifecycle_lock: WorkspaceLifecycleLock,
+    diagnostic_reporter: SourceDiagnosticReporter,
 }
 
 pub(crate) struct CreateBundledSourceCommand {
@@ -186,11 +188,28 @@ impl SourceManager {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
         layout: AppStateLayout,
         lifecycle_lock: WorkspaceLifecycleLock,
+    ) -> Self {
+        Self::with_diagnostic_reporter(
+            config_store,
+            credential_manager,
+            layout,
+            lifecycle_lock,
+            SourceDiagnosticReporter::default(),
+        )
+    }
+
+    pub(crate) fn with_diagnostic_reporter(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+        lifecycle_lock: WorkspaceLifecycleLock,
+        diagnostic_reporter: SourceDiagnosticReporter,
     ) -> Self {
         Self {
             config_store,
@@ -198,6 +217,7 @@ impl SourceManager {
             oauth_credential_service: OAuthCredentialService::new(),
             layout,
             lifecycle_lock,
+            diagnostic_reporter,
         }
     }
 
@@ -573,6 +593,8 @@ impl SourceManager {
             self.layout.workspace_dir(workspace_name).parent(),
         );
         drop(state_lock);
+        self.diagnostic_reporter
+            .clear_source(workspace_name, source_name);
         self.clear_catalog_projection_for_source_lifecycle_best_effort(workspace_name, source_name);
         Ok(removed)
     }

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 use coral_spec::v4::{
     Diagnostic, DiagnosticSeverity, Fingerprint, FingerprintSurface, MCP_IMPORTER_VERSION,
     MaterializedSurface, McpToolCatalog, OPENAPI_IMPORTER_VERSION, PROJECTION_GENERATOR_VERSION,
-    ProjectionCatalog, ProjectionCatalogFile, ProjectionPaginationInputSyncMode,
-    SURFACE_IMPORTER_VERSION, SemanticIr, SemanticIrFile, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION,
+    ProjectionCatalog, ProjectionCatalogDto, ProjectionPaginationInputSyncMode,
+    SURFACE_IMPORTER_VERSION, SemanticIr, SemanticIrDto, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION,
     V4MaterializedSource, V4SourceManifest, apply_parameter_metadata_overrides,
     generate_projection_catalog, import_mcp_surface, import_openapi_surface,
     normalize_mcp_tool_catalog, normalize_source_document, openapi_document_metadata,
@@ -314,7 +314,7 @@ fn load_projection_catalog(
 ) -> Result<ProjectionCatalog, AppError> {
     let projections = match projections_file.origin {
         V4ProjectionCatalogOrigin::Materialized => {
-            let file: ProjectionCatalogFile =
+            let file: ProjectionCatalogDto =
                 read_artifact_yaml(source_name, "projection catalog", &projections_file.path)?;
             file.try_into().map_err(|error| {
                 incompatible_materialization_error(
@@ -422,7 +422,7 @@ fn load_projected_surface(
     let surface_dir = layout.v4_surface_dir(workspace_name, source_name, &surface.id);
     let raw_source_document_path = surface_dir.join("source-document.raw");
     let semantic_ir_path = surface_dir.join("semantic-ir.yaml");
-    let semantic_ir_file: SemanticIrFile =
+    let semantic_ir_file: SemanticIrDto =
         read_artifact_yaml(source_name, "semantic IR", &semantic_ir_path).map_err(|error| {
             Box::new(materialization_warning(
                 "V4_SEMANTIC_IR_UNAVAILABLE",
@@ -916,7 +916,7 @@ fn write_materialization(
     write_yaml(&temp_dir.join(FINGERPRINT_FILENAME), &fingerprint)?;
     write_yaml(
         &temp_dir.join(PROJECTIONS_FILENAME),
-        &ProjectionCatalogFile::from(&projections),
+        &ProjectionCatalogDto::from(&projections),
     )?;
     write_yaml(&temp_dir.join(DIAGNOSTICS_FILENAME), &diagnostics)?;
     Ok(())
@@ -946,7 +946,7 @@ fn write_surface_artifacts(
     )?;
     write_yaml(
         &surface_dir.join("semantic-ir.yaml"),
-        &SemanticIrFile::from(&materialized_surface.semantic_ir),
+        &SemanticIrDto::from(&materialized_surface.semantic_ir),
     )?;
     Ok(())
 }
@@ -1376,7 +1376,7 @@ fn read_projection_override_yaml(
     source_name: &SourceName,
     path: &Path,
 ) -> Result<ProjectionCatalog, AppError> {
-    let file: ProjectionCatalogFile = read_yaml(path).map_err(|error| {
+    let file: ProjectionCatalogDto = read_yaml(path).map_err(|error| {
         invalid_projection_override_error(
             source_name,
             path,
@@ -1665,7 +1665,7 @@ surfaces:
             "generated lookup key metadata should live in semantic-ir.yaml"
         );
 
-        let semantic_ir_file: SemanticIrFile =
+        let semantic_ir_file: SemanticIrDto =
             read_yaml(&surface_dir.join("semantic-ir.yaml")).expect("read semantic IR");
         let semantic_ir = SemanticIr::try_from(semantic_ir_file).expect("migrate semantic IR");
         let operation = semantic_ir.operations.first().expect("operation");
@@ -1720,7 +1720,7 @@ surfaces:
         )
         .expect("build MCP materialization");
 
-        let semantic_ir_file: SemanticIrFile = read_yaml(
+        let semantic_ir_file: SemanticIrDto = read_yaml(
             &build
                 .temp_dir
                 .join("surfaces")
@@ -1740,7 +1740,7 @@ surfaces:
             vec!["meta".to_string(), "nextCursor".to_string()]
         );
 
-        let projections_file: ProjectionCatalogFile =
+        let projections_file: ProjectionCatalogDto =
             read_yaml(&build.temp_dir.join(PROJECTIONS_FILENAME)).expect("read projections");
         let projections =
             ProjectionCatalog::try_from(projections_file).expect("migrate projections");
@@ -2132,7 +2132,7 @@ operation_overrides:
         let semantic_ir_path = layout
             .v4_surface_dir(&workspace_name(), &source_name(), "rest")
             .join("semantic-ir.yaml");
-        let artifact_ir_file: SemanticIrFile =
+        let artifact_ir_file: SemanticIrDto =
             read_yaml(&semantic_ir_path).expect("read persisted semantic IR");
         let artifact_ir =
             SemanticIr::try_from(artifact_ir_file).expect("migrate persisted semantic IR");

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -227,23 +227,10 @@ pub(crate) fn load_v4_materialization(
         &mut projections,
         projection_sync_mode,
     );
-    let materialized = V4MaterializedSource {
-        fingerprint,
-        surfaces,
-        projections,
-        diagnostics: {
-            diagnostics.append(&mut load_diagnostics);
-            diagnostics
-        },
-    };
     if originally_published > 0
-        && !materialized
-            .projections
-            .projections
-            .iter()
-            .any(|projection| {
-                projection.visibility == coral_spec::v4::ProjectionVisibility::Published
-            })
+        && !projections.projections.iter().any(|projection| {
+            projection.visibility == coral_spec::v4::ProjectionVisibility::Published
+        })
     {
         return Err(incompatible_materialization_error(
             source_name,
@@ -254,12 +241,15 @@ pub(crate) fn load_v4_materialization(
         workspace_name,
         source_name,
         "materialization",
-        materialized
-            .diagnostics
-            .iter()
-            .filter(|diagnostic| diagnostic.code.starts_with("V4_")),
+        load_diagnostics.iter(),
     );
-    Ok(materialized)
+    diagnostics.append(&mut load_diagnostics);
+    Ok(V4MaterializedSource {
+        fingerprint,
+        surfaces,
+        projections,
+        diagnostics,
+    })
 }
 
 fn load_optional_fingerprint(

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -3,18 +3,19 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use coral_spec::v4::{
     Diagnostic, DiagnosticSeverity, Fingerprint, FingerprintSurface, MCP_IMPORTER_VERSION,
     MaterializedSurface, McpToolCatalog, OPENAPI_IMPORTER_VERSION, PROJECTION_GENERATOR_VERSION,
-    ProjectionCatalog, ProjectionPaginationInputSyncMode, SURFACE_IMPORTER_VERSION, SemanticIr,
-    SurfaceType, V4_ARTIFACT_SCHEMA_VERSION, V4MaterializedSource, V4SourceManifest,
-    apply_parameter_metadata_overrides, generate_projection_catalog, import_mcp_surface,
-    import_openapi_surface, normalize_mcp_tool_catalog, normalize_source_document,
-    openapi_document_metadata, parse_parameter_metadata_overrides_yaml,
-    sync_projection_pagination_inputs, validate_materialized_source,
-    validate_openapi_base_url_template,
+    ProjectionCatalog, ProjectionCatalogFile, ProjectionPaginationInputSyncMode,
+    SURFACE_IMPORTER_VERSION, SemanticIr, SemanticIrFile, SurfaceType, V4_ARTIFACT_SCHEMA_VERSION,
+    V4MaterializedSource, V4SourceManifest, apply_parameter_metadata_overrides,
+    generate_projection_catalog, import_mcp_surface, import_openapi_surface,
+    normalize_mcp_tool_catalog, normalize_source_document, openapi_document_metadata,
+    parse_parameter_metadata_overrides_yaml, sync_projection_pagination_inputs,
+    validate_materialized_source, validate_openapi_base_url_template,
 };
 use coral_spec::{
     ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestInputKind, ManifestInputSpec,
@@ -38,6 +39,11 @@ pub(crate) const PROJECTIONS_FILENAME: &str = "projections.yaml";
 pub(crate) const FINGERPRINT_FILENAME: &str = "fingerprint.yaml";
 pub(crate) const DIAGNOSTICS_FILENAME: &str = "diagnostics.yaml";
 pub(crate) const PARAMETER_METADATA_OVERRIDE_FILENAME: &str = "parameter_metadata.yaml";
+
+type ReportedDiagnosticKey = (String, String);
+type ReportedDiagnostics = BTreeMap<String, BTreeSet<ReportedDiagnosticKey>>;
+
+static REPORTED_LOAD_DIAGNOSTICS: OnceLock<Mutex<ReportedDiagnostics>> = OnceLock::new();
 
 #[derive(Debug)]
 pub(crate) struct MaterializationBuild {
@@ -159,70 +165,55 @@ pub(crate) fn load_v4_materialization(
     let fingerprint_path = layout.v4_fingerprint_file(workspace_name, source_name);
     let projections_file = layout.v4_projection_catalog_file(workspace_name, source_name);
     let diagnostics_path = layout.v4_diagnostics_file(workspace_name, source_name);
-    if !fingerprint_path.exists() || !projections_file.path.exists() || !diagnostics_path.exists() {
+    if !projections_file.path.exists() {
         return Err(incompatible_materialization_error(
             source_name,
-            "required artifact is missing",
+            format!(
+                "required projection catalog '{}' is missing",
+                projections_file.path.display()
+            ),
         ));
     }
-    let fingerprint: Fingerprint =
-        read_artifact_yaml(source_name, "fingerprint", &fingerprint_path)?;
-    validate_fingerprint_header(source_name, manifest, &fingerprint)?;
-    if fingerprint.manifest_sha256 != sha256_hex(manifest_yaml.as_bytes()) {
-        return Err(incompatible_materialization_error(
-            source_name,
-            "manifest fingerprint does not match installed manifest",
-        ));
-    }
-    let fingerprint_surfaces = validate_fingerprint_surfaces(source_name, manifest, &fingerprint)?;
-    let mut projections: ProjectionCatalog = match projections_file.origin {
-        V4ProjectionCatalogOrigin::Materialized => {
-            read_artifact_yaml(source_name, "projection catalog", &projections_file.path)?
-        }
-        V4ProjectionCatalogOrigin::Override => {
-            read_projection_override_yaml(source_name, &projections_file.path)?
-        }
-    };
-    validate_projection_catalog_header(source_name, manifest, &projections, &projections_file)?;
-    let diagnostics: Vec<Diagnostic> =
-        read_artifact_yaml(source_name, "diagnostics", &diagnostics_path)?;
-    let mut surfaces = Vec::new();
-    for fingerprint_surface in &fingerprint.surfaces {
-        let surface = manifest
-            .surface(&fingerprint_surface.surface_id)
-            .ok_or_else(|| {
-                incompatible_materialization_error(
-                    source_name,
-                    format!(
-                        "fingerprint references undeclared surface '{}'",
-                        fingerprint_surface.surface_id
-                    ),
-                )
-            })?;
-        let surface_dir = layout.v4_surface_dir(workspace_name, source_name, &surface.id);
-        let raw_source_document_path = surface_dir.join("source-document.raw");
-        let normalized_source_document_path = surface_dir.join("source-document.yaml");
-        let semantic_ir_path = surface_dir.join("semantic-ir.yaml");
-        require_file(source_name, &raw_source_document_path)?;
-        require_file(source_name, &normalized_source_document_path)?;
-        require_file(source_name, &semantic_ir_path)?;
-        let mut semantic_ir: SemanticIr =
-            read_artifact_yaml(source_name, "semantic IR", &semantic_ir_path)?;
-        apply_parameter_metadata_override_file(
-            layout,
-            workspace_name,
-            source_name,
-            &surface.id,
-            &mut semantic_ir,
-        )?;
-        surfaces.push(MaterializedSurface {
-            surface_id: surface.id.clone(),
-            semantic_ir,
-            source_document_sha256: fingerprint_surface.descriptor_sha256.clone(),
-            normalized_source_document_path,
-            raw_source_document_path,
-        });
-    }
+    let mut load_diagnostics = Vec::new();
+    let fingerprint = load_optional_fingerprint(
+        manifest_yaml,
+        manifest,
+        &fingerprint_path,
+        &mut load_diagnostics,
+    );
+    let mut projections = load_projection_catalog(
+        source_name,
+        manifest,
+        &projections_file,
+        &mut load_diagnostics,
+    )?;
+    let mut diagnostics = load_optional_diagnostics(&diagnostics_path, &mut load_diagnostics);
+    let originally_published = projections
+        .projections
+        .iter()
+        .filter(|projection| {
+            projection.visibility == coral_spec::v4::ProjectionVisibility::Published
+        })
+        .count();
+    let (surfaces, mut failed_surfaces) = load_projected_surfaces(
+        layout,
+        workspace_name,
+        source_name,
+        manifest,
+        &projections,
+        fingerprint.as_ref(),
+        &mut load_diagnostics,
+    );
+    collect_projection_coherence_diagnostics(
+        manifest,
+        &projections,
+        &surfaces,
+        &mut failed_surfaces,
+        &mut load_diagnostics,
+    );
+    projections
+        .projections
+        .retain(|projection| !failed_surfaces.contains(&projection.surface_id));
     let projection_sync_mode = match projections_file.origin {
         V4ProjectionCatalogOrigin::Materialized => {
             ProjectionPaginationInputSyncMode::RecomputeRestInputExposure
@@ -240,201 +231,517 @@ pub(crate) fn load_v4_materialization(
         fingerprint,
         surfaces,
         projections,
-        diagnostics,
+        diagnostics: {
+            diagnostics.append(&mut load_diagnostics);
+            diagnostics
+        },
     };
-    validate_loaded_materialization(source_name, manifest, &materialized, &fingerprint_surfaces)?;
+    if originally_published > 0
+        && !materialized
+            .projections
+            .projections
+            .iter()
+            .any(|projection| {
+                projection.visibility == coral_spec::v4::ProjectionVisibility::Published
+            })
+    {
+        return Err(incompatible_materialization_error(
+            source_name,
+            "no published projection surfaces could be loaded",
+        ));
+    }
+    report_source_diagnostics(
+        workspace_name,
+        source_name,
+        "materialization",
+        materialized
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code.starts_with("V4_")),
+    );
     Ok(materialized)
 }
 
-fn validate_fingerprint_header(
-    source_name: &SourceName,
+fn load_optional_fingerprint(
+    manifest_yaml: &str,
     manifest: &V4SourceManifest,
-    fingerprint: &Fingerprint,
-) -> Result<(), AppError> {
-    if fingerprint.artifact_schema_version != V4_ARTIFACT_SCHEMA_VERSION {
-        return Err(incompatible_materialization_error(
-            source_name,
-            "fingerprint artifact schema version mismatch",
+    path: &Path,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<Fingerprint> {
+    let fingerprint = match read_yaml::<Fingerprint>(path) {
+        Ok(fingerprint) => fingerprint,
+        Err(error) => {
+            diagnostics.push(materialization_warning(
+                "V4_FINGERPRINT_UNAVAILABLE",
+                format!(
+                    "could not read optional fingerprint '{}': {error}",
+                    path.display()
+                ),
+                None,
+            ));
+            return None;
+        }
+    };
+    if let Err(error) = validate_fingerprint_header(manifest, &fingerprint) {
+        diagnostics.push(materialization_warning(
+            "V4_FINGERPRINT_HEADER_MISMATCH",
+            error,
+            None,
         ));
     }
-    if fingerprint.source_name != manifest.common.name {
-        return Err(incompatible_materialization_error(
-            source_name,
-            "fingerprint source name does not match installed manifest",
+    if fingerprint.manifest_sha256 != sha256_hex(manifest_yaml.as_bytes()) {
+        diagnostics.push(materialization_warning(
+            "V4_MANIFEST_FINGERPRINT_MISMATCH",
+            "manifest fingerprint does not match installed manifest",
+            None,
         ));
+    }
+    if let Err(error) = validate_fingerprint_surfaces(manifest, &fingerprint) {
+        diagnostics.push(materialization_warning(
+            "V4_FINGERPRINT_SURFACE_MISMATCH",
+            error,
+            None,
+        ));
+    }
+    Some(fingerprint)
+}
+
+fn load_projection_catalog(
+    source_name: &SourceName,
+    manifest: &V4SourceManifest,
+    projections_file: &V4ProjectionCatalogFile,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Result<ProjectionCatalog, AppError> {
+    let projections = match projections_file.origin {
+        V4ProjectionCatalogOrigin::Materialized => {
+            let file: ProjectionCatalogFile =
+                read_artifact_yaml(source_name, "projection catalog", &projections_file.path)?;
+            file.try_into().map_err(|error| {
+                incompatible_materialization_error(
+                    source_name,
+                    format!("failed to migrate projection catalog: {error}"),
+                )
+            })?
+        }
+        V4ProjectionCatalogOrigin::Override => {
+            read_projection_override_yaml(source_name, &projections_file.path)?
+        }
+    };
+    if let Err(error) = validate_projection_catalog_header(manifest, &projections, projections_file)
+    {
+        diagnostics.push(materialization_warning(
+            "V4_PROJECTION_CATALOG_PROVENANCE_MISMATCH",
+            error,
+            None,
+        ));
+    }
+    Ok(projections)
+}
+
+fn load_optional_diagnostics(path: &Path, diagnostics: &mut Vec<Diagnostic>) -> Vec<Diagnostic> {
+    match read_yaml(path) {
+        Ok(diagnostics) => diagnostics,
+        Err(error) => {
+            diagnostics.push(materialization_warning(
+                "V4_DIAGNOSTICS_UNAVAILABLE",
+                format!(
+                    "could not read optional diagnostics '{}': {error}",
+                    path.display()
+                ),
+                None,
+            ));
+            Vec::new()
+        }
+    }
+}
+
+fn load_projected_surfaces(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    manifest: &V4SourceManifest,
+    projections: &ProjectionCatalog,
+    fingerprint: Option<&Fingerprint>,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> (Vec<MaterializedSurface>, BTreeSet<String>) {
+    let projected_surface_ids = projections
+        .projections
+        .iter()
+        .map(|projection| projection.surface_id.clone())
+        .collect::<BTreeSet<_>>();
+    let fingerprint_surfaces = fingerprint
+        .map(|fingerprint| {
+            fingerprint
+                .surfaces
+                .iter()
+                .map(|surface| (surface.surface_id.clone(), surface))
+                .collect::<BTreeMap<_, _>>()
+        })
+        .unwrap_or_default();
+    let mut surfaces = Vec::new();
+    let mut failed_surfaces = BTreeSet::new();
+    for surface_id in projected_surface_ids {
+        let Some(surface) = manifest.surface(&surface_id) else {
+            diagnostics.push(materialization_warning(
+                "V4_PROJECTED_SURFACE_NOT_DECLARED",
+                format!("projection catalog references undeclared surface '{surface_id}'"),
+                Some(surface_id.clone()),
+            ));
+            failed_surfaces.insert(surface_id);
+            continue;
+        };
+        match load_projected_surface(
+            layout,
+            workspace_name,
+            source_name,
+            manifest,
+            surface,
+            fingerprint_surfaces.get(&surface.id).copied(),
+        ) {
+            Ok((materialized_surface, mut surface_diagnostics)) => {
+                surfaces.push(materialized_surface);
+                diagnostics.append(&mut surface_diagnostics);
+            }
+            Err(diagnostic) => {
+                diagnostics.push(*diagnostic);
+                failed_surfaces.insert(surface.id.clone());
+            }
+        }
+    }
+    (surfaces, failed_surfaces)
+}
+
+fn load_projected_surface(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    manifest: &V4SourceManifest,
+    surface: &coral_spec::v4::V4Surface,
+    fingerprint: Option<&FingerprintSurface>,
+) -> Result<(MaterializedSurface, Vec<Diagnostic>), Box<Diagnostic>> {
+    let surface_dir = layout.v4_surface_dir(workspace_name, source_name, &surface.id);
+    let raw_source_document_path = surface_dir.join("source-document.raw");
+    let semantic_ir_path = surface_dir.join("semantic-ir.yaml");
+    let semantic_ir_file: SemanticIrFile =
+        read_artifact_yaml(source_name, "semantic IR", &semantic_ir_path).map_err(|error| {
+            Box::new(materialization_warning(
+                "V4_SEMANTIC_IR_UNAVAILABLE",
+                error.to_string(),
+                Some(surface.id.clone()),
+            ))
+        })?;
+    let mut semantic_ir = SemanticIr::try_from(semantic_ir_file).map_err(|error| {
+        Box::new(materialization_warning(
+            "V4_SEMANTIC_IR_MIGRATION_FAILED",
+            error.to_string(),
+            Some(surface.id.clone()),
+        ))
+    })?;
+    let mut diagnostics = Vec::new();
+    if let Err(error) = validate_semantic_ir(manifest, surface, &semantic_ir) {
+        diagnostics.push(materialization_warning(
+            "V4_SEMANTIC_IR_PROVENANCE_MISMATCH",
+            error,
+            Some(surface.id.clone()),
+        ));
+    }
+    apply_parameter_metadata_override_file(
+        layout,
+        workspace_name,
+        source_name,
+        &surface.id,
+        &mut semantic_ir,
+    )
+    .map_err(|error| {
+        Box::new(materialization_warning(
+            "V4_PARAMETER_METADATA_OVERRIDE_FAILED",
+            error.to_string(),
+            Some(surface.id.clone()),
+        ))
+    })?;
+    if let Some(fingerprint) = fingerprint {
+        match std::fs::read(&raw_source_document_path) {
+            Ok(raw_bytes) if sha256_hex(&raw_bytes) != fingerprint.descriptor_sha256 => {
+                diagnostics.push(materialization_warning(
+                    "V4_RAW_DOCUMENT_FINGERPRINT_MISMATCH",
+                    format!(
+                        "raw source document hash does not match for surface '{}'",
+                        surface.id
+                    ),
+                    Some(surface.id.clone()),
+                ));
+            }
+            Err(error) => diagnostics.push(materialization_warning(
+                "V4_RAW_DOCUMENT_UNAVAILABLE",
+                format!(
+                    "could not read raw source document '{}' for provenance validation: {error}",
+                    raw_source_document_path.display()
+                ),
+                Some(surface.id.clone()),
+            )),
+            _ => {}
+        }
+    }
+    Ok((
+        MaterializedSurface {
+            surface_id: surface.id.clone(),
+            semantic_ir,
+            source_document_sha256: fingerprint.map_or_else(String::new, |fingerprint| {
+                fingerprint.descriptor_sha256.clone()
+            }),
+            normalized_source_document_path: surface_dir.join("source-document.yaml"),
+            raw_source_document_path,
+        },
+        diagnostics,
+    ))
+}
+
+fn collect_projection_coherence_diagnostics(
+    manifest: &V4SourceManifest,
+    projections: &ProjectionCatalog,
+    surfaces: &[MaterializedSurface],
+    failed_surfaces: &mut BTreeSet<String>,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    for projection in &projections.projections {
+        let Some(surface) = manifest.surface(&projection.surface_id) else {
+            continue;
+        };
+        if projection.namespace != surface.relation_namespace {
+            diagnostics.push(materialization_warning(
+                "V4_PROJECTION_NAMESPACE_MISMATCH",
+                format!(
+                    "projection '{}' namespace '{}' does not match surface '{}' relation namespace '{}'",
+                    projection.name,
+                    projection.namespace,
+                    projection.surface_id,
+                    surface.relation_namespace
+                ),
+                Some(surface.id.clone()),
+            ));
+        }
+        if let Some(materialized_surface) = surfaces
+            .iter()
+            .find(|candidate| candidate.surface_id == projection.surface_id)
+            && !materialized_surface
+                .semantic_ir
+                .operations
+                .iter()
+                .any(|operation| operation.id == projection.operation_id)
+        {
+            diagnostics.push(materialization_warning(
+                "V4_PROJECTION_OPERATION_MISSING",
+                format!(
+                    "projection '{}' references missing operation '{}'",
+                    projection.name, projection.operation_id
+                ),
+                Some(surface.id.clone()),
+            ));
+            failed_surfaces.insert(surface.id.clone());
+        }
+    }
+}
+
+pub(crate) fn report_source_load_failure(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    code: &str,
+    detail: &str,
+) {
+    let diagnostic = Diagnostic {
+        code: code.to_string(),
+        severity: DiagnosticSeverity::Warning,
+        message: detail.to_string(),
+        surface_id: None,
+        operation_id: None,
+        projection_name: None,
+    };
+    report_source_diagnostics(
+        workspace_name,
+        source_name,
+        "source",
+        std::iter::once(&diagnostic),
+    );
+}
+
+pub(crate) fn clear_source_load_failure(workspace_name: &WorkspaceName, source_name: &SourceName) {
+    report_source_diagnostics(
+        workspace_name,
+        source_name,
+        "source",
+        std::iter::empty::<&Diagnostic>(),
+    );
+}
+
+pub(crate) fn report_runtime_surface_diagnostics(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    diagnostics: &[Diagnostic],
+) {
+    report_source_diagnostics(workspace_name, source_name, "runtime", diagnostics.iter());
+}
+
+fn report_source_diagnostics<'a>(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    stage: &str,
+    diagnostics: impl IntoIterator<Item = &'a Diagnostic>,
+) {
+    let state_key = format!("{workspace_name}\u{1f}{source_name}\u{1f}{stage}");
+    let diagnostics = diagnostics.into_iter().collect::<Vec<_>>();
+    let current = diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.code.clone(), diagnostic.message.clone()))
+        .collect::<BTreeSet<_>>();
+    let mut reported = REPORTED_LOAD_DIAGNOSTICS
+        .get_or_init(|| Mutex::new(BTreeMap::new()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let previous = reported.get(&state_key).cloned().unwrap_or_default();
+    for diagnostic in diagnostics {
+        let key = (diagnostic.code.clone(), diagnostic.message.clone());
+        if previous.contains(&key) {
+            continue;
+        }
+        tracing::warn!(
+            diagnostic.code = %diagnostic.code,
+            diagnostic.stage = stage,
+            workspace = %workspace_name,
+            source = %source_name,
+            surface = diagnostic.surface_id.as_deref().unwrap_or(""),
+            operation = diagnostic.operation_id.as_deref().unwrap_or(""),
+            projection = diagnostic.projection_name.as_deref().unwrap_or(""),
+            detail = %diagnostic.message,
+            "DSL v4 source load diagnostic"
+        );
+    }
+    if current.is_empty() {
+        reported.remove(&state_key);
+    } else {
+        reported.insert(state_key, current);
+    }
+}
+
+fn materialization_warning(
+    code: &str,
+    message: impl Into<String>,
+    surface_id: Option<String>,
+) -> Diagnostic {
+    Diagnostic {
+        code: code.to_string(),
+        severity: DiagnosticSeverity::Warning,
+        message: message.into(),
+        surface_id,
+        operation_id: None,
+        projection_name: None,
+    }
+}
+
+fn validate_fingerprint_header(
+    manifest: &V4SourceManifest,
+    fingerprint: &Fingerprint,
+) -> Result<(), String> {
+    if fingerprint.artifact_schema_version != V4_ARTIFACT_SCHEMA_VERSION {
+        return Err("fingerprint artifact schema version mismatch".to_string());
+    }
+    if fingerprint.source_name != manifest.common.name {
+        return Err("fingerprint source name does not match installed manifest".to_string());
     }
     if fingerprint.importer_version != SURFACE_IMPORTER_VERSION
         || fingerprint.projection_generator_version != PROJECTION_GENERATOR_VERSION
     {
-        return Err(incompatible_materialization_error(
-            source_name,
-            "fingerprint importer or generator version mismatch",
-        ));
+        return Err("fingerprint importer or generator version mismatch".to_string());
     }
     Ok(())
 }
 
 fn validate_fingerprint_surfaces(
-    source_name: &SourceName,
     manifest: &V4SourceManifest,
     fingerprint: &Fingerprint,
-) -> Result<BTreeMap<String, FingerprintSurface>, AppError> {
+) -> Result<(), String> {
     let declared_ids = manifest
         .surfaces
         .iter()
         .map(|surface| surface.id.as_str())
         .collect::<BTreeSet<_>>();
     let mut seen_ids = BTreeSet::new();
-    let mut by_id = BTreeMap::new();
     for surface in &fingerprint.surfaces {
         if !seen_ids.insert(surface.surface_id.as_str()) {
-            return Err(incompatible_materialization_error(
-                source_name,
-                format!("fingerprint repeats surface '{}'", surface.surface_id),
+            return Err(format!(
+                "fingerprint repeats surface '{}'",
+                surface.surface_id
             ));
         }
         if !declared_ids.contains(surface.surface_id.as_str()) {
-            return Err(incompatible_materialization_error(
-                source_name,
-                format!(
-                    "fingerprint surface set mismatch; missing [], extra [{}]",
-                    surface.surface_id
-                ),
+            return Err(format!(
+                "fingerprint surface set mismatch; missing [], extra [{}]",
+                surface.surface_id
             ));
         }
-        by_id.insert(surface.surface_id.clone(), surface.clone());
     }
     for fingerprint_surface in &fingerprint.surfaces {
         let surface = manifest
             .surface(&fingerprint_surface.surface_id)
             .ok_or_else(|| {
-                incompatible_materialization_error(
-                    source_name,
-                    format!(
-                        "fingerprint references undeclared surface '{}'",
-                        fingerprint_surface.surface_id
-                    ),
+                format!(
+                    "fingerprint references undeclared surface '{}'",
+                    fingerprint_surface.surface_id
                 )
             })?;
         if fingerprint_surface.surface_type != surface.surface_type {
-            return Err(incompatible_materialization_error(
-                source_name,
-                format!("surface '{}' type fingerprint does not match", surface.id),
+            return Err(format!(
+                "surface '{}' type fingerprint does not match",
+                surface.id
             ));
         }
         if fingerprint_surface.descriptor_kind != surface.descriptor.kind()
             || fingerprint_surface.descriptor_location != surface.descriptor.location()
         {
-            return Err(incompatible_materialization_error(
-                source_name,
-                format!(
-                    "surface '{}' descriptor fingerprint does not match",
-                    surface.id
-                ),
+            return Err(format!(
+                "surface '{}' descriptor fingerprint does not match",
+                surface.id
             ));
         }
-        let expected = stable_input_declarations_sha256(&surface.inputs)?;
+        let expected =
+            stable_input_declarations_sha256(&surface.inputs).map_err(|error| error.to_string())?;
         if fingerprint_surface.input_declarations_sha256 != expected {
-            return Err(incompatible_materialization_error(
-                source_name,
-                format!(
-                    "input declarations fingerprint does not match for surface '{}'",
-                    surface.id
-                ),
+            return Err(format!(
+                "input declarations fingerprint does not match for surface '{}'",
+                surface.id
             ));
         }
     }
-    Ok(by_id)
+    Ok(())
 }
 
 fn validate_projection_catalog_header(
-    source_name: &SourceName,
     manifest: &V4SourceManifest,
     projections: &ProjectionCatalog,
     projections_file: &V4ProjectionCatalogFile,
-) -> Result<(), AppError> {
+) -> Result<(), String> {
     if projections.artifact_schema_version != V4_ARTIFACT_SCHEMA_VERSION {
-        return Err(projection_catalog_error(
-            source_name,
-            projections_file,
-            "projection catalog artifact schema version mismatch",
-        ));
+        return Err("projection catalog artifact schema version mismatch".to_string());
     }
     if projections.source_name != manifest.common.name {
-        return Err(projection_catalog_error(
-            source_name,
-            projections_file,
-            "projection catalog source name does not match installed manifest",
-        ));
+        return Err("projection catalog source name does not match installed manifest".to_string());
     }
     match projections_file.origin {
         V4ProjectionCatalogOrigin::Materialized => {
             if projections.generator_version.as_deref() != Some(PROJECTION_GENERATOR_VERSION) {
-                return Err(projection_catalog_error(
-                    source_name,
-                    projections_file,
-                    "projection catalog generator version mismatch",
-                ));
+                return Err("projection catalog generator version mismatch".to_string());
             }
         }
         V4ProjectionCatalogOrigin::Override => {
             if let Some(generator_version) = projections.generator_version.as_deref()
                 && generator_version != PROJECTION_GENERATOR_VERSION
             {
-                return Err(projection_catalog_error(
-                    source_name,
-                    projections_file,
-                    format!(
-                        "projection override was copied from generator version '{generator_version}', but this Coral build expects '{PROJECTION_GENERATOR_VERSION}'; remove generator_version after reviewing the override or recreate it from the current generated catalog"
-                    ),
+                return Err(format!(
+                    "projection override was copied from generator version '{generator_version}', but this Coral build expects '{PROJECTION_GENERATOR_VERSION}'"
                 ));
             }
         }
     }
     Ok(())
-}
-
-fn projection_catalog_error(
-    source_name: &SourceName,
-    projections_file: &V4ProjectionCatalogFile,
-    detail: impl AsRef<str>,
-) -> AppError {
-    match projections_file.origin {
-        V4ProjectionCatalogOrigin::Materialized => {
-            incompatible_materialization_error(source_name, detail)
-        }
-        V4ProjectionCatalogOrigin::Override => {
-            invalid_projection_override_error(source_name, &projections_file.path, detail)
-        }
-    }
-}
-
-fn require_file(source_name: &SourceName, path: &Path) -> Result<(), AppError> {
-    if path.is_file() {
-        Ok(())
-    } else {
-        Err(incompatible_materialization_error(
-            source_name,
-            format!("required artifact '{}' is missing", path.display()),
-        ))
-    }
-}
-
-fn read_raw_source_document_artifact(
-    source_name: &SourceName,
-    surface: &coral_spec::v4::V4Surface,
-    path: &Path,
-) -> Result<Vec<u8>, AppError> {
-    std::fs::read(path).map_err(|error| {
-        incompatible_materialization_error(
-            source_name,
-            format!(
-                "failed to read raw source document artifact for surface '{}' '{}': {error}",
-                surface.id,
-                path.display()
-            ),
-        )
-    })
 }
 
 fn apply_parameter_metadata_override_file(
@@ -470,163 +777,30 @@ fn apply_parameter_metadata_override_file(
     Ok(())
 }
 
-fn validate_loaded_materialization(
-    source_name: &SourceName,
-    manifest: &V4SourceManifest,
-    materialized: &V4MaterializedSource,
-    fingerprint_surfaces: &BTreeMap<String, FingerprintSurface>,
-) -> Result<(), AppError> {
-    validate_materialized_source(manifest, materialized).map_err(|error| {
-        incompatible_materialization_error(
-            source_name,
-            format!("artifact validation failed: {error}"),
-        )
-    })?;
-    let mut operations_by_surface: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
-    for materialized_surface in &materialized.surfaces {
-        let surface = manifest
-            .surface(&materialized_surface.surface_id)
-            .ok_or_else(|| {
-                incompatible_materialization_error(
-                    source_name,
-                    format!(
-                        "materialized surface '{}' is not declared",
-                        materialized_surface.surface_id
-                    ),
-                )
-            })?;
-        let Some(fingerprint_surface) = fingerprint_surfaces.get(&materialized_surface.surface_id)
-        else {
-            return Err(incompatible_materialization_error(
-                source_name,
-                format!(
-                    "fingerprint is missing surface '{}'",
-                    materialized_surface.surface_id
-                ),
-            ));
-        };
-        let raw_bytes = read_raw_source_document_artifact(
-            source_name,
-            surface,
-            &materialized_surface.raw_source_document_path,
-        )?;
-        let observed_raw_hash = sha256_hex(&raw_bytes);
-        if observed_raw_hash != fingerprint_surface.descriptor_sha256 {
-            return Err(incompatible_materialization_error(
-                source_name,
-                format!(
-                    "raw source document hash does not match for surface '{}'",
-                    surface.id
-                ),
-            ));
-        }
-        validate_semantic_ir(
-            source_name,
-            manifest,
-            surface,
-            &materialized_surface.semantic_ir,
-        )?;
-        operations_by_surface.insert(
-            materialized_surface.surface_id.as_str(),
-            materialized_surface
-                .semantic_ir
-                .operations
-                .iter()
-                .map(|operation| operation.id.as_str())
-                .collect(),
-        );
-    }
-    validate_projection_references(source_name, manifest, materialized, &operations_by_surface)
-}
-
-fn validate_projection_references(
-    source_name: &SourceName,
-    manifest: &V4SourceManifest,
-    materialized: &V4MaterializedSource,
-    operations_by_surface: &BTreeMap<&str, BTreeSet<&str>>,
-) -> Result<(), AppError> {
-    let relation_namespace_by_surface = manifest
-        .surfaces
-        .iter()
-        .map(|surface| (surface.id.as_str(), surface.relation_namespace.as_str()))
-        .collect::<BTreeMap<_, _>>();
-    for projection in &materialized.projections.projections {
-        let Some(operations) = operations_by_surface.get(projection.surface_id.as_str()) else {
-            return Err(incompatible_materialization_error(
-                source_name,
-                format!(
-                    "projection '{}' references missing surface '{}'",
-                    projection.name, projection.surface_id
-                ),
-            ));
-        };
-        let expected_relation_namespace = relation_namespace_by_surface
-            .get(projection.surface_id.as_str())
-            .ok_or_else(|| {
-                incompatible_materialization_error(
-                    source_name,
-                    format!(
-                        "projection '{}' references missing surface '{}'",
-                        projection.name, projection.surface_id
-                    ),
-                )
-            })?;
-        if projection.namespace != *expected_relation_namespace {
-            return Err(incompatible_materialization_error(
-                source_name,
-                format!(
-                    "projection '{}' namespace '{}' does not match surface '{}' relation namespace '{}'",
-                    projection.name,
-                    projection.namespace,
-                    projection.surface_id,
-                    expected_relation_namespace
-                ),
-            ));
-        }
-        if !operations.contains(projection.operation_id.as_str()) {
-            return Err(incompatible_materialization_error(
-                source_name,
-                format!(
-                    "projection '{}' references missing operation '{}'",
-                    projection.name, projection.operation_id
-                ),
-            ));
-        }
-    }
-    Ok(())
-}
-
 fn validate_semantic_ir(
-    source_name: &SourceName,
     manifest: &V4SourceManifest,
     surface: &coral_spec::v4::V4Surface,
     semantic_ir: &SemanticIr,
-) -> Result<(), AppError> {
+) -> Result<(), String> {
     if semantic_ir.artifact_schema_version != V4_ARTIFACT_SCHEMA_VERSION {
-        return Err(incompatible_materialization_error(
-            source_name,
-            format!(
-                "semantic IR schema version mismatch for surface '{}'",
-                surface.id
-            ),
+        return Err(format!(
+            "semantic IR schema version mismatch for surface '{}'",
+            surface.id
         ));
     }
     if semantic_ir.source_name != manifest.common.name
         || semantic_ir.surface_id != surface.id
         || semantic_ir.surface_type != surface.surface_type
     {
-        return Err(incompatible_materialization_error(
-            source_name,
-            format!("semantic IR identity mismatch for surface '{}'", surface.id),
+        return Err(format!(
+            "semantic IR identity mismatch for surface '{}'",
+            surface.id
         ));
     }
     if semantic_ir.importer_version != expected_importer_version(surface.surface_type) {
-        return Err(incompatible_materialization_error(
-            source_name,
-            format!(
-                "semantic IR importer version mismatch for surface '{}'",
-                surface.id
-            ),
+        return Err(format!(
+            "semantic IR importer version mismatch for surface '{}'",
+            surface.id
         ));
     }
     Ok(())
@@ -732,7 +906,7 @@ fn write_materialization(
         projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
     };
     let materialized = V4MaterializedSource {
-        fingerprint: fingerprint.clone(),
+        fingerprint: Some(fingerprint.clone()),
         surfaces: materialized_surfaces,
         projections: projections.clone(),
         diagnostics: diagnostics.clone(),
@@ -740,7 +914,10 @@ fn write_materialization(
     validate_materialized_source(manifest, &materialized)
         .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
     write_yaml(&temp_dir.join(FINGERPRINT_FILENAME), &fingerprint)?;
-    write_yaml(&temp_dir.join(PROJECTIONS_FILENAME), &projections)?;
+    write_yaml(
+        &temp_dir.join(PROJECTIONS_FILENAME),
+        &ProjectionCatalogFile::from(&projections),
+    )?;
     write_yaml(&temp_dir.join(DIAGNOSTICS_FILENAME), &diagnostics)?;
     Ok(())
 }
@@ -769,7 +946,7 @@ fn write_surface_artifacts(
     )?;
     write_yaml(
         &surface_dir.join("semantic-ir.yaml"),
-        &materialized_surface.semantic_ir,
+        &SemanticIrFile::from(&materialized_surface.semantic_ir),
     )?;
     Ok(())
 }
@@ -1199,11 +1376,18 @@ fn read_projection_override_yaml(
     source_name: &SourceName,
     path: &Path,
 ) -> Result<ProjectionCatalog, AppError> {
-    read_yaml(path).map_err(|error| {
+    let file: ProjectionCatalogFile = read_yaml(path).map_err(|error| {
         invalid_projection_override_error(
             source_name,
             path,
             format!("failed to read projection override artifact: {error}"),
+        )
+    })?;
+    file.try_into().map_err(|error| {
+        invalid_projection_override_error(
+            source_name,
+            path,
+            format!("failed to migrate projection override artifact: {error}"),
         )
     })
 }
@@ -1255,6 +1439,17 @@ mod tests {
 
     fn source_name() -> SourceName {
         SourceName::parse("github_v4_materialization_test").expect("source name")
+    }
+
+    fn assert_load_diagnostic(materialized: &V4MaterializedSource, code: &str) {
+        assert!(
+            materialized
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == code),
+            "expected diagnostic {code}: {:#?}",
+            materialized.diagnostics
+        );
     }
 
     fn openapi_fixture() -> &'static str {
@@ -1470,8 +1665,9 @@ surfaces:
             "generated lookup key metadata should live in semantic-ir.yaml"
         );
 
-        let semantic_ir: SemanticIr =
+        let semantic_ir_file: SemanticIrFile =
             read_yaml(&surface_dir.join("semantic-ir.yaml")).expect("read semantic IR");
+        let semantic_ir = SemanticIr::try_from(semantic_ir_file).expect("migrate semantic IR");
         let operation = semantic_ir.operations.first().expect("operation");
         let input_excluded = |name: &str| {
             operation
@@ -1524,7 +1720,7 @@ surfaces:
         )
         .expect("build MCP materialization");
 
-        let semantic_ir: SemanticIr = read_yaml(
+        let semantic_ir_file: SemanticIrFile = read_yaml(
             &build
                 .temp_dir
                 .join("surfaces")
@@ -1532,6 +1728,7 @@ surfaces:
                 .join("semantic-ir.yaml"),
         )
         .expect("read semantic IR");
+        let semantic_ir = SemanticIr::try_from(semantic_ir_file).expect("migrate semantic IR");
         let operation = semantic_ir.operations.first().expect("operation");
         let coral_spec::v4::IrExecutionAttachment::Mcp(mcp) = &operation.execution else {
             panic!("expected MCP execution");
@@ -1543,8 +1740,10 @@ surfaces:
             vec!["meta".to_string(), "nextCursor".to_string()]
         );
 
-        let projections: ProjectionCatalog =
+        let projections_file: ProjectionCatalogFile =
             read_yaml(&build.temp_dir.join(PROJECTIONS_FILENAME)).expect("read projections");
+        let projections =
+            ProjectionCatalog::try_from(projections_file).expect("migrate projections");
         let projection = projections.projections.first().expect("projection");
         assert_eq!(projection.namespace, "mcp_materialization_test");
         let column_names = projection
@@ -1689,7 +1888,7 @@ surfaces:
     }
 
     #[test]
-    fn load_v4_materialization_rejects_mismatched_manifest_hash() {
+    fn load_v4_materialization_warns_on_mismatched_manifest_hash() {
         let (_state, _descriptor, layout, manifest_yaml, _manifest) = setup_materialization();
         let changed_manifest_yaml = format!("description: changed\n{manifest_yaml}");
         let changed_manifest = parse_source_manifest_yaml(&changed_manifest_yaml)
@@ -1698,25 +1897,20 @@ surfaces:
             .expect("v4")
             .clone();
 
-        let error = load_v4_materialization(
+        let materialized = load_v4_materialization(
             &layout,
             &workspace_name(),
             &source_name(),
             &changed_manifest_yaml,
             &changed_manifest,
         )
-        .expect_err("changed manifest hash should fail");
+        .expect("changed manifest hash should remain loadable");
 
-        assert!(
-            error
-                .to_string()
-                .contains("manifest fingerprint does not match installed manifest"),
-            "unexpected error: {error}"
-        );
+        assert_load_diagnostic(&materialized, "V4_MANIFEST_FINGERPRINT_MISMATCH");
     }
 
     #[test]
-    fn load_v4_materialization_rejects_generated_projection_catalog_without_generator_version() {
+    fn load_v4_materialization_warns_on_generated_catalog_without_generator_version() {
         let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
         let projection_path = layout
             .v4_materialized_dir(&workspace_name(), &source_name())
@@ -1729,21 +1923,16 @@ surfaces:
         )
         .expect("write generated projections");
 
-        let error = load_v4_materialization(
+        let materialized = load_v4_materialization(
             &layout,
             &workspace_name(),
             &source_name(),
             &manifest_yaml,
             &manifest,
         )
-        .expect_err("generated projection catalog without generator version should fail");
+        .expect("generated catalog provenance should not block loading");
 
-        assert!(
-            error
-                .to_string()
-                .contains("projection catalog generator version mismatch"),
-            "unexpected error: {error}"
-        );
+        assert_load_diagnostic(&materialized, "V4_PROJECTION_CATALOG_PROVENANCE_MISMATCH");
     }
 
     #[test]
@@ -1787,38 +1976,22 @@ surfaces:
     }
 
     #[test]
-    fn load_v4_materialization_rejects_stale_projection_override_generator_version() {
+    fn load_v4_materialization_warns_on_stale_projection_override_generator_version() {
         let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
         let mut catalog = installed_projection_catalog_value(&layout);
         set_generator_version(&mut catalog, "derive-read-v0");
-        let override_path = write_projection_override(&layout, &catalog);
+        write_projection_override(&layout, &catalog);
 
-        let error = load_v4_materialization(
+        let materialized = load_v4_materialization(
             &layout,
             &workspace_name(),
             &source_name(),
             &manifest_yaml,
             &manifest,
         )
-        .expect_err("stale projection override generator version should fail");
-        let message = error.to_string();
+        .expect("stale override provenance should not block loading");
 
-        assert!(
-            matches!(error, AppError::InvalidV4ProjectionOverride { .. }),
-            "unexpected error: {error:#}"
-        );
-        assert!(
-            message.contains(&override_path.display().to_string()),
-            "unexpected error: {message}"
-        );
-        assert!(
-            message.contains("Edit or remove the override file"),
-            "unexpected error: {message}"
-        );
-        assert!(
-            !message.contains("Re-add the source"),
-            "unexpected error: {message}"
-        );
+        assert_load_diagnostic(&materialized, "V4_PROJECTION_CATALOG_PROVENANCE_MISMATCH");
     }
 
     #[test]
@@ -1860,29 +2033,40 @@ surfaces:
     }
 
     #[test]
-    fn load_v4_materialization_rejects_corrupted_artifact_yaml_with_readd_guidance() {
+    fn load_v4_materialization_ignores_corrupted_optional_fingerprint() {
         let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
         let fingerprint_path = layout.v4_fingerprint_file(&workspace_name(), &source_name());
         std::fs::write(&fingerprint_path, b": not yaml").expect("corrupt fingerprint");
 
-        let error = load_v4_materialization(
+        let materialized = load_v4_materialization(
             &layout,
             &workspace_name(),
             &source_name(),
             &manifest_yaml,
             &manifest,
         )
-        .expect_err("corrupted artifact should fail");
-        let message = error.to_string();
+        .expect("corrupted optional fingerprint should not fail");
 
-        assert!(
-            message.contains("missing or incompatible DSL v4 materialized artifacts"),
-            "unexpected error: {error}"
-        );
-        assert!(
-            message.contains("Re-add the source"),
-            "unexpected error: {error}"
-        );
+        assert!(materialized.fingerprint.is_none());
+        assert_load_diagnostic(&materialized, "V4_FINGERPRINT_UNAVAILABLE");
+    }
+
+    #[test]
+    fn load_v4_materialization_ignores_missing_optional_diagnostics() {
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        std::fs::remove_file(layout.v4_diagnostics_file(&workspace_name(), &source_name()))
+            .expect("remove diagnostics");
+
+        let materialized = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect("missing optional diagnostics should not fail");
+
+        assert_load_diagnostic(&materialized, "V4_DIAGNOSTICS_UNAVAILABLE");
     }
 
     #[test]
@@ -1948,8 +2132,10 @@ operation_overrides:
         let semantic_ir_path = layout
             .v4_surface_dir(&workspace_name(), &source_name(), "rest")
             .join("semantic-ir.yaml");
-        let artifact_ir: SemanticIr =
+        let artifact_ir_file: SemanticIrFile =
             read_yaml(&semantic_ir_path).expect("read persisted semantic IR");
+        let artifact_ir =
+            SemanticIr::try_from(artifact_ir_file).expect("migrate persisted semantic IR");
         let artifact_operation = artifact_ir.operations.first().expect("artifact operation");
         let coral_spec::v4::IrExecutionAttachment::Rest(artifact_rest) =
             &artifact_operation.execution
@@ -1974,7 +2160,7 @@ operation_overrides:
     }
 
     #[test]
-    fn load_v4_materialization_rejects_extra_fingerprint_surface() {
+    fn load_v4_materialization_warns_on_extra_fingerprint_surface() {
         let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
         let fingerprint_path = layout.v4_fingerprint_file(&workspace_name(), &source_name());
         let mut fingerprint: serde_yaml::Value =
@@ -1996,51 +2182,41 @@ operation_overrides:
         )
         .expect("write fingerprint");
 
-        let error = load_v4_materialization(
+        let materialized = load_v4_materialization(
             &layout,
             &workspace_name(),
             &source_name(),
             &manifest_yaml,
             &manifest,
         )
-        .expect_err("extra surface should fail");
+        .expect("extra fingerprint surface should not fail");
 
-        assert!(
-            error
-                .to_string()
-                .contains("fingerprint surface set mismatch"),
-            "unexpected error: {error}"
-        );
+        assert_load_diagnostic(&materialized, "V4_FINGERPRINT_SURFACE_MISMATCH");
     }
 
     #[test]
-    fn load_v4_materialization_rejects_corrupted_raw_source_document() {
+    fn load_v4_materialization_warns_on_corrupted_raw_source_document() {
         let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
         let raw_path = layout
             .v4_surface_dir(&workspace_name(), &source_name(), "rest")
             .join("source-document.raw");
         std::fs::write(&raw_path, b"corrupted").expect("corrupt raw descriptor");
 
-        let error = load_v4_materialization(
+        let materialized = load_v4_materialization(
             &layout,
             &workspace_name(),
             &source_name(),
             &manifest_yaml,
             &manifest,
         )
-        .expect_err("corrupted raw descriptor should fail");
+        .expect("raw descriptor hash mismatch should not fail loading");
 
-        assert!(
-            error
-                .to_string()
-                .contains("raw source document hash does not match"),
-            "unexpected error: {error}"
-        );
+        assert_load_diagnostic(&materialized, "V4_RAW_DOCUMENT_FINGERPRINT_MISMATCH");
     }
 
     #[cfg(unix)]
     #[test]
-    fn load_v4_materialization_rejects_unreadable_raw_source_document_with_readd_guidance() {
+    fn load_v4_materialization_warns_on_unreadable_raw_source_document() {
         use std::os::unix::fs::PermissionsExt as _;
 
         let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
@@ -2070,21 +2246,8 @@ operation_overrides:
 
         std::fs::set_permissions(&raw_path, original_permissions)
             .expect("restore raw descriptor permissions");
-        let message = result
-            .expect_err("unreadable raw descriptor should fail")
-            .to_string();
-        assert!(
-            message.contains("missing or incompatible DSL v4 materialized artifacts"),
-            "unexpected error: {message}"
-        );
-        assert!(
-            message.contains("failed to read raw source document artifact"),
-            "unexpected error: {message}"
-        );
-        assert!(
-            message.contains("Re-add the source"),
-            "unexpected error: {message}"
-        );
+        let materialized = result.expect("unreadable optional raw descriptor should not fail");
+        assert_load_diagnostic(&materialized, "V4_RAW_DOCUMENT_UNAVAILABLE");
     }
 
     #[test]

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -312,7 +312,7 @@ fn load_projection_catalog(
     projections_file: &V4ProjectionCatalogFile,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<ProjectionCatalog, AppError> {
-    let projections = match projections_file.origin {
+    let mut projections = match projections_file.origin {
         V4ProjectionCatalogOrigin::Materialized => {
             let file: ProjectionCatalogDto =
                 read_artifact_yaml(source_name, "projection catalog", &projections_file.path)?;
@@ -327,6 +327,13 @@ fn load_projection_catalog(
             read_projection_override_yaml(source_name, &projections_file.path)?
         }
     };
+    for projection in &mut projections.projections {
+        if projection.namespace.is_empty()
+            && let Some(surface) = manifest.surface(&projection.surface_id)
+        {
+            projection.namespace = surface.relation_namespace.clone();
+        }
+    }
     if let Err(error) = validate_projection_catalog_header(manifest, &projections, projections_file)
     {
         diagnostics.push(materialization_warning(
@@ -1933,6 +1940,55 @@ surfaces:
         .expect("generated catalog provenance should not block loading");
 
         assert_load_diagnostic(&materialized, "V4_PROJECTION_CATALOG_PROVENANCE_MISMATCH");
+    }
+
+    #[test]
+    fn load_v4_materialization_defaults_missing_projection_namespace() {
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        let projection_path = layout
+            .v4_materialized_dir(&workspace_name(), &source_name())
+            .join(PROJECTIONS_FILENAME);
+        let mut catalog = installed_projection_catalog_value(&layout);
+        let first_projection = catalog
+            .get_mut("projections")
+            .and_then(serde_yaml::Value::as_sequence_mut)
+            .and_then(|projections| projections.first_mut())
+            .and_then(serde_yaml::Value::as_mapping_mut)
+            .expect("first projection mapping");
+        first_projection.remove(serde_yaml::Value::String("namespace".to_string()));
+        std::fs::write(
+            &projection_path,
+            serde_yaml::to_string(&catalog).expect("encode projections"),
+        )
+        .expect("write projections without namespace");
+
+        let materialized = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect("legacy projection namespace should be migrated");
+
+        let projection = materialized
+            .projections
+            .projections
+            .first()
+            .expect("first projection");
+        assert_eq!(
+            projection.namespace,
+            manifest
+                .surface("rest")
+                .expect("REST surface")
+                .relation_namespace
+        );
+        assert!(
+            !materialized
+                .diagnostics
+                .iter()
+                .any(|diagnostic| { diagnostic.code == "V4_PROJECTION_NAMESPACE_MISMATCH" })
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use coral_spec::v4::{
@@ -42,9 +42,124 @@ pub(crate) const DIAGNOSTICS_FILENAME: &str = "diagnostics.yaml";
 pub(crate) const PARAMETER_METADATA_OVERRIDE_FILENAME: &str = "parameter_metadata.yaml";
 
 type ReportedDiagnosticKey = (String, String);
-type ReportedDiagnostics = BTreeMap<String, BTreeSet<ReportedDiagnosticKey>>;
+type ReportedDiagnosticStateKey = (String, String, String);
+type ReportedDiagnostics = BTreeMap<ReportedDiagnosticStateKey, BTreeSet<ReportedDiagnosticKey>>;
 
-static REPORTED_LOAD_DIAGNOSTICS: OnceLock<Mutex<ReportedDiagnostics>> = OnceLock::new();
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SourceDiagnosticReporter {
+    reported: Arc<Mutex<ReportedDiagnostics>>,
+}
+
+impl SourceDiagnosticReporter {
+    pub(crate) fn report_source_load_failure(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        code: &str,
+        detail: &str,
+    ) {
+        let diagnostic = Diagnostic {
+            code: code.to_string(),
+            severity: DiagnosticSeverity::Warning,
+            message: detail.to_string(),
+            surface_id: None,
+            operation_id: None,
+            projection_name: None,
+        };
+        self.report_source_diagnostics(
+            workspace_name,
+            source_name,
+            "source",
+            std::iter::once(&diagnostic),
+        );
+    }
+
+    pub(crate) fn clear_source_load_failure(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) {
+        self.report_source_diagnostics(
+            workspace_name,
+            source_name,
+            "source",
+            std::iter::empty::<&Diagnostic>(),
+        );
+    }
+
+    pub(crate) fn report_runtime_surface_diagnostics(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        diagnostics: &[Diagnostic],
+    ) {
+        self.report_source_diagnostics(workspace_name, source_name, "runtime", diagnostics.iter());
+    }
+
+    pub(crate) fn clear_source(&self, workspace_name: &WorkspaceName, source_name: &SourceName) {
+        let mut reported = self
+            .reported
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        reported.retain(|(workspace, source, _stage), _diagnostics| {
+            workspace != workspace_name.as_str() || source != source_name.as_str()
+        });
+    }
+
+    fn report_source_diagnostics<'a>(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        stage: &str,
+        diagnostics: impl IntoIterator<Item = &'a Diagnostic>,
+    ) {
+        let state_key = (
+            workspace_name.to_string(),
+            source_name.to_string(),
+            stage.to_string(),
+        );
+        let diagnostics = diagnostics.into_iter().collect::<Vec<_>>();
+        let current = diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.code.clone(), diagnostic.message.clone()))
+            .collect::<BTreeSet<_>>();
+        let mut reported = self
+            .reported
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous = reported.get(&state_key).cloned().unwrap_or_default();
+        for diagnostic in diagnostics {
+            let key = (diagnostic.code.clone(), diagnostic.message.clone());
+            if previous.contains(&key) {
+                continue;
+            }
+            tracing::warn!(
+                diagnostic.code = %diagnostic.code,
+                diagnostic.stage = stage,
+                workspace = %workspace_name,
+                source = %source_name,
+                surface = diagnostic.surface_id.as_deref().unwrap_or(""),
+                operation = diagnostic.operation_id.as_deref().unwrap_or(""),
+                projection = diagnostic.projection_name.as_deref().unwrap_or(""),
+                detail = %diagnostic.message,
+                "DSL v4 source load diagnostic"
+            );
+        }
+        if current.is_empty() {
+            reported.remove(&state_key);
+        } else {
+            reported.insert(state_key, current);
+        }
+    }
+
+    #[cfg(test)]
+    fn tracked_stage_count(&self) -> usize {
+        self.reported
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct MaterializationBuild {
@@ -162,6 +277,7 @@ pub(crate) fn load_v4_materialization(
     source_name: &SourceName,
     manifest_yaml: &str,
     manifest: &V4SourceManifest,
+    diagnostic_reporter: &SourceDiagnosticReporter,
 ) -> Result<V4MaterializedSource, AppError> {
     let fingerprint_path = layout.v4_fingerprint_file(workspace_name, source_name);
     let projections_file = layout.v4_projection_catalog_file(workspace_name, source_name);
@@ -238,7 +354,7 @@ pub(crate) fn load_v4_materialization(
             "no published projection surfaces could be loaded",
         ));
     }
-    report_source_diagnostics(
+    diagnostic_reporter.report_source_diagnostics(
         workspace_name,
         source_name,
         "materialization",
@@ -251,8 +367,18 @@ pub(crate) fn load_v4_materialization(
         projections,
         diagnostics,
     };
-    if let Err(error) = validate_materialized_source_structure(manifest, &materialized) {
-        return Err(match projections_file.origin {
+    validate_loaded_materialized_source(source_name, manifest, &projections_file, &materialized)?;
+    Ok(materialized)
+}
+
+fn validate_loaded_materialized_source(
+    source_name: &SourceName,
+    manifest: &V4SourceManifest,
+    projections_file: &V4ProjectionCatalogFile,
+    materialized: &V4MaterializedSource,
+) -> Result<(), AppError> {
+    validate_materialized_source_structure(manifest, materialized).map_err(|error| {
+        match projections_file.origin {
             V4ProjectionCatalogOrigin::Materialized => {
                 incompatible_materialization_error(source_name, error.to_string())
             }
@@ -261,9 +387,8 @@ pub(crate) fn load_v4_materialization(
                 &projections_file.path,
                 error.to_string(),
             ),
-        });
-    }
-    Ok(materialized)
+        }
+    })
 }
 
 fn load_optional_fingerprint(
@@ -550,86 +675,6 @@ fn collect_projection_coherence_diagnostics(
             ));
             failed_surfaces.insert(surface.id.clone());
         }
-    }
-}
-
-pub(crate) fn report_source_load_failure(
-    workspace_name: &WorkspaceName,
-    source_name: &SourceName,
-    code: &str,
-    detail: &str,
-) {
-    let diagnostic = Diagnostic {
-        code: code.to_string(),
-        severity: DiagnosticSeverity::Warning,
-        message: detail.to_string(),
-        surface_id: None,
-        operation_id: None,
-        projection_name: None,
-    };
-    report_source_diagnostics(
-        workspace_name,
-        source_name,
-        "source",
-        std::iter::once(&diagnostic),
-    );
-}
-
-pub(crate) fn clear_source_load_failure(workspace_name: &WorkspaceName, source_name: &SourceName) {
-    report_source_diagnostics(
-        workspace_name,
-        source_name,
-        "source",
-        std::iter::empty::<&Diagnostic>(),
-    );
-}
-
-pub(crate) fn report_runtime_surface_diagnostics(
-    workspace_name: &WorkspaceName,
-    source_name: &SourceName,
-    diagnostics: &[Diagnostic],
-) {
-    report_source_diagnostics(workspace_name, source_name, "runtime", diagnostics.iter());
-}
-
-fn report_source_diagnostics<'a>(
-    workspace_name: &WorkspaceName,
-    source_name: &SourceName,
-    stage: &str,
-    diagnostics: impl IntoIterator<Item = &'a Diagnostic>,
-) {
-    let state_key = format!("{workspace_name}\u{1f}{source_name}\u{1f}{stage}");
-    let diagnostics = diagnostics.into_iter().collect::<Vec<_>>();
-    let current = diagnostics
-        .iter()
-        .map(|diagnostic| (diagnostic.code.clone(), diagnostic.message.clone()))
-        .collect::<BTreeSet<_>>();
-    let mut reported = REPORTED_LOAD_DIAGNOSTICS
-        .get_or_init(|| Mutex::new(BTreeMap::new()))
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let previous = reported.get(&state_key).cloned().unwrap_or_default();
-    for diagnostic in diagnostics {
-        let key = (diagnostic.code.clone(), diagnostic.message.clone());
-        if previous.contains(&key) {
-            continue;
-        }
-        tracing::warn!(
-            diagnostic.code = %diagnostic.code,
-            diagnostic.stage = stage,
-            workspace = %workspace_name,
-            source = %source_name,
-            surface = diagnostic.surface_id.as_deref().unwrap_or(""),
-            operation = diagnostic.operation_id.as_deref().unwrap_or(""),
-            projection = diagnostic.projection_name.as_deref().unwrap_or(""),
-            detail = %diagnostic.message,
-            "DSL v4 source load diagnostic"
-        );
-    }
-    if current.is_empty() {
-        reported.remove(&state_key);
-    } else {
-        reported.insert(state_key, current);
     }
 }
 
@@ -1452,6 +1497,23 @@ mod tests {
         SourceName::parse("github_v4_materialization_test").expect("source name")
     }
 
+    fn load_v4_materialization(
+        layout: &AppStateLayout,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        manifest_yaml: &str,
+        manifest: &V4SourceManifest,
+    ) -> Result<V4MaterializedSource, AppError> {
+        super::load_v4_materialization(
+            layout,
+            workspace_name,
+            source_name,
+            manifest_yaml,
+            manifest,
+            &SourceDiagnosticReporter::default(),
+        )
+    }
+
     fn assert_load_diagnostic(materialized: &V4MaterializedSource, code: &str) {
         assert!(
             materialized
@@ -1581,6 +1643,37 @@ paths:
         }));
 
         assert!(result.is_none(), "request methods must include an id");
+    }
+
+    #[test]
+    fn diagnostic_reporter_owns_and_clears_source_state() {
+        let reporter = SourceDiagnosticReporter::default();
+        let independent_reporter = SourceDiagnosticReporter::default();
+        let workspace_name = workspace_name();
+        let source_name = source_name();
+        reporter.report_source_load_failure(
+            &workspace_name,
+            &source_name,
+            "SOURCE_LOAD_FAILED",
+            "test failure",
+        );
+        reporter.report_runtime_surface_diagnostics(
+            &workspace_name,
+            &source_name,
+            &[materialization_warning(
+                "V4_RUNTIME_SURFACE_ASSEMBLY_FAILED",
+                "test runtime failure",
+                Some("rest".to_string()),
+            )],
+        );
+
+        assert_eq!(reporter.tracked_stage_count(), 2);
+        assert_eq!(reporter.clone().tracked_stage_count(), 2);
+        assert_eq!(independent_reporter.tracked_stage_count(), 0);
+
+        reporter.clear_source(&workspace_name, &source_name);
+
+        assert_eq!(reporter.tracked_stage_count(), 0);
     }
 
     fn setup_materialization() -> (TempDir, TempDir, AppStateLayout, String, V4SourceManifest) {

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -622,9 +622,8 @@ fn load_projected_surface(
         MaterializedSurface {
             surface_id: surface.id.clone(),
             semantic_ir,
-            source_document_sha256: fingerprint.map_or_else(String::new, |fingerprint| {
-                fingerprint.descriptor_sha256.clone()
-            }),
+            source_document_sha256: fingerprint
+                .map(|fingerprint| fingerprint.descriptor_sha256.clone()),
             normalized_source_document_path: surface_dir.join("source-document.yaml"),
             raw_source_document_path,
         },
@@ -918,7 +917,7 @@ fn write_materialization(
         materialized_surfaces.push(MaterializedSurface {
             surface_id: surface.id.clone(),
             semantic_ir: materialized_surface.semantic_ir.clone(),
-            source_document_sha256: materialized_surface.observed_sha256.clone(),
+            source_document_sha256: Some(materialized_surface.observed_sha256.clone()),
             normalized_source_document_path: surface_dir.join("source-document.yaml"),
             raw_source_document_path: surface_dir.join("source-document.raw"),
         });
@@ -2237,6 +2236,12 @@ surfaces:
         .expect("corrupted optional fingerprint should not fail");
 
         assert!(materialized.fingerprint.is_none());
+        assert!(
+            materialized
+                .surfaces
+                .iter()
+                .all(|surface| surface.source_document_sha256.is_none())
+        );
         assert_load_diagnostic(&materialized, "V4_FINGERPRINT_UNAVAILABLE");
     }
 

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -15,7 +15,8 @@ use coral_spec::v4::{
     generate_projection_catalog, import_mcp_surface, import_openapi_surface,
     normalize_mcp_tool_catalog, normalize_source_document, openapi_document_metadata,
     parse_parameter_metadata_overrides_yaml, sync_projection_pagination_inputs,
-    validate_materialized_source, validate_openapi_base_url_template,
+    validate_materialized_source, validate_materialized_source_structure,
+    validate_openapi_base_url_template,
 };
 use coral_spec::{
     ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestInputKind, ManifestInputSpec,
@@ -244,12 +245,25 @@ pub(crate) fn load_v4_materialization(
         load_diagnostics.iter(),
     );
     diagnostics.append(&mut load_diagnostics);
-    Ok(V4MaterializedSource {
+    let materialized = V4MaterializedSource {
         fingerprint,
         surfaces,
         projections,
         diagnostics,
-    })
+    };
+    if let Err(error) = validate_materialized_source_structure(manifest, &materialized) {
+        return Err(match projections_file.origin {
+            V4ProjectionCatalogOrigin::Materialized => {
+                incompatible_materialization_error(source_name, error.to_string())
+            }
+            V4ProjectionCatalogOrigin::Override => invalid_projection_override_error(
+                source_name,
+                &projections_file.path,
+                error.to_string(),
+            ),
+        });
+    }
+    Ok(materialized)
 }
 
 fn load_optional_fingerprint(
@@ -2075,6 +2089,42 @@ surfaces:
         assert!(
             !message.contains("Re-add the source"),
             "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn load_v4_materialization_rejects_duplicate_projection_override_names() {
+        let (_state, _descriptor, layout, manifest_yaml, manifest) = setup_materialization();
+        let mut catalog = installed_projection_catalog_value(&layout);
+        let projections = catalog
+            .get_mut("projections")
+            .and_then(serde_yaml::Value::as_sequence_mut)
+            .expect("projection sequence");
+        projections.push(projections.first().expect("first projection").clone());
+        let override_path = write_projection_override(&layout, &catalog);
+
+        let error = load_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            &manifest_yaml,
+            &manifest,
+        )
+        .expect_err("duplicate projection names should fail at load time");
+
+        assert!(
+            matches!(error, AppError::InvalidV4ProjectionOverride { .. }),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            error.to_string().contains("projection") && error.to_string().contains("is repeated"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            error
+                .to_string()
+                .contains(&override_path.display().to_string()),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -21,7 +21,7 @@ use coral_spec::{
 
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
-use crate::sources::materialization::report_runtime_surface_diagnostics;
+use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::workspaces::WorkspaceName;
 
 pub(crate) fn runtime_components_for_v4_source(
@@ -29,6 +29,7 @@ pub(crate) fn runtime_components_for_v4_source(
     source_name: &SourceName,
     manifest: &V4SourceManifest,
     materialized: &V4MaterializedSource,
+    diagnostic_reporter: &SourceDiagnosticReporter,
 ) -> Result<Vec<RuntimeSourceComponent>, AppError> {
     let mut components = Vec::new();
     let mut diagnostics = Vec::new();
@@ -62,7 +63,11 @@ pub(crate) fn runtime_components_for_v4_source(
             }
         }
     }
-    report_runtime_surface_diagnostics(workspace_name, source_name, &diagnostics);
+    diagnostic_reporter.report_runtime_surface_diagnostics(
+        workspace_name,
+        source_name,
+        &diagnostics,
+    );
     if published_surface_count > 0 && components.is_empty() {
         return Err(AppError::FailedPrecondition(format!(
             "DSL v4 source '{}' has no usable published surfaces{}",
@@ -448,6 +453,7 @@ mod tests {
             &source_name,
             manifest,
             materialized,
+            &crate::sources::materialization::SourceDiagnosticReporter::default(),
         )
     }
 

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -8,10 +8,11 @@ use coral_spec::backends::mcp::{
     McpSourceManifest, McpTableFilterBinding, McpTableFunctionSpec, McpTableSpec,
 };
 use coral_spec::v4::{
-    IrExecutionAttachment, Projection, ProjectionKind, ProjectionVisibility, SqlInputExposure,
-    SurfaceType, V4MaterializedSource, V4SourceManifest, mcp_projection_arg_specs,
-    openapi_document_metadata, projection_arg_specs, projection_column_specs,
-    projection_filter_specs, request_spec_for_projection, validate_openapi_base_url_template,
+    Diagnostic, DiagnosticSeverity, IrExecutionAttachment, Projection, ProjectionKind,
+    ProjectionVisibility, SqlInputExposure, SurfaceType, V4MaterializedSource, V4SourceManifest,
+    mcp_projection_arg_specs, openapi_document_metadata, projection_arg_specs,
+    projection_column_specs, projection_filter_specs, request_spec_for_projection,
+    validate_openapi_base_url_template,
 };
 use coral_spec::{
     PaginationSpec, ParsedTemplate, RequestSpec, ResponseSpec, SourceManifestCommon,
@@ -19,32 +20,57 @@ use coral_spec::{
 };
 
 use crate::bootstrap::AppError;
+use crate::sources::SourceName;
+use crate::sources::materialization::report_runtime_surface_diagnostics;
+use crate::workspaces::WorkspaceName;
 
 pub(crate) fn runtime_components_for_v4_source(
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
     manifest: &V4SourceManifest,
     materialized: &V4MaterializedSource,
 ) -> Result<Vec<RuntimeSourceComponent>, AppError> {
     let mut components = Vec::new();
+    let mut diagnostics = Vec::new();
+    let mut published_surface_count = 0_usize;
+    let mut first_surface_error = None;
     for surface in &manifest.surfaces {
         if !has_published_projection(materialized, &surface.id) {
             continue;
         }
-        match surface.surface_type {
-            SurfaceType::OpenApi => {
-                components.push(RuntimeSourceComponent::Http(http_manifest_for_surface(
-                    manifest,
-                    materialized,
-                    &surface.id,
-                )?));
-            }
-            SurfaceType::Mcp => {
-                components.push(RuntimeSourceComponent::Mcp(mcp_manifest_for_surface(
-                    manifest,
-                    materialized,
-                    &surface.id,
-                )?));
+        published_surface_count += 1;
+        let component = match surface.surface_type {
+            SurfaceType::OpenApi => http_manifest_for_surface(manifest, materialized, &surface.id)
+                .map(RuntimeSourceComponent::Http),
+            SurfaceType::Mcp => mcp_manifest_for_surface(manifest, materialized, &surface.id)
+                .map(RuntimeSourceComponent::Mcp),
+        };
+        match component {
+            Ok(component) => components.push(component),
+            Err(error) => {
+                if first_surface_error.is_none() {
+                    first_surface_error = Some(error.to_string());
+                }
+                diagnostics.push(Diagnostic {
+                    code: "V4_RUNTIME_SURFACE_ASSEMBLY_FAILED".to_string(),
+                    severity: DiagnosticSeverity::Warning,
+                    message: error.to_string(),
+                    surface_id: Some(surface.id.clone()),
+                    operation_id: None,
+                    projection_name: None,
+                });
             }
         }
+    }
+    report_runtime_surface_diagnostics(workspace_name, source_name, &diagnostics);
+    if published_surface_count > 0 && components.is_empty() {
+        return Err(AppError::FailedPrecondition(format!(
+            "DSL v4 source '{}' has no usable published surfaces{}",
+            manifest.common.name,
+            first_surface_error
+                .map(|error| format!(": {error}"))
+                .unwrap_or_default()
+        )));
     }
     Ok(components)
 }
@@ -410,7 +436,20 @@ mod tests {
     };
     use coral_spec::{PageSizeSpec, PaginationMode, PaginationSpec, ResponseSpec};
 
-    use super::{runtime_components_for_v4_source, surface_base_url};
+    use super::{runtime_components_for_v4_source as build_runtime_components, surface_base_url};
+
+    fn runtime_components_for_v4_source(
+        manifest: &V4SourceManifest,
+        materialized: &V4MaterializedSource,
+    ) -> Result<Vec<coral_engine::RuntimeSourceComponent>, crate::bootstrap::AppError> {
+        let source_name = crate::sources::SourceName::parse(&manifest.common.name)?;
+        build_runtime_components(
+            &crate::workspaces::WorkspaceName::default(),
+            &source_name,
+            manifest,
+            materialized,
+        )
+    }
 
     fn surface_without_authored_base_url() -> V4Surface {
         openapi_surface_with_base_url("rest", "demo", "")
@@ -638,14 +677,14 @@ mod tests {
             declared_inputs: Vec::new(),
         };
         let materialized = V4MaterializedSource {
-            fingerprint: Fingerprint {
+            fingerprint: Some(Fingerprint {
                 artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
                 source_name: "github_v4".to_string(),
                 manifest_sha256: String::new(),
                 surfaces: Vec::new(),
                 importer_version: SURFACE_IMPORTER_VERSION.to_string(),
                 projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
-            },
+            }),
             surfaces: vec![
                 mcp_materialized_surface("rest", "rest_list_issues"),
                 mcp_materialized_surface("mcp", "mcp_list_issues"),
@@ -671,6 +710,49 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(schema_names, ["github_v4_rest", "github_v4_mcp"]);
+    }
+
+    #[test]
+    fn runtime_components_skip_only_the_unusable_surface() {
+        let manifest = V4SourceManifest {
+            common: V4SourceCommon {
+                dsl_version: 4,
+                name: "github_v4".to_string(),
+                description: String::new(),
+                test_queries: Vec::new(),
+            },
+            surfaces: vec![
+                mcp_surface("healthy", "github_v4_healthy"),
+                mcp_surface("broken", "github_v4_broken"),
+            ],
+            declared_inputs: Vec::new(),
+        };
+        let materialized = V4MaterializedSource {
+            fingerprint: None,
+            surfaces: vec![mcp_materialized_surface("healthy", "healthy_list_issues")],
+            projections: ProjectionCatalog {
+                artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
+                source_name: "github_v4".to_string(),
+                generator_version: Some(PROJECTION_GENERATOR_VERSION.to_string()),
+                projections: vec![
+                    published_projection("healthy", "github_v4_healthy", "healthy_list_issues"),
+                    published_projection("broken", "github_v4_broken", "broken_list_issues"),
+                ],
+                diagnostics: Vec::new(),
+            },
+            diagnostics: Vec::new(),
+        };
+
+        let components = runtime_components_for_v4_source(&manifest, &materialized)
+            .expect("healthy surface should survive");
+
+        assert_eq!(components.len(), 1);
+        assert_eq!(
+            components
+                .first()
+                .map(coral_engine::RuntimeSourceComponent::source_name),
+            Some("github_v4_healthy")
+        );
     }
 
     #[test]
@@ -700,14 +782,14 @@ mod tests {
             ..PaginationSpec::default()
         };
         let materialized = V4MaterializedSource {
-            fingerprint: Fingerprint {
+            fingerprint: Some(Fingerprint {
                 artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
                 source_name: "github_v4".to_string(),
                 manifest_sha256: String::new(),
                 surfaces: Vec::new(),
                 importer_version: SURFACE_IMPORTER_VERSION.to_string(),
                 projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
-            },
+            }),
             surfaces: vec![rest_materialized_surface_with_pagination(
                 "rest",
                 "rest_list_issues",
@@ -768,14 +850,14 @@ mod tests {
             max_pages: None,
         };
         let materialized = V4MaterializedSource {
-            fingerprint: Fingerprint {
+            fingerprint: Some(Fingerprint {
                 artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
                 source_name: "github_v4".to_string(),
                 manifest_sha256: String::new(),
                 surfaces: Vec::new(),
                 importer_version: SURFACE_IMPORTER_VERSION.to_string(),
                 projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
-            },
+            }),
             surfaces: vec![mcp_materialized_surface_with_pagination(
                 "mcp",
                 "mcp_list_issues",
@@ -831,14 +913,14 @@ mod tests {
             max_pages: None,
         };
         let materialized = V4MaterializedSource {
-            fingerprint: Fingerprint {
+            fingerprint: Some(Fingerprint {
                 artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
                 source_name: "github_v4".to_string(),
                 manifest_sha256: String::new(),
                 surfaces: Vec::new(),
                 importer_version: SURFACE_IMPORTER_VERSION.to_string(),
                 projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
-            },
+            }),
             surfaces: vec![mcp_materialized_surface_with_pagination_and_offset(
                 "mcp",
                 "mcp_list_issues",

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -531,7 +531,7 @@ mod tests {
                 types: Vec::new(),
                 diagnostics: Vec::new(),
             },
-            source_document_sha256: String::new(),
+            source_document_sha256: None,
             normalized_source_document_path: PathBuf::from("/tmp/source-document.yaml"),
             raw_source_document_path: PathBuf::from("/tmp/source-document.raw"),
         }
@@ -563,7 +563,7 @@ mod tests {
                 types: Vec::new(),
                 diagnostics: Vec::new(),
             },
-            source_document_sha256: String::new(),
+            source_document_sha256: None,
             normalized_source_document_path: raw_source_document_path.clone(),
             raw_source_document_path,
         }
@@ -643,7 +643,7 @@ mod tests {
                 types: Vec::new(),
                 diagnostics: Vec::new(),
             },
-            source_document_sha256: String::new(),
+            source_document_sha256: None,
             normalized_source_document_path: PathBuf::from("/tmp/source-document.yaml"),
             raw_source_document_path: PathBuf::from("/tmp/source-document.raw"),
         }

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -6,14 +6,16 @@
 
 use std::fs;
 
-use coral_api::v1::{ExecuteSqlRequest, SourceSecret, SourceVariable};
-use coral_client::{batches_to_json_rows, decode_execute_sql_response, default_workspace};
+use coral_api::v1::{
+    ExecuteSqlRequest, ListCatalogRequest, PaginationRequest, SourceSecret, SourceVariable,
+};
+use coral_client::default_workspace;
 use tonic::Request;
 
 use crate::harness::{GrpcHarness, fixture_manifest_with_inputs_yaml, fixture_manifest_yaml};
 
 #[tokio::test]
-async fn broken_source_does_not_block_healthy_sources() {
+async fn missing_credential_file_fails_query_and_catalog_loading() {
     let harness = GrpcHarness::new().await;
 
     harness
@@ -48,44 +50,28 @@ async fn broken_source_does_not_block_healthy_sources() {
     )
     .expect("remove broken source secret file");
 
-    let tables = harness.list_tables().await;
-    assert!(
-        tables
-            .iter()
-            .any(|table| table.schema_name == "local_messages"),
-        "healthy source should remain queryable"
-    );
-    assert!(
-        !tables
-            .iter()
-            .any(|table| table.schema_name == "secured_messages"),
-        "broken source should be omitted from registered tables"
-    );
+    let catalog_error = harness
+        .catalog_client()
+        .list_catalog(Request::new(ListCatalogRequest {
+            workspace: Some(default_workspace()),
+            schema_name: String::new(),
+            kind: 1,
+            pagination: Some(PaginationRequest {
+                limit: 0,
+                offset: 0,
+            }),
+        }))
+        .await
+        .expect_err("missing credential file should fail catalog loading");
+    assert_eq!(catalog_error.code(), tonic::Code::FailedPrecondition);
 
-    let healthy = harness
+    let query_error = harness
         .query_client()
         .execute_sql(Request::new(ExecuteSqlRequest {
             workspace: Some(default_workspace()),
             sql: "SELECT COUNT(*) AS n FROM local_messages.messages".to_string(),
         }))
         .await
-        .expect("healthy source query should succeed")
-        .into_inner();
-    let healthy_rows = batches_to_json_rows(
-        decode_execute_sql_response(&healthy)
-            .expect("decode healthy query")
-            .batches(),
-    )
-    .expect("healthy rows");
-    assert_eq!(healthy_rows[0]["n"], 2);
-
-    let broken = harness
-        .query_client()
-        .execute_sql(Request::new(ExecuteSqlRequest {
-            workspace: Some(default_workspace()),
-            sql: "SELECT * FROM secured_messages.messages".to_string(),
-        }))
-        .await
-        .expect_err("broken source query should fail");
-    assert_eq!(broken.code(), tonic::Code::NotFound);
+        .expect_err("missing credential file should fail query-source loading");
+    assert_eq!(query_error.code(), tonic::Code::FailedPrecondition);
 }

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -6,16 +6,14 @@
 
 use std::fs;
 
-use coral_api::v1::{
-    ExecuteSqlRequest, ListCatalogRequest, PaginationRequest, SourceSecret, SourceVariable,
-};
-use coral_client::default_workspace;
+use coral_api::v1::{ExecuteSqlRequest, SourceSecret, SourceVariable};
+use coral_client::{batches_to_json_rows, decode_execute_sql_response, default_workspace};
 use tonic::Request;
 
 use crate::harness::{GrpcHarness, fixture_manifest_with_inputs_yaml, fixture_manifest_yaml};
 
 #[tokio::test]
-async fn missing_credential_file_fails_query_and_catalog_loading() {
+async fn broken_source_does_not_block_healthy_sources() {
     let harness = GrpcHarness::new().await;
 
     harness
@@ -50,28 +48,44 @@ async fn missing_credential_file_fails_query_and_catalog_loading() {
     )
     .expect("remove broken source secret file");
 
-    let catalog_error = harness
-        .catalog_client()
-        .list_catalog(Request::new(ListCatalogRequest {
-            workspace: Some(default_workspace()),
-            schema_name: String::new(),
-            kind: 1,
-            pagination: Some(PaginationRequest {
-                limit: 0,
-                offset: 0,
-            }),
-        }))
-        .await
-        .expect_err("missing credential file should fail catalog loading");
-    assert_eq!(catalog_error.code(), tonic::Code::FailedPrecondition);
+    let tables = harness.list_tables().await;
+    assert!(
+        tables
+            .iter()
+            .any(|table| table.schema_name == "local_messages"),
+        "healthy source should remain queryable"
+    );
+    assert!(
+        !tables
+            .iter()
+            .any(|table| table.schema_name == "secured_messages"),
+        "broken source should be omitted from registered tables"
+    );
 
-    let query_error = harness
+    let healthy = harness
         .query_client()
         .execute_sql(Request::new(ExecuteSqlRequest {
             workspace: Some(default_workspace()),
             sql: "SELECT COUNT(*) AS n FROM local_messages.messages".to_string(),
         }))
         .await
-        .expect_err("missing credential file should fail query-source loading");
-    assert_eq!(query_error.code(), tonic::Code::FailedPrecondition);
+        .expect("healthy source query should succeed")
+        .into_inner();
+    let healthy_rows = batches_to_json_rows(
+        decode_execute_sql_response(&healthy)
+            .expect("decode healthy query")
+            .batches(),
+    )
+    .expect("healthy rows");
+    assert_eq!(healthy_rows[0]["n"], 2);
+
+    let broken = harness
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: "SELECT * FROM secured_messages.messages".to_string(),
+        }))
+        .await
+        .expect_err("broken source query should fail");
+    assert_eq!(broken.code(), tonic::Code::NotFound);
 }

--- a/crates/coral-spec/AGENTS.md
+++ b/crates/coral-spec/AGENTS.md
@@ -31,3 +31,7 @@ discovery, and normalized source-definition models.
   table/function collision checks.
 - Prefer normalized source-spec values over raw YAML plumbing in public
   helpers.
+- Keep DSL v4 runtime IR/projection types separate from their persisted file
+  models. Schema-v3 artifact YAML is a permanent compatibility contract: add
+  optional file fields and explicit file-to-runtime migration defaults rather
+  than making runtime model changes deserialize old installations directly.

--- a/crates/coral-spec/AGENTS.md
+++ b/crates/coral-spec/AGENTS.md
@@ -31,7 +31,7 @@ discovery, and normalized source-definition models.
   table/function collision checks.
 - Prefer normalized source-spec values over raw YAML plumbing in public
   helpers.
-- Keep DSL v4 runtime IR/projection types separate from their persisted file
-  models. Schema-v3 artifact YAML is a permanent compatibility contract: add
-  optional file fields and explicit file-to-runtime migration defaults rather
-  than making runtime model changes deserialize old installations directly.
+- Keep DSL v4 runtime IR/projection types separate from their persisted DTOs.
+  Schema-v3 artifact YAML is a permanent compatibility contract: add optional
+  DTO fields and explicit DTO-to-runtime migration defaults rather than making
+  runtime model changes deserialize old installations directly.

--- a/crates/coral-spec/src/v4/artifact_model.rs
+++ b/crates/coral-spec/src/v4/artifact_model.rs
@@ -562,35 +562,183 @@ impl From<ProjectionKindDto> for ProjectionKind {
 #[cfg(test)]
 mod tests {
     use super::{ProjectionCatalogDto, SemanticIrDto};
-    use crate::v4::{ProjectionCatalog, SemanticIr};
+    use crate::v4::{
+        HttpMethod, IrExecutionAttachment, IrInputLocation, IrScalarType, IrTypeShape,
+        OutputCardinality, ProjectionCatalog, ProjectionKind, ProjectionVisibility, SemanticIr,
+        SqlInputExposure,
+    };
+    use crate::{ManifestDataType, PaginationMode, SourceTableFunctionKind};
+
+    fn decode_semantic_ir(raw: &str) -> SemanticIr {
+        let dto: SemanticIrDto =
+            serde_yaml::from_str(raw).expect("decode schema-v3 semantic IR fixture");
+        SemanticIr::try_from(dto).expect("migrate schema-v3 semantic IR")
+    }
+
+    fn decode_projections() -> ProjectionCatalog {
+        let dto: ProjectionCatalogDto =
+            serde_yaml::from_str(include_str!("fixtures/v3/projections.yaml"))
+                .expect("decode schema-v3 projection fixture");
+        ProjectionCatalog::try_from(dto).expect("migrate schema-v3 projections")
+    }
 
     #[test]
-    fn schema_v3_semantic_ir_fixture_migrates() {
-        let file: SemanticIrDto =
-            serde_yaml::from_str(include_str!("fixtures/v3/semantic-ir.yaml"))
-                .expect("decode schema-v3 semantic IR fixture");
-        let runtime = SemanticIr::try_from(file).expect("migrate schema-v3 semantic IR");
+    fn schema_v3_rest_semantic_ir_fixture_migrates_nested_models() {
+        let runtime = decode_semantic_ir(include_str!("fixtures/v3/semantic-ir.yaml"));
 
         assert_eq!(runtime.source_name, "compatibility_fixture");
         assert_eq!(runtime.surface_id, "rest");
+        assert_eq!(runtime.operations.len(), 1);
+        assert_eq!(runtime.types.len(), 6);
+        assert_eq!(runtime.diagnostics.len(), 1);
+
+        let operation = runtime.operations.first().expect("REST operation");
+        assert_eq!(operation.id, "list_items");
+        assert_eq!(operation.output.cardinality, OutputCardinality::WrappedList);
+        assert_eq!(operation.output.row_path, ["data", "items"]);
+        assert_eq!(operation.inputs.len(), 2);
+        let owner = operation.inputs.first().expect("owner input");
+        let cursor = operation.inputs.get(1).expect("cursor input");
+        assert_eq!(owner.location, IrInputLocation::Path);
+        assert!(cursor.exclude_from_lookup_keys);
+        assert_eq!(
+            operation.entity.as_ref().expect("entity").identity_fields,
+            ["id"]
+        );
+
+        let IrExecutionAttachment::Rest(execution) = &operation.execution else {
+            panic!("expected REST execution attachment");
+        };
+        assert_eq!(execution.method, HttpMethod::Get);
+        assert_eq!(execution.parameters.len(), 2);
+        assert_eq!(
+            execution
+                .request_body
+                .as_ref()
+                .expect("request body")
+                .type_ref,
+            "ItemQuery"
+        );
+        assert!(execution.response.response.allow_404_empty);
+        assert_eq!(execution.pagination.mode, PaginationMode::CursorQuery);
+        assert_eq!(execution.pagination.cursor_param.as_deref(), Some("cursor"));
+        assert_eq!(execution.pagination.max_pages, Some(10));
+
+        let shapes = runtime
+            .types
+            .iter()
+            .map(|ir_type| (&ir_type.id, &ir_type.shape))
+            .collect::<Vec<_>>();
+        assert!(shapes.iter().any(|(id, shape)| {
+            id.as_str() == "Item"
+                && matches!(shape, IrTypeShape::Object { fields } if fields.len() == 2)
+        }));
+        assert!(shapes.iter().any(|(id, shape)| {
+            id.as_str() == "ItemId" && matches!(shape, IrTypeShape::Scalar(IrScalarType::Id))
+        }));
+        assert!(shapes.iter().any(|(id, shape)| {
+            id.as_str() == "ItemList"
+                && matches!(shape, IrTypeShape::List { item_type_ref } if item_type_ref == "Item")
+        }));
+        assert!(shapes.iter().any(|(id, shape)| {
+            id.as_str() == "ItemMap"
+                && matches!(shape, IrTypeShape::Map { value_type_ref } if value_type_ref == "Item")
+        }));
+        assert!(shapes.iter().any(|(id, shape)| {
+            id.as_str() == "ItemState"
+                && matches!(shape, IrTypeShape::Enum { values } if values == &["open", "closed"])
+        }));
+        assert!(shapes
+            .iter()
+            .any(|(id, shape)| id.as_str() == "ItemQuery" && matches!(shape, IrTypeShape::Json)));
+    }
+
+    #[test]
+    fn schema_v3_mcp_semantic_ir_fixture_migrates_pagination() {
+        let runtime = decode_semantic_ir(include_str!("fixtures/v3/mcp-semantic-ir.yaml"));
+        let operation = runtime.operations.first().expect("MCP operation");
+
+        assert_eq!(runtime.surface_id, "mcp");
+        assert_eq!(operation.output.cardinality, OutputCardinality::List);
+        let query = operation.inputs.first().expect("query input");
+        let limit = operation.inputs.get(1).expect("limit input");
+        assert_eq!(query.location, IrInputLocation::ToolArg);
+        assert_eq!(limit.default_value.as_deref(), Some("20"));
+
+        let IrExecutionAttachment::Mcp(execution) = &operation.execution else {
+            panic!("expected MCP execution attachment");
+        };
+        assert_eq!(execution.tool_name, "search_items");
+        let cursor = execution.pagination.as_ref().expect("cursor pagination");
+        assert_eq!(cursor.cursor_arg, "cursor");
+        assert_eq!(cursor.response_cursor_path, ["next_cursor"]);
+        assert_eq!(cursor.max_pages, Some(5));
+        let offset = execution
+            .offset_pagination
+            .as_ref()
+            .expect("offset pagination");
+        assert_eq!(offset.limit_arg, "limit");
+        assert_eq!(offset.default_limit, 20);
+        assert_eq!(offset.max_limit, 100);
+        assert_eq!(offset.offset_arg, "offset");
+        assert_eq!(offset.max_pages, Some(8));
     }
 
     #[test]
     fn schema_v3_projection_fixture_migrates_legacy_defaults() {
-        let file: ProjectionCatalogDto =
-            serde_yaml::from_str(include_str!("fixtures/v3/projections.yaml"))
-                .expect("decode schema-v3 projection fixture");
-        let runtime = ProjectionCatalog::try_from(file).expect("migrate schema-v3 projections");
+        let runtime = decode_projections();
 
         assert_eq!(runtime.source_name, "compatibility_fixture");
-        assert_eq!(runtime.projections.len(), 1);
-        assert_eq!(
-            runtime
-                .projections
-                .first()
-                .expect("fixture projection")
-                .namespace,
-            ""
-        );
+        assert_eq!(runtime.projections.len(), 2);
+        assert_eq!(runtime.diagnostics.len(), 1);
+
+        let table = runtime.projections.first().expect("table projection");
+        assert_eq!(table.namespace, "");
+        assert!(matches!(table.kind, ProjectionKind::Table));
+        assert_eq!(table.visibility, ProjectionVisibility::Published);
+        assert_eq!(table.inputs.len(), 2);
+        let owner = table.inputs.first().expect("owner filter");
+        let cursor = table.inputs.get(1).expect("cursor input");
+        assert_eq!(owner.sql_exposure, SqlInputExposure::Filter);
+        assert!(owner.lookup_key);
+        assert_eq!(cursor.sql_exposure, SqlInputExposure::Internal);
+        assert_eq!(table.columns.len(), 2);
+        let id = table.columns.first().expect("id column");
+        assert_eq!(id.data_type, ManifestDataType::Utf8);
+        assert!(!id.nullable);
+        assert_eq!(table.diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn schema_v3_projection_fixture_migrates_function_metadata() {
+        let runtime = decode_projections();
+        let function = runtime
+            .projections
+            .get(1)
+            .expect("table-function projection");
+
+        assert_eq!(function.namespace, "compatibility_fixture_mcp");
+        assert!(matches!(
+            function.kind,
+            ProjectionKind::TableFunction {
+                function_kind: SourceTableFunctionKind::Search
+            }
+        ));
+        assert_eq!(function.visibility, ProjectionVisibility::Hidden);
+        let query = function.inputs.first().expect("query argument");
+        let limit = function.inputs.get(1).expect("limit input");
+        assert_eq!(query.sql_exposure, SqlInputExposure::FunctionArg);
+        assert_eq!(limit.data_type, ManifestDataType::Int64);
+        assert_eq!(limit.default_value.as_deref(), Some("20"));
+        let score = function.columns.get(1).expect("score column");
+        assert_eq!(score.data_type, ManifestDataType::Float64);
+        let limits = function.search_limits.as_ref().expect("search limits");
+        assert_eq!(limits.default_top_k, 20);
+        assert_eq!(limits.max_top_k, 100);
+        assert_eq!(limits.max_calls_per_query, 10);
+        let hint = function.detail_hints.first().expect("detail hint");
+        assert_eq!(hint.table, "items");
+        assert_eq!(hint.search_result_column, "id");
+        assert_eq!(hint.detail_filter, "id");
     }
 }

--- a/crates/coral-spec/src/v4/artifact_model.rs
+++ b/crates/coral-spec/src/v4/artifact_model.rs
@@ -20,6 +20,8 @@ use crate::{
     SourceTableFunctionKind,
 };
 
+/// Reserved for future DTO migrations that cannot produce a valid runtime model.
+/// The current field-for-field migrations are infallible but deliberately use `TryFrom`.
 #[derive(Debug, thiserror::Error)]
 #[error("failed to migrate {artifact} at {path}: {detail}")]
 pub struct ArtifactMigrationError {

--- a/crates/coral-spec/src/v4/artifact_model.rs
+++ b/crates/coral-spec/src/v4/artifact_model.rs
@@ -1,0 +1,600 @@
+//! Stable on-disk representations for DSL v4 semantic IR and projections.
+//!
+//! These types deliberately duplicate the runtime models. Persisted YAML is a
+//! compatibility contract; runtime models may evolve only through the explicit
+//! mappings in this module.
+
+use serde::{Deserialize, Serialize};
+
+use crate::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
+use crate::v4::{
+    Diagnostic, HttpMethod, IrEntityCandidate, IrExecutionAttachment, IrField, IrInputLocation,
+    IrOperation, IrOperationInput, IrOperationNaming, IrOperationOutput, IrScalarType, IrType,
+    IrTypeShape, McpExecutionAttachment, OutputCardinality, Projection, ProjectionCatalog,
+    ProjectionColumn, ProjectionInput, ProjectionKind, ProjectionVisibility,
+    RestExecutionAttachment, RestParameterBinding, RestRequestBody, RestResponseAttachment,
+    SemanticIr, SqlInputExposure, SurfaceType,
+};
+use crate::{
+    DetailHintSpec, ManifestDataType, PaginationSpec, ResponseSpec, SearchLimitsSpec,
+    SourceTableFunctionKind,
+};
+
+#[derive(Debug, thiserror::Error)]
+#[error("failed to migrate {artifact} at {path}: {detail}")]
+pub struct ArtifactMigrationError {
+    pub artifact: &'static str,
+    pub path: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SemanticIrFile {
+    pub artifact_schema_version: u32,
+    pub source_name: String,
+    pub surface_id: String,
+    pub surface_type: SurfaceType,
+    pub importer_version: String,
+    pub operations: Vec<IrOperationFile>,
+    pub types: Vec<IrTypeFile>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IrOperationFile {
+    pub id: String,
+    pub method_name: String,
+    pub description: String,
+    pub deprecated: bool,
+    pub read_only: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub naming: Option<IrOperationNamingFile>,
+    pub inputs: Vec<IrOperationInputFile>,
+    pub output: IrOperationOutputFile,
+    pub entity: Option<IrEntityCandidateFile>,
+    pub execution: IrExecutionAttachmentFile,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IrOperationNamingFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operation: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IrOperationInputFile {
+    pub name: String,
+    pub location: IrInputLocation,
+    pub required: bool,
+    pub data_type: IrScalarType,
+    pub default_value: Option<String>,
+    pub description: String,
+    #[serde(default)]
+    pub exclude_from_lookup_keys: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IrOperationOutputFile {
+    pub cardinality: OutputCardinality,
+    pub type_ref: String,
+    pub row_path: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IrEntityCandidateFile {
+    pub name: String,
+    pub type_ref: String,
+    pub identity_fields: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IrTypeFile {
+    pub id: String,
+    pub shape: IrTypeShapeFile,
+    pub nullable: bool,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+pub enum IrTypeShapeFile {
+    Scalar(IrScalarType),
+    Object { fields: Vec<IrFieldFile> },
+    List { item_type_ref: String },
+    Map { value_type_ref: String },
+    Enum { values: Vec<String> },
+    Json,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IrFieldFile {
+    pub name: String,
+    pub type_ref: String,
+    pub required: bool,
+    pub nullable: bool,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+pub enum IrExecutionAttachmentFile {
+    Rest(Box<RestExecutionAttachmentFile>),
+    Mcp(McpExecutionAttachmentFile),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RestExecutionAttachmentFile {
+    pub method: HttpMethod,
+    pub path_template: String,
+    pub parameters: Vec<RestParameterBindingFile>,
+    pub request_body: Option<RestRequestBodyFile>,
+    pub response: RestResponseAttachmentFile,
+    pub pagination: PaginationSpec,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RestRequestBodyFile {
+    pub required: bool,
+    pub media_type: String,
+    pub type_ref: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RestParameterBindingFile {
+    pub input_name: String,
+    pub location: IrInputLocation,
+    pub wire_name: String,
+    pub required: bool,
+    pub data_type: IrScalarType,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RestResponseAttachmentFile {
+    pub status_code: u16,
+    pub media_type: String,
+    pub response: ResponseSpec,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpExecutionAttachmentFile {
+    pub tool_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pagination: Option<McpPaginationSpec>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub offset_pagination: Option<McpOffsetPaginationSpec>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectionCatalogFile {
+    pub artifact_schema_version: u32,
+    pub source_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generator_version: Option<String>,
+    pub projections: Vec<ProjectionFile>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectionFile {
+    pub name: String,
+    #[serde(default)]
+    pub namespace: String,
+    pub kind: ProjectionKindFile,
+    pub description: String,
+    pub guide: String,
+    pub surface_id: String,
+    pub operation_id: String,
+    pub visibility: ProjectionVisibility,
+    pub inputs: Vec<ProjectionInputFile>,
+    pub columns: Vec<ProjectionColumnFile>,
+    pub search_limits: Option<SearchLimitsSpec>,
+    pub detail_hints: Vec<DetailHintSpec>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+pub enum ProjectionKindFile {
+    Table,
+    TableFunction {
+        function_kind: SourceTableFunctionKind,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectionInputFile {
+    pub name: String,
+    pub sql_exposure: SqlInputExposure,
+    pub source_location: IrInputLocation,
+    pub wire_name: String,
+    pub required: bool,
+    pub data_type: ManifestDataType,
+    pub default_value: Option<String>,
+    pub description: String,
+    #[serde(default)]
+    pub lookup_key: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectionColumnFile {
+    pub name: String,
+    pub data_type: ManifestDataType,
+    pub source_path: Vec<String>,
+    pub nullable: bool,
+    pub description: String,
+}
+
+impl From<&SemanticIr> for SemanticIrFile {
+    fn from(value: &SemanticIr) -> Self {
+        Self {
+            artifact_schema_version: value.artifact_schema_version,
+            source_name: value.source_name.clone(),
+            surface_id: value.surface_id.clone(),
+            surface_type: value.surface_type,
+            importer_version: value.importer_version.clone(),
+            operations: value.operations.iter().map(IrOperationFile::from).collect(),
+            types: value.types.iter().map(IrTypeFile::from).collect(),
+            diagnostics: value.diagnostics.clone(),
+        }
+    }
+}
+
+impl TryFrom<SemanticIrFile> for SemanticIr {
+    type Error = ArtifactMigrationError;
+
+    fn try_from(value: SemanticIrFile) -> Result<Self, Self::Error> {
+        Ok(Self {
+            artifact_schema_version: value.artifact_schema_version,
+            source_name: value.source_name,
+            surface_id: value.surface_id,
+            surface_type: value.surface_type,
+            importer_version: value.importer_version,
+            operations: value
+                .operations
+                .into_iter()
+                .map(IrOperation::from)
+                .collect(),
+            types: value.types.into_iter().map(IrType::from).collect(),
+            diagnostics: value.diagnostics,
+        })
+    }
+}
+
+impl From<&ProjectionCatalog> for ProjectionCatalogFile {
+    fn from(value: &ProjectionCatalog) -> Self {
+        Self {
+            artifact_schema_version: value.artifact_schema_version,
+            source_name: value.source_name.clone(),
+            generator_version: value.generator_version.clone(),
+            projections: value.projections.iter().map(ProjectionFile::from).collect(),
+            diagnostics: value.diagnostics.clone(),
+        }
+    }
+}
+
+impl TryFrom<ProjectionCatalogFile> for ProjectionCatalog {
+    type Error = ArtifactMigrationError;
+
+    fn try_from(value: ProjectionCatalogFile) -> Result<Self, Self::Error> {
+        Ok(Self {
+            artifact_schema_version: value.artifact_schema_version,
+            source_name: value.source_name,
+            generator_version: value.generator_version,
+            projections: value
+                .projections
+                .into_iter()
+                .map(Projection::from)
+                .collect(),
+            diagnostics: value.diagnostics,
+        })
+    }
+}
+
+impl From<&IrOperation> for IrOperationFile {
+    fn from(value: &IrOperation) -> Self {
+        Self {
+            id: value.id.clone(),
+            method_name: value.method_name.clone(),
+            description: value.description.clone(),
+            deprecated: value.deprecated,
+            read_only: value.read_only,
+            naming: value.naming.as_ref().map(IrOperationNamingFile::from),
+            inputs: value
+                .inputs
+                .iter()
+                .map(IrOperationInputFile::from)
+                .collect(),
+            output: IrOperationOutputFile::from(&value.output),
+            entity: value.entity.as_ref().map(IrEntityCandidateFile::from),
+            execution: IrExecutionAttachmentFile::from(&value.execution),
+            diagnostics: value.diagnostics.clone(),
+        }
+    }
+}
+
+impl From<IrOperationFile> for IrOperation {
+    fn from(value: IrOperationFile) -> Self {
+        Self {
+            id: value.id,
+            method_name: value.method_name,
+            description: value.description,
+            deprecated: value.deprecated,
+            read_only: value.read_only,
+            naming: value.naming.map(IrOperationNaming::from),
+            inputs: value
+                .inputs
+                .into_iter()
+                .map(IrOperationInput::from)
+                .collect(),
+            output: value.output.into(),
+            entity: value.entity.map(IrEntityCandidate::from),
+            execution: value.execution.into(),
+            diagnostics: value.diagnostics,
+        }
+    }
+}
+
+macro_rules! copy_struct {
+    ($file:ty => $runtime:ty { $($field:ident),+ $(,)? }) => {
+        impl From<&$runtime> for $file {
+            fn from(value: &$runtime) -> Self {
+                Self { $($field: value.$field.clone()),+ }
+            }
+        }
+        impl From<$file> for $runtime {
+            fn from(value: $file) -> Self {
+                Self { $($field: value.$field),+ }
+            }
+        }
+    };
+}
+
+copy_struct!(IrOperationNamingFile => IrOperationNaming { group, operation });
+copy_struct!(IrOperationInputFile => IrOperationInput {
+    name, location, required, data_type, default_value, description, exclude_from_lookup_keys
+});
+copy_struct!(IrOperationOutputFile => IrOperationOutput { cardinality, type_ref, row_path });
+copy_struct!(IrEntityCandidateFile => IrEntityCandidate { name, type_ref, identity_fields });
+copy_struct!(IrFieldFile => IrField { name, type_ref, required, nullable, description });
+copy_struct!(RestRequestBodyFile => RestRequestBody { required, media_type, type_ref });
+copy_struct!(RestParameterBindingFile => RestParameterBinding {
+    input_name, location, wire_name, required, data_type
+});
+copy_struct!(RestResponseAttachmentFile => RestResponseAttachment {
+    status_code, media_type, response
+});
+copy_struct!(McpExecutionAttachmentFile => McpExecutionAttachment {
+    tool_name, pagination, offset_pagination
+});
+copy_struct!(ProjectionInputFile => ProjectionInput {
+    name, sql_exposure, source_location, wire_name, required, data_type, default_value,
+    description, lookup_key
+});
+copy_struct!(ProjectionColumnFile => ProjectionColumn {
+    name, data_type, source_path, nullable, description
+});
+
+impl From<&IrType> for IrTypeFile {
+    fn from(value: &IrType) -> Self {
+        Self {
+            id: value.id.clone(),
+            shape: IrTypeShapeFile::from(&value.shape),
+            nullable: value.nullable,
+            description: value.description.clone(),
+        }
+    }
+}
+
+impl From<IrTypeFile> for IrType {
+    fn from(value: IrTypeFile) -> Self {
+        Self {
+            id: value.id,
+            shape: value.shape.into(),
+            nullable: value.nullable,
+            description: value.description,
+        }
+    }
+}
+
+impl From<&IrTypeShape> for IrTypeShapeFile {
+    fn from(value: &IrTypeShape) -> Self {
+        match value {
+            IrTypeShape::Scalar(value) => Self::Scalar(*value),
+            IrTypeShape::Object { fields } => Self::Object {
+                fields: fields.iter().map(IrFieldFile::from).collect(),
+            },
+            IrTypeShape::List { item_type_ref } => Self::List {
+                item_type_ref: item_type_ref.clone(),
+            },
+            IrTypeShape::Map { value_type_ref } => Self::Map {
+                value_type_ref: value_type_ref.clone(),
+            },
+            IrTypeShape::Enum { values } => Self::Enum {
+                values: values.clone(),
+            },
+            IrTypeShape::Json => Self::Json,
+        }
+    }
+}
+
+impl From<IrTypeShapeFile> for IrTypeShape {
+    fn from(value: IrTypeShapeFile) -> Self {
+        match value {
+            IrTypeShapeFile::Scalar(value) => Self::Scalar(value),
+            IrTypeShapeFile::Object { fields } => Self::Object {
+                fields: fields.into_iter().map(IrField::from).collect(),
+            },
+            IrTypeShapeFile::List { item_type_ref } => Self::List { item_type_ref },
+            IrTypeShapeFile::Map { value_type_ref } => Self::Map { value_type_ref },
+            IrTypeShapeFile::Enum { values } => Self::Enum { values },
+            IrTypeShapeFile::Json => Self::Json,
+        }
+    }
+}
+
+impl From<&IrExecutionAttachment> for IrExecutionAttachmentFile {
+    fn from(value: &IrExecutionAttachment) -> Self {
+        match value {
+            IrExecutionAttachment::Rest(value) => {
+                Self::Rest(Box::new(RestExecutionAttachmentFile::from(value.as_ref())))
+            }
+            IrExecutionAttachment::Mcp(value) => Self::Mcp(McpExecutionAttachmentFile::from(value)),
+        }
+    }
+}
+
+impl From<IrExecutionAttachmentFile> for IrExecutionAttachment {
+    fn from(value: IrExecutionAttachmentFile) -> Self {
+        match value {
+            IrExecutionAttachmentFile::Rest(value) => Self::Rest(Box::new((*value).into())),
+            IrExecutionAttachmentFile::Mcp(value) => Self::Mcp(value.into()),
+        }
+    }
+}
+
+impl From<&RestExecutionAttachment> for RestExecutionAttachmentFile {
+    fn from(value: &RestExecutionAttachment) -> Self {
+        Self {
+            method: value.method,
+            path_template: value.path_template.clone(),
+            parameters: value
+                .parameters
+                .iter()
+                .map(RestParameterBindingFile::from)
+                .collect(),
+            request_body: value.request_body.as_ref().map(RestRequestBodyFile::from),
+            response: RestResponseAttachmentFile::from(&value.response),
+            pagination: value.pagination.clone(),
+        }
+    }
+}
+
+impl From<RestExecutionAttachmentFile> for RestExecutionAttachment {
+    fn from(value: RestExecutionAttachmentFile) -> Self {
+        Self {
+            method: value.method,
+            path_template: value.path_template,
+            parameters: value
+                .parameters
+                .into_iter()
+                .map(RestParameterBinding::from)
+                .collect(),
+            request_body: value.request_body.map(RestRequestBody::from),
+            response: value.response.into(),
+            pagination: value.pagination,
+        }
+    }
+}
+
+impl From<&Projection> for ProjectionFile {
+    fn from(value: &Projection) -> Self {
+        Self {
+            name: value.name.clone(),
+            namespace: value.namespace.clone(),
+            kind: ProjectionKindFile::from(&value.kind),
+            description: value.description.clone(),
+            guide: value.guide.clone(),
+            surface_id: value.surface_id.clone(),
+            operation_id: value.operation_id.clone(),
+            visibility: value.visibility,
+            inputs: value.inputs.iter().map(ProjectionInputFile::from).collect(),
+            columns: value
+                .columns
+                .iter()
+                .map(ProjectionColumnFile::from)
+                .collect(),
+            search_limits: value.search_limits.clone(),
+            detail_hints: value.detail_hints.clone(),
+            diagnostics: value.diagnostics.clone(),
+        }
+    }
+}
+
+impl From<ProjectionFile> for Projection {
+    fn from(value: ProjectionFile) -> Self {
+        Self {
+            name: value.name,
+            namespace: value.namespace,
+            kind: value.kind.into(),
+            description: value.description,
+            guide: value.guide,
+            surface_id: value.surface_id,
+            operation_id: value.operation_id,
+            visibility: value.visibility,
+            inputs: value
+                .inputs
+                .into_iter()
+                .map(ProjectionInput::from)
+                .collect(),
+            columns: value
+                .columns
+                .into_iter()
+                .map(ProjectionColumn::from)
+                .collect(),
+            search_limits: value.search_limits,
+            detail_hints: value.detail_hints,
+            diagnostics: value.diagnostics,
+        }
+    }
+}
+
+impl From<&ProjectionKind> for ProjectionKindFile {
+    fn from(value: &ProjectionKind) -> Self {
+        match value {
+            ProjectionKind::Table => Self::Table,
+            ProjectionKind::TableFunction { function_kind } => Self::TableFunction {
+                function_kind: *function_kind,
+            },
+        }
+    }
+}
+
+impl From<ProjectionKindFile> for ProjectionKind {
+    fn from(value: ProjectionKindFile) -> Self {
+        match value {
+            ProjectionKindFile::Table => Self::Table,
+            ProjectionKindFile::TableFunction { function_kind } => {
+                Self::TableFunction { function_kind }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ProjectionCatalogFile, SemanticIrFile};
+    use crate::v4::{ProjectionCatalog, SemanticIr};
+
+    #[test]
+    fn schema_v3_semantic_ir_fixture_migrates() {
+        let file: SemanticIrFile =
+            serde_yaml::from_str(include_str!("fixtures/v3/semantic-ir.yaml"))
+                .expect("decode schema-v3 semantic IR fixture");
+        let runtime = SemanticIr::try_from(file).expect("migrate schema-v3 semantic IR");
+
+        assert_eq!(runtime.source_name, "compatibility_fixture");
+        assert_eq!(runtime.surface_id, "rest");
+    }
+
+    #[test]
+    fn schema_v3_projection_fixture_migrates_legacy_defaults() {
+        let file: ProjectionCatalogFile =
+            serde_yaml::from_str(include_str!("fixtures/v3/projections.yaml"))
+                .expect("decode schema-v3 projection fixture");
+        let runtime = ProjectionCatalog::try_from(file).expect("migrate schema-v3 projections");
+
+        assert_eq!(runtime.source_name, "compatibility_fixture");
+        assert_eq!(runtime.projections.len(), 1);
+        assert_eq!(
+            runtime
+                .projections
+                .first()
+                .expect("fixture projection")
+                .namespace,
+            ""
+        );
+    }
+}

--- a/crates/coral-spec/src/v4/artifact_model.rs
+++ b/crates/coral-spec/src/v4/artifact_model.rs
@@ -29,35 +29,35 @@ pub struct ArtifactMigrationError {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SemanticIrFile {
+pub struct SemanticIrDto {
     pub artifact_schema_version: u32,
     pub source_name: String,
     pub surface_id: String,
     pub surface_type: SurfaceType,
     pub importer_version: String,
-    pub operations: Vec<IrOperationFile>,
-    pub types: Vec<IrTypeFile>,
+    pub operations: Vec<IrOperationDto>,
+    pub types: Vec<IrTypeDto>,
     pub diagnostics: Vec<Diagnostic>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IrOperationFile {
+pub struct IrOperationDto {
     pub id: String,
     pub method_name: String,
     pub description: String,
     pub deprecated: bool,
     pub read_only: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub naming: Option<IrOperationNamingFile>,
-    pub inputs: Vec<IrOperationInputFile>,
-    pub output: IrOperationOutputFile,
-    pub entity: Option<IrEntityCandidateFile>,
-    pub execution: IrExecutionAttachmentFile,
+    pub naming: Option<IrOperationNamingDto>,
+    pub inputs: Vec<IrOperationInputDto>,
+    pub output: IrOperationOutputDto,
+    pub entity: Option<IrEntityCandidateDto>,
+    pub execution: IrExecutionAttachmentDto,
     pub diagnostics: Vec<Diagnostic>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IrOperationNamingFile {
+pub struct IrOperationNamingDto {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub group: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -65,7 +65,7 @@ pub struct IrOperationNamingFile {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IrOperationInputFile {
+pub struct IrOperationInputDto {
     pub name: String,
     pub location: IrInputLocation,
     pub required: bool,
@@ -77,32 +77,32 @@ pub struct IrOperationInputFile {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IrOperationOutputFile {
+pub struct IrOperationOutputDto {
     pub cardinality: OutputCardinality,
     pub type_ref: String,
     pub row_path: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IrEntityCandidateFile {
+pub struct IrEntityCandidateDto {
     pub name: String,
     pub type_ref: String,
     pub identity_fields: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IrTypeFile {
+pub struct IrTypeDto {
     pub id: String,
-    pub shape: IrTypeShapeFile,
+    pub shape: IrTypeShapeDto,
     pub nullable: bool,
     pub description: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type", content = "value")]
-pub enum IrTypeShapeFile {
+pub enum IrTypeShapeDto {
     Scalar(IrScalarType),
-    Object { fields: Vec<IrFieldFile> },
+    Object { fields: Vec<IrFieldDto> },
     List { item_type_ref: String },
     Map { value_type_ref: String },
     Enum { values: Vec<String> },
@@ -110,7 +110,7 @@ pub enum IrTypeShapeFile {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IrFieldFile {
+pub struct IrFieldDto {
     pub name: String,
     pub type_ref: String,
     pub required: bool,
@@ -120,30 +120,30 @@ pub struct IrFieldFile {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type", content = "value")]
-pub enum IrExecutionAttachmentFile {
-    Rest(Box<RestExecutionAttachmentFile>),
-    Mcp(McpExecutionAttachmentFile),
+pub enum IrExecutionAttachmentDto {
+    Rest(Box<RestExecutionAttachmentDto>),
+    Mcp(McpExecutionAttachmentDto),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RestExecutionAttachmentFile {
+pub struct RestExecutionAttachmentDto {
     pub method: HttpMethod,
     pub path_template: String,
-    pub parameters: Vec<RestParameterBindingFile>,
-    pub request_body: Option<RestRequestBodyFile>,
-    pub response: RestResponseAttachmentFile,
+    pub parameters: Vec<RestParameterBindingDto>,
+    pub request_body: Option<RestRequestBodyDto>,
+    pub response: RestResponseAttachmentDto,
     pub pagination: PaginationSpec,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RestRequestBodyFile {
+pub struct RestRequestBodyDto {
     pub required: bool,
     pub media_type: String,
     pub type_ref: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RestParameterBindingFile {
+pub struct RestParameterBindingDto {
     pub input_name: String,
     pub location: IrInputLocation,
     pub wire_name: String,
@@ -152,14 +152,14 @@ pub struct RestParameterBindingFile {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RestResponseAttachmentFile {
+pub struct RestResponseAttachmentDto {
     pub status_code: u16,
     pub media_type: String,
     pub response: ResponseSpec,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct McpExecutionAttachmentFile {
+pub struct McpExecutionAttachmentDto {
     pub tool_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pagination: Option<McpPaginationSpec>,
@@ -168,28 +168,28 @@ pub struct McpExecutionAttachmentFile {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProjectionCatalogFile {
+pub struct ProjectionCatalogDto {
     pub artifact_schema_version: u32,
     pub source_name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub generator_version: Option<String>,
-    pub projections: Vec<ProjectionFile>,
+    pub projections: Vec<ProjectionDto>,
     pub diagnostics: Vec<Diagnostic>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProjectionFile {
+pub struct ProjectionDto {
     pub name: String,
     #[serde(default)]
     pub namespace: String,
-    pub kind: ProjectionKindFile,
+    pub kind: ProjectionKindDto,
     pub description: String,
     pub guide: String,
     pub surface_id: String,
     pub operation_id: String,
     pub visibility: ProjectionVisibility,
-    pub inputs: Vec<ProjectionInputFile>,
-    pub columns: Vec<ProjectionColumnFile>,
+    pub inputs: Vec<ProjectionInputDto>,
+    pub columns: Vec<ProjectionColumnDto>,
     pub search_limits: Option<SearchLimitsSpec>,
     pub detail_hints: Vec<DetailHintSpec>,
     pub diagnostics: Vec<Diagnostic>,
@@ -197,7 +197,7 @@ pub struct ProjectionFile {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type", content = "value")]
-pub enum ProjectionKindFile {
+pub enum ProjectionKindDto {
     Table,
     TableFunction {
         function_kind: SourceTableFunctionKind,
@@ -205,7 +205,7 @@ pub enum ProjectionKindFile {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProjectionInputFile {
+pub struct ProjectionInputDto {
     pub name: String,
     pub sql_exposure: SqlInputExposure,
     pub source_location: IrInputLocation,
@@ -219,7 +219,7 @@ pub struct ProjectionInputFile {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProjectionColumnFile {
+pub struct ProjectionColumnDto {
     pub name: String,
     pub data_type: ManifestDataType,
     pub source_path: Vec<String>,
@@ -227,7 +227,7 @@ pub struct ProjectionColumnFile {
     pub description: String,
 }
 
-impl From<&SemanticIr> for SemanticIrFile {
+impl From<&SemanticIr> for SemanticIrDto {
     fn from(value: &SemanticIr) -> Self {
         Self {
             artifact_schema_version: value.artifact_schema_version,
@@ -235,17 +235,17 @@ impl From<&SemanticIr> for SemanticIrFile {
             surface_id: value.surface_id.clone(),
             surface_type: value.surface_type,
             importer_version: value.importer_version.clone(),
-            operations: value.operations.iter().map(IrOperationFile::from).collect(),
-            types: value.types.iter().map(IrTypeFile::from).collect(),
+            operations: value.operations.iter().map(IrOperationDto::from).collect(),
+            types: value.types.iter().map(IrTypeDto::from).collect(),
             diagnostics: value.diagnostics.clone(),
         }
     }
 }
 
-impl TryFrom<SemanticIrFile> for SemanticIr {
+impl TryFrom<SemanticIrDto> for SemanticIr {
     type Error = ArtifactMigrationError;
 
-    fn try_from(value: SemanticIrFile) -> Result<Self, Self::Error> {
+    fn try_from(value: SemanticIrDto) -> Result<Self, Self::Error> {
         Ok(Self {
             artifact_schema_version: value.artifact_schema_version,
             source_name: value.source_name,
@@ -263,22 +263,22 @@ impl TryFrom<SemanticIrFile> for SemanticIr {
     }
 }
 
-impl From<&ProjectionCatalog> for ProjectionCatalogFile {
+impl From<&ProjectionCatalog> for ProjectionCatalogDto {
     fn from(value: &ProjectionCatalog) -> Self {
         Self {
             artifact_schema_version: value.artifact_schema_version,
             source_name: value.source_name.clone(),
             generator_version: value.generator_version.clone(),
-            projections: value.projections.iter().map(ProjectionFile::from).collect(),
+            projections: value.projections.iter().map(ProjectionDto::from).collect(),
             diagnostics: value.diagnostics.clone(),
         }
     }
 }
 
-impl TryFrom<ProjectionCatalogFile> for ProjectionCatalog {
+impl TryFrom<ProjectionCatalogDto> for ProjectionCatalog {
     type Error = ArtifactMigrationError;
 
-    fn try_from(value: ProjectionCatalogFile) -> Result<Self, Self::Error> {
+    fn try_from(value: ProjectionCatalogDto) -> Result<Self, Self::Error> {
         Ok(Self {
             artifact_schema_version: value.artifact_schema_version,
             source_name: value.source_name,
@@ -293,7 +293,7 @@ impl TryFrom<ProjectionCatalogFile> for ProjectionCatalog {
     }
 }
 
-impl From<&IrOperation> for IrOperationFile {
+impl From<&IrOperation> for IrOperationDto {
     fn from(value: &IrOperation) -> Self {
         Self {
             id: value.id.clone(),
@@ -301,22 +301,18 @@ impl From<&IrOperation> for IrOperationFile {
             description: value.description.clone(),
             deprecated: value.deprecated,
             read_only: value.read_only,
-            naming: value.naming.as_ref().map(IrOperationNamingFile::from),
-            inputs: value
-                .inputs
-                .iter()
-                .map(IrOperationInputFile::from)
-                .collect(),
-            output: IrOperationOutputFile::from(&value.output),
-            entity: value.entity.as_ref().map(IrEntityCandidateFile::from),
-            execution: IrExecutionAttachmentFile::from(&value.execution),
+            naming: value.naming.as_ref().map(IrOperationNamingDto::from),
+            inputs: value.inputs.iter().map(IrOperationInputDto::from).collect(),
+            output: IrOperationOutputDto::from(&value.output),
+            entity: value.entity.as_ref().map(IrEntityCandidateDto::from),
+            execution: IrExecutionAttachmentDto::from(&value.execution),
             diagnostics: value.diagnostics.clone(),
         }
     }
 }
 
-impl From<IrOperationFile> for IrOperation {
-    fn from(value: IrOperationFile) -> Self {
+impl From<IrOperationDto> for IrOperation {
+    fn from(value: IrOperationDto) -> Self {
         Self {
             id: value.id,
             method_name: value.method_name,
@@ -352,44 +348,44 @@ macro_rules! copy_struct {
     };
 }
 
-copy_struct!(IrOperationNamingFile => IrOperationNaming { group, operation });
-copy_struct!(IrOperationInputFile => IrOperationInput {
+copy_struct!(IrOperationNamingDto => IrOperationNaming { group, operation });
+copy_struct!(IrOperationInputDto => IrOperationInput {
     name, location, required, data_type, default_value, description, exclude_from_lookup_keys
 });
-copy_struct!(IrOperationOutputFile => IrOperationOutput { cardinality, type_ref, row_path });
-copy_struct!(IrEntityCandidateFile => IrEntityCandidate { name, type_ref, identity_fields });
-copy_struct!(IrFieldFile => IrField { name, type_ref, required, nullable, description });
-copy_struct!(RestRequestBodyFile => RestRequestBody { required, media_type, type_ref });
-copy_struct!(RestParameterBindingFile => RestParameterBinding {
+copy_struct!(IrOperationOutputDto => IrOperationOutput { cardinality, type_ref, row_path });
+copy_struct!(IrEntityCandidateDto => IrEntityCandidate { name, type_ref, identity_fields });
+copy_struct!(IrFieldDto => IrField { name, type_ref, required, nullable, description });
+copy_struct!(RestRequestBodyDto => RestRequestBody { required, media_type, type_ref });
+copy_struct!(RestParameterBindingDto => RestParameterBinding {
     input_name, location, wire_name, required, data_type
 });
-copy_struct!(RestResponseAttachmentFile => RestResponseAttachment {
+copy_struct!(RestResponseAttachmentDto => RestResponseAttachment {
     status_code, media_type, response
 });
-copy_struct!(McpExecutionAttachmentFile => McpExecutionAttachment {
+copy_struct!(McpExecutionAttachmentDto => McpExecutionAttachment {
     tool_name, pagination, offset_pagination
 });
-copy_struct!(ProjectionInputFile => ProjectionInput {
+copy_struct!(ProjectionInputDto => ProjectionInput {
     name, sql_exposure, source_location, wire_name, required, data_type, default_value,
     description, lookup_key
 });
-copy_struct!(ProjectionColumnFile => ProjectionColumn {
+copy_struct!(ProjectionColumnDto => ProjectionColumn {
     name, data_type, source_path, nullable, description
 });
 
-impl From<&IrType> for IrTypeFile {
+impl From<&IrType> for IrTypeDto {
     fn from(value: &IrType) -> Self {
         Self {
             id: value.id.clone(),
-            shape: IrTypeShapeFile::from(&value.shape),
+            shape: IrTypeShapeDto::from(&value.shape),
             nullable: value.nullable,
             description: value.description.clone(),
         }
     }
 }
 
-impl From<IrTypeFile> for IrType {
-    fn from(value: IrTypeFile) -> Self {
+impl From<IrTypeDto> for IrType {
+    fn from(value: IrTypeDto) -> Self {
         Self {
             id: value.id,
             shape: value.shape.into(),
@@ -399,12 +395,12 @@ impl From<IrTypeFile> for IrType {
     }
 }
 
-impl From<&IrTypeShape> for IrTypeShapeFile {
+impl From<&IrTypeShape> for IrTypeShapeDto {
     fn from(value: &IrTypeShape) -> Self {
         match value {
             IrTypeShape::Scalar(value) => Self::Scalar(*value),
             IrTypeShape::Object { fields } => Self::Object {
-                fields: fields.iter().map(IrFieldFile::from).collect(),
+                fields: fields.iter().map(IrFieldDto::from).collect(),
             },
             IrTypeShape::List { item_type_ref } => Self::List {
                 item_type_ref: item_type_ref.clone(),
@@ -420,42 +416,42 @@ impl From<&IrTypeShape> for IrTypeShapeFile {
     }
 }
 
-impl From<IrTypeShapeFile> for IrTypeShape {
-    fn from(value: IrTypeShapeFile) -> Self {
+impl From<IrTypeShapeDto> for IrTypeShape {
+    fn from(value: IrTypeShapeDto) -> Self {
         match value {
-            IrTypeShapeFile::Scalar(value) => Self::Scalar(value),
-            IrTypeShapeFile::Object { fields } => Self::Object {
+            IrTypeShapeDto::Scalar(value) => Self::Scalar(value),
+            IrTypeShapeDto::Object { fields } => Self::Object {
                 fields: fields.into_iter().map(IrField::from).collect(),
             },
-            IrTypeShapeFile::List { item_type_ref } => Self::List { item_type_ref },
-            IrTypeShapeFile::Map { value_type_ref } => Self::Map { value_type_ref },
-            IrTypeShapeFile::Enum { values } => Self::Enum { values },
-            IrTypeShapeFile::Json => Self::Json,
+            IrTypeShapeDto::List { item_type_ref } => Self::List { item_type_ref },
+            IrTypeShapeDto::Map { value_type_ref } => Self::Map { value_type_ref },
+            IrTypeShapeDto::Enum { values } => Self::Enum { values },
+            IrTypeShapeDto::Json => Self::Json,
         }
     }
 }
 
-impl From<&IrExecutionAttachment> for IrExecutionAttachmentFile {
+impl From<&IrExecutionAttachment> for IrExecutionAttachmentDto {
     fn from(value: &IrExecutionAttachment) -> Self {
         match value {
             IrExecutionAttachment::Rest(value) => {
-                Self::Rest(Box::new(RestExecutionAttachmentFile::from(value.as_ref())))
+                Self::Rest(Box::new(RestExecutionAttachmentDto::from(value.as_ref())))
             }
-            IrExecutionAttachment::Mcp(value) => Self::Mcp(McpExecutionAttachmentFile::from(value)),
+            IrExecutionAttachment::Mcp(value) => Self::Mcp(McpExecutionAttachmentDto::from(value)),
         }
     }
 }
 
-impl From<IrExecutionAttachmentFile> for IrExecutionAttachment {
-    fn from(value: IrExecutionAttachmentFile) -> Self {
+impl From<IrExecutionAttachmentDto> for IrExecutionAttachment {
+    fn from(value: IrExecutionAttachmentDto) -> Self {
         match value {
-            IrExecutionAttachmentFile::Rest(value) => Self::Rest(Box::new((*value).into())),
-            IrExecutionAttachmentFile::Mcp(value) => Self::Mcp(value.into()),
+            IrExecutionAttachmentDto::Rest(value) => Self::Rest(Box::new((*value).into())),
+            IrExecutionAttachmentDto::Mcp(value) => Self::Mcp(value.into()),
         }
     }
 }
 
-impl From<&RestExecutionAttachment> for RestExecutionAttachmentFile {
+impl From<&RestExecutionAttachment> for RestExecutionAttachmentDto {
     fn from(value: &RestExecutionAttachment) -> Self {
         Self {
             method: value.method,
@@ -463,17 +459,17 @@ impl From<&RestExecutionAttachment> for RestExecutionAttachmentFile {
             parameters: value
                 .parameters
                 .iter()
-                .map(RestParameterBindingFile::from)
+                .map(RestParameterBindingDto::from)
                 .collect(),
-            request_body: value.request_body.as_ref().map(RestRequestBodyFile::from),
-            response: RestResponseAttachmentFile::from(&value.response),
+            request_body: value.request_body.as_ref().map(RestRequestBodyDto::from),
+            response: RestResponseAttachmentDto::from(&value.response),
             pagination: value.pagination.clone(),
         }
     }
 }
 
-impl From<RestExecutionAttachmentFile> for RestExecutionAttachment {
-    fn from(value: RestExecutionAttachmentFile) -> Self {
+impl From<RestExecutionAttachmentDto> for RestExecutionAttachment {
+    fn from(value: RestExecutionAttachmentDto) -> Self {
         Self {
             method: value.method,
             path_template: value.path_template,
@@ -489,22 +485,22 @@ impl From<RestExecutionAttachmentFile> for RestExecutionAttachment {
     }
 }
 
-impl From<&Projection> for ProjectionFile {
+impl From<&Projection> for ProjectionDto {
     fn from(value: &Projection) -> Self {
         Self {
             name: value.name.clone(),
             namespace: value.namespace.clone(),
-            kind: ProjectionKindFile::from(&value.kind),
+            kind: ProjectionKindDto::from(&value.kind),
             description: value.description.clone(),
             guide: value.guide.clone(),
             surface_id: value.surface_id.clone(),
             operation_id: value.operation_id.clone(),
             visibility: value.visibility,
-            inputs: value.inputs.iter().map(ProjectionInputFile::from).collect(),
+            inputs: value.inputs.iter().map(ProjectionInputDto::from).collect(),
             columns: value
                 .columns
                 .iter()
-                .map(ProjectionColumnFile::from)
+                .map(ProjectionColumnDto::from)
                 .collect(),
             search_limits: value.search_limits.clone(),
             detail_hints: value.detail_hints.clone(),
@@ -513,8 +509,8 @@ impl From<&Projection> for ProjectionFile {
     }
 }
 
-impl From<ProjectionFile> for Projection {
-    fn from(value: ProjectionFile) -> Self {
+impl From<ProjectionDto> for Projection {
+    fn from(value: ProjectionDto) -> Self {
         Self {
             name: value.name,
             namespace: value.namespace,
@@ -541,7 +537,7 @@ impl From<ProjectionFile> for Projection {
     }
 }
 
-impl From<&ProjectionKind> for ProjectionKindFile {
+impl From<&ProjectionKind> for ProjectionKindDto {
     fn from(value: &ProjectionKind) -> Self {
         match value {
             ProjectionKind::Table => Self::Table,
@@ -552,11 +548,11 @@ impl From<&ProjectionKind> for ProjectionKindFile {
     }
 }
 
-impl From<ProjectionKindFile> for ProjectionKind {
-    fn from(value: ProjectionKindFile) -> Self {
+impl From<ProjectionKindDto> for ProjectionKind {
+    fn from(value: ProjectionKindDto) -> Self {
         match value {
-            ProjectionKindFile::Table => Self::Table,
-            ProjectionKindFile::TableFunction { function_kind } => {
+            ProjectionKindDto::Table => Self::Table,
+            ProjectionKindDto::TableFunction { function_kind } => {
                 Self::TableFunction { function_kind }
             }
         }
@@ -565,12 +561,12 @@ impl From<ProjectionKindFile> for ProjectionKind {
 
 #[cfg(test)]
 mod tests {
-    use super::{ProjectionCatalogFile, SemanticIrFile};
+    use super::{ProjectionCatalogDto, SemanticIrDto};
     use crate::v4::{ProjectionCatalog, SemanticIr};
 
     #[test]
     fn schema_v3_semantic_ir_fixture_migrates() {
-        let file: SemanticIrFile =
+        let file: SemanticIrDto =
             serde_yaml::from_str(include_str!("fixtures/v3/semantic-ir.yaml"))
                 .expect("decode schema-v3 semantic IR fixture");
         let runtime = SemanticIr::try_from(file).expect("migrate schema-v3 semantic IR");
@@ -581,7 +577,7 @@ mod tests {
 
     #[test]
     fn schema_v3_projection_fixture_migrates_legacy_defaults() {
-        let file: ProjectionCatalogFile =
+        let file: ProjectionCatalogDto =
             serde_yaml::from_str(include_str!("fixtures/v3/projections.yaml"))
                 .expect("decode schema-v3 projection fixture");
         let runtime = ProjectionCatalog::try_from(file).expect("migrate schema-v3 projections");

--- a/crates/coral-spec/src/v4/artifacts.rs
+++ b/crates/coral-spec/src/v4/artifacts.rs
@@ -54,6 +54,7 @@ pub fn validate_materialized_source(
     manifest: &V4SourceManifest,
     materialized: &V4MaterializedSource,
 ) -> Result<()> {
+    validate_materialized_source_structure(manifest, materialized)?;
     let fingerprint = materialized.fingerprint.as_ref().ok_or_else(|| {
         ManifestError::validation("new DSL v4 materialization is missing its fingerprint")
     })?;
@@ -75,26 +76,11 @@ pub fn validate_materialized_source(
             "DSL v4 materialized importer or generator version mismatch",
         ));
     }
-    if materialized.surfaces.is_empty() {
-        return Err(ManifestError::validation(
-            "DSL v4 materialized source has no surfaces",
-        ));
-    }
-    let mut materialized_surface_ids = BTreeSet::new();
-    for materialized_surface in &materialized.surfaces {
-        if !materialized_surface_ids.insert(materialized_surface.surface_id.as_str()) {
-            return Err(ManifestError::validation(format!(
-                "DSL v4 materialized surface '{}' is repeated",
-                materialized_surface.surface_id
-            )));
-        }
-        if manifest.surface(&materialized_surface.surface_id).is_none() {
-            return Err(ManifestError::validation(format!(
-                "DSL v4 materialized surface '{}' is not declared",
-                materialized_surface.surface_id
-            )));
-        }
-    }
+    let materialized_surface_ids = materialized
+        .surfaces
+        .iter()
+        .map(|surface| surface.surface_id.as_str())
+        .collect::<BTreeSet<_>>();
     let mut fingerprint_surface_ids = BTreeSet::new();
     for fingerprint_surface in &fingerprint.surfaces {
         if !fingerprint_surface_ids.insert(fingerprint_surface.surface_id.as_str()) {
@@ -129,6 +115,43 @@ pub fn validate_materialized_source(
     Ok(())
 }
 
+/// Validates runtime invariants independently of optional artifact provenance.
+pub fn validate_materialized_source_structure(
+    manifest: &V4SourceManifest,
+    materialized: &V4MaterializedSource,
+) -> Result<()> {
+    if materialized.surfaces.is_empty() {
+        return Err(ManifestError::validation(
+            "DSL v4 materialized source has no surfaces",
+        ));
+    }
+    let mut materialized_surface_ids = BTreeSet::new();
+    for materialized_surface in &materialized.surfaces {
+        if !materialized_surface_ids.insert(materialized_surface.surface_id.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "DSL v4 materialized surface '{}' is repeated",
+                materialized_surface.surface_id
+            )));
+        }
+        if manifest.surface(&materialized_surface.surface_id).is_none() {
+            return Err(ManifestError::validation(format!(
+                "DSL v4 materialized surface '{}' is not declared",
+                materialized_surface.surface_id
+            )));
+        }
+    }
+    let mut projection_names = BTreeSet::new();
+    for projection in &materialized.projections.projections {
+        if !projection_names.insert((projection.namespace.as_str(), projection.name.as_str())) {
+            return Err(ManifestError::validation(format!(
+                "DSL v4 projection '{}.{}' is repeated",
+                projection.namespace, projection.name
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -143,7 +166,7 @@ mod tests {
 
     use super::{
         Fingerprint, FingerprintSurface, MaterializedSurface, V4MaterializedSource,
-        validate_materialized_source,
+        validate_materialized_source, validate_materialized_source_structure,
     };
 
     fn manifest() -> V4SourceManifest {
@@ -275,6 +298,30 @@ surfaces:
             error
                 .to_string()
                 .contains("fingerprint surface 'mcp' is not materialized"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn structural_validation_rejects_duplicate_projection_names() {
+        let manifest = manifest();
+        let mut materialized = materialized_source();
+        let dto: crate::v4::ProjectionCatalogDto =
+            serde_yaml::from_str(include_str!("fixtures/v3/projections.yaml"))
+                .expect("decode projection fixture");
+        materialized.projections = ProjectionCatalog::try_from(dto).expect("migrate projections");
+        materialized
+            .projections
+            .projections
+            .push(materialized.projections.projections[0].clone());
+
+        let error = validate_materialized_source_structure(&manifest, &materialized)
+            .expect_err("duplicate projection should fail structural validation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("projection '.items' is repeated"),
             "unexpected error: {error}"
         );
     }

--- a/crates/coral-spec/src/v4/artifacts.rs
+++ b/crates/coral-spec/src/v4/artifacts.rs
@@ -25,7 +25,7 @@ pub struct V4MaterializedSource {
 pub struct MaterializedSurface {
     pub surface_id: String,
     pub semantic_ir: SemanticIr,
-    pub source_document_sha256: String,
+    pub source_document_sha256: Option<String>,
     pub normalized_source_document_path: PathBuf,
     pub raw_source_document_path: PathBuf,
 }
@@ -244,7 +244,7 @@ surfaces:
                 types: Vec::new(),
                 diagnostics: Vec::new(),
             },
-            source_document_sha256: format!("{surface_id}-sha"),
+            source_document_sha256: Some(format!("{surface_id}-sha")),
             normalized_source_document_path: PathBuf::from(format!(
                 "surfaces/{surface_id}/source-document.yaml"
             )),
@@ -310,10 +310,13 @@ surfaces:
             serde_yaml::from_str(include_str!("fixtures/v3/projections.yaml"))
                 .expect("decode projection fixture");
         materialized.projections = ProjectionCatalog::try_from(dto).expect("migrate projections");
-        materialized
+        let duplicate = materialized
             .projections
             .projections
-            .push(materialized.projections.projections[0].clone());
+            .first()
+            .expect("fixture projection")
+            .clone();
+        materialized.projections.projections.push(duplicate);
 
         let error = validate_materialized_source_structure(&manifest, &materialized)
             .expect_err("duplicate projection should fail structural validation");

--- a/crates/coral-spec/src/v4/artifacts.rs
+++ b/crates/coral-spec/src/v4/artifacts.rs
@@ -12,15 +12,16 @@ use crate::v4::{
 };
 use crate::{ManifestError, Result};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct V4MaterializedSource {
-    pub fingerprint: Fingerprint,
+    /// Optional provenance metadata. Runtime loading must not depend on it.
+    pub fingerprint: Option<Fingerprint>,
     pub surfaces: Vec<MaterializedSurface>,
     pub projections: ProjectionCatalog,
     pub diagnostics: Vec<Diagnostic>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct MaterializedSurface {
     pub surface_id: String,
     pub semantic_ir: SemanticIr,
@@ -53,19 +54,22 @@ pub fn validate_materialized_source(
     manifest: &V4SourceManifest,
     materialized: &V4MaterializedSource,
 ) -> Result<()> {
-    if materialized.fingerprint.artifact_schema_version != V4_ARTIFACT_SCHEMA_VERSION {
+    let fingerprint = materialized.fingerprint.as_ref().ok_or_else(|| {
+        ManifestError::validation("new DSL v4 materialization is missing its fingerprint")
+    })?;
+    if fingerprint.artifact_schema_version != V4_ARTIFACT_SCHEMA_VERSION {
         return Err(ManifestError::validation(
             "DSL v4 materialized artifact schema version mismatch",
         ));
     }
-    if materialized.fingerprint.source_name != manifest.common.name {
+    if fingerprint.source_name != manifest.common.name {
         return Err(ManifestError::validation(format!(
             "DSL v4 materialized source identity mismatch for '{}'",
             manifest.common.name
         )));
     }
-    if materialized.fingerprint.importer_version != SURFACE_IMPORTER_VERSION
-        || materialized.fingerprint.projection_generator_version != PROJECTION_GENERATOR_VERSION
+    if fingerprint.importer_version != SURFACE_IMPORTER_VERSION
+        || fingerprint.projection_generator_version != PROJECTION_GENERATOR_VERSION
     {
         return Err(ManifestError::validation(
             "DSL v4 materialized importer or generator version mismatch",
@@ -92,7 +96,7 @@ pub fn validate_materialized_source(
         }
     }
     let mut fingerprint_surface_ids = BTreeSet::new();
-    for fingerprint_surface in &materialized.fingerprint.surfaces {
+    for fingerprint_surface in &fingerprint.surfaces {
         if !fingerprint_surface_ids.insert(fingerprint_surface.surface_id.as_str()) {
             return Err(ManifestError::validation(format!(
                 "DSL v4 fingerprint surface '{}' is repeated",
@@ -167,7 +171,7 @@ surfaces:
 
     fn materialized_source() -> V4MaterializedSource {
         V4MaterializedSource {
-            fingerprint: Fingerprint {
+            fingerprint: Some(Fingerprint {
                 artifact_schema_version: V4_ARTIFACT_SCHEMA_VERSION,
                 source_name: "demo".to_string(),
                 manifest_sha256: "manifest-sha".to_string(),
@@ -177,7 +181,7 @@ surfaces:
                 ],
                 importer_version: SURFACE_IMPORTER_VERSION.to_string(),
                 projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
-            },
+            }),
             surfaces: vec![
                 materialized_surface("rest", SurfaceType::OpenApi),
                 materialized_surface("mcp", SurfaceType::Mcp),
@@ -240,6 +244,8 @@ surfaces:
         let mut materialized = materialized_source();
         materialized
             .fingerprint
+            .as_mut()
+            .expect("fingerprint")
             .surfaces
             .retain(|surface| surface.surface_id != "mcp");
 

--- a/crates/coral-spec/src/v4/fixtures/v3/mcp-semantic-ir.yaml
+++ b/crates/coral-spec/src/v4/fixtures/v3/mcp-semantic-ir.yaml
@@ -1,0 +1,82 @@
+artifact_schema_version: 3
+source_name: compatibility_fixture
+surface_id: mcp
+surface_type: mcp
+importer_version: mcp-tools-v1
+operations:
+  - id: search_items
+    method_name: search_items
+    description: Search items exposed by an MCP server
+    deprecated: false
+    read_only: true
+    naming: null
+    inputs:
+      - name: query
+        location: tool_arg
+        required: true
+        data_type: string
+        default_value: null
+        description: Search expression
+        exclude_from_lookup_keys: false
+      - name: limit
+        location: tool_arg
+        required: false
+        data_type: integer
+        default_value: "20"
+        description: Maximum result count
+        exclude_from_lookup_keys: true
+    output:
+      cardinality: list
+      type_ref: McpItem
+      row_path:
+        - content
+        - items
+    entity: null
+    execution:
+      type: mcp
+      value:
+        tool_name: search_items
+        pagination:
+          cursor_arg: cursor
+          response_cursor_path:
+            - next_cursor
+          max_pages: 5
+        offset_pagination:
+          limit_arg: limit
+          default_limit: 20
+          max_limit: 100
+          offset_arg: offset
+          offset_start: 0
+          max_pages: 8
+    diagnostics: []
+types:
+  - id: McpItem
+    shape:
+      type: object
+      value:
+        fields:
+          - name: id
+            type_ref: McpItemId
+            required: true
+            nullable: false
+            description: MCP item identifier
+          - name: score
+            type_ref: McpScore
+            required: false
+            nullable: true
+            description: Search relevance
+    nullable: false
+    description: MCP search result
+  - id: McpItemId
+    shape:
+      type: scalar
+      value: string
+    nullable: false
+    description: MCP item identifier
+  - id: McpScore
+    shape:
+      type: scalar
+      value: number
+    nullable: true
+    description: Search relevance score
+diagnostics: []

--- a/crates/coral-spec/src/v4/fixtures/v3/projections.yaml
+++ b/crates/coral-spec/src/v4/fixtures/v3/projections.yaml
@@ -5,14 +5,109 @@ projections:
   - name: items
     kind:
       type: table
-    description: Compatibility fixture
-    guide: ""
+    description: Items owned by an account
+    guide: Filter by owner for an exact lookup
     surface_id: rest
     operation_id: list_items
     visibility: published
-    inputs: []
-    columns: []
+    inputs:
+      - name: owner
+        sql_exposure: filter
+        source_location: path
+        wire_name: owner
+        required: true
+        data_type: Utf8
+        default_value: null
+        description: Account owner
+        lookup_key: true
+      - name: cursor
+        sql_exposure: internal
+        source_location: query
+        wire_name: cursor
+        required: false
+        data_type: Utf8
+        default_value: null
+        description: Pagination cursor
+        lookup_key: false
+    columns:
+      - name: id
+        data_type: Utf8
+        source_path:
+          - id
+        nullable: false
+        description: Stable item identifier
+      - name: state
+        data_type: Utf8
+        source_path:
+          - state
+        nullable: true
+        description: Current state
     search_limits: null
     detail_hints: []
+    diagnostics:
+      - code: V3_PROJECTION_NOTE
+        severity: info
+        message: Projection retained for schema-v3 compatibility
+        surface_id: rest
+        operation_id: list_items
+        projection_name: items
+  - name: search_items
+    namespace: compatibility_fixture_mcp
+    kind:
+      type: table_function
+      value:
+        function_kind: search
+    description: Search items through MCP
+    guide: Use a selective query and follow the detail hint
+    surface_id: mcp
+    operation_id: search_items
+    visibility: hidden
+    inputs:
+      - name: query
+        sql_exposure: function_arg
+        source_location: tool_arg
+        wire_name: query
+        required: true
+        data_type: Utf8
+        default_value: null
+        description: Search expression
+        lookup_key: false
+      - name: limit
+        sql_exposure: internal
+        source_location: tool_arg
+        wire_name: limit
+        required: false
+        data_type: Int64
+        default_value: "20"
+        description: Maximum result count
+        lookup_key: false
+    columns:
+      - name: id
+        data_type: Utf8
+        source_path:
+          - id
+        nullable: false
+        description: MCP item identifier
+      - name: score
+        data_type: Float64
+        source_path:
+          - score
+        nullable: true
+        description: Search relevance score
+    search_limits:
+      default_top_k: 20
+      max_top_k: 100
+      max_calls_per_query: 10
+    detail_hints:
+      - table: items
+        search_result_column: id
+        detail_filter: id
+        purpose: Fetch the complete item after search
     diagnostics: []
-diagnostics: []
+diagnostics:
+  - code: V3_CATALOG_NOTE
+    severity: warning
+    message: Fixture-level projection catalog diagnostic
+    surface_id: null
+    operation_id: null
+    projection_name: null

--- a/crates/coral-spec/src/v4/fixtures/v3/projections.yaml
+++ b/crates/coral-spec/src/v4/fixtures/v3/projections.yaml
@@ -1,0 +1,18 @@
+artifact_schema_version: 3
+source_name: compatibility_fixture
+generator_version: derive-read-v8
+projections:
+  - name: items
+    kind:
+      type: table
+    description: Compatibility fixture
+    guide: ""
+    surface_id: rest
+    operation_id: list_items
+    visibility: published
+    inputs: []
+    columns: []
+    search_limits: null
+    detail_hints: []
+    diagnostics: []
+diagnostics: []

--- a/crates/coral-spec/src/v4/fixtures/v3/semantic-ir.yaml
+++ b/crates/coral-spec/src/v4/fixtures/v3/semantic-ir.yaml
@@ -3,6 +3,160 @@ source_name: compatibility_fixture
 surface_id: rest
 surface_type: open_api
 importer_version: openapi-v4
-operations: []
-types: []
-diagnostics: []
+operations:
+  - id: list_items
+    method_name: listItems
+    description: List items owned by an account
+    deprecated: false
+    read_only: true
+    naming:
+      group: items
+      operation: list
+    inputs:
+      - name: owner
+        location: path
+        required: true
+        data_type: string
+        default_value: null
+        description: Account owner
+        exclude_from_lookup_keys: false
+      - name: cursor
+        location: query
+        required: false
+        data_type: string
+        default_value: null
+        description: Pagination cursor
+        exclude_from_lookup_keys: true
+    output:
+      cardinality: wrapped_list
+      type_ref: Item
+      row_path:
+        - data
+        - items
+    entity:
+      name: item
+      type_ref: Item
+      identity_fields:
+        - id
+    execution:
+      type: rest
+      value:
+        method: get
+        path_template: /owners/{owner}/items
+        parameters:
+          - input_name: owner
+            location: path
+            wire_name: owner
+            required: true
+            data_type: string
+          - input_name: cursor
+            location: query
+            wire_name: cursor
+            required: false
+            data_type: string
+        request_body:
+          required: false
+          media_type: application/json
+          type_ref: ItemQuery
+        response:
+          status_code: 200
+          media_type: application/json
+          response:
+            format: json
+            rows_path:
+              - data
+              - items
+            ok_path:
+              - ok
+            error_path:
+              - error
+            allow_404_empty: true
+            row_strategy: direct
+        pagination:
+          mode: cursor_query
+          page_size:
+            default: 25
+            max: 100
+            query_param: per_page
+            body_path: []
+          cursor_param: cursor
+          cursor_body_path: []
+          response_cursor_path:
+            - page_info
+            - next_cursor
+          response_cursor_header: null
+          page_param: null
+          page_start: 0
+          page_step: 1
+          offset_param: null
+          offset_start: 0
+          offset_step: null
+          link_header_require_results: false
+          next_url_header: null
+          max_pages: 10
+    diagnostics:
+      - code: V3_OPERATION_NOTE
+        severity: info
+        message: Imported from the schema-v3 compatibility fixture
+        surface_id: rest
+        operation_id: list_items
+        projection_name: null
+types:
+  - id: Item
+    shape:
+      type: object
+      value:
+        fields:
+          - name: id
+            type_ref: ItemId
+            required: true
+            nullable: false
+            description: Stable item identifier
+          - name: state
+            type_ref: ItemState
+            required: false
+            nullable: true
+            description: Current state
+    nullable: false
+    description: Item returned by the service
+  - id: ItemId
+    shape:
+      type: scalar
+      value: id
+    nullable: false
+    description: Item identifier
+  - id: ItemList
+    shape:
+      type: list
+      value:
+        item_type_ref: Item
+    nullable: false
+    description: List of items
+  - id: ItemMap
+    shape:
+      type: map
+      value:
+        value_type_ref: Item
+    nullable: false
+    description: Items keyed by identifier
+  - id: ItemState
+    shape:
+      type: enum
+      value:
+        values:
+          - open
+          - closed
+    nullable: true
+    description: Item lifecycle state
+  - id: ItemQuery
+    shape:
+      type: json
+    nullable: true
+    description: Optional request payload
+diagnostics:
+  - code: V3_IR_NOTE
+    severity: warning
+    message: Fixture-level semantic IR diagnostic
+    surface_id: rest
+    operation_id: null
+    projection_name: null

--- a/crates/coral-spec/src/v4/fixtures/v3/semantic-ir.yaml
+++ b/crates/coral-spec/src/v4/fixtures/v3/semantic-ir.yaml
@@ -1,0 +1,8 @@
+artifact_schema_version: 3
+source_name: compatibility_fixture
+surface_id: rest
+surface_type: open_api
+importer_version: openapi-v4
+operations: []
+types: []
+diagnostics: []

--- a/crates/coral-spec/src/v4/ir/mcp.rs
+++ b/crates/coral-spec/src/v4/ir/mcp.rs
@@ -1,12 +1,8 @@
-use serde::{Deserialize, Serialize};
-
 use crate::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct McpExecutionAttachment {
     pub tool_name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pagination: Option<McpPaginationSpec>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub offset_pagination: Option<McpOffsetPaginationSpec>,
 }

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -5,7 +5,7 @@ use crate::v4::ir::mcp::McpExecutionAttachment;
 use crate::v4::ir::rest::RestExecutionAttachment;
 use crate::v4::manifest::SurfaceType;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct SemanticIr {
     pub artifact_schema_version: u32,
     pub source_name: String,
@@ -17,14 +17,13 @@ pub struct SemanticIr {
     pub diagnostics: Vec<Diagnostic>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct IrOperation {
     pub id: String,
     pub method_name: String,
     pub description: String,
     pub deprecated: bool,
     pub read_only: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub naming: Option<IrOperationNaming>,
     pub inputs: Vec<IrOperationInput>,
     pub output: IrOperationOutput,
@@ -33,15 +32,13 @@ pub struct IrOperation {
     pub diagnostics: Vec<Diagnostic>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct IrOperationNaming {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub group: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub operation: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct IrOperationInput {
     pub name: String,
     pub location: IrInputLocation,
@@ -49,18 +46,17 @@ pub struct IrOperationInput {
     pub data_type: IrScalarType,
     pub default_value: Option<String>,
     pub description: String,
-    #[serde(default)]
     pub exclude_from_lookup_keys: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct IrOperationOutput {
     pub cardinality: OutputCardinality,
     pub type_ref: String,
     pub row_path: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct IrEntityCandidate {
     pub name: String,
     pub type_ref: String,
@@ -77,7 +73,7 @@ pub enum OutputCardinality {
     Unknown,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct IrType {
     pub id: String,
     pub shape: IrTypeShape,
@@ -85,8 +81,7 @@ pub struct IrType {
     pub description: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+#[derive(Debug, Clone)]
 pub enum IrTypeShape {
     Scalar(IrScalarType),
     Object { fields: Vec<IrField> },
@@ -96,7 +91,7 @@ pub enum IrTypeShape {
     Json,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct IrField {
     pub name: String,
     pub type_ref: String,
@@ -160,8 +155,7 @@ pub enum HttpMethod {
     Trace,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+#[derive(Debug, Clone)]
 pub enum IrExecutionAttachment {
     Rest(Box<RestExecutionAttachment>),
     Mcp(McpExecutionAttachment),
@@ -175,6 +169,7 @@ mod tests {
         SemanticIr,
     };
     use crate::PaginationSpec;
+    use crate::v4::artifact_model::{IrOperationInputFile, SemanticIrFile};
     use crate::v4::diagnostics::Diagnostic;
     use crate::v4::ir::mcp::McpExecutionAttachment;
     use crate::v4::ir::rest::{RestExecutionAttachment, RestResponseAttachment};
@@ -242,7 +237,8 @@ mod tests {
             )],
         };
 
-        let yaml = serde_yaml::to_string(&ir).expect("serialize semantic IR");
+        let yaml =
+            serde_yaml::to_string(&SemanticIrFile::from(&ir)).expect("serialize semantic IR");
         assert!(
             !yaml.contains('!'),
             "semantic IR should not use YAML local tags: {yaml}"
@@ -251,7 +247,9 @@ mod tests {
         assert!(yaml.contains("type: object"), "missing object tag: {yaml}");
         assert!(yaml.contains("type: scalar"), "missing scalar tag: {yaml}");
 
-        serde_yaml::from_str::<SemanticIr>(&yaml).expect("semantic IR should round-trip");
+        let file: SemanticIrFile =
+            serde_yaml::from_str(&yaml).expect("semantic IR file should round-trip");
+        SemanticIr::try_from(file).expect("semantic IR should migrate");
     }
 
     #[test]
@@ -300,7 +298,8 @@ mod tests {
             diagnostics: Vec::new(),
         };
 
-        let yaml = serde_yaml::to_string(&ir).expect("serialize MCP semantic IR");
+        let yaml =
+            serde_yaml::to_string(&SemanticIrFile::from(&ir)).expect("serialize MCP semantic IR");
         assert!(
             yaml.contains(&format!(
                 "artifact_schema_version: {V4_ARTIFACT_SCHEMA_VERSION}"
@@ -320,7 +319,9 @@ mod tests {
             "missing tool arg input: {yaml}"
         );
 
-        serde_yaml::from_str::<SemanticIr>(&yaml).expect("MCP semantic IR should round-trip");
+        let file: SemanticIrFile =
+            serde_yaml::from_str(&yaml).expect("MCP semantic IR file should round-trip");
+        SemanticIr::try_from(file).expect("MCP semantic IR should migrate");
     }
 
     #[test]
@@ -343,7 +344,7 @@ diagnostics: []
 "#
         );
 
-        let error = serde_yaml::from_str::<SemanticIr>(&legacy_yaml)
+        let error = serde_yaml::from_str::<SemanticIrFile>(&legacy_yaml)
             .expect_err("semantic IR should reject legacy local tags");
         assert!(
             error.to_string().contains("shape") || error.to_string().contains("type"),
@@ -363,7 +364,8 @@ diagnostics: []
             exclude_from_lookup_keys: false,
         };
 
-        let yaml = serde_yaml::to_string(&input).expect("serialize input");
+        let yaml =
+            serde_yaml::to_string(&IrOperationInputFile::from(&input)).expect("serialize input");
         assert!(
             yaml.contains("location: path"),
             "unexpected serialized input: {yaml}"
@@ -373,7 +375,7 @@ diagnostics: []
             "Rust type names must not leak into artifacts: {yaml}"
         );
 
-        let decoded: IrOperationInput = serde_yaml::from_str(&yaml).expect("deserialize input");
+        let decoded: IrOperationInputFile = serde_yaml::from_str(&yaml).expect("deserialize input");
         assert_eq!(decoded.location, IrInputLocation::Path);
     }
 }

--- a/crates/coral-spec/src/v4/ir/model.rs
+++ b/crates/coral-spec/src/v4/ir/model.rs
@@ -169,7 +169,7 @@ mod tests {
         SemanticIr,
     };
     use crate::PaginationSpec;
-    use crate::v4::artifact_model::{IrOperationInputFile, SemanticIrFile};
+    use crate::v4::artifact_model::{IrOperationInputDto, SemanticIrDto};
     use crate::v4::diagnostics::Diagnostic;
     use crate::v4::ir::mcp::McpExecutionAttachment;
     use crate::v4::ir::rest::{RestExecutionAttachment, RestResponseAttachment};
@@ -237,8 +237,7 @@ mod tests {
             )],
         };
 
-        let yaml =
-            serde_yaml::to_string(&SemanticIrFile::from(&ir)).expect("serialize semantic IR");
+        let yaml = serde_yaml::to_string(&SemanticIrDto::from(&ir)).expect("serialize semantic IR");
         assert!(
             !yaml.contains('!'),
             "semantic IR should not use YAML local tags: {yaml}"
@@ -247,7 +246,7 @@ mod tests {
         assert!(yaml.contains("type: object"), "missing object tag: {yaml}");
         assert!(yaml.contains("type: scalar"), "missing scalar tag: {yaml}");
 
-        let file: SemanticIrFile =
+        let file: SemanticIrDto =
             serde_yaml::from_str(&yaml).expect("semantic IR file should round-trip");
         SemanticIr::try_from(file).expect("semantic IR should migrate");
     }
@@ -299,7 +298,7 @@ mod tests {
         };
 
         let yaml =
-            serde_yaml::to_string(&SemanticIrFile::from(&ir)).expect("serialize MCP semantic IR");
+            serde_yaml::to_string(&SemanticIrDto::from(&ir)).expect("serialize MCP semantic IR");
         assert!(
             yaml.contains(&format!(
                 "artifact_schema_version: {V4_ARTIFACT_SCHEMA_VERSION}"
@@ -319,7 +318,7 @@ mod tests {
             "missing tool arg input: {yaml}"
         );
 
-        let file: SemanticIrFile =
+        let file: SemanticIrDto =
             serde_yaml::from_str(&yaml).expect("MCP semantic IR file should round-trip");
         SemanticIr::try_from(file).expect("MCP semantic IR should migrate");
     }
@@ -344,7 +343,7 @@ diagnostics: []
 "#
         );
 
-        let error = serde_yaml::from_str::<SemanticIrFile>(&legacy_yaml)
+        let error = serde_yaml::from_str::<SemanticIrDto>(&legacy_yaml)
             .expect_err("semantic IR should reject legacy local tags");
         assert!(
             error.to_string().contains("shape") || error.to_string().contains("type"),
@@ -365,7 +364,7 @@ diagnostics: []
         };
 
         let yaml =
-            serde_yaml::to_string(&IrOperationInputFile::from(&input)).expect("serialize input");
+            serde_yaml::to_string(&IrOperationInputDto::from(&input)).expect("serialize input");
         assert!(
             yaml.contains("location: path"),
             "unexpected serialized input: {yaml}"
@@ -375,7 +374,7 @@ diagnostics: []
             "Rust type names must not leak into artifacts: {yaml}"
         );
 
-        let decoded: IrOperationInputFile = serde_yaml::from_str(&yaml).expect("deserialize input");
+        let decoded: IrOperationInputDto = serde_yaml::from_str(&yaml).expect("deserialize input");
         assert_eq!(decoded.location, IrInputLocation::Path);
     }
 }

--- a/crates/coral-spec/src/v4/ir/rest.rs
+++ b/crates/coral-spec/src/v4/ir/rest.rs
@@ -1,9 +1,7 @@
-use serde::{Deserialize, Serialize};
-
 use crate::v4::ir::{HttpMethod, IrInputLocation, IrScalarType};
 use crate::{PaginationSpec, ResponseSpec};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct RestExecutionAttachment {
     pub method: HttpMethod,
     pub path_template: String,
@@ -13,14 +11,14 @@ pub struct RestExecutionAttachment {
     pub pagination: PaginationSpec,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct RestRequestBody {
     pub required: bool,
     pub media_type: String,
     pub type_ref: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct RestParameterBinding {
     pub input_name: String,
     pub location: IrInputLocation,
@@ -29,7 +27,7 @@ pub struct RestParameterBinding {
     pub data_type: IrScalarType,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct RestResponseAttachment {
     pub status_code: u16,
     pub media_type: String,

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -30,7 +30,7 @@ mod projection_tests;
 #[cfg(test)]
 mod test_support;
 
-pub use artifact_model::{ArtifactMigrationError, ProjectionCatalogFile, SemanticIrFile};
+pub use artifact_model::{ArtifactMigrationError, ProjectionCatalogDto, SemanticIrDto};
 pub use artifacts::{
     Fingerprint, FingerprintSurface, MaterializedSurface, V4MaterializedSource,
     validate_materialized_source,

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -9,6 +9,7 @@ pub const OPENAPI_IMPORTER_VERSION: &str = "openapi-v4";
 pub const MCP_IMPORTER_VERSION: &str = "mcp-tools-v1";
 pub const PROJECTION_GENERATOR_VERSION: &str = "derive-read-v8";
 
+mod artifact_model;
 mod artifacts;
 mod diagnostics;
 mod ir;
@@ -29,6 +30,7 @@ mod projection_tests;
 #[cfg(test)]
 mod test_support;
 
+pub use artifact_model::{ArtifactMigrationError, ProjectionCatalogFile, SemanticIrFile};
 pub use artifacts::{
     Fingerprint, FingerprintSurface, MaterializedSurface, V4MaterializedSource,
     validate_materialized_source,

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -33,7 +33,7 @@ mod test_support;
 pub use artifact_model::{ArtifactMigrationError, ProjectionCatalogDto, SemanticIrDto};
 pub use artifacts::{
     Fingerprint, FingerprintSurface, MaterializedSurface, V4MaterializedSource,
-    validate_materialized_source,
+    validate_materialized_source, validate_materialized_source_structure,
 };
 pub use diagnostics::{Diagnostic, DiagnosticSeverity};
 pub use ir::{

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -4,20 +4,18 @@ use crate::v4::diagnostics::Diagnostic;
 use crate::v4::ir::IrInputLocation;
 use crate::{DetailHintSpec, ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ProjectionCatalog {
     pub artifact_schema_version: u32,
     pub source_name: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub generator_version: Option<String>,
     pub projections: Vec<Projection>,
     pub diagnostics: Vec<Diagnostic>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Projection {
     pub name: String,
-    #[serde(default)]
     pub namespace: String,
     pub kind: ProjectionKind,
     pub description: String,
@@ -32,8 +30,7 @@ pub struct Projection {
     pub diagnostics: Vec<Diagnostic>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+#[derive(Debug, Clone)]
 pub enum ProjectionKind {
     Table,
     TableFunction {
@@ -48,7 +45,7 @@ pub enum ProjectionVisibility {
     Hidden,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ProjectionInput {
     pub name: String,
     pub sql_exposure: SqlInputExposure,
@@ -61,7 +58,6 @@ pub struct ProjectionInput {
     /// Whether this filter input is a complete exact lookup: the API returns
     /// every row matching an equality value, so dependent joins may bind to
     /// it. Meaningless (and false) for non-filter exposures.
-    #[serde(default)]
     pub lookup_key: bool,
 }
 
@@ -73,7 +69,7 @@ pub enum SqlInputExposure {
     Internal,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct ProjectionColumn {
     pub name: String,
     pub data_type: ManifestDataType,
@@ -87,6 +83,7 @@ mod tests {
     use super::{
         Projection, ProjectionCatalog, ProjectionKind, ProjectionVisibility, SqlInputExposure,
     };
+    use crate::v4::artifact_model::ProjectionCatalogFile;
     use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
     use crate::{ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
 
@@ -120,7 +117,8 @@ mod tests {
             diagnostics: Vec::new(),
         };
 
-        let yaml = serde_yaml::to_string(&catalog).expect("serialize projection catalog");
+        let yaml = serde_yaml::to_string(&ProjectionCatalogFile::from(&catalog))
+            .expect("serialize projection catalog");
         assert!(
             !yaml.contains('!'),
             "projection catalog should not use YAML local tags: {yaml}"
@@ -138,8 +136,9 @@ mod tests {
             "projection catalog should not serialize pagination: {yaml}"
         );
 
-        serde_yaml::from_str::<ProjectionCatalog>(&yaml)
-            .expect("projection catalog should round-trip");
+        let file: ProjectionCatalogFile =
+            serde_yaml::from_str(&yaml).expect("projection catalog file should round-trip");
+        ProjectionCatalog::try_from(file).expect("projection catalog should migrate");
     }
 
     #[test]
@@ -169,8 +168,9 @@ diagnostics: []
 "
         );
 
-        let catalog: ProjectionCatalog =
+        let file: ProjectionCatalogFile =
             serde_yaml::from_str(&raw).expect("legacy projection catalog should deserialize");
+        let catalog = ProjectionCatalog::try_from(file).expect("legacy catalog should migrate");
         assert_eq!(
             catalog.projections.first().expect("projection").namespace,
             ""
@@ -188,8 +188,9 @@ diagnostics: []
 "
         );
 
-        let catalog: ProjectionCatalog =
+        let file: ProjectionCatalogFile =
             serde_yaml::from_str(&raw).expect("projection override catalog should deserialize");
+        let catalog = ProjectionCatalog::try_from(file).expect("override catalog should migrate");
 
         assert_eq!(catalog.generator_version, None);
     }

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -83,7 +83,7 @@ mod tests {
     use super::{
         Projection, ProjectionCatalog, ProjectionKind, ProjectionVisibility, SqlInputExposure,
     };
-    use crate::v4::artifact_model::ProjectionCatalogFile;
+    use crate::v4::artifact_model::ProjectionCatalogDto;
     use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
     use crate::{ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
 
@@ -117,7 +117,7 @@ mod tests {
             diagnostics: Vec::new(),
         };
 
-        let yaml = serde_yaml::to_string(&ProjectionCatalogFile::from(&catalog))
+        let yaml = serde_yaml::to_string(&ProjectionCatalogDto::from(&catalog))
             .expect("serialize projection catalog");
         assert!(
             !yaml.contains('!'),
@@ -136,7 +136,7 @@ mod tests {
             "projection catalog should not serialize pagination: {yaml}"
         );
 
-        let file: ProjectionCatalogFile =
+        let file: ProjectionCatalogDto =
             serde_yaml::from_str(&yaml).expect("projection catalog file should round-trip");
         ProjectionCatalog::try_from(file).expect("projection catalog should migrate");
     }
@@ -168,7 +168,7 @@ diagnostics: []
 "
         );
 
-        let file: ProjectionCatalogFile =
+        let file: ProjectionCatalogDto =
             serde_yaml::from_str(&raw).expect("legacy projection catalog should deserialize");
         let catalog = ProjectionCatalog::try_from(file).expect("legacy catalog should migrate");
         assert_eq!(
@@ -188,7 +188,7 @@ diagnostics: []
 "
         );
 
-        let file: ProjectionCatalogFile =
+        let file: ProjectionCatalogDto =
             serde_yaml::from_str(&raw).expect("projection override catalog should deserialize");
         let catalog = ProjectionCatalog::try_from(file).expect("override catalog should migrate");
 


### PR DESCRIPTION
## Problem

Coral currently treats a DSL v4 materialization fingerprint mismatch as proof that an installed source is unusable. A producer-version change, manifest edit, or stale provenance hash can therefore prevent Coral from starting even when the persisted semantic IR and projections remain readable and executable.

The root cause is that runtime IR/projection models double as the on-disk serialization contract, while provenance validation and artifact compatibility are handled as one fail-closed check. That couples harmless implementation evolution to source availability and lets one broken source or surface disable unrelated installed sources.

## Changes

- Add separate persisted DTOs for semantic IR and projection catalogs, with explicit DTO-to-runtime migration seams, expanded schema-v3 fixtures, and an app-level test that loads literal legacy artifacts into a usable catalog.
- Treat fingerprints, producer versions, identity metadata, and raw-document hashes as advisory provenance. Mismatches emit tracing diagnostics and do not block compatible artifacts.
- Make fingerprint and diagnostics artifacts optional at load time, and represent missing source-document provenance explicitly rather than as an empty hash.
- Migrate legacy projections without a namespace to the referenced surface namespace, avoiding false-positive mismatch diagnostics.
- Keep provenance-independent runtime structure strict: duplicate qualified projection names still fail loading because they cannot be interpreted unambiguously.
- Recover at surface granularity: a surface whose IR cannot be read or migrated is excluded while compatible sibling surfaces remain available.
- Recover at source granularity in query and local catalog loading: an unusable source emits a diagnostic and is skipped without disabling other installed sources. Operational failures such as unavailable credential storage and unreadable manifests still fail closed.
- Own diagnostic deduplication in app-scoped state shared by source, query, and search managers, and clear tracked state when a source is deleted.
- Preserve authoritative projection overrides and the existing user-owned lifecycle: Coral does not regenerate, refresh, or rewrite installed artifacts while loading them.
- Update contributor and agent guidance to make backward-compatible artifact migrations and source isolation durable project policy.

## User impact

Existing DSL v4 installations continue to run across harmless Coral changes. Only genuinely unreadable, unmigratable, or structurally ambiguous artifacts are excluded. If one surface or source is broken, healthy siblings remain usable and Coral continues starting.

Compatibility diagnostics currently emit through tracing. Making those diagnostics visible through user-facing Coral surfaces is a broader concern intentionally deferred to a separate PR.

## Validation

- `make rust-checks`
  - formatting and Clippy clean
  - 1,596 tests passed
  - Rustdoc warnings denied
- `make perf-check`
  - `coral.tables` mean: 200.9 ms
  - threshold: 750 ms
