### PR TITLE
test(cli): cover identity-spec commands

### DIFF
--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -17,8 +17,8 @@ use arrow::record_batch::RecordBatch;
 #[cfg(feature = "embedded-ui")]
 use assert_cmd::Command;
 use coral_api::v1::{
-    DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, ListWorkspacesResponse,
-    Source, SourceCredentialStorage, SourceInfo, SourceOrigin, Workspace,
+    DiscoverSourcesResponse, ExecuteSqlResponse, IdentitySpecInputValue, ListSourcesResponse,
+    ListWorkspacesResponse, Source, SourceCredentialStorage, SourceInfo, SourceOrigin, Workspace,
 };
 use tempfile::tempdir;
 use tonic::Code;
@@ -59,6 +59,36 @@ fn nonempty_lines(output: &str) -> Vec<&str> {
         .filter(|line| !line.is_empty())
         .collect()
 }
+
+const IDENTITY_SPEC_WITH_INPUTS: &str = r"kind: identity
+spec_version: 1
+name: demo_oauth
+version: 1.0.0
+issuer: demo
+type: oauth
+inputs:
+  TENANT:
+    kind: variable
+    default: public
+  CLIENT_SECRET:
+    kind: secret
+    required: true
+oauth:
+  method:
+    flow:
+      type: authorization_code
+      pkce: disabled
+    redirect_uri: http://127.0.0.1:53682/oauth/callback
+    endpoints:
+      authorization_url: https://provider.example.com/authorize
+      token_url: https://provider.example.com/token
+    client:
+      id:
+        input: TENANT
+      secret:
+        input: CLIENT_SECRET
+        transport: basic_auth
+";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn sql_command_renders_table_output() {
@@ -236,6 +266,183 @@ async fn workspace_remove_sends_request() {
     let requests = server.delete_workspace_requests();
     assert_eq!(requests.len(), 1, "expected one delete_workspace call");
     assert_workspace_name(requests[0].workspace.as_ref(), "work");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_add_preserves_manifest_and_maps_non_tty_inputs() {
+    let server = MockServer::start().await;
+    let directory = tempdir().expect("identity spec dir");
+    let manifest = directory.path().join("identity.yaml");
+    std::fs::write(&manifest, IDENTITY_SPEC_WITH_INPUTS).expect("write identity spec");
+    let secret = "super-secret-sentinel";
+
+    let default_assert = server
+        .cmd()
+        .env_remove("CORAL_WORKSPACE")
+        .env("TENANT", "tenant-from-env")
+        .env("CLIENT_SECRET", secret)
+        .args(["identity-spec", "add", "--file"])
+        .arg(&manifest)
+        .assert()
+        .success();
+    let default_stdout = String::from_utf8_lossy(&default_assert.get_output().stdout);
+    let default_stderr = String::from_utf8_lossy(&default_assert.get_output().stderr);
+    assert!(
+        default_stdout.contains("Added identity spec 'demo_oauth'")
+            && default_stdout.contains("workspace 'default'"),
+        "expected default-scope install: {default_stdout}"
+    );
+    assert!(!default_stdout.contains(secret), "secret leaked to stdout");
+    assert!(!default_stderr.contains(secret), "secret leaked to stderr");
+
+    let custom_assert = server
+        .cmd()
+        .env_remove("CORAL_WORKSPACE")
+        .env_remove("TENANT")
+        .env_remove("CLIENT_SECRET")
+        .args(["--workspace", "work", "identity-spec", "add", "--file"])
+        .arg(&manifest)
+        .assert()
+        .success();
+    let custom_stdout = String::from_utf8_lossy(&custom_assert.get_output().stdout);
+    assert!(
+        custom_stdout.contains("Replaced identity spec 'demo_oauth'")
+            && custom_stdout.contains("workspace 'work'"),
+        "expected custom-scope replacement: {custom_stdout}"
+    );
+
+    let requests = server.add_identity_spec_requests();
+    assert_eq!(requests.len(), 2, "expected two add_identity_spec calls");
+    assert_default_workspace(requests[0].workspace.as_ref());
+    assert_eq!(requests[0].manifest_yaml, IDENTITY_SPEC_WITH_INPUTS);
+    assert_eq!(
+        requests[0].input_values,
+        vec![
+            IdentitySpecInputValue {
+                key: "TENANT".to_string(),
+                value: "tenant-from-env".to_string(),
+            },
+            IdentitySpecInputValue {
+                key: "CLIENT_SECRET".to_string(),
+                value: secret.to_string(),
+            },
+        ]
+    );
+    assert_workspace_name(requests[1].workspace.as_ref(), "work");
+    assert_eq!(requests[1].manifest_yaml, IDENTITY_SPEC_WITH_INPUTS);
+    assert!(
+        requests[1].input_values.is_empty(),
+        "replacement must omit unavailable inputs"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_list_and_info_render_requested_scopes() {
+    let server = MockServer::start().await;
+
+    let default_assert = server
+        .cmd()
+        .env_remove("CORAL_WORKSPACE")
+        .args(["identity-spec", "list", "--include-global"])
+        .assert()
+        .success();
+    let default_stdout = String::from_utf8_lossy(&default_assert.get_output().stdout);
+    for expected in [
+        "Identity Spec",
+        "Scope",
+        "workspace_demo",
+        "workspace:default",
+        "global_demo",
+    ] {
+        assert!(
+            default_stdout.contains(expected),
+            "expected {expected:?} in list output: {default_stdout}"
+        );
+    }
+    assert!(
+        nonempty_lines(&default_stdout)
+            .iter()
+            .any(|line| line.starts_with("global_demo") && line.ends_with("global")),
+        "expected global scope column: {default_stdout}"
+    );
+
+    let custom_assert = server
+        .cmd()
+        .env_remove("CORAL_WORKSPACE")
+        .args(["--workspace", "work", "identity-spec", "list"])
+        .assert()
+        .success();
+    let custom_stdout = String::from_utf8_lossy(&custom_assert.get_output().stdout);
+    assert!(custom_stdout.contains("workspace:work"), "{custom_stdout}");
+    assert!(!custom_stdout.contains("global_demo"), "{custom_stdout}");
+
+    let list_requests = server.list_identity_specs_requests();
+    assert_eq!(list_requests.len(), 2, "expected two list calls");
+    assert_default_workspace(list_requests[0].workspace.as_ref());
+    assert!(list_requests[0].include_global);
+    assert_workspace_name(list_requests[1].workspace.as_ref(), "work");
+    assert!(!list_requests[1].include_global);
+
+    let info_assert = server
+        .cmd()
+        .env("CORAL_WORKSPACE", "ignored")
+        .args(["identity-spec", "info", "global_demo", "--global"])
+        .assert()
+        .success();
+    let info_stdout = String::from_utf8_lossy(&info_assert.get_output().stdout);
+    for expected in [
+        "global_demo",
+        "Scope:       global",
+        "Version:     1.0.0",
+        "Description: Mock identity spec",
+        "Issuer:      demo",
+        "Type:        fixed_token",
+        "Manifest:",
+        "name: global_demo",
+    ] {
+        assert!(
+            info_stdout.contains(expected),
+            "expected {expected:?} in info output: {info_stdout}"
+        );
+    }
+    let get_requests = server.get_identity_spec_requests();
+    assert_eq!(get_requests.len(), 1, "expected one get call");
+    assert_eq!(get_requests[0].name, "global_demo");
+    assert!(get_requests[0].workspace.is_none());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_remove_propagates_force_and_reports_orphan_count() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .env("CORAL_WORKSPACE", "ignored")
+        .args([
+            "identity-spec",
+            "remove",
+            "global_demo",
+            "--global",
+            "--force",
+        ])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert_eq!(
+        stdout.trim(),
+        "Removed identity spec 'global_demo' from global scope (2 orphaned identities)."
+    );
+    let requests = server.delete_identity_spec_requests();
+    assert_eq!(requests.len(), 1, "expected one delete call");
+    assert_eq!(requests[0].name, "global_demo");
+    assert!(requests[0].workspace.is_none());
+    assert!(requests[0].force);
 
     server.shutdown().await;
 }

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -14,27 +14,30 @@ use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
 use assert_cmd::Command;
 use coral_api::v1::catalog_service_server::{CatalogService, CatalogServiceServer};
+use coral_api::v1::identity_spec_service_server::{IdentitySpecService, IdentitySpecServiceServer};
 use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::search_service_server::{SearchService, SearchServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::workspace_service_server::{WorkspaceService, WorkspaceServiceServer};
 use coral_api::v1::{
-    CatalogCounts, CatalogItem, CatalogMetadata, CatalogSearchResult, Column, ColumnHint,
-    ColumnSearchResult, CreateBundledSourceRequest, CreateBundledSourceResponse,
-    CreateBundledSourceWithOAuthRequest, CreateBundledSourceWithOAuthResponse,
-    CreateWorkspaceRequest, CreateWorkspaceResponse, DeleteSourceRequest, DeleteSourceResponse,
-    DeleteWorkspaceRequest, DeleteWorkspaceResponse, DescribeTableRequest, DescribeTableResponse,
-    DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse,
-    ExplainSqlRequest, ExplainSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse,
-    GetSourceRequest, GetSourceResponse, ImportSourceRequest, ImportSourceResponse,
-    ListCatalogRequest, ListCatalogResponse, ListColumnsRequest, ListColumnsResponse,
-    ListSourcesRequest, ListSourcesResponse, ListWorkspacesRequest, ListWorkspacesResponse,
-    PaginationRequest, PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse,
-    SearchFieldRole, SearchProvider, SearchProviderCoverage, SearchProviderState, SearchRequest,
-    SearchResponse, SearchResult, SearchResultTruncation, SearchSurfaceKind,
-    SearchTableColumnPreview, SearchTableColumnPreviewColumn, Source, SourceCredentialStorage,
-    SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableSummary,
-    ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
+    AddIdentitySpecRequest, AddIdentitySpecResponse, CatalogCounts, CatalogItem, CatalogMetadata,
+    CatalogSearchResult, Column, ColumnHint, ColumnSearchResult, CreateBundledSourceRequest,
+    CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
+    CreateBundledSourceWithOAuthResponse, CreateWorkspaceRequest, CreateWorkspaceResponse,
+    DeleteIdentitySpecRequest, DeleteIdentitySpecResponse, DeleteSourceRequest,
+    DeleteSourceResponse, DeleteWorkspaceRequest, DeleteWorkspaceResponse, DescribeTableRequest,
+    DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest,
+    ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse, GetIdentitySpecRequest,
+    GetIdentitySpecResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
+    GetSourceResponse, IdentitySpec, ImportSourceRequest, ImportSourceResponse, ListCatalogRequest,
+    ListCatalogResponse, ListColumnsRequest, ListColumnsResponse, ListIdentitySpecsRequest,
+    ListIdentitySpecsResponse, ListSourcesRequest, ListSourcesResponse, ListWorkspacesRequest,
+    ListWorkspacesResponse, PaginationRequest, PaginationResponse, QueryPlan, SearchCatalogRequest,
+    SearchCatalogResponse, SearchFieldRole, SearchProvider, SearchProviderCoverage,
+    SearchProviderState, SearchRequest, SearchResponse, SearchResult, SearchResultTruncation,
+    SearchSurfaceKind, SearchTableColumnPreview, SearchTableColumnPreviewColumn, Source,
+    SourceCredentialStorage, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table,
+    TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
     create_bundled_source_with_o_auth_response, import_source_response, search_result,
     source_input_spec::Input as ProtoSourceInput,
 };
@@ -52,6 +55,24 @@ use tonic_types::{ErrorDetail, StatusExt as _};
 fn workspace() -> Workspace {
     Workspace {
         name: "default".to_string(),
+    }
+}
+
+fn identity_spec_manifest(name: &str) -> String {
+    format!(
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: 1.0.0\nissuer: demo\ntype: fixed_token\n"
+    )
+}
+
+fn mock_identity_spec(name: &str, workspace: Option<Workspace>) -> IdentitySpec {
+    IdentitySpec {
+        name: name.to_string(),
+        version: "1.0.0".to_string(),
+        description: "Mock identity spec".to_string(),
+        issuer: "demo".to_string(),
+        identity_type: "fixed_token".to_string(),
+        manifest_yaml: identity_spec_manifest(name),
+        workspace,
     }
 }
 
@@ -740,6 +761,10 @@ struct Captured {
     list_workspaces: Mutex<Vec<ListWorkspacesRequest>>,
     create_workspace: Mutex<Vec<CreateWorkspaceRequest>>,
     delete_workspace: Mutex<Vec<DeleteWorkspaceRequest>>,
+    add_identity_spec: Mutex<Vec<AddIdentitySpecRequest>>,
+    list_identity_specs: Mutex<Vec<ListIdentitySpecsRequest>>,
+    get_identity_spec: Mutex<Vec<GetIdentitySpecRequest>>,
+    delete_identity_spec: Mutex<Vec<DeleteIdentitySpecRequest>>,
 }
 
 pub(crate) fn encode_arrow_ipc_stream(
@@ -986,6 +1011,93 @@ impl CatalogService for MockCatalogService {
 }
 
 #[derive(Clone)]
+struct MockIdentitySpecService {
+    captured: Arc<Captured>,
+}
+
+#[tonic::async_trait]
+impl IdentitySpecService for MockIdentitySpecService {
+    async fn add_identity_spec(
+        &self,
+        request: Request<AddIdentitySpecRequest>,
+    ) -> Result<Response<AddIdentitySpecResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .add_identity_spec
+            .lock()
+            .expect("add_identity_spec capture")
+            .push(request.clone());
+        let replaced = request.input_values.is_empty();
+        Ok(Response::new(AddIdentitySpecResponse {
+            identity_spec: Some(IdentitySpec {
+                name: "demo_oauth".to_string(),
+                version: "1.0.0".to_string(),
+                description: "Mock identity spec".to_string(),
+                issuer: "demo".to_string(),
+                identity_type: "oauth".to_string(),
+                manifest_yaml: request.manifest_yaml,
+                workspace: request.workspace,
+            }),
+            replaced,
+        }))
+    }
+
+    async fn list_identity_specs(
+        &self,
+        request: Request<ListIdentitySpecsRequest>,
+    ) -> Result<Response<ListIdentitySpecsResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .list_identity_specs
+            .lock()
+            .expect("list_identity_specs capture")
+            .push(request.clone());
+        let identity_specs = match request.workspace {
+            Some(workspace) => {
+                let mut identity_specs =
+                    vec![mock_identity_spec("workspace_demo", Some(workspace))];
+                if request.include_global {
+                    identity_specs.push(mock_identity_spec("global_demo", None));
+                }
+                identity_specs
+            }
+            None => vec![mock_identity_spec("global_demo", None)],
+        };
+        Ok(Response::new(ListIdentitySpecsResponse { identity_specs }))
+    }
+
+    async fn get_identity_spec(
+        &self,
+        request: Request<GetIdentitySpecRequest>,
+    ) -> Result<Response<GetIdentitySpecResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .get_identity_spec
+            .lock()
+            .expect("get_identity_spec capture")
+            .push(request.clone());
+        Ok(Response::new(GetIdentitySpecResponse {
+            identity_spec: Some(mock_identity_spec(&request.name, request.workspace)),
+        }))
+    }
+
+    async fn delete_identity_spec(
+        &self,
+        request: Request<DeleteIdentitySpecRequest>,
+    ) -> Result<Response<DeleteIdentitySpecResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .delete_identity_spec
+            .lock()
+            .expect("delete_identity_spec capture")
+            .push(request);
+        Ok(Response::new(DeleteIdentitySpecResponse {
+            orphaned_identities: 2,
+        }))
+    }
+}
+
+#[derive(Clone)]
 struct MockSourceService {
     config: Arc<MockServerConfig>,
     captured: Arc<Captured>,
@@ -1222,6 +1334,7 @@ impl MockServer {
         let query_captured = Arc::clone(&captured);
         let search_captured = Arc::clone(&captured);
         let catalog_captured = Arc::clone(&captured);
+        let identity_spec_captured = Arc::clone(&captured);
         let source_captured = Arc::clone(&captured);
         let workspace_captured = Arc::clone(&captured);
         let query_config = Arc::clone(&config);
@@ -1232,6 +1345,9 @@ impl MockServer {
             Server::builder()
                 .add_service(CatalogServiceServer::new(MockCatalogService {
                     captured: catalog_captured,
+                }))
+                .add_service(IdentitySpecServiceServer::new(MockIdentitySpecService {
+                    captured: identity_spec_captured,
                 }))
                 .add_service(QueryServiceServer::new(MockQueryService {
                     config: query_config,
@@ -1396,6 +1512,38 @@ impl MockServer {
             .delete_workspace
             .lock()
             .expect("delete_workspace capture")
+            .clone()
+    }
+
+    pub(crate) fn add_identity_spec_requests(&self) -> Vec<AddIdentitySpecRequest> {
+        self.captured
+            .add_identity_spec
+            .lock()
+            .expect("add_identity_spec capture")
+            .clone()
+    }
+
+    pub(crate) fn list_identity_specs_requests(&self) -> Vec<ListIdentitySpecsRequest> {
+        self.captured
+            .list_identity_specs
+            .lock()
+            .expect("list_identity_specs capture")
+            .clone()
+    }
+
+    pub(crate) fn get_identity_spec_requests(&self) -> Vec<GetIdentitySpecRequest> {
+        self.captured
+            .get_identity_spec
+            .lock()
+            .expect("get_identity_spec capture")
+            .clone()
+    }
+
+    pub(crate) fn delete_identity_spec_requests(&self) -> Vec<DeleteIdentitySpecRequest> {
+        self.captured
+            .delete_identity_spec
+            .lock()
+            .expect("delete_identity_spec capture")
             .clone()
     }
 


### PR DESCRIPTION
## Intent

Lock the identity-spec CLI contract at the transport boundary without enlarging the production PR beyond the mission's review-size cap.

## What it enables

- Proves workspace-default, explicit-workspace, global, and include-global request scopes.
- Proves authored manifest YAML and non-TTY environment inputs reach the API unchanged while secrets never appear in output.
- Proves replacement, info/list rendering, force propagation, and exact orphan-count output.

## Usage examples

These tests cover the public commands introduced by the parent PR:

```sh
CLIENT_SECRET=example coral identity-spec add --file ./github-identity.yaml
coral --workspace team identity-spec list --include-global
coral identity-spec --global info github
coral identity-spec remove github --force
```

## Validation

- Focused `coral-cli` integration tests
- `make rust-checks`
