### PR TITLE
feat(reef): add workspace creation to the active shell

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -343,6 +343,9 @@ describe('Architectural Tests', () => {
       expect(routeConfig).toContain("layout('routes/app-shell.tsx', [")
       expect(routeConfig).toContain("index('routes/index.tsx')")
       expect(routeConfig).toContain(
+        "route(routePattern('workspaces'), 'routes/workspaces-action.ts')",
+      )
+      expect(routeConfig).toContain(
         "route(routePattern('workspaceSources'), 'routes/sources.tsx', [",
       )
       expect(routeConfig).toContain("route(':sourceName', 'routes/source-detail.tsx')")

--- a/apps/reef/app/components/sidebar/sidebar.test.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.test.tsx
@@ -1,10 +1,11 @@
-import { createMemoryRouter, RouterProvider } from 'react-router'
+import { createMemoryRouter, data, RouterProvider } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { page } from 'vitest/browser'
 import { render } from 'vitest-browser-react'
 
 import { Sidebar } from './sidebar'
 import { SIDEBAR_COOKIE_NAME } from './sidebar-state'
+import { validateWorkspaceName } from '@/lib/workspace-name'
 import { routePath, routePattern } from '@/routing/routemap'
 
 const WORKSPACES = [{ name: 'default' }, { name: 'analytics' }]
@@ -16,6 +17,19 @@ async function renderSidebar(
 ) {
   const router = createMemoryRouter(
     [
+      {
+        action: async ({ request }) => {
+          const formData = await request.formData()
+          const nameValue = formData.get('name')
+          const name = typeof nameValue === 'string' ? nameValue : ''
+          if (formData.get('intent') !== 'create') {
+            return data({ error: 'Unsupported workspace action.', name }, { status: 400 })
+          }
+          const error = validateWorkspaceName(name)
+          return data({ error: error ?? '', name }, { status: error ? 400 : 200 })
+        },
+        path: routePattern('workspaces'),
+      },
       {
         element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
         path: routePattern('workspaceSource'),
@@ -48,7 +62,7 @@ async function renderSidebar(
     { initialEntries: [initialEntry] },
   )
 
-  return render(<RouterProvider router={router} />)
+  return Object.assign(await render(<RouterProvider router={router} />), { router })
 }
 
 describe('Sidebar', () => {
@@ -159,6 +173,63 @@ describe('Sidebar', () => {
     await expect.element(activeWorkspace).toHaveAttribute('aria-checked', 'true')
     expect(defaultWorkspace.element().querySelector('svg')).toBeNull()
     expect(activeWorkspace.element().querySelector('svg')).not.toBeNull()
+  })
+
+  it('opens and closes the create workspace dialog from the workspace menu', async () => {
+    const screen = await renderSidebar(false, '/workspaces/analytics/sources', WORKSPACES)
+
+    await screen.getByRole('button', { name: 'Open workspace menu' }).click()
+    await screen.getByRole('menuitem', { name: 'Create workspace' }).click()
+    await expect.element(screen.getByRole('heading', { name: 'Create workspace' })).toBeVisible()
+
+    await screen.getByRole('button', { name: 'Close' }).click()
+    await expect
+      .element(screen.getByRole('heading', { name: 'Create workspace' }))
+      .not.toBeInTheDocument()
+  })
+
+  it('keeps the create workspace dialog closed after back and forward navigation', async () => {
+    const tracesPath = routePath('workspaceTraces', { workspaceId: 'analytics' })
+    const sourcesPath = routePath('workspaceSources', { workspaceId: 'analytics' })
+    const screen = await renderSidebar(false, tracesPath, WORKSPACES)
+
+    await screen.getByRole('link', { name: 'Sources' }).click()
+    await expect.poll(() => screen.router.state.location.pathname).toBe(sourcesPath)
+    await screen.getByRole('button', { name: 'Open workspace menu' }).click()
+    await screen.getByRole('menuitem', { name: 'Create workspace' }).click()
+    await expect.element(screen.getByRole('heading', { name: 'Create workspace' })).toBeVisible()
+
+    await screen.router.navigate(-1)
+    await expect.poll(() => screen.router.state.location.pathname).toBe(tracesPath)
+    await expect
+      .element(screen.getByRole('heading', { name: 'Create workspace' }))
+      .not.toBeInTheDocument()
+
+    await screen.router.navigate(1)
+    await expect.poll(() => screen.router.state.location.pathname).toBe(sourcesPath)
+    await expect
+      .element(screen.getByRole('heading', { name: 'Create workspace' }))
+      .not.toBeInTheDocument()
+  })
+
+  it('keeps validation errors while open and clears them when reopening', async () => {
+    const screen = await renderSidebar(false, '/workspaces/analytics/sources', WORKSPACES)
+
+    await screen.getByRole('button', { name: 'Open workspace menu' }).click()
+    await screen.getByRole('menuitem', { name: 'Create workspace' }).click()
+    await screen.getByLabelText('Workspace name').fill('New Team')
+    await screen.getByRole('button', { name: 'Create workspace' }).click()
+
+    await expect
+      .element(screen.getByRole('alert'))
+      .toHaveTextContent('Workspace name may only contain lowercase letters, numbers, and hyphens')
+    await expect.element(screen.getByRole('heading', { name: 'Create workspace' })).toBeVisible()
+
+    await screen.getByRole('button', { name: 'Close' }).click()
+    await screen.getByRole('button', { name: 'Open workspace menu' }).click()
+    await screen.getByRole('menuitem', { name: 'Create workspace' }).click()
+
+    await expect.element(screen.getByRole('alert')).not.toBeInTheDocument()
   })
 
   it.each([

--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames'
+import { useEffect, useRef, useState } from 'react'
 import { Link, NavLink, useLocation, useParams } from 'react-router'
 
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
@@ -11,6 +12,7 @@ import type { IconName } from '@/wax/components/icon'
 import * as Menu from '@/wax/components/menu'
 import { getAvatarColorFromSeed } from '@/wax/components/avatar/utils/get-avatar-color'
 import type { Workspace } from '@/generated/coral/v1/resources_pb'
+import { WorkspaceCreationDialog } from '@/components/workspaces'
 import { isCoralDesktopBuild } from '@/lib/coral-desktop'
 import { workspacePathForCurrentSection } from '@/lib/workspace-routing'
 import { routePath } from '@/routing/routemap'
@@ -27,6 +29,9 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
   const location = useLocation()
   const { workspaceId } = useParams()
   const { isMinimized, toggleSidebar } = useSidebarState(initialIsMinimized)
+  const [createWorkspaceDialogOpen, setCreateWorkspaceDialogOpen] = useState(false)
+  const createWorkspaceDialogSession = useRef(0)
+  const createWorkspaceFetcherKey = `create-workspace-${createWorkspaceDialogSession.current}`
   const currentWorkspace = workspaces.find((workspace) => workspace.name === workspaceId)
   const workspaceNavTarget = currentWorkspace ?? workspaces[0]
   const workspaceSelectorLabel = workspaceNavTarget?.name ?? 'Coral'
@@ -69,6 +74,15 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
   const handleToggleSidebar = (event: KeyboardEvent) => {
     event.preventDefault()
     toggleSidebar()
+  }
+
+  useEffect(() => {
+    setCreateWorkspaceDialogOpen(false)
+  }, [location.key])
+
+  const handleCreateWorkspaceDialogOpenChange = (open: boolean) => {
+    if (open) createWorkspaceDialogSession.current += 1
+    setCreateWorkspaceDialogOpen(open)
   }
 
   return (
@@ -139,8 +153,18 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
                   </Menu.RadioGroup>
                 )}
               </Menu.Group>
+              <Menu.Separator />
+              <Menu.Item icon="Plus" onClick={() => handleCreateWorkspaceDialogOpenChange(true)}>
+                Create workspace
+              </Menu.Item>
             </Menu.Content>
           </Menu.Container>
+
+          <WorkspaceCreationDialog
+            fetcherKey={createWorkspaceFetcherKey}
+            onOpenChange={handleCreateWorkspaceDialogOpenChange}
+            open={createWorkspaceDialogOpen}
+          />
 
           {!isMinimized && (
             <div className={styles.toggleButton}>

--- a/apps/reef/app/components/workspaces/index.ts
+++ b/apps/reef/app/components/workspaces/index.ts
@@ -1,0 +1,2 @@
+export { WorkspaceCreationDialog } from './workspace-creation-dialog'
+export type { WorkspaceCreationDialogProps } from './workspace-creation-dialog'

--- a/apps/reef/app/components/workspaces/workspace-creation-dialog.css.ts
+++ b/apps/reef/app/components/workspaces/workspace-creation-dialog.css.ts
@@ -1,0 +1,14 @@
+import { style } from '@vanilla-extract/css'
+
+export const createWorkspaceForm = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+  marginBlockStart: '4px',
+})
+
+export const createWorkspaceField = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6px',
+})

--- a/apps/reef/app/components/workspaces/workspace-creation-dialog.stories.tsx
+++ b/apps/reef/app/components/workspaces/workspace-creation-dialog.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { useState } from 'react'
+import { createRoutesStub } from 'react-router'
+import { fn } from 'storybook/test'
+
+import { Button } from '@/wax/components'
+import { routePattern } from '@/routing/routemap'
+
+import {
+  WorkspaceCreationDialog,
+  type WorkspaceCreationDialogProps,
+} from './workspace-creation-dialog'
+
+const meta = {
+  component: WorkspaceCreationDialog,
+  decorators: [
+    (Story) => {
+      const RoutesStub = createRoutesStub([
+        { Component: () => <Story />, path: '/' },
+        {
+          action: fn(() => null).mockName('createWorkspaceAction'),
+          path: routePattern('workspaces'),
+        },
+      ])
+
+      return <RoutesStub initialEntries={['/']} />
+    },
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  render: (args) => <DialogStory {...args} />,
+  tags: ['autodocs'],
+  title: 'Components/Workspaces/WorkspaceCreationDialog',
+} satisfies Meta<typeof WorkspaceCreationDialog>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    fetcherKey: 'workspace-creation-dialog-story',
+    onOpenChange: fn(),
+    open: true,
+  },
+}
+
+function DialogStory({ onOpenChange, open: initialOpen, ...props }: WorkspaceCreationDialogProps) {
+  const [open, setOpen] = useState(initialOpen)
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen)
+    onOpenChange(nextOpen)
+  }
+
+  return (
+    <>
+      <Button.TextButton onClick={() => handleOpenChange(true)}>Open dialog</Button.TextButton>
+      <WorkspaceCreationDialog {...props} onOpenChange={handleOpenChange} open={open} />
+    </>
+  )
+}

--- a/apps/reef/app/components/workspaces/workspace-creation-dialog.tsx
+++ b/apps/reef/app/components/workspaces/workspace-creation-dialog.tsx
@@ -1,0 +1,68 @@
+import { Form, useFetcher } from 'react-router'
+
+import { Button, Dialog, Inputs, Typography } from '@/wax/components'
+import type { CreateWorkspaceActionData } from '@/lib/workspace-name'
+import { routePath } from '@/routing/routemap'
+
+import * as styles from './workspace-creation-dialog.css'
+
+export interface WorkspaceCreationDialogProps {
+  fetcherKey: string
+  onOpenChange: (open: boolean) => void
+  open: boolean
+}
+
+export function WorkspaceCreationDialog({
+  fetcherKey,
+  onOpenChange,
+  open,
+}: WorkspaceCreationDialogProps) {
+  const createWorkspaceFetcher = useFetcher<CreateWorkspaceActionData>({ key: fetcherKey })
+  const isCreatingWorkspace = createWorkspaceFetcher.state !== 'idle'
+
+  return (
+    <Dialog.Root onOpenChange={onOpenChange} open={open}>
+      <Dialog.Portal>
+        <Dialog.Backdrop />
+        <Dialog.Popup size="m">
+          <Dialog.Title>Create workspace</Dialog.Title>
+          <Dialog.Description>
+            Choose a name for the local workspace. Use lowercase letters, numbers, and hyphens.
+          </Dialog.Description>
+          <Dialog.Close />
+          <Form
+            action={routePath('workspaces')}
+            className={styles.createWorkspaceForm}
+            fetcherKey={fetcherKey}
+            method="post"
+            navigate={false}
+          >
+            <input name="intent" type="hidden" value="create" />
+            <label className={styles.createWorkspaceField}>
+              <Typography.BodySmallStrong>Workspace name</Typography.BodySmallStrong>
+              <Inputs.TextInput autoFocus name="name" placeholder="engineering" />
+            </label>
+            {createWorkspaceFetcher.data?.error && (
+              <Typography.BodySmall as="p" role="alert" variant="error">
+                {createWorkspaceFetcher.data.error}
+              </Typography.BodySmall>
+            )}
+            <Dialog.Actions>
+              <Button.TextButton
+                disabled={isCreatingWorkspace}
+                onClick={() => onOpenChange(false)}
+                type="button"
+                variant="secondary"
+              >
+                Cancel
+              </Button.TextButton>
+              <Button.TextButton disabled={isCreatingWorkspace} type="submit">
+                {isCreatingWorkspace ? 'Creating…' : 'Create workspace'}
+              </Button.TextButton>
+            </Dialog.Actions>
+          </Form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/apps/reef/app/lib/workspace-name.ts
+++ b/apps/reef/app/lib/workspace-name.ts
@@ -1,0 +1,18 @@
+export interface CreateWorkspaceActionData {
+  error: string
+  name: string
+}
+
+const WORKSPACE_NAME_CHARACTERS = /^[a-z0-9-]+$/
+
+export function validateWorkspaceName(name: string): string | null {
+  if (name.trim().length === 0) return 'Workspace name is required'
+  if (name.length > 63) return 'Workspace name must be 63 characters or fewer'
+  if (name.startsWith('-') || name.endsWith('-')) {
+    return 'Workspace name must not start or end with a hyphen'
+  }
+  if (!WORKSPACE_NAME_CHARACTERS.test(name)) {
+    return 'Workspace name may only contain lowercase letters, numbers, and hyphens'
+  }
+  return null
+}

--- a/apps/reef/app/lib/workspaces.server.ts
+++ b/apps/reef/app/lib/workspaces.server.ts
@@ -1,4 +1,8 @@
+import { create } from '@bufbuild/protobuf'
+
+import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
 import type { Workspace } from '@/generated/coral/v1/resources_pb'
+import { CreateWorkspaceRequestSchema } from '@/generated/coral/v1/workspaces_pb'
 import { workspaceClientForRequest } from '@/lib/coral-request.server'
 
 export async function listWorkspacesForRequest(request: Request): Promise<Workspace[]> {
@@ -14,4 +18,18 @@ export async function firstWorkspaceForRequest(request: Request): Promise<Worksp
     status: 404,
     statusText: 'Workspace Not Found',
   })
+}
+
+export async function createWorkspaceForRequest(
+  request: Request,
+  name: string,
+): Promise<Workspace> {
+  const response = await workspaceClientForRequest(request).createWorkspace(
+    create(CreateWorkspaceRequestSchema, {
+      workspace: create(WorkspaceSchema, { name }),
+    }),
+  )
+  if (response.workspace) return response.workspace
+
+  throw new Error('Coral did not return the created workspace')
 }

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -13,6 +13,7 @@ export default [
   route('sources/:sourceName/oauth-install', 'routes/source-oauth-install.ts'),
   layout('routes/app-shell.tsx', [
     index('routes/index.tsx'),
+    route(routePattern('workspaces'), 'routes/workspaces-action.ts'),
     route(routePattern('workspaceSources'), 'routes/sources.tsx', [
       route(':sourceName', 'routes/source-detail.tsx'),
     ]),

--- a/apps/reef/app/routes/workspaces-action.server.test.ts
+++ b/apps/reef/app/routes/workspaces-action.server.test.ts
@@ -1,0 +1,86 @@
+import { create } from '@bufbuild/protobuf'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createWorkspace } = vi.hoisted(() => ({ createWorkspace: vi.fn() }))
+
+vi.mock('@/lib/coral-request.server', () => ({
+  workspaceClientForRequest: () => ({ createWorkspace }),
+}))
+
+import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
+
+import { action } from './workspaces-action'
+
+function createRequest(name: string, intent = 'create') {
+  return new Request('http://reef.test/workspaces', {
+    body: new URLSearchParams({ intent, name }),
+    method: 'POST',
+  })
+}
+
+describe('create workspace action', () => {
+  beforeEach(() => {
+    createWorkspace.mockReset()
+  })
+
+  it('rejects unsupported intents before mutation', async () => {
+    const result = await action({
+      request: createRequest('analytics', 'rename'),
+    } as Parameters<typeof action>[0])
+
+    expect(result).toMatchObject({
+      data: { error: 'Unsupported workspace action.', name: '' },
+      init: { status: 400 },
+    })
+    expect(createWorkspace).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['', 'Workspace name is required'],
+    ['Team', 'Workspace name may only contain lowercase letters, numbers, and hyphens'],
+    ['team_name', 'Workspace name may only contain lowercase letters, numbers, and hyphens'],
+    ['-team', 'Workspace name must not start or end with a hyphen'],
+    ['team-', 'Workspace name must not start or end with a hyphen'],
+    ['a'.repeat(64), 'Workspace name must be 63 characters or fewer'],
+  ])('rejects invalid workspace name %j before mutation', async (name, error) => {
+    const result = await action({ request: createRequest(name) } as Parameters<typeof action>[0])
+
+    expect(result).toMatchObject({
+      data: { error, name },
+      init: { status: 400 },
+      type: 'DataWithResponseInit',
+    })
+    expect(createWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('creates the local workspace and redirects to its sources', async () => {
+    createWorkspace.mockResolvedValue({
+      workspace: create(WorkspaceSchema, { name: 'analytics' }),
+    })
+
+    const result = await action({
+      request: createRequest('analytics'),
+    } as Parameters<typeof action>[0])
+
+    expect(createWorkspace).toHaveBeenCalledOnce()
+    expect(createWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace: expect.objectContaining({ name: 'analytics' }),
+      }),
+    )
+    expect(result).toBeInstanceOf(Response)
+    expect((result as Response).status).toBe(302)
+    expect((result as Response).headers.get('Location')).toBe('/workspaces/analytics/sources')
+  })
+
+  it('returns service errors to the dialog without redirecting', async () => {
+    createWorkspace.mockRejectedValue(new Error('workspace already exists'))
+
+    await expect(
+      action({ request: createRequest('analytics') } as Parameters<typeof action>[0]),
+    ).resolves.toMatchObject({
+      data: { error: 'workspace already exists', name: 'analytics' },
+      init: { status: 502 },
+    })
+  })
+})

--- a/apps/reef/app/routes/workspaces-action.ts
+++ b/apps/reef/app/routes/workspaces-action.ts
@@ -1,0 +1,36 @@
+import { data, redirect } from 'react-router'
+
+import type { Route } from './+types/workspaces-action'
+
+import { errorMessage } from '@/lib/utils'
+import { type CreateWorkspaceActionData, validateWorkspaceName } from '@/lib/workspace-name'
+import { createWorkspaceForRequest } from '@/lib/workspaces.server'
+import { routePath } from '@/routing/routemap'
+
+export async function action({ request }: Route.ActionArgs) {
+  const formData = await request.formData()
+  const intent = formData.get('intent')
+
+  switch (intent) {
+    case 'create': {
+      const nameValue = formData.get('name')
+      const name = typeof nameValue === 'string' ? nameValue : ''
+      const validationError = validateWorkspaceName(name)
+
+      if (validationError) return actionError(name, validationError, 400)
+
+      try {
+        const workspace = await createWorkspaceForRequest(request, name)
+        return redirect(routePath('workspaceSources', { workspaceId: workspace.name }))
+      } catch (error) {
+        return actionError(name, errorMessage(error), 502)
+      }
+    }
+    default:
+      return actionError('', 'Unsupported workspace action.', 400)
+  }
+}
+
+function actionError(name: string, error: string, status: number) {
+  return data<CreateWorkspaceActionData>({ error, name }, { status })
+}


### PR DESCRIPTION
## Summary

- Add workspace creation to the Reef workspace menu, with local-compatible name validation and inline service errors.
- Submit creation through a dedicated React Router action backed by the local `WorkspaceService`, then redirect to the new workspace's Sources page.
- Keep workspace UI and server helpers within the workspace domain boundary while the sidebar remains the invoking shell.
- Reset dialog fetcher state between openings and permanently close the dialog on navigation, including Back/Forward history traversal, without unmounting it and breaking exit animations.

## Screenshots

![Create workspace dialog](https://app.graphite.com/user-attachments/assets/36313764-43be-4762-9bae-fa93610f84fd.png)

![Create workspace validation](https://app.graphite.com/user-attachments/assets/ce9d07e0-1a44-48d3-bae2-7b4e0b2b8853.png)

## Validation

- `npm --prefix apps/reef run check`
- `npm --prefix apps/reef run typecheck`
- `npm --prefix apps/reef test` — 79 files, 320 tests
- `npm --prefix apps/reef run build`

Constraint: Part 3 uses only the local WorkspaceService, preserves dialog exit animations, and excludes settings management.
Rejected: Create through a settings management route | Phase 4 owns that UI and behavior.
Rejected: Unmount the dialog when closed | Immediate unmounting bypasses the exit animation.
Rejected: Hide an open dialog by history location key | Returning to that history entry resurrects stale open state.
Confidence: high
Scope-risk: narrow
Directive: Keep member and broader workspace management APIs out until local services exist; permanently close transient shell UI on navigation.
Not-tested: Live CreateWorkspace call against a running Coral sidecar.
