### PR TITLE
refactor(reef): centralize canonical route generation

### DIFF
--- a/apps/reef/app/routing/routemap.test.ts
+++ b/apps/reef/app/routing/routemap.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AppRouteId } from './routemap'
+import { routeMap, routeObjects, routePath, routePattern } from './routemap'
+
+const CANONICAL_PATTERNS = {
+  home: '/',
+  settings: '/settings',
+  workspaces: '/workspaces',
+  workspaceSchema: '/workspaces/:workspaceId/schema',
+  workspaceSchemaTable: '/workspaces/:workspaceId/schema/:schemaName/:tableName',
+  workspaceSource: '/workspaces/:workspaceId/sources/:sourceName',
+  workspaceSources: '/workspaces/:workspaceId/sources',
+  workspaceTrace: '/workspaces/:workspaceId/traces/:traceId',
+  workspaceTraces: '/workspaces/:workspaceId/traces',
+} satisfies Record<AppRouteId, string>
+
+describe('route map', () => {
+  it('exposes canonical route patterns only', () => {
+    expect(Object.fromEntries([...routeMap].map(([id]) => [id, routePattern(id)]))).toEqual(
+      CANONICAL_PATTERNS,
+    )
+  })
+
+  it('creates React Router route objects from mapped routes', () => {
+    expect(routeObjects(['home', 'workspaceSource'])).toEqual([
+      { id: 'home', path: '/' },
+      { id: 'workspaceSource', path: '/workspaces/:workspaceId/sources/:sourceName' },
+    ])
+  })
+
+  it('generates canonical URLs for every mapped route', () => {
+    const paths = {
+      home: routePath('home'),
+      settings: routePath('settings'),
+      workspaces: routePath('workspaces'),
+      workspaceSchema: routePath('workspaceSchema', { workspaceId: 'analytics' }),
+      workspaceSchemaTable: routePath('workspaceSchemaTable', {
+        schemaName: 'github',
+        tableName: 'issues',
+        workspaceId: 'analytics',
+      }),
+      workspaceSource: routePath('workspaceSource', {
+        sourceName: 'github',
+        workspaceId: 'analytics',
+      }),
+      workspaceSources: routePath('workspaceSources', { workspaceId: 'analytics' }),
+      workspaceTrace: routePath('workspaceTrace', {
+        traceId: 'trace_123',
+        workspaceId: 'analytics',
+      }),
+      workspaceTraces: routePath('workspaceTraces', { workspaceId: 'analytics' }),
+    } satisfies Record<AppRouteId, string>
+
+    expect(paths).toEqual({
+      home: '/',
+      settings: '/settings',
+      workspaces: '/workspaces',
+      workspaceSchema: '/workspaces/analytics/schema',
+      workspaceSchemaTable: '/workspaces/analytics/schema/github/issues',
+      workspaceSource: '/workspaces/analytics/sources/github',
+      workspaceSources: '/workspaces/analytics/sources',
+      workspaceTrace: '/workspaces/analytics/traces/trace_123',
+      workspaceTraces: '/workspaces/analytics/traces',
+    })
+  })
+})

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -1,0 +1,107 @@
+import { generatePath } from 'react-router'
+import type { RouteObject } from 'react-router'
+
+const HOME_PATH = '/'
+const WORKSPACES_PATH = '/workspaces'
+const WORKSPACE_SCHEMA_PATH = '/workspaces/:workspaceId/schema'
+const WORKSPACE_SCHEMA_TABLE_PATH = '/workspaces/:workspaceId/schema/:schemaName/:tableName'
+const WORKSPACE_SOURCES_PATH = '/workspaces/:workspaceId/sources'
+const WORKSPACE_SOURCE_PATH = '/workspaces/:workspaceId/sources/:sourceName'
+const WORKSPACE_TRACES_PATH = '/workspaces/:workspaceId/traces'
+const WORKSPACE_TRACE_PATH = '/workspaces/:workspaceId/traces/:traceId'
+const SETTINGS_PATH = '/settings'
+
+export const routeDefinitions = {
+  home: {
+    path: HOME_PATH,
+    toPath: () => HOME_PATH,
+  },
+  settings: {
+    path: SETTINGS_PATH,
+    toPath: () => SETTINGS_PATH,
+  },
+  workspaces: {
+    path: WORKSPACES_PATH,
+    toPath: () => WORKSPACES_PATH,
+  },
+  workspaceSchema: {
+    path: WORKSPACE_SCHEMA_PATH,
+    toPath: (params: { workspaceId: string }) =>
+      generatePath(WORKSPACE_SCHEMA_PATH, {
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceSchemaTable: {
+    path: WORKSPACE_SCHEMA_TABLE_PATH,
+    toPath: (params: { schemaName: string; tableName: string; workspaceId: string }) =>
+      generatePath(WORKSPACE_SCHEMA_TABLE_PATH, {
+        schemaName: params.schemaName,
+        tableName: params.tableName,
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceSource: {
+    path: WORKSPACE_SOURCE_PATH,
+    toPath: (params: { sourceName: string; workspaceId: string }) =>
+      generatePath(WORKSPACE_SOURCE_PATH, {
+        sourceName: params.sourceName,
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceSources: {
+    path: WORKSPACE_SOURCES_PATH,
+    toPath: (params: { workspaceId: string }) =>
+      generatePath(WORKSPACE_SOURCES_PATH, {
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceTrace: {
+    path: WORKSPACE_TRACE_PATH,
+    toPath: (params: { traceId: string; workspaceId: string }) =>
+      generatePath(WORKSPACE_TRACE_PATH, {
+        traceId: params.traceId,
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceTraces: {
+    path: WORKSPACE_TRACES_PATH,
+    toPath: (params: { workspaceId: string }) =>
+      generatePath(WORKSPACE_TRACES_PATH, {
+        workspaceId: params.workspaceId,
+      }),
+  },
+} as const
+
+export type AppRouteId = keyof typeof routeDefinitions
+export type AppRoute = (typeof routeDefinitions)[AppRouteId]
+
+export const routeMap: ReadonlyMap<AppRouteId, AppRoute> = new Map(
+  Object.entries(routeDefinitions) as [AppRouteId, AppRoute][],
+)
+
+export type RoutePathArgs<RouteId extends AppRouteId> = Parameters<
+  (typeof routeDefinitions)[RouteId]['toPath']
+>
+
+export function routePattern(routeId: AppRouteId): string {
+  const route = routeMap.get(routeId)
+  if (!route) throw new Error(`Unknown route id: ${routeId}`)
+  return route.path
+}
+
+export function routePath<RouteId extends AppRouteId>(
+  routeId: RouteId,
+  ...args: RoutePathArgs<RouteId>
+): string {
+  const route = routeDefinitions[routeId]
+  return (route.toPath as (...params: RoutePathArgs<RouteId>) => string)(...args)
+}
+
+export function routeObjects(
+  routeIds: readonly AppRouteId[] = [...routeMap.keys()],
+): RouteObject[] {
+  return routeIds.map((routeId) => ({
+    id: routeId,
+    path: routePattern(routeId),
+  }))
+}


### PR DESCRIPTION
Constraint: The map contains only canonical workspace-aware URLs while remaining independently valid on rr-traces
Rejected: Move workspace route modules into this branch | those modules belong to the workspace-aware descendant
Confidence: high
Scope-risk: narrow
Directive: Generate Reef application URLs through routePath and inspect patterns through routePattern
Tested: npm test --prefix apps/reef -- app/routing/routemap.test.ts; npm run typecheck --prefix apps/reef
Not-tested: Full Reef suite until descendant branches are restacked