### PR TITLE
fix: openapi json media types

### DIFF
--- a/crates/coral-spec/src/v4/openapi_tests.rs
+++ b/crates/coral-spec/src/v4/openapi_tests.rs
@@ -531,7 +531,11 @@ components:
 }
 
 #[test]
-fn importer_handles_2xx_response_range_success_codes() {
+#[expect(
+    clippy::too_many_lines,
+    reason = "The OpenAPI fixture keeps related success-response selection cases together."
+)]
+fn importer_selects_supported_success_responses() {
     let manifest = parse_source_manifest_yaml(
         r"
 name: response_ranges
@@ -585,6 +589,37 @@ paths:
                 type: object
                 properties:
                   id: {type: string}
+  /vendor-items:
+    get:
+      operationId: vendor/list
+      responses:
+        '200':
+          content:
+            application/vnd.vimeo.video+json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
+  /preferred-items:
+    get:
+      operationId: preferred/list
+      responses:
+        '200':
+          content:
+            application/vnd.example+json:
+              schema:
+                type: object
+                properties:
+                  id: {type: string}
+            'application/json; charset=utf-8':
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: string}
 "
         .as_bytes(),
     )
@@ -608,6 +643,28 @@ paths:
         panic!("numeric operation should be REST");
     };
     assert_eq!(numeric_rest.response.status_code, 201);
+
+    let vendor = operations.get("vendor_list").expect("vendor operation");
+    assert_eq!(vendor.output.cardinality, OutputCardinality::List);
+    let IrExecutionAttachment::Rest(vendor_rest) = &vendor.execution else {
+        panic!("vendor operation should be REST");
+    };
+    assert_eq!(
+        vendor_rest.response.media_type,
+        "application/vnd.vimeo.video+json"
+    );
+
+    let preferred = operations
+        .get("preferred_list")
+        .expect("preferred operation");
+    assert_eq!(preferred.output.cardinality, OutputCardinality::List);
+    let IrExecutionAttachment::Rest(preferred_rest) = &preferred.execution else {
+        panic!("preferred operation should be REST");
+    };
+    assert_eq!(
+        preferred_rest.response.media_type,
+        "application/json; charset=utf-8"
+    );
 }
 
 #[test]
@@ -986,6 +1043,7 @@ paths:
     get:
       operationId: odata/list
       parameters:
+        - {name: $count, in: query, schema: {type: boolean}}
         - {name: $skip, in: query, schema: {type: integer, default: 10}}
         - {name: $top, in: query, schema: {type: integer, default: 25}}
       responses:

--- a/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/operations.rs
@@ -419,23 +419,28 @@ fn detect_page_size(inputs: &[IrOperationInput]) -> Option<PageSizeSpec> {
 }
 
 fn detect_page_size_input(inputs: &[IrOperationInput]) -> Option<&IrOperationInput> {
-    find_query_input(
-        inputs,
-        &[
-            "amount",
-            "count",
-            "itemsperpage",
-            "limit",
-            "maxresults",
-            "pagelimit",
-            "pagesize",
-            "perpage",
-            "resultsperpage",
-            "size",
-            "take",
-            "top",
-        ],
-    )
+    const PAGE_SIZE_TOKENS: &[&str] = &[
+        "amount",
+        "count",
+        "itemsperpage",
+        "limit",
+        "maxresults",
+        "pagelimit",
+        "pagesize",
+        "perpage",
+        "resultsperpage",
+        "size",
+        "take",
+        "top",
+    ];
+
+    inputs
+        .iter()
+        .filter(|input| input.location == IrInputLocation::Query)
+        .find(|input| {
+            input.data_type != IrScalarType::Boolean
+                && PAGE_SIZE_TOKENS.contains(&name_token(&input.name).as_str())
+        })
 }
 
 fn find_page_input(inputs: &[IrOperationInput]) -> Option<&IrOperationInput> {

--- a/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
+++ b/crates/coral-spec/src/v4/surfaces/openapi/responses.rs
@@ -154,14 +154,14 @@ impl OpenApiImporter<'_> {
             let Some(content) = response.get("content").and_then(Value::as_object) else {
                 continue;
             };
-            let Some(json) = content.get("application/json") else {
+            let Some((media_type, json)) = select_json_content(content) else {
                 continue;
             };
             let schema = json.get("schema").cloned().unwrap_or(Value::Null);
             let headers = response_headers(&response, operation_id, diagnostics, self);
             let candidate = SelectedJsonResponse {
                 status_code: status.representative_status_code(),
-                media_type: "application/json".to_string(),
+                media_type: media_type.to_string(),
                 schema,
                 headers,
             };
@@ -174,6 +174,36 @@ impl OpenApiImporter<'_> {
         preferred_numeric_response(numeric_candidates)
             .or_else(|| range_candidates.into_iter().next())
     }
+}
+
+fn select_json_content(content: &Map<String, Value>) -> Option<(&str, &Value)> {
+    content
+        .iter()
+        .filter(|(media_type, _)| {
+            media_type_essence(media_type).eq_ignore_ascii_case("application/json")
+        })
+        .min_by(|(left, _), (right, _)| left.cmp(right))
+        .or_else(|| {
+            content
+                .iter()
+                .filter(|(media_type, _)| is_structured_json_media_type(media_type))
+                .min_by(|(left, _), (right, _)| left.cmp(right))
+        })
+        .map(|(media_type, value)| (media_type.as_str(), value))
+}
+
+fn is_structured_json_media_type(media_type: &str) -> bool {
+    let Some((type_, subtype)) = media_type_essence(media_type).split_once('/') else {
+        return false;
+    };
+    type_.eq_ignore_ascii_case("application") && subtype.to_ascii_lowercase().ends_with("+json")
+}
+
+fn media_type_essence(media_type: &str) -> &str {
+    media_type
+        .split_once(';')
+        .map_or(media_type, |(essence, _)| essence)
+        .trim()
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
Accepts structured `application/*+json` and parameterized JSON responses during OpenAPI import while preserving `application/json` precedence. Prevents boolean fields such as $count from being inferred as page size