### PR TITLE
feat(api): scope trace queries by workspace

### DIFF
--- a/apps/reef/app/routes/trace-detail-loader.ts
+++ b/apps/reef/app/routes/trace-detail-loader.ts
@@ -3,6 +3,7 @@ import { create } from '@bufbuild/protobuf'
 import type { Route } from './+types/trace-detail'
 
 import { GetTraceRequestSchema } from '@/generated/coral/v1/traces_pb'
+import { WORKSPACE } from '@/lib/constants'
 import { traceClientForRequest } from '@/lib/coral-request.server'
 import { errorMessage } from '@/lib/utils'
 import { formatTraceError, type TraceDetailData } from '@/views/traces/trace-utils'
@@ -33,5 +34,7 @@ export async function loadTraceDetailRouteData(
 }
 
 async function getTraceForRequest(request: Request, traceId: string): Promise<TraceDetailData> {
-  return traceClientForRequest(request).getTrace(create(GetTraceRequestSchema, { traceId }))
+  return traceClientForRequest(request).getTrace(
+    create(GetTraceRequestSchema, { traceId, workspace: WORKSPACE }),
+  )
 }

--- a/apps/reef/app/routes/traces-loader.ts
+++ b/apps/reef/app/routes/traces-loader.ts
@@ -3,6 +3,7 @@ import { create } from '@bufbuild/protobuf'
 import type { Route } from './+types/traces'
 
 import { ListTracesRequestSchema } from '@/generated/coral/v1/traces_pb'
+import { WORKSPACE } from '@/lib/constants'
 import { traceClientForRequest } from '@/lib/coral-request.server'
 import { errorMessage } from '@/lib/utils'
 import { formatTraceError, isQueryTrace, type TraceSummaryData } from '@/views/traces/trace-utils'
@@ -85,6 +86,6 @@ async function listTracePageForRequest(
   pageToken: string,
 ): Promise<{ nextPageToken: string; traces: TraceSummaryData[] }> {
   return traceClientForRequest(request).listTraces(
-    create(ListTracesRequestSchema, { pageSize, pageToken }),
+    create(ListTracesRequestSchema, { pageSize, pageToken, workspace: WORKSPACE }),
   )
 }

--- a/apps/ui/src/lib/coral-traces-client.ts
+++ b/apps/ui/src/lib/coral-traces-client.ts
@@ -10,6 +10,8 @@ import {
   type ListTracesResponse,
 } from '@/generated/coral/v1/traces_pb'
 
+import { WORKSPACE } from './coral-clients'
+
 function grpcWebBaseUrl(): string {
   return import.meta.env.VITE_CORAL_GRPC_WEB_URL ?? window.location.origin
 }
@@ -28,7 +30,7 @@ export async function listTraces(pageSize = 50, pageToken = ''): Promise<ListTra
   if (inFlight) return inFlight
 
   const request = traces
-    .listTraces(create(ListTracesRequestSchema, { pageSize, pageToken }))
+    .listTraces(create(ListTracesRequestSchema, { pageSize, pageToken, workspace: WORKSPACE }))
     .finally(() => listTraceRequests.delete(key))
   listTraceRequests.set(key, request)
   return request
@@ -39,7 +41,7 @@ export async function getTrace(traceId: string): Promise<GetTraceResponse> {
   if (inFlight) return inFlight
 
   const request = traces
-    .getTrace(create(GetTraceRequestSchema, { traceId }))
+    .getTrace(create(GetTraceRequestSchema, { traceId, workspace: WORKSPACE }))
     .finally(() => getTraceRequests.delete(traceId))
   getTraceRequests.set(traceId, request)
   return request

--- a/crates/coral-api/proto/coral/v1/traces.proto
+++ b/crates/coral-api/proto/coral/v1/traces.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package coral.v1;
 
+import "coral/v1/resources.proto";
+
 // Query status derived from locally captured spans.
 enum TraceStatus {
   // Status was not recorded or could not be inferred.
@@ -45,6 +47,9 @@ message ListTracesRequest {
   int32 page_size = 1;
   // Opaque token returned by a previous list response.
   string page_token = 2;
+  // Optional workspace that scopes returned traces. Omit to list all local
+  // traces visible to the local server.
+  Workspace workspace = 3;
 }
 
 // Page of locally captured traces.
@@ -59,6 +64,9 @@ message ListTracesResponse {
 message GetTraceRequest {
   // W3C trace identifier.
   string trace_id = 1;
+  // Optional workspace that the trace must belong to. Omit for the global
+  // trace lookup.
+  Workspace workspace = 2;
 }
 
 // One stored trace span.

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -842,6 +842,7 @@ enabled = false
             .list_traces(Request::new(ListTracesRequest {
                 page_size: 10,
                 page_token: String::new(),
+                workspace: None,
             }))
             .await
             .expect_err("trace service should be disabled");
@@ -942,6 +943,7 @@ backend = "unsupported"
             .list_traces(Request::new(ListTracesRequest {
                 page_size: 10,
                 page_token: String::new(),
+                workspace: None,
             }))
             .await
             .expect("list traces")

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -546,6 +546,7 @@ struct TraceListAggregate {
     span_count: u32,
     error_count: u32,
     found_root_span: bool,
+    matches_workspace: bool,
     primary: Option<TracePrimaryCandidate>,
 }
 
@@ -597,6 +598,20 @@ impl TraceStore {
             .map_err(|source| TraceStoreError::Worker { source })?
     }
 
+    pub(crate) async fn list_traces_for_workspace(
+        &self,
+        limit: usize,
+        offset: usize,
+        workspace_name: String,
+    ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+        let traces = self.clone();
+        task::spawn_blocking(move || {
+            traces.list_traces_for_workspace_sync(limit, offset, &workspace_name)
+        })
+        .await
+        .map_err(|source| TraceStoreError::Worker { source })?
+    }
+
     pub(crate) async fn get_trace(
         &self,
         trace_id: String,
@@ -605,6 +620,19 @@ impl TraceStore {
         task::spawn_blocking(move || traces.get_trace_sync(&trace_id))
             .await
             .map_err(|source| TraceStoreError::Worker { source })?
+    }
+
+    pub(crate) async fn get_trace_for_workspace(
+        &self,
+        trace_id: String,
+        workspace_name: String,
+    ) -> Result<TraceDetailRecord, TraceStoreError> {
+        let traces = self.clone();
+        task::spawn_blocking(move || {
+            traces.get_trace_for_workspace_sync(&trace_id, &workspace_name)
+        })
+        .await
+        .map_err(|source| TraceStoreError::Worker { source })?
     }
 
     pub(crate) async fn delete_traces_for_workspace(
@@ -622,6 +650,24 @@ impl TraceStore {
         limit: usize,
         offset: usize,
     ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+        self.list_traces_filtered_sync(limit, offset, None)
+    }
+
+    fn list_traces_for_workspace_sync(
+        &self,
+        limit: usize,
+        offset: usize,
+        workspace_name: &str,
+    ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
+        self.list_traces_filtered_sync(limit, offset, Some(workspace_name))
+    }
+
+    fn list_traces_filtered_sync(
+        &self,
+        limit: usize,
+        offset: usize,
+        workspace_name: Option<&str>,
+    ) -> Result<Vec<TraceSummaryRecord>, TraceStoreError> {
         if limit == 0 {
             return Ok(Vec::new());
         }
@@ -636,7 +682,7 @@ impl TraceStore {
         for (file_index, file) in files.iter().enumerate().rev() {
             oldest_scanned_file_index = Some(file_index);
             for span in read_list_spans_file(&file.path)? {
-                record_list_span(span, &mut spans_by_id, &mut traces);
+                record_list_span(span, workspace_name, &mut spans_by_id, &mut traces);
             }
 
             let Some(newest_unscanned_file) =
@@ -648,16 +694,18 @@ impl TraceStore {
                 &traces,
                 required_trace_count,
                 newest_unscanned_file.span_end_upper_bound_unix_nanos,
+                workspace_name,
             ) {
                 break;
             }
         }
 
-        let page_trace_ids = trace_page_ids(&traces, offset, limit);
+        let page_trace_ids = trace_page_ids(&traces, offset, limit, workspace_name);
         complete_list_aggregates_for_page(
             &files,
             oldest_scanned_file_index,
             &page_trace_ids,
+            workspace_name,
             &mut spans_by_id,
             &mut traces,
         )?;
@@ -709,6 +757,23 @@ impl TraceStore {
 
         let summary = summary_from_spans(trace_id, &spans);
         Ok(TraceDetailRecord { summary, spans })
+    }
+
+    fn get_trace_for_workspace_sync(
+        &self,
+        trace_id: &str,
+        workspace_name: &str,
+    ) -> Result<TraceDetailRecord, TraceStoreError> {
+        let detail = self.get_trace_sync(trace_id)?;
+        if detail
+            .spans
+            .iter()
+            .any(|span| attributes_match_workspace(&span.attributes_json, workspace_name))
+        {
+            Ok(detail)
+        } else {
+            Err(TraceStoreError::NotFound(trace_id.to_string()))
+        }
     }
 
     pub(crate) fn list_query_history_sync(
@@ -894,7 +959,7 @@ impl TracePrimaryCandidate {
 }
 
 impl TraceListAggregate {
-    fn new(span: &TraceListSpanRecord) -> Self {
+    fn new(span: &TraceListSpanRecord, workspace_name: Option<&str>) -> Self {
         let mut aggregate = Self {
             trace_id: span.trace_id.clone(),
             start_time_unix_nanos: span.start_time_unix_nanos,
@@ -902,13 +967,14 @@ impl TraceListAggregate {
             span_count: 0,
             error_count: 0,
             found_root_span: false,
+            matches_workspace: false,
             primary: None,
         };
-        aggregate.record_span(span);
+        aggregate.record_span(span, workspace_name);
         aggregate
     }
 
-    fn record_span(&mut self, span: &TraceListSpanRecord) {
+    fn record_span(&mut self, span: &TraceListSpanRecord, workspace_name: Option<&str>) {
         self.start_time_unix_nanos = self.start_time_unix_nanos.min(span.start_time_unix_nanos);
         self.end_time_unix_nanos = self.end_time_unix_nanos.max(span.end_time_unix_nanos);
         self.span_count = self.span_count.saturating_add(1);
@@ -916,6 +982,9 @@ impl TraceListAggregate {
             self.error_count = self.error_count.saturating_add(1);
         }
         self.found_root_span |= is_root_span_parent(span.parent_span_id.as_deref());
+        self.matches_workspace |= workspace_name.is_some_and(|workspace_name| {
+            attributes_match_workspace(&span.attributes_json, workspace_name)
+        });
 
         let primary = TracePrimaryCandidate::from_span(span);
         if self
@@ -941,6 +1010,7 @@ impl TraceListAggregate {
 
 fn record_list_span(
     span: TraceListSpanRecord,
+    workspace_name: Option<&str>,
     spans_by_id: &mut HashMap<(String, String), TraceListSpanRecord>,
     traces: &mut HashMap<String, TraceListAggregate>,
 ) {
@@ -950,8 +1020,8 @@ fn record_list_span(
         Entry::Vacant(entry) => {
             traces
                 .entry(span.trace_id.clone())
-                .and_modify(|aggregate| aggregate.record_span(&span))
-                .or_insert_with(|| TraceListAggregate::new(&span));
+                .and_modify(|aggregate| aggregate.record_span(&span, workspace_name))
+                .or_insert_with(|| TraceListAggregate::new(&span, workspace_name));
             entry.insert(span);
         }
     }
@@ -961,8 +1031,12 @@ fn trace_page_ids(
     traces: &HashMap<String, TraceListAggregate>,
     offset: usize,
     limit: usize,
+    workspace_name: Option<&str>,
 ) -> HashSet<String> {
-    let mut aggregates = traces.values().collect::<Vec<_>>();
+    let mut aggregates = traces
+        .values()
+        .filter(|aggregate| trace_matches_workspace_filter(aggregate, workspace_name))
+        .collect::<Vec<_>>();
     sort_trace_aggregates(&mut aggregates);
     aggregates
         .into_iter()
@@ -976,6 +1050,7 @@ fn complete_list_aggregates_for_page(
     files: &[TraceStoreFile],
     oldest_scanned_file_index: Option<usize>,
     page_trace_ids: &HashSet<String>,
+    workspace_name: Option<&str>,
     spans_by_id: &mut HashMap<(String, String), TraceListSpanRecord>,
     traces: &mut HashMap<String, TraceListAggregate>,
 ) -> Result<(), TraceStoreError> {
@@ -995,7 +1070,7 @@ fn complete_list_aggregates_for_page(
             break;
         }
         for span in read_list_spans_file_for_trace_ids(&file.path, page_trace_ids)? {
-            record_list_span(span, spans_by_id, traces);
+            record_list_span(span, workspace_name, spans_by_id, traces);
         }
     }
 
@@ -1021,18 +1096,73 @@ fn list_page_is_newer_than_unscanned_files(
     traces: &HashMap<String, TraceListAggregate>,
     required_trace_count: usize,
     newest_unscanned_span_end_upper_bound_unix_nanos: i64,
+    workspace_name: Option<&str>,
 ) -> bool {
-    if required_trace_count == 0 || traces.len() < required_trace_count {
+    if required_trace_count == 0 {
         return false;
     }
 
-    let mut aggregates = traces.values().collect::<Vec<_>>();
+    let mut aggregates = traces
+        .values()
+        .filter(|aggregate| trace_matches_workspace_filter(aggregate, workspace_name))
+        .collect::<Vec<_>>();
+    if aggregates.len() < required_trace_count {
+        return false;
+    }
     sort_trace_aggregates(&mut aggregates);
-    aggregates
-        .get(required_trace_count - 1)
-        .is_some_and(|aggregate| {
-            aggregate.end_time_unix_nanos > newest_unscanned_span_end_upper_bound_unix_nanos
-        })
+    let Some(boundary) = aggregates.get(required_trace_count - 1) else {
+        return false;
+    };
+    if boundary.end_time_unix_nanos <= newest_unscanned_span_end_upper_bound_unix_nanos {
+        return false;
+    }
+
+    workspace_name.is_none_or(|_| {
+        workspace_filter_is_settled_for_page_boundary(
+            traces,
+            boundary,
+            newest_unscanned_span_end_upper_bound_unix_nanos,
+        )
+    })
+}
+
+fn trace_matches_workspace_filter(
+    aggregate: &TraceListAggregate,
+    workspace_name: Option<&str>,
+) -> bool {
+    workspace_name.is_none_or(|_| aggregate.matches_workspace)
+}
+
+fn workspace_filter_is_settled_for_page_boundary(
+    traces: &HashMap<String, TraceListAggregate>,
+    boundary: &TraceListAggregate,
+    newest_unscanned_span_end_upper_bound_unix_nanos: i64,
+) -> bool {
+    traces.values().all(|aggregate| {
+        aggregate.matches_workspace
+            || !could_sort_before_or_at_boundary(aggregate, boundary)
+            || trace_is_complete_before_unscanned_files(
+                aggregate,
+                newest_unscanned_span_end_upper_bound_unix_nanos,
+            )
+    })
+}
+
+fn could_sort_before_or_at_boundary(
+    aggregate: &TraceListAggregate,
+    boundary: &TraceListAggregate,
+) -> bool {
+    aggregate.end_time_unix_nanos > boundary.end_time_unix_nanos
+        || (aggregate.end_time_unix_nanos == boundary.end_time_unix_nanos
+            && aggregate.trace_id <= boundary.trace_id)
+}
+
+fn trace_is_complete_before_unscanned_files(
+    aggregate: &TraceListAggregate,
+    newest_unscanned_span_end_upper_bound_unix_nanos: i64,
+) -> bool {
+    aggregate.found_root_span
+        && newest_unscanned_span_end_upper_bound_unix_nanos < aggregate.start_time_unix_nanos
 }
 
 fn sort_trace_aggregates(aggregates: &mut [&TraceListAggregate]) {
@@ -2438,6 +2568,94 @@ mod tests {
                 .attributes_json,
             r#"{"sql":"SELECT 'new'"}"#
         );
+    }
+
+    #[test]
+    fn workspace_filtered_traces_include_complete_matching_traces() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+
+        let mut alpha_query = trace_record("alpha-new", "alpha-query");
+        alpha_query.attributes_json =
+            r#"{"workspace":"alpha","sql":"SELECT alpha_new"}"#.to_string();
+        alpha_query.start_time_unix_nanos = 10;
+        alpha_query.end_time_unix_nanos = 15;
+
+        let mut alpha_child = trace_record("alpha-new", "alpha-child");
+        alpha_child.parent_span_id = Some("alpha-query".to_string());
+        alpha_child.name = "http.request".to_string();
+        alpha_child.start_time_unix_nanos = 15;
+        alpha_child.end_time_unix_nanos = 20;
+
+        let mut beta_query = trace_record("beta-trace", "beta-query");
+        beta_query.attributes_json = r#"{"workspace":"beta","sql":"SELECT beta"}"#.to_string();
+        beta_query.start_time_unix_nanos = 30;
+        beta_query.end_time_unix_nanos = 40;
+
+        let mut alpha_old = trace_record("alpha-old", "alpha-old-query");
+        alpha_old.attributes_json = r#"{"workspace":"alpha","sql":"SELECT alpha_old"}"#.to_string();
+        alpha_old.start_time_unix_nanos = 1;
+        alpha_old.end_time_unix_nanos = 2;
+
+        let mut older_duplicate = trace_record("duplicate-workspace", "duplicate-span");
+        older_duplicate.attributes_json =
+            r#"{"workspace":"alpha","sql":"SELECT duplicate_old"}"#.to_string();
+        older_duplicate.start_time_unix_nanos = 50;
+        older_duplicate.end_time_unix_nanos = 60;
+
+        let mut newer_duplicate = trace_record("duplicate-workspace", "duplicate-span");
+        newer_duplicate.attributes_json =
+            r#"{"workspace":"beta","sql":"SELECT duplicate_new"}"#.to_string();
+        newer_duplicate.start_time_unix_nanos = 50;
+        newer_duplicate.end_time_unix_nanos = 70;
+
+        let path = dir.join(timestamped_jsonl_path(SystemTime::now()));
+        write_record_file_lines(
+            &path,
+            &[
+                alpha_query,
+                alpha_child,
+                beta_query,
+                alpha_old,
+                older_duplicate,
+                newer_duplicate,
+            ],
+        );
+
+        let store = TraceStore::new(dir);
+        let summaries = store
+            .list_traces_for_workspace_sync(10, 0, "alpha")
+            .expect("list alpha traces");
+
+        assert_eq!(
+            summaries
+                .iter()
+                .map(|summary| summary.trace_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha-new", "alpha-old"]
+        );
+        assert_eq!(summaries.first().expect("alpha-new").span_count, 2);
+        assert_eq!(
+            summaries.first().expect("alpha-new").end_time_unix_nanos,
+            20
+        );
+
+        let paged = store
+            .list_traces_for_workspace_sync(1, 1, "alpha")
+            .expect("list second alpha trace");
+        assert_eq!(paged.first().expect("paged alpha").trace_id, "alpha-old");
+
+        let detail = store
+            .get_trace_for_workspace_sync("alpha-new", "alpha")
+            .expect("alpha trace detail");
+        assert_eq!(detail.spans.len(), 2);
+        store
+            .get_trace_for_workspace_sync("beta-trace", "alpha")
+            .expect_err("beta trace must not be visible through alpha filter");
+        store
+            .get_trace_for_workspace_sync("duplicate-workspace", "alpha")
+            .expect_err("newer beta duplicate must not be visible through alpha filter");
     }
 
     #[test]

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -6,15 +6,17 @@ use std::time::Duration;
 use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
 use coral_api::v1::{
     GetTraceRequest, GetTraceResponse, ListTracesRequest, ListTracesResponse, TraceSpan,
-    TraceStatus, TraceSummary,
+    TraceStatus, TraceSummary, Workspace,
 };
 use tonic::{Code, Request, Response, Status};
 
+use crate::bootstrap::app_status;
 use crate::telemetry::local_store::{
     StoredTraceStatus, TraceDetailRecord, TraceSpanRecord, TraceStore, TraceStoreError,
     TraceSummaryRecord,
 };
 use crate::transport::{grpc_span, instrument_grpc};
+use crate::workspaces::WorkspaceName;
 
 const DEFAULT_TRACE_PAGE_SIZE: usize = 50;
 const MAX_TRACE_PAGE_SIZE: usize = 200;
@@ -44,10 +46,24 @@ impl TraceServiceApi for TraceService {
             let request = request.into_inner();
             let page_size = normalize_page_size(request.page_size);
             let offset = parse_page_token(&request.page_token)?;
-            let mut summaries = traces
-                .list_traces(page_size.saturating_add(1), offset)
-                .await
-                .map_err(trace_store_status)?;
+            let workspace_name = workspace_filter_from_proto(request.workspace.as_ref())?;
+            let mut summaries = match workspace_name {
+                Some(workspace_name) => {
+                    traces
+                        .list_traces_for_workspace(
+                            page_size.saturating_add(1),
+                            offset,
+                            workspace_name,
+                        )
+                        .await
+                }
+                None => {
+                    traces
+                        .list_traces(page_size.saturating_add(1), offset)
+                        .await
+                }
+            }
+            .map_err(trace_store_status)?;
             let next_page_token = if summaries.len() > page_size {
                 summaries.truncate(page_size);
                 offset.saturating_add(page_size).to_string()
@@ -76,10 +92,16 @@ impl TraceServiceApi for TraceService {
                     "invalid input: missing trace_id",
                 ));
             }
-            let trace = traces
-                .get_trace(request.trace_id)
-                .await
-                .map_err(trace_store_status)?;
+            let workspace_name = workspace_filter_from_proto(request.workspace.as_ref())?;
+            let trace = match workspace_name {
+                Some(workspace_name) => {
+                    traces
+                        .get_trace_for_workspace(request.trace_id, workspace_name)
+                        .await
+                }
+                None => traces.get_trace(request.trace_id).await,
+            }
+            .map_err(trace_store_status)?;
             Ok(Response::new(trace_detail_to_proto(trace)))
         })
         .await
@@ -106,6 +128,16 @@ fn parse_page_token(page_token: &str) -> Result<usize, Status> {
             "invalid input: page_token must be returned by ListTraces",
         )
     })
+}
+
+fn workspace_filter_from_proto(workspace: Option<&Workspace>) -> Result<Option<String>, Status> {
+    workspace
+        .map(|workspace| {
+            WorkspaceName::parse(&workspace.name)
+                .map(|workspace_name| workspace_name.as_str().to_string())
+                .map_err(app_status)
+        })
+        .transpose()
 }
 
 fn trace_store_status(error: TraceStoreError) -> Status {
@@ -188,7 +220,15 @@ fn trace_status_to_proto(status: StoredTraceStatus) -> TraceStatus {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_page_size, parse_page_token};
+    use std::time::Duration;
+
+    use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
+    use coral_api::v1::{GetTraceRequest, ListTracesRequest, Workspace};
+    use serde_json::json;
+    use tempfile::TempDir;
+    use tonic::{Code, Request};
+
+    use super::{TraceService, normalize_page_size, parse_page_token};
 
     #[test]
     fn page_size_defaults_and_caps() {
@@ -203,5 +243,113 @@ mod tests {
         assert_eq!(parse_page_token("").expect("empty token"), 0);
         assert_eq!(parse_page_token("25").expect("offset token"), 25);
         parse_page_token("not-an-offset").unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn trace_service_scopes_list_and_get_by_workspace() {
+        let temp = TempDir::new().expect("temp dir");
+        let trace_store = temp.path().join("trace-store");
+        std::fs::create_dir_all(&trace_store).expect("trace store dir");
+        write_trace_records(
+            &trace_store,
+            &[
+                trace_record_json("alpha-trace", "alpha-span", "alpha", 10, 20),
+                trace_record_json("beta-trace", "beta-span", "beta", 30, 40),
+            ],
+        );
+        let service = TraceService::new(trace_store, Duration::from_mins(1));
+
+        let response = TraceServiceApi::list_traces(
+            &service,
+            Request::new(ListTracesRequest {
+                page_size: 10,
+                page_token: String::new(),
+                workspace: Some(workspace("alpha")),
+            }),
+        )
+        .await
+        .expect("list alpha traces")
+        .into_inner();
+
+        assert_eq!(response.traces.len(), 1);
+        assert_eq!(
+            response.traces.first().expect("alpha trace").trace_id,
+            "alpha-trace"
+        );
+
+        let detail = TraceServiceApi::get_trace(
+            &service,
+            Request::new(GetTraceRequest {
+                trace_id: "alpha-trace".to_string(),
+                workspace: Some(workspace("alpha")),
+            }),
+        )
+        .await
+        .expect("get alpha trace")
+        .into_inner();
+        assert_eq!(detail.spans.len(), 1);
+
+        let status = TraceServiceApi::get_trace(
+            &service,
+            Request::new(GetTraceRequest {
+                trace_id: "beta-trace".to_string(),
+                workspace: Some(workspace("alpha")),
+            }),
+        )
+        .await
+        .expect_err("beta trace should not match alpha workspace");
+        assert_eq!(status.code(), Code::NotFound);
+    }
+
+    fn workspace(name: &str) -> Workspace {
+        Workspace {
+            name: name.to_string(),
+        }
+    }
+
+    fn write_trace_records(dir: &std::path::Path, records: &[serde_json::Value]) {
+        let mut lines = String::new();
+        for record in records {
+            lines.push_str(&record.to_string());
+            lines.push('\n');
+        }
+        std::fs::write(dir.join("spans-test.jsonl"), lines).expect("write trace records");
+    }
+
+    fn trace_record_json(
+        trace_id: &str,
+        span_id: &str,
+        workspace: &str,
+        start_time_unix_nanos: i64,
+        end_time_unix_nanos: i64,
+    ) -> serde_json::Value {
+        json!({
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "parent_span_id": null,
+            "parent_span_is_remote": false,
+            "name": "coral.query",
+            "kind": "internal",
+            "status": "ok",
+            "status_message": null,
+            "start_time_unix_nanos": start_time_unix_nanos,
+            "end_time_unix_nanos": end_time_unix_nanos,
+            "duration_nanos": end_time_unix_nanos - start_time_unix_nanos,
+            "attributes_json": json!({
+                "workspace": workspace,
+                "sql": format!("SELECT {workspace}"),
+                "status": "ok",
+            }).to_string(),
+            "events_json": "[]",
+            "links_json": "[]",
+            "resource_json": "{}",
+            "scope_name": "test",
+            "scope_version": null,
+            "scope_schema_url": null,
+            "scope_attributes_json": "{}",
+            "trace_flags": 0,
+            "trace_state": "",
+            "is_remote": false
+        })
     }
 }

--- a/crates/coral-app/tests/telemetry_host_subscriber.rs
+++ b/crates/coral-app/tests/telemetry_host_subscriber.rs
@@ -63,6 +63,7 @@ async fn host_subscriber_does_not_block_server_startup() {
         .list_traces(Request::new(ListTracesRequest {
             page_size: 10,
             page_token: String::new(),
+            workspace: None,
         }))
         .await
         .expect_err("host-owned subscriber should leave trace service disabled");

--- a/crates/coral-app/tests/telemetry_local_trace_lifecycle.rs
+++ b/crates/coral-app/tests/telemetry_local_trace_lifecycle.rs
@@ -122,6 +122,7 @@ async fn list_trace_ids(endpoint_uri: &str) -> Vec<String> {
         .list_traces(Request::new(ListTracesRequest {
             page_size: 10,
             page_token: String::new(),
+            workspace: None,
         }))
         .await
         .expect("list traces")


### PR DESCRIPTION
## Intent

Add workspace scoping to Coral trace inspection so clients can query trace history for a single workspace instead of only reading the process-wide trace stream.

## What it enables

- `TraceService.ListTraces` can accept an optional `workspace` and return only traces attributed to that workspace.
- `TraceService.GetTrace` can accept an optional `workspace` and fail closed when the trace does not belong to that workspace.
- Reef and the embedded UI now request trace list/detail data for the default workspace, consistent with existing source and schema requests.

## Usage examples

```protobuf
ListTracesRequest {
  page_size: 50
  workspace: { name: "default" }
}

GetTraceRequest {
  trace_id: "<trace-id>"
  workspace: { name: "default" }
}
```

Omitting `workspace` preserves the previous global local trace lookup behavior.

## Validation

- `cargo test -p coral-app telemetry::`
- `cargo clippy -p coral-app --all-targets --all-features --locked -- -D warnings`
- `npm run check --prefix apps/ui`
- `npm run type-check --prefix apps/ui`
- `npm run check --prefix apps/reef`
- `npm run typecheck --prefix apps/reef`
- `npm test --prefix apps/reef`
- `npm run build --prefix apps/reef`
- `make rust-checks` (`1600 passed, 2 skipped`)
- `git diff --check`
- `python3 /Users/saul/.codex/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Notes: `npm test --prefix apps/reef` passed with existing Storybook/Base UI console warnings. Autoreview initially found two store-level issues around bounded workspace listing and duplicate-span membership; both were fixed, and the final autoreview run reported no accepted/actionable findings.