### PR TITLE
feat(search): honor source-authored do-not-index policy

### DIFF
--- a/apps/docs/reference/source-spec-reference.mdx
+++ b/apps/docs/reference/source-spec-reference.mdx
@@ -72,6 +72,19 @@ Each column also supports:
 
 - `nullable` (boolean, default `true`): whether the column can contain NULL values
 - `description` (string): human-readable description, surfaced through `coral.columns`
+- `do_not_index` (boolean, default `false`): exclude the column from observed-value
+  indexing before Coral inspects or persists its values
+
+Set `do_not_index: true` on a field whose values should not be indexed or stored
+in plaintext in Coral's local search database. The field remains queryable
+through SQL:
+
+```yaml
+columns:
+  - name: internal_note
+    type: Utf8
+    do_not_index: true
+```
 
 ### Nested field naming
 

--- a/crates/coral-app/src/search/observed/collector.rs
+++ b/crates/coral-app/src/search/observed/collector.rs
@@ -14,6 +14,7 @@ use arrow::array::{
 use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
 use arrow::util::display::array_value_to_string;
+use coral_spec::DO_NOT_INDEX_COLUMN_METADATA_KEY;
 
 use crate::hash::sha256_hex;
 use crate::search::observed::sensitive::{is_sensitive_column, sanitize_observed_value};
@@ -32,7 +33,13 @@ impl ObservedValuesCollector {
         let mut seen = HashSet::new();
         let schema = batch.schema();
         let eligible_column_indices = (0..batch.num_columns())
-            .filter(|&column_index| !is_sensitive_column(schema.field(column_index).name()))
+            .filter(|&column_index| {
+                let field = schema.field(column_index);
+                !field
+                    .metadata()
+                    .contains_key(DO_NOT_INDEX_COLUMN_METADATA_KEY)
+                    && !is_sensitive_column(field.name())
+            })
             .collect::<Vec<_>>();
         for row_index in 0..batch.num_rows() {
             for &column_index in &eligible_column_indices {
@@ -188,15 +195,47 @@ fn normalize_search_text(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use arrow::array::{BinaryArray, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
 
-    use super::{ObservedValuesCollectionBudget, ObservedValuesCollector, raw_value_len};
+    use super::{
+        DO_NOT_INDEX_COLUMN_METADATA_KEY, ObservedValuesCollectionBudget, ObservedValuesCollector,
+        raw_value_len,
+    };
     use crate::search::observed::sqlite_queue::ObservedValuesQueuePayload;
     use crate::search::observed::writer::payload_json_with_budget;
+
+    #[test]
+    fn excludes_source_authored_do_not_index_columns_before_collection() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("internal_note", DataType::Utf8, false).with_metadata(HashMap::from([(
+                DO_NOT_INDEX_COLUMN_METADATA_KEY.to_string(),
+                "true".to_string(),
+            )])),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec!["Grace"])),
+                Arc::new(StringArray::from(vec!["persist-me-never"])),
+            ],
+        )
+        .expect("record batch");
+
+        let payload = ObservedValuesCollector::default().collect_batch(&batch);
+        let values = payload
+            .values
+            .iter()
+            .map(|candidate| candidate.display_value.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(values, ["Grace"]);
+    }
 
     #[test]
     fn suppresses_sensitive_columns_and_values() {

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -230,7 +230,7 @@ fn observed_surface_kind(kind: SourceObservationSurfaceKind) -> ObservedValuesSu
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashMap};
     use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
@@ -242,7 +242,7 @@ mod tests {
         QuerySource, RuntimeSourceComponent, RuntimeSourcePackage, SourceObservationSurfaceKind,
         SourceScanObservation,
     };
-    use coral_spec::parse_source_manifest_yaml;
+    use coral_spec::{DO_NOT_INDEX_COLUMN_METADATA_KEY, parse_source_manifest_yaml};
     use serde_json::json;
     use tempfile::tempdir;
     use uuid::Uuid;
@@ -348,6 +348,47 @@ mod tests {
         assert!(payloads.contains("coral"));
         assert!(!payloads.contains("literal-secret"));
         assert!(!payloads.contains("ghp_supersecret"));
+    }
+
+    #[test]
+    fn publisher_does_not_persist_source_authored_do_not_index_columns() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let handle = SearchObservationHandle::new(layout.clone());
+        let extensions = handle.extensions_for(&workspace, &[secret_input_query_source()]);
+        let publisher = extensions
+            .source_observation_publishers
+            .first()
+            .expect("publisher");
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![
+                Field::new("name", DataType::Utf8, false),
+                Field::new("internal_note", DataType::Utf8, false).with_metadata(HashMap::from([
+                    (
+                        DO_NOT_INDEX_COLUMN_METADATA_KEY.to_string(),
+                        "true".to_string(),
+                    ),
+                ])),
+            ])),
+            vec![
+                Arc::new(StringArray::from(vec!["Grace"])),
+                Arc::new(StringArray::from(vec!["persist-me-never"])),
+            ],
+        )
+        .expect("batch");
+
+        publisher.publish_source_scan(SourceScanObservation {
+            source_name: "github",
+            surface_kind: SourceObservationSurfaceKind::Table,
+            surface_name: "issues",
+            batch: &batch,
+        });
+
+        let payloads = wait_for_payloads(&layout, &workspace).join("\n");
+        assert!(payloads.contains("Grace"));
+        assert!(!payloads.contains("persist-me-never"));
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -9,8 +9,9 @@ use crate::{
 };
 use async_trait::async_trait;
 use coral_spec::{
-    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec,
-    SearchLimitsSpec, SourceBackend, SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon,
+    ColumnSpec, DO_NOT_INDEX_COLUMN_METADATA_KEY, FilterSpec, ManifestDataType, ManifestInputKind,
+    ManifestInputSpec, SearchLimitsSpec, SourceBackend, SourceTableFunctionKind,
+    SourceTableFunctionSpec, TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use datafusion::datasource::TableProvider;
@@ -385,11 +386,14 @@ pub(crate) fn schema_from_columns(
 
     let mut fields = Vec::with_capacity(columns.len());
     for column in columns {
-        fields.push(Field::new(
-            &column.name,
-            arrow_type_for_column(column),
-            column.nullable,
-        ));
+        let mut field = Field::new(&column.name, arrow_type_for_column(column), column.nullable);
+        if column.do_not_index {
+            field = field.with_metadata(HashMap::from([(
+                DO_NOT_INDEX_COLUMN_METADATA_KEY.to_string(),
+                "true".to_string(),
+            )]));
+        }
+        fields.push(field);
     }
     Ok(Arc::new(Schema::new(fields)))
 }
@@ -435,6 +439,36 @@ mod tests {
     use super::*;
 
     #[test]
+    fn schema_marks_source_authored_do_not_index_columns() {
+        let schema = schema_from_columns(
+            &[
+                test_column("visible", false),
+                test_column("internal_note", true),
+            ],
+            "demo",
+            "items",
+        )
+        .expect("schema");
+
+        assert!(
+            !schema
+                .field_with_name("visible")
+                .expect("visible field")
+                .metadata()
+                .contains_key(DO_NOT_INDEX_COLUMN_METADATA_KEY)
+        );
+        assert_eq!(
+            schema
+                .field_with_name("internal_note")
+                .expect("excluded field")
+                .metadata()
+                .get(DO_NOT_INDEX_COLUMN_METADATA_KEY)
+                .map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
     fn default_http_client_is_shared_only_within_registration_context() {
         let build_count = AtomicUsize::new(0);
         let first_context = BackendRegistrationContext::default();
@@ -469,5 +503,17 @@ mod tests {
         reqwest::Client::builder()
             .build()
             .map_err(|error| error.to_string())
+    }
+
+    fn test_column(name: &str, do_not_index: bool) -> ColumnSpec {
+        ColumnSpec {
+            name: name.to_string(),
+            data_type: ManifestDataType::Utf8,
+            nullable: true,
+            r#virtual: false,
+            description: String::new(),
+            expr: None,
+            do_not_index,
+        }
     }
 }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -21,6 +21,10 @@ use crate::{ManifestError, ParsedTemplate, Result};
 
 const RESERVED_SOURCE_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin", "public"];
 
+/// Arrow field metadata key marking a source-authored column as excluded from
+/// observed-value indexing.
+pub const DO_NOT_INDEX_COLUMN_METADATA_KEY: &str = "coral.do_not_index";
+
 /// Common top-level source metadata shared by every backend source spec.
 #[derive(Debug, Clone)]
 pub struct SourceManifestCommon {
@@ -989,6 +993,9 @@ pub struct ColumnSpec {
     pub description: String,
     #[serde(default)]
     pub expr: Option<ExprSpec>,
+    /// Excludes this column from observed-value indexing when true.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub do_not_index: bool,
 }
 
 impl ColumnSpec {

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -94,12 +94,13 @@ pub use backends::mcp::{
     McpTableFilterBinding, McpTableFilterSpec, McpTableFunctionSpec, McpTableSpec,
 };
 pub use common::{
-    BodyFieldSpec, BodySpec, ColumnSpec, DetailHintSpec, ExprSpec, FilterMode, FilterSpec,
-    FunctionArgBinding, HeaderSpec, HttpMethod, ManifestDataType, PageSizeSpec, PaginationMode,
-    PaginationSpec, QueryParamSpec, RequestRouteSpec, RequestSpec, ResponseBodyFormat,
-    ResponseSpec, RowStrategy, SearchLimitsSpec, SourceBackend, SourceManifestCommon,
-    SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon, TableFunctionArgSpec,
-    TimestampInput, ValidatedPagination, ValidatedPaginationMode, ValueSourceSpec,
+    BodyFieldSpec, BodySpec, ColumnSpec, DO_NOT_INDEX_COLUMN_METADATA_KEY, DetailHintSpec,
+    ExprSpec, FilterMode, FilterSpec, FunctionArgBinding, HeaderSpec, HttpMethod, ManifestDataType,
+    PageSizeSpec, PaginationMode, PaginationSpec, QueryParamSpec, RequestRouteSpec, RequestSpec,
+    ResponseBodyFormat, ResponseSpec, RowStrategy, SearchLimitsSpec, SourceBackend,
+    SourceManifestCommon, SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon,
+    TableFunctionArgSpec, TimestampInput, ValidatedPagination, ValidatedPaginationMode,
+    ValueSourceSpec,
 };
 pub(crate) use common::{
     validate_reserved_source_schema_name, validate_source_name, validate_test_queries,

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -290,6 +290,41 @@ tables:
     }
 
     #[test]
+    fn parse_source_manifest_preserves_do_not_index_policy() {
+        let manifest = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: file
+tables:
+  - name: messages
+    description: Demo messages
+    format: jsonl
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: title
+        type: Utf8
+      - name: internal_note
+        type: Utf8
+        do_not_index: true
+",
+        )
+        .expect("manifest should parse");
+        let columns = manifest
+            .as_file()
+            .expect("file manifest")
+            .tables
+            .first()
+            .expect("messages table")
+            .columns();
+
+        assert!(!columns.first().expect("title column").do_not_index);
+        assert!(columns.get(1).expect("internal note column").do_not_index);
+    }
+
+    #[test]
     fn reserved_source_name_is_rejected() {
         let error = parse_source_manifest_yaml(
             r"

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -1306,7 +1306,8 @@
         "nullable": { "type": "boolean" },
         "virtual": { "type": "boolean" },
         "description": { "type": "string" },
-        "expr": { "$ref": "#/$defs/expr" }
+        "expr": { "$ref": "#/$defs/expr" },
+        "do_not_index": { "type": "boolean" }
       }
     },
     "expr": {

--- a/crates/coral-spec/src/v4/projections/derive.rs
+++ b/crates/coral-spec/src/v4/projections/derive.rs
@@ -329,6 +329,7 @@ fn projection_columns(
                 source_path: Vec::new(),
                 nullable: true,
                 description: "Full decoded tool response row rendered as text.".to_string(),
+                do_not_index: false,
             },
             ProjectionColumn {
                 name: "result_json".to_string(),
@@ -336,6 +337,7 @@ fn projection_columns(
                 source_path: Vec::new(),
                 nullable: true,
                 description: "Full decoded tool response row rendered as JSON.".to_string(),
+                do_not_index: false,
             },
         ];
     }
@@ -346,6 +348,7 @@ fn projection_columns(
             source_path: Vec::new(),
             nullable: true,
             description: String::new(),
+            do_not_index: false,
         }];
     };
     let IrTypeShape::Object { fields } = &row_type.shape else {
@@ -355,6 +358,7 @@ fn projection_columns(
             source_path: Vec::new(),
             nullable: true,
             description: row_type.description.clone(),
+            do_not_index: false,
         }];
     };
     let mut columns = Vec::new();
@@ -374,6 +378,7 @@ fn projection_columns(
             source_path: vec![field.name.clone()],
             nullable: true,
             description: field.description.clone(),
+            do_not_index: false,
         });
     }
     columns

--- a/crates/coral-spec/src/v4/projections/model.rs
+++ b/crates/coral-spec/src/v4/projections/model.rs
@@ -80,12 +80,16 @@ pub struct ProjectionColumn {
     pub source_path: Vec<String>,
     pub nullable: bool,
     pub description: String,
+    /// Excludes this column from observed-value indexing when true.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub do_not_index: bool,
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        Projection, ProjectionCatalog, ProjectionKind, ProjectionVisibility, SqlInputExposure,
+        Projection, ProjectionCatalog, ProjectionColumn, ProjectionKind, ProjectionVisibility,
+        SqlInputExposure,
     };
     use crate::v4::{PROJECTION_GENERATOR_VERSION, V4_ARTIFACT_SCHEMA_VERSION};
     use crate::{ManifestDataType, SearchLimitsSpec, SourceTableFunctionKind};
@@ -108,7 +112,14 @@ mod tests {
                 operation_id: "issues/search".to_string(),
                 visibility: ProjectionVisibility::Published,
                 inputs: Vec::new(),
-                columns: Vec::new(),
+                columns: vec![ProjectionColumn {
+                    name: "internal_note".to_string(),
+                    data_type: ManifestDataType::Utf8,
+                    source_path: vec!["internalNote".to_string()],
+                    nullable: true,
+                    description: String::new(),
+                    do_not_index: true,
+                }],
                 search_limits: Some(SearchLimitsSpec {
                     default_top_k: 30,
                     max_top_k: 100,
@@ -137,9 +148,24 @@ mod tests {
             !yaml.contains("pagination:"),
             "projection catalog should not serialize pagination: {yaml}"
         );
+        assert!(
+            yaml.contains("do_not_index: true"),
+            "projection catalog should serialize explicit indexing policy: {yaml}"
+        );
 
-        serde_yaml::from_str::<ProjectionCatalog>(&yaml)
+        let decoded = serde_yaml::from_str::<ProjectionCatalog>(&yaml)
             .expect("projection catalog should round-trip");
+        assert!(
+            decoded
+                .projections
+                .first()
+                .expect("projection")
+                .columns
+                .first()
+                .expect("column")
+                .do_not_index,
+            "projection column policy should survive round-trip"
+        );
     }
 
     #[test]
@@ -161,7 +187,12 @@ projections:
     operation_id: issues/search
     visibility: published
     inputs: []
-    columns: []
+    columns:
+      - name: title
+        data_type: Utf8
+        source_path: [title]
+        nullable: true
+        description: ''
     search_limits: null
     detail_hints: []
     diagnostics: []
@@ -174,6 +205,17 @@ diagnostics: []
         assert_eq!(
             catalog.projections.first().expect("projection").namespace,
             ""
+        );
+        assert!(
+            !catalog
+                .projections
+                .first()
+                .expect("projection")
+                .columns
+                .first()
+                .expect("column")
+                .do_not_index,
+            "legacy projection columns should default to indexable"
         );
     }
 

--- a/crates/coral-spec/src/v4/projections/runtime.rs
+++ b/crates/coral-spec/src/v4/projections/runtime.rs
@@ -73,6 +73,7 @@ pub fn projection_column_specs(projection: &Projection) -> Vec<ColumnSpec> {
             expr: Some(ExprSpec::Path {
                 path: column.source_path.clone(),
             }),
+            do_not_index: column.do_not_index,
         })
         .collect::<Vec<_>>();
     let existing = columns
@@ -94,6 +95,7 @@ pub fn projection_column_specs(projection: &Projection) -> Vec<ColumnSpec> {
                 expr: Some(ExprSpec::FromFilter {
                     key: input.name.clone(),
                 }),
+                do_not_index: false,
             }),
     );
     columns

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -939,6 +939,7 @@ mod tests {
             r#virtual: false,
             description: String::new(),
             expr: None,
+            do_not_index: false,
         }
     }
 
@@ -982,6 +983,34 @@ mod tests {
             error.to_string().contains("unknown variant `Banana`"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn column_spec_do_not_index_defaults_false_and_round_trips() {
+        let default = serde_json::from_value::<ColumnSpec>(json!({
+            "name": "title",
+            "type": "Utf8",
+        }))
+        .expect("default column policy");
+        assert!(!default.do_not_index);
+        assert!(
+            serde_json::to_value(&default)
+                .expect("serialize default column")
+                .get("do_not_index")
+                .is_none()
+        );
+
+        let excluded = serde_json::from_value::<ColumnSpec>(json!({
+            "name": "internal_note",
+            "type": "Utf8",
+            "do_not_index": true,
+        }))
+        .expect("explicit column policy");
+        let serialized = serde_json::to_value(&excluded).expect("serialize excluded column");
+        assert_eq!(serialized.get("do_not_index"), Some(&json!(true)));
+        let round_tripped =
+            serde_json::from_value::<ColumnSpec>(serialized).expect("round-trip column policy");
+        assert!(round_tripped.do_not_index);
     }
 
     fn base_request() -> RequestSpec {


### PR DESCRIPTION
## Summary

- add source-authored `do_not_index` column policy for v3 manifests and v4 projections, defaulting to `false`
- carry the policy through runtime schemas and Arrow field metadata
- exclude opted-out fields before value inspection or persistence, while retaining Coral's mandatory sensitive-name and sensitive-value suppression
- document the field, default, SQL behavior, and a concrete YAML example in the public source-spec reference

This is intentionally a child of the observed-values queue substrate: PR #1472 remains policy-agnostic, and this PR owns the source-author policy contract and its reference documentation.

## Testing

- `cargo test -p coral-spec -p coral-engine -p coral-app do_not_index`
- `make docs-check`
- covered by the top-of-stack `make rust-checks`


## Feature flag

Source-authored `do_not_index` metadata remains valid regardless of the runtime flag. Its observed-value collection effect is dormant while `observed_values_search` is disabled.
