### PR TITLE
fix(mcp): simplify task lifecycle results

### DIFF
--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -82,7 +82,7 @@ fn task_started_value(task: &coral_api::v1::Task) -> Result<TaskStartedValue, to
     Ok(TaskStartedValue {
         task_id,
         message: "Task started.",
-        instructions: "Pass this task_id as task_id on subsequent Coral MCP tool calls for this work, then call end_task when the task is complete.",
+        instructions: "Pass this task_id on subsequent Coral MCP tool calls, then call end_task when the task is complete.",
     })
 }
 
@@ -496,7 +496,6 @@ impl CoralMcpServer {
         serialize_tool_value(TaskEndedValue {
             task_id,
             task_status: task_status_from_proto(task_end.task_status)?,
-            success: "Task ended.",
             note: "Task status recorded.",
         })
     }

--- a/crates/coral-mcp/src/surface/task.rs
+++ b/crates/coral-mcp/src/surface/task.rs
@@ -99,7 +99,6 @@ pub(crate) struct TaskStartedValue {
 pub(crate) struct TaskEndedValue {
     pub(crate) task_id: TaskId,
     pub(crate) task_status: TaskStatus,
-    pub(crate) success: &'static str,
     pub(crate) note: &'static str,
 }
 

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -555,7 +555,11 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
     assert_structured_content_only(&end);
     let end = end.structured_content.expect("end structured content");
     assert_matches_output_schema(end_task_tool, &end);
-    assert_eq!(end["success"], "Task ended.");
+    assert!(
+        !end.as_object()
+            .expect("end task object")
+            .contains_key("success")
+    );
     assert_eq!(end["task_status"], "success");
 
     let invalid_task_id = client


### PR DESCRIPTION
Text cleanup on the task MCP tools.

## Summary

- simplify the `start_task` instruction so it says to pass the returned task id on subsequent Coral calls
- remove the redundant `success: "Task ended."` field from `end_task`
- keep the structured `task_id`, `task_status`, and `note` fields as the lifecycle result contract
- update the MCP lifecycle test to assert that the redundant field is absent

## Why

`task_status` already communicates whether the task ended successfully or failed, while `note` confirms that the status was recorded. Returning an additional fixed success string duplicates that structured state and gives callers one more field with no additional information.

The shorter start instruction communicates the same lifecycle requirement without repeating `task_id` or adding extra phrasing.

## Scope

This is a standalone MCP result-shape cleanup based directly on `main`. It does not include trajectory capture, distillation, indexing, suggested paths, feature configuration, or documentation changes.

## Validation

- `cargo test --locked -p coral-mcp mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls`
- `make rust-checks`