### PR TITLE
feat(app): persist tasks in SQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,6 +1396,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sqlx",
  "tempfile",
  "thiserror",
  "tokio",

--- a/crates/coral-app/migrations/0003_tasks.sql
+++ b/crates/coral-app/migrations/0003_tasks.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS tasks (
+    workspace_id TEXT NOT NULL,
+    id TEXT NOT NULL,
+    intent TEXT NOT NULL,
+    status TEXT,
+    started_at_unix_nanos BIGINT NOT NULL,
+    ended_at_unix_nanos BIGINT,
+    PRIMARY KEY (workspace_id, id),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -60,7 +60,7 @@ use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_stat
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::task::manager::TaskManager;
 use crate::task::service::TaskService;
-use crate::task::store::JsonlTaskEventStore;
+use crate::task::store::TaskStore;
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcRequestContextLayer;
@@ -316,7 +316,7 @@ impl ServerBuilder {
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
-        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
+        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&coral_db)));
         let body_capture_max_bytes = telemetry_config
             .trace_history
             .http_body_recording_max_bytes();
@@ -762,6 +762,7 @@ mod tests {
     };
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
     use tempfile::TempDir;
     use tonic::transport::Endpoint;
     use tonic::{Code, Request};
@@ -778,7 +779,7 @@ mod tests {
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig, run_state_migrations};
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::task::manager::TaskManager;
-    use crate::task::store::JsonlTaskEventStore;
+    use crate::task::store::TaskStore;
     use crate::telemetry::service::TraceService;
     use crate::transport::workspace_to_proto;
     use crate::workspaces::{WorkspaceManager, WorkspaceName};
@@ -938,18 +939,23 @@ backend = "unsupported"
         assert_eq!(task_end.task_status, TaskStatus::Success as i32);
 
         let layout = AppStateLayout::discover(Some(config_dir)).expect("layout");
-        let workspace = WorkspaceName::default();
-        let tasks =
-            std::fs::read_to_string(layout.task_events_file(&workspace)).expect("task events file");
-        assert!(tasks.contains(&task.task_id));
-        assert!(
-            tasks.contains("find the HR onboarding form"),
-            "task events should contain start intent, got: {tasks}"
-        );
-        assert!(
-            tasks.contains("success"),
-            "task events should contain end status, got: {tasks}"
-        );
+        let pool = SqlitePoolOptions::new()
+            .connect_with(
+                SqliteConnectOptions::new()
+                    .filename(layout.database_file())
+                    .create_if_missing(false),
+            )
+            .await
+            .expect("open database");
+        let stored: (String, Option<String>) =
+            sqlx::query_as("SELECT intent, status FROM tasks WHERE workspace_id = ? AND id = ?")
+                .bind("default")
+                .bind(&task.task_id)
+                .fetch_one(&pool)
+                .await
+                .expect("task row");
+        assert_eq!(stored.0, "find the HR onboarding form");
+        assert_eq!(stored.1.as_deref(), Some("success"));
         server.shutdown().await.expect("shutdown");
     }
 
@@ -969,7 +975,7 @@ backend = "unsupported"
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
-        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
+        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&db)));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -1408,7 +1414,7 @@ tables:
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
-        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
+        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&db)));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -1528,7 +1534,7 @@ tables:
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
-        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
+        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&db)));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -1645,7 +1651,7 @@ tables:
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
-        let task_manager = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
+        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&db)));
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -17,5 +17,6 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
+pub(crate) use repositories::tasks::TaskRecord;
 pub(crate) use session::{DbRepos, DbSession};
 pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod state_migrations;
+pub(crate) mod tasks;
 pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/repositories/tasks.rs
+++ b/crates/coral-app/src/state/db/repositories/tasks.rs
@@ -1,0 +1,200 @@
+use sea_query::{Expr, ExprTrait, Query};
+
+use crate::state::db::schema::Tasks;
+use crate::state::db::{DbError, DbSession};
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub(crate) struct TaskRecord {
+    pub(crate) id: String,
+    pub(crate) intent: String,
+    pub(crate) status: Option<String>,
+    pub(crate) started_at_unix_nanos: i64,
+    pub(crate) ended_at_unix_nanos: Option<i64>,
+}
+
+pub(crate) struct TasksRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> TasksRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn insert(
+        &mut self,
+        workspace_id: &str,
+        task: &TaskRecord,
+    ) -> Result<(), DbError> {
+        let statement = task_insert(workspace_id, task);
+        self.session.execute(statement).await
+    }
+
+    pub(crate) async fn update_status(
+        &mut self,
+        workspace_id: &str,
+        task_id: &str,
+        status: &str,
+        ended_at_unix_nanos: i64,
+    ) -> Result<(), DbError> {
+        let statement = Query::update()
+            .table(Tasks::Table)
+            .values([
+                (Tasks::Status, Expr::val(status.to_string())),
+                (
+                    Tasks::EndedAtUnixNanos,
+                    Expr::val(Some(ended_at_unix_nanos)),
+                ),
+            ])
+            .and_where(Expr::col(Tasks::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(Tasks::Id).eq(task_id))
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    pub(crate) async fn get(
+        &mut self,
+        workspace_id: &str,
+        task_id: &str,
+    ) -> Result<Option<TaskRecord>, DbError> {
+        let statement = Query::select()
+            .columns(task_columns())
+            .from(Tasks::Table)
+            .and_where(Expr::col(Tasks::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(Tasks::Id).eq(task_id))
+            .to_owned();
+        self.session.fetch_optional(statement).await
+    }
+}
+
+fn task_insert(workspace_id: &str, task: &TaskRecord) -> sea_query::InsertStatement {
+    Query::insert()
+        .into_table(Tasks::Table)
+        .columns([
+            Tasks::WorkspaceId,
+            Tasks::Id,
+            Tasks::Intent,
+            Tasks::Status,
+            Tasks::StartedAtUnixNanos,
+            Tasks::EndedAtUnixNanos,
+        ])
+        .values_panic([
+            Expr::val(workspace_id.to_string()),
+            Expr::val(task.id.clone()),
+            Expr::val(task.intent.clone()),
+            Expr::val(task.status.clone()),
+            Expr::val(task.started_at_unix_nanos),
+            Expr::val(task.ended_at_unix_nanos),
+        ])
+        .to_owned()
+}
+
+fn task_columns() -> [Tasks; 5] {
+    [
+        Tasks::Id,
+        Tasks::Intent,
+        Tasks::Status,
+        Tasks::StartedAtUnixNanos,
+        Tasks::EndedAtUnixNanos,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::TaskRecord;
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+
+    #[tokio::test]
+    async fn task_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let db = open_sqlite(&layout).await;
+
+        assert_task_repository_round_trip(&db, "sqlite_task_round_trip").await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn task_repository_round_trips_against_postgres() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        assert_task_repository_round_trip(&db, &format!("postgres_task_{suffix}")).await;
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    async fn assert_task_repository_round_trip(db: &CoralDb, workspace_id: &str) {
+        let task = TaskRecord {
+            id: uuid::Uuid::new_v4().to_string(),
+            intent: "Find renewal risk".to_string(),
+            status: None,
+            started_at_unix_nanos: 41,
+            ended_at_unix_nanos: None,
+        };
+        let mut tx = db.begin().await.expect("begin tx");
+        tx.workspaces()
+            .ensure(workspace_id, 40)
+            .await
+            .expect("workspace");
+        tx.tasks().insert(workspace_id, &task).await.expect("task");
+        tx.commit().await.expect("commit task");
+
+        let mut session = db;
+        assert_eq!(
+            session
+                .tasks()
+                .get(workspace_id, &task.id)
+                .await
+                .expect("get"),
+            Some(task.clone())
+        );
+
+        let mut tx = db.begin().await.expect("begin status tx");
+        tx.tasks()
+            .update_status(workspace_id, &task.id, "success", 42)
+            .await
+            .expect("update status");
+        tx.commit().await.expect("commit status");
+
+        assert_eq!(
+            session
+                .tasks()
+                .get(workspace_id, &task.id)
+                .await
+                .expect("get ended")
+                .expect("task")
+                .status
+                .as_deref(),
+            Some("success")
+        );
+    }
+
+    fn postgres_test_url() -> Option<String> {
+        bootstrap::env_var("CORAL_TEST_POSTGRES_URL").expect("read CORAL_TEST_POSTGRES_URL")
+    }
+}

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -13,3 +13,14 @@ pub(in crate::state::db) enum AppStateMigrations {
     Id,
     CompletedAtUnixNanos,
 }
+
+#[derive(Iden)]
+pub(in crate::state::db) enum Tasks {
+    Table,
+    WorkspaceId,
+    Id,
+    Intent,
+    Status,
+    StartedAtUnixNanos,
+    EndedAtUnixNanos,
+}

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -7,6 +7,7 @@ use sqlx::{FromRow, Postgres, Sqlite};
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
 use crate::state::db::repositories::state_migrations::StateMigrationsRepo;
+use crate::state::db::repositories::tasks::TasksRepo;
 use crate::state::db::repositories::workspaces::WorkspacesRepo;
 
 pub(crate) trait DbSession {
@@ -34,6 +35,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn workspaces(&mut self) -> WorkspacesRepo<'_, Self> {
         WorkspacesRepo::new(self)
+    }
+
+    fn tasks(&mut self) -> TasksRepo<'_, Self> {
+        TasksRepo::new(self)
     }
 }
 

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -138,13 +138,6 @@ impl AppStateLayout {
         self.search_dir(workspace_name).join("search.sqlite3")
     }
 
-    /// Per-workspace task lifecycle event log (JSONL).
-    pub(crate) fn task_events_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
-        self.workspace_dir(workspace_name)
-            .join("tasks")
-            .join("tasks.jsonl")
-    }
-
     pub(crate) fn source_dir(
         &self,
         workspace_name: &WorkspaceName,
@@ -348,14 +341,6 @@ mod tests {
                 .join("default")
                 .join("search")
                 .join("search.sqlite3")
-        );
-        assert_eq!(
-            layout.task_events_file(&workspace_name),
-            config_dir
-                .join("workspaces")
-                .join("default")
-                .join("tasks")
-                .join("tasks.jsonl")
         );
         assert_eq!(
             layout.local_trace_store_dir(),

--- a/crates/coral-app/src/task/manager.rs
+++ b/crates/coral-app/src/task/manager.rs
@@ -1,23 +1,21 @@
 //! App-domain task lifecycle orchestration.
 
-use std::sync::Arc;
-
 use super::id::TaskId;
-use super::store::{TaskEnd, TaskEventStore, TaskStart, TaskStatus, TaskStoreError};
+use super::store::{TaskEnd, TaskStart, TaskStatus, TaskStore, TaskStoreError};
 use crate::workspaces::WorkspaceName;
 
 /// Coordinates task lifecycle persistence and validation.
 #[derive(Clone)]
 pub(crate) struct TaskManager {
-    store: Arc<dyn TaskEventStore>,
+    store: TaskStore,
 }
 
 impl TaskManager {
-    pub(crate) fn new(store: Arc<dyn TaskEventStore>) -> Self {
+    pub(crate) fn new(store: TaskStore) -> Self {
         Self { store }
     }
 
-    pub(crate) fn start_task(
+    pub(crate) async fn start_task(
         &self,
         workspace: WorkspaceName,
         intent: String,
@@ -27,17 +25,17 @@ impl TaskManager {
             workspace,
             intent,
         };
-        self.store.start_task(&start)?;
+        self.store.start_task(&start).await?;
         Ok(start)
     }
 
-    pub(crate) fn end_task(
+    pub(crate) async fn end_task(
         &self,
         workspace: WorkspaceName,
         task_id: TaskId,
         status: TaskStatus,
     ) -> Result<TaskEnd, TaskManagerError> {
-        if !self.store.contains_started_task(&workspace, &task_id)? {
+        if self.store.task(&workspace, &task_id).await?.is_none() {
             return Err(TaskManagerError::TaskNotFound {
                 task_id: task_id.to_string(),
             });
@@ -47,7 +45,7 @@ impl TaskManager {
             workspace,
             status,
         };
-        self.store.end_task(&end)?;
+        self.store.end_task(&end).await?;
         Ok(end)
     }
 }

--- a/crates/coral-app/src/task/service.rs
+++ b/crates/coral-app/src/task/service.rs
@@ -38,6 +38,7 @@ impl TaskServiceApi for TaskService {
             let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
             let start = task
                 .start_task(workspace, request.intent)
+                .await
                 .map_err(|error| task_manager_status(&error))?;
             Ok(Response::new(StartTaskResponse {
                 task: Some(task_start_to_proto(&start)),
@@ -59,6 +60,7 @@ impl TaskServiceApi for TaskService {
             let task_status = task_status_from_proto(request.task_status).map_err(app_status)?;
             let end = task
                 .end_task(workspace, task_id, task_status)
+                .await
                 .map_err(|error| task_manager_status(&error))?;
             Ok(Response::new(EndTaskResponse {
                 task_end: Some(task_end_to_proto(&end)),
@@ -107,7 +109,7 @@ fn task_manager_status(error: &TaskManagerError) -> Status {
         TaskManagerError::Store(TaskStoreError::InvalidIntent { .. }) => {
             Status::invalid_argument(error.to_string())
         }
-        TaskManagerError::Store(TaskStoreError::Io(_) | TaskStoreError::Serde(_)) => {
+        TaskManagerError::Store(TaskStoreError::Database(_) | TaskStoreError::Clock(_)) => {
             warn!(%error, "failed to persist task lifecycle event");
             Status::internal("failed to persist task lifecycle event")
         }
@@ -116,7 +118,6 @@ fn task_manager_status(error: &TaskManagerError) -> Status {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
     use std::sync::Arc;
 
     use coral_api::v1::{EndTaskRequest, StartTaskRequest, TaskStatus, Workspace};
@@ -125,19 +126,30 @@ mod tests {
 
     use super::{TaskService, TaskServiceApi};
     use crate::state::AppStateLayout;
+    use crate::state::db::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
     use crate::task::manager::TaskManager;
-    use crate::task::store::JsonlTaskEventStore;
-    use crate::workspaces::WorkspaceName;
+    use crate::task::store::TaskStore;
 
     const UNKNOWN_TASK_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
 
-    fn service() -> (TempDir, AppStateLayout, TaskService) {
+    async fn service() -> (TempDir, Arc<CoralDb>, TaskService) {
         let dir = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(dir.path().join("coral-config")))
             .expect("layout should resolve");
-        let task = TaskManager::new(Arc::new(JsonlTaskEventStore::new(layout.clone())));
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default database is sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        let task = TaskManager::new(TaskStore::new(Arc::clone(&db)));
         let service = TaskService::new(task);
-        (dir, layout, service)
+        (dir, db, service)
     }
 
     fn workspace(name: &str) -> Workspace {
@@ -148,7 +160,7 @@ mod tests {
 
     #[tokio::test]
     async fn start_task_persists_task() {
-        let (_dir, layout, service) = service();
+        let (_dir, db, service) = service().await;
 
         let response = service
             .start_task(Request::new(StartTaskRequest {
@@ -161,16 +173,19 @@ mod tests {
 
         let task = response.task.expect("task");
         uuid::Uuid::parse_str(&task.task_id).expect("task id is a UUID");
-        let raw =
-            fs::read_to_string(layout.task_events_file(&WorkspaceName::parse("acme").unwrap()))
-                .expect("task file");
-        assert!(raw.contains(&task.task_id));
-        assert!(raw.contains("Find renewal risk"));
+        let mut session = db.as_ref();
+        let stored = session
+            .tasks()
+            .get("acme", &task.task_id)
+            .await
+            .expect("get task")
+            .expect("task row");
+        assert_eq!(stored.intent, "Find renewal risk");
     }
 
     #[tokio::test]
     async fn end_task_persists_success_status() {
-        let (_dir, layout, service) = service();
+        let (_dir, db, service) = service().await;
 
         let task = service
             .start_task(Request::new(StartTaskRequest {
@@ -195,14 +210,19 @@ mod tests {
         let task_end = response.task_end.expect("task end");
         assert_eq!(task_end.task_id, task.task_id);
         assert_eq!(task_end.task_status, TaskStatus::Success as i32);
-        let raw = fs::read_to_string(layout.task_events_file(&WorkspaceName::default()))
-            .expect("task file");
-        assert!(raw.contains("success"), "got: {raw}");
+        let mut session = db.as_ref();
+        let stored = session
+            .tasks()
+            .get("default", &task.task_id)
+            .await
+            .expect("get task")
+            .expect("task row");
+        assert_eq!(stored.status.as_deref(), Some("success"));
     }
 
     #[tokio::test]
     async fn start_task_rejects_blank_intent() {
-        let (_dir, _layout, service) = service();
+        let (_dir, _db, service) = service().await;
 
         let status = service
             .start_task(Request::new(StartTaskRequest {
@@ -217,7 +237,7 @@ mod tests {
 
     #[tokio::test]
     async fn end_task_rejects_unknown_task() {
-        let (_dir, _layout, service) = service();
+        let (_dir, _db, service) = service().await;
 
         let status = service
             .end_task(Request::new(EndTaskRequest {
@@ -233,7 +253,7 @@ mod tests {
 
     #[tokio::test]
     async fn end_task_rejects_malformed_task_id() {
-        let (_dir, _layout, service) = service();
+        let (_dir, _db, service) = service().await;
 
         let status = service
             .end_task(Request::new(EndTaskRequest {
@@ -249,7 +269,7 @@ mod tests {
 
     #[tokio::test]
     async fn end_task_rejects_unspecified_status() {
-        let (_dir, _layout, service) = service();
+        let (_dir, _db, service) = service().await;
         let task = service
             .start_task(Request::new(StartTaskRequest {
                 workspace: Some(workspace("default")),

--- a/crates/coral-app/src/task/store.rs
+++ b/crates/coral-app/src/task/store.rs
@@ -1,30 +1,29 @@
-//! Per-workspace, append-only task lifecycle store.
+//! Database-backed task lifecycle store.
 
-#![allow(
-    dead_code,
-    reason = "The task stack introduces stores before service slices consume them."
-)]
-
-use std::path::Path;
+use std::sync::Arc;
 
 use coral_api::CORAL_TASK_INTENT_MAX_CHARS;
-use serde::{Deserialize, Serialize};
 
 use super::id::TaskId;
-use crate::state::AppStateLayout;
-use crate::storage::fs::{self as storage_fs, FileLock};
+use crate::state::db::{CoralDb, DbError, DbRepos, TaskRecord, now_unix_nanos_i64};
 use crate::workspaces::WorkspaceName;
 
-const MAX_TASK_BYTES_PER_WORKSPACE: u64 = 256 * 1024 * 1024;
-
 /// Final task status.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TaskStatus {
     /// Task succeeded.
     Success,
     /// Task failed.
     Failure,
+}
+
+impl TaskStatus {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Failure => "failure",
+        }
+    }
 }
 
 /// A task start event.
@@ -43,48 +42,15 @@ pub(crate) struct TaskEnd {
     pub(crate) status: TaskStatus,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "event", rename_all = "snake_case")]
-enum PersistedTaskEvent {
-    Start {
-        task_id: String,
-        workspace: String,
-        intent: String,
-    },
-    End {
-        task_id: String,
-        workspace: String,
-        task_status: TaskStatus,
-    },
-}
-
-impl PersistedTaskEvent {
-    fn from_start(start: &TaskStart, intent: &str) -> Self {
-        Self::Start {
-            task_id: start.id.to_string(),
-            workspace: start.workspace.as_str().to_string(),
-            intent: intent.to_string(),
-        }
-    }
-
-    fn from_end(end: &TaskEnd) -> Self {
-        Self::End {
-            task_id: end.id.to_string(),
-            workspace: end.workspace.as_str().to_string(),
-            task_status: end.status,
-        }
-    }
-}
-
 /// Errors from the task lifecycle store.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum TaskStoreError {
-    /// Filesystem error reading or writing the store.
-    #[error("task store io: {0}")]
-    Io(#[from] std::io::Error),
-    /// JSON serialization error.
-    #[error("task store serialization: {0}")]
-    Serde(#[from] serde_json::Error),
+    /// Database error reading or writing the store.
+    #[error(transparent)]
+    Database(#[from] DbError),
+    /// System clock error while timestamping a lifecycle event.
+    #[error("task store clock: {0}")]
+    Clock(String),
     /// The task intent is empty or exceeds the maximum length.
     #[error("task intent must be non-empty and at most {max} characters")]
     InvalidIntent {
@@ -93,304 +59,151 @@ pub(crate) enum TaskStoreError {
     },
 }
 
-/// Storage boundary for task lifecycle events.
-pub(crate) trait TaskEventStore: Send + Sync {
-    /// Persists a task start event.
-    fn start_task(&self, start: &TaskStart) -> Result<(), TaskStoreError>;
-
-    /// Persists a task end event.
-    fn end_task(&self, end: &TaskEnd) -> Result<(), TaskStoreError>;
-
-    /// Returns whether a task has been started for this workspace.
-    fn contains_started_task(
-        &self,
-        workspace: &WorkspaceName,
-        task_id: &TaskId,
-    ) -> Result<bool, TaskStoreError>;
-}
-
-/// Append-only, per-workspace JSONL task lifecycle store, bounded by a byte
-/// ceiling with oldest-out eviction.
+/// Database-backed task lifecycle persistence.
 #[derive(Clone)]
-pub(crate) struct JsonlTaskEventStore {
-    layout: AppStateLayout,
-    max_bytes: u64,
+pub(crate) struct TaskStore {
+    db: Arc<CoralDb>,
 }
 
-impl JsonlTaskEventStore {
-    /// Creates a store that persists under `layout`.
-    pub(crate) fn new(layout: AppStateLayout) -> Self {
-        Self {
-            layout,
-            max_bytes: MAX_TASK_BYTES_PER_WORKSPACE,
-        }
+impl TaskStore {
+    pub(crate) fn new(db: Arc<CoralDb>) -> Self {
+        Self { db }
     }
 
-    /// Overrides the per-workspace byte ceiling for tests.
-    #[cfg(test)]
-    pub(crate) fn with_max_bytes(mut self, max_bytes: u64) -> Self {
-        self.max_bytes = max_bytes;
-        self
-    }
-
-    fn append_event(
-        &self,
-        workspace: &WorkspaceName,
-        event: PersistedTaskEvent,
-    ) -> Result<(), TaskStoreError> {
-        let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        let path = self.layout.task_events_file(workspace);
-        let records = read_all_records(&path)?;
-        append_within_budget(&path, records, event, self.max_bytes)
-    }
-}
-
-impl TaskEventStore for JsonlTaskEventStore {
-    fn start_task(&self, start: &TaskStart) -> Result<(), TaskStoreError> {
+    pub(crate) async fn start_task(&self, start: &TaskStart) -> Result<(), TaskStoreError> {
         let intent = start.intent.trim();
         if intent.is_empty() || intent.chars().count() > CORAL_TASK_INTENT_MAX_CHARS {
             return Err(TaskStoreError::InvalidIntent {
                 max: CORAL_TASK_INTENT_MAX_CHARS,
             });
         }
-        self.append_event(
-            &start.workspace,
-            PersistedTaskEvent::from_start(start, intent),
-        )
+        let started_at_unix_nanos =
+            now_unix_nanos_i64().map_err(|error| TaskStoreError::Clock(error.to_string()))?;
+        let record = TaskRecord {
+            id: start.id.to_string(),
+            intent: intent.to_string(),
+            status: None,
+            started_at_unix_nanos,
+            ended_at_unix_nanos: None,
+        };
+        let mut tx = self.db.begin().await?;
+        tx.workspaces()
+            .ensure(start.workspace.as_str(), started_at_unix_nanos)
+            .await?;
+        tx.tasks().insert(start.workspace.as_str(), &record).await?;
+        tx.commit().await?;
+        Ok(())
     }
 
-    fn end_task(&self, end: &TaskEnd) -> Result<(), TaskStoreError> {
-        self.append_event(&end.workspace, PersistedTaskEvent::from_end(end))
+    pub(crate) async fn end_task(&self, end: &TaskEnd) -> Result<(), TaskStoreError> {
+        let ended_at_unix_nanos =
+            now_unix_nanos_i64().map_err(|error| TaskStoreError::Clock(error.to_string()))?;
+        let mut tx = self.db.begin().await?;
+        tx.tasks()
+            .update_status(
+                end.workspace.as_str(),
+                &end.id.to_string(),
+                end.status.as_str(),
+                ended_at_unix_nanos,
+            )
+            .await?;
+        tx.commit().await?;
+        Ok(())
     }
 
-    fn contains_started_task(
+    pub(crate) async fn task(
         &self,
         workspace: &WorkspaceName,
         task_id: &TaskId,
-    ) -> Result<bool, TaskStoreError> {
-        let _lock = FileLock::shared(self.layout.state_lock())?;
-        let path = self.layout.task_events_file(workspace);
-        let records = read_all_records(&path)?;
-        let task_id = task_id.to_string();
-        Ok(records.iter().any(|record| match record {
-            PersistedTaskEvent::Start {
-                task_id: started_task_id,
-                ..
-            } => started_task_id == &task_id,
-            PersistedTaskEvent::End { .. } => false,
-        }))
+    ) -> Result<Option<TaskRecord>, TaskStoreError> {
+        let mut session = self.db.as_ref();
+        session
+            .tasks()
+            .get(workspace.as_str(), &task_id.to_string())
+            .await
+            .map_err(Into::into)
     }
-}
-
-fn read_all_records(path: &Path) -> Result<Vec<PersistedTaskEvent>, TaskStoreError> {
-    let contents = match std::fs::read(path) {
-        Ok(contents) => contents,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(error) => return Err(error.into()),
-    };
-    Ok(contents
-        .split(|&byte| byte == b'\n')
-        .filter_map(|raw_line| {
-            let Ok(line) = std::str::from_utf8(raw_line) else {
-                tracing::warn!("skipping task record with invalid UTF-8");
-                return None;
-            };
-            if line.trim().is_empty() {
-                return None;
-            }
-            match serde_json::from_str::<PersistedTaskEvent>(line) {
-                Ok(record) => Some(record),
-                Err(error) => {
-                    tracing::warn!(%error, "skipping unparsable task record");
-                    None
-                }
-            }
-        })
-        .collect())
-}
-
-fn append_within_budget(
-    path: &Path,
-    existing: Vec<PersistedTaskEvent>,
-    record: PersistedTaskEvent,
-    max_bytes: u64,
-) -> Result<(), TaskStoreError> {
-    let mut kept = existing;
-    kept.push(record);
-    let encoded: Vec<Vec<u8>> = kept
-        .iter()
-        .map(serde_json::to_vec)
-        .collect::<Result<_, _>>()?;
-    let record_count = encoded.len();
-    let mut total: u64 = encoded.iter().map(|line| line.len() as u64 + 1).sum();
-    let mut dropped = 0;
-    for line in &encoded {
-        if total <= max_bytes || dropped + 1 >= record_count {
-            break;
-        }
-        total -= line.len() as u64 + 1;
-        dropped += 1;
-    }
-    let mut bytes = Vec::new();
-    for line in encoded.iter().skip(dropped) {
-        bytes.extend_from_slice(line);
-        bytes.push(b'\n');
-    }
-    if let Some(parent) = path.parent() {
-        storage_fs::ensure_dir(parent)?;
-    }
-    storage_fs::write_atomic(path, &bytes)?;
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    #![expect(
-        clippy::indexing_slicing,
-        reason = "JSON record assertions intentionally fail loudly in tests"
-    )]
+    use std::sync::Arc;
 
-    use std::fs;
-
-    use serde_json::Value;
     use tempfile::TempDir;
 
-    use super::{
-        JsonlTaskEventStore, PersistedTaskEvent, TaskEnd, TaskEventStore, TaskStart, TaskStatus,
-        TaskStoreError,
-    };
+    use super::{TaskEnd, TaskStart, TaskStatus, TaskStore, TaskStoreError};
     use crate::state::AppStateLayout;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
     use crate::task::id::TaskId;
     use crate::workspaces::WorkspaceName;
 
-    const TASK_ID_1: &str = "550e8400-e29b-41d4-a716-446655440000";
-    const TASK_ID_2: &str = "650e8400-e29b-41d4-a716-446655440000";
+    const TASK_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
 
-    fn layout() -> (TempDir, AppStateLayout) {
+    async fn store() -> (TempDir, TaskStore) {
         let dir = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(dir.path().join("coral-config")))
             .expect("layout should resolve");
-        (dir, layout)
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default database is sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        (dir, TaskStore::new(db))
     }
 
-    fn start(workspace: &WorkspaceName, id: &str, intent: &str) -> TaskStart {
+    fn start(workspace: &WorkspaceName, intent: &str) -> TaskStart {
         TaskStart {
-            id: TaskId::parse(id).expect("valid task id"),
+            id: TaskId::parse(TASK_ID).expect("valid task id"),
             workspace: workspace.clone(),
             intent: intent.to_string(),
         }
     }
 
-    fn end(workspace: &WorkspaceName, id: &str, status: TaskStatus) -> TaskEnd {
-        TaskEnd {
-            id: TaskId::parse(id).expect("valid task id"),
-            workspace: workspace.clone(),
-            status,
-        }
-    }
-
-    #[test]
-    fn start_task_persists_task() {
-        let (_dir, layout) = layout();
-        let workspace = WorkspaceName::parse("acme").expect("workspace");
-        let store = JsonlTaskEventStore::new(layout.clone());
-
-        store
-            .start_task(&start(&workspace, TASK_ID_1, "Find renewal risk"))
-            .expect("start task");
-
-        let raw = fs::read_to_string(layout.task_events_file(&workspace)).expect("task file");
-        let record: Value = serde_json::from_str(raw.trim()).expect("task JSONL should parse");
-        assert_eq!(record["event"], "start");
-        assert_eq!(record["task_id"], TASK_ID_1);
-        assert_eq!(record["workspace"], "acme");
-        assert_eq!(record["intent"], "Find renewal risk");
-    }
-
-    #[test]
-    fn contains_started_task_matches_start_events_only() {
-        let (_dir, layout) = layout();
+    #[tokio::test]
+    async fn stores_task_lifecycle_in_database() {
+        let (_dir, store) = store().await;
         let workspace = WorkspaceName::default();
-        let store = JsonlTaskEventStore::new(layout);
+        let start = start(&workspace, "  Find renewal risk  ");
+
+        store.start_task(&start).await.expect("start task");
+        let stored = store
+            .task(&workspace, &start.id)
+            .await
+            .expect("get task")
+            .expect("task");
+        assert_eq!(stored.intent, "Find renewal risk");
+        assert_eq!(stored.status, None);
 
         store
-            .end_task(&end(&workspace, TASK_ID_1, TaskStatus::Failure))
-            .expect("end task");
-        assert!(
-            !store
-                .contains_started_task(
-                    &workspace,
-                    &TaskId::parse(TASK_ID_1).expect("valid task id")
-                )
-                .expect("contains task")
-        );
-
-        store
-            .start_task(&start(&workspace, TASK_ID_1, "Find renewal risk"))
-            .expect("start task");
-        assert!(
-            store
-                .contains_started_task(
-                    &workspace,
-                    &TaskId::parse(TASK_ID_1).expect("valid task id")
-                )
-                .expect("contains task")
-        );
-    }
-
-    #[test]
-    fn end_task_preserves_existing_start_event() {
-        let (_dir, layout) = layout();
-        let workspace = WorkspaceName::default();
-        let store = JsonlTaskEventStore::new(layout.clone());
-
-        store
-            .start_task(&start(&workspace, TASK_ID_1, "Find renewal risk"))
-            .expect("start task");
-        let raw_after_start =
-            fs::read_to_string(layout.task_events_file(&workspace)).expect("task file");
-        assert!(
-            raw_after_start.contains("Find renewal risk"),
-            "got after start: {raw_after_start}"
-        );
-        let _parsed: PersistedTaskEvent =
-            serde_json::from_str(raw_after_start.trim()).expect("start event should parse");
-        store
-            .end_task(&end(&workspace, TASK_ID_1, TaskStatus::Success))
+            .end_task(&TaskEnd {
+                id: start.id,
+                workspace: workspace.clone(),
+                status: TaskStatus::Success,
+            })
+            .await
             .expect("end task");
 
-        let raw = fs::read_to_string(layout.task_events_file(&workspace)).expect("task file");
-        assert!(raw.contains("Find renewal risk"), "got: {raw}");
-        assert!(raw.contains("success"), "got: {raw}");
+        let ended = store
+            .task(&workspace, &start.id)
+            .await
+            .expect("get ended task")
+            .expect("ended task");
+        assert_eq!(ended.status.as_deref(), Some("success"));
+        assert!(ended.ended_at_unix_nanos.is_some());
     }
 
-    #[test]
-    fn validates_intent() {
-        let (_dir, layout) = layout();
-        let workspace = WorkspaceName::default();
-        let store = JsonlTaskEventStore::new(layout);
-
-        let blank_start = store
-            .start_task(&start(&workspace, TASK_ID_1, " "))
+    #[tokio::test]
+    async fn validates_intent_before_writing() {
+        let (_dir, store) = store().await;
+        let error = store
+            .start_task(&start(&WorkspaceName::default(), " "))
+            .await
             .expect_err("blank intent");
-        assert!(matches!(blank_start, TaskStoreError::InvalidIntent { .. }));
-    }
-
-    #[test]
-    fn task_events_evict_oldest_records_within_budget() {
-        let (_dir, layout) = layout();
-        let workspace = WorkspaceName::default();
-        let store = JsonlTaskEventStore::new(layout.clone()).with_max_bytes(1);
-
-        store
-            .end_task(&end(&workspace, TASK_ID_1, TaskStatus::Success))
-            .expect("first event");
-        store
-            .end_task(&end(&workspace, TASK_ID_2, TaskStatus::Failure))
-            .expect("second event");
-
-        let raw = fs::read_to_string(layout.task_events_file(&workspace)).expect("task file");
-        assert!(!raw.contains(TASK_ID_1));
-        assert!(raw.contains(TASK_ID_2));
+        assert!(matches!(error, TaskStoreError::InvalidIntent { .. }));
     }
 }

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -30,5 +30,6 @@ coral-telemetry.workspace = true
 [dev-dependencies]
 coral-app.workspace = true
 jsonschema.workspace = true
+sqlx.workspace = true
 tempfile.workspace = true
 tonic-types.workspace = true

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -19,6 +19,7 @@ use rmcp::{
     service::RunningService,
 };
 use serde_json::{Map, Value, json};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use tempfile::TempDir;
 use tonic::Request;
 
@@ -443,6 +444,21 @@ fn assert_tool_error_text_contains(result: &CallToolResult, expected: &str) {
     );
 }
 
+async fn sqlite_task_count(temp: &TempDir) -> i64 {
+    let options = SqliteConnectOptions::new()
+        .filename(temp.path().join("coral-config/coral.db"))
+        .create_if_missing(false);
+    let pool = SqlitePoolOptions::new()
+        .connect_with(options)
+        .await
+        .expect("open Coral SQLite database");
+    let task_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM tasks")
+        .fetch_one(&pool)
+        .await
+        .expect("count tasks");
+    task_count.0
+}
+
 #[tokio::test]
 #[expect(
     clippy::too_many_lines,
@@ -619,26 +635,23 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
             .contains("unknown argument 'initialize_session'")
     );
 
-    let tasks_path = temp
-        .path()
-        .join("coral-config/workspaces/default/tasks/tasks.jsonl");
-    let raw = fs::read_to_string(&tasks_path).expect("task file should exist");
-    let records = raw
-        .lines()
-        .map(|line| serde_json::from_str::<Value>(line).expect("task JSONL should parse"))
-        .collect::<Vec<_>>();
-    assert_eq!(records.len(), 2);
-    let root_record = records
-        .iter()
-        .find(|record| record["task_id"] == root_task_id.as_str())
-        .expect("root task record");
-    assert_eq!(root_record["workspace"], "default");
-    assert_eq!(root_record["intent"], "Investigate customer renewal risk");
-    let end_record = records
-        .iter()
-        .find(|record| record["task_id"] == root_task_id.as_str() && record["event"] == "end")
-        .expect("task end record");
-    assert_eq!(end_record["task_status"], "success");
+    let options = SqliteConnectOptions::new()
+        .filename(temp.path().join("coral-config/coral.db"))
+        .create_if_missing(false);
+    let pool = SqlitePoolOptions::new()
+        .connect_with(options)
+        .await
+        .expect("open Coral SQLite database");
+    let root_record: (String, Option<String>) =
+        sqlx::query_as("SELECT intent, status FROM tasks WHERE workspace_id = ? AND id = ?")
+            .bind("default")
+            .bind(&root_task_id)
+            .fetch_one(&pool)
+            .await
+            .expect("root task row");
+    assert_eq!(root_record.0, "Investigate customer renewal risk");
+    assert_eq!(root_record.1.as_deref(), Some("success"));
+    assert_eq!(sqlite_task_count(&temp).await, 1);
 
     let blank_intent = client
         .call_tool(
@@ -653,8 +666,7 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
             .to_string()
             .contains("missing string argument 'intent'")
     );
-    let raw_after_error = fs::read_to_string(&tasks_path).expect("task file should exist");
-    assert_eq!(raw_after_error.lines().count(), 2);
+    assert_eq!(sqlite_task_count(&temp).await, 1);
 
     session.shutdown().await;
 }
@@ -703,12 +715,7 @@ async fn mcp_task_tools_are_disabled_by_default() {
             .to_string()
             .contains("tool 'open_episode' not found")
     );
-    assert!(
-        !temp
-            .path()
-            .join("coral-config/workspaces/default/tasks/tasks.jsonl")
-            .exists()
-    );
+    assert_eq!(sqlite_task_count(&temp).await, 0);
 
     session.shutdown().await;
 }


### PR DESCRIPTION
Jsonl -> SQLite for tasks.

Tasks are currently stored as JSONL; this moves them into SQLite. Please disregard the rest of the stack in draft, if visible.

## Scope

- Store task lifecycle records through the `CoralDb` / `DbSession` foundation already on `main`.
- Remove the JSONL task store and its filesystem layout paths.
- Keep the authored task `intent` unchanged. Intent normalization is deliberately outside this PR and first appears in the later distillation PR (#1767).

## Cutover behavior

This is intentionally a clean, backward-incompatible cutover. Coral does not inspect or import existing task JSONL; SQL is the only task store from first startup on this branch.

## Validation

- cumulative stack: `make rust-checks` — formatting, clippy, tests, and rustdoc passed
- #1765: unchanged `make postgres-tests` target passed; the new ignored task repository Postgres case also passed when invoked explicitly
- cumulative stack: the ignored exact-match retrieval Postgres case passed when invoked explicitly
- cumulative stack: `make perf-check` — 220.8 ms mean, below the 750 ms limit
