### PR TITLE
feat(app): persist raw trajectory operations

### DIFF
--- a/crates/coral-app/migrations/0004_trajectory_raw_steps.sql
+++ b/crates/coral-app/migrations/0004_trajectory_raw_steps.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS trajectory_raw_steps (
+    workspace_id TEXT NOT NULL,
+    id TEXT NOT NULL,
+    task_id TEXT NOT NULL,
+    started_at_unix_nanos BIGINT NOT NULL,
+    completed_at_unix_nanos BIGINT NOT NULL,
+    operation TEXT NOT NULL,
+    input TEXT NOT NULL,
+    status TEXT NOT NULL,
+    row_count BIGINT,
+    output_summary_json TEXT,
+    error_kind TEXT,
+    error_type TEXT,
+    error_message TEXT,
+    PRIMARY KEY (workspace_id, id),
+    FOREIGN KEY (workspace_id, task_id)
+        REFERENCES tasks(workspace_id, id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS trajectory_raw_steps_task_order_idx
+    ON trajectory_raw_steps(
+        workspace_id,
+        task_id,
+        started_at_unix_nanos,
+        completed_at_unix_nanos,
+        id
+    );

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -63,6 +63,7 @@ use crate::task::service::TaskService;
 use crate::task::store::TaskStore;
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
+use crate::trajectory_memory::TrajectoryMemoryManager;
 use crate::transport::GrpcRequestContextLayer;
 use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceManager, WorkspaceService};
 
@@ -317,6 +318,7 @@ impl ServerBuilder {
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
         let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&coral_db)));
+        let trajectory_memory = TrajectoryMemoryManager::new(Arc::clone(&coral_db));
         let body_capture_max_bytes = telemetry_config
             .trace_history
             .http_body_recording_max_bytes();
@@ -331,8 +333,10 @@ impl ServerBuilder {
             query_runtime_context,
             layout.clone(),
             self.config.engine_extensions_providers,
-        );
-        let search_manager = SearchManager::new(layout, &config_store, workspace_manager.clone());
+        )
+        .with_trajectory_memory(trajectory_memory.clone());
+        let search_manager = SearchManager::new(layout, &config_store, workspace_manager.clone())
+            .with_trajectory_memory(trajectory_memory);
         let trace_components =
             active_trace_store.map_or_else(TraceServerComponents::default, |store| {
                 TraceServerComponents {

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -57,6 +57,7 @@ mod state;
 mod storage;
 mod task;
 pub mod telemetry;
+mod trajectory_memory;
 mod transport;
 mod workspaces;
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1,6 +1,6 @@
 //! Query-time loading, validation, and execution over installed sources.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
@@ -33,6 +33,9 @@ use crate::sources::runtime_package::runtime_components_for_v4_source;
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::task::id::TaskId;
 use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
+use crate::trajectory_memory::{
+    RawTrajectoryStep, TrajectoryMemoryManager, TrajectoryOutputSummary,
+};
 use crate::workspaces::{WorkspaceManager, WorkspaceName};
 
 #[derive(Debug)]
@@ -67,6 +70,7 @@ pub(crate) struct QueryManager {
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    trajectory_memory: Option<TrajectoryMemoryManager>,
 }
 
 impl QueryManager {
@@ -85,7 +89,16 @@ impl QueryManager {
             runtime_context,
             layout,
             engine_extensions_providers,
+            trajectory_memory: None,
         }
+    }
+
+    pub(crate) fn with_trajectory_memory(
+        mut self,
+        trajectory_memory: TrajectoryMemoryManager,
+    ) -> Self {
+        self.trajectory_memory = Some(trajectory_memory);
+        self
     }
 
     pub(crate) async fn list_tables(
@@ -97,10 +110,13 @@ impl QueryManager {
     ) -> Result<Vec<TableInfo>, QueryManagerError> {
         let trace_sql = list_tables_trace_sql(schema_filter, table_filter);
         run_query_operation(
-            QueryOperation::ListTables,
-            workspace_name,
-            &trace_sql,
-            attribution.task_id.as_ref(),
+            QueryOperationContext {
+                operation: QueryOperation::ListTables,
+                workspace_name,
+                sql: &trace_sql,
+                task_id: attribution.task_id.as_ref(),
+                trajectory_memory: self.trajectory_memory.as_ref(),
+            },
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
@@ -121,6 +137,7 @@ impl QueryManager {
             },
             |tables| Some(u64::try_from(tables.len()).unwrap_or(u64::MAX)),
             |_, _| {},
+            |tables| Some(summary_from_tables(tables)),
         )
         .await
     }
@@ -133,10 +150,13 @@ impl QueryManager {
     ) -> Result<CatalogInfo, QueryManagerError> {
         let trace_sql = list_catalog_trace_sql(schema_filter);
         run_query_operation(
-            QueryOperation::ListCatalog,
-            workspace_name,
-            &trace_sql,
-            attribution.task_id.as_ref(),
+            QueryOperationContext {
+                operation: QueryOperation::ListCatalog,
+                workspace_name,
+                sql: &trace_sql,
+                task_id: attribution.task_id.as_ref(),
+                trajectory_memory: self.trajectory_memory.as_ref(),
+            },
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
@@ -167,6 +187,7 @@ impl QueryManager {
                 )
             },
             |_, _| {},
+            |catalog| Some(summary_from_catalog(catalog)),
         )
         .await
     }
@@ -180,10 +201,13 @@ impl QueryManager {
     ) -> Result<DescribeTableInfo, QueryManagerError> {
         let trace_sql = describe_table_trace_sql(schema_name, table_name);
         run_query_operation(
-            QueryOperation::DescribeTable,
-            workspace_name,
-            &trace_sql,
-            attribution.task_id.as_ref(),
+            QueryOperationContext {
+                operation: QueryOperation::DescribeTable,
+                workspace_name,
+                sql: &trace_sql,
+                task_id: attribution.task_id.as_ref(),
+                trajectory_memory: self.trajectory_memory.as_ref(),
+            },
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
@@ -199,6 +223,7 @@ impl QueryManager {
             },
             |_| None,
             |_, _| {},
+            |description| Some(summary_from_describe_table(description)),
         )
         .await
     }
@@ -210,10 +235,13 @@ impl QueryManager {
         attribution: &QueryAttribution,
     ) -> Result<QueryExecution, QueryManagerError> {
         run_query_operation(
-            QueryOperation::ExecuteSql,
-            workspace_name,
-            sql,
-            attribution.task_id.as_ref(),
+            QueryOperationContext {
+                operation: QueryOperation::ExecuteSql,
+                workspace_name,
+                sql,
+                task_id: attribution.task_id.as_ref(),
+                trajectory_memory: self.trajectory_memory.as_ref(),
+            },
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
@@ -229,6 +257,7 @@ impl QueryManager {
             },
             |execution| Some(u64::try_from(execution.row_count()).unwrap_or(u64::MAX)),
             |span, execution| record_query_provenance(span, execution.provenance()),
+            |execution| Some(summary_from_execution(execution)),
         )
         .await
     }
@@ -240,10 +269,13 @@ impl QueryManager {
         attribution: &QueryAttribution,
     ) -> Result<QueryPlan, QueryManagerError> {
         run_query_operation(
-            QueryOperation::ExplainSql,
-            workspace_name,
-            sql,
-            attribution.task_id.as_ref(),
+            QueryOperationContext {
+                operation: QueryOperation::ExplainSql,
+                workspace_name,
+                sql,
+                task_id: attribution.task_id.as_ref(),
+                trajectory_memory: self.trajectory_memory.as_ref(),
+            },
             async {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
@@ -259,6 +291,7 @@ impl QueryManager {
             },
             |_| None,
             |_, _| {},
+            |_| None,
         )
         .await
     }
@@ -522,6 +555,94 @@ fn query_sources_from_loaded(loaded_sources: &[LoadedQuerySource]) -> Vec<QueryS
         .collect()
 }
 
+fn summary_from_tables(tables: &[TableInfo]) -> TrajectoryOutputSummary {
+    let sources = tables
+        .iter()
+        .map(|table| table.schema_name.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let relations = tables
+        .iter()
+        .map(|table| format!("{}.{}", table.schema_name, table.table_name))
+        .collect();
+    TrajectoryOutputSummary {
+        sources,
+        relations,
+        column_count: None,
+    }
+}
+
+fn summary_from_catalog(catalog: &CatalogInfo) -> TrajectoryOutputSummary {
+    let mut relations = catalog
+        .tables
+        .iter()
+        .map(|table| format!("{}.{}", table.schema_name, table.table_name))
+        .collect::<Vec<_>>();
+    relations.extend(
+        catalog
+            .table_functions
+            .iter()
+            .map(|function| format!("{}.{}", function.schema_name, function.function_name)),
+    );
+    let sources = relations
+        .iter()
+        .filter_map(|relation| relation.split('.').next().map(ToString::to_string))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    TrajectoryOutputSummary {
+        sources,
+        relations,
+        column_count: None,
+    }
+}
+
+fn summary_from_describe_table(description: &DescribeTableInfo) -> TrajectoryOutputSummary {
+    let tables = description
+        .table
+        .iter()
+        .chain(&description.missing_context_tables)
+        .cloned()
+        .collect::<Vec<_>>();
+    summary_from_tables(&tables)
+}
+
+fn summary_from_provenance(provenance: &QueryExecutionProvenance) -> TrajectoryOutputSummary {
+    let sources = provenance.sources().to_vec();
+    let relations = provenance
+        .tables()
+        .iter()
+        .map(|table| {
+            format!(
+                "{}.{}.{}",
+                table.source_name(),
+                table.schema_name(),
+                table.table_name()
+            )
+        })
+        .chain(provenance.table_functions().iter().map(|function| {
+            format!(
+                "{}.{}.{}",
+                function.source_name(),
+                function.schema_name(),
+                function.function_name()
+            )
+        }))
+        .collect();
+    TrajectoryOutputSummary {
+        sources,
+        relations,
+        column_count: None,
+    }
+}
+
+fn summary_from_execution(execution: &QueryExecution) -> TrajectoryOutputSummary {
+    let mut summary = summary_from_provenance(execution.provenance());
+    summary.column_count = Some(u64::try_from(execution.schema().len()).unwrap_or(u64::MAX));
+    summary
+}
+
 #[derive(Clone, Copy)]
 enum QueryOperation {
     ExecuteSql,
@@ -529,6 +650,14 @@ enum QueryOperation {
     ListTables,
     ListCatalog,
     DescribeTable,
+}
+
+struct QueryOperationContext<'a> {
+    operation: QueryOperation,
+    workspace_name: &'a WorkspaceName,
+    sql: &'a str,
+    task_id: Option<&'a TaskId>,
+    trajectory_memory: Option<&'a TrajectoryMemoryManager>,
 }
 
 impl QueryOperation {
@@ -564,19 +693,25 @@ fn describe_table_trace_sql(schema_name: &str, table_name: &str) -> String {
 }
 
 async fn run_query_operation<T, Fut, RowCount>(
-    operation: QueryOperation,
-    workspace_name: &WorkspaceName,
-    sql: &str,
-    task_id: Option<&TaskId>,
+    context: QueryOperationContext<'_>,
     query: Fut,
     row_count: RowCount,
     record_success_fields: impl FnOnce(&tracing::Span, &T),
+    capture_summary: impl FnOnce(&T) -> Option<TrajectoryOutputSummary>,
 ) -> Result<T, QueryManagerError>
 where
     Fut: Future<Output = Result<T, QueryManagerError>>,
     RowCount: FnOnce(&T) -> Option<u64>,
 {
+    let QueryOperationContext {
+        operation,
+        workspace_name,
+        sql,
+        task_id,
+        trajectory_memory,
+    } = context;
     let started_at = Instant::now();
+    let started_at_unix_nanos = trajectory_timestamp();
     let query_span = create_query_span(operation, workspace_name, sql, task_id);
     let result = query.instrument(query_span.clone()).await;
 
@@ -588,27 +723,69 @@ where
         result.is_ok(),
     );
 
-    if result.is_ok() {
-        query_span.record("status", "ok");
-        query_span.set_status(OtelStatus::Ok);
-        if let Some(row_count) = row_count {
-            query_span.record("row_count", row_count);
-        }
-        if let Ok(value) = &result {
+    let (status, error_kind, error_type, error_message) = match &result {
+        Ok(value) => {
+            query_span.record("status", "ok");
+            query_span.set_status(OtelStatus::Ok);
+            if let Some(row_count) = row_count {
+                query_span.record("row_count", row_count);
+            }
             record_success_fields(&query_span, value);
+            ("success", None, None, None)
         }
-    } else if let Err(error) = &result {
-        let error_kind = query_error_kind(error);
-        let error_type = query_error_type(error);
-        let error_message = query_error_message(error);
-        query_span.record("status", "error");
-        query_span.record("error.kind", error_kind);
-        query_span.record("error.type", error_type.as_str());
-        query_span.record("exception.message", error_message.as_str());
-        query_span.set_status(OtelStatus::error(error_message));
+        Err(error) => {
+            let error_kind = query_error_kind(error);
+            let error_type = query_error_type(error);
+            let error_message = query_error_message(error);
+            query_span.record("status", "error");
+            query_span.record("error.kind", error_kind);
+            query_span.record("error.type", error_type.as_str());
+            query_span.record("exception.message", error_message.as_str());
+            query_span.set_status(OtelStatus::error(error_message.clone()));
+            (
+                "error",
+                Some(error_kind.to_string()),
+                Some(error_type),
+                Some(error_message),
+            )
+        }
+    };
+
+    let output_summary = result.as_ref().ok().and_then(capture_summary);
+    if let (Some(trajectory_memory), Some(task_id)) = (trajectory_memory, task_id)
+        && let Err(error) = trajectory_memory
+            .record_raw_step(
+                workspace_name,
+                RawTrajectoryStep {
+                    task_id: *task_id,
+                    started_at_unix_nanos,
+                    completed_at_unix_nanos: trajectory_timestamp(),
+                    operation: operation.as_str().to_string(),
+                    input: sql.to_string(),
+                    status,
+                    row_count,
+                    output_summary,
+                    error_kind,
+                    error_type,
+                    error_message,
+                },
+            )
+            .await
+    {
+        tracing::warn!(%error, task_id = %task_id, "failed to capture raw trajectory step");
     }
 
     result
+}
+
+fn trajectory_timestamp() -> i64 {
+    match crate::state::db::now_unix_nanos_i64() {
+        Ok(timestamp) => timestamp,
+        Err(error) => {
+            tracing::warn!(%error, "failed to timestamp raw trajectory step");
+            0
+        }
+    }
 }
 
 fn create_query_span(

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -6,12 +6,14 @@ use crate::search::catalog::provider::CatalogMetadataProvider;
 use crate::search::engine::UniversalSearchEngine;
 use crate::search::result::{SearchManagerError, SearchRequest, SearchResponse};
 use crate::state::{AppStateLayout, ConfigStore};
+use crate::trajectory_memory::{RawTrajectoryStep, TrajectoryMemoryManager};
 use crate::workspaces::WorkspaceManager;
 
 #[derive(Clone)]
 pub(crate) struct SearchManager {
     engine: UniversalSearchEngine,
     workspaces: WorkspaceManager,
+    trajectory_memory: Option<TrajectoryMemoryManager>,
 }
 
 impl SearchManager {
@@ -25,7 +27,16 @@ impl SearchManager {
         Self {
             engine: UniversalSearchEngine::new(catalog),
             workspaces: workspace_manager,
+            trajectory_memory: None,
         }
+    }
+
+    pub(crate) fn with_trajectory_memory(
+        mut self,
+        trajectory_memory: TrajectoryMemoryManager,
+    ) -> Self {
+        self.trajectory_memory = Some(trajectory_memory);
+        self
     }
 
     pub(crate) async fn search(
@@ -33,9 +44,58 @@ impl SearchManager {
         request: &SearchRequest,
         attribution: &QueryAttribution,
     ) -> Result<SearchResponse, SearchManagerError> {
-        self.workspaces
+        let started_at_unix_nanos = trajectory_timestamp();
+        let result = match self
+            .workspaces
             .require_workspace(&request.workspace_name)
-            .await?;
-        Ok(self.engine.search(request, attribution))
+            .await
+        {
+            Ok(()) => Ok(self.engine.search(request, attribution)),
+            Err(error) => Err(error.into()),
+        };
+        if let (Some(memory), Some(task_id)) =
+            (self.trajectory_memory.as_ref(), attribution.task_id)
+        {
+            let (status, row_count, error_message) = match &result {
+                Ok(response) => (
+                    "success",
+                    Some(u64::try_from(response.results.len()).unwrap_or(u64::MAX)),
+                    None,
+                ),
+                Err(SearchManagerError::App(error)) => ("error", None, Some(error.to_string())),
+            };
+            if let Err(error) = memory
+                .record_raw_step(
+                    &request.workspace_name,
+                    RawTrajectoryStep {
+                        task_id,
+                        started_at_unix_nanos,
+                        completed_at_unix_nanos: trajectory_timestamp(),
+                        operation: "search".to_string(),
+                        input: request.query.clone(),
+                        status,
+                        row_count,
+                        output_summary: None,
+                        error_kind: error_message.as_ref().map(|_| "app".to_string()),
+                        error_type: error_message.as_ref().map(|_| "SEARCH".to_string()),
+                        error_message,
+                    },
+                )
+                .await
+            {
+                tracing::warn!(%error, task_id = %task_id, "failed to capture raw trajectory step");
+            }
+        }
+        result
+    }
+}
+
+fn trajectory_timestamp() -> i64 {
+    match crate::state::db::now_unix_nanos_i64() {
+        Ok(timestamp) => timestamp,
+        Err(error) => {
+            tracing::warn!(%error, "failed to timestamp raw trajectory step");
+            0
+        }
     }
 }

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -18,5 +18,6 @@ pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
 pub(crate) use repositories::tasks::TaskRecord;
+pub(crate) use repositories::trajectory_memory::RawTrajectoryStepRecord;
 pub(crate) use session::{DbRepos, DbSession};
 pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,3 +1,4 @@
 pub(crate) mod state_migrations;
 pub(crate) mod tasks;
+pub(crate) mod trajectory_memory;
 pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/repositories/trajectory_memory.rs
+++ b/crates/coral-app/src/state/db/repositories/trajectory_memory.rs
@@ -1,0 +1,118 @@
+#[cfg(test)]
+use sea_query::ExprTrait;
+use sea_query::{Expr, Query};
+
+use crate::state::db::schema::TrajectoryRawSteps;
+use crate::state::db::{DbError, DbSession};
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub(crate) struct RawTrajectoryStepRecord {
+    pub(crate) id: String,
+    pub(crate) task_id: String,
+    pub(crate) started_at_unix_nanos: i64,
+    pub(crate) completed_at_unix_nanos: i64,
+    pub(crate) operation: String,
+    pub(crate) input: String,
+    pub(crate) status: String,
+    pub(crate) row_count: Option<i64>,
+    pub(crate) output_summary_json: Option<String>,
+    pub(crate) error_kind: Option<String>,
+    pub(crate) error_type: Option<String>,
+    pub(crate) error_message: Option<String>,
+}
+
+pub(crate) struct TrajectoryMemoryRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> TrajectoryMemoryRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn insert_raw_step(
+        &mut self,
+        workspace_id: &str,
+        step: &RawTrajectoryStepRecord,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(TrajectoryRawSteps::Table)
+            .columns([
+                TrajectoryRawSteps::WorkspaceId,
+                TrajectoryRawSteps::Id,
+                TrajectoryRawSteps::TaskId,
+                TrajectoryRawSteps::StartedAtUnixNanos,
+                TrajectoryRawSteps::CompletedAtUnixNanos,
+                TrajectoryRawSteps::Operation,
+                TrajectoryRawSteps::Input,
+                TrajectoryRawSteps::Status,
+                TrajectoryRawSteps::RowCount,
+                TrajectoryRawSteps::OutputSummaryJson,
+                TrajectoryRawSteps::ErrorKind,
+                TrajectoryRawSteps::ErrorType,
+                TrajectoryRawSteps::ErrorMessage,
+            ])
+            .values_panic([
+                Expr::val(workspace_id.to_string()),
+                Expr::val(step.id.clone()),
+                Expr::val(step.task_id.clone()),
+                Expr::val(step.started_at_unix_nanos),
+                Expr::val(step.completed_at_unix_nanos),
+                Expr::val(step.operation.clone()),
+                Expr::val(step.input.clone()),
+                Expr::val(step.status.clone()),
+                Expr::val(step.row_count),
+                Expr::val(step.output_summary_json.clone()),
+                Expr::val(step.error_kind.clone()),
+                Expr::val(step.error_type.clone()),
+                Expr::val(step.error_message.clone()),
+            ])
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn list_raw_steps_for_task(
+        &mut self,
+        workspace_id: &str,
+        task_id: &str,
+    ) -> Result<Vec<RawTrajectoryStepRecord>, DbError> {
+        let statement = Query::select()
+            .columns(raw_step_columns())
+            .from(TrajectoryRawSteps::Table)
+            .and_where(Expr::col(TrajectoryRawSteps::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(TrajectoryRawSteps::TaskId).eq(task_id))
+            .order_by(
+                TrajectoryRawSteps::StartedAtUnixNanos,
+                sea_query::Order::Asc,
+            )
+            .order_by(
+                TrajectoryRawSteps::CompletedAtUnixNanos,
+                sea_query::Order::Asc,
+            )
+            .order_by(TrajectoryRawSteps::Id, sea_query::Order::Asc)
+            .to_owned();
+        self.session.fetch_all(statement).await
+    }
+}
+
+#[cfg(test)]
+fn raw_step_columns() -> [TrajectoryRawSteps; 12] {
+    [
+        TrajectoryRawSteps::Id,
+        TrajectoryRawSteps::TaskId,
+        TrajectoryRawSteps::StartedAtUnixNanos,
+        TrajectoryRawSteps::CompletedAtUnixNanos,
+        TrajectoryRawSteps::Operation,
+        TrajectoryRawSteps::Input,
+        TrajectoryRawSteps::Status,
+        TrajectoryRawSteps::RowCount,
+        TrajectoryRawSteps::OutputSummaryJson,
+        TrajectoryRawSteps::ErrorKind,
+        TrajectoryRawSteps::ErrorType,
+        TrajectoryRawSteps::ErrorMessage,
+    ]
+}

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -24,3 +24,21 @@ pub(in crate::state::db) enum Tasks {
     StartedAtUnixNanos,
     EndedAtUnixNanos,
 }
+
+#[derive(Iden)]
+pub(in crate::state::db) enum TrajectoryRawSteps {
+    Table,
+    WorkspaceId,
+    Id,
+    TaskId,
+    StartedAtUnixNanos,
+    CompletedAtUnixNanos,
+    Operation,
+    Input,
+    Status,
+    RowCount,
+    OutputSummaryJson,
+    ErrorKind,
+    ErrorType,
+    ErrorMessage,
+}

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -8,6 +8,7 @@ use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
 use crate::state::db::repositories::state_migrations::StateMigrationsRepo;
 use crate::state::db::repositories::tasks::TasksRepo;
+use crate::state::db::repositories::trajectory_memory::TrajectoryMemoryRepo;
 use crate::state::db::repositories::workspaces::WorkspacesRepo;
 
 pub(crate) trait DbSession {
@@ -39,6 +40,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn tasks(&mut self) -> TasksRepo<'_, Self> {
         TasksRepo::new(self)
+    }
+
+    fn trajectory_memory(&mut self) -> TrajectoryMemoryRepo<'_, Self> {
+        TrajectoryMemoryRepo::new(self)
     }
 }
 

--- a/crates/coral-app/src/trajectory_memory.rs
+++ b/crates/coral-app/src/trajectory_memory.rs
@@ -1,0 +1,248 @@
+//! Raw task-attributed trajectory capture.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::bootstrap::AppError;
+use crate::state::db::{CoralDb, DbRepos, RawTrajectoryStepRecord};
+use crate::task::id::TaskId;
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub(crate) struct TrajectoryOutputSummary {
+    pub(crate) sources: Vec<String>,
+    pub(crate) relations: Vec<String>,
+    #[serde(default)]
+    pub(crate) column_count: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RawTrajectoryStep {
+    pub(crate) task_id: TaskId,
+    pub(crate) started_at_unix_nanos: i64,
+    pub(crate) completed_at_unix_nanos: i64,
+    pub(crate) operation: String,
+    pub(crate) input: String,
+    pub(crate) status: &'static str,
+    pub(crate) row_count: Option<u64>,
+    pub(crate) output_summary: Option<TrajectoryOutputSummary>,
+    pub(crate) error_kind: Option<String>,
+    pub(crate) error_type: Option<String>,
+    pub(crate) error_message: Option<String>,
+}
+
+#[derive(Clone)]
+pub(crate) struct TrajectoryMemoryManager {
+    db: Arc<CoralDb>,
+}
+
+impl TrajectoryMemoryManager {
+    pub(crate) fn new(db: Arc<CoralDb>) -> Self {
+        Self { db }
+    }
+
+    pub(crate) async fn record_raw_step(
+        &self,
+        workspace: &WorkspaceName,
+        step: RawTrajectoryStep,
+    ) -> Result<(), AppError> {
+        let task_id = step.task_id.to_string();
+        let mut session = self.db.as_ref();
+        if session
+            .tasks()
+            .get(workspace.as_str(), &task_id)
+            .await?
+            .is_none()
+        {
+            return Ok(());
+        }
+        let row_count = step
+            .row_count
+            .map(i64::try_from)
+            .transpose()
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!("trajectory row count exceeds i64: {error}"))
+            })?;
+        let output_summary_json = step
+            .output_summary
+            .map(|summary| serde_json::to_string(&summary))
+            .transpose()?;
+        session
+            .trajectory_memory()
+            .insert_raw_step(
+                workspace.as_str(),
+                &RawTrajectoryStepRecord {
+                    id: format!("raw_{}", uuid::Uuid::new_v4().simple()),
+                    task_id,
+                    started_at_unix_nanos: step.started_at_unix_nanos,
+                    completed_at_unix_nanos: step.completed_at_unix_nanos,
+                    operation: step.operation,
+                    input: step.input,
+                    status: step.status.to_string(),
+                    row_count,
+                    output_summary_json,
+                    error_kind: step.error_kind,
+                    error_type: step.error_type,
+                    error_message: step.error_message,
+                },
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+
+    use super::{RawTrajectoryStep, TrajectoryMemoryManager, TrajectoryOutputSummary};
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
+    use crate::task::id::TaskId;
+    use crate::task::manager::TaskManager;
+    use crate::task::store::TaskStore;
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    async fn raw_capture_round_trips_against_sqlite() {
+        let (temp, db) = open_sqlite().await;
+
+        assert_raw_capture(db, WorkspaceName::default()).await;
+
+        drop(temp);
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared raw trajectory harness against Postgres"]
+    async fn raw_capture_round_trips_against_postgres() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+                .await
+                .expect("open postgres"),
+        );
+        db.migrate().await.expect("migrate postgres");
+        let workspace =
+            WorkspaceName::parse(&format!("trajectory_{}", uuid::Uuid::new_v4().simple()))
+                .expect("workspace");
+
+        assert_raw_capture(db, workspace).await;
+    }
+
+    async fn assert_raw_capture(db: Arc<CoralDb>, workspace: WorkspaceName) {
+        let memory = TrajectoryMemoryManager::new(Arc::clone(&db));
+        let tasks = TaskManager::new(TaskStore::new(Arc::clone(&db)));
+        let task = tasks
+            .start_task(workspace.clone(), "Find renewal risk".to_string())
+            .await
+            .expect("start task");
+
+        memory
+            .record_raw_step(
+                &workspace,
+                RawTrajectoryStep {
+                    task_id: task.id,
+                    started_at_unix_nanos: 20,
+                    completed_at_unix_nanos: 21,
+                    operation: "execute_sql".to_string(),
+                    input: "SELECT customer_id FROM crm.accounts WHERE region = 'emea'".to_string(),
+                    status: "success",
+                    row_count: Some(3),
+                    output_summary: Some(TrajectoryOutputSummary {
+                        sources: vec!["crm".to_string()],
+                        relations: vec!["crm.accounts".to_string()],
+                        column_count: Some(1),
+                    }),
+                    error_kind: None,
+                    error_type: None,
+                    error_message: None,
+                },
+            )
+            .await
+            .expect("record successful step");
+        memory
+            .record_raw_step(
+                &workspace,
+                RawTrajectoryStep {
+                    task_id: task.id,
+                    started_at_unix_nanos: 10,
+                    completed_at_unix_nanos: 11,
+                    operation: "search".to_string(),
+                    input: "renewal risk".to_string(),
+                    status: "error",
+                    row_count: None,
+                    output_summary: None,
+                    error_kind: Some("app".to_string()),
+                    error_type: Some("SEARCH".to_string()),
+                    error_message: Some("search failed".to_string()),
+                },
+            )
+            .await
+            .expect("record failed step");
+        memory
+            .record_raw_step(
+                &workspace,
+                RawTrajectoryStep {
+                    task_id: TaskId::new(),
+                    started_at_unix_nanos: 30,
+                    completed_at_unix_nanos: 31,
+                    operation: "execute_sql".to_string(),
+                    input: "SELECT 1".to_string(),
+                    status: "success",
+                    row_count: Some(1),
+                    output_summary: None,
+                    error_kind: None,
+                    error_type: None,
+                    error_message: None,
+                },
+            )
+            .await
+            .expect("unknown task is ignored");
+
+        let mut session = db.as_ref();
+        let raw = session
+            .trajectory_memory()
+            .list_raw_steps_for_task(workspace.as_str(), &task.id.to_string())
+            .await
+            .expect("list raw steps");
+        let mut raw = raw.into_iter();
+        let search = raw.next().expect("search step");
+        assert_eq!(search.operation, "search");
+        assert_eq!(search.status, "error");
+        assert_eq!(search.error_type.as_deref(), Some("SEARCH"));
+        let sql = raw.next().expect("SQL step");
+        assert_eq!(sql.operation, "execute_sql");
+        assert_eq!(sql.row_count, Some(3));
+        let summary = sql.output_summary_json.as_deref().expect("output summary");
+        assert!(summary.contains("crm.accounts"));
+        assert!(!summary.contains("customer_id"));
+        assert!(raw.next().is_none());
+    }
+
+    async fn open_sqlite() -> (TempDir, Arc<CoralDb>) {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default database is sqlite");
+        };
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+                .await
+                .expect("open sqlite"),
+        );
+        db.migrate().await.expect("migrate sqlite");
+        (temp, db)
+    }
+
+    fn postgres_test_url() -> Option<String> {
+        bootstrap::env_var("CORAL_TEST_POSTGRES_URL").expect("read CORAL_TEST_POSTGRES_URL")
+    }
+}

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -444,7 +444,7 @@ fn assert_tool_error_text_contains(result: &CallToolResult, expected: &str) {
     );
 }
 
-async fn sqlite_task_count(temp: &TempDir) -> i64 {
+async fn sqlite_task_counts(temp: &TempDir) -> (i64, i64) {
     let options = SqliteConnectOptions::new()
         .filename(temp.path().join("coral-config/coral.db"))
         .create_if_missing(false);
@@ -456,7 +456,11 @@ async fn sqlite_task_count(temp: &TempDir) -> i64 {
         .fetch_one(&pool)
         .await
         .expect("count tasks");
-    task_count.0
+    let raw_step_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM trajectory_raw_steps")
+        .fetch_one(&pool)
+        .await
+        .expect("count raw trajectory steps");
+    (task_count.0, raw_step_count.0)
 }
 
 #[tokio::test]
@@ -651,7 +655,7 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
             .expect("root task row");
     assert_eq!(root_record.0, "Investigate customer renewal risk");
     assert_eq!(root_record.1.as_deref(), Some("success"));
-    assert_eq!(sqlite_task_count(&temp).await, 1);
+    assert_eq!(sqlite_task_counts(&temp).await, (1, 1));
 
     let blank_intent = client
         .call_tool(
@@ -666,7 +670,7 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
             .to_string()
             .contains("missing string argument 'intent'")
     );
-    assert_eq!(sqlite_task_count(&temp).await, 1);
+    assert_eq!(sqlite_task_counts(&temp).await, (1, 1));
 
     session.shutdown().await;
 }
@@ -715,7 +719,7 @@ async fn mcp_task_tools_are_disabled_by_default() {
             .to_string()
             .contains("tool 'open_episode' not found")
     );
-    assert_eq!(sqlite_task_count(&temp).await, 0);
+    assert_eq!(sqlite_task_counts(&temp).await, (0, 0));
 
     session.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- add the raw trajectory-step schema and repository
- capture task-attributed SQL and search operations, including successes and failures
- store operation input, timing, status, row count, output metadata, and error details
- cover the same capture path on SQLite and Postgres

## Why

Indexing needs an auditable local input layer. This PR records every attributed processing input before any lossy distillation occurs.

Raw inputs intentionally include full SQL for this local-development phase. Result rows are not stored; output summaries contain only source/relation/column-count metadata. Operations with unknown task ids are ignored.

## Stack position

2 of 5 in the trajectory-memory draft stack. Base: `codex/trajectory-memory-01-sql-tasks`.

1. #1765 — SQL task persistence
2. **#1766 — raw trajectory capture**
3. #1767 — successful-SQL distillation
4. #1768 — exact index and retrieval
5. #1763 — MCP exposure and docs

## Validation

- strict clippy for `coral-app` and `coral-mcp`
- focused SQLite raw-capture and MCP persistence scenarios
- cumulative stack: `make rust-checks` and `make postgres-tests`
