### PR TITLE
feat(app): distill successful SQL trajectories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
+ "sqlparser 0.59.0",
  "sqlx",
  "tempfile",
  "thiserror",
@@ -1731,7 +1732,7 @@ dependencies = [
  "parquet",
  "rand 0.9.4",
  "regex",
- "sqlparser",
+ "sqlparser 0.61.0",
  "tempfile",
  "tokio",
  "url",
@@ -1807,7 +1808,7 @@ dependencies = [
  "parquet",
  "paste",
  "recursive",
- "sqlparser",
+ "sqlparser 0.61.0",
  "tokio",
  "web-time",
 ]
@@ -2008,7 +2009,7 @@ dependencies = [
  "paste",
  "recursive",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.61.0",
 ]
 
 [[package]]
@@ -2357,7 +2358,7 @@ dependencies = [
  "log",
  "recursive",
  "regex",
- "sqlparser",
+ "sqlparser 0.61.0",
 ]
 
 [[package]]
@@ -5506,6 +5507,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
+dependencies = [
+ "log",
+ "recursive",
 ]
 
 [[package]]

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -30,6 +30,7 @@ serde_yaml.workspace = true
 sea-query.workspace = true
 sea-query-sqlx.workspace = true
 sha2.workspace = true
+sqlparser.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/coral-app/migrations/0005_trajectory_distillations.sql
+++ b/crates/coral-app/migrations/0005_trajectory_distillations.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS trajectory_distillations (
+    workspace_id TEXT NOT NULL,
+    id TEXT NOT NULL,
+    task_id TEXT NOT NULL,
+    strategy TEXT NOT NULL,
+    normalized_intent TEXT NOT NULL,
+    path_key TEXT NOT NULL,
+    input_step_count BIGINT NOT NULL,
+    output_step_count BIGINT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, id),
+    UNIQUE (workspace_id, task_id),
+    FOREIGN KEY (workspace_id, task_id)
+        REFERENCES tasks(workspace_id, id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS trajectory_distillations_path_idx
+    ON trajectory_distillations(workspace_id, path_key);
+
+CREATE TABLE IF NOT EXISTS trajectory_distilled_steps (
+    workspace_id TEXT NOT NULL,
+    id TEXT NOT NULL,
+    distillation_id TEXT NOT NULL,
+    source_raw_step_id TEXT NOT NULL,
+    ordinal BIGINT NOT NULL,
+    sql_template TEXT NOT NULL,
+    relations_json TEXT NOT NULL,
+    result_row_count BIGINT,
+    result_column_count BIGINT,
+    exact_key TEXT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, id),
+    UNIQUE (workspace_id, distillation_id, ordinal),
+    FOREIGN KEY (workspace_id, distillation_id)
+        REFERENCES trajectory_distillations(workspace_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (workspace_id, source_raw_step_id)
+        REFERENCES trajectory_raw_steps(workspace_id, id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS trajectory_distilled_steps_distillation_idx
+    ON trajectory_distilled_steps(workspace_id, distillation_id, ordinal);

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -317,8 +317,11 @@ impl ServerBuilder {
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
-        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&coral_db)));
         let trajectory_memory = TrajectoryMemoryManager::new(Arc::clone(&coral_db));
+        let task_manager = TaskManager::new(
+            TaskStore::new(Arc::clone(&coral_db)),
+            trajectory_memory.clone(),
+        );
         let body_capture_max_bytes = telemetry_config
             .trace_history
             .http_body_recording_max_bytes();
@@ -785,6 +788,7 @@ mod tests {
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
     use crate::telemetry::service::TraceService;
+    use crate::trajectory_memory::TrajectoryMemoryManager;
     use crate::transport::workspace_to_proto;
     use crate::workspaces::{WorkspaceManager, WorkspaceName};
     use crate::{
@@ -979,7 +983,10 @@ backend = "unsupported"
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
-        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&db)));
+        let task_manager = TaskManager::new(
+            TaskStore::new(Arc::clone(&db)),
+            TrajectoryMemoryManager::new(Arc::clone(&db)),
+        );
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -1418,7 +1425,10 @@ tables:
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
-        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&db)));
+        let task_manager = TaskManager::new(
+            TaskStore::new(Arc::clone(&db)),
+            TrajectoryMemoryManager::new(Arc::clone(&db)),
+        );
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -1538,7 +1548,10 @@ tables:
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
-        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&db)));
+        let task_manager = TaskManager::new(
+            TaskStore::new(Arc::clone(&db)),
+            TrajectoryMemoryManager::new(Arc::clone(&db)),
+        );
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),
@@ -1655,7 +1668,10 @@ tables:
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
-        let task_manager = TaskManager::new(TaskStore::new(Arc::clone(&db)));
+        let task_manager = TaskManager::new(
+            TaskStore::new(Arc::clone(&db)),
+            TrajectoryMemoryManager::new(Arc::clone(&db)),
+        );
         let workspace_manager = WorkspaceManager::new_for_tests(
             config_store.clone(),
             credential_manager.clone(),

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -18,6 +18,8 @@ pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
 pub(crate) use repositories::tasks::TaskRecord;
-pub(crate) use repositories::trajectory_memory::RawTrajectoryStepRecord;
+pub(crate) use repositories::trajectory_memory::{
+    DistillationRecord, DistilledStepRecord, RawTrajectoryStepRecord,
+};
 pub(crate) use session::{DbRepos, DbSession};
 pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/repositories/trajectory_memory.rs
+++ b/crates/coral-app/src/state/db/repositories/trajectory_memory.rs
@@ -1,8 +1,8 @@
-#[cfg(test)]
-use sea_query::ExprTrait;
-use sea_query::{Expr, Query};
+use sea_query::{Expr, ExprTrait, OnConflict, Query};
 
-use crate::state::db::schema::TrajectoryRawSteps;
+use crate::state::db::schema::{
+    TrajectoryDistillations, TrajectoryDistilledSteps, TrajectoryRawSteps,
+};
 use crate::state::db::{DbError, DbSession};
 
 #[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
@@ -19,6 +19,32 @@ pub(crate) struct RawTrajectoryStepRecord {
     pub(crate) error_kind: Option<String>,
     pub(crate) error_type: Option<String>,
     pub(crate) error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub(crate) struct DistillationRecord {
+    pub(crate) id: String,
+    pub(crate) task_id: String,
+    pub(crate) strategy: String,
+    pub(crate) normalized_intent: String,
+    pub(crate) path_key: String,
+    pub(crate) input_step_count: i64,
+    pub(crate) output_step_count: i64,
+    pub(crate) created_at_unix_nanos: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub(crate) struct DistilledStepRecord {
+    pub(crate) id: String,
+    pub(crate) distillation_id: String,
+    pub(crate) source_raw_step_id: String,
+    pub(crate) ordinal: i64,
+    pub(crate) sql_template: String,
+    pub(crate) relations_json: String,
+    pub(crate) result_row_count: Option<i64>,
+    pub(crate) result_column_count: Option<i64>,
+    pub(crate) exact_key: String,
+    pub(crate) created_at_unix_nanos: i64,
 }
 
 pub(crate) struct TrajectoryMemoryRepo<'a, S> {
@@ -74,7 +100,6 @@ where
         self.session.execute(statement).await
     }
 
-    #[cfg(test)]
     pub(crate) async fn list_raw_steps_for_task(
         &mut self,
         workspace_id: &str,
@@ -97,9 +122,138 @@ where
             .to_owned();
         self.session.fetch_all(statement).await
     }
+
+    pub(crate) async fn upsert_distillation(
+        &mut self,
+        workspace_id: &str,
+        distillation: &DistillationRecord,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(TrajectoryDistillations::Table)
+            .columns([
+                TrajectoryDistillations::WorkspaceId,
+                TrajectoryDistillations::Id,
+                TrajectoryDistillations::TaskId,
+                TrajectoryDistillations::Strategy,
+                TrajectoryDistillations::NormalizedIntent,
+                TrajectoryDistillations::PathKey,
+                TrajectoryDistillations::InputStepCount,
+                TrajectoryDistillations::OutputStepCount,
+                TrajectoryDistillations::CreatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_id.to_string()),
+                Expr::val(distillation.id.clone()),
+                Expr::val(distillation.task_id.clone()),
+                Expr::val(distillation.strategy.clone()),
+                Expr::val(distillation.normalized_intent.clone()),
+                Expr::val(distillation.path_key.clone()),
+                Expr::val(distillation.input_step_count),
+                Expr::val(distillation.output_step_count),
+                Expr::val(distillation.created_at_unix_nanos),
+            ])
+            .on_conflict(
+                OnConflict::columns([
+                    TrajectoryDistillations::WorkspaceId,
+                    TrajectoryDistillations::Id,
+                ])
+                .update_columns([
+                    TrajectoryDistillations::TaskId,
+                    TrajectoryDistillations::Strategy,
+                    TrajectoryDistillations::NormalizedIntent,
+                    TrajectoryDistillations::PathKey,
+                    TrajectoryDistillations::InputStepCount,
+                    TrajectoryDistillations::OutputStepCount,
+                    TrajectoryDistillations::CreatedAtUnixNanos,
+                ])
+                .to_owned(),
+            )
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn get_distillation(
+        &mut self,
+        workspace_id: &str,
+        distillation_id: &str,
+    ) -> Result<Option<DistillationRecord>, DbError> {
+        let statement = Query::select()
+            .columns(distillation_columns())
+            .from(TrajectoryDistillations::Table)
+            .and_where(Expr::col(TrajectoryDistillations::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(TrajectoryDistillations::Id).eq(distillation_id))
+            .to_owned();
+        self.session.fetch_optional(statement).await
+    }
+
+    pub(crate) async fn delete_distilled_steps(
+        &mut self,
+        workspace_id: &str,
+        distillation_id: &str,
+    ) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(TrajectoryDistilledSteps::Table)
+            .and_where(Expr::col(TrajectoryDistilledSteps::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(TrajectoryDistilledSteps::DistillationId).eq(distillation_id))
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    pub(crate) async fn insert_distilled_step(
+        &mut self,
+        workspace_id: &str,
+        step: &DistilledStepRecord,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(TrajectoryDistilledSteps::Table)
+            .columns([
+                TrajectoryDistilledSteps::WorkspaceId,
+                TrajectoryDistilledSteps::Id,
+                TrajectoryDistilledSteps::DistillationId,
+                TrajectoryDistilledSteps::SourceRawStepId,
+                TrajectoryDistilledSteps::Ordinal,
+                TrajectoryDistilledSteps::SqlTemplate,
+                TrajectoryDistilledSteps::RelationsJson,
+                TrajectoryDistilledSteps::ResultRowCount,
+                TrajectoryDistilledSteps::ResultColumnCount,
+                TrajectoryDistilledSteps::ExactKey,
+                TrajectoryDistilledSteps::CreatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_id.to_string()),
+                Expr::val(step.id.clone()),
+                Expr::val(step.distillation_id.clone()),
+                Expr::val(step.source_raw_step_id.clone()),
+                Expr::val(step.ordinal),
+                Expr::val(step.sql_template.clone()),
+                Expr::val(step.relations_json.clone()),
+                Expr::val(step.result_row_count),
+                Expr::val(step.result_column_count),
+                Expr::val(step.exact_key.clone()),
+                Expr::val(step.created_at_unix_nanos),
+            ])
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn list_distilled_steps(
+        &mut self,
+        workspace_id: &str,
+        distillation_id: &str,
+    ) -> Result<Vec<DistilledStepRecord>, DbError> {
+        let statement = Query::select()
+            .columns(distilled_step_columns())
+            .from(TrajectoryDistilledSteps::Table)
+            .and_where(Expr::col(TrajectoryDistilledSteps::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(TrajectoryDistilledSteps::DistillationId).eq(distillation_id))
+            .order_by(TrajectoryDistilledSteps::Ordinal, sea_query::Order::Asc)
+            .to_owned();
+        self.session.fetch_all(statement).await
+    }
 }
 
-#[cfg(test)]
 fn raw_step_columns() -> [TrajectoryRawSteps; 12] {
     [
         TrajectoryRawSteps::Id,
@@ -114,5 +268,35 @@ fn raw_step_columns() -> [TrajectoryRawSteps; 12] {
         TrajectoryRawSteps::ErrorKind,
         TrajectoryRawSteps::ErrorType,
         TrajectoryRawSteps::ErrorMessage,
+    ]
+}
+
+#[cfg(test)]
+fn distillation_columns() -> [TrajectoryDistillations; 8] {
+    [
+        TrajectoryDistillations::Id,
+        TrajectoryDistillations::TaskId,
+        TrajectoryDistillations::Strategy,
+        TrajectoryDistillations::NormalizedIntent,
+        TrajectoryDistillations::PathKey,
+        TrajectoryDistillations::InputStepCount,
+        TrajectoryDistillations::OutputStepCount,
+        TrajectoryDistillations::CreatedAtUnixNanos,
+    ]
+}
+
+#[cfg(test)]
+fn distilled_step_columns() -> [TrajectoryDistilledSteps; 10] {
+    [
+        TrajectoryDistilledSteps::Id,
+        TrajectoryDistilledSteps::DistillationId,
+        TrajectoryDistilledSteps::SourceRawStepId,
+        TrajectoryDistilledSteps::Ordinal,
+        TrajectoryDistilledSteps::SqlTemplate,
+        TrajectoryDistilledSteps::RelationsJson,
+        TrajectoryDistilledSteps::ResultRowCount,
+        TrajectoryDistilledSteps::ResultColumnCount,
+        TrajectoryDistilledSteps::ExactKey,
+        TrajectoryDistilledSteps::CreatedAtUnixNanos,
     ]
 }

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -42,3 +42,33 @@ pub(in crate::state::db) enum TrajectoryRawSteps {
     ErrorType,
     ErrorMessage,
 }
+
+#[derive(Iden)]
+pub(in crate::state::db) enum TrajectoryDistillations {
+    Table,
+    WorkspaceId,
+    Id,
+    TaskId,
+    Strategy,
+    NormalizedIntent,
+    PathKey,
+    InputStepCount,
+    OutputStepCount,
+    CreatedAtUnixNanos,
+}
+
+#[derive(Iden)]
+pub(in crate::state::db) enum TrajectoryDistilledSteps {
+    Table,
+    WorkspaceId,
+    Id,
+    DistillationId,
+    SourceRawStepId,
+    Ordinal,
+    SqlTemplate,
+    RelationsJson,
+    ResultRowCount,
+    ResultColumnCount,
+    ExactKey,
+    CreatedAtUnixNanos,
+}

--- a/crates/coral-app/src/task/manager.rs
+++ b/crates/coral-app/src/task/manager.rs
@@ -2,17 +2,23 @@
 
 use super::id::TaskId;
 use super::store::{TaskEnd, TaskStart, TaskStatus, TaskStore, TaskStoreError};
+use crate::bootstrap::AppError;
+use crate::trajectory_memory::TrajectoryMemoryManager;
 use crate::workspaces::WorkspaceName;
 
 /// Coordinates task lifecycle persistence and validation.
 #[derive(Clone)]
 pub(crate) struct TaskManager {
     store: TaskStore,
+    trajectory_memory: TrajectoryMemoryManager,
 }
 
 impl TaskManager {
-    pub(crate) fn new(store: TaskStore) -> Self {
-        Self { store }
+    pub(crate) fn new(store: TaskStore, trajectory_memory: TrajectoryMemoryManager) -> Self {
+        Self {
+            store,
+            trajectory_memory,
+        }
     }
 
     pub(crate) async fn start_task(
@@ -46,6 +52,11 @@ impl TaskManager {
             status,
         };
         self.store.end_task(&end).await?;
+        if status == TaskStatus::Success {
+            self.trajectory_memory
+                .distill_task(&end.workspace, &end.id)
+                .await?;
+        }
         Ok(end)
     }
 }
@@ -56,4 +67,6 @@ pub(crate) enum TaskManagerError {
     TaskNotFound { task_id: String },
     #[error(transparent)]
     Store(#[from] TaskStoreError),
+    #[error(transparent)]
+    TrajectoryMemory(#[from] AppError),
 }

--- a/crates/coral-app/src/task/service.rs
+++ b/crates/coral-app/src/task/service.rs
@@ -113,6 +113,10 @@ fn task_manager_status(error: &TaskManagerError) -> Status {
             warn!(%error, "failed to persist task lifecycle event");
             Status::internal("failed to persist task lifecycle event")
         }
+        TaskManagerError::TrajectoryMemory(_) => {
+            warn!(%error, "failed to distill trajectory memory");
+            Status::internal("failed to distill trajectory memory")
+        }
     }
 }
 
@@ -130,6 +134,7 @@ mod tests {
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
     use crate::task::manager::TaskManager;
     use crate::task::store::TaskStore;
+    use crate::trajectory_memory::TrajectoryMemoryManager;
 
     const UNKNOWN_TASK_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
 
@@ -147,7 +152,10 @@ mod tests {
                 .expect("open sqlite"),
         );
         db.migrate().await.expect("migrate sqlite");
-        let task = TaskManager::new(TaskStore::new(Arc::clone(&db)));
+        let task = TaskManager::new(
+            TaskStore::new(Arc::clone(&db)),
+            TrajectoryMemoryManager::new(Arc::clone(&db)),
+        );
         let service = TaskService::new(task);
         (dir, db, service)
     }

--- a/crates/coral-app/src/trajectory_memory.rs
+++ b/crates/coral-app/src/trajectory_memory.rs
@@ -1,13 +1,22 @@
-//! Raw task-attributed trajectory capture.
+//! Raw task-attributed trajectory capture and deterministic SQL distillation.
 
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use sqlparser::dialect::GenericDialect;
+use sqlparser::tokenizer::{Token, Tokenizer};
 
 use crate::bootstrap::AppError;
-use crate::state::db::{CoralDb, DbRepos, RawTrajectoryStepRecord};
+use crate::state::db::{
+    CoralDb, DbRepos, DistillationRecord, DistilledStepRecord, RawTrajectoryStepRecord,
+    now_unix_nanos_i64,
+};
 use crate::task::id::TaskId;
 use crate::workspaces::WorkspaceName;
+
+const DISTILLATION_STRATEGY: &str = "oracle_free_successful_sql_v1";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub(crate) struct TrajectoryOutputSummary {
@@ -90,6 +99,194 @@ impl TrajectoryMemoryManager {
             .await?;
         Ok(())
     }
+
+    pub(crate) async fn distill_task(
+        &self,
+        workspace: &WorkspaceName,
+        task_id: &TaskId,
+    ) -> Result<(), AppError> {
+        let task_id = task_id.to_string();
+        let mut session = self.db.as_ref();
+        let task = session
+            .tasks()
+            .get(workspace.as_str(), &task_id)
+            .await?
+            .ok_or_else(|| {
+                AppError::FailedPrecondition(format!("task '{task_id}' was not found"))
+            })?;
+        let raw_steps = session
+            .trajectory_memory()
+            .list_raw_steps_for_task(workspace.as_str(), &task_id)
+            .await?;
+        let created_at_unix_nanos = now_unix_nanos_i64()?;
+        let distillation_id = stable_id("dist", [task_id.as_str()]);
+        let distilled_steps = distill_steps(&distillation_id, &raw_steps, created_at_unix_nanos)?;
+        let distillation = DistillationRecord {
+            id: distillation_id.clone(),
+            task_id,
+            strategy: DISTILLATION_STRATEGY.to_string(),
+            normalized_intent: normalize_intent(&task.intent),
+            path_key: path_key(&distilled_steps),
+            input_step_count: usize_to_i64(raw_steps.len(), "raw trajectory step count")?,
+            output_step_count: usize_to_i64(
+                distilled_steps.len(),
+                "distilled trajectory step count",
+            )?,
+            created_at_unix_nanos,
+        };
+
+        let mut tx = self.db.begin().await?;
+        tx.trajectory_memory()
+            .delete_distilled_steps(workspace.as_str(), &distillation_id)
+            .await?;
+        tx.trajectory_memory()
+            .upsert_distillation(workspace.as_str(), &distillation)
+            .await?;
+        for step in &distilled_steps {
+            tx.trajectory_memory()
+                .insert_distilled_step(workspace.as_str(), step)
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+}
+
+fn distill_steps(
+    distillation_id: &str,
+    raw_steps: &[RawTrajectoryStepRecord],
+    created_at_unix_nanos: i64,
+) -> Result<Vec<DistilledStepRecord>, AppError> {
+    let mut seen = BTreeSet::new();
+    let mut distilled = Vec::new();
+    for raw in raw_steps {
+        if raw.operation != "execute_sql" || raw.status != "success" {
+            continue;
+        }
+        let sql_template = parameterize_sql(&raw.input);
+        if sql_template.is_empty() {
+            continue;
+        }
+        let summary = raw
+            .output_summary_json
+            .as_deref()
+            .map(serde_json::from_str::<TrajectoryOutputSummary>)
+            .transpose()?
+            .unwrap_or_default();
+        let result_column_count = summary
+            .column_count
+            .map(i64::try_from)
+            .transpose()
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!(
+                    "trajectory column count exceeds i64: {error}"
+                ))
+            })?;
+        let relations = summary.relations.into_iter().collect::<BTreeSet<_>>();
+        let relations_json = serde_json::to_string(&relations.iter().collect::<Vec<_>>())?;
+        let exact_key = stable_id("step", [sql_template.as_str()]);
+        if !seen.insert(exact_key.clone()) {
+            continue;
+        }
+        let ordinal = usize_to_i64(distilled.len(), "distilled step ordinal")?;
+        let ordinal_string = ordinal.to_string();
+        distilled.push(DistilledStepRecord {
+            id: stable_id(
+                "dstep",
+                [distillation_id, ordinal_string.as_str(), exact_key.as_str()],
+            ),
+            distillation_id: distillation_id.to_string(),
+            source_raw_step_id: raw.id.clone(),
+            ordinal,
+            sql_template,
+            relations_json,
+            result_row_count: raw.row_count,
+            result_column_count,
+            exact_key,
+            created_at_unix_nanos,
+        });
+    }
+    Ok(distilled)
+}
+
+fn path_key(steps: &[DistilledStepRecord]) -> String {
+    stable_id("path", steps.iter().map(|step| step.exact_key.as_str()))
+}
+
+fn normalize_intent(intent: &str) -> String {
+    intent
+        .split_whitespace()
+        .map(str::to_lowercase)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn parameterize_sql(sql: &str) -> String {
+    let trimmed = sql.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let Ok(tokens) = Tokenizer::new(&GenericDialect {}, trimmed).tokenize() else {
+        return collapse_sql_whitespace(trimmed);
+    };
+    let mut parameter_index = 0_u64;
+    let mut template = String::new();
+    for token in tokens {
+        match token {
+            Token::EOF => {}
+            Token::Whitespace(_) => push_space(&mut template),
+            token if is_literal(&token) => {
+                parameter_index = parameter_index.saturating_add(1);
+                template.push_str(":param_");
+                template.push_str(&parameter_index.to_string());
+            }
+            token => template.push_str(&token.to_string()),
+        }
+    }
+    collapse_sql_whitespace(&template)
+}
+
+fn is_literal(token: &Token) -> bool {
+    match token {
+        Token::Number(value, _) => !matches!(value.as_str(), "0" | "1" | "100"),
+        Token::SingleQuotedString(_)
+        | Token::TripleSingleQuotedString(_)
+        | Token::DollarQuotedString(_)
+        | Token::SingleQuotedByteStringLiteral(_)
+        | Token::TripleSingleQuotedByteStringLiteral(_)
+        | Token::SingleQuotedRawStringLiteral(_)
+        | Token::TripleSingleQuotedRawStringLiteral(_)
+        | Token::NationalStringLiteral(_)
+        | Token::EscapedStringLiteral(_)
+        | Token::UnicodeStringLiteral(_)
+        | Token::HexStringLiteral(_) => true,
+        _ => false,
+    }
+}
+
+fn push_space(sql: &mut String) {
+    if !sql.is_empty() && !sql.ends_with(' ') {
+        sql.push(' ');
+    }
+}
+
+fn collapse_sql_whitespace(sql: &str) -> String {
+    sql.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn stable_id<'a>(prefix: &str, parts: impl IntoIterator<Item = &'a str>) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(prefix.as_bytes());
+    for part in parts {
+        hasher.update([0]);
+        hasher.update(part.as_bytes());
+    }
+    format!("{prefix}_{:x}", hasher.finalize())
+}
+
+fn usize_to_i64(value: usize, name: &str) -> Result<i64, AppError> {
+    i64::try_from(value)
+        .map_err(|error| AppError::FailedPrecondition(format!("{name} exceeds i64: {error}")))
 }
 
 #[cfg(test)]
@@ -98,27 +295,44 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use super::{RawTrajectoryStep, TrajectoryMemoryManager, TrajectoryOutputSummary};
+    use super::{
+        RawTrajectoryStep, TrajectoryMemoryManager, TrajectoryOutputSummary, parameterize_sql,
+        stable_id,
+    };
     use crate::bootstrap;
     use crate::state::AppStateLayout;
     use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
     use crate::task::id::TaskId;
     use crate::task::manager::TaskManager;
-    use crate::task::store::TaskStore;
+    use crate::task::store::{TaskStatus, TaskStore};
     use crate::workspaces::WorkspaceName;
 
+    #[test]
+    fn parameterizes_literals_and_removes_comments() {
+        assert_eq!(
+            parameterize_sql(
+                "SELECT * FROM orders WHERE customer = 'Daisey' AND id = 42 -- private"
+            ),
+            "SELECT * FROM orders WHERE customer = :param_1 AND id = :param_2"
+        );
+        assert_eq!(
+            parameterize_sql("SELECT 0, 1, 100, 101"),
+            "SELECT 0, 1, 100, :param_1"
+        );
+    }
+
     #[tokio::test]
-    async fn raw_capture_round_trips_against_sqlite() {
+    async fn successful_sql_distills_against_sqlite() {
         let (temp, db) = open_sqlite().await;
 
-        assert_raw_capture(db, WorkspaceName::default()).await;
+        assert_successful_sql_distills(db, WorkspaceName::default()).await;
 
         drop(temp);
     }
 
     #[tokio::test]
-    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared raw trajectory harness against Postgres"]
-    async fn raw_capture_round_trips_against_postgres() {
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared trajectory harness against Postgres"]
+    async fn successful_sql_distills_against_postgres() {
         let Some(url) = postgres_test_url() else {
             return;
         };
@@ -132,38 +346,19 @@ mod tests {
             WorkspaceName::parse(&format!("trajectory_{}", uuid::Uuid::new_v4().simple()))
                 .expect("workspace");
 
-        assert_raw_capture(db, workspace).await;
+        assert_successful_sql_distills(db, workspace).await;
     }
 
-    async fn assert_raw_capture(db: Arc<CoralDb>, workspace: WorkspaceName) {
+    async fn assert_successful_sql_distills(db: Arc<CoralDb>, workspace: WorkspaceName) {
         let memory = TrajectoryMemoryManager::new(Arc::clone(&db));
-        let tasks = TaskManager::new(TaskStore::new(Arc::clone(&db)));
+        let tasks = TaskManager::new(TaskStore::new(Arc::clone(&db)), memory.clone());
         let task = tasks
-            .start_task(workspace.clone(), "Find renewal risk".to_string())
+            .start_task(workspace.clone(), "  Find   Renewal RISK  ".to_string())
             .await
             .expect("start task");
 
         memory
-            .record_raw_step(
-                &workspace,
-                RawTrajectoryStep {
-                    task_id: task.id,
-                    started_at_unix_nanos: 20,
-                    completed_at_unix_nanos: 21,
-                    operation: "execute_sql".to_string(),
-                    input: "SELECT customer_id FROM crm.accounts WHERE region = 'emea'".to_string(),
-                    status: "success",
-                    row_count: Some(3),
-                    output_summary: Some(TrajectoryOutputSummary {
-                        sources: vec!["crm".to_string()],
-                        relations: vec!["crm.accounts".to_string()],
-                        column_count: Some(1),
-                    }),
-                    error_kind: None,
-                    error_type: None,
-                    error_message: None,
-                },
-            )
+            .record_raw_step(&workspace, successful_sql_step(task.id, 20, "emea", 3))
             .await
             .expect("record successful step");
         memory
@@ -185,6 +380,10 @@ mod tests {
             )
             .await
             .expect("record failed step");
+        memory
+            .record_raw_step(&workspace, successful_sql_step(task.id, 22, "apac", 2))
+            .await
+            .expect("record duplicate successful step");
         memory
             .record_raw_step(
                 &workspace,
@@ -211,18 +410,78 @@ mod tests {
             .list_raw_steps_for_task(workspace.as_str(), &task.id.to_string())
             .await
             .expect("list raw steps");
-        let mut raw = raw.into_iter();
-        let search = raw.next().expect("search step");
+        assert_raw_steps(&raw);
+
+        tasks
+            .end_task(workspace.clone(), task.id, TaskStatus::Success)
+            .await
+            .expect("end task");
+
+        let distillation_id = stable_id("dist", [task.id.to_string().as_str()]);
+        let distillation = session
+            .trajectory_memory()
+            .get_distillation(workspace.as_str(), &distillation_id)
+            .await
+            .expect("get distillation")
+            .expect("distillation");
+        assert_eq!(distillation.input_step_count, 3);
+        assert_eq!(distillation.output_step_count, 1);
+        assert_eq!(distillation.normalized_intent, "find renewal risk");
+        let distilled = session
+            .trajectory_memory()
+            .list_distilled_steps(workspace.as_str(), &distillation_id)
+            .await
+            .expect("list distilled steps");
+        let [step] = distilled.as_slice() else {
+            panic!("expected one deduplicated distilled step: {distilled:#?}");
+        };
+        assert_eq!(
+            step.sql_template,
+            "SELECT customer_id FROM crm.accounts WHERE region = :param_1"
+        );
+        assert_eq!(step.result_row_count, Some(3));
+        assert_eq!(step.result_column_count, Some(1));
+        assert_eq!(step.relations_json, r#"["crm.accounts"]"#);
+    }
+
+    fn successful_sql_step(
+        task_id: TaskId,
+        started_at_unix_nanos: i64,
+        region: &str,
+        row_count: u64,
+    ) -> RawTrajectoryStep {
+        RawTrajectoryStep {
+            task_id,
+            started_at_unix_nanos,
+            completed_at_unix_nanos: started_at_unix_nanos + 1,
+            operation: "execute_sql".to_string(),
+            input: format!("SELECT customer_id FROM crm.accounts WHERE region = '{region}'"),
+            status: "success",
+            row_count: Some(row_count),
+            output_summary: Some(TrajectoryOutputSummary {
+                sources: vec!["crm".to_string()],
+                relations: vec!["crm.accounts".to_string()],
+                column_count: Some(1),
+            }),
+            error_kind: None,
+            error_type: None,
+            error_message: None,
+        }
+    }
+
+    fn assert_raw_steps(raw: &[crate::state::db::RawTrajectoryStepRecord]) {
+        let [search, sql, duplicate] = raw else {
+            panic!("expected three raw steps: {raw:#?}");
+        };
         assert_eq!(search.operation, "search");
         assert_eq!(search.status, "error");
         assert_eq!(search.error_type.as_deref(), Some("SEARCH"));
-        let sql = raw.next().expect("SQL step");
         assert_eq!(sql.operation, "execute_sql");
         assert_eq!(sql.row_count, Some(3));
         let summary = sql.output_summary_json.as_deref().expect("output summary");
         assert!(summary.contains("crm.accounts"));
         assert!(!summary.contains("customer_id"));
-        assert!(raw.next().is_none());
+        assert!(duplicate.input.contains("apac"));
     }
 
     async fn open_sqlite() -> (TempDir, Arc<CoralDb>) {


### PR DESCRIPTION
## Summary

- add durable distillation and distilled-step tables
- distill successful `execute_sql` operations when a task ends successfully
- canonicalize the authored task intent when creating the distillation and persist that retrieval key on the distillation record
- parameterize SQL literals, remove comments/formatting noise, and deduplicate identical templates
- retain step provenance plus relation and result-shape summaries

## Why

Raw trajectories are too literal for reuse. This creates a deterministic, oracle-free SQL distillation stage while deliberately stopping before consolidation or retrieval.

Intent canonicalization belongs here rather than in base task persistence: task rows retain the authored intent, while the derived distillation owns the key later used to group and retrieve paths.

The current prototype uses SQL tokenization rather than logical-plan provenance. The strategy is versioned as `oracle_free_successful_sql_v1` so a later implementation can coexist or rebuild cleanly.

## Stack position

3 of 5 in the trajectory-memory draft stack. Base: `codex/trajectory-memory-02-raw-capture`.

1. #1765 — SQL task persistence
2. #1766 — raw trajectory capture
3. **#1767 — successful-SQL distillation**
4. #1768 — exact index and retrieval
5. #1763 — MCP exposure and docs

## Validation

- strict clippy for `coral-app` and `coral-mcp`
- 519 focused app/MCP tests passed, 4 skipped
- shared SQLite/Postgres distillation scenario verifies the canonical intent, failed-step exclusion, and template deduplication
