### PR TITLE
feat(app): index exact-match task trajectories

### DIFF
--- a/crates/coral-api/proto/coral/v1/task.proto
+++ b/crates/coral-api/proto/coral/v1/task.proto
@@ -46,6 +46,28 @@ message EndTaskResponse {
 message Task {
   // Server-minted, opaque task id.
   string task_id = 1;
+  // Exact-intent trajectory suggestions available when the task starts.
+  repeated SuggestedPath suggested_paths = 2;
+}
+
+// One advisory path distilled from successful prior tasks.
+message SuggestedPath {
+  // Stable structural path identifier.
+  string path_id = 1;
+  // Number of matching successful distilled paths supporting this selection.
+  uint64 support_count = 2;
+  // Relations touched across the whole path.
+  repeated string relations = 3;
+  // Ordered, parameterized SQL templates to re-run against live data.
+  repeated SuggestedPathStep steps = 4;
+}
+
+// One ordered SQL step within a suggested path.
+message SuggestedPathStep {
+  // Parameterized SQL template; placeholders must be rebound for the live task.
+  string sql_template = 1;
+  // Relations touched by this step.
+  repeated string relations = 2;
 }
 
 // A task end event.

--- a/crates/coral-app/migrations/0006_trajectory_exact_index.sql
+++ b/crates/coral-app/migrations/0006_trajectory_exact_index.sql
@@ -1,0 +1,50 @@
+CREATE TABLE IF NOT EXISTS trajectory_consolidated_paths (
+    workspace_id TEXT NOT NULL,
+    normalized_intent TEXT NOT NULL,
+    path_key TEXT NOT NULL,
+    representative_distillation_id TEXT NOT NULL,
+    support_count BIGINT NOT NULL,
+    step_count BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, normalized_intent, path_key),
+    FOREIGN KEY (workspace_id, representative_distillation_id)
+        REFERENCES trajectory_distillations(workspace_id, id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS trajectory_consolidated_paths_intent_rank_idx
+    ON trajectory_consolidated_paths(
+        workspace_id,
+        normalized_intent,
+        support_count,
+        step_count,
+        path_key
+    );
+
+CREATE TABLE IF NOT EXISTS trajectory_exact_index (
+    workspace_id TEXT NOT NULL,
+    normalized_intent TEXT NOT NULL,
+    path_key TEXT NOT NULL,
+    support_count BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, normalized_intent),
+    FOREIGN KEY (workspace_id, normalized_intent, path_key)
+        REFERENCES trajectory_consolidated_paths(workspace_id, normalized_intent, path_key)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS trajectory_index_builds (
+    workspace_id TEXT NOT NULL,
+    id TEXT NOT NULL,
+    normalized_intent TEXT NOT NULL,
+    candidate_path_count BIGINT NOT NULL,
+    selected_distillation_id TEXT,
+    selected_path_key TEXT,
+    selected_support_count BIGINT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (workspace_id, id),
+    FOREIGN KEY (workspace_id, selected_distillation_id)
+        REFERENCES trajectory_distillations(workspace_id, id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS trajectory_index_builds_intent_idx
+    ON trajectory_index_builds(workspace_id, normalized_intent, created_at_unix_nanos);

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -19,7 +19,8 @@ pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
 pub(crate) use repositories::tasks::TaskRecord;
 pub(crate) use repositories::trajectory_memory::{
-    DistillationRecord, DistilledStepRecord, RawTrajectoryStepRecord,
+    ConsolidatedPathRecord, DistillationRecord, DistilledStepRecord, ExactIndexRecord,
+    IndexBuildRecord, PathCandidateRecord, RawTrajectoryStepRecord,
 };
 pub(crate) use session::{DbRepos, DbSession};
 pub(crate) use transaction::CoralTx;

--- a/crates/coral-app/src/state/db/repositories/trajectory_memory.rs
+++ b/crates/coral-app/src/state/db/repositories/trajectory_memory.rs
@@ -1,7 +1,8 @@
-use sea_query::{Expr, ExprTrait, OnConflict, Query};
+use sea_query::{Alias, Expr, ExprTrait, JoinType, OnConflict, Query};
 
 use crate::state::db::schema::{
-    TrajectoryDistillations, TrajectoryDistilledSteps, TrajectoryRawSteps,
+    Tasks, TrajectoryConsolidatedPaths, TrajectoryDistillations, TrajectoryDistilledSteps,
+    TrajectoryExactIndex, TrajectoryIndexBuilds, TrajectoryRawSteps,
 };
 use crate::state::db::{DbError, DbSession};
 
@@ -44,6 +45,43 @@ pub(crate) struct DistilledStepRecord {
     pub(crate) result_row_count: Option<i64>,
     pub(crate) result_column_count: Option<i64>,
     pub(crate) exact_key: String,
+    pub(crate) created_at_unix_nanos: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub(crate) struct ConsolidatedPathRecord {
+    pub(crate) normalized_intent: String,
+    pub(crate) path_key: String,
+    pub(crate) representative_distillation_id: String,
+    pub(crate) support_count: i64,
+    pub(crate) step_count: i64,
+    pub(crate) updated_at_unix_nanos: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub(crate) struct PathCandidateRecord {
+    pub(crate) distillation_id: String,
+    pub(crate) path_key: String,
+    pub(crate) step_count: i64,
+    pub(crate) created_at_unix_nanos: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub(crate) struct ExactIndexRecord {
+    pub(crate) normalized_intent: String,
+    pub(crate) path_key: String,
+    pub(crate) support_count: i64,
+    pub(crate) updated_at_unix_nanos: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IndexBuildRecord {
+    pub(crate) id: String,
+    pub(crate) normalized_intent: String,
+    pub(crate) candidate_path_count: i64,
+    pub(crate) selected_distillation_id: Option<String>,
+    pub(crate) selected_path_key: Option<String>,
+    pub(crate) selected_support_count: i64,
     pub(crate) created_at_unix_nanos: i64,
 }
 
@@ -237,7 +275,6 @@ where
         self.session.execute(statement).await
     }
 
-    #[cfg(test)]
     pub(crate) async fn list_distilled_steps(
         &mut self,
         workspace_id: &str,
@@ -251,6 +288,235 @@ where
             .order_by(TrajectoryDistilledSteps::Ordinal, sea_query::Order::Asc)
             .to_owned();
         self.session.fetch_all(statement).await
+    }
+
+    pub(crate) async fn delete_consolidated_paths_for_intent(
+        &mut self,
+        workspace_id: &str,
+        normalized_intent: &str,
+    ) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(TrajectoryConsolidatedPaths::Table)
+            .and_where(Expr::col(TrajectoryConsolidatedPaths::WorkspaceId).eq(workspace_id))
+            .and_where(
+                Expr::col(TrajectoryConsolidatedPaths::NormalizedIntent).eq(normalized_intent),
+            )
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    pub(crate) async fn insert_consolidated_path(
+        &mut self,
+        workspace_id: &str,
+        path: &ConsolidatedPathRecord,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(TrajectoryConsolidatedPaths::Table)
+            .columns([
+                TrajectoryConsolidatedPaths::WorkspaceId,
+                TrajectoryConsolidatedPaths::NormalizedIntent,
+                TrajectoryConsolidatedPaths::PathKey,
+                TrajectoryConsolidatedPaths::RepresentativeDistillationId,
+                TrajectoryConsolidatedPaths::SupportCount,
+                TrajectoryConsolidatedPaths::StepCount,
+                TrajectoryConsolidatedPaths::UpdatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_id.to_string()),
+                Expr::val(path.normalized_intent.clone()),
+                Expr::val(path.path_key.clone()),
+                Expr::val(path.representative_distillation_id.clone()),
+                Expr::val(path.support_count),
+                Expr::val(path.step_count),
+                Expr::val(path.updated_at_unix_nanos),
+            ])
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    pub(crate) async fn get_consolidated_path(
+        &mut self,
+        workspace_id: &str,
+        normalized_intent: &str,
+        path_key: &str,
+    ) -> Result<Option<ConsolidatedPathRecord>, DbError> {
+        let statement = Query::select()
+            .columns(consolidated_path_columns())
+            .from(TrajectoryConsolidatedPaths::Table)
+            .and_where(Expr::col(TrajectoryConsolidatedPaths::WorkspaceId).eq(workspace_id))
+            .and_where(
+                Expr::col(TrajectoryConsolidatedPaths::NormalizedIntent).eq(normalized_intent),
+            )
+            .and_where(Expr::col(TrajectoryConsolidatedPaths::PathKey).eq(path_key))
+            .to_owned();
+        self.session.fetch_optional(statement).await
+    }
+
+    pub(crate) async fn list_path_candidates_for_intent(
+        &mut self,
+        workspace_id: &str,
+        normalized_intent: &str,
+    ) -> Result<Vec<PathCandidateRecord>, DbError> {
+        let statement = Query::select()
+            .expr_as(
+                Expr::col((TrajectoryDistillations::Table, TrajectoryDistillations::Id)),
+                Alias::new("distillation_id"),
+            )
+            .expr_as(
+                Expr::col((
+                    TrajectoryDistillations::Table,
+                    TrajectoryDistillations::PathKey,
+                )),
+                Alias::new("path_key"),
+            )
+            .expr_as(
+                Expr::col((
+                    TrajectoryDistillations::Table,
+                    TrajectoryDistillations::OutputStepCount,
+                )),
+                Alias::new("step_count"),
+            )
+            .expr_as(
+                Expr::col((
+                    TrajectoryDistillations::Table,
+                    TrajectoryDistillations::CreatedAtUnixNanos,
+                )),
+                Alias::new("created_at_unix_nanos"),
+            )
+            .from(TrajectoryDistillations::Table)
+            .join(
+                JoinType::InnerJoin,
+                Tasks::Table,
+                Expr::col((
+                    TrajectoryDistillations::Table,
+                    TrajectoryDistillations::WorkspaceId,
+                ))
+                .equals((Tasks::Table, Tasks::WorkspaceId))
+                .and(
+                    Expr::col((
+                        TrajectoryDistillations::Table,
+                        TrajectoryDistillations::TaskId,
+                    ))
+                    .equals((Tasks::Table, Tasks::Id)),
+                ),
+            )
+            .and_where(
+                Expr::col((
+                    TrajectoryDistillations::Table,
+                    TrajectoryDistillations::WorkspaceId,
+                ))
+                .eq(workspace_id),
+            )
+            .and_where(
+                Expr::col((
+                    TrajectoryDistillations::Table,
+                    TrajectoryDistillations::NormalizedIntent,
+                ))
+                .eq(normalized_intent),
+            )
+            .and_where(Expr::col((Tasks::Table, Tasks::Status)).eq("success"))
+            .and_where(
+                Expr::col((
+                    TrajectoryDistillations::Table,
+                    TrajectoryDistillations::OutputStepCount,
+                ))
+                .gt(0_i64),
+            )
+            .order_by(
+                (
+                    TrajectoryDistillations::Table,
+                    TrajectoryDistillations::CreatedAtUnixNanos,
+                ),
+                sea_query::Order::Asc,
+            )
+            .order_by(
+                (TrajectoryDistillations::Table, TrajectoryDistillations::Id),
+                sea_query::Order::Asc,
+            )
+            .to_owned();
+        self.session.fetch_all(statement).await
+    }
+
+    pub(crate) async fn get_exact_index(
+        &mut self,
+        workspace_id: &str,
+        normalized_intent: &str,
+    ) -> Result<Option<ExactIndexRecord>, DbError> {
+        let statement = Query::select()
+            .columns(exact_index_columns())
+            .from(TrajectoryExactIndex::Table)
+            .and_where(Expr::col(TrajectoryExactIndex::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(TrajectoryExactIndex::NormalizedIntent).eq(normalized_intent))
+            .to_owned();
+        self.session.fetch_optional(statement).await
+    }
+
+    pub(crate) async fn upsert_exact_index(
+        &mut self,
+        workspace_id: &str,
+        record: &ExactIndexRecord,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(TrajectoryExactIndex::Table)
+            .columns([
+                TrajectoryExactIndex::WorkspaceId,
+                TrajectoryExactIndex::NormalizedIntent,
+                TrajectoryExactIndex::PathKey,
+                TrajectoryExactIndex::SupportCount,
+                TrajectoryExactIndex::UpdatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_id.to_string()),
+                Expr::val(record.normalized_intent.clone()),
+                Expr::val(record.path_key.clone()),
+                Expr::val(record.support_count),
+                Expr::val(record.updated_at_unix_nanos),
+            ])
+            .on_conflict(
+                OnConflict::columns([
+                    TrajectoryExactIndex::WorkspaceId,
+                    TrajectoryExactIndex::NormalizedIntent,
+                ])
+                .update_columns([
+                    TrajectoryExactIndex::PathKey,
+                    TrajectoryExactIndex::SupportCount,
+                    TrajectoryExactIndex::UpdatedAtUnixNanos,
+                ])
+                .to_owned(),
+            )
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    pub(crate) async fn insert_index_build(
+        &mut self,
+        workspace_id: &str,
+        build: &IndexBuildRecord,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(TrajectoryIndexBuilds::Table)
+            .columns([
+                TrajectoryIndexBuilds::WorkspaceId,
+                TrajectoryIndexBuilds::Id,
+                TrajectoryIndexBuilds::NormalizedIntent,
+                TrajectoryIndexBuilds::CandidatePathCount,
+                TrajectoryIndexBuilds::SelectedDistillationId,
+                TrajectoryIndexBuilds::SelectedPathKey,
+                TrajectoryIndexBuilds::SelectedSupportCount,
+                TrajectoryIndexBuilds::CreatedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(workspace_id.to_string()),
+                Expr::val(build.id.clone()),
+                Expr::val(build.normalized_intent.clone()),
+                Expr::val(build.candidate_path_count),
+                Expr::val(build.selected_distillation_id.clone()),
+                Expr::val(build.selected_path_key.clone()),
+                Expr::val(build.selected_support_count),
+                Expr::val(build.created_at_unix_nanos),
+            ])
+            .to_owned();
+        self.session.execute(statement).await
     }
 }
 
@@ -285,7 +551,6 @@ fn distillation_columns() -> [TrajectoryDistillations; 8] {
     ]
 }
 
-#[cfg(test)]
 fn distilled_step_columns() -> [TrajectoryDistilledSteps; 10] {
     [
         TrajectoryDistilledSteps::Id,
@@ -298,5 +563,25 @@ fn distilled_step_columns() -> [TrajectoryDistilledSteps; 10] {
         TrajectoryDistilledSteps::ResultColumnCount,
         TrajectoryDistilledSteps::ExactKey,
         TrajectoryDistilledSteps::CreatedAtUnixNanos,
+    ]
+}
+
+fn consolidated_path_columns() -> [TrajectoryConsolidatedPaths; 6] {
+    [
+        TrajectoryConsolidatedPaths::NormalizedIntent,
+        TrajectoryConsolidatedPaths::PathKey,
+        TrajectoryConsolidatedPaths::RepresentativeDistillationId,
+        TrajectoryConsolidatedPaths::SupportCount,
+        TrajectoryConsolidatedPaths::StepCount,
+        TrajectoryConsolidatedPaths::UpdatedAtUnixNanos,
+    ]
+}
+
+fn exact_index_columns() -> [TrajectoryExactIndex; 4] {
+    [
+        TrajectoryExactIndex::NormalizedIntent,
+        TrajectoryExactIndex::PathKey,
+        TrajectoryExactIndex::SupportCount,
+        TrajectoryExactIndex::UpdatedAtUnixNanos,
     ]
 }

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -72,3 +72,38 @@ pub(in crate::state::db) enum TrajectoryDistilledSteps {
     ExactKey,
     CreatedAtUnixNanos,
 }
+
+#[derive(Iden)]
+pub(in crate::state::db) enum TrajectoryConsolidatedPaths {
+    Table,
+    WorkspaceId,
+    NormalizedIntent,
+    PathKey,
+    RepresentativeDistillationId,
+    SupportCount,
+    StepCount,
+    UpdatedAtUnixNanos,
+}
+
+#[derive(Iden)]
+pub(in crate::state::db) enum TrajectoryExactIndex {
+    Table,
+    WorkspaceId,
+    NormalizedIntent,
+    PathKey,
+    SupportCount,
+    UpdatedAtUnixNanos,
+}
+
+#[derive(Iden)]
+pub(in crate::state::db) enum TrajectoryIndexBuilds {
+    Table,
+    WorkspaceId,
+    Id,
+    NormalizedIntent,
+    CandidatePathCount,
+    SelectedDistillationId,
+    SelectedPathKey,
+    SelectedSupportCount,
+    CreatedAtUnixNanos,
+}

--- a/crates/coral-app/src/task/manager.rs
+++ b/crates/coral-app/src/task/manager.rs
@@ -26,10 +26,15 @@ impl TaskManager {
         workspace: WorkspaceName,
         intent: String,
     ) -> Result<TaskStart, TaskManagerError> {
+        let suggested_paths = self
+            .trajectory_memory
+            .suggested_paths(&workspace, &intent)
+            .await?;
         let start = TaskStart {
             id: TaskId::new(),
             workspace,
             intent,
+            suggested_paths,
         };
         self.store.start_task(&start).await?;
         Ok(start)
@@ -54,7 +59,7 @@ impl TaskManager {
         self.store.end_task(&end).await?;
         if status == TaskStatus::Success {
             self.trajectory_memory
-                .distill_task(&end.workspace, &end.id)
+                .distill_and_index(&end.workspace, &end.id)
                 .await?;
         }
         Ok(end)

--- a/crates/coral-app/src/task/service.rs
+++ b/crates/coral-app/src/task/service.rs
@@ -2,8 +2,9 @@
 
 use coral_api::v1::task_service_server::TaskService as TaskServiceApi;
 use coral_api::v1::{
-    EndTaskRequest, EndTaskResponse, StartTaskRequest, StartTaskResponse, Task as ProtoTask,
-    TaskEnd as ProtoTaskEnd, TaskStatus as ProtoTaskStatus,
+    EndTaskRequest, EndTaskResponse, StartTaskRequest, StartTaskResponse,
+    SuggestedPath as ProtoSuggestedPath, SuggestedPathStep as ProtoSuggestedPathStep,
+    Task as ProtoTask, TaskEnd as ProtoTaskEnd, TaskStatus as ProtoTaskStatus,
 };
 use tonic::{Request, Response, Status};
 use tracing::warn;
@@ -73,6 +74,23 @@ impl TaskServiceApi for TaskService {
 pub(crate) fn task_start_to_proto(start: &TaskStart) -> ProtoTask {
     ProtoTask {
         task_id: start.id.to_string(),
+        suggested_paths: start
+            .suggested_paths
+            .iter()
+            .map(|path| ProtoSuggestedPath {
+                path_id: path.path_id.clone(),
+                support_count: path.support_count,
+                relations: path.relations.clone(),
+                steps: path
+                    .steps
+                    .iter()
+                    .map(|step| ProtoSuggestedPathStep {
+                        sql_template: step.sql_template.clone(),
+                        relations: step.relations.clone(),
+                    })
+                    .collect(),
+            })
+            .collect(),
     }
 }
 
@@ -114,8 +132,8 @@ fn task_manager_status(error: &TaskManagerError) -> Status {
             Status::internal("failed to persist task lifecycle event")
         }
         TaskManagerError::TrajectoryMemory(_) => {
-            warn!(%error, "failed to distill trajectory memory");
-            Status::internal("failed to distill trajectory memory")
+            warn!(%error, "failed to process trajectory memory");
+            Status::internal("failed to process trajectory memory")
         }
     }
 }

--- a/crates/coral-app/src/task/store.rs
+++ b/crates/coral-app/src/task/store.rs
@@ -6,6 +6,7 @@ use coral_api::CORAL_TASK_INTENT_MAX_CHARS;
 
 use super::id::TaskId;
 use crate::state::db::{CoralDb, DbError, DbRepos, TaskRecord, now_unix_nanos_i64};
+use crate::trajectory_memory::SuggestedPath;
 use crate::workspaces::WorkspaceName;
 
 /// Final task status.
@@ -32,6 +33,7 @@ pub(crate) struct TaskStart {
     pub(crate) id: TaskId,
     pub(crate) workspace: WorkspaceName,
     pub(crate) intent: String,
+    pub(crate) suggested_paths: Vec<SuggestedPath>,
 }
 
 /// A task end event.
@@ -161,6 +163,7 @@ mod tests {
             id: TaskId::parse(TASK_ID).expect("valid task id"),
             workspace: workspace.clone(),
             intent: intent.to_string(),
+            suggested_paths: Vec::new(),
         }
     }
 

--- a/crates/coral-app/src/trajectory_memory.rs
+++ b/crates/coral-app/src/trajectory_memory.rs
@@ -1,6 +1,6 @@
-//! Raw task-attributed trajectory capture and deterministic SQL distillation.
+//! Exact-match trajectory capture, distillation, indexing, and retrieval.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,8 @@ use sqlparser::tokenizer::{Token, Tokenizer};
 
 use crate::bootstrap::AppError;
 use crate::state::db::{
-    CoralDb, DbRepos, DistillationRecord, DistilledStepRecord, RawTrajectoryStepRecord,
+    ConsolidatedPathRecord, CoralDb, DbRepos, DistillationRecord, DistilledStepRecord,
+    ExactIndexRecord, IndexBuildRecord, PathCandidateRecord, RawTrajectoryStepRecord,
     now_unix_nanos_i64,
 };
 use crate::task::id::TaskId;
@@ -39,6 +40,20 @@ pub(crate) struct RawTrajectoryStep {
     pub(crate) error_kind: Option<String>,
     pub(crate) error_type: Option<String>,
     pub(crate) error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SuggestedPathStep {
+    pub(crate) sql_template: String,
+    pub(crate) relations: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SuggestedPath {
+    pub(crate) path_id: String,
+    pub(crate) support_count: u64,
+    pub(crate) relations: Vec<String>,
+    pub(crate) steps: Vec<SuggestedPathStep>,
 }
 
 #[derive(Clone)]
@@ -100,7 +115,7 @@ impl TrajectoryMemoryManager {
         Ok(())
     }
 
-    pub(crate) async fn distill_task(
+    pub(crate) async fn distill_and_index(
         &self,
         workspace: &WorkspaceName,
         task_id: &TaskId,
@@ -121,6 +136,7 @@ impl TrajectoryMemoryManager {
         let created_at_unix_nanos = now_unix_nanos_i64()?;
         let distillation_id = stable_id("dist", [task_id.as_str()]);
         let distilled_steps = distill_steps(&distillation_id, &raw_steps, created_at_unix_nanos)?;
+        let output_step_count = usize_to_i64(distilled_steps.len(), "distilled step count")?;
         let distillation = DistillationRecord {
             id: distillation_id.clone(),
             task_id,
@@ -128,10 +144,7 @@ impl TrajectoryMemoryManager {
             normalized_intent: normalize_intent(&task.intent),
             path_key: path_key(&distilled_steps),
             input_step_count: usize_to_i64(raw_steps.len(), "raw trajectory step count")?,
-            output_step_count: usize_to_i64(
-                distilled_steps.len(),
-                "distilled trajectory step count",
-            )?,
+            output_step_count,
             created_at_unix_nanos,
         };
 
@@ -147,9 +160,159 @@ impl TrajectoryMemoryManager {
                 .insert_distilled_step(workspace.as_str(), step)
                 .await?;
         }
+
+        let normalized_intent = &distillation.normalized_intent;
+        let candidates = tx
+            .trajectory_memory()
+            .list_path_candidates_for_intent(workspace.as_str(), normalized_intent)
+            .await?;
+        let groups = consolidate_candidates(candidates);
+        let winner = groups.first();
+        tx.trajectory_memory()
+            .delete_consolidated_paths_for_intent(workspace.as_str(), normalized_intent)
+            .await?;
+        for group in &groups {
+            tx.trajectory_memory()
+                .insert_consolidated_path(
+                    workspace.as_str(),
+                    &ConsolidatedPathRecord {
+                        normalized_intent: distillation.normalized_intent.clone(),
+                        path_key: group.representative.path_key.clone(),
+                        representative_distillation_id: group
+                            .representative
+                            .distillation_id
+                            .clone(),
+                        support_count: group.support_count,
+                        step_count: group.representative.step_count,
+                        updated_at_unix_nanos: created_at_unix_nanos,
+                    },
+                )
+                .await?;
+        }
+        if let Some(winner) = winner {
+            tx.trajectory_memory()
+                .upsert_exact_index(
+                    workspace.as_str(),
+                    &ExactIndexRecord {
+                        normalized_intent: distillation.normalized_intent.clone(),
+                        path_key: winner.representative.path_key.clone(),
+                        support_count: winner.support_count,
+                        updated_at_unix_nanos: created_at_unix_nanos,
+                    },
+                )
+                .await?;
+        }
+        tx.trajectory_memory()
+            .insert_index_build(
+                workspace.as_str(),
+                &IndexBuildRecord {
+                    id: format!("build_{}", uuid::Uuid::new_v4().simple()),
+                    normalized_intent: distillation.normalized_intent,
+                    candidate_path_count: usize_to_i64(groups.len(), "candidate path count")?,
+                    selected_distillation_id: winner
+                        .map(|group| group.representative.distillation_id.clone()),
+                    selected_path_key: winner.map(|group| group.representative.path_key.clone()),
+                    selected_support_count: winner.map_or(0, |group| group.support_count),
+                    created_at_unix_nanos,
+                },
+            )
+            .await?;
         tx.commit().await?;
         Ok(())
     }
+
+    pub(crate) async fn suggested_paths(
+        &self,
+        workspace: &WorkspaceName,
+        intent: &str,
+    ) -> Result<Vec<SuggestedPath>, AppError> {
+        let normalized_intent = normalize_intent(intent);
+        let mut session = self.db.as_ref();
+        let Some(index) = session
+            .trajectory_memory()
+            .get_exact_index(workspace.as_str(), &normalized_intent)
+            .await?
+        else {
+            return Ok(Vec::new());
+        };
+        let Some(consolidated) = session
+            .trajectory_memory()
+            .get_consolidated_path(workspace.as_str(), &normalized_intent, &index.path_key)
+            .await?
+        else {
+            return Ok(Vec::new());
+        };
+        if index.support_count != consolidated.support_count {
+            return Err(AppError::FailedPrecondition(format!(
+                "trajectory index support {} does not match consolidated support {}",
+                index.support_count, consolidated.support_count
+            )));
+        }
+        let records = session
+            .trajectory_memory()
+            .list_distilled_steps(
+                workspace.as_str(),
+                &consolidated.representative_distillation_id,
+            )
+            .await?;
+        let mut all_relations = BTreeSet::new();
+        let mut steps = Vec::with_capacity(records.len());
+        for record in records {
+            let relations = parse_relations(&record.relations_json)?;
+            all_relations.extend(relations.iter().cloned());
+            steps.push(SuggestedPathStep {
+                sql_template: record.sql_template,
+                relations,
+            });
+        }
+        let support_count = u64::try_from(consolidated.support_count).map_err(|error| {
+            AppError::FailedPrecondition(format!("trajectory support count is invalid: {error}"))
+        })?;
+        Ok(vec![SuggestedPath {
+            path_id: index.path_key,
+            support_count,
+            relations: all_relations.into_iter().collect(),
+            steps,
+        }])
+    }
+}
+
+#[derive(Debug)]
+struct CandidateGroup {
+    representative: PathCandidateRecord,
+    support_count: i64,
+}
+
+fn consolidate_candidates(candidates: Vec<PathCandidateRecord>) -> Vec<CandidateGroup> {
+    let mut grouped = BTreeMap::<String, CandidateGroup>::new();
+    for candidate in candidates {
+        let key = candidate.path_key.clone();
+        let group = grouped.entry(key).or_insert_with(|| CandidateGroup {
+            representative: candidate.clone(),
+            support_count: 0,
+        });
+        group.support_count = group.support_count.saturating_add(1);
+        if candidate.created_at_unix_nanos > group.representative.created_at_unix_nanos {
+            group.representative = candidate;
+        }
+    }
+    let mut groups = grouped.into_values().collect::<Vec<_>>();
+    groups.sort_by(|left, right| {
+        right
+            .support_count
+            .cmp(&left.support_count)
+            .then_with(|| {
+                left.representative
+                    .step_count
+                    .cmp(&right.representative.step_count)
+            })
+            .then_with(|| {
+                left.representative
+                    .path_key
+                    .cmp(&right.representative.path_key)
+            })
+    });
+    groups
 }
 
 fn distill_steps(
@@ -274,6 +437,10 @@ fn collapse_sql_whitespace(sql: &str) -> String {
     sql.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+fn parse_relations(raw: &str) -> Result<Vec<String>, AppError> {
+    serde_json::from_str(raw).map_err(Into::into)
+}
+
 fn stable_id<'a>(prefix: &str, parts: impl IntoIterator<Item = &'a str>) -> String {
     let mut hasher = Sha256::new();
     hasher.update(prefix.as_bytes());
@@ -296,13 +463,12 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        RawTrajectoryStep, TrajectoryMemoryManager, TrajectoryOutputSummary, parameterize_sql,
-        stable_id,
+        PathCandidateRecord, RawTrajectoryStep, TrajectoryMemoryManager, TrajectoryOutputSummary,
+        consolidate_candidates, parameterize_sql,
     };
     use crate::bootstrap;
     use crate::state::AppStateLayout;
     use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
-    use crate::task::id::TaskId;
     use crate::task::manager::TaskManager;
     use crate::task::store::{TaskStatus, TaskStore};
     use crate::workspaces::WorkspaceName;
@@ -321,18 +487,35 @@ mod tests {
         );
     }
 
+    #[test]
+    fn consolidation_prefers_support_then_shortness() {
+        let candidates = vec![
+            candidate("long", "task-a", 3, 1),
+            candidate("long", "task-b", 3, 2),
+            candidate("short", "task-c", 1, 3),
+            candidate("short", "task-d", 1, 4),
+        ];
+        let groups = consolidate_candidates(candidates);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(
+            groups.first().expect("winner").representative.path_key,
+            "short"
+        );
+        assert_eq!(groups.first().expect("winner").support_count, 2);
+    }
+
     #[tokio::test]
-    async fn successful_sql_distills_against_sqlite() {
+    async fn exact_match_retrieval_is_cold_then_warm_against_sqlite() {
         let (temp, db) = open_sqlite().await;
 
-        assert_successful_sql_distills(db, WorkspaceName::default()).await;
+        assert_exact_match_retrieval(db, WorkspaceName::default()).await;
 
         drop(temp);
     }
 
     #[tokio::test]
     #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared trajectory harness against Postgres"]
-    async fn successful_sql_distills_against_postgres() {
+    async fn exact_match_retrieval_is_cold_then_warm_against_postgres() {
         let Some(url) = postgres_test_url() else {
             return;
         };
@@ -346,142 +529,146 @@ mod tests {
             WorkspaceName::parse(&format!("trajectory_{}", uuid::Uuid::new_v4().simple()))
                 .expect("workspace");
 
-        assert_successful_sql_distills(db, workspace).await;
+        assert_exact_match_retrieval(db, workspace).await;
     }
 
-    async fn assert_successful_sql_distills(db: Arc<CoralDb>, workspace: WorkspaceName) {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "The shared backend scenario keeps the cold-to-warm lifecycle in one readable test flow."
+    )]
+    async fn assert_exact_match_retrieval(db: Arc<CoralDb>, workspace: WorkspaceName) {
         let memory = TrajectoryMemoryManager::new(Arc::clone(&db));
         let tasks = TaskManager::new(TaskStore::new(Arc::clone(&db)), memory.clone());
-        let task = tasks
-            .start_task(workspace.clone(), "  Find   Renewal RISK  ".to_string())
-            .await
-            .expect("start task");
+        let intent = "Find renewal risk";
 
-        memory
-            .record_raw_step(&workspace, successful_sql_step(task.id, 20, "emea", 3))
+        let cold = tasks
+            .start_task(workspace.clone(), intent.to_string())
             .await
-            .expect("record successful step");
+            .expect("start cold task");
+        assert!(cold.suggested_paths.is_empty());
+
+        for (started_at_unix_nanos, status) in [(10, "success"), (20, "success")] {
+            memory
+                .record_raw_step(
+                    &workspace,
+                    RawTrajectoryStep {
+                        task_id: cold.id,
+                        started_at_unix_nanos,
+                        completed_at_unix_nanos: started_at_unix_nanos + 1,
+                        operation: "execute_sql".to_string(),
+                        input: "SELECT customer_id FROM crm.accounts WHERE region = 'emea' AND score > 42 -- live values".to_string(),
+                        status,
+                        row_count: Some(3),
+                        output_summary: Some(TrajectoryOutputSummary {
+                            sources: vec!["crm".to_string()],
+                            relations: vec!["crm.accounts".to_string()],
+                            column_count: Some(1),
+                        }),
+                        error_kind: None,
+                        error_type: None,
+                        error_message: None,
+                    },
+                )
+                .await
+                .expect("record successful raw step");
+        }
         memory
             .record_raw_step(
                 &workspace,
                 RawTrajectoryStep {
-                    task_id: task.id,
-                    started_at_unix_nanos: 10,
-                    completed_at_unix_nanos: 11,
-                    operation: "search".to_string(),
-                    input: "renewal risk".to_string(),
-                    status: "error",
-                    row_count: None,
-                    output_summary: None,
-                    error_kind: Some("app".to_string()),
-                    error_type: Some("SEARCH".to_string()),
-                    error_message: Some("search failed".to_string()),
-                },
-            )
-            .await
-            .expect("record failed step");
-        memory
-            .record_raw_step(&workspace, successful_sql_step(task.id, 22, "apac", 2))
-            .await
-            .expect("record duplicate successful step");
-        memory
-            .record_raw_step(
-                &workspace,
-                RawTrajectoryStep {
-                    task_id: TaskId::new(),
+                    task_id: cold.id,
                     started_at_unix_nanos: 30,
                     completed_at_unix_nanos: 31,
                     operation: "execute_sql".to_string(),
-                    input: "SELECT 1".to_string(),
-                    status: "success",
-                    row_count: Some(1),
+                    input: "SELECT * FROM missing.table".to_string(),
+                    status: "error",
+                    row_count: None,
                     output_summary: None,
-                    error_kind: None,
-                    error_type: None,
-                    error_message: None,
+                    error_kind: Some("engine".to_string()),
+                    error_type: Some("EXECUTION".to_string()),
+                    error_message: Some("table not found".to_string()),
                 },
             )
             .await
-            .expect("unknown task is ignored");
+            .expect("record failed raw step");
+
+        tasks
+            .end_task(workspace.clone(), cold.id, TaskStatus::Success)
+            .await
+            .expect("end cold task");
+
+        let warm = tasks
+            .start_task(workspace.clone(), "  FIND   renewal RISK  ".to_string())
+            .await
+            .expect("start warm task");
+        let suggested = warm.suggested_paths.first().expect("suggested path");
+        assert_eq!(warm.suggested_paths.len(), 1);
+        assert_eq!(suggested.support_count, 1);
+        assert_eq!(suggested.relations, ["crm.accounts"]);
+        assert_eq!(
+            suggested.steps.len(),
+            1,
+            "duplicate SQL should be distilled once"
+        );
+        let suggested_step = suggested.steps.first().expect("suggested step");
+        assert_eq!(
+            suggested_step.sql_template,
+            "SELECT customer_id FROM crm.accounts WHERE region = :param_1 AND score > :param_2"
+        );
+        assert_eq!(suggested_step.relations, ["crm.accounts"]);
+        assert!(
+            memory
+                .suggested_paths(&workspace, "Find renewal risk!")
+                .await
+                .expect("lookup punctuation miss")
+                .is_empty(),
+            "exact matching preserves punctuation"
+        );
 
         let mut session = db.as_ref();
         let raw = session
             .trajectory_memory()
-            .list_raw_steps_for_task(workspace.as_str(), &task.id.to_string())
+            .list_raw_steps_for_task(workspace.as_str(), &cold.id.to_string())
             .await
             .expect("list raw steps");
-        assert_raw_steps(&raw);
-
-        tasks
-            .end_task(workspace.clone(), task.id, TaskStatus::Success)
+        assert_eq!(raw.len(), 3, "every attributed operation should persist");
+        let index = session
+            .trajectory_memory()
+            .get_exact_index(workspace.as_str(), "find renewal risk")
             .await
-            .expect("end task");
-
-        let distillation_id = stable_id("dist", [task.id.to_string().as_str()]);
+            .expect("get exact index")
+            .expect("exact index");
+        let consolidated = session
+            .trajectory_memory()
+            .get_consolidated_path(workspace.as_str(), "find renewal risk", &index.path_key)
+            .await
+            .expect("get consolidated path")
+            .expect("consolidated path");
+        assert_eq!(consolidated.support_count, 1);
+        assert_eq!(consolidated.step_count, 1);
         let distillation = session
             .trajectory_memory()
-            .get_distillation(workspace.as_str(), &distillation_id)
+            .get_distillation(
+                workspace.as_str(),
+                &consolidated.representative_distillation_id,
+            )
             .await
             .expect("get distillation")
             .expect("distillation");
         assert_eq!(distillation.input_step_count, 3);
         assert_eq!(distillation.output_step_count, 1);
         assert_eq!(distillation.normalized_intent, "find renewal risk");
-        let distilled = session
+        let distilled_steps = session
             .trajectory_memory()
-            .list_distilled_steps(workspace.as_str(), &distillation_id)
+            .list_distilled_steps(
+                workspace.as_str(),
+                &consolidated.representative_distillation_id,
+            )
             .await
             .expect("list distilled steps");
-        let [step] = distilled.as_slice() else {
-            panic!("expected one deduplicated distilled step: {distilled:#?}");
-        };
-        assert_eq!(
-            step.sql_template,
-            "SELECT customer_id FROM crm.accounts WHERE region = :param_1"
-        );
-        assert_eq!(step.result_row_count, Some(3));
-        assert_eq!(step.result_column_count, Some(1));
-        assert_eq!(step.relations_json, r#"["crm.accounts"]"#);
-    }
-
-    fn successful_sql_step(
-        task_id: TaskId,
-        started_at_unix_nanos: i64,
-        region: &str,
-        row_count: u64,
-    ) -> RawTrajectoryStep {
-        RawTrajectoryStep {
-            task_id,
-            started_at_unix_nanos,
-            completed_at_unix_nanos: started_at_unix_nanos + 1,
-            operation: "execute_sql".to_string(),
-            input: format!("SELECT customer_id FROM crm.accounts WHERE region = '{region}'"),
-            status: "success",
-            row_count: Some(row_count),
-            output_summary: Some(TrajectoryOutputSummary {
-                sources: vec!["crm".to_string()],
-                relations: vec!["crm.accounts".to_string()],
-                column_count: Some(1),
-            }),
-            error_kind: None,
-            error_type: None,
-            error_message: None,
-        }
-    }
-
-    fn assert_raw_steps(raw: &[crate::state::db::RawTrajectoryStepRecord]) {
-        let [search, sql, duplicate] = raw else {
-            panic!("expected three raw steps: {raw:#?}");
-        };
-        assert_eq!(search.operation, "search");
-        assert_eq!(search.status, "error");
-        assert_eq!(search.error_type.as_deref(), Some("SEARCH"));
-        assert_eq!(sql.operation, "execute_sql");
-        assert_eq!(sql.row_count, Some(3));
-        let summary = sql.output_summary_json.as_deref().expect("output summary");
-        assert!(summary.contains("crm.accounts"));
-        assert!(!summary.contains("customer_id"));
-        assert!(duplicate.input.contains("apac"));
+        let distilled_step = distilled_steps.first().expect("distilled step");
+        assert_eq!(distilled_step.result_row_count, Some(3));
+        assert_eq!(distilled_step.result_column_count, Some(1));
     }
 
     async fn open_sqlite() -> (TempDir, Arc<CoralDb>) {
@@ -490,7 +677,7 @@ mod tests {
         layout.ensure().expect("ensure layout");
         let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
         else {
-            panic!("default database is sqlite");
+            panic!("default test config should be sqlite");
         };
         let db = Arc::new(
             CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
@@ -503,5 +690,19 @@ mod tests {
 
     fn postgres_test_url() -> Option<String> {
         bootstrap::env_var("CORAL_TEST_POSTGRES_URL").expect("read CORAL_TEST_POSTGRES_URL")
+    }
+
+    fn candidate(
+        path_key: &str,
+        task_id: &str,
+        step_count: i64,
+        created_at_unix_nanos: i64,
+    ) -> PathCandidateRecord {
+        PathCandidateRecord {
+            distillation_id: format!("dist-{task_id}"),
+            path_key: path_key.to_string(),
+            step_count,
+            created_at_unix_nanos,
+        }
     }
 }


### PR DESCRIPTION
## Summary

- consolidate successful distilled paths by normalized intent and full ordered path key
- build and audit an exact-match index with deterministic winner selection
- return cold/warm `suggested_paths` through the task gRPC contract
- return only path id, support, relations, and ordered SQL templates; historical task intent remains internal provenance
- preserve punctuation while normalizing case and repeated whitespace for exact intent lookup

## Why

This is the retrieval layer: a completed successful task updates the local exact index, and the next task with the same normalized intent receives a parameterized advisory path.

Selection prefers path support, then shorter paths, then stable path-key order. Suggestions contain templates and relation metadata, not cached result rows; callers must bind current values and execute against live sources.

The selected distillation still links back to its source task in SQL. That provenance does not need to be repeated in the public suggestion response, and retrieval therefore does not read the historical task row.

## Stack position

4 of 4 in the trajectory-memory stack. Base: `codex/trajectory-memory-03-distill-sql`.

1. #1765 — SQL task persistence
2. #1766 — raw trajectory capture
3. #1767 — successful-SQL distillation
4. **#1768 — exact index and retrieval**

## Validation

- `make rust-checks`
- SQLite cold-to-warm exact-retrieval scenario
- ignored Postgres cold-to-warm exact-retrieval scenario invoked explicitly
