### PR TITLE
fix(reef): prevent Storybook CI from missing protobuf bindings

### DIFF
--- a/apps/reef/package.json
+++ b/apps/reef/package.json
@@ -16,7 +16,7 @@
     "format:check": "oxfmt --check",
     "check": "oxfmt --check && oxlint --deny-warnings",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "npm run proto:gen && storybook build",
     "storybook:doctor": "storybook doctor"
   },
   "dependencies": {


### PR DESCRIPTION
TL/DR some stories (in descendant PR) will need type def from protobuf generation, make sure building storybook does the generation first  
  
Constraint: generated Reef protobuf bindings remain gitignored

Rejected: commit generated bindings | generated output must stay out of version control

Confidence: high

Scope-risk: narrow

Tested: npm --prefix apps/reef run build-storybook -- --output-dir /tmp/reef-storybook-pr1727; npm --prefix apps/reef run check