### PR TITLE
test(reef): align Storybook routers with route stubs

### DIFF
--- a/apps/reef/app/components/navigation-progress-bar/navigation-progress-bar.stories.tsx
+++ b/apps/reef/app/components/navigation-progress-bar/navigation-progress-bar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { useEffect, useMemo } from 'react'
-import { createMemoryRouter, RouterProvider, useNavigate } from 'react-router'
+import { useEffect } from 'react'
+import { createRoutesStub, useNavigate } from 'react-router'
 
 import { Typography } from '@/wax/components/typography'
 import { theme } from '@/wax/theme/theme.css'
@@ -52,27 +52,20 @@ function DemoRoute() {
   )
 }
 
-function NavigationProgressBarStory() {
-  const router = useMemo(
-    () =>
-      createMemoryRouter(
-        [
-          {
-            element: <DemoRoute />,
-            path: '/',
-          },
-          {
-            element: <DemoRoute />,
-            loader: createPendingLoader,
-            path: PENDING_ROUTE,
-          },
-        ],
-        { initialEntries: ['/'] },
-      ),
-    [],
-  )
+const NavigationProgressBarRoutesStub = createRoutesStub([
+  {
+    Component: DemoRoute,
+    path: '/',
+  },
+  {
+    Component: DemoRoute,
+    loader: createPendingLoader,
+    path: PENDING_ROUTE,
+  },
+])
 
-  return <RouterProvider router={router} />
+function NavigationProgressBarStory() {
+  return <NavigationProgressBarRoutesStub initialEntries={['/']} />
 }
 
 const meta = {

--- a/apps/reef/app/components/sidebar/sidebar.stories.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { createMemoryRouter, RouterProvider } from 'react-router'
+import { createRoutesStub } from 'react-router'
 
 import { Typography } from '@/wax/components/typography'
 import { theme } from '@/wax/theme/theme.css'
@@ -11,20 +11,15 @@ const meta = {
   component: Sidebar,
   decorators: [
     (Story, context) => {
-      const router = createMemoryRouter(
-        [
-          {
-            children: [{ index: true, element: <div /> }],
-            element: <Story />,
-            path: '/',
-          },
-        ],
+      const RoutesStub = createRoutesStub([
         {
-          initialEntries: [context.parameters.initialEntry ?? '/'],
+          children: [{ index: true, Component: () => null }],
+          Component: () => <Story />,
+          path: '/',
         },
-      )
+      ])
 
-      return <RouterProvider router={router} />
+      return <RoutesStub initialEntries={[context.parameters.initialEntry ?? '/']} />
     },
   ],
   parameters: {

--- a/apps/reef/app/components/sources/source-card-list.stories.tsx
+++ b/apps/reef/app/components/sources/source-card-list.stories.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { RouterProvider, createMemoryRouter } from 'react-router'
+import { createRoutesStub } from 'react-router'
 import { expect, fn, within } from 'storybook/test'
 
 import { oauthInstallEventToNdjson } from '@/lib/source-oauth-install-stream'
@@ -111,6 +111,15 @@ const oauthStateLabels: Record<OAuthStoryState, string> = {
   error: 'GitHub denied the authorization request.',
 }
 
+const OAuthStoryStateContext = createContext<OAuthStoryState>('awaiting-authorization')
+
+const OAuthInstallFlowRoutesStub = createRoutesStub([
+  {
+    Component: OAuthInstallFlowRoute,
+    path: '*',
+  },
+])
+
 export const OAuthInstallFlow: OAuthInstallFlowStory = {
   args: {
     oauthState: 'awaiting-authorization',
@@ -148,19 +157,16 @@ export const OAuthInstallFlow: OAuthInstallFlowStory = {
 }
 
 function OAuthInstallFlowPreview({ oauthState }: { oauthState: OAuthStoryState }) {
-  const [router] = useState(() =>
-    createMemoryRouter(
-      [
-        {
-          element: <OAuthInstallFlowSurface oauthState={oauthState} />,
-          path: '*',
-        },
-      ],
-      { initialEntries: ['/sources'] },
-    ),
+  return (
+    <OAuthStoryStateContext.Provider value={oauthState}>
+      <OAuthInstallFlowRoutesStub initialEntries={['/sources']} />
+    </OAuthStoryStateContext.Provider>
   )
+}
 
-  return <RouterProvider router={router} />
+function OAuthInstallFlowRoute() {
+  const oauthState = useContext(OAuthStoryStateContext)
+  return <OAuthInstallFlowSurface oauthState={oauthState} />
 }
 
 function OAuthInstallFlowSurface({ oauthState }: { oauthState: OAuthStoryState }) {

--- a/apps/reef/app/wax/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/apps/reef/app/wax/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { createMemoryRouter, RouterProvider } from 'react-router'
+import { createRoutesStub } from 'react-router'
 
 import { Breadcrumbs } from './breadcrumbs'
 
@@ -25,10 +25,8 @@ const meta = {
   component: Breadcrumbs,
   decorators: [
     (Story) => {
-      const router = createMemoryRouter([{ element: <Story />, path: '*' }], {
-        initialEntries: ['/'],
-      })
-      return <RouterProvider router={router} />
+      const RoutesStub = createRoutesStub([{ Component: () => <Story />, path: '*' }])
+      return <RoutesStub initialEntries={['/']} />
     },
   ],
   parameters: {

--- a/apps/reef/app/wax/components/page-layout/page-layout.stories.tsx
+++ b/apps/reef/app/wax/components/page-layout/page-layout.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { createMemoryRouter, RouterProvider } from 'react-router'
+import { createRoutesStub } from 'react-router'
 
 import { Button } from '@/wax/components'
 import { Typography } from '@/wax/components/typography'
@@ -27,10 +27,8 @@ const meta = {
   component: PageLayout,
   decorators: [
     (Story) => {
-      const router = createMemoryRouter([{ element: <Story />, path: '*' }], {
-        initialEntries: ['/'],
-      })
-      return <RouterProvider router={router} />
+      const RoutesStub = createRoutesStub([{ Component: () => <Story />, path: '*' }])
+      return <RoutesStub initialEntries={['/']} />
     },
   ],
   parameters: {


### PR DESCRIPTION
## Why

These Storybook fixtures model React Router route trees, loaders, and navigation state. Using React Router's test-focused `createRoutesStub` API makes that intent explicit, removes manual `createMemoryRouter`/`RouterProvider` wiring, and keeps each story focused on the component behavior being demonstrated.

The installed `react-router@7.17.0` exports the plural `createRoutesStub`; it does not export `createRouteStub`. Stories that only need lightweight `Link` context continue to use `MemoryRouter`, avoiding an unnecessary broad migration.

## What changed

- Replaced manual `createMemoryRouter` and `RouterProvider` setup in five Reef Storybook files with `createRoutesStub`.
- Expressed route elements as stub route `Component` entries.
- Preserved the pending loader used by the navigation progress story.
- Added a small context bridge so the OAuth story can keep reacting to Storybook controls while using a stable route stub.
- Left link-only `MemoryRouter` stories unchanged.

## Validation

- `npm run check --prefix apps/reef`
- `npm run typecheck --prefix apps/reef`
- `npm test --prefix apps/reef` — 77 files, 307 tests passed
- `npm run build --prefix apps/reef`
- `npm run build-storybook --prefix apps/reef`
- `git diff --check`