### PR TITLE
feat(reef): source creation wizard for DSL v4 manifests

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -359,6 +359,7 @@ describe('Architectural Tests', () => {
       expect(routeConfig).toContain(
         "route(routePattern('workspaceSources'), 'routes/sources.tsx', [",
       )
+      expect(routeConfig).toContain("route('install', 'routes/source-install.tsx')")
       expect(routeConfig).toContain("route(':sourceName', 'routes/source-detail.tsx')")
       // Schema is a layout with nested table-detail routes.
       expect(routeConfig).toContain("route(routePattern('workspaceSchema'), 'routes/schema.tsx', [")

--- a/apps/reef/app/components/sources/source-catalog-surface.css.ts
+++ b/apps/reef/app/components/sources/source-catalog-surface.css.ts
@@ -91,13 +91,21 @@ export const searchBar = style({
 
 export const searchBarVariant = styleVariants({
   compact: {
-    flex: '0 0 280px',
+    flex: '0 1 280px',
     maxWidth: 280,
+    minWidth: 180,
   },
   full: {
-    flex: '0 0 360px',
+    flex: '0 1 360px',
     maxWidth: 360,
+    minWidth: 200,
   },
+})
+
+export const headerAction = style({
+  alignItems: 'center',
+  display: 'flex',
+  flexShrink: 0,
 })
 
 export const statusPanel = style({

--- a/apps/reef/app/components/sources/source-catalog-surface.stories.tsx
+++ b/apps/reef/app/components/sources/source-catalog-surface.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { fn } from 'storybook/test'
 
 import type { CatalogEntry } from '@/lib/sources'
+import { Button } from '@/wax/components'
 import { theme } from '@/wax/theme/theme.css'
 
 import { SourceCatalogSurface } from './source-catalog-surface'
@@ -62,6 +63,22 @@ type Story = StoryObj<typeof meta>
 export const Full: Story = {
   args: {
     entries,
+    loadState: 'idle',
+    onPick: fn(),
+    onSearchChange: fn(),
+    search: '',
+  },
+}
+
+export const WithHeaderAction: Story = {
+  args: {
+    entries,
+    headerAction: (
+      <Button.Container variant="primary">
+        <Button.Icon name="Plus" />
+        <Button.Text>Create source</Button.Text>
+      </Button.Container>
+    ),
     loadState: 'idle',
     onPick: fn(),
     onSearchChange: fn(),

--- a/apps/reef/app/components/sources/source-catalog-surface.tsx
+++ b/apps/reef/app/components/sources/source-catalog-surface.tsx
@@ -21,6 +21,7 @@ export type SourceCatalogSurfaceVariant = 'compact' | 'full'
 interface SourceCatalogSurfaceBaseProps {
   entries: SourceCatalogEntry[]
   errorMessage?: string | null
+  headerAction?: React.ReactNode
   loadState?: SourceCatalogLoadState
   onRetry?: () => void
   onSearchChange: (search: string) => void
@@ -38,6 +39,7 @@ export function SourceCatalogSurface(props: SourceCatalogSurfaceProps) {
   const {
     entries,
     errorMessage = null,
+    headerAction = null,
     loadState = 'idle',
     onRetry,
     onSearchChange,
@@ -57,7 +59,7 @@ export function SourceCatalogSurface(props: SourceCatalogSurfaceProps) {
     : { onPick: props.onPick }
   const loading = loadState === 'loading'
   const error = loadState === 'error'
-  const shouldShowHeader = showHeader && (showTitle || showSearch)
+  const shouldShowHeader = showHeader && (showTitle || showSearch || headerAction !== null)
 
   return (
     <section
@@ -88,6 +90,8 @@ export function SourceCatalogSurface(props: SourceCatalogSurfaceProps) {
                 />
               </div>
             ) : null}
+
+            {headerAction ? <div className={styles.headerAction}>{headerAction}</div> : null}
           </div>
         </div>
       ) : null}

--- a/apps/reef/app/components/sources/source-create.stories.tsx
+++ b/apps/reef/app/components/sources/source-create.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { createContext, useContext, type ComponentProps } from 'react'
+
+import { createRoutesStub } from 'react-router'
+import { expect, fn, waitFor, within } from 'storybook/test'
+
+import { SourceCreateDialog } from '@/views/sources/source-create'
+
+type SourceCreateDialogProps = ComponentProps<typeof SourceCreateDialog>
+
+const SourceCreateStoryContext = createContext<SourceCreateDialogProps | null>(null)
+const SourceCreateRoutesStub = createRoutesStub([
+  {
+    Component: SourceCreateStoryRoute,
+    path: '*',
+  },
+])
+
+const meta = {
+  args: {
+    actionData: undefined,
+    onOpenChange: fn(),
+    open: true,
+  },
+  component: SourceCreateDialog,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: (args) => <SourceCreateDialogStory {...args} />,
+  tags: ['autodocs'],
+  title: 'Components/Sources/SourceCreateDialog',
+} satisfies Meta<typeof SourceCreateDialog>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Basics: Story = {
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body)
+
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByText('Step 1 of 3 — Basics')).toBeVisible()
+    await expect(page.getByLabelText('Name')).toBeVisible()
+    await expect(page.getByLabelText('Description (optional)')).toBeVisible()
+  },
+}
+
+export const Connection: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const page = within(canvasElement.ownerDocument.body)
+
+    await userEvent.type(page.getByLabelText('Name'), 'weather_api')
+    await userEvent.click(page.getByRole('button', { name: 'Next' }))
+
+    await waitFor(() => expect(page.getByLabelText('OpenAPI descriptor URL')).toBeVisible())
+    await waitFor(() => expect(activeDialogCount(canvasElement.ownerDocument)).toBe(2))
+    await userEvent.click(page.getByRole('button', { name: 'Custom header' }))
+    await expect(page.getByLabelText('Header name')).toBeVisible()
+  },
+}
+
+export const Credentials: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const page = within(canvasElement.ownerDocument.body)
+
+    await userEvent.type(page.getByLabelText('Name'), 'weather_api')
+    await userEvent.click(page.getByRole('button', { name: 'Next' }))
+    await userEvent.type(
+      page.getByLabelText('OpenAPI descriptor URL'),
+      'https://weather.example/openapi.yaml',
+    )
+    await userEvent.click(page.getByRole('button', { name: 'Next' }))
+
+    await waitFor(() => expect(page.getByLabelText('Bearer token')).toBeVisible())
+    await waitFor(() => expect(activeDialogCount(canvasElement.ownerDocument)).toBe(3))
+  },
+}
+
+export const ImportError: Story = {
+  args: {
+    actionData: {
+      intent: 'import',
+      message: 'The OpenAPI descriptor could not be loaded.',
+      name: 'weather_api',
+      status: 'error',
+    },
+  },
+  name: 'Import error',
+  play: async ({ canvasElement, userEvent }) => {
+    const page = within(canvasElement.ownerDocument.body)
+
+    await userEvent.type(page.getByLabelText('Name'), 'weather_api')
+    await userEvent.click(page.getByRole('button', { name: 'Next' }))
+    await userEvent.type(
+      page.getByLabelText('OpenAPI descriptor URL'),
+      'https://weather.example/openapi.yaml',
+    )
+    await userEvent.click(page.getByRole('button', { name: 'Next' }))
+
+    await waitFor(() => expect(activeDialogCount(canvasElement.ownerDocument)).toBe(3))
+    const dialogs = activeDialogs(canvasElement.ownerDocument)
+    const credentialsDialog = dialogs.item(dialogs.length - 1)
+    if (!(credentialsDialog instanceof HTMLElement)) throw new Error('Credentials dialog not found')
+    await expect(
+      within(credentialsDialog).getByText('The OpenAPI descriptor could not be loaded.'),
+    ).toBeVisible()
+  },
+}
+
+function activeDialogCount(document: Document) {
+  return activeDialogs(document).length
+}
+
+function activeDialogs(document: Document) {
+  return document.querySelectorAll('[role="dialog"]:not([data-ending-style])')
+}
+
+function SourceCreateDialogStory(args: SourceCreateDialogProps) {
+  return (
+    <SourceCreateStoryContext.Provider value={args}>
+      <SourceCreateRoutesStub initialEntries={['/workspaces/default/sources/install']} />
+    </SourceCreateStoryContext.Provider>
+  )
+}
+
+function SourceCreateStoryRoute() {
+  const args = useContext(SourceCreateStoryContext)
+  if (!args) return null
+  return <SourceCreateDialog {...args} />
+}

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -15,6 +15,7 @@ export default [
     index('routes/index.tsx'),
     route(routePattern('workspaces'), 'routes/workspaces-action.ts'),
     route(routePattern('workspaceSources'), 'routes/sources.tsx', [
+      route('install', 'routes/source-install.tsx'),
       route(':sourceName', 'routes/source-detail.tsx'),
     ]),
     route(routePattern('workspaceSchema'), 'routes/schema.tsx', [

--- a/apps/reef/app/routes/source-install.tsx
+++ b/apps/reef/app/routes/source-install.tsx
@@ -1,0 +1,22 @@
+import type { Route } from './+types/source-install'
+import { useNavigate } from 'react-router'
+
+import { SourceCreateDialog } from '@/views/sources/source-create'
+import { routePath } from '@/routing/routemap'
+
+export { action } from './sources-action'
+
+export default function SourceInstallRoute({ actionData, params }: Route.ComponentProps) {
+  const navigate = useNavigate()
+  const sourcesPath = routePath('workspaceSources', { workspaceId: params.workspaceId })
+
+  return (
+    <SourceCreateDialog
+      actionData={actionData}
+      open
+      onOpenChange={(open) => {
+        if (!open) navigate(sourcesPath)
+      }}
+    />
+  )
+}

--- a/apps/reef/app/routes/sources-action.ts
+++ b/apps/reef/app/routes/sources-action.ts
@@ -6,6 +6,7 @@ import {
   DeleteSourceRequestSchema,
   GetSourceInfoRequestSchema,
   GetSourceRequestSchema,
+  ImportSourceRequestSchema,
 } from '@/generated/coral/v1/sources_pb'
 import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { sourceClientForRequest } from '@/lib/coral-request.server'
@@ -32,7 +33,7 @@ export {
   type InstallInput,
 } from '@/lib/source-install-form'
 
-export type SourceActionIntent = 'delete' | 'edit' | 'install'
+export type SourceActionIntent = 'delete' | 'edit' | 'import' | 'install'
 
 export type SourcesActionData =
   | {
@@ -96,10 +97,21 @@ export async function action({
       await sourceClient.deleteSource(create(DeleteSourceRequestSchema, { name, workspace }))
       return redirect(routePath('workspaceSources', { workspaceId: workspace.name }))
     }
+    if (intent === 'import') {
+      const manifestYaml = formData.get('manifest_yaml')
+      if (typeof manifestYaml !== 'string' || manifestYaml.trim().length === 0) {
+        return actionError('import', name, 'Missing source manifest')
+      }
+      const secretKey = formValue(formData, 'secret_key')
+      const secretValue = formValue(formData, 'secret_value')
+      const secrets = secretKey && secretValue ? [{ key: secretKey, value: secretValue }] : []
+      await importSourceManifest(sourceClient, workspace, manifestYaml, secrets)
+      return redirect(routePath('workspaceSources', { workspaceId: workspace.name }))
+    }
     return actionError('install', name, 'Unknown source action')
   } catch (error) {
     return actionError(
-      intent === 'edit' || intent === 'delete' ? intent : 'install',
+      intent === 'edit' || intent === 'delete' || intent === 'import' ? intent : 'install',
       name,
       errorMessage(error),
     )
@@ -145,6 +157,23 @@ async function createBundledSource(
   )
   if (!response.source) throw new Error(`Coral did not return installed source ${name}`)
   return response.source
+}
+
+async function importSourceManifest(
+  sourceClient: ReturnType<typeof sourceClientForRequest>,
+  workspace: Workspace,
+  manifestYaml: string,
+  secrets: { key: string; value: string }[],
+) {
+  const stream = sourceClient.importSource(
+    create(ImportSourceRequestSchema, { manifestYaml, secrets, workspace }),
+  )
+  // The import wizard has no OAuth inputs, so the stream only carries the
+  // terminal source event.
+  for await (const response of stream) {
+    if (response.event.case === 'source') return response.event.value
+  }
+  throw new Error('Coral did not return the imported source')
 }
 
 function actionError(intent: SourceActionIntent, name: string, message: string): SourcesActionData {

--- a/apps/reef/app/routes/sources.tsx
+++ b/apps/reef/app/routes/sources.tsx
@@ -5,7 +5,6 @@ import type { Route } from './+types/sources'
 import { SourcesIndex } from '@/views/sources/sources-index'
 import { routePattern } from '@/routing/routemap'
 
-export { action } from './sources-action'
 export { loader } from './sources-loader'
 
 export function shouldRevalidate({

--- a/apps/reef/app/routing/routemap.test.ts
+++ b/apps/reef/app/routing/routemap.test.ts
@@ -10,6 +10,7 @@ const CANONICAL_PATTERNS = {
   workspaceSchema: '/workspaces/:workspaceId/schema',
   workspaceSchemaTable: '/workspaces/:workspaceId/schema/:schemaName/:tableName',
   workspaceSource: '/workspaces/:workspaceId/sources/:sourceName',
+  workspaceSourceInstall: '/workspaces/:workspaceId/sources/install',
   workspaceSources: '/workspaces/:workspaceId/sources',
   workspaceTrace: '/workspaces/:workspaceId/traces/:traceId',
   workspaceTraces: '/workspaces/:workspaceId/traces',
@@ -44,6 +45,7 @@ describe('route map', () => {
         sourceName: 'github',
         workspaceId: 'analytics',
       }),
+      workspaceSourceInstall: routePath('workspaceSourceInstall', { workspaceId: 'analytics' }),
       workspaceSources: routePath('workspaceSources', { workspaceId: 'analytics' }),
       workspaceTrace: routePath('workspaceTrace', {
         traceId: 'trace_123',
@@ -59,6 +61,7 @@ describe('route map', () => {
       workspaceSchema: '/workspaces/analytics/schema',
       workspaceSchemaTable: '/workspaces/analytics/schema/github/issues',
       workspaceSource: '/workspaces/analytics/sources/github',
+      workspaceSourceInstall: '/workspaces/analytics/sources/install',
       workspaceSources: '/workspaces/analytics/sources',
       workspaceTrace: '/workspaces/analytics/traces/trace_123',
       workspaceTraces: '/workspaces/analytics/traces',

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -5,6 +5,7 @@ const HOME_PATH = '/'
 const WORKSPACES_PATH = '/workspaces'
 const WORKSPACE_SCHEMA_PATH = '/workspaces/:workspaceId/schema'
 const WORKSPACE_SCHEMA_TABLE_PATH = '/workspaces/:workspaceId/schema/:schemaName/:tableName'
+const WORKSPACE_SOURCE_INSTALL_PATH = '/workspaces/:workspaceId/sources/install'
 const WORKSPACE_SOURCES_PATH = '/workspaces/:workspaceId/sources'
 const WORKSPACE_SOURCE_PATH = '/workspaces/:workspaceId/sources/:sourceName'
 const WORKSPACE_TRACES_PATH = '/workspaces/:workspaceId/traces'
@@ -45,6 +46,13 @@ export const routeDefinitions = {
     toPath: (params: { sourceName: string; workspaceId: string }) =>
       generatePath(WORKSPACE_SOURCE_PATH, {
         sourceName: params.sourceName,
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceSourceInstall: {
+    path: WORKSPACE_SOURCE_INSTALL_PATH,
+    toPath: (params: { workspaceId: string }) =>
+      generatePath(WORKSPACE_SOURCE_INSTALL_PATH, {
         workspaceId: params.workspaceId,
       }),
   },

--- a/apps/reef/app/views/sources/source-create.css.ts
+++ b/apps/reef/app/views/sources/source-create.css.ts
@@ -1,0 +1,111 @@
+import { style } from '@vanilla-extract/css'
+
+import { fontFamily } from '@/wax/theme/font.css'
+import { theme } from '@/wax/theme/theme.css'
+
+export const header = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  marginBlockEnd: 6,
+})
+
+export const dialogContent = style({
+  display: 'flex',
+  flexDirection: 'column',
+})
+
+export const stepLabel = style({
+  color: theme.content.tertiary,
+})
+
+export const fieldGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 14,
+})
+
+export const fieldItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+})
+
+export const fieldLabel = style({
+  color: theme.content.primary,
+  fontWeight: 500,
+})
+
+export const choiceTabs = style({
+  background: theme.surface.onMainContent,
+  borderRadius: 8,
+  display: 'inline-flex',
+  gap: 4,
+  padding: 4,
+  width: 'fit-content',
+})
+
+export const choiceTab = style({
+  background: 'transparent',
+  border: 'none',
+  borderRadius: 6,
+  color: theme.content.secondary,
+  cursor: 'pointer',
+  fontSize: 12,
+  fontWeight: 500,
+  padding: '4px 10px',
+  transition: 'background 80ms ease, color 80ms ease',
+  ':disabled': { cursor: 'not-allowed', opacity: 0.6 },
+  ':hover': { background: theme.surface.onMainContentHover, color: theme.content.primary },
+  selectors: {
+    '&[data-active="true"]': {
+      background: theme.surface.card,
+      color: theme.content.primary,
+    },
+  },
+})
+
+export const summaryBox = style({
+  background: theme.surface.onMainContent,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 8,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  padding: 12,
+})
+
+export const summaryRow = style({
+  display: 'flex',
+  gap: 8,
+})
+
+export const summaryKey = style({
+  color: theme.content.tertiary,
+  flex: '0 0 96px',
+})
+
+export const summaryValue = style({
+  color: theme.content.primary,
+  fontFamily: fontFamily.dmMono,
+  fontSize: 12,
+  minWidth: 0,
+  overflowWrap: 'anywhere',
+})
+
+export const alertBox = style({
+  alignItems: 'center',
+  borderRadius: 6,
+  display: 'flex',
+  fontSize: 12,
+  gap: 8,
+  lineHeight: '16px',
+  paddingBlock: 8,
+  paddingInline: 12,
+})
+
+export const alertError = style({
+  background: theme.pill.red.background,
+  border: `1px solid ${theme.pill.red.stroke}`,
+  color: theme.pill.red.color,
+})

--- a/apps/reef/app/views/sources/source-create.test.tsx
+++ b/apps/reef/app/views/sources/source-create.test.tsx
@@ -1,0 +1,77 @@
+import { createMemoryRouter, RouterProvider, useNavigate } from 'react-router'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { SourceCreateDialog } from './source-create'
+
+function RoutedSourceCreateDialog() {
+  const navigate = useNavigate()
+  return (
+    <SourceCreateDialog
+      actionData={undefined}
+      open
+      onOpenChange={(open) => {
+        if (!open) navigate('/workspaces/analytics/sources')
+      }}
+    />
+  )
+}
+
+async function renderSourceCreate() {
+  const router = createMemoryRouter(
+    [
+      {
+        element: <RoutedSourceCreateDialog />,
+        path: '/workspaces/:workspaceId/sources/install',
+      },
+      {
+        element: <div>Sources catalog</div>,
+        path: '/workspaces/:workspaceId/sources',
+      },
+    ],
+    { initialEntries: ['/workspaces/analytics/sources/install'] },
+  )
+
+  return { router, screen: await render(<RouterProvider router={router} />) }
+}
+
+describe('SourceCreateDialog', () => {
+  it('renders as a routed modal and cancels back to the workspace source catalog', async () => {
+    const { router, screen } = await renderSourceCreate()
+
+    await expect.element(screen.getByRole('dialog')).toBeVisible()
+    await expect.element(screen.getByRole('heading', { name: 'Create source' })).toBeVisible()
+    await screen.getByRole('button', { name: 'Cancel' }).click()
+
+    expect(router.state.location.pathname).toBe('/workspaces/analytics/sources')
+  })
+
+  it('opens each wizard step as a nested dialog', async () => {
+    const { screen } = await renderSourceCreate()
+
+    await expect.poll(activeDialogCount).toBe(1)
+
+    await screen.getByLabelText('Name').fill('weather_api')
+    await screen.getByRole('button', { name: 'Next' }).click()
+
+    await expect.element(screen.getByText('Step 2 of 3 — Connection')).toBeVisible()
+    await expect.poll(activeDialogCount).toBe(2)
+
+    await screen
+      .getByLabelText('OpenAPI descriptor URL')
+      .fill('https://weather.example/openapi.yaml')
+    await screen.getByRole('button', { name: 'Next' }).click()
+
+    await expect.element(screen.getByText('Step 3 of 3 — Credentials')).toBeVisible()
+    await expect.poll(activeDialogCount).toBe(3)
+
+    await screen.getByRole('button', { name: 'Back' }).click()
+
+    await expect.element(screen.getByText('Step 2 of 3 — Connection')).toBeVisible()
+    await expect.poll(activeDialogCount).toBe(2)
+  })
+})
+
+function activeDialogCount() {
+  return document.querySelectorAll('[role="dialog"]:not([data-ending-style])').length
+}

--- a/apps/reef/app/views/sources/source-create.tsx
+++ b/apps/reef/app/views/sources/source-create.tsx
@@ -1,0 +1,527 @@
+import classNames from 'classnames'
+import { useEffect, useId, useRef, useState } from 'react'
+import { Form, useNavigation } from 'react-router'
+
+import { Container as ButtonContainer } from '@/wax/components/button/container'
+import { SpinningButtonIcon } from '@/wax/components/button/icon'
+import { Text as ButtonText } from '@/wax/components/button/text'
+import { Dialog } from '@/wax/components'
+import { Icon } from '@/wax/components/icon'
+import { TextInput } from '@/wax/components/inputs/text'
+import { addToast } from '@/wax/components/toast'
+import { Typography } from '@/wax/components/typography'
+
+import type { SourcesActionData } from '@/routes/sources-action'
+
+import * as styles from './source-create.css'
+
+const SECRET_KEY = 'API_TOKEN'
+const NAME_PATTERN = /^[a-z][a-z0-9_]*$/
+
+type SurfaceType = 'openapi' | 'mcp'
+type AuthChoice = 'none' | 'bearer' | 'header'
+
+interface Draft {
+  name: string
+  description: string
+  surfaceType: SurfaceType
+  url: string
+  auth: AuthChoice
+  headerName: string
+  token: string
+}
+
+const EMPTY_DRAFT: Draft = {
+  name: '',
+  description: '',
+  surfaceType: 'openapi',
+  url: '',
+  auth: 'bearer',
+  headerName: '',
+  token: '',
+}
+
+const STEP_COUNT = 3
+
+export function SourceCreateDialog({
+  actionData,
+  open,
+  onOpenChange,
+}: {
+  actionData: SourcesActionData
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop />
+        <Dialog.Popup size="l">
+          {open ? (
+            <SourceCreateDialogContent
+              actionData={actionData}
+              onCancel={() => onOpenChange(false)}
+              onCreated={() => onOpenChange(false)}
+            />
+          ) : null}
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function SourceCreateDialogContent({
+  actionData,
+  onCancel,
+  onCreated,
+}: {
+  actionData: SourcesActionData
+  onCancel: () => void
+  onCreated: () => void
+}) {
+  const [step, setStep] = useState(0)
+  const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT)
+  const formId = useId()
+
+  const navigation = useNavigation()
+  const submitting = navigation.state !== 'idle' && navigation.formData?.get('_intent') === 'import'
+  const importError =
+    actionData?.status === 'error' && actionData.intent === 'import' ? actionData.message : null
+
+  // The action redirects on success, so a submit that settles without an
+  // import error means the source was created.
+  const wasSubmitting = useRef(false)
+  useEffect(() => {
+    if (submitting) {
+      wasSubmitting.current = true
+      return
+    }
+    if (!wasSubmitting.current || navigation.state !== 'idle') return
+    wasSubmitting.current = false
+    if (!importError) {
+      addToast('neutral', {
+        title: `Created ${draft.name.trim()}`,
+        description: 'The source was validated and installed.',
+      })
+      onCreated()
+    }
+  }, [submitting, navigation.state, importError, draft.name, onCreated])
+
+  const update = (patch: Partial<Draft>) => setDraft((prev) => ({ ...prev, ...patch }))
+
+  const stepValid = (() => {
+    if (step === 0) return NAME_PATTERN.test(draft.name.trim())
+    if (step === 1) {
+      if (!draft.url.trim().startsWith('https://')) return false
+      if (draft.auth === 'header' && draft.headerName.trim().length === 0) return false
+      return true
+    }
+    return draft.auth === 'none' || draft.token.trim().length > 0
+  })()
+
+  return (
+    <Form className={styles.dialogContent} id={formId} method="post">
+      <input type="hidden" name="_intent" value="import" />
+      <input type="hidden" name="name" value={draft.name.trim()} />
+      <input type="hidden" name="manifest_yaml" value={buildManifestYaml(draft)} />
+      {draft.auth !== 'none' ? (
+        <>
+          <input type="hidden" name="secret_key" value={SECRET_KEY} />
+          <input type="hidden" name="secret_value" value={draft.token.trim()} />
+        </>
+      ) : null}
+
+      <StepHeader step={0} />
+      <BasicsStep draft={draft} update={update} />
+
+      <Dialog.Actions>
+        <ButtonContainer disabled={submitting} onClick={onCancel} size="32" variant="bare">
+          <ButtonText>Cancel</ButtonText>
+        </ButtonContainer>
+        <ButtonContainer
+          disabled={!stepValid}
+          onClick={() => setStep(1)}
+          size="32"
+          variant="primary"
+        >
+          <ButtonText>Next</ButtonText>
+        </ButtonContainer>
+      </Dialog.Actions>
+
+      <Dialog.Root
+        open={step >= 1}
+        onOpenChange={(open) => {
+          if (!open) setStep(0)
+        }}
+      >
+        <Dialog.Portal>
+          <Dialog.Popup size="l">
+            <div className={styles.dialogContent}>
+              <StepHeader step={1} />
+              <ConnectionStep draft={draft} update={update} />
+
+              <Dialog.Actions>
+                <ButtonContainer disabled={submitting} onClick={onCancel} size="32" variant="bare">
+                  <ButtonText>Cancel</ButtonText>
+                </ButtonContainer>
+                <ButtonContainer
+                  disabled={submitting}
+                  onClick={() => setStep(0)}
+                  size="32"
+                  variant="secondary"
+                >
+                  <ButtonText>Back</ButtonText>
+                </ButtonContainer>
+                <ButtonContainer
+                  disabled={!stepValid}
+                  onClick={() => setStep(2)}
+                  size="32"
+                  variant="primary"
+                >
+                  <ButtonText>Next</ButtonText>
+                </ButtonContainer>
+              </Dialog.Actions>
+
+              <Dialog.Root
+                open={step >= 2}
+                onOpenChange={(open) => {
+                  if (!open) setStep(1)
+                }}
+              >
+                <Dialog.Portal>
+                  <Dialog.Popup size="l">
+                    <div className={styles.dialogContent}>
+                      <StepHeader step={2} />
+                      <CredentialsStep draft={draft} update={update} disabled={submitting} />
+
+                      {importError ? (
+                        <div className={classNames(styles.alertBox, styles.alertError)}>
+                          <Icon color="inherit" name="CircleAlert" size="14" />
+                          <Typography.BodySmall>{importError}</Typography.BodySmall>
+                        </div>
+                      ) : null}
+
+                      <Dialog.Actions>
+                        <ButtonContainer
+                          disabled={submitting}
+                          onClick={onCancel}
+                          size="32"
+                          variant="bare"
+                        >
+                          <ButtonText>Cancel</ButtonText>
+                        </ButtonContainer>
+                        <ButtonContainer
+                          disabled={submitting}
+                          onClick={() => setStep(1)}
+                          size="32"
+                          variant="secondary"
+                        >
+                          <ButtonText>Back</ButtonText>
+                        </ButtonContainer>
+                        <ButtonContainer
+                          disabled={submitting || !stepValid}
+                          form={formId}
+                          size="32"
+                          type="submit"
+                          variant="primary"
+                        >
+                          {submitting ? <SpinningButtonIcon name="Loader" /> : null}
+                          <ButtonText>{submitting ? 'Creating…' : 'Create source'}</ButtonText>
+                        </ButtonContainer>
+                      </Dialog.Actions>
+                    </div>
+                  </Dialog.Popup>
+                </Dialog.Portal>
+              </Dialog.Root>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </Form>
+  )
+}
+
+function StepHeader({ step }: { step: number }) {
+  return (
+    <div className={styles.header}>
+      <Dialog.Title>
+        <Typography.HeadingMedium as="span">Create source</Typography.HeadingMedium>
+      </Dialog.Title>
+      <Dialog.Description render={<div />}>
+        <Typography.BodySmall className={styles.stepLabel}>
+          Step {step + 1} of {STEP_COUNT} — {stepTitle(step)}
+        </Typography.BodySmall>
+      </Dialog.Description>
+    </div>
+  )
+}
+
+function stepTitle(step: number): string {
+  if (step === 0) return 'Basics'
+  if (step === 1) return 'Connection'
+  return 'Credentials'
+}
+
+function BasicsStep({ draft, update }: { draft: Draft; update: (patch: Partial<Draft>) => void }) {
+  const idName = useId()
+  const idDescription = useId()
+  const name = draft.name.trim()
+  const nameInvalid = name.length > 0 && !NAME_PATTERN.test(name)
+  return (
+    <div className={styles.fieldGroup}>
+      <div className={styles.fieldItem}>
+        <Typography.Body as="label" htmlFor={idName} className={styles.fieldLabel}>
+          Name
+        </Typography.Body>
+        <TextInput
+          id={idName}
+          value={draft.name}
+          onChange={(value) => update({ name: value })}
+          placeholder="my_api"
+        />
+        <Typography.BodySmall variant={nameInvalid ? 'primary' : 'tertiary'}>
+          Lowercase letters, digits, and underscores; must start with a letter. Used as the schema
+          name in queries.
+        </Typography.BodySmall>
+      </div>
+      <div className={styles.fieldItem}>
+        <Typography.Body as="label" htmlFor={idDescription} className={styles.fieldLabel}>
+          Description (optional)
+        </Typography.Body>
+        <TextInput
+          id={idDescription}
+          value={draft.description}
+          onChange={(value) => update({ description: value })}
+          placeholder="What this source connects to"
+        />
+      </div>
+    </div>
+  )
+}
+
+function ConnectionStep({
+  draft,
+  update,
+}: {
+  draft: Draft
+  update: (patch: Partial<Draft>) => void
+}) {
+  const idUrl = useId()
+  const idHeaderName = useId()
+  const authChoices: { key: AuthChoice; label: string }[] =
+    draft.surfaceType === 'openapi'
+      ? [
+          { key: 'none', label: 'None' },
+          { key: 'bearer', label: 'Bearer token' },
+          { key: 'header', label: 'Custom header' },
+        ]
+      : [
+          { key: 'none', label: 'None' },
+          { key: 'bearer', label: 'Bearer token' },
+        ]
+
+  return (
+    <div className={styles.fieldGroup}>
+      <div className={styles.fieldItem}>
+        <Typography.Body className={styles.fieldLabel}>Type</Typography.Body>
+        <ChoiceTabs
+          choices={[
+            { key: 'openapi', label: 'REST API (OpenAPI)' },
+            { key: 'mcp', label: 'MCP server' },
+          ]}
+          selected={draft.surfaceType}
+          onSelect={(key) =>
+            update({
+              surfaceType: key,
+              // Custom-header auth only applies to OpenAPI surfaces.
+              auth: key === 'mcp' && draft.auth === 'header' ? 'bearer' : draft.auth,
+            })
+          }
+        />
+      </div>
+      <div className={styles.fieldItem}>
+        <Typography.Body as="label" htmlFor={idUrl} className={styles.fieldLabel}>
+          {draft.surfaceType === 'openapi' ? 'OpenAPI descriptor URL' : 'MCP server URL'}
+        </Typography.Body>
+        <TextInput
+          id={idUrl}
+          value={draft.url}
+          onChange={(value) => update({ url: value })}
+          placeholder={
+            draft.surfaceType === 'openapi'
+              ? 'https://example.com/openapi.yaml'
+              : 'https://example.com/mcp'
+          }
+        />
+        <Typography.BodySmall variant="tertiary">
+          {draft.surfaceType === 'openapi'
+            ? 'HTTPS link to the OpenAPI (Swagger) document describing the API.'
+            : 'HTTPS URL of a streamable-HTTP MCP server.'}
+        </Typography.BodySmall>
+      </div>
+      <div className={styles.fieldItem}>
+        <Typography.Body className={styles.fieldLabel}>Authentication</Typography.Body>
+        <ChoiceTabs
+          choices={authChoices}
+          selected={draft.auth}
+          onSelect={(key) => update({ auth: key })}
+        />
+      </div>
+      {draft.auth === 'header' ? (
+        <div className={styles.fieldItem}>
+          <Typography.Body as="label" htmlFor={idHeaderName} className={styles.fieldLabel}>
+            Header name
+          </Typography.Body>
+          <TextInput
+            id={idHeaderName}
+            value={draft.headerName}
+            onChange={(value) => update({ headerName: value })}
+            placeholder="X-Api-Key"
+          />
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function CredentialsStep({
+  draft,
+  update,
+  disabled,
+}: {
+  draft: Draft
+  update: (patch: Partial<Draft>) => void
+  disabled: boolean
+}) {
+  const idToken = useId()
+  return (
+    <div className={styles.fieldGroup}>
+      {draft.auth === 'none' ? (
+        <Typography.BodySmall variant="tertiary">
+          No credentials needed — click Create source to install.
+        </Typography.BodySmall>
+      ) : (
+        <div className={styles.fieldItem}>
+          <Typography.Body as="label" htmlFor={idToken} className={styles.fieldLabel}>
+            {draft.auth === 'bearer' ? 'Bearer token' : `${draft.headerName.trim()} value`}
+          </Typography.Body>
+          <TextInput
+            id={idToken}
+            type="password"
+            value={draft.token}
+            onChange={(value) => update({ token: value })}
+            placeholder="Paste token"
+            disabled={disabled}
+          />
+        </div>
+      )}
+      <div className={styles.summaryBox}>
+        <SummaryRow label="Name" value={draft.name.trim()} />
+        <SummaryRow
+          label="Type"
+          value={draft.surfaceType === 'openapi' ? 'REST API (OpenAPI)' : 'MCP server'}
+        />
+        <SummaryRow label="URL" value={draft.url.trim()} />
+        <SummaryRow label="Auth" value={authSummary(draft)} />
+      </div>
+    </div>
+  )
+}
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className={styles.summaryRow}>
+      <Typography.BodySmall className={styles.summaryKey}>{label}</Typography.BodySmall>
+      <span className={styles.summaryValue}>{value}</span>
+    </div>
+  )
+}
+
+function authSummary(draft: Draft): string {
+  if (draft.auth === 'none') return 'None'
+  if (draft.auth === 'bearer') return 'Bearer token'
+  return `Header ${draft.headerName.trim()}`
+}
+
+function ChoiceTabs<K extends string>({
+  choices,
+  selected,
+  onSelect,
+}: {
+  choices: { key: K; label: string }[]
+  selected: K
+  onSelect: (key: K) => void
+}) {
+  return (
+    <div className={styles.choiceTabs}>
+      {choices.map((choice) => (
+        <button
+          key={choice.key}
+          type="button"
+          className={styles.choiceTab}
+          data-active={choice.key === selected ? 'true' : 'false'}
+          onClick={() => onSelect(choice.key)}
+        >
+          {choice.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/** Quote a scalar as a JSON string, which YAML parses as a flow scalar. */
+const s = (value: string) => JSON.stringify(value)
+
+/** Build a DSL v4 source manifest from the wizard fields. */
+function buildManifestYaml(draft: Draft): string {
+  const name = draft.name.trim()
+  const url = draft.url.trim()
+  const lines: string[] = [`name: ${s(name)}`, 'dsl_version: 4']
+  if (draft.description.trim()) lines.push(`description: ${s(draft.description.trim())}`)
+  lines.push('surfaces:')
+
+  const inputLines =
+    draft.auth === 'none'
+      ? []
+      : [
+          '    inputs:',
+          `      ${SECRET_KEY}:`,
+          '        kind: secret',
+          `        hint: ${s(`API token for ${name}`)}`,
+        ]
+
+  if (draft.surfaceType === 'openapi') {
+    lines.push('  - id: api', '    type: openapi', `    url: ${s(url)}`, ...inputLines)
+    if (draft.auth !== 'none') {
+      const headerName = draft.auth === 'bearer' ? 'Authorization' : draft.headerName.trim()
+      const template =
+        draft.auth === 'bearer' ? `Bearer {{input.${SECRET_KEY}}}` : `{{input.${SECRET_KEY}}}`
+      lines.push(
+        '    auth:',
+        '      type: HeaderAuth',
+        '      headers:',
+        `        - name: ${s(headerName)}`,
+        '          from: template',
+        `          template: ${s(template)}`,
+      )
+    }
+  } else {
+    lines.push(
+      '  - id: mcp',
+      '    type: mcp',
+      ...inputLines,
+      '    server:',
+      '      transport: streamable_http',
+      `      url: ${s(url)}`,
+    )
+    if (draft.auth !== 'none') {
+      lines.push(
+        '      auth:',
+        '        type: bearer',
+        '        from: input',
+        `        key: ${SECRET_KEY}`,
+      )
+    }
+  }
+  return lines.join('\n') + '\n'
+}

--- a/apps/reef/app/views/sources/sources-index.test.tsx
+++ b/apps/reef/app/views/sources/sources-index.test.tsx
@@ -21,6 +21,14 @@ function renderSourcesIndex(entries: CatalogEntry[]) {
 }
 
 describe('SourcesIndex', () => {
+  it('links source creation to the dedicated install route', async () => {
+    const screen = await renderSourcesIndex([])
+
+    await expect
+      .element(screen.getByRole('link', { name: 'Create source' }))
+      .toHaveAttribute('href', '/workspaces/team%20alpha/sources/install')
+  })
+
   it('routes installable sources through the source detail route', async () => {
     const screen = await renderSourcesIndex([
       {

--- a/apps/reef/app/views/sources/sources-index.tsx
+++ b/apps/reef/app/views/sources/sources-index.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useRef, useState } from 'react'
-import { useRevalidator } from 'react-router'
+import { Link, useRevalidator } from 'react-router'
 
+import { Container as ButtonContainer } from '@/wax/components/button/container'
+import { Icon as ButtonIcon } from '@/wax/components/button/icon'
+import { Text as ButtonText } from '@/wax/components/button/text'
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
 
 import { SourceCatalogSurface } from '@/components/sources'
@@ -39,6 +42,17 @@ export function SourcesIndex({
         errorMessage={loadError}
         getEntryTo={(entry) =>
           routePath('workspaceSource', { sourceName: entry.name, workspaceId })
+        }
+        headerAction={
+          <ButtonContainer
+            as={Link}
+            size="32"
+            to={routePath('workspaceSourceInstall', { workspaceId })}
+            variant="primary"
+          >
+            <ButtonIcon name="Plus" />
+            <ButtonText>Create source</ButtonText>
+          </ButtonContainer>
         }
         loadState={loadError ? 'error' : loading ? 'loading' : 'idle'}
         onRetry={() => revalidator.revalidate()}

--- a/apps/reef/package-lock.json
+++ b/apps/reef/package-lock.json
@@ -100,7 +100,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -500,7 +499,6 @@
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/parser": "^7.29.7",
@@ -758,8 +756,7 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
       "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@bufbuild/protoc-gen-es": {
       "version": "2.12.1",
@@ -868,7 +865,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
       "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -890,6 +886,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -902,6 +899,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -912,7 +910,6 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3275,7 +3272,6 @@
       "integrity": "sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "picomatch": "^4.0.4"
       },
@@ -4020,7 +4016,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4153,7 +4150,6 @@
       "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -4163,7 +4159,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4174,7 +4169,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4239,7 +4233,6 @@
       "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.20.1.tgz",
       "integrity": "sha512-5I9RNo5uZW9tsBnqrWzJqELegOqTHBrZyDFnES0gR9gJJHBB9dom1N0bwITM9tKwBcfKrTX4a6DHVeQdJ2ubQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.9",
@@ -4340,7 +4333,6 @@
       "integrity": "sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@blazediff/core": "1.9.1",
         "@vitest/mocker": "4.1.9",
@@ -4364,7 +4356,6 @@
       "integrity": "sha512-Bq1rOGf9waevzG3EOkO/dene6bvKTUsZMVg8S1i+WH3JcMjuXEjiahP9rAqZRELUqjBySOJsvvSWqK/B3wjKQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -4507,7 +4498,6 @@
       "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
@@ -4626,6 +4616,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4636,6 +4627,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4724,7 +4716,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -4795,7 +4786,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5216,7 +5206,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.372",
@@ -5259,7 +5250,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5804,7 +5794,6 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -6125,6 +6114,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7257,7 +7247,6 @@
       "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.61.0"
       },
@@ -7345,6 +7334,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7369,7 +7359,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7450,7 +7439,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7480,7 +7468,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7718,7 +7707,6 @@
       "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -7763,7 +7751,6 @@
       "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -7913,7 +7900,6 @@
       "integrity": "sha512-QZuv1gS9Tf9RMCjDw5JOfv1XSB5IhU0uhSKQNS7l/N9zDpmSydirCspkCNT9e0zkFfPkZ9vmQUTzHY/BA07saA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.2",
@@ -8696,7 +8682,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8921,7 +8906,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9619,7 +9603,6 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",


### PR DESCRIPTION
## Summary

Adds a "Create source" flow to the sources index so users can install a custom DSL v4 source from the UI instead of `coral source add --file`.

- **`SourceCreateDialog`** (new `source-create.tsx` / `source-create.css.ts`): three-step wizard — Basics (name + optional description), Connection (OpenAPI vs MCP surface, HTTPS URL, auth choice of none / bearer / custom header), Credentials (token + summary). Builds the DSL v4 manifest YAML client-side and submits it as a form post. Success is inferred from the action's redirect settling without an import error, then toasts and closes.
- **`sources-action.ts`**: new `import` intent that calls the streaming `ImportSource` RPC with the manifest and an optional single `API_TOKEN` secret, redirecting to the sources index on success.
- **`SourceCatalogSurface`**: gains a `headerAction` slot; `sources-index.tsx` uses it to mount the Create source button and dialog, and the sources route now passes `actionData` through.

## Status / open questions

Draft — still to confirm:

- End-to-end import against a live sidecar (wizard-built manifest through `ImportSource`), including the MCP `server.auth` and OpenAPI `HeaderAuth` shapes matching what the DSL v4 parser accepts.
- Only a single secret (`API_TOKEN`) is supported by design; the action currently drops the secret silently if key or value is missing rather than erroring.

## Test plan

- `npm run check` and `npm run typecheck` pass
- Manual wizard walkthrough against a live sidecar: pending (see above)