### PR TITLE
feat(reef): unify source detail presentation

### DIFF
--- a/apps/reef/app/views/sources/source-detail.css.ts
+++ b/apps/reef/app/views/sources/source-detail.css.ts
@@ -2,54 +2,11 @@ import { style } from '@vanilla-extract/css'
 
 import { theme } from '@/wax/theme/theme.css'
 
-export const header = style({
-  alignItems: 'flex-start',
-  display: 'flex',
-  gap: 16,
-  paddingBlockEnd: 8,
-})
-
-export const headerText = style({
-  display: 'flex',
-  flexDirection: 'column',
-  flexGrow: 1,
-  gap: 8,
-  minWidth: 0,
-})
-
-export const headerTitleRow = style({
-  alignItems: 'center',
-  display: 'flex',
-  gap: 10,
-  marginInlineEnd: 24,
-})
-
-export const headerTitle = style({
-  textTransform: 'capitalize',
-})
-
-export const section = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 12,
-  paddingBlockStart: 16,
-})
-
 export const fieldGroup = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 16,
-})
-
-export const fieldItem = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 8,
-})
-
-export const fieldLabel = style({
-  color: theme.content.primary,
-  fontWeight: 500,
+  paddingBlockStart: 16,
 })
 
 export const alertError = style({

--- a/apps/reef/app/views/sources/source-detail.test.tsx
+++ b/apps/reef/app/views/sources/source-detail.test.tsx
@@ -2,39 +2,144 @@ import { createMemoryRouter, RouterProvider } from 'react-router'
 import { describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-react'
 
+import type { CatalogEntry } from '@/lib/sources'
+
 import { SourceDetailView } from './source-detail'
+
+const installedEntry: CatalogEntry = {
+  description: 'Query GitHub data.',
+  inputSpecs: [
+    {
+      hint: 'Choose the API endpoint.',
+      input: { case: 'variable', value: { defaultValue: 'https://api.github.com' } },
+      key: 'API_BASE_URL',
+      required: true,
+    },
+    {
+      hint: 'Use a token with **read access**.',
+      input: {
+        case: 'secret',
+        value: {
+          credential: {
+            methods: [
+              {
+                description: 'Paste an existing token.',
+                hint: 'Create one in GitHub settings.',
+                label: 'Personal access token',
+                method: { case: 'sourceConfig', value: {} },
+              },
+              {
+                description: 'Authorize with GitHub.',
+                hint: 'A browser window will open.',
+                label: 'OAuth',
+                method: { case: 'oauth', value: {} },
+              },
+            ],
+          },
+        },
+      },
+      key: 'GITHUB_TOKEN',
+      required: true,
+    },
+  ],
+  installed: true,
+  name: 'github',
+  origin: 'bundled',
+  source: {
+    name: 'github',
+    origin: 'bundled',
+    secrets: [{ key: 'GITHUB_TOKEN', value: '' }],
+    variables: [{ key: 'API_BASE_URL', value: 'https://github.example.test' }],
+    version: '1.0.0',
+  },
+  version: '1.0.0',
+}
 
 describe('SourceDetailView', () => {
   it('renders the source dialog from route data passed by the adapter', async () => {
-    const router = createMemoryRouter(
-      [
-        {
-          element: (
-            <SourceDetailView
-              actionData={undefined}
-              loaderData={{
-                entry: {
-                  description: 'Query GitHub data.',
-                  installed: false,
-                  name: 'github',
-                  origin: 'bundled',
-                  version: '1.0.0',
-                },
-                loadError: null,
-              }}
-              sourcesPath="/workspaces/default/sources"
-              workspaceId="default"
-            />
-          ),
-          path: '/workspaces/:workspaceId/sources/:sourceName',
-        },
-      ],
-      { initialEntries: ['/workspaces/default/sources/github'] },
-    )
-
-    const screen = await render(<RouterProvider router={router} />)
+    const screen = await renderSourceDetail({
+      description: 'Query GitHub data.',
+      installed: false,
+      name: 'github',
+      origin: 'bundled',
+      version: '1.0.0',
+    })
 
     await expect.element(screen.getByRole('dialog')).toBeVisible()
     await expect.element(screen.getByRole('button', { name: 'Add source' })).toBeVisible()
   })
+
+  it('keeps manifest copy, formatted fields, hints, and masked secrets after installation', async () => {
+    const screen = await renderSourceDetail(installedEntry)
+    const dialog = screen.getByRole('dialog')
+
+    await expect.element(dialog).toBeVisible()
+    await expect.element(screen.getByText('Query GitHub data.')).toBeVisible()
+    await expect.element(screen.getByText('Api base url')).toBeVisible()
+    await expect.element(screen.getByText('Github token')).toBeVisible()
+    await expect.element(screen.getByText('Choose the API endpoint.')).toBeVisible()
+    await expect.element(screen.getByText('Use a token with read access.')).toBeVisible()
+    await expect
+      .element(screen.getByLabelText('Api base url'))
+      .toHaveValue('https://github.example.test')
+    const secretInput = screen.getByLabelText('Github token')
+    await expect.element(secretInput).toHaveValue('••••••••')
+
+    await secretInput.click()
+    await expect.element(secretInput).toHaveValue('')
+    secretInput.element().blur()
+    await expect.element(secretInput).toHaveValue('••••••••')
+  })
+
+  it('does not present a credential method as stored state', async () => {
+    const screen = await renderSourceDetail(installedEntry)
+    const dialog = screen.getByRole('dialog')
+
+    await expect.element(dialog).toBeVisible()
+    expect(dialog.element().querySelector('[role="tablist"]')).toBeNull()
+    expect(dialog.element().textContent).not.toContain('Personal access token')
+    expect(dialog.element().textContent).not.toContain('OAuth')
+  })
+
+  it('keeps imported source fields non-editable', async () => {
+    const entry: CatalogEntry = {
+      ...installedEntry,
+      origin: 'imported',
+      source: { ...installedEntry.source!, origin: 'imported' },
+    }
+    const screen = await renderSourceDetail(entry)
+
+    await expect.element(screen.getByText('Imported', { exact: true })).toBeVisible()
+    await expect
+      .element(
+        screen.getByText(
+          "Imported sources can't be edited. Please remove and re-import the source spec",
+        ),
+      )
+      .toBeVisible()
+    await expect.element(screen.getByLabelText('Api base url')).toBeDisabled()
+    await expect.element(screen.getByLabelText('Github token')).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Save changes' }).query()).toBeNull()
+  })
 })
+
+async function renderSourceDetail(entry: CatalogEntry) {
+  const router = createMemoryRouter(
+    [
+      {
+        element: (
+          <SourceDetailView
+            actionData={undefined}
+            loaderData={{ entry, loadError: null }}
+            sourcesPath="/workspaces/default/sources"
+            workspaceId="default"
+          />
+        ),
+        path: '/workspaces/:workspaceId/sources/:sourceName',
+      },
+    ],
+    { initialEntries: ['/workspaces/default/sources/github'] },
+  )
+
+  return render(<RouterProvider router={router} />)
+}

--- a/apps/reef/app/views/sources/source-detail.tsx
+++ b/apps/reef/app/views/sources/source-detail.tsx
@@ -7,25 +7,26 @@ import { Text as ButtonText } from '@/wax/components/button/text'
 import { Dialog } from '@/wax/components'
 import { Icon } from '@/wax/components/icon'
 import { TextInput } from '@/wax/components/inputs/text'
-import { Pill } from '@/wax/components/pill'
 import { Typography } from '@/wax/components/typography'
 
-import type {
-  CatalogEntry,
-  CatalogSource,
-  CatalogSourceInputSpec,
-  SourceOriginLabel,
-} from '@/lib/sources'
+import type { CatalogEntry, CatalogSource, CatalogSourceInputSpec } from '@/lib/sources'
 import type { SourcesActionData } from '@/routes/sources-action'
 
-import { formatSourceName, ProviderLogo } from '@/components/sources'
+import { formatSourceName } from '@/components/sources'
 import * as styles from './source-detail.css'
 import { SourceInstallDialog } from './source-install'
+import {
+  formatFieldName,
+  SourceField,
+  SourceHeader,
+  SourceInputField,
+  SourceNoConfiguration,
+} from './source-presentation'
 
 const SECRET_PLACEHOLDER = '••••••••'
 
 const IMPORTED_EDIT_NOTICE =
-  "Imported sources can't be edited here yet — re-import the source spec to change its credentials."
+  "Imported sources can't be edited. Please remove and re-import the source spec"
 
 export function SourceDetailView({
   actionData,
@@ -170,32 +171,18 @@ function SourceDetailDialogContent({
     return false
   }, [drafts, source, inputSpecs])
 
-  const origin = source ? source.origin : entry.origin
-
   return (
     <>
       <Form method="post">
         <input type="hidden" name="_intent" value="edit" />
         <input type="hidden" name="name" value={entry.name} />
 
-        <div className={styles.header}>
-          <ProviderLogo name={entry.name} size="large" />
-          <div className={styles.headerText}>
-            <Dialog.Title className={styles.headerTitleRow}>
-              <Typography.HeadingMedium as="span" className={styles.headerTitle}>
-                {sourceDisplayName}
-              </Typography.HeadingMedium>
-              {origin ? <Pill color="graySubtle">{originBadgeLabel(origin)}</Pill> : null}
-            </Dialog.Title>
-            <Dialog.Description render={<div />}>
-              <Typography.BodySmall variant="secondary">
-                {source?.version || entry.version
-                  ? `v${source?.version || entry.version}`
-                  : 'Configured source'}
-              </Typography.BodySmall>
-            </Dialog.Description>
-          </div>
-        </div>
+        <SourceHeader
+          description={entry.description}
+          name={entry.name}
+          origin={source?.origin ?? entry.origin}
+          version={source?.version || entry.version}
+        />
 
         {!source ? (
           <div className={styles.alertError}>
@@ -240,10 +227,7 @@ function SourceDetailDialogContent({
             source={source}
           />
         ) : source.variables.length === 0 && source.secrets.length === 0 ? (
-          <section className={styles.section}>
-            <Typography.HeadingXSmall as="h3">Configuration</Typography.HeadingXSmall>
-            <Typography.BodySmall variant="tertiary">No bindings recorded.</Typography.BodySmall>
-          </section>
+          <SourceNoConfiguration />
         ) : (
           <InstalledBindings
             disabled={!editable || saving || deleting}
@@ -351,45 +335,44 @@ function InstalledBindings({
   source: CatalogSource
 }) {
   return (
-    <section className={styles.section}>
-      <Typography.HeadingXSmall as="h3">Configuration</Typography.HeadingXSmall>
+    <div className={styles.fieldGroup}>
       {!editable ? (
         <Typography.BodySmall variant="tertiary">{IMPORTED_EDIT_NOTICE}</Typography.BodySmall>
       ) : null}
-      <div className={styles.fieldGroup}>
-        {source.variables.map((v) => {
-          const draftKey = `var:${v.key}`
-          return (
-            <div key={draftKey} className={styles.fieldItem}>
-              <Typography.Body className={styles.fieldLabel}>{v.key}</Typography.Body>
-              <TextInput
-                name={draftKey}
-                value={drafts[draftKey] ?? v.value}
-                onChange={(value) => onValueChange(draftKey, value)}
-                placeholder={v.key}
-                disabled={disabled}
-              />
-            </div>
-          )
-        })}
-        {source.secrets.map((s) => {
-          const draftKey = `sec:${s.key}`
-          return (
-            <div key={draftKey} className={styles.fieldItem}>
-              <Typography.Body className={styles.fieldLabel}>{s.key}</Typography.Body>
-              <input type="hidden" name={draftKey} value={drafts[draftKey] ?? ''} />
-              <TextInput
-                type="password"
-                value={drafts[draftKey] ?? ''}
-                onChange={(value) => onValueChange(draftKey, value)}
-                placeholder={SECRET_PLACEHOLDER}
-                disabled={disabled}
-              />
-            </div>
-          )
-        })}
-      </div>
-    </section>
+      {source.variables.map((v) => {
+        const draftKey = `var:${v.key}`
+        const label = formatFieldName(v.key)
+        return (
+          <SourceField key={draftKey} label={label}>
+            <TextInput
+              ariaLabel={label}
+              name={draftKey}
+              value={drafts[draftKey] ?? v.value}
+              onChange={(value) => onValueChange(draftKey, value)}
+              placeholder={label}
+              disabled={disabled}
+            />
+          </SourceField>
+        )
+      })}
+      {source.secrets.map((s) => {
+        const draftKey = `sec:${s.key}`
+        const label = formatFieldName(s.key)
+        return (
+          <SourceField key={draftKey} label={label}>
+            <input type="hidden" name={draftKey} value={drafts[draftKey] ?? ''} />
+            <TextInput
+              ariaLabel={label}
+              type="password"
+              value={drafts[draftKey] ?? ''}
+              onChange={(value) => onValueChange(draftKey, value)}
+              placeholder={SECRET_PLACEHOLDER}
+              disabled={disabled}
+            />
+          </SourceField>
+        )
+      })}
+    </div>
   )
 }
 
@@ -447,36 +430,28 @@ function SourceInputBindings({
   const configuredSecrets = useMemo(() => new Set(source.secrets.map((s) => s.key)), [source])
 
   if (inputSpecs.length === 0) {
-    return (
-      <section className={styles.section}>
-        <Typography.HeadingXSmall as="h3">Configuration</Typography.HeadingXSmall>
-        <Typography.BodySmall variant="tertiary">No bindings recorded.</Typography.BodySmall>
-      </section>
-    )
+    return <SourceNoConfiguration />
   }
 
   return (
-    <section className={styles.section}>
-      <Typography.HeadingXSmall as="h3">Configuration</Typography.HeadingXSmall>
+    <div className={styles.fieldGroup}>
       {!editable ? (
         <Typography.BodySmall variant="tertiary">{IMPORTED_EDIT_NOTICE}</Typography.BodySmall>
       ) : null}
-      <div className={styles.fieldGroup}>
-        {inputSpecs.map((input) => (
-          <SourceInfoInputRow
-            key={input.key}
-            configuredSecret={configuredSecrets.has(input.key)}
-            disabled={disabled}
-            draft={drafts[`${input.input.case === 'secret' ? 'sec' : 'var'}:${input.key}`]}
-            input={input}
-            onSecretBlur={onSecretBlur}
-            onSecretFocus={onSecretFocus}
-            onValueChange={onValueChange}
-            value={variables.get(input.key)}
-          />
-        ))}
-      </div>
-    </section>
+      {inputSpecs.map((input) => (
+        <SourceInfoInputRow
+          key={input.key}
+          configuredSecret={configuredSecrets.has(input.key)}
+          disabled={disabled}
+          draft={drafts[`${input.input.case === 'secret' ? 'sec' : 'var'}:${input.key}`]}
+          input={input}
+          onSecretBlur={onSecretBlur}
+          onSecretFocus={onSecretFocus}
+          onValueChange={onValueChange}
+          value={variables.get(input.key)}
+        />
+      ))}
+    </div>
   )
 }
 
@@ -502,47 +477,34 @@ function SourceInfoInputRow({
   if (input.input.case === 'variable') {
     const resolved = value ?? input.input.value.defaultValue ?? ''
     return (
-      <Field input={input}>
+      <SourceInputField input={input}>
         <TextInput
+          ariaLabel={formatFieldName(input.key)}
           name={`var:${input.key}`}
           value={draft ?? resolved}
           onChange={(next) => onValueChange(input.key, next, false)}
-          placeholder={resolved || input.key}
+          placeholder={resolved || formatFieldName(input.key)}
           disabled={disabled}
         />
-      </Field>
+      </SourceInputField>
     )
   }
 
   if (input.input.case !== 'secret') return null
 
   return (
-    <Field input={input}>
+    <SourceInputField input={input}>
       <input type="hidden" name={`sec:${input.key}`} value={draft ?? ''} />
       <TextInput
+        ariaLabel={formatFieldName(input.key)}
         type="password"
         value={draft ?? (configuredSecret ? SECRET_PLACEHOLDER : '')}
         onBlur={() => onSecretBlur(input.key)}
         onChange={(next) => onValueChange(input.key, next, true)}
         onFocus={() => onSecretFocus(input.key)}
-        placeholder={input.key}
+        placeholder={formatFieldName(input.key)}
         disabled={disabled}
       />
-    </Field>
+    </SourceInputField>
   )
-}
-
-function Field({ input, children }: { input: CatalogSourceInputSpec; children: React.ReactNode }) {
-  return (
-    <div className={styles.fieldItem}>
-      <Typography.Body className={styles.fieldLabel}>{input.key}</Typography.Body>
-      {children}
-    </div>
-  )
-}
-
-function originBadgeLabel(origin: SourceOriginLabel): string {
-  if (origin === 'bundled') return 'Core'
-  if (origin === 'imported') return 'Imported'
-  return '—'
 }

--- a/apps/reef/app/views/sources/source-install.css.ts
+++ b/apps/reef/app/views/sources/source-install.css.ts
@@ -2,49 +2,12 @@ import { style } from '@vanilla-extract/css'
 
 import { theme } from '@/wax/theme/theme.css'
 
-export const header = style({
-  alignItems: 'flex-start',
-  display: 'flex',
-  gap: 16,
-  paddingBlockEnd: 8,
-})
-
-export const headerText = style({
-  display: 'flex',
-  flexDirection: 'column',
-  flexGrow: 1,
-  gap: 8,
-  minWidth: 0,
-})
-
-export const headerTitleRow = style({
-  alignItems: 'center',
-  display: 'flex',
-  gap: 10,
-  marginInlineEnd: 24,
-})
-
-export const headerTitle = style({
-  textTransform: 'capitalize',
-})
-
 export const fieldGroup = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 16,
   paddingBlockStart: 16,
 })
-
-export const fieldItem = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 8,
-})
-
-// Kept so the public API of <Field> is unchanged even though all fields are
-// now full-width — selecting this className is a no-op against the flex
-// column layout above.
-export const fieldItemFull = style({})
 
 export const methodTabsRoot = style({
   display: 'flex',

--- a/apps/reef/app/views/sources/source-install.test.tsx
+++ b/apps/reef/app/views/sources/source-install.test.tsx
@@ -155,6 +155,8 @@ describe('SourceInstallDialog', () => {
     ])
     const screen = await render(<RoutesStub />)
 
+    await expect.element(screen.getByText('Query GitHub data.')).toBeVisible()
+    await expect.element(screen.getByText('Core', { exact: true })).toBeVisible()
     await expect.element(screen.getByText('Github token')).toBeVisible()
   })
 

--- a/apps/reef/app/views/sources/source-install.tsx
+++ b/apps/reef/app/views/sources/source-install.tsx
@@ -8,7 +8,6 @@ import { Text as ButtonText } from '@/wax/components/button/text'
 import { Dialog, Tabs } from '@/wax/components'
 import { Icon } from '@/wax/components/icon'
 import { TextInput } from '@/wax/components/inputs/text'
-import { Pill } from '@/wax/components/pill'
 import { Typography } from '@/wax/components/typography'
 
 import { Markdown } from '@/components/markdown'
@@ -23,10 +22,14 @@ import type {
   CatalogSourceInputSpec,
 } from '@/lib/sources'
 import { routePath } from '@/routing/routemap'
-import { toSentenceCase } from '@/utils/to-sentence-case'
 
-import { formatSourceName, ProviderLogo } from '@/components/sources'
 import * as styles from './source-install.css'
+import {
+  formatFieldName,
+  SourceHeader,
+  SourceInputField,
+  SourceNoConfiguration,
+} from './source-presentation'
 
 type InstallProgress =
   | { kind: 'idle' }
@@ -42,10 +45,6 @@ type InstallProgress =
   | { kind: 'oauth-callback-received'; inputKey: string }
   | { kind: 'oauth-completed'; inputKey: string }
   | { kind: 'success'; name: string }
-
-function formatFieldName(key: string): string {
-  return toSentenceCase(key.replace(/_/g, ' '))
-}
 
 export function SourceInstallDialog({
   actionError,
@@ -118,8 +117,6 @@ function SourceInstallDialogContent({
   const [methodChoices, setMethodChoices] = useState<Record<string, number>>({})
   const [progress, setProgress] = useState<InstallProgress>({ kind: 'idle' })
   const [streamError, setStreamError] = useState<string | null>(null)
-  const sourceDisplayName = formatSourceName(entry.name)
-
   const inputSpecs = entry.inputSpecs
   const inputs: CatalogSourceInputSpec[] = inputSpecs ?? []
   const oauthBusy = progress.kind !== 'idle'
@@ -237,20 +234,12 @@ function SourceInstallDialogContent({
       <input type="hidden" name="_intent" value="install" />
       <input type="hidden" name="name" value={entry.name} />
 
-      <div className={styles.header}>
-        <ProviderLogo name={entry.name} size="large" />
-        <div className={styles.headerText}>
-          <Dialog.Title className={styles.headerTitleRow}>
-            <Typography.HeadingMedium as="span" className={styles.headerTitle}>
-              {sourceDisplayName}
-            </Typography.HeadingMedium>
-            <Pill color="graySubtle">Core</Pill>
-          </Dialog.Title>
-          <Dialog.Description render={<div />}>
-            <Markdown>{entry.description}</Markdown>
-          </Dialog.Description>
-        </div>
-      </div>
+      <SourceHeader
+        description={entry.description}
+        name={entry.name}
+        origin={entry.origin}
+        version={entry.version}
+      />
 
       {!inputSpecs ? (
         <div className={classNames(styles.alertBox, styles.alertError)}>
@@ -258,9 +247,7 @@ function SourceInstallDialogContent({
           <Typography.BodySmall>Source metadata is unavailable.</Typography.BodySmall>
         </div>
       ) : inputs.length === 0 ? (
-        <Typography.BodySmall variant="tertiary">
-          No configuration needed — click Add source to install.
-        </Typography.BodySmall>
+        <SourceNoConfiguration />
       ) : (
         <div className={styles.fieldGroup}>
           {inputs.map((input) => (
@@ -362,15 +349,16 @@ function InputRow({
   if (input.input.case === 'variable') {
     const def = input.input.value.defaultValue
     return (
-      <Field input={input}>
+      <SourceInputField input={input}>
         <TextInput
+          ariaLabel={formatFieldName(input.key)}
           name={`var:${input.key}`}
           value={values[input.key] ?? def}
           onChange={(value) => onValueChange(input.key, value)}
           placeholder={def || formatFieldName(input.key)}
           disabled={disabled}
         />
-      </Field>
+      </SourceInputField>
     )
   }
 
@@ -381,12 +369,7 @@ function InputRow({
   const selected = methods[methodIndex]
 
   return (
-    <Field
-      input={input}
-      fullWidth={methods.length > 1 || isOAuth(selected)}
-      showHint={methods.length <= 1}
-      showLabel={methods.length <= 1}
-    >
+    <SourceInputField input={input} showHint={methods.length <= 1} showLabel={methods.length <= 1}>
       {methods.length > 0 ? (
         <input type="hidden" name={`method:${input.key}`} value={methodIndex} />
       ) : null}
@@ -444,7 +427,7 @@ function InputRow({
           values={values}
         />
       )}
-    </Field>
+    </SourceInputField>
   )
 }
 
@@ -502,41 +485,11 @@ function CredentialMethodFields({
   return null
 }
 
-function Field({
-  input,
-  children,
-  fullWidth,
-  showHint = true,
-  showLabel = true,
-}: {
-  input: CatalogSourceInputSpec
-  children: React.ReactNode
-  fullWidth?: boolean
-  showHint?: boolean
-  showLabel?: boolean
-}) {
-  return (
-    <div className={classNames(styles.fieldItem, fullWidth ? styles.fieldItemFull : null)}>
-      {showLabel ? (
-        <Typography.BodyStrong variant="primary">
-          {formatFieldName(input.key)}
-        </Typography.BodyStrong>
-      ) : null}
-      {children}
-      {showHint && input.hint ? <Markdown>{input.hint}</Markdown> : null}
-    </div>
-  )
-}
-
 function methodLabel(method: CatalogSourceCredentialMethod, index: number): string {
   if (method.label) return method.label
   if (method.method.case === 'sourceConfig') return 'Paste token'
   if (method.method.case === 'oauth') return 'OAuth'
   return `Method ${index + 1}`
-}
-
-function isOAuth(method: CatalogSourceCredentialMethod | undefined): boolean {
-  return method?.method.case === 'oauth'
 }
 
 interface OAuthInput extends OAuthField {

--- a/apps/reef/app/views/sources/source-presentation.css.ts
+++ b/apps/reef/app/views/sources/source-presentation.css.ts
@@ -1,0 +1,46 @@
+import { style } from '@vanilla-extract/css'
+
+export const header = style({
+  alignItems: 'flex-start',
+  display: 'flex',
+  gap: 16,
+  paddingBlockEnd: 8,
+})
+
+export const headerText = style({
+  display: 'flex',
+  flexDirection: 'column',
+  flexGrow: 1,
+  gap: 8,
+  minWidth: 0,
+})
+
+export const headerTitleRow = style({
+  alignItems: 'center',
+  display: 'flex',
+  gap: 10,
+  marginInlineEnd: 24,
+})
+
+export const headerIdentity = style({
+  alignItems: 'baseline',
+  display: 'inline-flex',
+  gap: 10,
+})
+
+export const headerTitle = style({
+  textTransform: 'capitalize',
+})
+
+export const fieldItem = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+})
+
+export const noConfiguration = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  paddingBlockStart: 16,
+})

--- a/apps/reef/app/views/sources/source-presentation.tsx
+++ b/apps/reef/app/views/sources/source-presentation.tsx
@@ -1,0 +1,110 @@
+import type { ReactNode } from 'react'
+
+import { Dialog } from '@/wax/components'
+import { Pill } from '@/wax/components/pill'
+import { Typography } from '@/wax/components/typography'
+
+import { Markdown } from '@/components/markdown'
+import { formatSourceName, ProviderLogo } from '@/components/sources'
+import type { CatalogSourceInputSpec, SourceOriginLabel } from '@/lib/sources'
+import { toSentenceCase } from '@/utils/to-sentence-case'
+
+import * as styles from './source-presentation.css'
+
+export function SourceHeader({
+  description,
+  name,
+  origin,
+  version,
+}: {
+  description: string
+  name: string
+  origin: SourceOriginLabel
+  version?: string
+}) {
+  const originLabel = sourceOriginLabel(origin)
+
+  return (
+    <div className={styles.header}>
+      <ProviderLogo name={name} size="large" />
+      <div className={styles.headerText}>
+        <Dialog.Title className={styles.headerTitleRow}>
+          <span className={styles.headerIdentity}>
+            <Typography.HeadingMedium as="span" className={styles.headerTitle}>
+              {formatSourceName(name)}
+            </Typography.HeadingMedium>
+            {version ? (
+              <Typography.BodySmall as="span" variant="tertiary">
+                {version}
+              </Typography.BodySmall>
+            ) : null}
+          </span>
+          {originLabel ? <Pill color="graySubtle">{originLabel}</Pill> : null}
+        </Dialog.Title>
+        <Dialog.Description render={<div />}>
+          <Markdown>{description}</Markdown>
+        </Dialog.Description>
+      </div>
+    </div>
+  )
+}
+
+export function SourceInputField({
+  children,
+  input,
+  showHint = true,
+  showLabel = true,
+}: {
+  children: ReactNode
+  input: CatalogSourceInputSpec
+  showHint?: boolean
+  showLabel?: boolean
+}) {
+  return (
+    <SourceField
+      hint={showHint ? input.hint : undefined}
+      label={showLabel ? formatFieldName(input.key) : undefined}
+    >
+      {children}
+    </SourceField>
+  )
+}
+
+export function SourceNoConfiguration() {
+  return (
+    <div className={styles.noConfiguration}>
+      <Typography.BodyStrong variant="primary">No setup required</Typography.BodyStrong>
+      <Typography.BodySmall variant="secondary">
+        This source doesn’t need credentials or additional settings.
+      </Typography.BodySmall>
+    </div>
+  )
+}
+
+export function SourceField({
+  children,
+  hint,
+  label,
+}: {
+  children: ReactNode
+  hint?: string
+  label?: string
+}) {
+  return (
+    <div className={styles.fieldItem}>
+      {label ? <Typography.BodyStrong variant="primary">{label}</Typography.BodyStrong> : null}
+      {children}
+      {hint ? <Markdown>{hint}</Markdown> : null}
+    </div>
+  )
+}
+
+export function formatFieldName(key: string): string {
+  return toSentenceCase(key.replace(/_/g, ' '))
+}
+
+function sourceOriginLabel(origin: SourceOriginLabel): string | null {
+  if (origin === 'bundled') return 'Core'
+  if (origin === 'imported') return 'Imported'
+  return null
+}


### PR DESCRIPTION
## Summary

Polishing the cards of sources that have already been added; they should both look very much alike.

## Test plan

Before

<img width="602" height="348" alt="image" src="https://github.com/user-attachments/assets/a06f3511-d3ac-49c0-91af-b90c609af4a8" />

<img width="607" height="213" alt="image" src="https://github.com/user-attachments/assets/2ffaefbb-ea25-494e-a2f9-7aa0db2ac86f" />


After

<img width="646" height="454" alt="image" src="https://github.com/user-attachments/assets/a60dde6f-29d5-4954-8b90-61c058f0de96" />

<img width="601" height="230" alt="image" src="https://github.com/user-attachments/assets/b0d0017f-ca29-44be-956b-39a14e0c1d7e" />

