### PR TITLE
fix(reef): preserve workspace context after OAuth source installs

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -338,7 +338,7 @@ describe('Architectural Tests', () => {
       const routeConfig = fs.readFileSync(ROUTE_CONFIG_FILE, 'utf-8')
 
       expect(routeConfig).toContain(
-        "route('sources/:sourceName/oauth-install', 'routes/source-oauth-install.ts')",
+        "route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts')",
       )
       expect(routeConfig).toContain("layout('routes/app-shell.tsx', [")
       expect(routeConfig).toContain("index('routes/index.tsx')")
@@ -361,7 +361,7 @@ describe('Architectural Tests', () => {
       // Structural check: the OAuth streaming resource route stays outside the
       // app shell, while canonical workspace routes and settings stay inside it.
       expect(routeConfig).toMatch(
-        /export default \[\s*(?:\/\/[^\n]*\n\s*)*route\('sources\/:sourceName\/oauth-install', 'routes\/source-oauth-install\.ts'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\] satisfies RouteConfig/,
+        /export default \[\s*(?:\/\/[^\n]*\n\s*)*route\(`\$\{routePattern\('workspaceSource'\)\}\/oauth-install`, 'routes\/source-oauth-install\.ts'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\] satisfies RouteConfig/,
       )
     })
 

--- a/apps/reef/app/components/sources/source-card-list.stories.tsx
+++ b/apps/reef/app/components/sources/source-card-list.stories.tsx
@@ -196,6 +196,7 @@ function OAuthInstallFlowSurface({ oauthState }: { oauthState: OAuthStoryState }
         }}
         open={selectedEntry !== null}
         openAuthorization={() => undefined}
+        workspaceId="storybook"
       />
     </>
   )

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -10,7 +10,7 @@ export default [
   // Action-only resource route: OAuth/device-code install streams progress over
   // same-origin fetch. It intentionally sits outside the app shell and does not
   // render a page.
-  route('sources/:sourceName/oauth-install', 'routes/source-oauth-install.ts'),
+  route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts'),
   layout('routes/app-shell.tsx', [
     index('routes/index.tsx'),
     route(routePattern('workspaces'), 'routes/workspaces-action.ts'),

--- a/apps/reef/app/routes/source-detail.tsx
+++ b/apps/reef/app/routes/source-detail.tsx
@@ -73,6 +73,7 @@ export default function SourceDetailRoute({
       actionData={actionData}
       loaderData={loaderData}
       sourcesPath={routePath('workspaceSources', { workspaceId: params.workspaceId })}
+      workspaceId={params.workspaceId}
     />
   )
 }

--- a/apps/reef/app/routes/source-oauth-install.server.test.ts
+++ b/apps/reef/app/routes/source-oauth-install.server.test.ts
@@ -1,21 +1,109 @@
 import { create } from '@bufbuild/protobuf'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createBundledSourceWithOAuth, getSourceInfo } = vi.hoisted(() => ({
+  createBundledSourceWithOAuth: vi.fn(),
+  getSourceInfo: vi.fn(),
+}))
+
+vi.mock('@/lib/coral-request.server', () => ({
+  sourceClientForRequest: () => ({ createBundledSourceWithOAuth, getSourceInfo }),
+}))
 
 import {
   CreateBundledSourceWithOAuthResponseSchema,
+  OAuthCredentialMethodSchema,
   OAuthCredentialCallbackReceivedSchema,
+  SourceCredentialMethodSchema,
+  SourceCredentialSchema,
+  SourceInfoSchema,
+  SourceInputSpecSchema,
+  SourceOrigin,
   SourceSchema,
+  SourceSecretInputSchema,
   type CreateBundledSourceWithOAuthResponse,
 } from '@/generated/coral/v1/sources_pb'
 import type { OAuthInstallStreamEvent } from '@/lib/source-oauth-install-stream'
 
-import { relayOAuthInstallStreamEvents } from './source-oauth-install'
+import { action, relayOAuthInstallStreamEvents } from './source-oauth-install'
 
 async function* responses(
   events: CreateBundledSourceWithOAuthResponse[],
 ): AsyncIterable<CreateBundledSourceWithOAuthResponse> {
   yield* events
 }
+
+const oauthSourceInfo = create(SourceInfoSchema, {
+  inputs: [
+    create(SourceInputSpecSchema, {
+      input: {
+        case: 'secret',
+        value: create(SourceSecretInputSchema, {
+          credential: create(SourceCredentialSchema, {
+            methods: [
+              create(SourceCredentialMethodSchema, {
+                method: { case: 'oauth', value: create(OAuthCredentialMethodSchema) },
+              }),
+            ],
+          }),
+        }),
+      },
+      key: 'GITHUB_TOKEN',
+      required: true,
+    }),
+  ],
+  name: 'github',
+  origin: SourceOrigin.BUNDLED,
+})
+
+describe('action', () => {
+  beforeEach(() => {
+    createBundledSourceWithOAuth.mockReset()
+    getSourceInfo.mockReset()
+  })
+
+  it('installs the source in the route workspace', async () => {
+    getSourceInfo.mockResolvedValue({ sourceInfo: oauthSourceInfo })
+    createBundledSourceWithOAuth.mockImplementation(async function* () {
+      yield create(CreateBundledSourceWithOAuthResponseSchema, {
+        event: {
+          case: 'source',
+          value: create(SourceSchema, { name: 'github', version: '1.0.0' }),
+        },
+      })
+    })
+    const request = new Request(
+      'http://localhost/workspaces/analytics/sources/github/oauth-install',
+      {
+        body: new URLSearchParams({
+          'method:GITHUB_TOKEN': '0',
+          name: 'github',
+        }),
+        method: 'POST',
+      },
+    )
+
+    const response = await action({
+      params: { sourceName: 'github', workspaceId: 'analytics' },
+      request,
+    } as Parameters<typeof action>[0])
+    await response.text()
+
+    expect(getSourceInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'github',
+        workspace: expect.objectContaining({ name: 'analytics' }),
+      }),
+    )
+    expect(createBundledSourceWithOAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'github',
+        workspace: expect.objectContaining({ name: 'analytics' }),
+      }),
+      expect.objectContaining({ signal: request.signal }),
+    )
+  })
+})
 
 describe('relayOAuthInstallStreamEvents', () => {
   it('relays callback receipt before the terminal source event', async () => {

--- a/apps/reef/app/routes/source-oauth-install.ts
+++ b/apps/reef/app/routes/source-oauth-install.ts
@@ -19,12 +19,12 @@ import {
   splitInstallBindings,
 } from '@/lib/source-install-form'
 import { originLabel } from '@/lib/sources'
-import { firstWorkspaceForRequest } from '@/lib/workspaces.server'
 import {
   oauthInstallEventToNdjson,
   type OAuthInstallStreamEvent,
 } from '@/lib/source-oauth-install-stream'
 import { errorMessage } from '@/lib/utils'
+import { workspaceFromParams } from '@/lib/workspace-routing'
 
 const NDJSON_HEADERS = {
   'Cache-Control': 'no-store',
@@ -48,7 +48,7 @@ export async function action({ params, request }: Route.ActionArgs): Promise<Res
 
   const sourceClient = sourceClientForRequest(request)
   try {
-    const workspace = await firstWorkspaceForRequest(request)
+    const workspace = workspaceFromParams(params)
     const info = await getSourceInfo(sourceClient, name, workspace)
     if (info.installed && originLabel(info.origin) !== 'bundled') {
       return ndjsonErrorResponse("Imported sources can't be installed here yet", 400)

--- a/apps/reef/app/views/sources/source-detail.test.tsx
+++ b/apps/reef/app/views/sources/source-detail.test.tsx
@@ -23,6 +23,7 @@ describe('SourceDetailView', () => {
                 loadError: null,
               }}
               sourcesPath="/workspaces/default/sources"
+              workspaceId="default"
             />
           ),
           path: '/workspaces/:workspaceId/sources/:sourceName',

--- a/apps/reef/app/views/sources/source-detail.tsx
+++ b/apps/reef/app/views/sources/source-detail.tsx
@@ -31,6 +31,7 @@ export function SourceDetailView({
   actionData,
   loaderData,
   sourcesPath,
+  workspaceId,
 }: {
   actionData: SourcesActionData | undefined
   loaderData: {
@@ -38,6 +39,7 @@ export function SourceDetailView({
     loadError: string | null
   }
   sourcesPath: string
+  workspaceId: string
 }) {
   const navigate = useNavigate()
   const navigation = useNavigation()
@@ -60,6 +62,7 @@ export function SourceDetailView({
           if (!open) navigate(sourcesPath)
         }}
         submitting={pendingName === entry.name && pendingIntent === 'install'}
+        workspaceId={workspaceId}
       />
     )
   }

--- a/apps/reef/app/views/sources/source-install.test.tsx
+++ b/apps/reef/app/views/sources/source-install.test.tsx
@@ -44,15 +44,13 @@ describe('SourceInstallDialog', () => {
   it('commits catalog revalidation before leaving the detail route', async () => {
     let installed = false
     let loaderCalls = 0
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => {
-        installed = true
-        return streamedResponse([
-          oauthInstallEventToNdjson({ type: 'source', name: 'github', version: '1.0.0' }),
-        ])
-      }),
-    )
+    const fetchOAuthInstall = vi.fn(async () => {
+      installed = true
+      return streamedResponse([
+        oauthInstallEventToNdjson({ type: 'source', name: 'github', version: '1.0.0' }),
+      ])
+    })
+    vi.stubGlobal('fetch', fetchOAuthInstall)
 
     const router = createMemoryRouter(
       [
@@ -60,7 +58,14 @@ describe('SourceInstallDialog', () => {
           children: [
             { index: true, element: <CatalogStatus /> },
             {
-              element: <SourceInstallDialog entry={entry} open onOpenChange={() => undefined} />,
+              element: (
+                <SourceInstallDialog
+                  entry={entry}
+                  open
+                  onOpenChange={() => undefined}
+                  workspaceId="analytics"
+                />
+              ),
               path: ':sourceName',
             },
           ],
@@ -72,13 +77,13 @@ describe('SourceInstallDialog', () => {
             await abortableDelay(request.signal)
             return { installed: snapshot }
           },
-          path: '/sources',
+          path: '/workspaces/:workspaceId/sources',
           shouldRevalidate,
         },
       ],
       {
         hydrationData: { loaderData: { sources: { installed: false } } },
-        initialEntries: ['/sources/github'],
+        initialEntries: ['/workspaces/analytics/sources/github'],
       },
     )
     const screen = await render(<RouterProvider router={router} />)
@@ -86,7 +91,11 @@ describe('SourceInstallDialog', () => {
     await screen.getByRole('button', { name: 'Add source' }).click()
 
     await expect.element(screen.getByText('Configured')).toBeVisible()
-    expect(router.state.location.pathname).toBe('/sources')
+    expect(fetchOAuthInstall).toHaveBeenCalledWith(
+      '/workspaces/analytics/sources/github/oauth-install',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(router.state.location.pathname).toBe('/workspaces/analytics/sources')
     expect(loaderCalls).toBe(1)
   })
 })

--- a/apps/reef/app/views/sources/source-install.tsx
+++ b/apps/reef/app/views/sources/source-install.tsx
@@ -21,6 +21,7 @@ import type {
   CatalogSourceCredentialMethod,
   CatalogSourceInputSpec,
 } from '@/lib/sources'
+import { routePath } from '@/routing/routemap'
 import { toSentenceCase } from '@/utils/to-sentence-case'
 
 import { formatSourceName, ProviderLogo } from '@/components/sources'
@@ -53,6 +54,7 @@ export function SourceInstallDialog({
   openAuthorization = (url) => window.open(url, '_blank', 'noopener,noreferrer'),
   onOpenChange,
   submitting,
+  workspaceId,
 }: {
   actionError?: string | null
   entry: CatalogEntry | null
@@ -61,6 +63,7 @@ export function SourceInstallDialog({
   openAuthorization?: (url: string) => unknown
   onOpenChange: (open: boolean) => void
   submitting?: boolean
+  workspaceId: string
 }) {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -75,6 +78,7 @@ export function SourceInstallDialog({
               onCancel={() => onOpenChange(false)}
               openAuthorization={openAuthorization}
               submitting={submitting ?? false}
+              workspaceId={workspaceId}
             />
           ) : null}
         </Dialog.Popup>
@@ -90,6 +94,7 @@ function SourceInstallDialogContent({
   onCancel,
   openAuthorization,
   submitting,
+  workspaceId,
 }: {
   actionError?: string | null
   entry: CatalogEntry
@@ -97,6 +102,7 @@ function SourceInstallDialogContent({
   onCancel: () => void
   openAuthorization: (url: string) => unknown
   submitting: boolean
+  workspaceId: string
 }) {
   const navigate = useNavigate()
   const revalidator = useRevalidator()
@@ -159,7 +165,7 @@ function SourceInstallDialogContent({
     const abortController = new AbortController()
     abortRef.current = abortController
     try {
-      const response = await fetchOAuthInstall(oauthInstallEndpoint(entry.name), {
+      const response = await fetchOAuthInstall(oauthInstallEndpoint(workspaceId, entry.name), {
         body: new FormData(formRef.current),
         method: 'POST',
         signal: abortController.signal,
@@ -190,7 +196,9 @@ function SourceInstallDialogContent({
       if (!abortController.signal.aborted) {
         setProgress({ kind: 'success', name: source.name })
         await revalidator.revalidate()
-        if (!abortController.signal.aborted) await navigate('/sources')
+        if (!abortController.signal.aborted) {
+          await navigate(routePath('workspaceSources', { workspaceId }))
+        }
       }
     } catch (error) {
       if (abortController.signal.aborted) return
@@ -467,8 +475,8 @@ function oauthMethodReady(
   })
 }
 
-function oauthInstallEndpoint(name: string): string {
-  return `/sources/${encodeURIComponent(name)}/oauth-install`
+function oauthInstallEndpoint(workspaceId: string, name: string): string {
+  return `${routePath('workspaceSource', { sourceName: name, workspaceId })}/oauth-install`
 }
 
 function busyLabel(progress: InstallProgress, submitting: boolean): string {


### PR DESCRIPTION
## Why

Reef's streamed OAuth source install flow still used legacy unscoped `/sources` URLs after source routes moved under workspaces. On success it navigated to a broken route, and the resource action installed into the first workspace rather than the workspace the user was viewing.

## What changed

- Scope the OAuth install resource route to `/workspaces/:workspaceId/sources/:sourceName/oauth-install`.
- Resolve OAuth installs from the route workspace instead of selecting the first workspace.
- Generate the OAuth endpoint and success destination with Reef's canonical route helpers.
- Preserve catalog revalidation before returning to the active workspace's source list.
- Add focused server and browser regression coverage for OAuth navigation and the outgoing source workspace value.

## Validation

- `npm run check --prefix apps/reef` — passed (456 files formatted/linted)
- `npm run typecheck --prefix apps/reef` — passed
- `npm test --prefix apps/reef` — 79 files, 321 tests passed
- `npm run build --prefix apps/reef` — passed (client and SSR builds)
- `git diff --check` — passed

## Notes

- Restacked onto current `main`, including #1785; the duplicate trace-loader patch from the previous revision was dropped.
- No backend crate or Sandcastle configuration changes.
- A live third-party OAuth provider callback was not exercised locally; streamed callback and success events are covered by browser/server tests.