### PR TITLE
fix(reef): pass workspace into trace loaders

### DIFF
--- a/apps/reef/app/routes/trace-detail-loader.server.test.ts
+++ b/apps/reef/app/routes/trace-detail-loader.server.test.ts
@@ -1,3 +1,6 @@
+import { create } from '@bufbuild/protobuf'
+
+import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
 import { TraceStatus } from '@/generated/coral/v1/traces_pb'
 import type { TraceDetailData } from '@/views/traces/trace-utils'
 import { describe, expect, it, vi } from 'vitest'
@@ -25,19 +28,22 @@ function detail(traceId: string): TraceDetailData {
 
 describe('trace detail loader', () => {
   const request = new Request('http://reef.test/workspaces/analytics/traces/trace-07')
+  const workspace = create(WorkspaceSchema, { name: 'analytics' })
 
   it('loads the URL-selected trace without decoding it again', async () => {
     const getTrace = vi.fn().mockResolvedValue(detail('trace/with?reserved'))
 
     await expect(
-      loadTraceDetailRouteData(request, 'trace/with?reserved', getTrace),
+      loadTraceDetailRouteData(request, 'trace/with?reserved', workspace, getTrace),
     ).resolves.toEqual({ detail: detail('trace/with?reserved'), loadError: null })
-    expect(getTrace).toHaveBeenCalledWith(request, 'trace/with?reserved')
+    expect(getTrace).toHaveBeenCalledWith(request, 'trace/with?reserved', workspace)
   })
 
   it('returns an inline error for a missing trace ID', async () => {
     const getTrace = vi.fn()
-    await expect(loadTraceDetailRouteData(request, undefined, getTrace)).resolves.toEqual({
+    await expect(
+      loadTraceDetailRouteData(request, undefined, workspace, getTrace),
+    ).resolves.toEqual({
       detail: null,
       loadError: 'Missing trace ID',
     })
@@ -49,6 +55,7 @@ describe('trace detail loader', () => {
       loadTraceDetailRouteData(
         request,
         'trace-07',
+        workspace,
         vi.fn().mockRejectedValue(new Error('HTTP 404 from TraceService')),
       ),
     ).resolves.toMatchObject({
@@ -61,6 +68,7 @@ describe('trace detail loader', () => {
       loadTraceDetailRouteData(
         request,
         'trace-07',
+        workspace,
         vi.fn().mockRejectedValue(new Error('trace lookup failed')),
       ),
     ).resolves.toEqual({ detail: null, loadError: 'trace lookup failed' })
@@ -72,11 +80,15 @@ describe('trace detail loader', () => {
       .mockResolvedValueOnce(detail('trace-a'))
       .mockRejectedValueOnce(new Error('trace-b failed'))
 
-    await expect(loadTraceDetailRouteData(request, 'trace-a', getTrace)).resolves.toEqual({
+    await expect(
+      loadTraceDetailRouteData(request, 'trace-a', workspace, getTrace),
+    ).resolves.toEqual({
       detail: detail('trace-a'),
       loadError: null,
     })
-    await expect(loadTraceDetailRouteData(request, 'trace-b', getTrace)).resolves.toEqual({
+    await expect(
+      loadTraceDetailRouteData(request, 'trace-b', workspace, getTrace),
+    ).resolves.toEqual({
       detail: null,
       loadError: 'trace-b failed',
     })

--- a/apps/reef/app/routes/trace-detail-loader.ts
+++ b/apps/reef/app/routes/trace-detail-loader.ts
@@ -2,10 +2,11 @@ import { create } from '@bufbuild/protobuf'
 
 import type { Route } from './+types/trace-detail'
 
+import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { GetTraceRequestSchema } from '@/generated/coral/v1/traces_pb'
-import { WORKSPACE } from '@/lib/constants'
 import { traceClientForRequest } from '@/lib/coral-request.server'
 import { errorMessage } from '@/lib/utils'
+import { workspaceFromParams } from '@/lib/workspace-routing'
 import { formatTraceError, type TraceDetailData } from '@/views/traces/trace-utils'
 
 export interface TraceDetailRouteData {
@@ -13,28 +14,37 @@ export interface TraceDetailRouteData {
   loadError: string | null
 }
 
-export type GetTraceForRequest = (request: Request, traceId: string) => Promise<TraceDetailData>
+export type GetTraceForRequest = (
+  request: Request,
+  traceId: string,
+  workspace: Workspace,
+) => Promise<TraceDetailData>
 
 export async function loader({ params, request }: Route.LoaderArgs): Promise<TraceDetailRouteData> {
-  return loadTraceDetailRouteData(request, params.traceId)
+  return loadTraceDetailRouteData(request, params.traceId, workspaceFromParams(params))
 }
 
 export async function loadTraceDetailRouteData(
   request: Request,
   traceId: string | undefined,
+  workspace: Workspace,
   getTrace: GetTraceForRequest = getTraceForRequest,
 ): Promise<TraceDetailRouteData> {
   if (!traceId) return { detail: null, loadError: 'Missing trace ID' }
 
   try {
-    return { detail: await getTrace(request, traceId), loadError: null }
+    return { detail: await getTrace(request, traceId, workspace), loadError: null }
   } catch (error) {
     return { detail: null, loadError: formatTraceError(errorMessage(error)) }
   }
 }
 
-async function getTraceForRequest(request: Request, traceId: string): Promise<TraceDetailData> {
+async function getTraceForRequest(
+  request: Request,
+  traceId: string,
+  workspace: Workspace,
+): Promise<TraceDetailData> {
   return traceClientForRequest(request).getTrace(
-    create(GetTraceRequestSchema, { traceId, workspace: WORKSPACE }),
+    create(GetTraceRequestSchema, { traceId, workspace }),
   )
 }

--- a/apps/reef/app/routes/traces-loader.server.test.ts
+++ b/apps/reef/app/routes/traces-loader.server.test.ts
@@ -1,3 +1,6 @@
+import { create } from '@bufbuild/protobuf'
+
+import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
 import { TraceStatus } from '@/generated/coral/v1/traces_pb'
 import type { TraceSummaryData } from '@/views/traces/trace-utils'
 import { describe, expect, it, vi } from 'vitest'
@@ -22,6 +25,7 @@ function summary(traceId: string, query = `select '${traceId}'`): TraceSummaryDa
 
 describe('traces list loader', () => {
   const request = new Request('http://reef.test/workspaces/analytics/traces')
+  const workspace = create(WorkspaceSchema, { name: 'analytics' })
 
   it('filters query traces and returns a deterministic endpoint label', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(123_456)
@@ -30,13 +34,13 @@ describe('traces list loader', () => {
       traces: [summary('query'), summary('http', '')],
     })
 
-    await expect(loadTracesRouteData(request, listPage)).resolves.toEqual({
+    await expect(loadTracesRouteData(request, workspace, listPage)).resolves.toEqual({
       endpointLabel: 'reef.test',
       loadError: null,
       referenceTimeMs: 123_456,
       traces: [summary('query')],
     })
-    expect(listPage).toHaveBeenCalledWith(request, 100, '')
+    expect(listPage).toHaveBeenCalledWith(request, workspace, 100, '')
   })
 
   it('loads at most two pages, preserves ordering, and caps query traces at 80', async () => {
@@ -47,10 +51,10 @@ describe('traces list loader', () => {
       .mockResolvedValueOnce({ nextPageToken: 'page-2', traces: firstPage })
       .mockResolvedValueOnce({ nextPageToken: 'page-3', traces: secondPage })
 
-    const traces = await listQueryTraces(request, listPage)
+    const traces = await listQueryTraces(request, workspace, listPage)
 
     expect(listPage).toHaveBeenCalledTimes(2)
-    expect(listPage).toHaveBeenNthCalledWith(2, request, 100, 'page-2')
+    expect(listPage).toHaveBeenNthCalledWith(2, request, workspace, 100, 'page-2')
     expect(traces).toHaveLength(80)
     expect(traces.map(({ traceId }) => traceId)).toEqual(
       Array.from({ length: 80 }, (_, index) => `trace-${index}`),
@@ -59,14 +63,14 @@ describe('traces list loader', () => {
 
   it('maps unavailable and generic failures into route data', async () => {
     const unavailable = vi.fn().mockRejectedValue(new Error('rpc unimplemented'))
-    await expect(loadTracesRouteData(request, unavailable)).resolves.toMatchObject({
+    await expect(loadTracesRouteData(request, workspace, unavailable)).resolves.toMatchObject({
       loadError:
         'Trace storage is not enabled for this Coral server. Enable [local_traces].enabled = true, restart the Coral server, then run a query.',
       traces: [],
     })
 
     const generic = vi.fn().mockRejectedValue(new Error('sidecar unavailable'))
-    await expect(loadTracesRouteData(request, generic)).resolves.toMatchObject({
+    await expect(loadTracesRouteData(request, workspace, generic)).resolves.toMatchObject({
       loadError: 'sidecar unavailable',
       traces: [],
     })

--- a/apps/reef/app/routes/traces-loader.ts
+++ b/apps/reef/app/routes/traces-loader.ts
@@ -2,10 +2,11 @@ import { create } from '@bufbuild/protobuf'
 
 import type { Route } from './+types/traces'
 
+import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { ListTracesRequestSchema } from '@/generated/coral/v1/traces_pb'
-import { WORKSPACE } from '@/lib/constants'
 import { traceClientForRequest } from '@/lib/coral-request.server'
 import { errorMessage } from '@/lib/utils'
+import { workspaceFromParams } from '@/lib/workspace-routing'
 import { formatTraceError, isQueryTrace, type TraceSummaryData } from '@/views/traces/trace-utils'
 
 const MAX_QUERY_TRACES = 80
@@ -21,16 +22,18 @@ export interface TracesRouteData {
 
 export type ListTracePage = (
   request: Request,
+  workspace: Workspace,
   pageSize: number,
   pageToken: string,
 ) => Promise<{ nextPageToken: string; traces: TraceSummaryData[] }>
 
-export async function loader({ request }: Route.LoaderArgs): Promise<TracesRouteData> {
-  return loadTracesRouteData(request)
+export async function loader({ params, request }: Route.LoaderArgs): Promise<TracesRouteData> {
+  return loadTracesRouteData(request, workspaceFromParams(params))
 }
 
 export async function loadTracesRouteData(
   request: Request,
+  workspace: Workspace,
   listPage: ListTracePage = listTracePageForRequest,
 ): Promise<TracesRouteData> {
   const referenceTimeMs = Date.now()
@@ -39,7 +42,7 @@ export async function loadTracesRouteData(
       endpointLabel: traceEndpointLabel(request),
       loadError: null,
       referenceTimeMs,
-      traces: await listQueryTraces(request, listPage),
+      traces: await listQueryTraces(request, workspace, listPage),
     }
   } catch (error) {
     return {
@@ -53,6 +56,7 @@ export async function loadTracesRouteData(
 
 export async function listQueryTraces(
   request: Request,
+  workspace: Workspace,
   listPage: ListTracePage = listTracePageForRequest,
 ): Promise<TraceSummaryData[]> {
   const queryTraces: TraceSummaryData[] = []
@@ -63,7 +67,7 @@ export async function listQueryTraces(
     page < MAX_TRACE_LIST_PAGES && queryTraces.length < MAX_QUERY_TRACES;
     page += 1
   ) {
-    const response = await listPage(request, TRACE_LIST_PAGE_SIZE, pageToken)
+    const response = await listPage(request, workspace, TRACE_LIST_PAGE_SIZE, pageToken)
     queryTraces.push(...response.traces.filter(isQueryTrace))
     pageToken = response.nextPageToken
     if (!pageToken) break
@@ -82,10 +86,11 @@ export function traceEndpointLabel(request: Request): string {
 
 async function listTracePageForRequest(
   request: Request,
+  workspace: Workspace,
   pageSize: number,
   pageToken: string,
 ): Promise<{ nextPageToken: string; traces: TraceSummaryData[] }> {
   return traceClientForRequest(request).listTraces(
-    create(ListTracesRequestSchema, { pageSize, pageToken, workspace: WORKSPACE }),
+    create(ListTracesRequestSchema, { pageSize, pageToken, workspace }),
   )
 }


### PR DESCRIPTION
## Summary
- Thread the route workspace through trace list and trace detail loaders instead of using the fixed workspace constant.
- Update loader helpers and tests so trace RPC calls receive the resolved workspace from the URL params.
- Keep query-trace filtering and trace-detail error handling unchanged.

## Testing
- Updated server loader tests to cover workspace-aware request wiring.
- Not run (not requested).