### PR TITLE
test(reef): assert trace loaders use route workspace

### DIFF
--- a/apps/reef/app/routes/trace-detail-loader.server.test.ts
+++ b/apps/reef/app/routes/trace-detail-loader.server.test.ts
@@ -1,11 +1,19 @@
 import { create } from '@bufbuild/protobuf'
 
+const traceClientMocks = vi.hoisted(() => ({
+  getTrace: vi.fn(),
+}))
+
+vi.mock('@/lib/coral-request.server', () => ({
+  traceClientForRequest: () => ({ getTrace: traceClientMocks.getTrace }),
+}))
+
 import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
 import { TraceStatus } from '@/generated/coral/v1/traces_pb'
 import type { TraceDetailData } from '@/views/traces/trace-utils'
 import { describe, expect, it, vi } from 'vitest'
 
-import { loadTraceDetailRouteData } from './trace-detail-loader'
+import { loadTraceDetailRouteData, loader } from './trace-detail-loader'
 
 function detail(traceId: string): TraceDetailData {
   return {
@@ -29,6 +37,22 @@ function detail(traceId: string): TraceDetailData {
 describe('trace detail loader', () => {
   const request = new Request('http://reef.test/workspaces/analytics/traces/trace-07')
   const workspace = create(WorkspaceSchema, { name: 'analytics' })
+
+  it('scopes TraceService detail requests to the route workspace', async () => {
+    traceClientMocks.getTrace.mockResolvedValue(detail('trace-07'))
+
+    await loader({
+      params: { traceId: 'trace-07', workspaceId: 'research' },
+      request,
+    } as Parameters<typeof loader>[0])
+
+    expect(traceClientMocks.getTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: 'trace-07',
+        workspace: expect.objectContaining({ name: 'research' }),
+      }),
+    )
+  })
 
   it('loads the URL-selected trace without decoding it again', async () => {
     const getTrace = vi.fn().mockResolvedValue(detail('trace/with?reserved'))

--- a/apps/reef/app/routes/traces-loader.server.test.ts
+++ b/apps/reef/app/routes/traces-loader.server.test.ts
@@ -1,11 +1,19 @@
 import { create } from '@bufbuild/protobuf'
 
+const traceClientMocks = vi.hoisted(() => ({
+  listTraces: vi.fn(),
+}))
+
+vi.mock('@/lib/coral-request.server', () => ({
+  traceClientForRequest: () => ({ listTraces: traceClientMocks.listTraces }),
+}))
+
 import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
 import { TraceStatus } from '@/generated/coral/v1/traces_pb'
 import type { TraceSummaryData } from '@/views/traces/trace-utils'
 import { describe, expect, it, vi } from 'vitest'
 
-import { listQueryTraces, loadTracesRouteData, traceEndpointLabel } from './traces-loader'
+import { listQueryTraces, loadTracesRouteData, loader, traceEndpointLabel } from './traces-loader'
 
 function summary(traceId: string, query = `select '${traceId}'`): TraceSummaryData {
   return {
@@ -26,6 +34,18 @@ function summary(traceId: string, query = `select '${traceId}'`): TraceSummaryDa
 describe('traces list loader', () => {
   const request = new Request('http://reef.test/workspaces/analytics/traces')
   const workspace = create(WorkspaceSchema, { name: 'analytics' })
+
+  it('scopes TraceService list requests to the route workspace', async () => {
+    traceClientMocks.listTraces.mockResolvedValue({ nextPageToken: '', traces: [] })
+
+    await loader({ params: { workspaceId: 'research' }, request } as Parameters<typeof loader>[0])
+
+    expect(traceClientMocks.listTraces).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace: expect.objectContaining({ name: 'research' }),
+      }),
+    )
+  })
 
   it('filters query traces and returns a deterministic endpoint label', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(123_456)


### PR DESCRIPTION
## Why

The OAuth redirect fix PR exposed that stale trace loader code can fail or accidentally drift away from workspace-scoped routing. On current main the trace list/detail loaders already use `workspaceFromParams(params)`, but there was no loader-level regression asserting that the TraceService requests are actually scoped with the route `workspaceId`.

## What changed

- Added a trace list loader regression that calls the route `loader` with `workspaceId: "research"` and asserts `listTraces` receives `workspace.name === "research"`.
- Added a trace detail loader regression that calls the route `loader` with `workspaceId: "research"` and asserts `getTrace` receives both the selected `traceId` and `workspace.name === "research"`.
- No runtime loader changes were needed on top of current main: both loaders already use `workspaceFromParams(params)` and pass that workspace into `ListTracesRequest` / `GetTraceRequest`.

## Validation

- `npm test --prefix apps/reef -- app/routes/traces-loader.server.test.ts app/routes/trace-detail-loader.server.test.ts` — 10 tests passed
- `npm run typecheck --prefix apps/reef`
- `npm run check --prefix apps/reef`
