### PR TITLE
feat(reef): keep local auth optional and hosted mode explicit

### DIFF
--- a/apps/reef/.env.example
+++ b/apps/reef/.env.example
@@ -1,0 +1,16 @@
+# Reef authentication is optional. Local development defaults to disabled.
+# REEF_AUTH_MODE=disabled
+
+# Hosted Reef should set REEF_AUTH_MODE=required and configure these server-only
+# values. Never expose the session secret through a VITE_ variable.
+# REEF_SESSION_SECRET=
+# REEF_AUTH_ISSUER=https://login.example.com
+# Optional when the issuer advertises an OAuth dynamic registration endpoint.
+# REEF_AUTH_CLIENT_ID=coral-cloud-ui
+# REEF_AUTH_REDIRECT_URI=https://reef.example.com/auth/callback
+# REEF_AUTH_SCOPE=coral:mcp
+
+# Optional session overrides.
+# REEF_SESSION_COOKIE_NAME=reef_session
+# REEF_SESSION_MAX_AGE_SECONDS=3600
+# REEF_COOKIE_SECURE=true

--- a/apps/reef/README.md
+++ b/apps/reef/README.md
@@ -18,6 +18,15 @@ npm run dev
 
 Open `http://localhost:5173` unless the dev server prints a different URL.
 
+Authentication is disabled by default for local development and for Coral
+Desktop. No auth environment variables are needed for those modes.
+
+Hosted Reef must choose its auth behavior explicitly. Set
+`REEF_AUTH_MODE=required` together with the server-only issuer, callback, and
+session values documented in `.env.example`. A non-desktop production server
+without an explicit mode fails closed rather than accidentally publishing an
+unauthenticated app.
+
 Run checks:
 
 ```bash

--- a/apps/reef/app/auth/config.server.test.ts
+++ b/apps/reef/app/auth/config.server.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveAuthConfig } from './config.server'
+
+const SESSION_SECRET = '0123456789abcdef0123456789abcdef'
+
+describe('Reef auth config', () => {
+  it('defaults local development and tests to disabled auth', () => {
+    expect(resolveAuthConfig({ env: { NODE_ENV: 'development' }, isDesktopBuild: false })).toEqual({
+      mode: 'disabled',
+    })
+    expect(resolveAuthConfig({ env: { NODE_ENV: 'test' }, isDesktopBuild: false })).toEqual({
+      mode: 'disabled',
+    })
+  })
+
+  it('keeps desktop builds disabled regardless of ambient hosted config', () => {
+    expect(
+      resolveAuthConfig({
+        env: {
+          NODE_ENV: 'production',
+          REEF_AUTH_ISSUER: 'https://login.example.test',
+          REEF_AUTH_MODE: 'required',
+          REEF_SESSION_SECRET: SESSION_SECRET,
+        },
+        isDesktopBuild: true,
+      }),
+    ).toEqual({ mode: 'disabled' })
+  })
+
+  it('fails closed when a non-desktop production server has no explicit mode', () => {
+    expect(() =>
+      resolveAuthConfig({ env: { NODE_ENV: 'production' }, isDesktopBuild: false }),
+    ).toThrow('REEF_AUTH_MODE must be set to disabled or required in production')
+  })
+
+  it('allows production to explicitly disable auth', () => {
+    expect(
+      resolveAuthConfig({
+        env: { NODE_ENV: 'production', REEF_AUTH_MODE: 'disabled' },
+        isDesktopBuild: false,
+      }),
+    ).toEqual({ mode: 'disabled' })
+  })
+
+  it('validates required auth config without changing exact OAuth identifiers', () => {
+    expect(
+      resolveAuthConfig({
+        env: {
+          NODE_ENV: 'production',
+          REEF_AUTH_CLIENT_ID: 'coral-cloud-ui',
+          REEF_AUTH_ISSUER: 'https://login.example.test:443/tenant/',
+          REEF_AUTH_MODE: 'required',
+          REEF_AUTH_REDIRECT_URI: 'https://reef.example.test:443/auth/callback?tenant=coral',
+          REEF_AUTH_SCOPE: 'coral:mcp',
+          REEF_SESSION_COOKIE_NAME: 'custom_session',
+          REEF_SESSION_MAX_AGE_SECONDS: '1800',
+          REEF_SESSION_SECRET: SESSION_SECRET,
+        },
+        isDesktopBuild: false,
+      }),
+    ).toEqual({
+      clientId: 'coral-cloud-ui',
+      cookieName: 'custom_session',
+      cookieSecure: true,
+      issuer: 'https://login.example.test:443/tenant/',
+      mode: 'required',
+      redirectUri: 'https://reef.example.test:443/auth/callback?tenant=coral',
+      scope: 'coral:mcp',
+      sessionMaxAgeSeconds: 1800,
+      sessionSecret: SESSION_SECRET,
+    })
+  })
+
+  it('rejects insecure hosted production cookies', () => {
+    expect(() =>
+      resolveAuthConfig({
+        env: {
+          NODE_ENV: 'production',
+          REEF_AUTH_ISSUER: 'https://login.example.test',
+          REEF_AUTH_MODE: 'required',
+          REEF_AUTH_REDIRECT_URI: 'https://reef.example.test/auth/callback',
+          REEF_COOKIE_SECURE: 'false',
+          REEF_SESSION_SECRET: SESSION_SECRET,
+        },
+        isDesktopBuild: false,
+      }),
+    ).toThrow('REEF_COOKIE_SECURE cannot be false in production')
+  })
+
+  it.each([
+    [{ REEF_AUTH_MODE: 'sometimes' }, 'REEF_AUTH_MODE must be set to disabled or required'],
+    [
+      { REEF_AUTH_ISSUER: 'https://login.example.test', REEF_AUTH_MODE: 'required' },
+      'REEF_SESSION_SECRET must be at least 32 characters',
+    ],
+    [
+      { REEF_AUTH_MODE: 'required', REEF_SESSION_SECRET: SESSION_SECRET },
+      'REEF_AUTH_ISSUER must be set',
+    ],
+    [
+      {
+        REEF_AUTH_ISSUER: 'file:///tmp/issuer',
+        REEF_AUTH_MODE: 'required',
+        REEF_SESSION_SECRET: SESSION_SECRET,
+      },
+      'REEF_AUTH_ISSUER must be an absolute HTTP(S) URL',
+    ],
+    [
+      {
+        REEF_AUTH_ISSUER: 'https://login.example.test/tenant?region=us',
+        REEF_AUTH_MODE: 'required',
+        REEF_SESSION_SECRET: SESSION_SECRET,
+      },
+      'REEF_AUTH_ISSUER must not include a query string or fragment',
+    ],
+    [
+      {
+        REEF_AUTH_ISSUER: 'https://login.example.test',
+        REEF_AUTH_MODE: 'required',
+        REEF_AUTH_REDIRECT_URI: 'https://reef.example.test/auth/callback#done',
+        REEF_SESSION_SECRET: SESSION_SECRET,
+      },
+      'REEF_AUTH_REDIRECT_URI must not include a fragment',
+    ],
+    [
+      {
+        REEF_AUTH_ISSUER: 'https://login.example.test',
+        REEF_AUTH_MODE: 'required',
+        REEF_SESSION_MAX_AGE_SECONDS: '0',
+        REEF_SESSION_SECRET: SESSION_SECRET,
+      },
+      'REEF_SESSION_MAX_AGE_SECONDS must be a positive integer',
+    ],
+  ])('rejects invalid config %#', (env, message) => {
+    expect(() => resolveAuthConfig({ env, isDesktopBuild: false })).toThrow(message)
+  })
+})

--- a/apps/reef/app/auth/config.server.ts
+++ b/apps/reef/app/auth/config.server.ts
@@ -1,0 +1,122 @@
+import type { AuthConfig, RequiredAuthConfig } from './types'
+
+const DEFAULT_COOKIE_NAME = 'reef_session'
+const DEFAULT_SESSION_MAX_AGE_SECONDS = 60 * 60
+
+interface AuthConfigInput {
+  env: NodeJS.ProcessEnv
+  isDesktopBuild: boolean
+}
+
+export function reefAuthConfig(): AuthConfig {
+  return resolveAuthConfig({
+    env: process.env,
+    isDesktopBuild: import.meta.env.VITE_CORAL_DESKTOP_APP === '1',
+  })
+}
+
+export function resolveAuthConfig({ env, isDesktopBuild }: AuthConfigInput): AuthConfig {
+  if (isDesktopBuild) return { mode: 'disabled' }
+
+  const configuredMode = env.REEF_AUTH_MODE?.trim().toLowerCase()
+  if (!configuredMode) {
+    if (env.NODE_ENV === 'production') {
+      throw new Error('REEF_AUTH_MODE must be set to disabled or required in production')
+    }
+
+    return { mode: 'disabled' }
+  }
+  if (configuredMode === 'disabled') return { mode: 'disabled' }
+  if (configuredMode !== 'required') {
+    throw new Error('REEF_AUTH_MODE must be set to disabled or required')
+  }
+
+  return requiredAuthConfig(env)
+}
+
+function requiredAuthConfig(env: NodeJS.ProcessEnv): RequiredAuthConfig {
+  const sessionSecret = env.REEF_SESSION_SECRET?.trim()
+  if (!sessionSecret || sessionSecret.length < 32) {
+    throw new Error('REEF_SESSION_SECRET must be at least 32 characters when auth is required')
+  }
+
+  const issuer = requiredString(env.REEF_AUTH_ISSUER, 'REEF_AUTH_ISSUER')
+  const issuerUrl = httpUrl(issuer, 'REEF_AUTH_ISSUER')
+  if (issuerUrl.search || issuerUrl.hash) {
+    throw new Error('REEF_AUTH_ISSUER must not include a query string or fragment')
+  }
+
+  const redirectUri = optionalString(env.REEF_AUTH_REDIRECT_URI)
+  const redirectUrl = redirectUri ? httpUrl(redirectUri, 'REEF_AUTH_REDIRECT_URI') : null
+  if (redirectUrl?.hash) throw new Error('REEF_AUTH_REDIRECT_URI must not include a fragment')
+
+  const cookieSecure = booleanEnv(env.REEF_COOKIE_SECURE) ?? redirectUrl?.protocol === 'https:'
+  if (env.NODE_ENV === 'production') {
+    if (issuerUrl.protocol !== 'https:')
+      throw new Error('REEF_AUTH_ISSUER must use HTTPS in production')
+    if (!redirectUrl) throw new Error('REEF_AUTH_REDIRECT_URI must be set in production')
+    if (redirectUrl.protocol !== 'https:') {
+      throw new Error('REEF_AUTH_REDIRECT_URI must use HTTPS in production')
+    }
+    if (!cookieSecure) throw new Error('REEF_COOKIE_SECURE cannot be false in production')
+  }
+
+  return {
+    clientId: optionalString(env.REEF_AUTH_CLIENT_ID),
+    cookieName: optionalString(env.REEF_SESSION_COOKIE_NAME) ?? DEFAULT_COOKIE_NAME,
+    cookieSecure,
+    issuer,
+    mode: 'required',
+    redirectUri,
+    scope: optionalString(env.REEF_AUTH_SCOPE),
+    sessionMaxAgeSeconds: positiveIntegerEnv(
+      env.REEF_SESSION_MAX_AGE_SECONDS,
+      'REEF_SESSION_MAX_AGE_SECONDS',
+      DEFAULT_SESSION_MAX_AGE_SECONDS,
+    ),
+    sessionSecret,
+  }
+}
+
+function requiredString(value: string | undefined, name: string): string {
+  const configured = optionalString(value)
+  if (!configured) throw new Error(`${name} must be set when auth is required`)
+  return configured
+}
+
+function httpUrl(value: string, name: string): URL {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${name} must be an absolute HTTP(S) URL`)
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`${name} must be an absolute HTTP(S) URL`)
+  }
+
+  return url
+}
+
+function booleanEnv(value: string | undefined): boolean | null {
+  const configured = optionalString(value)?.toLowerCase()
+  if (!configured) return null
+  if (['1', 'true', 'yes'].includes(configured)) return true
+  if (['0', 'false', 'no'].includes(configured)) return false
+  throw new Error('REEF_COOKIE_SECURE must be true or false')
+}
+
+function positiveIntegerEnv(value: string | undefined, name: string, fallback: number): number {
+  const configured = optionalString(value)
+  if (!configured) return fallback
+  const parsed = Number.parseInt(configured, 10)
+  if (!/^[0-9]+$/.test(configured) || !Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`)
+  }
+
+  return parsed
+}
+
+function optionalString(value: string | undefined): string | null {
+  return value?.trim() || null
+}

--- a/apps/reef/app/auth/types.ts
+++ b/apps/reef/app/auth/types.ts
@@ -1,0 +1,19 @@
+export type AuthMode = 'disabled' | 'required'
+
+export interface DisabledAuthConfig {
+  mode: 'disabled'
+}
+
+export interface RequiredAuthConfig {
+  clientId: string | null
+  cookieName: string
+  cookieSecure: boolean
+  issuer: string
+  mode: 'required'
+  redirectUri: string | null
+  scope: string | null
+  sessionMaxAgeSeconds: number
+  sessionSecret: string
+}
+
+export type AuthConfig = DisabledAuthConfig | RequiredAuthConfig


### PR DESCRIPTION
Constraint: Desktop and local Reef must not require auth configuration or display an auth wall.
Rejected: Inferring auth from hostname or CORAL_ENDPOINT | deployment role must be explicit and production must fail closed.
Confidence: high
Scope-risk: narrow
Directive: Preserve the compile-time desktop override when extending auth configuration.
Tested: config server tests; npm run check --prefix apps/reef; npm run typecheck --prefix apps/reef
Not-tested: Production identity-provider integration is deferred.