### PR TITLE
feat(reef): keep Coral OAuth tokens in encrypted server sessions

### DIFF
--- a/apps/reef/app/auth/coral-oauth.server.test.ts
+++ b/apps/reef/app/auth/coral-oauth.server.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { completeCoralOAuthLogin, startCoralOAuthLogin } from './coral-oauth.server'
+import { readReefSession } from './session.server'
+import type { RequiredAuthConfig } from './types'
+
+const AUTH_ISSUER = 'https://login.example.test'
+const CLIENT_ID = 'coral-cloud-ui'
+const config: RequiredAuthConfig = {
+  clientId: 'coral-cloud-ui',
+  cookieName: 'reef_session',
+  cookieSecure: true,
+  issuer: AUTH_ISSUER,
+  mode: 'required',
+  redirectUri: 'https://reef.example.test/auth/callback',
+  scope: 'coral:mcp',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+const metadata = {
+  authorization_endpoint: `${AUTH_ISSUER}/authorize`,
+  issuer: AUTH_ISSUER,
+  token_endpoint: `${AUTH_ISSUER}/token`,
+}
+
+describe('Coral OAuth adapter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('starts login with PKCE, provider-neutral config, and a safe return path', async () => {
+    const fetch = mockFetch(jsonResponse(metadata))
+    const response = await startCoralOAuthLogin(
+      new Request('https://reef.example.test/login?returnTo=/workspaces/analytics?tab=mine'),
+      config,
+    )
+    const location = new URL(response.headers.get('location') ?? '')
+
+    expect(fetch).toHaveBeenCalledWith(`${AUTH_ISSUER}/.well-known/oauth-authorization-server`, {
+      headers: { accept: 'application/json' },
+    })
+    expect(location.origin).toBe(AUTH_ISSUER)
+    expect(location.searchParams.get('client_id')).toBe(CLIENT_ID)
+    expect(location.searchParams.get('redirect_uri')).toBe(config.redirectUri)
+    expect(location.searchParams.get('scope')).toBe('coral:mcp')
+    expect(location.searchParams.get('state')).toBeTruthy()
+    expect(location.searchParams.get('code_challenge')).toBeTruthy()
+    expect(location.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(setCookies(response)).toEqual([expect.stringContaining('reef_oauth=')])
+  })
+
+  it('completes login, clears OAuth state, and stores a bounded encrypted session', async () => {
+    const fetch = mockFetch(
+      jsonResponse(metadata),
+      jsonResponse(metadata),
+      jsonResponse({ access_token: 'opaque-coral-token', expires_in: 7200, token_type: 'Bearer' }),
+    )
+    const login = await startCoralOAuthLogin(
+      new Request('https://reef.example.test/login?returnTo=/workspaces/analytics?tab=mine'),
+      config,
+    )
+    const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
+    const callback = await completeCoralOAuthLogin(
+      new Request(`https://reef.example.test/auth/callback?code=abc123&state=${state}`, {
+        headers: { cookie: cookieHeader(login, 'reef_oauth') },
+      }),
+      config,
+    )
+    const cookies = setCookies(callback)
+    const session = await readReefSession(
+      new Request('https://reef.example.test/', {
+        headers: { cookie: cookieHeader(callback, 'reef_session') },
+      }),
+      config,
+    )
+
+    expect(callback.headers.get('location')).toBe('/workspaces/analytics?tab=mine')
+    expect(cookies[0]).toContain('reef_oauth=')
+    expect(cookies[0]).toContain('Max-Age=0')
+    expect(cookies[1]).toContain('reef_session=')
+    expect(cookies[1]).not.toContain('opaque-coral-token')
+    expect(session).toEqual({
+      accessToken: 'opaque-coral-token',
+      expiresAt: unixTimestamp() + 3600,
+      tokenType: 'Bearer',
+    })
+
+    const tokenRequest = fetch.mock.calls[2]
+    const body = tokenRequest?.[1]?.body as URLSearchParams
+    expect(tokenRequest?.[0]).toBe(`${AUTH_ISSUER}/token`)
+    expect(body.get('grant_type')).toBe('authorization_code')
+    expect(body.get('code')).toBe('abc123')
+    expect(body.get('code_verifier')).toBeTruthy()
+    expect(body.get('client_id')).toBe(CLIENT_ID)
+  })
+
+  it('falls back to home for an external return target', async () => {
+    mockFetch(
+      jsonResponse(metadata),
+      jsonResponse(metadata),
+      jsonResponse({ access_token: 'token', expires_in: 3600 }),
+    )
+    const login = await startCoralOAuthLogin(
+      new Request('https://reef.example.test/login?returnTo=https://evil.example/phish'),
+      config,
+    )
+    const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
+    const callback = await completeCoralOAuthLogin(
+      new Request(`https://reef.example.test/auth/callback?code=abc123&state=${state}`, {
+        headers: { cookie: cookieHeader(login, 'reef_oauth') },
+      }),
+      config,
+    )
+
+    expect(callback.headers.get('location')).toBe('/')
+  })
+
+  it('clears OAuth state only after a callback matches the active transaction', async () => {
+    const fetch = mockFetch(jsonResponse(metadata))
+    const login = await startCoralOAuthLogin(new Request('https://reef.example.test/login'), config)
+    const cookie = cookieHeader(login, 'reef_oauth')
+    const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
+
+    const providerError = await completeCoralOAuthLogin(
+      new Request(`https://reef.example.test/auth/callback?error=access_denied&state=${state}`, {
+        headers: { cookie },
+      }),
+      config,
+    ).catch((error: unknown) => error)
+    const stateError = await completeCoralOAuthLogin(
+      new Request('https://reef.example.test/auth/callback?code=abc&state=wrong', {
+        headers: { cookie },
+      }),
+      config,
+    ).catch((error: unknown) => error)
+
+    expect(providerError).toMatchObject({ status: 400 })
+    expect((providerError as Response).headers.get('Set-Cookie')).toContain('Max-Age=0')
+    expect(stateError).toMatchObject({ status: 400 })
+    expect((stateError as Response).headers.has('Set-Cookie')).toBe(false)
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses RFC 8414 discovery for a path issuer and requires its exact identifier', async () => {
+    const issuer = 'https://login.example.test/tenant/'
+    const pathConfig = { ...config, issuer }
+    const pathMetadata = {
+      ...metadata,
+      authorization_endpoint: `${issuer}authorize`,
+      issuer,
+      token_endpoint: `${issuer}token`,
+    }
+    const fetch = mockFetch(jsonResponse(pathMetadata))
+
+    await startCoralOAuthLogin(new Request('https://reef.example.test/login'), pathConfig)
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://login.example.test/.well-known/oauth-authorization-server/tenant/',
+      { headers: { accept: 'application/json' } },
+    )
+  })
+
+  it('dynamically registers a client when none is configured', async () => {
+    const registrationEndpoint = `${AUTH_ISSUER}/register`
+    const fetch = mockFetch(
+      jsonResponse({ ...metadata, registration_endpoint: registrationEndpoint }),
+      jsonResponse({ client_id: 'dynamic-client' }),
+    )
+    const response = await startCoralOAuthLogin(new Request('http://localhost:5173/login'), {
+      ...config,
+      clientId: null,
+      cookieSecure: false,
+      redirectUri: null,
+    })
+
+    expect(fetch.mock.calls[1]?.[0]).toBe(registrationEndpoint)
+    expect(new URL(response.headers.get('location') ?? '').searchParams.get('client_id')).toBe(
+      'dynamic-client',
+    )
+  })
+
+  it('rejects metadata for a different issuer', async () => {
+    mockFetch(jsonResponse({ ...metadata, issuer: 'https://attacker.example' }))
+
+    await expect(
+      startCoralOAuthLogin(new Request('https://reef.example.test/login'), config),
+    ).rejects.toThrow('metadata issuer does not match')
+  })
+
+  it('requires a positive standards-based token expiry', async () => {
+    mockFetch(
+      jsonResponse(metadata),
+      jsonResponse(metadata),
+      jsonResponse({ access_token: 'token-with-ignored-jwt-shape' }),
+    )
+    const login = await startCoralOAuthLogin(new Request('https://reef.example.test/login'), config)
+    const state = new URL(login.headers.get('location') ?? '').searchParams.get('state')
+
+    await expect(
+      completeCoralOAuthLogin(
+        new Request(`https://reef.example.test/auth/callback?code=abc&state=${state}`, {
+          headers: { cookie: cookieHeader(login, 'reef_oauth') },
+        }),
+        config,
+      ),
+    ).rejects.toThrow('positive expires_in')
+  })
+})
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}
+
+function mockFetch(...responses: Response[]) {
+  const fetch = vi.fn<typeof globalThis.fetch>(async () => {
+    const response = responses.shift()
+    if (!response) throw new Error('unexpected fetch call')
+    return response
+  })
+  vi.stubGlobal('fetch', fetch)
+  return fetch
+}
+
+function setCookies(response: Response): string[] {
+  const headers = response.headers as Headers & { getSetCookie?: () => string[] }
+  const cookies = headers.getSetCookie?.()
+  if (cookies?.length) return cookies
+  const cookie = response.headers.get('set-cookie')
+  return cookie ? [cookie] : []
+}
+
+function cookieHeader(response: Response, name: string): string {
+  const cookie = setCookies(response).find((value) => value.startsWith(`${name}=`))
+  if (!cookie) throw new Error(`missing ${name} Set-Cookie header`)
+  return cookie.split(';', 1)[0]
+}
+
+function unixTimestamp(): number {
+  return Math.floor(Date.now() / 1000)
+}

--- a/apps/reef/app/auth/coral-oauth.server.ts
+++ b/apps/reef/app/auth/coral-oauth.server.ts
@@ -1,0 +1,250 @@
+import { createHash } from 'node:crypto'
+
+import { redirect } from 'react-router'
+
+import {
+  clearOAuthTransaction,
+  commitOAuthTransaction,
+  commitReefSession,
+  randomToken,
+  readOAuthTransaction,
+} from './session.server'
+import type { AuthSession, RequiredAuthConfig } from './types'
+
+const DEFAULT_SCOPE = 'coral:mcp'
+
+interface AuthorizationServerMetadata {
+  authorization_endpoint: string
+  issuer: string
+  registration_endpoint?: string
+  resource?: string
+  scopes_supported?: string[]
+  token_endpoint: string
+}
+
+interface TokenResponse {
+  access_token?: unknown
+  expires_in?: unknown
+  token_type?: unknown
+}
+
+export async function startCoralOAuthLogin(
+  request: Request,
+  config: RequiredAuthConfig,
+): Promise<Response> {
+  const metadata = await authorizationServerMetadata(config)
+  const url = new URL(request.url)
+  const returnTo = safeReturnTo(url.searchParams.get('returnTo'))
+  const redirectUri = callbackUrl(request, config)
+  const clientId = await oauthClientId(metadata, redirectUri, config)
+  const state = randomToken(32)
+  const codeVerifier = randomToken(32)
+  const authorizationUrl = new URL(metadata.authorization_endpoint)
+
+  authorizationUrl.searchParams.set('response_type', 'code')
+  authorizationUrl.searchParams.set('client_id', clientId)
+  authorizationUrl.searchParams.set('redirect_uri', redirectUri)
+  authorizationUrl.searchParams.set('scope', oauthScope(metadata, config))
+  authorizationUrl.searchParams.set('state', state)
+  authorizationUrl.searchParams.set('code_challenge', pkceChallenge(codeVerifier))
+  authorizationUrl.searchParams.set('code_challenge_method', 'S256')
+  if (metadata.resource) authorizationUrl.searchParams.set('resource', metadata.resource)
+
+  return redirect(authorizationUrl.toString(), {
+    headers: {
+      'Set-Cookie': await commitOAuthTransaction(
+        { clientId, codeVerifier, returnTo, state },
+        config,
+      ),
+    },
+  })
+}
+
+export async function completeCoralOAuthLogin(
+  request: Request,
+  config: RequiredAuthConfig,
+): Promise<Response> {
+  const url = new URL(request.url)
+  const state = url.searchParams.get('state')
+  const transaction = await readOAuthTransaction(request, config)
+  if (!state || !transaction || state !== transaction.state) {
+    throw callbackError('Invalid Reef auth callback state')
+  }
+
+  const providerError = url.searchParams.get('error')
+  if (providerError) {
+    const description = url.searchParams.get('error_description')
+    throw await callbackError(
+      description ? `${providerError}: ${description}` : providerError,
+      await clearOAuthTransaction(config),
+    )
+  }
+
+  const code = url.searchParams.get('code')
+  if (!code) {
+    throw callbackError('Invalid Reef auth callback code', await clearOAuthTransaction(config))
+  }
+
+  const metadata = await authorizationServerMetadata(config)
+  const token = await exchangeAuthorizationCode(metadata, {
+    clientId: transaction.clientId,
+    code,
+    codeVerifier: transaction.codeVerifier,
+    redirectUri: callbackUrl(request, config),
+  })
+  const session = sessionFromToken(token, config)
+  const headers = new Headers()
+  headers.append('Set-Cookie', await clearOAuthTransaction(config))
+  headers.append('Set-Cookie', await commitReefSession(session, config))
+
+  return redirect(transaction.returnTo, { headers })
+}
+
+async function authorizationServerMetadata(
+  config: RequiredAuthConfig,
+): Promise<AuthorizationServerMetadata> {
+  const response = await fetch(authorizationServerMetadataUrl(config.issuer), {
+    headers: { accept: 'application/json' },
+  })
+  if (!response.ok) {
+    throw new Error(`Coral auth metadata request failed with HTTP ${response.status}`)
+  }
+
+  const metadata = (await response.json()) as AuthorizationServerMetadata
+  if (
+    typeof metadata.authorization_endpoint !== 'string' ||
+    typeof metadata.issuer !== 'string' ||
+    typeof metadata.token_endpoint !== 'string'
+  ) {
+    throw new Error('Coral auth metadata is missing required OAuth endpoints')
+  }
+  if (metadata.issuer !== config.issuer) {
+    throw new Error('Coral auth metadata issuer does not match REEF_AUTH_ISSUER')
+  }
+
+  return metadata
+}
+
+async function oauthClientId(
+  metadata: AuthorizationServerMetadata,
+  redirectUri: string,
+  config: RequiredAuthConfig,
+): Promise<string> {
+  if (config.clientId) return config.clientId
+  if (!metadata.registration_endpoint) {
+    throw new Error('Coral auth metadata did not include registration_endpoint')
+  }
+
+  const response = await fetch(metadata.registration_endpoint, {
+    body: JSON.stringify({
+      client_name: 'Coral Reef',
+      grant_types: ['authorization_code'],
+      redirect_uris: [redirectUri],
+      response_types: ['code'],
+      scope: oauthScope(metadata, config),
+      token_endpoint_auth_method: 'none',
+    }),
+    headers: { accept: 'application/json', 'content-type': 'application/json' },
+    method: 'POST',
+  })
+  if (!response.ok) {
+    throw new Error(`Coral OAuth registration failed with HTTP ${response.status}`)
+  }
+  const registration = (await response.json()) as { client_id?: unknown }
+  if (typeof registration.client_id !== 'string' || !registration.client_id) {
+    throw new Error('Coral OAuth registration response did not include client_id')
+  }
+
+  return registration.client_id
+}
+
+async function exchangeAuthorizationCode(
+  metadata: AuthorizationServerMetadata,
+  input: { clientId: string; code: string; codeVerifier: string; redirectUri: string },
+): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    client_id: input.clientId,
+    code: input.code,
+    code_verifier: input.codeVerifier,
+    grant_type: 'authorization_code',
+    redirect_uri: input.redirectUri,
+  })
+  const response = await fetch(metadata.token_endpoint, {
+    body,
+    headers: { accept: 'application/json', 'content-type': 'application/x-www-form-urlencoded' },
+    method: 'POST',
+  })
+  if (!response.ok) {
+    throw new Error(`Coral OAuth token exchange failed with HTTP ${response.status}`)
+  }
+
+  return response.json() as Promise<TokenResponse>
+}
+
+function sessionFromToken(token: TokenResponse, config: RequiredAuthConfig): AuthSession {
+  if (typeof token.access_token !== 'string' || !token.access_token) {
+    throw new Error('Coral OAuth token response did not include access_token')
+  }
+  if (
+    typeof token.expires_in !== 'number' ||
+    !Number.isFinite(token.expires_in) ||
+    token.expires_in <= 0
+  ) {
+    throw new Error('Coral OAuth token response did not include a positive expires_in')
+  }
+
+  return {
+    accessToken: token.access_token,
+    expiresAt: unixTimestamp() + Math.min(token.expires_in, config.sessionMaxAgeSeconds),
+    tokenType:
+      typeof token.token_type === 'string' && token.token_type ? token.token_type : 'Bearer',
+  }
+}
+
+function callbackUrl(request: Request, config: RequiredAuthConfig): string {
+  if (config.redirectUri) return config.redirectUri
+  const url = new URL(request.url)
+  url.pathname = '/auth/callback'
+  url.search = ''
+  url.hash = ''
+  return url.toString()
+}
+
+function oauthScope(metadata: AuthorizationServerMetadata, config: RequiredAuthConfig): string {
+  return config.scope ?? metadata.scopes_supported?.[0] ?? DEFAULT_SCOPE
+}
+
+function safeReturnTo(value: string | null): string {
+  if (!value) return '/'
+  try {
+    const parsed = new URL(value, 'http://reef.local')
+    if (parsed.origin !== 'http://reef.local') return '/'
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+  } catch {
+    return '/'
+  }
+}
+
+function pkceChallenge(codeVerifier: string): string {
+  return createHash('sha256').update(codeVerifier).digest('base64url')
+}
+
+function authorizationServerMetadataUrl(issuer: string): string {
+  const url = new URL(issuer)
+  const issuerPath = url.pathname.replace(/^\/+/, '')
+  url.pathname = `/.well-known/oauth-authorization-server${issuerPath ? `/${issuerPath}` : ''}`
+  return url.toString()
+}
+
+function callbackError(message: string, clearTransaction?: string): Response {
+  const headers = new Headers()
+  if (clearTransaction) headers.set('Set-Cookie', clearTransaction)
+  return new Response(message, {
+    headers,
+    status: 400,
+  })
+}
+
+function unixTimestamp(): number {
+  return Math.floor(Date.now() / 1000)
+}

--- a/apps/reef/app/auth/session.server.test.ts
+++ b/apps/reef/app/auth/session.server.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { commitReefSession, readReefSession } from './session.server'
+import type { RequiredAuthConfig } from './types'
+
+const config: RequiredAuthConfig = {
+  clientId: 'coral-cloud-ui',
+  cookieName: 'reef_session',
+  cookieSecure: true,
+  issuer: 'https://login.example.test',
+  mode: 'required',
+  redirectUri: 'https://reef.example.test/auth/callback',
+  scope: 'coral:mcp',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+
+describe('Reef auth sessions', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('round trips an encrypted server session with secure cookie attributes', async () => {
+    const session = {
+      accessToken: 'coral-access-token',
+      expiresAt: unixTimestamp() + 1800,
+      tokenType: 'Bearer',
+    }
+    const cookie = await commitReefSession(session, config)
+
+    expect(cookie).toContain('reef_session=')
+    expect(cookie).not.toContain('coral-access-token')
+    expect(cookie).toContain('HttpOnly')
+    expect(cookie).toContain('SameSite=Lax')
+    expect(cookie).toContain('Secure')
+    await expect(readReefSession(requestWith(cookie), config)).resolves.toEqual(session)
+  })
+
+  it('keeps a representative opaque access token below the cookie size limit', async () => {
+    const cookie = await commitReefSession(
+      {
+        accessToken: 'a'.repeat(1500),
+        expiresAt: unixTimestamp() + 1800,
+        tokenType: 'Bearer',
+      },
+      config,
+    )
+
+    expect(Buffer.byteLength(cookie)).toBeLessThan(4096)
+    await expect(readReefSession(requestWith(cookie), config)).resolves.toMatchObject({
+      accessToken: 'a'.repeat(1500),
+    })
+  })
+
+  it('ignores absent, malformed, tampered, and expired sessions', async () => {
+    await expect(
+      readReefSession(new Request('https://reef.example.test/'), config),
+    ).resolves.toBeNull()
+    await expect(
+      readReefSession(requestWith('reef_session=not-a-session'), config),
+    ).resolves.toBeNull()
+
+    const cookie = await commitReefSession(
+      { accessToken: 'token', expiresAt: unixTimestamp() + 20, tokenType: 'Bearer' },
+      config,
+    )
+    await expect(readReefSession(requestWith(cookie), config)).resolves.toBeNull()
+
+    const wrongSecret = { ...config, sessionSecret: 'abcdef0123456789abcdef0123456789' }
+    await expect(readReefSession(requestWith(cookie), wrongSecret)).resolves.toBeNull()
+  })
+})
+
+function requestWith(setCookie: string): Request {
+  return new Request('https://reef.example.test/', {
+    headers: { cookie: setCookie.split(';', 1)[0] },
+  })
+}
+
+function unixTimestamp(): number {
+  return Math.floor(Date.now() / 1000)
+}

--- a/apps/reef/app/auth/session.server.ts
+++ b/apps/reef/app/auth/session.server.ts
@@ -1,0 +1,150 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto'
+
+import { createCookie } from 'react-router'
+
+import type { AuthSession, RequiredAuthConfig } from './types'
+
+const OAUTH_COOKIE_NAME = 'reef_oauth'
+const OAUTH_MAX_AGE_SECONDS = 10 * 60
+const CLOCK_SKEW_SECONDS = 30
+
+export interface OAuthTransaction {
+  clientId: string
+  codeVerifier: string
+  returnTo: string
+  state: string
+}
+
+export async function commitOAuthTransaction(
+  transaction: OAuthTransaction,
+  config: RequiredAuthConfig,
+): Promise<string> {
+  return oauthCookie(config).serialize(transaction)
+}
+
+export async function readOAuthTransaction(
+  request: Request,
+  config: RequiredAuthConfig,
+): Promise<OAuthTransaction | null> {
+  const value = await oauthCookie(config).parse(request.headers.get('cookie'))
+  return isOAuthTransaction(value) ? value : null
+}
+
+export async function clearOAuthTransaction(config: RequiredAuthConfig): Promise<string> {
+  return oauthCookie(config).serialize('', { maxAge: 0 })
+}
+
+export async function commitReefSession(
+  session: AuthSession,
+  config: RequiredAuthConfig,
+): Promise<string> {
+  return sessionCookie(config).serialize(encryptSession(session, config.sessionSecret))
+}
+
+export async function readReefSession(
+  request: Request,
+  config: RequiredAuthConfig,
+): Promise<AuthSession | null> {
+  const encrypted = await sessionCookie(config).parse(request.headers.get('cookie'))
+  if (typeof encrypted !== 'string' || !encrypted) return null
+  const session = decryptSession(encrypted, config.sessionSecret)
+  if (!session || session.expiresAt <= unixTimestamp() + CLOCK_SKEW_SECONDS) return null
+
+  return session
+}
+
+export async function clearReefSession(config: RequiredAuthConfig): Promise<string> {
+  return sessionCookie(config).serialize('', { maxAge: 0 })
+}
+
+export function randomToken(byteCount: number): string {
+  return randomBytes(byteCount).toString('base64url')
+}
+
+function oauthCookie(config: RequiredAuthConfig) {
+  return createCookie(OAUTH_COOKIE_NAME, {
+    httpOnly: true,
+    maxAge: OAUTH_MAX_AGE_SECONDS,
+    path: '/',
+    sameSite: 'lax',
+    secrets: [config.sessionSecret],
+    secure: config.cookieSecure,
+  })
+}
+
+function sessionCookie(config: RequiredAuthConfig) {
+  return createCookie(config.cookieName, {
+    httpOnly: true,
+    maxAge: config.sessionMaxAgeSeconds,
+    path: '/',
+    sameSite: 'lax',
+    secrets: [config.sessionSecret],
+    secure: config.cookieSecure,
+  })
+}
+
+function encryptSession(session: AuthSession, secret: string): string {
+  const iv = randomBytes(12)
+  const cipher = createCipheriv('aes-256-gcm', encryptionKey(secret), iv)
+  const ciphertext = Buffer.concat([cipher.update(JSON.stringify(session), 'utf8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+
+  return [iv, tag, ciphertext].map((part) => part.toString('base64url')).join('.')
+}
+
+function decryptSession(value: string, secret: string): AuthSession | null {
+  const [ivPart, tagPart, ciphertextPart] = value.split('.')
+  if (!ivPart || !tagPart || !ciphertextPart) return null
+
+  try {
+    const decipher = createDecipheriv(
+      'aes-256-gcm',
+      encryptionKey(secret),
+      Buffer.from(ivPart, 'base64url'),
+    )
+    decipher.setAuthTag(Buffer.from(tagPart, 'base64url'))
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(ciphertextPart, 'base64url')),
+      decipher.final(),
+    ]).toString('utf8')
+    const session = JSON.parse(plaintext) as unknown
+
+    return isAuthSession(session) ? session : null
+  } catch {
+    return null
+  }
+}
+
+function encryptionKey(secret: string): Buffer {
+  return createHash('sha256').update(secret).digest()
+}
+
+function isOAuthTransaction(value: unknown): value is OAuthTransaction {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<OAuthTransaction>
+
+  return (
+    typeof candidate.clientId === 'string' &&
+    typeof candidate.codeVerifier === 'string' &&
+    typeof candidate.returnTo === 'string' &&
+    typeof candidate.state === 'string'
+  )
+}
+
+function isAuthSession(value: unknown): value is AuthSession {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<AuthSession>
+
+  return (
+    typeof candidate.accessToken === 'string' &&
+    candidate.accessToken.length > 0 &&
+    typeof candidate.expiresAt === 'number' &&
+    Number.isFinite(candidate.expiresAt) &&
+    typeof candidate.tokenType === 'string' &&
+    candidate.tokenType.length > 0
+  )
+}
+
+function unixTimestamp(): number {
+  return Math.floor(Date.now() / 1000)
+}

--- a/apps/reef/app/auth/types.ts
+++ b/apps/reef/app/auth/types.ts
@@ -17,3 +17,9 @@ export interface RequiredAuthConfig {
 }
 
 export type AuthConfig = DisabledAuthConfig | RequiredAuthConfig
+
+export interface AuthSession {
+  accessToken: string
+  expiresAt: number
+  tokenType: string
+}


### PR DESCRIPTION
Constraint: Reef must remain provider-agnostic and the browser must never receive the Coral bearer token.
Rejected: Reusing WorkOS AuthKit or decoding JWT claims | both couple Reef to upstream implementation details.
Confidence: high
Scope-risk: moderate
Directive: Use expires_in or a verified future identity contract; do not add unverified token-claim policy.
Tested: config, OAuth, and session server tests; npm run check --prefix apps/reef; npm run typecheck --prefix apps/reef
Not-tested: Production identity-provider integration is deferred.