### PR TITLE
feat(reef): protect hosted routes without gating local Reef

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -348,6 +348,7 @@ describe('Architectural Tests', () => {
     it('app shell should wrap only top-level app routes', () => {
       const routeConfig = fs.readFileSync(ROUTE_CONFIG_FILE, 'utf-8')
 
+      expect(routeConfig).toContain("layout('routes/_protected.tsx', [")
       expect(routeConfig).toContain(
         "route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts')",
       )
@@ -372,10 +373,9 @@ describe('Architectural Tests', () => {
       expect(routeConfig).toContain("route(routePattern('settings'), 'routes/settings.tsx')")
 
       // Structural check: the same-origin resource route and onboarding stay
-      // outside the app shell, while canonical workspace routes and settings
-      // stay inside it.
+      // outside the app shell while sharing its request authentication boundary.
       expect(routeConfig).toMatch(
-        /export default \[\s*(?:\/\/[^\n]*\n\s*)*route\(`\$\{routePattern\('workspaceSource'\)\}\/oauth-install`, 'routes\/source-oauth-install\.ts'\),\s*route\('onboarding', 'routes\/onboarding\.tsx'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\] satisfies RouteConfig/,
+        /export default \[\s*layout\(\s*'routes\/_protected\.tsx',\s*\[\s*(?:\/\/[^\n]*\n\s*)*route\(`\$\{routePattern\('workspaceSource'\)\}\/oauth-install`, 'routes\/source-oauth-install\.ts'\),\s*route\('onboarding', 'routes\/onboarding\.tsx'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\]\s*\),?\s*\] satisfies RouteConfig/,
       )
     })
 

--- a/apps/reef/app/auth/server-context.ts
+++ b/apps/reef/app/auth/server-context.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react-router'
+
+import type { RequestAuth } from './types'
+
+export const requestAuthContext = createContext<RequestAuth>()

--- a/apps/reef/app/auth/types.ts
+++ b/apps/reef/app/auth/types.ts
@@ -23,3 +23,7 @@ export interface AuthSession {
   expiresAt: number
   tokenType: string
 }
+
+export type RequestAuth =
+  | { accessToken: null; mode: 'disabled' }
+  | { accessToken: string; mode: 'required'; session: AuthSession }

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -7,24 +7,26 @@ import { routePattern } from './routing/routemap'
 const isDesktopApp = process.env.CORAL_DESKTOP_APP === '1'
 
 export default [
-  // Action-only resource route: OAuth/device-code install streams progress over
-  // same-origin fetch. It intentionally sits outside the app shell and does not
-  // render a page.
-  route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts'),
-  route('onboarding', 'routes/onboarding.tsx'),
-  layout('routes/app-shell.tsx', [
-    index('routes/index.tsx'),
-    route(routePattern('workspaces'), 'routes/workspaces-action.ts'),
-    route(routePattern('workspaceSources'), 'routes/sources.tsx', [
-      route(':sourceName', 'routes/source-detail.tsx'),
+  layout('routes/_protected.tsx', [
+    // Action-only resource route: OAuth/device-code install streams progress over
+    // same-origin fetch. It and onboarding share the auth boundary but do not
+    // render the app shell.
+    route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts'),
+    route('onboarding', 'routes/onboarding.tsx'),
+    layout('routes/app-shell.tsx', [
+      index('routes/index.tsx'),
+      route(routePattern('workspaces'), 'routes/workspaces-action.ts'),
+      route(routePattern('workspaceSources'), 'routes/sources.tsx', [
+        route(':sourceName', 'routes/source-detail.tsx'),
+      ]),
+      route(routePattern('workspaceSchema'), 'routes/schema.tsx', [
+        index('routes/schema-empty.tsx'),
+        route(':schemaName/:tableName', 'routes/schema-table.tsx'),
+      ]),
+      route(routePattern('workspaceTraces'), 'routes/traces.tsx', [
+        route(':traceId', 'routes/trace-detail.tsx'),
+      ]),
+      ...(isDesktopApp ? [route(routePattern('settings'), 'routes/settings.tsx')] : []),
     ]),
-    route(routePattern('workspaceSchema'), 'routes/schema.tsx', [
-      index('routes/schema-empty.tsx'),
-      route(':schemaName/:tableName', 'routes/schema-table.tsx'),
-    ]),
-    route(routePattern('workspaceTraces'), 'routes/traces.tsx', [
-      route(':traceId', 'routes/trace-detail.tsx'),
-    ]),
-    ...(isDesktopApp ? [route(routePattern('settings'), 'routes/settings.tsx')] : []),
   ]),
 ] satisfies RouteConfig

--- a/apps/reef/app/routes/_protected.server.test.tsx
+++ b/apps/reef/app/routes/_protected.server.test.tsx
@@ -1,0 +1,234 @@
+import { createRequestHandler, RouterContextProvider, type ServerBuild } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RequiredAuthConfig } from '@/auth/types'
+
+const authMocks = vi.hoisted(() => ({
+  clearReefSession: vi.fn(async () => 'reef_session=; Max-Age=0; Path=/; HttpOnly'),
+  readReefSession: vi.fn(),
+  reefAuthConfig: vi.fn(),
+}))
+
+vi.mock('@/auth/config.server', () => ({ reefAuthConfig: authMocks.reefAuthConfig }))
+vi.mock('@/auth/session.server', () => ({
+  clearReefSession: authMocks.clearReefSession,
+  readReefSession: authMocks.readReefSession,
+}))
+
+import { requestAuthContext } from '@/auth/server-context'
+
+import { middleware } from './_protected'
+
+const requiredConfig: RequiredAuthConfig = {
+  clientId: 'coral-cloud-ui',
+  cookieName: 'reef_session',
+  cookieSecure: true,
+  issuer: 'https://login.example.test',
+  mode: 'required',
+  redirectUri: 'https://reef.example.test/auth/callback',
+  scope: 'coral:mcp',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+const session = {
+  accessToken: 'server-only-token',
+  expiresAt: 4_102_444_800,
+  tokenType: 'Bearer',
+}
+const descendantLoader = vi.fn(() => ({ ok: true }))
+const descendantAction = vi.fn(() => ({ ok: true }))
+const routeComponent = () => null
+
+const handlerBuild = {
+  assets: {
+    entry: { imports: [], module: '' },
+    routes: {},
+    url: '',
+    version: '',
+  },
+  assetsBuildDirectory: '',
+  basename: '/',
+  entry: {
+    module: {
+      default: async () => new Response('document'),
+    },
+  },
+  future: {
+    v8_middleware: true,
+    v8_passThroughRequests: false,
+    v8_trailingSlashAwareDataRequests: false,
+  },
+  isSpaMode: false,
+  prerender: [],
+  publicPath: '/',
+  routeDiscovery: { manifestPath: '/__manifest', mode: 'lazy' },
+  routes: {
+    root: {
+      id: 'root',
+      module: { default: routeComponent },
+      path: '',
+    },
+    'routes/_protected': {
+      id: 'routes/_protected',
+      module: { default: routeComponent, middleware },
+      parentId: 'root',
+    },
+    'routes/protected': {
+      id: 'routes/protected',
+      module: {
+        action: descendantAction,
+        default: routeComponent,
+        loader: descendantLoader,
+      },
+      parentId: 'routes/_protected',
+      path: 'protected',
+    },
+  },
+  ssr: true,
+} as unknown as ServerBuild
+
+describe('optional auth boundary', () => {
+  beforeEach(() => {
+    authMocks.clearReefSession.mockClear()
+    authMocks.readReefSession.mockReset()
+    authMocks.reefAuthConfig.mockReset()
+    descendantAction.mockClear()
+    descendantLoader.mockClear()
+  })
+
+  it('is a true no-op for disabled local and desktop requests', async () => {
+    authMocks.reefAuthConfig.mockReturnValue({ mode: 'disabled' })
+    const context = new RouterContextProvider()
+    const response = new Response('local app')
+    const next = vi.fn(async () => response)
+
+    await expect(runMiddleware(new Request('http://localhost:5173/'), next, context)).resolves.toBe(
+      response,
+    )
+    expect(next).toHaveBeenCalledOnce()
+    expect(authMocks.readReefSession).not.toHaveBeenCalled()
+    expect(authMocks.clearReefSession).not.toHaveBeenCalled()
+    expect(context.get(requestAuthContext)).toEqual({ accessToken: null, mode: 'disabled' })
+    expect(response.headers.has('Cache-Control')).toBe(false)
+  })
+
+  it.each([
+    ['document', 'GET', 'https://reef.example.test/workspaces/analytics/sources'],
+    ['data', 'GET', 'https://reef.example.test/workspaces/analytics/sources.data?index'],
+    ['action', 'POST', 'https://reef.example.test/workspaces'],
+    ['resource action', 'POST', 'https://reef.example.test/sources/github/oauth-install'],
+  ])(
+    'redirects an anonymous required-auth %s request before descendants',
+    async (_, method, url) => {
+      authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+      authMocks.readReefSession.mockResolvedValue(null)
+      const next = vi.fn()
+
+      const thrown = await runMiddleware(new Request(url, { method }), next).catch(
+        (error: unknown) => error,
+      )
+
+      expect(thrown).toBeInstanceOf(Response)
+      expect((thrown as Response).status).toBe(302)
+      const requested = new URL(url)
+      expect((thrown as Response).headers.get('location')).toBe(
+        `/login?returnTo=${encodeURIComponent(`${requested.pathname}${requested.search}`)}`,
+      )
+      expectPrivate(thrown as Response)
+      expect(next).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([
+    ['document', 'GET', '/protected'],
+    ['data loader', 'GET', '/protected.data'],
+    ['data action', 'POST', '/protected.data'],
+  ])(
+    'blocks anonymous required-auth %s requests in the React Router handler',
+    async (_, method, pathname) => {
+      authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+      authMocks.readReefSession.mockResolvedValue(null)
+      const handleRequest = createRequestHandler(handlerBuild, 'test')
+
+      const response = await handleRequest(
+        new Request(`https://reef.example.test${pathname}`, { method }),
+      )
+
+      const routedPathname = pathname.replace(/\.data$/, '')
+      const loginLocation = `/login?returnTo=${encodeURIComponent(routedPathname)}`
+      if (pathname.endsWith('.data')) {
+        expect(response.status).toBe(202)
+        expect(await response.text()).toContain(loginLocation)
+      } else {
+        expect(response.status).toBe(302)
+        expect(response.headers.get('location')).toBe(loginLocation)
+      }
+      expect(descendantLoader).not.toHaveBeenCalled()
+      expect(descendantAction).not.toHaveBeenCalled()
+    },
+  )
+
+  it('clears an unreadable session cookie on the login redirect', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(null)
+
+    const thrown = await runMiddleware(
+      new Request('https://reef.example.test/', {
+        headers: { cookie: 'other=value; reef_session=unreadable' },
+      }),
+      vi.fn(),
+    ).catch((error: unknown) => error)
+
+    expect(authMocks.clearReefSession).toHaveBeenCalledWith(requiredConfig)
+    expect((thrown as Response).headers.get('Set-Cookie')).toContain('Max-Age=0')
+  })
+
+  it('keeps the token only in server request context', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(session)
+    const context = new RouterContextProvider()
+
+    await runMiddleware(
+      new Request('https://reef.example.test/workspaces/analytics/sources'),
+      async () => new Response('hosted app'),
+      context,
+    )
+
+    expect(context.get(requestAuthContext)).toEqual({
+      accessToken: 'server-only-token',
+      mode: 'required',
+      session,
+    })
+  })
+
+  it('marks normal and thrown hosted responses private and non-cacheable', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(session)
+
+    const response = await runMiddleware(
+      new Request('https://reef.example.test/'),
+      async () => new Response('ok'),
+    )
+    expectPrivate(response)
+
+    const childRedirect = new Response(null, { headers: { location: '/elsewhere' }, status: 302 })
+    const thrown = await runMiddleware(new Request('https://reef.example.test/'), async () => {
+      throw childRedirect
+    }).catch((error: unknown) => error)
+    expect(thrown).toBe(childRedirect)
+    expectPrivate(thrown as Response)
+  })
+})
+
+async function runMiddleware(
+  request: Request,
+  next: () => Promise<Response>,
+  context = new RouterContextProvider(),
+): Promise<Response> {
+  return (await middleware[0]({ context, params: {}, request } as never, next)) as Response
+}
+
+function expectPrivate(response: Response): void {
+  expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+  expect(response.headers.get('Vary')).toContain('Cookie')
+}

--- a/apps/reef/app/routes/_protected.tsx
+++ b/apps/reef/app/routes/_protected.tsx
@@ -1,0 +1,68 @@
+import { Outlet, redirect } from 'react-router'
+
+import type { Route } from './+types/_protected'
+
+import { reefAuthConfig } from '@/auth/config.server'
+import { requestAuthContext } from '@/auth/server-context'
+import { clearReefSession, readReefSession } from '@/auth/session.server'
+import type { RequiredAuthConfig } from '@/auth/types'
+
+const PRIVATE_RESPONSE_HEADERS = {
+  'Cache-Control': 'private, no-store',
+  Vary: 'Cookie',
+} as const
+
+export const middleware: Route.MiddlewareFunction[] = [
+  async ({ context, request }, next) => {
+    const config = reefAuthConfig()
+
+    if (config.mode === 'disabled') {
+      context.set(requestAuthContext, { accessToken: null, mode: 'disabled' })
+      return next()
+    }
+
+    const session = await readReefSession(request, config)
+    if (!session) throw await loginRedirect(request, config)
+    context.set(requestAuthContext, {
+      accessToken: session.accessToken,
+      mode: 'required',
+      session,
+    })
+
+    try {
+      const response = await next()
+      applyPrivateHeaders(response)
+      return response
+    } catch (error) {
+      if (error instanceof Response) applyPrivateHeaders(error)
+      throw error
+    }
+  },
+]
+
+export default function Protected() {
+  return <Outlet />
+}
+
+async function loginRedirect(request: Request, config: RequiredAuthConfig): Promise<Response> {
+  const url = new URL(request.url)
+  const returnTo = `${url.pathname}${url.search}`
+  const headers = new Headers()
+  if (hasSessionCookie(request, config.cookieName)) {
+    headers.append('Set-Cookie', await clearReefSession(config))
+  }
+
+  const response = redirect(`/login?returnTo=${encodeURIComponent(returnTo)}`, { headers })
+  applyPrivateHeaders(response)
+  return response
+}
+
+function hasSessionCookie(request: Request, name: string): boolean {
+  const cookie = request.headers.get('cookie')
+  return cookie?.split(';').some((part) => part.trim().startsWith(`${name}=`)) ?? false
+}
+
+function applyPrivateHeaders(response: Response): void {
+  response.headers.set('Cache-Control', PRIVATE_RESPONSE_HEADERS['Cache-Control'])
+  response.headers.append('Vary', PRIVATE_RESPONSE_HEADERS.Vary)
+}


### PR DESCRIPTION
Constraint: The same route tree must bypass auth for desktop/local while guarding documents, data requests, actions, and resource routes when hosted auth is required.
Rejected: Client-side auth effects | they cause hydration flashes and cannot guard server actions or resource routes.
Confidence: high
Scope-risk: moderate
Directive: Keep every server resource route that touches Coral beneath the auth boundary.
Tested: npm run check --prefix apps/reef; npm run typecheck --prefix apps/reef; npm test --prefix apps/reef (83 files, 352 tests); npm run build --prefix apps/reef; client secret scan
Not-tested: Production identity-provider integration and desktop packaged smoke testing are deferred.