### PR TITLE
chore(github): minimise CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,21 +1,2 @@
-# Ownership policy, CI, release, build, and repo automation.
-/.github/ @withcoral/core-maintainers
-/.github/CODEOWNERS @withcoral/core-maintainers
-/release-please-config.json @withcoral/core-maintainers
-/.release-please-manifest.json @withcoral/core-maintainers
-/Makefile @withcoral/core-maintainers
-/rust-toolchain.toml @withcoral/core-maintainers
-/Cargo.toml @withcoral/core-maintainers
-
-# Project docs.
-/CONTRIBUTING.md @withcoral/core-maintainers
-/LICENSE @withcoral/core-maintainers
-/README.md @withcoral/core-maintainers
-/SECURITY.md @withcoral/core-maintainers
-AGENTS.md @withcoral/core-maintainers
-
-# User docs.
-/apps/docs/ @withcoral/docs
-
-# Sources
+# Community sources
 /sources/community/ @jsummerfield

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,10 @@
   See `apps/docs/AGENTS.md` for the full publishing model.
 - Keep checked-in generated files marked in `.gitattributes` with
   `linguist-generated` so GitHub collapses them by default in PR diffs.
+- Keep `.github/CODEOWNERS` limited to paths that intentionally require
+  automatic review assignment. The community source catalog is explicitly
+  owned by `@jsummerfield`; do not infer broad ownership from crate or team
+  boundaries.
 - Source inputs that carry credentials must be `kind: secret`, never
   `kind: variable`. This includes API keys, bearer tokens, access tokens,
   passwords, private keys, authorization header values, and admin/read keys,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,10 +119,6 @@
   See `apps/docs/AGENTS.md` for the full publishing model.
 - Keep checked-in generated files marked in `.gitattributes` with
   `linguist-generated` so GitHub collapses them by default in PR diffs.
-- Keep `.github/CODEOWNERS` limited to paths that intentionally require
-  automatic review assignment. The community source catalog is explicitly
-  owned by `@jsummerfield`; do not infer broad ownership from crate or team
-  boundaries.
 - Source inputs that carry credentials must be `kind: secret`, never
   `kind: variable`. This includes API keys, bearer tokens, access tokens,
   passwords, private keys, authorization header values, and admin/read keys,


### PR DESCRIPTION
Replace CODEOWNERS with trust. Keep community source assignment to me for the review workflow.