### PR TITLE
feat(engine): lazy per-source column metadata for coral.columns

### DIFF
--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -31,7 +31,8 @@ message PaginationResponse {
 message Column {
   // The column name as exposed by the query engine.
   string name = 1;
-  // The DataFusion/Arrow data type rendered as text.
+  // The column data type rendered as text: DataFusion/Arrow form for static
+  // sources, the provider-native type name for database catalogs.
   string data_type = 2;
   // Whether the column can contain null values.
   bool nullable = 3;

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -312,7 +312,7 @@ impl CatalogDiscovery {
         query: ListColumnsQuery<'_>,
         attribution: &QueryAttribution,
     ) -> Result<Option<Page<ColumnSearchResult>>, QueryManagerError> {
-        let table = self
+        let mut matches = self
             .queries
             .list_tables(
                 workspace_name,
@@ -323,8 +323,22 @@ impl CatalogDiscovery {
             )
             .await?
             .into_iter()
-            .find(|table| table_matches_ref(table, query.table_ref));
-        let Some(table) = table else {
+            .filter(|table| table_matches_ref(table, query.table_ref))
+            .collect::<Vec<_>>();
+        // An omitted catalog is a wildcard; refuse to guess when the same
+        // schema.table pair exists in more than one catalog.
+        if matches.len() > 1 {
+            let candidates = matches
+                .iter()
+                .map(|table| format!("`{}`", table_addressable_name(table)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(QueryManagerError::App(AppError::InvalidInput(format!(
+                "table reference `{}.{}` is ambiguous; qualify the catalog: {candidates}",
+                query.table_ref.schema_name, query.table_ref.table_name
+            ))));
+        }
+        let Some(table) = matches.pop() else {
             return Ok(None);
         };
 
@@ -600,9 +614,23 @@ fn table_matches_ref(table: &TableInfo, table_ref: CatalogTableRef<'_>) -> bool 
     table.table_name == table_ref.table_name && table_qualifier_matches(table, table_ref)
 }
 
+/// An omitted catalog is a wildcard, matching the engine's catalog-filter
+/// semantics and `describe_table`'s behavior; a supplied catalog is strict.
+/// A dotted schema with no catalog also matches its `catalog.schema` reading,
+/// so the compound names advertised in miss-hints replay verbatim. Callers
+/// that resolve a single table reject wildcard matches spanning more than one
+/// catalog instead of guessing.
 fn table_qualifier_matches(table: &TableInfo, table_ref: CatalogTableRef<'_>) -> bool {
-    table.catalog_name == table_ref.catalog_name.unwrap_or_default()
-        && table.schema_name == table_ref.schema_name
+    match table_ref.catalog_name {
+        Some(catalog_name) => {
+            table.catalog_name == catalog_name && table.schema_name == table_ref.schema_name
+        }
+        None => {
+            table.schema_name == table_ref.schema_name
+                || (!table.catalog_name.is_empty()
+                    && table_addressable_schema_name(table) == table_ref.schema_name)
+        }
+    }
 }
 
 pub(crate) fn page_items<T>(items: Vec<T>, pagination: Pagination) -> Page<T> {
@@ -693,6 +721,28 @@ mod tests {
             main_table,
             CatalogTableRef::new(Some("coral_db"), "analytics", "users")
         ));
+        assert!(
+            table_matches_ref(main_table, CatalogTableRef::new(None, "main", "users")),
+            "an omitted catalog is a wildcard, matching describe_table"
+        );
+        assert!(
+            table_matches_ref(
+                main_table,
+                CatalogTableRef::new(None, "coral_db.main", "users")
+            ),
+            "advertised compound schema hints must replay verbatim"
+        );
+        assert!(!table_matches_ref(
+            main_table,
+            CatalogTableRef::new(Some("other_db"), "main", "users")
+        ));
+        assert!(
+            !table_matches_ref(
+                main_table,
+                CatalogTableRef::new(Some("coral_db"), "coral_db.main", "users")
+            ),
+            "an explicit catalog keeps the schema comparison strict"
+        );
         assert_eq!(
             table_matched_fields(
                 main_table,

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -132,6 +132,48 @@ pub(crate) struct BackendCatalogRegistration {
     pub(crate) catalog_name: String,
     pub(crate) catalog: Arc<dyn CatalogProvider>,
     pub(crate) source: RegisteredSource,
+    pub(crate) column_fetcher: Arc<dyn DatabaseColumnFetcher>,
+}
+
+/// Row-set restriction for one lazy database column-metadata fetch.
+///
+/// `None` means "no restriction on this dimension"; `Some` restricts the
+/// remote query to the listed values. An empty list matches nothing.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ColumnInventoryFilter {
+    pub(crate) schemas: Option<Vec<String>>,
+    pub(crate) tables: Option<Vec<String>>,
+}
+
+/// One column described by a remote database's own catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DatabaseColumnRow {
+    pub(crate) schema_name: String,
+    pub(crate) table_name: String,
+    pub(crate) ordinal_position: i32,
+    pub(crate) column_name: String,
+    pub(crate) data_type: String,
+    pub(crate) is_nullable: bool,
+}
+
+/// Query-time source of column metadata for one registered database catalog.
+///
+/// Fetches answer from the remote database's catalog (`information_schema`,
+/// `pragma_table_info`) in one round trip per call, so `coral.columns` cost
+/// scales with source count instead of table count.
+#[async_trait]
+pub(crate) trait DatabaseColumnFetcher: std::fmt::Debug + Send + Sync {
+    async fn fetch_columns(
+        &self,
+        filter: &ColumnInventoryFilter,
+    ) -> datafusion::error::Result<Vec<DatabaseColumnRow>>;
+}
+
+/// Pairs a registered catalog name with its lazy column fetcher.
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogColumnFetcher {
+    pub(crate) catalog_name: String,
+    pub(crate) fetcher: Arc<dyn DatabaseColumnFetcher>,
 }
 
 pub(crate) struct BackendCompileRequest<'a> {

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -173,6 +173,12 @@ pub(crate) trait DatabaseColumnFetcher: std::fmt::Debug + Send + Sync {
 #[derive(Debug, Clone)]
 pub(crate) struct CatalogColumnFetcher {
     pub(crate) catalog_name: String,
+    /// Schema and table names captured from the registration-time relation
+    /// snapshot. Used only to prune fetches whose pins cannot match this
+    /// catalog (e.g. a static-table describe never contacts a database);
+    /// answers always come from the live fetch, never from these sets.
+    pub(crate) schema_names: BTreeSet<String>,
+    pub(crate) table_names: BTreeSet<String>,
     pub(crate) fetcher: Arc<dyn DatabaseColumnFetcher>,
 }
 

--- a/crates/coral-engine/src/backends/database/columns.rs
+++ b/crates/coral-engine/src/backends/database/columns.rs
@@ -18,13 +18,14 @@ use crate::backends::{ColumnInventoryFilter, DatabaseColumnFetcher, DatabaseColu
 
 /// Normalized inventory queries. Every provider projects the same six Utf8
 /// columns so one Arrow schema and one row parser serve all of them:
-/// `schema_name`, `table_name`, `ordinal_position` (1-based, as text),
+/// `schema_name`, `table_name`, `ordinal_position` (zero-based, as text,
+/// matching the `coral.columns` contract),
 /// `column_name`, `data_type` (provider-native name), `is_nullable`
 /// ('true'/'false').
 pub(super) const POSTGRES_COLUMNS_SQL: &str = "
 SELECT table_schema AS schema_name,
        table_name,
-       CAST(ordinal_position AS TEXT) AS ordinal_position,
+       CAST(ordinal_position - 1 AS TEXT) AS ordinal_position,
        column_name,
        data_type,
        CASE WHEN is_nullable = 'YES' THEN 'true' ELSE 'false' END AS is_nullable
@@ -34,7 +35,7 @@ WHERE table_schema NOT IN ('pg_catalog', 'information_schema')";
 pub(super) const MYSQL_COLUMNS_SQL: &str = "
 SELECT TABLE_SCHEMA AS schema_name,
        TABLE_NAME AS table_name,
-       CAST(ORDINAL_POSITION AS CHAR) AS ordinal_position,
+       CAST(ORDINAL_POSITION - 1 AS CHAR) AS ordinal_position,
        COLUMN_NAME AS column_name,
        DATA_TYPE AS data_type,
        CASE WHEN IS_NULLABLE = 'YES' THEN 'true' ELSE 'false' END AS is_nullable
@@ -44,7 +45,7 @@ WHERE TABLE_SCHEMA NOT IN ('information_schema', 'mysql', 'performance_schema', 
 pub(super) const SQLITE_COLUMNS_SQL: &str = "
 SELECT 'main' AS schema_name,
        m.name AS table_name,
-       CAST(p.cid + 1 AS TEXT) AS ordinal_position,
+       CAST(p.cid AS TEXT) AS ordinal_position,
        p.name AS column_name,
        CASE WHEN p.type = '' THEN 'unknown' ELSE p.type END AS data_type,
        CASE WHEN p.\"notnull\" = 0 THEN 'true' ELSE 'false' END AS is_nullable
@@ -305,14 +306,14 @@ mod tests {
         assert_eq!(
             described,
             [
-                "main.named_users.name:1",
-                "main.orders.order_id:1",
-                "main.orders.user_id:2",
-                "main.orders.note:3",
-                "main.users.id:1",
-                "main.users.name:2",
+                "main.named_users.name:0",
+                "main.orders.order_id:0",
+                "main.orders.user_id:1",
+                "main.orders.note:2",
+                "main.users.id:0",
+                "main.users.name:1",
             ],
-            "inventory should cover tables and views with 1-based ordinals"
+            "inventory should cover tables and views with zero-based ordinals"
         );
 
         let name = rows

--- a/crates/coral-engine/src/backends/database/columns.rs
+++ b/crates/coral-engine/src/backends/database/columns.rs
@@ -1,0 +1,368 @@
+//! Lazy column-metadata inventory for relational database sources.
+//!
+//! Each provider answers column metadata from its own catalog
+//! (`information_schema.columns`, `pragma_table_info`) in a single round
+//! trip, instead of probing every table's Arrow schema individually.
+
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion_table_providers::sql::db_connection_pool::dbconnection::query_arrow;
+use futures::TryStreamExt as _;
+
+use crate::backends::database::{Pool, boxed_provider_error, database_inventory_column};
+use crate::backends::{ColumnInventoryFilter, DatabaseColumnFetcher, DatabaseColumnRow};
+
+/// Normalized inventory queries. Every provider projects the same six Utf8
+/// columns so one Arrow schema and one row parser serve all of them:
+/// `schema_name`, `table_name`, `ordinal_position` (1-based, as text),
+/// `column_name`, `data_type` (provider-native name), `is_nullable`
+/// ('true'/'false').
+pub(super) const POSTGRES_COLUMNS_SQL: &str = "
+SELECT table_schema AS schema_name,
+       table_name,
+       CAST(ordinal_position AS TEXT) AS ordinal_position,
+       column_name,
+       data_type,
+       CASE WHEN is_nullable = 'YES' THEN 'true' ELSE 'false' END AS is_nullable
+FROM information_schema.columns
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')";
+
+pub(super) const MYSQL_COLUMNS_SQL: &str = "
+SELECT TABLE_SCHEMA AS schema_name,
+       TABLE_NAME AS table_name,
+       CAST(ORDINAL_POSITION AS CHAR) AS ordinal_position,
+       COLUMN_NAME AS column_name,
+       DATA_TYPE AS data_type,
+       CASE WHEN IS_NULLABLE = 'YES' THEN 'true' ELSE 'false' END AS is_nullable
+FROM INFORMATION_SCHEMA.COLUMNS
+WHERE TABLE_SCHEMA NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')";
+
+pub(super) const SQLITE_COLUMNS_SQL: &str = "
+SELECT 'main' AS schema_name,
+       m.name AS table_name,
+       CAST(p.cid + 1 AS TEXT) AS ordinal_position,
+       p.name AS column_name,
+       CASE WHEN p.type = '' THEN 'unknown' ELSE p.type END AS data_type,
+       CASE WHEN p.\"notnull\" = 0 THEN 'true' ELSE 'false' END AS is_nullable
+FROM sqlite_master AS m
+JOIN pragma_table_info(m.name) AS p
+WHERE m.type IN ('table', 'view') AND m.name NOT LIKE 'sqlite_%'";
+
+/// [`DatabaseColumnFetcher`] backed by a connection pool and one of the
+/// provider inventory queries above.
+pub(super) struct PooledColumnFetcher<T: 'static, P: 'static> {
+    pool: Pool<T, P>,
+    base_sql: &'static str,
+}
+
+impl<T: 'static, P: 'static> PooledColumnFetcher<T, P> {
+    pub(super) fn new(pool: &Pool<T, P>, base_sql: &'static str) -> Arc<Self> {
+        Arc::new(Self {
+            pool: Arc::clone(pool),
+            base_sql,
+        })
+    }
+}
+
+impl<T: 'static, P: 'static> fmt::Debug for PooledColumnFetcher<T, P> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PooledColumnFetcher")
+            .field("base_sql", &self.base_sql)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl<T: 'static, P: 'static> DatabaseColumnFetcher for PooledColumnFetcher<T, P> {
+    async fn fetch_columns(
+        &self,
+        filter: &ColumnInventoryFilter,
+    ) -> DataFusionResult<Vec<DatabaseColumnRow>> {
+        if filter_matches_nothing(filter) {
+            return Ok(Vec::new());
+        }
+        let sql = compose_columns_sql(self.base_sql, filter);
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("schema_name", DataType::Utf8, false),
+            Field::new("table_name", DataType::Utf8, false),
+            Field::new("ordinal_position", DataType::Utf8, false),
+            Field::new("column_name", DataType::Utf8, false),
+            Field::new("data_type", DataType::Utf8, false),
+            Field::new("is_nullable", DataType::Utf8, false),
+        ]));
+        let connection = self.pool.connect().await.map_err(boxed_provider_error)?;
+        let batches = query_arrow(connection, sql, Some(schema))
+            .await
+            .map_err(|error| DataFusionError::External(Box::new(error)))?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let mut rows = Vec::new();
+        for batch in batches {
+            let schema_names = database_inventory_column(&batch, "schema_name")?;
+            let table_names = database_inventory_column(&batch, "table_name")?;
+            let ordinals = database_inventory_column(&batch, "ordinal_position")?;
+            let column_names = database_inventory_column(&batch, "column_name")?;
+            let data_types = database_inventory_column(&batch, "data_type")?;
+            let nullables = database_inventory_column(&batch, "is_nullable")?;
+            for row in 0..batch.num_rows() {
+                rows.push(DatabaseColumnRow {
+                    schema_name: schema_names.value(row).to_string(),
+                    table_name: table_names.value(row).to_string(),
+                    ordinal_position: parse_ordinal(ordinals.value(row))?,
+                    column_name: column_names.value(row).to_string(),
+                    data_type: data_types.value(row).to_string(),
+                    is_nullable: nullables.value(row) == "true",
+                });
+            }
+        }
+        rows.sort_by(|left, right| {
+            (&left.schema_name, &left.table_name, left.ordinal_position).cmp(&(
+                &right.schema_name,
+                &right.table_name,
+                right.ordinal_position,
+            ))
+        });
+        Ok(rows)
+    }
+}
+
+fn parse_ordinal(value: &str) -> DataFusionResult<i32> {
+    value.trim().parse::<i32>().map_err(|_parse_error| {
+        DataFusionError::Execution(format!(
+            "database column inventory returned non-integer ordinal_position '{value}'"
+        ))
+    })
+}
+
+fn filter_matches_nothing(filter: &ColumnInventoryFilter) -> bool {
+    filter.schemas.as_ref().is_some_and(Vec::is_empty)
+        || filter.tables.as_ref().is_some_and(Vec::is_empty)
+}
+
+/// Wraps the base inventory query with the caller's schema/table restriction.
+/// The subquery aliases every provider's columns to a common shape, so the
+/// outer predicates are provider-independent.
+///
+/// Restrictions are pruning-only (the engine re-applies exact predicates
+/// above the scan), so a dimension whose values cannot be embedded verbatim
+/// is fetched unfiltered instead of escaped: dropping a whole restriction
+/// fetches more rows and stays correct, while embedding a hostile value
+/// would hand attacker-controlled SQL to the remote database (`MySQL`'s
+/// default `sql_mode` treats `\` as a string escape, so quote-doubling
+/// alone is not a safe quoting strategy there).
+fn compose_columns_sql(base_sql: &str, filter: &ColumnInventoryFilter) -> String {
+    let mut predicates = Vec::new();
+    if let Some(schemas) = filter.schemas.as_ref()
+        && values_embed_safely(schemas)
+    {
+        predicates.push(format!("schema_name IN ({})", sql_string_list(schemas)));
+    }
+    if let Some(tables) = filter.tables.as_ref()
+        && values_embed_safely(tables)
+    {
+        predicates.push(format!("table_name IN ({})", sql_string_list(tables)));
+    }
+    if predicates.is_empty() {
+        return base_sql.to_string();
+    }
+    format!(
+        "SELECT * FROM ({base_sql}\n) AS columns_inventory WHERE {}",
+        predicates.join(" AND ")
+    )
+}
+
+/// Whether every value can sit inside a single-quoted SQL literal without any
+/// escaping, across all supported providers' string-literal dialects.
+fn values_embed_safely(values: &[String]) -> bool {
+    values
+        .iter()
+        .all(|value| !value.contains('\'') && !value.contains('\\') && !value.contains('\0'))
+}
+
+fn sql_string_list(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|value| format!("'{value}'"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use datafusion_table_providers::sql::db_connection_pool::Mode;
+    use datafusion_table_providers::sql::db_connection_pool::sqlitepool::SqliteConnectionPoolFactory;
+
+    use super::*;
+
+    #[test]
+    fn compose_columns_sql_without_filter_returns_base() {
+        let filter = ColumnInventoryFilter::default();
+        assert_eq!(
+            compose_columns_sql("SELECT 1", &filter),
+            "SELECT 1".to_string()
+        );
+    }
+
+    #[test]
+    fn compose_columns_sql_combines_safe_predicates() {
+        let filter = ColumnInventoryFilter {
+            schemas: Some(vec!["main".to_string()]),
+            tables: Some(vec!["users".to_string(), "orders".to_string()]),
+        };
+        let sql = compose_columns_sql("SELECT 1", &filter);
+        assert_eq!(
+            sql,
+            "SELECT * FROM (SELECT 1\n) AS columns_inventory \
+             WHERE schema_name IN ('main') AND table_name IN ('users', 'orders')"
+        );
+    }
+
+    #[test]
+    fn compose_columns_sql_drops_dimensions_it_cannot_embed_verbatim() {
+        // Values with quote/backslash/NUL never reach the remote SQL text —
+        // the whole dimension falls back to an unfiltered fetch (pruning-only
+        // semantics keep results correct), so injection shapes like a
+        // trailing backslash (MySQL escape) cannot smuggle SQL.
+        for hostile in ["o'brien", "x\\", "x' UNION SELECT 1 --", "x\0"] {
+            let filter = ColumnInventoryFilter {
+                schemas: Some(vec!["main".to_string()]),
+                tables: Some(vec!["users".to_string(), hostile.to_string()]),
+            };
+            let sql = compose_columns_sql("SELECT 1", &filter);
+            assert_eq!(
+                sql,
+                "SELECT * FROM (SELECT 1\n) AS columns_inventory \
+                 WHERE schema_name IN ('main')",
+                "hostile table value {hostile:?} must drop the table restriction"
+            );
+        }
+
+        let filter = ColumnInventoryFilter {
+            schemas: Some(vec!["ma'in".to_string()]),
+            tables: None,
+        };
+        assert_eq!(
+            compose_columns_sql("SELECT 1", &filter),
+            "SELECT 1",
+            "hostile schema value with no other predicate returns the base query"
+        );
+    }
+
+    async fn sqlite_fetcher(db_path: &std::path::Path) -> Arc<dyn DatabaseColumnFetcher> {
+        let pool = SqliteConnectionPoolFactory::new(
+            &db_path.to_string_lossy(),
+            Mode::File,
+            Duration::from_secs(5),
+        )
+        .build()
+        .await
+        .expect("sqlite pool");
+        let pool: Pool<_, _> = Arc::new(pool);
+        PooledColumnFetcher::new(&pool, SQLITE_COLUMNS_SQL)
+    }
+
+    fn sqlite_fixture(dir: &std::path::Path) -> std::path::PathBuf {
+        let db_path = dir.join("columns.sqlite");
+        let conn = rusqlite::Connection::open(&db_path).expect("sqlite db");
+        conn.execute_batch(
+            "
+            CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+            CREATE TABLE orders (order_id INTEGER PRIMARY KEY, user_id INTEGER, note TEXT);
+            CREATE VIEW named_users AS SELECT name FROM users;
+            ",
+        )
+        .expect("sqlite fixture");
+        db_path
+    }
+
+    #[tokio::test]
+    async fn sqlite_inventory_fetches_all_columns_in_one_query() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let fetcher = sqlite_fetcher(&sqlite_fixture(temp.path())).await;
+
+        let rows = fetcher
+            .fetch_columns(&ColumnInventoryFilter::default())
+            .await
+            .expect("fetch all columns");
+
+        let described = rows
+            .iter()
+            .map(|row| {
+                format!(
+                    "{}.{}.{}:{}",
+                    row.schema_name, row.table_name, row.column_name, row.ordinal_position
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            described,
+            [
+                "main.named_users.name:1",
+                "main.orders.order_id:1",
+                "main.orders.user_id:2",
+                "main.orders.note:3",
+                "main.users.id:1",
+                "main.users.name:2",
+            ],
+            "inventory should cover tables and views with 1-based ordinals"
+        );
+
+        let name = rows
+            .iter()
+            .find(|row| row.table_name == "users" && row.column_name == "name")
+            .expect("users.name row");
+        assert_eq!(name.data_type, "TEXT");
+        assert!(!name.is_nullable, "NOT NULL column reports non-nullable");
+        let user_id = rows
+            .iter()
+            .find(|row| row.table_name == "orders" && row.column_name == "user_id")
+            .expect("orders.user_id row");
+        assert!(user_id.is_nullable);
+    }
+
+    #[tokio::test]
+    async fn sqlite_inventory_applies_schema_and_table_filters() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let fetcher = sqlite_fetcher(&sqlite_fixture(temp.path())).await;
+
+        let rows = fetcher
+            .fetch_columns(&ColumnInventoryFilter {
+                schemas: Some(vec!["main".to_string()]),
+                tables: Some(vec!["users".to_string()]),
+            })
+            .await
+            .expect("fetch filtered columns");
+        assert_eq!(
+            rows.iter()
+                .map(|row| row.column_name.as_str())
+                .collect::<Vec<_>>(),
+            ["id", "name"]
+        );
+
+        let rows = fetcher
+            .fetch_columns(&ColumnInventoryFilter {
+                schemas: Some(vec!["other".to_string()]),
+                tables: None,
+            })
+            .await
+            .expect("fetch mismatched schema");
+        assert!(rows.is_empty(), "non-'main' schema filter matches nothing");
+
+        let rows = fetcher
+            .fetch_columns(&ColumnInventoryFilter {
+                schemas: None,
+                tables: Some(Vec::new()),
+            })
+            .await
+            .expect("fetch with empty table list");
+        assert!(rows.is_empty(), "empty restriction short-circuits");
+    }
+}

--- a/crates/coral-engine/src/backends/database/mod.rs
+++ b/crates/coral-engine/src/backends/database/mod.rs
@@ -22,6 +22,7 @@ use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::logical_expr::TableType;
 use datafusion::prelude::SessionContext;
 use datafusion::sql::TableReference;
+use datafusion::sql::unparser::dialect::{Dialect, MySqlDialect, PostgreSqlDialect, SqliteDialect};
 use datafusion_table_providers::UnsupportedTypeAction;
 use datafusion_table_providers::sql::db_connection_pool::dbconnection::query_arrow;
 use datafusion_table_providers::sql::db_connection_pool::mysqlpool::MySQLConnectionPool;
@@ -160,7 +161,14 @@ async fn postgres_catalog(
                         .with_unsupported_type_action(UnsupportedTypeAction::String))
                 }
             },
-            |pool| database_catalog(pool, POSTGRES_RELATIONS_SQL, POSTGRES_COLUMNS_SQL),
+            |pool| {
+                database_catalog(
+                    pool,
+                    POSTGRES_RELATIONS_SQL,
+                    POSTGRES_COLUMNS_SQL,
+                    Arc::new(PostgreSqlDialect {}),
+                )
+            },
         )
         .await
 }
@@ -200,7 +208,14 @@ async fn mysql_catalog(
                         .map_err(provider_error)
                 }
             },
-            |pool| database_catalog(pool, MYSQL_RELATIONS_SQL, MYSQL_COLUMNS_SQL),
+            |pool| {
+                database_catalog(
+                    pool,
+                    MYSQL_RELATIONS_SQL,
+                    MYSQL_COLUMNS_SQL,
+                    Arc::new(MySqlDialect {}),
+                )
+            },
         )
         .await
 }
@@ -224,7 +239,13 @@ async fn sqlite_catalog(
         .build()
         .await
         .map_err(boxed_provider_error)?;
-    database_catalog(Arc::new(pool), SQLITE_RELATIONS_SQL, SQLITE_COLUMNS_SQL).await
+    database_catalog(
+        Arc::new(pool),
+        SQLITE_RELATIONS_SQL,
+        SQLITE_COLUMNS_SQL,
+        Arc::new(SqliteDialect {}),
+    )
+    .await
 }
 
 const POSTGRES_RELATIONS_SQL: &str = "
@@ -269,14 +290,22 @@ struct DatabaseRelation {
     table_type: TableType,
 }
 
+/// Unparser dialect for the remote SQL sent to one provider. Without it,
+/// `SqlTable` falls back to ANSI double-quoted identifiers, which MySQL
+/// (without `ANSI_QUOTES`) reads as string literals — silently returning the
+/// column name instead of column values.
+type SqlDialect = Arc<dyn Dialect + Send + Sync>;
+
 async fn database_catalog<T: 'static, P: 'static>(
     pool: Pool<T, P>,
     inventory_sql: &str,
     columns_sql: &'static str,
+    dialect: SqlDialect,
 ) -> DataFusionResult<DatabaseCatalog> {
     let relations = load_database_inventory(&pool, inventory_sql).await?;
-    let provider =
-        Arc::new(CoralDatabaseCatalogProvider::new(&pool, &relations)) as Arc<dyn CatalogProvider>;
+    let provider = Arc::new(CoralDatabaseCatalogProvider::new(
+        &pool, &relations, &dialect,
+    )) as Arc<dyn CatalogProvider>;
     let column_fetcher = PooledColumnFetcher::new(&pool, columns_sql);
     Ok(DatabaseCatalog {
         provider,
@@ -347,7 +376,11 @@ struct CoralDatabaseCatalogProvider {
 }
 
 impl CoralDatabaseCatalogProvider {
-    fn new<T: 'static, P: 'static>(pool: &Pool<T, P>, relations: &[DatabaseRelation]) -> Self {
+    fn new<T: 'static, P: 'static>(
+        pool: &Pool<T, P>,
+        relations: &[DatabaseRelation],
+        dialect: &SqlDialect,
+    ) -> Self {
         let mut by_schema = BTreeMap::<String, BTreeMap<String, TableType>>::new();
         for relation in relations {
             by_schema
@@ -362,6 +395,7 @@ impl CoralDatabaseCatalogProvider {
                     schema_name: schema_name.clone(),
                     tables,
                     pool: Arc::clone(pool),
+                    dialect: Arc::clone(dialect),
                 };
                 (schema_name, Arc::new(provider) as Arc<dyn SchemaProvider>)
             })
@@ -397,6 +431,7 @@ struct CoralDatabaseSchemaProvider<T: 'static, P: 'static> {
     schema_name: String,
     tables: BTreeMap<String, TableType>,
     pool: Pool<T, P>,
+    dialect: SqlDialect,
 }
 
 impl<T: 'static, P: 'static> fmt::Debug for CoralDatabaseSchemaProvider<T, P> {
@@ -429,7 +464,10 @@ impl<T: 'static, P: 'static> SchemaProvider for CoralDatabaseSchemaProvider<T, P
             TableReference::partial(self.schema_name.clone(), name.to_string()),
         )
         .await
-        .map(|table| Some(Arc::new(table) as Arc<dyn TableProvider>))
+        .map(|table| {
+            let table = table.with_dialect(Arc::clone(&self.dialect));
+            Some(Arc::new(table) as Arc<dyn TableProvider>)
+        })
         .map_err(provider_error)
     }
 
@@ -560,6 +598,9 @@ mod tests {
             "
             CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
             INSERT INTO users (id, name) VALUES (1, 'Ada'), (2, 'Lin');
+            CREATE TABLE cased (\"createdAt\" TEXT NOT NULL, status TEXT NOT NULL);
+            INSERT INTO cased (\"createdAt\", status)
+            VALUES ('2026-01-01', 'open'), ('2026-01-02', 'closed');
             ",
         )
         .expect("sqlite fixture");
@@ -711,6 +752,23 @@ mod tests {
         )
         .await
         .expect("query all database columns");
-        assert_eq!(all_database_columns.row_count(), 2);
+        assert_eq!(all_database_columns.row_count(), 4);
+    }
+
+    /// The remote scan SQL is unparsed with the provider's dialect; a
+    /// case-sensitive column in a pushed-down projection and filter proves
+    /// quoted identifiers round-trip as identifiers, not string literals.
+    #[tokio::test]
+    async fn sqlite_database_source_round_trips_case_sensitive_identifiers() {
+        let (_temp, sources) = sqlite_test_sources();
+
+        let result = CoralQuery::execute_sql(
+            &sources,
+            QueryRuntimeConfig::default(),
+            "SELECT \"createdAt\" FROM coral_db.main.cased WHERE status = 'open'",
+        )
+        .await
+        .expect("query case-sensitive column");
+        assert_eq!(result.row_count(), 1, "filter must match the real row");
     }
 }

--- a/crates/coral-engine/src/backends/database/mod.rs
+++ b/crates/coral-engine/src/backends/database/mod.rs
@@ -291,7 +291,7 @@ struct DatabaseRelation {
 }
 
 /// Unparser dialect for the remote SQL sent to one provider. Without it,
-/// `SqlTable` falls back to ANSI double-quoted identifiers, which MySQL
+/// `SqlTable` falls back to ANSI double-quoted identifiers, which `MySQL`
 /// (without `ANSI_QUOTES`) reads as string literals — silently returning the
 /// column name instead of column values.
 type SqlDialect = Arc<dyn Dialect + Send + Sync>;
@@ -588,11 +588,8 @@ mod tests {
         }
     }
 
-    /// Builds a sqlite-backed database source. The returned tempdir must stay
-    /// alive for as long as the sources are queried.
-    fn sqlite_test_sources() -> (tempfile::TempDir, Vec<QuerySource>) {
-        let temp = tempfile::tempdir().expect("temp dir");
-        let db_path = temp.path().join("coral.sqlite");
+    fn sqlite_fixture_db(dir: &std::path::Path, file_name: &str) -> std::path::PathBuf {
+        let db_path = dir.join(file_name);
         let conn = rusqlite::Connection::open(&db_path).expect("sqlite db");
         conn.execute_batch(
             "
@@ -604,12 +601,14 @@ mod tests {
             ",
         )
         .expect("sqlite fixture");
-        drop(conn);
+        db_path
+    }
 
+    fn sqlite_source(db_path: &std::path::Path, source_name: &str) -> QuerySource {
         let database = DatabaseSourceManifest {
             common: SourceManifestCommon {
                 dsl_version: 4,
-                name: "coral_db".to_string(),
+                name: source_name.to_string(),
                 version: String::new(),
                 description: "Coral test database".to_string(),
                 test_queries: Vec::new(),
@@ -621,9 +620,9 @@ mod tests {
             }),
             declared_inputs: Vec::new(),
         };
-        let source = QuerySource::from_runtime_components(
+        QuerySource::from_runtime_components(
             RuntimeSourcePackage {
-                source_name: "coral_db".to_string(),
+                source_name: source_name.to_string(),
                 authored_version: None,
                 description: String::new(),
                 declared_inputs: Vec::new(),
@@ -633,8 +632,15 @@ mod tests {
             BTreeMap::new(),
             BTreeMap::new(),
         )
-        .expect("database runtime source");
-        (temp, vec![source])
+        .expect("database runtime source")
+    }
+
+    /// Builds a sqlite-backed database source. The returned tempdir must stay
+    /// alive for as long as the sources are queried.
+    fn sqlite_test_sources() -> (tempfile::TempDir, Vec<QuerySource>) {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let db_path = sqlite_fixture_db(temp.path(), "coral.sqlite");
+        (temp, vec![sqlite_source(&db_path, "coral_db")])
     }
 
     #[tokio::test]
@@ -753,6 +759,66 @@ mod tests {
         .await
         .expect("query all database columns");
         assert_eq!(all_database_columns.row_count(), 4);
+    }
+
+    #[tokio::test]
+    async fn describe_table_replays_advertised_compound_schema() {
+        let (_temp, sources) = sqlite_test_sources();
+
+        // Miss-hints advertise `coral_db.main`; that string must work as the
+        // schema argument without a catalog.
+        let described = CoralQuery::describe_table(
+            &sources,
+            QueryRuntimeConfig::default(),
+            None,
+            "coral_db.main",
+            "users",
+        )
+        .await
+        .expect("compound schema describe succeeds");
+        let table = described.table.expect("described table");
+        assert_eq!(table.catalog_name, "coral_db");
+        assert_eq!(table.schema_name, "main");
+    }
+
+    #[tokio::test]
+    async fn describe_table_rejects_ambiguous_wildcard_catalog() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let first = sqlite_fixture_db(temp.path(), "first.sqlite");
+        let second = sqlite_fixture_db(temp.path(), "second.sqlite");
+        let sources = vec![
+            sqlite_source(&first, "coral_db"),
+            sqlite_source(&second, "coral_db2"),
+        ];
+
+        let error = CoralQuery::describe_table(
+            &sources,
+            QueryRuntimeConfig::default(),
+            None,
+            "main",
+            "users",
+        )
+        .await
+        .expect_err("wildcard catalog over two matches must not guess");
+        let message = error.to_string();
+        assert!(
+            message.contains("ambiguous")
+                && message.contains("coral_db.main.users")
+                && message.contains("coral_db2.main.users"),
+            "ambiguity error should list every candidate, got: {message}"
+        );
+
+        let described = CoralQuery::describe_table(
+            &sources,
+            QueryRuntimeConfig::default(),
+            Some("coral_db2"),
+            "main",
+            "users",
+        )
+        .await
+        .expect("qualified describe succeeds");
+        let table = described.table.expect("described table");
+        assert_eq!(table.catalog_name, "coral_db2");
     }
 
     /// The remote scan SQL is unparsed with the provider's dialect; a

--- a/crates/coral-engine/src/backends/database/mod.rs
+++ b/crates/coral-engine/src/backends/database/mod.rs
@@ -652,6 +652,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sqlite_database_source_suggests_three_part_table_on_typo() {
+        let (_temp, sources) = sqlite_test_sources();
+
+        let error = CoralQuery::execute_sql(
+            &sources,
+            QueryRuntimeConfig::default(),
+            "SELECT id FROM coral_db.main.usrs",
+        )
+        .await
+        .expect_err("typo'd table reference should fail");
+        let message = error.to_string();
+        assert!(
+            message.contains("coral_db.main.users"),
+            "three-part miss should suggest the real table, got: {message}"
+        );
+    }
+
+    #[tokio::test]
     async fn sqlite_database_source_exposes_lazy_column_metadata() {
         let (_temp, sources) = sqlite_test_sources();
 

--- a/crates/coral-engine/src/backends/database/mod.rs
+++ b/crates/coral-engine/src/backends/database/mod.rs
@@ -1,5 +1,6 @@
 //! Relational database backend registration through `datafusion-table-providers`.
 
+mod columns;
 mod pool_cache;
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -31,12 +32,15 @@ use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
 use datafusion_table_providers::util::secrets::to_secret_map;
 use futures::TryStreamExt as _;
 
+use crate::backends::database::columns::{
+    MYSQL_COLUMNS_SQL, POSTGRES_COLUMNS_SQL, PooledColumnFetcher, SQLITE_COLUMNS_SQL,
+};
 use crate::backends::database::pool_cache::{PoolCache, PoolKey};
 use crate::backends::shared::template::{RenderContext, render_template};
 use crate::backends::{
     BackendCatalogRegistration, BackendCompileRequest, BackendRegistration,
-    BackendRegistrationContext, CompiledBackendSource, RegisteredSource, RegisteredTable,
-    build_registered_inputs,
+    BackendRegistrationContext, CompiledBackendSource, DatabaseColumnFetcher, RegisteredSource,
+    RegisteredTable, build_registered_inputs,
 };
 
 pub(crate) fn compile_manifest(
@@ -97,6 +101,7 @@ impl CompiledBackendSource for CompiledDatabaseSource {
                 catalog_name: self.manifest.common.name.clone(),
                 catalog: database_catalog.provider,
                 source,
+                column_fetcher: database_catalog.column_fetcher,
             }],
         })
     }
@@ -155,7 +160,7 @@ async fn postgres_catalog(
                         .with_unsupported_type_action(UnsupportedTypeAction::String))
                 }
             },
-            |pool| database_catalog(pool, POSTGRES_RELATIONS_SQL),
+            |pool| database_catalog(pool, POSTGRES_RELATIONS_SQL, POSTGRES_COLUMNS_SQL),
         )
         .await
 }
@@ -195,7 +200,7 @@ async fn mysql_catalog(
                         .map_err(provider_error)
                 }
             },
-            |pool| database_catalog(pool, MYSQL_RELATIONS_SQL),
+            |pool| database_catalog(pool, MYSQL_RELATIONS_SQL, MYSQL_COLUMNS_SQL),
         )
         .await
 }
@@ -219,7 +224,7 @@ async fn sqlite_catalog(
         .build()
         .await
         .map_err(boxed_provider_error)?;
-    database_catalog(Arc::new(pool), SQLITE_RELATIONS_SQL).await
+    database_catalog(Arc::new(pool), SQLITE_RELATIONS_SQL, SQLITE_COLUMNS_SQL).await
 }
 
 const POSTGRES_RELATIONS_SQL: &str = "
@@ -254,6 +259,7 @@ static MYSQL_POOLS: LazyLock<PoolCache<MySQLConnectionPool>> = LazyLock::new(Poo
 struct DatabaseCatalog {
     provider: Arc<dyn CatalogProvider>,
     relations: Vec<DatabaseRelation>,
+    column_fetcher: Arc<dyn DatabaseColumnFetcher>,
 }
 
 #[derive(Clone, Debug)]
@@ -266,13 +272,16 @@ struct DatabaseRelation {
 async fn database_catalog<T: 'static, P: 'static>(
     pool: Pool<T, P>,
     inventory_sql: &str,
+    columns_sql: &'static str,
 ) -> DataFusionResult<DatabaseCatalog> {
     let relations = load_database_inventory(&pool, inventory_sql).await?;
     let provider =
         Arc::new(CoralDatabaseCatalogProvider::new(&pool, &relations)) as Arc<dyn CatalogProvider>;
+    let column_fetcher = PooledColumnFetcher::new(&pool, columns_sql);
     Ok(DatabaseCatalog {
         provider,
         relations,
+        column_fetcher,
     })
 }
 
@@ -541,8 +550,9 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn sqlite_database_source_registers_catalog_and_queries_three_part_table() {
+    /// Builds a sqlite-backed database source. The returned tempdir must stay
+    /// alive for as long as the sources are queried.
+    fn sqlite_test_sources() -> (tempfile::TempDir, Vec<QuerySource>) {
         let temp = tempfile::tempdir().expect("temp dir");
         let db_path = temp.path().join("coral.sqlite");
         let conn = rusqlite::Connection::open(&db_path).expect("sqlite db");
@@ -583,7 +593,12 @@ mod tests {
             BTreeMap::new(),
         )
         .expect("database runtime source");
-        let sources = vec![source];
+        (temp, vec![source])
+    }
+
+    #[tokio::test]
+    async fn sqlite_database_source_registers_catalog_and_queries_three_part_table() {
+        let (_temp, sources) = sqlite_test_sources();
 
         let tables = CoralQuery::list_tables(
             &sources,
@@ -630,6 +645,16 @@ mod tests {
         .expect("query coral tables");
         assert_eq!(catalog_result.row_count(), 1);
 
+        let source = sources.first().expect("source");
+        CoralQuery::validate_source(source, QueryRuntimeConfig::default(), &[])
+            .await
+            .expect("database source validates");
+    }
+
+    #[tokio::test]
+    async fn sqlite_database_source_exposes_lazy_column_metadata() {
+        let (_temp, sources) = sqlite_test_sources();
+
         let tables = CoralQuery::list_tables(
             &sources,
             QueryRuntimeConfig::default(),
@@ -638,12 +663,36 @@ mod tests {
             Some("users"),
         )
         .await
-        .expect("list tables by catalog and schema");
-        assert_eq!(tables.len(), 1);
+        .expect("list tables");
+        let table = tables.first().expect("table metadata");
+        assert_eq!(
+            table
+                .columns
+                .iter()
+                .map(|column| (column.name.as_str(), column.data_type.as_str()))
+                .collect::<Vec<_>>(),
+            [("id", "INTEGER"), ("name", "TEXT")],
+            "lazy column inventory populates listed table metadata"
+        );
 
-        let source = sources.first().expect("source");
-        CoralQuery::validate_source(source, QueryRuntimeConfig::default(), &[])
-            .await
-            .expect("database source validates");
+        let pinned_columns = CoralQuery::execute_sql(
+            &sources,
+            QueryRuntimeConfig::default(),
+            "SELECT column_name, data_type, is_nullable FROM coral.columns \
+             WHERE catalog_name = 'coral_db' AND schema_name = 'main' AND table_name = 'users' \
+             ORDER BY ordinal_position",
+        )
+        .await
+        .expect("query pinned coral columns");
+        assert_eq!(pinned_columns.row_count(), 2);
+
+        let all_database_columns = CoralQuery::execute_sql(
+            &sources,
+            QueryRuntimeConfig::default(),
+            "SELECT column_name FROM coral.columns WHERE catalog_name <> ''",
+        )
+        .await
+        .expect("query all database columns");
+        assert_eq!(all_database_columns.row_count(), 2);
     }
 }

--- a/crates/coral-engine/src/backends/file/tests.rs
+++ b/crates/coral-engine/src/backends/file/tests.rs
@@ -275,9 +275,12 @@ async fn parquet_provider_exposes_inferred_schema_in_coral_columns() {
 
     let active_sources = register_sources_blocking(&ctx, compile_sources(vec![manifest]))
         .expect("file source should register");
-    catalog::register(&ctx, &active_sources.active_sources)
-        .await
-        .expect("metadata tables should register");
+    catalog::register(
+        &ctx,
+        &active_sources.active_sources,
+        &active_sources.column_fetchers,
+    )
+    .expect("metadata tables should register");
 
     let batches = ctx
         .sql(

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -437,14 +437,14 @@ fn register_test_sources(ctx: &SessionContext, sources: Vec<CompiledQuerySource>
         .expect("source function planner should register");
 }
 
-async fn register_test_sources_with_catalog(
-    ctx: &SessionContext,
-    sources: Vec<CompiledQuerySource>,
-) {
+fn register_test_sources_with_catalog(ctx: &SessionContext, sources: Vec<CompiledQuerySource>) {
     let registration = register_sources_blocking(ctx, sources).expect("mcp source should register");
-    catalog::register(ctx, &registration.active_sources)
-        .await
-        .expect("catalog should register");
+    catalog::register(
+        ctx,
+        &registration.active_sources,
+        &registration.column_fetchers,
+    )
+    .expect("catalog should register");
     let source_functions = SourceFunctionRegistry::new(
         registration
             .active_sources
@@ -1537,7 +1537,7 @@ async fn mcp_table_appears_in_catalog_metadata() {
     let caller = Arc::new(FakeMcpTableCaller {
         calls: Mutex::new(Vec::new()),
     });
-    register_test_sources_with_catalog(&ctx, compile_sources(mcp_table_manifest(), caller)).await;
+    register_test_sources_with_catalog(&ctx, compile_sources(mcp_table_manifest(), caller));
 
     let batches = ctx
         .sql(

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -80,11 +80,13 @@ pub(crate) mod common;
 mod composite;
 pub(crate) use common::{
     BackendCatalogRegistration, BackendCompileRequest, BackendRegistration,
-    BackendRegistrationContext, BackendSchemaRegistration, CompiledBackendSource, RegisteredInput,
-    RegisteredSource, RegisteredTable, RegisteredTableFunction, RegisteredTableFunctionArgument,
-    SourceFunctionProviderFactory, build_registered_inputs, build_registered_table,
-    build_registered_table_function, registered_columns_from_schema, registered_columns_from_specs,
-    required_filter_names, schema_from_columns, validate_lookup_key_filter_backend_support,
+    BackendRegistrationContext, BackendSchemaRegistration, CatalogColumnFetcher,
+    ColumnInventoryFilter, CompiledBackendSource, DatabaseColumnFetcher, DatabaseColumnRow,
+    RegisteredInput, RegisteredSource, RegisteredTable, RegisteredTableFunction,
+    RegisteredTableFunctionArgument, SourceFunctionProviderFactory, build_registered_inputs,
+    build_registered_table, build_registered_table_function, registered_columns_from_schema,
+    registered_columns_from_specs, required_filter_names, schema_from_columns,
+    validate_lookup_key_filter_backend_support,
 };
 
 pub(crate) mod database;

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -5,7 +5,8 @@
 pub struct ColumnInfo {
     /// Column name.
     pub name: String,
-    /// Data type rendered in `Arrow`/`DataFusion` string form.
+    /// Data type rendered as text: `Arrow`/`DataFusion` string form for
+    /// static sources, the provider-native type name for database catalogs.
     pub data_type: String,
     /// Whether the column can contain null values.
     pub nullable: bool,

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -1,31 +1,39 @@
 //! Registers the `coral` system schema for discoverable source metadata.
 
-use std::collections::HashMap;
+use std::any::Any;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use coral_spec::ManifestInputKind;
 use datafusion::arrow::array::{ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray};
-use datafusion::arrow::datatypes::{DataType, Field, Schema};
-use datafusion::catalog::{MemorySchemaProvider, SchemaProvider};
-use datafusion::datasource::{MemTable, ViewTable};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::catalog::Session;
+use datafusion::datasource::MemTable;
 use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::{Expr, Operator, TableProviderFilterPushDown, TableType};
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
+use futures::future::join_all;
 use serde::Serialize;
 
 use crate::backends::common::{
     RegisteredTableFunctionArgument, RegisteredTableFunctionResultColumn,
 };
-use crate::backends::{RegisteredSource, RegisteredTableFunction};
+use crate::backends::shared::filter_expr::literal_to_string;
+use crate::backends::{
+    CatalogColumnFetcher, ColumnInventoryFilter, DatabaseColumnRow, RegisteredSource,
+    RegisteredTableFunction,
+};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
     ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
     TableInfo,
 };
+use datafusion::datasource::TableProvider;
 
 /// Schema name for source metadata tables such as `coral.tables`.
 pub(crate) const SYSTEM_SCHEMA: &str = "coral";
-const STATIC_TABLES_TABLE: &str = "_tables_static";
-const STATIC_COLUMNS_TABLE: &str = "_columns_static";
 
 /// Register `coral.tables` and `coral.columns` for the active source set.
 ///
@@ -33,24 +41,21 @@ const STATIC_COLUMNS_TABLE: &str = "_columns_static";
 ///
 /// Returns a `DataFusionError` if the catalog is missing or the metadata
 /// tables cannot be materialized.
-pub(crate) async fn register(
+pub(crate) fn register(
     ctx: &SessionContext,
     active_sources: &[RegisteredSource],
+    column_fetchers: &[CatalogColumnFetcher],
 ) -> Result<()> {
     let tables_table = build_tables_table(active_sources)?;
-    let columns_table = build_columns_table(active_sources)?;
+    let columns_table = build_columns_table(active_sources, column_fetchers)?;
     let filters_table = build_filters_table(active_sources)?;
     let inputs_table = build_inputs_table(active_sources)?;
     let table_functions_table = build_table_functions_table(active_sources)?;
-    let catalog_names = active_sources
-        .iter()
-        .filter_map(|source| source.catalog_name.as_deref())
-        .collect::<Vec<_>>();
 
     let mut meta_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
         HashMap::new();
-    meta_tables.insert(STATIC_TABLES_TABLE.to_string(), Arc::new(tables_table));
-    meta_tables.insert(STATIC_COLUMNS_TABLE.to_string(), Arc::new(columns_table));
+    meta_tables.insert("tables".to_string(), Arc::new(tables_table));
+    meta_tables.insert("columns".to_string(), Arc::new(columns_table));
     meta_tables.insert("filters".to_string(), Arc::new(filters_table));
     meta_tables.insert("inputs".to_string(), Arc::new(inputs_table));
     meta_tables.insert(
@@ -61,69 +66,12 @@ pub(crate) async fn register(
     let catalog = ctx
         .catalog("datafusion")
         .ok_or_else(|| DataFusionError::Plan("catalog 'datafusion' not found".to_string()))?;
-    let planning_schema = Arc::new(MemorySchemaProvider::new());
-    for (name, table) in &meta_tables {
-        planning_schema.register_table(name.clone(), table.clone())?;
-    }
-    catalog.register_schema(SYSTEM_SCHEMA, planning_schema)?;
-
-    let tables_sql = tables_view_sql();
-    let tables_view = view_table_for_sql(ctx, &tables_sql).await?;
-    meta_tables.insert("tables".to_string(), Arc::new(tables_view));
-
-    let columns_sql = columns_view_sql(&catalog_names);
-    let columns_view = view_table_for_sql(ctx, &columns_sql).await?;
-    meta_tables.insert("columns".to_string(), Arc::new(columns_view));
-
     catalog.register_schema(
         SYSTEM_SCHEMA,
         Arc::new(StaticSchemaProvider::new(meta_tables)),
     )?;
 
     Ok(())
-}
-
-async fn view_table_for_sql(ctx: &SessionContext, sql: &str) -> Result<ViewTable> {
-    let df = ctx.sql(sql).await?;
-    let (_state, plan) = df.into_parts();
-    Ok(ViewTable::new(plan, Some(sql.to_string())))
-}
-
-fn tables_view_sql() -> String {
-    format!(
-        "SELECT schema_name, table_name, description, guide, required_filters, \
-         search_limits_json, catalog_name FROM {SYSTEM_SCHEMA}.{STATIC_TABLES_TABLE}"
-    )
-}
-
-fn columns_view_sql(catalog_names: &[&str]) -> String {
-    let static_sql = format!(
-        "SELECT schema_name, table_name, ordinal_position, column_name, data_type, \
-         is_nullable, is_virtual, is_required_filter, description, filter_mode, catalog_name \
-         FROM {SYSTEM_SCHEMA}.{STATIC_COLUMNS_TABLE}"
-    );
-    if catalog_names.is_empty() {
-        return static_sql;
-    }
-    format!(
-        "{static_sql} UNION ALL \
-         SELECT table_schema AS schema_name, table_name, \
-         CAST(ordinal_position AS INT) AS ordinal_position, column_name, data_type, \
-         is_nullable = 'YES' AS is_nullable, false AS is_virtual, \
-         false AS is_required_filter, '' AS description, '' AS filter_mode, \
-         table_catalog AS catalog_name \
-         FROM information_schema.columns \
-         WHERE table_catalog IN ({}) AND table_schema <> 'information_schema'",
-        sql_string_list(catalog_names)
-    )
-}
-
-fn sql_string_list(values: &[&str]) -> String {
-    values
-        .iter()
-        .map(|value| sql_string_literal(value))
-        .collect::<Vec<_>>()
-        .join(", ")
 }
 
 fn sql_string_literal(value: &str) -> String {
@@ -1246,7 +1194,10 @@ struct CatalogColumn {
     ordinal_position: usize,
 }
 
-fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
+fn build_columns_table(
+    active_sources: &[RegisteredSource],
+    column_fetchers: &[CatalogColumnFetcher],
+) -> Result<CoralColumnsTable> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("schema_name", DataType::Utf8, false),
         Field::new("table_name", DataType::Utf8, false),
@@ -1262,9 +1213,233 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
     ]));
 
     let rows = catalog_column_rows(active_sources);
-    let batch = catalog_columns_batch(schema.clone(), &rows)?;
+    let static_batch = catalog_columns_batch(schema.clone(), &rows)?;
 
-    MemTable::try_new(schema, vec![vec![batch]])
+    Ok(CoralColumnsTable {
+        schema,
+        static_batch,
+        fetchers: column_fetchers.to_vec(),
+    })
+}
+
+/// `coral.columns`: static source metadata unioned, at scan time, with column
+/// metadata fetched lazily from registered database catalogs.
+///
+/// Recognized pushed-down pins prune which databases are contacted and narrow
+/// each remote fetch to the pinned schemas/tables. Pushdown is Inexact, so
+/// `DataFusion` re-applies every predicate above the scan: an unrecognized
+/// filter shape only costs extra fetching, never correctness.
+#[derive(Debug)]
+struct CoralColumnsTable {
+    schema: Arc<Schema>,
+    static_batch: RecordBatch,
+    fetchers: Vec<CatalogColumnFetcher>,
+}
+
+#[async_trait]
+impl TableProvider for CoralColumnsTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|filter| {
+                if column_pin(filter).is_some() {
+                    TableProviderFilterPushDown::Inexact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let pins = ColumnPins::from_filters(filters);
+        let inventory_filter = pins.inventory_filter();
+        let relevant = self
+            .fetchers
+            .iter()
+            .filter(|fetcher| pins.includes_catalog(&fetcher.catalog_name))
+            .collect::<Vec<_>>();
+        let outcomes = join_all(
+            relevant
+                .iter()
+                .map(|fetcher| fetcher.fetcher.fetch_columns(&inventory_filter)),
+        )
+        .await;
+
+        let mut batches = vec![self.static_batch.clone()];
+        for (fetcher, outcome) in relevant.iter().zip(outcomes) {
+            match outcome {
+                Ok(rows) => {
+                    let rows = database_catalog_columns(&fetcher.catalog_name, rows);
+                    batches.push(catalog_columns_batch(Arc::clone(&self.schema), &rows)?);
+                }
+                Err(error) => {
+                    // Keep metadata browsing available when one of several
+                    // databases is unreachable; its rows are simply absent.
+                    tracing::warn!(
+                        catalog = fetcher.catalog_name.as_str(),
+                        detail = %error,
+                        "failed to fetch database column metadata; omitting catalog from coral.columns"
+                    );
+                }
+            }
+        }
+
+        let table = MemTable::try_new(Arc::clone(&self.schema), vec![batches])?;
+        table.scan(state, projection, &[], limit).await
+    }
+}
+
+fn database_catalog_columns(
+    catalog_name: &str,
+    rows: Vec<DatabaseColumnRow>,
+) -> Vec<CatalogColumn> {
+    rows.into_iter()
+        .map(|row| CatalogColumn {
+            catalog_name: catalog_name.to_string(),
+            schema_name: row.schema_name,
+            table_name: row.table_name,
+            column_name: row.column_name,
+            data_type: row.data_type,
+            is_nullable: row.is_nullable,
+            is_virtual: false,
+            is_required_filter: false,
+            filter_mode: None,
+            description: String::new(),
+            ordinal_position: usize::try_from(row.ordinal_position).unwrap_or_default(),
+        })
+        .collect()
+}
+
+/// Per-column value restrictions recognized in pushed-down predicates.
+/// `None` means the column is unrestricted.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ColumnPins {
+    catalogs: Option<BTreeSet<String>>,
+    schemas: Option<BTreeSet<String>>,
+    tables: Option<BTreeSet<String>>,
+}
+
+impl ColumnPins {
+    fn from_filters(filters: &[Expr]) -> Self {
+        let mut pins = Self::default();
+        for filter in filters {
+            if let Some((column, values)) = column_pin(filter) {
+                pins.restrict(column, values);
+            }
+        }
+        pins
+    }
+
+    fn restrict(&mut self, column: PinColumn, values: BTreeSet<String>) {
+        let slot = match column {
+            PinColumn::Catalog => &mut self.catalogs,
+            PinColumn::Schema => &mut self.schemas,
+            PinColumn::Table => &mut self.tables,
+        };
+        *slot = Some(match slot.take() {
+            None => values,
+            Some(existing) => existing.intersection(&values).cloned().collect(),
+        });
+    }
+
+    fn includes_catalog(&self, catalog_name: &str) -> bool {
+        self.catalogs
+            .as_ref()
+            .is_none_or(|catalogs| catalogs.contains(catalog_name))
+    }
+
+    fn inventory_filter(&self) -> ColumnInventoryFilter {
+        ColumnInventoryFilter {
+            schemas: self
+                .schemas
+                .as_ref()
+                .map(|values| values.iter().cloned().collect()),
+            tables: self
+                .tables
+                .as_ref()
+                .map(|values| values.iter().cloned().collect()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PinColumn {
+    Catalog,
+    Schema,
+    Table,
+}
+
+fn pin_column(name: &str) -> Option<PinColumn> {
+    match name {
+        "catalog_name" => Some(PinColumn::Catalog),
+        "schema_name" => Some(PinColumn::Schema),
+        "table_name" => Some(PinColumn::Table),
+        _ => None,
+    }
+}
+
+/// Recognizes one pushed-down conjunct as a single-column string restriction:
+/// `col = 'x'`, `col IN (...)`, or an OR chain of same-column equalities.
+fn column_pin(expr: &Expr) -> Option<(PinColumn, BTreeSet<String>)> {
+    match expr {
+        Expr::BinaryExpr(binary) if binary.op == Operator::Eq => {
+            let (column, value) = column_equality(binary.left.as_ref(), binary.right.as_ref())
+                .or_else(|| column_equality(binary.right.as_ref(), binary.left.as_ref()))?;
+            Some((column, BTreeSet::from([value])))
+        }
+        Expr::BinaryExpr(binary) if binary.op == Operator::Or => {
+            let (column, mut values) = column_pin(binary.left.as_ref())?;
+            let (right_column, right_values) = column_pin(binary.right.as_ref())?;
+            if column != right_column {
+                return None;
+            }
+            values.extend(right_values);
+            Some((column, values))
+        }
+        Expr::InList(in_list) if !in_list.negated => {
+            let Expr::Column(column) = in_list.expr.as_ref() else {
+                return None;
+            };
+            let column = pin_column(column.name())?;
+            let values = in_list
+                .list
+                .iter()
+                .map(literal_to_string)
+                .collect::<Option<BTreeSet<_>>>()?;
+            Some((column, values))
+        }
+        _ => None,
+    }
+}
+
+fn column_equality(column_side: &Expr, literal_side: &Expr) -> Option<(PinColumn, String)> {
+    let Expr::Column(column) = column_side else {
+        return None;
+    };
+    let column = pin_column(column.name())?;
+    Some((column, literal_to_string(literal_side)?))
 }
 
 fn catalog_column_rows(active_sources: &[RegisteredSource]) -> Vec<CatalogColumn> {
@@ -1406,12 +1581,195 @@ fn catalog_columns_batch(schema: Arc<Schema>, rows: &[CatalogColumn]) -> Result<
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
+
+    use datafusion::prelude::{col, lit};
 
     use crate::backends::common::test_support::StubSourceFunctionFactory;
     use crate::backends::{RegisteredSource, RegisteredTableFunction};
 
     use super::collect_table_functions;
+    use super::*;
+
+    fn pins(filters: &[Expr]) -> ColumnPins {
+        ColumnPins::from_filters(filters)
+    }
+
+    fn set(values: &[&str]) -> BTreeSet<String> {
+        values.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn column_pin_recognizes_equality_on_either_side() {
+        let left = pins(&[col("catalog_name").eq(lit("db"))]);
+        let right = pins(&[lit("db").eq(col("catalog_name"))]);
+        assert_eq!(left.catalogs, Some(set(&["db"])));
+        assert_eq!(left, right);
+        assert_eq!(left.schemas, None);
+        assert_eq!(left.tables, None);
+    }
+
+    #[test]
+    fn column_pin_recognizes_in_list_and_or_chains() {
+        let in_list = pins(&[col("table_name").in_list(vec![lit("users"), lit("orders")], false)]);
+        assert_eq!(in_list.tables, Some(set(&["orders", "users"])));
+
+        let or_chain = pins(&[col("schema_name")
+            .eq(lit("main"))
+            .or(col("schema_name").eq(lit("sales")))]);
+        assert_eq!(or_chain.schemas, Some(set(&["main", "sales"])));
+    }
+
+    #[test]
+    fn column_pin_conjuncts_intersect_per_column() {
+        let intersected = pins(&[
+            col("table_name").in_list(vec![lit("users"), lit("orders")], false),
+            col("table_name").eq(lit("users")),
+        ]);
+        assert_eq!(intersected.tables, Some(set(&["users"])));
+    }
+
+    #[test]
+    fn column_pin_rejects_unprunable_shapes() {
+        let unpinned = pins(&[
+            // Disjunction across different columns restricts neither column.
+            col("catalog_name")
+                .eq(lit("db"))
+                .or(col("schema_name").eq(lit("main"))),
+            // Negated membership is not a value restriction.
+            col("table_name").in_list(vec![lit("users")], true),
+            // Unknown column.
+            col("column_name").eq(lit("id")),
+            // Column-to-column comparison has no literal to pin.
+            col("table_name").eq(col("schema_name")),
+        ]);
+        assert_eq!(unpinned, ColumnPins::default());
+    }
+
+    #[derive(Debug, Default)]
+    struct StubColumnFetcher {
+        rows: Vec<DatabaseColumnRow>,
+        calls: Mutex<Vec<ColumnInventoryFilter>>,
+    }
+
+    #[async_trait]
+    impl crate::backends::DatabaseColumnFetcher for StubColumnFetcher {
+        async fn fetch_columns(
+            &self,
+            filter: &ColumnInventoryFilter,
+        ) -> Result<Vec<DatabaseColumnRow>> {
+            self.calls.lock().expect("stub lock").push(filter.clone());
+            Ok(self.rows.clone())
+        }
+    }
+
+    fn stub_row(table_name: &str, column_name: &str) -> DatabaseColumnRow {
+        DatabaseColumnRow {
+            schema_name: "main".to_string(),
+            table_name: table_name.to_string(),
+            ordinal_position: 1,
+            column_name: column_name.to_string(),
+            data_type: "integer".to_string(),
+            is_nullable: false,
+        }
+    }
+
+    fn columns_ctx(fetchers: &[CatalogColumnFetcher]) -> SessionContext {
+        let ctx = SessionContext::new();
+        let table = build_columns_table(&[], fetchers).expect("columns table");
+        ctx.register_table("columns", Arc::new(table))
+            .expect("register columns table");
+        ctx
+    }
+
+    #[tokio::test]
+    async fn columns_scan_prunes_fetchers_and_narrows_remote_fetch() {
+        let pinned = Arc::new(StubColumnFetcher {
+            rows: vec![stub_row("users", "id")],
+            calls: Mutex::default(),
+        });
+        let pruned = Arc::new(StubColumnFetcher::default());
+        let ctx = columns_ctx(&[
+            CatalogColumnFetcher {
+                catalog_name: "db1".to_string(),
+                fetcher: Arc::clone(&pinned) as Arc<dyn crate::backends::DatabaseColumnFetcher>,
+            },
+            CatalogColumnFetcher {
+                catalog_name: "db2".to_string(),
+                fetcher: Arc::clone(&pruned) as Arc<dyn crate::backends::DatabaseColumnFetcher>,
+            },
+        ]);
+
+        let batches = ctx
+            .sql(
+                "SELECT column_name FROM columns \
+                 WHERE catalog_name = 'db1' AND schema_name = 'main' AND table_name = 'users'",
+            )
+            .await
+            .expect("plan pinned query")
+            .collect()
+            .await
+            .expect("run pinned query");
+        let rows = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
+        assert_eq!(rows, 1, "pinned scan returns the stubbed users.id row");
+
+        let calls = pinned.calls.lock().expect("stub lock");
+        assert_eq!(calls.len(), 1, "pinned catalog fetches exactly once");
+        let filter = calls.first().expect("recorded filter");
+        assert_eq!(
+            filter.schemas.as_deref(),
+            Some(["main".to_string()].as_slice())
+        );
+        assert_eq!(
+            filter.tables.as_deref(),
+            Some(["users".to_string()].as_slice())
+        );
+        assert!(
+            pruned.calls.lock().expect("stub lock").is_empty(),
+            "catalog pin must prevent contacting other databases"
+        );
+    }
+
+    #[tokio::test]
+    async fn columns_scan_without_pins_fetches_all_catalogs_unfiltered() {
+        let first = Arc::new(StubColumnFetcher {
+            rows: vec![stub_row("users", "id")],
+            calls: Mutex::default(),
+        });
+        let second = Arc::new(StubColumnFetcher {
+            rows: vec![stub_row("orders", "order_id")],
+            calls: Mutex::default(),
+        });
+        let ctx = columns_ctx(&[
+            CatalogColumnFetcher {
+                catalog_name: "db1".to_string(),
+                fetcher: Arc::clone(&first) as Arc<dyn crate::backends::DatabaseColumnFetcher>,
+            },
+            CatalogColumnFetcher {
+                catalog_name: "db2".to_string(),
+                fetcher: Arc::clone(&second) as Arc<dyn crate::backends::DatabaseColumnFetcher>,
+            },
+        ]);
+
+        // `<>` is deliberately not a recognizable pin: the scan stays
+        // unpruned while the predicate hides the static system-table rows.
+        let batches = ctx
+            .sql("SELECT column_name FROM columns WHERE catalog_name <> '' ORDER BY column_name")
+            .await
+            .expect("plan unpinned query")
+            .collect()
+            .await
+            .expect("run unpinned query");
+        let rows = batches.iter().map(RecordBatch::num_rows).sum::<usize>();
+        assert_eq!(rows, 2, "both catalogs contribute rows");
+
+        for fetcher in [&first, &second] {
+            let calls = fetcher.calls.lock().expect("stub lock");
+            assert_eq!(calls.len(), 1, "each catalog fetches exactly once");
+            let filter = calls.first().expect("recorded filter");
+            assert!(filter.schemas.is_none() && filter.tables.is_none());
+        }
+    }
 
     #[test]
     fn collect_table_functions_preserves_registered_function_schema() {

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -269,7 +269,7 @@ const COLUMNS_COLUMNS: &[SystemColumnDefinition] = &[
         name: "data_type",
         data_type: "Utf8",
         nullable: false,
-        description: "Column data type rendered in Arrow/DataFusion string form.",
+        description: "Column data type: Arrow/DataFusion string form for static sources; the provider-native type name for database catalogs.",
     },
     SystemColumnDefinition {
         name: "is_nullable",

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -713,10 +713,7 @@ fn append_catalog_filter(
         ));
     }
     if let Some(schema_filter) = schema_filter {
-        predicates.push(format!(
-            "schema_name = {}",
-            sql_string_literal(schema_filter)
-        ));
+        predicates.push(schema_filter_predicate(catalog_filter, schema_filter));
     }
     if !qualifier_filters.is_empty() {
         let qualifier_predicates = qualifier_filters
@@ -886,12 +883,44 @@ fn table_matches_query_filter(
     table_filter: Option<&str>,
 ) -> bool {
     catalog_filter.is_none_or(|value| catalog_name == value)
-        && schema_filter.is_none_or(|value| schema_name == value)
+        && schema_filter.is_none_or(|value| {
+            schema_matches_filter(catalog_name, schema_name, catalog_filter, value)
+        })
         && (qualifier_filters.is_empty()
             || qualifier_filters
                 .iter()
                 .any(|value| catalog_name == *value || schema_name == *value))
         && table_filter.is_none_or(|value| table_name == value)
+}
+
+/// Without an explicit catalog, a dotted schema filter also matches its
+/// `catalog.schema` reading, so agents can replay advertised compound schema
+/// hints like `coral_db.main` verbatim instead of dead-ending.
+fn schema_matches_filter(
+    catalog_name: &str,
+    schema_name: &str,
+    catalog_filter: Option<&str>,
+    schema_filter: &str,
+) -> bool {
+    if schema_name == schema_filter {
+        return true;
+    }
+    catalog_filter.is_none()
+        && !catalog_name.is_empty()
+        && format!("{catalog_name}.{schema_name}") == schema_filter
+}
+
+/// SQL twin of [`schema_matches_filter`] for the `coral.tables` /
+/// `coral.columns` queries.
+fn schema_filter_predicate(catalog_filter: Option<&str>, schema_filter: &str) -> String {
+    let literal = sql_string_literal(schema_filter);
+    if catalog_filter.is_some() || !schema_filter.contains('.') {
+        return format!("schema_name = {literal}");
+    }
+    format!(
+        "(schema_name = {literal} OR (catalog_name <> '' AND \
+         catalog_name || '.' || schema_name = {literal}))"
+    )
 }
 
 /// Collect typed source-scoped table function metadata for the active source set.
@@ -1275,10 +1304,17 @@ impl TableProvider for CoralColumnsTable {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let pins = ColumnPins::from_filters(filters);
         let inventory_filter = pins.inventory_filter();
+        // Registration-time name snapshots prune catalogs the pins cannot
+        // match, so e.g. describing a static table never contacts (or waits
+        // on) any database source.
         let relevant = self
             .fetchers
             .iter()
-            .filter(|fetcher| pins.includes_catalog(&fetcher.catalog_name))
+            .filter(|fetcher| {
+                pins.includes_catalog(&fetcher.catalog_name)
+                    && pins.intersects_schemas(&fetcher.schema_names)
+                    && pins.intersects_tables(&fetcher.table_names)
+            })
             .collect::<Vec<_>>();
         let outcomes = join_all(
             relevant
@@ -1368,6 +1404,18 @@ impl ColumnPins {
         self.catalogs
             .as_ref()
             .is_none_or(|catalogs| catalogs.contains(catalog_name))
+    }
+
+    fn intersects_schemas(&self, known: &BTreeSet<String>) -> bool {
+        Self::pin_intersects(self.schemas.as_ref(), known)
+    }
+
+    fn intersects_tables(&self, known: &BTreeSet<String>) -> bool {
+        Self::pin_intersects(self.tables.as_ref(), known)
+    }
+
+    fn pin_intersects(pinned: Option<&BTreeSet<String>>, known: &BTreeSet<String>) -> bool {
+        pinned.is_none_or(|values| values.iter().any(|value| known.contains(value)))
     }
 
     fn inventory_filter(&self) -> ColumnInventoryFilter {
@@ -1682,6 +1730,20 @@ mod tests {
         ctx
     }
 
+    fn stub_fetcher(
+        catalog_name: &str,
+        stub: &Arc<StubColumnFetcher>,
+        schemas: &[&str],
+        tables: &[&str],
+    ) -> CatalogColumnFetcher {
+        CatalogColumnFetcher {
+            catalog_name: catalog_name.to_string(),
+            schema_names: schemas.iter().map(ToString::to_string).collect(),
+            table_names: tables.iter().map(ToString::to_string).collect(),
+            fetcher: Arc::clone(stub) as Arc<dyn crate::backends::DatabaseColumnFetcher>,
+        }
+    }
+
     #[tokio::test]
     async fn columns_scan_prunes_fetchers_and_narrows_remote_fetch() {
         let pinned = Arc::new(StubColumnFetcher {
@@ -1690,14 +1752,8 @@ mod tests {
         });
         let pruned = Arc::new(StubColumnFetcher::default());
         let ctx = columns_ctx(&[
-            CatalogColumnFetcher {
-                catalog_name: "db1".to_string(),
-                fetcher: Arc::clone(&pinned) as Arc<dyn crate::backends::DatabaseColumnFetcher>,
-            },
-            CatalogColumnFetcher {
-                catalog_name: "db2".to_string(),
-                fetcher: Arc::clone(&pruned) as Arc<dyn crate::backends::DatabaseColumnFetcher>,
-            },
+            stub_fetcher("db1", &pinned, &["main"], &["users"]),
+            stub_fetcher("db2", &pruned, &["main"], &["users"]),
         ]);
 
         let batches = ctx
@@ -1731,6 +1787,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn columns_scan_skips_catalogs_whose_snapshot_cannot_match_pins() {
+        let database = Arc::new(StubColumnFetcher::default());
+        let ctx = columns_ctx(&[stub_fetcher("db1", &database, &["main"], &["users"])]);
+
+        // A static-table describe: the schema pin names no database schema,
+        // so the database must not be contacted at all.
+        let batches = ctx
+            .sql(
+                "SELECT column_name FROM columns \
+                 WHERE schema_name = 'github' AND table_name = 'pulls'",
+            )
+            .await
+            .expect("plan static-schema query")
+            .collect()
+            .await
+            .expect("run static-schema query");
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 0);
+        assert!(
+            database.calls.lock().expect("stub lock").is_empty(),
+            "schema pin outside the snapshot must skip the fetcher"
+        );
+
+        // Same for a table pin that names no known table.
+        ctx.sql("SELECT column_name FROM columns WHERE table_name = 'pulls'")
+            .await
+            .expect("plan unknown-table query")
+            .collect()
+            .await
+            .expect("run unknown-table query");
+        assert!(
+            database.calls.lock().expect("stub lock").is_empty(),
+            "table pin outside the snapshot must skip the fetcher"
+        );
+    }
+
+    #[tokio::test]
     async fn columns_scan_without_pins_fetches_all_catalogs_unfiltered() {
         let first = Arc::new(StubColumnFetcher {
             rows: vec![stub_row("users", "id")],
@@ -1741,14 +1833,8 @@ mod tests {
             calls: Mutex::default(),
         });
         let ctx = columns_ctx(&[
-            CatalogColumnFetcher {
-                catalog_name: "db1".to_string(),
-                fetcher: Arc::clone(&first) as Arc<dyn crate::backends::DatabaseColumnFetcher>,
-            },
-            CatalogColumnFetcher {
-                catalog_name: "db2".to_string(),
-                fetcher: Arc::clone(&second) as Arc<dyn crate::backends::DatabaseColumnFetcher>,
-            },
+            stub_fetcher("db1", &first, &["main"], &["users"]),
+            stub_fetcher("db2", &second, &["main"], &["orders"]),
         ]);
 
         // `<>` is deliberately not a recognizable pin: the scan stays

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -311,6 +311,12 @@ fn without_default_catalog(parts: &[String]) -> &[String] {
     }
 }
 
+/// Drops `DataFusion`'s implicit default catalog from an explicit reference:
+/// `datafusion.schema.table` addresses the same relation as `schema.table`.
+pub(crate) fn strip_default_catalog(catalog: Option<&str>) -> Option<&str> {
+    catalog.filter(|name| !name.eq_ignore_ascii_case(DATAFUSION_DEFAULT_CATALOG))
+}
+
 struct SchemaQualifiedName {
     schema: String,
     name: String,

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -497,14 +497,14 @@ impl QueryRuntimeAdapter {
         error: &DataFusionError,
         sql: &str,
     ) -> Vec<TableInfo> {
-        let schema_filters = missing_table_reference(error, Some(sql))
-            .map(|reference| table_context_schema_filters(reference.parts.as_slice()))
+        let filters = missing_table_reference(error, Some(sql))
+            .map(|reference| table_context_filters(reference.parts.as_slice()))
             .unwrap_or_default();
-        if schema_filters.is_empty() {
+        if filters.is_empty() {
             return self.tables.clone();
         }
 
-        match self.table_metadata_for_error_context(&schema_filters).await {
+        match self.table_metadata_for_error_context(&filters).await {
             Ok(tables) => tables,
             Err(error) => {
                 tracing::debug!(
@@ -518,16 +518,36 @@ impl QueryRuntimeAdapter {
 
     async fn table_metadata_for_error_context(
         &self,
-        schema_filters: &[String],
+        filters: &TableContextFilters,
     ) -> Result<Vec<TableInfo>, CoreError> {
         let mut tables = Vec::new();
-        for filter in schema_filters {
+        for qualifier in &filters.qualifiers {
             tables.extend(
-                catalog::collect_table_metadata_for_qualifier(&self.ctx, filter)
+                catalog::collect_table_metadata_for_qualifier(&self.ctx, qualifier)
                     .await
                     .map_err(|err| datafusion_to_core(&err, &self.tables))?,
             );
         }
+        for (catalog_name, schema_name) in &filters.pairs {
+            tables.extend(
+                catalog::collect_table_metadata(
+                    &self.ctx,
+                    Some(catalog_name),
+                    Some(schema_name),
+                    None,
+                )
+                .await
+                .map_err(|err| datafusion_to_core(&err, &self.tables))?,
+            );
+        }
+        let mut seen = std::collections::HashSet::new();
+        tables.retain(|table| {
+            seen.insert((
+                table.catalog_name.clone(),
+                table.schema_name.clone(),
+                table.table_name.clone(),
+            ))
+        });
         Ok(tables)
     }
 
@@ -903,15 +923,42 @@ fn schema_to_source_names(sources: &[QuerySource]) -> HashMap<String, String> {
         .collect()
 }
 
-fn table_context_schema_filters(parts: &[String]) -> Vec<String> {
+/// Metadata filters recovered from a missing table reference's qualifier.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TableContextFilters {
+    /// Whole-qualifier matches against either `catalog_name` or `schema_name`.
+    /// Recovers dotted source names like `"foo.bar"` from their exploded form.
+    qualifiers: Vec<String>,
+    /// Split `(catalog, schema)` pairs for multi-part references, since a
+    /// reference like `warehouse.public.typo` names a catalog and schema that
+    /// no whole-qualifier comparison can match.
+    pairs: Vec<(String, String)>,
+}
+
+impl TableContextFilters {
+    fn is_empty(&self) -> bool {
+        self.qualifiers.is_empty() && self.pairs.is_empty()
+    }
+}
+
+fn table_context_filters(parts: &[String]) -> TableContextFilters {
     let body = match parts {
         [catalog, rest @ ..] if catalog == "datafusion" => rest,
         _ => parts,
     };
     match body {
-        [] | [_] => Vec::new(),
-        [schema, _table] => vec![schema.clone()],
-        [schema @ .., _table] => vec![schema.join(".")],
+        [] | [_] => TableContextFilters::default(),
+        [schema, _table] => TableContextFilters {
+            qualifiers: vec![schema.clone()],
+            pairs: Vec::new(),
+        },
+        [catalog, schema @ .., _table] => {
+            let schema = schema.join(".");
+            TableContextFilters {
+                qualifiers: vec![format!("{catalog}.{schema}")],
+                pairs: vec![(catalog.clone(), schema)],
+            }
+        }
     }
 }
 
@@ -1027,27 +1074,34 @@ mod tests {
 
     #[test]
     fn table_context_filters_scope_dynamic_error_hints() {
-        assert!(table_context_schema_filters(&["missing".to_string()]).is_empty());
+        assert!(table_context_filters(&["missing".to_string()]).is_empty());
         assert_eq!(
-            table_context_schema_filters(&["demo".to_string(), "evetns".to_string()]),
-            ["demo".to_string()]
+            table_context_filters(&["demo".to_string(), "evetns".to_string()]),
+            TableContextFilters {
+                qualifiers: vec!["demo".to_string()],
+                pairs: Vec::new(),
+            }
         );
+        let three_part = TableContextFilters {
+            qualifiers: vec!["pickl.pgboss".to_string()],
+            pairs: vec![("pickl".to_string(), "pgboss".to_string())],
+        };
         assert_eq!(
-            table_context_schema_filters(&[
+            table_context_filters(&[
                 "pickl".to_string(),
                 "pgboss".to_string(),
                 "queu".to_string()
             ]),
-            ["pickl.pgboss".to_string()]
+            three_part
         );
         assert_eq!(
-            table_context_schema_filters(&[
+            table_context_filters(&[
                 "datafusion".to_string(),
                 "pickl".to_string(),
                 "pgboss".to_string(),
                 "queu".to_string()
             ]),
-            ["pickl.pgboss".to_string()]
+            three_part
         );
     }
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -308,10 +308,14 @@ impl QueryRuntimeAdapter {
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
     ) -> Result<CatalogInfo, CoreError> {
+        // Catalog summaries never surface columns, so skip the coral.columns
+        // expansion (and the remote database inventory fetches behind it).
+        let tables =
+            catalog::collect_table_metadata(&self.ctx, catalog_filter, schema_filter, None)
+                .await
+                .map_err(|err| datafusion_to_core(&err, &self.tables))?;
         Ok(CatalogInfo {
-            tables: self
-                .list_tables(catalog_filter, schema_filter, None)
-                .await?,
+            tables,
             table_functions: if catalog_filter.is_none() {
                 self.list_table_functions(schema_filter, None)
             } else {

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -24,7 +24,7 @@ use crate::runtime::dependent_join::optimizer;
 use crate::runtime::dependent_join::planner::DependentJoinExtensionPlanner;
 use crate::runtime::error::{
     datafusion_to_core, datafusion_to_core_with_sql_and_table_functions, missing_table_reference,
-    query_result_observer_error_to_core,
+    query_result_observer_error_to_core, strip_default_catalog,
 };
 use crate::runtime::json::register_json_support;
 use crate::runtime::pattern_validator::register_pattern_validator;
@@ -351,12 +351,23 @@ impl QueryRuntimeAdapter {
         schema_name: &str,
         table_name: &str,
     ) -> Result<DescribeTableInfo, CoreError> {
-        if let Some(table) = self
+        let matches = self
             .list_tables(catalog_name, Some(schema_name), Some(table_name))
-            .await?
-            .into_iter()
-            .next()
-        {
+            .await?;
+        // An omitted catalog is a wildcard; refuse to guess when the same
+        // schema.table pair exists in more than one catalog.
+        if matches.len() > 1 {
+            let candidates = matches
+                .iter()
+                .map(Self::qualified_table_reference)
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(CoreError::InvalidInput(format!(
+                "table reference `{schema_name}.{table_name}` is ambiguous; \
+                 qualify the catalog: {candidates}"
+            )));
+        }
+        if let Some(table) = matches.into_iter().next() {
             return Ok(DescribeTableInfo {
                 table: Some(table),
                 missing_context_tables: Vec::new(),
@@ -551,6 +562,17 @@ impl QueryRuntimeAdapter {
         Ok(tables)
     }
 
+    fn qualified_table_reference(table: &TableInfo) -> String {
+        if table.catalog_name.is_empty() {
+            format!("`{}.{}`", table.schema_name, table.table_name)
+        } else {
+            format!(
+                "`{}.{}.{}`",
+                table.catalog_name, table.schema_name, table.table_name
+            )
+        }
+    }
+
     async fn table_metadata_for_describe_miss(&self) -> Result<Vec<TableInfo>, CoreError> {
         catalog::collect_table_metadata(&self.ctx, None, None, None)
             .await
@@ -623,7 +645,10 @@ impl QueryRuntimeAdapter {
         let Some((schema_name, table_name)) = relation_parts(table_reference) else {
             return;
         };
-        let catalog_name = table_reference.catalog();
+        // `datafusion.schema.table` is the same relation as `schema.table`;
+        // without stripping, explicit default-catalog references match no
+        // registered table and drop out of provenance.
+        let catalog_name = strip_default_catalog(table_reference.catalog());
         if let Some(catalog) = catalog_name
             && self.schema_to_source.contains_key(catalog)
         {
@@ -1040,6 +1065,24 @@ mod tests {
             failures: Vec::new(),
             schema_to_source: HashMap::from([("demo".to_string(), "demo".to_string())]),
             query_result_observers: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn table_scan_usage_keeps_explicit_default_catalog_references() {
+        let adapter = adapter_with_table();
+
+        for reference in [
+            TableReference::partial("demo", "events"),
+            TableReference::full("datafusion", "demo", "events"),
+            TableReference::full("DataFusion", "demo", "events"),
+        ] {
+            let mut tables = std::collections::BTreeSet::new();
+            adapter.collect_table_scan_usage(&reference, &mut tables);
+            let usage = tables
+                .first()
+                .unwrap_or_else(|| panic!("reference {reference} must record provenance"));
+            assert_eq!(usage.source_name(), "demo");
         }
     }
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -162,9 +162,12 @@ async fn build_registered_runtime(
         source_decorators,
     )
     .await?;
-    catalog::register(&ctx, &registration.active_sources)
-        .await
-        .map_err(|err| datafusion_to_core(&err, &[]))?;
+    catalog::register(
+        &ctx,
+        &registration.active_sources,
+        &registration.column_fetchers,
+    )
+    .map_err(|err| datafusion_to_core(&err, &[]))?;
     let tables = catalog::collect_static_tables(&registration.active_sources);
     let table_functions = catalog::collect_table_functions(&registration.active_sources);
     let source_functions = SourceFunctionRegistry::new(
@@ -949,7 +952,7 @@ mod tests {
     use crate::backends::{RegisteredSource, RegisteredTable};
     use crate::{DependentJoinConfig, MemorySize, QueryMemoryConfig, QueryRuntimeContext};
 
-    async fn adapter_with_table() -> QueryRuntimeAdapter {
+    fn adapter_with_table() -> QueryRuntimeAdapter {
         let active_sources = vec![RegisteredSource {
             catalog_name: None,
             schema_name: "demo".to_string(),
@@ -975,9 +978,7 @@ mod tests {
             inputs: Vec::new(),
         }];
         let ctx = Arc::new(SessionContext::new());
-        catalog::register(&ctx, &active_sources)
-            .await
-            .expect("catalog should register");
+        catalog::register(&ctx, &active_sources, &[]).expect("catalog should register");
         let tables = catalog::collect_static_tables(&active_sources);
         QueryRuntimeAdapter {
             ctx,
@@ -994,7 +995,6 @@ mod tests {
     #[tokio::test]
     async fn describe_table_hit_returns_full_table_without_missing_context() {
         let result = adapter_with_table()
-            .await
             .describe_table(None, "demo", "events")
             .await
             .expect("describe table");
@@ -1007,7 +1007,6 @@ mod tests {
     #[tokio::test]
     async fn describe_table_miss_returns_columnless_context_tables() {
         let result = adapter_with_table()
-            .await
             .describe_table(None, "demo", "missing")
             .await
             .expect("describe table miss");

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -355,11 +355,21 @@ fn register_backend_registration(
         result.active_sources.push(registered_source);
     }
     for (catalog_name, _registered_catalog, registered_source, column_fetcher) in catalog_staged {
-        result.active_sources.push(registered_source);
         result.column_fetchers.push(CatalogColumnFetcher {
             catalog_name,
+            schema_names: registered_source
+                .tables
+                .iter()
+                .filter_map(|table| table.schema_name.clone())
+                .collect(),
+            table_names: registered_source
+                .tables
+                .iter()
+                .map(|table| table.table_name.clone())
+                .collect(),
             fetcher: column_fetcher,
         });
+        result.active_sources.push(registered_source);
     }
     Ok(())
 }

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -9,7 +9,7 @@ use tracing::{Instrument as _, info_span};
 
 use crate::backends::{
     BackendCatalogRegistration, BackendRegistration, BackendRegistrationContext,
-    BackendSchemaRegistration, CompiledBackendSource, RegisteredSource,
+    BackendSchemaRegistration, CatalogColumnFetcher, CompiledBackendSource, RegisteredSource,
 };
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
@@ -57,6 +57,9 @@ pub(crate) struct SourceRegistrationFailure {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SourceRegistrationResult {
     pub(crate) active_sources: Vec<RegisteredSource>,
+    /// Lazy column-metadata fetchers for registered database catalogs, in
+    /// registration order.
+    pub(crate) column_fetchers: Vec<CatalogColumnFetcher>,
     pub(crate) failures: Vec<SourceRegistrationFailure>,
 }
 
@@ -307,8 +310,9 @@ fn register_backend_registration(
             catalog_name,
             catalog,
             source,
+            column_fetcher,
         } = catalog_registration;
-        catalog_staged.push((catalog_name, catalog, source));
+        catalog_staged.push((catalog_name, catalog, source, column_fetcher));
     }
 
     for schema_registration in registration.schemas {
@@ -343,15 +347,19 @@ fn register_backend_registration(
         }
     }
 
-    for (catalog_name, registered_catalog, _registered_source) in &catalog_staged {
+    for (catalog_name, registered_catalog, _registered_source, _column_fetcher) in &catalog_staged {
         ctx.register_catalog(catalog_name, Arc::clone(registered_catalog));
     }
 
     for (_schema_name, _decorated_tables, registered_source) in staged {
         result.active_sources.push(registered_source);
     }
-    for (_catalog_name, _registered_catalog, registered_source) in catalog_staged {
+    for (catalog_name, _registered_catalog, registered_source, column_fetcher) in catalog_staged {
         result.active_sources.push(registered_source);
+        result.column_fetchers.push(CatalogColumnFetcher {
+            catalog_name,
+            fetcher: column_fetcher,
+        });
     }
     Ok(())
 }


### PR DESCRIPTION
Stacked on #1600.

## Problem

`coral.columns` unioned DataFusion's `information_schema.columns`, which materializes by awaiting `table()` for every relation in every registered catalog — one remote Arrow-schema probe per table. A database with 500 tables cost ~500 remote round trips per scan, even when filtered to a single table, and `list_tables`/`describe_table` issue a `coral.columns` query on every call.

## Approach

Replace the view with a purpose-built `coral.columns` TableProvider:

- **One round trip per source, not per table.** Each provider answers from its own catalog — `information_schema.columns` for Postgres/MySQL, `sqlite_master ⋈ pragma_table_info` for SQLite — normalized to a common shape and fetched concurrently at scan time on the cached connection pool.
- **Pin-based pruning.** Pushed-down predicates on `catalog_name`/`schema_name`/`table_name` (equality, `IN`, same-column OR chains) skip non-matching sources entirely and narrow the remote WHERE. Pushdown is Inexact, so DataFusion re-applies every predicate above the scan: unrecognized filter shapes fetch more, never return wrong results.
- **Injection-safe by construction.** Pinned values that cannot sit verbatim inside a quoted SQL literal (quote/backslash/NUL) drop the whole dimension's remote restriction instead of being escaped — fetch-more stays correct under Inexact semantics, and attacker-controlled text never reaches remote SQL (MySQL treats `\` as a string escape under its default `sql_mode`).
- **Degraded, not failed.** An unreachable database logs a warning and drops out of the scan; other sources still answer.
- **Less machinery.** The planning-schema double registration, `ViewTable` indirection, and view-SQL builders are deleted; `catalog::register` is synchronous again.

## User-visible changes

- `list_tables`, `describe_table`, and MCP `list_columns` now return real column metadata for database tables (previously empty) — including empty tables, which the old row-sampling probe reported as columnless.
- `data_type` for database columns is the provider-native name (`INTEGER`, `character varying`) instead of an Arrow rendering, since metadata now comes from the remote catalog.

## Testing

- Unit: sqlite-backed inventory tests (one-query fetch, filters, escaping policy, injection shapes), pin-extraction matrix (equality both sides, IN, OR chains, intersection, unprunable shapes), stub-fetcher pruning regression test proving a catalog-pinned scan contacts exactly one source with the narrowed filter.
- E2E: sqlite source via `CoralQuery` (pinned + unpinned `coral.columns`, populated `list_tables` columns).
- Live: drove the CLI and MCP stdio surfaces against a live sqlite source — pinned/IN/OR queries, hostile literals, cross-column ORs, and mid-session DDL freshness.
- `cargo test -p coral-engine` 515 passed; clippy and fmt clean. The two failing coral-mcp tests are pre-existing on the base branch (verified with this work stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)