### PR TITLE
fix(app): verify derived v4 base URLs

### DIFF
--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -84,11 +84,13 @@ root.
 - Treat DSL v4 materialization as a user-chosen lifecycle event: generate at
   source add and never re-fetch descriptors, recompute projections, or rewrite
   artifacts implicitly during query/list/validate. Fingerprints, producer
-  versions, identity metadata, and raw-document hashes are tracing diagnostics,
-  not runtime gates. Load readable, structurally compatible artifacts and
-  isolate source-local compatibility failures while preserving fail-closed
-  behavior for operational errors. RDBMS migration machinery must not turn
-  load-time compatibility into silent regeneration.
+  versions and identity metadata are tracing diagnostics, not runtime gates.
+  Raw-document hashes remain advisory at load time, but a raw document used to
+  derive an OpenAPI base URL must match its recorded hash before it can control
+  runtime request routing. Load readable, structurally compatible artifacts,
+  degrade per surface, and isolate source-local compatibility failures while
+  preserving fail-closed behavior for operational errors. RDBMS migration
+  machinery must not turn load-time compatibility into silent regeneration.
 - Treat `projections.yaml` as an immutable materialized snapshot. Effective
   operation-metadata overrides never reconcile projection exposure or lookup
   keys at runtime. Reject incompatible selected artifact combinations instead

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -471,6 +471,21 @@ fn surface_base_url(
             "failed to read materialized OpenAPI surface document: {error}"
         ))
     })?;
+    let expected_sha256 = materialized_surface
+        .source_document_sha256
+        .as_deref()
+        .ok_or_else(|| {
+            AppError::FailedPrecondition(
+                "cannot derive base_url for DSL v4 surface without a raw source document fingerprint"
+                    .to_string(),
+            )
+        })?;
+    if sha256_hex(&bytes) != expected_sha256 {
+        return Err(AppError::FailedPrecondition(
+            "refusing to derive base_url for DSL v4 surface because its raw source document fingerprint does not match"
+                .to_string(),
+        ));
+    }
     let metadata = openapi_document_metadata(&bytes).map_err(|error| {
         AppError::FailedPrecondition(format!(
             "failed to derive base_url for DSL v4 surface: {error}"
@@ -532,6 +547,7 @@ mod tests {
     };
 
     use crate::bootstrap::AppError;
+    use crate::hash::sha256_hex;
 
     use super::{runtime_component_for_v4_source, runtime_contract_fingerprint, surface_base_url};
 
@@ -1513,13 +1529,45 @@ paths: {}
 
         let surface = surface_without_authored_base_url();
         let manifest = manifest_with_surface(surface.clone());
-        let error = surface_base_url(&manifest, &surface, &materialized_surface(openapi))
+        let mut materialized_surface = materialized_surface(openapi.clone());
+        materialized_surface.source_document_sha256 = Some(sha256_hex(
+            &std::fs::read(&openapi).expect("read OpenAPI document"),
+        ));
+        let error = surface_base_url(&manifest, &surface, &materialized_surface)
             .expect_err("runtime token should be rejected");
 
         assert!(
             error
                 .to_string()
                 .contains("base_url may only reference top-level inputs"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn derived_openapi_server_url_rejects_tampered_raw_document() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let openapi = temp.path().join("openapi.yaml");
+        let original = b"openapi: 3.0.3\nservers:\n  - url: https://api.example.com\npaths: {}\n";
+        std::fs::write(&openapi, original).expect("write original OpenAPI document");
+
+        let surface = surface_without_authored_base_url();
+        let manifest = manifest_with_surface(surface.clone());
+        let mut materialized_surface = materialized_surface(openapi.clone());
+        materialized_surface.source_document_sha256 = Some(sha256_hex(original));
+        std::fs::write(
+            &openapi,
+            b"openapi: 3.0.3\nservers:\n  - url: https://attacker.example\npaths: {}\n",
+        )
+        .expect("tamper OpenAPI document");
+
+        let error = surface_base_url(&manifest, &surface, &materialized_surface)
+            .expect_err("tampered OpenAPI document must not supply the base URL");
+
+        assert!(
+            error
+                .to_string()
+                .contains("raw source document fingerprint"),
             "unexpected error: {error}"
         );
     }


### PR DESCRIPTION
### Motivation
- A materialized DSL v4 raw OpenAPI document could be tampered with on disk and still be used at runtime to derive a `base_url`, which could redirect authenticated requests to an attacker-controlled origin. 
- The materialization changes made provenance/hash mismatches advisory at load time but the runtime still consumed the raw document for routing, which is a security-sensitive operation that must be fail-closed.

### Description
- Add a SHA-256 verification step in `surface_base_url` to refuse deriving a runtime base URL when the materialized `source-document.raw` does not have a recorded `source_document_sha256` or when its SHA-256 does not match the recorded value (`crates/coral-app/src/sources/runtime_package.rs`).
- Make the code return a `FailedPrecondition` error instead of accepting a tampered raw document for derived routing, preserving existing behavior for authored `base_url` templates.
- Add a regression test `derived_openapi_server_url_rejects_tampered_raw_document` that verifies a tampered `servers[0].url` cannot be used if the raw document fingerprint does not match (test located in the same file's test module).
- Update `crates/coral-app/AGENTS.md` to clarify that raw-document hashes remain advisory during materialization loading, but documents that determine OpenAPI runtime routing must pass fingerprint verification before being used.

### Testing
- Ran `cargo test -p coral-app --all-features derived_openapi_server_url` and the added/related tests passed.
- Ran repository checks `cargo fmt --all -- --check` and `make rust-checks` (which includes `cargo clippy` and workspace checks) and they completed successfully.
- Verified no `git diff --check` failures after formatting and changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5a0c8e1c24832a84e8cd157c392542)