### PR TITLE
feat(reef): forward ids through text inputs

### DIFF
--- a/apps/reef/app/wax/components/inputs/text/text-input.tsx
+++ b/apps/reef/app/wax/components/inputs/text/text-input.tsx
@@ -10,6 +10,7 @@ export interface TextInputProps {
   className?: string
   disabled?: boolean
   icon?: IconName
+  id?: string
   name?: string
   onBlur?: () => void
   onChange?: (value: string) => void
@@ -26,6 +27,7 @@ export function TextInput({
   className,
   disabled,
   icon,
+  id,
   name,
   onBlur,
   onChange,
@@ -54,6 +56,7 @@ export function TextInput({
         <Field.Control
           autoFocus={autoFocus}
           className={classNames(styles.input, { [styles.inputWithIcon]: !!icon }, className)}
+          id={id}
           name={name}
           onBlur={onBlur}
           onChange={handleChange}


### PR DESCRIPTION
TL/DR useful to pair with a `label` and `htmlFor`  
  
Constraint: TextInput must forward an optional id without changing existing call sites.

Confidence: high

Scope-risk: narrow

Tested: npm run check --prefix apps/reef; npm run typecheck --prefix apps/reef; npm test --prefix apps/reef