### PR TITLE
feat(reef): source creation wizard for DSL v4 manifests

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -361,6 +361,7 @@ describe('Architectural Tests', () => {
       expect(routeConfig).toContain(
         "route(routePattern('workspaceSources'), 'routes/sources.tsx', [",
       )
+      expect(routeConfig).toContain("route('install', 'routes/source-install.tsx')")
       expect(routeConfig).toContain("route(':sourceName', 'routes/source-detail.tsx')")
       // Schema is a layout with nested table-detail routes.
       expect(routeConfig).toContain("route(routePattern('workspaceSchema'), 'routes/schema.tsx', [")

--- a/apps/reef/app/components/sources/source-catalog-surface.css.ts
+++ b/apps/reef/app/components/sources/source-catalog-surface.css.ts
@@ -67,16 +67,8 @@ export const headerText = style({
   flex: '1 1 auto',
   flexDirection: 'column',
   gap: 4,
+  maxWidth: 363,
   minWidth: 0,
-})
-
-export const headerTextVariant = styleVariants({
-  compact: {
-    maxWidth: 420,
-  },
-  full: {
-    maxWidth: 680,
-  },
 })
 
 export const searchBar = style({
@@ -91,13 +83,21 @@ export const searchBar = style({
 
 export const searchBarVariant = styleVariants({
   compact: {
-    flex: '0 0 280px',
+    flex: '0 1 280px',
     maxWidth: 280,
+    minWidth: 180,
   },
   full: {
-    flex: '0 0 360px',
+    flex: '0 1 360px',
     maxWidth: 360,
+    minWidth: 200,
   },
+})
+
+export const headerAction = style({
+  alignItems: 'center',
+  display: 'flex',
+  flexShrink: 0,
 })
 
 export const statusPanel = style({

--- a/apps/reef/app/components/sources/source-catalog-surface.css.ts
+++ b/apps/reef/app/components/sources/source-catalog-surface.css.ts
@@ -26,8 +26,7 @@ export const headerInner = style({
   alignItems: 'flex-start',
   boxSizing: 'border-box',
   display: 'flex',
-  gap: 24,
-  justifyContent: 'space-between',
+  gap: 8,
   marginInline: 'auto',
   width: '100%',
 })
@@ -72,6 +71,7 @@ export const headerText = style({
 })
 
 export const searchBar = style({
+  marginInlineStart: 'auto',
   width: '100%',
   '@media': {
     [`screen and (max-width: ${breakpoints.mobile})`]: {
@@ -88,9 +88,9 @@ export const searchBarVariant = styleVariants({
     minWidth: 180,
   },
   full: {
-    flex: '0 1 360px',
-    maxWidth: 360,
-    minWidth: 200,
+    flex: '0 1 280px',
+    maxWidth: 280,
+    minWidth: 180,
   },
 })
 

--- a/apps/reef/app/components/sources/source-catalog-surface.stories.tsx
+++ b/apps/reef/app/components/sources/source-catalog-surface.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { fn } from 'storybook/test'
 
 import type { CatalogEntry } from '@/lib/sources'
+import { Button } from '@/wax/components'
 import { theme } from '@/wax/theme/theme.css'
 
 import { SourceCatalogSurface } from './source-catalog-surface'
@@ -62,6 +63,22 @@ type Story = StoryObj<typeof meta>
 export const Full: Story = {
   args: {
     entries,
+    loadState: 'idle',
+    onPick: fn(),
+    onSearchChange: fn(),
+    search: '',
+  },
+}
+
+export const WithHeaderAction: Story = {
+  args: {
+    entries,
+    headerAction: (
+      <Button.Container variant="primary">
+        <Button.Icon name="Plus" />
+        <Button.Text>Create source</Button.Text>
+      </Button.Container>
+    ),
     loadState: 'idle',
     onPick: fn(),
     onSearchChange: fn(),

--- a/apps/reef/app/components/sources/source-catalog-surface.stories.tsx
+++ b/apps/reef/app/components/sources/source-catalog-surface.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { fn } from 'storybook/test'
+import { expect, fn } from 'storybook/test'
 
 import type { CatalogEntry } from '@/lib/sources'
 import { Button } from '@/wax/components'
@@ -74,7 +74,7 @@ export const WithHeaderAction: Story = {
   args: {
     entries,
     headerAction: (
-      <Button.Container variant="primary">
+      <Button.Container size="36" variant="primary">
         <Button.Icon name="Plus" />
         <Button.Text>Create source</Button.Text>
       </Button.Container>
@@ -83,6 +83,15 @@ export const WithHeaderAction: Story = {
     onPick: fn(),
     onSearchChange: fn(),
     search: '',
+  },
+  play: async ({ canvas }) => {
+    const search = canvas.getByPlaceholderText('Search sources…')
+    const action = canvas.getByRole('button', { name: 'Create source' })
+
+    expect(search.getBoundingClientRect().width).toBeLessThanOrEqual(280)
+    expect(
+      Math.abs(action.getBoundingClientRect().height - search.getBoundingClientRect().height),
+    ).toBeLessThanOrEqual(1)
   },
 }
 

--- a/apps/reef/app/components/sources/source-catalog-surface.tsx
+++ b/apps/reef/app/components/sources/source-catalog-surface.tsx
@@ -21,6 +21,7 @@ export type SourceCatalogSurfaceVariant = 'compact' | 'full'
 interface SourceCatalogSurfaceBaseProps {
   entries: SourceCatalogEntry[]
   errorMessage?: string | null
+  headerAction?: React.ReactNode
   loadState?: SourceCatalogLoadState
   onRetry?: () => void
   onSearchChange: (search: string) => void
@@ -38,6 +39,7 @@ export function SourceCatalogSurface(props: SourceCatalogSurfaceProps) {
   const {
     entries,
     errorMessage = null,
+    headerAction = null,
     loadState = 'idle',
     onRetry,
     onSearchChange,
@@ -57,7 +59,7 @@ export function SourceCatalogSurface(props: SourceCatalogSurfaceProps) {
     : { onPick: props.onPick }
   const loading = loadState === 'loading'
   const error = loadState === 'error'
-  const shouldShowHeader = showHeader && (showTitle || showSearch)
+  const shouldShowHeader = showHeader && (showTitle || showSearch || headerAction !== null)
 
   return (
     <section
@@ -68,7 +70,7 @@ export function SourceCatalogSurface(props: SourceCatalogSurfaceProps) {
         <div className={styles.header}>
           <div className={classNames(styles.headerInner, styles.headerInnerVariant[variant])}>
             {showTitle ? (
-              <div className={classNames(styles.headerText, styles.headerTextVariant[variant])}>
+              <div className={styles.headerText}>
                 <Typography.HeadingLarge as="h1">Sources</Typography.HeadingLarge>
                 <Typography.Body variant="secondary">
                   Connect external systems to query their data from Coral. Click a source to install
@@ -88,6 +90,8 @@ export function SourceCatalogSurface(props: SourceCatalogSurfaceProps) {
                 />
               </div>
             ) : null}
+
+            {headerAction ? <div className={styles.headerAction}>{headerAction}</div> : null}
           </div>
         </div>
       ) : null}

--- a/apps/reef/app/components/sources/source-create.stories.tsx
+++ b/apps/reef/app/components/sources/source-create.stories.tsx
@@ -1,0 +1,149 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { createContext, useContext, type ComponentProps } from 'react'
+
+import { createRoutesStub } from 'react-router'
+import { expect, fn, waitFor, within } from 'storybook/test'
+
+import { SourceCreateDialog } from '@/views/sources/source-create'
+
+type SourceCreateDialogProps = ComponentProps<typeof SourceCreateDialog>
+
+const DISCOVERY_PATH = '/workspaces/default/sources/discover'
+const DISCOVERY = {
+  auth: { kind: 'bearer' as const, label: 'Bearer token' },
+  description: 'Weather observations and forecasts',
+  format: 'openapi-yaml' as const,
+  name: 'weather_api',
+  status: 'success' as const,
+  url: 'https://weather.example/openapi.yaml',
+}
+
+const SourceCreateStoryContext = createContext<SourceCreateDialogProps | null>(null)
+const SourceCreateRoutesStub = createRoutesStub([
+  {
+    loader: () => DISCOVERY,
+    path: '/workspaces/:workspaceId/sources/discover',
+  },
+  {
+    Component: SourceCreateStoryRoute,
+    path: '/workspaces/:workspaceId/sources/install',
+  },
+])
+
+const meta = {
+  args: {
+    actionData: undefined,
+    discoveryPath: DISCOVERY_PATH,
+    onOpenChange: fn(),
+    open: true,
+  },
+  component: SourceCreateDialog,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: (args) => <SourceCreateDialogStory {...args} />,
+  tags: ['autodocs'],
+  title: 'Components/Sources/SourceCreateDialog',
+} satisfies Meta<typeof SourceCreateDialog>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Basics: Story = {
+  name: 'URL',
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body)
+
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByText('Step 1 of 3 — URL')).toBeVisible()
+    await expect(page.getByLabelText('Source URL')).toBeVisible()
+  },
+}
+
+export const Connection: Story = {
+  name: 'Details',
+  play: async ({ canvasElement, userEvent }) => {
+    const page = within(canvasElement.ownerDocument.body)
+
+    await userEvent.type(page.getByLabelText('Source URL'), DISCOVERY.url)
+    await userEvent.click(page.getByRole('button', { name: 'Next' }))
+
+    await waitFor(() => expect(page.getByLabelText('Name')).toHaveValue('weather_api'))
+    await waitFor(() => expect(activeDialogCount(canvasElement.ownerDocument)).toBe(2))
+    await userEvent.click(page.getByRole('radio', { name: 'MCP server' }))
+    await expect(page.getByRole('radio', { name: 'MCP server' })).toBeChecked()
+  },
+}
+
+export const Credentials: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const page = within(canvasElement.ownerDocument.body)
+
+    await userEvent.type(page.getByLabelText('Source URL'), DISCOVERY.url)
+    await userEvent.click(page.getByRole('button', { name: 'Next' }))
+    await waitFor(() => expect(page.getByLabelText('Name')).toHaveValue('weather_api'))
+    await userEvent.click(page.getByRole('button', { name: 'Next' }))
+
+    await waitFor(() => {
+      const activeToken = page
+        .getAllByPlaceholderText('Paste token')
+        .find((element) => !element.hasAttribute('disabled'))
+      if (!activeToken) throw new Error('Active token input not found')
+      return expect(activeToken).toBeVisible()
+    })
+    await waitFor(() => expect(activeDialogCount(canvasElement.ownerDocument)).toBe(3))
+  },
+}
+
+export const ImportError: Story = {
+  args: {
+    actionData: {
+      intent: 'import',
+      message: 'The OpenAPI descriptor could not be loaded.',
+      name: 'weather_api',
+      status: 'error',
+    },
+  },
+  name: 'Import error',
+  play: async ({ canvasElement, userEvent }) => {
+    const page = within(canvasElement.ownerDocument.body)
+
+    await userEvent.type(page.getByLabelText('Source URL'), DISCOVERY.url)
+    await userEvent.click(page.getByRole('button', { name: 'Next' }))
+    await waitFor(() => expect(page.getByLabelText('Name')).toHaveValue('weather_api'))
+    await userEvent.click(page.getByRole('button', { name: 'Next' }))
+
+    await waitFor(() => expect(activeDialogCount(canvasElement.ownerDocument)).toBe(3))
+    await waitFor(() => {
+      const dialogs = activeDialogs(canvasElement.ownerDocument)
+      const credentialsDialog = dialogs.item(dialogs.length - 1)
+      if (!(credentialsDialog instanceof HTMLElement))
+        throw new Error('Credentials dialog not found')
+      return expect(
+        within(credentialsDialog).getByText('The OpenAPI descriptor could not be loaded.'),
+      ).toBeVisible()
+    })
+  },
+}
+
+function activeDialogCount(document: Document) {
+  return activeDialogs(document).length
+}
+
+function activeDialogs(document: Document) {
+  return document.querySelectorAll('[role="dialog"]:not([data-ending-style])')
+}
+
+function SourceCreateDialogStory(args: SourceCreateDialogProps) {
+  return (
+    <SourceCreateStoryContext.Provider value={args}>
+      <SourceCreateRoutesStub initialEntries={['/workspaces/default/sources/install']} />
+    </SourceCreateStoryContext.Provider>
+  )
+}
+
+function SourceCreateStoryRoute() {
+  const args = useContext(SourceCreateStoryContext)
+  if (!args) return null
+  return <SourceCreateDialog {...args} />
+}

--- a/apps/reef/app/components/sources/source-create.stories.tsx
+++ b/apps/reef/app/components/sources/source-create.stories.tsx
@@ -55,8 +55,27 @@ export const Basics: Story = {
     const page = within(canvasElement.ownerDocument.body)
 
     await expect(page.getByRole('dialog')).toBeVisible()
-    await expect(page.getByText('Step 1 of 3 — URL')).toBeVisible()
+    await expect(page.getByText('Step 1/3')).toBeVisible()
     await expect(page.getByLabelText('Source URL')).toBeVisible()
+    await expect(
+      page.getByText('Enter an OpenAPI document or streamable HTTP MCP endpoint.'),
+    ).toBeVisible()
+  },
+}
+
+export const DiscardConfirmation: Story = {
+  name: 'Discard confirmation',
+  play: async ({ canvasElement, userEvent }) => {
+    const page = within(canvasElement.ownerDocument.body)
+
+    await userEvent.type(page.getByLabelText('Source URL'), DISCOVERY.url)
+    await userEvent.click(page.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() =>
+      expect(page.getByRole('dialog', { name: 'Discard source draft?' })).toBeVisible(),
+    )
+    await expect(page.getByRole('button', { name: 'Keep editing' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Discard' })).toBeVisible()
   },
 }
 
@@ -69,6 +88,7 @@ export const Connection: Story = {
     await userEvent.click(page.getByRole('button', { name: 'Next' }))
 
     await waitFor(() => expect(page.getByLabelText('Name')).toHaveValue('weather_api'))
+    await waitFor(() => expect(page.getByText('Step 2/3')).toBeVisible())
     await waitFor(() => expect(activeDialogCount(canvasElement.ownerDocument)).toBe(2))
     await userEvent.click(page.getByRole('radio', { name: 'MCP server' }))
     await expect(page.getByRole('radio', { name: 'MCP server' })).toBeChecked()
@@ -84,14 +104,16 @@ export const Credentials: Story = {
     await waitFor(() => expect(page.getByLabelText('Name')).toHaveValue('weather_api'))
     await userEvent.click(page.getByRole('button', { name: 'Next' }))
 
-    await waitFor(() => {
-      const activeToken = page
-        .getAllByPlaceholderText('Paste token')
-        .find((element) => !element.hasAttribute('disabled'))
-      if (!activeToken) throw new Error('Active token input not found')
-      return expect(activeToken).toBeVisible()
-    })
+    const activeToken = page
+      .getAllByPlaceholderText('Paste token')
+      .find((element) => !element.hasAttribute('disabled'))
+    if (!activeToken) throw new Error('Active token input not found')
+    await waitFor(() => expect(activeToken).toBeVisible())
     await waitFor(() => expect(activeDialogCount(canvasElement.ownerDocument)).toBe(3))
+    await waitFor(() => expect(page.getByText('Step 3/3')).toBeVisible())
+    await userEvent.click(page.getByRole('radio', { name: 'None' }))
+    await expect(page.getByText('This endpoint doesn’t require credentials.')).toBeVisible()
+    await expect(activeToken).not.toBeVisible()
   },
 }
 

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -12,6 +12,8 @@ export default [
     index('routes/index.tsx'),
     route(routePattern('workspaces'), 'routes/workspaces-action.ts'),
     route(routePattern('workspaceSources'), 'routes/sources.tsx', [
+      route('discover', 'routes/source-discovery.ts'),
+      route('install', 'routes/source-install.tsx'),
       route(':sourceName', 'routes/source-detail.tsx'),
     ]),
     route(routePattern('workspaceSchema'), 'routes/schema.tsx', [

--- a/apps/reef/app/routes/source-discovery.server.test.ts
+++ b/apps/reef/app/routes/source-discovery.server.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { inspectSourceDocument, loader } from './source-discovery'
+
+describe('source discovery', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('extracts source details from OpenAPI JSON', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: {
+            securitySchemes: {
+              bearerAuth: { scheme: 'bearer', type: 'http' },
+            },
+          },
+          info: { description: 'Weather observations and forecasts', title: 'Weather API' },
+          openapi: '3.1.0',
+          security: [{ bearerAuth: [] }],
+        }),
+      ),
+    ).toEqual({
+      auth: { kind: 'bearer', label: 'Bearer token' },
+      description: 'Weather observations and forecasts',
+      format: 'openapi-json',
+      title: 'Weather API',
+    })
+  })
+
+  it('extracts source details from OpenAPI YAML', () => {
+    expect(
+      inspectSourceDocument(`openapi: 3.1.0
+info:
+  title: Weather API
+  description: >
+    Weather observations
+    and forecasts
+paths: {}
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-Api-Key
+`),
+    ).toEqual({
+      auth: { headerName: 'X-Api-Key', kind: 'header', label: 'Header X-Api-Key' },
+      description: 'Weather observations and forecasts',
+      format: 'openapi-yaml',
+      title: 'Weather API',
+    })
+  })
+
+  it('reports documents without an OpenAPI version as unknown', () => {
+    expect(inspectSourceDocument('{"name":"not-openapi"}')).toEqual({
+      auth: { kind: 'unknown', label: '' },
+      description: '',
+      format: 'unknown',
+      title: '',
+    })
+  })
+
+  it('maps OAuth security schemes to a bearer credential', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: { securitySchemes: { oauth: { flows: {}, type: 'oauth2' } } },
+          info: { title: 'OAuth API' },
+          openapi: '3.1.0',
+          security: [{ oauth: [] }],
+        }),
+      ).auth,
+    ).toEqual({ kind: 'bearer', label: 'OAuth 2.0 bearer token' })
+  })
+
+  it('reports unsupported authentication without selecting an incompatible credential', () => {
+    expect(
+      inspectSourceDocument(
+        JSON.stringify({
+          components: {
+            securitySchemes: { queryKey: { in: 'query', name: 'api_key', type: 'apiKey' } },
+          },
+          info: { title: 'Query API' },
+          openapi: '3.1.0',
+          security: [{ queryKey: [] }],
+        }),
+      ).auth,
+    ).toEqual({ kind: 'unsupported', label: 'query API key' })
+  })
+
+  it('loads the URL and returns a query-safe source name', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            info: { description: 'Status checks', title: '123 Status API' },
+            openapi: '3.0.3',
+            security: [],
+          }),
+          { status: 200 },
+        ),
+      ),
+    )
+    const request = new Request(
+      'http://reef.test/workspaces/default/sources/discover?url=https%3A%2F%2Fstatus.example%2Fopenapi.json',
+    )
+
+    await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toEqual({
+      auth: { kind: 'none', label: 'No authentication' },
+      description: 'Status checks',
+      format: 'openapi-json',
+      name: 'source_123_status_api',
+      status: 'success',
+      url: 'https://status.example/openapi.json',
+    })
+  })
+
+  it('rejects non-HTTPS discovery URLs without fetching them', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    const request = new Request(
+      'http://reef.test/workspaces/default/sources/discover?url=http%3A%2F%2Flocalhost%2Fopenapi.json',
+    )
+
+    await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toEqual({
+      message: 'Source discovery requires an HTTPS URL',
+      status: 'error',
+      url: 'http://localhost/openapi.json',
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('detects an HTTP-rejecting /mcp endpoint as an MCP server', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 405 })))
+    const request = new Request(
+      'http://reef.test/workspaces/default/sources/discover?url=https%3A%2F%2Ftools.example%2Fmcp',
+    )
+
+    await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toEqual({
+      auth: { kind: 'unknown', label: '' },
+      description: '',
+      format: 'mcp',
+      name: 'mcp',
+      status: 'success',
+      url: 'https://tools.example/mcp',
+      warning: 'The URL returned HTTP 405',
+    })
+  })
+
+  it('detects an /sse endpoint with a trailing slash and query as an MCP server', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('event: endpoint', { status: 200 })),
+    )
+    const request = new Request(
+      'http://reef.test/workspaces/default/sources/discover?url=https%3A%2F%2Ftools.example%2Fevents%2Fsse%2F%3Ftoken%3Dsecret',
+    )
+
+    await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toEqual({
+      auth: { kind: 'unknown', label: '' },
+      description: '',
+      format: 'mcp',
+      name: 'sse',
+      status: 'success',
+      url: 'https://tools.example/events/sse/?token=secret',
+    })
+  })
+
+  it('keeps OpenAPI detection authoritative for an /mcp URL', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ info: { title: 'Tools API' }, openapi: '3.1.0' }), {
+          status: 200,
+        }),
+      ),
+    )
+    const request = new Request(
+      'http://reef.test/workspaces/default/sources/discover?url=https%3A%2F%2Ftools.example%2Fmcp',
+    )
+
+    await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toMatchObject({
+      format: 'openapi-json',
+      name: 'tools_api',
+    })
+  })
+})

--- a/apps/reef/app/routes/source-discovery.ts
+++ b/apps/reef/app/routes/source-discovery.ts
@@ -1,0 +1,424 @@
+import type { Route } from './+types/source-discovery'
+
+const MAX_DESCRIPTOR_BYTES = 2 * 1024 * 1024
+
+export type SourceDocumentFormat = 'mcp' | 'openapi-json' | 'openapi-yaml' | 'unknown'
+export type SourceDetectedAuth = {
+  headerName?: string
+  kind: 'bearer' | 'header' | 'none' | 'unknown' | 'unsupported'
+  label: string
+}
+
+export type SourceDiscoveryData =
+  | {
+      auth: SourceDetectedAuth
+      description: string
+      format: SourceDocumentFormat
+      name: string
+      status: 'success'
+      url: string
+      warning?: string
+    }
+  | {
+      message: string
+      status: 'error'
+      url: string
+    }
+
+export async function loader({ request }: Route.LoaderArgs): Promise<SourceDiscoveryData> {
+  const rawUrl = new URL(request.url).searchParams.get('url')?.trim() ?? ''
+  if (!rawUrl) return discoveryError(rawUrl, 'Enter a source URL')
+
+  let sourceUrl: URL
+  try {
+    sourceUrl = new URL(rawUrl)
+  } catch {
+    return discoveryError(rawUrl, 'Enter a valid HTTPS URL')
+  }
+  if (sourceUrl.protocol !== 'https:') {
+    return discoveryError(rawUrl, 'Source discovery requires an HTTPS URL')
+  }
+
+  const signal = AbortSignal.any([request.signal, AbortSignal.timeout(10_000)])
+  try {
+    const response = await fetch(sourceUrl, {
+      headers: {
+        accept: 'application/json, application/yaml, text/yaml, text/plain, */*;q=0.1',
+      },
+      signal,
+    })
+    if (!response.ok) {
+      return discoveredSource(rawUrl, sourceUrl, {
+        auth: unknownAuth(),
+        description: '',
+        format: 'unknown',
+        title: '',
+        warning: `The URL returned HTTP ${response.status}`,
+      })
+    }
+
+    const document = await responseTextWithinLimit(response)
+    const metadata = inspectSourceDocument(document)
+    return discoveredSource(rawUrl, sourceUrl, metadata)
+  } catch (error) {
+    if (request.signal.aborted) throw error
+    let warning = 'The source URL could not be loaded'
+    if (signal.aborted) warning = 'Source discovery timed out'
+    else if (error instanceof Error) warning = error.message
+    return discoveredSource(rawUrl, sourceUrl, {
+      auth: unknownAuth(),
+      description: '',
+      format: 'unknown',
+      title: '',
+      warning,
+    })
+  }
+}
+
+export function inspectSourceDocument(document: string): {
+  auth: SourceDetectedAuth
+  description: string
+  format: SourceDocumentFormat
+  title: string
+} {
+  const json = parseJsonObject(document)
+  if (json && hasOpenApiVersion(json)) {
+    const info = objectValue(json.info)
+    return {
+      auth: inspectJsonAuth(json),
+      description: stringValue(info?.description),
+      format: 'openapi-json',
+      title: stringValue(info?.title),
+    }
+  }
+
+  const yaml = inspectOpenApiYaml(document)
+  if (yaml) return { ...yaml, format: 'openapi-yaml' }
+
+  return { auth: unknownAuth(), description: '', format: 'unknown', title: '' }
+}
+
+function inspectJsonAuth(document: Record<string, unknown>): SourceDetectedAuth {
+  const security = Array.isArray(document.security) ? document.security : undefined
+  if (
+    security?.length === 0 ||
+    security?.some((requirement) => objectKeys(requirement).length === 0)
+  ) {
+    return { kind: 'none', label: 'No authentication' }
+  }
+
+  const components = objectValue(document.components)
+  const schemes =
+    objectValue(components?.securitySchemes) ?? objectValue(document.securityDefinitions)
+  if (!schemes) return unknownAuth()
+
+  const requiredSchemeNames = security?.flatMap(objectKeys) ?? []
+  const candidates = requiredSchemeNames.length
+    ? requiredSchemeNames.map((name) => schemes[name])
+    : Object.values(schemes)
+  return bestDetectedAuth(candidates.map((scheme) => authFromScheme(objectValue(scheme))))
+}
+
+function inspectYamlAuth(lines: string[]): SourceDetectedAuth {
+  const rootSecurity = lines.find((line) => indentation(line) === 0 && yamlKey(line) === 'security')
+  if (rootSecurity && yamlScalar(rootSecurity) === '[]') {
+    return { kind: 'none', label: 'No authentication' }
+  }
+
+  const componentsIndex = findYamlKey(lines, 'components', 0)
+  let schemesIndex =
+    componentsIndex >= 0 ? findYamlChildKey(lines, componentsIndex, 'securityschemes') : -1
+  if (schemesIndex < 0) schemesIndex = findYamlKey(lines, 'securitydefinitions', 0)
+  if (schemesIndex < 0) return unknownAuth()
+
+  return bestDetectedAuth(
+    yamlChildIndexes(lines, schemesIndex).map((index) =>
+      authFromScheme(yamlMappingFields(lines, index)),
+    ),
+  )
+}
+
+function authFromScheme(scheme: Record<string, unknown> | undefined): SourceDetectedAuth {
+  if (!scheme) return unknownAuth()
+  const type = stringValue(scheme.type).toLowerCase()
+  const httpScheme = stringValue(scheme.scheme).toLowerCase()
+  const location = stringValue(scheme.in).toLowerCase()
+  const name = stringValue(scheme.name)
+
+  if (type === 'http' && httpScheme === 'bearer') {
+    return { kind: 'bearer', label: 'Bearer token' }
+  }
+  if (type === 'oauth2') {
+    return { kind: 'bearer', label: 'OAuth 2.0 bearer token' }
+  }
+  if (type === 'openidconnect') {
+    return { kind: 'bearer', label: 'OpenID Connect bearer token' }
+  }
+  if (type === 'apikey' && location === 'header' && name) {
+    return { headerName: name, kind: 'header', label: `Header ${name}` }
+  }
+  if (type === 'apikey') {
+    return {
+      kind: 'unsupported',
+      label: `${location || 'non-header'} API key`,
+    }
+  }
+  if (type === 'http' && httpScheme) {
+    return { kind: 'unsupported', label: `HTTP ${httpScheme} authentication` }
+  }
+  if (type === 'basic') {
+    return { kind: 'unsupported', label: 'HTTP basic authentication' }
+  }
+  return unknownAuth()
+}
+
+function bestDetectedAuth(candidates: SourceDetectedAuth[]): SourceDetectedAuth {
+  return (
+    candidates.find((auth) => auth.kind === 'bearer' || auth.kind === 'header') ??
+    candidates.find((auth) => auth.kind !== 'unknown') ??
+    unknownAuth()
+  )
+}
+
+function unknownAuth(): SourceDetectedAuth {
+  return { kind: 'unknown', label: '' }
+}
+
+function objectKeys(value: unknown): string[] {
+  return Object.keys(objectValue(value) ?? {})
+}
+
+async function responseTextWithinLimit(response: Response): Promise<string> {
+  const declaredLength = Number(response.headers.get('content-length'))
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_DESCRIPTOR_BYTES) {
+    throw new Error('The source document is larger than 2 MB')
+  }
+  if (!response.body) return ''
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let bytesRead = 0
+  let text = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    bytesRead += value.byteLength
+    if (bytesRead > MAX_DESCRIPTOR_BYTES) {
+      await reader.cancel()
+      throw new Error('The source document is larger than 2 MB')
+    }
+    text += decoder.decode(value, { stream: true })
+  }
+  return text + decoder.decode()
+}
+
+function inspectOpenApiYaml(document: string): {
+  auth: SourceDetectedAuth
+  description: string
+  title: string
+} | null {
+  const lines = document.replace(/^\uFEFF/, '').split(/\r?\n/)
+  const hasVersion = lines.some((line) => {
+    if (indentation(line) !== 0) return false
+    const key = yamlKey(line)
+    return key === 'openapi' || key === 'swagger'
+  })
+  if (!hasVersion) return null
+
+  const infoIndex = lines.findIndex((line) => indentation(line) === 0 && yamlKey(line) === 'info')
+  if (infoIndex < 0) return { auth: inspectYamlAuth(lines), description: '', title: '' }
+  const infoIndent = lines.slice(infoIndex + 1).find((line) => line.trim() && indentation(line) > 0)
+  if (!infoIndent) return { auth: inspectYamlAuth(lines), description: '', title: '' }
+  const fieldIndent = indentation(infoIndent)
+
+  let title = ''
+  let description = ''
+  for (let index = infoIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line.trim() && indentation(line) === 0) break
+    if (indentation(line) !== fieldIndent) continue
+    const key = yamlKey(line)
+    if (key === 'title') title = yamlScalar(line)
+    if (key === 'description') {
+      const scalar = yamlScalar(line)
+      if (scalar === '|' || scalar === '>') {
+        description = yamlBlock(lines, index + 1, indentation(line), scalar === '>')
+      } else {
+        description = scalar
+      }
+    }
+  }
+  return { auth: inspectYamlAuth(lines), description, title }
+}
+
+function yamlBlock(lines: string[], start: number, parentIndent: number, folded: boolean): string {
+  const values: string[] = []
+  for (let index = start; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line.trim() && indentation(line) <= parentIndent) break
+    values.push(line.trim())
+  }
+  return values.join(folded ? ' ' : '\n').trim()
+}
+
+function yamlKey(line: string): string | null {
+  const match = line.trim().match(/^([A-Za-z][A-Za-z0-9_-]*)\s*:/)
+  return match?.[1]?.toLowerCase() ?? null
+}
+
+function yamlScalar(line: string): string {
+  const colon = line.indexOf(':')
+  if (colon < 0) return ''
+  const value = line
+    .slice(colon + 1)
+    .trim()
+    .replace(/\s+#.*$/, '')
+  if (
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    return value.slice(1, -1).replace(/''/g, "'")
+  }
+  return value
+}
+
+function findYamlKey(lines: string[], key: string, indent: number): number {
+  return lines.findIndex(
+    (line) => indentation(line) === indent && yamlKey(line) === key.toLowerCase(),
+  )
+}
+
+function findYamlChildKey(lines: string[], parentIndex: number, key: string): number {
+  const parentIndent = indentation(lines[parentIndex])
+  const childIndent = nextYamlIndent(lines, parentIndex, parentIndent)
+  if (childIndent === undefined) return -1
+  for (let index = parentIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line.trim() && indentation(line) <= parentIndent) break
+    if (indentation(line) === childIndent && yamlKey(line) === key.toLowerCase()) return index
+  }
+  return -1
+}
+
+function yamlChildIndexes(lines: string[], parentIndex: number): number[] {
+  const parentIndent = indentation(lines[parentIndex])
+  const childIndent = nextYamlIndent(lines, parentIndex, parentIndent)
+  if (childIndent === undefined) return []
+  const indexes: number[] = []
+  for (let index = parentIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line.trim() && indentation(line) <= parentIndent) break
+    if (line.trim() && indentation(line) === childIndent) indexes.push(index)
+  }
+  return indexes
+}
+
+function nextYamlIndent(
+  lines: string[],
+  parentIndex: number,
+  parentIndent: number,
+): number | undefined {
+  for (let index = parentIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (!line.trim()) continue
+    const indent = indentation(line)
+    if (indent <= parentIndent) return undefined
+    return indent
+  }
+  return undefined
+}
+
+function yamlMappingFields(lines: string[], mappingIndex: number): Record<string, string> {
+  const fields: Record<string, string> = {}
+  const mappingIndent = indentation(lines[mappingIndex])
+  const fieldIndent = nextYamlIndent(lines, mappingIndex, mappingIndent)
+  if (fieldIndent === undefined) return fields
+  for (let index = mappingIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index]
+    if (line.trim() && indentation(line) <= mappingIndent) break
+    if (indentation(line) !== fieldIndent) continue
+    const key = yamlKey(line)
+    if (key) fields[key] = yamlScalar(line)
+  }
+  return fields
+}
+
+function indentation(line: string): number {
+  return line.match(/^\s*/)?.[0].length ?? 0
+}
+
+function parseJsonObject(document: string): Record<string, unknown> | null {
+  try {
+    return objectValue(JSON.parse(document)) ?? null
+  } catch {
+    return null
+  }
+}
+
+function hasOpenApiVersion(document: Record<string, unknown>): boolean {
+  return typeof document.openapi === 'string' || typeof document.swagger === 'string'
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function fallbackTitle(url: URL): string {
+  const pathName = url.pathname
+    .split('/')
+    .filter(Boolean)
+    .at(-1)
+    ?.replace(/\.[^.]+$/, '')
+  if (pathName && !['openapi', 'swagger', 'schema'].includes(pathName.toLowerCase()))
+    return pathName
+  return url.hostname.replace(/^www\./, '').split('.')[0] || 'source'
+}
+
+function sourceName(title: string): string {
+  let name = title
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+  if (!name) name = 'source'
+  if (!/^[a-z]/.test(name)) name = `source_${name}`
+  if (['coral', 'coral_admin', 'public'].includes(name)) name = `${name}_source`
+  return name
+}
+
+function discoveryError(url: string, message: string): SourceDiscoveryData {
+  return { message, status: 'error', url }
+}
+
+function discoveredSource(
+  url: string,
+  sourceUrl: URL,
+  metadata: {
+    auth: SourceDetectedAuth
+    description: string
+    format: SourceDocumentFormat
+    title: string
+    warning?: string
+  },
+): SourceDiscoveryData {
+  return {
+    auth: metadata.auth,
+    description: metadata.description,
+    format:
+      metadata.format === 'unknown' && /\/(?:mcp|sse)\/?$/i.test(sourceUrl.pathname)
+        ? 'mcp'
+        : metadata.format,
+    name: sourceName(metadata.title || fallbackTitle(sourceUrl)),
+    status: 'success',
+    url,
+    ...(metadata.warning ? { warning: metadata.warning } : {}),
+  }
+}

--- a/apps/reef/app/routes/source-install.test.ts
+++ b/apps/reef/app/routes/source-install.test.ts
@@ -24,7 +24,7 @@ describe('source install client action', () => {
       serverAction,
     } as never)
 
-    expect(addToast).toHaveBeenCalledWith('neutral', {
+    expect(addToast).toHaveBeenCalledWith('success', {
       title: 'Created spotify',
       description: 'The source was validated and installed.',
     })

--- a/apps/reef/app/routes/source-install.test.ts
+++ b/apps/reef/app/routes/source-install.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { addToast } = vi.hoisted(() => ({ addToast: vi.fn() }))
+
+vi.mock('@/wax/components/toast', () => ({ addToast }))
+
+import type { SourcesActionData } from './sources-action'
+import { clientAction } from './source-install'
+
+describe('source install client action', () => {
+  beforeEach(() => {
+    addToast.mockReset()
+  })
+
+  it('shows a success toast before redirecting to the source catalog', async () => {
+    const serverAction = vi.fn().mockResolvedValue({
+      intent: 'import',
+      name: 'spotify',
+      status: 'success',
+    } satisfies SourcesActionData)
+
+    const response = await clientAction({
+      params: { workspaceId: 'analytics' },
+      serverAction,
+    } as never)
+
+    expect(addToast).toHaveBeenCalledWith('neutral', {
+      title: 'Created spotify',
+      description: 'The source was validated and installed.',
+    })
+    expect(response).toBeInstanceOf(Response)
+    expect((response as Response).headers.get('location')).toBe('/workspaces/analytics/sources')
+  })
+
+  it('returns server validation errors without showing a toast or redirecting', async () => {
+    const error = {
+      intent: 'import',
+      message: 'The descriptor could not be loaded.',
+      name: 'spotify',
+      status: 'error',
+    } satisfies SourcesActionData
+
+    const result = await clientAction({
+      params: { workspaceId: 'analytics' },
+      serverAction: vi.fn().mockResolvedValue(error),
+    } as never)
+
+    expect(result).toBe(error)
+    expect(addToast).not.toHaveBeenCalled()
+  })
+})

--- a/apps/reef/app/routes/source-install.tsx
+++ b/apps/reef/app/routes/source-install.tsx
@@ -20,7 +20,7 @@ export async function clientAction({
   const result = await serverAction()
   if (result?.status !== 'success') return result
 
-  addToast('neutral', {
+  addToast('success', {
     title: `Created ${result.name}`,
     description: 'The source was validated and installed.',
   })

--- a/apps/reef/app/routes/source-install.tsx
+++ b/apps/reef/app/routes/source-install.tsx
@@ -1,0 +1,44 @@
+import type { Route } from './+types/source-install'
+import { redirect, useNavigate } from 'react-router'
+
+import type { SourcesActionData } from './sources-action'
+import { runSourcesAction } from './sources-action'
+
+import { addToast } from '@/wax/components/toast'
+import { SourceCreateDialog } from '@/views/sources/source-create'
+import { routePath } from '@/routing/routemap'
+import { workspaceFromParams } from '@/lib/workspace-routing'
+
+export async function action({ params, request }: Route.ActionArgs): Promise<SourcesActionData> {
+  return runSourcesAction(request, workspaceFromParams(params))
+}
+
+export async function clientAction({
+  params,
+  serverAction,
+}: Route.ClientActionArgs): Promise<SourcesActionData | Response> {
+  const result = await serverAction()
+  if (result?.status !== 'success') return result
+
+  addToast('neutral', {
+    title: `Created ${result.name}`,
+    description: 'The source was validated and installed.',
+  })
+  return redirect(routePath('workspaceSources', { workspaceId: params.workspaceId }))
+}
+
+export default function SourceInstallRoute({ actionData, params }: Route.ComponentProps) {
+  const navigate = useNavigate()
+  const sourcesPath = routePath('workspaceSources', { workspaceId: params.workspaceId })
+
+  return (
+    <SourceCreateDialog
+      actionData={actionData}
+      discoveryPath={routePath('workspaceSourceDiscovery', { workspaceId: params.workspaceId })}
+      open
+      onOpenChange={(open) => {
+        if (!open) navigate(sourcesPath)
+      }}
+    />
+  )
+}

--- a/apps/reef/app/routes/sources-action.ts
+++ b/apps/reef/app/routes/sources-action.ts
@@ -6,6 +6,7 @@ import {
   DeleteSourceRequestSchema,
   GetSourceInfoRequestSchema,
   GetSourceRequestSchema,
+  ImportSourceRequestSchema,
 } from '@/generated/coral/v1/sources_pb'
 import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { sourceClientForRequest } from '@/lib/coral-request.server'
@@ -32,7 +33,7 @@ export {
   type InstallInput,
 } from '@/lib/source-install-form'
 
-export type SourceActionIntent = 'delete' | 'edit' | 'install'
+export type SourceActionIntent = 'delete' | 'edit' | 'import' | 'install'
 
 export type SourcesActionData =
   | {
@@ -113,10 +114,21 @@ export async function runSourcesAction(
       await sourceClient.deleteSource(create(DeleteSourceRequestSchema, { name, workspace }))
       return actionSuccess('delete', name)
     }
+    if (intent === 'import') {
+      const manifestYaml = formData.get('manifest_yaml')
+      if (typeof manifestYaml !== 'string' || manifestYaml.trim().length === 0) {
+        return actionError('import', name, 'Missing source manifest')
+      }
+      const secretKey = formValue(formData, 'secret_key')
+      const secretValue = formValue(formData, 'secret_value')
+      const secrets = secretKey && secretValue ? [{ key: secretKey, value: secretValue }] : []
+      await importSourceManifest(sourceClient, workspace, manifestYaml, secrets)
+      return actionSuccess('import', name)
+    }
     return actionError('install', name, 'Unknown source action')
   } catch (error) {
     return actionError(
-      intent === 'edit' || intent === 'delete' ? intent : 'install',
+      intent === 'edit' || intent === 'delete' || intent === 'import' ? intent : 'install',
       name,
       errorMessage(error),
     )
@@ -162,6 +174,23 @@ async function createBundledSource(
   )
   if (!response.source) throw new Error(`Coral did not return installed source ${name}`)
   return response.source
+}
+
+async function importSourceManifest(
+  sourceClient: ReturnType<typeof sourceClientForRequest>,
+  workspace: Workspace,
+  manifestYaml: string,
+  secrets: { key: string; value: string }[],
+) {
+  const stream = sourceClient.importSource(
+    create(ImportSourceRequestSchema, { manifestYaml, secrets, workspace }),
+  )
+  // The import wizard has no OAuth inputs, so the stream only carries the
+  // terminal source event.
+  for await (const response of stream) {
+    if (response.event.case === 'source') return response.event.value
+  }
+  throw new Error('Coral did not return the imported source')
 }
 
 function actionError(

--- a/apps/reef/app/routes/sources.tsx
+++ b/apps/reef/app/routes/sources.tsx
@@ -5,7 +5,6 @@ import type { Route } from './+types/sources'
 import { SourcesIndex } from '@/views/sources/sources-index'
 import { routePattern } from '@/routing/routemap'
 
-export { action } from './sources-action'
 export { loader } from './sources-loader'
 
 export function shouldRevalidate({

--- a/apps/reef/app/routing/routemap.test.ts
+++ b/apps/reef/app/routing/routemap.test.ts
@@ -10,6 +10,8 @@ const CANONICAL_PATTERNS = {
   workspaceSchema: '/workspaces/:workspaceId/schema',
   workspaceSchemaTable: '/workspaces/:workspaceId/schema/:schemaName/:tableName',
   workspaceSource: '/workspaces/:workspaceId/sources/:sourceName',
+  workspaceSourceDiscovery: '/workspaces/:workspaceId/sources/discover',
+  workspaceSourceInstall: '/workspaces/:workspaceId/sources/install',
   workspaceSources: '/workspaces/:workspaceId/sources',
   workspaceTrace: '/workspaces/:workspaceId/traces/:traceId',
   workspaceTraces: '/workspaces/:workspaceId/traces',
@@ -44,6 +46,10 @@ describe('route map', () => {
         sourceName: 'github',
         workspaceId: 'analytics',
       }),
+      workspaceSourceDiscovery: routePath('workspaceSourceDiscovery', {
+        workspaceId: 'analytics',
+      }),
+      workspaceSourceInstall: routePath('workspaceSourceInstall', { workspaceId: 'analytics' }),
       workspaceSources: routePath('workspaceSources', { workspaceId: 'analytics' }),
       workspaceTrace: routePath('workspaceTrace', {
         traceId: 'trace_123',
@@ -59,6 +65,8 @@ describe('route map', () => {
       workspaceSchema: '/workspaces/analytics/schema',
       workspaceSchemaTable: '/workspaces/analytics/schema/github/issues',
       workspaceSource: '/workspaces/analytics/sources/github',
+      workspaceSourceDiscovery: '/workspaces/analytics/sources/discover',
+      workspaceSourceInstall: '/workspaces/analytics/sources/install',
       workspaceSources: '/workspaces/analytics/sources',
       workspaceTrace: '/workspaces/analytics/traces/trace_123',
       workspaceTraces: '/workspaces/analytics/traces',

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -5,6 +5,8 @@ const HOME_PATH = '/'
 const WORKSPACES_PATH = '/workspaces'
 const WORKSPACE_SCHEMA_PATH = '/workspaces/:workspaceId/schema'
 const WORKSPACE_SCHEMA_TABLE_PATH = '/workspaces/:workspaceId/schema/:schemaName/:tableName'
+const WORKSPACE_SOURCE_DISCOVERY_PATH = '/workspaces/:workspaceId/sources/discover'
+const WORKSPACE_SOURCE_INSTALL_PATH = '/workspaces/:workspaceId/sources/install'
 const WORKSPACE_SOURCES_PATH = '/workspaces/:workspaceId/sources'
 const WORKSPACE_SOURCE_PATH = '/workspaces/:workspaceId/sources/:sourceName'
 const WORKSPACE_TRACES_PATH = '/workspaces/:workspaceId/traces'
@@ -45,6 +47,20 @@ export const routeDefinitions = {
     toPath: (params: { sourceName: string; workspaceId: string }) =>
       generatePath(WORKSPACE_SOURCE_PATH, {
         sourceName: params.sourceName,
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceSourceDiscovery: {
+    path: WORKSPACE_SOURCE_DISCOVERY_PATH,
+    toPath: (params: { workspaceId: string }) =>
+      generatePath(WORKSPACE_SOURCE_DISCOVERY_PATH, {
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceSourceInstall: {
+    path: WORKSPACE_SOURCE_INSTALL_PATH,
+    toPath: (params: { workspaceId: string }) =>
+      generatePath(WORKSPACE_SOURCE_INSTALL_PATH, {
         workspaceId: params.workspaceId,
       }),
   },

--- a/apps/reef/app/views/sources/source-create.css.ts
+++ b/apps/reef/app/views/sources/source-create.css.ts
@@ -1,0 +1,75 @@
+import { style } from '@vanilla-extract/css'
+
+import { fontFamily } from '@/wax/theme/font.css'
+import { theme } from '@/wax/theme/theme.css'
+
+export const header = style({
+  alignItems: 'center',
+  gap: 10,
+  marginBlockEnd: 14,
+  paddingBlockEnd: 0,
+})
+
+export const dialogContent = style({
+  display: 'flex',
+  flexDirection: 'column',
+})
+
+export const fieldGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 14,
+})
+
+export const fieldItem = style({
+  gap: 6,
+})
+
+export const authPanelStack = style({
+  display: 'grid',
+})
+
+export const authPanel = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 14,
+  gridArea: '1 / 1',
+  minWidth: 0,
+})
+
+export const authPanelHidden = style({
+  pointerEvents: 'none',
+  visibility: 'hidden',
+})
+
+export const summaryBox = style({
+  background: theme.surface.onMainContent,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 8,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+  padding: 12,
+})
+
+export const summaryRow = style({
+  display: 'flex',
+  gap: 8,
+})
+
+export const summaryKey = style({
+  color: theme.content.tertiary,
+  flex: '0 0 96px',
+})
+
+export const summaryValue = style({
+  color: theme.content.primary,
+  fontFamily: fontFamily.dmMono,
+  fontSize: 12,
+  minWidth: 0,
+  overflowWrap: 'anywhere',
+})
+
+export const importError = style({
+  marginBlockStart: 14,
+})

--- a/apps/reef/app/views/sources/source-create.css.ts
+++ b/apps/reef/app/views/sources/source-create.css.ts
@@ -1,8 +1,5 @@
 import { style } from '@vanilla-extract/css'
 
-import { fontFamily } from '@/wax/theme/font.css'
-import { theme } from '@/wax/theme/theme.css'
-
 export const header = style({
   alignItems: 'center',
   gap: 10,
@@ -40,34 +37,6 @@ export const authPanel = style({
 export const authPanelHidden = style({
   pointerEvents: 'none',
   visibility: 'hidden',
-})
-
-export const summaryBox = style({
-  background: theme.surface.onMainContent,
-  border: `1px solid ${theme.stroke.secondary}`,
-  borderRadius: 8,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 6,
-  padding: 12,
-})
-
-export const summaryRow = style({
-  display: 'flex',
-  gap: 8,
-})
-
-export const summaryKey = style({
-  color: theme.content.tertiary,
-  flex: '0 0 96px',
-})
-
-export const summaryValue = style({
-  color: theme.content.primary,
-  fontFamily: fontFamily.dmMono,
-  fontSize: 12,
-  minWidth: 0,
-  overflowWrap: 'anywhere',
 })
 
 export const importError = style({

--- a/apps/reef/app/views/sources/source-create.test.tsx
+++ b/apps/reef/app/views/sources/source-create.test.tsx
@@ -1,5 +1,5 @@
 import { createMemoryRouter, RouterProvider, useActionData, useNavigate } from 'react-router'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { render } from 'vitest-browser-react'
 
@@ -71,6 +71,51 @@ describe('SourceCreateDialog', () => {
     expect(router.state.location.pathname).toBe('/workspaces/analytics/sources')
   })
 
+  it('confirms before discarding a draft with user-entered information', async () => {
+    const { router, screen } = await renderSourceCreate()
+
+    await screen.getByLabelText('Source URL').fill('https://example.com/openapi.yaml')
+    await screen.getByRole('button', { name: 'Cancel' }).click()
+
+    const confirmation = screen.getByRole('dialog', { name: 'Discard source draft?' })
+    await expect.element(confirmation).toBeVisible()
+    await confirmation.getByRole('button', { name: 'Keep editing' }).click()
+    await expect.element(confirmation).not.toBeInTheDocument()
+    expect(router.state.location.pathname).toBe('/workspaces/analytics/sources/install')
+
+    await userEvent.keyboard('{Escape}')
+    await screen
+      .getByRole('dialog', { name: 'Discard source draft?' })
+      .getByRole('button', { name: 'Discard' })
+      .click()
+
+    expect(router.state.location.pathname).toBe('/workspaces/analytics/sources')
+  })
+
+  it('does not submit the import form when Enter is pressed with an invalid URL', async () => {
+    const action = vi.fn(async () => ({
+      intent: 'import' as const,
+      message: 'The import form should not have been submitted.',
+      name: 'weather_api',
+      status: 'error' as const,
+    }))
+    const { screen } = await renderSourceCreate(DISCOVERY, action)
+
+    await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await expect.element(screen.getByText('Step 2/3')).toBeVisible()
+    await screen.getByRole('button', { name: 'Back' }).click()
+
+    const urlInput = screen.getByLabelText('Source URL')
+    await urlInput.fill('oioioi')
+    urlInput.element().focus()
+    await userEvent.keyboard('{Enter}')
+
+    expect(action).not.toHaveBeenCalled()
+    await expect.element(screen.getByText('Step 1/3')).toBeVisible()
+    await expect.element(screen.getByText('Step 2/3')).not.toBeInTheDocument()
+  })
+
   it('opens each wizard step as a nested dialog', async () => {
     const { screen } = await renderSourceCreate()
 
@@ -79,7 +124,7 @@ describe('SourceCreateDialog', () => {
     await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
     await screen.getByRole('button', { name: 'Next' }).click()
 
-    await expect.element(screen.getByText('Step 2 of 3 — Details')).toBeVisible()
+    await expect.element(screen.getByText('Step 2/3')).toBeVisible()
     await expect.poll(activeDialogCount).toBe(2)
     await expect.element(screen.getByLabelText('Name')).toHaveValue('weather_api')
     await expect
@@ -89,12 +134,12 @@ describe('SourceCreateDialog', () => {
 
     await screen.getByRole('button', { name: 'Next' }).click()
 
-    await expect.element(screen.getByText('Step 3 of 3 — Credentials')).toBeVisible()
+    await expect.element(screen.getByText('Step 3/3')).toBeVisible()
     await expect.poll(activeDialogCount).toBe(3)
 
     await screen.getByRole('button', { name: 'Back' }).click()
 
-    await expect.element(screen.getByText('Step 2 of 3 — Details')).toBeVisible()
+    await expect.element(screen.getByText('Step 2/3')).toBeVisible()
     await expect.poll(activeDialogCount).toBe(2)
   })
 
@@ -238,6 +283,9 @@ describe('SourceCreateDialog', () => {
 
     await screen.getByRole('radio', { name: 'None' }).click()
     await expect.element(screen.getByRole('radio', { name: 'None' })).toBeChecked()
+    await expect
+      .element(screen.getByText('This endpoint doesn’t require credentials.'))
+      .toBeVisible()
     await expect.poll(activeDialogHeight).toBe(initialHeight)
 
     await screen.getByRole('radio', { name: 'Custom header' }).click()

--- a/apps/reef/app/views/sources/source-create.test.tsx
+++ b/apps/reef/app/views/sources/source-create.test.tsx
@@ -1,0 +1,288 @@
+import { createMemoryRouter, RouterProvider, useActionData, useNavigate } from 'react-router'
+import { describe, expect, it } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { render } from 'vitest-browser-react'
+
+import type { SourceDiscoveryData } from '@/routes/source-discovery'
+import type { SourcesActionData } from '@/routes/sources-action'
+
+import { SourceCreateDialog } from './source-create'
+
+type SuccessfulDiscovery = Extract<SourceDiscoveryData, { status: 'success' }>
+
+const DISCOVERY: SuccessfulDiscovery = {
+  auth: { kind: 'bearer', label: 'Bearer token' },
+  description: 'Weather observations and forecasts',
+  format: 'openapi-yaml' as const,
+  name: 'weather_api',
+  status: 'success' as const,
+  url: 'https://weather.example/openapi.yaml',
+}
+
+function RoutedSourceCreateDialog() {
+  const navigate = useNavigate()
+  const actionData = useActionData<SourcesActionData>()
+  return (
+    <SourceCreateDialog
+      actionData={actionData}
+      discoveryPath="/workspaces/analytics/sources/discover"
+      open
+      onOpenChange={(open) => {
+        if (!open) navigate('/workspaces/analytics/sources')
+      }}
+    />
+  )
+}
+
+async function renderSourceCreate(
+  discovery: SuccessfulDiscovery = DISCOVERY,
+  action?: () => Promise<SourcesActionData>,
+) {
+  const router = createMemoryRouter(
+    [
+      {
+        action,
+        element: <RoutedSourceCreateDialog />,
+        path: '/workspaces/:workspaceId/sources/install',
+      },
+      {
+        element: <div>Sources catalog</div>,
+        path: '/workspaces/:workspaceId/sources',
+      },
+      {
+        loader: () => ({ ...discovery, auth: { ...discovery.auth } }),
+        path: '/workspaces/:workspaceId/sources/discover',
+      },
+    ],
+    { initialEntries: ['/workspaces/analytics/sources/install'] },
+  )
+
+  return { router, screen: await render(<RouterProvider router={router} />) }
+}
+
+describe('SourceCreateDialog', () => {
+  it('renders as a routed modal and cancels back to the workspace source catalog', async () => {
+    const { router, screen } = await renderSourceCreate()
+
+    await expect.element(screen.getByRole('dialog')).toBeVisible()
+    await expect.element(screen.getByRole('heading', { name: 'Create source' })).toBeVisible()
+    await screen.getByRole('button', { name: 'Cancel' }).click()
+
+    expect(router.state.location.pathname).toBe('/workspaces/analytics/sources')
+  })
+
+  it('opens each wizard step as a nested dialog', async () => {
+    const { screen } = await renderSourceCreate()
+
+    await expect.poll(activeDialogCount).toBe(1)
+
+    await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+
+    await expect.element(screen.getByText('Step 2 of 3 — Details')).toBeVisible()
+    await expect.poll(activeDialogCount).toBe(2)
+    await expect.element(screen.getByLabelText('Name')).toHaveValue('weather_api')
+    await expect
+      .element(screen.getByLabelText('Description (optional)'))
+      .toHaveValue('Weather observations and forecasts')
+    await expect.element(screen.getByText('Detected an OpenAPI YAML document.')).toBeVisible()
+
+    await screen.getByRole('button', { name: 'Next' }).click()
+
+    await expect.element(screen.getByText('Step 3 of 3 — Credentials')).toBeVisible()
+    await expect.poll(activeDialogCount).toBe(3)
+
+    await screen.getByRole('button', { name: 'Back' }).click()
+
+    await expect.element(screen.getByText('Step 2 of 3 — Details')).toBeVisible()
+    await expect.poll(activeDialogCount).toBe(2)
+  })
+
+  it.each(['coral', 'coral_admin', 'public'])('rejects reserved source name %s', async (name) => {
+    const { screen } = await renderSourceCreate()
+
+    await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await expect.element(screen.getByLabelText('Name')).toBeVisible()
+    const nameInput = screen.getByLabelText('Name')
+    await nameInput.clear()
+    await nameInput.fill(name)
+
+    await expect
+      .element(screen.getByText(`“${name}” is reserved by Coral. Choose another source name.`))
+      .not.toBeInTheDocument()
+    await userEvent.tab()
+    await expect
+      .element(screen.getByText(`“${name}” is reserved by Coral. Choose another source name.`))
+      .toBeVisible()
+    await expect.element(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
+  })
+
+  it('shows a syntax error only after the name field is blurred', async () => {
+    const { screen } = await renderSourceCreate()
+
+    await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+    const nameInput = screen.getByLabelText('Name')
+    await nameInput.clear()
+    await nameInput.fill('weather-api')
+
+    await expect
+      .element(
+        screen.getByText(
+          'Use lowercase letters, digits, and underscores; the name must start with a letter.',
+        ),
+      )
+      .not.toBeInTheDocument()
+    await userEvent.tab()
+    await expect
+      .element(
+        screen.getByText(
+          'Use lowercase letters, digits, and underscores; the name must start with a letter.',
+        ),
+      )
+      .toBeVisible()
+  })
+
+  it('uses accessible Base UI radios for source choices', async () => {
+    const { screen } = await renderSourceCreate()
+
+    await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+
+    const sourceTypeGroup = screen.getByRole('radiogroup', { name: 'Source type' })
+    await expect.element(sourceTypeGroup).toBeVisible()
+    await expect.element(screen.getByRole('radio', { name: 'REST API (OpenAPI)' })).toBeChecked()
+    await screen.getByRole('radio', { name: 'MCP server' }).click()
+    await expect.element(screen.getByRole('radio', { name: 'MCP server' })).toBeChecked()
+  })
+
+  it('keeps type selection editable when the URL is not an OpenAPI document', async () => {
+    const url = 'https://tools.example/mcp'
+    const { screen } = await renderSourceCreate({
+      auth: { kind: 'unknown', label: '' },
+      description: '',
+      format: 'unknown',
+      name: 'tools',
+      status: 'success',
+      url,
+    })
+
+    await screen.getByLabelText('Source URL').fill(url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+
+    await expect.element(screen.getByText('No OpenAPI document was detected.')).toBeVisible()
+    await screen.getByRole('radio', { name: 'MCP server' }).click()
+    await expect.element(screen.getByRole('radio', { name: 'MCP server' })).toBeChecked()
+  })
+
+  it('prefills MCP for endpoints detected from their URL', async () => {
+    const url = 'https://tools.example/mcp'
+    const { screen } = await renderSourceCreate({
+      auth: { kind: 'unknown', label: '' },
+      description: '',
+      format: 'mcp',
+      name: 'mcp',
+      status: 'success',
+      url,
+    })
+
+    await screen.getByLabelText('Source URL').fill(url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+
+    await expect.element(screen.getByText('Detected an MCP endpoint from its URL.')).toBeVisible()
+    await expect.element(screen.getByRole('radio', { name: 'MCP server' })).toBeChecked()
+  })
+
+  it('prefills detected header authentication on the credentials step', async () => {
+    const { screen } = await renderSourceCreate({
+      ...DISCOVERY,
+      auth: { headerName: 'X-Api-Key', kind: 'header', label: 'Header X-Api-Key' },
+    })
+
+    await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await expect.element(screen.getByLabelText('Name')).toBeVisible()
+    await screen.getByRole('button', { name: 'Next' }).click()
+
+    await expect
+      .element(screen.getByText('Detected authentication: Header X-Api-Key.'))
+      .toBeVisible()
+    await expect.element(screen.getByRole('radio', { name: 'Custom header' })).toBeChecked()
+    await expect.element(screen.getByLabelText('Header name')).toHaveValue('X-Api-Key')
+  })
+
+  it('builds a single-surface DSL v4 manifest with top-level inputs', async () => {
+    const { screen } = await renderSourceCreate()
+
+    await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await expect.element(screen.getByLabelText('Name')).toBeVisible()
+
+    const manifest = submittedManifest()
+    expect(manifest).toContain('\ninputs:\n  API_TOKEN:\n    kind: secret\n')
+    expect(manifest).toContain('\nsurface:\n  type: openapi\n')
+    expect(manifest).not.toContain('\nsurfaces:\n')
+  })
+
+  it('keeps the credentials dialog height stable across authentication choices', async () => {
+    const { screen } = await renderSourceCreate()
+
+    await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await expect.element(screen.getByLabelText('Name')).toBeVisible()
+    await screen.getByRole('button', { name: 'Next' }).click()
+
+    await expect.element(screen.getByRole('radio', { name: 'Bearer token' })).toBeChecked()
+    const initialHeight = activeDialogHeight()
+
+    await screen.getByRole('radio', { name: 'None' }).click()
+    await expect.element(screen.getByRole('radio', { name: 'None' })).toBeChecked()
+    await expect.poll(activeDialogHeight).toBe(initialHeight)
+
+    await screen.getByRole('radio', { name: 'Custom header' }).click()
+    await expect.element(screen.getByRole('radio', { name: 'Custom header' })).toBeChecked()
+    await expect.poll(activeDialogHeight).toBe(initialHeight)
+  })
+
+  it('keeps the credentials dialog open when source creation fails', async () => {
+    const message = 'The OpenAPI descriptor could not be loaded.'
+    const { screen } = await renderSourceCreate(DISCOVERY, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      return { intent: 'import', message, name: DISCOVERY.name, status: 'error' }
+    })
+
+    await screen.getByLabelText('Source URL').fill(DISCOVERY.url)
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await expect.element(screen.getByLabelText('Name')).toBeVisible()
+    await screen.getByRole('button', { name: 'Next' }).click()
+    await screen.getByRole('radio', { name: 'None' }).click()
+    const createButton = screen.getByRole('button', { name: 'Create source' })
+    createButton.element().focus()
+    await expect.element(createButton).toHaveFocus()
+    await createButton.click()
+    await expect.element(screen.getByRole('button', { name: 'Creating…' })).toBeVisible()
+    await userEvent.keyboard('{Escape}')
+
+    await expect.element(screen.getByText(message)).toBeVisible()
+    await expect.poll(activeDialogCount).toBe(3)
+  })
+})
+
+function activeDialogCount() {
+  return document.querySelectorAll('[role="dialog"]:not([data-ending-style])').length
+}
+
+function submittedManifest() {
+  const input = document.querySelector<HTMLInputElement>('input[name="manifest_yaml"]')
+  if (!input) throw new Error('Manifest input not found')
+  return input.value
+}
+
+function activeDialogHeight() {
+  const dialog = document.querySelector<HTMLElement>(
+    '[role="dialog"]:not([aria-hidden="true"]):not([data-ending-style])',
+  )
+  if (!dialog) throw new Error('Active dialog not found')
+  return dialog.offsetHeight
+}

--- a/apps/reef/app/views/sources/source-create.tsx
+++ b/apps/reef/app/views/sources/source-create.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { useEffect, useId, useRef, useState } from 'react'
+import { type FormEvent, type RefObject, useEffect, useId, useRef, useState } from 'react'
 import { Form, useFetcher, useNavigation } from 'react-router'
 
 import { Container as ButtonContainer } from '@/wax/components/button/container'
@@ -60,8 +60,15 @@ export function SourceCreateDialog({
   open: boolean
   onOpenChange: (open: boolean) => void
 }) {
+  const requestCancelRef = useRef<() => void>(() => onOpenChange(false))
+
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) requestCancelRef.current()
+      }}
+    >
       <Dialog.Portal>
         <Dialog.Backdrop />
         <Dialog.Popup size="l">
@@ -70,6 +77,7 @@ export function SourceCreateDialog({
               actionData={actionData}
               discoveryPath={discoveryPath}
               onCancel={() => onOpenChange(false)}
+              requestCancelRef={requestCancelRef}
             />
           ) : null}
         </Dialog.Popup>
@@ -82,13 +90,16 @@ function SourceCreateDialogContent({
   actionData,
   discoveryPath,
   onCancel,
+  requestCancelRef,
 }: {
   actionData: SourcesActionData
   discoveryPath: string
   onCancel: () => void
+  requestCancelRef: RefObject<() => void>
 }) {
   const [step, setStep] = useState(0)
   const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT)
+  const [confirmingCancel, setConfirmingCancel] = useState(false)
   const formId = useId()
   const discovery = useFetcher<SourceDiscoveryData>()
 
@@ -130,6 +141,18 @@ function SourceCreateDialogContent({
   }, [discovery.data, step])
 
   const update = (patch: Partial<Draft>) => setDraft((prev) => ({ ...prev, ...patch }))
+  const inspectUrl = () =>
+    discovery.load(`${discoveryPath}?url=${encodeURIComponent(draft.url.trim())}`)
+  const requestCancel = () => {
+    if (draftIsDirty(draft)) {
+      setConfirmingCancel(true)
+      return
+    }
+    onCancel()
+  }
+  useEffect(() => {
+    requestCancelRef.current = requestCancel
+  })
 
   const stepValid = (() => {
     if (step === 0) return draft.url.trim().startsWith('https://')
@@ -141,8 +164,20 @@ function SourceCreateDialogContent({
     return draft.auth === 'none' || draft.token.trim().length > 0
   })()
 
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    if (step === 2) return
+
+    event.preventDefault()
+    if (!stepValid || discovering || submitting) return
+    if (step === 0) {
+      inspectUrl()
+      return
+    }
+    setStep(2)
+  }
+
   return (
-    <Form className={styles.dialogContent} id={formId} method="post">
+    <Form className={styles.dialogContent} id={formId} method="post" onSubmit={handleSubmit}>
       <input type="hidden" name="_intent" value="import" />
       <input type="hidden" name="name" value={draft.name.trim()} />
       <input type="hidden" name="manifest_yaml" value={buildManifestYaml(draft)} />
@@ -159,14 +194,12 @@ function SourceCreateDialogContent({
       {discoveryError ? <SourceError>{discoveryError}</SourceError> : null}
 
       <Dialog.Actions>
-        <ButtonContainer disabled={submitting} onClick={onCancel} size="32" variant="bare">
+        <ButtonContainer disabled={submitting} onClick={requestCancel} size="32" variant="bare">
           <ButtonText>Cancel</ButtonText>
         </ButtonContainer>
         <ButtonContainer
           disabled={!stepValid || discovering}
-          onClick={() =>
-            discovery.load(`${discoveryPath}?url=${encodeURIComponent(draft.url.trim())}`)
-          }
+          onClick={inspectUrl}
           size="32"
           variant="primary"
         >
@@ -188,7 +221,12 @@ function SourceCreateDialogContent({
               <DetailsStep discovery={discoveryResult} draft={draft} update={update} />
 
               <Dialog.Actions>
-                <ButtonContainer disabled={submitting} onClick={onCancel} size="32" variant="bare">
+                <ButtonContainer
+                  disabled={submitting}
+                  onClick={requestCancel}
+                  size="32"
+                  variant="bare"
+                >
                   <ButtonText>Cancel</ButtonText>
                 </ButtonContainer>
                 <ButtonContainer
@@ -228,7 +266,7 @@ function SourceCreateDialogContent({
                       <Dialog.Actions>
                         <ButtonContainer
                           disabled={submitting}
-                          onClick={onCancel}
+                          onClick={requestCancel}
                           size="32"
                           variant="bare"
                         >
@@ -261,6 +299,26 @@ function SourceCreateDialogContent({
           </Dialog.Popup>
         </Dialog.Portal>
       </Dialog.Root>
+      <Dialog.Root open={confirmingCancel} onOpenChange={setConfirmingCancel}>
+        <Dialog.Portal>
+          <Dialog.Popup size="m">
+            <Dialog.Title>Discard source draft?</Dialog.Title>
+            <Dialog.Description>The information you entered will be lost.</Dialog.Description>
+            <Dialog.Actions>
+              <ButtonContainer
+                onClick={() => setConfirmingCancel(false)}
+                size="32"
+                variant="secondary"
+              >
+                <ButtonText>Keep editing</ButtonText>
+              </ButtonContainer>
+              <ButtonContainer onClick={onCancel} size="32" variant="destructive">
+                <ButtonText>Discard</ButtonText>
+              </ButtonContainer>
+            </Dialog.Actions>
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>
     </Form>
   )
 }
@@ -271,18 +329,12 @@ function StepHeader({ step }: { step: number }) {
       className={styles.header}
       pill={
         <Pill as="span" color="graySubtle">
-          Step {step + 1} of {STEP_COUNT} — {stepTitle(step)}
+          Step {step + 1}/{STEP_COUNT}
         </Pill>
       }
       title={<Typography.HeadingMedium as="span">Create source</Typography.HeadingMedium>}
     />
   )
-}
-
-function stepTitle(step: number): string {
-  if (step === 0) return 'URL'
-  if (step === 1) return 'Details'
-  return 'Credentials'
 }
 
 function UrlStep({ draft, update }: { draft: Draft; update: (patch: Partial<Draft>) => void }) {
@@ -293,8 +345,7 @@ function UrlStep({ draft, update }: { draft: Draft; update: (patch: Partial<Draf
         className={styles.fieldItem}
         hint={
           <Typography.BodySmall variant="tertiary">
-            Enter an OpenAPI document or streamable HTTP MCP endpoint. Coral will inspect the URL
-            before you continue.
+            Enter an OpenAPI document or streamable HTTP MCP endpoint.
           </Typography.BodySmall>
         }
         htmlFor={idUrl}
@@ -330,7 +381,7 @@ function DetailsStep({
     <div className={styles.fieldGroup}>
       {discovery ? (
         <Typography.BodySmall variant="tertiary">
-          {discoverySummary(discovery)} Review the detected details or choose MCP instead.
+          {discoverySummary(discovery)} Review the detected details.
         </Typography.BodySmall>
       ) : null}
       <SourceField
@@ -443,7 +494,7 @@ function CredentialsStep({
           className={classNames(styles.authPanel, draft.auth !== 'none' && styles.authPanelHidden)}
         >
           <Typography.BodySmall variant="tertiary">
-            No credentials needed — click Create source to install.
+            This endpoint doesn’t require credentials.
           </Typography.BodySmall>
         </div>
         <div
@@ -496,15 +547,6 @@ function CredentialsStep({
           </SourceField>
         </div>
       </div>
-      <div className={styles.summaryBox}>
-        <SummaryRow label="Name" value={draft.name.trim()} />
-        <SummaryRow
-          label="Type"
-          value={draft.surfaceType === 'openapi' ? 'REST API (OpenAPI)' : 'MCP server'}
-        />
-        <SummaryRow label="URL" value={draft.url.trim()} />
-        <SummaryRow label="Auth" value={authSummary(draft)} />
-      </div>
     </div>
   )
 }
@@ -514,19 +556,11 @@ function authChoiceFromDiscovery(auth: SourceDetectedAuth): AuthChoice | null {
   return null
 }
 
-function SummaryRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div className={styles.summaryRow}>
-      <Typography.BodySmall className={styles.summaryKey}>{label}</Typography.BodySmall>
-      <span className={styles.summaryValue}>{value}</span>
-    </div>
-  )
-}
-
-function authSummary(draft: Draft): string {
-  if (draft.auth === 'none') return 'None'
-  if (draft.auth === 'bearer') return 'Bearer token'
-  return `Header ${draft.headerName.trim()}`
+function draftIsDirty(draft: Draft): boolean {
+  return Object.keys(EMPTY_DRAFT).some((key) => {
+    const draftKey = key as keyof Draft
+    return draft[draftKey] !== EMPTY_DRAFT[draftKey]
+  })
 }
 
 function sourceNameIsValid(name: string): boolean {

--- a/apps/reef/app/views/sources/source-create.tsx
+++ b/apps/reef/app/views/sources/source-create.tsx
@@ -1,0 +1,588 @@
+import classNames from 'classnames'
+import { useEffect, useId, useRef, useState } from 'react'
+import { Form, useFetcher, useNavigation } from 'react-router'
+
+import { Container as ButtonContainer } from '@/wax/components/button/container'
+import { SpinningButtonIcon } from '@/wax/components/button/icon'
+import { Text as ButtonText } from '@/wax/components/button/text'
+import { Dialog, Radio } from '@/wax/components'
+import { TextArea, TextInput } from '@/wax/components/inputs/text'
+import { Pill } from '@/wax/components/pill'
+import { Typography } from '@/wax/components/typography'
+
+import type { SourcesActionData } from '@/routes/sources-action'
+import type {
+  SourceDetectedAuth,
+  SourceDiscoveryData,
+  SourceDocumentFormat,
+} from '@/routes/source-discovery'
+
+import * as styles from './source-create.css'
+import { SourceError, SourceField, SourceHeader } from './source-presentation'
+
+const SECRET_KEY = 'API_TOKEN'
+const NAME_PATTERN = /^[a-z][a-z0-9_]*$/
+const RESERVED_SOURCE_NAMES = new Set(['coral', 'coral_admin', 'public'])
+
+type SurfaceType = 'openapi' | 'mcp'
+type AuthChoice = 'none' | 'bearer' | 'header'
+
+interface Draft {
+  name: string
+  description: string
+  surfaceType: SurfaceType
+  url: string
+  auth: AuthChoice
+  headerName: string
+  token: string
+}
+
+const EMPTY_DRAFT: Draft = {
+  name: '',
+  description: '',
+  surfaceType: 'openapi',
+  url: '',
+  auth: 'bearer',
+  headerName: '',
+  token: '',
+}
+
+const STEP_COUNT = 3
+
+export function SourceCreateDialog({
+  actionData,
+  discoveryPath,
+  open,
+  onOpenChange,
+}: {
+  actionData: SourcesActionData
+  discoveryPath: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop />
+        <Dialog.Popup size="l">
+          {open ? (
+            <SourceCreateDialogContent
+              actionData={actionData}
+              discoveryPath={discoveryPath}
+              onCancel={() => onOpenChange(false)}
+            />
+          ) : null}
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function SourceCreateDialogContent({
+  actionData,
+  discoveryPath,
+  onCancel,
+}: {
+  actionData: SourcesActionData
+  discoveryPath: string
+  onCancel: () => void
+}) {
+  const [step, setStep] = useState(0)
+  const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT)
+  const formId = useId()
+  const discovery = useFetcher<SourceDiscoveryData>()
+
+  const navigation = useNavigation()
+  const submitting = navigation.state !== 'idle' && navigation.formData?.get('_intent') === 'import'
+  const importError =
+    actionData?.status === 'error' && actionData.intent === 'import' ? actionData.message : null
+  const discovering = discovery.state !== 'idle'
+  const discoveryError =
+    discovery.data?.status === 'error' && discovery.data.url === draft.url.trim()
+      ? discovery.data.message
+      : null
+  const discoveryResult =
+    discovery.data?.status === 'success' && discovery.data.url === draft.url.trim()
+      ? discovery.data
+      : null
+
+  const appliedDiscovery = useRef<SourceDiscoveryData | undefined>(undefined)
+  useEffect(() => {
+    const result = discovery.data
+    if (!result || result === appliedDiscovery.current || result.status !== 'success') return
+    appliedDiscovery.current = result
+    if (step !== 0) return
+    const detectedAuth = authChoiceFromDiscovery(result.auth)
+    setDraft((current) => ({
+      ...current,
+      ...(detectedAuth ? { auth: detectedAuth } : {}),
+      description: result.description || current.description,
+      headerName: result.auth.headerName || current.headerName,
+      name: result.name || current.name,
+      surfaceType:
+        result.format === 'mcp'
+          ? 'mcp'
+          : result.format === 'unknown'
+            ? current.surfaceType
+            : 'openapi',
+    }))
+    setStep(1)
+  }, [discovery.data, step])
+
+  const update = (patch: Partial<Draft>) => setDraft((prev) => ({ ...prev, ...patch }))
+
+  const stepValid = (() => {
+    if (step === 0) return draft.url.trim().startsWith('https://')
+    if (step === 1) {
+      if (!sourceNameIsValid(draft.name.trim())) return false
+      return true
+    }
+    if (draft.auth === 'header' && draft.headerName.trim().length === 0) return false
+    return draft.auth === 'none' || draft.token.trim().length > 0
+  })()
+
+  return (
+    <Form className={styles.dialogContent} id={formId} method="post">
+      <input type="hidden" name="_intent" value="import" />
+      <input type="hidden" name="name" value={draft.name.trim()} />
+      <input type="hidden" name="manifest_yaml" value={buildManifestYaml(draft)} />
+      {draft.auth !== 'none' ? (
+        <>
+          <input type="hidden" name="secret_key" value={SECRET_KEY} />
+          <input type="hidden" name="secret_value" value={draft.token.trim()} />
+        </>
+      ) : null}
+
+      <StepHeader step={0} />
+      <UrlStep draft={draft} update={update} />
+
+      {discoveryError ? <SourceError>{discoveryError}</SourceError> : null}
+
+      <Dialog.Actions>
+        <ButtonContainer disabled={submitting} onClick={onCancel} size="32" variant="bare">
+          <ButtonText>Cancel</ButtonText>
+        </ButtonContainer>
+        <ButtonContainer
+          disabled={!stepValid || discovering}
+          onClick={() =>
+            discovery.load(`${discoveryPath}?url=${encodeURIComponent(draft.url.trim())}`)
+          }
+          size="32"
+          variant="primary"
+        >
+          {discovering ? <SpinningButtonIcon name="Loader" /> : null}
+          <ButtonText>{discovering ? 'Inspecting…' : 'Next'}</ButtonText>
+        </ButtonContainer>
+      </Dialog.Actions>
+
+      <Dialog.Root
+        open={step >= 1}
+        onOpenChange={(open) => {
+          if (!open) setStep(0)
+        }}
+      >
+        <Dialog.Portal>
+          <Dialog.Popup size="l">
+            <div className={styles.dialogContent}>
+              <StepHeader step={1} />
+              <DetailsStep discovery={discoveryResult} draft={draft} update={update} />
+
+              <Dialog.Actions>
+                <ButtonContainer disabled={submitting} onClick={onCancel} size="32" variant="bare">
+                  <ButtonText>Cancel</ButtonText>
+                </ButtonContainer>
+                <ButtonContainer
+                  disabled={submitting}
+                  onClick={() => setStep(0)}
+                  size="32"
+                  variant="secondary"
+                >
+                  <ButtonText>Back</ButtonText>
+                </ButtonContainer>
+                <ButtonContainer
+                  disabled={!stepValid}
+                  onClick={() => setStep(2)}
+                  size="32"
+                  variant="primary"
+                >
+                  <ButtonText>Next</ButtonText>
+                </ButtonContainer>
+              </Dialog.Actions>
+
+              <Dialog.Root open={step >= 2}>
+                <Dialog.Portal>
+                  <Dialog.Popup size="l">
+                    <div className={styles.dialogContent}>
+                      <StepHeader step={2} />
+                      <CredentialsStep
+                        discovery={discoveryResult}
+                        draft={draft}
+                        update={update}
+                        disabled={submitting}
+                      />
+
+                      {importError ? (
+                        <SourceError className={styles.importError}>{importError}</SourceError>
+                      ) : null}
+
+                      <Dialog.Actions>
+                        <ButtonContainer
+                          disabled={submitting}
+                          onClick={onCancel}
+                          size="32"
+                          variant="bare"
+                        >
+                          <ButtonText>Cancel</ButtonText>
+                        </ButtonContainer>
+                        <ButtonContainer
+                          disabled={submitting}
+                          onClick={() => setStep(1)}
+                          size="32"
+                          variant="secondary"
+                        >
+                          <ButtonText>Back</ButtonText>
+                        </ButtonContainer>
+                        <ButtonContainer
+                          disabled={submitting || !stepValid}
+                          form={formId}
+                          size="32"
+                          type="submit"
+                          variant="primary"
+                        >
+                          {submitting ? <SpinningButtonIcon name="Loader" /> : null}
+                          <ButtonText>{submitting ? 'Creating…' : 'Create source'}</ButtonText>
+                        </ButtonContainer>
+                      </Dialog.Actions>
+                    </div>
+                  </Dialog.Popup>
+                </Dialog.Portal>
+              </Dialog.Root>
+            </div>
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </Form>
+  )
+}
+
+function StepHeader({ step }: { step: number }) {
+  return (
+    <SourceHeader
+      className={styles.header}
+      pill={
+        <Pill as="span" color="graySubtle">
+          Step {step + 1} of {STEP_COUNT} — {stepTitle(step)}
+        </Pill>
+      }
+      title={<Typography.HeadingMedium as="span">Create source</Typography.HeadingMedium>}
+    />
+  )
+}
+
+function stepTitle(step: number): string {
+  if (step === 0) return 'URL'
+  if (step === 1) return 'Details'
+  return 'Credentials'
+}
+
+function UrlStep({ draft, update }: { draft: Draft; update: (patch: Partial<Draft>) => void }) {
+  const idUrl = useId()
+  return (
+    <div className={styles.fieldGroup}>
+      <SourceField
+        className={styles.fieldItem}
+        hint={
+          <Typography.BodySmall variant="tertiary">
+            Enter an OpenAPI document or streamable HTTP MCP endpoint. Coral will inspect the URL
+            before you continue.
+          </Typography.BodySmall>
+        }
+        htmlFor={idUrl}
+        label="Source URL"
+      >
+        <TextInput
+          id={idUrl}
+          value={draft.url}
+          onChange={(value) => update({ url: value })}
+          placeholder="https://example.com/openapi.yaml"
+        />
+      </SourceField>
+    </div>
+  )
+}
+
+function DetailsStep({
+  discovery,
+  draft,
+  update,
+}: {
+  discovery: Extract<SourceDiscoveryData, { status: 'success' }> | null
+  draft: Draft
+  update: (patch: Partial<Draft>) => void
+}) {
+  const idName = useId()
+  const idDescription = useId()
+  const [nameTouched, setNameTouched] = useState(false)
+  const name = draft.name.trim()
+  const nameError = nameTouched ? sourceNameValidationError(name) : null
+
+  return (
+    <div className={styles.fieldGroup}>
+      {discovery ? (
+        <Typography.BodySmall variant="tertiary">
+          {discoverySummary(discovery)} Review the detected details or choose MCP instead.
+        </Typography.BodySmall>
+      ) : null}
+      <SourceField
+        className={styles.fieldItem}
+        hint={
+          <Typography.BodySmall variant={nameError ? 'error' : 'tertiary'}>
+            {nameError ?? 'Used as the schema name in queries.'}
+          </Typography.BodySmall>
+        }
+        htmlFor={idName}
+        label="Name"
+      >
+        <TextInput
+          id={idName}
+          value={draft.name}
+          onBlur={() => setNameTouched(true)}
+          onChange={(value) => update({ name: value })}
+          placeholder="my_api"
+        />
+      </SourceField>
+      <SourceField
+        className={styles.fieldItem}
+        htmlFor={idDescription}
+        label="Description (optional)"
+      >
+        <TextArea
+          id={idDescription}
+          value={draft.description}
+          onChange={(value) => update({ description: value })}
+          placeholder="What this source connects to"
+        />
+      </SourceField>
+      <SourceField className={styles.fieldItem} label="Type">
+        <Radio.Group
+          aria-label="Source type"
+          value={draft.surfaceType}
+          onValueChange={(surfaceType) =>
+            update({
+              surfaceType,
+              // Custom-header auth only applies to OpenAPI surfaces.
+              auth: surfaceType === 'mcp' && draft.auth === 'header' ? 'bearer' : draft.auth,
+            })
+          }
+        >
+          <Radio.Item value="openapi">REST API (OpenAPI)</Radio.Item>
+          <Radio.Item value="mcp">MCP server</Radio.Item>
+        </Radio.Group>
+      </SourceField>
+    </div>
+  )
+}
+
+function discoverySummary(discovery: { format: SourceDocumentFormat; warning?: string }): string {
+  if (discovery.format === 'mcp') return 'Detected an MCP endpoint from its URL.'
+  if (discovery.format === 'openapi-json') return 'Detected an OpenAPI JSON document.'
+  if (discovery.format === 'openapi-yaml') return 'Detected an OpenAPI YAML document.'
+  return discovery.warning
+    ? `No OpenAPI document was detected. ${discovery.warning}.`
+    : 'No OpenAPI document was detected.'
+}
+
+function CredentialsStep({
+  discovery,
+  draft,
+  update,
+  disabled,
+}: {
+  discovery: Extract<SourceDiscoveryData, { status: 'success' }> | null
+  draft: Draft
+  update: (patch: Partial<Draft>) => void
+  disabled: boolean
+}) {
+  const idBearerToken = useId()
+  const idHeaderName = useId()
+  const idHeaderToken = useId()
+  const authChoices: { key: AuthChoice; label: string }[] =
+    draft.surfaceType === 'openapi'
+      ? [
+          { key: 'none', label: 'None' },
+          { key: 'bearer', label: 'Bearer token' },
+          { key: 'header', label: 'Custom header' },
+        ]
+      : [
+          { key: 'none', label: 'None' },
+          { key: 'bearer', label: 'Bearer token' },
+        ]
+  return (
+    <div className={styles.fieldGroup}>
+      {discovery && discovery.auth.kind !== 'unknown' ? (
+        <Typography.BodySmall variant="tertiary">
+          Detected authentication: {discovery.auth.label}.
+        </Typography.BodySmall>
+      ) : null}
+      <SourceField className={styles.fieldItem} label="Authentication">
+        <Radio.Group
+          aria-label="Authentication"
+          value={draft.auth}
+          onValueChange={(auth) => update({ auth })}
+        >
+          {authChoices.map((choice) => (
+            <Radio.Item key={choice.key} value={choice.key}>
+              {choice.label}
+            </Radio.Item>
+          ))}
+        </Radio.Group>
+      </SourceField>
+      <div className={styles.authPanelStack}>
+        <div
+          aria-hidden={draft.auth !== 'none'}
+          className={classNames(styles.authPanel, draft.auth !== 'none' && styles.authPanelHidden)}
+        >
+          <Typography.BodySmall variant="tertiary">
+            No credentials needed — click Create source to install.
+          </Typography.BodySmall>
+        </div>
+        <div
+          aria-hidden={draft.auth !== 'bearer'}
+          className={classNames(
+            styles.authPanel,
+            draft.auth !== 'bearer' && styles.authPanelHidden,
+          )}
+        >
+          <SourceField className={styles.fieldItem} htmlFor={idBearerToken} label="Bearer token">
+            <TextInput
+              id={idBearerToken}
+              type="password"
+              value={draft.token}
+              onChange={(value) => update({ token: value })}
+              placeholder="Paste token"
+              disabled={disabled || draft.auth !== 'bearer'}
+            />
+          </SourceField>
+        </div>
+        <div
+          aria-hidden={draft.auth !== 'header'}
+          className={classNames(
+            styles.authPanel,
+            draft.auth !== 'header' && styles.authPanelHidden,
+          )}
+        >
+          <SourceField className={styles.fieldItem} htmlFor={idHeaderName} label="Header name">
+            <TextInput
+              id={idHeaderName}
+              value={draft.headerName}
+              onChange={(value) => update({ headerName: value })}
+              placeholder="X-Api-Key"
+              disabled={disabled || draft.auth !== 'header'}
+            />
+          </SourceField>
+          <SourceField
+            className={styles.fieldItem}
+            htmlFor={idHeaderToken}
+            label={`${draft.headerName.trim() || 'Header'} value`}
+          >
+            <TextInput
+              id={idHeaderToken}
+              type="password"
+              value={draft.token}
+              onChange={(value) => update({ token: value })}
+              placeholder="Paste token"
+              disabled={disabled || draft.auth !== 'header'}
+            />
+          </SourceField>
+        </div>
+      </div>
+      <div className={styles.summaryBox}>
+        <SummaryRow label="Name" value={draft.name.trim()} />
+        <SummaryRow
+          label="Type"
+          value={draft.surfaceType === 'openapi' ? 'REST API (OpenAPI)' : 'MCP server'}
+        />
+        <SummaryRow label="URL" value={draft.url.trim()} />
+        <SummaryRow label="Auth" value={authSummary(draft)} />
+      </div>
+    </div>
+  )
+}
+
+function authChoiceFromDiscovery(auth: SourceDetectedAuth): AuthChoice | null {
+  if (auth.kind === 'bearer' || auth.kind === 'header' || auth.kind === 'none') return auth.kind
+  return null
+}
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className={styles.summaryRow}>
+      <Typography.BodySmall className={styles.summaryKey}>{label}</Typography.BodySmall>
+      <span className={styles.summaryValue}>{value}</span>
+    </div>
+  )
+}
+
+function authSummary(draft: Draft): string {
+  if (draft.auth === 'none') return 'None'
+  if (draft.auth === 'bearer') return 'Bearer token'
+  return `Header ${draft.headerName.trim()}`
+}
+
+function sourceNameIsValid(name: string): boolean {
+  return sourceNameValidationError(name) === null
+}
+
+function sourceNameValidationError(name: string): string | null {
+  if (!name) return 'Enter a source name.'
+  if (RESERVED_SOURCE_NAMES.has(name)) {
+    return `“${name}” is reserved by Coral. Choose another source name.`
+  }
+  if (!NAME_PATTERN.test(name)) {
+    return 'Use lowercase letters, digits, and underscores; the name must start with a letter.'
+  }
+  return null
+}
+
+/** Quote a scalar as a JSON string, which YAML parses as a flow scalar. */
+const s = (value: string) => JSON.stringify(value)
+
+/** Build a DSL v4 source manifest from the wizard fields. */
+function buildManifestYaml(draft: Draft): string {
+  const name = draft.name.trim()
+  const url = draft.url.trim()
+  const lines: string[] = [`name: ${s(name)}`, 'dsl_version: 4']
+  if (draft.description.trim()) lines.push(`description: ${s(draft.description.trim())}`)
+  if (draft.auth !== 'none') {
+    lines.push(
+      'inputs:',
+      `  ${SECRET_KEY}:`,
+      '    kind: secret',
+      `    hint: ${s(`API token for ${name}`)}`,
+    )
+  }
+  lines.push('surface:')
+
+  if (draft.surfaceType === 'openapi') {
+    lines.push('  type: openapi', `  url: ${s(url)}`)
+    if (draft.auth !== 'none') {
+      const headerName = draft.auth === 'bearer' ? 'Authorization' : draft.headerName.trim()
+      const template =
+        draft.auth === 'bearer' ? `Bearer {{input.${SECRET_KEY}}}` : `{{input.${SECRET_KEY}}}`
+      lines.push(
+        '  auth:',
+        '    type: HeaderAuth',
+        '    headers:',
+        `      - name: ${s(headerName)}`,
+        '        from: template',
+        `        template: ${s(template)}`,
+      )
+    }
+  } else {
+    lines.push('  type: mcp', '  server:', '    transport: streamable_http', `    url: ${s(url)}`)
+    if (draft.auth !== 'none') {
+      lines.push('    auth:', '      type: bearer', '      from: input', `      key: ${SECRET_KEY}`)
+    }
+  }
+  return lines.join('\n') + '\n'
+}

--- a/apps/reef/app/views/sources/source-detail.css.ts
+++ b/apps/reef/app/views/sources/source-detail.css.ts
@@ -1,26 +1,10 @@
 import { style } from '@vanilla-extract/css'
 
-import { theme } from '@/wax/theme/theme.css'
-
 export const fieldGroup = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 16,
   paddingBlockStart: 16,
-})
-
-export const alertError = style({
-  alignItems: 'center',
-  background: theme.pill.red.background,
-  border: `1px solid ${theme.pill.red.stroke}`,
-  borderRadius: 6,
-  color: theme.pill.red.color,
-  display: 'flex',
-  fontSize: 12,
-  gap: 8,
-  lineHeight: '16px',
-  paddingBlock: 8,
-  paddingInline: 12,
 })
 
 export const removeConfirmText = style({

--- a/apps/reef/app/views/sources/source-detail.test.tsx
+++ b/apps/reef/app/views/sources/source-detail.test.tsx
@@ -121,6 +121,29 @@ describe('SourceDetailView', () => {
     await expect.element(screen.getByLabelText('Github token')).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Save changes' }).query()).toBeNull()
   })
+
+  it('submits an imported source canonical name when removing it', async () => {
+    const name = 'spotify_web_api_with_fixes_and_improvements_from_sonallux'
+    const entry: CatalogEntry = {
+      ...installedEntry,
+      name,
+      origin: 'imported',
+      source: { ...installedEntry.source!, name, origin: 'imported' },
+    }
+    const screen = await renderSourceDetail(entry)
+
+    await screen.getByRole('button', { name: 'Remove' }).click()
+    await expect
+      .element(screen.getByRole('heading', { name: /Remove spotify web api/ }))
+      .toBeVisible()
+
+    const dialogs = document.querySelectorAll<HTMLElement>(
+      '[role="dialog"]:not([data-ending-style])',
+    )
+    const confirmation = dialogs.item(dialogs.length - 1)
+    const nameInput = confirmation?.querySelector<HTMLInputElement>('input[name="name"]')
+    expect(nameInput?.value).toBe(name)
+  })
 })
 
 async function renderSourceDetail(entry: CatalogEntry) {
@@ -138,7 +161,7 @@ async function renderSourceDetail(entry: CatalogEntry) {
         path: '/workspaces/:workspaceId/sources/:sourceName',
       },
     ],
-    { initialEntries: ['/workspaces/default/sources/github'] },
+    { initialEntries: [`/workspaces/default/sources/${entry.name}`] },
   )
 
   return render(<RouterProvider router={router} />)

--- a/apps/reef/app/views/sources/source-detail.tsx
+++ b/apps/reef/app/views/sources/source-detail.tsx
@@ -5,7 +5,6 @@ import { Container as ButtonContainer } from '@/wax/components/button/container'
 import { SpinningButtonIcon } from '@/wax/components/button/icon'
 import { Text as ButtonText } from '@/wax/components/button/text'
 import { Dialog } from '@/wax/components'
-import { Icon } from '@/wax/components/icon'
 import { TextInput } from '@/wax/components/inputs/text'
 import { Typography } from '@/wax/components/typography'
 
@@ -17,8 +16,9 @@ import * as styles from './source-detail.css'
 import { SourceInstallDialog } from './source-install'
 import {
   formatFieldName,
+  SourceError,
   SourceField,
-  SourceHeader,
+  SourceIdentityHeader,
   SourceInputField,
   SourceNoConfiguration,
 } from './source-presentation'
@@ -177,26 +177,16 @@ function SourceDetailDialogContent({
         <input type="hidden" name="_intent" value="edit" />
         <input type="hidden" name="name" value={entry.name} />
 
-        <SourceHeader
+        <SourceIdentityHeader
           description={entry.description}
           name={entry.name}
           origin={source?.origin ?? entry.origin}
           version={source?.version || entry.version}
         />
 
-        {!source ? (
-          <div className={styles.alertError}>
-            <Icon name="CircleAlert" size="14" color="inherit" />
-            <Typography.BodySmall>Installed source details are unavailable.</Typography.BodySmall>
-          </div>
-        ) : null}
+        {!source ? <SourceError>Installed source details are unavailable.</SourceError> : null}
 
-        {actionError ? (
-          <div className={styles.alertError}>
-            <Icon name="CircleAlert" size="14" color="inherit" />
-            <Typography.BodySmall>{actionError}</Typography.BodySmall>
-          </div>
-        ) : null}
+        {actionError ? <SourceError>{actionError}</SourceError> : null}
 
         {!source ? null : inputSpecs ? (
           <SourceInputBindings
@@ -268,8 +258,9 @@ function SourceDetailDialogContent({
           <Dialog.Popup size="m">
             <RemoveConfirmation
               deleting={deleting}
+              displayName={sourceDisplayName}
               error={removeError}
-              name={sourceDisplayName}
+              name={entry.name}
               onCancel={() => setConfirmingRemove(false)}
             />
           </Dialog.Popup>
@@ -281,11 +272,13 @@ function SourceDetailDialogContent({
 
 function RemoveConfirmation({
   deleting,
+  displayName,
   error,
   name,
   onCancel,
 }: {
   deleting: boolean
+  displayName: string
   error?: string | null
   name: string
   onCancel: () => void
@@ -296,18 +289,13 @@ function RemoveConfirmation({
       <input type="hidden" name="name" value={name} />
 
       <div className={styles.removeConfirmText}>
-        <Dialog.Title>Remove {name}?</Dialog.Title>
+        <Dialog.Title>Remove {displayName}?</Dialog.Title>
         <Dialog.Description>
           This deletes the source configuration and stored credentials from this workspace. You can
           reinstall later, but you'll need to re-supply any secrets.
         </Dialog.Description>
       </div>
-      {error ? (
-        <div className={styles.alertError}>
-          <Icon name="CircleAlert" size="14" color="inherit" />
-          <Typography.BodySmall>{error}</Typography.BodySmall>
-        </div>
-      ) : null}
+      {error ? <SourceError>{error}</SourceError> : null}
       <Dialog.Actions className={styles.removeConfirmActions}>
         <ButtonContainer variant="secondary" size="32" onClick={onCancel} disabled={deleting}>
           <ButtonText>Cancel</ButtonText>

--- a/apps/reef/app/views/sources/source-install.css.ts
+++ b/apps/reef/app/views/sources/source-install.css.ts
@@ -1,7 +1,5 @@
 import { style } from '@vanilla-extract/css'
 
-import { theme } from '@/wax/theme/theme.css'
-
 export const fieldGroup = style({
   display: 'flex',
   flexDirection: 'column',
@@ -34,21 +32,4 @@ export const methodPanelContent = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 8,
-})
-
-export const alertBox = style({
-  alignItems: 'center',
-  borderRadius: 6,
-  display: 'flex',
-  fontSize: 12,
-  gap: 8,
-  lineHeight: '16px',
-  paddingBlock: 8,
-  paddingInline: 12,
-})
-
-export const alertError = style({
-  background: theme.pill.red.background,
-  border: `1px solid ${theme.pill.red.stroke}`,
-  color: theme.pill.red.color,
 })

--- a/apps/reef/app/views/sources/source-install.tsx
+++ b/apps/reef/app/views/sources/source-install.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Form, useNavigate, useRevalidator } from 'react-router'
 
@@ -26,7 +25,8 @@ import { routePath } from '@/routing/routemap'
 import * as styles from './source-install.css'
 import {
   formatFieldName,
-  SourceHeader,
+  SourceError,
+  SourceIdentityHeader,
   SourceInputField,
   SourceNoConfiguration,
 } from './source-presentation'
@@ -234,7 +234,7 @@ function SourceInstallDialogContent({
       <input type="hidden" name="_intent" value="install" />
       <input type="hidden" name="name" value={entry.name} />
 
-      <SourceHeader
+      <SourceIdentityHeader
         description={entry.description}
         name={entry.name}
         origin={entry.origin}
@@ -242,10 +242,7 @@ function SourceInstallDialogContent({
       />
 
       {!inputSpecs ? (
-        <div className={classNames(styles.alertBox, styles.alertError)}>
-          <Icon color="inherit" name="CircleAlert" size="14" />
-          <Typography.BodySmall>Source metadata is unavailable.</Typography.BodySmall>
-        </div>
+        <SourceError>Source metadata is unavailable.</SourceError>
       ) : inputs.length === 0 ? (
         <SourceNoConfiguration />
       ) : (
@@ -298,19 +295,9 @@ function SourceInstallDialogContent({
         </div>
       ) : null}
 
-      {streamError ? (
-        <div className={classNames(styles.alertBox, styles.alertError)}>
-          <Icon color="inherit" name="CircleAlert" size="14" />
-          <Typography.BodySmall>{streamError}</Typography.BodySmall>
-        </div>
-      ) : null}
+      {streamError ? <SourceError>{streamError}</SourceError> : null}
 
-      {actionError ? (
-        <div className={classNames(styles.alertBox, styles.alertError)}>
-          <Icon color="inherit" name="CircleAlert" size="14" />
-          <Typography.BodySmall>{actionError}</Typography.BodySmall>
-        </div>
-      ) : null}
+      {actionError ? <SourceError>{actionError}</SourceError> : null}
 
       <Dialog.Actions>
         <ButtonContainer disabled={submitting} onClick={cancel} size="32" variant="bare">

--- a/apps/reef/app/views/sources/source-presentation.css.ts
+++ b/apps/reef/app/views/sources/source-presentation.css.ts
@@ -1,5 +1,21 @@
 import { style } from '@vanilla-extract/css'
 
+import { theme } from '@/wax/theme/theme.css'
+
+export const error = style({
+  alignItems: 'center',
+  background: theme.pill.red.background,
+  border: `1px solid ${theme.pill.red.stroke}`,
+  borderRadius: 6,
+  color: theme.pill.red.color,
+  display: 'flex',
+  fontSize: 12,
+  gap: 8,
+  lineHeight: '16px',
+  paddingBlock: 8,
+  paddingInline: 12,
+})
+
 export const header = style({
   alignItems: 'flex-start',
   display: 'flex',

--- a/apps/reef/app/views/sources/source-presentation.tsx
+++ b/apps/reef/app/views/sources/source-presentation.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from 'react'
+import classNames from 'classnames'
 
 import { Dialog } from '@/wax/components'
+import { Icon } from '@/wax/components/icon'
 import { Pill } from '@/wax/components/pill'
 import { Typography } from '@/wax/components/typography'
 
@@ -11,7 +13,45 @@ import { toSentenceCase } from '@/utils/to-sentence-case'
 
 import * as styles from './source-presentation.css'
 
+export function SourceError({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div className={classNames(styles.error, className)}>
+      <Icon color="inherit" name="CircleAlert" size="14" />
+      <Typography.BodySmall>{children}</Typography.BodySmall>
+    </div>
+  )
+}
+
 export function SourceHeader({
+  className,
+  description,
+  leading,
+  pill,
+  title,
+}: {
+  className?: string
+  description?: ReactNode
+  leading?: ReactNode
+  pill?: ReactNode
+  title: ReactNode
+}) {
+  return (
+    <div className={classNames(styles.header, className)}>
+      {leading}
+      <div className={styles.headerText}>
+        <Dialog.Title className={styles.headerTitleRow}>
+          {title}
+          {pill}
+        </Dialog.Title>
+        {description ? (
+          <Dialog.Description render={<div />}>{description}</Dialog.Description>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export function SourceIdentityHeader({
   description,
   name,
   origin,
@@ -25,27 +65,23 @@ export function SourceHeader({
   const originLabel = sourceOriginLabel(origin)
 
   return (
-    <div className={styles.header}>
-      <ProviderLogo name={name} size="large" />
-      <div className={styles.headerText}>
-        <Dialog.Title className={styles.headerTitleRow}>
-          <span className={styles.headerIdentity}>
-            <Typography.HeadingMedium as="span" className={styles.headerTitle}>
-              {formatSourceName(name)}
-            </Typography.HeadingMedium>
-            {version ? (
-              <Typography.BodySmall as="span" variant="tertiary">
-                {version}
-              </Typography.BodySmall>
-            ) : null}
-          </span>
-          {originLabel ? <Pill color="graySubtle">{originLabel}</Pill> : null}
-        </Dialog.Title>
-        <Dialog.Description render={<div />}>
-          <Markdown>{description}</Markdown>
-        </Dialog.Description>
-      </div>
-    </div>
+    <SourceHeader
+      description={<Markdown>{description}</Markdown>}
+      leading={<ProviderLogo name={name} size="large" />}
+      pill={originLabel ? <Pill color="graySubtle">{originLabel}</Pill> : null}
+      title={
+        <span className={styles.headerIdentity}>
+          <Typography.HeadingMedium as="span" className={styles.headerTitle}>
+            {formatSourceName(name)}
+          </Typography.HeadingMedium>
+          {version ? (
+            <Typography.BodySmall as="span" variant="tertiary">
+              {version}
+            </Typography.BodySmall>
+          ) : null}
+        </span>
+      }
+    />
   )
 }
 
@@ -86,17 +122,19 @@ export function SourceNoConfiguration() {
 
 export function SourceField({
   children,
+  className,
   hint,
   htmlFor,
   label,
 }: {
   children: ReactNode
-  hint?: string
+  className?: string
+  hint?: ReactNode
   htmlFor?: string
-  label?: string
+  label?: ReactNode
 }) {
   return (
-    <div className={styles.fieldItem}>
+    <div className={classNames(styles.fieldItem, className)}>
       {label ? (
         htmlFor ? (
           <Typography.BodyStrong as="label" htmlFor={htmlFor} variant="primary">
@@ -107,7 +145,7 @@ export function SourceField({
         )
       ) : null}
       {children}
-      {hint ? <Markdown>{hint}</Markdown> : null}
+      {typeof hint === 'string' ? <Markdown>{hint}</Markdown> : hint}
     </div>
   )
 }

--- a/apps/reef/app/views/sources/sources-index.test.tsx
+++ b/apps/reef/app/views/sources/sources-index.test.tsx
@@ -21,6 +21,14 @@ function renderSourcesIndex(entries: CatalogEntry[]) {
 }
 
 describe('SourcesIndex', () => {
+  it('links source creation to the dedicated install route', async () => {
+    const screen = await renderSourcesIndex([])
+
+    await expect
+      .element(screen.getByRole('link', { name: 'Create source' }))
+      .toHaveAttribute('href', '/workspaces/team%20alpha/sources/install')
+  })
+
   it('routes installable sources through the source detail route', async () => {
     const screen = await renderSourcesIndex([
       {

--- a/apps/reef/app/views/sources/sources-index.tsx
+++ b/apps/reef/app/views/sources/sources-index.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useRef, useState } from 'react'
-import { useRevalidator } from 'react-router'
+import { Link, useRevalidator } from 'react-router'
 
+import { Container as ButtonContainer } from '@/wax/components/button/container'
+import { Icon as ButtonIcon } from '@/wax/components/button/icon'
+import { Text as ButtonText } from '@/wax/components/button/text'
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
 
 import { SourceCatalogSurface } from '@/components/sources'
@@ -39,6 +42,17 @@ export function SourcesIndex({
         errorMessage={loadError}
         getEntryTo={(entry) =>
           routePath('workspaceSource', { sourceName: entry.name, workspaceId })
+        }
+        headerAction={
+          <ButtonContainer
+            as={Link}
+            size="32"
+            to={routePath('workspaceSourceInstall', { workspaceId })}
+            variant="primary"
+          >
+            <ButtonIcon name="Plus" />
+            <ButtonText>Create source</ButtonText>
+          </ButtonContainer>
         }
         loadState={loadError ? 'error' : loading ? 'loading' : 'idle'}
         onRetry={() => revalidator.revalidate()}

--- a/apps/reef/app/views/sources/sources-index.tsx
+++ b/apps/reef/app/views/sources/sources-index.tsx
@@ -46,7 +46,7 @@ export function SourcesIndex({
         headerAction={
           <ButtonContainer
             as={Link}
-            size="32"
+            size="36"
             to={routePath('workspaceSourceInstall', { workspaceId })}
             variant="primary"
           >

--- a/apps/reef/package-lock.json
+++ b/apps/reef/package-lock.json
@@ -101,7 +101,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -501,7 +500,6 @@
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/parser": "^7.29.7",
@@ -759,8 +757,7 @@
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
       "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@bufbuild/protoc-gen-es": {
       "version": "2.12.1",
@@ -869,7 +866,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
       "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -891,6 +887,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -903,6 +900,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -913,7 +911,6 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3276,7 +3273,6 @@
       "integrity": "sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "picomatch": "^4.0.4"
       },
@@ -4021,7 +4017,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4174,7 +4171,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4185,7 +4181,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4250,7 +4245,6 @@
       "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.20.1.tgz",
       "integrity": "sha512-5I9RNo5uZW9tsBnqrWzJqELegOqTHBrZyDFnES0gR9gJJHBB9dom1N0bwITM9tKwBcfKrTX4a6DHVeQdJ2ubQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.9",
@@ -4351,7 +4345,6 @@
       "integrity": "sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@blazediff/core": "1.9.1",
         "@vitest/mocker": "4.1.9",
@@ -4375,7 +4368,6 @@
       "integrity": "sha512-Bq1rOGf9waevzG3EOkO/dene6bvKTUsZMVg8S1i+WH3JcMjuXEjiahP9rAqZRELUqjBySOJsvvSWqK/B3wjKQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -4518,7 +4510,6 @@
       "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
@@ -4637,6 +4628,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4647,6 +4639,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4764,7 +4757,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -4835,7 +4827,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5358,7 +5349,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.372",
@@ -5401,7 +5393,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5986,7 +5977,6 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -6313,6 +6303,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7445,7 +7436,6 @@
       "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.61.0"
       },
@@ -7533,6 +7523,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7557,7 +7548,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7638,7 +7628,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7668,7 +7657,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7906,7 +7896,6 @@
       "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -7951,7 +7940,6 @@
       "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -8101,7 +8089,6 @@
       "integrity": "sha512-QZuv1gS9Tf9RMCjDw5JOfv1XSB5IhU0uhSKQNS7l/N9zDpmSydirCspkCNT9e0zkFfPkZ9vmQUTzHY/BA07saA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.2",
@@ -8909,7 +8896,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9142,7 +9128,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9840,7 +9825,6 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",


### PR DESCRIPTION
## Summary

- add a dedicated routed source-install modal with nested Wax dialogs
- start source creation from a URL and discover OpenAPI JSON or YAML metadata through a server resource route
- prefill source name, description, and detected authentication while keeping source type and credentials editable
- keep every authentication variant mounted in an overlapping grid so radio toggles never resize the dialog
- use the new Wax textarea and Base UI-backed radio group for form-appropriate semantics
- add Storybook interactions and server/browser test coverage

## Provenance

This PR continues and replaces [#1779](https://github.com/withcoral/coral/pull/1779), originally opened by @martinrajdl.

The shared `TextInput` `id` forwarding change was split out and merged separately in [#1799](https://github.com/withcoral/coral/pull/1799). The remaining reusable prerequisites are stacked as [#1866](https://github.com/withcoral/coral/pull/1866), [#1868](https://github.com/withcoral/coral/pull/1868), and [#1869](https://github.com/withcoral/coral/pull/1869).

## Validation

- `npm run check --prefix apps/reef`
- `npm run typecheck --prefix apps/reef`
- `npm test --prefix apps/reef` — 90 files, 388 tests passed
- `npm run build --prefix apps/reef`
- Playwright measured the bearer, none, and custom-header variants at the same 532px dialog height