### PR TITLE
feat(app): persist identity spec documents with shared envelopes

### DIFF
--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -32,6 +32,7 @@ use tracing::warn;
 use zeroize::{Zeroize as _, Zeroizing};
 
 use super::CredentialsError;
+use crate::encrypted_document::EncryptedEnvelopeDocument;
 use crate::sources::SourceName;
 use crate::state::AppStateLayout;
 use crate::storage::fs as storage_fs;
@@ -47,6 +48,8 @@ const KEY_LEN: usize = 32;
 const NONCE_LEN: usize = 12;
 
 static LOCAL_KEY_FILE_LOCK: Mutex<()> = Mutex::new(());
+
+pub(crate) type EncryptedCredentialDocument = EncryptedEnvelopeDocument;
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct CredentialEncryptionKey {
@@ -201,17 +204,6 @@ impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct EncryptedCredentialDocument {
-    pub(crate) ciphertext: Vec<u8>,
-    pub(crate) nonce: Vec<u8>,
-    pub(crate) wrapped_dek: Vec<u8>,
-    pub(crate) wrapped_dek_nonce: Vec<u8>,
-    pub(crate) key_id: String,
-    pub(crate) algorithm: String,
-    pub(crate) aad_version: i64,
-}
-
 #[derive(serde::Serialize)]
 struct PlaintextCredentialDocument<'a> {
     version: u32,
@@ -258,15 +250,16 @@ pub(crate) fn encrypt_credential_values(
         &mut wrapped_dek,
     )?;
 
-    Ok(EncryptedCredentialDocument {
-        ciphertext: std::mem::take(&mut *document_bytes),
-        nonce: nonce.to_vec(),
-        wrapped_dek: std::mem::take(&mut *wrapped_dek),
-        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
-        key_id: kek.key_id.clone(),
-        algorithm: CREDENTIAL_DOCUMENT_ALGORITHM.to_string(),
-        aad_version: CREDENTIAL_DOCUMENT_AAD_VERSION,
-    })
+    EncryptedCredentialDocument::new(
+        std::mem::take(&mut *document_bytes),
+        nonce.to_vec(),
+        std::mem::take(&mut *wrapped_dek),
+        wrapped_dek_nonce.to_vec(),
+        kek.key_id.clone(),
+        CREDENTIAL_DOCUMENT_ALGORITHM,
+        CREDENTIAL_DOCUMENT_AAD_VERSION,
+    )
+    .map_err(|error| CredentialsError::Crypto(error.to_string()))
 }
 
 pub(crate) fn decrypt_credential_values(
@@ -329,15 +322,17 @@ pub(crate) fn rewrap_credential_document(
         &mut wrapped_dek,
     )?;
 
-    Ok(Some(EncryptedCredentialDocument {
-        ciphertext: document.ciphertext.clone(),
-        nonce: document.nonce.clone(),
-        wrapped_dek: std::mem::take(&mut *wrapped_dek),
-        wrapped_dek_nonce: wrapped_dek_nonce.to_vec(),
-        key_id: active_kek.key_id.clone(),
-        algorithm: document.algorithm.clone(),
-        aad_version: document.aad_version,
-    }))
+    EncryptedCredentialDocument::new(
+        document.ciphertext.clone(),
+        document.nonce.clone(),
+        std::mem::take(&mut *wrapped_dek),
+        wrapped_dek_nonce.to_vec(),
+        active_kek.key_id.clone(),
+        document.algorithm.clone(),
+        document.binding_version,
+    )
+    .map(Some)
+    .map_err(|error| CredentialsError::Crypto(error.to_string()))
 }
 
 fn decrypt_credential_document_bytes(
@@ -417,16 +412,19 @@ fn validate_dek_plaintext(
 fn validate_document_metadata(
     document: &EncryptedCredentialDocument,
 ) -> Result<(), CredentialsError> {
+    document
+        .validate()
+        .map_err(|error| CredentialsError::Crypto(error.to_string()))?;
     if document.algorithm != CREDENTIAL_DOCUMENT_ALGORITHM {
         return Err(CredentialsError::Crypto(format!(
             "unsupported credential encryption algorithm '{}'",
             document.algorithm
         )));
     }
-    if document.aad_version != CREDENTIAL_DOCUMENT_AAD_VERSION {
+    if document.binding_version != CREDENTIAL_DOCUMENT_AAD_VERSION {
         return Err(CredentialsError::Crypto(format!(
             "unsupported credential AAD version {}",
-            document.aad_version
+            document.binding_version
         )));
     }
     Ok(())

--- a/crates/coral-app/src/credentials/encryption_tests.rs
+++ b/crates/coral-app/src/credentials/encryption_tests.rs
@@ -211,7 +211,7 @@ fn credential_document_rejects_aad_version_mismatch() {
         &provider,
     )
     .expect("encrypt");
-    encrypted.aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION + 1;
+    encrypted.binding_version = CREDENTIAL_DOCUMENT_AAD_VERSION + 1;
 
     let error = decrypt_credential_values(&workspace, &source, &encrypted, &provider)
         .expect_err("unsupported AAD version should fail");

--- a/crates/coral-app/src/encrypted_document.rs
+++ b/crates/coral-app/src/encrypted_document.rs
@@ -1,0 +1,152 @@
+//! Shared envelope-encrypted document representation.
+
+use std::fmt;
+
+/// Opaque envelope-encrypted bytes and the metadata needed to decrypt them.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct EncryptedEnvelopeDocument {
+    pub(crate) ciphertext: Vec<u8>,
+    pub(crate) nonce: Vec<u8>,
+    pub(crate) wrapped_dek: Vec<u8>,
+    pub(crate) wrapped_dek_nonce: Vec<u8>,
+    pub(crate) key_id: String,
+    pub(crate) algorithm: String,
+    pub(crate) binding_version: i64,
+}
+
+impl EncryptedEnvelopeDocument {
+    /// Build an envelope after validating its storage-independent shape.
+    pub(crate) fn new(
+        ciphertext: Vec<u8>,
+        nonce: Vec<u8>,
+        wrapped_dek: Vec<u8>,
+        wrapped_dek_nonce: Vec<u8>,
+        key_id: impl Into<String>,
+        algorithm: impl Into<String>,
+        binding_version: i64,
+    ) -> Result<Self, EncryptedEnvelopeError> {
+        let envelope = Self {
+            ciphertext,
+            nonce,
+            wrapped_dek,
+            wrapped_dek_nonce,
+            key_id: key_id.into(),
+            algorithm: algorithm.into(),
+            binding_version,
+        };
+        envelope.validate()?;
+        Ok(envelope)
+    }
+
+    /// Validate structural envelope invariants without enforcing crypto policy.
+    pub(crate) fn validate(&self) -> Result<(), EncryptedEnvelopeError> {
+        if self.ciphertext.is_empty()
+            || self.nonce.is_empty()
+            || self.wrapped_dek.is_empty()
+            || self.wrapped_dek_nonce.is_empty()
+        {
+            return Err(EncryptedEnvelopeError::EmptyEncryptedField);
+        }
+        if self.key_id.trim().is_empty()
+            || self.algorithm.trim().is_empty()
+            || self.binding_version < 1
+        {
+            return Err(EncryptedEnvelopeError::InvalidMetadata);
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for EncryptedEnvelopeDocument {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EncryptedEnvelopeDocument")
+            .field("ciphertext_len", &self.ciphertext.len())
+            .field("nonce_len", &self.nonce.len())
+            .field("wrapped_dek_len", &self.wrapped_dek.len())
+            .field("wrapped_dek_nonce_len", &self.wrapped_dek_nonce.len())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Invalid structural envelope data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum EncryptedEnvelopeError {
+    #[error("encrypted document envelope has an empty encrypted byte field")]
+    EmptyEncryptedField,
+    #[error("encrypted document envelope has invalid metadata")]
+    InvalidMetadata,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EncryptedEnvelopeDocument;
+
+    #[test]
+    fn envelope_validation_and_debug_are_shared_and_secret_safe() {
+        let present = || vec![1];
+        for (bytes, key_id, algorithm, binding_version) in [
+            (
+                [Vec::new(), present(), present(), present()],
+                "key",
+                "algorithm",
+                1,
+            ),
+            (
+                [present(), Vec::new(), present(), present()],
+                "key",
+                "algorithm",
+                1,
+            ),
+            (
+                [present(), present(), Vec::new(), present()],
+                "key",
+                "algorithm",
+                1,
+            ),
+            (
+                [present(), present(), present(), Vec::new()],
+                "key",
+                "algorithm",
+                1,
+            ),
+            (
+                [present(), present(), present(), present()],
+                " ",
+                "algorithm",
+                1,
+            ),
+            ([present(), present(), present(), present()], "key", "", 1),
+            (
+                [present(), present(), present(), present()],
+                "key",
+                "algorithm",
+                0,
+            ),
+        ] {
+            let [ciphertext, nonce, wrapped_dek, wrapped_dek_nonce] = bytes;
+            EncryptedEnvelopeDocument::new(
+                ciphertext,
+                nonce,
+                wrapped_dek,
+                wrapped_dek_nonce,
+                key_id,
+                algorithm,
+                binding_version,
+            )
+            .expect_err("invalid envelope shape must fail");
+        }
+
+        let envelope = EncryptedEnvelopeDocument::new(
+            b"sentinel-secret".to_vec(),
+            b"sentinel-nonce".to_vec(),
+            b"sentinel-wrapped".to_vec(),
+            b"sentinel-wrap-nonce".to_vec(),
+            "sentinel-key",
+            "sentinel-algorithm",
+            99,
+        )
+        .expect("positive binding versions are structurally valid");
+        assert!(!format!("{envelope:?}").contains("sentinel"));
+    }
+}

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -46,6 +46,7 @@ mod auth;
 pub mod bootstrap;
 mod catalog;
 mod credentials;
+mod encrypted_document;
 pub mod features;
 mod feedback;
 mod functions;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -24,8 +24,7 @@ pub(crate) use import::run_state_migrations;
     reason = "identity persistence types are not yet wired to production consumers"
 )]
 pub(crate) use repositories::identity_specs::{
-    IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecRecord,
-    IdentitySpecScope,
+    IdentitySpecDocumentRecord, IdentitySpecKey, IdentitySpecRecord, IdentitySpecScope,
 };
 pub(crate) use repositories::tasks::{TaskCompletionUpdate, TaskLifecycleState};
 pub(crate) use session::{DbRepos, DbSession};

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -24,7 +24,8 @@ pub(crate) use import::run_state_migrations;
     reason = "identity persistence types are not yet wired to production consumers"
 )]
 pub(crate) use repositories::identity_specs::{
-    IdentitySpecKey, IdentitySpecRecord, IdentitySpecScope,
+    IdentitySpecDocumentRecord, IdentitySpecDocumentWrite, IdentitySpecKey, IdentitySpecRecord,
+    IdentitySpecScope,
 };
 pub(crate) use repositories::tasks::{TaskCompletionUpdate, TaskLifecycleState};
 pub(crate) use session::{DbRepos, DbSession};

--- a/crates/coral-app/src/state/db/repositories/identity_specs.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs.rs
@@ -988,12 +988,14 @@ mod tests {
         assert_mutations_are_exact_and_transactional(&db, "sqlite").await;
     }
 
-    /// Runs the identity-spec mutation contract against a live Postgres backend.
+    /// Runs the identity-spec and document contracts against a live Postgres backend.
     ///
-    /// `upsert` selects its arbiter index through `ON CONFLICT ... WHERE`, which
-    /// each backend resolves against its own partial-index inference rules, so the
-    /// two tests above cannot stand in for this coverage. CI selects this test by
-    /// the shared `repository_round_trips_against_postgres` name filter.
+    /// Spec `upsert` selects its arbiter index through `ON CONFLICT ... WHERE`, which
+    /// each backend resolves against its own partial-index inference rules, and
+    /// document envelopes round-trip through a `BYTEA` column that `SQLite` stores
+    /// under a different type affinity, so the tests above cannot stand in for this
+    /// coverage. CI selects this test by the shared
+    /// `repository_round_trips_against_postgres` name filter.
     #[tokio::test]
     #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
     async fn identity_spec_repository_round_trips_against_postgres() {
@@ -1007,6 +1009,7 @@ mod tests {
 
         assert_upserts_preserve_creation_and_monotonic_update_time(&db, &unique_suffix()).await;
         assert_mutations_are_exact_and_transactional(&db, &unique_suffix()).await;
+        assert_encrypted_documents_round_trip(&db, &unique_suffix()).await;
     }
 
     async fn assert_upserts_preserve_creation_and_monotonic_update_time(
@@ -1136,7 +1139,11 @@ mod tests {
     #[tokio::test]
     async fn encrypted_documents_round_trip_by_exact_key() {
         let (_temp, db) = open_sqlite().await;
-        let (global, workspace) = seed_scoped_specs(&db, "sqlite").await;
+        assert_encrypted_documents_round_trip(&db, "sqlite").await;
+    }
+
+    async fn assert_encrypted_documents_round_trip(db: &CoralDb, suffix: &str) {
+        let (global, workspace) = seed_scoped_specs(db, suffix).await;
         let mut tx = db.begin().await.expect("begin document transaction");
         let mut invalid = valid_document(1, 1);
         invalid.binding_version = 0;
@@ -1190,7 +1197,7 @@ mod tests {
         );
         tx.commit().await.expect("commit documents");
 
-        let mut session = &db;
+        let mut session = db;
         assert!(
             session
                 .identity_spec_documents()

--- a/crates/coral-app/src/state/db/repositories/identity_specs.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs.rs
@@ -1,12 +1,15 @@
-#![expect(
-    dead_code,
-    reason = "identity persistence APIs are not yet wired to production consumers"
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "identity persistence APIs are not yet wired to production consumers"
+    )
 )]
 
 use sea_query::{Expr, ExprTrait, OnConflict, Order, Query};
 
 use crate::bootstrap::AppError;
-use crate::state::db::schema::IdentitySpecs;
+use crate::state::db::schema::{IdentitySpecDocuments, IdentitySpecs};
 use crate::state::db::{CoralTx, DbError, DbSession};
 use crate::workspaces::WorkspaceName;
 use coral_spec::{
@@ -196,6 +199,156 @@ impl IdentitySpecRow {
     }
 }
 
+/// Opaque encrypted setup-input document persisted for one identity spec.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct IdentitySpecDocumentRecord {
+    /// Identity spec that owns the encrypted document.
+    pub(crate) identity_spec_id: IdentitySpecId,
+    /// Monotonic storage version incremented on each replacement.
+    pub(crate) document_version: i64,
+    /// Opaque encrypted setup-input bytes.
+    pub(crate) ciphertext: Vec<u8>,
+    /// Nonce paired with the encrypted setup-input bytes.
+    pub(crate) nonce: Vec<u8>,
+    /// Opaque wrapped data-encryption-key bytes.
+    pub(crate) wrapped_dek: Vec<u8>,
+    /// Nonce paired with the wrapped data-encryption key.
+    pub(crate) wrapped_dek_nonce: Vec<u8>,
+    /// Identifier of the key-encryption key used for the envelope.
+    pub(crate) key_id: String,
+    /// Authored envelope algorithm identifier.
+    pub(crate) algorithm: String,
+    /// Authored AAD encoding version, interpreted by the crypto layer.
+    pub(crate) aad_version: i64,
+    /// Creation timestamp in Unix nanoseconds.
+    pub(crate) created_at_unix_nanos: i64,
+    /// Last update timestamp in Unix nanoseconds.
+    pub(crate) updated_at_unix_nanos: i64,
+}
+
+/// Validated opaque envelope fields used to insert or replace a document.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct IdentitySpecDocumentWrite {
+    ciphertext: Vec<u8>,
+    nonce: Vec<u8>,
+    wrapped_dek: Vec<u8>,
+    wrapped_dek_nonce: Vec<u8>,
+    key_id: String,
+    algorithm: String,
+    aad_version: i64,
+}
+
+impl IdentitySpecDocumentWrite {
+    /// Validate opaque envelope shape without interpreting crypto policy.
+    pub(crate) fn new(
+        ciphertext: Vec<u8>,
+        nonce: Vec<u8>,
+        wrapped_dek: Vec<u8>,
+        wrapped_dek_nonce: Vec<u8>,
+        key_id: impl Into<String>,
+        algorithm: impl Into<String>,
+        aad_version: i64,
+    ) -> Result<Self, AppError> {
+        let write = Self {
+            ciphertext,
+            nonce,
+            wrapped_dek,
+            wrapped_dek_nonce,
+            key_id: key_id.into(),
+            algorithm: algorithm.into(),
+            aad_version,
+        };
+        validate_identity_spec_document_fields(
+            &write.ciphertext,
+            &write.nonce,
+            &write.wrapped_dek,
+            &write.wrapped_dek_nonce,
+            &write.key_id,
+            &write.algorithm,
+            write.aad_version,
+        )
+        .map_err(AppError::InvalidInput)?;
+        Ok(write)
+    }
+}
+
+impl std::fmt::Debug for IdentitySpecDocumentRecord {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("IdentitySpecDocumentRecord")
+            .field("identity_spec_id", &self.identity_spec_id)
+            .field("document_version", &self.document_version)
+            .field("ciphertext_len", &self.ciphertext.len())
+            .field("nonce_len", &self.nonce.len())
+            .field("wrapped_dek_len", &self.wrapped_dek.len())
+            .field("wrapped_dek_nonce_len", &self.wrapped_dek_nonce.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for IdentitySpecDocumentWrite {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("IdentitySpecDocumentWrite")
+            .field("ciphertext_len", &self.ciphertext.len())
+            .field("nonce_len", &self.nonce.len())
+            .field("wrapped_dek_len", &self.wrapped_dek.len())
+            .field("wrapped_dek_nonce_len", &self.wrapped_dek_nonce.len())
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct IdentitySpecDocumentRow {
+    identity_spec_id: String,
+    document_version: i64,
+    ciphertext: Vec<u8>,
+    nonce: Vec<u8>,
+    wrapped_dek: Vec<u8>,
+    wrapped_dek_nonce: Vec<u8>,
+    key_id: String,
+    algorithm: String,
+    aad_version: i64,
+    created_at_unix_nanos: i64,
+    updated_at_unix_nanos: i64,
+}
+
+impl IdentitySpecDocumentRow {
+    fn validate(self) -> Result<IdentitySpecDocumentRecord, DbError> {
+        if self.document_version < 1
+            || self.created_at_unix_nanos < 0
+            || self.updated_at_unix_nanos < self.created_at_unix_nanos
+        {
+            return Err(DbError::CorruptData(
+                "identity spec document row has invalid version or timestamps".to_string(),
+            ));
+        }
+        validate_identity_spec_document_fields(
+            &self.ciphertext,
+            &self.nonce,
+            &self.wrapped_dek,
+            &self.wrapped_dek_nonce,
+            &self.key_id,
+            &self.algorithm,
+            self.aad_version,
+        )
+        .map_err(DbError::CorruptData)?;
+        Ok(IdentitySpecDocumentRecord {
+            identity_spec_id: IdentitySpecId::from_storage(self.identity_spec_id)?,
+            document_version: self.document_version,
+            ciphertext: self.ciphertext,
+            nonce: self.nonce,
+            wrapped_dek: self.wrapped_dek,
+            wrapped_dek_nonce: self.wrapped_dek_nonce,
+            key_id: self.key_id,
+            algorithm: self.algorithm,
+            aad_version: self.aad_version,
+            created_at_unix_nanos: self.created_at_unix_nanos,
+            updated_at_unix_nanos: self.updated_at_unix_nanos,
+        })
+    }
+}
+
 /// Repository for durable DSL v4 identity spec definitions.
 pub(crate) struct IdentitySpecsRepo<'a, S> {
     session: &'a mut S,
@@ -344,6 +497,121 @@ where
     pub(crate) fn new(session: &'a mut S) -> Self {
         Self { session }
     }
+
+    /// Load one encrypted document by its owning identity spec id.
+    pub(crate) async fn get(
+        &mut self,
+        identity_spec_id: &IdentitySpecId,
+    ) -> Result<Option<IdentitySpecDocumentRecord>, DbError> {
+        let row: Option<IdentitySpecDocumentRow> = self
+            .session
+            .fetch_optional(
+                Query::select()
+                    .columns(identity_spec_document_columns())
+                    .from(IdentitySpecDocuments::Table)
+                    .and_where(identity_spec_document_id_where(identity_spec_id))
+                    .to_owned(),
+            )
+            .await?;
+        row.map(IdentitySpecDocumentRow::validate).transpose()
+    }
+}
+
+impl IdentitySpecDocumentsRepo<'_, CoralTx<'_>> {
+    /// Insert or atomically replace an encrypted document and increment its version.
+    pub(crate) async fn upsert(
+        &mut self,
+        identity_spec_id: &IdentitySpecId,
+        document: &IdentitySpecDocumentWrite,
+        now_unix_nanos: i64,
+    ) -> Result<IdentitySpecDocumentRecord, AppError> {
+        validate_write_timestamp(now_unix_nanos)?;
+        let current_version = Expr::col((
+            IdentitySpecDocuments::Table,
+            IdentitySpecDocuments::DocumentVersion,
+        ));
+        let current_updated_at = Expr::col((
+            IdentitySpecDocuments::Table,
+            IdentitySpecDocuments::UpdatedAtUnixNanos,
+        ));
+        let statement = Query::insert()
+            .into_table(IdentitySpecDocuments::Table)
+            .columns(identity_spec_document_columns())
+            .values_panic([
+                Expr::val(identity_spec_id.as_str()),
+                Expr::val(1),
+                Expr::val(document.ciphertext.clone()),
+                Expr::val(document.nonce.clone()),
+                Expr::val(document.wrapped_dek.clone()),
+                Expr::val(document.wrapped_dek_nonce.clone()),
+                Expr::val(document.key_id.clone()),
+                Expr::val(document.algorithm.clone()),
+                Expr::val(document.aad_version),
+                Expr::val(now_unix_nanos),
+                Expr::val(now_unix_nanos),
+            ])
+            .on_conflict(
+                OnConflict::column(IdentitySpecDocuments::IdentitySpecId)
+                    .value(
+                        IdentitySpecDocuments::DocumentVersion,
+                        current_version.clone().add(1),
+                    )
+                    .update_columns([
+                        IdentitySpecDocuments::Ciphertext,
+                        IdentitySpecDocuments::Nonce,
+                        IdentitySpecDocuments::WrappedDek,
+                        IdentitySpecDocuments::WrappedDekNonce,
+                        IdentitySpecDocuments::KeyId,
+                        IdentitySpecDocuments::Algorithm,
+                        IdentitySpecDocuments::AadVersion,
+                    ])
+                    .value(
+                        IdentitySpecDocuments::UpdatedAtUnixNanos,
+                        Expr::case(
+                            current_updated_at.clone().gt(now_unix_nanos),
+                            current_updated_at,
+                        )
+                        .finally(now_unix_nanos),
+                    )
+                    .action_and_where(current_version.lt(i64::MAX))
+                    .to_owned(),
+            )
+            .to_owned();
+        match self.session.execute_affected(statement).await? {
+            1 => {}
+            0 => {
+                return Err(AppError::FailedPrecondition(format!(
+                    "identity spec document version is exhausted for {}",
+                    identity_spec_id.as_str()
+                )));
+            }
+            rows_affected => {
+                return Err(AppError::Database(format!(
+                    "identity spec document upsert affected {rows_affected} rows"
+                )));
+            }
+        }
+        self.get(identity_spec_id).await?.ok_or_else(|| {
+            AppError::Database("identity spec document disappeared after upsert".to_string())
+        })
+    }
+
+    /// Delete one encrypted document without deleting its definition.
+    pub(crate) async fn delete(
+        &mut self,
+        identity_spec_id: &IdentitySpecId,
+    ) -> Result<bool, DbError> {
+        let rows_affected = self
+            .session
+            .execute_affected(
+                Query::delete()
+                    .from_table(IdentitySpecDocuments::Table)
+                    .and_where(identity_spec_document_id_where(identity_spec_id))
+                    .to_owned(),
+            )
+            .await?;
+        zero_or_one_affected(rows_affected, "identity spec document delete")
+    }
 }
 
 fn parse_identity_spec_name(name: &str) -> Result<String, AppError> {
@@ -392,6 +660,28 @@ const fn identity_spec_type_label(identity_type: IdentitySpecType) -> &'static s
         IdentitySpecType::OAuth => "oauth",
         IdentitySpecType::FixedToken => "fixed_token",
     }
+}
+
+fn validate_identity_spec_document_fields(
+    ciphertext: &[u8],
+    nonce: &[u8],
+    wrapped_dek: &[u8],
+    wrapped_dek_nonce: &[u8],
+    key_id: &str,
+    algorithm: &str,
+    aad_version: i64,
+) -> Result<(), String> {
+    if ciphertext.is_empty()
+        || nonce.is_empty()
+        || wrapped_dek.is_empty()
+        || wrapped_dek_nonce.is_empty()
+    {
+        return Err("identity spec document has an empty encrypted byte field".to_string());
+    }
+    if key_id.trim().is_empty() || algorithm.trim().is_empty() || aad_version < 1 {
+        return Err("identity spec document has invalid envelope metadata".to_string());
+    }
+    Ok(())
 }
 
 fn validate_write_timestamp(now_unix_nanos: i64) -> Result<(), AppError> {
@@ -459,6 +749,22 @@ fn identity_spec_columns() -> [IdentitySpecs; 10] {
     ]
 }
 
+fn identity_spec_document_columns() -> [IdentitySpecDocuments; 11] {
+    [
+        IdentitySpecDocuments::IdentitySpecId,
+        IdentitySpecDocuments::DocumentVersion,
+        IdentitySpecDocuments::Ciphertext,
+        IdentitySpecDocuments::Nonce,
+        IdentitySpecDocuments::WrappedDek,
+        IdentitySpecDocuments::WrappedDekNonce,
+        IdentitySpecDocuments::KeyId,
+        IdentitySpecDocuments::Algorithm,
+        IdentitySpecDocuments::AadVersion,
+        IdentitySpecDocuments::CreatedAtUnixNanos,
+        IdentitySpecDocuments::UpdatedAtUnixNanos,
+    ]
+}
+
 fn identity_spec_key_where(key: &IdentitySpecKey) -> sea_query::SimpleExpr {
     identity_spec_scope_where(&key.scope).and(Expr::col(IdentitySpecs::Name).eq(key.name.as_str()))
 }
@@ -472,6 +778,10 @@ fn identity_spec_scope_where(scope: &IdentitySpecScope) -> sea_query::SimpleExpr
     }
 }
 
+fn identity_spec_document_id_where(identity_spec_id: &IdentitySpecId) -> sea_query::SimpleExpr {
+    Expr::col(IdentitySpecDocuments::IdentitySpecId).eq(identity_spec_id.as_str())
+}
+
 #[cfg(test)]
 mod tests {
     use sea_query::{Expr, ExprTrait, Query};
@@ -479,8 +789,8 @@ mod tests {
     use uuid::Uuid;
 
     use super::{
-        IdentitySpecId, IdentitySpecKey, IdentitySpecRecord, identity_spec_columns,
-        validate_identity_spec_write,
+        IdentitySpecDocumentWrite, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord,
+        identity_spec_columns, validate_identity_spec_write,
     };
     use crate::bootstrap::{self, AppError};
     use crate::state::db::schema::IdentitySpecs;
@@ -603,6 +913,69 @@ mod tests {
             validate_identity_spec_write(&key, &manifest, "not: [valid"),
             Err(AppError::InvalidInput(_))
         ));
+    }
+
+    #[test]
+    fn document_writes_validate_shape_without_exposing_envelope_data() {
+        let present = || vec![1];
+        for (bytes, key_id, algorithm, aad_version) in [
+            (
+                [Vec::new(), present(), present(), present()],
+                "key",
+                "alg",
+                1,
+            ),
+            (
+                [present(), Vec::new(), present(), present()],
+                "key",
+                "alg",
+                1,
+            ),
+            (
+                [present(), present(), Vec::new(), present()],
+                "key",
+                "alg",
+                1,
+            ),
+            (
+                [present(), present(), present(), Vec::new()],
+                "key",
+                "alg",
+                1,
+            ),
+            ([present(), present(), present(), present()], " ", "alg", 1),
+            ([present(), present(), present(), present()], "key", "", 1),
+            (
+                [present(), present(), present(), present()],
+                "key",
+                "alg",
+                0,
+            ),
+        ] {
+            let [ciphertext, nonce, wrapped_dek, wrapped_dek_nonce] = bytes;
+            let result = IdentitySpecDocumentWrite::new(
+                ciphertext,
+                nonce,
+                wrapped_dek,
+                wrapped_dek_nonce,
+                key_id,
+                algorithm,
+                aad_version,
+            );
+            assert!(matches!(result, Err(AppError::InvalidInput(_))));
+        }
+
+        let write = IdentitySpecDocumentWrite::new(
+            b"sentinel-secret".to_vec(),
+            b"sentinel-nonce".to_vec(),
+            b"sentinel-wrapped".to_vec(),
+            b"sentinel-wrap-nonce".to_vec(),
+            "sentinel-key",
+            "sentinel-algorithm",
+            99,
+        )
+        .expect("opaque positive AAD versions are storage-valid");
+        assert!(!format!("{write:?}").contains("sentinel"));
     }
 
     #[tokio::test]
@@ -848,7 +1221,9 @@ mod tests {
     }
 
     async fn assert_mutations_are_exact_and_transactional(db: &CoralDb, suffix: &str) {
-        let (global, workspace_key) = seed_scoped_specs(db, suffix).await;
+        let (global_record, workspace_record) = seed_scoped_specs(db, suffix).await;
+        let global = global_record.key;
+        let workspace_key = workspace_record.key;
         let negative_timestamp =
             IdentitySpecKey::global(&format!("negative_timestamp_{suffix}")).expect("key");
         let mut tx = db.begin().await.expect("begin validation transaction");
@@ -917,7 +1292,87 @@ mod tests {
         }
     }
 
-    async fn seed_scoped_specs(db: &CoralDb, suffix: &str) -> (IdentitySpecKey, IdentitySpecKey) {
+    #[tokio::test]
+    async fn encrypted_documents_round_trip_by_exact_key() {
+        let (_temp, db) = open_sqlite().await;
+        let (global, workspace) = seed_scoped_specs(&db, "sqlite").await;
+        let mut tx = db.begin().await.expect("begin document transaction");
+        let first = tx
+            .identity_spec_documents()
+            .upsert(&global.id, &valid_document(1, 1), 50)
+            .await
+            .expect("insert document");
+        let replaced = tx
+            .identity_spec_documents()
+            .upsert(&global.id, &valid_document(10, 99), 40)
+            .await
+            .expect("replace document with stale clock");
+        tx.identity_spec_documents()
+            .upsert(&workspace.id, &valid_document(20, 2), 60)
+            .await
+            .expect("insert exact workspace document");
+        assert_eq!((first.document_version, replaced.document_version), (1, 2));
+        assert_eq!(
+            (
+                replaced.created_at_unix_nanos,
+                replaced.updated_at_unix_nanos
+            ),
+            (50, 50)
+        );
+        assert_eq!(replaced.ciphertext, [10]);
+        assert_eq!(replaced.nonce, [11]);
+        assert_eq!(replaced.wrapped_dek, [12]);
+        assert_eq!(replaced.wrapped_dek_nonce, [13]);
+        assert_eq!(replaced.key_id, "key-10");
+        assert_eq!(replaced.algorithm, "alg-10");
+        assert_eq!(replaced.aad_version, 99);
+        assert!(!format!("{replaced:?}").contains("key-10"));
+        assert!(
+            tx.identity_spec_documents()
+                .delete(&global.id)
+                .await
+                .expect("delete")
+        );
+        assert!(
+            !tx.identity_spec_documents()
+                .delete(&global.id)
+                .await
+                .expect("repeat delete")
+        );
+        tx.commit().await.expect("commit documents");
+
+        let mut session = &db;
+        assert!(
+            session
+                .identity_spec_documents()
+                .get(&global.id)
+                .await
+                .expect("read")
+                .is_none()
+        );
+        assert_eq!(
+            session
+                .identity_spec_documents()
+                .get(&workspace.id)
+                .await
+                .expect("read workspace")
+                .map(|record| record.identity_spec_id),
+            Some(workspace.id.clone())
+        );
+        assert!(
+            session
+                .identity_specs()
+                .get(&global.key)
+                .await
+                .expect("read spec")
+                .is_some()
+        );
+    }
+
+    async fn seed_scoped_specs(
+        db: &CoralDb,
+        suffix: &str,
+    ) -> (IdentitySpecRecord, IdentitySpecRecord) {
         let workspace = WorkspaceName::parse(&format!("team_{suffix}")).expect("workspace");
         let spec_name = format!("github_{suffix}");
         let global = IdentitySpecKey::global(&spec_name).expect("global key");
@@ -928,14 +1383,14 @@ mod tests {
             .ensure(workspace.as_str(), 1)
             .await
             .expect("create workspace");
-        upsert_spec(&mut tx, &global, "global", 10)
+        let global_record = upsert_spec(&mut tx, &global, "global", 10)
             .await
             .expect("insert global spec");
-        upsert_spec(&mut tx, &workspace_key, "workspace", 12)
+        let workspace_record = upsert_spec(&mut tx, &workspace_key, "workspace", 12)
             .await
             .expect("insert workspace spec");
         tx.commit().await.expect("commit seed transaction");
-        (global, workspace_key)
+        (global_record, workspace_record)
     }
 
     async fn open_sqlite() -> (tempfile::TempDir, CoralDb) {
@@ -1030,5 +1485,18 @@ mod tests {
         let manifest =
             parse_identity_manifest_yaml(&manifest_yaml).expect("valid identity manifest");
         (manifest, manifest_yaml)
+    }
+
+    fn valid_document(marker: u8, aad_version: i64) -> IdentitySpecDocumentWrite {
+        IdentitySpecDocumentWrite::new(
+            vec![marker],
+            vec![marker + 1],
+            vec![marker + 2],
+            vec![marker + 3],
+            format!("key-{marker}"),
+            format!("alg-{marker}"),
+            aad_version,
+        )
+        .expect("valid identity spec document write")
     }
 }

--- a/crates/coral-app/src/state/db/repositories/identity_specs.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs.rs
@@ -502,7 +502,7 @@ impl IdentitySpecDocumentsRepo<'_, CoralTx<'_>> {
                     .to_owned(),
             )
             .to_owned();
-        match self.session.execute_affected(statement).await? {
+        match self.session.execute_rows_affected(statement).await? {
             1 => {}
             0 => {
                 return Err(AppError::FailedPrecondition(format!(
@@ -528,7 +528,7 @@ impl IdentitySpecDocumentsRepo<'_, CoralTx<'_>> {
     ) -> Result<bool, DbError> {
         let rows_affected = self
             .session
-            .execute_affected(
+            .execute_rows_affected(
                 Query::delete()
                     .from_table(IdentitySpecDocuments::Table)
                     .and_where(identity_spec_document_id_where(identity_spec_id))

--- a/crates/coral-app/src/state/db/repositories/identity_specs.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs.rs
@@ -9,6 +9,7 @@
 use sea_query::{Expr, ExprTrait, OnConflict, Order, Query};
 
 use crate::bootstrap::AppError;
+use crate::encrypted_document::EncryptedEnvelopeDocument;
 use crate::state::db::schema::{IdentitySpecDocuments, IdentitySpecs};
 use crate::state::db::{CoralTx, DbError, DbSession};
 use crate::workspaces::WorkspaceName;
@@ -206,70 +207,12 @@ pub(crate) struct IdentitySpecDocumentRecord {
     pub(crate) identity_spec_id: IdentitySpecId,
     /// Monotonic storage version incremented on each replacement.
     pub(crate) document_version: i64,
-    /// Opaque encrypted setup-input bytes.
-    pub(crate) ciphertext: Vec<u8>,
-    /// Nonce paired with the encrypted setup-input bytes.
-    pub(crate) nonce: Vec<u8>,
-    /// Opaque wrapped data-encryption-key bytes.
-    pub(crate) wrapped_dek: Vec<u8>,
-    /// Nonce paired with the wrapped data-encryption key.
-    pub(crate) wrapped_dek_nonce: Vec<u8>,
-    /// Identifier of the key-encryption key used for the envelope.
-    pub(crate) key_id: String,
-    /// Authored envelope algorithm identifier.
-    pub(crate) algorithm: String,
-    /// Authored AAD encoding version, interpreted by the crypto layer.
-    pub(crate) aad_version: i64,
+    /// Opaque encrypted setup-input envelope.
+    pub(crate) envelope: EncryptedEnvelopeDocument,
     /// Creation timestamp in Unix nanoseconds.
     pub(crate) created_at_unix_nanos: i64,
     /// Last update timestamp in Unix nanoseconds.
     pub(crate) updated_at_unix_nanos: i64,
-}
-
-/// Validated opaque envelope fields used to insert or replace a document.
-#[derive(Clone, PartialEq, Eq)]
-pub(crate) struct IdentitySpecDocumentWrite {
-    ciphertext: Vec<u8>,
-    nonce: Vec<u8>,
-    wrapped_dek: Vec<u8>,
-    wrapped_dek_nonce: Vec<u8>,
-    key_id: String,
-    algorithm: String,
-    aad_version: i64,
-}
-
-impl IdentitySpecDocumentWrite {
-    /// Validate opaque envelope shape without interpreting crypto policy.
-    pub(crate) fn new(
-        ciphertext: Vec<u8>,
-        nonce: Vec<u8>,
-        wrapped_dek: Vec<u8>,
-        wrapped_dek_nonce: Vec<u8>,
-        key_id: impl Into<String>,
-        algorithm: impl Into<String>,
-        aad_version: i64,
-    ) -> Result<Self, AppError> {
-        let write = Self {
-            ciphertext,
-            nonce,
-            wrapped_dek,
-            wrapped_dek_nonce,
-            key_id: key_id.into(),
-            algorithm: algorithm.into(),
-            aad_version,
-        };
-        validate_identity_spec_document_fields(
-            &write.ciphertext,
-            &write.nonce,
-            &write.wrapped_dek,
-            &write.wrapped_dek_nonce,
-            &write.key_id,
-            &write.algorithm,
-            write.aad_version,
-        )
-        .map_err(AppError::InvalidInput)?;
-        Ok(write)
-    }
 }
 
 impl std::fmt::Debug for IdentitySpecDocumentRecord {
@@ -278,22 +221,7 @@ impl std::fmt::Debug for IdentitySpecDocumentRecord {
             .debug_struct("IdentitySpecDocumentRecord")
             .field("identity_spec_id", &self.identity_spec_id)
             .field("document_version", &self.document_version)
-            .field("ciphertext_len", &self.ciphertext.len())
-            .field("nonce_len", &self.nonce.len())
-            .field("wrapped_dek_len", &self.wrapped_dek.len())
-            .field("wrapped_dek_nonce_len", &self.wrapped_dek_nonce.len())
-            .finish_non_exhaustive()
-    }
-}
-
-impl std::fmt::Debug for IdentitySpecDocumentWrite {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("IdentitySpecDocumentWrite")
-            .field("ciphertext_len", &self.ciphertext.len())
-            .field("nonce_len", &self.nonce.len())
-            .field("wrapped_dek_len", &self.wrapped_dek.len())
-            .field("wrapped_dek_nonce_len", &self.wrapped_dek_nonce.len())
+            .field("envelope", &self.envelope)
             .finish_non_exhaustive()
     }
 }
@@ -308,7 +236,7 @@ struct IdentitySpecDocumentRow {
     wrapped_dek_nonce: Vec<u8>,
     key_id: String,
     algorithm: String,
-    aad_version: i64,
+    binding_version: i64,
     created_at_unix_nanos: i64,
     updated_at_unix_nanos: i64,
 }
@@ -323,26 +251,20 @@ impl IdentitySpecDocumentRow {
                 "identity spec document row has invalid version or timestamps".to_string(),
             ));
         }
-        validate_identity_spec_document_fields(
-            &self.ciphertext,
-            &self.nonce,
-            &self.wrapped_dek,
-            &self.wrapped_dek_nonce,
-            &self.key_id,
-            &self.algorithm,
-            self.aad_version,
+        let envelope = EncryptedEnvelopeDocument::new(
+            self.ciphertext,
+            self.nonce,
+            self.wrapped_dek,
+            self.wrapped_dek_nonce,
+            self.key_id,
+            self.algorithm,
+            self.binding_version,
         )
-        .map_err(DbError::CorruptData)?;
+        .map_err(|error| DbError::CorruptData(error.to_string()))?;
         Ok(IdentitySpecDocumentRecord {
             identity_spec_id: IdentitySpecId::from_storage(self.identity_spec_id)?,
             document_version: self.document_version,
-            ciphertext: self.ciphertext,
-            nonce: self.nonce,
-            wrapped_dek: self.wrapped_dek,
-            wrapped_dek_nonce: self.wrapped_dek_nonce,
-            key_id: self.key_id,
-            algorithm: self.algorithm,
-            aad_version: self.aad_version,
+            envelope,
             created_at_unix_nanos: self.created_at_unix_nanos,
             updated_at_unix_nanos: self.updated_at_unix_nanos,
         })
@@ -522,9 +444,12 @@ impl IdentitySpecDocumentsRepo<'_, CoralTx<'_>> {
     pub(crate) async fn upsert(
         &mut self,
         identity_spec_id: &IdentitySpecId,
-        document: &IdentitySpecDocumentWrite,
+        document: &EncryptedEnvelopeDocument,
         now_unix_nanos: i64,
     ) -> Result<IdentitySpecDocumentRecord, AppError> {
+        document
+            .validate()
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         validate_write_timestamp(now_unix_nanos)?;
         let current_version = Expr::col((
             IdentitySpecDocuments::Table,
@@ -546,7 +471,7 @@ impl IdentitySpecDocumentsRepo<'_, CoralTx<'_>> {
                 Expr::val(document.wrapped_dek_nonce.clone()),
                 Expr::val(document.key_id.clone()),
                 Expr::val(document.algorithm.clone()),
-                Expr::val(document.aad_version),
+                Expr::val(document.binding_version),
                 Expr::val(now_unix_nanos),
                 Expr::val(now_unix_nanos),
             ])
@@ -563,7 +488,7 @@ impl IdentitySpecDocumentsRepo<'_, CoralTx<'_>> {
                         IdentitySpecDocuments::WrappedDekNonce,
                         IdentitySpecDocuments::KeyId,
                         IdentitySpecDocuments::Algorithm,
-                        IdentitySpecDocuments::AadVersion,
+                        IdentitySpecDocuments::BindingVersion,
                     ])
                     .value(
                         IdentitySpecDocuments::UpdatedAtUnixNanos,
@@ -662,28 +587,6 @@ const fn identity_spec_type_label(identity_type: IdentitySpecType) -> &'static s
     }
 }
 
-fn validate_identity_spec_document_fields(
-    ciphertext: &[u8],
-    nonce: &[u8],
-    wrapped_dek: &[u8],
-    wrapped_dek_nonce: &[u8],
-    key_id: &str,
-    algorithm: &str,
-    aad_version: i64,
-) -> Result<(), String> {
-    if ciphertext.is_empty()
-        || nonce.is_empty()
-        || wrapped_dek.is_empty()
-        || wrapped_dek_nonce.is_empty()
-    {
-        return Err("identity spec document has an empty encrypted byte field".to_string());
-    }
-    if key_id.trim().is_empty() || algorithm.trim().is_empty() || aad_version < 1 {
-        return Err("identity spec document has invalid envelope metadata".to_string());
-    }
-    Ok(())
-}
-
 fn validate_write_timestamp(now_unix_nanos: i64) -> Result<(), AppError> {
     match now_unix_nanos {
         0.. => Ok(()),
@@ -759,7 +662,7 @@ fn identity_spec_document_columns() -> [IdentitySpecDocuments; 11] {
         IdentitySpecDocuments::WrappedDekNonce,
         IdentitySpecDocuments::KeyId,
         IdentitySpecDocuments::Algorithm,
-        IdentitySpecDocuments::AadVersion,
+        IdentitySpecDocuments::BindingVersion,
         IdentitySpecDocuments::CreatedAtUnixNanos,
         IdentitySpecDocuments::UpdatedAtUnixNanos,
     ]
@@ -789,10 +692,11 @@ mod tests {
     use uuid::Uuid;
 
     use super::{
-        IdentitySpecDocumentWrite, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord,
-        identity_spec_columns, validate_identity_spec_write,
+        IdentitySpecId, IdentitySpecKey, IdentitySpecRecord, identity_spec_columns,
+        validate_identity_spec_write,
     };
     use crate::bootstrap::{self, AppError};
+    use crate::encrypted_document::EncryptedEnvelopeDocument;
     use crate::state::db::schema::IdentitySpecs;
     use crate::state::db::{CoralDb, CoralTx, DbError, DbRepos, ResolvedDatabaseConfig};
     use crate::workspaces::WorkspaceName;
@@ -913,69 +817,6 @@ mod tests {
             validate_identity_spec_write(&key, &manifest, "not: [valid"),
             Err(AppError::InvalidInput(_))
         ));
-    }
-
-    #[test]
-    fn document_writes_validate_shape_without_exposing_envelope_data() {
-        let present = || vec![1];
-        for (bytes, key_id, algorithm, aad_version) in [
-            (
-                [Vec::new(), present(), present(), present()],
-                "key",
-                "alg",
-                1,
-            ),
-            (
-                [present(), Vec::new(), present(), present()],
-                "key",
-                "alg",
-                1,
-            ),
-            (
-                [present(), present(), Vec::new(), present()],
-                "key",
-                "alg",
-                1,
-            ),
-            (
-                [present(), present(), present(), Vec::new()],
-                "key",
-                "alg",
-                1,
-            ),
-            ([present(), present(), present(), present()], " ", "alg", 1),
-            ([present(), present(), present(), present()], "key", "", 1),
-            (
-                [present(), present(), present(), present()],
-                "key",
-                "alg",
-                0,
-            ),
-        ] {
-            let [ciphertext, nonce, wrapped_dek, wrapped_dek_nonce] = bytes;
-            let result = IdentitySpecDocumentWrite::new(
-                ciphertext,
-                nonce,
-                wrapped_dek,
-                wrapped_dek_nonce,
-                key_id,
-                algorithm,
-                aad_version,
-            );
-            assert!(matches!(result, Err(AppError::InvalidInput(_))));
-        }
-
-        let write = IdentitySpecDocumentWrite::new(
-            b"sentinel-secret".to_vec(),
-            b"sentinel-nonce".to_vec(),
-            b"sentinel-wrapped".to_vec(),
-            b"sentinel-wrap-nonce".to_vec(),
-            "sentinel-key",
-            "sentinel-algorithm",
-            99,
-        )
-        .expect("opaque positive AAD versions are storage-valid");
-        assert!(!format!("{write:?}").contains("sentinel"));
     }
 
     #[tokio::test]
@@ -1297,6 +1138,14 @@ mod tests {
         let (_temp, db) = open_sqlite().await;
         let (global, workspace) = seed_scoped_specs(&db, "sqlite").await;
         let mut tx = db.begin().await.expect("begin document transaction");
+        let mut invalid = valid_document(1, 1);
+        invalid.binding_version = 0;
+        assert!(matches!(
+            tx.identity_spec_documents()
+                .upsert(&global.id, &invalid, 50)
+                .await,
+            Err(AppError::InvalidInput(_))
+        ));
         let first = tx
             .identity_spec_documents()
             .upsert(&global.id, &valid_document(1, 1), 50)
@@ -1319,13 +1168,13 @@ mod tests {
             ),
             (50, 50)
         );
-        assert_eq!(replaced.ciphertext, [10]);
-        assert_eq!(replaced.nonce, [11]);
-        assert_eq!(replaced.wrapped_dek, [12]);
-        assert_eq!(replaced.wrapped_dek_nonce, [13]);
-        assert_eq!(replaced.key_id, "key-10");
-        assert_eq!(replaced.algorithm, "alg-10");
-        assert_eq!(replaced.aad_version, 99);
+        assert_eq!(replaced.envelope.ciphertext, [10]);
+        assert_eq!(replaced.envelope.nonce, [11]);
+        assert_eq!(replaced.envelope.wrapped_dek, [12]);
+        assert_eq!(replaced.envelope.wrapped_dek_nonce, [13]);
+        assert_eq!(replaced.envelope.key_id, "key-10");
+        assert_eq!(replaced.envelope.algorithm, "alg-10");
+        assert_eq!(replaced.envelope.binding_version, 99);
         assert!(!format!("{replaced:?}").contains("key-10"));
         assert!(
             tx.identity_spec_documents()
@@ -1487,15 +1336,15 @@ mod tests {
         (manifest, manifest_yaml)
     }
 
-    fn valid_document(marker: u8, aad_version: i64) -> IdentitySpecDocumentWrite {
-        IdentitySpecDocumentWrite::new(
+    fn valid_document(marker: u8, binding_version: i64) -> EncryptedEnvelopeDocument {
+        EncryptedEnvelopeDocument::new(
             vec![marker],
             vec![marker + 1],
             vec![marker + 2],
             vec![marker + 3],
             format!("key-{marker}"),
             format!("alg-{marker}"),
-            aad_version,
+            binding_version,
         )
         .expect("valid identity spec document write")
     }

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -41,10 +41,6 @@ pub(in crate::state::db) enum IdentitySpecs {
     UpdatedAtUnixNanos,
 }
 
-#[expect(
-    dead_code,
-    reason = "identity schema lands before repository behavior in the B1 stack"
-)]
 #[derive(Iden)]
 pub(in crate::state::db) enum IdentitySpecDocuments {
     Table,

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -53,10 +53,7 @@ pub(crate) trait DbRepos: DbSession + Sized {
         IdentitySpecsRepo::new(self)
     }
 
-    #[expect(
-        dead_code,
-        reason = "identity repository behavior lands in the next B1 stack units"
-    )]
+    #[cfg_attr(not(test), expect(dead_code, reason = "B2 wires production consumers"))]
     fn identity_spec_documents(&mut self) -> IdentitySpecDocumentsRepo<'_, Self> {
         IdentitySpecDocumentsRepo::new(self)
     }


### PR DESCRIPTION
## Intent

Persist opaque envelope-encrypted setup-input documents for exact identity specs while establishing one app-owned envelope representation shared with credential encryption. The database layer validates storage-independent envelope shape and row integrity without interpreting cryptographic algorithms or authenticated binding recipes.

## What it enables

- Reuse of `EncryptedEnvelopeDocument` across credential encryption and identity-spec persistence instead of maintaining duplicate envelope types.
- Storage of a positive `binding_version` alongside the algorithm and key metadata needed by later crypto layers.
- Transaction-only identity-spec document upserts and deletes, with exact-id reads through generic database sessions.
- Atomic monotonic document versions, stable creation timestamps, and non-decreasing update timestamps.
- Fail-closed persisted-row decoding and secret-safe `Debug` output.
- A common storage seam for later identity-spec manager and envelope-crypto layers.

## Usage examples

Build a validated envelope once, then persist it within an existing transaction:

```rust
let envelope = EncryptedEnvelopeDocument::new(
    ciphertext,
    nonce,
    wrapped_dek,
    wrapped_dek_nonce,
    key_id,
    algorithm,
    binding_version,
)?;

let record = tx
    .identity_spec_documents()
    .upsert(&identity_spec.id, &envelope, now_unix_nanos)
    .await?;
```

Read the exact persisted envelope with `session.identity_spec_documents().get(&identity_spec.id)`, or delete it transactionally without deleting the identity-spec definition.
