### PR TITLE
refactor(app): bind encrypted envelopes with versioned contexts

### DIFF
--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -138,6 +138,11 @@ impl EnvelopeContext {
                 "envelope binding version must be positive".to_string(),
             ));
         }
+        if domain.contains('\0') {
+            return Err(CredentialsError::Crypto(
+                "envelope domain must not contain NUL".to_string(),
+            ));
+        }
         let binding_version_text = binding_version.to_string();
         let mut versioned_fields = Vec::with_capacity(fields.len() + 2);
         versioned_fields.push(binding_version_text.as_str());
@@ -147,6 +152,13 @@ impl EnvelopeContext {
             binding_version,
             encoded_aad: encode_aad_fields(domain, &versioned_fields),
         })
+    }
+
+    /// Bind a wrapped DEK to the same owner context as its encrypted payload.
+    pub(crate) fn dek_aad(&self, key_id: &str) -> Vec<u8> {
+        let mut aad = self.encoded_aad.clone();
+        encode_aad_field(&mut aad, key_id);
+        aad
     }
 }
 
@@ -317,7 +329,7 @@ fn decrypt_credential_document_bytes(
         credential_document_context(document.binding_version, workspace_name, source_name)?;
     validate_document_metadata(document, &context)?;
     let kek = key_provider.key(&document.key_id)?;
-    let dek = unwrap_credential_dek(document, &kek)?;
+    let dek = unwrap_credential_dek(document, &kek, &context)?;
 
     let mut ciphertext = Zeroizing::new(document.ciphertext.clone());
     match open(
@@ -346,19 +358,21 @@ fn decrypt_credential_document_bytes(
 fn unwrap_credential_dek(
     document: &EncryptedCredentialDocument,
     kek: &CredentialEncryptionKey,
+    context: &EnvelopeContext,
 ) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
-    match unwrap_current_dek(document, kek, document.binding_version) {
+    match unwrap_current_dek(document, kek, context) {
         Ok(dek) => Ok(dek),
         Err(primary_error) if document.binding_version == LEGACY_CREDENTIAL_BINDING_VERSION => {
-            let mut legacy_dek = Zeroizing::new(document.wrapped_dek.clone());
-            match open(
-                &kek.bytes,
-                document.wrapped_dek_nonce.as_slice(),
-                &legacy_credential_dek_aad(&document.key_id),
-                legacy_dek.as_mut_slice(),
+            match unwrap_dek_with_aad(
+                document,
+                kek,
+                &legacy_length_prefixed_credential_dek_aad(&document.key_id),
             ) {
-                Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
-                Err(_) => Err(primary_error),
+                Ok(dek) => Ok(dek),
+                Err(_) => {
+                    unwrap_dek_with_aad(document, kek, &legacy_credential_dek_aad(&document.key_id))
+                        .map_err(|_legacy_error| primary_error)
+                }
             }
         }
         Err(error) => Err(error),
@@ -368,13 +382,21 @@ fn unwrap_credential_dek(
 fn unwrap_current_dek(
     document: &EncryptedEnvelopeDocument,
     kek: &CredentialEncryptionKey,
-    binding_version: i64,
+    context: &EnvelopeContext,
+) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
+    unwrap_dek_with_aad(document, kek, &context.dek_aad(&document.key_id))
+}
+
+fn unwrap_dek_with_aad(
+    document: &EncryptedEnvelopeDocument,
+    kek: &CredentialEncryptionKey,
+    aad: &[u8],
 ) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
     let mut dek = Zeroizing::new(document.wrapped_dek.clone());
     open(
         &kek.bytes,
         document.wrapped_dek_nonce.as_slice(),
-        &envelope_dek_aad(binding_version, &document.key_id),
+        aad,
         dek.as_mut_slice(),
     )
     .and_then(validate_dek_plaintext)
@@ -398,14 +420,14 @@ fn rewrap_dek(
     document: &EncryptedEnvelopeDocument,
     active_kek: &CredentialEncryptionKey,
     dek: &[u8; KEY_LEN],
-    binding_version: i64,
-) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
+    context: &EnvelopeContext,
+) -> Result<EncryptedEnvelopeDocument, CredentialsError> {
     let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
     let mut wrapped_dek = Zeroizing::new(dek.to_vec());
     seal(
         &active_kek.bytes,
         &wrapped_dek_nonce,
-        &envelope_dek_aad(binding_version, active_kek.key_id()),
+        &context.dek_aad(active_kek.key_id()),
         &mut wrapped_dek,
     )?;
 
@@ -416,9 +438,8 @@ fn rewrap_dek(
         wrapped_dek_nonce.to_vec(),
         active_kek.key_id.clone(),
         document.algorithm.clone(),
-        document.binding_version,
+        context.binding_version,
     )
-    .map(Some)
     .map_err(|error| CredentialsError::Crypto(error.to_string()))
 }
 
@@ -461,7 +482,7 @@ pub(crate) fn seal_envelope_document(
     seal(
         &kek.bytes,
         &wrapped_dek_nonce,
-        &envelope_dek_aad(context.binding_version, kek.key_id()),
+        &context.dek_aad(kek.key_id()),
         &mut wrapped_dek,
     )?;
 
@@ -485,7 +506,7 @@ pub(crate) fn open_envelope_document(
 ) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
     validate_document_metadata(document, context)?;
     let kek = key_provider.key(&document.key_id)?;
-    let dek = unwrap_current_dek(document, &kek, context.binding_version)?;
+    let dek = unwrap_current_dek(document, &kek, context)?;
 
     let mut ciphertext = Zeroizing::new(document.ciphertext.clone());
     open(
@@ -506,7 +527,7 @@ pub(crate) fn rewrap_envelope_document(
     validate_document_metadata(document, context)?;
     let old_kek = key_provider.key(&document.key_id)?;
     let active_kek = key_provider.active_key()?;
-    let dek = unwrap_current_dek(document, &old_kek, context.binding_version)?;
+    let dek = unwrap_current_dek(document, &old_kek, context)?;
     let mut document_probe = Zeroizing::new(document.ciphertext.clone());
     open(
         &*dek,
@@ -518,7 +539,7 @@ pub(crate) fn rewrap_envelope_document(
         return Ok(None);
     }
 
-    rewrap_dek(document, &active_kek, &dek, context.binding_version)
+    rewrap_dek(document, &active_kek, &dek, context).map(Some)
 }
 
 fn seal(
@@ -593,8 +614,8 @@ fn legacy_credential_document_aad(
     .into_bytes()
 }
 
-fn envelope_dek_aad(binding_version: i64, key_id: &str) -> Vec<u8> {
-    let binding_version = binding_version.to_string();
+fn legacy_length_prefixed_credential_dek_aad(key_id: &str) -> Vec<u8> {
+    let binding_version = LEGACY_CREDENTIAL_BINDING_VERSION.to_string();
     encode_aad_fields("coral-credential-dek", &[binding_version.as_str(), key_id])
 }
 
@@ -607,11 +628,15 @@ fn encode_aad_fields(domain: &str, fields: &[&str]) -> Vec<u8> {
     aad.extend_from_slice(domain.as_bytes());
     aad.push(0);
     for field in fields {
-        let bytes = field.as_bytes();
-        aad.extend_from_slice(&(bytes.len() as u64).to_be_bytes());
-        aad.extend_from_slice(bytes);
+        encode_aad_field(&mut aad, field);
     }
     aad
+}
+
+fn encode_aad_field(aad: &mut Vec<u8>, field: &str) {
+    let bytes = field.as_bytes();
+    aad.extend_from_slice(&(bytes.len() as u64).to_be_bytes());
+    aad.extend_from_slice(bytes);
 }
 
 fn random_array<const N: usize>() -> Result<[u8; N], CredentialsError> {

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -15,7 +15,7 @@
     not(test),
     expect(
         dead_code,
-        reason = "Credential DB runtime wiring lands in a later stack branch; this branch isolates cryptographic primitives for review."
+        reason = "Credential DB runtime wiring and identity document callers land in later stack branches; this branch isolates cryptographic primitives for review."
     )
 )]
 
@@ -39,10 +39,11 @@ use crate::storage::fs as storage_fs;
 use crate::storage::fs::FileLock;
 use crate::workspaces::WorkspaceName;
 
-pub(crate) const CREDENTIAL_DOCUMENT_ALGORITHM: &str = "AES-256-GCM";
-pub(crate) const CREDENTIAL_DOCUMENT_AAD_VERSION: i64 = 1;
+pub(crate) const ENVELOPE_DOCUMENT_ALGORITHM: &str = "AES-256-GCM";
+pub(crate) const CREDENTIAL_DOCUMENT_BINDING_VERSION: i64 = 2;
 
 const CREDENTIAL_DOCUMENT_VERSION: u32 = 1;
+const LEGACY_CREDENTIAL_BINDING_VERSION: i64 = 1;
 const KEY_FILE_VERSION: &str = "v1";
 const KEY_LEN: usize = 32;
 const NONCE_LEN: usize = 12;
@@ -117,6 +118,36 @@ pub(crate) trait CredentialKeyProvider: Send + Sync {
     fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError>;
 
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError>;
+}
+
+/// Versioned authenticated context that binds an encrypted envelope to its owner.
+pub(crate) struct EnvelopeContext {
+    binding_version: i64,
+    encoded_aad: Vec<u8>,
+}
+
+impl EnvelopeContext {
+    /// Build canonical AAD with the binding version first and algorithm last.
+    pub(crate) fn new(
+        domain: &str,
+        binding_version: i64,
+        fields: &[&str],
+    ) -> Result<Self, CredentialsError> {
+        if binding_version < 1 {
+            return Err(CredentialsError::Crypto(
+                "envelope binding version must be positive".to_string(),
+            ));
+        }
+        let binding_version_text = binding_version.to_string();
+        let mut versioned_fields = Vec::with_capacity(fields.len() + 2);
+        versioned_fields.push(binding_version_text.as_str());
+        versioned_fields.extend_from_slice(fields);
+        versioned_fields.push(ENVELOPE_DOCUMENT_ALGORITHM);
+        Ok(Self {
+            binding_version,
+            encoded_aad: encode_aad_fields(domain, &versioned_fields),
+        })
+    }
 }
 
 /// Resolves an explicitly supplied key or falls back to a key file scoped to
@@ -222,44 +253,20 @@ pub(crate) fn encrypt_credential_values(
     values: &BTreeMap<String, String>,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<EncryptedCredentialDocument, CredentialsError> {
-    let kek = key_provider.active_key()?;
-    let dek = Zeroizing::new(random_array::<KEY_LEN>()?);
-    let nonce = random_array::<NONCE_LEN>()?;
-    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
-
     let plaintext = PlaintextCredentialDocument {
         version: CREDENTIAL_DOCUMENT_VERSION,
         values,
     };
-    let mut document_bytes = Zeroizing::new(
+    let document_bytes = Zeroizing::new(
         serde_json::to_vec(&plaintext)
             .map_err(|error| CredentialsError::Parse(error.to_string()))?,
     );
-    seal(
-        &*dek,
-        &nonce,
-        credential_document_aad(workspace_name, source_name),
-        &mut document_bytes,
+    let context = credential_document_context(
+        CREDENTIAL_DOCUMENT_BINDING_VERSION,
+        workspace_name,
+        source_name,
     )?;
-
-    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
-    seal(
-        &kek.bytes,
-        &wrapped_dek_nonce,
-        credential_dek_aad(kek.key_id()),
-        &mut wrapped_dek,
-    )?;
-
-    EncryptedCredentialDocument::new(
-        std::mem::take(&mut *document_bytes),
-        nonce.to_vec(),
-        std::mem::take(&mut *wrapped_dek),
-        wrapped_dek_nonce.to_vec(),
-        kek.key_id.clone(),
-        CREDENTIAL_DOCUMENT_ALGORITHM,
-        CREDENTIAL_DOCUMENT_AAD_VERSION,
-    )
-    .map_err(|error| CredentialsError::Crypto(error.to_string()))
+    seal_envelope_document(&context, document_bytes, key_provider)
 }
 
 pub(crate) fn decrypt_credential_values(
@@ -287,52 +294,17 @@ pub(crate) fn rewrap_credential_document(
     document: &EncryptedCredentialDocument,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<Option<EncryptedCredentialDocument>, CredentialsError> {
-    validate_document_metadata(document)?;
-    let old_kek = key_provider.key(&document.key_id)?;
-    let active_kek = key_provider.active_key()?;
-    if old_kek.key_id == active_kek.key_id {
-        return Ok(None);
-    }
-
-    let dek = unwrap_dek(document, &old_kek)?;
-    let mut document_probe = Zeroizing::new(document.ciphertext.clone());
-    if open(
-        &*dek,
-        document.nonce.as_slice(),
-        credential_document_aad(workspace_name, source_name),
-        document_probe.as_mut_slice(),
-    )
-    .is_err()
-    {
-        // Documents written before this rotation-safe envelope shape bound the
-        // payload AAD to the KEK id. Re-encrypt those once so future rotations
-        // only need to rewrap the DEK.
+    let context =
+        credential_document_context(document.binding_version, workspace_name, source_name)?;
+    if document.binding_version == LEGACY_CREDENTIAL_BINDING_VERSION {
+        // Binding version 1 includes both historical credential AAD encodings.
+        // Authenticate either shape, then reseal once into the exact v2 recipe.
         let values =
             decrypt_credential_values(workspace_name, source_name, document, key_provider)?;
         return encrypt_credential_values(workspace_name, source_name, &values, key_provider)
             .map(Some);
     }
-
-    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
-    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
-    seal(
-        &active_kek.bytes,
-        &wrapped_dek_nonce,
-        credential_dek_aad(active_kek.key_id()),
-        &mut wrapped_dek,
-    )?;
-
-    EncryptedCredentialDocument::new(
-        document.ciphertext.clone(),
-        document.nonce.clone(),
-        std::mem::take(&mut *wrapped_dek),
-        wrapped_dek_nonce.to_vec(),
-        active_kek.key_id.clone(),
-        document.algorithm.clone(),
-        document.binding_version,
-    )
-    .map(Some)
-    .map_err(|error| CredentialsError::Crypto(error.to_string()))
+    rewrap_envelope_document(&context, document, key_provider)
 }
 
 fn decrypt_credential_document_bytes(
@@ -341,58 +313,71 @@ fn decrypt_credential_document_bytes(
     document: &EncryptedCredentialDocument,
     key_provider: &dyn CredentialKeyProvider,
 ) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
-    validate_document_metadata(document)?;
+    let context =
+        credential_document_context(document.binding_version, workspace_name, source_name)?;
+    validate_document_metadata(document, &context)?;
     let kek = key_provider.key(&document.key_id)?;
-    let dek = unwrap_dek(document, &kek)?;
+    let dek = unwrap_credential_dek(document, &kek)?;
 
     let mut ciphertext = Zeroizing::new(document.ciphertext.clone());
     match open(
         &*dek,
         document.nonce.as_slice(),
-        credential_document_aad(workspace_name, source_name),
+        &context.encoded_aad,
         ciphertext.as_mut_slice(),
     ) {
         Ok(plaintext) => Ok(Zeroizing::new(plaintext.to_vec())),
-        Err(primary_error) => {
+        Err(primary_error) if document.binding_version == LEGACY_CREDENTIAL_BINDING_VERSION => {
             let mut legacy_ciphertext = Zeroizing::new(document.ciphertext.clone());
             match open(
                 &*dek,
                 document.nonce.as_slice(),
-                legacy_credential_document_aad(workspace_name, source_name, &document.key_id),
+                &legacy_credential_document_aad(workspace_name, source_name, &document.key_id),
                 legacy_ciphertext.as_mut_slice(),
             ) {
                 Ok(plaintext) => Ok(Zeroizing::new(plaintext.to_vec())),
                 Err(_) => Err(primary_error),
             }
         }
+        Err(error) => Err(error),
     }
 }
 
-fn unwrap_dek(
+fn unwrap_credential_dek(
     document: &EncryptedCredentialDocument,
     kek: &CredentialEncryptionKey,
 ) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
-    let mut dek = Zeroizing::new(document.wrapped_dek.clone());
-    match open(
-        &kek.bytes,
-        document.wrapped_dek_nonce.as_slice(),
-        credential_dek_aad(&document.key_id),
-        dek.as_mut_slice(),
-    ) {
-        Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
-        Err(primary_error) => {
+    match unwrap_current_dek(document, kek, document.binding_version) {
+        Ok(dek) => Ok(dek),
+        Err(primary_error) if document.binding_version == LEGACY_CREDENTIAL_BINDING_VERSION => {
             let mut legacy_dek = Zeroizing::new(document.wrapped_dek.clone());
             match open(
                 &kek.bytes,
                 document.wrapped_dek_nonce.as_slice(),
-                legacy_credential_dek_aad(&document.key_id),
+                &legacy_credential_dek_aad(&document.key_id),
                 legacy_dek.as_mut_slice(),
             ) {
                 Ok(dek_plaintext) => validate_dek_plaintext(dek_plaintext),
                 Err(_) => Err(primary_error),
             }
         }
+        Err(error) => Err(error),
     }
+}
+
+fn unwrap_current_dek(
+    document: &EncryptedEnvelopeDocument,
+    kek: &CredentialEncryptionKey,
+    binding_version: i64,
+) -> Result<Zeroizing<[u8; KEY_LEN]>, CredentialsError> {
+    let mut dek = Zeroizing::new(document.wrapped_dek.clone());
+    open(
+        &kek.bytes,
+        document.wrapped_dek_nonce.as_slice(),
+        &envelope_dek_aad(binding_version, &document.key_id),
+        dek.as_mut_slice(),
+    )
+    .and_then(validate_dek_plaintext)
 }
 
 fn validate_dek_plaintext(
@@ -409,31 +394,137 @@ fn validate_dek_plaintext(
     Ok(Zeroizing::new(dek))
 }
 
+fn rewrap_dek(
+    document: &EncryptedEnvelopeDocument,
+    active_kek: &CredentialEncryptionKey,
+    dek: &[u8; KEY_LEN],
+    binding_version: i64,
+) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
+    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
+    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
+    seal(
+        &active_kek.bytes,
+        &wrapped_dek_nonce,
+        &envelope_dek_aad(binding_version, active_kek.key_id()),
+        &mut wrapped_dek,
+    )?;
+
+    EncryptedEnvelopeDocument::new(
+        document.ciphertext.clone(),
+        document.nonce.clone(),
+        std::mem::take(&mut *wrapped_dek),
+        wrapped_dek_nonce.to_vec(),
+        active_kek.key_id.clone(),
+        document.algorithm.clone(),
+        document.binding_version,
+    )
+    .map(Some)
+    .map_err(|error| CredentialsError::Crypto(error.to_string()))
+}
+
 fn validate_document_metadata(
-    document: &EncryptedCredentialDocument,
+    document: &EncryptedEnvelopeDocument,
+    context: &EnvelopeContext,
 ) -> Result<(), CredentialsError> {
     document
         .validate()
         .map_err(|error| CredentialsError::Crypto(error.to_string()))?;
-    if document.algorithm != CREDENTIAL_DOCUMENT_ALGORITHM {
+    if document.algorithm != ENVELOPE_DOCUMENT_ALGORITHM {
         return Err(CredentialsError::Crypto(format!(
-            "unsupported credential encryption algorithm '{}'",
+            "unsupported envelope encryption algorithm '{}'",
             document.algorithm
         )));
     }
-    if document.binding_version != CREDENTIAL_DOCUMENT_AAD_VERSION {
+    if document.binding_version != context.binding_version {
         return Err(CredentialsError::Crypto(format!(
-            "unsupported credential AAD version {}",
-            document.binding_version
+            "envelope binding version {} does not match context version {}",
+            document.binding_version, context.binding_version
         )));
     }
     Ok(())
 }
 
+/// Seal serialized plaintext with a random DEK and wrap that DEK with the active KEK.
+pub(crate) fn seal_envelope_document(
+    context: &EnvelopeContext,
+    mut document_bytes: Zeroizing<Vec<u8>>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<EncryptedEnvelopeDocument, CredentialsError> {
+    let kek = key_provider.active_key()?;
+    let dek = Zeroizing::new(random_array::<KEY_LEN>()?);
+    let nonce = random_array::<NONCE_LEN>()?;
+    let wrapped_dek_nonce = random_array::<NONCE_LEN>()?;
+
+    seal(&*dek, &nonce, &context.encoded_aad, &mut document_bytes)?;
+
+    let mut wrapped_dek = Zeroizing::new(dek.to_vec());
+    seal(
+        &kek.bytes,
+        &wrapped_dek_nonce,
+        &envelope_dek_aad(context.binding_version, kek.key_id()),
+        &mut wrapped_dek,
+    )?;
+
+    EncryptedEnvelopeDocument::new(
+        std::mem::take(&mut *document_bytes),
+        nonce.to_vec(),
+        std::mem::take(&mut *wrapped_dek),
+        wrapped_dek_nonce.to_vec(),
+        kek.key_id.clone(),
+        ENVELOPE_DOCUMENT_ALGORITHM,
+        context.binding_version,
+    )
+    .map_err(|error| CredentialsError::Crypto(error.to_string()))
+}
+
+/// Open an envelope document when its persisted and expected bindings match.
+pub(crate) fn open_envelope_document(
+    context: &EnvelopeContext,
+    document: &EncryptedEnvelopeDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
+    validate_document_metadata(document, context)?;
+    let kek = key_provider.key(&document.key_id)?;
+    let dek = unwrap_current_dek(document, &kek, context.binding_version)?;
+
+    let mut ciphertext = Zeroizing::new(document.ciphertext.clone());
+    open(
+        &*dek,
+        document.nonce.as_slice(),
+        &context.encoded_aad,
+        ciphertext.as_mut_slice(),
+    )
+    .map(|plaintext| Zeroizing::new(plaintext.to_vec()))
+}
+
+/// Authenticate and rewrap an envelope document when its KEK is stale.
+pub(crate) fn rewrap_envelope_document(
+    context: &EnvelopeContext,
+    document: &EncryptedEnvelopeDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Option<EncryptedEnvelopeDocument>, CredentialsError> {
+    validate_document_metadata(document, context)?;
+    let old_kek = key_provider.key(&document.key_id)?;
+    let active_kek = key_provider.active_key()?;
+    let dek = unwrap_current_dek(document, &old_kek, context.binding_version)?;
+    let mut document_probe = Zeroizing::new(document.ciphertext.clone());
+    open(
+        &*dek,
+        document.nonce.as_slice(),
+        &context.encoded_aad,
+        document_probe.as_mut_slice(),
+    )?;
+    if old_kek.key_id == active_kek.key_id {
+        return Ok(None);
+    }
+
+    rewrap_dek(document, &active_kek, &dek, context.binding_version)
+}
+
 fn seal(
     key_bytes: &[u8],
     nonce_bytes: &[u8; NONCE_LEN],
-    aad: Vec<u8>,
+    aad: &[u8],
     in_out: &mut Vec<u8>,
 ) -> Result<(), CredentialsError> {
     let key = LessSafeKey::new(
@@ -451,7 +542,7 @@ fn seal(
 fn open<'a>(
     key_bytes: &[u8],
     nonce_bytes: &[u8],
-    aad: Vec<u8>,
+    aad: &[u8],
     in_out: &'a mut [u8],
 ) -> Result<&'a [u8], CredentialsError> {
     let nonce = nonce_bytes.try_into().map_err(|_error| {
@@ -466,16 +557,23 @@ fn open<'a>(
         .map_err(|_error| CredentialsError::Crypto("AES-256-GCM open failed".to_string()))
 }
 
-fn credential_document_aad(workspace_name: &WorkspaceName, source_name: &SourceName) -> Vec<u8> {
-    let aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION.to_string();
-    encode_aad_fields(
+fn credential_document_context(
+    binding_version: i64,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+) -> Result<EnvelopeContext, CredentialsError> {
+    match binding_version {
+        LEGACY_CREDENTIAL_BINDING_VERSION | CREDENTIAL_DOCUMENT_BINDING_VERSION => {}
+        unsupported => {
+            return Err(CredentialsError::Crypto(format!(
+                "unsupported credential binding version {unsupported}"
+            )));
+        }
+    }
+    EnvelopeContext::new(
         "coral-credential-document",
-        &[
-            aad_version.as_str(),
-            workspace_name.as_str(),
-            source_name.as_str(),
-            CREDENTIAL_DOCUMENT_ALGORITHM,
-        ],
+        binding_version,
+        &[workspace_name.as_str(), source_name.as_str()],
     )
 }
 
@@ -486,22 +584,22 @@ fn legacy_credential_document_aad(
 ) -> Vec<u8> {
     format!(
         "coral-credential-document:v{}:{}:{}:{}:{}",
-        CREDENTIAL_DOCUMENT_AAD_VERSION,
+        LEGACY_CREDENTIAL_BINDING_VERSION,
         workspace_name.as_str(),
         source_name.as_str(),
-        CREDENTIAL_DOCUMENT_ALGORITHM,
+        ENVELOPE_DOCUMENT_ALGORITHM,
         key_id
     )
     .into_bytes()
 }
 
-fn credential_dek_aad(key_id: &str) -> Vec<u8> {
-    let aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION.to_string();
-    encode_aad_fields("coral-credential-dek", &[aad_version.as_str(), key_id])
+fn envelope_dek_aad(binding_version: i64, key_id: &str) -> Vec<u8> {
+    let binding_version = binding_version.to_string();
+    encode_aad_fields("coral-credential-dek", &[binding_version.as_str(), key_id])
 }
 
 fn legacy_credential_dek_aad(key_id: &str) -> Vec<u8> {
-    format!("coral-credential-dek:v{CREDENTIAL_DOCUMENT_AAD_VERSION}:{key_id}").into_bytes()
+    format!("coral-credential-dek:v{LEGACY_CREDENTIAL_BINDING_VERSION}:{key_id}").into_bytes()
 }
 
 fn encode_aad_fields(domain: &str, fields: &[&str]) -> Vec<u8> {

--- a/crates/coral-app/src/credentials/encryption_tests.rs
+++ b/crates/coral-app/src/credentials/encryption_tests.rs
@@ -4,12 +4,14 @@ use std::thread;
 
 use ring::aead::{self, Aad, LessSafeKey, Nonce, UnboundKey};
 use tempfile::tempdir;
+use zeroize::Zeroizing;
 
 use super::CredentialsError;
 use super::encryption::{
-    CREDENTIAL_DOCUMENT_AAD_VERSION, CredentialEncryptionKey, CredentialKeyProvider,
-    LocalFileCredentialKeyProvider, decrypt_credential_values, encrypt_credential_values,
-    rewrap_credential_document,
+    CREDENTIAL_DOCUMENT_BINDING_VERSION, CredentialEncryptionKey, CredentialKeyProvider,
+    ENVELOPE_DOCUMENT_ALGORITHM, EnvelopeContext, LocalFileCredentialKeyProvider,
+    decrypt_credential_values, encrypt_credential_values, open_envelope_document,
+    rewrap_credential_document, rewrap_envelope_document, seal_envelope_document,
 };
 use crate::sources::SourceName;
 use crate::state::AppStateLayout;
@@ -65,6 +67,10 @@ fn encrypt_decrypt_authenticates_context_and_redacts_key_debug() {
 
     let document = encrypt_credential_values(&workspace, &source, &values, &provider)
         .expect("encrypt credentials");
+    assert_eq!(
+        document.binding_version,
+        CREDENTIAL_DOCUMENT_BINDING_VERSION
+    );
     assert_eq!(
         decrypt_credential_values(&workspace, &source, &document, &provider).expect("decrypt"),
         values
@@ -175,14 +181,14 @@ fn credential_document_rejects_key_id_aad_mismatch_even_when_key_resolves() {
     let dek = open_for_test(
         &original_key_bytes,
         encrypted.wrapped_dek_nonce.as_slice(),
-        current_dek_aad_for_test(&original_key_id),
+        current_dek_aad_for_test(encrypted.binding_version, &original_key_id),
         &encrypted.wrapped_dek,
     );
     let mismatched_nonce = [6; 12];
     encrypted.wrapped_dek = seal_for_test(
         &mutated_key_bytes,
         mismatched_nonce,
-        current_dek_aad_for_test(&original_key_id),
+        current_dek_aad_for_test(encrypted.binding_version, &original_key_id),
         &dek,
     );
     encrypted.wrapped_dek_nonce = mismatched_nonce.to_vec();
@@ -198,7 +204,7 @@ fn credential_document_rejects_key_id_aad_mismatch_even_when_key_resolves() {
 }
 
 #[test]
-fn credential_document_rejects_aad_version_mismatch() {
+fn credential_document_rejects_binding_version_mismatch() {
     let workspace = WorkspaceName::parse("default").expect("workspace");
     let source = SourceName::parse("github").expect("source");
     let provider = StaticKeyProvider {
@@ -211,15 +217,15 @@ fn credential_document_rejects_aad_version_mismatch() {
         &provider,
     )
     .expect("encrypt");
-    encrypted.binding_version = CREDENTIAL_DOCUMENT_AAD_VERSION + 1;
+    encrypted.binding_version = CREDENTIAL_DOCUMENT_BINDING_VERSION + 1;
 
     let error = decrypt_credential_values(&workspace, &source, &encrypted, &provider)
-        .expect_err("unsupported AAD version should fail");
+        .expect_err("unsupported binding version should fail");
 
     assert!(
         error
             .to_string()
-            .contains("unsupported credential AAD version"),
+            .contains("unsupported credential binding version"),
         "unexpected error: {error}"
     );
 }
@@ -233,13 +239,12 @@ fn decrypt_accepts_legacy_colon_delimited_dek_aad() {
         key: CredentialEncryptionKey::from_static_bytes_for_test(key_bytes),
     };
     let values = BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]);
-    let mut encrypted =
-        encrypt_credential_values(&workspace, &source, &values, &provider).expect("encrypt");
+    let mut encrypted = encrypt_credential_v1_for_test(&workspace, &source, &values, &provider);
     let key_id = encrypted.key_id.clone();
     let dek = open_for_test(
         &key_bytes,
         encrypted.wrapped_dek_nonce.as_slice(),
-        current_dek_aad_for_test(&key_id),
+        current_dek_aad_for_test(encrypted.binding_version, &key_id),
         &encrypted.wrapped_dek,
     );
     let legacy_nonce = [3; 12];
@@ -291,7 +296,7 @@ fn credential_document_rewrap_changes_kek_without_reencrypting_payload() {
         try_open_for_test(
             &old_key_bytes,
             rewrapped.wrapped_dek_nonce.as_slice(),
-            current_dek_aad_for_test(&rewrapped.key_id),
+            current_dek_aad_for_test(rewrapped.binding_version, &rewrapped.key_id),
             &rewrapped.wrapped_dek,
         )
         .is_err(),
@@ -301,6 +306,215 @@ fn credential_document_rewrap_changes_kek_without_reencrypting_payload() {
         decrypt_credential_values(&workspace, &source, &rewrapped, &rotating_provider)
             .expect("decrypt rewrapped"),
         values
+    );
+}
+
+#[test]
+fn credential_document_same_key_rewrap_authenticates_payload_context() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let other_workspace = WorkspaceName::parse("other").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let provider = StaticKeyProvider {
+        key: CredentialEncryptionKey::from_static_bytes_for_test([27; 32]),
+    };
+    let encrypted = encrypt_credential_values(
+        &workspace,
+        &source,
+        &BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+        &provider,
+    )
+    .expect("encrypt");
+
+    assert_open_failed(
+        &rewrap_credential_document(&other_workspace, &source, &encrypted, &provider)
+            .expect_err("same-key rewrap must authenticate context"),
+    );
+    let mut tampered = encrypted;
+    *tampered.ciphertext.first_mut().expect("ciphertext") ^= 1;
+    assert_open_failed(
+        &rewrap_credential_document(&workspace, &source, &tampered, &provider)
+            .expect_err("same-key rewrap must authenticate ciphertext"),
+    );
+}
+
+#[test]
+fn credential_v1_rewrap_migrates_to_v2_with_same_key() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let provider = StaticKeyProvider {
+        key: CredentialEncryptionKey::from_static_bytes_for_test([28; 32]),
+    };
+    let values = BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]);
+    let v1 = encrypt_credential_v1_for_test(&workspace, &source, &values, &provider);
+
+    let migrated = rewrap_credential_document(&workspace, &source, &v1, &provider)
+        .expect("rewrap v1")
+        .expect("v1 must be resealed");
+
+    assert_eq!(
+        migrated.binding_version,
+        CREDENTIAL_DOCUMENT_BINDING_VERSION
+    );
+    assert_eq!(migrated.key_id, v1.key_id);
+    assert_ne!(migrated.ciphertext, v1.ciphertext);
+    assert_eq!(
+        decrypt_credential_values(&workspace, &source, &migrated, &provider)
+            .expect("decrypt migrated credential"),
+        values
+    );
+}
+
+#[test]
+fn credential_document_rewrap_migrates_legacy_payload_aad() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let old_key_bytes = [29; 32];
+    let old_key = CredentialEncryptionKey::from_static_bytes_for_test(old_key_bytes);
+    let new_key = CredentialEncryptionKey::from_static_bytes_for_test([31; 32]);
+    let old_provider = RotatingKeyProvider {
+        active: old_key.clone(),
+        keys: vec![old_key.clone()],
+    };
+    let rotating_provider = RotatingKeyProvider {
+        active: new_key.clone(),
+        keys: vec![old_key, new_key.clone()],
+    };
+    let values = BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]);
+    let mut legacy = encrypt_credential_v1_for_test(&workspace, &source, &values, &old_provider);
+    let key_id = legacy.key_id.clone();
+    let dek: [u8; 32] = open_for_test(
+        &old_key_bytes,
+        legacy.wrapped_dek_nonce.as_slice(),
+        current_dek_aad_for_test(legacy.binding_version, &key_id),
+        &legacy.wrapped_dek,
+    )
+    .try_into()
+    .expect("DEK length");
+    let plaintext = serde_json::to_vec(&serde_json::json!({
+        "version": 1,
+        "values": values,
+    }))
+    .expect("serialize legacy document");
+    let legacy_nonce = [5; 12];
+    legacy.ciphertext = seal_for_test(
+        &dek,
+        legacy_nonce,
+        legacy_document_aad_for_test(&workspace, &source, &key_id),
+        &plaintext,
+    );
+    legacy.nonce = legacy_nonce.to_vec();
+
+    let migrated = rewrap_credential_document(&workspace, &source, &legacy, &rotating_provider)
+        .expect("rewrap legacy document")
+        .expect("stale key should migrate");
+    assert_eq!(migrated.key_id, new_key.key_id());
+    assert_eq!(
+        migrated.binding_version,
+        CREDENTIAL_DOCUMENT_BINDING_VERSION
+    );
+    assert_ne!(migrated.ciphertext, legacy.ciphertext);
+    assert_ne!(migrated.nonce, legacy.nonce);
+    assert_eq!(
+        decrypt_credential_values(&workspace, &source, &migrated, &rotating_provider)
+            .expect("decrypt migrated document"),
+        values
+    );
+}
+
+#[test]
+fn shared_envelope_context_authenticates_open_and_rewrap() {
+    const BINDING_VERSION: i64 = 7;
+
+    let old_key = CredentialEncryptionKey::from_static_bytes_for_test([37; 32]);
+    let new_key = CredentialEncryptionKey::from_static_bytes_for_test([41; 32]);
+    let old_provider = RotatingKeyProvider {
+        active: old_key.clone(),
+        keys: vec![old_key.clone()],
+    };
+    let rotating_provider = RotatingKeyProvider {
+        active: new_key.clone(),
+        keys: vec![old_key, new_key.clone()],
+    };
+    let context =
+        EnvelopeContext::new("test-envelope", BINDING_VERSION, &["workspace", "document"])
+            .expect("envelope context");
+    let plaintext = b"envelope payload".to_vec();
+
+    let encrypted =
+        seal_envelope_document(&context, Zeroizing::new(plaintext.clone()), &old_provider)
+            .expect("seal envelope");
+    assert_eq!(encrypted.binding_version, BINDING_VERSION);
+    assert_eq!(
+        open_envelope_document(&context, &encrypted, &old_provider)
+            .expect("open envelope")
+            .as_slice(),
+        plaintext
+    );
+    let wrong_context = EnvelopeContext::new(
+        "test-envelope",
+        BINDING_VERSION,
+        &["other-workspace", "document"],
+    )
+    .expect("wrong envelope context");
+    assert_open_failed(
+        &open_envelope_document(&wrong_context, &encrypted, &old_provider)
+            .expect_err("wrong binding should fail authentication"),
+    );
+    let wrong_version =
+        EnvelopeContext::new("test-envelope", 1, &["workspace", "document"]).expect("context");
+    assert!(
+        open_envelope_document(&wrong_version, &encrypted, &old_provider)
+            .expect_err("wrong expected binding version should fail")
+            .to_string()
+            .contains("binding version 7 does not match context version 1")
+    );
+    let Err(error) = EnvelopeContext::new("test-envelope", 0, &["workspace"]) else {
+        panic!("nonpositive binding version should fail");
+    };
+    assert!(error.to_string().contains("must be positive"));
+    let mut unsupported = encrypted.clone();
+    unsupported.algorithm = "unsupported".to_string();
+    assert!(
+        open_envelope_document(&context, &unsupported, &old_provider)
+            .expect_err("unsupported algorithm should fail")
+            .to_string()
+            .contains("unsupported envelope encryption algorithm")
+    );
+    let mut rebound = encrypted.clone();
+    rebound.binding_version += 1;
+    let rebound_context = EnvelopeContext::new(
+        "test-envelope",
+        rebound.binding_version,
+        &["workspace", "document"],
+    )
+    .expect("rebound context");
+    assert_open_failed(
+        &open_envelope_document(&rebound_context, &rebound, &old_provider)
+            .expect_err("stored version must also bind the wrapped DEK"),
+    );
+
+    let rewrapped = rewrap_envelope_document(&context, &encrypted, &rotating_provider)
+        .expect("rewrap envelope")
+        .expect("stale key should rewrap");
+    assert_eq!(rewrapped.key_id, new_key.key_id());
+    assert_eq!(rewrapped.ciphertext, encrypted.ciphertext);
+    assert_eq!(rewrapped.nonce, encrypted.nonce);
+    assert_ne!(rewrapped.wrapped_dek, encrypted.wrapped_dek);
+    assert_ne!(rewrapped.wrapped_dek_nonce, encrypted.wrapped_dek_nonce);
+    assert_eq!(
+        open_envelope_document(&context, &rewrapped, &rotating_provider)
+            .expect("open rewrapped envelope")
+            .as_slice(),
+        plaintext
+    );
+    assert!(
+        rewrap_envelope_document(&context, &rewrapped, &rotating_provider)
+            .expect("rewrap current envelope")
+            .is_none()
+    );
+    assert_open_failed(
+        &rewrap_envelope_document(&wrong_context, &rewrapped, &rotating_provider)
+            .expect_err("same-key rewrap must still authenticate binding"),
     );
 }
 
@@ -398,13 +612,50 @@ fn local_file_key_provider(layout: &AppStateLayout) -> LocalFileCredentialKeyPro
     LocalFileCredentialKeyProvider::new(layout, None)
 }
 
-fn current_dek_aad_for_test(key_id: &str) -> Vec<u8> {
-    let aad_version = CREDENTIAL_DOCUMENT_AAD_VERSION.to_string();
-    encode_aad_fields_for_test("coral-credential-dek", &[aad_version.as_str(), key_id])
+fn encrypt_credential_v1_for_test(
+    workspace: &WorkspaceName,
+    source: &SourceName,
+    values: &BTreeMap<String, String>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> super::encryption::EncryptedCredentialDocument {
+    let context = EnvelopeContext::new(
+        "coral-credential-document",
+        1,
+        &[workspace.as_str(), source.as_str()],
+    )
+    .expect("v1 credential context");
+    let plaintext = serde_json::to_vec(&serde_json::json!({
+        "version": 1,
+        "values": values,
+    }))
+    .expect("serialize v1 credential document");
+    seal_envelope_document(&context, Zeroizing::new(plaintext), key_provider)
+        .expect("encrypt v1 credential document")
+}
+
+fn current_dek_aad_for_test(binding_version: i64, key_id: &str) -> Vec<u8> {
+    let binding_version = binding_version.to_string();
+    encode_aad_fields_for_test("coral-credential-dek", &[binding_version.as_str(), key_id])
 }
 
 fn legacy_dek_aad_for_test(key_id: &str) -> Vec<u8> {
-    format!("coral-credential-dek:v{CREDENTIAL_DOCUMENT_AAD_VERSION}:{key_id}").into_bytes()
+    format!("coral-credential-dek:v1:{key_id}").into_bytes()
+}
+
+fn legacy_document_aad_for_test(
+    workspace: &WorkspaceName,
+    source: &SourceName,
+    key_id: &str,
+) -> Vec<u8> {
+    format!(
+        "coral-credential-document:v{}:{}:{}:{}:{}",
+        1,
+        workspace.as_str(),
+        source.as_str(),
+        ENVELOPE_DOCUMENT_ALGORITHM,
+        key_id
+    )
+    .into_bytes()
 }
 
 fn encode_aad_fields_for_test(domain: &str, fields: &[&str]) -> Vec<u8> {

--- a/crates/coral-app/src/credentials/encryption_tests.rs
+++ b/crates/coral-app/src/credentials/encryption_tests.rs
@@ -181,14 +181,24 @@ fn credential_document_rejects_key_id_aad_mismatch_even_when_key_resolves() {
     let dek = open_for_test(
         &original_key_bytes,
         encrypted.wrapped_dek_nonce.as_slice(),
-        current_dek_aad_for_test(encrypted.binding_version, &original_key_id),
+        credential_dek_aad_for_test(
+            &workspace,
+            &source,
+            encrypted.binding_version,
+            &original_key_id,
+        ),
         &encrypted.wrapped_dek,
     );
     let mismatched_nonce = [6; 12];
     encrypted.wrapped_dek = seal_for_test(
         &mutated_key_bytes,
         mismatched_nonce,
-        current_dek_aad_for_test(encrypted.binding_version, &original_key_id),
+        credential_dek_aad_for_test(
+            &workspace,
+            &source,
+            encrypted.binding_version,
+            &original_key_id,
+        ),
         &dek,
     );
     encrypted.wrapped_dek_nonce = mismatched_nonce.to_vec();
@@ -244,7 +254,7 @@ fn decrypt_accepts_legacy_colon_delimited_dek_aad() {
     let dek = open_for_test(
         &key_bytes,
         encrypted.wrapped_dek_nonce.as_slice(),
-        current_dek_aad_for_test(encrypted.binding_version, &key_id),
+        credential_dek_aad_for_test(&workspace, &source, encrypted.binding_version, &key_id),
         &encrypted.wrapped_dek,
     );
     let legacy_nonce = [3; 12];
@@ -259,6 +269,39 @@ fn decrypt_accepts_legacy_colon_delimited_dek_aad() {
     assert_eq!(
         decrypt_credential_values(&workspace, &source, &encrypted, &provider)
             .expect("legacy DEK AAD should decrypt"),
+        values
+    );
+}
+
+#[test]
+fn decrypt_accepts_legacy_length_prefixed_dek_aad() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let key_bytes = [18; 32];
+    let provider = StaticKeyProvider {
+        key: CredentialEncryptionKey::from_static_bytes_for_test(key_bytes),
+    };
+    let values = BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]);
+    let mut encrypted = encrypt_credential_v1_for_test(&workspace, &source, &values, &provider);
+    let key_id = encrypted.key_id.clone();
+    let dek = open_for_test(
+        &key_bytes,
+        encrypted.wrapped_dek_nonce.as_slice(),
+        credential_dek_aad_for_test(&workspace, &source, encrypted.binding_version, &key_id),
+        &encrypted.wrapped_dek,
+    );
+    let legacy_nonce = [4; 12];
+    encrypted.wrapped_dek = seal_for_test(
+        &key_bytes,
+        legacy_nonce,
+        legacy_length_prefixed_dek_aad_for_test(&key_id),
+        &dek,
+    );
+    encrypted.wrapped_dek_nonce = legacy_nonce.to_vec();
+
+    assert_eq!(
+        decrypt_credential_values(&workspace, &source, &encrypted, &provider)
+            .expect("legacy length-prefixed DEK AAD should decrypt"),
         values
     );
 }
@@ -296,7 +339,12 @@ fn credential_document_rewrap_changes_kek_without_reencrypting_payload() {
         try_open_for_test(
             &old_key_bytes,
             rewrapped.wrapped_dek_nonce.as_slice(),
-            current_dek_aad_for_test(rewrapped.binding_version, &rewrapped.key_id),
+            credential_dek_aad_for_test(
+                &workspace,
+                &source,
+                rewrapped.binding_version,
+                &rewrapped.key_id,
+            ),
             &rewrapped.wrapped_dek,
         )
         .is_err(),
@@ -385,7 +433,7 @@ fn credential_document_rewrap_migrates_legacy_payload_aad() {
     let dek: [u8; 32] = open_for_test(
         &old_key_bytes,
         legacy.wrapped_dek_nonce.as_slice(),
-        current_dek_aad_for_test(legacy.binding_version, &key_id),
+        credential_dek_aad_for_test(&workspace, &source, legacy.binding_version, &key_id),
         &legacy.wrapped_dek,
     )
     .try_into()
@@ -418,6 +466,60 @@ fn credential_document_rewrap_migrates_legacy_payload_aad() {
         decrypt_credential_values(&workspace, &source, &migrated, &rotating_provider)
             .expect("decrypt migrated document"),
         values
+    );
+}
+
+#[test]
+fn envelope_context_rejects_nul_in_domain() {
+    let Err(error) = EnvelopeContext::new("test-envelope\0other", 1, &["workspace"]) else {
+        panic!("NUL-containing envelope domain should fail");
+    };
+    assert!(error.to_string().contains("must not contain NUL"));
+}
+
+#[test]
+fn wrapped_dek_authenticates_full_envelope_context() {
+    const BINDING_VERSION: i64 = 7;
+
+    let old_key_bytes = [37; 32];
+    let provider = StaticKeyProvider {
+        key: CredentialEncryptionKey::from_static_bytes_for_test(old_key_bytes),
+    };
+    let context =
+        EnvelopeContext::new("test-envelope", BINDING_VERSION, &["workspace", "document"])
+            .expect("envelope context");
+    let wrong_context = EnvelopeContext::new(
+        "test-envelope",
+        BINDING_VERSION,
+        &["other-workspace", "document"],
+    )
+    .expect("wrong envelope context");
+    let encrypted = seal_envelope_document(
+        &context,
+        Zeroizing::new(b"envelope payload".to_vec()),
+        &provider,
+    )
+    .expect("seal envelope");
+
+    assert_eq!(
+        open_for_test(
+            &old_key_bytes,
+            encrypted.wrapped_dek_nonce.as_slice(),
+            context.dek_aad(&encrypted.key_id),
+            &encrypted.wrapped_dek,
+        )
+        .len(),
+        32
+    );
+    assert!(
+        try_open_for_test(
+            &old_key_bytes,
+            encrypted.wrapped_dek_nonce.as_slice(),
+            wrong_context.dek_aad(&encrypted.key_id),
+            &encrypted.wrapped_dek,
+        )
+        .is_err(),
+        "wrapped DEK must authenticate the full envelope context"
     );
 }
 
@@ -633,9 +735,27 @@ fn encrypt_credential_v1_for_test(
         .expect("encrypt v1 credential document")
 }
 
-fn current_dek_aad_for_test(binding_version: i64, key_id: &str) -> Vec<u8> {
+fn credential_dek_aad_for_test(
+    workspace: &WorkspaceName,
+    source: &SourceName,
+    binding_version: i64,
+    key_id: &str,
+) -> Vec<u8> {
     let binding_version = binding_version.to_string();
-    encode_aad_fields_for_test("coral-credential-dek", &[binding_version.as_str(), key_id])
+    encode_aad_fields_for_test(
+        "coral-credential-document",
+        &[
+            binding_version.as_str(),
+            workspace.as_str(),
+            source.as_str(),
+            ENVELOPE_DOCUMENT_ALGORITHM,
+            key_id,
+        ],
+    )
+}
+
+fn legacy_length_prefixed_dek_aad_for_test(key_id: &str) -> Vec<u8> {
+    encode_aad_fields_for_test("coral-credential-dek", &["1", key_id])
 }
 
 fn legacy_dek_aad_for_test(key_id: &str) -> Vec<u8> {

--- a/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
@@ -26,6 +26,31 @@ async fn identity_spec_persistence_contract_holds_against_sqlite() {
 }
 
 #[tokio::test]
+async fn identity_spec_contract_preserves_preexisting_reserved_name_workspace() {
+    let temp = tempdir().expect("temp dir");
+    let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+        path: temp.path().join("coral.sqlite"),
+    })
+    .await
+    .expect("open sqlite");
+    db.migrate().await.expect("migrate sqlite");
+
+    let reserved = parsed_workspace("__global__");
+    let preexisting = scoped_key(&reserved, "preexisting");
+    let mut tx = db.begin().await.expect("begin preexisting transaction");
+    tx.workspaces()
+        .ensure(reserved.as_str(), 1)
+        .await
+        .expect("ensure preexisting workspace");
+    seed_pair(&mut tx, &preexisting, "preexisting", 2).await;
+    tx.commit().await.expect("commit preexisting fixture");
+
+    assert_identity_spec_persistence_contract(&db).await;
+
+    assert_pair(&db, &preexisting, "preexisting", 2, 1).await;
+}
+
+#[tokio::test]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared contract against Postgres"]
 async fn identity_spec_persistence_contract_on_postgres() {
     let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
@@ -65,15 +90,10 @@ async fn assert_identity_spec_persistence_contract(db: &CoralDb) {
     for (key, label, now) in [(&global, "global", 10), (&global_zeta, "zeta", 11)] {
         seed_pair(&mut tx, key, label, now).await;
     }
-    tx.workspaces()
-        .ensure(reserved.as_str(), 1)
-        .await
-        .expect("ensure reserved-name workspace");
     for (key, label, now) in [
         (&workspace_shared, "workspace", 20),
         (&workspace_beta, "beta", 21),
         (&alternate_shared, "alternate", 30),
-        (&reserved_shared, "reserved", 40),
     ] {
         seed_pair(&mut tx, key, label, now).await;
     }
@@ -86,9 +106,9 @@ async fn assert_identity_spec_persistence_contract(db: &CoralDb) {
         .expect("replace document with stale clock");
     tx.commit().await.expect("commit seed transaction");
 
+    assert_reserved_workspace_name_is_not_global(db, &reserved, &reserved_shared).await;
     assert_pair(db, &global, "replacement", 10, 2).await;
     assert_pair(db, &workspace_shared, "workspace", 20, 1).await;
-    assert_pair(db, &reserved_shared, "reserved", 40, 1).await;
     assert_fixture_scope_lists(
         db,
         &global,
@@ -159,7 +179,6 @@ async fn assert_identity_spec_persistence_contract(db: &CoralDb) {
 
     assert_foreign_keys(db, &suffix).await;
     assert_rollback_invisibility(db, &suffix).await;
-    assert_max_version_is_nonmutating(db, &reserved_shared).await;
     assert_concurrent_document_versions(db, &global_zeta).await;
 
     let mut tx = db.begin().await.expect("begin cleanup transaction");
@@ -171,13 +190,39 @@ async fn assert_identity_spec_persistence_contract(db: &CoralDb) {
                 .expect("delete global spec")
         );
     }
-    for workspace in [&workspace, &reserved] {
-        tx.workspaces()
-            .delete(workspace.as_str())
-            .await
-            .expect("delete workspace");
-    }
+    tx.workspaces()
+        .delete(workspace.as_str())
+        .await
+        .expect("delete workspace");
     tx.commit().await.expect("commit cleanup");
+}
+
+async fn assert_reserved_workspace_name_is_not_global(
+    db: &CoralDb,
+    workspace: &WorkspaceName,
+    key: &IdentitySpecKey,
+) {
+    let mut tx = db.begin().await.expect("begin reserved-name transaction");
+    tx.workspaces()
+        .ensure(workspace.as_str(), 1)
+        .await
+        .expect("ensure reserved-name workspace");
+    let (spec, persisted_document) = seed_pair(&mut tx, key, "reserved", 40).await;
+    assert_eq!(spec, expected_spec(spec.id.clone(), key, "reserved", 40));
+    assert_eq!(
+        persisted_document,
+        IdentitySpecDocumentRecord {
+            identity_spec_id: spec.id.clone(),
+            document_version: 1,
+            envelope: document("reserved"),
+            created_at_unix_nanos: 40,
+            updated_at_unix_nanos: 40,
+        }
+    );
+    assert_max_version_is_nonmutating(&mut tx, &spec.id).await;
+    tx.rollback()
+        .await
+        .expect("roll back reserved-name fixture");
 }
 
 async fn assert_fixture_scope_lists(
@@ -259,45 +304,39 @@ async fn assert_rollback_invisibility(db: &CoralDb, suffix: &str) {
     assert_absent(db, &key).await;
 }
 
-async fn assert_max_version_is_nonmutating(db: &CoralDb, key: &IdentitySpecKey) {
-    let mut tx = db.begin().await.expect("begin max-version transaction");
-    let identity_spec_id = tx
-        .identity_specs()
-        .get(key)
-        .await
-        .expect("read max-version spec")
-        .expect("max-version spec exists")
-        .id;
+async fn assert_max_version_is_nonmutating(
+    tx: &mut CoralTx<'_>,
+    identity_spec_id: &IdentitySpecId,
+) {
     tx.execute(
         Query::update()
             .table(IdentitySpecDocuments::Table)
             .value(IdentitySpecDocuments::DocumentVersion, i64::MAX)
-            .and_where(document_id_where(&identity_spec_id))
+            .and_where(document_id_where(identity_spec_id))
             .to_owned(),
     )
     .await
     .expect("set max document version");
     let before = tx
         .identity_spec_documents()
-        .get(&identity_spec_id)
+        .get(identity_spec_id)
         .await
         .expect("read max-version document")
         .expect("document exists");
     let error = tx
         .identity_spec_documents()
-        .upsert(&identity_spec_id, &document("overflow"), 70)
+        .upsert(identity_spec_id, &document("overflow"), 70)
         .await
         .expect_err("max version must not wrap");
     assert!(matches!(error, AppError::FailedPrecondition(_)));
     assert_eq!(
         tx.identity_spec_documents()
-            .get(&identity_spec_id)
+            .get(identity_spec_id)
             .await
             .expect("reread max-version document")
             .expect("document remains"),
         before
     );
-    tx.rollback().await.expect("rollback max-version change");
 }
 
 async fn assert_concurrent_document_versions(db: &CoralDb, key: &IdentitySpecKey) {


### PR DESCRIPTION
## Intent

Replace the loose version-and-AAD envelope API with an opaque `EnvelopeContext` that owns the authenticated binding recipe. Identity-spec and identity-instance documents can then reuse the envelope primitives without exposing raw AAD or DEK helpers as their contract.

## What it enables

- Builds canonical, length-prefixed authenticated context from a domain, positive `binding_version`, ordered binding fields, and the envelope algorithm.
- Makes new credential documents use binding version 2.
- Keeps historical credential binding version 1 readable and reseals it as version 2 during rewrap, even when the active KEK has not changed.
- Rejects unsupported credential binding versions before opening or rewrapping a document.
- Authenticates the payload before a same-key rewrap returns `None`.
- Rotates stale KEKs by rewrapping the DEK without re-encrypting the payload.

## Usage examples

```rust
let context = EnvelopeContext::new(
    "coral-credential-document",
    CREDENTIAL_DOCUMENT_BINDING_VERSION,
    &[workspace_name.as_str(), source_name.as_str()],
)?;

let encrypted = seal_envelope_document(&context, plaintext, key_provider)?;
let decrypted = open_envelope_document(&context, &encrypted, key_provider)?;
let replacement = rewrap_envelope_document(&context, &encrypted, key_provider)?;
```

Credential callers normally use `encrypt_credential_values`, `decrypt_credential_values`, and `rewrap_credential_document`; those wrappers select the appropriate persisted binding recipe.

## Validation

- `make rust-checks`
