### PR TITLE
feat(app): resolve encrypted identity spec inputs

### DIFF
--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -114,6 +114,12 @@ impl CredentialEncryptionKey {
     }
 }
 
+/// Resolves KEKs, and mints one when a deployment has none yet.
+///
+/// `active_key` is a minting capability: [`LocalFileCredentialKeyProvider`] creates
+/// durable key material on disk when none exists. Only sealing and rewrapping take a
+/// provider; opening takes the [`CredentialEncryptionKey`] its document names, so a
+/// read path cannot create or rotate key material.
 pub(crate) trait CredentialKeyProvider: Send + Sync {
     fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError>;
 
@@ -285,10 +291,9 @@ pub(crate) fn decrypt_credential_values(
     workspace_name: &WorkspaceName,
     source_name: &SourceName,
     document: &EncryptedCredentialDocument,
-    key_provider: &dyn CredentialKeyProvider,
+    kek: &CredentialEncryptionKey,
 ) -> Result<BTreeMap<String, String>, CredentialsError> {
-    let plaintext =
-        decrypt_credential_document_bytes(workspace_name, source_name, document, key_provider)?;
+    let plaintext = decrypt_credential_document_bytes(workspace_name, source_name, document, kek)?;
     let decoded: DecryptedCredentialDocument = serde_json::from_slice(&plaintext)
         .map_err(|error| CredentialsError::Parse(error.to_string()))?;
     if decoded.version != CREDENTIAL_DOCUMENT_VERSION {
@@ -311,8 +316,8 @@ pub(crate) fn rewrap_credential_document(
     if document.binding_version == LEGACY_CREDENTIAL_BINDING_VERSION {
         // Binding version 1 includes both historical credential AAD encodings.
         // Authenticate either shape, then reseal once into the exact v2 recipe.
-        let values =
-            decrypt_credential_values(workspace_name, source_name, document, key_provider)?;
+        let kek = key_provider.key(&document.key_id)?;
+        let values = decrypt_credential_values(workspace_name, source_name, document, &kek)?;
         return encrypt_credential_values(workspace_name, source_name, &values, key_provider)
             .map(Some);
     }
@@ -323,13 +328,13 @@ fn decrypt_credential_document_bytes(
     workspace_name: &WorkspaceName,
     source_name: &SourceName,
     document: &EncryptedCredentialDocument,
-    key_provider: &dyn CredentialKeyProvider,
+    kek: &CredentialEncryptionKey,
 ) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
     let context =
         credential_document_context(document.binding_version, workspace_name, source_name)?;
     validate_document_metadata(document, &context)?;
-    let kek = key_provider.key(&document.key_id)?;
-    let dek = unwrap_credential_dek(document, &kek, &context)?;
+    validate_unwrapping_key(document, kek)?;
+    let dek = unwrap_credential_dek(document, kek, &context)?;
 
     let mut ciphertext = Zeroizing::new(document.ciphertext.clone());
     match open(
@@ -465,6 +470,25 @@ fn validate_document_metadata(
     Ok(())
 }
 
+/// Reject a KEK that is not the one the stored document names.
+///
+/// The wrapped DEK already authenticates `key_id` through its AAD, so a mismatched
+/// KEK cannot unwrap it. Checking first turns that into a precise error instead of a
+/// bare AEAD failure. Key identifiers are non-secret digests, so naming both is safe.
+fn validate_unwrapping_key(
+    document: &EncryptedEnvelopeDocument,
+    kek: &CredentialEncryptionKey,
+) -> Result<(), CredentialsError> {
+    if kek.key_id() != document.key_id {
+        return Err(CredentialsError::Crypto(format!(
+            "envelope key '{}' does not match document key '{}'",
+            kek.key_id(),
+            document.key_id
+        )));
+    }
+    Ok(())
+}
+
 /// Seal serialized plaintext with a random DEK and wrap that DEK with the active KEK.
 pub(crate) fn seal_envelope_document(
     context: &EnvelopeContext,
@@ -499,14 +523,18 @@ pub(crate) fn seal_envelope_document(
 }
 
 /// Open an envelope document when its persisted and expected bindings match.
+///
+/// Takes the KEK the document names rather than a [`CredentialKeyProvider`]: opening
+/// needs no authority to mint or rotate keys, and resolving the KEK in the caller
+/// keeps provider failures distinguishable from authentication failures.
 pub(crate) fn open_envelope_document(
     context: &EnvelopeContext,
     document: &EncryptedEnvelopeDocument,
-    key_provider: &dyn CredentialKeyProvider,
+    kek: &CredentialEncryptionKey,
 ) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
     validate_document_metadata(document, context)?;
-    let kek = key_provider.key(&document.key_id)?;
-    let dek = unwrap_current_dek(document, &kek, context)?;
+    validate_unwrapping_key(document, kek)?;
+    let dek = unwrap_current_dek(document, kek, context)?;
 
     let mut ciphertext = Zeroizing::new(document.ciphertext.clone());
     open(

--- a/crates/coral-app/src/credentials/encryption_tests.rs
+++ b/crates/coral-app/src/credentials/encryption_tests.rs
@@ -14,6 +14,7 @@ use super::encryption::{
     decrypt_credential_values, encrypt_credential_values, open_envelope_document,
     rewrap_credential_document, rewrap_envelope_document, seal_envelope_document,
 };
+use crate::encrypted_document::EncryptedEnvelopeDocument;
 use crate::sources::SourceName;
 use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
@@ -34,28 +35,28 @@ fn encrypt_decrypt_authenticates_context_and_redacts_key_debug() {
         CREDENTIAL_DOCUMENT_BINDING_VERSION
     );
     assert_eq!(
-        decrypt_credential_values(&workspace, &source, &document, &provider).expect("decrypt"),
+        decrypt_values_with_provider(&workspace, &source, &document, &provider).expect("decrypt"),
         values
     );
 
     let mut tampered = document.clone();
     *tampered.ciphertext.first_mut().expect("ciphertext byte") ^= 1;
-    decrypt_credential_values(&workspace, &source, &tampered, &provider)
+    decrypt_values_with_provider(&workspace, &source, &tampered, &provider)
         .expect_err("tampered ciphertext should fail");
     let mut tampered = document.clone();
     *tampered.wrapped_dek.first_mut().expect("wrapped DEK byte") ^= 1;
-    decrypt_credential_values(&workspace, &source, &tampered, &provider)
+    decrypt_values_with_provider(&workspace, &source, &tampered, &provider)
         .expect_err("tampered wrapped DEK should fail");
     let other_workspace = WorkspaceName::parse("other").expect("workspace");
-    decrypt_credential_values(&other_workspace, &source, &document, &provider)
+    decrypt_values_with_provider(&other_workspace, &source, &document, &provider)
         .expect_err("wrong workspace should fail");
     let other_source = SourceName::parse("slack").expect("source");
-    decrypt_credential_values(&workspace, &other_source, &document, &provider)
+    decrypt_values_with_provider(&workspace, &other_source, &document, &provider)
         .expect_err("wrong source should fail");
     let mismatch = StaticKeyProvider {
         key: CredentialEncryptionKey::from_static_bytes_for_test([8; 32]),
     };
-    decrypt_credential_values(&workspace, &source, &document, &mismatch)
+    decrypt_values_with_provider(&workspace, &source, &document, &mismatch)
         .expect_err("wrong key should fail");
 
     let debug = format!("{:?}", provider.key);
@@ -81,8 +82,9 @@ fn credential_document_aad_disambiguates_colon_bearing_identities() {
     )
     .expect("encrypt");
 
-    let error = decrypt_credential_values(&replay_workspace, &replay_source, &encrypted, &provider)
-        .expect_err("ambiguous colon-delimited identity should not decrypt");
+    let error =
+        decrypt_values_with_provider(&replay_workspace, &replay_source, &encrypted, &provider)
+            .expect_err("ambiguous colon-delimited identity should not decrypt");
 
     assert!(error.to_string().contains("open failed"));
 }
@@ -105,7 +107,7 @@ fn credential_document_rejects_tampered_nonces() {
     let mut tampered = encrypted.clone();
     *tampered.nonce.first_mut().expect("payload nonce") ^= 0x01;
     assert_open_failed(
-        &decrypt_credential_values(&workspace, &source, &tampered, &provider)
+        &decrypt_values_with_provider(&workspace, &source, &tampered, &provider)
             .expect_err("tampered payload nonce should fail authentication"),
     );
 
@@ -115,7 +117,7 @@ fn credential_document_rejects_tampered_nonces() {
         .first_mut()
         .expect("wrapped DEK nonce") ^= 0x01;
     assert_open_failed(
-        &decrypt_credential_values(&workspace, &source, &tampered, &provider)
+        &decrypt_values_with_provider(&workspace, &source, &tampered, &provider)
             .expect_err("tampered wrapped DEK nonce should fail authentication"),
     );
 }
@@ -170,7 +172,7 @@ fn credential_document_rejects_key_id_aad_mismatch_even_when_key_resolves() {
         .expect("mutated key id should resolve");
 
     assert_open_failed(
-        &decrypt_credential_values(&workspace, &source, &encrypted, &provider)
+        &decrypt_values_with_provider(&workspace, &source, &encrypted, &provider)
             .expect_err("mismatched key-id AAD should fail authentication"),
     );
 }
@@ -191,7 +193,7 @@ fn credential_document_rejects_binding_version_mismatch() {
     .expect("encrypt");
     encrypted.binding_version = CREDENTIAL_DOCUMENT_BINDING_VERSION + 1;
 
-    let error = decrypt_credential_values(&workspace, &source, &encrypted, &provider)
+    let error = decrypt_values_with_provider(&workspace, &source, &encrypted, &provider)
         .expect_err("unsupported binding version should fail");
 
     assert!(
@@ -229,7 +231,7 @@ fn decrypt_accepts_legacy_colon_delimited_dek_aad() {
     encrypted.wrapped_dek_nonce = legacy_nonce.to_vec();
 
     assert_eq!(
-        decrypt_credential_values(&workspace, &source, &encrypted, &provider)
+        decrypt_values_with_provider(&workspace, &source, &encrypted, &provider)
             .expect("legacy DEK AAD should decrypt"),
         values
     );
@@ -262,7 +264,7 @@ fn decrypt_accepts_legacy_length_prefixed_dek_aad() {
     encrypted.wrapped_dek_nonce = legacy_nonce.to_vec();
 
     assert_eq!(
-        decrypt_credential_values(&workspace, &source, &encrypted, &provider)
+        decrypt_values_with_provider(&workspace, &source, &encrypted, &provider)
             .expect("legacy length-prefixed DEK AAD should decrypt"),
         values
     );
@@ -313,7 +315,7 @@ fn credential_document_rewrap_changes_kek_without_reencrypting_payload() {
         "old KEK should not unwrap the rewrapped DEK"
     );
     assert_eq!(
-        decrypt_credential_values(&workspace, &source, &rewrapped, &rotating_provider)
+        decrypt_values_with_provider(&workspace, &source, &rewrapped, &rotating_provider)
             .expect("decrypt rewrapped"),
         values
     );
@@ -368,7 +370,7 @@ fn credential_v1_rewrap_migrates_to_v2_with_same_key() {
     assert_eq!(migrated.key_id, v1.key_id);
     assert_ne!(migrated.ciphertext, v1.ciphertext);
     assert_eq!(
-        decrypt_credential_values(&workspace, &source, &migrated, &provider)
+        decrypt_values_with_provider(&workspace, &source, &migrated, &provider)
             .expect("decrypt migrated credential"),
         values
     );
@@ -425,7 +427,7 @@ fn credential_document_rewrap_migrates_legacy_payload_aad() {
     assert_ne!(migrated.ciphertext, legacy.ciphertext);
     assert_ne!(migrated.nonce, legacy.nonce);
     assert_eq!(
-        decrypt_credential_values(&workspace, &source, &migrated, &rotating_provider)
+        decrypt_values_with_provider(&workspace, &source, &migrated, &rotating_provider)
             .expect("decrypt migrated document"),
         values
     );
@@ -509,7 +511,7 @@ fn shared_envelope_context_authenticates_open_and_rewrap() {
             .expect("seal envelope");
     assert_eq!(encrypted.binding_version, BINDING_VERSION);
     assert_eq!(
-        open_envelope_document(&context, &encrypted, &old_provider)
+        open_with_provider(&context, &encrypted, &old_provider)
             .expect("open envelope")
             .as_slice(),
         plaintext
@@ -521,13 +523,13 @@ fn shared_envelope_context_authenticates_open_and_rewrap() {
     )
     .expect("wrong envelope context");
     assert_open_failed(
-        &open_envelope_document(&wrong_context, &encrypted, &old_provider)
+        &open_with_provider(&wrong_context, &encrypted, &old_provider)
             .expect_err("wrong binding should fail authentication"),
     );
     let wrong_version =
         EnvelopeContext::new("test-envelope", 1, &["workspace", "document"]).expect("context");
     assert!(
-        open_envelope_document(&wrong_version, &encrypted, &old_provider)
+        open_with_provider(&wrong_version, &encrypted, &old_provider)
             .expect_err("wrong expected binding version should fail")
             .to_string()
             .contains("binding version 7 does not match context version 1")
@@ -539,7 +541,7 @@ fn shared_envelope_context_authenticates_open_and_rewrap() {
     let mut unsupported = encrypted.clone();
     unsupported.algorithm = "unsupported".to_string();
     assert!(
-        open_envelope_document(&context, &unsupported, &old_provider)
+        open_with_provider(&context, &unsupported, &old_provider)
             .expect_err("unsupported algorithm should fail")
             .to_string()
             .contains("unsupported envelope encryption algorithm")
@@ -553,7 +555,7 @@ fn shared_envelope_context_authenticates_open_and_rewrap() {
     )
     .expect("rebound context");
     assert_open_failed(
-        &open_envelope_document(&rebound_context, &rebound, &old_provider)
+        &open_with_provider(&rebound_context, &rebound, &old_provider)
             .expect_err("stored version must also bind the wrapped DEK"),
     );
 
@@ -566,7 +568,7 @@ fn shared_envelope_context_authenticates_open_and_rewrap() {
     assert_ne!(rewrapped.wrapped_dek, encrypted.wrapped_dek);
     assert_ne!(rewrapped.wrapped_dek_nonce, encrypted.wrapped_dek_nonce);
     assert_eq!(
-        open_envelope_document(&context, &rewrapped, &rotating_provider)
+        open_with_provider(&context, &rewrapped, &rotating_provider)
             .expect("open rewrapped envelope")
             .as_slice(),
         plaintext
@@ -659,10 +661,36 @@ fn decrypt_rejects_unknown_key_id() {
     .expect("encrypt");
     encrypted.key_id = "missing-key".to_string();
 
-    let error = decrypt_credential_values(&workspace, &source, &encrypted, &provider)
+    let error = decrypt_values_with_provider(&workspace, &source, &encrypted, &provider)
         .expect_err("missing KEK should fail");
 
     assert!(error.to_string().contains("missing test key"));
+}
+
+#[test]
+fn open_rejects_a_key_the_document_does_not_name() {
+    let workspace = WorkspaceName::parse("default").expect("workspace");
+    let source = SourceName::parse("github").expect("source");
+    let stored_key = CredentialEncryptionKey::from_static_bytes_for_test([43; 32]);
+    let other_key = CredentialEncryptionKey::from_static_bytes_for_test([47; 32]);
+    let provider = StaticKeyProvider {
+        key: stored_key.clone(),
+    };
+    let values = BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]);
+    let encrypted =
+        encrypt_credential_values(&workspace, &source, &values, &provider).expect("encrypt");
+
+    let error = decrypt_credential_values(&workspace, &source, &encrypted, &other_key)
+        .expect_err("a key the document does not name must be rejected");
+
+    assert!(
+        error.to_string().contains("does not match document key"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(
+        decrypt_credential_values(&workspace, &source, &encrypted, &stored_key).expect("decrypt"),
+        values
+    );
 }
 
 fn assert_open_failed(error: &CredentialsError) {
@@ -670,6 +698,27 @@ fn assert_open_failed(error: &CredentialsError) {
         error.to_string().contains("open failed"),
         "unexpected error: {error}"
     );
+}
+
+/// Resolve the KEK a document names, then decrypt with it.
+fn decrypt_values_with_provider(
+    workspace: &WorkspaceName,
+    source: &SourceName,
+    document: &EncryptedEnvelopeDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<BTreeMap<String, String>, CredentialsError> {
+    let kek = key_provider.key(&document.key_id)?;
+    decrypt_credential_values(workspace, source, document, &kek)
+}
+
+/// Resolve the KEK a document names, then open it.
+fn open_with_provider(
+    context: &EnvelopeContext,
+    document: &EncryptedEnvelopeDocument,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Zeroizing<Vec<u8>>, CredentialsError> {
+    let kek = key_provider.key(&document.key_id)?;
+    open_envelope_document(context, document, &kek)
 }
 
 fn local_file_key_provider(layout: &AppStateLayout) -> LocalFileCredentialKeyProvider {

--- a/crates/coral-app/src/identity/spec_document.rs
+++ b/crates/coral-app/src/identity/spec_document.rs
@@ -19,8 +19,8 @@ use zeroize::Zeroizing;
 
 use crate::credentials::CredentialsError;
 use crate::credentials::encryption::{
-    CredentialKeyProvider, ENVELOPE_DOCUMENT_ALGORITHM, EnvelopeContext, open_envelope_document,
-    rewrap_envelope_document, seal_envelope_document,
+    CredentialEncryptionKey, CredentialKeyProvider, ENVELOPE_DOCUMENT_ALGORITHM, EnvelopeContext,
+    open_envelope_document, rewrap_envelope_document, seal_envelope_document,
 };
 use crate::encrypted_document::EncryptedEnvelopeDocument;
 use crate::state::db::IdentitySpecKey;
@@ -63,13 +63,16 @@ pub(crate) fn encrypt_identity_spec_document(
 }
 
 /// Decrypt identity-spec setup inputs for the exact durable spec key.
+///
+/// Takes the stored KEK the document names, so reading installed material can neither
+/// create nor rotate key material.
 pub(crate) fn decrypt_identity_spec_document(
     key: &IdentitySpecKey,
     document: &EncryptedEnvelopeDocument,
-    key_provider: &dyn CredentialKeyProvider,
+    kek: &CredentialEncryptionKey,
 ) -> Result<BTreeMap<String, String>, CredentialsError> {
     let context = identity_spec_document_context(document.binding_version, key)?;
-    let plaintext = open_envelope_document(&context, document, key_provider)?;
+    let plaintext = open_envelope_document(&context, document, kek)?;
     let decoded: DecryptedIdentitySpecDocument = serde_json::from_slice(&plaintext)
         .map_err(|error| CredentialsError::Parse(error.to_string()))?;
     if decoded.version != IDENTITY_SPEC_DOCUMENT_VERSION {
@@ -209,7 +212,7 @@ mod tests {
                 .expect_err("credential must not open as identity-spec material"),
         );
         assert_open_failed(
-            &decrypt_credential_values(&workspace, &source, &spec, &provider)
+            &decrypt_credential_values(&workspace, &source, &spec, &provider.key)
                 .expect_err("identity-spec material must not open as credentials"),
         );
     }
@@ -309,7 +312,8 @@ mod tests {
         document: &EncryptedEnvelopeDocument,
         provider: &dyn CredentialKeyProvider,
     ) -> Result<BTreeMap<String, String>, CredentialsError> {
-        decrypt_identity_spec_document(key, document, provider)
+        let kek = provider.key(&document.key_id)?;
+        decrypt_identity_spec_document(key, document, &kek)
     }
 
     fn assert_open_failed(error: &CredentialsError) {

--- a/crates/coral-app/src/identity/spec_document.rs
+++ b/crates/coral-app/src/identity/spec_document.rs
@@ -39,6 +39,7 @@ struct PlaintextIdentitySpecDocument<'a> {
 }
 
 #[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 struct DecryptedIdentitySpecDocument {
     version: u32,
     values: BTreeMap<String, String>,
@@ -78,6 +79,16 @@ pub(crate) fn decrypt_identity_spec_document(
         )));
     }
     Ok(decoded.values)
+}
+
+#[cfg(test)]
+pub(crate) fn seal_identity_spec_plaintext_for_test(
+    key: &IdentitySpecKey,
+    plaintext: Vec<u8>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<EncryptedEnvelopeDocument, CredentialsError> {
+    let context = identity_spec_document_context(IDENTITY_SPEC_DOCUMENT_BINDING_VERSION, key)?;
+    seal_envelope_document(&context, Zeroizing::new(plaintext), key_provider)
 }
 
 /// Rewrap an identity-spec setup document after authenticating its exact durable key.

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -1,12 +1,21 @@
 //! Read and workspace-fallback behavior for installed identity specs.
 
+use std::collections::BTreeMap;
+use std::fmt;
 use std::sync::Arc;
 
 use coral_spec::{IdentityManifest, IdentitySpecType, parse_identity_manifest_yaml};
 
 use crate::bootstrap::AppError;
+use crate::credentials::CredentialsError;
+use crate::credentials::encryption::{CredentialEncryptionKey, CredentialKeyProvider};
+use crate::identity::decrypt_identity_spec_document;
+use crate::identity_specs::inputs::{
+    ResolvedIdentitySpecInputs, resolve_identity_spec_inputs_for_use,
+};
 use crate::state::db::{
-    CoralDb, CoralTx, DbError, DbRepos, IdentitySpecKey, IdentitySpecRecord, IdentitySpecScope,
+    CoralDb, CoralTx, DbError, DbRepos, IdentitySpecDocumentRecord, IdentitySpecId,
+    IdentitySpecKey, IdentitySpecRecord, IdentitySpecScope,
 };
 use crate::workspaces::WorkspaceName;
 
@@ -18,15 +27,55 @@ pub(crate) struct InstalledIdentitySpec {
     pub(crate) manifest: IdentityManifest,
 }
 
+/// One installed identity spec with its setup inputs resolved for use.
+pub(crate) struct ResolvedIdentitySpec {
+    pub(crate) spec: InstalledIdentitySpec,
+    pub(crate) inputs: ResolvedIdentitySpecInputs,
+}
+
+impl fmt::Debug for ResolvedIdentitySpec {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ResolvedIdentitySpec")
+            .field("key", &self.spec.key)
+            .field("inputs", &self.inputs)
+            .finish_non_exhaustive()
+    }
+}
+
+struct IdentitySpecUseSnapshot {
+    record: IdentitySpecRecord,
+    document: Option<IdentitySpecDocumentRecord>,
+}
+
+struct PinnedKeyProvider {
+    key: CredentialEncryptionKey,
+}
+
+impl CredentialKeyProvider for PinnedKeyProvider {
+    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        Err(CredentialsError::Crypto(
+            "active key access is not allowed while reading an identity spec".to_string(),
+        ))
+    }
+
+    fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+        (key_id == self.key.key_id())
+            .then(|| self.key.clone())
+            .ok_or_else(|| CredentialsError::Crypto("identity spec key id changed".to_string()))
+    }
+}
+
 /// Database-backed identity-spec read and resolution behavior.
 #[derive(Clone)]
 pub(crate) struct IdentitySpecManager {
     db: Arc<CoralDb>,
+    key_provider: Arc<dyn CredentialKeyProvider>,
 }
 
 impl IdentitySpecManager {
-    pub(crate) fn new(db: Arc<CoralDb>) -> Self {
-        Self { db }
+    pub(crate) fn new(db: Arc<CoralDb>, key_provider: Arc<dyn CredentialKeyProvider>) -> Self {
+        Self { db, key_provider }
     }
 
     /// Fetch one spec in exactly the requested scope, without fallback.
@@ -40,6 +89,28 @@ impl IdentitySpecManager {
     /// Fetch one global spec by name.
     pub(crate) async fn get_global(&self, name: &str) -> Result<InstalledIdentitySpec, AppError> {
         self.read_exact(&IdentitySpecKey::global(name)?).await
+    }
+
+    /// Fetch one exact spec and resolve its encrypted setup inputs for use.
+    pub(crate) async fn get_exact_for_use(
+        &self,
+        key: &IdentitySpecKey,
+    ) -> Result<ResolvedIdentitySpec, AppError> {
+        let mut tx = self.db.begin_read_snapshot().await?;
+        require_scope_workspace(&mut tx, key.scope()).await?;
+        let snapshot = read_use_snapshot(&mut tx, key).await?;
+        tx.commit().await?;
+        let snapshot = snapshot.ok_or_else(|| spec_not_found(key))?;
+        self.resolve_snapshot_for_use(snapshot).await
+    }
+
+    /// Fetch one global spec and resolve its encrypted setup inputs for use.
+    pub(crate) async fn get_global_for_use(
+        &self,
+        name: &str,
+    ) -> Result<ResolvedIdentitySpec, AppError> {
+        self.get_exact_for_use(&IdentitySpecKey::global(name)?)
+            .await
     }
 
     /// List specs in exactly one scope, without fallback.
@@ -95,6 +166,24 @@ impl IdentitySpecManager {
         convert_optional(record, &requested)
     }
 
+    /// Resolve a workspace spec with global fallback and decrypt the winning spec's inputs.
+    pub(crate) async fn resolve_for_workspace_for_use(
+        &self,
+        workspace: &WorkspaceName,
+        name: &str,
+    ) -> Result<ResolvedIdentitySpec, AppError> {
+        let requested = IdentitySpecKey::workspace(workspace.clone(), name)?;
+        let mut tx = self.db.begin_read_snapshot().await?;
+        require_workspace(&mut tx, workspace).await?;
+        let snapshot = match read_use_snapshot(&mut tx, &requested).await? {
+            some @ Some(_) => some,
+            None => read_use_snapshot(&mut tx, &IdentitySpecKey::global(name)?).await?,
+        };
+        tx.commit().await?;
+        let snapshot = snapshot.ok_or_else(|| spec_not_found(&requested))?;
+        self.resolve_snapshot_for_use(snapshot).await
+    }
+
     async fn read_exact(&self, key: &IdentitySpecKey) -> Result<InstalledIdentitySpec, AppError> {
         let mut tx = self.db.begin_read_snapshot().await?;
         require_scope_workspace(&mut tx, key.scope()).await?;
@@ -102,6 +191,48 @@ impl IdentitySpecManager {
         tx.commit().await?;
         convert_optional(record, key)
     }
+
+    async fn resolve_snapshot_for_use(
+        &self,
+        snapshot: IdentitySpecUseSnapshot,
+    ) -> Result<ResolvedIdentitySpec, AppError> {
+        let key_provider = Arc::clone(&self.key_provider);
+        run_blocking_identity_spec_operation(move || {
+            let IdentitySpecUseSnapshot { record, document } = snapshot;
+            let identity_spec_id = record.id.clone();
+            let spec = record_to_installed(record)?;
+            let material = decrypt_input_material(
+                &spec.key,
+                &identity_spec_id,
+                document,
+                key_provider.as_ref(),
+            )?;
+            let inputs =
+                resolve_identity_spec_inputs_for_use(&spec.key, &spec.manifest, &material)?;
+            Ok(ResolvedIdentitySpec { spec, inputs })
+        })
+        .await
+    }
+}
+
+async fn read_use_snapshot(
+    tx: &mut CoralTx<'_>,
+    key: &IdentitySpecKey,
+) -> Result<Option<IdentitySpecUseSnapshot>, DbError> {
+    let Some(record) = tx.identity_specs().get(key).await? else {
+        return Ok(None);
+    };
+    let document = tx.identity_spec_documents().get(&record.id).await?;
+    Ok(Some(IdentitySpecUseSnapshot { record, document }))
+}
+
+async fn run_blocking_identity_spec_operation<T, F>(operation: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, AppError> + Send + 'static,
+{
+    let span = tracing::Span::current();
+    tokio::task::spawn_blocking(move || span.in_scope(operation)).await?
 }
 
 async fn require_scope_workspace(
@@ -140,6 +271,44 @@ fn convert_records(
         .into_iter()
         .map(|record| record_to_installed(record).map_err(Into::into))
         .collect()
+}
+
+fn decrypt_input_material(
+    key: &IdentitySpecKey,
+    identity_spec_id: &IdentitySpecId,
+    document: Option<IdentitySpecDocumentRecord>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<BTreeMap<String, String>, AppError> {
+    let Some(document) = document else {
+        return Ok(BTreeMap::new());
+    };
+    let IdentitySpecDocumentRecord {
+        identity_spec_id: document_identity_spec_id,
+        envelope,
+        ..
+    } = document;
+    if document_identity_spec_id != *identity_spec_id {
+        return Err(corrupt_record(
+            key,
+            "encrypted setup document belongs to a different identity spec",
+        )
+        .into());
+    }
+    let resolved_key = key_provider
+        .key(&envelope.key_id)
+        .map_err(AppError::Credentials)?;
+    if resolved_key.key_id() != envelope.key_id {
+        return Err(AppError::Credentials(CredentialsError::Crypto(
+            "credential key provider returned a different key id".to_string(),
+        )));
+    }
+    let pinned_provider = PinnedKeyProvider { key: resolved_key };
+    decrypt_identity_spec_document(key, &envelope, &pinned_provider).map_err(|_error| {
+        AppError::from(corrupt_record(
+            key,
+            "encrypted setup document failed authentication or decoding",
+        ))
+    })
 }
 
 fn record_to_installed(record: IdentitySpecRecord) -> Result<InstalledIdentitySpec, DbError> {
@@ -210,17 +379,76 @@ fn scope_label(scope: &IdentitySpecScope) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread::{self, ThreadId};
 
-    use tempfile::tempdir;
+    use tempfile::{TempDir, tempdir};
 
     use super::{IdentitySpecManager, identity_type_label, record_to_installed, scope_label};
     use crate::bootstrap::AppError;
+    use crate::credentials::CredentialsError;
+    use crate::credentials::encryption::{CredentialEncryptionKey, CredentialKeyProvider};
+    use crate::encrypted_document::EncryptedEnvelopeDocument;
+    use crate::identity::{encrypt_identity_spec_document, seal_identity_spec_plaintext_for_test};
     use crate::state::db::{
-        CoralDb, DbRepos, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord, IdentitySpecScope,
-        ResolvedDatabaseConfig,
+        CoralDb, CoralTx, DbRepos, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord,
+        IdentitySpecScope, ResolvedDatabaseConfig,
     };
     use crate::workspaces::WorkspaceName;
+
+    struct WriteKeyProvider(CredentialEncryptionKey);
+
+    impl CredentialKeyProvider for WriteKeyProvider {
+        fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+            Ok(self.0.clone())
+        }
+
+        fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+            if key_id != self.0.key_id() {
+                return Err(CredentialsError::Crypto("unexpected test key".into()));
+            }
+            Ok(self.0.clone())
+        }
+    }
+
+    struct ReadKeyProvider {
+        key: CredentialEncryptionKey,
+        key_calls: AtomicUsize,
+        active_key_calls: AtomicUsize,
+        runtime_thread: ThreadId,
+    }
+
+    impl CredentialKeyProvider for ReadKeyProvider {
+        fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+            self.active_key_calls.fetch_add(1, Ordering::SeqCst);
+            Err(CredentialsError::Crypto("active key read".into()))
+        }
+
+        fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+            if key_id != self.key.key_id() {
+                return Err(CredentialsError::Crypto("unexpected test key".into()));
+            }
+            if thread::current().id() == self.runtime_thread {
+                return Err(CredentialsError::Crypto("key lookup ran on runtime".into()));
+            }
+            self.key_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.key.clone())
+        }
+    }
+
+    struct UnavailableKeyProvider;
+
+    impl CredentialKeyProvider for UnavailableKeyProvider {
+        fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+            Err(CredentialsError::Crypto("active key read".into()))
+        }
+
+        fn key(&self, _key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+            Err(CredentialsError::Unavailable("unavailable".into()))
+        }
+    }
 
     #[tokio::test]
     async fn manager_reads_resolves_and_rejects_corruption() {
@@ -256,7 +484,7 @@ mod tests {
                 .unwrap();
         }
         tx.commit().await.unwrap();
-        let manager = IdentitySpecManager::new(db);
+        let manager = IdentitySpecManager::new(db, read_key_provider(test_key()));
 
         assert_eq!(
             manager.get_global("alpha").await.unwrap().manifest.version,
@@ -317,6 +545,233 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn decrypts_inputs_for_the_actual_resolved_scope_without_rotating_keys() {
+        let fixture = encrypted_read_fixture().await;
+        let EncryptedReadFixture {
+            _temp,
+            db,
+            workspace,
+            reader,
+            manager,
+            keys,
+        } = fixture;
+        let EncryptedSpecKeys {
+            missing,
+            invalid,
+            invalid_version,
+            invalid_schema,
+            default_only,
+            ..
+        } = keys;
+
+        let global = manager.get_global_for_use("oauth").await.unwrap();
+        let shadow = manager
+            .resolve_for_workspace_for_use(&workspace, "oauth")
+            .await
+            .unwrap();
+        let fallback = manager
+            .resolve_for_workspace_for_use(&workspace, "fallback")
+            .await
+            .unwrap();
+        let default_only = manager.get_exact_for_use(&default_only).await.unwrap();
+        assert_eq!(
+            default_only.inputs.variables().get("TENANT").unwrap(),
+            "tenant-default"
+        );
+        let exact_fallback = IdentitySpecKey::workspace(workspace.clone(), "fallback").unwrap();
+        assert!(matches!(
+            manager.get_exact_for_use(&exact_fallback).await,
+            Err(AppError::IdentitySpecNotFound { .. })
+        ));
+        assert_resolved(&global, "global", "tenant-global", "global-secret");
+        assert_resolved(
+            &shadow,
+            "workspace:work",
+            "tenant-workspace",
+            "workspace-secret",
+        );
+        assert_resolved(&fallback, "global", "tenant-fallback", "fallback-secret");
+        let rendered = format!("{global:?}{shadow:?}{fallback:?}");
+        for value in [
+            "global-secret",
+            "workspace-secret",
+            "fallback-secret",
+            "tenant-global",
+            "tenant-workspace",
+            "tenant-fallback",
+        ] {
+            assert!(!rendered.contains(value));
+        }
+        assert!(matches!(
+            manager.get_exact_for_use(&missing).await,
+            Err(AppError::FailedPrecondition(detail)) if detail.contains("CLIENT_SECRET")
+        ));
+        for key in [&invalid, &invalid_version, &invalid_schema] {
+            let error = manager.get_exact_for_use(key).await.unwrap_err();
+            assert!(matches!(error, AppError::Database(_)));
+            for secret in ["invalid-secret", "version-secret", "schema-secret"] {
+                assert!(!format!("{error:?}").contains(secret));
+            }
+        }
+        assert_eq!(reader.key_calls.load(Ordering::SeqCst), 6);
+        assert_eq!(reader.active_key_calls.load(Ordering::SeqCst), 0);
+        let unavailable = IdentitySpecManager::new(db, Arc::new(UnavailableKeyProvider));
+        assert!(matches!(
+            unavailable.get_global_for_use("oauth").await,
+            Err(AppError::Credentials(CredentialsError::Unavailable(_)))
+        ));
+    }
+
+    struct EncryptedReadFixture {
+        _temp: TempDir,
+        db: Arc<CoralDb>,
+        workspace: WorkspaceName,
+        reader: Arc<ReadKeyProvider>,
+        manager: IdentitySpecManager,
+        keys: EncryptedSpecKeys,
+    }
+
+    struct EncryptedSpecKeys {
+        global: IdentitySpecKey,
+        workspace: IdentitySpecKey,
+        fallback: IdentitySpecKey,
+        missing: IdentitySpecKey,
+        invalid: IdentitySpecKey,
+        invalid_version: IdentitySpecKey,
+        invalid_schema: IdentitySpecKey,
+        default_only: IdentitySpecKey,
+    }
+
+    async fn encrypted_read_fixture() -> EncryptedReadFixture {
+        let temp = tempdir().unwrap();
+        let db = Arc::new(
+            CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+                path: temp.path().join("coral.sqlite"),
+            })
+            .await
+            .unwrap(),
+        );
+        db.migrate().await.unwrap();
+        let workspace = WorkspaceName::parse("work").unwrap();
+        let stored_key = test_key();
+        let writer = WriteKeyProvider(stored_key.clone());
+        let reader = Arc::new(ReadKeyProvider {
+            key: stored_key,
+            key_calls: AtomicUsize::new(0),
+            active_key_calls: AtomicUsize::new(0),
+            runtime_thread: thread::current().id(),
+        });
+        let keys = EncryptedSpecKeys {
+            global: IdentitySpecKey::global("oauth").unwrap(),
+            workspace: IdentitySpecKey::workspace(workspace.clone(), "oauth").unwrap(),
+            fallback: IdentitySpecKey::global("fallback").unwrap(),
+            missing: IdentitySpecKey::global("missing_inputs").unwrap(),
+            invalid: IdentitySpecKey::global("invalid_inputs").unwrap(),
+            invalid_version: IdentitySpecKey::global("invalid_version").unwrap(),
+            invalid_schema: IdentitySpecKey::global("invalid_schema").unwrap(),
+            default_only: IdentitySpecKey::global("default_only").unwrap(),
+        };
+        let mut tx = db.begin().await.unwrap();
+        tx.workspaces().ensure(workspace.as_str(), 1).await.unwrap();
+        seed_encrypted_specs(&mut tx, &keys, &writer).await;
+        tx.commit().await.unwrap();
+        let manager = IdentitySpecManager::new(Arc::clone(&db), reader.clone());
+        EncryptedReadFixture {
+            _temp: temp,
+            db,
+            workspace,
+            reader,
+            manager,
+            keys,
+        }
+    }
+
+    async fn seed_encrypted_specs(
+        tx: &mut CoralTx<'_>,
+        keys: &EncryptedSpecKeys,
+        writer: &WriteKeyProvider,
+    ) {
+        for (key, label, values) in [
+            (
+                &keys.global,
+                "global",
+                Some(BTreeMap::from([(
+                    "CLIENT_SECRET".to_string(),
+                    "global-secret".to_string(),
+                )])),
+            ),
+            (
+                &keys.workspace,
+                "workspace",
+                Some(BTreeMap::from([(
+                    "CLIENT_SECRET".to_string(),
+                    "workspace-secret".to_string(),
+                )])),
+            ),
+            (
+                &keys.fallback,
+                "fallback",
+                Some(BTreeMap::from([(
+                    "CLIENT_SECRET".to_string(),
+                    "fallback-secret".to_string(),
+                )])),
+            ),
+            (&keys.missing, "missing", None),
+            (
+                &keys.invalid,
+                "invalid",
+                Some(BTreeMap::from([(
+                    "UNDECLARED".to_string(),
+                    "invalid-secret".to_string(),
+                )])),
+            ),
+            (&keys.invalid_version, "invalid_version", None),
+            (&keys.invalid_schema, "invalid_schema", None),
+        ] {
+            seed_oauth(tx, key, label, values.as_ref(), writer).await;
+        }
+        seed_spec(
+            tx,
+            &keys.default_only,
+            default_only_manifest(keys.default_only.name()),
+        )
+        .await;
+        seed_invalid_documents(tx, keys, writer).await;
+    }
+
+    async fn seed_invalid_documents(
+        tx: &mut CoralTx<'_>,
+        keys: &EncryptedSpecKeys,
+        writer: &WriteKeyProvider,
+    ) {
+        for (key, plaintext) in [
+            (
+                &keys.invalid_version,
+                serde_json::json!({
+                    "version": 2,
+                    "values": {"CLIENT_SECRET": "version-secret"},
+                }),
+            ),
+            (
+                &keys.invalid_schema,
+                serde_json::json!({
+                    "version": 1,
+                    "values": {"CLIENT_SECRET": "schema-secret"},
+                    "unexpected": true,
+                }),
+            ),
+        ] {
+            let encrypted = seal_identity_spec_plaintext_for_test(
+                key,
+                serde_json::to_vec(&plaintext).unwrap(),
+                writer,
+            )
+            .unwrap();
+            seed_document(tx, key, encrypted).await;
+        }
+    }
+
     #[test]
     fn conversion_rejects_corrupt_manifest_and_metadata_drift() {
         let record = canonical_record();
@@ -369,6 +824,85 @@ mod tests {
             created_at_unix_nanos: 1,
             updated_at_unix_nanos: 1,
         }
+    }
+
+    async fn seed_oauth(
+        tx: &mut CoralTx<'_>,
+        key: &IdentitySpecKey,
+        label: &str,
+        values: Option<&BTreeMap<String, String>>,
+        key_provider: &dyn CredentialKeyProvider,
+    ) {
+        let yaml = oauth_manifest(key.name(), label);
+        seed_spec(tx, key, yaml).await;
+        let Some(values) = values else { return };
+        let encrypted = encrypt_identity_spec_document(key, values, key_provider).unwrap();
+        seed_document(tx, key, encrypted).await;
+    }
+
+    async fn seed_spec(tx: &mut CoralTx<'_>, key: &IdentitySpecKey, yaml: String) {
+        let parsed = coral_spec::parse_identity_manifest_yaml(&yaml).unwrap();
+        tx.identity_specs()
+            .upsert(key, &parsed, &yaml, 2)
+            .await
+            .unwrap();
+    }
+
+    async fn seed_document(
+        tx: &mut CoralTx<'_>,
+        key: &IdentitySpecKey,
+        encrypted: EncryptedEnvelopeDocument,
+    ) {
+        let identity_spec_id = tx
+            .identity_specs()
+            .get(key)
+            .await
+            .unwrap()
+            .expect("seeded identity spec")
+            .id;
+        tx.identity_spec_documents()
+            .upsert(&identity_spec_id, &encrypted, 3)
+            .await
+            .unwrap();
+    }
+
+    fn assert_resolved(
+        resolved: &super::ResolvedIdentitySpec,
+        scope: &str,
+        tenant: &str,
+        secret: &str,
+    ) {
+        assert_eq!(scope_label(resolved.spec.key.scope()), scope);
+        assert_eq!(resolved.inputs.variables().get("TENANT").unwrap(), tenant);
+        assert_eq!(
+            resolved.inputs.secrets().get("CLIENT_SECRET").unwrap(),
+            secret
+        );
+    }
+
+    fn test_key() -> CredentialEncryptionKey {
+        CredentialEncryptionKey::from_static_bytes_for_test([43; 32])
+    }
+
+    fn read_key_provider(key: CredentialEncryptionKey) -> Arc<dyn CredentialKeyProvider> {
+        Arc::new(ReadKeyProvider {
+            key,
+            key_calls: AtomicUsize::new(0),
+            active_key_calls: AtomicUsize::new(0),
+            runtime_thread: thread::current().id(),
+        })
+    }
+
+    fn oauth_manifest(name: &str, label: &str) -> String {
+        format!(
+            "kind: identity\nspec_version: 1\nname: {name}\nversion: {label}\ndescription: OAuth {label}\nissuer: issuer_{label}\ntype: oauth\naudience: {{host: provider.example.com}}\ninputs:\n  TENANT:\n    kind: variable\n    default: tenant-{label}\n  CLIENT_SECRET:\n    kind: secret\n    required: true\noauth:\n  method:\n    flow:\n      type: authorization_code\n      pkce: disabled\n    redirect_uri: http://127.0.0.1:53682/oauth/callback\n    endpoints:\n      authorization_url: https://provider.example.com/authorize\n      token_url: https://provider.example.com/token\n    client:\n      id:\n        input: TENANT\n      secret:\n        input: CLIENT_SECRET\n        transport: basic_auth\n"
+        )
+    }
+
+    fn default_only_manifest(name: &str) -> String {
+        format!(
+            "kind: identity\nspec_version: 1\nname: {name}\nversion: default\ndescription: default-only OAuth\nissuer: default\ntype: oauth\naudience: {{host: provider.example.com}}\ninputs:\n  TENANT:\n    kind: variable\n    default: tenant-default\noauth:\n  method:\n    flow: {{type: device_code}}\n    endpoints:\n      device_authorization_url: https://provider.example.com/device\n      token_url: https://provider.example.com/token\n    client:\n      id: {{input: TENANT}}\n"
+        )
     }
 
     fn assert_corrupt(record: IdentitySpecRecord) {

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -9,7 +9,7 @@ use coral_spec::{IdentityManifest, IdentitySpecType, parse_identity_manifest_yam
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialsError;
 use crate::credentials::encryption::{CredentialEncryptionKey, CredentialKeyProvider};
-use crate::identity::decrypt_identity_spec_document;
+use crate::identity::spec_document::decrypt_identity_spec_document;
 use crate::identity_specs::inputs::{
     ResolvedIdentitySpecInputs, resolve_identity_spec_inputs_for_use,
 };
@@ -391,7 +391,9 @@ mod tests {
     use crate::credentials::CredentialsError;
     use crate::credentials::encryption::{CredentialEncryptionKey, CredentialKeyProvider};
     use crate::encrypted_document::EncryptedEnvelopeDocument;
-    use crate::identity::{encrypt_identity_spec_document, seal_identity_spec_plaintext_for_test};
+    use crate::identity::spec_document::{
+        encrypt_identity_spec_document, seal_identity_spec_plaintext_for_test,
+    };
     use crate::state::db::{
         CoralDb, CoralTx, DbRepos, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord,
         IdentitySpecScope, ResolvedDatabaseConfig,

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -7,8 +7,7 @@ use std::sync::Arc;
 use coral_spec::{IdentityManifest, IdentitySpecType, parse_identity_manifest_yaml};
 
 use crate::bootstrap::AppError;
-use crate::credentials::CredentialsError;
-use crate::credentials::encryption::{CredentialEncryptionKey, CredentialKeyProvider};
+use crate::credentials::encryption::CredentialKeyProvider;
 use crate::identity::spec_document::decrypt_identity_spec_document;
 use crate::identity_specs::inputs::{
     ResolvedIdentitySpecInputs, resolve_identity_spec_inputs_for_use,
@@ -46,24 +45,6 @@ impl fmt::Debug for ResolvedIdentitySpec {
 struct IdentitySpecUseSnapshot {
     record: IdentitySpecRecord,
     document: Option<IdentitySpecDocumentRecord>,
-}
-
-struct PinnedKeyProvider {
-    key: CredentialEncryptionKey,
-}
-
-impl CredentialKeyProvider for PinnedKeyProvider {
-    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
-        Err(CredentialsError::Crypto(
-            "active key access is not allowed while reading an identity spec".to_string(),
-        ))
-    }
-
-    fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
-        (key_id == self.key.key_id())
-            .then(|| self.key.clone())
-            .ok_or_else(|| CredentialsError::Crypto("identity spec key id changed".to_string()))
-    }
 }
 
 /// Database-backed identity-spec read and resolution behavior.
@@ -294,16 +275,12 @@ fn decrypt_input_material(
         )
         .into());
     }
-    let resolved_key = key_provider
+    // Resolve the stored key first so an unavailable key provider stays a credential
+    // error; everything the envelope layer rejects afterward is stored-material fault.
+    let kek = key_provider
         .key(&envelope.key_id)
         .map_err(AppError::Credentials)?;
-    if resolved_key.key_id() != envelope.key_id {
-        return Err(AppError::Credentials(CredentialsError::Crypto(
-            "credential key provider returned a different key id".to_string(),
-        )));
-    }
-    let pinned_provider = PinnedKeyProvider { key: resolved_key };
-    decrypt_identity_spec_document(key, &envelope, &pinned_provider).map_err(|_error| {
+    decrypt_identity_spec_document(key, &envelope, &kek).map_err(|_error| {
         AppError::from(corrupt_record(
             key,
             "encrypted setup document failed authentication or decoding",

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -20,10 +20,6 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 pub(crate) use import::run_state_migrations;
-#[expect(
-    unused_imports,
-    reason = "identity persistence types are not yet wired to production consumers"
-)]
 pub(crate) use repositories::identity_specs::{
     IdentitySpecDocumentRecord, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord,
     IdentitySpecScope,

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -62,7 +62,6 @@ pub(crate) trait DbRepos: DbSession + Sized {
         IdentitySpecsRepo::new(self)
     }
 
-    #[cfg_attr(not(test), expect(dead_code, reason = "B2 wires production consumers"))]
     fn identity_spec_documents(&mut self) -> IdentitySpecDocumentsRepo<'_, Self> {
         IdentitySpecDocumentsRepo::new(self)
     }


### PR DESCRIPTION
## Intent

Resolve an installed identity spec and its encrypted setup document from one
coherent database snapshot, then decrypt and validate the winning spec inputs
without blocking the async runtime.

## What it enables

- Exact, global, and workspace-with-global-fallback reads that return runtime-ready
  identity-spec inputs.
- Authentication against the actual persisted spec key selected by fallback, so
  global material cannot be mistaken for workspace material.
- Stored-key reads without active-key lookup, rotation, rewrap, or mutation.
- Clear failure boundaries: unavailable key providers remain credential errors,
  while authenticated malformed or tampered stored documents become database
  corruption errors.
- Default input resolution, required-input preconditions, unknown-input rejection,
  and redacted debug output.

## Opening an envelope takes the key, not the provider

`open_envelope_document` previously took a `CredentialKeyProvider` — an interface
whose `active_key` **mints** key material, creating a key file on disk when none
exists. Opening a document needs no such authority, so the read path wrapped the
provider in a `PinnedKeyProvider` decorator whose `active_key` returned an error,
revoking at runtime a capability the signature had granted for no reason.

Opening now takes the `CredentialEncryptionKey` the document names. Sealing and
rewrapping still take the provider, because they genuinely need minting rights. A
read path can no longer create or rotate key material, enforced by the type rather
than by a guard each caller has to remember.

That also collapsed three scattered `key_id` equality checks into one assertion in
the envelope layer, which now reports a mismatched key precisely instead of as a
bare `AES-256-GCM open failed`.

## Usage examples

- `get_global_for_use("github")` resolves the global GitHub spec and its encrypted
  setup inputs.
- `resolve_for_workspace_for_use(&workspace, "github")` prefers a workspace override
  and otherwise authenticates the global fallback with the global spec key.
- `get_exact_for_use(&key)` performs no fallback and reports a missing exact scope
  directly.

## Validation

- `cargo nextest run -p coral-app -E 'test(credentials::encryption) or test(identity::spec_document) or test(identity_specs::)'` — 41 passed.
- `make rust-checks` — formatting, Clippy, 2,581 tests, and rustdoc passed.