### PR TITLE
feat(app): classify retryable transaction conflicts

### DIFF
--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -114,6 +114,9 @@ pub enum AppError {
     /// A required remote dependency was unavailable.
     #[error("unavailable: {0}")]
     Unavailable(String),
+    /// A database mutation conflicted with another transaction and may be retried.
+    #[error("unavailable: database transaction conflict; retry the request")]
+    RetryableTransactionConflict,
     /// The server exhausted a resource required to complete the request.
     #[error("resource exhausted: {0}")]
     ResourceExhausted(String),
@@ -168,6 +171,7 @@ impl From<DbError> for AppError {
             )),
             DbError::Io(error) => Self::Io(error),
             DbError::TomlDecode(error) => Self::TomlDecode(error),
+            DbError::RetryableTransactionConflict(_) => Self::RetryableTransactionConflict,
             DbError::Sqlx(error) => Self::Database(error.to_string()),
             DbError::Migration(error) => Self::Database(error.to_string()),
         }
@@ -325,7 +329,7 @@ fn app_code(error: &AppError) -> Code {
         | AppError::Credentials(CredentialsError::Parse(_) | CredentialsError::Unavailable(_)) => {
             Code::FailedPrecondition
         }
-        AppError::Unavailable(_) => Code::Unavailable,
+        AppError::Unavailable(_) | AppError::RetryableTransactionConflict => Code::Unavailable,
         AppError::ResourceExhausted(_) => Code::ResourceExhausted,
         AppError::Io(error) if error.kind() == std::io::ErrorKind::NotFound => Code::NotFound,
         AppError::Internal(_)
@@ -497,6 +501,14 @@ mod tests {
             "remote descriptor timed out".to_string(),
         ));
         assert_eq!(status.code(), Code::Unavailable);
+    }
+
+    #[test]
+    fn app_status_maps_retryable_database_conflicts_to_unavailable() {
+        let status = app_status(AppError::RetryableTransactionConflict);
+
+        assert_eq!(status.code(), Code::Unavailable);
+        assert!(status.message().contains("retry the request"));
     }
 
     #[test]

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -30,6 +30,15 @@ impl CoralDb {
         CoralTx::begin_read_snapshot(&self.backend).await
     }
 
+    /// Begin a transaction that detects conflicting concurrent writes.
+    #[expect(
+        dead_code,
+        reason = "the next stack layer wires identity-spec mutations"
+    )]
+    pub(crate) async fn begin_serializable(&self) -> Result<CoralTx<'_>, DbError> {
+        CoralTx::begin_serializable(&self.backend).await
+    }
+
     #[cfg_attr(
         not(test),
         expect(

--- a/crates/coral-app/src/state/db/error.rs
+++ b/crates/coral-app/src/state/db/error.rs
@@ -13,8 +13,10 @@ pub(crate) enum DbError {
     Io(#[from] std::io::Error),
     #[error(transparent)]
     TomlDecode(#[from] toml::de::Error),
+    #[error("retryable database transaction conflict: {0}")]
+    RetryableTransactionConflict(sqlx::Error),
     #[error(transparent)]
-    Sqlx(#[from] sqlx::Error),
+    Sqlx(sqlx::Error),
     #[error(transparent)]
     Migration(#[from] sqlx::migrate::MigrateError),
 }
@@ -28,8 +30,58 @@ impl DbError {
             | Self::MissingDatabaseParent(_)
             | Self::Io(_)
             | Self::TomlDecode(_)
+            | Self::RetryableTransactionConflict(_)
             | Self::Sqlx(_)
             | Self::Migration(_) => false,
         }
+    }
+}
+
+impl From<sqlx::Error> for DbError {
+    fn from(error: sqlx::Error) -> Self {
+        if is_retryable_transaction_conflict(&error) {
+            Self::RetryableTransactionConflict(error)
+        } else {
+            Self::Sqlx(error)
+        }
+    }
+}
+
+fn is_retryable_transaction_conflict(error: &sqlx::Error) -> bool {
+    let sqlx::Error::Database(database) = error else {
+        return false;
+    };
+    if let Some(postgres) = database.try_downcast_ref::<sqlx::postgres::PgDatabaseError>() {
+        return is_retryable_postgres_code(postgres.code());
+    }
+    database
+        .try_downcast_ref::<sqlx::sqlite::SqliteError>()
+        .and_then(|_| database.code())
+        .and_then(|code| code.parse::<i32>().ok())
+        .is_some_and(is_retryable_sqlite_code)
+}
+
+fn is_retryable_postgres_code(code: &str) -> bool {
+    matches!(code, "40001" | "40P01")
+}
+
+fn is_retryable_sqlite_code(extended_code: i32) -> bool {
+    matches!(extended_code & 0xff, 5 | 6)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_retryable_postgres_code, is_retryable_sqlite_code};
+
+    #[test]
+    fn classifies_retryable_backend_codes() {
+        for code in ["40001", "40P01"] {
+            assert!(is_retryable_postgres_code(code));
+        }
+        assert!(!is_retryable_postgres_code("23505"));
+        for code in [5, 6, 5 | (2 << 8), 6 | (3 << 8)] {
+            assert!(is_retryable_sqlite_code(code));
+        }
+        assert!(!is_retryable_sqlite_code(19));
     }
 }

--- a/crates/coral-app/src/state/db/transaction.rs
+++ b/crates/coral-app/src/state/db/transaction.rs
@@ -38,6 +38,18 @@ impl<'a> CoralTx<'a> {
         Ok(Self { backend })
     }
 
+    pub(super) async fn begin_serializable(backend: &'a CoralDbBackend) -> Result<Self, DbError> {
+        let backend = match backend {
+            CoralDbBackend::Sqlite(db) => CoralTxBackend::Sqlite(db.pool.begin().await?),
+            CoralDbBackend::Postgres(db) => CoralTxBackend::Postgres(
+                db.pool
+                    .begin_with("BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+                    .await?,
+            ),
+        };
+        Ok(Self { backend })
+    }
+
     pub(crate) async fn commit(self) -> Result<(), DbError> {
         match self.backend {
             CoralTxBackend::Sqlite(tx) => tx.commit().await?,

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -80,6 +80,7 @@ pub(crate) fn app_error_type(error: &AppError) -> &'static str {
         }
         AppError::CredentialRefresh(_) => "CREDENTIAL_REFRESH",
         AppError::Unavailable(_) => "UNAVAILABLE",
+        AppError::RetryableTransactionConflict => "DATABASE_TRANSACTION_CONFLICT",
         AppError::ResourceExhausted(_) => "RESOURCE_EXHAUSTED",
         AppError::Internal(_) => "INTERNAL",
         AppError::Io(_) => "IO",


### PR DESCRIPTION
## Intent

Give identity-spec mutation orchestration a backend-neutral way to detect and retry genuine concurrent transaction conflicts without retrying validation, corruption, credential, or constraint failures.

## What it enables

- PostgreSQL write transactions begin at `SERIALIZABLE` isolation in one statement.
- SQLite keeps its normal serializable deferred transaction behavior instead of globally serializing writers with `BEGIN IMMEDIATE`.
- PostgreSQL serialization failures and deadlocks, plus SQLite busy and locked errors including extended codes, map to one typed retryable database error.
- External callers receive a generic gRPC `Unavailable` response without driver details, while query telemetry retains a stable conflict category.
- Replay policy remains manager-owned; this layer deliberately does not add a generic transaction retry closure around arbitrary side effects.

## Usage examples

- `db.begin_serializable().await?` starts a transaction suitable for a manager-owned compare-and-swap mutation.
- `DbError::RetryableTransactionConflict(_)` converts to `AppError::RetryableTransactionConflict`, which callers may retry as a whole operation.
- Unique, foreign-key, corruption, pool, and credential failures remain non-retryable and preserve their existing classifications.

## Validation

- `cargo test --locked -p coral-app --lib retryable` — 2 passed.
- `make postgres-tests` — shared Postgres persistence, corruption, and server-startup contracts passed.
- `make rust-checks` — formatting, Clippy, 1,928 tests, and rustdoc passed; 4 tests skipped.