### PR TITLE
feat(app): manage identity spec mutations

### DIFF
--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -513,18 +513,56 @@ pub(crate) mod tests {
     };
     use crate::workspaces::WorkspaceName;
 
-    struct WriteKeyProvider(CredentialEncryptionKey);
+    struct TestKeyProvider {
+        active_key: CredentialEncryptionKey,
+        decryption_keys: Vec<CredentialEncryptionKey>,
+        blocking_thread_check: Option<ThreadId>,
+    }
 
-    impl CredentialKeyProvider for WriteKeyProvider {
+    impl TestKeyProvider {
+        fn new(active_key: CredentialEncryptionKey) -> Self {
+            Self {
+                active_key,
+                decryption_keys: Vec::new(),
+                blocking_thread_check: None,
+            }
+        }
+
+        fn requiring_blocking_access(
+            active_key: CredentialEncryptionKey,
+            decryption_keys: impl IntoIterator<Item = CredentialEncryptionKey>,
+        ) -> Self {
+            Self {
+                active_key,
+                decryption_keys: decryption_keys.into_iter().collect(),
+                blocking_thread_check: Some(thread::current().id()),
+            }
+        }
+
+        fn require_blocking_thread(&self) {
+            if let Some(runtime_thread) = self.blocking_thread_check {
+                assert_ne!(
+                    thread::current().id(),
+                    runtime_thread,
+                    "identity spec key access ran on the async runtime"
+                );
+            }
+        }
+    }
+
+    impl CredentialKeyProvider for TestKeyProvider {
         fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
-            Ok(self.0.clone())
+            self.require_blocking_thread();
+            Ok(self.active_key.clone())
         }
 
         fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
-            if key_id != self.0.key_id() {
-                return Err(CredentialsError::Crypto("unexpected test key".into()));
-            }
-            Ok(self.0.clone())
+            self.require_blocking_thread();
+            std::iter::once(&self.active_key)
+                .chain(&self.decryption_keys)
+                .find(|key| key.key_id() == key_id)
+                .cloned()
+                .ok_or_else(|| CredentialsError::Crypto("missing test key".to_string()))
         }
     }
 
@@ -565,41 +603,6 @@ pub(crate) mod tests {
         }
     }
 
-    struct MutationKeyProvider(Vec<CredentialEncryptionKey>, ThreadId);
-
-    impl MutationKeyProvider {
-        fn new(keys: Vec<CredentialEncryptionKey>) -> Self {
-            Self(keys, thread::current().id())
-        }
-
-        fn require_blocking_thread(&self) {
-            assert_ne!(
-                thread::current().id(),
-                self.1,
-                "identity spec key access ran on the async runtime"
-            );
-        }
-    }
-
-    impl CredentialKeyProvider for MutationKeyProvider {
-        fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
-            self.require_blocking_thread();
-            self.0
-                .last()
-                .cloned()
-                .ok_or_else(|| CredentialsError::Crypto("missing mutation key".to_string()))
-        }
-
-        fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
-            self.require_blocking_thread();
-            self.0
-                .iter()
-                .find(|key| key.key_id() == key_id)
-                .cloned()
-                .ok_or_else(|| CredentialsError::Crypto("missing mutation key".to_string()))
-        }
-    }
-
     #[expect(clippy::too_many_lines, reason = "shared backend mutation contract")]
     pub(crate) async fn assert_identity_spec_mutation_contract(db: &Arc<CoralDb>) {
         let suffix = uuid::Uuid::new_v4().simple().to_string();
@@ -612,7 +615,10 @@ pub(crate) mod tests {
         tx.commit().await.unwrap();
 
         let old_key = CredentialEncryptionKey::from_static_bytes_for_test([51; 32]);
-        let old_provider = Arc::new(MutationKeyProvider::new(vec![old_key.clone()]));
+        let old_provider = Arc::new(TestKeyProvider::requiring_blocking_access(
+            old_key.clone(),
+            [],
+        ));
         let manager = IdentitySpecManager::new(Arc::clone(db), old_provider);
         let (_, replaced) = mutate(
             &manager,
@@ -642,7 +648,10 @@ pub(crate) mod tests {
 
         let new_key = CredentialEncryptionKey::from_static_bytes_for_test([52; 32]);
         let new_key_id = new_key.key_id().to_string();
-        let rotating_provider = Arc::new(MutationKeyProvider::new(vec![old_key, new_key]));
+        let rotating_provider = Arc::new(TestKeyProvider::requiring_blocking_access(
+            new_key,
+            [old_key],
+        ));
         let manager = IdentitySpecManager::new(Arc::clone(db), rotating_provider.clone());
         assert!(
             mutate(
@@ -1028,7 +1037,7 @@ pub(crate) mod tests {
         db.migrate().await.unwrap();
         let workspace = WorkspaceName::parse("work").unwrap();
         let stored_key = test_key();
-        let writer = WriteKeyProvider(stored_key.clone());
+        let writer = TestKeyProvider::new(stored_key.clone());
         let reader = Arc::new(ReadKeyProvider {
             key: stored_key,
             key_calls: AtomicUsize::new(0),
@@ -1063,7 +1072,7 @@ pub(crate) mod tests {
     async fn seed_encrypted_specs(
         tx: &mut CoralTx<'_>,
         keys: &EncryptedSpecKeys,
-        writer: &WriteKeyProvider,
+        writer: &TestKeyProvider,
     ) {
         for (key, label, values) in [
             (
@@ -1116,7 +1125,7 @@ pub(crate) mod tests {
     async fn seed_invalid_documents(
         tx: &mut CoralTx<'_>,
         keys: &EncryptedSpecKeys,
-        writer: &WriteKeyProvider,
+        writer: &TestKeyProvider,
     ) {
         for (key, plaintext) in [
             (

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -8,15 +8,21 @@ use coral_spec::{IdentityManifest, IdentitySpecType, parse_identity_manifest_yam
 
 use crate::bootstrap::AppError;
 use crate::credentials::encryption::CredentialKeyProvider;
-use crate::identity::spec_document::decrypt_identity_spec_document;
+use crate::encrypted_document::EncryptedEnvelopeDocument;
+use crate::identity::spec_document::{
+    decrypt_identity_spec_document, encrypt_identity_spec_document,
+};
 use crate::identity_specs::inputs::{
-    ResolvedIdentitySpecInputs, resolve_identity_spec_inputs_for_use,
+    IdentitySpecInputValue, ResolvedIdentitySpecInputs, prepare_identity_spec_input_material,
+    resolve_identity_spec_inputs_for_use,
 };
 use crate::state::db::{
     CoralDb, CoralTx, DbError, DbRepos, IdentitySpecDocumentRecord, IdentitySpecId,
-    IdentitySpecKey, IdentitySpecRecord, IdentitySpecScope,
+    IdentitySpecKey, IdentitySpecRecord, IdentitySpecScope, now_unix_nanos_i64,
 };
 use crate::workspaces::WorkspaceName;
+
+const MAX_MUTATION_ATTEMPTS: usize = 8;
 
 /// One installed identity spec and the exact scope that supplied it.
 #[derive(Debug, Clone, PartialEq)]
@@ -47,16 +53,132 @@ struct IdentitySpecUseSnapshot {
     document: Option<IdentitySpecDocumentRecord>,
 }
 
+#[derive(Clone, PartialEq, Eq)]
+struct IdentitySpecMutationSnapshot {
+    record: Option<IdentitySpecRecord>,
+    document: Option<IdentitySpecDocumentRecord>,
+}
+
 /// Database-backed identity-spec read and resolution behavior.
 #[derive(Clone)]
 pub(crate) struct IdentitySpecManager {
     db: Arc<CoralDb>,
     key_provider: Arc<dyn CredentialKeyProvider>,
+    #[cfg(test)]
+    mutation_barrier: Option<Arc<tokio::sync::Barrier>>,
 }
 
 impl IdentitySpecManager {
     pub(crate) fn new(db: Arc<CoralDb>, key_provider: Arc<dyn CredentialKeyProvider>) -> Self {
-        Self { db, key_provider }
+        Self {
+            db,
+            key_provider,
+            #[cfg(test)]
+            mutation_barrier: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_mutation_barrier(mut self, barrier: Arc<tokio::sync::Barrier>) -> Self {
+        self.mutation_barrier = Some(barrier);
+        self
+    }
+
+    /// Install or replace one spec in exactly the selected scope.
+    pub(crate) async fn add_or_replace_exact(
+        &self,
+        scope: IdentitySpecScope,
+        manifest_yaml: &str,
+        input_values: Vec<IdentitySpecInputValue>,
+    ) -> Result<(InstalledIdentitySpec, bool), AppError> {
+        let manifest = Arc::new(
+            parse_identity_manifest_yaml(manifest_yaml)
+                .map_err(|error| AppError::InvalidInput(error.to_string()))?,
+        );
+        let key = IdentitySpecKey::new(scope, &manifest.name)?;
+        let input_values = Arc::new(input_values);
+        #[cfg(test)]
+        let mut mutation_barrier = self.mutation_barrier.clone();
+
+        for _ in 0..MAX_MUTATION_ATTEMPTS {
+            let snapshot = match self.load_mutation_snapshot(&key).await {
+                Ok(snapshot) => snapshot,
+                Err(AppError::RetryableTransactionConflict) => {
+                    tokio::task::yield_now().await;
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            #[cfg(test)]
+            if let Some(barrier) = mutation_barrier.take() {
+                barrier.wait().await;
+            }
+            let expected = snapshot.clone();
+            let prepare_key = key.clone();
+            let prepare_manifest = Arc::clone(&manifest);
+            let prepare_inputs = Arc::clone(&input_values);
+            let key_provider = Arc::clone(&self.key_provider);
+            let document = run_blocking_identity_spec_operation(move || {
+                let previous_identity_spec_id =
+                    snapshot.record.as_ref().map(|record| record.id.clone());
+                let previous = snapshot
+                    .record
+                    .clone()
+                    .map(record_to_installed)
+                    .transpose()?;
+                let previous_values = match previous_identity_spec_id {
+                    Some(identity_spec_id) => decrypt_input_material(
+                        &prepare_key,
+                        &identity_spec_id,
+                        snapshot.document,
+                        key_provider.as_ref(),
+                    )?,
+                    None => BTreeMap::new(),
+                };
+                let prepared = prepare_identity_spec_input_material(
+                    &prepare_key,
+                    prepare_manifest.as_ref(),
+                    previous.as_ref().map(|spec| &spec.manifest),
+                    &previous_values,
+                    prepare_inputs.as_slice(),
+                )?;
+                prepare_document_write(&prepare_key, prepared.values(), key_provider.as_ref())
+            })
+            .await?;
+            let replaced = expected.record.is_some();
+
+            match self
+                .try_write_mutation(
+                    &key,
+                    &expected,
+                    manifest.as_ref(),
+                    manifest_yaml,
+                    document.as_ref(),
+                )
+                .await
+            {
+                Ok(Some(installed)) => return Ok((installed, replaced)),
+                Ok(None) | Err(AppError::RetryableTransactionConflict) => {
+                    tokio::task::yield_now().await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Err(AppError::RetryableTransactionConflict)
+    }
+
+    /// Delete one spec in exactly the selected scope.
+    pub(crate) async fn delete_exact(&self, key: &IdentitySpecKey) -> Result<(), AppError> {
+        for _ in 0..MAX_MUTATION_ATTEMPTS {
+            match self.try_delete_exact(key).await {
+                Ok(()) => return Ok(()),
+                Err(AppError::RetryableTransactionConflict) => {
+                    tokio::task::yield_now().await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Err(AppError::RetryableTransactionConflict)
     }
 
     /// Fetch one spec in exactly the requested scope, without fallback.
@@ -173,6 +295,79 @@ impl IdentitySpecManager {
         convert_optional(record, key)
     }
 
+    async fn load_mutation_snapshot(
+        &self,
+        key: &IdentitySpecKey,
+    ) -> Result<IdentitySpecMutationSnapshot, AppError> {
+        let mut tx = self.db.begin_read_snapshot().await?;
+        let snapshot = load_mutation_snapshot(&mut tx, key).await?;
+        tx.commit().await?;
+        Ok(snapshot)
+    }
+
+    async fn try_write_mutation(
+        &self,
+        key: &IdentitySpecKey,
+        expected: &IdentitySpecMutationSnapshot,
+        manifest: &IdentityManifest,
+        manifest_yaml: &str,
+        document: Option<&EncryptedEnvelopeDocument>,
+    ) -> Result<Option<InstalledIdentitySpec>, AppError> {
+        let mut tx = self.db.begin_serializable().await?;
+        if load_mutation_snapshot(&mut tx, key).await? != *expected {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+        let now = now_unix_nanos_i64()?;
+        let result = async {
+            let record = tx
+                .identity_specs()
+                .upsert(key, manifest, manifest_yaml, now)
+                .await?;
+            match document {
+                Some(document) => {
+                    tx.identity_spec_documents()
+                        .upsert(&record.id, document, now)
+                        .await?;
+                }
+                None => {
+                    tx.identity_spec_documents().delete(&record.id).await?;
+                }
+            }
+            record_to_installed(record).map_err(Into::into)
+        }
+        .await;
+        match result {
+            Ok(installed) => {
+                tx.commit().await?;
+                Ok(Some(installed))
+            }
+            Err(error) => {
+                tx.rollback().await?;
+                Err(error)
+            }
+        }
+    }
+
+    async fn try_delete_exact(&self, key: &IdentitySpecKey) -> Result<(), AppError> {
+        let mut tx = self.db.begin_serializable().await?;
+        require_scope_workspace(&mut tx, key.scope()).await?;
+        match tx.identity_specs().delete(key).await {
+            Ok(true) => {
+                tx.commit().await?;
+                Ok(())
+            }
+            Ok(false) => {
+                tx.rollback().await?;
+                Err(spec_not_found(key))
+            }
+            Err(error) => {
+                tx.rollback().await?;
+                Err(error.into())
+            }
+        }
+    }
+
     async fn resolve_snapshot_for_use(
         &self,
         snapshot: IdentitySpecUseSnapshot,
@@ -205,6 +400,19 @@ async fn read_use_snapshot(
     };
     let document = tx.identity_spec_documents().get(&record.id).await?;
     Ok(Some(IdentitySpecUseSnapshot { record, document }))
+}
+
+async fn load_mutation_snapshot(
+    tx: &mut CoralTx<'_>,
+    key: &IdentitySpecKey,
+) -> Result<IdentitySpecMutationSnapshot, AppError> {
+    require_scope_workspace(tx, key.scope()).await?;
+    let record = tx.identity_specs().get(key).await?;
+    let document = match record.as_ref() {
+        Some(record) => tx.identity_spec_documents().get(&record.id).await?,
+        None => None,
+    };
+    Ok(IdentitySpecMutationSnapshot { record, document })
 }
 
 async fn run_blocking_identity_spec_operation<T, F>(operation: F) -> Result<T, AppError>
@@ -288,6 +496,19 @@ fn decrypt_input_material(
     })
 }
 
+fn prepare_document_write(
+    key: &IdentitySpecKey,
+    values: &BTreeMap<String, String>,
+    key_provider: &dyn CredentialKeyProvider,
+) -> Result<Option<EncryptedEnvelopeDocument>, AppError> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+    encrypt_identity_spec_document(key, values, key_provider)
+        .map(Some)
+        .map_err(Into::into)
+}
+
 fn record_to_installed(record: IdentitySpecRecord) -> Result<InstalledIdentitySpec, DbError> {
     let manifest = parse_identity_manifest_yaml(&record.manifest_yaml).map_err(|error| {
         corrupt_record(&record.key, &format!("manifest cannot be parsed: {error}"))
@@ -355,7 +576,7 @@ fn scope_label(scope: &IdentitySpecScope) -> String {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::collections::BTreeMap;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -371,9 +592,10 @@ mod tests {
     use crate::identity::spec_document::{
         encrypt_identity_spec_document, seal_identity_spec_plaintext_for_test,
     };
+    use crate::identity_specs::inputs::IdentitySpecInputValue;
     use crate::state::db::{
         CoralDb, CoralTx, DbRepos, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord,
-        IdentitySpecScope, ResolvedDatabaseConfig,
+        IdentitySpecScope, ResolvedDatabaseConfig, set_identity_spec_document_version,
     };
     use crate::workspaces::WorkspaceName;
 
@@ -427,6 +649,255 @@ mod tests {
         fn key(&self, _key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
             Err(CredentialsError::Unavailable("unavailable".into()))
         }
+    }
+
+    struct MutationKeyProvider(Vec<CredentialEncryptionKey>, ThreadId);
+
+    impl MutationKeyProvider {
+        fn new(keys: Vec<CredentialEncryptionKey>) -> Self {
+            Self(keys, thread::current().id())
+        }
+
+        fn require_blocking_thread(&self) {
+            assert_ne!(
+                thread::current().id(),
+                self.1,
+                "identity spec key access ran on the async runtime"
+            );
+        }
+    }
+
+    impl CredentialKeyProvider for MutationKeyProvider {
+        fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+            self.require_blocking_thread();
+            self.0
+                .last()
+                .cloned()
+                .ok_or_else(|| CredentialsError::Crypto("missing mutation key".to_string()))
+        }
+
+        fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+            self.require_blocking_thread();
+            self.0
+                .iter()
+                .find(|key| key.key_id() == key_id)
+                .cloned()
+                .ok_or_else(|| CredentialsError::Crypto("missing mutation key".to_string()))
+        }
+    }
+
+    #[expect(clippy::too_many_lines, reason = "shared backend mutation contract")]
+    pub(crate) async fn assert_identity_spec_mutation_contract(db: &Arc<CoralDb>) {
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let workspace = WorkspaceName::parse(&format!("mutation{suffix}")).unwrap();
+        let name = format!("mutation_{suffix}");
+        let global_key = IdentitySpecKey::global(&name).unwrap();
+        let workspace_key = IdentitySpecKey::workspace(workspace.clone(), &name).unwrap();
+        let mut tx = db.begin().await.unwrap();
+        tx.workspaces().ensure(workspace.as_str(), 1).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let old_key = CredentialEncryptionKey::from_static_bytes_for_test([51; 32]);
+        let old_provider = Arc::new(MutationKeyProvider::new(vec![old_key.clone()]));
+        let manager = IdentitySpecManager::new(Arc::clone(db), old_provider);
+        let (_, replaced) = mutate(
+            &manager,
+            IdentitySpecScope::global(),
+            &name,
+            "v1",
+            &[("CLIENT_SECRET", "global-secret")],
+        )
+        .await;
+        assert!(!replaced);
+        mutate(
+            &manager,
+            IdentitySpecScope::workspace(workspace.clone()),
+            &name,
+            "workspace",
+            &[("CLIENT_SECRET", "workspace-secret")],
+        )
+        .await;
+        assert_exact(&manager, &global_key, "tenant-v1", "global-secret").await;
+        assert_exact(
+            &manager,
+            &workspace_key,
+            "tenant-workspace",
+            "workspace-secret",
+        )
+        .await;
+
+        let new_key = CredentialEncryptionKey::from_static_bytes_for_test([52; 32]);
+        let new_key_id = new_key.key_id().to_string();
+        let rotating_provider = Arc::new(MutationKeyProvider::new(vec![old_key, new_key]));
+        let manager = IdentitySpecManager::new(Arc::clone(db), rotating_provider.clone());
+        assert!(
+            mutate(&manager, IdentitySpecScope::global(), &name, "v2", &[],)
+                .await
+                .1
+        );
+        assert_exact(&manager, &global_key, "tenant-v2", "global-secret").await;
+        assert_eq!(
+            manager
+                .load_mutation_snapshot(&global_key)
+                .await
+                .unwrap()
+                .document
+                .unwrap()
+                .envelope
+                .key_id,
+            new_key_id
+        );
+
+        let mut tx = db.begin().await.unwrap();
+        let global_id = tx
+            .identity_specs()
+            .get(&global_key)
+            .await
+            .unwrap()
+            .expect("global spec exists")
+            .id;
+        set_identity_spec_document_version(&mut tx, &global_id, i64::MAX).await;
+        tx.commit().await.unwrap();
+        let before = manager.load_mutation_snapshot(&global_key).await.unwrap();
+        let overflow_secret = "overflow-secret-must-not-leak";
+        let error = manager
+            .add_or_replace_exact(
+                IdentitySpecScope::global(),
+                &oauth_manifest(&name, "overflow"),
+                vec![IdentitySpecInputValue::new(
+                    "CLIENT_SECRET",
+                    overflow_secret,
+                )],
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, AppError::FailedPrecondition(_)));
+        assert!(!format!("{error:?}").contains(overflow_secret));
+        assert!(manager.load_mutation_snapshot(&global_key).await.unwrap() == before);
+
+        let global_before_delete = manager.load_mutation_snapshot(&global_key).await.unwrap();
+        manager.delete_exact(&workspace_key).await.unwrap();
+        let deleted = manager
+            .load_mutation_snapshot(&workspace_key)
+            .await
+            .unwrap();
+        assert!(deleted.record.is_none() && deleted.document.is_none());
+        assert!(manager.load_mutation_snapshot(&global_key).await.unwrap() == global_before_delete);
+        assert!(matches!(
+            manager.delete_exact(&workspace_key).await,
+            Err(AppError::IdentitySpecNotFound { .. })
+        ));
+
+        let missing = WorkspaceName::parse(&format!("missing{suffix}")).unwrap();
+        let missing_key = IdentitySpecKey::workspace(missing.clone(), &name).unwrap();
+        assert!(matches!(
+            manager
+                .add_or_replace_exact(
+                    IdentitySpecScope::workspace(missing),
+                    &manifest(&name, "missing"),
+                    vec![],
+                )
+                .await,
+            Err(AppError::WorkspaceNotFound(_))
+        ));
+        assert!(matches!(
+            manager.delete_exact(&missing_key).await,
+            Err(AppError::WorkspaceNotFound(_))
+        ));
+
+        assert_disjoint_replacements_converge(db, &manager, &suffix).await;
+        manager
+            .add_or_replace_exact(
+                IdentitySpecScope::global(),
+                &manifest(&name, "fixed"),
+                vec![],
+            )
+            .await
+            .unwrap();
+        let empty = manager.load_mutation_snapshot(&global_key).await.unwrap();
+        assert!(empty.document.is_none());
+        assert_eq!(
+            record_to_installed(empty.record.unwrap())
+                .unwrap()
+                .manifest
+                .version,
+            "fixed"
+        );
+    }
+
+    async fn mutate(
+        manager: &IdentitySpecManager,
+        scope: IdentitySpecScope,
+        name: &str,
+        label: &str,
+        values: &[(&str, &str)],
+    ) -> (super::InstalledIdentitySpec, bool) {
+        manager
+            .add_or_replace_exact(
+                scope,
+                &oauth_manifest(name, label),
+                values
+                    .iter()
+                    .map(|(key, value)| IdentitySpecInputValue::new(*key, *value))
+                    .collect(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn assert_exact(
+        manager: &IdentitySpecManager,
+        key: &IdentitySpecKey,
+        tenant: &str,
+        secret: &str,
+    ) {
+        let resolved = manager.get_exact_for_use(key).await.unwrap();
+        assert_eq!(resolved.inputs.variables().get("TENANT").unwrap(), tenant);
+        assert_eq!(
+            resolved.inputs.secrets().get("CLIENT_SECRET").unwrap(),
+            secret
+        );
+    }
+
+    async fn assert_disjoint_replacements_converge(
+        db: &Arc<CoralDb>,
+        manager: &IdentitySpecManager,
+        suffix: &str,
+    ) {
+        let name = format!("concurrent_{suffix}");
+        let key = IdentitySpecKey::global(&name).unwrap();
+        mutate(
+            manager,
+            IdentitySpecScope::global(),
+            &name,
+            "race",
+            &[("TENANT", "before"), ("CLIENT_SECRET", "before")],
+        )
+        .await;
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let left = IdentitySpecManager::new(Arc::clone(db), Arc::clone(&manager.key_provider))
+            .with_mutation_barrier(Arc::clone(&barrier));
+        let right = IdentitySpecManager::new(Arc::clone(db), Arc::clone(&manager.key_provider))
+            .with_mutation_barrier(barrier);
+        let manifest = oauth_manifest(&name, "race");
+        let (left, right) = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            tokio::join!(
+                left.add_or_replace_exact(
+                    IdentitySpecScope::global(),
+                    &manifest,
+                    vec![IdentitySpecInputValue::new("TENANT", "left")],
+                ),
+                right.add_or_replace_exact(
+                    IdentitySpecScope::global(),
+                    &manifest,
+                    vec![IdentitySpecInputValue::new("CLIENT_SECRET", "right")],
+                )
+            )
+        })
+        .await
+        .expect("concurrent identity spec replacements timed out");
+        assert!(left.unwrap().1 && right.unwrap().1);
+        assert_exact(manager, &key, "left", "right").await;
     }
 
     #[tokio::test]

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -16,9 +16,11 @@ use crate::identity_specs::inputs::{
     IdentitySpecInputValue, ResolvedIdentitySpecInputs, prepare_identity_spec_input_material,
     resolve_identity_spec_inputs_for_use,
 };
+#[cfg(test)]
+use crate::state::db::IdentitySpecMutationSnapshot;
 use crate::state::db::{
     CoralDb, CoralTx, DbError, DbRepos, IdentitySpecDocumentRecord, IdentitySpecId,
-    IdentitySpecKey, IdentitySpecRecord, IdentitySpecScope, now_unix_nanos_i64,
+    IdentitySpecKey, IdentitySpecRecord, IdentitySpecScope,
 };
 use crate::workspaces::WorkspaceName;
 
@@ -50,12 +52,6 @@ impl fmt::Debug for ResolvedIdentitySpec {
 
 struct IdentitySpecUseSnapshot {
     record: IdentitySpecRecord,
-    document: Option<IdentitySpecDocumentRecord>,
-}
-
-#[derive(Clone, PartialEq, Eq)]
-struct IdentitySpecMutationSnapshot {
-    record: Option<IdentitySpecRecord>,
     document: Option<IdentitySpecDocumentRecord>,
 }
 
@@ -101,64 +97,59 @@ impl IdentitySpecManager {
         let mut mutation_barrier = self.mutation_barrier.clone();
 
         for _ in 0..MAX_MUTATION_ATTEMPTS {
-            let snapshot = match self.load_mutation_snapshot(&key).await {
-                Ok(snapshot) => snapshot,
-                Err(AppError::RetryableTransactionConflict) => {
-                    tokio::task::yield_now().await;
-                    continue;
-                }
-                Err(error) => return Err(error),
-            };
             #[cfg(test)]
-            if let Some(barrier) = mutation_barrier.take() {
-                barrier.wait().await;
-            }
-            let expected = snapshot.clone();
+            let barrier = mutation_barrier.take();
             let prepare_key = key.clone();
             let prepare_manifest = Arc::clone(&manifest);
             let prepare_inputs = Arc::clone(&input_values);
             let key_provider = Arc::clone(&self.key_provider);
-            let document = run_blocking_identity_spec_operation(move || {
-                let previous_identity_spec_id =
-                    snapshot.record.as_ref().map(|record| record.id.clone());
-                let previous = snapshot
-                    .record
-                    .clone()
-                    .map(record_to_installed)
-                    .transpose()?;
-                let previous_values = match previous_identity_spec_id {
-                    Some(identity_spec_id) => decrypt_input_material(
-                        &prepare_key,
-                        &identity_spec_id,
-                        snapshot.document,
-                        key_provider.as_ref(),
-                    )?,
-                    None => BTreeMap::new(),
-                };
-                let prepared = prepare_identity_spec_input_material(
-                    &prepare_key,
-                    prepare_manifest.as_ref(),
-                    previous.as_ref().map(|spec| &spec.manifest),
-                    &previous_values,
-                    prepare_inputs.as_slice(),
-                )?;
-                prepare_document_write(&prepare_key, prepared.values(), key_provider.as_ref())
-            })
-            .await?;
-            let replaced = expected.record.is_some();
-
-            match self
-                .try_write_mutation(
+            let result = self
+                .db
+                .identity_spec_state()
+                .add_or_replace_exact(
                     &key,
-                    &expected,
                     manifest.as_ref(),
                     manifest_yaml,
-                    document.as_ref(),
+                    move |snapshot| async move {
+                        #[cfg(test)]
+                        if let Some(barrier) = barrier {
+                            barrier.wait().await;
+                        }
+                        run_blocking_identity_spec_operation(move || {
+                            let previous_identity_spec_id =
+                                snapshot.record.as_ref().map(|record| record.id.clone());
+                            let previous = snapshot.record.map(record_to_installed).transpose()?;
+                            let previous_values = match previous_identity_spec_id {
+                                Some(identity_spec_id) => decrypt_input_material(
+                                    &prepare_key,
+                                    &identity_spec_id,
+                                    snapshot.document,
+                                    key_provider.as_ref(),
+                                )?,
+                                None => BTreeMap::new(),
+                            };
+                            let prepared = prepare_identity_spec_input_material(
+                                &prepare_key,
+                                prepare_manifest.as_ref(),
+                                previous.as_ref().map(|spec| &spec.manifest),
+                                &previous_values,
+                                prepare_inputs.as_slice(),
+                            )?;
+                            prepare_document_write(
+                                &prepare_key,
+                                prepared.values(),
+                                key_provider.as_ref(),
+                            )
+                        })
+                        .await
+                    },
                 )
-                .await
-            {
-                Ok(Some(installed)) => return Ok((installed, replaced)),
-                Ok(None) | Err(AppError::RetryableTransactionConflict) => {
+                .await;
+            match result {
+                Ok((record, replaced)) => {
+                    return Ok((record_to_installed(record)?, replaced));
+                }
+                Err(AppError::RetryableTransactionConflict) => {
                     tokio::task::yield_now().await;
                 }
                 Err(error) => return Err(error),
@@ -170,8 +161,9 @@ impl IdentitySpecManager {
     /// Delete one spec in exactly the selected scope.
     pub(crate) async fn delete_exact(&self, key: &IdentitySpecKey) -> Result<(), AppError> {
         for _ in 0..MAX_MUTATION_ATTEMPTS {
-            match self.try_delete_exact(key).await {
-                Ok(()) => return Ok(()),
+            match self.db.identity_spec_state().delete_exact(key).await {
+                Ok(true) => return Ok(()),
+                Ok(false) => return Err(spec_not_found(key)),
                 Err(AppError::RetryableTransactionConflict) => {
                     tokio::task::yield_now().await;
                 }
@@ -295,77 +287,12 @@ impl IdentitySpecManager {
         convert_optional(record, key)
     }
 
+    #[cfg(test)]
     async fn load_mutation_snapshot(
         &self,
         key: &IdentitySpecKey,
     ) -> Result<IdentitySpecMutationSnapshot, AppError> {
-        let mut tx = self.db.begin_read_snapshot().await?;
-        let snapshot = load_mutation_snapshot(&mut tx, key).await?;
-        tx.commit().await?;
-        Ok(snapshot)
-    }
-
-    async fn try_write_mutation(
-        &self,
-        key: &IdentitySpecKey,
-        expected: &IdentitySpecMutationSnapshot,
-        manifest: &IdentityManifest,
-        manifest_yaml: &str,
-        document: Option<&EncryptedEnvelopeDocument>,
-    ) -> Result<Option<InstalledIdentitySpec>, AppError> {
-        let mut tx = self.db.begin_serializable().await?;
-        if load_mutation_snapshot(&mut tx, key).await? != *expected {
-            tx.rollback().await?;
-            return Ok(None);
-        }
-        let now = now_unix_nanos_i64()?;
-        let result = async {
-            let record = tx
-                .identity_specs()
-                .upsert(key, manifest, manifest_yaml, now)
-                .await?;
-            match document {
-                Some(document) => {
-                    tx.identity_spec_documents()
-                        .upsert(&record.id, document, now)
-                        .await?;
-                }
-                None => {
-                    tx.identity_spec_documents().delete(&record.id).await?;
-                }
-            }
-            record_to_installed(record).map_err(Into::into)
-        }
-        .await;
-        match result {
-            Ok(installed) => {
-                tx.commit().await?;
-                Ok(Some(installed))
-            }
-            Err(error) => {
-                tx.rollback().await?;
-                Err(error)
-            }
-        }
-    }
-
-    async fn try_delete_exact(&self, key: &IdentitySpecKey) -> Result<(), AppError> {
-        let mut tx = self.db.begin_serializable().await?;
-        require_scope_workspace(&mut tx, key.scope()).await?;
-        match tx.identity_specs().delete(key).await {
-            Ok(true) => {
-                tx.commit().await?;
-                Ok(())
-            }
-            Ok(false) => {
-                tx.rollback().await?;
-                Err(spec_not_found(key))
-            }
-            Err(error) => {
-                tx.rollback().await?;
-                Err(error.into())
-            }
-        }
+        self.db.identity_spec_state().load_exact(key).await
     }
 
     async fn resolve_snapshot_for_use(
@@ -400,19 +327,6 @@ async fn read_use_snapshot(
     };
     let document = tx.identity_spec_documents().get(&record.id).await?;
     Ok(Some(IdentitySpecUseSnapshot { record, document }))
-}
-
-async fn load_mutation_snapshot(
-    tx: &mut CoralTx<'_>,
-    key: &IdentitySpecKey,
-) -> Result<IdentitySpecMutationSnapshot, AppError> {
-    require_scope_workspace(tx, key.scope()).await?;
-    let record = tx.identity_specs().get(key).await?;
-    let document = match record.as_ref() {
-        Some(record) => tx.identity_spec_documents().get(&record.id).await?,
-        None => None,
-    };
-    Ok(IdentitySpecMutationSnapshot { record, document })
 }
 
 async fn run_blocking_identity_spec_operation<T, F>(operation: F) -> Result<T, AppError>

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -731,9 +731,15 @@ pub(crate) mod tests {
         let rotating_provider = Arc::new(MutationKeyProvider::new(vec![old_key, new_key]));
         let manager = IdentitySpecManager::new(Arc::clone(db), rotating_provider.clone());
         assert!(
-            mutate(&manager, IdentitySpecScope::global(), &name, "v2", &[],)
-                .await
-                .1
+            mutate(
+                &manager,
+                IdentitySpecScope::global(),
+                &name,
+                "v2",
+                &[("CLIENT_SECRET", "global-secret")],
+            )
+            .await
+            .1
         );
         assert_exact(&manager, &global_key, "tenant-v2", "global-secret").await;
         assert_eq!(
@@ -885,7 +891,10 @@ pub(crate) mod tests {
                 left.add_or_replace_exact(
                     IdentitySpecScope::global(),
                     &manifest,
-                    vec![IdentitySpecInputValue::new("TENANT", "left")],
+                    vec![
+                        IdentitySpecInputValue::new("TENANT", "left"),
+                        IdentitySpecInputValue::new("CLIENT_SECRET", "right"),
+                    ],
                 ),
                 right.add_or_replace_exact(
                     IdentitySpecScope::global(),

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -31,10 +31,6 @@ impl CoralDb {
     }
 
     /// Begin a transaction that detects conflicting concurrent writes.
-    #[expect(
-        dead_code,
-        reason = "the next stack layer wires identity-spec mutations"
-    )]
     pub(crate) async fn begin_serializable(&self) -> Result<CoralTx<'_>, DbError> {
         CoralTx::begin_serializable(&self.backend).await
     }

--- a/crates/coral-app/src/state/db/identity_spec_state.rs
+++ b/crates/coral-app/src/state/db/identity_spec_state.rs
@@ -1,0 +1,134 @@
+use std::future::Future;
+
+use coral_spec::IdentityManifest;
+
+use super::{
+    CoralDb, CoralTx, DbRepos, IdentitySpecDocumentRecord, IdentitySpecKey, IdentitySpecRecord,
+    IdentitySpecScope, now_unix_nanos_i64,
+};
+use crate::bootstrap::AppError;
+use crate::encrypted_document::EncryptedEnvelopeDocument;
+
+pub(crate) struct IdentitySpecState<'a> {
+    db: &'a CoralDb,
+}
+
+#[derive(PartialEq, Eq)]
+pub(crate) struct IdentitySpecMutationSnapshot {
+    pub(crate) record: Option<IdentitySpecRecord>,
+    pub(crate) document: Option<IdentitySpecDocumentRecord>,
+}
+
+impl CoralDb {
+    pub(crate) fn identity_spec_state(&self) -> IdentitySpecState<'_> {
+        IdentitySpecState { db: self }
+    }
+}
+
+impl IdentitySpecState<'_> {
+    pub(crate) async fn add_or_replace_exact<F, Fut>(
+        &self,
+        key: &IdentitySpecKey,
+        manifest: &IdentityManifest,
+        manifest_yaml: &str,
+        prepare_document: F,
+    ) -> Result<(IdentitySpecRecord, bool), AppError>
+    where
+        F: FnOnce(IdentitySpecMutationSnapshot) -> Fut,
+        Fut: Future<Output = Result<Option<EncryptedEnvelopeDocument>, AppError>>,
+    {
+        let mut tx = self.db.begin_serializable().await?;
+        let result = async {
+            require_scope_workspace(&mut tx, key.scope()).await?;
+            let snapshot = load_mutation_snapshot(&mut tx, key).await?;
+            let replaced = snapshot.record.is_some();
+            let document = prepare_document(snapshot).await?;
+            let now = now_unix_nanos_i64()?;
+            let record = tx
+                .identity_specs()
+                .upsert(key, manifest, manifest_yaml, now)
+                .await?;
+            match document.as_ref() {
+                Some(document) => {
+                    tx.identity_spec_documents()
+                        .upsert(&record.id, document, now)
+                        .await?;
+                }
+                None => {
+                    tx.identity_spec_documents().delete(&record.id).await?;
+                }
+            }
+            Ok((record, replaced))
+        }
+        .await;
+        match result {
+            Ok(output) => {
+                tx.commit().await?;
+                Ok(output)
+            }
+            Err(error) => {
+                tx.rollback().await?;
+                Err(error)
+            }
+        }
+    }
+
+    pub(crate) async fn delete_exact(&self, key: &IdentitySpecKey) -> Result<bool, AppError> {
+        let mut tx = self.db.begin_serializable().await?;
+        let result = async {
+            require_scope_workspace(&mut tx, key.scope()).await?;
+            tx.identity_specs().delete(key).await.map_err(Into::into)
+        }
+        .await;
+        match result {
+            Ok(true) => {
+                tx.commit().await?;
+                Ok(true)
+            }
+            Ok(false) => {
+                tx.rollback().await?;
+                Ok(false)
+            }
+            Err(error) => {
+                tx.rollback().await?;
+                Err(error)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn load_exact(
+        &self,
+        key: &IdentitySpecKey,
+    ) -> Result<IdentitySpecMutationSnapshot, AppError> {
+        let mut tx = self.db.begin_read_snapshot().await?;
+        require_scope_workspace(&mut tx, key.scope()).await?;
+        let snapshot = load_mutation_snapshot(&mut tx, key).await?;
+        tx.commit().await?;
+        Ok(snapshot)
+    }
+}
+
+async fn load_mutation_snapshot(
+    tx: &mut CoralTx<'_>,
+    key: &IdentitySpecKey,
+) -> Result<IdentitySpecMutationSnapshot, AppError> {
+    let record = tx.identity_specs().get(key).await?;
+    let document = match record.as_ref() {
+        Some(record) => tx.identity_spec_documents().get(&record.id).await?,
+        None => None,
+    };
+    Ok(IdentitySpecMutationSnapshot { record, document })
+}
+
+async fn require_scope_workspace(
+    tx: &mut CoralTx<'_>,
+    scope: &IdentitySpecScope,
+) -> Result<(), AppError> {
+    if let IdentitySpecScope::Workspace(workspace) = scope
+        && tx.workspaces().get(workspace.as_str()).await?.is_none()
+    {
+        return Err(AppError::WorkspaceNotFound(workspace.to_string()));
+    }
+    Ok(())
+}

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -25,6 +25,8 @@ pub(crate) use repositories::identity_specs::{
     IdentitySpecDocumentRecord, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord,
     IdentitySpecScope,
 };
+#[cfg(test)]
+pub(crate) use repositories::identity_specs_contract_tests::set_identity_spec_document_version;
 pub(crate) use repositories::tasks::{TaskCompletionUpdate, TaskLifecycleState};
 pub(crate) use session::{DbRepos, DbSession};
 #[cfg(test)]

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -5,6 +5,7 @@ mod clock;
 mod config;
 mod coral_db;
 mod error;
+mod identity_spec_state;
 mod import;
 mod migrations;
 mod repositories;
@@ -20,6 +21,8 @@ pub(crate) use clock::now_unix_nanos_i64;
 pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
+#[cfg(test)]
+pub(crate) use identity_spec_state::IdentitySpecMutationSnapshot;
 pub(crate) use import::run_state_migrations;
 pub(crate) use repositories::identity_specs::{
     IdentitySpecDocumentRecord, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord,

--- a/crates/coral-app/src/state/db/repositories/identity_specs.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs.rs
@@ -1,11 +1,3 @@
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "identity persistence APIs are not yet wired to production consumers"
-    )
-)]
-
 use sea_query::{Expr, ExprTrait, OnConflict, Order, Query};
 
 use crate::bootstrap::AppError;

--- a/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use sea_query::{Expr, ExprTrait, Query};
@@ -13,16 +14,35 @@ use crate::state::db::{CoralDb, CoralTx, DbRepos, ResolvedDatabaseConfig};
 use crate::workspaces::WorkspaceName;
 use coral_spec::{IdentityManifest, parse_identity_manifest_yaml};
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn identity_spec_persistence_contract_holds_against_sqlite() {
     let temp = tempdir().expect("temp dir");
-    let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
-        path: temp.path().join("coral.sqlite"),
-    })
-    .await
-    .expect("open sqlite");
+    let db = Arc::new(
+        CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite"),
+    );
     db.migrate().await.expect("migrate sqlite");
     assert_identity_spec_persistence_contract(&db).await;
+    crate::identity_specs::manager::tests::assert_identity_spec_mutation_contract(&db).await;
+}
+
+pub(crate) async fn set_identity_spec_document_version(
+    tx: &mut CoralTx<'_>,
+    identity_spec_id: &IdentitySpecId,
+    version: i64,
+) {
+    tx.execute(
+        Query::update()
+            .table(IdentitySpecDocuments::Table)
+            .value(IdentitySpecDocuments::DocumentVersion, version)
+            .and_where(document_id_where(identity_spec_id))
+            .to_owned(),
+    )
+    .await
+    .expect("set identity spec document version");
 }
 
 #[tokio::test]

--- a/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
@@ -79,11 +79,14 @@ async fn identity_spec_persistence_contract_on_postgres() {
     else {
         return;
     };
-    let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
-        .await
-        .expect("open postgres");
+    let db = Arc::new(
+        CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres"),
+    );
     db.migrate().await.expect("migrate postgres");
     assert_identity_spec_persistence_contract(&db).await;
+    crate::identity_specs::manager::tests::assert_identity_spec_mutation_contract(&db).await;
 }
 
 #[expect(clippy::too_many_lines, reason = "shared backend contract fixture")]

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -7,6 +7,6 @@ pub(crate) mod trace_search_responses;
 pub(crate) mod workspaces;
 
 #[cfg(test)]
-mod identity_specs_contract_tests;
+pub(super) mod identity_specs_contract_tests;
 #[cfg(test)]
 mod identity_specs_negative_contract_tests;


### PR DESCRIPTION
## Intent

Make identity-spec installation, partial replacement, and deletion atomic and concurrency-safe across SQLite and PostgreSQL while keeping encrypted setup material bound to the exact global or workspace spec key.

## What it enables

- Exact-scope replacements preserve compatible omitted variables, never inherit prior secrets, discard removed or kind-changed material, and never persist authored defaults.
- Each install-or-replace attempt uses one serializable transaction: it reads the current spec and encrypted document, prepares the merged replacement, checks dependent identities, writes the manifest and document, and commits atomically. Deletes run their existence and dependency checks inside the same serializable-transaction shape.
- Serialization conflicts rerun the complete transaction, up to eight attempts in total; validation, corruption, credential, dependency, and version-exhaustion failures are not retried.
- Successful replacements rotate encrypted material to the active key, while replacements with no stored material remove the setup document.
- Referenced specs can be deleted only after their dependent identities are removed and can be installed or replaced only with a semantically equivalent manifest.
- Exact deletes affect only the selected scope and never fall back between workspace and global specs.

## Usage examples

- Adding a new global spec returns `replaced = false`; installing again at that exact global key returns `replaced = true`.
- Replacing an OAuth spec may preserve a compatible omitted variable, but every required secret must be supplied again.
- Replacing an OAuth spec with a fixed-token spec removes the now-unused encrypted setup document.
- Deleting `workspace:acme:github_oauth` leaves `global:github_oauth` untouched.

## Validation

- `cargo test --locked -p coral-app --lib identity_specs -- --nocapture`
- `make postgres-tests`
- `make rust-checks`
