### PR TITLE
feat(app): configure envelope encryption keys

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1,5 +1,7 @@
 //! Builds and runs the Coral gRPC server.
 
+use std::collections::BTreeSet;
+use std::env::VarError;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -27,6 +29,7 @@ use tokio::task::{self, JoinHandle};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::service::Routes;
 use tonic::transport::Server;
+use zeroize::Zeroizing;
 
 use super::env::AppEnvironment;
 use super::error::AppError;
@@ -36,6 +39,10 @@ use crate::EngineExtensionsProvider;
 use crate::catalog::discovery::CatalogDiscovery;
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
+use crate::credentials::encryption::{
+    ConfiguredCredentialKeyProvider, CredentialEncryptionKey, CredentialKeyProvider,
+    LocalFileCredentialKeyProvider,
+};
 use crate::credentials::{CredentialManager, CredentialStore};
 use crate::features::service::FeatureService;
 use crate::features::{Feature, FeatureOverrides, FeatureStore, Features};
@@ -486,6 +493,115 @@ async fn init_database(layout: &AppStateLayout) -> Result<CoralDb, AppError> {
     Ok(coral_db)
 }
 
+#[expect(
+    dead_code,
+    reason = "the next stack layer activates identity-spec encryption during server bootstrap"
+)]
+fn configured_credential_key_provider(
+    config: &CredentialStorageConfig,
+) -> Result<Option<ConfiguredCredentialKeyProvider>, AppError> {
+    configured_credential_key_provider_with(config, AppEnvironment::env_var)
+}
+
+fn configured_credential_key_provider_with<F>(
+    config: &CredentialStorageConfig,
+    mut env_var: F,
+) -> Result<Option<ConfiguredCredentialKeyProvider>, AppError>
+where
+    F: FnMut(&str) -> Result<Option<String>, VarError>,
+{
+    let Some(active_env) = config.encryption_key_env.as_deref() else {
+        if config.decryption_key_envs.is_empty() {
+            return Ok(None);
+        }
+        return Err(AppError::FailedPrecondition(
+            "[encryption].decryption_key_envs requires [encryption].encryption_key_env".to_string(),
+        ));
+    };
+    let active_env = validate_key_env_name(active_env, "encryption_key_env")?;
+    let mut env_names = BTreeSet::from([active_env]);
+    let active_key = credential_encryption_key_from_env(active_env, &mut env_var)?;
+    let mut decryption_keys = Vec::with_capacity(config.decryption_key_envs.len());
+    for env_name in &config.decryption_key_envs {
+        let env_name = validate_key_env_name(env_name, "decryption_key_envs")?;
+        if !env_names.insert(env_name) {
+            return Err(AppError::FailedPrecondition(format!(
+                "credential encryption key environment variable '{env_name}' is configured more than once"
+            )));
+        }
+        decryption_keys.push(credential_encryption_key_from_env(env_name, &mut env_var)?);
+    }
+    ConfiguredCredentialKeyProvider::new(active_key, decryption_keys)
+        .map(Some)
+        .map_err(|_error| {
+            AppError::FailedPrecondition(
+                "credential encryption key configuration contains duplicate key material"
+                    .to_string(),
+            )
+        })
+}
+
+fn validate_key_env_name<'a>(name: &'a str, field: &str) -> Result<&'a str, AppError> {
+    if name.is_empty() || name.trim() != name || name.contains(['=', '\0']) {
+        return Err(AppError::FailedPrecondition(format!(
+            "[credentials].{field} must contain valid, non-empty environment variable names without surrounding whitespace, '=' or NUL"
+        )));
+    }
+    Ok(name)
+}
+
+fn credential_encryption_key_from_env<F>(
+    env_name: &str,
+    env_var: &mut F,
+) -> Result<CredentialEncryptionKey, AppError>
+where
+    F: FnMut(&str) -> Result<Option<String>, VarError>,
+{
+    let material = Zeroizing::new(
+        env_var(env_name)
+            .map_err(|_error| {
+                AppError::FailedPrecondition(format!(
+                    "credential encryption key environment variable '{env_name}' must contain valid UTF-8"
+                ))
+            })?
+            .ok_or_else(|| {
+                AppError::FailedPrecondition(format!(
+                    "credential encryption key environment variable '{env_name}' is not set"
+                ))
+            })?,
+    );
+    CredentialEncryptionKey::from_encoded_material(material.as_str()).map_err(|_error| {
+        AppError::FailedPrecondition(format!(
+            "credential encryption key environment variable '{env_name}' contains invalid key material"
+        ))
+    })
+}
+
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the next stack layer activates identity-spec encryption during server bootstrap"
+    )
+)]
+fn identity_spec_key_provider(
+    layout: &AppStateLayout,
+    database_config: &ResolvedDatabaseConfig,
+    configured: Option<ConfiguredCredentialKeyProvider>,
+) -> (Arc<dyn CredentialKeyProvider>, bool) {
+    let postgres_without_key =
+        matches!(database_config, ResolvedDatabaseConfig::Postgres { .. }) && configured.is_none();
+    let provider: Arc<dyn CredentialKeyProvider> = match database_config {
+        ResolvedDatabaseConfig::Sqlite { .. } => Arc::new(
+            LocalFileCredentialKeyProvider::with_configured_keys(layout, configured),
+        ),
+        ResolvedDatabaseConfig::Postgres { .. } => {
+            Arc::new(configured.unwrap_or_else(ConfiguredCredentialKeyProvider::unavailable))
+        }
+    };
+    (provider, postgres_without_key)
+}
+
 fn resolve_database_config(layout: &AppStateLayout) -> Result<ResolvedDatabaseConfig, AppError> {
     match DatabaseConfig::load(layout)? {
         DatabaseConfig::Sqlite { path } => Ok(ResolvedDatabaseConfig::Sqlite { path }),
@@ -811,6 +927,7 @@ mod tests {
         reason = "JSON row assertions intentionally fail loudly in tests"
     )]
 
+    use std::collections::BTreeMap;
     use std::future::Future as _;
     use std::net::{Ipv4Addr, SocketAddr, TcpListener};
     use std::path::Path;
@@ -818,6 +935,7 @@ mod tests {
     use std::task::Poll;
     use std::time::Duration;
 
+    use base64::Engine as _;
     use coral_api::v1::gui_onboarding_service_client::GuiOnboardingServiceClient;
     use coral_api::v1::query_service_client::QueryServiceClient;
     use coral_api::v1::source_service_client::SourceServiceClient;
@@ -837,11 +955,15 @@ mod tests {
 
     use super::{
         RunningServer, ServerBuilder, ServerDependencies, ServerMode, TraceServerComponents,
-        start_server,
+        configured_credential_key_provider_with, identity_spec_key_provider, start_server,
     };
     use crate::bootstrap::AppError;
     use crate::catalog::discovery::CatalogDiscovery;
-    use crate::credentials::{CredentialManager, CredentialStore};
+    use crate::credentials::config::CredentialStorageConfig;
+    use crate::credentials::encryption::{
+        ConfiguredCredentialKeyProvider, CredentialEncryptionKey, CredentialKeyProvider,
+    };
+    use crate::credentials::{CredentialManager, CredentialStore, CredentialsError};
     use crate::features::{Feature, FeatureOverrides, FeatureStore, Features};
     use crate::feedback::manager::FeedbackManager;
     use crate::gui_onboarding::manager::GuiOnboardingManager;
@@ -863,6 +985,169 @@ mod tests {
         AwsEngineExtensionsProvider, LocalPrincipalProvider, NoopEngineExtensionsProvider,
         Principal, PrincipalProvider, PrincipalProviderError,
     };
+
+    fn encoded_key(byte: u8) -> String {
+        format!(
+            "v1:{}",
+            base64::engine::general_purpose::STANDARD.encode([byte; 32])
+        )
+    }
+
+    #[test]
+    fn configured_key_provider_resolves_rotation_keys_and_rejects_bad_configuration() {
+        let active_material = encoded_key(7);
+        let previous_material = encoded_key(8);
+        let values = BTreeMap::from([
+            ("ACTIVE", active_material.clone()),
+            ("DUPLICATE", active_material.clone()),
+            ("PREVIOUS", previous_material.clone()),
+            ("INVALID", "not-a-key".to_string()),
+        ]);
+        let config = CredentialStorageConfig {
+            encryption_key_env: Some("ACTIVE".to_string()),
+            decryption_key_envs: vec!["PREVIOUS".to_string()],
+            ..CredentialStorageConfig::default()
+        };
+        let provider =
+            configured_credential_key_provider_with(&config, |name| Ok(values.get(name).cloned()))
+                .expect("valid config")
+                .expect("configured provider");
+        let active = CredentialEncryptionKey::from_encoded_material(&active_material).expect("key");
+        let previous =
+            CredentialEncryptionKey::from_encoded_material(&previous_material).expect("key");
+        assert_eq!(provider.active_key().expect("active key"), active);
+        assert_eq!(
+            provider.key(previous.key_id()).expect("previous key"),
+            previous
+        );
+
+        for (config, expected) in [
+            (
+                CredentialStorageConfig {
+                    decryption_key_envs: vec!["PREVIOUS".to_string()],
+                    ..CredentialStorageConfig::default()
+                },
+                "requires",
+            ),
+            (
+                CredentialStorageConfig {
+                    encryption_key_env: Some("MISSING".to_string()),
+                    ..CredentialStorageConfig::default()
+                },
+                "is not set",
+            ),
+            (
+                CredentialStorageConfig {
+                    encryption_key_env: Some(" ACTIVE".to_string()),
+                    ..CredentialStorageConfig::default()
+                },
+                "without surrounding whitespace",
+            ),
+            (
+                CredentialStorageConfig {
+                    encryption_key_env: Some("BAD=NAME".to_string()),
+                    ..CredentialStorageConfig::default()
+                },
+                "without surrounding whitespace, '=' or NUL",
+            ),
+            (
+                CredentialStorageConfig {
+                    encryption_key_env: Some("BAD\0NAME".to_string()),
+                    ..CredentialStorageConfig::default()
+                },
+                "without surrounding whitespace, '=' or NUL",
+            ),
+            (
+                CredentialStorageConfig {
+                    encryption_key_env: Some("INVALID".to_string()),
+                    ..CredentialStorageConfig::default()
+                },
+                "contains invalid key material",
+            ),
+            (
+                CredentialStorageConfig {
+                    encryption_key_env: Some("ACTIVE".to_string()),
+                    decryption_key_envs: vec!["ACTIVE".to_string()],
+                    ..CredentialStorageConfig::default()
+                },
+                "configured more than once",
+            ),
+            (
+                CredentialStorageConfig {
+                    encryption_key_env: Some("ACTIVE".to_string()),
+                    decryption_key_envs: vec!["DUPLICATE".to_string()],
+                    ..CredentialStorageConfig::default()
+                },
+                "duplicate key material",
+            ),
+        ] {
+            let error = configured_credential_key_provider_with(&config, |name| {
+                Ok(values.get(name).cloned())
+            })
+            .expect_err("invalid config");
+            assert!(matches!(&error, AppError::FailedPrecondition(_)));
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+    }
+
+    #[test]
+    fn postgres_key_selection_never_falls_back_to_a_local_file() {
+        let temp = TempDir::new().expect("tempdir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let sqlite = ResolvedDatabaseConfig::Sqlite {
+            path: layout.database_file(),
+        };
+        let (sqlite_provider, missing_key) = identity_spec_key_provider(&layout, &sqlite, None);
+        assert!(!missing_key);
+        let local_key = sqlite_provider.active_key().expect("local key");
+
+        let active = CredentialEncryptionKey::from_static_bytes_for_test([9; 32]);
+        let previous = CredentialEncryptionKey::from_static_bytes_for_test([8; 32]);
+        let configured =
+            ConfiguredCredentialKeyProvider::new(active.clone(), [previous.clone()]).expect("keys");
+        let (sqlite_provider, missing_key) =
+            identity_spec_key_provider(&layout, &sqlite, Some(configured));
+        assert!(!missing_key);
+        assert_eq!(
+            sqlite_provider.active_key().expect("configured key"),
+            active
+        );
+        assert_eq!(
+            sqlite_provider
+                .key(previous.key_id())
+                .expect("previous key"),
+            previous
+        );
+        assert_eq!(
+            sqlite_provider.key(local_key.key_id()).expect("local key"),
+            local_key
+        );
+
+        let postgres = ResolvedDatabaseConfig::Postgres {
+            url: "postgres://example.invalid/coral".to_string(),
+        };
+        let (provider, missing_key) = identity_spec_key_provider(&layout, &postgres, None);
+        assert!(missing_key);
+        assert!(matches!(
+            provider.active_key(),
+            Err(CredentialsError::Unavailable(_))
+        ));
+        assert!(matches!(
+            provider.key(local_key.key_id()),
+            Err(CredentialsError::Unavailable(_))
+        ));
+
+        let active = CredentialEncryptionKey::from_static_bytes_for_test([7; 32]);
+        let configured = ConfiguredCredentialKeyProvider::new(active.clone(), []).expect("keys");
+        let (provider, missing_key) =
+            identity_spec_key_provider(&layout, &postgres, Some(configured));
+        assert!(!missing_key);
+        assert_eq!(provider.active_key().expect("configured key"), active);
+        assert!(matches!(
+            provider.key(local_key.key_id()),
+            Err(CredentialsError::Unavailable(_))
+        ));
+    }
 
     fn default_workspace() -> Workspace {
         workspace_to_proto(&WorkspaceName::default())

--- a/crates/coral-app/src/credentials/config.rs
+++ b/crates/coral-app/src/credentials/config.rs
@@ -1,4 +1,9 @@
-//! Credential storage configuration loaded from `config.toml`.
+//! Credential storage and envelope-encryption configuration from `config.toml`.
+//!
+//! `[credentials].storage` selects where credential *material* is kept. The
+//! encryption keys live under `[encryption]` instead, because one key protects
+//! every envelope domain — credential documents, identity-spec setup documents,
+//! and identity documents — not credentials alone.
 
 use serde::Deserialize;
 
@@ -7,21 +12,36 @@ use crate::state::AppStateLayout;
 
 use super::CredentialStoragePreference;
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct CredentialStorageConfig {
     pub(crate) storage: CredentialStoragePreference,
+    pub(crate) encryption_key_env: Option<String>,
+    pub(crate) decryption_key_envs: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
 struct CredentialStorageConfigFile {
     #[serde(default)]
     credentials: CredentialStorageConfigSection,
+    #[serde(default)]
+    encryption: EnvelopeEncryptionConfigSection,
 }
 
 #[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 struct CredentialStorageConfigSection {
     #[serde(default)]
     storage: CredentialStoragePreference,
+}
+
+/// Envelope-encryption keys, which protect identity material as well as credentials.
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct EnvelopeEncryptionConfigSection {
+    #[serde(default)]
+    encryption_key_env: Option<String>,
+    #[serde(default)]
+    decryption_key_envs: Vec<String>,
 }
 
 impl CredentialStorageConfig {
@@ -33,6 +53,8 @@ impl CredentialStorageConfig {
         let file = toml::from_str::<CredentialStorageConfigFile>(&raw)?;
         Ok(Self {
             storage: file.credentials.storage,
+            encryption_key_env: file.encryption.encryption_key_env,
+            decryption_key_envs: file.encryption.decryption_key_envs,
         })
     }
 }
@@ -57,5 +79,49 @@ storage = "file"
         )
         .expect("config");
         assert_eq!(file.credentials.storage, CredentialStoragePreference::File);
+    }
+
+    #[test]
+    fn parses_encryption_key_environment_variables() {
+        let file = toml::from_str::<CredentialStorageConfigFile>(
+            r#"
+[encryption]
+encryption_key_env = "CORAL_ACTIVE_KEY"
+decryption_key_envs = ["CORAL_PREVIOUS_KEY"]
+"#,
+        )
+        .expect("config");
+
+        assert_eq!(
+            file.encryption.encryption_key_env.as_deref(),
+            Some("CORAL_ACTIVE_KEY")
+        );
+        assert_eq!(file.encryption.decryption_key_envs, ["CORAL_PREVIOUS_KEY"]);
+    }
+
+    #[test]
+    fn encryption_keys_are_rejected_under_the_credentials_section() {
+        // The keys protect identity material too, so `[credentials]` must not
+        // silently accept them and leave encryption unconfigured.
+        toml::from_str::<CredentialStorageConfigFile>(
+            r#"
+[credentials]
+encryption_key_env = "CORAL_ACTIVE_KEY"
+"#,
+        )
+        .expect_err("encryption keys belong under [encryption]");
+    }
+
+    #[test]
+    fn rejects_unknown_credential_fields() {
+        let error = toml::from_str::<CredentialStorageConfigFile>(
+            r#"
+[credentials]
+decryption_key_env = "CORAL_PREVIOUS_KEY"
+"#,
+        )
+        .expect_err("misspelled key field");
+
+        assert!(error.to_string().contains("unknown field"), "{error}");
     }
 }

--- a/crates/coral-app/src/credentials/encryption.rs
+++ b/crates/coral-app/src/credentials/encryption.rs
@@ -45,6 +45,7 @@ pub(crate) const CREDENTIAL_DOCUMENT_BINDING_VERSION: i64 = 2;
 const CREDENTIAL_DOCUMENT_VERSION: u32 = 1;
 const LEGACY_CREDENTIAL_BINDING_VERSION: i64 = 1;
 const KEY_FILE_VERSION: &str = "v1";
+const KEY_FILE_MAX_BYTES: u64 = 4 * 1024;
 const KEY_LEN: usize = 32;
 const NONCE_LEN: usize = 12;
 
@@ -168,12 +169,84 @@ impl EnvelopeContext {
     }
 }
 
+/// Immutable configured encryption keys resolved during app bootstrap.
+#[derive(Debug, Clone)]
+pub(crate) struct ConfiguredCredentialKeyProvider {
+    active_key_id: Option<String>,
+    keys_by_id: BTreeMap<String, CredentialEncryptionKey>,
+}
+
+impl ConfiguredCredentialKeyProvider {
+    pub(crate) fn new(
+        active_key: CredentialEncryptionKey,
+        decryption_keys: impl IntoIterator<Item = CredentialEncryptionKey>,
+    ) -> Result<Self, CredentialsError> {
+        let active_key_id = active_key.key_id().to_string();
+        let mut keys_by_id = BTreeMap::from([(active_key_id.clone(), active_key)]);
+        for key in decryption_keys {
+            let key_id = key.key_id().to_string();
+            if keys_by_id.contains_key(&key_id) {
+                return Err(CredentialsError::Parse(format!(
+                    "duplicate credential encryption key id '{key_id}'"
+                )));
+            }
+            keys_by_id.insert(key_id, key);
+        }
+        Ok(Self {
+            active_key_id: Some(active_key_id),
+            keys_by_id,
+        })
+    }
+
+    pub(crate) fn unavailable() -> Self {
+        Self {
+            active_key_id: None,
+            keys_by_id: BTreeMap::new(),
+        }
+    }
+
+    fn single(active_key: CredentialEncryptionKey) -> Self {
+        let active_key_id = active_key.key_id().to_string();
+        Self {
+            active_key_id: Some(active_key_id.clone()),
+            keys_by_id: BTreeMap::from([(active_key_id, active_key)]),
+        }
+    }
+
+    fn key_if_present(&self, key_id: &str) -> Option<CredentialEncryptionKey> {
+        self.keys_by_id.get(key_id).cloned()
+    }
+}
+
+impl CredentialKeyProvider for ConfiguredCredentialKeyProvider {
+    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        self.active_key_id
+            .as_deref()
+            .and_then(|key_id| self.key_if_present(key_id))
+            .ok_or_else(configured_key_required)
+    }
+
+    fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+        self.key_if_present(key_id).ok_or_else(|| {
+            CredentialsError::Unavailable(format!(
+                "credential encryption key '{key_id}' is unavailable"
+            ))
+        })
+    }
+}
+
+fn configured_key_required() -> CredentialsError {
+    CredentialsError::Unavailable(
+        "encrypted identity inputs require a configured credential encryption key".to_string(),
+    )
+}
+
 /// Resolves an explicitly supplied key or falls back to a key file scoped to
 /// this app-state config directory. Callers own config and environment resolution.
 #[derive(Debug, Clone)]
 pub(crate) struct LocalFileCredentialKeyProvider {
     path: PathBuf,
-    provided_key: Option<CredentialEncryptionKey>,
+    configured_keys: Option<ConfiguredCredentialKeyProvider>,
 }
 
 impl LocalFileCredentialKeyProvider {
@@ -181,21 +254,31 @@ impl LocalFileCredentialKeyProvider {
         layout: &AppStateLayout,
         provided_key: Option<CredentialEncryptionKey>,
     ) -> Self {
+        let configured_keys = provided_key.map(ConfiguredCredentialKeyProvider::single);
+        Self::with_configured_keys(layout, configured_keys)
+    }
+
+    pub(crate) fn with_configured_keys(
+        layout: &AppStateLayout,
+        configured_keys: Option<ConfiguredCredentialKeyProvider>,
+    ) -> Self {
         Self {
             path: layout.credential_encryption_key_file(),
-            provided_key,
+            configured_keys,
         }
     }
 
     fn load_key(&self) -> Result<Option<CredentialEncryptionKey>, CredentialsError> {
-        match std::fs::read_to_string(&self.path) {
-            Ok(raw) => {
-                let raw = Zeroizing::new(raw);
-                CredentialEncryptionKey::from_encoded_material(raw.as_str()).map(Some)
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(error) => Err(error.into()),
+        match std::fs::symlink_metadata(&self.path) {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.into()),
         }
+        let raw = Zeroizing::new(storage_fs::read_to_string_private(
+            &self.path,
+            KEY_FILE_MAX_BYTES,
+        )?);
+        CredentialEncryptionKey::from_encoded_material(raw.as_str()).map(Some)
     }
 
     fn load_or_create_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
@@ -203,7 +286,7 @@ impl LocalFileCredentialKeyProvider {
             CredentialsError::Crypto("credential encryption key lock is poisoned".to_string())
         })?;
         if let Some(parent) = self.path.parent() {
-            storage_fs::ensure_private_dir(parent)?;
+            storage_fs::ensure_private_dir_no_symlink(parent)?;
         }
         let lock_path = self.path.with_extension("key.lock");
         let _process_guard = FileLock::exclusive(&lock_path)?;
@@ -230,24 +313,26 @@ impl LocalFileCredentialKeyProvider {
 
 impl CredentialKeyProvider for LocalFileCredentialKeyProvider {
     fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
-        if let Some(key) = &self.provided_key {
-            return Ok(key.clone());
+        if let Some(keys) = &self.configured_keys {
+            return keys.active_key();
         }
         self.load_or_create_key()
     }
 
     fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
-        if let Some(key) = &self.provided_key
-            && key.key_id == key_id
+        if let Some(key) = self
+            .configured_keys
+            .as_ref()
+            .and_then(|keys| keys.key_if_present(key_id))
         {
-            return Ok(key.clone());
+            return Ok(key);
         }
         if let Some(key) = self.load_key()?
             && key.key_id == key_id
         {
             return Ok(key);
         }
-        Err(CredentialsError::Crypto(format!(
+        Err(CredentialsError::Unavailable(format!(
             "credential encryption key '{key_id}' is unavailable"
         )))
     }
@@ -734,10 +819,39 @@ mod tests {
     use tempfile::tempdir;
 
     use super::{
-        CredentialEncryptionKey, CredentialKeyProvider, KEY_FILE_VERSION, KEY_LEN,
-        LocalFileCredentialKeyProvider,
+        ConfiguredCredentialKeyProvider, CredentialEncryptionKey, CredentialKeyProvider,
+        KEY_FILE_VERSION, KEY_LEN, LocalFileCredentialKeyProvider,
     };
+    use crate::credentials::CredentialsError;
     use crate::state::AppStateLayout;
+
+    #[test]
+    fn configured_provider_selects_active_and_resolves_decryption_keys() {
+        let active = CredentialEncryptionKey::from_static_bytes_for_test([7_u8; KEY_LEN]);
+        let previous = CredentialEncryptionKey::from_static_bytes_for_test([8_u8; KEY_LEN]);
+        let provider = ConfiguredCredentialKeyProvider::new(active.clone(), [previous.clone()])
+            .expect("configured key ring");
+
+        assert_eq!(provider.active_key().expect("active key"), active);
+        assert_eq!(
+            provider.key(previous.key_id()).expect("previous key"),
+            previous
+        );
+        assert!(matches!(
+            provider.key("missing-key"),
+            Err(CredentialsError::Unavailable(_))
+        ));
+    }
+
+    #[test]
+    fn configured_provider_rejects_duplicate_key_material() {
+        let active = CredentialEncryptionKey::from_static_bytes_for_test([7_u8; KEY_LEN]);
+
+        let error = ConfiguredCredentialKeyProvider::new(active.clone(), [active])
+            .expect_err("duplicate key id");
+
+        assert!(matches!(error, CredentialsError::Parse(_)));
+    }
 
     #[test]
     fn provided_key_does_not_create_a_local_key_file() {
@@ -767,6 +881,13 @@ mod tests {
 
         assert!(error.to_string().contains("is unavailable"));
         assert!(!layout.credential_encryption_key_file().exists());
+        assert!(
+            !layout
+                .credential_encryption_key_file()
+                .parent()
+                .unwrap()
+                .exists()
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -58,9 +58,30 @@ fn ensure_private_dir_no_symlink_inner(path: &Path, tighten_existing: bool) -> i
         }
         Err(error) => return Err(error),
     }
-    let dir = File::open(path)?;
-    set_open_dir_permissions_private(&dir)?;
-    Ok(())
+    tighten_private_dir_no_symlink(path)
+}
+
+fn ensure_existing_private_dir_no_symlink(path: &Path) -> io::Result<()> {
+    if path.as_os_str().is_empty() || path == Path::new(".") {
+        return Ok(());
+    }
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_dir() => tighten_private_dir_no_symlink(path),
+        Ok(_) => Err(private_directory_error(path)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Err(private_directory_error(path)),
+        Err(error) => Err(error),
+    }
+}
+
+fn tighten_private_dir_no_symlink(path: &Path) -> io::Result<()> {
+    let dir = File::open(path).map_err(|error| {
+        if error.kind() == io::ErrorKind::NotFound {
+            private_directory_error(path)
+        } else {
+            error
+        }
+    })?;
+    set_open_dir_permissions_private(&dir)
 }
 
 pub(crate) fn create_new_file_private(path: &Path) -> io::Result<File> {
@@ -91,16 +112,9 @@ pub(crate) fn ensure_file_private(path: &Path) -> io::Result<()> {
 /// requires write access to it, and anything able to write there can generally read
 /// the key outright. The value here is tightening loose modes, which is a real and
 /// common failure, not defeating a local attacker who already has the directory.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the next stack layer activates strict reads for local encryption keys"
-    )
-)]
 pub(crate) fn read_to_string_private(path: &Path, max_bytes: u64) -> io::Result<String> {
     if let Some(parent) = path.parent() {
-        ensure_private_dir_no_symlink(parent)?;
+        ensure_existing_private_dir_no_symlink(parent)?;
     }
     let path_metadata = fs::symlink_metadata(path)?;
     if !path_metadata.file_type().is_file() {
@@ -419,7 +433,8 @@ fn set_open_dir_permissions_private(_directory: &File) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        DirectoryBackup, ensure_file_private, read_to_string_private, remove_file_if_exists,
+        DirectoryBackup, ensure_file_private, ensure_private_dir_no_symlink,
+        read_to_string_private, remove_file_if_exists,
     };
 
     #[test]
@@ -508,7 +523,7 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn read_to_string_private_rejects_missing_directory_beneath_symlink() {
+    fn ensure_private_dir_no_symlink_rejects_missing_directory_beneath_symlink() {
         use std::os::unix::fs::{PermissionsExt as _, symlink};
 
         let temp = tempfile::tempdir().expect("tempdir");
@@ -519,9 +534,8 @@ mod tests {
         let config = temp.path().join("config");
         symlink(&target, &config).expect("config symlink");
 
-        let error =
-            read_to_string_private(&config.join("credentials").join("encryption.key"), 1024)
-                .expect_err("symlinked ancestor should be rejected");
+        let error = ensure_private_dir_no_symlink(&config.join("credentials"))
+            .expect_err("symlinked ancestor should be rejected");
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
         assert!(!target.join("credentials").exists());
@@ -535,7 +549,7 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
-    fn read_to_string_private_does_not_tighten_existing_ancestor() {
+    fn ensure_private_dir_no_symlink_does_not_tighten_existing_ancestor() {
         use std::os::unix::fs::PermissionsExt as _;
 
         let temp = tempfile::tempdir().expect("tempdir");
@@ -544,10 +558,7 @@ mod tests {
         let private = temp.path().join("private");
         let credentials = private.join("credentials");
 
-        let error = read_to_string_private(&credentials.join("encryption.key"), 1024)
-            .expect_err("missing key should remain missing");
-
-        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+        ensure_private_dir_no_symlink(&credentials).expect("create private directories");
         for path in [&private, &credentials] {
             let mode = std::fs::metadata(path)
                 .expect("created private directory")
@@ -562,6 +573,18 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(ancestor_mode, 0o755);
+    }
+
+    #[test]
+    fn read_to_string_private_does_not_recreate_a_missing_parent() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let parent = temp.path().join("credentials");
+
+        let error = read_to_string_private(&parent.join("encryption.key"), 1024)
+            .expect_err("missing parent should be rejected");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert!(!parent.exists());
     }
 
     #[test]


### PR DESCRIPTION
## Intent

Resolve encryption keys at startup from environment variables named in
`config.toml`, support one active key plus decrypt-only previous keys for rotation,
and choose the key provider by database backend.

## What it enables

- Postgres-backed Coral instances share configured keys and never fall back to a
  node-local key file, so several servers can decrypt the same material.
- SQLite keeps its local key and can migrate existing ciphertext to configured keys.
- Rotation works: the active key encrypts new documents while previous keys stay
  decrypt-only until removed from configuration.
- Malformed or ambiguous configuration is rejected at startup, and key values never
  appear in errors.

## Configuration lives under `[encryption]`, not `[credentials]`

One key-encryption key protects **every** envelope domain — source credential
documents, identity-spec setup documents, and identity documents. Filing it under
`[credentials]` understated the blast radius: an operator reading that section would
reasonably conclude that rotating or losing the key affects stored source secrets
alone.

`[credentials]` keeps only `storage`, which genuinely is credential-specific.

```toml
[credentials]
storage = "auto"

[encryption]
encryption_key_env = "CORAL_ENVELOPE_KEK_CURRENT"
decryption_key_envs = ["CORAL_ENVELOPE_KEK_PREVIOUS"]
```

Each referenced environment variable holds `v1:<base64>` decoding to exactly 32
bytes. The material lives in the environment variable, never in `config.toml`.

`[credentials]` uses `deny_unknown_fields`, so the old placement is a startup error
rather than a silently ignored key that leaves encryption unconfigured. There is a
test pinning that, because the dangerous failure is a config that looks configured
but is not.

No deprecation alias is needed: `encryption_key_env` has never existed on `main`, so
no deployment has used the old placement.

## Usage examples

Rotate by moving the current variable name into `decryption_key_envs`, pointing
`encryption_key_env` at the new key, and restarting. New documents use only the
active key; previous keys remain readable until removed.

## Validation

- `cargo nextest run -p coral-app -E 'test(credentials::config)'` — 5 passed,
  including a test that the keys are rejected under `[credentials]`.
- `cargo clippy -p coral-app --all-features --all-targets` — no warnings.
- `cargo fmt --all -- --check` — clean.