### PR TITLE
feat(app): activate identity spec service

### DIFF
--- a/apps/docs/project/security.mdx
+++ b/apps/docs/project/security.mdx
@@ -39,6 +39,9 @@ trust boundary:
 
 - Source secrets are stored separately from non-secret source variables and are
   never written into `config.toml`.
+- Identity-spec setup inputs use a separate envelope-encryption path. Coral
+  stores their encrypted documents in the app database and does not return the
+  input values from identity-spec management APIs.
 - By default, sources use the operating-system credential store when Coral
   can successfully write, read, and delete a probe item. On macOS this uses
   Keychain; on Windows, Credential Manager; on Linux, Secret Service.
@@ -56,9 +59,9 @@ trust boundary:
 - MCP clients can query installed sources, but they do not receive raw stored
   secret values through the discovery tables or resources.
 
-## Secret storage configuration
+## Source secret storage
 
-Coral reads the credential storage preference from `config.toml`:
+Coral reads the source-secret storage preference from `config.toml`:
 
 ```toml
 [credentials]
@@ -76,6 +79,43 @@ Supported values:
 <Note>
 Changing the global preference does not rewrite existing credentials. To update those, remove and re-add the source you want to update.
 </Note>
+
+This preference does not control identity setup inputs. Source secrets use the
+keychain or plaintext file backend described above; identity setup inputs use
+the database-backed envelope encryption described next.
+
+## Identity setup input encryption
+
+Coral envelope-encrypts persisted identity setup inputs. A per-document
+data-encryption key encrypts the input values, and a longer-lived
+key-encryption key (KEK) wraps that data key. The database stores the encrypted
+document and its key identifier, not the KEK itself.
+
+You can supply KEKs through environment variables named by
+`[encryption].encryption_key_env` and
+`[encryption].decryption_key_envs`. Coral reads them once at startup. The
+active key encrypts new documents; previous keys are decrypt-only so existing
+documents remain readable during rotation. One KEK protects every encrypted
+document — source credentials and identity material alike — so rotating or
+losing it reaches further than source secrets. See
+[Configuration](/reference/configuration#encryption) for the format and
+rotation behavior.
+
+The KEK location defines the protection boundary:
+
+- SQLite uses a private local key file in Coral's local state directory by
+  default. When you configure a KEK, Coral uses it for new writes while
+  retaining lookup compatibility with an existing local key for older
+  documents. Protect both the key file and the configured SQLite database
+  location with your operating-system account controls.
+- PostgreSQL never uses a node-local fallback. Every Coral server that needs to
+  write or decrypt identity setup inputs must receive the same configured key
+  ring. A server without an active configured KEK can start, but encrypted
+  identity setup input operations are unavailable.
+
+Envelope encryption separates database contents from the KEK, but it does not
+protect against an attacker who controls the Coral process, its environment,
+or the local user account that can read a SQLite key file.
 
 ## What you still need to trust
 
@@ -95,6 +135,9 @@ you configure; it does not make an otherwise untrusted local agent safe.
   configured sources. If a source uses file-backed secret storage, anyone who
   can read your local Coral config directory should also be treated as able to
   read its stored source secrets.
+- Anyone who can read the configured identity KEKs, Coral process memory, or a
+  SQLite local encryption-key file should be treated as able to decrypt the
+  corresponding identity setup inputs when they also obtain the database.
 - Coral does not attempt to protect against a compromised machine, compromised
   MCP client, malicious shell environment, or malicious upstream API response.
 

--- a/apps/docs/project/security.mdx
+++ b/apps/docs/project/security.mdx
@@ -82,7 +82,7 @@ Changing the global preference does not rewrite existing credentials. To update 
 
 This preference does not control identity setup inputs. Source secrets use the
 keychain or plaintext file backend described above; identity setup inputs use
-the database-backed envelope encryption described next.
+the envelope encryption described next.
 
 ## Identity setup input encryption
 
@@ -91,31 +91,16 @@ data-encryption key encrypts the input values, and a longer-lived
 key-encryption key (KEK) wraps that data key. The database stores the encrypted
 document and its key identifier, not the KEK itself.
 
-You can supply KEKs through environment variables named by
-`[encryption].encryption_key_env` and
-`[encryption].decryption_key_envs`. Coral reads them once at startup. The
-active key encrypts new documents; previous keys are decrypt-only so existing
-documents remain readable during rotation. One KEK protects every encrypted
-document — source credentials and identity material alike — so rotating or
-losing it reaches further than source secrets. See
-[Configuration](/reference/configuration#encryption) for the format and
-rotation behavior.
-
-The KEK location defines the protection boundary:
-
-- SQLite uses a private local key file in Coral's local state directory by
-  default. When you configure a KEK, Coral uses it for new writes while
-  retaining lookup compatibility with an existing local key for older
-  documents. Protect both the key file and the configured SQLite database
-  location with your operating-system account controls.
-- PostgreSQL never uses a node-local fallback. Every Coral server that needs to
-  write or decrypt identity setup inputs must receive the same configured key
-  ring. A server without an active configured KEK can start, but encrypted
-  identity setup input operations are unavailable.
+Coral creates the KEK in the private `credentials/encryption.key` file under
+its local config directory when it first needs to encrypt identity setup input.
+The same local key-file behavior applies regardless of the configured database
+backend. Protect the key file and database with your operating-system account
+controls, and back them up together: losing the key makes the encrypted inputs
+unreadable.
 
 Envelope encryption separates database contents from the KEK, but it does not
 protect against an attacker who controls the Coral process, its environment,
-or the local user account that can read a SQLite key file.
+or the local user account that can read the local key file.
 
 ## What you still need to trust
 
@@ -135,9 +120,9 @@ you configure; it does not make an otherwise untrusted local agent safe.
   configured sources. If a source uses file-backed secret storage, anyone who
   can read your local Coral config directory should also be treated as able to
   read its stored source secrets.
-- Anyone who can read the configured identity KEKs, Coral process memory, or a
-  SQLite local encryption-key file should be treated as able to decrypt the
-  corresponding identity setup inputs when they also obtain the database.
+- Anyone who can read the local envelope encryption key file or Coral process
+  memory should be treated as able to decrypt the corresponding identity setup
+  inputs when they also obtain the database.
 - Coral does not attempt to protect against a compromised machine, compromised
   MCP client, malicious shell environment, or malicious upstream API response.
 

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -43,6 +43,66 @@ export CORAL_DATABASE_URL="postgres://coral:secret@db.example.com:5432/coral?ssl
   Remote Postgres URLs must set `sslmode=verify-full` so Coral verifies the server identity. Loopback and local-socket Postgres URLs may omit TLS for local development.
 </Note>
 
+## Credentials
+
+The `[credentials]` section selects where source secrets are stored:
+
+- `storage` selects where source secrets are stored. See the
+  [security model](/project/security#source-secret-storage).
+
+```toml
+[credentials]
+storage = "auto"
+```
+
+## Encryption
+
+The `[encryption]` section configures the key-encryption keys (KEKs) that protect
+every encrypted document Coral stores — source credential documents, identity spec
+setup inputs, and identity setup inputs alike. One key covers all of them, so
+losing or rotating it affects more than stored source secrets.
+
+- `encryption_key_env` names the environment variable containing the active KEK
+  used for new writes.
+- `decryption_key_envs` lists environment variables containing previous KEKs that
+  may decrypt existing documents but are never used for new writes.
+
+```toml
+[encryption]
+encryption_key_env = "CORAL_ENVELOPE_KEK_CURRENT"
+decryption_key_envs = ["CORAL_ENVELOPE_KEK_PREVIOUS"]
+```
+
+Each referenced environment variable must contain `v1:` followed by standard
+Base64 that decodes to exactly 32 bytes. The key material belongs in the
+environment variable, not in `config.toml`.
+
+```text
+v1:<base64-encoded-32-byte-key>
+```
+
+Coral resolves the configured keys once during server startup and keeps that
+immutable key ring for the process lifetime. Restart Coral after changing the
+configuration or referenced environment variables. Startup fails when an
+explicitly configured key is missing or invalid, when key names or material
+are duplicated, or when `decryption_key_envs` is set without
+`encryption_key_env`.
+
+To rotate keys, move the old active environment-variable name into
+`decryption_key_envs`, point `encryption_key_env` at the new key, and restart
+Coral. New identity setup documents use only the active key; previous keys
+remain decrypt-only until you remove them from the configuration.
+
+With SQLite, Coral uses `encryption/envelope.key` in the local state
+directory when no active key is configured. If you later configure an active
+key, Coral still consults an existing local key when decrypting older identity
+setup documents.
+
+With PostgreSQL, Coral never falls back to a node-local key file. Configure the
+same active and previous keys on every Coral server that must write or decrypt
+identity setup inputs. Without an active configured key, Coral can start, but
+operations that require encrypted identity setup inputs are unavailable.
+
 ## Workspaces
 
 Workspace metadata is stored under `[workspaces]`. The `default` workspace

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -45,63 +45,15 @@ export CORAL_DATABASE_URL="postgres://coral:secret@db.example.com:5432/coral?ssl
 
 ## Credentials
 
-The `[credentials]` section selects where source secrets are stored:
+The `[credentials]` section controls source secret storage:
 
-- `storage` selects where source secrets are stored. See the
-  [security model](/project/security#source-secret-storage).
+- `storage` selects the storage backend (`auto`, `keychain`, or `file`). See
+  the [security model](/project/security#source-secret-storage).
 
 ```toml
 [credentials]
 storage = "auto"
 ```
-
-## Encryption
-
-The `[encryption]` section configures the key-encryption keys (KEKs) that protect
-every encrypted document Coral stores — source credential documents, identity spec
-setup inputs, and identity setup inputs alike. One key covers all of them, so
-losing or rotating it affects more than stored source secrets.
-
-- `encryption_key_env` names the environment variable containing the active KEK
-  used for new writes.
-- `decryption_key_envs` lists environment variables containing previous KEKs that
-  may decrypt existing documents but are never used for new writes.
-
-```toml
-[encryption]
-encryption_key_env = "CORAL_ENVELOPE_KEK_CURRENT"
-decryption_key_envs = ["CORAL_ENVELOPE_KEK_PREVIOUS"]
-```
-
-Each referenced environment variable must contain `v1:` followed by standard
-Base64 that decodes to exactly 32 bytes. The key material belongs in the
-environment variable, not in `config.toml`.
-
-```text
-v1:<base64-encoded-32-byte-key>
-```
-
-Coral resolves the configured keys once during server startup and keeps that
-immutable key ring for the process lifetime. Restart Coral after changing the
-configuration or referenced environment variables. Startup fails when an
-explicitly configured key is missing or invalid, when key names or material
-are duplicated, or when `decryption_key_envs` is set without
-`encryption_key_env`.
-
-To rotate keys, move the old active environment-variable name into
-`decryption_key_envs`, point `encryption_key_env` at the new key, and restart
-Coral. New identity setup documents use only the active key; previous keys
-remain decrypt-only until you remove them from the configuration.
-
-With SQLite, Coral uses `encryption/envelope.key` in the local state
-directory when no active key is configured. If you later configure an active
-key, Coral still consults an existing local key when decrypting older identity
-setup documents.
-
-With PostgreSQL, Coral never falls back to a node-local key file. Configure the
-same active and previous keys on every Coral server that must write or decrypt
-identity setup inputs. Without an active configured key, Coral can start, but
-operations that require encrypted identity setup inputs are unavailable.
 
 ## Workspaces
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -10,6 +10,7 @@ use coral_api::v1::feature_service_server::FeatureServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
 use coral_api::v1::function_service_server::FunctionServiceServer;
 use coral_api::v1::gui_onboarding_service_server::GuiOnboardingServiceServer;
+use coral_api::v1::identity_spec_service_server::IdentitySpecServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::search_service_server::SearchServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
@@ -17,7 +18,8 @@ use coral_api::v1::task_service_server::TaskServiceServer;
 use coral_api::v1::trace_service_server::TraceServiceServer;
 use coral_api::v1::workspace_service_server::WorkspaceServiceServer;
 use coral_api::{
-    CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
+    CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE,
+    IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
     SEARCH_RESPONSE_MAX_MESSAGE_SIZE, SOURCE_RESPONSE_MAX_MESSAGE_SIZE,
     TRACE_RESPONSE_MAX_MESSAGE_SIZE,
 };
@@ -36,6 +38,7 @@ use crate::EngineExtensionsProvider;
 use crate::catalog::discovery::CatalogDiscovery;
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
+use crate::credentials::encryption::{CredentialKeyProvider, LocalFileCredentialKeyProvider};
 use crate::credentials::{CredentialManager, CredentialStore};
 use crate::features::service::FeatureService;
 use crate::features::{Feature, FeatureOverrides, FeatureStore, Features};
@@ -48,6 +51,8 @@ use crate::functions::service::FunctionService;
 use crate::gui_onboarding::manager::GuiOnboardingManager;
 use crate::gui_onboarding::service::GuiOnboardingService;
 use crate::identity::{LocalPrincipalProvider, PrincipalProvider};
+use crate::identity_specs::manager::IdentitySpecManager;
+use crate::identity_specs::service::IdentitySpecService;
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::search::manager::SearchManager;
@@ -338,6 +343,10 @@ impl ServerBuilder {
     /// Returns [`AppError`] if the config directory cannot be determined,
     /// required directories cannot be created, the config or credential backends
     /// fail to initialize, or the gRPC server cannot be started.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "startup composition stays explicit so initialization order and ownership remain visible"
+    )]
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir.clone())?;
@@ -345,16 +354,22 @@ impl ServerBuilder {
         let principal_provider = self.config.principal_provider.clone();
         let grpc_listener = self.config.grpc_listener.clone();
         layout.ensure()?;
+        let credential_config = CredentialStorageConfig::load(&layout)?;
+        let database_config = resolve_database_config(&layout)?;
+        let identity_spec_key_provider: Arc<dyn CredentialKeyProvider> =
+            Arc::new(LocalFileCredentialKeyProvider::new(&layout, None));
         let feature_store = FeatureStore::from_layout(layout.clone());
         let features = feature_store.load_with_overrides(&self.config.feature_overrides)?;
-        let coral_db = init_database(&layout).await?;
+        let coral_db = init_database(database_config).await?;
         let config_store = ConfigStore::new(layout.clone());
         run_state_migrations(&coral_db, &config_store, &layout).await?;
         let coral_db = Arc::new(coral_db);
+        let identity_specs =
+            IdentitySpecManager::new(Arc::clone(&coral_db), identity_spec_key_provider);
         let (telemetry_config, active_trace_store) =
             init_server_telemetry(&layout, self.config.enable_stderr_logs)?;
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
-        let credential_config = CredentialStorageConfig::load(&layout)?;
+        let trace_components = trace_components_for_store(active_trace_store);
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
         let credential_manager = CredentialManager::new(credential_store);
@@ -417,7 +432,6 @@ impl ServerBuilder {
             CatalogDiscovery::new(query_manager.clone()),
             workspace_lifecycle_lock,
         );
-        let trace_components = trace_components_for_store(active_trace_store);
         start_server(
             ServerDependencies {
                 gui_onboarding: GuiOnboardingManager::new(Arc::clone(&coral_db)),
@@ -430,6 +444,7 @@ impl ServerBuilder {
                 task: task_manager,
                 feature_store,
                 active_features: features,
+                identity_specs,
             },
             trace_components,
             principal_provider,
@@ -479,8 +494,7 @@ fn trace_components_for_store(
     })
 }
 
-async fn init_database(layout: &AppStateLayout) -> Result<CoralDb, AppError> {
-    let database_config = resolve_database_config(layout)?;
+async fn init_database(database_config: ResolvedDatabaseConfig) -> Result<CoralDb, AppError> {
     let coral_db = CoralDb::open(database_config).await?;
     coral_db.migrate().await?;
     Ok(coral_db)
@@ -647,6 +661,7 @@ struct ServerDependencies {
     // The resolution `start` performed, carried forward so the feature service
     // can report what this server is running rather than only what config says.
     active_features: Features,
+    identity_specs: IdentitySpecManager,
 }
 
 /// Builds the gRPC routes for every application service, and returns the query
@@ -666,6 +681,7 @@ fn application_routes(
         task,
         feature_store,
         active_features,
+        identity_specs,
     } = dependencies;
     let (source, query) = match search_observations.as_ref() {
         Some(search_observations) => (
@@ -685,6 +701,7 @@ fn application_routes(
     let feature_service = FeatureService::new(feature_store, active_features);
     let task_service = TaskService::new(task);
     let gui_onboarding_service = GuiOnboardingService::new(gui_onboarding);
+    let identity_spec_service = IdentitySpecService::new(identity_specs);
     let mut routes = Routes::default()
         .add_service(GuiOnboardingServiceServer::new(gui_onboarding_service))
         .add_service(
@@ -698,6 +715,10 @@ fn application_routes(
         )
         .add_service(FeedbackServiceServer::new(feedback_service))
         .add_service(FeatureServiceServer::new(feature_service))
+        .add_service(
+            IdentitySpecServiceServer::new(identity_spec_service)
+                .max_encoding_message_size(IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE),
+        )
         .add_service(FunctionServiceServer::new(function_service))
         .add_service(TaskServiceServer::new(task_service))
         .add_service(
@@ -841,10 +862,12 @@ mod tests {
     };
     use crate::bootstrap::AppError;
     use crate::catalog::discovery::CatalogDiscovery;
+    use crate::credentials::encryption::LocalFileCredentialKeyProvider;
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::features::{Feature, FeatureOverrides, FeatureStore, Features};
     use crate::feedback::manager::FeedbackManager;
     use crate::gui_onboarding::manager::GuiOnboardingManager;
+    use crate::identity_specs::manager::IdentitySpecManager;
     use crate::query::manager::QueryManager;
     use crate::search::manager::SearchManager;
     use crate::search::observed::{
@@ -937,6 +960,16 @@ enabled = false
             .await
             .expect("run state migrations");
         Arc::new(db)
+    }
+
+    fn test_identity_spec_manager(
+        layout: &AppStateLayout,
+        db: &Arc<CoralDb>,
+    ) -> IdentitySpecManager {
+        IdentitySpecManager::new(
+            Arc::clone(db),
+            Arc::new(LocalFileCredentialKeyProvider::new(layout, None)),
+        )
     }
 
     #[tokio::test]
@@ -1583,6 +1616,7 @@ backend = "unsupported"
                 task: task_manager,
                 feature_store: FeatureStore::from_layout(layout.clone()),
                 active_features: Features::default(),
+                identity_specs: test_identity_spec_manager(&layout, &db),
             },
             TraceServerComponents {
                 service: Some(trace_service),
@@ -1731,6 +1765,7 @@ backend = "unsupported"
                 task: task_manager,
                 feature_store: FeatureStore::from_layout(layout.clone()),
                 active_features: Features::default(),
+                identity_specs: test_identity_spec_manager(&layout, &db),
             },
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
@@ -1863,6 +1898,7 @@ tables:
                 task: task_manager,
                 feature_store: FeatureStore::from_layout(layout.clone()),
                 active_features: Features::default(),
+                identity_specs: test_identity_spec_manager(&layout, &db),
             },
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
@@ -1995,6 +2031,7 @@ tables:
                 task: task_manager,
                 feature_store: FeatureStore::from_layout(layout.clone()),
                 active_features: Features::default(),
+                identity_specs: test_identity_spec_manager(&layout, &db),
             },
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),

--- a/crates/coral-app/src/identity_specs/service.rs
+++ b/crates/coral-app/src/identity_specs/service.rs
@@ -1,11 +1,4 @@
 //! Implements the gRPC `IdentitySpecService` management boundary.
-#![cfg_attr(
-    test,
-    expect(
-        dead_code,
-        reason = "the next stack layer mounts this adapter in server bootstrap"
-    )
-)]
 
 use coral_api::v1::identity_spec_service_server::IdentitySpecService as IdentitySpecServiceApi;
 use coral_api::v1::{

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -17,6 +17,8 @@ mod gui_onboarding_tests;
 mod harness;
 #[path = "grpc/health_service_tests.rs"]
 mod health_service_tests;
+#[path = "grpc/identity_spec_lifecycle_tests.rs"]
+mod identity_spec_lifecycle_tests;
 #[path = "grpc/oauth_refresh_tests.rs"]
 mod oauth_refresh_tests;
 #[path = "grpc/resilience_tests.rs"]

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -10,8 +10,9 @@ use coral_api::v1::{
 use coral_app::EngineExtensionsProvider;
 use coral_app::features::{Feature, FeatureOverrides};
 use coral_client::{
-    AppClient, CatalogClient, FunctionClient, QueryClient, SearchClient, SourceClient,
-    WorkspaceClient, batches_to_json_rows, decode_execute_sql_response, default_workspace,
+    AppClient, CatalogClient, FunctionClient, IdentitySpecClient, QueryClient, SearchClient,
+    SourceClient, WorkspaceClient, batches_to_json_rows, decode_execute_sql_response,
+    default_workspace,
     local::{RunningServer, ServerBuilder},
 };
 use serde_json::{Value, json};
@@ -135,6 +136,10 @@ impl GrpcHarness {
 
     pub(crate) fn workspace_client(&self) -> WorkspaceClient {
         self.app.workspace_client()
+    }
+
+    pub(crate) fn identity_spec_client(&self) -> IdentitySpecClient {
+        self.app.identity_spec_client()
     }
 
     pub(crate) fn search_client(&self) -> SearchClient {

--- a/crates/coral-app/tests/grpc/identity_spec_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_spec_lifecycle_tests.rs
@@ -1,0 +1,255 @@
+use coral_api::v1::{
+    AddIdentitySpecRequest, AddIdentitySpecResponse, CreateWorkspaceRequest,
+    DeleteIdentitySpecRequest, GetIdentitySpecRequest, GlobalIdentitySpecScope, IdentitySpec,
+    IdentitySpecInputValue, IdentitySpecScope, ListIdentitySpecsRequest, Workspace,
+    identity_spec_scope,
+};
+use tonic::{Code, Request};
+
+use crate::harness::GrpcHarness;
+
+const NAME: &str = "demo_oauth";
+const GLOBAL_TENANT: &str = "global-tenant-value";
+const GLOBAL_SECRET: &str = "global-secret-value";
+const WORKSPACE_TENANT: &str = "workspace-tenant-value";
+const WORKSPACE_SECRET: &str = "workspace-secret-value";
+const REPLACEMENT_TENANT: &str = "replacement-tenant-value";
+const REPLACEMENT_SECRET: &str = "replacement-secret-value";
+const SUPPLIED_VALUES: [&str; 6] = [
+    GLOBAL_TENANT,
+    GLOBAL_SECRET,
+    WORKSPACE_TENANT,
+    WORKSPACE_SECRET,
+    REPLACEMENT_TENANT,
+    REPLACEMENT_SECRET,
+];
+
+#[tokio::test]
+async fn manages_identity_specs_in_exact_global_and_workspace_scopes() {
+    let harness = GrpcHarness::new().await;
+    let workspace = Workspace {
+        name: "team".to_string(),
+    };
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace.clone()),
+        }))
+        .await
+        .expect("create workspace");
+    let global_scope = global_scope();
+    let workspace_scope = workspace_scope(workspace);
+
+    let global_add = add(
+        &harness,
+        "global-v1",
+        global_scope.clone(),
+        [GLOBAL_TENANT, GLOBAL_SECRET],
+    )
+    .await;
+    assert!(!global_add.replaced);
+    assert_spec(
+        global_add.identity_spec.as_ref(),
+        "global-v1",
+        &global_scope,
+    );
+    assert_no_supplied_values(&global_add);
+
+    let workspace_add = add(
+        &harness,
+        "workspace-v1",
+        workspace_scope.clone(),
+        [WORKSPACE_TENANT, WORKSPACE_SECRET],
+    )
+    .await;
+    assert!(!workspace_add.replaced);
+    assert_spec(
+        workspace_add.identity_spec.as_ref(),
+        "workspace-v1",
+        &workspace_scope,
+    );
+    assert_no_supplied_values(&workspace_add);
+
+    let global_get = get(&harness, global_scope.clone()).await;
+    assert_spec(Some(&global_get), "global-v1", &global_scope);
+    assert_no_supplied_values(&global_get);
+    let workspace_get = get(&harness, workspace_scope.clone()).await;
+    assert_spec(Some(&workspace_get), "workspace-v1", &workspace_scope);
+    assert_no_supplied_values(&workspace_get);
+
+    assert_combined_list(&harness, &workspace_scope, &global_scope).await;
+
+    let replacement = add(
+        &harness,
+        "workspace-v2",
+        workspace_scope.clone(),
+        [REPLACEMENT_TENANT, REPLACEMENT_SECRET],
+    )
+    .await;
+    assert!(replacement.replaced);
+    assert_spec(
+        replacement.identity_spec.as_ref(),
+        "workspace-v2",
+        &workspace_scope,
+    );
+    assert_no_supplied_values(&replacement);
+    assert_spec(
+        Some(&get(&harness, global_scope.clone()).await),
+        "global-v1",
+        &global_scope,
+    );
+
+    harness
+        .identity_spec_client()
+        .delete_identity_spec(Request::new(DeleteIdentitySpecRequest {
+            name: NAME.to_string(),
+            scope: Some(workspace_scope.clone()),
+        }))
+        .await
+        .expect("delete exact workspace identity spec");
+    let deleted = harness
+        .identity_spec_client()
+        .get_identity_spec(Request::new(GetIdentitySpecRequest {
+            name: NAME.to_string(),
+            scope: Some(workspace_scope),
+        }))
+        .await
+        .expect_err("deleted workspace identity spec should be absent");
+    assert_eq!(deleted.code(), Code::NotFound);
+    assert_spec(
+        Some(&get(&harness, global_scope.clone()).await),
+        "global-v1",
+        &global_scope,
+    );
+
+    assert_invalid_list_requests(&harness, &global_scope).await;
+}
+
+async fn assert_combined_list(
+    harness: &GrpcHarness,
+    workspace_scope: &IdentitySpecScope,
+    global_scope: &IdentitySpecScope,
+) {
+    let combined = harness
+        .identity_spec_client()
+        .list_identity_specs(Request::new(ListIdentitySpecsRequest {
+            scope: Some(workspace_scope.clone()),
+            include_global: true,
+        }))
+        .await
+        .expect("list workspace and global identity specs")
+        .into_inner();
+    assert_eq!(combined.identity_specs.len(), 2);
+    let global_summary = combined.identity_specs.first().expect("global summary");
+    assert_eq!(global_summary.name, NAME);
+    assert_eq!(global_summary.version, "global-v1");
+    assert_eq!(global_summary.scope.as_ref(), Some(global_scope));
+    let workspace_summary = combined.identity_specs.get(1).expect("workspace summary");
+    assert_eq!(workspace_summary.name, NAME);
+    assert_eq!(workspace_summary.version, "workspace-v1");
+    assert_eq!(workspace_summary.scope.as_ref(), Some(workspace_scope));
+    assert_no_supplied_values(&combined);
+}
+
+async fn assert_invalid_list_requests(harness: &GrpcHarness, global_scope: &IdentitySpecScope) {
+    for (request, reason) in [
+        (
+            ListIdentitySpecsRequest {
+                scope: None,
+                include_global: false,
+            },
+            "missing identity spec scope should fail",
+        ),
+        (
+            ListIdentitySpecsRequest {
+                scope: Some(global_scope.clone()),
+                include_global: true,
+            },
+            "global scope cannot include global fallback",
+        ),
+    ] {
+        let error = harness
+            .identity_spec_client()
+            .list_identity_specs(Request::new(request))
+            .await
+            .expect_err(reason);
+        assert_eq!(error.code(), Code::InvalidArgument);
+    }
+}
+
+async fn add(
+    harness: &GrpcHarness,
+    version: &str,
+    scope: IdentitySpecScope,
+    values: [&str; 2],
+) -> AddIdentitySpecResponse {
+    harness
+        .identity_spec_client()
+        .add_identity_spec(Request::new(AddIdentitySpecRequest {
+            manifest_yaml: oauth_manifest(version),
+            input_values: ["TENANT", "CLIENT_SECRET"]
+                .into_iter()
+                .zip(values)
+                .map(|(key, value)| IdentitySpecInputValue {
+                    key: key.to_string(),
+                    value: value.to_string(),
+                })
+                .collect(),
+            scope: Some(scope),
+        }))
+        .await
+        .expect("add identity spec")
+        .into_inner()
+}
+
+async fn get(harness: &GrpcHarness, scope: IdentitySpecScope) -> IdentitySpec {
+    harness
+        .identity_spec_client()
+        .get_identity_spec(Request::new(GetIdentitySpecRequest {
+            name: NAME.to_string(),
+            scope: Some(scope),
+        }))
+        .await
+        .expect("get identity spec")
+        .into_inner()
+        .identity_spec
+        .expect("identity spec response")
+}
+
+fn assert_spec(spec: Option<&IdentitySpec>, version: &str, scope: &IdentitySpecScope) {
+    let spec = spec.expect("identity spec");
+    assert_eq!(spec.name, NAME);
+    assert_eq!(spec.version, version);
+    assert_eq!(spec.scope.as_ref(), Some(scope));
+    assert!(spec.manifest_yaml.contains("port: 443"));
+}
+
+fn assert_no_supplied_values(response: &impl std::fmt::Debug) {
+    let response = format!("{response:?}");
+    for value in SUPPLIED_VALUES {
+        assert!(
+            !response.contains(value),
+            "identity-spec response leaked supplied input value"
+        );
+    }
+}
+
+fn global_scope() -> IdentitySpecScope {
+    IdentitySpecScope {
+        value: Some(identity_spec_scope::Value::Global(
+            GlobalIdentitySpecScope {},
+        )),
+    }
+}
+
+fn workspace_scope(workspace: Workspace) -> IdentitySpecScope {
+    IdentitySpecScope {
+        value: Some(identity_spec_scope::Value::Workspace(workspace)),
+    }
+}
+
+fn oauth_manifest(version: &str) -> String {
+    format!(
+        "kind: identity\nspec_version: 1\nname: {NAME}\nversion: {version}\ndescription: test identity {version}\nissuer: demo\ntype: oauth\naudience: {{host: api.example.com, port: 443}}\ninputs:\n  TENANT: {{kind: variable, required: true}}\n  CLIENT_SECRET: {{kind: secret, required: true}}\noauth:\n  method:\n    flow: {{type: authorization_code, pkce: disabled}}\n    redirect_uri: http://127.0.0.1:53682/oauth/callback\n    endpoints:\n      authorization_url: https://provider.example.com/authorize\n      token_url: https://provider.example.com/token\n    client:\n      id: {{input: TENANT}}\n      secret: {{input: CLIENT_SECRET, transport: basic_auth}}\n"
+    )
+}

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -87,6 +87,49 @@ async fn server_lifecycle_rejects_postgres_config_without_url_env_value() {
     }
 }
 
+#[tokio::test]
+async fn server_lifecycle_validates_configured_encryption_key_before_opening_database() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let missing_key_env = format!(
+        "CORAL_TEST_CREDENTIAL_KEY_MISSING_FOR_SERVER_START_{}",
+        uuid::Uuid::new_v4()
+            .simple()
+            .to_string()
+            .to_ascii_uppercase()
+    );
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.toml"),
+        format!("[encryption]\nencryption_key_env = \"{missing_key_env}\"\n"),
+    )
+    .expect("write config");
+
+    let result = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await;
+    let error = match result {
+        Err(error) => error,
+        Ok(server) => {
+            server.shutdown().await.expect("shutdown unexpected server");
+            panic!("server start should fail without the configured encryption key");
+        }
+    };
+
+    match error {
+        LocalServerError::FailedPrecondition(detail) => assert!(
+            detail.contains(&missing_key_env),
+            "unexpected detail: {detail}"
+        ),
+        other => panic!("unexpected error: {other}"),
+    }
+    assert!(
+        !config_dir.join("coral.db").exists(),
+        "credential-key validation must happen before the database is opened"
+    );
+}
+
 async fn assert_default_sqlite_db_is_migrated(config_dir: &std::path::Path) {
     let database_file = config_dir.join("coral.db");
     assert!(

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -87,49 +87,6 @@ async fn server_lifecycle_rejects_postgres_config_without_url_env_value() {
     }
 }
 
-#[tokio::test]
-async fn server_lifecycle_validates_configured_encryption_key_before_opening_database() {
-    let temp = TempDir::new().expect("temp dir");
-    let config_dir = temp.path().join("coral-config");
-    let missing_key_env = format!(
-        "CORAL_TEST_CREDENTIAL_KEY_MISSING_FOR_SERVER_START_{}",
-        uuid::Uuid::new_v4()
-            .simple()
-            .to_string()
-            .to_ascii_uppercase()
-    );
-    fs::create_dir_all(&config_dir).expect("create config dir");
-    fs::write(
-        config_dir.join("config.toml"),
-        format!("[encryption]\nencryption_key_env = \"{missing_key_env}\"\n"),
-    )
-    .expect("write config");
-
-    let result = ServerBuilder::new()
-        .with_config_dir(&config_dir)
-        .start()
-        .await;
-    let error = match result {
-        Err(error) => error,
-        Ok(server) => {
-            server.shutdown().await.expect("shutdown unexpected server");
-            panic!("server start should fail without the configured encryption key");
-        }
-    };
-
-    match error {
-        LocalServerError::FailedPrecondition(detail) => assert!(
-            detail.contains(&missing_key_env),
-            "unexpected detail: {detail}"
-        ),
-        other => panic!("unexpected error: {other}"),
-    }
-    assert!(
-        !config_dir.join("coral.db").exists(),
-        "credential-key validation must happen before the database is opened"
-    );
-}
-
 async fn assert_default_sqlite_db_is_migrated(config_dir: &std::path::Path) {
     let database_file = config_dir.join("coral.db");
     assert!(

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -8,6 +8,11 @@
 use std::collections::BTreeMap;
 use std::fs;
 
+use coral_api::v1::{
+    AddIdentitySpecRequest, GlobalIdentitySpecScope, IdentitySpecInputValue, IdentitySpecScope,
+    identity_spec_scope,
+};
+use coral_client::AppClient;
 use coral_client::local::ServerBuilder;
 use coral_engine::{
     CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
@@ -18,6 +23,7 @@ use coral_spec::{
 };
 use sqlx::postgres::PgPoolOptions;
 use tempfile::TempDir;
+use tonic::{Code, Request};
 
 #[tokio::test]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run configured Postgres startup coverage"]
@@ -40,6 +46,45 @@ async fn server_lifecycle_can_start_with_postgres_database_config() {
         .await
         .expect("start server with Postgres config");
     assert_postgres_db_is_migrated(&database_url).await;
+
+    let app = AppClient::connect(server.endpoint_uri())
+        .await
+        .expect("connect client");
+    let fixed = app
+        .identity_spec_client()
+        .add_identity_spec(Request::new(AddIdentitySpecRequest {
+            manifest_yaml: fixed_token_manifest().to_string(),
+            input_values: Vec::new(),
+            scope: Some(global_scope()),
+        }))
+        .await
+        .expect("install fixed-token identity spec without setup inputs")
+        .into_inner();
+    assert_eq!(
+        fixed.identity_spec.expect("installed identity spec").name,
+        "postgres_fixed_token"
+    );
+
+    let error = app
+        .identity_spec_client()
+        .add_identity_spec(Request::new(AddIdentitySpecRequest {
+            manifest_yaml: oauth_manifest().to_string(),
+            input_values: vec![IdentitySpecInputValue {
+                key: "CLIENT_SECRET".to_string(),
+                value: "not-persisted".to_string(),
+            }],
+            scope: Some(global_scope()),
+        }))
+        .await
+        .expect_err("Postgres setup-input persistence requires a configured encryption key");
+    assert_eq!(error.code(), Code::FailedPrecondition);
+    assert!(
+        !config_dir
+            .join("credentials")
+            .join("encryption.key")
+            .exists(),
+        "Postgres must never create a node-local identity encryption key"
+    );
 
     server.shutdown().await.expect("shutdown server");
 }
@@ -152,6 +197,22 @@ fn postgres_source(database_url: &str) -> QuerySource {
         BTreeMap::new(),
     )
     .expect("build Postgres inventory source")
+}
+
+fn global_scope() -> IdentitySpecScope {
+    IdentitySpecScope {
+        value: Some(identity_spec_scope::Value::Global(
+            GlobalIdentitySpecScope {},
+        )),
+    }
+}
+
+fn fixed_token_manifest() -> &'static str {
+    "kind: identity\nspec_version: 1\nname: postgres_fixed_token\nversion: 1.0.0\nissuer: demo\ntype: fixed_token\naudience: {host: example.com}\n"
+}
+
+fn oauth_manifest() -> &'static str {
+    "kind: identity\nspec_version: 1\nname: postgres_oauth\nversion: 1.0.0\nissuer: demo\ntype: oauth\naudience: {host: example.com}\ninputs:\n  CLIENT_SECRET: {kind: secret, required: true}\noauth:\n  method:\n    flow: {type: authorization_code, pkce: disabled}\n    redirect_uri: http://127.0.0.1:53682/oauth/callback\n    endpoints: {authorization_url: 'https://example.com/authorize', token_url: 'https://example.com/token'}\n    client:\n      id: {default: demo}\n      secret: {input: CLIENT_SECRET, transport: basic_auth}\n"
 }
 
 async fn assert_postgres_db_is_migrated(database_url: &str) {

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -23,7 +23,7 @@ use coral_spec::{
 };
 use sqlx::postgres::PgPoolOptions;
 use tempfile::TempDir;
-use tonic::{Code, Request};
+use tonic::Request;
 
 #[tokio::test]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run configured Postgres startup coverage"]
@@ -65,7 +65,7 @@ async fn server_lifecycle_can_start_with_postgres_database_config() {
         "postgres_fixed_token"
     );
 
-    let error = app
+    let oauth = app
         .identity_spec_client()
         .add_identity_spec(Request::new(AddIdentitySpecRequest {
             manifest_yaml: oauth_manifest().to_string(),
@@ -76,14 +76,18 @@ async fn server_lifecycle_can_start_with_postgres_database_config() {
             scope: Some(global_scope()),
         }))
         .await
-        .expect_err("Postgres setup-input persistence requires a configured encryption key");
-    assert_eq!(error.code(), Code::FailedPrecondition);
+        .expect("install OAuth identity spec with setup inputs")
+        .into_inner();
+    assert_eq!(
+        oauth.identity_spec.expect("installed identity spec").name,
+        "postgres_oauth"
+    );
     assert!(
-        !config_dir
+        config_dir
             .join("credentials")
             .join("encryption.key")
             .exists(),
-        "Postgres must never create a node-local identity encryption key"
+        "identity setup-input persistence should create the local encryption key"
     );
 
     server.shutdown().await.expect("shutdown server");


### PR DESCRIPTION
## Intent

Activate the identity-spec management service in the real Coral server and bind encrypted setup-input persistence to one startup-resolved key-provider contract.

## What it enables

- Exact global and workspace identity-spec management over the mounted gRPC service.
- Redacted responses and ordered global-plus-workspace listing without leaking supplied setup inputs.
- Startup-only configured KEK loading with active and decrypt-only rotation keys.
- SQLite compatibility with its private local key and PostgreSQL operation without any node-local key fallback.
- Keyless PostgreSQL startup for no-input specs, while encrypted setup-input operations fail with `FailedPrecondition` until a shared key is configured.

## Usage examples

Identity-spec API callers select an explicit `global` or workspace scope for every mutation and exact read. Workspace list requests may set `include_global`; results retain same-name entries and return global entries before workspace entries.

For a shared database, configure the active envelope KEK by naming its environment variable:

```toml
[encryption]
encryption_key_env = "CORAL_ENVELOPE_KEK_CURRENT"
decryption_key_envs = ["CORAL_ENVELOPE_KEK_PREVIOUS"]
```

Each referenced value uses `v1:<base64-encoded-32-byte-key>`. Coral loads the immutable key ring once at startup; restart after changing the configuration or environment.

## Documentation

The reference and security docs in this PR describe the key under `[encryption]`
rather than `[credentials]`, and state that one KEK protects source credential
documents, identity-spec setup inputs, and identity setup inputs alike — so its
blast radius is wider than source secrets. The SQLite local key file is documented
at `encryption/envelope.key`.

## Validation

- Focused identity-spec gRPC lifecycle and startup-order tests
- `cargo nextest run -p coral-app -E 'test(credentials::config)'` — 5 passed
- `make docs-check`