### PR TITLE
feat(app): add identity metadata schema

### DIFF
--- a/crates/coral-app/migrations/0010_identities.sql
+++ b/crates/coral-app/migrations/0010_identities.sql
@@ -1,0 +1,51 @@
+-- Identity spec references deliberately are not foreign keys: app lifecycle
+-- owns replacement/orphan policy while fingerprints pin exact semantics.
+CREATE TABLE IF NOT EXISTS identities (
+    owner_kind TEXT NOT NULL,
+    owner_key TEXT NOT NULL,
+    workspace_id TEXT,
+    name TEXT NOT NULL,
+    identity_spec_workspace_id TEXT,
+    identity_spec_name TEXT NOT NULL,
+    identity_spec_fingerprint TEXT NOT NULL,
+    issuer TEXT NOT NULL,
+    identity_type TEXT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (owner_kind, owner_key, name),
+    CHECK (
+        (
+            owner_kind = 'user'
+            AND workspace_id IS NULL
+        )
+        OR (
+            owner_kind = 'workspace'
+            AND workspace_id IS NOT NULL
+            AND owner_key = workspace_id
+        )
+    ),
+    CHECK (
+        (
+            owner_kind = 'user'
+            AND identity_spec_workspace_id IS NULL
+        )
+        OR (
+            owner_kind = 'workspace'
+            AND (
+                identity_spec_workspace_id IS NULL
+                OR identity_spec_workspace_id = workspace_id
+            )
+        )
+    ),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS identities_workspace_id_idx
+    ON identities (workspace_id);
+
+CREATE INDEX IF NOT EXISTS identities_identity_spec_idx
+    ON identities (
+        identity_spec_workspace_id,
+        identity_spec_name,
+        identity_spec_fingerprint
+    );

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -1,0 +1,3 @@
+//! App-owned identity instance domain types.
+
+pub(crate) mod model;

--- a/crates/coral-app/src/identities/model.rs
+++ b/crates/coral-app/src/identities/model.rs
@@ -1,0 +1,246 @@
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Identity persistence consumers land in the next stack units."
+    )
+)]
+
+use std::fmt;
+
+use crate::bootstrap::AppError;
+use crate::identity::{UserPrincipal, parse_path_segment};
+use crate::state::db::{IdentitySpecKey, IdentitySpecScope};
+use crate::workspaces::WorkspaceName;
+
+const USER_OWNER_KIND: &str = "user";
+const WORKSPACE_OWNER_KIND: &str = "workspace";
+
+/// Validated name of one identity instance within an owner.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct IdentityName(String);
+
+impl IdentityName {
+    /// Parse and normalize an identity name.
+    pub(crate) fn parse(name: &str) -> Result<Self, AppError> {
+        parse_path_segment("identity", name).map(Self)
+    }
+
+    /// Borrow the normalized identity name.
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for IdentityName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// User or workspace that owns one identity instance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum IdentityOwner {
+    User(UserPrincipal),
+    Workspace(WorkspaceName),
+}
+
+impl IdentityOwner {
+    /// Build a user owner from an already validated request principal.
+    pub(crate) fn for_user(principal: UserPrincipal) -> Self {
+        Self::User(principal)
+    }
+
+    /// Build a workspace owner from an already validated workspace name.
+    pub(crate) fn workspace(workspace: WorkspaceName) -> Self {
+        Self::Workspace(workspace)
+    }
+
+    /// Storage discriminator for this owner.
+    pub(crate) fn kind(&self) -> &'static str {
+        match self {
+            Self::User(_) => USER_OWNER_KIND,
+            Self::Workspace(_) => WORKSPACE_OWNER_KIND,
+        }
+    }
+
+    /// Stable storage key within the owner kind.
+    pub(crate) fn key(&self) -> &str {
+        match self {
+            Self::User(principal) => principal.user_id(),
+            Self::Workspace(workspace) => workspace.as_str(),
+        }
+    }
+
+    /// Workspace foreign-key value, absent for user-owned identities.
+    pub(crate) fn workspace_name(&self) -> Option<&WorkspaceName> {
+        match self {
+            Self::User(_) => None,
+            Self::Workspace(workspace) => Some(workspace),
+        }
+    }
+}
+
+/// Exact identity-spec version selected when an identity is written.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IdentitySpecReference {
+    key: IdentitySpecKey,
+    fingerprint: String,
+    issuer: String,
+    identity_type: String,
+}
+
+impl IdentitySpecReference {
+    /// Validate an exact spec reference against the identity owner.
+    pub(crate) fn new(
+        owner: &IdentityOwner,
+        key: IdentitySpecKey,
+        fingerprint: impl Into<String>,
+        issuer: impl Into<String>,
+        identity_type: impl Into<String>,
+    ) -> Result<Self, AppError> {
+        validate_scope(owner, key.scope())?;
+        let reference = Self {
+            key,
+            fingerprint: fingerprint.into(),
+            issuer: issuer.into(),
+            identity_type: identity_type.into(),
+        };
+        for (field, value) in [
+            ("identity spec fingerprint", reference.fingerprint.as_str()),
+            ("identity spec issuer", reference.issuer.as_str()),
+            ("identity spec type", reference.identity_type.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                return Err(AppError::InvalidInput(format!("missing {field}")));
+            }
+        }
+        Ok(reference)
+    }
+
+    pub(crate) fn key(&self) -> &IdentitySpecKey {
+        &self.key
+    }
+
+    pub(crate) fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    pub(crate) fn issuer(&self) -> &str {
+        &self.issuer
+    }
+
+    pub(crate) fn identity_type(&self) -> &str {
+        &self.identity_type
+    }
+}
+
+fn validate_scope(owner: &IdentityOwner, scope: &IdentitySpecScope) -> Result<(), AppError> {
+    let valid = match (owner, scope) {
+        (_, IdentitySpecScope::Global) => true,
+        (IdentityOwner::Workspace(owner), IdentitySpecScope::Workspace(spec)) => owner == spec,
+        (IdentityOwner::User(_), IdentitySpecScope::Workspace(_)) => false,
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(AppError::InvalidInput(
+            "identity spec scope is incompatible with its owner".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IdentityName, IdentityOwner, IdentitySpecReference};
+    use crate::identity::UserPrincipal;
+    use crate::state::db::IdentitySpecKey;
+    use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn identity_names_are_safe_normalized_and_orderable() {
+        let alpha = IdentityName::parse("  alpha  ").expect("normalized name");
+        let beta = IdentityName::parse("beta").expect("second name");
+        assert_eq!(alpha.as_str(), "alpha");
+        assert_eq!(alpha.to_string(), "alpha");
+        assert!(alpha < beta);
+        for invalid in ["", "  ", ".", "..", "bad/name", r"bad\name"] {
+            assert!(
+                IdentityName::parse(invalid).is_err(),
+                "accepted {invalid:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn owners_expose_stable_storage_values() {
+        let local = IdentityOwner::for_user(UserPrincipal::local());
+        assert_eq!((local.kind(), local.key()), ("user", "local"));
+        assert!(local.workspace_name().is_none());
+
+        let user = IdentityOwner::for_user(UserPrincipal::for_user("member-1").expect("user"));
+        assert_eq!((user.kind(), user.key()), ("user", "member-1"));
+
+        let workspace = WorkspaceName::parse("team-1").expect("workspace");
+        let owner = IdentityOwner::workspace(workspace.clone());
+        assert_eq!((owner.kind(), owner.key()), ("workspace", "team-1"));
+        assert_eq!(owner.workspace_name(), Some(&workspace));
+    }
+
+    #[test]
+    fn spec_references_enforce_the_full_owner_scope_matrix() {
+        let user = IdentityOwner::for_user(UserPrincipal::local());
+        let alpha = WorkspaceName::parse("alpha").expect("alpha");
+        let beta = WorkspaceName::parse("beta").expect("beta");
+        let workspace = IdentityOwner::workspace(alpha.clone());
+        let reference = |owner: &IdentityOwner, key| {
+            IdentitySpecReference::new(owner, key, "fingerprint", "issuer", "fixed_token")
+        };
+
+        reference(&user, IdentitySpecKey::global("token").expect("global"))
+            .expect("user may reference a global spec");
+        reference(
+            &user,
+            IdentitySpecKey::workspace(alpha.clone(), "token").expect("scoped"),
+        )
+        .expect_err("user must not reference a workspace spec");
+        let global = reference(
+            &workspace,
+            IdentitySpecKey::global("token").expect("global"),
+        )
+        .expect("workspace global fallback");
+        assert_eq!(global.key().name(), "token");
+        assert_eq!(global.fingerprint(), "fingerprint");
+        assert_eq!(global.issuer(), "issuer");
+        assert_eq!(global.identity_type(), "fixed_token");
+        reference(
+            &workspace,
+            IdentitySpecKey::workspace(alpha, "token").expect("same workspace"),
+        )
+        .expect("workspace may reference its own spec");
+        reference(
+            &workspace,
+            IdentitySpecKey::workspace(beta, "token").expect("other workspace"),
+        )
+        .expect_err("workspace must not reference another workspace's spec");
+    }
+
+    #[test]
+    fn spec_references_reject_blank_required_fields() {
+        let owner = IdentityOwner::for_user(UserPrincipal::local());
+        for fields in [
+            (" ", "issuer", "fixed_token"),
+            ("fingerprint", "\t", "fixed_token"),
+            ("fingerprint", "issuer", "\n"),
+        ] {
+            IdentitySpecReference::new(
+                &owner,
+                IdentitySpecKey::global("token").expect("key"),
+                fields.0,
+                fields.1,
+                fields.2,
+            )
+            .expect_err("blank required spec-reference field must be rejected");
+        }
+    }
+}

--- a/crates/coral-app/src/identities/model.rs
+++ b/crates/coral-app/src/identities/model.rs
@@ -9,7 +9,7 @@
 use std::fmt;
 
 use crate::bootstrap::AppError;
-use crate::identity::{UserPrincipal, parse_path_segment};
+use crate::identity::{Principal, parse_path_segment};
 use crate::state::db::{IdentitySpecKey, IdentitySpecScope};
 use crate::workspaces::WorkspaceName;
 
@@ -41,13 +41,13 @@ impl fmt::Display for IdentityName {
 /// User or workspace that owns one identity instance.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum IdentityOwner {
-    User(UserPrincipal),
+    User(Principal),
     Workspace(WorkspaceName),
 }
 
 impl IdentityOwner {
     /// Build a user owner from an already validated request principal.
-    pub(crate) fn for_user(principal: UserPrincipal) -> Self {
+    pub(crate) fn for_user(principal: Principal) -> Self {
         Self::User(principal)
     }
 
@@ -67,7 +67,7 @@ impl IdentityOwner {
     /// Stable storage key within the owner kind.
     pub(crate) fn key(&self) -> &str {
         match self {
-            Self::User(principal) => principal.user_id(),
+            Self::User(principal) => principal.id().as_str(),
             Self::Workspace(workspace) => workspace.as_str(),
         }
     }
@@ -153,7 +153,7 @@ fn validate_scope(owner: &IdentityOwner, scope: &IdentitySpecScope) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::{IdentityName, IdentityOwner, IdentitySpecReference};
-    use crate::identity::UserPrincipal;
+    use crate::identity::{Principal, PrincipalKind};
     use crate::state::db::IdentitySpecKey;
     use crate::workspaces::WorkspaceName;
 
@@ -174,11 +174,13 @@ mod tests {
 
     #[test]
     fn owners_expose_stable_storage_values() {
-        let local = IdentityOwner::for_user(UserPrincipal::local());
-        assert_eq!((local.kind(), local.key()), ("user", "local"));
+        let local = IdentityOwner::for_user(Principal::local());
+        assert_eq!((local.kind(), local.key()), ("user", "coral:local"));
         assert!(local.workspace_name().is_none());
 
-        let user = IdentityOwner::for_user(UserPrincipal::for_user("member-1").expect("user"));
+        let user = IdentityOwner::for_user(
+            Principal::parse("member-1", PrincipalKind::User).expect("user"),
+        );
         assert_eq!((user.kind(), user.key()), ("user", "member-1"));
 
         let workspace = WorkspaceName::parse("team-1").expect("workspace");
@@ -189,7 +191,7 @@ mod tests {
 
     #[test]
     fn spec_references_enforce_the_full_owner_scope_matrix() {
-        let user = IdentityOwner::for_user(UserPrincipal::local());
+        let user = IdentityOwner::for_user(Principal::local());
         let alpha = WorkspaceName::parse("alpha").expect("alpha");
         let beta = WorkspaceName::parse("beta").expect("beta");
         let workspace = IdentityOwner::workspace(alpha.clone());
@@ -227,7 +229,7 @@ mod tests {
 
     #[test]
     fn spec_references_reject_blank_required_fields() {
-        let owner = IdentityOwner::for_user(UserPrincipal::local());
+        let owner = IdentityOwner::for_user(Principal::local());
         for fields in [
             (" ", "issuer", "fixed_token"),
             ("fingerprint", "\t", "fixed_token"),

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -52,6 +52,7 @@ mod feedback;
 mod functions;
 mod gui_onboarding;
 mod hash;
+mod identities;
 mod identity;
 mod identity_specs;
 mod oauth_resource;

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -71,6 +71,8 @@ fn rows_match_current_migrations(rows: &[(i64, Vec<u8>, bool)]) -> bool {
 mod tests {
     use super::{MIGRATOR, rows_match_current_migrations};
 
+    type IdentityRow<'a> = (&'a str, &'a str, Option<&'a str>, &'a str, Option<&'a str>);
+
     #[test]
     fn current_migration_rows_must_match_versions_checksums_and_success() {
         let current_rows: Vec<_> = MIGRATOR
@@ -141,5 +143,102 @@ mod tests {
             columns.iter().all(|(column,)| column != "identity_type"),
             "identity_type must be derived from manifest_yaml"
         );
+    }
+
+    #[tokio::test]
+    async fn sqlite_identity_schema_enforces_owner_and_spec_scope_structure() {
+        let pool = sqlx::SqlitePool::connect(":memory:")
+            .await
+            .expect("sqlite pool");
+        MIGRATOR.run(&pool).await.expect("run migrations");
+        for workspace in ["alpha", "beta"] {
+            sqlx::query("INSERT INTO workspaces (id, created_at_unix_nanos) VALUES (?, 0)")
+                .bind(workspace)
+                .execute(&pool)
+                .await
+                .expect("seed workspace");
+        }
+
+        for row in [
+            ("user", "local", None, "user-global", None),
+            (
+                "workspace",
+                "alpha",
+                Some("alpha"),
+                "workspace-global",
+                None,
+            ),
+            (
+                "workspace",
+                "alpha",
+                Some("alpha"),
+                "workspace-scoped",
+                Some("alpha"),
+            ),
+        ] {
+            insert_identity(&pool, row)
+                .await
+                .expect("valid identity row");
+        }
+        let identity_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM identities")
+            .fetch_one(&pool)
+            .await
+            .expect("count identities");
+        assert_eq!(identity_count, 3);
+
+        for row in [
+            ("workspace", "alpha", Some("beta"), "owner-mismatch", None),
+            (
+                "workspace",
+                "missing",
+                Some("missing"),
+                "missing-workspace",
+                None,
+            ),
+            ("user", "member", None, "user-scoped", Some("alpha")),
+            (
+                "workspace",
+                "alpha",
+                Some("alpha"),
+                "cross-workspace",
+                Some("beta"),
+            ),
+        ] {
+            insert_identity(&pool, row)
+                .await
+                .expect_err("invalid identity row must be rejected");
+        }
+
+        sqlx::query("DELETE FROM workspaces WHERE id = 'alpha'")
+            .execute(&pool)
+            .await
+            .expect("delete workspace");
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM identities")
+            .fetch_one(&pool)
+            .await
+            .expect("count cascaded identity rows");
+        assert_eq!(remaining, 1);
+    }
+
+    async fn insert_identity(
+        pool: &sqlx::SqlitePool,
+        (owner_kind, owner_key, workspace_id, name, identity_spec_workspace_id): IdentityRow<'_>,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO identities (
+                owner_kind, owner_key, workspace_id, name,
+                identity_spec_workspace_id, identity_spec_name,
+                identity_spec_fingerprint, issuer, identity_type,
+                created_at_unix_nanos, updated_at_unix_nanos
+             ) VALUES (?, ?, ?, ?, ?, 'missing-spec', 'fingerprint', 'issuer', 'fixed_token', 1, 1)",
+        )
+        .bind(owner_kind)
+        .bind(owner_key)
+        .bind(workspace_id)
+        .bind(name)
+        .bind(identity_spec_workspace_id)
+        .execute(pool)
+        .await
+        .map(|_| ())
     }
 }

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -98,3 +98,23 @@ pub(in crate::state::db) enum GuiOnboardingCompletions {
     PrincipalId,
     CompletedAtUnixNanos,
 }
+
+#[expect(
+    dead_code,
+    reason = "Identity repository consumers land in the next stack units."
+)]
+#[derive(Iden)]
+pub(in crate::state::db) enum Identities {
+    Table,
+    OwnerKind,
+    OwnerKey,
+    WorkspaceId,
+    Name,
+    IdentitySpecWorkspaceId,
+    IdentitySpecName,
+    IdentitySpecFingerprint,
+    Issuer,
+    IdentityType,
+    CreatedAtUnixNanos,
+    UpdatedAtUnixNanos,
+}

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -25,6 +25,9 @@ use sqlx::postgres::PgPoolOptions;
 use tempfile::TempDir;
 use tonic::Request;
 
+const ALPHA: &str = "identity-alpha";
+const BETA: &str = "identity-beta";
+
 #[tokio::test]
 #[ignore = "set CORAL_TEST_POSTGRES_URL to run configured Postgres startup coverage"]
 async fn server_lifecycle_can_start_with_postgres_database_config() {
@@ -230,6 +233,88 @@ async fn assert_postgres_db_is_migrated(database_url: &str) {
             .await
             .expect("inspect migrated Postgres schema");
     assert!(table_exists, "workspaces table should be migrated");
+    assert_postgres_identity_schema(&pool).await;
+}
+
+async fn assert_postgres_identity_schema(pool: &sqlx::PgPool) {
+    for workspace in [ALPHA, BETA] {
+        sqlx::query("INSERT INTO workspaces (id, created_at_unix_nanos) VALUES ($1, 0)")
+            .bind(workspace)
+            .execute(pool)
+            .await
+            .expect("seed identity workspace");
+    }
+    for row in [
+        ("user", "local", None, "user-global", None),
+        ("workspace", ALPHA, Some(ALPHA), "workspace-global", None),
+        (
+            "workspace",
+            ALPHA,
+            Some(ALPHA),
+            "workspace-scoped",
+            Some(ALPHA),
+        ),
+    ] {
+        insert_postgres_identity(pool, row)
+            .await
+            .expect("valid Postgres identity row");
+    }
+    assert_postgres_identity_rejects_invalid_rows(pool).await;
+    sqlx::query("DELETE FROM workspaces WHERE id = 'identity-alpha'")
+        .execute(pool)
+        .await
+        .expect("delete Postgres workspace");
+    let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM identities")
+        .fetch_one(pool)
+        .await
+        .expect("count cascaded Postgres identity rows");
+    assert_eq!(remaining, 1);
+}
+
+async fn assert_postgres_identity_rejects_invalid_rows(pool: &sqlx::PgPool) {
+    for row in [
+        ("unknown", "member", None, "unknown-owner", None),
+        ("user", "member", Some(ALPHA), "user-workspace", None),
+        ("workspace", ALPHA, None, "missing-workspace", None),
+        ("user", "member", None, "user-scoped", Some(ALPHA)),
+        (
+            "workspace",
+            ALPHA,
+            Some(ALPHA),
+            "cross-workspace",
+            Some(BETA),
+        ),
+        ("workspace", ALPHA, Some(BETA), "owner-mismatch", None),
+        ("workspace", "missing", Some("missing"), "missing-row", None),
+    ] {
+        insert_postgres_identity(pool, row)
+            .await
+            .expect_err("invalid Postgres identity row must be rejected");
+    }
+}
+
+type IdentityRow<'a> = (&'a str, &'a str, Option<&'a str>, &'a str, Option<&'a str>);
+
+async fn insert_postgres_identity(
+    pool: &sqlx::PgPool,
+    (owner_kind, owner_key, workspace_id, name, identity_spec_workspace_id): IdentityRow<'_>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO identities (
+            owner_kind, owner_key, workspace_id, name,
+            identity_spec_workspace_id, identity_spec_name,
+            identity_spec_fingerprint, issuer, identity_type,
+            created_at_unix_nanos, updated_at_unix_nanos
+         ) VALUES ($1, $2, $3, $4, $5, 'missing-spec', 'fingerprint', 'issuer', 'fixed_token', 1, 1)",
+    )
+    .bind(owner_kind)
+    .bind(owner_key)
+    .bind(workspace_id)
+    .bind(name)
+    .bind(identity_spec_workspace_id)
+    .execute(pool)
+    .await
+    .map(|_| ())
 }
 
 #[expect(


### PR DESCRIPTION
## Intent

Add the durable metadata foundation for user- and workspace-owned identity instances without reviving stale per-surface identity semantics.

The schema stores each identity under its exact owner/name key and pins the exact resolved identity-spec scope, name, and semantic fingerprint. User identities may reference only global specs; workspace identities may reference global specs or specs owned by that same workspace.

## What it enables

- Exact, owner-scoped identity repository reads and transaction-only mutations in the next stack layer.
- Safe inspection of issuer/type metadata even when an identity's pinned spec is unavailable.
- Manager-owned workspace-first/global fallback while repositories remain exact-key storage adapters.
- Future encrypted identity documents whose AAD binds owner, identity name, exact spec key, and fingerprint.
- Matching owner/scope and workspace-cascade behavior on SQLite and Postgres.

Encrypted identity material, source bindings, OAuth state, and runtime selection are deliberately deferred. Identity requirements remain source-level; this schema stores no surface IDs, accepted-requirement IDs, audience copies, or runtime authenticator state.

## Usage examples

This is an internal persistence layer and adds no user-facing command yet. A later manager can persist identities such as:

- user `local` / identity `github-main` pinned to global spec `github` at an exact semantic fingerprint;
- workspace `team-a` / identity `billing-token` pinned either to workspace spec `team-a/billing` or the resolved global fallback.

Invalid combinations—such as a user identity referencing a workspace spec, or a workspace identity referencing another workspace's spec—are rejected by both the domain model and database constraints.

## Validation

- `make rust-checks` — 1,950 passed, 4 skipped; Clippy and rustdoc clean.
- `make postgres-tests` — all fresh-database Postgres contracts passed, including the new owner/scope matrix and cascade coverage.
- Focused identity model and SQLite migration tests passed.
- `make perf-check` — 216.8 ms mean versus the 750 ms threshold.
- Three local read-only reviews found no remaining P0–P3 issues.
