### PR TITLE
feat(app): add exact identity row repository

### DIFF
--- a/crates/coral-app/src/identities/model.rs
+++ b/crates/coral-app/src/identities/model.rs
@@ -1,16 +1,8 @@
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Identity persistence consumers land in the next stack units."
-    )
-)]
-
 use std::fmt;
 
 use crate::bootstrap::AppError;
-use crate::identity::{Principal, parse_path_segment};
-use crate::state::db::{IdentitySpecKey, IdentitySpecScope};
+use crate::identity::{LOCAL_PRINCIPAL_ID, Principal, PrincipalKind, parse_path_segment};
+use crate::state::db::{DbError, IdentitySpecKey, IdentitySpecScope};
 use crate::workspaces::WorkspaceName;
 
 const USER_OWNER_KIND: &str = "user";
@@ -29,6 +21,20 @@ impl IdentityName {
     /// Borrow the normalized identity name.
     pub(crate) fn as_str(&self) -> &str {
         &self.0
+    }
+
+    pub(crate) fn from_storage(value: &str) -> Result<Self, DbError> {
+        let name = Self::parse(value).map_err(|error| {
+            DbError::CorruptData(format!(
+                "invalid persisted identity name '{value}': {error}"
+            ))
+        })?;
+        if name.as_str() != value {
+            return Err(DbError::CorruptData(format!(
+                "persisted identity name '{value}' is not normalized"
+            )));
+        }
+        Ok(name)
     }
 }
 
@@ -79,6 +85,48 @@ impl IdentityOwner {
             Self::Workspace(workspace) => Some(workspace),
         }
     }
+
+    pub(crate) fn from_storage_parts(
+        owner_kind: &str,
+        owner_key: &str,
+        workspace_id: Option<&str>,
+    ) -> Result<Self, DbError> {
+        match (owner_kind, workspace_id) {
+            (USER_OWNER_KIND, None) => {
+                let principal = if owner_key == LOCAL_PRINCIPAL_ID {
+                    Principal::local()
+                } else {
+                    Principal::parse(owner_key, PrincipalKind::User).map_err(|error| {
+                        DbError::CorruptData(format!(
+                            "invalid persisted identity user owner '{owner_key}': {error}"
+                        ))
+                    })?
+                };
+                if principal.id().as_str() != owner_key {
+                    return Err(DbError::CorruptData(format!(
+                        "persisted identity user owner '{owner_key}' is not normalized"
+                    )));
+                }
+                Ok(Self::for_user(principal))
+            }
+            (WORKSPACE_OWNER_KIND, Some(workspace_id)) if owner_key == workspace_id => {
+                let workspace = WorkspaceName::parse(workspace_id).map_err(|error| {
+                    DbError::CorruptData(format!(
+                        "invalid persisted identity workspace owner '{workspace_id}': {error}"
+                    ))
+                })?;
+                if workspace.as_str() != workspace_id {
+                    return Err(DbError::CorruptData(format!(
+                        "persisted identity workspace owner '{workspace_id}' is not normalized"
+                    )));
+                }
+                Ok(Self::workspace(workspace))
+            }
+            _ => Err(DbError::CorruptData(
+                "persisted identity row has invalid owner columns".to_string(),
+            )),
+        }
+    }
 }
 
 /// Exact identity-spec version selected when an identity is written.
@@ -115,6 +163,11 @@ impl IdentitySpecReference {
                 return Err(AppError::InvalidInput(format!("missing {field}")));
             }
         }
+        if !matches!(reference.identity_type.as_str(), "oauth" | "fixed_token") {
+            return Err(AppError::InvalidInput(
+                "identity spec type must be 'oauth' or 'fixed_token'".to_string(),
+            ));
+        }
         Ok(reference)
     }
 
@@ -132,6 +185,26 @@ impl IdentitySpecReference {
 
     pub(crate) fn identity_type(&self) -> &str {
         &self.identity_type
+    }
+
+    pub(crate) fn validate_for_owner(&self, owner: &IdentityOwner) -> Result<(), AppError> {
+        validate_scope(owner, self.key.scope())
+    }
+
+    pub(crate) fn from_storage_parts(
+        owner: &IdentityOwner,
+        workspace_id: Option<&str>,
+        name: &str,
+        fingerprint: String,
+        issuer: String,
+        identity_type: String,
+    ) -> Result<Self, DbError> {
+        let key = IdentitySpecKey::from_reference_storage_parts(workspace_id, name)?;
+        Self::new(owner, key, fingerprint, issuer, identity_type).map_err(|error| {
+            DbError::CorruptData(format!(
+                "invalid persisted identity spec reference: {error}"
+            ))
+        })
     }
 }
 
@@ -234,6 +307,7 @@ mod tests {
             (" ", "issuer", "fixed_token"),
             ("fingerprint", "\t", "fixed_token"),
             ("fingerprint", "issuer", "\n"),
+            ("fingerprint", "issuer", "unknown"),
         ] {
             IdentitySpecReference::new(
                 &owner,
@@ -244,5 +318,29 @@ mod tests {
             )
             .expect_err("blank required spec-reference field must be rejected");
         }
+    }
+
+    #[test]
+    fn persisted_identity_parts_reject_corrupt_or_non_normalized_values() {
+        IdentityName::from_storage(" alpha").expect_err("non-normalized name");
+        IdentityName::from_storage("bad/name").expect_err("unsafe name");
+        IdentityOwner::from_storage_parts("unknown", "local", None).expect_err("unknown owner");
+        IdentityOwner::from_storage_parts("user", " member", None)
+            .expect_err("non-normalized user");
+        IdentityOwner::from_storage_parts("user", "local", Some("local"))
+            .expect_err("user workspace column");
+        IdentityOwner::from_storage_parts("workspace", "alpha", Some("beta"))
+            .expect_err("mismatched workspace columns");
+
+        let owner = IdentityOwner::for_user(Principal::local());
+        IdentitySpecReference::from_storage_parts(
+            &owner,
+            Some("alpha"),
+            "token",
+            "fingerprint".to_string(),
+            "issuer".to_string(),
+            "fixed_token".to_string(),
+        )
+        .expect_err("user cannot reference a workspace spec");
     }
 }

--- a/crates/coral-app/src/state/db/repositories/identities.rs
+++ b/crates/coral-app/src/state/db/repositories/identities.rs
@@ -1,0 +1,433 @@
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "Identity manager consumers land in later stack layers."
+    )
+)]
+
+use sea_query::{Alias, Expr, ExprTrait, OnConflict, Order, Query};
+
+use crate::bootstrap::AppError;
+use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+use crate::state::db::schema::Identities;
+use crate::state::db::{CoralTx, DbError, DbSession, IdentitySpecKey};
+
+const IDENTITY_COUNT: &str = "identity_count";
+
+/// Safe persisted fields for one owner-scoped identity instance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IdentityRecord {
+    pub(crate) owner: IdentityOwner,
+    pub(crate) name: IdentityName,
+    pub(crate) spec_reference: IdentitySpecReference,
+    pub(crate) created_at_unix_nanos: i64,
+    pub(crate) updated_at_unix_nanos: i64,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct IdentityRow {
+    owner_kind: String,
+    owner_key: String,
+    workspace_id: Option<String>,
+    name: String,
+    identity_spec_workspace_id: Option<String>,
+    identity_spec_name: String,
+    identity_spec_fingerprint: String,
+    issuer: String,
+    identity_type: String,
+    created_at_unix_nanos: i64,
+    updated_at_unix_nanos: i64,
+}
+
+impl IdentityRow {
+    fn validate(self) -> Result<IdentityRecord, DbError> {
+        if self.created_at_unix_nanos < 0 || self.updated_at_unix_nanos < self.created_at_unix_nanos
+        {
+            return Err(DbError::CorruptData(
+                "identity row has invalid timestamps".to_string(),
+            ));
+        }
+        let owner = IdentityOwner::from_storage_parts(
+            &self.owner_kind,
+            &self.owner_key,
+            self.workspace_id.as_deref(),
+        )?;
+        let name = IdentityName::from_storage(&self.name)?;
+        let spec_reference = IdentitySpecReference::from_storage_parts(
+            &owner,
+            self.identity_spec_workspace_id.as_deref(),
+            &self.identity_spec_name,
+            self.identity_spec_fingerprint,
+            self.issuer,
+            self.identity_type,
+        )?;
+        Ok(IdentityRecord {
+            owner,
+            name,
+            spec_reference,
+            created_at_unix_nanos: self.created_at_unix_nanos,
+            updated_at_unix_nanos: self.updated_at_unix_nanos,
+        })
+    }
+}
+
+#[derive(sqlx::FromRow)]
+struct IdentityCountRow {
+    identity_count: i64,
+}
+
+/// Repository for durable owner-scoped identity metadata.
+pub(crate) struct IdentitiesRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> IdentitiesRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    /// Load one identity by its complete owner and name key.
+    pub(crate) async fn get(
+        &mut self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+    ) -> Result<Option<IdentityRecord>, DbError> {
+        let row: Option<IdentityRow> = self
+            .session
+            .fetch_optional(
+                identity_select()
+                    .and_where(identity_key_where(owner, name))
+                    .to_owned(),
+            )
+            .await?;
+        row.map(IdentityRow::validate).transpose()
+    }
+
+    /// List identities owned by one exact owner in name order.
+    pub(crate) async fn list(
+        &mut self,
+        owner: &IdentityOwner,
+    ) -> Result<Vec<IdentityRecord>, DbError> {
+        let rows: Vec<IdentityRow> = self
+            .session
+            .fetch_all(
+                identity_select()
+                    .and_where(identity_owner_where(owner))
+                    .order_by(Identities::Name, Order::Asc)
+                    .to_owned(),
+            )
+            .await?;
+        rows.into_iter().map(IdentityRow::validate).collect()
+    }
+
+    /// Count identities pinned to one exact spec scope and name.
+    pub(crate) async fn count_dependents(&mut self, key: &IdentitySpecKey) -> Result<u64, DbError> {
+        self.count_where(identity_spec_where(key)).await
+    }
+
+    /// Count identities pinned to one exact spec scope, name, and fingerprint.
+    pub(crate) async fn count_exact_dependents(
+        &mut self,
+        key: &IdentitySpecKey,
+        fingerprint: &str,
+    ) -> Result<u64, DbError> {
+        self.count_where(
+            identity_spec_where(key)
+                .and(Expr::col(Identities::IdentitySpecFingerprint).eq(fingerprint)),
+        )
+        .await
+    }
+
+    async fn count_where(&mut self, predicate: sea_query::SimpleExpr) -> Result<u64, DbError> {
+        let row: IdentityCountRow = self
+            .session
+            .fetch_optional(
+                Query::select()
+                    .expr_as(
+                        Expr::col(Identities::Name).count(),
+                        Alias::new(IDENTITY_COUNT),
+                    )
+                    .from(Identities::Table)
+                    .and_where(predicate)
+                    .to_owned(),
+            )
+            .await?
+            .ok_or_else(|| {
+                DbError::CorruptData("identity count query returned no row".to_string())
+            })?;
+        u64::try_from(row.identity_count).map_err(|error| {
+            DbError::CorruptData(format!(
+                "identity count query returned invalid count {}: {error}",
+                row.identity_count,
+            ))
+        })
+    }
+}
+
+impl IdentitiesRepo<'_, CoralTx<'_>> {
+    /// Insert or replace one identity while preserving its creation time.
+    pub(crate) async fn upsert(
+        &mut self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        spec_reference: &IdentitySpecReference,
+        now_unix_nanos: i64,
+    ) -> Result<IdentityRecord, AppError> {
+        validate_write_timestamp(now_unix_nanos)?;
+        spec_reference.validate_for_owner(owner)?;
+        let current_updated_at = Expr::col((Identities::Table, Identities::UpdatedAtUnixNanos));
+        let key = spec_reference.key();
+        let statement = Query::insert()
+            .into_table(Identities::Table)
+            .columns(identity_columns())
+            .values_panic([
+                Expr::val(owner.kind()),
+                Expr::val(owner.key()),
+                Expr::val(
+                    owner
+                        .workspace_name()
+                        .map(|workspace| workspace.as_str().to_owned()),
+                ),
+                Expr::val(name.as_str()),
+                Expr::val(key.scope().workspace_id().map(ToOwned::to_owned)),
+                Expr::val(key.name()),
+                Expr::val(spec_reference.fingerprint()),
+                Expr::val(spec_reference.issuer()),
+                Expr::val(spec_reference.identity_type()),
+                Expr::val(now_unix_nanos),
+                Expr::val(now_unix_nanos),
+            ])
+            .on_conflict(
+                OnConflict::columns([
+                    Identities::OwnerKind,
+                    Identities::OwnerKey,
+                    Identities::Name,
+                ])
+                .update_columns([
+                    Identities::IdentitySpecWorkspaceId,
+                    Identities::IdentitySpecName,
+                    Identities::IdentitySpecFingerprint,
+                    Identities::Issuer,
+                    Identities::IdentityType,
+                ])
+                .value(
+                    Identities::UpdatedAtUnixNanos,
+                    Expr::case(
+                        current_updated_at.clone().gt(now_unix_nanos),
+                        current_updated_at,
+                    )
+                    .finally(now_unix_nanos),
+                )
+                .to_owned(),
+            )
+            .to_owned();
+        let rows_affected = self.session.execute_rows_affected(statement).await?;
+        if rows_affected != 1 {
+            return Err(AppError::Database(format!(
+                "identity upsert affected {rows_affected} rows"
+            )));
+        }
+        self.get(owner, name)
+            .await?
+            .ok_or_else(|| AppError::Database("identity disappeared after upsert".to_string()))
+    }
+
+    /// Delete one exact identity row.
+    pub(crate) async fn delete(
+        &mut self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+    ) -> Result<bool, DbError> {
+        let rows_affected = self
+            .session
+            .execute_rows_affected(
+                Query::delete()
+                    .from_table(Identities::Table)
+                    .and_where(identity_key_where(owner, name))
+                    .to_owned(),
+            )
+            .await?;
+        zero_or_one_affected(rows_affected, "identity delete")
+    }
+}
+
+fn validate_write_timestamp(now_unix_nanos: i64) -> Result<(), AppError> {
+    match now_unix_nanos {
+        0.. => Ok(()),
+        _ => Err(AppError::InvalidInput(
+            "identity timestamp is negative".to_string(),
+        )),
+    }
+}
+
+fn zero_or_one_affected(rows_affected: u64, operation: &str) -> Result<bool, DbError> {
+    match rows_affected {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(DbError::CorruptData(format!(
+            "{operation} affected {rows_affected} rows"
+        ))),
+    }
+}
+
+fn identity_select() -> sea_query::SelectStatement {
+    Query::select()
+        .columns(identity_columns())
+        .from(Identities::Table)
+        .to_owned()
+}
+
+fn identity_columns() -> [Identities; 11] {
+    [
+        Identities::OwnerKind,
+        Identities::OwnerKey,
+        Identities::WorkspaceId,
+        Identities::Name,
+        Identities::IdentitySpecWorkspaceId,
+        Identities::IdentitySpecName,
+        Identities::IdentitySpecFingerprint,
+        Identities::Issuer,
+        Identities::IdentityType,
+        Identities::CreatedAtUnixNanos,
+        Identities::UpdatedAtUnixNanos,
+    ]
+}
+
+fn identity_owner_where(owner: &IdentityOwner) -> sea_query::SimpleExpr {
+    Expr::col(Identities::OwnerKind)
+        .eq(owner.kind())
+        .and(Expr::col(Identities::OwnerKey).eq(owner.key()))
+}
+
+fn identity_key_where(owner: &IdentityOwner, name: &IdentityName) -> sea_query::SimpleExpr {
+    identity_owner_where(owner).and(Expr::col(Identities::Name).eq(name.as_str()))
+}
+
+fn identity_spec_where(key: &IdentitySpecKey) -> sea_query::SimpleExpr {
+    let scope = match key.scope().workspace_id() {
+        None => Expr::col(Identities::IdentitySpecWorkspaceId).is_null(),
+        Some(workspace_id) => Expr::col(Identities::IdentitySpecWorkspaceId).eq(workspace_id),
+    };
+    scope.and(Expr::col(Identities::IdentitySpecName).eq(key.name()))
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::IdentityRow;
+    use crate::bootstrap::AppError;
+    use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+    use crate::identity::{Principal, PrincipalKind};
+    use crate::state::db::{CoralDb, DbError, DbRepos, IdentitySpecKey, ResolvedDatabaseConfig};
+
+    fn reference(
+        owner: &IdentityOwner,
+        key: IdentitySpecKey,
+        fingerprint: &str,
+    ) -> IdentitySpecReference {
+        IdentitySpecReference::new(owner, key, fingerprint, "github", "fixed_token")
+            .expect("valid reference")
+    }
+
+    #[tokio::test]
+    async fn repository_is_exact_transactional_and_monotonic() {
+        let temp = tempdir().expect("temp dir");
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        let user = IdentityOwner::for_user(
+            Principal::parse("member-1", PrincipalKind::User).expect("user"),
+        );
+        let other = IdentityOwner::for_user(
+            Principal::parse("member-2", PrincipalKind::User).expect("user"),
+        );
+        let alpha = IdentityName::parse("alpha").expect("alpha");
+        let beta = IdentityName::parse("beta").expect("beta");
+        let global_key = IdentitySpecKey::global("github").expect("global key");
+        let global = reference(&user, global_key.clone(), "fp-1");
+
+        let mut tx = db.begin().await.expect("begin seed");
+        for name in [&beta, &alpha] {
+            tx.identities()
+                .upsert(&user, name, &global, 10)
+                .await
+                .expect("upsert identity");
+        }
+        assert!(matches!(
+            tx.identities().upsert(&user, &alpha, &global, -1).await,
+            Err(AppError::InvalidInput(_))
+        ));
+        tx.commit().await.expect("commit seed");
+
+        let mut session = &db;
+        let listed = session.identities().list(&user).await.expect("list");
+        let names = listed
+            .iter()
+            .map(|row| row.name.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["alpha", "beta"]);
+        let missing = session.identities().get(&other, &alpha).await.expect("get");
+        assert!(missing.is_none());
+        let count = session
+            .identities()
+            .count_dependents(&global_key)
+            .await
+            .expect("count");
+        assert_eq!(count, 2);
+        let exact = session
+            .identities()
+            .count_exact_dependents(&global_key, "fp-1")
+            .await
+            .expect("exact count");
+        assert_eq!(exact, 2);
+        let updated = reference(&user, global_key.clone(), "fp-2");
+        let mut tx = db.begin().await.expect("begin update");
+        let record = tx
+            .identities()
+            .upsert(&user, &alpha, &updated, 30)
+            .await
+            .expect("update");
+        assert_eq!(
+            (record.created_at_unix_nanos, record.updated_at_unix_nanos),
+            (10, 30)
+        );
+        assert_eq!(record.spec_reference.fingerprint(), "fp-2");
+        assert!(tx.identities().delete(&user, &alpha).await.expect("delete"));
+        assert!(
+            !tx.identities()
+                .delete(&user, &alpha)
+                .await
+                .expect("delete missing")
+        );
+        tx.commit().await.expect("commit update");
+    }
+
+    #[test]
+    fn persisted_rows_fail_closed() {
+        let row = || IdentityRow {
+            owner_kind: "user".into(),
+            owner_key: "member-1".into(),
+            workspace_id: None,
+            name: "alpha".into(),
+            identity_spec_workspace_id: None,
+            identity_spec_name: "github".into(),
+            identity_spec_fingerprint: "fp".into(),
+            issuer: "github".into(),
+            identity_type: "fixed_token".into(),
+            created_at_unix_nanos: 10,
+            updated_at_unix_nanos: 20,
+        };
+        row().validate().expect("valid row");
+        let mut corrupt = row();
+        corrupt.updated_at_unix_nanos = 9;
+        assert!(matches!(corrupt.validate(), Err(DbError::CorruptData(_))));
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/identity_specs.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs.rs
@@ -129,6 +129,13 @@ impl IdentitySpecKey {
             name: parse_persisted_identity_spec_name(name)?,
         })
     }
+
+    pub(crate) fn from_reference_storage_parts(
+        workspace_id: Option<&str>,
+        name: &str,
+    ) -> Result<Self, DbError> {
+        Self::from_spec_storage_parts(workspace_id, name)
+    }
 }
 
 /// Persisted authored definition for one identity spec.
@@ -723,7 +730,8 @@ mod tests {
         for result in [
             IdentitySpecKey::from_spec_storage_parts(None, " github"),
             IdentitySpecKey::from_spec_storage_parts(Some(" default"), "github"),
-            IdentitySpecKey::from_spec_storage_parts(None, "github "),
+            IdentitySpecKey::from_reference_storage_parts(None, "github "),
+            IdentitySpecKey::from_reference_storage_parts(Some(" default"), "github"),
             IdentitySpecKey::from_spec_storage_parts(None, "github-oauth"),
         ] {
             assert!(matches!(result, Err(DbError::CorruptData(_))));

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod gui_onboarding;
+pub(crate) mod identities;
 pub(crate) mod identity_specs;
 pub(crate) mod state_migrations;
 pub(crate) mod task_queries;

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -99,10 +99,6 @@ pub(in crate::state::db) enum GuiOnboardingCompletions {
     CompletedAtUnixNanos,
 }
 
-#[expect(
-    dead_code,
-    reason = "Identity repository consumers land in the next stack units."
-)]
 #[derive(Iden)]
 pub(in crate::state::db) enum Identities {
     Table,

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -7,6 +7,7 @@ use sqlx::{FromRow, Postgres, Sqlite};
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
 use crate::state::db::repositories::gui_onboarding::GuiOnboardingRepo;
+use crate::state::db::repositories::identities::IdentitiesRepo;
 use crate::state::db::repositories::identity_specs::{
     IdentitySpecDocumentsRepo, IdentitySpecsRepo,
 };
@@ -69,6 +70,14 @@ pub(crate) trait DbRepos: DbSession + Sized {
 
     fn identity_specs(&mut self) -> IdentitySpecsRepo<'_, Self> {
         IdentitySpecsRepo::new(self)
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "Identity manager consumers land later.")
+    )]
+    fn identities(&mut self) -> IdentitiesRepo<'_, Self> {
+        IdentitiesRepo::new(self)
     }
 
     fn identity_spec_documents(&mut self) -> IdentitySpecDocumentsRepo<'_, Self> {


### PR DESCRIPTION
## Intent

Add the database repository boundary for durable user- and workspace-owned identity metadata. Reads stay exact and backend-neutral, while mutations require an explicit database transaction.

## What it enables

This gives later identity managers a fail-closed persistence layer for exact owner/name records and exact identity-spec references. It preserves creation time, updates mutable spec metadata monotonically, exposes dependency counts for safe spec lifecycle checks, and deliberately leaves workspace-over-global fallback and encrypted setup documents to later stack layers.

## Usage examples

- Load or list identities for one exact user or workspace owner through the shared database session.
- Upsert or delete identity rows only inside a Coral transaction.
- Count every identity pinned to a spec key, or only identities pinned to one exact spec fingerprint.
- Reject non-normalized persisted owners, names, spec keys, invalid timestamps, and unsupported identity types as corrupt data.

## Validation

- cargo test -p coral-app --lib state::db::repositories::identities
- cargo test -p coral-app --lib identities::model
- cargo clippy -p coral-app --all-targets --all-features -- -D warnings
- make postgres-tests
- make rust-checks (1,953 tests passed; 4 skipped)