### PR TITLE
feat(app): add identity document schema

### DIFF
--- a/crates/coral-app/migrations/0011_identity_documents.sql
+++ b/crates/coral-app/migrations/0011_identity_documents.sql
@@ -9,7 +9,7 @@ CREATE TABLE IF NOT EXISTS identity_documents (
     wrapped_dek_nonce BYTEA NOT NULL,
     key_id TEXT NOT NULL,
     algorithm TEXT NOT NULL,
-    aad_version BIGINT NOT NULL,
+    binding_version BIGINT NOT NULL,
     created_at_unix_nanos BIGINT NOT NULL,
     updated_at_unix_nanos BIGINT NOT NULL,
     PRIMARY KEY (owner_kind, owner_key, name),

--- a/crates/coral-app/migrations/0011_identity_documents.sql
+++ b/crates/coral-app/migrations/0011_identity_documents.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS identity_documents (
+    owner_kind TEXT NOT NULL,
+    owner_key TEXT NOT NULL,
+    name TEXT NOT NULL,
+    document_version BIGINT NOT NULL,
+    ciphertext BYTEA NOT NULL,
+    nonce BYTEA NOT NULL,
+    wrapped_dek BYTEA NOT NULL,
+    wrapped_dek_nonce BYTEA NOT NULL,
+    key_id TEXT NOT NULL,
+    algorithm TEXT NOT NULL,
+    aad_version BIGINT NOT NULL,
+    created_at_unix_nanos BIGINT NOT NULL,
+    updated_at_unix_nanos BIGINT NOT NULL,
+    PRIMARY KEY (owner_kind, owner_key, name),
+    FOREIGN KEY (owner_kind, owner_key, name)
+        REFERENCES identities(owner_kind, owner_key, name)
+        ON DELETE CASCADE
+);

--- a/crates/coral-app/migrations/0014_identity_document_binding_version.sql
+++ b/crates/coral-app/migrations/0014_identity_document_binding_version.sql
@@ -1,0 +1,2 @@
+ALTER TABLE identity_documents
+RENAME COLUMN aad_version TO binding_version;

--- a/crates/coral-app/migrations/0014_identity_document_binding_version.sql
+++ b/crates/coral-app/migrations/0014_identity_document_binding_version.sql
@@ -1,2 +1,0 @@
-ALTER TABLE identity_documents
-RENAME COLUMN aad_version TO binding_version;

--- a/crates/coral-app/src/state/db/migrations.rs
+++ b/crates/coral-app/src/state/db/migrations.rs
@@ -220,6 +220,92 @@ mod tests {
         assert_eq!(remaining, 1);
     }
 
+    #[tokio::test]
+    async fn sqlite_identity_document_schema_enforces_exact_parent_and_cascade() {
+        let pool = sqlx::SqlitePool::connect(":memory:")
+            .await
+            .expect("sqlite pool");
+        MIGRATOR.run(&pool).await.expect("run migrations");
+
+        let columns: Vec<String> = sqlx::query_scalar(
+            "SELECT name FROM pragma_table_info('identity_documents') ORDER BY cid",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("identity document columns");
+        assert_eq!(
+            columns.iter().map(String::as_str).collect::<Vec<_>>(),
+            [
+                "owner_kind",
+                "owner_key",
+                "name",
+                "document_version",
+                "ciphertext",
+                "nonce",
+                "wrapped_dek",
+                "wrapped_dek_nonce",
+                "key_id",
+                "algorithm",
+                "binding_version",
+                "created_at_unix_nanos",
+                "updated_at_unix_nanos",
+            ]
+        );
+
+        sqlx::query("INSERT INTO workspaces (id, created_at_unix_nanos) VALUES ('shared', 0)")
+            .execute(&pool)
+            .await
+            .expect("seed document workspace");
+        for row in [
+            ("user", "shared", None, "alpha", None),
+            ("workspace", "shared", Some("shared"), "beta", None),
+            ("user", "other", None, "beta", None),
+        ] {
+            insert_identity(&pool, row)
+                .await
+                .expect("seed identity document parent");
+        }
+        for key in [
+            ("user", "shared", "alpha"),
+            ("workspace", "shared", "beta"),
+            ("user", "other", "beta"),
+        ] {
+            insert_identity_document(&pool, key.0, key.1, key.2)
+                .await
+                .expect("identity document with exact parent");
+        }
+        insert_identity_document(&pool, "user", "shared", "alpha")
+            .await
+            .expect_err("an identity may have only one setup document");
+        insert_identity_document(&pool, "user", "shared", "beta")
+            .await
+            .expect_err("recombined parent tuple must be rejected");
+        insert_identity_document(&pool, "user", "missing", "missing")
+            .await
+            .expect_err("orphan identity document must be rejected");
+
+        sqlx::query(
+            "DELETE FROM identities WHERE owner_kind = 'user' AND owner_key = 'shared' AND name = 'alpha'",
+        )
+        .execute(&pool)
+        .await
+        .expect("delete direct identity parent");
+        sqlx::query("DELETE FROM workspaces WHERE id = 'shared'")
+            .execute(&pool)
+            .await
+            .expect("delete workspace parent");
+        let surviving: Vec<(String, String, String)> = sqlx::query_as(
+            "SELECT owner_kind, owner_key, name FROM identity_documents ORDER BY owner_kind, owner_key, name",
+        )
+        .fetch_all(&pool)
+        .await
+        .expect("surviving identity documents");
+        assert_eq!(
+            surviving,
+            vec![("user".to_string(), "other".to_string(), "beta".to_string())]
+        );
+    }
+
     async fn insert_identity(
         pool: &sqlx::SqlitePool,
         (owner_kind, owner_key, workspace_id, name, identity_spec_workspace_id): IdentityRow<'_>,
@@ -237,6 +323,32 @@ mod tests {
         .bind(workspace_id)
         .bind(name)
         .bind(identity_spec_workspace_id)
+        .execute(pool)
+        .await
+        .map(|_| ())
+    }
+
+    async fn insert_identity_document(
+        pool: &sqlx::SqlitePool,
+        owner_kind: &str,
+        owner_key: &str,
+        name: &str,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "INSERT INTO identity_documents (
+                owner_kind, owner_key, name, document_version,
+                ciphertext, nonce, wrapped_dek, wrapped_dek_nonce,
+                key_id, algorithm, binding_version,
+                created_at_unix_nanos, updated_at_unix_nanos
+             ) VALUES (?, ?, ?, 1, ?, ?, ?, ?, 'test-key', 'test-algorithm', 1, 1, 1)",
+        )
+        .bind(owner_kind)
+        .bind(owner_key)
+        .bind(name)
+        .bind([1_u8].as_slice())
+        .bind([2_u8].as_slice())
+        .bind([3_u8].as_slice())
+        .bind([4_u8].as_slice())
         .execute(pool)
         .await
         .map(|_| ())

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -114,3 +114,25 @@ pub(in crate::state::db) enum Identities {
     CreatedAtUnixNanos,
     UpdatedAtUnixNanos,
 }
+
+#[expect(
+    dead_code,
+    reason = "Identity document repository consumers land in the next stack unit."
+)]
+#[derive(Iden)]
+pub(in crate::state::db) enum IdentityDocuments {
+    Table,
+    OwnerKind,
+    OwnerKey,
+    Name,
+    DocumentVersion,
+    Ciphertext,
+    Nonce,
+    WrappedDek,
+    WrappedDekNonce,
+    KeyId,
+    Algorithm,
+    BindingVersion,
+    CreatedAtUnixNanos,
+    UpdatedAtUnixNanos,
+}

--- a/crates/coral-app/tests/postgres_database_tests.rs
+++ b/crates/coral-app/tests/postgres_database_tests.rs
@@ -269,6 +269,109 @@ async fn assert_postgres_identity_schema(pool: &sqlx::PgPool) {
         .await
         .expect("count cascaded Postgres identity rows");
     assert_eq!(remaining, 1);
+    assert_postgres_identity_document_schema(pool).await;
+}
+
+async fn assert_postgres_identity_document_schema(pool: &sqlx::PgPool) {
+    assert_postgres_identity_document_columns(pool).await;
+
+    sqlx::query("INSERT INTO workspaces (id, created_at_unix_nanos) VALUES ('document-shared', 0)")
+        .execute(pool)
+        .await
+        .expect("seed Postgres document workspace");
+    for row in [
+        ("user", "document-shared", None, "document-alpha", None),
+        (
+            "workspace",
+            "document-shared",
+            Some("document-shared"),
+            "document-beta",
+            None,
+        ),
+        ("user", "document-other", None, "document-beta", None),
+    ] {
+        insert_postgres_identity(pool, row)
+            .await
+            .expect("seed Postgres identity document parent");
+    }
+    for key in [
+        ("user", "document-shared", "document-alpha"),
+        ("workspace", "document-shared", "document-beta"),
+        ("user", "document-other", "document-beta"),
+    ] {
+        insert_postgres_identity_document(pool, key.0, key.1, key.2)
+            .await
+            .expect("Postgres identity document with exact parent");
+    }
+    insert_postgres_identity_document(pool, "user", "document-shared", "document-alpha")
+        .await
+        .expect_err("a Postgres identity may have only one setup document");
+    insert_postgres_identity_document(pool, "user", "document-shared", "document-beta")
+        .await
+        .expect_err("recombined Postgres parent tuple must be rejected");
+    insert_postgres_identity_document(pool, "user", "missing", "missing")
+        .await
+        .expect_err("orphan Postgres identity document must be rejected");
+
+    sqlx::query(
+        "DELETE FROM identities
+         WHERE owner_kind = 'user'
+           AND owner_key = 'document-shared'
+           AND name = 'document-alpha'",
+    )
+    .execute(pool)
+    .await
+    .expect("delete direct Postgres identity parent");
+    sqlx::query("DELETE FROM workspaces WHERE id = 'document-shared'")
+        .execute(pool)
+        .await
+        .expect("delete Postgres workspace parent");
+    let surviving: Vec<(String, String, String)> = sqlx::query_as(
+        "SELECT owner_kind, owner_key, name
+         FROM identity_documents
+         ORDER BY owner_kind, owner_key, name",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("surviving Postgres identity documents");
+    assert_eq!(
+        surviving,
+        vec![(
+            "user".to_string(),
+            "document-other".to_string(),
+            "document-beta".to_string(),
+        )]
+    );
+}
+
+async fn assert_postgres_identity_document_columns(pool: &sqlx::PgPool) {
+    let columns: Vec<String> = sqlx::query_scalar(
+        "SELECT column_name
+         FROM information_schema.columns
+         WHERE table_schema = current_schema() AND table_name = 'identity_documents'
+         ORDER BY ordinal_position",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("Postgres identity document columns");
+    assert_eq!(
+        columns.iter().map(String::as_str).collect::<Vec<_>>(),
+        [
+            "owner_kind",
+            "owner_key",
+            "name",
+            "document_version",
+            "ciphertext",
+            "nonce",
+            "wrapped_dek",
+            "wrapped_dek_nonce",
+            "key_id",
+            "algorithm",
+            "binding_version",
+            "created_at_unix_nanos",
+            "updated_at_unix_nanos",
+        ]
+    );
 }
 
 async fn assert_postgres_identity_rejects_invalid_rows(pool: &sqlx::PgPool) {
@@ -312,6 +415,32 @@ async fn insert_postgres_identity(
     .bind(workspace_id)
     .bind(name)
     .bind(identity_spec_workspace_id)
+    .execute(pool)
+    .await
+    .map(|_| ())
+}
+
+async fn insert_postgres_identity_document(
+    pool: &sqlx::PgPool,
+    owner_kind: &str,
+    owner_key: &str,
+    name: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO identity_documents (
+            owner_kind, owner_key, name, document_version,
+            ciphertext, nonce, wrapped_dek, wrapped_dek_nonce,
+            key_id, algorithm, binding_version,
+            created_at_unix_nanos, updated_at_unix_nanos
+         ) VALUES ($1, $2, $3, 1, $4, $5, $6, $7, 'test-key', 'test-algorithm', 1, 1, 1)",
+    )
+    .bind(owner_kind)
+    .bind(owner_key)
+    .bind(name)
+    .bind([1_u8].as_slice())
+    .bind([2_u8].as_slice())
+    .bind([3_u8].as_slice())
+    .bind([4_u8].as_slice())
     .execute(pool)
     .await
     .map(|_| ())


### PR DESCRIPTION
## Intent

Add the portable encrypted setup-document storage boundary for persisted identities without coupling the envelope row to source, surface, audience, or duplicated identity-spec metadata.

## What it enables

- Gives each exact identity key one opaque envelope record.
- Uses a composite foreign key to reject recombined or orphan owner tuples and to cascade both direct identity deletion and workspace-driven deletion.
- Persists the algorithm and authenticated `binding_version` needed by the later exact-spec encryption layer.
- Keeps migration `0011` immutable and applies migration `0014` to rename `aad_version` to `binding_version`.
- Verifies the final schema against both SQLite and PostgreSQL.

## Usage examples

This is an internal persistence layer with no new user-facing API. Later repository and manager PRs store ciphertext, nonces, wrapped DEKs, key ids, algorithms, and binding versions through the `identity_documents` table.

## Validation

- Focused SQLite identity-document migration contract
- `make postgres-tests`
- `make rust-checks`
- `make perf-check`
