### PR TITLE
feat(app): create user fixed-token identities

### DIFF
--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -1,0 +1,201 @@
+//! Database-backed identity instance creation.
+
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "identity service consumers land in a later stack layer"
+    )
+)]
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use coral_spec::IdentitySpecType;
+
+use super::crypto::{IdentityDocumentBinding, encrypt_identity_document};
+use super::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+use crate::bootstrap::AppError;
+use crate::credentials::encryption::CredentialKeyProvider;
+use crate::encrypted_document::EncryptedEnvelopeDocument;
+use crate::identity::UserPrincipal;
+use crate::identity_specs::identity_spec_fingerprint;
+use crate::identity_specs::manager::record_to_installed;
+use crate::state::db::{
+    CoralDb, DbRepos, IdentityRecord, IdentitySpecKey, IdentitySpecRecord,
+    now_unix_nanos_i64,
+};
+
+const FIXED_TOKEN_KEY: &str = "TOKEN";
+const MAX_MUTATION_ATTEMPTS: usize = 8;
+
+/// Database-backed behavior for owner-scoped identities.
+#[derive(Clone)]
+pub(crate) struct IdentityManager {
+    db: Arc<CoralDb>,
+    key_provider: Arc<dyn CredentialKeyProvider>,
+}
+
+struct SelectedFixedTokenSpec {
+    record: IdentitySpecRecord,
+    reference: IdentitySpecReference,
+}
+
+impl IdentityManager {
+    pub(crate) fn new(db: Arc<CoralDb>, key_provider: Arc<dyn CredentialKeyProvider>) -> Self {
+        Self { db, key_provider }
+    }
+
+    /// Create or replace one user-owned fixed-token identity from an exact global spec.
+    pub(crate) async fn create_or_replace_user_fixed_token(
+        &self,
+        principal: &UserPrincipal,
+        identity_name: &str,
+        identity_spec_name: &str,
+        token: String,
+    ) -> Result<IdentityRecord, AppError> {
+        let owner = IdentityOwner::for_user(principal.clone());
+        let name = IdentityName::parse(identity_name)?;
+        let spec_key = IdentitySpecKey::global(identity_spec_name)?;
+        let token = token.trim().to_owned();
+        if token.is_empty() {
+            return Err(AppError::InvalidInput(
+                "fixed-token identity token must not be blank".to_string(),
+            ));
+        }
+        for _ in 0..MAX_MUTATION_ATTEMPTS {
+            let selected = match self.load_fixed_token_spec(&owner, &spec_key).await {
+                Ok(selected) => selected,
+                Err(AppError::RetryableTransactionConflict) => {
+                    tokio::task::yield_now().await;
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            let document = self
+                .prepare_fixed_token_document(&owner, &name, &selected.reference, token.clone())
+                .await?;
+            match self.try_write(&owner, &name, &selected, &document).await {
+                Ok(Some(record)) => return Ok(record),
+                Ok(None) | Err(AppError::RetryableTransactionConflict) => {
+                    tokio::task::yield_now().await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Err(AppError::RetryableTransactionConflict)
+    }
+
+    async fn load_fixed_token_spec(
+        &self,
+        owner: &IdentityOwner,
+        key: &IdentitySpecKey,
+    ) -> Result<SelectedFixedTokenSpec, AppError> {
+        let mut tx = self.db.begin_read_snapshot().await?;
+        let record = tx.identity_specs().get(key).await?;
+        tx.commit().await?;
+        let record = record.ok_or_else(|| global_spec_not_found(key))?;
+        let installed = record_to_installed(record.clone())?;
+        if installed.manifest.identity_type != IdentitySpecType::FixedToken {
+            return Err(AppError::InvalidInput(format!(
+                "identity spec '{}' has type 'oauth', not 'fixed_token'",
+                key.name()
+            )));
+        }
+        let reference = IdentitySpecReference::new(
+            owner,
+            installed.key,
+            identity_spec_fingerprint(&installed.manifest)?,
+            installed.manifest.issuer,
+            "fixed_token",
+        )?;
+        Ok(SelectedFixedTokenSpec { record, reference })
+    }
+
+    async fn prepare_fixed_token_document(
+        &self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        reference: &IdentitySpecReference,
+        token: String,
+    ) -> Result<EncryptedEnvelopeDocument, AppError> {
+        let owner = owner.clone();
+        let name = name.clone();
+        let reference = reference.clone();
+        let key_provider = Arc::clone(&self.key_provider);
+        run_blocking_identity_operation(move || {
+            let values = BTreeMap::from([(FIXED_TOKEN_KEY.to_string(), token)]);
+            let binding = IdentityDocumentBinding::new(&owner, &name, &reference)?;
+            encrypt_identity_document(&binding, &values, key_provider.as_ref()).map_err(Into::into)
+        })
+        .await
+    }
+
+    async fn try_write(
+        &self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        selected: &SelectedFixedTokenSpec,
+        document: &EncryptedEnvelopeDocument,
+    ) -> Result<Option<IdentityRecord>, AppError> {
+        let mut tx = self.db.begin_serializable().await?;
+        let current = match tx.identity_specs().get(selected.reference.key()).await {
+            Ok(current) => current,
+            Err(error) => {
+                tx.rollback().await?;
+                return Err(error.into());
+            }
+        };
+        if current.as_ref() != Some(&selected.record) {
+            tx.rollback().await?;
+            return Ok(None);
+        }
+        let now = match now_unix_nanos_i64() {
+            Ok(now) => now,
+            Err(error) => {
+                tx.rollback().await?;
+                return Err(error);
+            }
+        };
+        let result = async {
+            let record = tx
+                .identities()
+                .upsert(owner, name, &selected.reference, now)
+                .await?;
+            tx.identity_documents()
+                .upsert(owner, name, document, now)
+                .await?;
+            Ok::<_, AppError>(record)
+        }
+        .await;
+        match result {
+            Ok(record) => {
+                tx.commit().await?;
+                Ok(Some(record))
+            }
+            Err(error) => {
+                tx.rollback().await?;
+                Err(error)
+            }
+        }
+    }
+}
+
+async fn run_blocking_identity_operation<T, F>(operation: F) -> Result<T, AppError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, AppError> + Send + 'static,
+{
+    let span = tracing::Span::current();
+    tokio::task::spawn_blocking(move || span.in_scope(operation)).await?
+}
+
+fn global_spec_not_found(key: &IdentitySpecKey) -> AppError {
+    AppError::IdentitySpecNotFound {
+        name: key.name().to_string(),
+        scope: "global".to_string(),
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests;

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -18,12 +18,11 @@ use super::model::{IdentityName, IdentityOwner, IdentitySpecReference};
 use crate::bootstrap::AppError;
 use crate::credentials::encryption::CredentialKeyProvider;
 use crate::encrypted_document::EncryptedEnvelopeDocument;
-use crate::identity::UserPrincipal;
+use crate::identity::Principal;
 use crate::identity_specs::identity_spec_fingerprint;
 use crate::identity_specs::manager::record_to_installed;
 use crate::state::db::{
-    CoralDb, DbRepos, IdentityRecord, IdentitySpecKey, IdentitySpecRecord,
-    now_unix_nanos_i64,
+    CoralDb, DbRepos, IdentityRecord, IdentitySpecKey, IdentitySpecRecord, now_unix_nanos_i64,
 };
 
 const FIXED_TOKEN_KEY: &str = "TOKEN";
@@ -49,7 +48,7 @@ impl IdentityManager {
     /// Create or replace one user-owned fixed-token identity from an exact global spec.
     pub(crate) async fn create_or_replace_user_fixed_token(
         &self,
-        principal: &UserPrincipal,
+        principal: &Principal,
         identity_name: &str,
         identity_spec_name: &str,
         token: String,

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -1,0 +1,253 @@
+use std::sync::Arc;
+
+use coral_spec::parse_identity_manifest_yaml;
+
+use super::IdentityManager;
+use crate::bootstrap::AppError;
+use crate::credentials::CredentialsError;
+use crate::credentials::encryption::{CredentialEncryptionKey, CredentialKeyProvider};
+use crate::identities::crypto::{IdentityDocumentBinding, decrypt_identity_document};
+use crate::identities::model::{IdentityName, IdentityOwner};
+use crate::identity::UserPrincipal;
+use crate::identity_specs::identity_spec_fingerprint;
+use crate::state::db::{
+    CoralDb, DbRepos, IdentityDocumentRecord, IdentityRecord, IdentitySpecKey,
+    set_identity_document_version,
+};
+
+struct TestKeyProvider(Vec<CredentialEncryptionKey>);
+
+impl CredentialKeyProvider for TestKeyProvider {
+    fn active_key(&self) -> Result<CredentialEncryptionKey, CredentialsError> {
+        self.0
+            .last()
+            .cloned()
+            .ok_or_else(|| CredentialsError::Unavailable("missing test key".to_string()))
+    }
+
+    fn key(&self, key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
+        self.0
+            .iter()
+            .find(|key| key.key_id() == key_id)
+            .cloned()
+            .ok_or_else(|| CredentialsError::Unavailable("missing test key".to_string()))
+    }
+}
+
+#[expect(
+    clippy::too_many_lines,
+    reason = "shared SQLite/Postgres manager contract"
+)]
+pub(crate) async fn assert_user_global_fixed_token_create_contract(db: &Arc<CoralDb>) {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let fixed_a = format!("fixeda_{suffix}");
+    let fixed_b = format!("fixedb_{suffix}");
+    let oauth = format!("oauth_{suffix}");
+    let missing = format!("missing_{suffix}");
+    for (name, yaml) in [
+        (&fixed_a, fixed_manifest(&fixed_a, "a")),
+        (&fixed_b, fixed_manifest(&fixed_b, "b")),
+        (&oauth, oauth_manifest(&oauth)),
+    ] {
+        put_spec(db, name, &yaml).await;
+    }
+
+    let principal = UserPrincipal::for_user(&format!("user-{suffix}")).expect("principal");
+    let owner = IdentityOwner::for_user(principal.clone());
+    let unavailable = Arc::new(TestKeyProvider(Vec::new()));
+    let unavailable_manager = IdentityManager::new(db.clone(), unavailable);
+    for (name, spec, token, expected) in [
+        ("blank", fixed_a.as_str(), " \t ", "invalid"),
+        ("missing", missing.as_str(), "token", "missing"),
+        ("oauth", oauth.as_str(), "token", "invalid"),
+        ("no_key", fixed_a.as_str(), "token", "credentials"),
+    ] {
+        let identity_name = format!("{name}_{suffix}");
+        let error = unavailable_manager
+            .create_or_replace_user_fixed_token(&principal, &identity_name, spec, token.to_string())
+            .await
+            .expect_err("invalid creation must fail");
+        match expected {
+            "missing" => assert!(matches!(
+                error,
+                AppError::IdentitySpecNotFound { scope, .. } if scope == "global"
+            )),
+            "credentials" => assert!(matches!(error, AppError::Credentials(_))),
+            _ => assert!(matches!(error, AppError::InvalidInput(_))),
+        }
+        assert_eq!(load_pair(db, &owner, &identity_name).await, (None, None));
+    }
+
+    let old_key = CredentialEncryptionKey::from_static_bytes_for_test([61; 32]);
+    let old_provider = Arc::new(TestKeyProvider(vec![old_key.clone()]));
+    let manager = IdentityManager::new(db.clone(), old_provider.clone());
+    let identity = format!("primary_{suffix}");
+    let created = manager
+        .create_or_replace_user_fixed_token(
+            &principal,
+            &identity,
+            &fixed_a,
+            "  alpha-token  ".to_string(),
+        )
+        .await
+        .expect("create fixed-token identity");
+    assert_reference(&created, &fixed_a, "a");
+    let created_pair = load_pair(db, &owner, &identity).await;
+    assert_eq!(created_pair.0.as_ref(), Some(&created));
+    let created_document = created_pair.1.as_ref().expect("created document");
+    assert_eq!(created_document.document_version, 1);
+    assert_eq!(created_document.envelope.key_id, old_key.key_id());
+    assert_material(
+        &created,
+        created_document,
+        "alpha-token",
+        old_provider.as_ref(),
+    );
+
+    let new_key = CredentialEncryptionKey::from_static_bytes_for_test([62; 32]);
+    let rotated_provider = Arc::new(TestKeyProvider(vec![old_key, new_key.clone()]));
+    let rotated = IdentityManager::new(db.clone(), rotated_provider.clone());
+    let replaced = rotated
+        .create_or_replace_user_fixed_token(
+            &principal,
+            &identity,
+            &fixed_b,
+            " beta-token ".to_string(),
+        )
+        .await
+        .expect("replace fixed-token identity");
+    assert_reference(&replaced, &fixed_b, "b");
+    let replaced_pair = load_pair(db, &owner, &identity).await;
+    let replaced_document = replaced_pair.1.as_ref().expect("replaced document");
+    assert_eq!(
+        replaced.created_at_unix_nanos,
+        created.created_at_unix_nanos
+    );
+    assert_eq!(replaced_document.document_version, 2);
+    assert_eq!(
+        replaced_document.created_at_unix_nanos,
+        created_document.created_at_unix_nanos
+    );
+    assert_eq!(replaced_document.envelope.key_id, new_key.key_id());
+    assert_material(
+        &replaced,
+        replaced_document,
+        "beta-token",
+        rotated_provider.as_ref(),
+    );
+
+    let identity_name = IdentityName::parse(&identity).expect("identity name");
+    set_identity_document_version(db, &owner, &identity_name, i64::MAX).await;
+    let before_failure = load_pair(db, &owner, &identity).await;
+    let error = rotated
+        .create_or_replace_user_fixed_token(
+            &principal,
+            &identity,
+            &fixed_a,
+            "rollback-token".to_string(),
+        )
+        .await
+        .expect_err("exhausted document version must fail");
+    assert!(
+        matches!(error, AppError::FailedPrecondition(detail) if detail.contains("version is exhausted"))
+    );
+    assert_eq!(load_pair(db, &owner, &identity).await, before_failure);
+
+    let mut cleanup = db.begin().await.expect("begin identity cleanup");
+    assert!(
+        cleanup
+            .identities()
+            .delete(&owner, &identity_name)
+            .await
+            .expect("delete test identity")
+    );
+    for spec_name in [&fixed_a, &fixed_b, &oauth] {
+        assert!(
+            cleanup
+                .identity_specs()
+                .delete(&IdentitySpecKey::global(spec_name).expect("cleanup spec key"))
+                .await
+                .expect("delete test identity spec")
+        );
+    }
+    cleanup.commit().await.expect("commit identity cleanup");
+}
+
+async fn put_spec(db: &CoralDb, name: &str, yaml: &str) {
+    let manifest = parse_identity_manifest_yaml(yaml).expect("identity manifest");
+    let key = IdentitySpecKey::global(name).expect("global spec key");
+    let mut tx = db.begin().await.expect("begin spec write");
+    tx.identity_specs()
+        .upsert(&key, &manifest, yaml, 1)
+        .await
+        .expect("upsert identity spec");
+    tx.commit().await.expect("commit identity spec");
+}
+
+async fn load_pair(
+    db: &CoralDb,
+    owner: &IdentityOwner,
+    identity_name: &str,
+) -> (Option<IdentityRecord>, Option<IdentityDocumentRecord>) {
+    let name = IdentityName::parse(identity_name).expect("identity name");
+    let mut session = db;
+    let identity = session
+        .identities()
+        .get(owner, &name)
+        .await
+        .expect("identity");
+    let document = session
+        .identity_documents()
+        .get(owner, &name)
+        .await
+        .expect("identity document");
+    (identity, document)
+}
+
+fn assert_reference(record: &IdentityRecord, spec_name: &str, revision: &str) {
+    let manifest = parse_identity_manifest_yaml(&fixed_manifest(spec_name, revision))
+        .expect("expected manifest");
+    assert_eq!(
+        record.spec_reference.key(),
+        &IdentitySpecKey::global(spec_name).expect("global spec key")
+    );
+    assert_eq!(
+        record.spec_reference.fingerprint(),
+        identity_spec_fingerprint(&manifest).expect("fingerprint")
+    );
+    assert_eq!(record.spec_reference.issuer(), format!("issuer_{revision}"));
+    assert_eq!(record.spec_reference.identity_type(), "fixed_token");
+}
+
+fn assert_material(
+    identity: &IdentityRecord,
+    document: &IdentityDocumentRecord,
+    token: &str,
+    provider: &dyn CredentialKeyProvider,
+) {
+    let binding =
+        IdentityDocumentBinding::new(&document.owner, &document.name, &identity.spec_reference)
+            .expect("document binding");
+    let values =
+        decrypt_identity_document(&binding, &document.envelope, provider).expect("decrypt token");
+    assert_eq!(values.get("TOKEN").map(String::as_str), Some(token));
+    assert!(
+        !document
+            .envelope
+            .ciphertext
+            .windows(token.len())
+            .any(|window| window == token.as_bytes())
+    );
+}
+
+fn fixed_manifest(name: &str, revision: &str) -> String {
+    format!(
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: {revision}\ndescription: {revision}\nissuer: issuer_{revision}\ntype: fixed_token\naudience: {{host: api.example.com}}\n"
+    )
+}
+
+fn oauth_manifest(name: &str) -> String {
+    format!(
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: oauth\ndescription: oauth\nissuer: oauth_issuer\ntype: oauth\naudience: {{host: api.example.com}}\noauth:\n  method:\n    flow: {{type: device_code}}\n    endpoints: {{device_authorization_url: 'https://provider.example.com/device', token_url: 'https://provider.example.com/token'}}\n    client: {{id: {{default: demo-client}}}}\n"
+    )
+}

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -8,7 +8,7 @@ use crate::credentials::CredentialsError;
 use crate::credentials::encryption::{CredentialEncryptionKey, CredentialKeyProvider};
 use crate::identities::crypto::{IdentityDocumentBinding, decrypt_identity_document};
 use crate::identities::model::{IdentityName, IdentityOwner};
-use crate::identity::UserPrincipal;
+use crate::identity::{Principal, PrincipalKind};
 use crate::identity_specs::identity_spec_fingerprint;
 use crate::state::db::{
     CoralDb, DbRepos, IdentityDocumentRecord, IdentityRecord, IdentitySpecKey,
@@ -52,7 +52,8 @@ pub(crate) async fn assert_user_global_fixed_token_create_contract(db: &Arc<Cora
         put_spec(db, name, &yaml).await;
     }
 
-    let principal = UserPrincipal::for_user(&format!("user-{suffix}")).expect("principal");
+    let principal =
+        Principal::parse(&format!("user-{suffix}"), PrincipalKind::User).expect("principal");
     let owner = IdentityOwner::for_user(principal.clone());
     let unavailable = Arc::new(TestKeyProvider(Vec::new()));
     let unavailable_manager = IdentityManager::new(db.clone(), unavailable);
@@ -228,8 +229,11 @@ fn assert_material(
     let binding =
         IdentityDocumentBinding::new(&document.owner, &document.name, &identity.spec_reference)
             .expect("document binding");
+    let kek = provider
+        .key(&document.envelope.key_id)
+        .expect("stored envelope key");
     let values =
-        decrypt_identity_document(&binding, &document.envelope, provider).expect("decrypt token");
+        decrypt_identity_document(&binding, &document.envelope, &kek).expect("decrypt token");
     assert_eq!(values.get("TOKEN").map(String::as_str), Some(token));
     assert!(
         !document

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -1,4 +1,5 @@
 //! App-owned identity instance domain types.
 
 mod crypto;
+pub(crate) mod manager;
 pub(crate) mod model;

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -423,7 +423,9 @@ fn prepare_document_write(
         .map_err(Into::into)
 }
 
-fn record_to_installed(record: IdentitySpecRecord) -> Result<InstalledIdentitySpec, DbError> {
+pub(crate) fn record_to_installed(
+    record: IdentitySpecRecord,
+) -> Result<InstalledIdentitySpec, DbError> {
     let manifest = parse_identity_manifest_yaml(&record.manifest_yaml).map_err(|error| {
         corrupt_record(&record.key, &format!("manifest cannot be parsed: {error}"))
     })?;

--- a/crates/coral-app/src/identity_specs/mod.rs
+++ b/crates/coral-app/src/identity_specs/mod.rs
@@ -9,8 +9,4 @@ pub(crate) mod inputs;
 pub(crate) mod manager;
 pub(crate) mod service;
 
-#[expect(
-    unused_imports,
-    reason = "the identity manager consumes this in the next stack layer"
-)]
 pub(crate) use fingerprint::identity_spec_fingerprint;

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -24,6 +24,11 @@ pub(crate) use error::DbError;
 #[cfg(test)]
 pub(crate) use identity_spec_state::IdentitySpecMutationSnapshot;
 pub(crate) use import::run_state_migrations;
+pub(crate) use repositories::identities::IdentityRecord;
+#[cfg(test)]
+pub(crate) use repositories::identity_documents::IdentityDocumentRecord;
+#[cfg(test)]
+pub(crate) use repositories::identity_documents_contract_tests::set_identity_document_version;
 pub(crate) use repositories::identity_specs::{
     IdentitySpecDocumentRecord, IdentitySpecId, IdentitySpecKey, IdentitySpecRecord,
     IdentitySpecScope,

--- a/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use sea_query::{Expr, ExprTrait, Query, SimpleExpr};
 use tempfile::tempdir;
 
@@ -14,14 +16,17 @@ use crate::workspaces::WorkspaceName;
 #[tokio::test(flavor = "current_thread")]
 async fn identity_repository_contract_holds_against_sqlite() {
     let temp = tempdir().expect("temp dir");
-    let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite {
-        path: temp.path().join("coral.sqlite"),
-    })
-    .await
-    .expect("open sqlite");
+    let db = Arc::new(
+        CoralDb::open(ResolvedDatabaseConfig::Sqlite {
+            path: temp.path().join("coral.sqlite"),
+        })
+        .await
+        .expect("open sqlite"),
+    );
     db.migrate().await.expect("migrate sqlite");
     assert_identity_repository_contract(&db).await;
     assert_identity_repository_corruption_contract(&db).await;
+    crate::identities::manager::tests::assert_user_global_fixed_token_create_contract(&db).await;
 }
 
 #[expect(clippy::too_many_lines, reason = "shared backend contract fixture")]

--- a/crates/coral-app/src/state/db/repositories/identity_documents.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_documents.rs
@@ -1,11 +1,3 @@
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Identity manager consumers land in later stack layers."
-    )
-)]
-
 use sea_query::{Expr, ExprTrait, OnConflict, Query};
 
 use crate::bootstrap::AppError;

--- a/crates/coral-app/src/state/db/repositories/identity_documents_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_documents_contract_tests.rs
@@ -1,3 +1,4 @@
+use sea_query::{Expr, ExprTrait, Query};
 use tempfile::tempdir;
 
 use super::identity_documents::IdentityDocumentRecord;
@@ -5,8 +6,30 @@ use crate::bootstrap::AppError;
 use crate::encrypted_document::EncryptedEnvelopeDocument;
 use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
 use crate::identity::{Principal, PrincipalKind};
+use crate::state::db::schema::IdentityDocuments;
 use crate::state::db::{CoralDb, CoralTx, DbRepos, IdentitySpecKey, ResolvedDatabaseConfig};
 use crate::workspaces::WorkspaceName;
+
+pub(crate) async fn set_identity_document_version(
+    db: &CoralDb,
+    owner: &IdentityOwner,
+    name: &IdentityName,
+    version: i64,
+) {
+    let mut tx = db.begin().await.expect("begin document version update");
+    tx.execute(
+        Query::update()
+            .table(IdentityDocuments::Table)
+            .value(IdentityDocuments::DocumentVersion, version)
+            .and_where(Expr::col(IdentityDocuments::OwnerKind).eq(owner.kind()))
+            .and_where(Expr::col(IdentityDocuments::OwnerKey).eq(owner.key()))
+            .and_where(Expr::col(IdentityDocuments::Name).eq(name.as_str()))
+            .to_owned(),
+    )
+    .await
+    .expect("set identity document version");
+    tx.commit().await.expect("commit document version update");
+}
 
 #[tokio::test(flavor = "current_thread")]
 async fn identity_document_repository_contract_holds_against_sqlite() {

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -73,18 +73,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
         IdentitySpecsRepo::new(self)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "Identity manager consumers land later.")
-    )]
     fn identities(&mut self) -> IdentitiesRepo<'_, Self> {
         IdentitiesRepo::new(self)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "Identity manager consumers land later.")
-    )]
     fn identity_documents(&mut self) -> IdentityDocumentsRepo<'_, Self> {
         IdentityDocumentsRepo::new(self)
     }


### PR DESCRIPTION
## Intent

Add the first identity-instance mutation on top of the reviewed identity metadata, encrypted-document, manifest-fingerprint, and exact-spec crypto layers. User-owned fixed-token identities must be persisted without reintroducing surface-level identity semantics or allowing metadata and secret material to diverge.

## What it enables

- Creates or replaces a user-owned fixed-token identity from one exact global identity spec.
- Parses the stored spec, requires `fixed_token`, and records its semantic manifest fingerprint, issuer, and exact global key.
- Encrypts the trimmed `TOKEN` value outside the database transaction using owner, identity name, and exact spec revision as authenticated context.
- Revalidates the complete spec record in a serializable transaction, then atomically upserts identity metadata and encrypted material. A spec drift or retryable conflict causes a fresh selection and fresh encryption.
- Shares the same success, failure, replacement, key-rotation, and rollback contract across SQLite and Postgres.

## Usage examples

This is an internal manager layer; transport wiring lands later in the stack. Its intended call shape is:

```rust
let identity = IdentityManager::new(db, key_provider)
    .create_or_replace_user_fixed_token(
        &principal,
        "github_personal",
        "github",
        token,
    )
    .await?;
```

The `github` spec lookup is exact-global for a user identity. The returned record contains only safe metadata; the token is stored only in the encrypted identity document.

## Validation

- `cargo test -p coral-app state::db::repositories::identities_contract_tests::identity_repository_contract_holds_against_sqlite --lib -- --exact --nocapture`
- `make postgres-tests`
- `make rust-checks` (1,972 passed, 7 skipped; rustdoc passed)
- 572 changed lines (543 additions, 29 deletions)