### PR TITLE
test(app): cover fixed-token identity races

### DIFF
--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -10,6 +10,8 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use coral_spec::IdentitySpecType;
 
@@ -33,6 +35,25 @@ const MAX_MUTATION_ATTEMPTS: usize = 8;
 pub(crate) struct IdentityManager {
     db: Arc<CoralDb>,
     key_provider: Arc<dyn CredentialKeyProvider>,
+    #[cfg(test)]
+    before_write_gate: Option<BeforeWriteGate>,
+    #[cfg(test)]
+    before_upsert_gate: Option<BeforeUpsertGate>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct BeforeWriteGate {
+    prepared: Arc<tokio::sync::Barrier>,
+    resume: Arc<tokio::sync::Barrier>,
+    used: Arc<AtomicBool>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+struct BeforeUpsertGate {
+    barrier: Arc<tokio::sync::Barrier>,
+    used: Arc<AtomicBool>,
 }
 
 struct SelectedFixedTokenSpec {
@@ -42,7 +63,37 @@ struct SelectedFixedTokenSpec {
 
 impl IdentityManager {
     pub(crate) fn new(db: Arc<CoralDb>, key_provider: Arc<dyn CredentialKeyProvider>) -> Self {
-        Self { db, key_provider }
+        Self {
+            db,
+            key_provider,
+            #[cfg(test)]
+            before_write_gate: None,
+            #[cfg(test)]
+            before_upsert_gate: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_before_write_gate(
+        mut self,
+        prepared: Arc<tokio::sync::Barrier>,
+        resume: Arc<tokio::sync::Barrier>,
+    ) -> Self {
+        self.before_write_gate = Some(BeforeWriteGate {
+            prepared,
+            resume,
+            used: Arc::new(AtomicBool::new(false)),
+        });
+        self
+    }
+
+    #[cfg(test)]
+    fn with_before_upsert_gate(mut self, barrier: Arc<tokio::sync::Barrier>) -> Self {
+        self.before_upsert_gate = Some(BeforeUpsertGate {
+            barrier,
+            used: Arc::new(AtomicBool::new(false)),
+        });
+        self
     }
 
     /// Create or replace one user-owned fixed-token identity from an exact global spec.
@@ -74,6 +125,13 @@ impl IdentityManager {
             let document = self
                 .prepare_fixed_token_document(&owner, &name, &selected.reference, token.clone())
                 .await?;
+            #[cfg(test)]
+            if let Some(gate) = &self.before_write_gate
+                && !gate.used.swap(true, Ordering::SeqCst)
+            {
+                gate.prepared.wait().await;
+                gate.resume.wait().await;
+            }
             match self.try_write(&owner, &name, &selected, &document).await {
                 Ok(Some(record)) => return Ok(record),
                 Ok(None) | Err(AppError::RetryableTransactionConflict) => {
@@ -148,6 +206,12 @@ impl IdentityManager {
         if current.as_ref() != Some(&selected.record) {
             tx.rollback().await?;
             return Ok(None);
+        }
+        #[cfg(test)]
+        if let Some(gate) = &self.before_upsert_gate
+            && !gate.used.swap(true, Ordering::SeqCst)
+        {
+            gate.barrier.wait().await;
         }
         let now = match now_unix_nanos_i64() {
             Ok(now) => now,

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use coral_spec::parse_identity_manifest_yaml;
 
@@ -43,11 +44,13 @@ pub(crate) async fn assert_user_global_fixed_token_create_contract(db: &Arc<Cora
     let fixed_a = format!("fixeda_{suffix}");
     let fixed_b = format!("fixedb_{suffix}");
     let oauth = format!("oauth_{suffix}");
+    let race = format!("race_{suffix}");
     let missing = format!("missing_{suffix}");
     for (name, yaml) in [
         (&fixed_a, fixed_manifest(&fixed_a, "a")),
         (&fixed_b, fixed_manifest(&fixed_b, "b")),
         (&oauth, oauth_manifest(&oauth)),
+        (&race, fixed_manifest(&race, "before")),
     ] {
         put_spec(db, name, &yaml).await;
     }
@@ -154,15 +157,109 @@ pub(crate) async fn assert_user_global_fixed_token_create_contract(db: &Arc<Cora
     );
     assert_eq!(load_pair(db, &owner, &identity).await, before_failure);
 
-    let mut cleanup = db.begin().await.expect("begin identity cleanup");
-    assert!(
-        cleanup
-            .identities()
-            .delete(&owner, &identity_name)
-            .await
-            .expect("delete test identity")
+    let conflict_name = format!("conflict_{suffix}");
+    let conflict_gate = Arc::new(tokio::sync::Barrier::new(2));
+    let left = rotated
+        .clone()
+        .with_before_upsert_gate(conflict_gate.clone());
+    let right = rotated.clone().with_before_upsert_gate(conflict_gate);
+    let (left, right) = tokio::time::timeout(Duration::from_secs(10), async {
+        tokio::join!(
+            left.create_or_replace_user_fixed_token(
+                &principal,
+                &conflict_name,
+                &fixed_a,
+                "left-token".to_string(),
+            ),
+            right.create_or_replace_user_fixed_token(
+                &principal,
+                &conflict_name,
+                &fixed_b,
+                "right-token".to_string(),
+            ),
+        )
+    })
+    .await
+    .expect("conflicting writes must not deadlock");
+    let left = left.expect("left write");
+    let right = right.expect("right write");
+    assert_reference(&left, &fixed_a, "a");
+    assert_reference(&right, &fixed_b, "b");
+    let conflict = load_pair(db, &owner, &conflict_name).await;
+    let conflict_identity = conflict.0.as_ref().expect("conflict identity");
+    let conflict_document = conflict.1.as_ref().expect("conflict document");
+    assert_eq!(conflict_document.document_version, 2);
+    let (winning, winning_token) = match conflict_identity.spec_reference.key().name() {
+        name if name == fixed_a.as_str() => (&left, "left-token"),
+        name if name == fixed_b.as_str() => (&right, "right-token"),
+        name => panic!("unexpected winning spec {name}"),
+    };
+    assert_eq!(conflict_identity, winning);
+    assert_material(
+        conflict_identity,
+        conflict_document,
+        winning_token,
+        rotated_provider.as_ref(),
     );
-    for spec_name in [&fixed_a, &fixed_b, &oauth] {
+
+    let prepared = Arc::new(tokio::sync::Barrier::new(2));
+    let resume = Arc::new(tokio::sync::Barrier::new(2));
+    let gated = rotated
+        .clone()
+        .with_before_write_gate(prepared.clone(), resume.clone());
+    let raced_name = format!("raced_{suffix}");
+    let raced = tokio::time::timeout(Duration::from_secs(10), async {
+        let create = gated.create_or_replace_user_fixed_token(
+            &principal,
+            &raced_name,
+            &race,
+            "race-token".to_string(),
+        );
+        let replace = async {
+            prepared.wait().await;
+            put_spec(db, &race, &fixed_manifest(&race, "after")).await;
+            resume.wait().await;
+        };
+        tokio::join!(create, replace).0
+    })
+    .await
+    .expect("spec replacement race must not deadlock")
+    .expect("raced create");
+    assert_reference(&raced, &race, "after");
+    let raced_pair = load_pair(db, &owner, &raced_name).await;
+    assert_eq!(raced_pair.0.as_ref(), Some(&raced));
+    assert_eq!(
+        raced_pair
+            .1
+            .as_ref()
+            .expect("raced document")
+            .document_version,
+        1
+    );
+    assert_material(
+        &raced,
+        raced_pair.1.as_ref().expect("raced document"),
+        "race-token",
+        rotated_provider.as_ref(),
+    );
+
+    let mut cleanup = db.begin().await.expect("begin identity cleanup");
+    let conflict_identity_name = IdentityName::parse(&conflict_name).expect("conflict name");
+    let raced_identity_name = IdentityName::parse(&raced_name).expect("raced name");
+    for name in [
+        &identity_name,
+        &conflict_identity_name,
+        &raced_identity_name,
+    ] {
+        assert!(
+            cleanup
+                .identities()
+                .delete(&owner, name)
+                .await
+                .expect("delete test identity")
+        );
+    }
+    for spec_name in [&fixed_a, &fixed_b, &oauth, &race] {
         assert!(
             cleanup
                 .identity_specs()

--- a/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
@@ -26,7 +26,10 @@ async fn identity_repository_contract_holds_against_sqlite() {
     db.migrate().await.expect("migrate sqlite");
     assert_identity_repository_contract(&db).await;
     assert_identity_repository_corruption_contract(&db).await;
-    crate::identities::manager::tests::assert_user_global_fixed_token_create_contract(&db).await;
+    Box::pin(
+        crate::identities::manager::tests::assert_user_global_fixed_token_create_contract(&db),
+    )
+    .await;
 }
 
 #[expect(clippy::too_many_lines, reason = "shared backend contract fixture")]


### PR DESCRIPTION
## Intent

Pin the concurrency contract for user-owned fixed-token identity creation. Exact identity-spec replacement must not allow ciphertext prepared against a stale spec to commit, and concurrent writers must leave identity metadata and encrypted material from the same winning write.

## What it enables

- Deterministic shared SQLite and Postgres coverage for spec-replacement retries.
- Proof that stale prepared documents are discarded and re-encrypted against the newly resolved exact spec.
- Proof that concurrent writers both complete while the final identity row, document version, and decryptable token remain coherent.
- Test-only synchronization hooks; production layout and behavior are unchanged.

## Usage examples

No public API is added. The shared repository contract now exercises two scenarios:

1. Pause creation after encryption, replace the exact global fixed-token spec, then verify the retry persists the new semantic fingerprint and ciphertext bound to it.
2. Race two writes using different specs and tokens, then verify both calls succeed, the document reaches version 2, and the persisted winner decrypts to its matching token.