### PR TITLE
feat(app): create workspace fixed-token identities

### DIFF
--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -24,8 +24,10 @@ use crate::identity::Principal;
 use crate::identity_specs::identity_spec_fingerprint;
 use crate::identity_specs::manager::record_to_installed;
 use crate::state::db::{
-    CoralDb, DbRepos, IdentityRecord, IdentitySpecKey, IdentitySpecRecord, now_unix_nanos_i64,
+    CoralDb, CoralTx, DbRepos, IdentityRecord, IdentitySpecKey, IdentitySpecRecord,
+    IdentitySpecScope, now_unix_nanos_i64,
 };
+use crate::workspaces::WorkspaceName;
 
 const FIXED_TOKEN_KEY: &str = "TOKEN";
 const MAX_MUTATION_ATTEMPTS: usize = 8;
@@ -57,6 +59,8 @@ struct BeforeUpsertGate {
 }
 
 struct SelectedFixedTokenSpec {
+    requested_key: IdentitySpecKey,
+    workspace_created_at_unix_nanos: Option<i64>,
     record: IdentitySpecRecord,
     reference: IdentitySpecReference,
 }
@@ -107,14 +111,48 @@ impl IdentityManager {
         let owner = IdentityOwner::for_user(principal.clone());
         let name = IdentityName::parse(identity_name)?;
         let spec_key = IdentitySpecKey::global(identity_spec_name)?;
+        self.create_or_replace_fixed_token(owner, name, spec_key, token)
+            .await
+    }
+
+    /// Create or replace one workspace-owned fixed-token identity with global fallback.
+    pub(crate) async fn create_or_replace_workspace_fixed_token(
+        &self,
+        workspace: &WorkspaceName,
+        identity_name: &str,
+        identity_spec_name: &str,
+        token: String,
+    ) -> Result<IdentityRecord, AppError> {
+        let owner = IdentityOwner::workspace(workspace.clone());
+        let name = IdentityName::parse(identity_name)?;
+        let spec_key = IdentitySpecKey::workspace(workspace.clone(), identity_spec_name)?;
+        self.create_or_replace_fixed_token(owner, name, spec_key, token)
+            .await
+    }
+
+    async fn create_or_replace_fixed_token(
+        &self,
+        owner: IdentityOwner,
+        name: IdentityName,
+        requested_key: IdentitySpecKey,
+        token: String,
+    ) -> Result<IdentityRecord, AppError> {
         let token = token.trim().to_owned();
         if token.is_empty() {
             return Err(AppError::InvalidInput(
                 "fixed-token identity token must not be blank".to_string(),
             ));
         }
+        let mut pinned_workspace_created_at_unix_nanos = None;
         for _ in 0..MAX_MUTATION_ATTEMPTS {
-            let selected = match self.load_fixed_token_spec(&owner, &spec_key).await {
+            let selected = match self
+                .load_fixed_token_spec(
+                    &owner,
+                    &requested_key,
+                    pinned_workspace_created_at_unix_nanos,
+                )
+                .await
+            {
                 Ok(selected) => selected,
                 Err(AppError::RetryableTransactionConflict) => {
                     tokio::task::yield_now().await;
@@ -122,6 +160,9 @@ impl IdentityManager {
                 }
                 Err(error) => return Err(error),
             };
+            if pinned_workspace_created_at_unix_nanos.is_none() {
+                pinned_workspace_created_at_unix_nanos = selected.workspace_created_at_unix_nanos;
+            }
             let document = self
                 .prepare_fixed_token_document(&owner, &name, &selected.reference, token.clone())
                 .await?;
@@ -146,17 +187,25 @@ impl IdentityManager {
     async fn load_fixed_token_spec(
         &self,
         owner: &IdentityOwner,
-        key: &IdentitySpecKey,
+        requested_key: &IdentitySpecKey,
+        expected_workspace_created_at_unix_nanos: Option<i64>,
     ) -> Result<SelectedFixedTokenSpec, AppError> {
         let mut tx = self.db.begin_read_snapshot().await?;
-        let record = tx.identity_specs().get(key).await?;
+        let workspace_created_at_unix_nanos = owner_workspace_created_at(&mut tx, owner).await?;
+        if expected_workspace_created_at_unix_nanos
+            .is_some_and(|expected| Some(expected) != workspace_created_at_unix_nanos)
+        {
+            tx.rollback().await?;
+            return Err(owner_workspace_not_found(owner));
+        }
+        let record = resolve_spec_record(&mut tx, requested_key).await?;
         tx.commit().await?;
-        let record = record.ok_or_else(|| global_spec_not_found(key))?;
+        let record = record.ok_or_else(|| spec_not_found(requested_key))?;
         let installed = record_to_installed(record.clone())?;
         if installed.manifest.identity_type != IdentitySpecType::FixedToken {
             return Err(AppError::InvalidInput(format!(
                 "identity spec '{}' has type 'oauth', not 'fixed_token'",
-                key.name()
+                requested_key.name()
             )));
         }
         let reference = IdentitySpecReference::new(
@@ -166,7 +215,12 @@ impl IdentityManager {
             installed.manifest.issuer,
             "fixed_token",
         )?;
-        Ok(SelectedFixedTokenSpec { record, reference })
+        Ok(SelectedFixedTokenSpec {
+            requested_key: requested_key.clone(),
+            workspace_created_at_unix_nanos,
+            record,
+            reference,
+        })
     }
 
     async fn prepare_fixed_token_document(
@@ -196,11 +250,23 @@ impl IdentityManager {
         document: &EncryptedEnvelopeDocument,
     ) -> Result<Option<IdentityRecord>, AppError> {
         let mut tx = self.db.begin_serializable().await?;
-        let current = match tx.identity_specs().get(selected.reference.key()).await {
+        let workspace_created_at_unix_nanos = match owner_workspace_created_at(&mut tx, owner).await
+        {
+            Ok(created_at) => created_at,
+            Err(error) => {
+                tx.rollback().await?;
+                return Err(error);
+            }
+        };
+        if workspace_created_at_unix_nanos != selected.workspace_created_at_unix_nanos {
+            tx.rollback().await?;
+            return Err(owner_workspace_not_found(owner));
+        }
+        let current = match resolve_spec_record(&mut tx, &selected.requested_key).await {
             Ok(current) => current,
             Err(error) => {
                 tx.rollback().await?;
-                return Err(error.into());
+                return Err(error);
             }
         };
         if current.as_ref() != Some(&selected.record) {
@@ -244,6 +310,42 @@ impl IdentityManager {
     }
 }
 
+async fn resolve_spec_record(
+    tx: &mut CoralTx<'_>,
+    requested_key: &IdentitySpecKey,
+) -> Result<Option<IdentitySpecRecord>, AppError> {
+    if let some @ Some(_) = tx.identity_specs().get(requested_key).await? {
+        return Ok(some);
+    }
+    let IdentitySpecScope::Workspace(_) = requested_key.scope() else {
+        return Ok(None);
+    };
+    let global_key = IdentitySpecKey::global(requested_key.name())?;
+    Ok(tx.identity_specs().get(&global_key).await?)
+}
+
+async fn owner_workspace_created_at(
+    tx: &mut CoralTx<'_>,
+    owner: &IdentityOwner,
+) -> Result<Option<i64>, AppError> {
+    let Some(workspace) = owner.workspace_name() else {
+        return Ok(None);
+    };
+    let record = tx
+        .workspaces()
+        .get(workspace.as_str())
+        .await?
+        .ok_or_else(|| AppError::WorkspaceNotFound(workspace.to_string()))?;
+    Ok(Some(record.created_at_unix_nanos))
+}
+
+fn owner_workspace_not_found(owner: &IdentityOwner) -> AppError {
+    let workspace = owner
+        .workspace_name()
+        .expect("only workspace owners have a persisted workspace generation");
+    AppError::WorkspaceNotFound(workspace.to_string())
+}
+
 async fn run_blocking_identity_operation<T, F>(operation: F) -> Result<T, AppError>
 where
     T: Send + 'static,
@@ -253,10 +355,14 @@ where
     tokio::task::spawn_blocking(move || span.in_scope(operation)).await?
 }
 
-fn global_spec_not_found(key: &IdentitySpecKey) -> AppError {
+fn spec_not_found(key: &IdentitySpecKey) -> AppError {
+    let scope = match key.scope() {
+        IdentitySpecScope::Global => "global".to_string(),
+        IdentitySpecScope::Workspace(workspace) => format!("workspace:{workspace}"),
+    };
     AppError::IdentitySpecNotFound {
         name: key.name().to_string(),
-        scope: "global".to_string(),
+        scope,
     }
 }
 

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -15,6 +15,7 @@ use crate::state::db::{
     CoralDb, DbRepos, IdentityDocumentRecord, IdentityRecord, IdentitySpecKey,
     set_identity_document_version,
 };
+use crate::workspaces::WorkspaceName;
 
 struct TestKeyProvider(Vec<CredentialEncryptionKey>);
 
@@ -52,7 +53,7 @@ pub(crate) async fn assert_user_global_fixed_token_create_contract(db: &Arc<Cora
         (&oauth, oauth_manifest(&oauth)),
         (&race, fixed_manifest(&race, "before")),
     ] {
-        put_spec(db, name, &yaml).await;
+        put_global_spec(db, name, &yaml).await;
     }
 
     let principal =
@@ -217,7 +218,7 @@ pub(crate) async fn assert_user_global_fixed_token_create_contract(db: &Arc<Cora
         );
         let replace = async {
             prepared.wait().await;
-            put_spec(db, &race, &fixed_manifest(&race, "after")).await;
+            put_global_spec(db, &race, &fixed_manifest(&race, "after")).await;
             resume.wait().await;
         };
         tokio::join!(create, replace).0
@@ -271,12 +272,345 @@ pub(crate) async fn assert_user_global_fixed_token_create_contract(db: &Arc<Cora
     cleanup.commit().await.expect("commit identity cleanup");
 }
 
-async fn put_spec(db: &CoralDb, name: &str, yaml: &str) {
-    let manifest = parse_identity_manifest_yaml(yaml).expect("identity manifest");
+#[expect(
+    clippy::too_many_lines,
+    reason = "shared SQLite/Postgres workspace manager contract"
+)]
+pub(crate) async fn assert_workspace_fixed_token_create_contract(db: &Arc<CoralDb>) {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let workspace = WorkspaceName::parse(&format!("workspace{suffix}")).expect("workspace");
+    let other = WorkspaceName::parse(&format!("other{suffix}")).expect("other workspace");
+    let recreated = WorkspaceName::parse(&format!("recreated{suffix}")).expect("recreated");
+    let missing_workspace =
+        WorkspaceName::parse(&format!("missing{suffix}")).expect("missing workspace");
+    put_workspace(db, &workspace).await;
+    put_workspace(db, &other).await;
+    put_workspace(db, &recreated).await;
+
+    let fallback = format!("fallback_{suffix}");
+    let shadowed = format!("shadowed_{suffix}");
+    let wrong_type = format!("wrong_{suffix}");
+    let generation = format!("generation_{suffix}");
+    let missing_spec = format!("missing_spec_{suffix}");
+    let fallback_global = IdentitySpecKey::global(&fallback).expect("fallback global key");
+    let fallback_workspace =
+        IdentitySpecKey::workspace(workspace.clone(), &fallback).expect("fallback workspace key");
+    let fallback_other =
+        IdentitySpecKey::workspace(other.clone(), &fallback).expect("other fallback key");
+    let shadowed_global = IdentitySpecKey::global(&shadowed).expect("shadowed global key");
+    let shadowed_workspace =
+        IdentitySpecKey::workspace(workspace.clone(), &shadowed).expect("shadowed workspace key");
+    let wrong_global = IdentitySpecKey::global(&wrong_type).expect("wrong global key");
+    let wrong_workspace =
+        IdentitySpecKey::workspace(workspace.clone(), &wrong_type).expect("wrong workspace key");
+    let generation_global = IdentitySpecKey::global(&generation).expect("generation global key");
+    for (key, yaml) in [
+        (
+            &fallback_global,
+            fixed_manifest(&fallback, "fallback_global"),
+        ),
+        (
+            &fallback_other,
+            fixed_manifest(&fallback, "other_workspace"),
+        ),
+        (
+            &shadowed_global,
+            fixed_manifest(&shadowed, "shadowed_global"),
+        ),
+        (
+            &shadowed_workspace,
+            fixed_manifest(&shadowed, "shadowed_workspace"),
+        ),
+        (&wrong_global, fixed_manifest(&wrong_type, "wrong_global")),
+        (&wrong_workspace, oauth_manifest(&wrong_type)),
+        (
+            &generation_global,
+            fixed_manifest(&generation, "generation"),
+        ),
+    ] {
+        put_spec(db, key, &yaml).await;
+    }
+
+    let old_key = CredentialEncryptionKey::from_static_bytes_for_test([73; 32]);
+    let old_provider = Arc::new(TestKeyProvider(vec![old_key.clone()]));
+    let manager = IdentityManager::new(db.clone(), old_provider.clone());
+    let unavailable = IdentityManager::new(db.clone(), Arc::new(TestKeyProvider(Vec::new())));
+    let owner = IdentityOwner::workspace(workspace.clone());
+
+    let missing_workspace_identity = format!("missing_workspace_{suffix}");
+    assert!(matches!(
+        manager
+            .create_or_replace_workspace_fixed_token(
+                &missing_workspace,
+                &missing_workspace_identity,
+                &fallback,
+                "token".to_string(),
+            )
+            .await,
+        Err(AppError::WorkspaceNotFound(name)) if name == missing_workspace.as_str()
+    ));
+    let missing_spec_identity = format!("missing_spec_{suffix}");
+    assert!(matches!(
+        manager
+            .create_or_replace_workspace_fixed_token(
+                &workspace,
+                &missing_spec_identity,
+                &missing_spec,
+                "token".to_string(),
+            )
+            .await,
+        Err(AppError::IdentitySpecNotFound { scope, .. })
+            if scope == format!("workspace:{workspace}")
+    ));
+    let wrong_type_identity = format!("wrong_type_{suffix}");
+    assert!(matches!(
+        manager
+            .create_or_replace_workspace_fixed_token(
+                &workspace,
+                &wrong_type_identity,
+                &wrong_type,
+                "token".to_string(),
+            )
+            .await,
+        Err(AppError::InvalidInput(_))
+    ));
+    let blank_identity = format!("blank_{suffix}");
+    assert!(matches!(
+        manager
+            .create_or_replace_workspace_fixed_token(
+                &workspace,
+                &blank_identity,
+                &fallback,
+                " \t ".to_string(),
+            )
+            .await,
+        Err(AppError::InvalidInput(_))
+    ));
+    let no_key_identity = format!("no_key_{suffix}");
+    assert!(matches!(
+        unavailable
+            .create_or_replace_workspace_fixed_token(
+                &workspace,
+                &no_key_identity,
+                &fallback,
+                "token".to_string(),
+            )
+            .await,
+        Err(AppError::Credentials(_))
+    ));
+    for name in [
+        &missing_spec_identity,
+        &wrong_type_identity,
+        &blank_identity,
+        &no_key_identity,
+    ] {
+        assert_eq!(load_pair(db, &owner, name).await, (None, None));
+    }
+
+    let fallback_identity = format!("fallback_identity_{suffix}");
+    let fallback_created = manager
+        .create_or_replace_workspace_fixed_token(
+            &workspace,
+            &fallback_identity,
+            &fallback,
+            " fallback-token ".to_string(),
+        )
+        .await
+        .expect("create from global fallback");
+    assert_reference_key(&fallback_created, &fallback_global, "fallback_global");
+    let fallback_created_pair = load_pair(db, &owner, &fallback_identity).await;
+    let fallback_created_document = fallback_created_pair.1.as_ref().expect("fallback document");
+    assert_eq!(fallback_created_pair.0.as_ref(), Some(&fallback_created));
+    assert_eq!(fallback_created_document.document_version, 1);
+    assert_eq!(fallback_created_document.envelope.key_id, old_key.key_id());
+    assert_material(
+        &fallback_created,
+        fallback_created_document,
+        "fallback-token",
+        old_provider.as_ref(),
+    );
+
+    let shadowed_identity = format!("shadowed_identity_{suffix}");
+    let shadowed_created = manager
+        .create_or_replace_workspace_fixed_token(
+            &workspace,
+            &shadowed_identity,
+            &shadowed,
+            "workspace-token".to_string(),
+        )
+        .await
+        .expect("create from workspace override");
+    assert_reference_key(&shadowed_created, &shadowed_workspace, "shadowed_workspace");
+    let shadowed_pair = load_pair(db, &owner, &shadowed_identity).await;
+    assert_eq!(shadowed_pair.0.as_ref(), Some(&shadowed_created));
+    assert_eq!(
+        shadowed_pair
+            .1
+            .as_ref()
+            .expect("shadowed document")
+            .document_version,
+        1
+    );
+    assert_material(
+        &shadowed_created,
+        shadowed_pair.1.as_ref().expect("shadowed document"),
+        "workspace-token",
+        old_provider.as_ref(),
+    );
+
+    put_spec(
+        db,
+        &fallback_workspace,
+        &fixed_manifest(&fallback, "late_workspace"),
+    )
+    .await;
+    let new_key = CredentialEncryptionKey::from_static_bytes_for_test([74; 32]);
+    let rotated_provider = Arc::new(TestKeyProvider(vec![old_key, new_key.clone()]));
+    let rotated = IdentityManager::new(db.clone(), rotated_provider.clone());
+    let fallback_replaced = rotated
+        .create_or_replace_workspace_fixed_token(
+            &workspace,
+            &fallback_identity,
+            &fallback,
+            "replacement-token".to_string(),
+        )
+        .await
+        .expect("replace from late workspace override");
+    assert_reference_key(&fallback_replaced, &fallback_workspace, "late_workspace");
+    let fallback_replaced_pair = load_pair(db, &owner, &fallback_identity).await;
+    assert_eq!(fallback_replaced_pair.0.as_ref(), Some(&fallback_replaced));
+    let fallback_replaced_document = fallback_replaced_pair
+        .1
+        .as_ref()
+        .expect("replaced document");
+    assert_eq!(
+        fallback_replaced.created_at_unix_nanos,
+        fallback_created.created_at_unix_nanos
+    );
+    assert_eq!(fallback_replaced_document.document_version, 2);
+    assert_eq!(
+        fallback_replaced_document.created_at_unix_nanos,
+        fallback_created_document.created_at_unix_nanos
+    );
+    assert_eq!(fallback_replaced_document.envelope.key_id, new_key.key_id());
+    assert_material(
+        &fallback_replaced,
+        fallback_replaced_document,
+        "replacement-token",
+        rotated_provider.as_ref(),
+    );
+
+    let fallback_name = IdentityName::parse(&fallback_identity).expect("fallback identity name");
+    set_identity_document_version(db, &owner, &fallback_name, i64::MAX).await;
+    let before_failure = load_pair(db, &owner, &fallback_identity).await;
+    let error = rotated
+        .create_or_replace_workspace_fixed_token(
+            &workspace,
+            &fallback_identity,
+            &shadowed,
+            "rollback-token".to_string(),
+        )
+        .await
+        .expect_err("exhausted document version must fail");
+    assert!(
+        matches!(error, AppError::FailedPrecondition(detail) if detail.contains("version is exhausted"))
+    );
+    assert_eq!(
+        load_pair(db, &owner, &fallback_identity).await,
+        before_failure
+    );
+
+    let prepared = Arc::new(tokio::sync::Barrier::new(2));
+    let resume = Arc::new(tokio::sync::Barrier::new(2));
+    let gated = rotated
+        .clone()
+        .with_before_write_gate(prepared.clone(), resume.clone());
+    let generation_identity = format!("generation_identity_{suffix}");
+    let generation_result = tokio::time::timeout(Duration::from_secs(10), async {
+        let create = gated.create_or_replace_workspace_fixed_token(
+            &recreated,
+            &generation_identity,
+            &generation,
+            "generation-token".to_string(),
+        );
+        let recreate = async {
+            prepared.wait().await;
+            let mut tx = db.begin().await.expect("begin workspace recreation");
+            tx.workspaces()
+                .delete(recreated.as_str())
+                .await
+                .expect("delete workspace generation");
+            tx.workspaces()
+                .ensure(recreated.as_str(), 2)
+                .await
+                .expect("recreate workspace generation");
+            tx.commit().await.expect("commit workspace recreation");
+            resume.wait().await;
+        };
+        tokio::join!(create, recreate).0
+    })
+    .await
+    .expect("workspace recreation race must not deadlock");
+    assert!(matches!(
+        generation_result,
+        Err(AppError::WorkspaceNotFound(name)) if name == recreated.as_str()
+    ));
+    let recreated_owner = IdentityOwner::workspace(recreated.clone());
+    assert_eq!(
+        load_pair(db, &recreated_owner, &generation_identity).await,
+        (None, None)
+    );
+
+    let mut cleanup = db.begin().await.expect("begin workspace cleanup");
+    let shadowed_name = IdentityName::parse(&shadowed_identity).expect("shadowed identity name");
+    for name in [&fallback_name, &shadowed_name] {
+        assert!(cleanup.identities().delete(&owner, name).await.unwrap());
+    }
+    for key in [
+        &fallback_global,
+        &fallback_workspace,
+        &fallback_other,
+        &shadowed_global,
+        &shadowed_workspace,
+        &wrong_global,
+        &wrong_workspace,
+        &generation_global,
+    ] {
+        assert!(cleanup.identity_specs().delete(key).await.unwrap());
+    }
+    cleanup
+        .workspaces()
+        .delete(workspace.as_str())
+        .await
+        .unwrap();
+    cleanup.workspaces().delete(other.as_str()).await.unwrap();
+    cleanup
+        .workspaces()
+        .delete(recreated.as_str())
+        .await
+        .unwrap();
+    cleanup.commit().await.expect("commit workspace cleanup");
+}
+
+async fn put_workspace(db: &CoralDb, workspace: &WorkspaceName) {
+    let mut tx = db.begin().await.expect("begin workspace write");
+    tx.workspaces()
+        .ensure(workspace.as_str(), 1)
+        .await
+        .expect("write workspace");
+    tx.commit().await.expect("commit workspace write");
+}
+
+async fn put_global_spec(db: &CoralDb, name: &str, yaml: &str) {
     let key = IdentitySpecKey::global(name).expect("global spec key");
+    put_spec(db, &key, yaml).await;
+}
+
+async fn put_spec(db: &CoralDb, key: &IdentitySpecKey, yaml: &str) {
+    let manifest = parse_identity_manifest_yaml(yaml).expect("identity manifest");
     let mut tx = db.begin().await.expect("begin spec write");
     tx.identity_specs()
-        .upsert(&key, &manifest, yaml, 1)
+        .upsert(key, &manifest, yaml, 1)
         .await
         .expect("upsert identity spec");
     tx.commit().await.expect("commit identity spec");
@@ -303,12 +637,14 @@ async fn load_pair(
 }
 
 fn assert_reference(record: &IdentityRecord, spec_name: &str, revision: &str) {
-    let manifest = parse_identity_manifest_yaml(&fixed_manifest(spec_name, revision))
+    let key = IdentitySpecKey::global(spec_name).expect("global spec key");
+    assert_reference_key(record, &key, revision);
+}
+
+fn assert_reference_key(record: &IdentityRecord, key: &IdentitySpecKey, revision: &str) {
+    let manifest = parse_identity_manifest_yaml(&fixed_manifest(key.name(), revision))
         .expect("expected manifest");
-    assert_eq!(
-        record.spec_reference.key(),
-        &IdentitySpecKey::global(spec_name).expect("global spec key")
-    );
+    assert_eq!(record.spec_reference.key(), key);
     assert_eq!(
         record.spec_reference.fingerprint(),
         identity_spec_fingerprint(&manifest).expect("fingerprint")

--- a/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
@@ -30,6 +30,8 @@ async fn identity_repository_contract_holds_against_sqlite() {
         crate::identities::manager::tests::assert_user_global_fixed_token_create_contract(&db),
     )
     .await;
+    Box::pin(crate::identities::manager::tests::assert_workspace_fixed_token_create_contract(&db))
+        .await;
 }
 
 #[expect(clippy::too_many_lines, reason = "shared backend contract fixture")]


### PR DESCRIPTION
## Intent

Add the workspace-owned fixed-token creation path without weakening the source-level identity contracts already established through PR #1515. Workspace creation must resolve the effective identity spec coherently, bind encrypted setup material to the exact winning spec, and reject writes across workspace deletion/recreation.

## What it enables

- Resolves an exact workspace identity spec first, with exact global fallback only when no workspace spec shadows it.
- Persists the actual winning spec scope, semantic fingerprint, and issuer alongside encrypted token material.
- Re-encrypts on every retry with exact-spec AAD, while serializable revalidation prevents stale workspace/spec selections from committing.
- Fences the operation to the workspace generation and atomically writes identity metadata plus its setup document on SQLite and Postgres.

## Usage examples

The app manager can create or replace a workspace-owned fixed-token identity internally:

```rust
manager
    .create_or_replace_workspace_fixed_token(
        "acme",
        "github-ci",
        "github",
        token,
    )
    .await?;
```

If `workspace:acme/github` exists, that exact spec wins. Otherwise the manager uses `global/github`. A workspace-scoped OAuth spec shadows the global fixed-token spec and is rejected instead of silently falling back. No public transport endpoint is added in this layer.