### PR TITLE
test(app): cover identity spec lifecycle races

### DIFF
--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -120,7 +120,7 @@ impl IdentityManager {
     }
 
     #[cfg(test)]
-    fn with_before_upsert_gate(mut self, barrier: Arc<tokio::sync::Barrier>) -> Self {
+    pub(crate) fn with_before_upsert_gate(mut self, barrier: Arc<tokio::sync::Barrier>) -> Self {
         self.before_upsert_gate = Some(BeforeUpsertGate {
             barrier,
             used: Arc::new(AtomicBool::new(false)),

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -797,6 +797,20 @@ async fn load_pair(
     (identity, document)
 }
 
+pub(crate) async fn assert_persisted_fixed_token_material(
+    db: &CoralDb,
+    owner: &IdentityOwner,
+    identity_name: &str,
+    token: &str,
+    provider: &dyn CredentialKeyProvider,
+) -> IdentityRecord {
+    let (identity, document) = load_pair(db, owner, identity_name).await;
+    let identity = identity.expect("persisted identity");
+    let document = document.expect("persisted identity document");
+    assert_material(&identity, &document, token, provider);
+    identity
+}
+
 fn assert_reference(record: &IdentityRecord, spec_name: &str, revision: &str) {
     let key = IdentitySpecKey::global(spec_name).expect("global spec key");
     assert_reference_key(record, &key, revision);

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -18,7 +18,7 @@ use crate::identity_specs::inputs::{
     resolve_identity_spec_inputs_for_use,
 };
 #[cfg(test)]
-use crate::state::db::IdentitySpecMutationSnapshot;
+use crate::state::db::{BeforeLifecycleWriteGate, IdentitySpecMutationSnapshot};
 use crate::state::db::{
     CoralDb, CoralTx, DbError, DbRepos, IdentitySpecDocumentRecord, IdentitySpecId,
     IdentitySpecKey, IdentitySpecRecord, IdentitySpecScope,
@@ -63,6 +63,8 @@ pub(crate) struct IdentitySpecManager {
     key_provider: Arc<dyn CredentialKeyProvider>,
     #[cfg(test)]
     mutation_barrier: Option<Arc<tokio::sync::Barrier>>,
+    #[cfg(test)]
+    before_lifecycle_write: Option<BeforeLifecycleWriteGate>,
 }
 
 impl IdentitySpecManager {
@@ -72,12 +74,20 @@ impl IdentitySpecManager {
             key_provider,
             #[cfg(test)]
             mutation_barrier: None,
+            #[cfg(test)]
+            before_lifecycle_write: None,
         }
     }
 
     #[cfg(test)]
     fn with_mutation_barrier(mut self, barrier: Arc<tokio::sync::Barrier>) -> Self {
         self.mutation_barrier = Some(barrier);
+        self
+    }
+
+    #[cfg(test)]
+    fn with_before_lifecycle_write(mut self, barrier: Arc<tokio::sync::Barrier>) -> Self {
+        self.before_lifecycle_write = Some(BeforeLifecycleWriteGate::new(barrier));
         self
     }
 
@@ -104,9 +114,10 @@ impl IdentitySpecManager {
             let prepare_manifest = Arc::clone(&manifest);
             let prepare_inputs = Arc::clone(&input_values);
             let key_provider = Arc::clone(&self.key_provider);
-            let result = self
-                .db
-                .identity_spec_state()
+            let state = self.db.identity_spec_state();
+            #[cfg(test)]
+            let state = state.with_before_lifecycle_write(self.before_lifecycle_write.clone());
+            let result = state
                 .add_or_replace_exact(
                     &key,
                     manifest.as_ref(),
@@ -164,7 +175,10 @@ impl IdentitySpecManager {
     /// Delete one spec in exactly the selected scope.
     pub(crate) async fn delete_exact(&self, key: &IdentitySpecKey) -> Result<(), AppError> {
         for _ in 0..MAX_MUTATION_ATTEMPTS {
-            match self.db.identity_spec_state().delete_exact(key).await {
+            let state = self.db.identity_spec_state();
+            #[cfg(test)]
+            let state = state.with_before_lifecycle_write(self.before_lifecycle_write.clone());
+            match state.delete_exact(key).await {
                 Ok(true) => return Ok(()),
                 Ok(false) => return Err(spec_not_found(key)),
                 Err(AppError::RetryableTransactionConflict) => {
@@ -487,6 +501,7 @@ pub(crate) mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::thread::{self, ThreadId};
+    use std::time::Duration;
 
     use tempfile::{TempDir, tempdir};
 
@@ -496,6 +511,7 @@ pub(crate) mod tests {
     use crate::credentials::encryption::{CredentialEncryptionKey, CredentialKeyProvider};
     use crate::encrypted_document::EncryptedEnvelopeDocument;
     use crate::identities::manager::IdentityManager;
+    use crate::identities::manager::tests::assert_persisted_fixed_token_material;
     use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
     use crate::identity::Principal;
     use crate::identity::spec_document::{
@@ -596,6 +612,196 @@ pub(crate) mod tests {
         fn key(&self, _key_id: &str) -> Result<CredentialEncryptionKey, CredentialsError> {
             Err(CredentialsError::Unavailable("unavailable".into()))
         }
+    }
+
+    pub(crate) async fn assert_identity_spec_lifecycle_race_contract(db: &Arc<CoralDb>) {
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let key_provider: Arc<dyn CredentialKeyProvider> = Arc::new(TestKeyProvider::new(
+            CredentialEncryptionKey::from_static_bytes_for_test([53; 32]),
+        ));
+        assert_changed_replacement_create_race(db, Arc::clone(&key_provider), &suffix).await;
+        assert_guarded_delete_create_race(db, key_provider, &suffix).await;
+    }
+
+    async fn assert_changed_replacement_create_race(
+        db: &Arc<CoralDb>,
+        key_provider: Arc<dyn CredentialKeyProvider>,
+        suffix: &str,
+    ) {
+        let name = format!("replace_race_{suffix}");
+        let token = "replacement-race-token";
+        let key = IdentitySpecKey::global(&name).unwrap();
+        let specs = IdentitySpecManager::new(Arc::clone(db), Arc::clone(&key_provider));
+        specs
+            .add_or_replace_exact(
+                IdentitySpecScope::global(),
+                &manifest(&name, "before"),
+                vec![],
+            )
+            .await
+            .unwrap();
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let gated_specs = IdentitySpecManager::new(Arc::clone(db), Arc::clone(&key_provider))
+            .with_before_lifecycle_write(Arc::clone(&barrier));
+        let gated_identities = IdentityManager::new(Arc::clone(db), Arc::clone(&key_provider))
+            .with_before_upsert_gate(barrier);
+        let principal = Principal::local();
+        let changed_manifest = manifest(&name, "after");
+        let (created, replaced) = tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(
+                gated_identities.create_or_replace_user_fixed_token(
+                    &principal,
+                    &name,
+                    &name,
+                    token.to_string(),
+                ),
+                gated_specs.add_or_replace_exact(
+                    IdentitySpecScope::global(),
+                    &changed_manifest,
+                    vec![],
+                ),
+            )
+        })
+        .await
+        .expect("replacement/create race must not deadlock");
+        let created = created.expect("identity creation must converge");
+        let owner = IdentityOwner::for_user(principal);
+        let persisted = assert_persisted_fixed_token_material(
+            db.as_ref(),
+            &owner,
+            &name,
+            token,
+            key_provider.as_ref(),
+        )
+        .await;
+        assert_eq!(persisted, created);
+        assert_eq!(persisted.spec_reference.key(), &key);
+        let current = specs.get_global(&name).await.unwrap();
+        assert_eq!(
+            persisted.spec_reference.fingerprint(),
+            identity_spec_fingerprint(&current.manifest).unwrap()
+        );
+        match replaced {
+            Ok((_installed, true)) => assert_eq!(current.manifest.version, "after"),
+            Err(AppError::FailedPrecondition(detail)) => {
+                assert!(detail.contains("semantically equivalent manifest"));
+                assert_eq!(current.manifest.version, "before");
+            }
+            other => panic!("unexpected replacement/create result: {other:?}"),
+        }
+        cleanup_lifecycle_race_fixture(db, &specs, &owner, &name, &key).await;
+    }
+
+    async fn assert_guarded_delete_create_race(
+        db: &Arc<CoralDb>,
+        key_provider: Arc<dyn CredentialKeyProvider>,
+        suffix: &str,
+    ) {
+        let name = format!("delete_race_{suffix}");
+        let token = "delete-race-token";
+        let key = IdentitySpecKey::global(&name).unwrap();
+        let specs = IdentitySpecManager::new(Arc::clone(db), Arc::clone(&key_provider));
+        specs
+            .add_or_replace_exact(
+                IdentitySpecScope::global(),
+                &manifest(&name, "before"),
+                vec![],
+            )
+            .await
+            .unwrap();
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let gated_specs = IdentitySpecManager::new(Arc::clone(db), Arc::clone(&key_provider))
+            .with_before_lifecycle_write(Arc::clone(&barrier));
+        let gated_identities = IdentityManager::new(Arc::clone(db), Arc::clone(&key_provider))
+            .with_before_upsert_gate(barrier);
+        let principal = Principal::local();
+        let (created, deleted) = tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(
+                gated_identities.create_or_replace_user_fixed_token(
+                    &principal,
+                    &name,
+                    &name,
+                    token.to_string(),
+                ),
+                gated_specs.delete_exact(&key),
+            )
+        })
+        .await
+        .expect("delete/create race must not deadlock");
+        let owner = IdentityOwner::for_user(principal);
+        match (created, deleted) {
+            (Ok(created), Err(AppError::FailedPrecondition(detail))) => {
+                assert!(detail.contains("1 stored identity reference"));
+                let current = specs.get_global(&name).await.unwrap();
+                let persisted = assert_persisted_fixed_token_material(
+                    db.as_ref(),
+                    &owner,
+                    &name,
+                    token,
+                    key_provider.as_ref(),
+                )
+                .await;
+                assert_eq!(persisted, created);
+                assert_eq!(persisted.spec_reference.key(), &key);
+                assert_eq!(
+                    persisted.spec_reference.fingerprint(),
+                    identity_spec_fingerprint(&current.manifest).unwrap()
+                );
+            }
+            (Err(AppError::IdentitySpecNotFound { scope, .. }), Ok(())) if scope == "global" => {
+                assert!(matches!(
+                    specs.get_global(&name).await,
+                    Err(AppError::IdentitySpecNotFound { .. })
+                ));
+                assert_eq!(
+                    identity_pair_exists(db, &owner, &name).await,
+                    (false, false)
+                );
+            }
+            other => panic!("unexpected delete/create result: {other:?}"),
+        }
+        cleanup_lifecycle_race_fixture(db, &specs, &owner, &name, &key).await;
+    }
+
+    async fn identity_pair_exists(
+        db: &Arc<CoralDb>,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> (bool, bool) {
+        let name = IdentityName::parse(identity_name).unwrap();
+        let mut session = db.as_ref();
+        let identity = session.identities().get(owner, &name).await.unwrap();
+        let document = session
+            .identity_documents()
+            .get(owner, &name)
+            .await
+            .unwrap();
+        (identity.is_some(), document.is_some())
+    }
+
+    async fn cleanup_lifecycle_race_fixture(
+        db: &Arc<CoralDb>,
+        specs: &IdentitySpecManager,
+        owner: &IdentityOwner,
+        identity_name: &str,
+        key: &IdentitySpecKey,
+    ) {
+        let name = IdentityName::parse(identity_name).unwrap();
+        let mut tx = db.begin().await.unwrap();
+        tx.identities().delete(owner, &name).await.unwrap();
+        tx.commit().await.unwrap();
+        match specs.delete_exact(key).await {
+            Ok(()) | Err(AppError::IdentitySpecNotFound { .. }) => {}
+            other => panic!("unexpected lifecycle race cleanup: {other:?}"),
+        }
+        assert_eq!(
+            identity_pair_exists(db, owner, identity_name).await,
+            (false, false)
+        );
+        assert!(matches!(
+            specs.get_exact(key).await,
+            Err(AppError::IdentitySpecNotFound { .. })
+        ));
     }
 
     #[expect(clippy::too_many_lines, reason = "shared backend mutation contract")]

--- a/crates/coral-app/src/state/db/identity_spec_state.rs
+++ b/crates/coral-app/src/state/db/identity_spec_state.rs
@@ -1,4 +1,8 @@
 use std::future::Future;
+#[cfg(test)]
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use coral_spec::IdentityManifest;
 
@@ -11,6 +15,25 @@ use crate::encrypted_document::EncryptedEnvelopeDocument;
 
 pub(crate) struct IdentitySpecState<'a> {
     db: &'a CoralDb,
+    #[cfg(test)]
+    before_lifecycle_write: Option<BeforeLifecycleWriteGate>,
+}
+
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct BeforeLifecycleWriteGate {
+    barrier: Arc<tokio::sync::Barrier>,
+    used: Arc<AtomicBool>,
+}
+
+#[cfg(test)]
+impl BeforeLifecycleWriteGate {
+    pub(crate) fn new(barrier: Arc<tokio::sync::Barrier>) -> Self {
+        Self {
+            barrier,
+            used: Arc::new(AtomicBool::new(false)),
+        }
+    }
 }
 
 #[derive(PartialEq, Eq)]
@@ -21,11 +44,24 @@ pub(crate) struct IdentitySpecMutationSnapshot {
 
 impl CoralDb {
     pub(crate) fn identity_spec_state(&self) -> IdentitySpecState<'_> {
-        IdentitySpecState { db: self }
+        IdentitySpecState {
+            db: self,
+            #[cfg(test)]
+            before_lifecycle_write: None,
+        }
     }
 }
 
 impl IdentitySpecState<'_> {
+    #[cfg(test)]
+    pub(crate) fn with_before_lifecycle_write(
+        mut self,
+        gate: Option<BeforeLifecycleWriteGate>,
+    ) -> Self {
+        self.before_lifecycle_write = gate;
+        self
+    }
+
     pub(crate) async fn add_or_replace_exact<F, Fut>(
         &self,
         key: &IdentitySpecKey,
@@ -44,6 +80,8 @@ impl IdentitySpecState<'_> {
             let replaced = snapshot.record.is_some();
             let (document, fingerprint) = prepare_mutation(snapshot).await?;
             require_equivalent_dependents(&mut tx, key, &fingerprint).await?;
+            #[cfg(test)]
+            self.wait_before_lifecycle_write().await;
             let now = now_unix_nanos_i64()?;
             let record = tx
                 .identity_specs()
@@ -89,6 +127,8 @@ impl IdentitySpecState<'_> {
                     scope_label(key.scope()),
                 )));
             }
+            #[cfg(test)]
+            self.wait_before_lifecycle_write().await;
             tx.identity_specs().delete(key).await.map_err(Into::into)
         }
         .await;
@@ -118,6 +158,15 @@ impl IdentitySpecState<'_> {
         let snapshot = load_mutation_snapshot(&mut tx, key).await?;
         tx.commit().await?;
         Ok(snapshot)
+    }
+
+    #[cfg(test)]
+    async fn wait_before_lifecycle_write(&self) {
+        if let Some(gate) = &self.before_lifecycle_write
+            && !gate.used.swap(true, Ordering::SeqCst)
+        {
+            gate.barrier.wait().await;
+        }
     }
 }
 

--- a/crates/coral-app/src/state/db/mod.rs
+++ b/crates/coral-app/src/state/db/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use config::{DatabaseConfig, ResolvedDatabaseConfig};
 pub(crate) use coral_db::CoralDb;
 pub(crate) use error::DbError;
 #[cfg(test)]
-pub(crate) use identity_spec_state::IdentitySpecMutationSnapshot;
+pub(crate) use identity_spec_state::{BeforeLifecycleWriteGate, IdentitySpecMutationSnapshot};
 pub(crate) use import::run_state_migrations;
 pub(crate) use repositories::identities::IdentityRecord;
 #[cfg(test)]

--- a/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_specs_contract_tests.rs
@@ -28,6 +28,10 @@ async fn identity_spec_persistence_contract_holds_against_sqlite() {
     assert_identity_spec_persistence_contract(&db).await;
     Box::pin(crate::identity_specs::manager::tests::assert_identity_spec_mutation_contract(&db))
         .await;
+    Box::pin(
+        crate::identity_specs::manager::tests::assert_identity_spec_lifecycle_race_contract(&db),
+    )
+    .await;
 }
 
 pub(crate) async fn set_identity_spec_document_version(


### PR DESCRIPTION
## Intent

Prove that fixed-token identity creation remains atomic with exact identity-spec replacement and deletion on both SQLite and PostgreSQL. The tests exercise the real serializable manager paths and preserve the strict no-force lifecycle semantics established by the lower stack.

## What it enables

- Deterministic coverage of changed exact-spec replacement racing user identity creation.
- Deterministic coverage of guarded exact-spec deletion racing user identity creation.
- Verification that the only committed outcomes retain an exact live spec reference and matching semantic fingerprint, or leave no identity/document pair behind.
- Decryption of the persisted token with the final exact-spec AAD, proving metadata and encrypted material remain coherent after retry convergence.
- One shared contract for SQLite locking and PostgreSQL SSI behavior, with cleanup suitable for the reused PostgreSQL fixture.

## Usage examples

These are internal lifecycle guarantees. During concurrent replacement and creation, either replacement commits and creation retries against the new fingerprint, or creation commits and the changed replacement is rejected. During concurrent deletion and creation, either deletion commits and creation reports the exact global spec missing, or creation commits and deletion reports the dependent identity.

## Verification

- `cargo test -p coral-app --all-features --locked identity_spec_persistence_contract_holds_against_sqlite -- --nocapture`
- `make postgres-tests`
- `cargo clippy -p coral-app --all-targets --all-features --locked -- -D warnings`
- `make rust-checks` (1,972 tests passed; 7 skipped; rustdoc passed)