### PR TITLE
feat(app): manage exact owner identities

### DIFF
--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -119,6 +119,9 @@ pub const CORAL_ERROR_REASON_FUNCTION_NOT_FOUND: &str = "FUNCTION_NOT_FOUND";
 /// Machine-readable reason for an installed identity-spec lookup miss.
 pub const CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND: &str = "IDENTITY_SPEC_NOT_FOUND";
 
+/// Machine-readable reason for a stored-identity lookup miss.
+pub const CORAL_ERROR_REASON_IDENTITY_NOT_FOUND: &str = "IDENTITY_NOT_FOUND";
+
 /// Machine-readable reason for a configured workspace lookup miss.
 pub const CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND: &str = "WORKSPACE_NOT_FOUND";
 

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -3,8 +3,8 @@
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_DETAIL, CORAL_ERROR_METADATA_HINT,
     CORAL_ERROR_METADATA_SUMMARY, CORAL_ERROR_REASON_FUNCTION_NOT_FOUND,
-    CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND, CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
-    CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND,
+    CORAL_ERROR_REASON_IDENTITY_NOT_FOUND, CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND,
+    CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND,
 };
 use coral_engine::{CoreError, StatusCode};
 use tonic::{Code, Status};
@@ -36,6 +36,9 @@ pub enum AppError {
         /// Canonical requested scope (`global` or `workspace:<name>`).
         scope: String,
     },
+    /// A requested owner-scoped identity was not found.
+    #[error("identity '{0}' not found")]
+    IdentityNotFound(String),
     /// A requested workspace was not found in config.
     #[error("workspace '{0}' not found")]
     WorkspaceNotFound(String),
@@ -222,6 +225,7 @@ pub(crate) fn app_status(error: AppError) -> Status {
     let not_found_reason = match &error {
         AppError::SourceNotFound(_) => Some(CORAL_ERROR_REASON_SOURCE_NOT_FOUND),
         AppError::FunctionNotFound(_) => Some(CORAL_ERROR_REASON_FUNCTION_NOT_FOUND),
+        AppError::IdentityNotFound(_) => Some(CORAL_ERROR_REASON_IDENTITY_NOT_FOUND),
         AppError::IdentitySpecNotFound { .. } => Some(CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND),
         AppError::WorkspaceNotFound(_) => Some(CORAL_ERROR_REASON_WORKSPACE_NOT_FOUND),
         _ => None,
@@ -311,6 +315,7 @@ fn app_code(error: &AppError) -> Code {
         AppError::Unauthenticated(_) => Code::Unauthenticated,
         AppError::SourceNotFound(_)
         | AppError::FunctionNotFound(_)
+        | AppError::IdentityNotFound(_)
         | AppError::IdentitySpecNotFound { .. }
         | AppError::WorkspaceNotFound(_) => Code::NotFound,
         AppError::FunctionAlreadyExists(_) | AppError::WorkspaceAlreadyExists(_) => {
@@ -457,6 +462,24 @@ mod tests {
             .expect("identity-spec miss must carry ErrorInfo");
         assert_eq!(info.reason, CORAL_ERROR_REASON_IDENTITY_SPEC_NOT_FOUND);
         assert_eq!(info.domain, CORAL_ERROR_DOMAIN);
+    }
+
+    #[test]
+    fn app_status_attaches_structured_reason_for_identity_not_found() {
+        let status = app_status(AppError::IdentityNotFound("private-name".to_string()));
+        assert_eq!(status.code(), Code::NotFound);
+
+        let info = status
+            .get_error_details_vec()
+            .into_iter()
+            .find_map(|detail| match detail {
+                ErrorDetail::ErrorInfo(info) => Some(info),
+                _ => None,
+            })
+            .expect("identity miss must carry ErrorInfo");
+        assert_eq!(info.reason, CORAL_ERROR_REASON_IDENTITY_NOT_FOUND);
+        assert_eq!(info.domain, CORAL_ERROR_DOMAIN);
+        assert!(info.metadata.is_empty());
     }
 
     #[test]

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -1,4 +1,4 @@
-//! Database-backed identity instance creation.
+//! Database-backed identity instance management.
 
 #![cfg_attr(
     not(test),
@@ -216,6 +216,116 @@ impl IdentityManager {
         Err(AppError::RetryableTransactionConflict)
     }
 
+    /// List safe persisted metadata for one exact owner in identity-name order.
+    ///
+    /// Management reads remain available when the referenced exact spec is no
+    /// longer installed so callers can inspect and delete legacy identities.
+    pub(crate) async fn list_for_owner(
+        &self,
+        owner: &IdentityOwner,
+    ) -> Result<Vec<IdentityRecord>, AppError> {
+        let mut tx = self.db.begin_read_snapshot().await?;
+        let result = async {
+            owner_workspace_created_at(&mut tx, owner).await?;
+            Ok(tx.identities().list(owner).await?)
+        }
+        .await;
+        complete_transaction(tx, result).await
+    }
+
+    /// Get safe persisted metadata for one exact owner and identity name.
+    ///
+    /// This does not resolve the referenced spec or decrypt setup material.
+    pub(crate) async fn get(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<IdentityRecord, AppError> {
+        let user_name = owner
+            .workspace_name()
+            .is_none()
+            .then(|| IdentityName::parse(identity_name))
+            .transpose()?;
+        let mut tx = self.db.begin_read_snapshot().await?;
+        let result = async {
+            owner_workspace_created_at(&mut tx, owner).await?;
+            let name = match user_name {
+                Some(name) => name,
+                None => IdentityName::parse(identity_name)?,
+            };
+            tx.identities()
+                .get(owner, &name)
+                .await?
+                .ok_or_else(|| identity_not_found(&name))
+        }
+        .await;
+        complete_transaction(tx, result).await
+    }
+
+    /// Delete one identity and its cascading encrypted setup document.
+    pub(crate) async fn delete(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<(), AppError> {
+        let (name, workspace_created_at_unix_nanos) =
+            self.prepare_delete(owner, identity_name).await?;
+        for _ in 0..MAX_MUTATION_ATTEMPTS {
+            match self
+                .try_delete(owner, &name, workspace_created_at_unix_nanos)
+                .await
+            {
+                Ok(()) => return Ok(()),
+                Err(AppError::RetryableTransactionConflict) => {
+                    tokio::task::yield_now().await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Err(AppError::RetryableTransactionConflict)
+    }
+
+    async fn prepare_delete(
+        &self,
+        owner: &IdentityOwner,
+        identity_name: &str,
+    ) -> Result<(IdentityName, Option<i64>), AppError> {
+        if owner.workspace_name().is_none() {
+            return Ok((IdentityName::parse(identity_name)?, None));
+        }
+        let mut tx = self.db.begin_read_snapshot().await?;
+        let result = async {
+            let workspace_created_at_unix_nanos =
+                owner_workspace_created_at(&mut tx, owner).await?;
+            let name = IdentityName::parse(identity_name)?;
+            Ok((name, workspace_created_at_unix_nanos))
+        }
+        .await;
+        complete_transaction(tx, result).await
+    }
+
+    async fn try_delete(
+        &self,
+        owner: &IdentityOwner,
+        name: &IdentityName,
+        expected_workspace_created_at_unix_nanos: Option<i64>,
+    ) -> Result<(), AppError> {
+        let mut tx = self.db.begin_serializable().await?;
+        let result = async {
+            let workspace_created_at_unix_nanos =
+                owner_workspace_created_at(&mut tx, owner).await?;
+            if workspace_created_at_unix_nanos != expected_workspace_created_at_unix_nanos {
+                return Err(owner_workspace_not_found(owner));
+            }
+            if !tx.identities().delete(owner, name).await? {
+                return Err(identity_not_found(name));
+            }
+            Ok(())
+        }
+        .await;
+        complete_transaction(tx, result).await
+    }
+
     async fn load_fixed_token_spec(
         &self,
         owner: &IdentityOwner,
@@ -385,6 +495,26 @@ where
 {
     let span = tracing::Span::current();
     tokio::task::spawn_blocking(move || span.in_scope(operation)).await?
+}
+
+async fn complete_transaction<T>(
+    tx: CoralTx<'_>,
+    result: Result<T, AppError>,
+) -> Result<T, AppError> {
+    match result {
+        Ok(value) => {
+            tx.commit().await?;
+            Ok(value)
+        }
+        Err(error) => {
+            tx.rollback().await?;
+            Err(error)
+        }
+    }
+}
+
+fn identity_not_found(name: &IdentityName) -> AppError {
+    AppError::IdentityNotFound(name.to_string())
 }
 
 fn spec_not_found(key: &IdentitySpecKey) -> AppError {

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -38,6 +38,199 @@ impl CredentialKeyProvider for TestKeyProvider {
 
 #[expect(
     clippy::too_many_lines,
+    reason = "shared SQLite/Postgres identity management contract"
+)]
+pub(crate) async fn assert_identity_management_contract(db: &Arc<CoralDb>) {
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let spec = format!("manage_spec_{suffix}");
+    let spec_key = IdentitySpecKey::global(&spec).expect("global spec key");
+    put_global_spec(db, &spec, &fixed_manifest(&spec, "manage")).await;
+
+    let workspace = WorkspaceName::parse(&format!("manage{suffix}")).expect("workspace");
+    put_workspace(db, &workspace).await;
+    let primary_user = UserPrincipal::for_user(&format!("manage-a-{suffix}")).expect("principal");
+    let other_user = UserPrincipal::for_user(&format!("manage-b-{suffix}")).expect("principal");
+    let primary_owner = IdentityOwner::for_user(primary_user.clone());
+    let other_owner = IdentityOwner::for_user(other_user.clone());
+    let workspace_owner = IdentityOwner::workspace(workspace.clone());
+    let alpha = format!("alpha_{suffix}");
+    let zeta = format!("zeta_{suffix}");
+    let provider = Arc::new(TestKeyProvider(vec![
+        CredentialEncryptionKey::from_static_bytes_for_test([70; 32]),
+    ]));
+    let manager = IdentityManager::new(db.clone(), provider);
+
+    let primary_zeta = manager
+        .create_or_replace_user_fixed_token(&primary_user, &zeta, &spec, "zeta-token".to_string())
+        .await
+        .expect("create second user identity");
+    let primary_alpha = manager
+        .create_or_replace_user_fixed_token(&primary_user, &alpha, &spec, "alpha-token".to_string())
+        .await
+        .expect("create first user identity");
+    let other_alpha = manager
+        .create_or_replace_user_fixed_token(&other_user, &alpha, &spec, "other-token".to_string())
+        .await
+        .expect("create other user identity");
+    let workspace_alpha = manager
+        .create_or_replace_workspace_fixed_token(
+            &workspace,
+            &alpha,
+            &spec,
+            "workspace-token".to_string(),
+        )
+        .await
+        .expect("create workspace identity");
+
+    assert_eq!(
+        manager
+            .list_for_owner(&primary_owner)
+            .await
+            .expect("list user identities"),
+        vec![primary_alpha.clone(), primary_zeta.clone()]
+    );
+    assert_eq!(
+        manager
+            .list_for_owner(&other_owner)
+            .await
+            .expect("list other user identities"),
+        vec![other_alpha.clone()]
+    );
+    assert_eq!(
+        manager
+            .list_for_owner(&workspace_owner)
+            .await
+            .expect("list workspace identities"),
+        vec![workspace_alpha.clone()]
+    );
+    assert_eq!(
+        manager
+            .get(&primary_owner, &alpha)
+            .await
+            .expect("get user identity"),
+        primary_alpha
+    );
+    assert_eq!(
+        manager
+            .get(&workspace_owner, &alpha)
+            .await
+            .expect("get workspace identity"),
+        workspace_alpha
+    );
+
+    let mut remove_spec = db.begin().await.expect("begin exact spec removal");
+    assert!(
+        remove_spec
+            .identity_specs()
+            .delete(&spec_key)
+            .await
+            .expect("remove exact spec")
+    );
+    remove_spec
+        .commit()
+        .await
+        .expect("commit exact spec removal");
+    assert_eq!(
+        manager
+            .get(&primary_owner, &alpha)
+            .await
+            .expect("get legacy identity without installed spec"),
+        primary_alpha
+    );
+    assert_eq!(
+        manager
+            .list_for_owner(&workspace_owner)
+            .await
+            .expect("list legacy workspace identity"),
+        vec![workspace_alpha.clone()]
+    );
+
+    for result in [
+        manager.get(&primary_owner, "bad/name").await.map(drop),
+        manager.delete(&primary_owner, "bad/name").await,
+    ] {
+        assert!(matches!(result, Err(AppError::InvalidInput(_))));
+    }
+    let missing_name = format!("missing_{suffix}");
+    assert!(matches!(
+        manager.get(&primary_owner, &missing_name).await,
+        Err(AppError::IdentityNotFound(name)) if name == missing_name
+    ));
+    assert!(matches!(
+        manager.delete(&primary_owner, &missing_name).await,
+        Err(AppError::IdentityNotFound(name)) if name == missing_name
+    ));
+
+    let missing_workspace =
+        WorkspaceName::parse(&format!("missing{suffix}")).expect("missing workspace name");
+    let missing_workspace_owner = IdentityOwner::workspace(missing_workspace.clone());
+    assert!(matches!(
+        manager.list_for_owner(&missing_workspace_owner).await,
+        Err(AppError::WorkspaceNotFound(name)) if name == missing_workspace.as_str()
+    ));
+    assert!(matches!(
+        manager.get(&missing_workspace_owner, "bad/name").await,
+        Err(AppError::WorkspaceNotFound(name)) if name == missing_workspace.as_str()
+    ));
+    assert!(matches!(
+        manager.delete(&missing_workspace_owner, "bad/name").await,
+        Err(AppError::WorkspaceNotFound(name)) if name == missing_workspace.as_str()
+    ));
+
+    manager
+        .delete(&primary_owner, &alpha)
+        .await
+        .expect("delete exact user identity");
+    assert_eq!(load_pair(db, &primary_owner, &alpha).await, (None, None));
+    assert_eq!(
+        manager
+            .get(&other_owner, &alpha)
+            .await
+            .expect("other user identity remains"),
+        other_alpha
+    );
+    assert_eq!(
+        manager
+            .get(&workspace_owner, &alpha)
+            .await
+            .expect("workspace identity remains"),
+        workspace_alpha
+    );
+    assert!(matches!(
+        manager.delete(&primary_owner, &alpha).await,
+        Err(AppError::IdentityNotFound(name)) if name == alpha
+    ));
+
+    manager
+        .delete(&workspace_owner, &alpha)
+        .await
+        .expect("delete workspace identity");
+    manager
+        .delete(&primary_owner, &zeta)
+        .await
+        .expect("delete remaining first-user identity");
+    manager
+        .delete(&other_owner, &alpha)
+        .await
+        .expect("delete remaining second-user identity");
+    for (owner, name) in [
+        (&workspace_owner, alpha.as_str()),
+        (&primary_owner, zeta.as_str()),
+        (&other_owner, alpha.as_str()),
+    ] {
+        assert_eq!(load_pair(db, owner, name).await, (None, None));
+    }
+    let mut cleanup = db.begin().await.expect("begin identity cleanup");
+    cleanup
+        .workspaces()
+        .delete(workspace.as_str())
+        .await
+        .expect("delete workspace");
+    cleanup.commit().await.expect("commit identity cleanup");
+}
+
+#[expect(
+    clippy::too_many_lines,
     reason = "shared SQLite/Postgres manager contract"
 )]
 pub(crate) async fn assert_user_global_fixed_token_create_contract(db: &Arc<CoralDb>) {

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -48,8 +48,10 @@ pub(crate) async fn assert_identity_management_contract(db: &Arc<CoralDb>) {
 
     let workspace = WorkspaceName::parse(&format!("manage{suffix}")).expect("workspace");
     put_workspace(db, &workspace).await;
-    let primary_user = UserPrincipal::for_user(&format!("manage-a-{suffix}")).expect("principal");
-    let other_user = UserPrincipal::for_user(&format!("manage-b-{suffix}")).expect("principal");
+    let primary_user =
+        Principal::parse(&format!("manage-a-{suffix}"), PrincipalKind::User).expect("principal");
+    let other_user =
+        Principal::parse(&format!("manage-b-{suffix}"), PrincipalKind::User).expect("principal");
     let primary_owner = IdentityOwner::for_user(primary_user.clone());
     let other_owner = IdentityOwner::for_user(other_user.clone());
     let workspace_owner = IdentityOwner::workspace(workspace.clone());

--- a/crates/coral-app/src/state/db/repositories/identities.rs
+++ b/crates/coral-app/src/state/db/repositories/identities.rs
@@ -1,11 +1,3 @@
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "Identity manager consumers land in later stack layers."
-    )
-)]
-
 use sea_query::{Alias, Expr, ExprTrait, OnConflict, Order, Query};
 
 use crate::bootstrap::AppError;

--- a/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
@@ -34,6 +34,7 @@ async fn identity_repository_contract_holds_against_sqlite() {
         .await;
     Box::pin(crate::identities::manager::tests::assert_workspace_fixed_token_race_contract(&db))
         .await;
+    Box::pin(crate::identities::manager::tests::assert_identity_management_contract(&db)).await;
 }
 
 #[expect(clippy::too_many_lines, reason = "shared backend contract fixture")]

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -62,6 +62,7 @@ pub(crate) fn app_error_type(error: &AppError) -> &'static str {
         AppError::FunctionNotFound(_) => "FUNCTION_NOT_FOUND",
         AppError::FunctionAlreadyExists(_) => "FUNCTION_ALREADY_EXISTS",
         AppError::IdentitySpecNotFound { .. } => "IDENTITY_SPEC_NOT_FOUND",
+        AppError::IdentityNotFound(_) => "IDENTITY_NOT_FOUND",
         AppError::WorkspaceNotFound(_) => "WORKSPACE_NOT_FOUND",
         AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",
         AppError::InvalidInput(_) => "INVALID_INPUT",


### PR DESCRIPTION
## Intent

Add the missing identity-management lifecycle above the persisted user and workspace fixed-token records: exact-owner list, get, and delete operations with typed misses and coherent workspace lifecycle checks.

## What it enables

- Lists safe identity metadata for one exact user or workspace owner in deterministic name order.
- Gets one exact owner/name record without resolving a fallback spec or decrypting setup material.
- Deletes identity metadata and its encrypted setup document atomically through the existing foreign-key cascade.
- Pins a workspace generation before serializable delete retries, preventing a retry from crossing a workspace delete/recreate boundary.
- Keeps management reads available for legacy persisted records whose exact spec is no longer installed, without adding any force-delete or orphan-creation API.
- Adds a typed `IdentityNotFound` application error and machine-readable `IDENTITY_NOT_FOUND` status reason.

## Usage examples

These methods are the manager boundary used by upcoming user and workspace identity services. A user list only returns that user's records; a workspace list only returns that workspace's records. Deleting `primary` removes both its safe metadata and encrypted document while preserving same-named identities owned elsewhere.

## Verification

- `cargo test -p coral-app --all-features --locked identity_repository_contract_holds_against_sqlite -- --nocapture`
- `make postgres-tests`
- `cargo clippy -p coral-app --all-targets --all-features --locked -- -D warnings`
- `make rust-checks` (1,973 tests passed; 7 skipped; rustdoc passed)