### PR TITLE
test(app): cover workspace identity lifecycle races

### DIFF
--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -227,6 +227,10 @@ impl IdentityManager {
         let mut tx = self.db.begin_read_snapshot().await?;
         let result = async {
             owner_workspace_created_at(&mut tx, owner).await?;
+            #[cfg(test)]
+            if let Some(gate) = &self.before_write_gate {
+                gate.wait().await;
+            }
             Ok(tx.identities().list(owner).await?)
         }
         .await;
@@ -249,6 +253,10 @@ impl IdentityManager {
         let mut tx = self.db.begin_read_snapshot().await?;
         let result = async {
             owner_workspace_created_at(&mut tx, owner).await?;
+            #[cfg(test)]
+            if let Some(gate) = &self.before_write_gate {
+                gate.wait().await;
+            }
             let name = match user_name {
                 Some(name) => name,
                 None => IdentityName::parse(identity_name)?,
@@ -277,6 +285,10 @@ impl IdentityManager {
             {
                 Ok(()) => return Ok(()),
                 Err(AppError::RetryableTransactionConflict) => {
+                    #[cfg(test)]
+                    if let Some(gate) = &self.before_retry_gate {
+                        gate.wait().await;
+                    }
                     tokio::task::yield_now().await;
                 }
                 Err(error) => return Err(error),
@@ -316,6 +328,10 @@ impl IdentityManager {
                 owner_workspace_created_at(&mut tx, owner).await?;
             if workspace_created_at_unix_nanos != expected_workspace_created_at_unix_nanos {
                 return Err(owner_workspace_not_found(owner));
+            }
+            #[cfg(test)]
+            if let Some(gate) = &self.before_write_gate {
+                gate.wait().await;
             }
             if !tx.identities().delete(owner, name).await? {
                 return Err(identity_not_found(name));

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -231,6 +231,208 @@ pub(crate) async fn assert_identity_management_contract(db: &Arc<CoralDb>) {
     cleanup.commit().await.expect("commit identity cleanup");
 }
 
+#[derive(Clone, Copy)]
+enum ManagementRead {
+    List,
+    Get,
+}
+
+pub(crate) async fn assert_identity_management_race_contract(db: &Arc<CoralDb>) {
+    db.enable_sqlite_wal_for_tests()
+        .await
+        .expect("enable SQLite WAL for committed snapshot races");
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let spec = format!("manage_race_spec_{suffix}");
+    put_global_spec(db, &spec, &fixed_manifest(&spec, "manage_race")).await;
+    let provider = Arc::new(TestKeyProvider(vec![
+        CredentialEncryptionKey::from_static_bytes_for_test([76; 32]),
+    ]));
+    let manager = IdentityManager::new(db.clone(), provider.clone());
+
+    for (operation, prefix) in [(ManagementRead::List, "list"), (ManagementRead::Get, "get")] {
+        let workspace =
+            WorkspaceName::parse(&format!("{prefix}race{suffix}")).expect("read-race workspace");
+        put_workspace(db, &workspace).await;
+        let identity = format!("{prefix}_identity_{suffix}");
+        let expected = manager
+            .create_or_replace_workspace_fixed_token(
+                &workspace,
+                &identity,
+                &spec,
+                format!("{prefix}-token"),
+            )
+            .await
+            .expect("create read-race identity");
+        assert_workspace_read_delete_race(
+            db, &manager, &workspace, &identity, &expected, operation,
+        )
+        .await;
+    }
+
+    let generation_workspace =
+        WorkspaceName::parse(&format!("deleterace{suffix}")).expect("delete-race workspace");
+    put_workspace(db, &generation_workspace).await;
+    let generation_identity = format!("generation_identity_{suffix}");
+    manager
+        .create_or_replace_workspace_fixed_token(
+            &generation_workspace,
+            &generation_identity,
+            &spec,
+            "old-generation-token".to_string(),
+        )
+        .await
+        .expect("create old-generation identity");
+    assert_workspace_delete_recreate_race(
+        db,
+        &manager,
+        provider.as_ref(),
+        &generation_workspace,
+        &generation_identity,
+        &spec,
+    )
+    .await;
+
+    let mut cleanup = db.begin().await.expect("begin race cleanup");
+    cleanup
+        .workspaces()
+        .delete(generation_workspace.as_str())
+        .await
+        .expect("delete recreated workspace");
+    let spec_key = IdentitySpecKey::global(&spec).expect("race spec key");
+    assert!(
+        cleanup
+            .identity_specs()
+            .delete(&spec_key)
+            .await
+            .expect("delete race spec")
+    );
+    cleanup.commit().await.expect("commit race cleanup");
+}
+
+async fn assert_workspace_read_delete_race(
+    db: &Arc<CoralDb>,
+    manager: &IdentityManager,
+    workspace: &WorkspaceName,
+    identity: &str,
+    expected: &IdentityRecord,
+    operation: ManagementRead,
+) {
+    let owner = IdentityOwner::workspace(workspace.clone());
+    let prepared = Arc::new(tokio::sync::Barrier::new(2));
+    let resume = Arc::new(tokio::sync::Barrier::new(2));
+    let gated = manager
+        .clone()
+        .with_before_write_gate(prepared.clone(), resume.clone());
+
+    let (read_result, ()) = tokio::time::timeout(Duration::from_secs(10), async {
+        tokio::join!(
+            async {
+                match operation {
+                    ManagementRead::List => gated.list_for_owner(&owner).await,
+                    ManagementRead::Get => gated.get(&owner, identity).await.map(|row| vec![row]),
+                }
+            },
+            async {
+                prepared.wait().await;
+                let mut tx = db.begin().await.expect("begin concurrent workspace delete");
+                tx.workspaces()
+                    .delete(workspace.as_str())
+                    .await
+                    .expect("stage concurrent workspace delete");
+                tx.commit()
+                    .await
+                    .expect("commit workspace delete before read resumes");
+                resume.wait().await;
+            }
+        )
+    })
+    .await
+    .expect("workspace read/delete race must not deadlock");
+
+    assert_eq!(
+        read_result.expect("read from one workspace snapshot"),
+        vec![expected.clone()]
+    );
+    let after_delete = match operation {
+        ManagementRead::List => manager.list_for_owner(&owner).await.map(drop),
+        ManagementRead::Get => manager.get(&owner, identity).await.map(drop),
+    };
+    assert!(matches!(
+        after_delete,
+        Err(AppError::WorkspaceNotFound(name)) if name == workspace.as_str()
+    ));
+}
+
+async fn assert_workspace_delete_recreate_race(
+    db: &Arc<CoralDb>,
+    manager: &IdentityManager,
+    provider: &dyn CredentialKeyProvider,
+    workspace: &WorkspaceName,
+    identity: &str,
+    spec: &str,
+) {
+    let owner = IdentityOwner::workspace(workspace.clone());
+    let prepared = Arc::new(tokio::sync::Barrier::new(2));
+    let resume = Arc::new(tokio::sync::Barrier::new(2));
+    let retry_prepared = Arc::new(tokio::sync::Barrier::new(2));
+    let retry_resume = Arc::new(tokio::sync::Barrier::new(2));
+    let gated = manager
+        .clone()
+        .with_before_write_gate(prepared.clone(), resume.clone())
+        .with_before_retry_gate(retry_prepared.clone(), retry_resume.clone());
+
+    let (deleted, replacement) = tokio::time::timeout(Duration::from_secs(10), async {
+        tokio::join!(gated.delete(&owner, identity), async {
+            prepared.wait().await;
+            let mut tx = db.begin().await.expect("begin workspace recreation");
+            tx.workspaces()
+                .delete(workspace.as_str())
+                .await
+                .expect("delete old workspace generation");
+            tx.workspaces()
+                .ensure(workspace.as_str(), 2)
+                .await
+                .expect("stage new workspace generation");
+            tx.commit().await.expect("commit workspace recreation");
+            resume.wait().await;
+            retry_prepared.wait().await;
+            let replacement = manager
+                .create_or_replace_workspace_fixed_token(
+                    workspace,
+                    identity,
+                    spec,
+                    "new-generation-token".to_string(),
+                )
+                .await
+                .expect("create new-generation identity");
+            retry_resume.wait().await;
+            replacement
+        })
+    })
+    .await
+    .expect("workspace delete/recreate race must not deadlock");
+
+    assert!(matches!(
+        deleted,
+        Err(AppError::WorkspaceNotFound(name)) if name == workspace.as_str()
+    ));
+    assert_eq!(
+        manager
+            .get(&owner, identity)
+            .await
+            .expect("get new-generation identity"),
+        replacement
+    );
+    let (record, document) = load_pair(db, &owner, identity).await;
+    assert_eq!(record.as_ref(), Some(&replacement));
+    assert_material(
+        &replacement,
+        document.as_ref().expect("new-generation document"),
+        "new-generation-token",
+        provider,
+    );
+}
+
 #[expect(
     clippy::too_many_lines,
     reason = "shared SQLite/Postgres manager contract"

--- a/crates/coral-app/src/state/db/coral_db.rs
+++ b/crates/coral-app/src/state/db/coral_db.rs
@@ -35,6 +35,22 @@ impl CoralDb {
         CoralTx::begin_serializable(&self.backend).await
     }
 
+    #[cfg(test)]
+    pub(crate) async fn enable_sqlite_wal_for_tests(&self) -> Result<(), DbError> {
+        let CoralDbBackend::Sqlite(db) = &self.backend else {
+            return Ok(());
+        };
+        let mode = sqlx::query_scalar::<_, String>("PRAGMA journal_mode = WAL")
+            .fetch_one(&db.pool)
+            .await?;
+        if !mode.eq_ignore_ascii_case("wal") {
+            return Err(DbError::Config(format!(
+                "SQLite did not enable WAL mode for concurrency test: {mode}"
+            )));
+        }
+        Ok(())
+    }
+
     #[cfg_attr(
         not(test),
         expect(

--- a/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
@@ -35,6 +35,8 @@ async fn identity_repository_contract_holds_against_sqlite() {
     Box::pin(crate::identities::manager::tests::assert_workspace_fixed_token_race_contract(&db))
         .await;
     Box::pin(crate::identities::manager::tests::assert_identity_management_contract(&db)).await;
+    Box::pin(crate::identities::manager::tests::assert_identity_management_race_contract(&db))
+        .await;
 }
 
 #[expect(clippy::too_many_lines, reason = "shared backend contract fixture")]


### PR DESCRIPTION
## Intent

Prove that workspace-owned identity management remains coherent when workspace deletion or delete/recreation races list, get, and identity deletion.

## What it enables

- Verifies list and get return the exact pre-delete identity record from the workspace snapshot they established, even after the workspace cascade commits.
- Verifies a stale identity delete retains its original workspace generation across serialization retries.
- Proves that a same-named identity and encrypted setup document created in the recreated workspace survive the stale delete.
- Runs the same committed-race contract against SQLite and PostgreSQL; SQLite uses WAL only in this isolated final test contract so the competing lifecycle transaction can commit while the read snapshot remains open.
- Keeps all orchestration seams test-only and leaves the production manager algorithm unchanged.

## Usage examples

The upcoming user and workspace identity services can call the existing manager list, get, and delete operations without adding their own workspace prechecks. If a workspace is deleted and recreated during an identity delete, the old request returns `WorkspaceNotFound` and cannot delete identity material from the new workspace generation.

## Verification

- `cargo test -p coral-app --all-features --locked identity_repository_contract_holds_against_sqlite -- --nocapture`
- `make postgres-tests`
- `make rust-checks` (1,973 tests passed; 7 skipped; rustdoc passed)