### PR TITLE
feat(api): add user identity contracts

### DIFF
--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -26,6 +26,7 @@ fn main() {
                 "proto/coral/v1/features.proto",
                 "proto/coral/v1/sources.proto",
                 "proto/coral/v1/identity_specs.proto",
+                "proto/coral/v1/identities.proto",
                 "proto/coral/v1/query.proto",
                 "proto/coral/v1/search.proto",
                 "proto/coral/v1/functions.proto",

--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -1,0 +1,113 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/identity_specs.proto";
+import "coral/v1/resources.proto";
+
+// Explicit current-user identity owner marker.
+message CurrentUserIdentityOwner {}
+
+// Exact owner of one stored provider-facing identity.
+message IdentityOwner {
+  // The selected identity owner. Servers set exactly one value.
+  oneof value {
+    // The current authenticated Coral user principal owns the identity.
+    CurrentUserIdentityOwner current_user = 1;
+    // The selected workspace owns the identity independently of any user.
+    Workspace workspace = 2;
+  }
+}
+
+// Exact installed identity spec revision pinned by one stored identity.
+message IdentitySpecReference {
+  // Stable installed identity spec name.
+  string name = 1;
+  // Exact scope where the selected identity spec is installed.
+  IdentitySpecScope scope = 2;
+  // Semantic manifest fingerprint selected when the identity was written.
+  string fingerprint = 3;
+  // Provider or issuer copied from the selected identity spec.
+  string issuer = 4;
+  // Identity mechanism copied from the selected identity spec.
+  IdentitySpecType identity_type = 5;
+}
+
+// Safe metadata for one stored provider-facing identity.
+message Identity {
+  // Stable identity name used by source identity bindings.
+  string name = 1;
+  // Exact user or workspace owner.
+  IdentityOwner owner = 2;
+  // Exact identity spec revision selected when this identity was written.
+  IdentitySpecReference identity_spec = 3;
+  // Creation time as Unix epoch nanoseconds.
+  int64 created_at_unix_nanos = 4 [jstype = JS_STRING];
+  // Last replacement time as Unix epoch nanoseconds.
+  int64 updated_at_unix_nanos = 5 [jstype = JS_STRING];
+}
+
+// Fixed-token setup payload. The token is write-only and never returned.
+message FixedTokenIdentitySetup {
+  // Bearer token to encrypt and store for this identity.
+  string token = 1;
+}
+
+// Creates or replaces one fixed-token identity owned by the request Coral user
+// principal.
+message CreateUserOwnedFixedTokenIdentityRequest {
+  // Stable identity name used by source identity bindings.
+  string name = 1;
+  // Globally installed fixed-token identity spec name.
+  string identity_spec_name = 2;
+  // Write-only fixed-token setup material.
+  FixedTokenIdentitySetup setup = 3;
+}
+
+// Returns the created or replaced user-owned identity metadata.
+message CreateUserOwnedFixedTokenIdentityResponse {
+  // Stored identity. Setup material is never returned.
+  Identity identity = 1;
+}
+
+// Lists identities owned by the request Coral user principal.
+message ListUserOwnedIdentitiesRequest {}
+
+// Returns user-owned identities in identity-name order.
+message ListUserOwnedIdentitiesResponse {
+  // Stored user-owned identity metadata.
+  repeated Identity identities = 1;
+}
+
+// Fetches one identity owned by the request Coral user principal.
+message GetUserOwnedIdentityRequest {
+  // Stored identity name.
+  string name = 1;
+}
+
+// Returns one user-owned identity.
+message GetUserOwnedIdentityResponse {
+  // Stored identity metadata.
+  Identity identity = 1;
+}
+
+// Deletes one identity owned by the request Coral user principal.
+message DeleteUserOwnedIdentityRequest {
+  // Stored identity name.
+  string name = 1;
+}
+
+// Confirms user-owned identity deletion.
+message DeleteUserOwnedIdentityResponse {}
+
+// Current-user stored identity management APIs.
+service IdentityService {
+  // Creates or replaces one current-user fixed-token identity.
+  rpc CreateUserOwnedFixedTokenIdentity(CreateUserOwnedFixedTokenIdentityRequest) returns (CreateUserOwnedFixedTokenIdentityResponse);
+  // Lists current-user identities.
+  rpc ListUserOwnedIdentities(ListUserOwnedIdentitiesRequest) returns (ListUserOwnedIdentitiesResponse);
+  // Fetches one current-user identity.
+  rpc GetUserOwnedIdentity(GetUserOwnedIdentityRequest) returns (GetUserOwnedIdentityResponse);
+  // Deletes one current-user identity.
+  rpc DeleteUserOwnedIdentity(DeleteUserOwnedIdentityRequest) returns (DeleteUserOwnedIdentityResponse);
+}

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -70,6 +70,12 @@ pub const SOURCE_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE
 /// default even though full manifest YAML is only returned by Add and Get.
 pub const IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE_SIZE;
 
+/// Maximum gRPC message size for stored-identity service *responses*, in bytes.
+///
+/// Identity listing is unpaginated and may aggregate enough safe metadata to
+/// exceed tonic's 4 MB default.
+pub const IDENTITY_RESPONSE_MAX_MESSAGE_SIZE: usize = CATALOG_RESPONSE_MAX_MESSAGE_SIZE;
+
 /// Maximum gRPC message size for `SearchService` *responses*, in bytes.
 ///
 /// Universal Search returns bounded metadata hints, but it may include table,

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -648,7 +648,7 @@ pub async fn run_from_env() -> Result<(), CliError> {
                 )
                 .await
             };
-            bootstrap.shutdown().await;
+            Box::pin(bootstrap.shutdown()).await;
             result
         }
         RequiredRuntime::None => {

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -6,6 +6,7 @@ use coral_api::v1::Workspace;
 use coral_api::v1::catalog_service_client::CatalogServiceClient;
 use coral_api::v1::feedback_service_client::FeedbackServiceClient;
 use coral_api::v1::function_service_client::FunctionServiceClient;
+use coral_api::v1::identity_service_client::IdentityServiceClient;
 use coral_api::v1::identity_spec_service_client::IdentitySpecServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::search_service_client::SearchServiceClient;
@@ -14,8 +15,9 @@ use coral_api::v1::task_service_client::TaskServiceClient;
 use coral_api::v1::workspace_service_client::WorkspaceServiceClient;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE,
-    IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
-    SEARCH_RESPONSE_MAX_MESSAGE_SIZE, SOURCE_RESPONSE_MAX_MESSAGE_SIZE,
+    IDENTITY_RESPONSE_MAX_MESSAGE_SIZE, IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE,
+    QUERY_RESPONSE_MAX_MESSAGE_SIZE, SEARCH_RESPONSE_MAX_MESSAGE_SIZE,
+    SOURCE_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use coral_app::READINESS_SERVICE_NAME;
 use tonic::service::interceptor::InterceptedService;
@@ -60,6 +62,9 @@ pub type WorkspaceClient = WorkspaceServiceClient<GrpcService>;
 /// Public identity-spec management gRPC client.
 pub type IdentitySpecClient = IdentitySpecServiceClient<GrpcService>;
 
+/// Public current-user stored-identity gRPC client.
+pub type IdentityClient = IdentityServiceClient<GrpcService>;
+
 /// Public catalog-discovery gRPC client.
 pub type CatalogClient = CatalogServiceClient<GrpcService>;
 
@@ -89,6 +94,7 @@ pub struct AppClient {
     source: SourceClient,
     workspace: WorkspaceClient,
     identity_spec: IdentitySpecClient,
+    identity: IdentityClient,
     catalog: CatalogClient,
     query: QueryClient,
     search: SearchClient,
@@ -210,6 +216,12 @@ impl AppClient {
             static_metadata.clone(),
         ))
         .max_decoding_message_size(IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE);
+        let identity_client = IdentityClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ))
+        .max_decoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE);
         let catalog_client = CatalogClient::new(grpc_service(
             channel.clone(),
             &grpc_endpoint,
@@ -250,6 +262,7 @@ impl AppClient {
             source: source_client,
             workspace: workspace_client,
             identity_spec: identity_spec_client,
+            identity: identity_client,
             catalog: catalog_client,
             query: query_client,
             search: search_client,
@@ -276,6 +289,12 @@ impl AppClient {
     /// Returns a cloned identity-spec management client.
     pub fn identity_spec_client(&self) -> IdentitySpecClient {
         self.identity_spec.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned current-user stored-identity client.
+    pub fn identity_client(&self) -> IdentityClient {
+        self.identity.clone()
     }
 
     #[must_use]
@@ -447,13 +466,18 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use coral_api::v1::feedback_service_server::{FeedbackService, FeedbackServiceServer};
+    use coral_api::v1::identity_service_server::{IdentityService, IdentityServiceServer};
     use coral_api::v1::identity_spec_service_server::{
         IdentitySpecService, IdentitySpecServiceServer,
     };
     use coral_api::v1::{
-        AddIdentitySpecRequest, AddIdentitySpecResponse, DeleteIdentitySpecRequest,
-        DeleteIdentitySpecResponse, GetIdentitySpecRequest, GetIdentitySpecResponse,
+        AddIdentitySpecRequest, AddIdentitySpecResponse, CreateUserOwnedFixedTokenIdentityRequest,
+        CreateUserOwnedFixedTokenIdentityResponse, DeleteIdentitySpecRequest,
+        DeleteIdentitySpecResponse, DeleteUserOwnedIdentityRequest,
+        DeleteUserOwnedIdentityResponse, GetIdentitySpecRequest, GetIdentitySpecResponse,
+        GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse, Identity, IdentitySpecReference,
         IdentitySpecSummary, ListIdentitySpecsRequest, ListIdentitySpecsResponse,
+        ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse,
     };
     use coral_api::v1::{SubmitFeedbackRequest, SubmitFeedbackResponse};
     use opentelemetry::trace::TracerProvider as _;
@@ -671,6 +695,9 @@ mod tests {
     #[derive(Debug)]
     struct LargeIdentitySpecFixture;
 
+    #[derive(Debug)]
+    struct LargeIdentityFixture;
+
     #[tonic::async_trait]
     impl IdentitySpecService for LargeIdentitySpecFixture {
         async fn add_identity_spec(
@@ -707,6 +734,68 @@ mod tests {
         ) -> Result<Response<DeleteIdentitySpecResponse>, Status> {
             Err(Status::unimplemented("fixture only supports listing"))
         }
+    }
+
+    fn large_identities() -> Vec<Identity> {
+        (0..SPEC_COUNT)
+            .map(|index| Identity {
+                name: format!("large-{index}"),
+                identity_spec: Some(IdentitySpecReference {
+                    issuer: "x".repeat(DESCRIPTION_SIZE),
+                    ..IdentitySpecReference::default()
+                }),
+                ..Identity::default()
+            })
+            .collect()
+    }
+
+    #[tonic::async_trait]
+    impl IdentityService for LargeIdentityFixture {
+        async fn create_user_owned_fixed_token_identity(
+            &self,
+            _request: Request<CreateUserOwnedFixedTokenIdentityRequest>,
+        ) -> Result<Response<CreateUserOwnedFixedTokenIdentityResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+
+        async fn list_user_owned_identities(
+            &self,
+            _request: Request<ListUserOwnedIdentitiesRequest>,
+        ) -> Result<Response<ListUserOwnedIdentitiesResponse>, Status> {
+            Ok(Response::new(ListUserOwnedIdentitiesResponse {
+                identities: large_identities(),
+            }))
+        }
+
+        async fn get_user_owned_identity(
+            &self,
+            _request: Request<GetUserOwnedIdentityRequest>,
+        ) -> Result<Response<GetUserOwnedIdentityResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+
+        async fn delete_user_owned_identity(
+            &self,
+            _request: Request<DeleteUserOwnedIdentityRequest>,
+        ) -> Result<Response<DeleteUserOwnedIdentityResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+    }
+
+    fn assert_large_identity_aggregate(identities: &[Identity]) {
+        assert_eq!(identities.len(), SPEC_COUNT);
+        let issuer_bytes = identities
+            .iter()
+            .map(|identity| {
+                identity
+                    .identity_spec
+                    .as_ref()
+                    .expect("fixture identity has a spec reference")
+                    .issuer
+                    .len()
+            })
+            .sum::<usize>();
+        assert!(issuer_bytes > TONIC_DEFAULT_MAX_MESSAGE_SIZE);
     }
 
     #[tokio::test]
@@ -760,5 +849,34 @@ mod tests {
             .await
             .expect("join identity-spec fixture")
             .expect("server");
+    }
+
+    #[tokio::test]
+    async fn app_client_decodes_large_identity_aggregates() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind identity fixture");
+        let address = listener.local_addr().expect("read fixture address");
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .add_service(
+                    IdentityServiceServer::new(LargeIdentityFixture)
+                        .max_encoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE),
+                )
+                .serve_with_incoming(TcpListenerStream::new(listener))
+                .await
+        });
+        let app_client = AppClient::connect(&format!("http://{address}"))
+            .await
+            .expect("connect AppClient to identity fixture");
+
+        let user = app_client
+            .identity_client()
+            .list_user_owned_identities(ListUserOwnedIdentitiesRequest {})
+            .await
+            .expect("decode current-user identity aggregate")
+            .into_inner();
+        assert_large_identity_aggregate(&user.identities);
+        server.abort();
     }
 }

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -42,8 +42,8 @@ use serde_json::Value;
 
 pub use client::{
     AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, FunctionClient,
-    HealthCheckClient, IdentitySpecClient, QueryClient, SearchClient, SourceClient, TaskClient,
-    WorkspaceClient, default_workspace, workspace,
+    HealthCheckClient, IdentityClient, IdentitySpecClient, QueryClient, SearchClient, SourceClient,
+    TaskClient, WorkspaceClient, default_workspace, workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use propagation::{BearerToken, with_task_metadata};


### PR DESCRIPTION
## Intent

Define the first stored-identity transport layer without importing stale flat donor semantics. Current-user identity management now has an explicit fixed-token-only unary contract, a typed owner, and an exact installed-spec reference using scope, name, semantic fingerprint, issuer, and typed mechanism.

Pinned audience is deliberately deferred until the next persistence layer can snapshot host and optional port. This keeps orphan-safe list/get implementable without resolving a live spec.

## What it enables

- Generated current-user identity CRUD types and service/client bindings.
- A non-breaking path for separate OAuth streaming RPCs later instead of constraining generic identity creation to unary behavior.
- Thin `AppClient::identity_client()` access with the same large-response decoding guard used by other unpaginated management APIs.
- Future workspace identity APIs can reuse the typed owner and exact spec-reference messages without parallel workspace fields.

## Usage examples

```rust
use coral_api::v1::{
    CreateUserOwnedFixedTokenIdentityRequest, FixedTokenIdentitySetup,
};

let response = client
    .identity_client()
    .create_user_owned_fixed_token_identity(
        CreateUserOwnedFixedTokenIdentityRequest {
            name: "github_primary".to_string(),
            identity_spec_name: "github_pat".to_string(),
            setup: Some(FixedTokenIdentitySetup {
                token: token.to_string(),
            }),
        },
    )
    .await?;
```

The server implementation and registration intentionally land after pinned audience persistence.

## Verification

- `make lint-proto`
- `cargo test --locked -p coral-client` — 36 passed
- `make rust-checks` — clippy clean, 1,974 tests passed, 7 skipped, rustdoc clean
- Three final read-only review lanes clean after deferring audience to its persistence layer