### PR TITLE
feat(app): pin identity audiences

### DIFF
--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -31,6 +31,9 @@ message IdentitySpecReference {
   string issuer = 4;
   // Identity mechanism copied from the selected identity spec.
   IdentitySpecType identity_type = 5;
+  // Normalized audience copied from the selected identity spec. Absent only
+  // for legacy identities written before audience snapshots were persisted.
+  IdentityAudience audience = 6;
 }
 
 // Safe metadata for one stored provider-facing identity.

--- a/crates/coral-api/proto/coral/v1/identity_specs.proto
+++ b/crates/coral-api/proto/coral/v1/identity_specs.proto
@@ -14,6 +14,15 @@ enum IdentitySpecType {
   IDENTITY_SPEC_TYPE_FIXED_TOKEN = 2;
 }
 
+// Normalized provider audience declared by an identity spec.
+message IdentityAudience {
+  // Canonical DNS name or IP address matched against provider requests.
+  string host = 1;
+  // Required provider port when the identity spec constrains one. Absence
+  // means the known audience applies to every port on the exact host.
+  optional uint32 port = 2;
+}
+
 // Explicit global identity-spec scope marker.
 message GlobalIdentitySpecScope {}
 

--- a/crates/coral-app/migrations/0012_identity_audience.sql
+++ b/crates/coral-app/migrations/0012_identity_audience.sql
@@ -1,0 +1,21 @@
+-- Existing rows predate pinned identity audiences and remain NULL/NULL so
+-- management APIs can expose them without inventing authorization semantics.
+ALTER TABLE identities
+    ADD COLUMN identity_spec_audience_port BIGINT
+    CHECK (
+        identity_spec_audience_port IS NULL
+        OR identity_spec_audience_port BETWEEN 1 AND 65535
+    );
+
+ALTER TABLE identities
+    ADD COLUMN identity_spec_audience_host TEXT
+    CHECK (
+        (
+            identity_spec_audience_host IS NULL
+            AND identity_spec_audience_port IS NULL
+        )
+        OR (
+            identity_spec_audience_host IS NOT NULL
+            AND length(trim(identity_spec_audience_host)) > 0
+        )
+    );

--- a/crates/coral-app/src/identities/crypto.rs
+++ b/crates/coral-app/src/identities/crypto.rs
@@ -155,7 +155,9 @@ mod tests {
         encrypt_credential_values, seal_envelope_document,
     };
     use crate::encrypted_document::EncryptedEnvelopeDocument;
-    use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+    use crate::identities::model::{
+        IdentityAudience, IdentityName, IdentityOwner, IdentitySpecReference,
+    };
     use crate::identity::spec_document::{
         decrypt_identity_spec_document, encrypt_identity_spec_document,
     };
@@ -481,6 +483,7 @@ mod tests {
             fingerprint,
             "github",
             "fixed_token",
+            IdentityAudience::new("api.github.com", None).expect("audience"),
         )
         .expect("reference")
     }
@@ -501,6 +504,7 @@ mod tests {
             fingerprint,
             "github",
             "fixed_token",
+            IdentityAudience::new("api.github.com", None).expect("audience"),
         )
         .expect("reference")
     }

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -16,7 +16,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use coral_spec::IdentitySpecType;
 
 use super::crypto::{IdentityDocumentBinding, encrypt_identity_document};
-use super::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+use super::model::{IdentityAudience, IdentityName, IdentityOwner, IdentitySpecReference};
 use crate::bootstrap::AppError;
 use crate::credentials::encryption::CredentialKeyProvider;
 use crate::encrypted_document::EncryptedEnvelopeDocument;
@@ -366,12 +366,14 @@ impl IdentityManager {
                 requested_key.name()
             )));
         }
+        let audience = IdentityAudience::from_manifest(&installed.manifest.audience)?;
         let reference = IdentitySpecReference::new(
             owner,
             installed.key,
             identity_spec_fingerprint(&installed.manifest)?,
             installed.manifest.issuer,
             "fixed_token",
+            audience,
         )?;
         Ok(SelectedFixedTokenSpec {
             requested_key: requested_key.clone(),

--- a/crates/coral-app/src/identities/manager/tests.rs
+++ b/crates/coral-app/src/identities/manager/tests.rs
@@ -716,7 +716,7 @@ pub(crate) async fn assert_workspace_fixed_token_create_contract(db: &Arc<CoralD
         ),
         (
             &shadowed_workspace,
-            fixed_manifest(&shadowed, "shadowed_workspace"),
+            fixed_manifest_with_port(&shadowed, "shadowed_workspace", 8443),
         ),
         (&wrong_global, fixed_manifest(&wrong_type, "wrong_global")),
         (&wrong_workspace, oauth_manifest(&wrong_type)),
@@ -837,7 +837,12 @@ pub(crate) async fn assert_workspace_fixed_token_create_contract(db: &Arc<CoralD
         )
         .await
         .expect("create from workspace override");
-    assert_reference_key(&shadowed_created, &shadowed_workspace, "shadowed_workspace");
+    assert_reference_key_with_port(
+        &shadowed_created,
+        &shadowed_workspace,
+        "shadowed_workspace",
+        Some(8443),
+    );
     let shadowed_pair = load_pair(db, &owner, &shadowed_identity).await;
     assert_eq!(shadowed_pair.0.as_ref(), Some(&shadowed_created));
     assert_eq!(
@@ -1214,8 +1219,20 @@ fn assert_reference(record: &IdentityRecord, spec_name: &str, revision: &str) {
 }
 
 fn assert_reference_key(record: &IdentityRecord, key: &IdentitySpecKey, revision: &str) {
-    let manifest = parse_identity_manifest_yaml(&fixed_manifest(key.name(), revision))
-        .expect("expected manifest");
+    assert_reference_key_with_port(record, key, revision, None);
+}
+
+fn assert_reference_key_with_port(
+    record: &IdentityRecord,
+    key: &IdentitySpecKey,
+    revision: &str,
+    port: Option<u16>,
+) {
+    let yaml = port.map_or_else(
+        || fixed_manifest(key.name(), revision),
+        |port| fixed_manifest_with_port(key.name(), revision, port),
+    );
+    let manifest = parse_identity_manifest_yaml(&yaml).expect("expected manifest");
     assert_eq!(record.spec_reference.key(), key);
     assert_eq!(
         record.spec_reference.fingerprint(),
@@ -1223,6 +1240,9 @@ fn assert_reference_key(record: &IdentityRecord, key: &IdentitySpecKey, revision
     );
     assert_eq!(record.spec_reference.issuer(), format!("issuer_{revision}"));
     assert_eq!(record.spec_reference.identity_type(), "fixed_token");
+    let audience = record.spec_reference.audience().expect("pinned audience");
+    assert_eq!(audience.host(), "api.example.com");
+    assert_eq!(audience.port(), port);
 }
 
 fn assert_material(
@@ -1250,8 +1270,20 @@ fn assert_material(
 }
 
 fn fixed_manifest(name: &str, revision: &str) -> String {
+    fixed_manifest_with_audience(name, revision, "{host: api.example.com}")
+}
+
+fn fixed_manifest_with_port(name: &str, revision: &str, port: u16) -> String {
+    fixed_manifest_with_audience(
+        name,
+        revision,
+        &format!("{{host: api.example.com, port: {port}}}"),
+    )
+}
+
+fn fixed_manifest_with_audience(name: &str, revision: &str, audience: &str) -> String {
     format!(
-        "kind: identity\nspec_version: 1\nname: {name}\nversion: {revision}\ndescription: {revision}\nissuer: issuer_{revision}\ntype: fixed_token\naudience: {{host: api.example.com}}\n"
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: {revision}\ndescription: {revision}\nissuer: issuer_{revision}\ntype: fixed_token\naudience: {audience}\n"
     )
 }
 

--- a/crates/coral-app/src/identities/model.rs
+++ b/crates/coral-app/src/identities/model.rs
@@ -1,4 +1,8 @@
+use std::collections::BTreeMap;
 use std::fmt;
+use std::num::NonZeroU16;
+
+use serde_json::Value;
 
 use crate::bootstrap::AppError;
 use crate::identity::{LOCAL_PRINCIPAL_ID, Principal, PrincipalKind, parse_path_segment};
@@ -7,6 +11,94 @@ use crate::workspaces::WorkspaceName;
 
 const USER_OWNER_KIND: &str = "user";
 const WORKSPACE_OWNER_KIND: &str = "workspace";
+
+/// Normalized provider audience pinned when an identity is written.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct IdentityAudience {
+    host: String,
+    port: Option<NonZeroU16>,
+}
+
+impl IdentityAudience {
+    /// Parse and normalize one typed host and optional non-zero port.
+    pub(crate) fn new(host: &str, port: Option<u16>) -> Result<Self, AppError> {
+        if host.trim().is_empty() {
+            return Err(invalid_audience());
+        }
+        let host = url::Host::parse(host)
+            .map_err(|_error| invalid_audience())?
+            .to_string();
+        let port = port
+            .map(|port| NonZeroU16::new(port).ok_or_else(invalid_audience))
+            .transpose()?;
+        Ok(Self { host, port })
+    }
+
+    /// Extract an already normalized audience from a validated manifest.
+    pub(crate) fn from_manifest(audience: &BTreeMap<String, Value>) -> Result<Self, AppError> {
+        if audience.keys().any(|key| key != "host" && key != "port") {
+            return Err(invalid_audience());
+        }
+        let host = audience
+            .get("host")
+            .and_then(Value::as_str)
+            .ok_or_else(invalid_audience)?;
+        let port = audience
+            .get("port")
+            .map(|value| {
+                value
+                    .as_u64()
+                    .and_then(|port| u16::try_from(port).ok())
+                    .ok_or_else(invalid_audience)
+            })
+            .transpose()?;
+        let normalized = Self::new(host, port)?;
+        if normalized.host != host {
+            return Err(invalid_audience());
+        }
+        Ok(normalized)
+    }
+
+    pub(crate) fn host(&self) -> &str {
+        &self.host
+    }
+
+    pub(crate) fn port(&self) -> Option<u16> {
+        self.port.map(NonZeroU16::get)
+    }
+
+    fn from_storage_parts(
+        host: Option<String>,
+        port: Option<i64>,
+    ) -> Result<Option<Self>, DbError> {
+        let Some(host) = host else {
+            return if port.is_none() {
+                Ok(None)
+            } else {
+                Err(corrupt_audience())
+            };
+        };
+        let port = port
+            .map(|port| u16::try_from(port).map_err(|_error| corrupt_audience()))
+            .transpose()?;
+        let audience = Self::new(&host, port).map_err(|_error| corrupt_audience())?;
+        if audience.host != host {
+            return Err(corrupt_audience());
+        }
+        Ok(Some(audience))
+    }
+}
+
+fn invalid_audience() -> AppError {
+    AppError::InvalidInput(
+        "identity audience must contain a normalized host and optional port from 1 through 65535"
+            .to_string(),
+    )
+}
+
+fn corrupt_audience() -> DbError {
+    DbError::CorruptData("persisted identity audience is invalid or not normalized".to_string())
+}
 
 /// Validated name of one identity instance within an owner.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -145,6 +237,7 @@ pub(crate) struct IdentitySpecReference {
     fingerprint: String,
     issuer: String,
     identity_type: String,
+    audience: Option<IdentityAudience>,
 }
 
 impl IdentitySpecReference {
@@ -155,6 +248,7 @@ impl IdentitySpecReference {
         fingerprint: impl Into<String>,
         issuer: impl Into<String>,
         identity_type: impl Into<String>,
+        audience: IdentityAudience,
     ) -> Result<Self, AppError> {
         validate_scope(owner, key.scope())?;
         let reference = Self {
@@ -162,21 +256,9 @@ impl IdentitySpecReference {
             fingerprint: fingerprint.into(),
             issuer: issuer.into(),
             identity_type: identity_type.into(),
+            audience: Some(audience),
         };
-        for (field, value) in [
-            ("identity spec fingerprint", reference.fingerprint.as_str()),
-            ("identity spec issuer", reference.issuer.as_str()),
-            ("identity spec type", reference.identity_type.as_str()),
-        ] {
-            if value.trim().is_empty() {
-                return Err(AppError::InvalidInput(format!("missing {field}")));
-            }
-        }
-        if !matches!(reference.identity_type.as_str(), "oauth" | "fixed_token") {
-            return Err(AppError::InvalidInput(
-                "identity spec type must be 'oauth' or 'fixed_token'".to_string(),
-            ));
-        }
+        reference.validate_required_fields()?;
         Ok(reference)
     }
 
@@ -196,10 +278,19 @@ impl IdentitySpecReference {
         &self.identity_type
     }
 
+    /// Return the pinned audience, absent only for legacy persisted rows.
+    pub(crate) fn audience(&self) -> Option<&IdentityAudience> {
+        self.audience.as_ref()
+    }
+
     pub(crate) fn validate_for_owner(&self, owner: &IdentityOwner) -> Result<(), AppError> {
         validate_scope(owner, self.key.scope())
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "validates one complete persisted identity spec reference"
+    )]
     pub(crate) fn from_storage_parts(
         owner: &IdentityOwner,
         workspace_id: Option<&str>,
@@ -207,13 +298,46 @@ impl IdentitySpecReference {
         fingerprint: String,
         issuer: String,
         identity_type: String,
+        audience_host: Option<String>,
+        audience_port: Option<i64>,
     ) -> Result<Self, DbError> {
         let key = IdentitySpecKey::from_reference_storage_parts(workspace_id, name)?;
-        Self::new(owner, key, fingerprint, issuer, identity_type).map_err(|error| {
+        validate_scope(owner, key.scope()).map_err(|error| {
             DbError::CorruptData(format!(
                 "invalid persisted identity spec reference: {error}"
             ))
-        })
+        })?;
+        let reference = Self {
+            key,
+            fingerprint,
+            issuer,
+            identity_type,
+            audience: IdentityAudience::from_storage_parts(audience_host, audience_port)?,
+        };
+        reference.validate_required_fields().map_err(|error| {
+            DbError::CorruptData(format!(
+                "invalid persisted identity spec reference: {error}"
+            ))
+        })?;
+        Ok(reference)
+    }
+
+    fn validate_required_fields(&self) -> Result<(), AppError> {
+        for (field, value) in [
+            ("identity spec fingerprint", self.fingerprint.as_str()),
+            ("identity spec issuer", self.issuer.as_str()),
+            ("identity spec type", self.identity_type.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                return Err(AppError::InvalidInput(format!("missing {field}")));
+            }
+        }
+        if !matches!(self.identity_type.as_str(), "oauth" | "fixed_token") {
+            return Err(AppError::InvalidInput(
+                "identity spec type must be 'oauth' or 'fixed_token'".to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -234,7 +358,7 @@ fn validate_scope(owner: &IdentityOwner, scope: &IdentitySpecScope) -> Result<()
 
 #[cfg(test)]
 mod tests {
-    use super::{IdentityName, IdentityOwner, IdentitySpecReference};
+    use super::{IdentityAudience, IdentityName, IdentityOwner, IdentitySpecReference};
     use crate::identity::{Principal, PrincipalKind};
     use crate::state::db::IdentitySpecKey;
     use crate::workspaces::WorkspaceName;
@@ -290,7 +414,14 @@ mod tests {
         let beta = WorkspaceName::parse("beta").expect("beta");
         let workspace = IdentityOwner::workspace(alpha.clone());
         let reference = |owner: &IdentityOwner, key| {
-            IdentitySpecReference::new(owner, key, "fingerprint", "issuer", "fixed_token")
+            IdentitySpecReference::new(
+                owner,
+                key,
+                "fingerprint",
+                "issuer",
+                "fixed_token",
+                audience(),
+            )
         };
 
         reference(&user, IdentitySpecKey::global("token").expect("global"))
@@ -336,8 +467,55 @@ mod tests {
                 fields.0,
                 fields.1,
                 fields.2,
+                audience(),
             )
             .expect_err("blank required spec-reference field must be rejected");
+        }
+    }
+
+    #[test]
+    fn identity_audiences_are_typed_normalized_and_legacy_aware() {
+        let normalized = IdentityAudience::new("API.EXAMPLE.COM", Some(443)).expect("audience");
+        assert_eq!(normalized.host(), "api.example.com");
+        assert_eq!(normalized.port(), Some(443));
+        for (host, port) in [
+            ("", None),
+            ("https://api.example.com", None),
+            ("api.example.com", Some(0)),
+        ] {
+            IdentityAudience::new(host, port).expect_err("invalid audience");
+        }
+
+        let owner = IdentityOwner::for_user(UserPrincipal::local());
+        let stored = |host: Option<&str>, port| {
+            IdentitySpecReference::from_storage_parts(
+                &owner,
+                None,
+                "token",
+                "fingerprint".to_string(),
+                "issuer".to_string(),
+                "fixed_token".to_string(),
+                host.map(str::to_string),
+                port,
+            )
+        };
+        assert!(
+            stored(None, None)
+                .expect("legacy reference")
+                .audience()
+                .is_none()
+        );
+        let known = stored(Some("api.example.com"), Some(8443)).expect("known reference");
+        assert_eq!(known.audience().expect("audience").port(), Some(8443));
+        for (host, port) in [
+            (None, Some(443)),
+            (Some("API.EXAMPLE.COM"), None),
+            (Some("bad host"), None),
+            (Some("api.example.com"), Some(0)),
+            (Some("api.example.com"), Some(-1)),
+            (Some("api.example.com"), Some(65_536)),
+        ] {
+            stored(host, port).expect_err("corrupt stored audience");
         }
     }
 
@@ -361,7 +539,13 @@ mod tests {
             "fingerprint".to_string(),
             "issuer".to_string(),
             "fixed_token".to_string(),
+            None,
+            None,
         )
         .expect_err("user cannot reference a workspace spec");
+    }
+
+    fn audience() -> IdentityAudience {
+        IdentityAudience::new("api.example.com", Some(443)).expect("audience")
     }
 }

--- a/crates/coral-app/src/identities/model.rs
+++ b/crates/coral-app/src/identities/model.rs
@@ -486,7 +486,7 @@ mod tests {
             IdentityAudience::new(host, port).expect_err("invalid audience");
         }
 
-        let owner = IdentityOwner::for_user(UserPrincipal::local());
+        let owner = IdentityOwner::for_user(Principal::local());
         let stored = |host: Option<&str>, port| {
             IdentitySpecReference::from_storage_parts(
                 &owner,

--- a/crates/coral-app/src/identity_specs/manager.rs
+++ b/crates/coral-app/src/identity_specs/manager.rs
@@ -1260,6 +1260,7 @@ pub(crate) mod tests {
             "legacy-mixed-fingerprint",
             original.issuer(),
             original.identity_type(),
+            original.audience().expect("pinned audience").clone(),
         )
         .unwrap();
         let mut tx = db.begin().await.unwrap();

--- a/crates/coral-app/src/state/db/repositories/identities.rs
+++ b/crates/coral-app/src/state/db/repositories/identities.rs
@@ -28,6 +28,8 @@ struct IdentityRow {
     identity_spec_fingerprint: String,
     issuer: String,
     identity_type: String,
+    identity_spec_audience_port: Option<i64>,
+    identity_spec_audience_host: Option<String>,
     created_at_unix_nanos: i64,
     updated_at_unix_nanos: i64,
 }
@@ -53,6 +55,8 @@ impl IdentityRow {
             self.identity_spec_fingerprint,
             self.issuer,
             self.identity_type,
+            self.identity_spec_audience_host,
+            self.identity_spec_audience_port,
         )?;
         Ok(IdentityRecord {
             owner,
@@ -171,6 +175,11 @@ impl IdentitiesRepo<'_, CoralTx<'_>> {
     ) -> Result<IdentityRecord, AppError> {
         validate_write_timestamp(now_unix_nanos)?;
         spec_reference.validate_for_owner(owner)?;
+        let audience = spec_reference.audience().ok_or_else(|| {
+            AppError::InvalidInput(
+                "identity spec reference is missing its pinned audience".to_string(),
+            )
+        })?;
         let current_updated_at = Expr::col((Identities::Table, Identities::UpdatedAtUnixNanos));
         let key = spec_reference.key();
         let statement = Query::insert()
@@ -190,6 +199,8 @@ impl IdentitiesRepo<'_, CoralTx<'_>> {
                 Expr::val(spec_reference.fingerprint()),
                 Expr::val(spec_reference.issuer()),
                 Expr::val(spec_reference.identity_type()),
+                Expr::val(audience.port().map(i64::from)),
+                Expr::val(audience.host()),
                 Expr::val(now_unix_nanos),
                 Expr::val(now_unix_nanos),
             ])
@@ -205,6 +216,8 @@ impl IdentitiesRepo<'_, CoralTx<'_>> {
                     Identities::IdentitySpecFingerprint,
                     Identities::Issuer,
                     Identities::IdentityType,
+                    Identities::IdentitySpecAudiencePort,
+                    Identities::IdentitySpecAudienceHost,
                 ])
                 .value(
                     Identities::UpdatedAtUnixNanos,
@@ -273,7 +286,7 @@ fn identity_select() -> sea_query::SelectStatement {
         .to_owned()
 }
 
-fn identity_columns() -> [Identities; 11] {
+fn identity_columns() -> [Identities; 13] {
     [
         Identities::OwnerKind,
         Identities::OwnerKey,
@@ -284,6 +297,8 @@ fn identity_columns() -> [Identities; 11] {
         Identities::IdentitySpecFingerprint,
         Identities::Issuer,
         Identities::IdentityType,
+        Identities::IdentitySpecAudiencePort,
+        Identities::IdentitySpecAudienceHost,
         Identities::CreatedAtUnixNanos,
         Identities::UpdatedAtUnixNanos,
     ]

--- a/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identities_contract_tests.rs
@@ -5,7 +5,9 @@ use tempfile::tempdir;
 
 use super::identities::IdentityRecord;
 use crate::bootstrap::AppError;
-use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+use crate::identities::model::{
+    IdentityAudience, IdentityName, IdentityOwner, IdentitySpecReference,
+};
 use crate::identity::{Principal, PrincipalKind};
 use crate::state::db::schema::Identities;
 use crate::state::db::{
@@ -78,6 +80,7 @@ async fn assert_identity_repository_contract(db: &CoralDb) {
         "f3",
         "replacement-issuer",
         "oauth",
+        IdentityAudience::new("replacement.example.com", None).expect("replacement audience"),
     )
     .expect("replacement reference");
 
@@ -235,6 +238,44 @@ async fn assert_identity_repository_corruption_contract(db: &CoralDb) {
     seed_identity(&mut tx, &owner, &name, &reference, 10).await;
     tx.commit().await.expect("commit corruption seed");
 
+    let mut tx = db.begin().await.expect("begin legacy audience read");
+    tx.execute(
+        Query::update()
+            .table(Identities::Table)
+            .value(
+                Identities::IdentitySpecAudienceHost,
+                Expr::val(None::<String>),
+            )
+            .value(Identities::IdentitySpecAudiencePort, Expr::val(None::<i64>))
+            .and_where(identity_where(&owner, &name))
+            .to_owned(),
+    )
+    .await
+    .expect("clear legacy audience");
+    let legacy = tx
+        .identities()
+        .get(&owner, &name)
+        .await
+        .expect("read legacy identity")
+        .expect("legacy identity");
+    assert!(legacy.spec_reference.audience().is_none());
+    assert!(matches!(
+        tx.identities()
+            .upsert(&owner, &name, &legacy.spec_reference, 11)
+            .await,
+        Err(AppError::InvalidInput(_))
+    ));
+    tx.rollback().await.expect("restore pinned audience");
+
+    for (host, port) in [
+        (None, Some(443)),
+        (Some(" "), None),
+        (Some("api.example.com"), Some(0)),
+        (Some("api.example.com"), Some(65_536)),
+    ] {
+        assert_audience_constraint_rejected(db, &owner, &name, host, port).await;
+    }
+
     assert_corrupt_identity(
         db,
         &owner,
@@ -249,6 +290,10 @@ async fn assert_identity_repository_corruption_contract(db: &CoralDb) {
         (Identities::IdentitySpecFingerprint, Expr::val("")),
         (Identities::Issuer, Expr::val(" ")),
         (Identities::IdentityType, Expr::val("unknown")),
+        (
+            Identities::IdentitySpecAudienceHost,
+            Expr::val("API.EXAMPLE.COM"),
+        ),
         (Identities::CreatedAtUnixNanos, Expr::val(-1_i64)),
         (Identities::UpdatedAtUnixNanos, Expr::val(9_i64)),
     ] {
@@ -268,6 +313,32 @@ async fn assert_identity_repository_corruption_contract(db: &CoralDb) {
         .await
         .expect("delete corruption workspace");
     tx.commit().await.expect("commit corruption cleanup");
+}
+
+async fn assert_audience_constraint_rejected(
+    db: &CoralDb,
+    owner: &IdentityOwner,
+    name: &IdentityName,
+    host: Option<&str>,
+    port: Option<i64>,
+) {
+    let mut tx = db.begin().await.expect("begin invalid audience update");
+    tx.execute(
+        Query::update()
+            .table(Identities::Table)
+            .value(
+                Identities::IdentitySpecAudienceHost,
+                Expr::val(host.map(str::to_string)),
+            )
+            .value(Identities::IdentitySpecAudiencePort, Expr::val(port))
+            .and_where(identity_where(owner, name))
+            .to_owned(),
+    )
+    .await
+    .expect_err("invalid audience columns must be rejected");
+    tx.rollback()
+        .await
+        .expect("rollback invalid audience update");
 }
 
 #[derive(Clone, Copy)]
@@ -435,6 +506,13 @@ fn reference(
     key: IdentitySpecKey,
     fingerprint: &str,
 ) -> IdentitySpecReference {
-    IdentitySpecReference::new(owner, key, fingerprint, "issuer", "fixed_token")
-        .expect("identity reference")
+    IdentitySpecReference::new(
+        owner,
+        key,
+        fingerprint,
+        "issuer",
+        "fixed_token",
+        IdentityAudience::new("api.example.com", Some(8443)).expect("identity audience"),
+    )
+    .expect("identity reference")
 }

--- a/crates/coral-app/src/state/db/repositories/identity_documents_contract_tests.rs
+++ b/crates/coral-app/src/state/db/repositories/identity_documents_contract_tests.rs
@@ -4,7 +4,9 @@ use tempfile::tempdir;
 use super::identity_documents::IdentityDocumentRecord;
 use crate::bootstrap::AppError;
 use crate::encrypted_document::EncryptedEnvelopeDocument;
-use crate::identities::model::{IdentityName, IdentityOwner, IdentitySpecReference};
+use crate::identities::model::{
+    IdentityAudience, IdentityName, IdentityOwner, IdentitySpecReference,
+};
 use crate::identity::{Principal, PrincipalKind};
 use crate::state::db::schema::IdentityDocuments;
 use crate::state::db::{CoralDb, CoralTx, DbRepos, IdentitySpecKey, ResolvedDatabaseConfig};
@@ -350,8 +352,15 @@ pub(super) fn document(seed: u8) -> EncryptedEnvelopeDocument {
 }
 
 pub(super) fn reference(owner: &IdentityOwner, key: IdentitySpecKey) -> IdentitySpecReference {
-    IdentitySpecReference::new(owner, key, "fingerprint", "issuer", "fixed_token")
-        .expect("identity spec reference")
+    IdentitySpecReference::new(
+        owner,
+        key,
+        "fingerprint",
+        "issuer",
+        "fixed_token",
+        IdentityAudience::new("api.example.com", None).expect("identity audience"),
+    )
+    .expect("identity spec reference")
 }
 
 pub(super) fn parsed_workspace(value: &str) -> WorkspaceName {

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -111,6 +111,8 @@ pub(in crate::state::db) enum Identities {
     IdentitySpecFingerprint,
     Issuer,
     IdentityType,
+    IdentitySpecAudiencePort,
+    IdentitySpecAudienceHost,
     CreatedAtUnixNanos,
     UpdatedAtUnixNanos,
 }


### PR DESCRIPTION
## Intent

Persist the normalized provider audience selected from the exact identity-spec revision whenever an identity is created or replaced. Existing rows remain explicitly legacy-unknown instead of being backfilled from a potentially different live spec.

## What it enables

- Stable identity metadata that survives later identity-spec replacement or deletion.
- Future fail-closed runtime resolution that can compare the pinned host and optional port with the exact installed spec and request target.
- Additive API presence semantics: an absent audience means legacy unavailable data, while an absent nested port means a known host without a port constraint.
- Portable SQLite and PostgreSQL enforcement for valid host/port column shapes.

## Usage examples

A newly written identity for api.github.com pins identity_spec.audience.host to api.github.com and may pin identity_spec.audience.port to 443. Host-only specs leave the nested port absent. Legacy identities written before this migration leave identity_spec.audience absent and remain available to list, get, or delete, but cannot be rewritten without resolving a current exact spec.

## Verification

- make lint-proto
- cargo test -p coral-app identities::model::tests
- cargo test -p coral-app identity_repository_contract_holds_against_sqlite -- --nocapture
- make postgres-tests
- make rust-checks (1,975 passed; 7 skipped; Clippy and rustdoc clean)
- Three clean closeout review lanes: database portability, security invariants, and API compatibility