### PR TITLE
feat(app): manage current-user identities

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -10,6 +10,7 @@ use coral_api::v1::feature_service_server::FeatureServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
 use coral_api::v1::function_service_server::FunctionServiceServer;
 use coral_api::v1::gui_onboarding_service_server::GuiOnboardingServiceServer;
+use coral_api::v1::identity_service_server::IdentityServiceServer;
 use coral_api::v1::identity_spec_service_server::IdentitySpecServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::search_service_server::SearchServiceServer;
@@ -19,9 +20,9 @@ use coral_api::v1::trace_service_server::TraceServiceServer;
 use coral_api::v1::workspace_service_server::WorkspaceServiceServer;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE,
-    IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE,
-    SEARCH_RESPONSE_MAX_MESSAGE_SIZE, SOURCE_RESPONSE_MAX_MESSAGE_SIZE,
-    TRACE_RESPONSE_MAX_MESSAGE_SIZE,
+    IDENTITY_RESPONSE_MAX_MESSAGE_SIZE, IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE,
+    QUERY_RESPONSE_MAX_MESSAGE_SIZE, SEARCH_RESPONSE_MAX_MESSAGE_SIZE,
+    SOURCE_RESPONSE_MAX_MESSAGE_SIZE, TRACE_RESPONSE_MAX_MESSAGE_SIZE,
 };
 use tokio::net::TcpListener;
 use tokio::sync::{oneshot, watch};
@@ -50,6 +51,8 @@ use crate::feedback::service::FeedbackService;
 use crate::functions::service::FunctionService;
 use crate::gui_onboarding::manager::GuiOnboardingManager;
 use crate::gui_onboarding::service::GuiOnboardingService;
+use crate::identities::manager::IdentityManager;
+use crate::identities::service::IdentityService;
 use crate::identity::{LocalPrincipalProvider, PrincipalProvider};
 use crate::identity_specs::manager::IdentitySpecManager;
 use crate::identity_specs::service::IdentitySpecService;
@@ -356,7 +359,7 @@ impl ServerBuilder {
         layout.ensure()?;
         let credential_config = CredentialStorageConfig::load(&layout)?;
         let database_config = resolve_database_config(&layout)?;
-        let identity_spec_key_provider: Arc<dyn CredentialKeyProvider> =
+        let identity_key_provider: Arc<dyn CredentialKeyProvider> =
             Arc::new(LocalFileCredentialKeyProvider::new(&layout, None));
         let feature_store = FeatureStore::from_layout(layout.clone());
         let features = feature_store.load_with_overrides(&self.config.feature_overrides)?;
@@ -365,7 +368,8 @@ impl ServerBuilder {
         run_state_migrations(&coral_db, &config_store, &layout).await?;
         let coral_db = Arc::new(coral_db);
         let identity_specs =
-            IdentitySpecManager::new(Arc::clone(&coral_db), identity_spec_key_provider);
+            IdentitySpecManager::new(Arc::clone(&coral_db), Arc::clone(&identity_key_provider));
+        let identities = IdentityManager::new(Arc::clone(&coral_db), identity_key_provider);
         let (telemetry_config, active_trace_store) =
             init_server_telemetry(&layout, self.config.enable_stderr_logs)?;
         let active_trace_store_dir = active_trace_store.as_ref().map(|store| store.dir.clone());
@@ -445,6 +449,7 @@ impl ServerBuilder {
                 feature_store,
                 active_features: features,
                 identity_specs,
+                identities,
             },
             trace_components,
             principal_provider,
@@ -662,6 +667,7 @@ struct ServerDependencies {
     // can report what this server is running rather than only what config says.
     active_features: Features,
     identity_specs: IdentitySpecManager,
+    identities: IdentityManager,
 }
 
 /// Builds the gRPC routes for every application service, and returns the query
@@ -682,6 +688,7 @@ fn application_routes(
         feature_store,
         active_features,
         identity_specs,
+        identities,
     } = dependencies;
     let (source, query) = match search_observations.as_ref() {
         Some(search_observations) => (
@@ -702,6 +709,7 @@ fn application_routes(
     let task_service = TaskService::new(task);
     let gui_onboarding_service = GuiOnboardingService::new(gui_onboarding);
     let identity_spec_service = IdentitySpecService::new(identity_specs);
+    let identity_service = IdentityService::new(identities);
     let mut routes = Routes::default()
         .add_service(GuiOnboardingServiceServer::new(gui_onboarding_service))
         .add_service(
@@ -718,6 +726,10 @@ fn application_routes(
         .add_service(
             IdentitySpecServiceServer::new(identity_spec_service)
                 .max_encoding_message_size(IDENTITY_SPEC_RESPONSE_MAX_MESSAGE_SIZE),
+        )
+        .add_service(
+            IdentityServiceServer::new(identity_service)
+                .max_encoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE),
         )
         .add_service(FunctionServiceServer::new(function_service))
         .add_service(TaskServiceServer::new(task_service))
@@ -862,11 +874,12 @@ mod tests {
     };
     use crate::bootstrap::AppError;
     use crate::catalog::discovery::CatalogDiscovery;
-    use crate::credentials::encryption::LocalFileCredentialKeyProvider;
+    use crate::credentials::encryption::{CredentialKeyProvider, LocalFileCredentialKeyProvider};
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::features::{Feature, FeatureOverrides, FeatureStore, Features};
     use crate::feedback::manager::FeedbackManager;
     use crate::gui_onboarding::manager::GuiOnboardingManager;
+    use crate::identities::manager::IdentityManager;
     use crate::identity_specs::manager::IdentitySpecManager;
     use crate::query::manager::QueryManager;
     use crate::search::manager::SearchManager;
@@ -962,13 +975,15 @@ enabled = false
         Arc::new(db)
     }
 
-    fn test_identity_spec_manager(
+    fn test_identity_managers(
         layout: &AppStateLayout,
         db: &Arc<CoralDb>,
-    ) -> IdentitySpecManager {
-        IdentitySpecManager::new(
-            Arc::clone(db),
-            Arc::new(LocalFileCredentialKeyProvider::new(layout, None)),
+    ) -> (IdentitySpecManager, IdentityManager) {
+        let key_provider: Arc<dyn CredentialKeyProvider> =
+            Arc::new(LocalFileCredentialKeyProvider::new(layout, None));
+        (
+            IdentitySpecManager::new(Arc::clone(db), Arc::clone(&key_provider)),
+            IdentityManager::new(Arc::clone(db), key_provider),
         )
     }
 
@@ -1600,6 +1615,7 @@ backend = "unsupported"
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
         );
+        let (identity_specs, identities) = test_identity_managers(&layout, &db);
         let trace_service = TraceService::new(TraceManager::new(
             temp.path().join("trace-store"),
             Duration::from_mins(1),
@@ -1616,7 +1632,8 @@ backend = "unsupported"
                 task: task_manager,
                 feature_store: FeatureStore::from_layout(layout.clone()),
                 active_features: Features::default(),
-                identity_specs: test_identity_spec_manager(&layout, &db),
+                identity_specs,
+                identities,
             },
             TraceServerComponents {
                 service: Some(trace_service),
@@ -1753,6 +1770,7 @@ backend = "unsupported"
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
         );
+        let (identity_specs, identities) = test_identity_managers(&layout, &db);
         let running = start_server(
             ServerDependencies {
                 gui_onboarding: GuiOnboardingManager::new(Arc::clone(&db)),
@@ -1765,7 +1783,8 @@ backend = "unsupported"
                 task: task_manager,
                 feature_store: FeatureStore::from_layout(layout.clone()),
                 active_features: Features::default(),
-                identity_specs: test_identity_spec_manager(&layout, &db),
+                identity_specs,
+                identities,
             },
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
@@ -1886,6 +1905,7 @@ tables:
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
         );
+        let (identity_specs, identities) = test_identity_managers(&layout, &db);
         let running = start_server(
             ServerDependencies {
                 gui_onboarding: GuiOnboardingManager::new(Arc::clone(&db)),
@@ -1898,7 +1918,8 @@ tables:
                 task: task_manager,
                 feature_store: FeatureStore::from_layout(layout.clone()),
                 active_features: Features::default(),
-                identity_specs: test_identity_spec_manager(&layout, &db),
+                identity_specs,
+                identities,
             },
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),
@@ -2019,6 +2040,7 @@ tables:
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
         );
+        let (identity_specs, identities) = test_identity_managers(&layout, &db);
         let running = start_server(
             ServerDependencies {
                 gui_onboarding: GuiOnboardingManager::new(Arc::clone(&db)),
@@ -2031,7 +2053,8 @@ tables:
                 task: task_manager,
                 feature_store: FeatureStore::from_layout(layout.clone()),
                 active_features: Features::default(),
-                identity_specs: test_identity_spec_manager(&layout, &db),
+                identity_specs,
+                identities,
             },
             TraceServerComponents::default(),
             Arc::new(LocalPrincipalProvider),

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1712,6 +1712,10 @@ backend = "unsupported"
     }
 
     #[tokio::test]
+    #[expect(
+        clippy::too_many_lines,
+        reason = "one end-to-end fixture whose server dependencies grow with each registered service"
+    )]
     async fn file_tilde_sources_resolve_from_app_owned_runtime_context() {
         if !loopback_sockets_available() {
             return;

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -3,3 +3,4 @@
 mod crypto;
 pub(crate) mod manager;
 pub(crate) mod model;
+pub(crate) mod service;

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -1,0 +1,242 @@
+//! Implements the gRPC `IdentityService` current-user management boundary.
+
+use coral_api::v1::identity_service_server::IdentityService as IdentityServiceApi;
+use coral_api::v1::{
+    CreateUserOwnedFixedTokenIdentityRequest, CreateUserOwnedFixedTokenIdentityResponse,
+    CurrentUserIdentityOwner, DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse,
+    GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse, GlobalIdentitySpecScope,
+    Identity as IdentityProto, IdentityAudience as IdentityAudienceProto,
+    IdentityOwner as IdentityOwnerProto, IdentitySpecReference as IdentitySpecReferenceProto,
+    IdentitySpecScope as IdentitySpecScopeProto, IdentitySpecType as IdentitySpecTypeProto,
+    ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse, identity_owner,
+    identity_spec_scope,
+};
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::{AppError, app_status};
+use crate::identities::manager::IdentityManager;
+use crate::identities::model::{IdentityOwner, IdentitySpecReference};
+use crate::request_context::RequestContext;
+use crate::state::db::{IdentityRecord, IdentitySpecScope};
+use crate::transport::{grpc_span, instrument_grpc, workspace_to_proto};
+
+#[derive(Clone)]
+pub(crate) struct IdentityService {
+    identities: IdentityManager,
+}
+
+impl IdentityService {
+    pub(crate) fn new(identities: IdentityManager) -> Self {
+        Self { identities }
+    }
+}
+
+#[tonic::async_trait]
+impl IdentityServiceApi for IdentityService {
+    async fn create_user_owned_fixed_token_identity(
+        &self,
+        request: Request<CreateUserOwnedFixedTokenIdentityRequest>,
+    ) -> Result<Response<CreateUserOwnedFixedTokenIdentityResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let principal = request_principal(&request)?;
+            let request = request.into_inner();
+            let setup = request.setup.ok_or_else(|| {
+                app_status(AppError::InvalidInput(
+                    "missing fixed-token identity setup".to_string(),
+                ))
+            })?;
+            let identity = identities
+                .create_or_replace_user_fixed_token(
+                    &principal,
+                    &request.name,
+                    &request.identity_spec_name,
+                    setup.token,
+                )
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(CreateUserOwnedFixedTokenIdentityResponse {
+                identity: Some(identity_to_proto(&identity).map_err(app_status)?),
+            }))
+        })
+        .await
+    }
+
+    async fn list_user_owned_identities(
+        &self,
+        request: Request<ListUserOwnedIdentitiesRequest>,
+    ) -> Result<Response<ListUserOwnedIdentitiesResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let principal = request_principal(&request)?;
+            let owner = IdentityOwner::for_user(principal);
+            let identities = identities
+                .list_for_owner(&owner)
+                .await
+                .map_err(app_status)?
+                .into_iter()
+                .map(|identity| identity_to_proto(&identity))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(app_status)?;
+            Ok(Response::new(ListUserOwnedIdentitiesResponse {
+                identities,
+            }))
+        })
+        .await
+    }
+
+    async fn get_user_owned_identity(
+        &self,
+        request: Request<GetUserOwnedIdentityRequest>,
+    ) -> Result<Response<GetUserOwnedIdentityResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let principal = request_principal(&request)?;
+            let request = request.into_inner();
+            let owner = IdentityOwner::for_user(principal);
+            let identity = identities
+                .get(&owner, &request.name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(GetUserOwnedIdentityResponse {
+                identity: Some(identity_to_proto(&identity).map_err(app_status)?),
+            }))
+        })
+        .await
+    }
+
+    async fn delete_user_owned_identity(
+        &self,
+        request: Request<DeleteUserOwnedIdentityRequest>,
+    ) -> Result<Response<DeleteUserOwnedIdentityResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let principal = request_principal(&request)?;
+            let request = request.into_inner();
+            let owner = IdentityOwner::for_user(principal);
+            identities
+                .delete(&owner, &request.name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(DeleteUserOwnedIdentityResponse {}))
+        })
+        .await
+    }
+}
+
+fn request_principal<T>(request: &Request<T>) -> Result<crate::identity::Principal, Status> {
+    request
+        .extensions()
+        .get::<RequestContext>()
+        .map(|context| context.principal().clone())
+        .ok_or_else(|| Status::internal("request principal context is unavailable"))
+}
+
+fn identity_to_proto(record: &IdentityRecord) -> Result<IdentityProto, AppError> {
+    Ok(IdentityProto {
+        name: record.name.as_str().to_string(),
+        owner: Some(identity_owner_to_proto(&record.owner)),
+        identity_spec: Some(identity_spec_reference_to_proto(&record.spec_reference)?),
+        created_at_unix_nanos: record.created_at_unix_nanos,
+        updated_at_unix_nanos: record.updated_at_unix_nanos,
+    })
+}
+
+fn identity_owner_to_proto(owner: &IdentityOwner) -> IdentityOwnerProto {
+    let value = match owner {
+        IdentityOwner::User(_) => identity_owner::Value::CurrentUser(CurrentUserIdentityOwner {}),
+        IdentityOwner::Workspace(workspace) => {
+            identity_owner::Value::Workspace(workspace_to_proto(workspace))
+        }
+    };
+    IdentityOwnerProto { value: Some(value) }
+}
+
+fn identity_spec_reference_to_proto(
+    reference: &IdentitySpecReference,
+) -> Result<IdentitySpecReferenceProto, AppError> {
+    Ok(IdentitySpecReferenceProto {
+        name: reference.key().name().to_string(),
+        scope: Some(identity_scope_to_proto(reference.key().scope())),
+        fingerprint: reference.fingerprint().to_string(),
+        issuer: reference.issuer().to_string(),
+        identity_type: identity_type_to_proto(reference.identity_type())? as i32,
+        audience: reference.audience().map(|audience| IdentityAudienceProto {
+            host: audience.host().to_string(),
+            port: audience.port().map(u32::from),
+        }),
+    })
+}
+
+fn identity_scope_to_proto(scope: &IdentitySpecScope) -> IdentitySpecScopeProto {
+    let value = match scope {
+        IdentitySpecScope::Global => identity_spec_scope::Value::Global(GlobalIdentitySpecScope {}),
+        IdentitySpecScope::Workspace(workspace) => {
+            identity_spec_scope::Value::Workspace(workspace_to_proto(workspace))
+        }
+    };
+    IdentitySpecScopeProto { value: Some(value) }
+}
+
+fn identity_type_to_proto(identity_type: &str) -> Result<IdentitySpecTypeProto, AppError> {
+    match identity_type {
+        "oauth" => Ok(IdentitySpecTypeProto::Oauth),
+        "fixed_token" => Ok(IdentitySpecTypeProto::FixedToken),
+        _ => Err(AppError::Database(
+            "persisted identity spec type is invalid".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identities::model::{IdentityName, IdentitySpecReference};
+    use crate::identity::{Principal, PrincipalKind};
+
+    #[test]
+    fn proto_conversion_preserves_legacy_absent_audience_without_exposing_user_id() {
+        let owner = IdentityOwner::for_user(
+            Principal::parse("member-1", PrincipalKind::User).expect("user"),
+        );
+        let reference = IdentitySpecReference::from_storage_parts(
+            &owner,
+            None,
+            "github_token",
+            "fingerprint".to_string(),
+            "github".to_string(),
+            "fixed_token".to_string(),
+            None,
+            None,
+        )
+        .expect("legacy reference");
+        let proto = identity_to_proto(&IdentityRecord {
+            owner,
+            name: IdentityName::from_storage("github").expect("name"),
+            spec_reference: reference,
+            created_at_unix_nanos: 10,
+            updated_at_unix_nanos: 20,
+        })
+        .expect("proto");
+
+        assert!(matches!(
+            proto.owner.and_then(|owner| owner.value),
+            Some(identity_owner::Value::CurrentUser(_))
+        ));
+        let reference = proto.identity_spec.expect("spec reference");
+        assert_eq!(reference.name, "github_token");
+        assert_eq!(
+            reference.identity_type,
+            IdentitySpecTypeProto::FixedToken as i32
+        );
+        assert!(reference.audience.is_none());
+        assert!(matches!(
+            reference.scope.and_then(|scope| scope.value),
+            Some(identity_spec_scope::Value::Global(_))
+        ));
+    }
+}

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -17,6 +17,8 @@ mod gui_onboarding_tests;
 mod harness;
 #[path = "grpc/health_service_tests.rs"]
 mod health_service_tests;
+#[path = "grpc/identity_lifecycle_tests.rs"]
+mod identity_lifecycle_tests;
 #[path = "grpc/identity_spec_lifecycle_tests.rs"]
 mod identity_spec_lifecycle_tests;
 #[path = "grpc/oauth_refresh_tests.rs"]

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -10,8 +10,8 @@ use coral_api::v1::{
 use coral_app::EngineExtensionsProvider;
 use coral_app::features::{Feature, FeatureOverrides};
 use coral_client::{
-    AppClient, CatalogClient, FunctionClient, IdentitySpecClient, QueryClient, SearchClient,
-    SourceClient, WorkspaceClient, batches_to_json_rows, decode_execute_sql_response,
+    AppClient, CatalogClient, FunctionClient, IdentityClient, IdentitySpecClient, QueryClient,
+    SearchClient, SourceClient, WorkspaceClient, batches_to_json_rows, decode_execute_sql_response,
     default_workspace,
     local::{RunningServer, ServerBuilder},
 };
@@ -45,6 +45,20 @@ impl GrpcHarness {
         let mut feature_overrides = FeatureOverrides::default();
         feature_overrides.set(Feature::ObservedValuesSearch, true);
         Self::start_with_parts(temp_dir, config_dir, feature_overrides).await
+    }
+
+    pub(crate) async fn new_with_user_principal_provider(
+        user_principal_provider: Arc<dyn coral_app::PrincipalProvider>,
+    ) -> Self {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let config_dir = temp_dir.path().join("coral-config");
+        Self::start_with_builder(
+            temp_dir,
+            config_dir,
+            FeatureOverrides::default(),
+            ServerBuilder::new().with_principal_provider(user_principal_provider),
+        )
+        .await
     }
 
     pub(crate) async fn start_with_config_dir(config_dir: PathBuf) -> Self {
@@ -140,6 +154,10 @@ impl GrpcHarness {
 
     pub(crate) fn identity_spec_client(&self) -> IdentitySpecClient {
         self.app.identity_spec_client()
+    }
+
+    pub(crate) fn identity_client(&self) -> IdentityClient {
+        self.app.identity_client()
     }
 
     pub(crate) fn search_client(&self) -> SearchClient {

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -47,8 +47,8 @@ impl GrpcHarness {
         Self::start_with_parts(temp_dir, config_dir, feature_overrides).await
     }
 
-    pub(crate) async fn new_with_user_principal_provider(
-        user_principal_provider: Arc<dyn coral_app::PrincipalProvider>,
+    pub(crate) async fn new_with_principal_provider(
+        principal_provider: Arc<dyn coral_app::PrincipalProvider>,
     ) -> Self {
         let temp_dir = TempDir::new().expect("temp dir");
         let config_dir = temp_dir.path().join("coral-config");
@@ -56,7 +56,7 @@ impl GrpcHarness {
             temp_dir,
             config_dir,
             FeatureOverrides::default(),
-            ServerBuilder::new().with_principal_provider(user_principal_provider),
+            ServerBuilder::new().with_principal_provider(principal_provider),
         )
         .await
     }

--- a/crates/coral-app/tests/grpc/identity_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_lifecycle_tests.rs
@@ -19,10 +19,10 @@ const IDENTITY_NAME: &str = "example";
 const TOKEN: &str = "write-only-test-token";
 
 #[derive(Debug)]
-struct MetadataUserPrincipalProvider;
+struct MetadataPrincipalProvider;
 
 #[tonic::async_trait]
-impl PrincipalProvider for MetadataUserPrincipalProvider {
+impl PrincipalProvider for MetadataPrincipalProvider {
     async fn principal_for_metadata(
         &self,
         metadata: &tonic::metadata::MetadataMap,
@@ -40,8 +40,7 @@ impl PrincipalProvider for MetadataUserPrincipalProvider {
 #[tokio::test]
 async fn manages_current_user_fixed_token_identities_without_cross_user_leaks() {
     let harness =
-        GrpcHarness::new_with_user_principal_provider(Arc::new(MetadataUserPrincipalProvider))
-            .await;
+        GrpcHarness::new_with_principal_provider(Arc::new(MetadataPrincipalProvider)).await;
     install_global_spec(&harness).await;
 
     let missing_setup = harness

--- a/crates/coral-app/tests/grpc/identity_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/identity_lifecycle_tests.rs
@@ -1,0 +1,210 @@
+use std::sync::Arc;
+
+use coral_api::v1::{
+    AddIdentitySpecRequest, CreateUserOwnedFixedTokenIdentityRequest,
+    DeleteUserOwnedIdentityRequest, FixedTokenIdentitySetup, GetUserOwnedIdentityRequest,
+    GlobalIdentitySpecScope, Identity, IdentitySpecScope, IdentitySpecType,
+    ListUserOwnedIdentitiesRequest, identity_owner, identity_spec_scope,
+};
+use coral_app::{Principal, PrincipalKind, PrincipalProvider, PrincipalProviderError};
+use tonic::{Code, Request, Status};
+
+use crate::harness::GrpcHarness;
+
+const USER_HEADER: &str = "x-test-user";
+const ALICE: &str = "alice";
+const BOB: &str = "bob";
+const SPEC_NAME: &str = "example_token";
+const IDENTITY_NAME: &str = "example";
+const TOKEN: &str = "write-only-test-token";
+
+#[derive(Debug)]
+struct MetadataUserPrincipalProvider;
+
+#[tonic::async_trait]
+impl PrincipalProvider for MetadataUserPrincipalProvider {
+    async fn principal_for_metadata(
+        &self,
+        metadata: &tonic::metadata::MetadataMap,
+    ) -> Result<Principal, PrincipalProviderError> {
+        let user_id = metadata
+            .get(USER_HEADER)
+            .ok_or_else(|| PrincipalProviderError::unauthenticated("missing test user"))?
+            .to_str()
+            .map_err(|_error| PrincipalProviderError::unauthenticated("invalid test user"))?;
+        Principal::parse(user_id, PrincipalKind::User)
+            .map_err(|error| PrincipalProviderError::unauthenticated(error.to_string()))
+    }
+}
+
+#[tokio::test]
+async fn manages_current_user_fixed_token_identities_without_cross_user_leaks() {
+    let harness =
+        GrpcHarness::new_with_user_principal_provider(Arc::new(MetadataUserPrincipalProvider))
+            .await;
+    install_global_spec(&harness).await;
+
+    let missing_setup = harness
+        .identity_client()
+        .create_user_owned_fixed_token_identity(for_user(
+            CreateUserOwnedFixedTokenIdentityRequest {
+                name: IDENTITY_NAME.to_string(),
+                identity_spec_name: SPEC_NAME.to_string(),
+                setup: None,
+            },
+            ALICE,
+        ))
+        .await
+        .expect_err("fixed-token setup is required");
+    assert_eq!(missing_setup.code(), Code::InvalidArgument);
+
+    let created = harness
+        .identity_client()
+        .create_user_owned_fixed_token_identity(for_user(
+            CreateUserOwnedFixedTokenIdentityRequest {
+                name: IDENTITY_NAME.to_string(),
+                identity_spec_name: SPEC_NAME.to_string(),
+                setup: Some(FixedTokenIdentitySetup {
+                    token: TOKEN.to_string(),
+                }),
+            },
+            ALICE,
+        ))
+        .await
+        .expect("create Alice identity")
+        .into_inner()
+        .identity
+        .expect("created identity");
+    assert_identity(&created);
+    assert_token_absent(&created);
+
+    let alice_list = list(&harness, ALICE).await;
+    assert_eq!(alice_list, vec![created.clone()]);
+    assert_token_absent(&alice_list);
+
+    assert_eq!(
+        get(&harness, ALICE).await.expect("get Alice identity"),
+        created
+    );
+
+    assert!(list(&harness, BOB).await.is_empty());
+    assert_eq!(
+        get(&harness, BOB)
+            .await
+            .expect_err("Bob must not see Alice identity")
+            .code(),
+        Code::NotFound
+    );
+
+    harness
+        .identity_client()
+        .delete_user_owned_identity(for_user(
+            DeleteUserOwnedIdentityRequest {
+                name: IDENTITY_NAME.to_string(),
+            },
+            ALICE,
+        ))
+        .await
+        .expect("delete Alice identity");
+    assert_eq!(
+        get(&harness, ALICE)
+            .await
+            .expect_err("deleted identity must be absent")
+            .code(),
+        Code::NotFound
+    );
+}
+
+async fn install_global_spec(harness: &GrpcHarness) {
+    harness
+        .identity_spec_client()
+        .add_identity_spec(for_user(
+            AddIdentitySpecRequest {
+                manifest_yaml: format!(
+                    "kind: identity\nspec_version: 1\nname: {SPEC_NAME}\nversion: 1.0.0\ndescription: test fixed token\nissuer: example\ntype: fixed_token\naudience: {{host: api.example.com, port: 443}}\n"
+                ),
+                input_values: Vec::new(),
+                scope: Some(global_scope()),
+            },
+            ALICE,
+        ))
+        .await
+        .expect("install global fixed-token identity spec");
+}
+
+async fn list(harness: &GrpcHarness, user_id: &'static str) -> Vec<Identity> {
+    harness
+        .identity_client()
+        .list_user_owned_identities(for_user(ListUserOwnedIdentitiesRequest {}, user_id))
+        .await
+        .expect("list user identities")
+        .into_inner()
+        .identities
+}
+
+async fn get(harness: &GrpcHarness, user_id: &'static str) -> Result<Identity, Status> {
+    Ok(harness
+        .identity_client()
+        .get_user_owned_identity(for_user(
+            GetUserOwnedIdentityRequest {
+                name: IDENTITY_NAME.to_string(),
+            },
+            user_id,
+        ))
+        .await?
+        .into_inner()
+        .identity
+        .expect("identity response"))
+}
+
+fn assert_identity(identity: &Identity) {
+    assert_eq!(identity.name, IDENTITY_NAME);
+    assert!(matches!(
+        identity
+            .owner
+            .as_ref()
+            .and_then(|owner| owner.value.as_ref()),
+        Some(identity_owner::Value::CurrentUser(_))
+    ));
+
+    let spec = identity
+        .identity_spec
+        .as_ref()
+        .expect("identity spec reference");
+    assert_eq!(spec.name, SPEC_NAME);
+    assert!(matches!(
+        spec.scope.as_ref().and_then(|scope| scope.value.as_ref()),
+        Some(identity_spec_scope::Value::Global(_))
+    ));
+    assert!(!spec.fingerprint.is_empty());
+    assert_eq!(spec.issuer, "example");
+    assert_eq!(spec.identity_type, IdentitySpecType::FixedToken as i32);
+    let audience = spec.audience.as_ref().expect("pinned audience");
+    assert_eq!(audience.host, "api.example.com");
+    assert_eq!(audience.port, Some(443));
+    assert!(identity.created_at_unix_nanos > 0);
+    assert!(identity.updated_at_unix_nanos >= identity.created_at_unix_nanos);
+}
+
+fn assert_token_absent(response: &impl std::fmt::Debug) {
+    assert!(
+        !format!("{response:?}").contains(TOKEN),
+        "identity response leaked fixed-token setup material"
+    );
+}
+
+fn global_scope() -> IdentitySpecScope {
+    IdentitySpecScope {
+        value: Some(identity_spec_scope::Value::Global(
+            GlobalIdentitySpecScope {},
+        )),
+    }
+}
+
+fn for_user<T>(message: T, user_id: &'static str) -> Request<T> {
+    let mut request = Request::new(message);
+    request
+        .metadata_mut()
+        .insert(USER_HEADER, user_id.parse().expect("test user metadata"));
+    request
+}


### PR DESCRIPTION
## Intent

Activate current-user fixed-token identity management at the app transport boundary while preserving exact owner, identity-spec revision, and pinned audience metadata.

## What it enables

- Creates, lists, fetches, and deletes identities owned by the authenticated Coral user.
- Derives ownership exclusively from request context, so callers cannot select another user namespace.
- Shares the configured encryption key provider between identity-spec and identity managers, including fail-closed PostgreSQL behavior.
- Returns safe identity metadata only; fixed-token setup material remains write-only.
- Registers the identity service for native gRPC and gRPC-Web with the shared response-size limit.

## Usage examples

Call `create_user_owned_fixed_token_identity` with the exact spec scope and name, typed audience, and token setup document. Use `list_user_owned_identities` or `get_user_owned_identity` to read safe metadata, and `delete_user_owned_identity` to remove the identity and its encrypted material. The server derives the owner from the authenticated request principal.

## Validation

- Focused two-principal gRPC lifecycle and legacy-audience conversion coverage passed.
- Full Rust formatting, Clippy, test, and documentation gate passed.