### PR TITLE
feat(api): add workspace identity contracts

### DIFF
--- a/crates/coral-api/proto/coral/v1/identities.proto
+++ b/crates/coral-api/proto/coral/v1/identities.proto
@@ -103,6 +103,61 @@ message DeleteUserOwnedIdentityRequest {
 // Confirms user-owned identity deletion.
 message DeleteUserOwnedIdentityResponse {}
 
+// Creates or replaces one fixed-token identity owned by a workspace.
+message CreateWorkspaceOwnedFixedTokenIdentityRequest {
+  // Workspace that owns the identity independently of any user.
+  Workspace workspace = 1;
+  // Stable identity name used by source identity bindings.
+  string name = 2;
+  // Identity spec name resolved from the workspace with global fallback.
+  string identity_spec_name = 3;
+  // Write-only fixed-token setup material.
+  FixedTokenIdentitySetup setup = 4;
+}
+
+// Returns the created or replaced workspace-owned identity metadata.
+message CreateWorkspaceOwnedFixedTokenIdentityResponse {
+  // Stored identity. Setup material is never returned.
+  Identity identity = 1;
+}
+
+// Lists identities owned by one workspace.
+message ListWorkspaceOwnedIdentitiesRequest {
+  // Workspace whose identities should be listed.
+  Workspace workspace = 1;
+}
+
+// Returns workspace-owned identities in identity-name order.
+message ListWorkspaceOwnedIdentitiesResponse {
+  // Stored workspace-owned identity metadata.
+  repeated Identity identities = 1;
+}
+
+// Fetches one identity owned by a workspace.
+message GetWorkspaceOwnedIdentityRequest {
+  // Workspace that owns the identity.
+  Workspace workspace = 1;
+  // Stored identity name.
+  string name = 2;
+}
+
+// Returns one workspace-owned identity.
+message GetWorkspaceOwnedIdentityResponse {
+  // Stored identity metadata.
+  Identity identity = 1;
+}
+
+// Deletes one identity owned by a workspace.
+message DeleteWorkspaceOwnedIdentityRequest {
+  // Workspace that owns the identity.
+  Workspace workspace = 1;
+  // Stored identity name.
+  string name = 2;
+}
+
+// Confirms workspace-owned identity deletion.
+message DeleteWorkspaceOwnedIdentityResponse {}
+
 // Current-user stored identity management APIs.
 service IdentityService {
   // Creates or replaces one current-user fixed-token identity.
@@ -113,4 +168,16 @@ service IdentityService {
   rpc GetUserOwnedIdentity(GetUserOwnedIdentityRequest) returns (GetUserOwnedIdentityResponse);
   // Deletes one current-user identity.
   rpc DeleteUserOwnedIdentity(DeleteUserOwnedIdentityRequest) returns (DeleteUserOwnedIdentityResponse);
+}
+
+// Workspace-owned stored identity management APIs.
+service WorkspaceIdentityService {
+  // Creates or replaces one workspace-owned fixed-token identity.
+  rpc CreateWorkspaceOwnedFixedTokenIdentity(CreateWorkspaceOwnedFixedTokenIdentityRequest) returns (CreateWorkspaceOwnedFixedTokenIdentityResponse);
+  // Lists identities owned by one workspace.
+  rpc ListWorkspaceOwnedIdentities(ListWorkspaceOwnedIdentitiesRequest) returns (ListWorkspaceOwnedIdentitiesResponse);
+  // Fetches one identity owned by a workspace.
+  rpc GetWorkspaceOwnedIdentity(GetWorkspaceOwnedIdentityRequest) returns (GetWorkspaceOwnedIdentityResponse);
+  // Deletes one identity owned by a workspace.
+  rpc DeleteWorkspaceOwnedIdentity(DeleteWorkspaceOwnedIdentityRequest) returns (DeleteWorkspaceOwnedIdentityResponse);
 }

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -12,6 +12,7 @@ use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::search_service_client::SearchServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
 use coral_api::v1::task_service_client::TaskServiceClient;
+use coral_api::v1::workspace_identity_service_client::WorkspaceIdentityServiceClient;
 use coral_api::v1::workspace_service_client::WorkspaceServiceClient;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE,
@@ -65,6 +66,9 @@ pub type IdentitySpecClient = IdentitySpecServiceClient<GrpcService>;
 /// Public current-user stored-identity gRPC client.
 pub type IdentityClient = IdentityServiceClient<GrpcService>;
 
+/// Public workspace-owned stored-identity gRPC client.
+pub type WorkspaceIdentityClient = WorkspaceIdentityServiceClient<GrpcService>;
+
 /// Public catalog-discovery gRPC client.
 pub type CatalogClient = CatalogServiceClient<GrpcService>;
 
@@ -95,6 +99,7 @@ pub struct AppClient {
     workspace: WorkspaceClient,
     identity_spec: IdentitySpecClient,
     identity: IdentityClient,
+    workspace_identity: WorkspaceIdentityClient,
     catalog: CatalogClient,
     query: QueryClient,
     search: SearchClient,
@@ -222,6 +227,12 @@ impl AppClient {
             static_metadata.clone(),
         ))
         .max_decoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE);
+        let workspace_identity_client = WorkspaceIdentityClient::new(grpc_service(
+            channel.clone(),
+            &grpc_endpoint,
+            static_metadata.clone(),
+        ))
+        .max_decoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE);
         let catalog_client = CatalogClient::new(grpc_service(
             channel.clone(),
             &grpc_endpoint,
@@ -263,6 +274,7 @@ impl AppClient {
             workspace: workspace_client,
             identity_spec: identity_spec_client,
             identity: identity_client,
+            workspace_identity: workspace_identity_client,
             catalog: catalog_client,
             query: query_client,
             search: search_client,
@@ -295,6 +307,12 @@ impl AppClient {
     /// Returns a cloned current-user stored-identity client.
     pub fn identity_client(&self) -> IdentityClient {
         self.identity.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned workspace-owned stored-identity client.
+    pub fn workspace_identity_client(&self) -> WorkspaceIdentityClient {
+        self.workspace_identity.clone()
     }
 
     #[must_use]
@@ -470,14 +488,21 @@ mod tests {
     use coral_api::v1::identity_spec_service_server::{
         IdentitySpecService, IdentitySpecServiceServer,
     };
+    use coral_api::v1::workspace_identity_service_server::{
+        WorkspaceIdentityService, WorkspaceIdentityServiceServer,
+    };
     use coral_api::v1::{
         AddIdentitySpecRequest, AddIdentitySpecResponse, CreateUserOwnedFixedTokenIdentityRequest,
-        CreateUserOwnedFixedTokenIdentityResponse, DeleteIdentitySpecRequest,
+        CreateUserOwnedFixedTokenIdentityResponse, CreateWorkspaceOwnedFixedTokenIdentityRequest,
+        CreateWorkspaceOwnedFixedTokenIdentityResponse, DeleteIdentitySpecRequest,
         DeleteIdentitySpecResponse, DeleteUserOwnedIdentityRequest,
-        DeleteUserOwnedIdentityResponse, GetIdentitySpecRequest, GetIdentitySpecResponse,
-        GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse, Identity, IdentitySpecReference,
-        IdentitySpecSummary, ListIdentitySpecsRequest, ListIdentitySpecsResponse,
-        ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse,
+        DeleteUserOwnedIdentityResponse, DeleteWorkspaceOwnedIdentityRequest,
+        DeleteWorkspaceOwnedIdentityResponse, GetIdentitySpecRequest, GetIdentitySpecResponse,
+        GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse,
+        GetWorkspaceOwnedIdentityRequest, GetWorkspaceOwnedIdentityResponse, Identity,
+        IdentitySpecReference, IdentitySpecSummary, ListIdentitySpecsRequest,
+        ListIdentitySpecsResponse, ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse,
+        ListWorkspaceOwnedIdentitiesRequest, ListWorkspaceOwnedIdentitiesResponse,
     };
     use coral_api::v1::{SubmitFeedbackRequest, SubmitFeedbackResponse};
     use opentelemetry::trace::TracerProvider as _;
@@ -782,6 +807,39 @@ mod tests {
         }
     }
 
+    #[tonic::async_trait]
+    impl WorkspaceIdentityService for LargeIdentityFixture {
+        async fn create_workspace_owned_fixed_token_identity(
+            &self,
+            _request: Request<CreateWorkspaceOwnedFixedTokenIdentityRequest>,
+        ) -> Result<Response<CreateWorkspaceOwnedFixedTokenIdentityResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+
+        async fn list_workspace_owned_identities(
+            &self,
+            _request: Request<ListWorkspaceOwnedIdentitiesRequest>,
+        ) -> Result<Response<ListWorkspaceOwnedIdentitiesResponse>, Status> {
+            Ok(Response::new(ListWorkspaceOwnedIdentitiesResponse {
+                identities: large_identities(),
+            }))
+        }
+
+        async fn get_workspace_owned_identity(
+            &self,
+            _request: Request<GetWorkspaceOwnedIdentityRequest>,
+        ) -> Result<Response<GetWorkspaceOwnedIdentityResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+
+        async fn delete_workspace_owned_identity(
+            &self,
+            _request: Request<DeleteWorkspaceOwnedIdentityRequest>,
+        ) -> Result<Response<DeleteWorkspaceOwnedIdentityResponse>, Status> {
+            Err(Status::unimplemented("fixture only supports listing"))
+        }
+    }
+
     fn assert_large_identity_aggregate(identities: &[Identity]) {
         assert_eq!(identities.len(), SPEC_COUNT);
         let issuer_bytes = identities
@@ -852,7 +910,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn app_client_decodes_large_identity_aggregates() {
+    async fn app_client_decodes_large_identity_aggregates_for_both_owner_services() {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind identity fixture");
@@ -861,6 +919,10 @@ mod tests {
             Server::builder()
                 .add_service(
                     IdentityServiceServer::new(LargeIdentityFixture)
+                        .max_encoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE),
+                )
+                .add_service(
+                    WorkspaceIdentityServiceServer::new(LargeIdentityFixture)
                         .max_encoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE),
                 )
                 .serve_with_incoming(TcpListenerStream::new(listener))
@@ -877,6 +939,14 @@ mod tests {
             .expect("decode current-user identity aggregate")
             .into_inner();
         assert_large_identity_aggregate(&user.identities);
+
+        let workspace = app_client
+            .workspace_identity_client()
+            .list_workspace_owned_identities(ListWorkspaceOwnedIdentitiesRequest::default())
+            .await
+            .expect("decode workspace identity aggregate")
+            .into_inner();
+        assert_large_identity_aggregate(&workspace.identities);
         server.abort();
     }
 }

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -43,7 +43,7 @@ use serde_json::Value;
 pub use client::{
     AppClient, CatalogClient, DEFAULT_WORKSPACE_ID, FeedbackClient, FunctionClient,
     HealthCheckClient, IdentityClient, IdentitySpecClient, QueryClient, SearchClient, SourceClient,
-    TaskClient, WorkspaceClient, default_workspace, workspace,
+    TaskClient, WorkspaceClient, WorkspaceIdentityClient, default_workspace, workspace,
 };
 pub use error::{ClientError, QueryResultError};
 pub use propagation::{BearerToken, with_task_metadata};


### PR DESCRIPTION
## Intent

Add explicit workspace-owned fixed-token identity transport contracts without mixing current-user and shared-workspace ownership.

## What it enables

- A separate unary `WorkspaceIdentityService` for create, list, get, and delete operations.
- Explicit workspace targeting on every request.
- Workspace-first identity-spec resolution with global fallback while returning the actual exact spec scope.
- A public `WorkspaceIdentityClient` configured for large identity aggregate responses.

## Usage examples

Create a workspace-owned identity with `CreateWorkspaceOwnedFixedTokenIdentity`, providing the workspace, identity name, identity spec name, and fixed-token setup. List, get, or delete identities through the same service while passing the workspace explicitly.

## Verification

- `make lint-proto`
- `cargo test --locked -p coral-client app_client_decodes_large_identity_aggregates_for_both_owner_services`
- `make rust-checks` (1,977 tests passed; 7 skipped)