### PR TITLE
feat(app): manage workspace identities

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -17,6 +17,7 @@ use coral_api::v1::search_service_server::SearchServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
 use coral_api::v1::task_service_server::TaskServiceServer;
 use coral_api::v1::trace_service_server::TraceServiceServer;
+use coral_api::v1::workspace_identity_service_server::WorkspaceIdentityServiceServer;
 use coral_api::v1::workspace_service_server::WorkspaceServiceServer;
 use coral_api::{
     CATALOG_RESPONSE_MAX_MESSAGE_SIZE, HTTP2_MAX_HEADER_LIST_SIZE,
@@ -53,6 +54,7 @@ use crate::gui_onboarding::manager::GuiOnboardingManager;
 use crate::gui_onboarding::service::GuiOnboardingService;
 use crate::identities::manager::IdentityManager;
 use crate::identities::service::IdentityService;
+use crate::identities::workspace_service::WorkspaceIdentityService;
 use crate::identity::{LocalPrincipalProvider, PrincipalProvider};
 use crate::identity_specs::manager::IdentitySpecManager;
 use crate::identity_specs::service::IdentitySpecService;
@@ -709,7 +711,8 @@ fn application_routes(
     let task_service = TaskService::new(task);
     let gui_onboarding_service = GuiOnboardingService::new(gui_onboarding);
     let identity_spec_service = IdentitySpecService::new(identity_specs);
-    let identity_service = IdentityService::new(identities);
+    let identity_service = IdentityService::new(identities.clone());
+    let workspace_identity_service = WorkspaceIdentityService::new(identities);
     let mut routes = Routes::default()
         .add_service(GuiOnboardingServiceServer::new(gui_onboarding_service))
         .add_service(
@@ -729,6 +732,10 @@ fn application_routes(
         )
         .add_service(
             IdentityServiceServer::new(identity_service)
+                .max_encoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE),
+        )
+        .add_service(
+            WorkspaceIdentityServiceServer::new(workspace_identity_service)
                 .max_encoding_message_size(IDENTITY_RESPONSE_MAX_MESSAGE_SIZE),
         )
         .add_service(FunctionServiceServer::new(function_service))

--- a/crates/coral-app/src/identities/manager.rs
+++ b/crates/coral-app/src/identities/manager.rs
@@ -1,13 +1,5 @@
 //! Database-backed identity instance management.
 
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "identity service consumers land in a later stack layer"
-    )
-)]
-
 use std::collections::BTreeMap;
 use std::sync::Arc;
 #[cfg(test)]

--- a/crates/coral-app/src/identities/mod.rs
+++ b/crates/coral-app/src/identities/mod.rs
@@ -4,3 +4,4 @@ mod crypto;
 pub(crate) mod manager;
 pub(crate) mod model;
 pub(crate) mod service;
+pub(crate) mod workspace_service;

--- a/crates/coral-app/src/identities/service.rs
+++ b/crates/coral-app/src/identities/service.rs
@@ -136,7 +136,7 @@ fn request_principal<T>(request: &Request<T>) -> Result<crate::identity::Princip
         .ok_or_else(|| Status::internal("request principal context is unavailable"))
 }
 
-fn identity_to_proto(record: &IdentityRecord) -> Result<IdentityProto, AppError> {
+pub(super) fn identity_to_proto(record: &IdentityRecord) -> Result<IdentityProto, AppError> {
     Ok(IdentityProto {
         name: record.name.as_str().to_string(),
         owner: Some(identity_owner_to_proto(&record.owner)),

--- a/crates/coral-app/src/identities/workspace_service.rs
+++ b/crates/coral-app/src/identities/workspace_service.rs
@@ -1,0 +1,127 @@
+//! Implements the gRPC workspace-owned identity management boundary.
+
+use coral_api::v1::workspace_identity_service_server::WorkspaceIdentityService as WorkspaceIdentityServiceApi;
+use coral_api::v1::{
+    CreateWorkspaceOwnedFixedTokenIdentityRequest, CreateWorkspaceOwnedFixedTokenIdentityResponse,
+    DeleteWorkspaceOwnedIdentityRequest, DeleteWorkspaceOwnedIdentityResponse,
+    GetWorkspaceOwnedIdentityRequest, GetWorkspaceOwnedIdentityResponse,
+    ListWorkspaceOwnedIdentitiesRequest, ListWorkspaceOwnedIdentitiesResponse,
+};
+use tonic::{Request, Response, Status};
+
+use super::manager::IdentityManager;
+use super::model::IdentityOwner;
+use super::service::identity_to_proto;
+use crate::bootstrap::{AppError, app_status};
+use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto};
+
+#[derive(Clone)]
+pub(crate) struct WorkspaceIdentityService {
+    identities: IdentityManager,
+}
+
+impl WorkspaceIdentityService {
+    pub(crate) fn new(identities: IdentityManager) -> Self {
+        Self { identities }
+    }
+}
+
+#[tonic::async_trait]
+impl WorkspaceIdentityServiceApi for WorkspaceIdentityService {
+    async fn create_workspace_owned_fixed_token_identity(
+        &self,
+        request: Request<CreateWorkspaceOwnedFixedTokenIdentityRequest>,
+    ) -> Result<Response<CreateWorkspaceOwnedFixedTokenIdentityResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
+            let setup = request.setup.ok_or_else(|| {
+                app_status(AppError::InvalidInput(
+                    "missing fixed-token identity setup".to_string(),
+                ))
+            })?;
+            let identity = identities
+                .create_or_replace_workspace_fixed_token(
+                    &workspace,
+                    &request.name,
+                    &request.identity_spec_name,
+                    setup.token,
+                )
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(
+                CreateWorkspaceOwnedFixedTokenIdentityResponse {
+                    identity: Some(identity_to_proto(&identity).map_err(app_status)?),
+                },
+            ))
+        })
+        .await
+    }
+
+    async fn list_workspace_owned_identities(
+        &self,
+        request: Request<ListWorkspaceOwnedIdentitiesRequest>,
+    ) -> Result<Response<ListWorkspaceOwnedIdentitiesResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
+            let owner = IdentityOwner::workspace(workspace);
+            let identities = identities
+                .list_for_owner(&owner)
+                .await
+                .map_err(app_status)?
+                .into_iter()
+                .map(|identity| identity_to_proto(&identity))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(app_status)?;
+            Ok(Response::new(ListWorkspaceOwnedIdentitiesResponse {
+                identities,
+            }))
+        })
+        .await
+    }
+
+    async fn get_workspace_owned_identity(
+        &self,
+        request: Request<GetWorkspaceOwnedIdentityRequest>,
+    ) -> Result<Response<GetWorkspaceOwnedIdentityResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
+            let owner = IdentityOwner::workspace(workspace);
+            let identity = identities
+                .get(&owner, &request.name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(GetWorkspaceOwnedIdentityResponse {
+                identity: Some(identity_to_proto(&identity).map_err(app_status)?),
+            }))
+        })
+        .await
+    }
+
+    async fn delete_workspace_owned_identity(
+        &self,
+        request: Request<DeleteWorkspaceOwnedIdentityRequest>,
+    ) -> Result<Response<DeleteWorkspaceOwnedIdentityResponse>, Status> {
+        let span = grpc_span(&request);
+        let identities = self.identities.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace = workspace_name_from_proto(request.workspace.as_ref())?;
+            let owner = IdentityOwner::workspace(workspace);
+            identities
+                .delete(&owner, &request.name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(DeleteWorkspaceOwnedIdentityResponse {}))
+        })
+        .await
+    }
+}

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -31,5 +31,7 @@ mod search_tests;
 mod server_lifecycle_tests;
 #[path = "grpc/source_lifecycle_tests.rs"]
 mod source_lifecycle_tests;
+#[path = "grpc/workspace_identity_lifecycle_tests.rs"]
+mod workspace_identity_lifecycle_tests;
 #[path = "grpc/workspace_lifecycle_tests.rs"]
 mod workspace_lifecycle_tests;

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -11,8 +11,8 @@ use coral_app::EngineExtensionsProvider;
 use coral_app::features::{Feature, FeatureOverrides};
 use coral_client::{
     AppClient, CatalogClient, FunctionClient, IdentityClient, IdentitySpecClient, QueryClient,
-    SearchClient, SourceClient, WorkspaceClient, batches_to_json_rows, decode_execute_sql_response,
-    default_workspace,
+    SearchClient, SourceClient, WorkspaceClient, WorkspaceIdentityClient, batches_to_json_rows,
+    decode_execute_sql_response, default_workspace,
     local::{RunningServer, ServerBuilder},
 };
 use serde_json::{Value, json};
@@ -158,6 +158,10 @@ impl GrpcHarness {
 
     pub(crate) fn identity_client(&self) -> IdentityClient {
         self.app.identity_client()
+    }
+
+    pub(crate) fn workspace_identity_client(&self) -> WorkspaceIdentityClient {
+        self.app.workspace_identity_client()
     }
 
     pub(crate) fn search_client(&self) -> SearchClient {

--- a/crates/coral-app/tests/grpc/workspace_identity_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/workspace_identity_lifecycle_tests.rs
@@ -1,0 +1,254 @@
+use coral_api::v1::{
+    AddIdentitySpecRequest, CreateWorkspaceOwnedFixedTokenIdentityRequest, CreateWorkspaceRequest,
+    DeleteWorkspaceOwnedIdentityRequest, FixedTokenIdentitySetup, GetWorkspaceOwnedIdentityRequest,
+    GlobalIdentitySpecScope, Identity, IdentitySpecScope, IdentitySpecType,
+    ListWorkspaceOwnedIdentitiesRequest, Workspace, identity_owner, identity_spec_scope,
+};
+use tonic::{Code, Request, Status};
+
+use crate::harness::GrpcHarness;
+
+const SPEC_NAME: &str = "example_token";
+const IDENTITY_NAME: &str = "example";
+const TEAM_TOKEN: &str = "team-write-only-token";
+const OTHER_TOKEN: &str = "other-write-only-token";
+
+#[tokio::test]
+async fn manages_workspace_fixed_token_identities_with_exact_spec_fallback() {
+    let harness = GrpcHarness::new().await;
+    let team = workspace("team");
+    let other = workspace("other");
+    create_workspace(&harness, &team).await;
+    create_workspace(&harness, &other).await;
+
+    let global_scope = global_scope();
+    let team_scope = workspace_scope(&team);
+    install_spec(
+        &harness,
+        global_scope.clone(),
+        "global",
+        "global.example.com",
+        Some(443),
+    )
+    .await;
+    install_spec(
+        &harness,
+        team_scope.clone(),
+        "team",
+        "team.example.com",
+        None,
+    )
+    .await;
+
+    let missing_setup = harness
+        .workspace_identity_client()
+        .create_workspace_owned_fixed_token_identity(Request::new(
+            CreateWorkspaceOwnedFixedTokenIdentityRequest {
+                workspace: Some(team.clone()),
+                name: IDENTITY_NAME.to_string(),
+                identity_spec_name: SPEC_NAME.to_string(),
+                setup: None,
+            },
+        ))
+        .await
+        .expect_err("fixed-token setup is required");
+    assert_eq!(missing_setup.code(), Code::InvalidArgument);
+
+    let missing_workspace = harness
+        .workspace_identity_client()
+        .list_workspace_owned_identities(Request::new(ListWorkspaceOwnedIdentitiesRequest {
+            workspace: None,
+        }))
+        .await
+        .expect_err("workspace is required");
+    assert_eq!(missing_workspace.code(), Code::InvalidArgument);
+
+    let unknown_workspace = workspace("unknown");
+    let unknown = create(&harness, &unknown_workspace, TEAM_TOKEN)
+        .await
+        .expect_err("unknown workspace must fail");
+    assert_eq!(unknown.code(), Code::NotFound);
+
+    let team_identity = create(&harness, &team, TEAM_TOKEN)
+        .await
+        .expect("create team identity");
+    assert_identity(
+        &team_identity,
+        &team,
+        &team_scope,
+        "team",
+        "team.example.com",
+        None,
+    );
+
+    let other_identity = create(&harness, &other, OTHER_TOKEN)
+        .await
+        .expect("create fallback identity");
+    assert_identity(
+        &other_identity,
+        &other,
+        &global_scope,
+        "global",
+        "global.example.com",
+        Some(443),
+    );
+
+    assert_eq!(list(&harness, &team).await, vec![team_identity.clone()]);
+    assert_eq!(list(&harness, &other).await, vec![other_identity]);
+    assert_eq!(
+        get(&harness, &team).await.expect("get team identity"),
+        team_identity
+    );
+
+    harness
+        .workspace_identity_client()
+        .delete_workspace_owned_identity(Request::new(DeleteWorkspaceOwnedIdentityRequest {
+            workspace: Some(team.clone()),
+            name: IDENTITY_NAME.to_string(),
+        }))
+        .await
+        .expect("delete team identity");
+    assert_eq!(
+        get(&harness, &team)
+            .await
+            .expect_err("deleted identity must be absent")
+            .code(),
+        Code::NotFound
+    );
+    assert!(list(&harness, &team).await.is_empty());
+    assert_eq!(list(&harness, &other).await.len(), 1);
+}
+
+async fn create_workspace(harness: &GrpcHarness, workspace: &Workspace) {
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace.clone()),
+        }))
+        .await
+        .expect("create workspace");
+}
+
+async fn install_spec(
+    harness: &GrpcHarness,
+    scope: IdentitySpecScope,
+    issuer: &str,
+    host: &str,
+    port: Option<u16>,
+) {
+    let port = port.map_or_else(String::new, |port| format!(", port: {port}"));
+    harness
+        .identity_spec_client()
+        .add_identity_spec(Request::new(AddIdentitySpecRequest {
+            manifest_yaml: format!(
+                "kind: identity\nspec_version: 1\nname: {SPEC_NAME}\nversion: 1.0.0\ndescription: test fixed token\nissuer: {issuer}\ntype: fixed_token\naudience: {{host: {host}{port}}}\n"
+            ),
+            input_values: Vec::new(),
+            scope: Some(scope),
+        }))
+        .await
+        .expect("install fixed-token identity spec");
+}
+
+async fn create(
+    harness: &GrpcHarness,
+    workspace: &Workspace,
+    token: &str,
+) -> Result<Identity, Status> {
+    Ok(harness
+        .workspace_identity_client()
+        .create_workspace_owned_fixed_token_identity(Request::new(
+            CreateWorkspaceOwnedFixedTokenIdentityRequest {
+                workspace: Some(workspace.clone()),
+                name: IDENTITY_NAME.to_string(),
+                identity_spec_name: SPEC_NAME.to_string(),
+                setup: Some(FixedTokenIdentitySetup {
+                    token: token.to_string(),
+                }),
+            },
+        ))
+        .await?
+        .into_inner()
+        .identity
+        .expect("created identity"))
+}
+
+async fn list(harness: &GrpcHarness, workspace: &Workspace) -> Vec<Identity> {
+    harness
+        .workspace_identity_client()
+        .list_workspace_owned_identities(Request::new(ListWorkspaceOwnedIdentitiesRequest {
+            workspace: Some(workspace.clone()),
+        }))
+        .await
+        .expect("list workspace identities")
+        .into_inner()
+        .identities
+}
+
+async fn get(harness: &GrpcHarness, workspace: &Workspace) -> Result<Identity, Status> {
+    Ok(harness
+        .workspace_identity_client()
+        .get_workspace_owned_identity(Request::new(GetWorkspaceOwnedIdentityRequest {
+            workspace: Some(workspace.clone()),
+            name: IDENTITY_NAME.to_string(),
+        }))
+        .await?
+        .into_inner()
+        .identity
+        .expect("identity response"))
+}
+
+fn assert_identity(
+    identity: &Identity,
+    workspace: &Workspace,
+    scope: &IdentitySpecScope,
+    issuer: &str,
+    host: &str,
+    port: Option<u32>,
+) {
+    assert_eq!(identity.name, IDENTITY_NAME);
+    assert!(matches!(
+        identity
+            .owner
+            .as_ref()
+            .and_then(|owner| owner.value.as_ref()),
+        Some(identity_owner::Value::Workspace(owner)) if owner == workspace
+    ));
+    let spec = identity
+        .identity_spec
+        .as_ref()
+        .expect("identity spec reference");
+    assert_eq!(spec.name, SPEC_NAME);
+    assert_eq!(spec.scope.as_ref(), Some(scope));
+    assert!(!spec.fingerprint.is_empty());
+    assert_eq!(spec.issuer, issuer);
+    assert_eq!(spec.identity_type, IdentitySpecType::FixedToken as i32);
+    let audience = spec.audience.as_ref().expect("pinned audience");
+    assert_eq!(audience.host, host);
+    assert_eq!(audience.port, port);
+    assert!(identity.created_at_unix_nanos > 0);
+    assert!(identity.updated_at_unix_nanos >= identity.created_at_unix_nanos);
+    let debug = format!("{identity:?}");
+    assert!(!debug.contains(TEAM_TOKEN));
+    assert!(!debug.contains(OTHER_TOKEN));
+}
+
+fn workspace(name: &str) -> Workspace {
+    Workspace {
+        name: name.to_string(),
+    }
+}
+
+fn global_scope() -> IdentitySpecScope {
+    IdentitySpecScope {
+        value: Some(identity_spec_scope::Value::Global(
+            GlobalIdentitySpecScope {},
+        )),
+    }
+}
+
+fn workspace_scope(workspace: &Workspace) -> IdentitySpecScope {
+    IdentitySpecScope {
+        value: Some(identity_spec_scope::Value::Workspace(workspace.clone())),
+    }
+}


### PR DESCRIPTION
## Intent

Activate workspace-owned fixed-token identity management without conflating shared workspace ownership with the authenticated current user.

## What it enables

- Create, list, get, and delete workspace-owned identities through the dedicated `WorkspaceIdentityService`.
- Workspace-first identity-spec selection with global fallback and the actual exact spec scope returned in safe metadata.
- Shared bootstrap registration for native gRPC and gRPC-Web using the same database and encryption-key provider as current-user identities.
- Workspace isolation, typed audience metadata, optional audience ports, and write-only fixed-token setup material.

## Usage examples

Call `CreateWorkspaceOwnedFixedTokenIdentity` with an explicit workspace, identity name, identity spec name, and fixed-token setup. Use the workspace identity client to list, fetch, or delete identities for that same workspace. If no workspace-scoped spec exists, creation resolves the matching global spec and reports that global scope in the response.

## Verification

- Focused workspace identity gRPC lifecycle test
- All-feature focused Clippy for `coral-app`
- Two independent closeout reviews: clean with high confidence
- `make rust-checks` (1,978 tests passed; 7 skipped)