### PR TITLE
feat(cli): manage exact identity specs

### DIFF
--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -308,9 +308,8 @@ workspace-scoped artifacts such as source manifests, local credential material,
 feedback reports, and workspace-attributed local trace history.
 
 Imported source specs and source credential material are attached to the source
-installation in that workspace. Reusable global source specs and reusable
-credential references are separate concepts and are not represented by
-`coral workspace` today.
+installation in that workspace. Reusable identity specs are managed separately
+with `coral identity-spec`.
 
 ### `coral workspace list`
 
@@ -340,6 +339,52 @@ coral workspace remove work
 ```
 
 The `default` workspace cannot be removed.
+
+## `coral identity-spec`
+
+Manage reusable identity specifications in one exact scope. Commands target the selected workspace by default. Pass `--global` to target global scope instead; `--global` cannot be combined with an explicit `--workspace`.
+
+### `coral identity-spec add --file <PATH>`
+
+Validate, then install or replace an identity spec in the requested exact scope.
+
+```shellscript
+coral identity-spec add --file ./github-token.identity.yaml
+coral identity-spec --global add --file ./github-token.identity.yaml
+coral identity-spec add --file ./oauth.identity.yaml --interactive
+```
+
+By default, declare each setup value through an environment variable with the same name as its manifest input key. Pass `--interactive` in a terminal to prompt for missing values; secret prompts are hidden, and already-set environment values are preserved. Setup values are write-only and are never rendered by list or info commands.
+
+### `coral identity-spec list`
+
+List specs in the requested exact scope. For a workspace scope, `--include-global` also returns global specs without collapsing same-name specs from the two scopes.
+
+```shellscript
+coral identity-spec list
+coral identity-spec list --include-global --workspace work
+coral identity-spec --global list
+```
+
+### `coral identity-spec info <NAME>`
+
+Show the validated manifest and metadata for one spec in the requested exact scope.
+
+```shellscript
+coral identity-spec info github_token
+coral identity-spec --global info github_token
+```
+
+### `coral identity-spec remove <NAME>`
+
+Remove one spec from the requested exact scope. Coral rejects deletion while
+stored identities still reference that exact spec; remove those identities
+first.
+
+```shellscript
+coral identity-spec remove github_token
+coral identity-spec --global remove github_token
+```
 
 ## `coral functions`
 

--- a/crates/coral-cli/src/identity_spec_ops.rs
+++ b/crates/coral-cli/src/identity_spec_ops.rs
@@ -1,0 +1,432 @@
+//! Terminal adapter for exact-scope identity-spec lifecycle operations.
+
+use std::io::{IsTerminal as _, stdin, stdout};
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+use clap::{Args, Subcommand};
+use coral_api::v1::{
+    AddIdentitySpecRequest, DeleteIdentitySpecRequest, GetIdentitySpecRequest,
+    GlobalIdentitySpecScope, IdentitySpec, IdentitySpecInputValue, IdentitySpecScope,
+    IdentitySpecType, ListIdentitySpecsRequest, Workspace, identity_spec_scope,
+};
+use coral_client::AppClient;
+use coral_spec::{IdentityManifest, ManifestInputKind, ManifestInputSpec};
+use dialoguer::{Input, Password, theme::ColorfulTheme};
+use tonic::Request;
+
+use crate::source_ops::display_version;
+
+#[derive(Debug, Args)]
+/// Manage installed identity specifications
+pub(crate) struct IdentitySpecArgs {
+    /// Use global identity-spec scope instead of the selected workspace
+    #[arg(long, global = true)]
+    global: bool,
+    #[command(subcommand)]
+    command: IdentitySpecCommand,
+}
+
+impl IdentitySpecArgs {
+    pub(crate) fn validate_explicit_workspace(
+        &self,
+        workspace: Option<&str>,
+    ) -> Result<(), anyhow::Error> {
+        if self.global && workspace.is_some() {
+            anyhow::bail!("--global cannot be used together with --workspace");
+        }
+        if self.global
+            && matches!(
+                self.command,
+                IdentitySpecCommand::List {
+                    include_global: true
+                }
+            )
+        {
+            anyhow::bail!("--include-global cannot be used together with --global");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Subcommand)]
+enum IdentitySpecCommand {
+    /// Install or replace an identity spec from a manifest file
+    Add {
+        /// Path to an identity-spec YAML file
+        #[arg(long)]
+        file: PathBuf,
+        /// Prompt for missing setup inputs instead of using only environment variables
+        #[arg(long)]
+        interactive: bool,
+    },
+    /// List installed identity specs in the requested exact scope
+    List {
+        /// Include global specs alongside the selected workspace's specs
+        #[arg(long)]
+        include_global: bool,
+    },
+    /// Show one installed identity spec in the requested exact scope
+    Info {
+        /// Identity-spec name
+        name: String,
+    },
+    /// Remove one installed identity spec from the requested exact scope
+    Remove {
+        /// Identity-spec name
+        name: String,
+    },
+}
+
+pub(crate) async fn run(
+    app: &AppClient,
+    selected_workspace: &Workspace,
+    args: IdentitySpecArgs,
+) -> Result<(), anyhow::Error> {
+    let IdentitySpecArgs { global, command } = args;
+    let scope = requested_scope(global, selected_workspace);
+
+    match command {
+        IdentitySpecCommand::Add { file, interactive } => {
+            let (manifest_yaml, manifest) = load_manifest(&file)?;
+            let input_values = input_values_for_add(&manifest, interactive)?;
+            let response = app
+                .identity_spec_client()
+                .add_identity_spec(Request::new(AddIdentitySpecRequest {
+                    manifest_yaml,
+                    input_values,
+                    scope: Some(scope),
+                }))
+                .await?
+                .into_inner();
+            let identity_spec = response.identity_spec.ok_or_else(|| {
+                anyhow::anyhow!("add identity spec response missing identity_spec")
+            })?;
+            let action = if response.replaced {
+                "Replaced"
+            } else {
+                "Added"
+            };
+            println!(
+                "{action} identity spec '{}' ({}) in {}.",
+                identity_spec.name,
+                display_version(&identity_spec.version),
+                scope_description(identity_spec.scope.as_ref())?
+            );
+        }
+        IdentitySpecCommand::List { include_global } => {
+            let requested = requested_scope_description(&scope, include_global)?;
+            let response = app
+                .identity_spec_client()
+                .list_identity_specs(Request::new(ListIdentitySpecsRequest {
+                    scope: Some(scope),
+                    include_global,
+                }))
+                .await?
+                .into_inner();
+            if response.identity_specs.is_empty() {
+                println!("No identity specs installed for {requested}.");
+            } else {
+                let rows = response
+                    .identity_specs
+                    .into_iter()
+                    .map(|identity_spec| {
+                        Ok([
+                            identity_spec.name,
+                            display_version(&identity_spec.version),
+                            identity_spec.issuer,
+                            identity_type_label(identity_spec.identity_type).to_string(),
+                            scope_column(identity_spec.scope.as_ref())?,
+                        ])
+                    })
+                    .collect::<Result<Vec<_>, anyhow::Error>>()?;
+                super::print_text_table(
+                    ["Identity Spec", "Version", "Issuer", "Type", "Scope"],
+                    rows,
+                );
+            }
+        }
+        IdentitySpecCommand::Info { name } => {
+            let response = app
+                .identity_spec_client()
+                .get_identity_spec(Request::new(GetIdentitySpecRequest {
+                    name,
+                    scope: Some(scope),
+                }))
+                .await?
+                .into_inner();
+            let identity_spec = response.identity_spec.ok_or_else(|| {
+                anyhow::anyhow!("get identity spec response missing identity_spec")
+            })?;
+            print_info(&identity_spec)?;
+        }
+        IdentitySpecCommand::Remove { name } => {
+            let scope_description = scope_description(Some(&scope))?;
+            app.identity_spec_client()
+                .delete_identity_spec(Request::new(DeleteIdentitySpecRequest {
+                    name: name.clone(),
+                    scope: Some(scope),
+                }))
+                .await?;
+            println!("Removed identity spec '{name}' from {scope_description}.");
+        }
+    }
+    Ok(())
+}
+
+fn requested_scope(global: bool, workspace: &Workspace) -> IdentitySpecScope {
+    let value = if global {
+        identity_spec_scope::Value::Global(GlobalIdentitySpecScope {})
+    } else {
+        identity_spec_scope::Value::Workspace(workspace.clone())
+    };
+    IdentitySpecScope { value: Some(value) }
+}
+
+fn load_manifest(file: &Path) -> Result<(String, IdentityManifest), anyhow::Error> {
+    let manifest_yaml = std::fs::read_to_string(file)
+        .with_context(|| format!("failed to read identity spec '{}'", file.display()))?;
+    let manifest = coral_spec::parse_identity_manifest_yaml(&manifest_yaml)
+        .with_context(|| format!("invalid identity spec '{}'", file.display()))?;
+    Ok((manifest_yaml, manifest))
+}
+
+fn input_values_for_add(
+    manifest: &IdentityManifest,
+    interactive: bool,
+) -> Result<Vec<IdentitySpecInputValue>, anyhow::Error> {
+    if interactive && (!stdin().is_terminal() || !stdout().is_terminal()) {
+        anyhow::bail!("interactive identity-spec add requires a TTY");
+    }
+    if manifest.inputs.is_empty() {
+        return Ok(Vec::new());
+    }
+    if interactive {
+        prompt_input_values(&manifest.inputs)
+    } else {
+        Ok(collect_input_values(&manifest.inputs, read_input_env))
+    }
+}
+
+fn collect_input_values(
+    inputs: &[ManifestInputSpec],
+    mut lookup: impl FnMut(&str) -> Option<String>,
+) -> Vec<IdentitySpecInputValue> {
+    inputs
+        .iter()
+        .filter_map(|input| {
+            lookup(&input.key)
+                .filter(|value| !value.trim().is_empty())
+                .map(|value| IdentitySpecInputValue {
+                    key: input.key.clone(),
+                    value,
+                })
+        })
+        .collect()
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "identity-spec add reads declared setup inputs from matching environment variables outside a TTY"
+)]
+fn read_input_env(key: &str) -> Option<String> {
+    std::env::var(key).ok()
+}
+
+fn prompt_input_values(
+    inputs: &[ManifestInputSpec],
+) -> Result<Vec<IdentitySpecInputValue>, anyhow::Error> {
+    let theme = ColorfulTheme::default();
+    let mut values = Vec::new();
+    for input in inputs {
+        if let Some(value) = read_input_env(&input.key).filter(|value| !value.trim().is_empty()) {
+            values.push(IdentitySpecInputValue {
+                key: input.key.clone(),
+                value,
+            });
+            continue;
+        }
+        if let Some(hint) = input.hint.as_deref().filter(|hint| !hint.trim().is_empty()) {
+            println!("  Hint: {hint}");
+        }
+        let value = match input.kind {
+            ManifestInputKind::Variable => Input::<String>::with_theme(&theme)
+                .with_prompt(variable_prompt(input))
+                .allow_empty(true)
+                .interact_text()?,
+            ManifestInputKind::Secret => Password::with_theme(&theme)
+                .with_prompt(&input.key)
+                .allow_empty_password(true)
+                .interact()?,
+        };
+        if !value.trim().is_empty() {
+            values.push(IdentitySpecInputValue {
+                key: input.key.clone(),
+                value,
+            });
+        }
+    }
+    Ok(values)
+}
+
+fn variable_prompt(input: &ManifestInputSpec) -> String {
+    if input.default_value.is_empty() {
+        input.key.clone()
+    } else {
+        format!("{} [{}]", input.key, input.default_value)
+    }
+}
+
+fn scope_value(
+    scope: Option<&IdentitySpecScope>,
+) -> Result<&identity_spec_scope::Value, anyhow::Error> {
+    scope
+        .and_then(|scope| scope.value.as_ref())
+        .ok_or_else(|| anyhow::anyhow!("identity spec response missing exact scope"))
+}
+
+fn scope_column(scope: Option<&IdentitySpecScope>) -> Result<String, anyhow::Error> {
+    match scope_value(scope)? {
+        identity_spec_scope::Value::Global(_) => Ok("global".to_string()),
+        identity_spec_scope::Value::Workspace(workspace) => {
+            Ok(format!("workspace:{}", workspace.name))
+        }
+    }
+}
+
+fn scope_description(scope: Option<&IdentitySpecScope>) -> Result<String, anyhow::Error> {
+    match scope_value(scope)? {
+        identity_spec_scope::Value::Global(_) => Ok("global scope".to_string()),
+        identity_spec_scope::Value::Workspace(workspace) => {
+            Ok(format!("workspace '{}'", workspace.name))
+        }
+    }
+}
+
+fn requested_scope_description(
+    scope: &IdentitySpecScope,
+    include_global: bool,
+) -> Result<String, anyhow::Error> {
+    match (scope_value(Some(scope))?, include_global) {
+        (identity_spec_scope::Value::Workspace(workspace), true) => {
+            Ok(format!("workspace '{}' or global scope", workspace.name))
+        }
+        _ => scope_description(Some(scope)),
+    }
+}
+
+fn identity_type_label(value: i32) -> &'static str {
+    match IdentitySpecType::try_from(value) {
+        Ok(IdentitySpecType::Oauth) => "oauth",
+        Ok(IdentitySpecType::FixedToken) => "fixed_token",
+        Ok(IdentitySpecType::Unspecified) | Err(_) => "unknown",
+    }
+}
+
+fn print_info(identity_spec: &IdentitySpec) -> Result<(), anyhow::Error> {
+    println!("{}", identity_spec.name);
+    println!(
+        "  Scope:       {}",
+        scope_column(identity_spec.scope.as_ref())?
+    );
+    println!("  Version:     {}", display_version(&identity_spec.version));
+    println!("  Description: {}", identity_spec.description);
+    println!("  Issuer:      {}", identity_spec.issuer);
+    println!(
+        "  Type:        {}",
+        identity_type_label(identity_spec.identity_type)
+    );
+    println!("  Manifest:");
+    print!("{}", identity_spec.manifest_yaml);
+    if !identity_spec.manifest_yaml.ends_with('\n') {
+        println!();
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser as _;
+    use coral_api::v1::IdentitySpecInputValue;
+
+    use super::collect_input_values;
+    use crate::{Cli, Command, RequiredRuntime};
+
+    fn identity_spec_args(args: &[&str]) -> super::IdentitySpecArgs {
+        let cli = Cli::try_parse_from(args).expect("identity-spec args parse");
+        let Command::IdentitySpec(args) = cli.command else {
+            panic!("expected identity-spec command");
+        };
+        args
+    }
+
+    #[test]
+    fn command_requires_app_client_and_rejects_unsafe_or_incomplete_args() {
+        assert_eq!(
+            Cli::try_parse_from(["coral", "identity-spec", "list"])
+                .expect("list parses")
+                .command
+                .required_runtime(),
+            RequiredRuntime::AppClient
+        );
+        Cli::try_parse_from(["coral", "identity-spec", "add"])
+            .expect_err("add requires a manifest file");
+        Cli::try_parse_from(["coral", "identity-spec", "remove", "demo", "--force"])
+            .expect_err("force deletion must not be exposed");
+    }
+
+    #[test]
+    fn global_scope_rejects_explicit_workspace_and_include_global() {
+        let args = identity_spec_args(&[
+            "coral",
+            "--workspace",
+            "work",
+            "identity-spec",
+            "--global",
+            "list",
+        ]);
+        assert!(args.validate_explicit_workspace(Some("work")).is_err());
+        let args = identity_spec_args(&[
+            "coral",
+            "identity-spec",
+            "--global",
+            "list",
+            "--include-global",
+        ]);
+        assert!(args.validate_explicit_workspace(None).is_err());
+    }
+
+    #[test]
+    fn environment_inputs_preserve_order_and_omit_blank_values() {
+        let inputs = vec![
+            coral_spec::ManifestInputSpec {
+                key: "TENANT".to_string(),
+                kind: coral_spec::ManifestInputKind::Variable,
+                default_value: String::new(),
+                required: false,
+                hint: None,
+                credential: None,
+            },
+            coral_spec::ManifestInputSpec {
+                key: "CLIENT_SECRET".to_string(),
+                kind: coral_spec::ManifestInputKind::Secret,
+                default_value: String::new(),
+                required: true,
+                hint: None,
+                credential: None,
+            },
+        ];
+        let values = collect_input_values(&inputs, |key| match key {
+            "TENANT" => Some("  ".to_string()),
+            "CLIENT_SECRET" => Some("secret-value".to_string()),
+            _ => None,
+        });
+        assert_eq!(
+            values,
+            vec![IdentitySpecInputValue {
+                key: "CLIENT_SECRET".to_string(),
+                value: "secret-value".to_string(),
+            }]
+        );
+    }
+}

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -11,6 +11,7 @@ mod bootstrap;
 mod branding;
 mod browser;
 pub mod env;
+mod identity_spec_ops;
 mod onboard;
 mod query_error;
 mod serve;
@@ -78,6 +79,8 @@ enum Command {
     SearchIndex(SearchIndexArgs),
     /// Manage data sources
     Source(SourceArgs),
+    /// Manage installed identity specifications
+    IdentitySpec(identity_spec_ops::IdentitySpecArgs),
     /// Manage workspaces
     Workspace(WorkspaceArgs),
     /// Manage functions
@@ -513,6 +516,7 @@ impl Command {
             | Command::Search(_)
             | Command::SearchIndex(_)
             | Command::Source(_)
+            | Command::IdentitySpec(_)
             | Command::Workspace(_)
             | Command::Function(_)
             | Command::Onboard
@@ -534,6 +538,7 @@ impl Command {
                 | Command::Search(_)
                 | Command::SearchIndex(_)
                 | Command::Source(_)
+                | Command::IdentitySpec(_)
                 | Command::Function(_)
                 | Command::Onboard
                 | Command::McpStdio(_)
@@ -613,6 +618,9 @@ pub async fn run_from_env() -> Result<(), CliError> {
     } = Cli::parse();
     let workspace_flag_present = workspace_selection.workspace.is_some();
     command.apply_workspace_flag_presence(workspace_flag_present);
+    if let Command::IdentitySpec(args) = &command {
+        args.validate_explicit_workspace(workspace_selection.workspace.as_deref())?;
+    }
     let feature_overrides = feature_overrides.into_overrides();
     let ctx = coral_app::RunContext {
         trace_parent: env::trace_parent(),
@@ -835,6 +843,7 @@ async fn run_no_runtime_command(
         | Command::Search(_)
         | Command::SearchIndex(_)
         | Command::Source(_)
+        | Command::IdentitySpec(_)
         | Command::Workspace(_)
         | Command::Function(_)
         | Command::Onboard
@@ -878,6 +887,7 @@ async fn run_app_command(
         Command::Search(args) => run_search(&app, workspace, args).await?,
         Command::SearchIndex(args) => run_search_index(&app, workspace, args).await?,
         Command::Source(args) => run_source(&app, workspace, args).await?,
+        Command::IdentitySpec(args) => identity_spec_ops::run(&app, workspace, args).await?,
         Command::Workspace(args) => run_workspace(&app, args).await?,
         Command::Function(args) => run_function(&app, workspace, args).await?,
         Command::Onboard => {
@@ -2035,6 +2045,8 @@ mod tests {
         let search =
             Cli::try_parse_from(["coral", "search", "github", "issues"]).expect("search parses");
         let source = Cli::try_parse_from(["coral", "source", "list"]).expect("source parses");
+        let identity_spec = Cli::try_parse_from(["coral", "identity-spec", "list"])
+            .expect("identity-spec list parses");
         let functions =
             Cli::try_parse_from(["coral", "functions", "list"]).expect("functions parses");
         let onboard = Cli::try_parse_from(["coral", "onboard"]).expect("onboard parses");
@@ -2045,6 +2057,7 @@ mod tests {
         assert!(sql.command.uses_selected_workspace());
         assert!(search.command.uses_selected_workspace());
         assert!(source.command.uses_selected_workspace());
+        assert!(identity_spec.command.uses_selected_workspace());
         assert!(functions.command.uses_selected_workspace());
         assert!(onboard.command.uses_selected_workspace());
         assert!(mcp.command.uses_selected_workspace());


### PR DESCRIPTION
## Intent

Expose the exact-scope identity-spec lifecycle through the Coral CLI now that the persistence, manager, and gRPC service layers are available. Keep workspace and global scopes explicit, preserve existing same-kind setup material when replacement inputs are omitted, and retain strict referenced-spec deletion guards.

## What it enables

- Add or replace an identity spec in the selected workspace or global scope.
- List exact-scope specs, optionally including global specs alongside a workspace.
- Inspect validated manifest metadata without exposing stored setup values.
- Remove unreferenced specs without a force-or-orphan escape hatch.
- Collect setup values deterministically from matching environment variables, with an explicit hidden-prompt interactive mode for missing values.

## Usage examples

```shell
coral identity-spec add --file ./github-token.identity.yaml
coral identity-spec --global add --file ./oauth.identity.yaml --interactive
coral identity-spec list --include-global --workspace work
coral identity-spec info github_token
coral identity-spec --global remove github_token
```

## Validation

- `cargo test --locked -p coral-cli --all-features --lib identity_spec_ops`
- `make docs-check`
- `make rust-checks` (1,981 tests passed; 7 skipped)
- Two independent frozen-diff reviews, both clean at high confidence
