### PR TITLE
test(cli): cover exact identity-spec commands

### DIFF
--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -26,8 +26,8 @@ use tempfile::tempdir;
 use tonic::Code;
 
 use harness::{
-    MockServer, MockServerConfig, assert_default_workspace, assert_workspace_name,
-    encode_arrow_ipc_stream,
+    MockServer, MockServerConfig, assert_default_workspace, assert_identity_spec_global_scope,
+    assert_identity_spec_workspace_scope, assert_workspace_name, encode_arrow_ipc_stream,
 };
 
 fn nonempty_lines(output: &str) -> Vec<&str> {
@@ -37,6 +37,28 @@ fn nonempty_lines(output: &str) -> Vec<&str> {
         .filter(|line| !line.is_empty())
         .collect()
 }
+
+const IDENTITY_SPEC_WITH_INPUTS: &str = r"kind: identity
+spec_version: 1
+name: demo_oauth
+version: 1.0.0
+issuer: demo
+type: oauth
+audience: {host: api.example.com}
+inputs:
+  TENANT: {kind: variable, default: public}
+  CLIENT_SECRET: {kind: secret, required: true}
+oauth:
+  method:
+    flow: {type: authorization_code, pkce: disabled}
+    redirect_uri: http://127.0.0.1:53682/oauth/callback
+    endpoints:
+      authorization_url: https://provider.example.com/authorize
+      token_url: https://provider.example.com/token
+    client:
+      id: {input: TENANT}
+      secret: {input: CLIENT_SECRET, transport: basic_auth}
+";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn sql_command_renders_table_output() {
@@ -357,6 +379,204 @@ async fn workspace_remove_sends_request() {
     let requests = server.delete_workspace_requests();
     assert_eq!(requests.len(), 1, "expected one delete_workspace call");
     assert_workspace_name(requests[0].workspace.as_ref(), "work");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_add_preserves_manifest_inputs_and_workspace_selection() {
+    let server = MockServer::start().await;
+    let directory = tempdir().expect("identity spec dir");
+    let manifest = directory.path().join("identity.yaml");
+    std::fs::write(&manifest, IDENTITY_SPEC_WITH_INPUTS).expect("write identity spec");
+    let secret = "super-secret-sentinel";
+
+    let assert = server
+        .cmd()
+        .env("CORAL_WORKSPACE", "env-work")
+        .env("TENANT", "tenant-from-env")
+        .env("CLIENT_SECRET", secret)
+        .args(["identity-spec", "add", "--file"])
+        .arg(&manifest)
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stdout.contains("Added identity spec 'demo_oauth'")
+            && stdout.contains("workspace 'env-work'"),
+        "unexpected add output: {stdout}"
+    );
+    assert!(!stdout.contains(secret), "secret leaked to stdout");
+    assert!(!stderr.contains(secret), "secret leaked to stderr");
+
+    server
+        .cmd()
+        .env_remove("CORAL_WORKSPACE")
+        .env_remove("TENANT")
+        .env_remove("CLIENT_SECRET")
+        .args(["identity-spec", "add", "--file"])
+        .arg(&manifest)
+        .assert()
+        .success()
+        .stdout("Replaced identity spec 'demo_oauth' (1.0.0) in workspace 'default'.\n");
+
+    let requests = server.add_identity_spec_requests();
+    assert_eq!(requests.len(), 2, "expected two add calls");
+    for request in &requests {
+        assert_eq!(request.manifest_yaml, IDENTITY_SPEC_WITH_INPUTS);
+    }
+    assert_identity_spec_workspace_scope(requests[0].scope.as_ref(), "env-work");
+    assert_eq!(
+        requests[0]
+            .input_values
+            .iter()
+            .map(|input| (input.key.as_str(), input.value.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("TENANT", "tenant-from-env"), ("CLIENT_SECRET", secret)]
+    );
+    assert_identity_spec_workspace_scope(requests[1].scope.as_ref(), "default");
+    assert!(requests[1].input_values.is_empty());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_list_and_info_use_exact_scopes_and_render_safely() {
+    let server = MockServer::start().await;
+
+    let list = server
+        .cmd()
+        .env("CORAL_WORKSPACE", "ignored")
+        .args([
+            "--workspace",
+            "work",
+            "identity-spec",
+            "list",
+            "--include-global",
+        ])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&list.get_output().stdout);
+    let rows = nonempty_lines(&stdout);
+    for expected in [
+        ["global_demo", "1.0.0", "demo", "fixed_token", "global"],
+        [
+            "workspace_demo",
+            "1.0.0",
+            "demo",
+            "unknown",
+            "workspace:work",
+        ],
+    ] {
+        assert!(
+            rows.iter().any(|row| row.split_whitespace().eq(expected)),
+            "missing row {expected:?}: {stdout}"
+        );
+    }
+    let lists = server.list_identity_specs_requests();
+    assert_eq!(lists.len(), 1);
+    assert_identity_spec_workspace_scope(lists[0].scope.as_ref(), "work");
+    assert!(lists[0].include_global);
+
+    let info = server
+        .cmd()
+        .env("CORAL_WORKSPACE", "ignored")
+        .args(["identity-spec", "--global", "info", "global_demo"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&info.get_output().stdout);
+    for expected in [
+        "global_demo",
+        "Scope:       global",
+        "Type:        fixed_token",
+        "Manifest:",
+        "name: global_demo",
+    ] {
+        assert!(stdout.contains(expected), "missing {expected:?}: {stdout}");
+    }
+    let gets = server.get_identity_spec_requests();
+    assert_eq!(gets.len(), 1);
+    assert_identity_spec_global_scope(gets[0].scope.as_ref());
+
+    let missing_scope = server
+        .cmd()
+        .env_remove("CORAL_WORKSPACE")
+        .args(["identity-spec", "info", "missing_scope"])
+        .assert()
+        .failure();
+    assert!(
+        String::from_utf8_lossy(&missing_scope.get_output().stderr)
+            .contains("identity spec response missing exact scope")
+    );
+    let gets = server.get_identity_spec_requests();
+    assert_eq!(gets.len(), 2);
+    assert_identity_spec_workspace_scope(gets[1].scope.as_ref(), "default");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_remove_uses_strict_global_request() {
+    let server = MockServer::start().await;
+
+    server
+        .cmd()
+        .env("CORAL_WORKSPACE", "ignored")
+        .args(["identity-spec", "remove", "global_demo", "--global"])
+        .assert()
+        .success()
+        .stdout("Removed identity spec 'global_demo' from global scope.\n");
+    let requests = server.delete_identity_spec_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].name, "global_demo");
+    assert_identity_spec_global_scope(requests[0].scope.as_ref());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn identity_spec_invalid_scope_and_interactive_args_send_no_rpc() {
+    let server = MockServer::start().await;
+    let directory = tempdir().expect("identity spec dir");
+    let manifest = directory.path().join("identity.yaml");
+    std::fs::write(&manifest, IDENTITY_SPEC_WITH_INPUTS).expect("write identity spec");
+
+    server
+        .cmd()
+        .args(["--workspace", "work", "identity-spec", "--global", "list"])
+        .assert()
+        .failure();
+    server
+        .cmd()
+        .args(["identity-spec", "--global", "list", "--include-global"])
+        .assert()
+        .failure();
+    let interactive = server
+        .cmd()
+        .env_remove("CORAL_WORKSPACE")
+        .env_remove("TENANT")
+        .env_remove("CLIENT_SECRET")
+        .args(["identity-spec", "add", "--interactive", "--file"])
+        .arg(&manifest)
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&interactive.get_output().stderr);
+    assert!(
+        stderr.contains("interactive identity-spec add requires a TTY"),
+        "unexpected stderr: {stderr}"
+    );
+    server
+        .cmd()
+        .args(["identity-spec", "remove", "demo", "--force"])
+        .assert()
+        .failure();
+    server
+        .cmd()
+        .args(["identity-spec", "remove", "demo", "--orphan"])
+        .assert()
+        .failure();
+    assert_eq!(server.identity_spec_request_count(), 0);
 
     server.shutdown().await;
 }

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -16,36 +16,41 @@ use arrow::record_batch::RecordBatch;
 use assert_cmd::Command;
 use coral_api::v1::catalog_service_server::{CatalogService, CatalogServiceServer};
 use coral_api::v1::function_service_server::{FunctionService, FunctionServiceServer};
+use coral_api::v1::identity_spec_service_server::{IdentitySpecService, IdentitySpecServiceServer};
 use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::search_service_server::{SearchService, SearchServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::task_service_server::{TaskService, TaskServiceServer};
 use coral_api::v1::workspace_service_server::{WorkspaceService, WorkspaceServiceServer};
 use coral_api::v1::{
-    AddFunctionRequest, AddFunctionResponse, CatalogClearResult, CatalogCounts, CatalogItem,
-    CatalogRebuildResult, CatalogSearchResult, ClearSearchDataRequest, ClearSearchDataResponse,
-    Column, ColumnSearchResult, CreateBundledSourceRequest, CreateBundledSourceResponse,
-    CreateBundledSourceWithOAuthRequest, CreateBundledSourceWithOAuthResponse,
-    CreateWorkspaceRequest, CreateWorkspaceResponse, DeleteFunctionRequest, DeleteFunctionResponse,
-    DeleteSourceRequest, DeleteSourceResponse, DeleteWorkspaceRequest, DeleteWorkspaceResponse,
-    DescribeCatalogSurfaceRequest, DescribeCatalogSurfaceResponse, DiscoverSourcesRequest,
-    DiscoverSourcesResponse, DrainSearchQueueRequest, DrainSearchQueueResponse, EndTaskRequest,
-    EndTaskResponse, ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
-    GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest, GetSourceResponse,
-    ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListCatalogResponse,
-    ListColumnsRequest, ListColumnsResponse, ListFunctionsRequest, ListFunctionsResponse,
-    ListSourcesRequest, ListSourcesResponse, ListWorkspacesRequest, ListWorkspacesResponse,
-    MissingCatalogSurface, ObservedDrainResult, ObservedRebuildResult, PaginationRequest,
-    PaginationResponse, QueryPlan, RebuildSearchIndexRequest, RebuildSearchIndexResponse,
-    SearchCatalogRequest, SearchCatalogResponse, SearchField, SearchMaintenanceResult,
-    SearchMaintenanceState, SearchProvider, SearchProviderCoverage, SearchProviderState,
-    SearchRequest, SearchResponse, SearchResult, SearchResultTruncation,
+    AddFunctionRequest, AddFunctionResponse, AddIdentitySpecRequest, AddIdentitySpecResponse,
+    CatalogClearResult, CatalogCounts, CatalogItem, CatalogRebuildResult, CatalogSearchResult,
+    ClearSearchDataRequest, ClearSearchDataResponse, Column, ColumnSearchResult,
+    CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
+    CreateBundledSourceWithOAuthResponse, CreateWorkspaceRequest, CreateWorkspaceResponse,
+    DeleteFunctionRequest, DeleteFunctionResponse, DeleteIdentitySpecRequest,
+    DeleteIdentitySpecResponse, DeleteSourceRequest, DeleteSourceResponse, DeleteWorkspaceRequest,
+    DeleteWorkspaceResponse, DescribeCatalogSurfaceRequest, DescribeCatalogSurfaceResponse,
+    DiscoverSourcesRequest, DiscoverSourcesResponse, DrainSearchQueueRequest,
+    DrainSearchQueueResponse, EndTaskRequest, EndTaskResponse, ExecuteSqlRequest,
+    ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse, GetIdentitySpecRequest,
+    GetIdentitySpecResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
+    GetSourceResponse, GlobalIdentitySpecScope, IdentitySpec, IdentitySpecScope,
+    IdentitySpecSummary, IdentitySpecType, ImportSourceRequest, ImportSourceResponse,
+    ListCatalogRequest, ListCatalogResponse, ListColumnsRequest, ListColumnsResponse,
+    ListFunctionsRequest, ListFunctionsResponse, ListIdentitySpecsRequest,
+    ListIdentitySpecsResponse, ListSourcesRequest, ListSourcesResponse, ListWorkspacesRequest,
+    ListWorkspacesResponse, MissingCatalogSurface, ObservedDrainResult, ObservedRebuildResult,
+    PaginationRequest, PaginationResponse, QueryPlan, RebuildSearchIndexRequest,
+    RebuildSearchIndexResponse, SearchCatalogRequest, SearchCatalogResponse, SearchField,
+    SearchMaintenanceResult, SearchMaintenanceState, SearchProvider, SearchProviderCoverage,
+    SearchProviderState, SearchRequest, SearchResponse, SearchResult, SearchResultTruncation,
     SearchStorageCleanupResult, SearchSurfaceRef, SearchTableShape, Source,
     SourceCredentialStorage, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput,
     StartTaskRequest, StartTaskResponse, Table, TableFunction, TableSummary, Task as ProtoTask,
     TaskEnd as ProtoTaskEnd, TaskStatus, ValidateSourceRequest, ValidateSourceResponse, Workspace,
     catalog_item, create_bundled_source_with_o_auth_response, describe_catalog_surface_response,
-    import_source_response, search_maintenance_result, search_result,
+    identity_spec_scope, import_source_response, search_maintenance_result, search_result,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{
@@ -67,6 +72,51 @@ fn workspace() -> Workspace {
     }
 }
 
+fn global_identity_spec_scope() -> IdentitySpecScope {
+    IdentitySpecScope {
+        value: Some(identity_spec_scope::Value::Global(
+            GlobalIdentitySpecScope {},
+        )),
+    }
+}
+
+fn identity_spec_manifest(name: &str) -> String {
+    format!(
+        "kind: identity\nspec_version: 1\nname: {name}\nversion: 1.0.0\nissuer: demo\ntype: fixed_token\n"
+    )
+}
+
+fn mock_identity_spec(
+    name: &str,
+    identity_type: i32,
+    scope: Option<IdentitySpecScope>,
+) -> IdentitySpec {
+    IdentitySpec {
+        name: name.to_string(),
+        version: "1.0.0".to_string(),
+        description: "Mock identity spec".to_string(),
+        issuer: "demo".to_string(),
+        identity_type,
+        manifest_yaml: identity_spec_manifest(name),
+        scope,
+    }
+}
+
+fn mock_identity_spec_summary(
+    name: &str,
+    identity_type: i32,
+    scope: IdentitySpecScope,
+) -> IdentitySpecSummary {
+    IdentitySpecSummary {
+        name: name.to_string(),
+        version: "1.0.0".to_string(),
+        description: "Mock identity spec".to_string(),
+        issuer: "demo".to_string(),
+        identity_type,
+        scope: Some(scope),
+    }
+}
+
 pub(crate) fn assert_default_workspace(workspace: Option<&Workspace>) {
     assert_workspace_name(workspace, "default");
 }
@@ -76,6 +126,28 @@ pub(crate) fn assert_workspace_name(workspace: Option<&Workspace>, expected: &st
         workspace.map(|workspace| workspace.name.as_str()),
         Some(expected),
         "expected workspace {expected:?}, got {workspace:?}"
+    );
+}
+
+pub(crate) fn assert_identity_spec_workspace_scope(
+    scope: Option<&IdentitySpecScope>,
+    expected: &str,
+) {
+    match scope.and_then(|scope| scope.value.as_ref()) {
+        Some(identity_spec_scope::Value::Workspace(workspace)) => {
+            assert_eq!(workspace.name, expected);
+        }
+        other => panic!("expected identity-spec workspace scope {expected:?}, got {other:?}"),
+    }
+}
+
+pub(crate) fn assert_identity_spec_global_scope(scope: Option<&IdentitySpecScope>) {
+    assert!(
+        matches!(
+            scope.and_then(|scope| scope.value.as_ref()),
+            Some(identity_spec_scope::Value::Global(_))
+        ),
+        "expected global identity-spec scope, got {scope:?}"
     );
 }
 
@@ -881,6 +953,10 @@ struct Captured {
     delete_workspace: Mutex<Vec<DeleteWorkspaceRequest>>,
     start_task: Mutex<Vec<StartTaskRequest>>,
     end_task: Mutex<Vec<EndTaskRequest>>,
+    add_identity_spec: Mutex<Vec<AddIdentitySpecRequest>>,
+    list_identity_specs: Mutex<Vec<ListIdentitySpecsRequest>>,
+    get_identity_spec: Mutex<Vec<GetIdentitySpecRequest>>,
+    delete_identity_spec: Mutex<Vec<DeleteIdentitySpecRequest>>,
 }
 
 pub(crate) fn encode_arrow_ipc_stream(
@@ -1168,6 +1244,120 @@ impl CatalogService for MockCatalogService {
             columns,
             pagination: Some(pagination),
         }))
+    }
+}
+
+#[derive(Clone)]
+struct MockIdentitySpecService {
+    captured: Arc<Captured>,
+}
+
+#[tonic::async_trait]
+impl IdentitySpecService for MockIdentitySpecService {
+    async fn add_identity_spec(
+        &self,
+        request: Request<AddIdentitySpecRequest>,
+    ) -> Result<Response<AddIdentitySpecResponse>, Status> {
+        let request = request.into_inner();
+        let replaced = request.input_values.is_empty();
+        self.captured
+            .add_identity_spec
+            .lock()
+            .expect("add_identity_spec capture")
+            .push(request.clone());
+        Ok(Response::new(AddIdentitySpecResponse {
+            identity_spec: Some(IdentitySpec {
+                name: "demo_oauth".to_string(),
+                version: "1.0.0".to_string(),
+                description: "Mock identity spec".to_string(),
+                issuer: "demo".to_string(),
+                identity_type: IdentitySpecType::Oauth as i32,
+                manifest_yaml: request.manifest_yaml,
+                scope: request.scope,
+            }),
+            replaced,
+        }))
+    }
+
+    async fn list_identity_specs(
+        &self,
+        request: Request<ListIdentitySpecsRequest>,
+    ) -> Result<Response<ListIdentitySpecsResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .list_identity_specs
+            .lock()
+            .expect("list_identity_specs capture")
+            .push(request.clone());
+        let mut identity_specs = Vec::new();
+        match request
+            .scope
+            .as_ref()
+            .and_then(|scope| scope.value.as_ref())
+        {
+            Some(identity_spec_scope::Value::Global(_)) => {
+                identity_specs.push(mock_identity_spec_summary(
+                    "global_demo",
+                    IdentitySpecType::FixedToken as i32,
+                    global_identity_spec_scope(),
+                ));
+            }
+            Some(identity_spec_scope::Value::Workspace(_)) => {
+                if request.include_global {
+                    identity_specs.push(mock_identity_spec_summary(
+                        "global_demo",
+                        IdentitySpecType::FixedToken as i32,
+                        global_identity_spec_scope(),
+                    ));
+                }
+                identity_specs.push(mock_identity_spec_summary(
+                    "workspace_demo",
+                    777,
+                    request.scope.clone().expect("workspace scope"),
+                ));
+            }
+            None => {
+                return Err(Status::invalid_argument(
+                    "missing exact identity-spec scope",
+                ));
+            }
+        }
+        Ok(Response::new(ListIdentitySpecsResponse { identity_specs }))
+    }
+
+    async fn get_identity_spec(
+        &self,
+        request: Request<GetIdentitySpecRequest>,
+    ) -> Result<Response<GetIdentitySpecResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .get_identity_spec
+            .lock()
+            .expect("get_identity_spec capture")
+            .push(request.clone());
+        let scope = (request.name != "missing_scope")
+            .then_some(request.scope)
+            .flatten();
+        let identity_type = if request.name == "unknown_type" {
+            777
+        } else {
+            IdentitySpecType::FixedToken as i32
+        };
+        Ok(Response::new(GetIdentitySpecResponse {
+            identity_spec: Some(mock_identity_spec(&request.name, identity_type, scope)),
+        }))
+    }
+
+    async fn delete_identity_spec(
+        &self,
+        request: Request<DeleteIdentitySpecRequest>,
+    ) -> Result<Response<DeleteIdentitySpecResponse>, Status> {
+        self.captured
+            .delete_identity_spec
+            .lock()
+            .expect("delete_identity_spec capture")
+            .push(request.into_inner());
+        Ok(Response::new(DeleteIdentitySpecResponse {}))
     }
 }
 
@@ -1549,6 +1739,7 @@ impl MockServer {
         let query_captured = Arc::clone(&captured);
         let search_captured = Arc::clone(&captured);
         let catalog_captured = Arc::clone(&captured);
+        let identity_spec_captured = Arc::clone(&captured);
         let source_captured = Arc::clone(&captured);
         let function_captured = Arc::clone(&captured);
         let workspace_captured = Arc::clone(&captured);
@@ -1561,6 +1752,9 @@ impl MockServer {
             Server::builder()
                 .add_service(CatalogServiceServer::new(MockCatalogService {
                     captured: catalog_captured,
+                }))
+                .add_service(IdentitySpecServiceServer::new(MockIdentitySpecService {
+                    captured: identity_spec_captured,
                 }))
                 .add_service(QueryServiceServer::new(MockQueryService {
                     config: query_config,
@@ -1806,6 +2000,45 @@ impl MockServer {
             .lock()
             .expect("end_task capture")
             .clone()
+    }
+
+    pub(crate) fn add_identity_spec_requests(&self) -> Vec<AddIdentitySpecRequest> {
+        self.captured
+            .add_identity_spec
+            .lock()
+            .expect("add_identity_spec capture")
+            .clone()
+    }
+
+    pub(crate) fn list_identity_specs_requests(&self) -> Vec<ListIdentitySpecsRequest> {
+        self.captured
+            .list_identity_specs
+            .lock()
+            .expect("list_identity_specs capture")
+            .clone()
+    }
+
+    pub(crate) fn get_identity_spec_requests(&self) -> Vec<GetIdentitySpecRequest> {
+        self.captured
+            .get_identity_spec
+            .lock()
+            .expect("get_identity_spec capture")
+            .clone()
+    }
+
+    pub(crate) fn delete_identity_spec_requests(&self) -> Vec<DeleteIdentitySpecRequest> {
+        self.captured
+            .delete_identity_spec
+            .lock()
+            .expect("delete_identity_spec capture")
+            .clone()
+    }
+
+    pub(crate) fn identity_spec_request_count(&self) -> usize {
+        self.add_identity_spec_requests().len()
+            + self.list_identity_specs_requests().len()
+            + self.get_identity_spec_requests().len()
+            + self.delete_identity_spec_requests().len()
     }
 
     pub(crate) fn endpoint_uri(&self) -> &str {


### PR DESCRIPTION
## Intent

Lock the exact identity-spec CLI contract introduced by PR #1841 to the reviewed global/workspace scope and strict lifecycle semantics.

## What it enables

- Proves add, list, info, and remove requests carry explicit exact scopes.
- Covers environment-first setup inputs, authored input order, omitted-value replacement, and secret non-egress.
- Verifies typed and unknown identity rendering, malformed response rejection, and zero RPCs for conflicting or unsupported arguments.
- Prevents stale force/orphan deletion behavior from reappearing.

## Usage examples

```sh
coral identity-spec add --file identity.yaml
coral --workspace work identity-spec list --include-global
coral identity-spec --global info github
coral identity-spec remove github --global
```

This layer adds contract tests and a mock IdentitySpecService only; the production commands are introduced by the parent PR.