### PR TITLE
test(cli): cover current-user identity commands

### DIFF
--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -582,6 +582,236 @@ async fn identity_spec_invalid_scope_and_interactive_args_send_no_rpc() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn current_user_identity_add_reads_stdin_without_secret_egress_or_spec_lookup() {
+    let server = MockServer::start().await;
+    let token = "fixed-token-secret-sentinel";
+
+    let added = server
+        .cmd()
+        .env("CORAL_WORKSPACE", "ignored")
+        .args([
+            "identity",
+            "add",
+            "github_local",
+            "--identity-spec",
+            "global_token",
+            "--token-stdin",
+        ])
+        .write_stdin(format!("{token}\r\n"))
+        .assert()
+        .success()
+        .stdout(
+            "Stored current-user identity 'github_local' using global identity spec 'global_token'.\n",
+        );
+    let stderr = String::from_utf8_lossy(&added.get_output().stderr);
+    assert!(!stderr.contains(token), "secret leaked to stderr: {stderr}");
+    assert!(
+        !String::from_utf8_lossy(&added.get_output().stdout).contains(token),
+        "secret leaked to stdout"
+    );
+
+    let requests = server.create_user_identity_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].name, "github_local");
+    assert_eq!(requests[0].identity_spec_name, "global_token");
+    assert_eq!(
+        requests[0].setup.as_ref().map(|setup| setup.token.as_str()),
+        Some(token)
+    );
+    assert_eq!(server.identity_spec_request_count(), 0);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn current_user_identity_list_and_info_render_exact_metadata_safely() {
+    let server = MockServer::start().await;
+
+    let listed = server
+        .cmd()
+        .env("CORAL_WORKSPACE", "ignored")
+        .args(["identity", "list"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&listed.get_output().stdout);
+    let rows = nonempty_lines(&stdout);
+    for expected in [
+        [
+            "with_port",
+            "global_token",
+            "demo",
+            "fixed_token",
+            "api.example.com:443",
+            "global",
+        ],
+        [
+            "host_only",
+            "global_oauth",
+            "demo",
+            "oauth",
+            "login.example.com",
+            "global",
+        ],
+        ["legacy", "global_legacy", "demo", "unknown", "-", "global"],
+    ] {
+        assert!(
+            rows.iter().any(|row| row.split_whitespace().eq(expected)),
+            "missing row {expected:?}: {stdout}"
+        );
+    }
+    assert_eq!(server.list_user_identities_requests().len(), 1);
+
+    let info = server
+        .cmd()
+        .env("CORAL_WORKSPACE", "ignored")
+        .args(["identity", "info", "with_port"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&info.get_output().stdout);
+    for expected in [
+        "with_port",
+        "Owner:         current_user",
+        "Identity spec: global_token",
+        "Spec scope:    global",
+        "Fingerprint:   fingerprint-global_token",
+        "Type:          fixed_token",
+        "Audience:      api.example.com:443",
+    ] {
+        assert!(stdout.contains(expected), "missing {expected:?}: {stdout}");
+    }
+    let gets = server.get_user_identity_requests();
+    assert_eq!(gets.len(), 1);
+    assert_eq!(gets[0].name, "with_port");
+    assert_eq!(server.identity_spec_request_count(), 0);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn current_user_identity_remove_sends_exact_request() {
+    let server = MockServer::start().await;
+
+    server
+        .cmd()
+        .env("CORAL_WORKSPACE", "ignored")
+        .args(["identity", "remove", "github_local"])
+        .assert()
+        .success()
+        .stdout("Removed current-user identity 'github_local'.\n");
+    let requests = server.delete_user_identity_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].name, "github_local");
+    assert_eq!(server.identity_spec_request_count(), 0);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn current_user_identity_rejects_unsafe_invocations_without_rpc() {
+    let server = MockServer::start().await;
+
+    let workspace = server
+        .cmd()
+        .args(["--workspace", "work", "identity", "list"])
+        .assert()
+        .failure();
+    assert!(
+        String::from_utf8_lossy(&workspace.get_output().stderr)
+            .contains("--workspace cannot be used with current-user identity commands")
+    );
+    let non_tty = server
+        .cmd()
+        .args(["identity", "add", "demo", "--identity-spec", "global_token"])
+        .assert()
+        .failure();
+    assert!(
+        String::from_utf8_lossy(&non_tty.get_output().stderr)
+            .contains("fixed-token identity setup requires a TTY or an explicit --token-stdin")
+    );
+    let blank = server
+        .cmd()
+        .args([
+            "identity",
+            "add",
+            "demo",
+            "--identity-spec",
+            "global_token",
+            "--token-stdin",
+        ])
+        .write_stdin("\r\n")
+        .assert()
+        .failure();
+    assert!(
+        String::from_utf8_lossy(&blank.get_output().stderr)
+            .contains("fixed-token identity token must not be blank")
+    );
+    server
+        .cmd()
+        .args([
+            "identity",
+            "add",
+            "demo",
+            "--identity-spec",
+            "global_token",
+            "--token",
+            "plaintext-token-must-be-rejected",
+        ])
+        .assert()
+        .failure();
+    server
+        .cmd()
+        .args(["identity", "list", "--global"])
+        .assert()
+        .failure();
+    for flag in ["--force", "--orphan"] {
+        server
+            .cmd()
+            .args(["identity", "remove", "demo", flag])
+            .assert()
+            .failure();
+    }
+    assert_eq!(server.current_user_identity_request_count(), 0);
+    assert_eq!(server.identity_spec_request_count(), 0);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn current_user_identity_malformed_responses_fail_closed() {
+    let server = MockServer::start().await;
+    let cases = [
+        ("missing_owner", "missing exact owner"),
+        ("workspace_owner", "workspace owner"),
+        ("missing_spec", "missing identity spec reference"),
+        ("missing_scope", "missing exact identity-spec scope"),
+        ("workspace_scope", "workspace identity-spec scope"),
+    ];
+
+    for (name, expected) in cases {
+        let result = server
+            .cmd()
+            .env("CORAL_WORKSPACE", "ignored")
+            .args(["identity", "info", name])
+            .assert()
+            .failure()
+            .stdout("");
+        let stderr = String::from_utf8_lossy(&result.get_output().stderr);
+        assert!(stderr.contains(expected), "missing {expected:?}: {stderr}");
+    }
+    assert_eq!(
+        server
+            .get_user_identity_requests()
+            .iter()
+            .map(|request| request.name.as_str())
+            .collect::<Vec<_>>(),
+        cases.map(|(name, _)| name).as_slice()
+    );
+    assert_eq!(server.identity_spec_request_count(), 0);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn source_list_renders_configured_sources() {
     let server = MockServer::start().await;
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -16,6 +16,7 @@ use arrow::record_batch::RecordBatch;
 use assert_cmd::Command;
 use coral_api::v1::catalog_service_server::{CatalogService, CatalogServiceServer};
 use coral_api::v1::function_service_server::{FunctionService, FunctionServiceServer};
+use coral_api::v1::identity_service_server::{IdentityService, IdentityServiceServer};
 use coral_api::v1::identity_spec_service_server::{IdentitySpecService, IdentitySpecServiceServer};
 use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::search_service_server::{SearchService, SearchServiceServer};
@@ -27,19 +28,23 @@ use coral_api::v1::{
     CatalogClearResult, CatalogCounts, CatalogItem, CatalogRebuildResult, CatalogSearchResult,
     ClearSearchDataRequest, ClearSearchDataResponse, Column, ColumnSearchResult,
     CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
-    CreateBundledSourceWithOAuthResponse, CreateWorkspaceRequest, CreateWorkspaceResponse,
-    DeleteFunctionRequest, DeleteFunctionResponse, DeleteIdentitySpecRequest,
-    DeleteIdentitySpecResponse, DeleteSourceRequest, DeleteSourceResponse, DeleteWorkspaceRequest,
-    DeleteWorkspaceResponse, DescribeCatalogSurfaceRequest, DescribeCatalogSurfaceResponse,
-    DiscoverSourcesRequest, DiscoverSourcesResponse, DrainSearchQueueRequest,
-    DrainSearchQueueResponse, EndTaskRequest, EndTaskResponse, ExecuteSqlRequest,
-    ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse, GetIdentitySpecRequest,
-    GetIdentitySpecResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
-    GetSourceResponse, GlobalIdentitySpecScope, IdentitySpec, IdentitySpecScope,
-    IdentitySpecSummary, IdentitySpecType, ImportSourceRequest, ImportSourceResponse,
-    ListCatalogRequest, ListCatalogResponse, ListColumnsRequest, ListColumnsResponse,
-    ListFunctionsRequest, ListFunctionsResponse, ListIdentitySpecsRequest,
-    ListIdentitySpecsResponse, ListSourcesRequest, ListSourcesResponse, ListWorkspacesRequest,
+    CreateBundledSourceWithOAuthResponse, CreateUserOwnedFixedTokenIdentityRequest,
+    CreateUserOwnedFixedTokenIdentityResponse, CreateWorkspaceRequest, CreateWorkspaceResponse,
+    CurrentUserIdentityOwner, DeleteFunctionRequest, DeleteFunctionResponse,
+    DeleteIdentitySpecRequest, DeleteIdentitySpecResponse, DeleteSourceRequest,
+    DeleteSourceResponse, DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse,
+    DeleteWorkspaceRequest, DeleteWorkspaceResponse, DescribeCatalogSurfaceRequest,
+    DescribeCatalogSurfaceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
+    DrainSearchQueueRequest, DrainSearchQueueResponse, EndTaskRequest, EndTaskResponse,
+    ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
+    GetIdentitySpecRequest, GetIdentitySpecResponse, GetSourceInfoRequest, GetSourceInfoResponse,
+    GetSourceRequest, GetSourceResponse, GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse,
+    GlobalIdentitySpecScope, Identity, IdentityAudience, IdentityOwner, IdentitySpec,
+    IdentitySpecReference, IdentitySpecScope, IdentitySpecSummary, IdentitySpecType,
+    ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListCatalogResponse,
+    ListColumnsRequest, ListColumnsResponse, ListFunctionsRequest, ListFunctionsResponse,
+    ListIdentitySpecsRequest, ListIdentitySpecsResponse, ListSourcesRequest, ListSourcesResponse,
+    ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse, ListWorkspacesRequest,
     ListWorkspacesResponse, MissingCatalogSurface, ObservedDrainResult, ObservedRebuildResult,
     PaginationRequest, PaginationResponse, QueryPlan, RebuildSearchIndexRequest,
     RebuildSearchIndexResponse, SearchCatalogRequest, SearchCatalogResponse, SearchField,
@@ -50,8 +55,8 @@ use coral_api::v1::{
     StartTaskRequest, StartTaskResponse, Table, TableFunction, TableSummary, Task as ProtoTask,
     TaskEnd as ProtoTaskEnd, TaskStatus, ValidateSourceRequest, ValidateSourceResponse, Workspace,
     catalog_item, create_bundled_source_with_o_auth_response, describe_catalog_surface_response,
-    identity_spec_scope, import_source_response, search_maintenance_result, search_result,
-    source_input_spec::Input as ProtoSourceInput,
+    identity_owner, identity_spec_scope, import_source_response, search_maintenance_result,
+    search_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_TASK_ID_METADATA_KEY,
@@ -115,6 +120,61 @@ fn mock_identity_spec_summary(
         identity_type,
         scope: Some(scope),
     }
+}
+
+fn mock_user_identity(
+    name: &str,
+    spec_name: &str,
+    identity_type: i32,
+    audience: Option<IdentityAudience>,
+) -> Identity {
+    Identity {
+        name: name.to_string(),
+        owner: Some(IdentityOwner {
+            value: Some(identity_owner::Value::CurrentUser(
+                CurrentUserIdentityOwner {},
+            )),
+        }),
+        identity_spec: Some(IdentitySpecReference {
+            name: spec_name.to_string(),
+            scope: Some(global_identity_spec_scope()),
+            fingerprint: format!("fingerprint-{spec_name}"),
+            issuer: "demo".to_string(),
+            identity_type,
+            audience,
+        }),
+        created_at_unix_nanos: 10,
+        updated_at_unix_nanos: 20,
+    }
+}
+
+fn mock_user_identity_for_get(name: &str) -> Identity {
+    let mut identity = mock_user_identity(
+        name,
+        "global_token",
+        IdentitySpecType::FixedToken as i32,
+        Some(IdentityAudience {
+            host: "api.example.com".to_string(),
+            port: Some(443),
+        }),
+    );
+    match name {
+        "missing_owner" => identity.owner = None,
+        "workspace_owner" => {
+            identity.owner = Some(IdentityOwner {
+                value: Some(identity_owner::Value::Workspace(workspace())),
+            });
+        }
+        "missing_spec" => identity.identity_spec = None,
+        "missing_scope" => identity.identity_spec.as_mut().expect("spec").scope = None,
+        "workspace_scope" => {
+            identity.identity_spec.as_mut().expect("spec").scope = Some(IdentitySpecScope {
+                value: Some(identity_spec_scope::Value::Workspace(workspace())),
+            });
+        }
+        _ => {}
+    }
+    identity
 }
 
 pub(crate) fn assert_default_workspace(workspace: Option<&Workspace>) {
@@ -957,6 +1017,10 @@ struct Captured {
     list_identity_specs: Mutex<Vec<ListIdentitySpecsRequest>>,
     get_identity_spec: Mutex<Vec<GetIdentitySpecRequest>>,
     delete_identity_spec: Mutex<Vec<DeleteIdentitySpecRequest>>,
+    create_user_identity: Mutex<Vec<CreateUserOwnedFixedTokenIdentityRequest>>,
+    list_user_identities: Mutex<Vec<ListUserOwnedIdentitiesRequest>>,
+    get_user_identity: Mutex<Vec<GetUserOwnedIdentityRequest>>,
+    delete_user_identity: Mutex<Vec<DeleteUserOwnedIdentityRequest>>,
 }
 
 pub(crate) fn encode_arrow_ipc_stream(
@@ -1362,6 +1426,98 @@ impl IdentitySpecService for MockIdentitySpecService {
 }
 
 #[derive(Clone)]
+struct MockIdentityService {
+    captured: Arc<Captured>,
+}
+
+#[tonic::async_trait]
+impl IdentityService for MockIdentityService {
+    async fn create_user_owned_fixed_token_identity(
+        &self,
+        request: Request<CreateUserOwnedFixedTokenIdentityRequest>,
+    ) -> Result<Response<CreateUserOwnedFixedTokenIdentityResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .create_user_identity
+            .lock()
+            .expect("create_user_identity capture")
+            .push(request.clone());
+        Ok(Response::new(CreateUserOwnedFixedTokenIdentityResponse {
+            identity: Some(mock_user_identity(
+                &request.name,
+                &request.identity_spec_name,
+                IdentitySpecType::FixedToken as i32,
+                Some(IdentityAudience {
+                    host: "api.example.com".to_string(),
+                    port: Some(443),
+                }),
+            )),
+        }))
+    }
+
+    async fn list_user_owned_identities(
+        &self,
+        request: Request<ListUserOwnedIdentitiesRequest>,
+    ) -> Result<Response<ListUserOwnedIdentitiesResponse>, Status> {
+        self.captured
+            .list_user_identities
+            .lock()
+            .expect("list_user_identities capture")
+            .push(request.into_inner());
+        Ok(Response::new(ListUserOwnedIdentitiesResponse {
+            identities: vec![
+                mock_user_identity(
+                    "with_port",
+                    "global_token",
+                    IdentitySpecType::FixedToken as i32,
+                    Some(IdentityAudience {
+                        host: "api.example.com".to_string(),
+                        port: Some(443),
+                    }),
+                ),
+                mock_user_identity(
+                    "host_only",
+                    "global_oauth",
+                    IdentitySpecType::Oauth as i32,
+                    Some(IdentityAudience {
+                        host: "login.example.com".to_string(),
+                        port: None,
+                    }),
+                ),
+                mock_user_identity("legacy", "global_legacy", 777, None),
+            ],
+        }))
+    }
+
+    async fn get_user_owned_identity(
+        &self,
+        request: Request<GetUserOwnedIdentityRequest>,
+    ) -> Result<Response<GetUserOwnedIdentityResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .get_user_identity
+            .lock()
+            .expect("get_user_identity capture")
+            .push(request.clone());
+        Ok(Response::new(GetUserOwnedIdentityResponse {
+            identity: Some(mock_user_identity_for_get(&request.name)),
+        }))
+    }
+
+    async fn delete_user_owned_identity(
+        &self,
+        request: Request<DeleteUserOwnedIdentityRequest>,
+    ) -> Result<Response<DeleteUserOwnedIdentityResponse>, Status> {
+        self.captured
+            .delete_user_identity
+            .lock()
+            .expect("delete_user_identity capture")
+            .push(request.into_inner());
+        Ok(Response::new(DeleteUserOwnedIdentityResponse {}))
+    }
+}
+
+#[derive(Clone)]
 struct MockSourceService {
     config: Arc<MockServerConfig>,
     captured: Arc<Captured>,
@@ -1739,6 +1895,7 @@ impl MockServer {
         let query_captured = Arc::clone(&captured);
         let search_captured = Arc::clone(&captured);
         let catalog_captured = Arc::clone(&captured);
+        let identity_captured = Arc::clone(&captured);
         let identity_spec_captured = Arc::clone(&captured);
         let source_captured = Arc::clone(&captured);
         let function_captured = Arc::clone(&captured);
@@ -1752,6 +1909,9 @@ impl MockServer {
             Server::builder()
                 .add_service(CatalogServiceServer::new(MockCatalogService {
                     captured: catalog_captured,
+                }))
+                .add_service(IdentityServiceServer::new(MockIdentityService {
+                    captured: identity_captured,
                 }))
                 .add_service(IdentitySpecServiceServer::new(MockIdentitySpecService {
                     captured: identity_spec_captured,
@@ -2039,6 +2199,47 @@ impl MockServer {
             + self.list_identity_specs_requests().len()
             + self.get_identity_spec_requests().len()
             + self.delete_identity_spec_requests().len()
+    }
+
+    pub(crate) fn create_user_identity_requests(
+        &self,
+    ) -> Vec<CreateUserOwnedFixedTokenIdentityRequest> {
+        self.captured
+            .create_user_identity
+            .lock()
+            .expect("create_user_identity capture")
+            .clone()
+    }
+
+    pub(crate) fn list_user_identities_requests(&self) -> Vec<ListUserOwnedIdentitiesRequest> {
+        self.captured
+            .list_user_identities
+            .lock()
+            .expect("list_user_identities capture")
+            .clone()
+    }
+
+    pub(crate) fn get_user_identity_requests(&self) -> Vec<GetUserOwnedIdentityRequest> {
+        self.captured
+            .get_user_identity
+            .lock()
+            .expect("get_user_identity capture")
+            .clone()
+    }
+
+    pub(crate) fn delete_user_identity_requests(&self) -> Vec<DeleteUserOwnedIdentityRequest> {
+        self.captured
+            .delete_user_identity
+            .lock()
+            .expect("delete_user_identity capture")
+            .clone()
+    }
+
+    pub(crate) fn current_user_identity_request_count(&self) -> usize {
+        self.create_user_identity_requests().len()
+            + self.list_user_identities_requests().len()
+            + self.get_user_identity_requests().len()
+            + self.delete_user_identity_requests().len()
     }
 
     pub(crate) fn endpoint_uri(&self) -> &str {


### PR DESCRIPTION
## Intent

Lock down the current-user identity CLI's transport, secret-handling, ownership, and exact-spec behavior in a review-sized contract-test layer separate from the production command implementation.

## What it enables

- Verify CRLF-only token normalization, write-only token handling, and zero secret egress.
- Prove current-user commands ignore `CORAL_WORKSPACE`, reject explicit workspace and unsafe flags before RPC, and never prefetch identity specs.
- Exercise exact global spec metadata for list and info plus exact create/get/delete request shapes.
- Fail closed when the server omits or contradicts owner, identity-spec reference, or exact scope metadata.

## Usage examples

```bash
cargo test --locked -p coral-cli --all-features --test cli_e2e current_user_identity
printf '%s' "$GITHUB_TOKEN" | coral identity add github-ci --identity-spec github --token-stdin
coral identity info github-ci
```