### PR TITLE
feat(cli): manage workspace identities

### DIFF
--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -342,9 +342,8 @@ The `default` workspace cannot be removed.
 
 ## `coral identity`
 
-Manage fixed-token identities owned by the current Coral user. Identity commands
-are not workspace-scoped and reject an explicit `--workspace`; each identity
-uses an exact revision of a globally installed identity spec.
+Manage fixed-token identities. Commands target the current Coral user by default, ignore `CORAL_WORKSPACE`, and reject an explicit `--workspace` unless you also pass `identity --workspace-owned`.
+Workspace-owned commands require an explicit `--workspace NAME`; their identity spec resolves from that workspace with global fallback, and the stored identity pins the exact resolved revision.
 
 ### `coral identity add <NAME> --identity-spec <SPEC>`
 
@@ -353,6 +352,12 @@ spec. In a terminal, Coral prompts for the token without echoing it.
 
 ```shellscript
 coral identity add github_local --identity-spec github_token
+```
+
+To create or replace a workspace-owned identity, select both the owner kind and workspace explicitly:
+
+```shellscript
+coral --workspace work identity --workspace-owned add github_shared --identity-spec github_token
 ```
 
 For automation, pass `--token-stdin` and pipe the token on standard input:
@@ -366,28 +371,30 @@ returns it from identity management APIs or renders it in command output.
 
 ### `coral identity list`
 
-List identities owned by the current user, including each identity's global
-spec name, scope, and provider audience. Use `identity info` to inspect the
-exact pinned fingerprint.
+List identities owned by the current user, including each identity's spec name, scope, and provider audience.
+Use `identity info` to inspect the exact pinned fingerprint; add the explicit workspace selectors to list workspace-owned identities.
 
 ```shellscript
 coral identity list
+coral --workspace work identity --workspace-owned list
 ```
 
 ### `coral identity info <NAME>`
 
-Show one current-user identity's safe metadata and pinned spec fingerprint.
+Show one identity's safe metadata, exact owner, and pinned spec fingerprint.
 
 ```shellscript
 coral identity info github_local
+coral --workspace work identity --workspace-owned info github_shared
 ```
 
 ### `coral identity remove <NAME>`
 
-Remove one current-user identity and its encrypted token material.
+Remove one identity owned by the selected owner and its encrypted token material.
 
 ```shellscript
 coral identity remove github_local
+coral --workspace work identity --workspace-owned remove github_shared
 ```
 
 ## `coral identity-spec`

--- a/crates/coral-cli/src/identity_ops.rs
+++ b/crates/coral-cli/src/identity_ops.rs
@@ -1,64 +1,90 @@
-//! Terminal adapter for current-user fixed-token identity lifecycle operations.
+//! Terminal adapter for fixed-token identity lifecycle operations.
 
 use std::io::{IsTerminal as _, Read as _, stdin, stdout};
 
 use clap::{Args, Subcommand};
 use coral_api::v1::{
-    CreateUserOwnedFixedTokenIdentityRequest, DeleteUserOwnedIdentityRequest,
-    FixedTokenIdentitySetup, GetUserOwnedIdentityRequest, Identity, IdentityAudience,
-    IdentitySpecReference, IdentitySpecType, ListUserOwnedIdentitiesRequest, identity_owner,
-    identity_spec_scope,
+    CreateUserOwnedFixedTokenIdentityRequest, CreateWorkspaceOwnedFixedTokenIdentityRequest,
+    DeleteUserOwnedIdentityRequest, DeleteWorkspaceOwnedIdentityRequest, FixedTokenIdentitySetup,
+    GetUserOwnedIdentityRequest, GetWorkspaceOwnedIdentityRequest, Identity, IdentityAudience,
+    IdentitySpecReference, IdentitySpecType, ListUserOwnedIdentitiesRequest,
+    ListWorkspaceOwnedIdentitiesRequest, Workspace, identity_owner, identity_spec_scope,
 };
 use coral_client::AppClient;
 use dialoguer::{Password, theme::ColorfulTheme};
 use tonic::Request;
 
 #[derive(Debug, Args)]
-/// Manage identities owned by the current Coral user
+/// Manage current-user or explicitly selected workspace identities
 pub(crate) struct IdentityArgs {
+    /// Manage identities owned by the explicitly selected workspace
+    #[arg(long)]
+    workspace_owned: bool,
     #[command(subcommand)]
     command: IdentityCommand,
 }
 
 impl IdentityArgs {
-    pub(crate) fn validate_explicit_workspace(
+    pub(crate) fn validate_workspace_selection(
+        &self,
         workspace: Option<&str>,
     ) -> Result<(), anyhow::Error> {
-        if workspace.is_some() {
-            anyhow::bail!("--workspace cannot be used with current-user identity commands");
+        match (self.workspace_owned, workspace) {
+            (false, Some(_)) => {
+                anyhow::bail!(
+                    "--workspace cannot be used with current-user identity commands; add --workspace-owned to manage workspace identities"
+                );
+            }
+            (true, None) => {
+                anyhow::bail!("--workspace-owned requires an explicit --workspace NAME");
+            }
+            _ => {}
         }
         Ok(())
+    }
+
+    pub(crate) const fn uses_selected_workspace(&self) -> bool {
+        self.workspace_owned
     }
 }
 
 #[derive(Debug, Subcommand)]
 enum IdentityCommand {
-    /// Create or replace a current-user fixed-token identity
+    /// Create or replace a fixed-token identity for the selected owner
     Add {
         /// Identity name used by source identity bindings
         name: String,
-        /// Globally installed fixed-token identity-spec name
+        /// Fixed-token identity-spec name resolved for the selected owner
         #[arg(long = "identity-spec", value_name = "NAME")]
         identity_spec: String,
         /// Read the fixed token from stdin instead of prompting
         #[arg(long)]
         token_stdin: bool,
     },
-    /// List identities owned by the current user
+    /// List identities owned by the selected owner
     List,
-    /// Show one identity owned by the current user
+    /// Show one identity owned by the selected owner
     Info {
         /// Identity name
         name: String,
     },
-    /// Remove one identity owned by the current user
+    /// Remove one identity owned by the selected owner
     Remove {
         /// Identity name
         name: String,
     },
 }
 
-pub(crate) async fn run(app: &AppClient, args: IdentityArgs) -> Result<(), anyhow::Error> {
+pub(crate) async fn run(
+    app: &AppClient,
+    selected_workspace: &Workspace,
+    args: IdentityArgs,
+) -> Result<(), anyhow::Error> {
+    let target = if args.workspace_owned {
+        IdentityTarget::Workspace(selected_workspace)
+    } else {
+        IdentityTarget::CurrentUser
+    };
     match args.command {
         IdentityCommand::Add {
             name,
@@ -66,39 +92,26 @@ pub(crate) async fn run(app: &AppClient, args: IdentityArgs) -> Result<(), anyho
             token_stdin,
         } => {
             let token = fixed_token(token_stdin)?;
-            let response = app
-                .identity_client()
-                .create_user_owned_fixed_token_identity(Request::new(
-                    CreateUserOwnedFixedTokenIdentityRequest {
-                        name,
-                        identity_spec_name: identity_spec,
-                        setup: Some(FixedTokenIdentitySetup { token }),
-                    },
-                ))
-                .await?
-                .into_inner();
-            let identity = response.identity.ok_or_else(|| {
-                anyhow::anyhow!("create current-user identity response missing identity")
-            })?;
-            let view = current_user_identity(&identity)?;
-            println!(
-                "Stored current-user identity '{}' using global identity spec '{}'.",
-                identity.name, view.identity_spec.name
-            );
+            let identity = create_identity(app, target, name, identity_spec, token).await?;
+            let view = identity_view(&identity, target)?;
+            print_stored(&identity, &view, target);
         }
         IdentityCommand::List => {
-            let response = app
-                .identity_client()
-                .list_user_owned_identities(Request::new(ListUserOwnedIdentitiesRequest {}))
-                .await?
-                .into_inner();
-            if response.identities.is_empty() {
-                println!("No current-user identities configured.");
+            let identities = list_identities(app, target).await?;
+            if identities.is_empty() {
+                match target {
+                    IdentityTarget::CurrentUser => {
+                        println!("No current-user identities configured.");
+                    }
+                    IdentityTarget::Workspace(workspace) => println!(
+                        "No identities configured for workspace '{}'.",
+                        workspace.name
+                    ),
+                }
             } else {
-                let rows = response
-                    .identities
+                let rows = identities
                     .iter()
-                    .map(identity_row)
+                    .map(|identity| identity_row(identity, target))
                     .collect::<Result<Vec<_>, _>>()?;
                 super::print_text_table(
                     [
@@ -114,23 +127,134 @@ pub(crate) async fn run(app: &AppClient, args: IdentityArgs) -> Result<(), anyho
             }
         }
         IdentityCommand::Info { name } => {
-            let response = app
-                .identity_client()
-                .get_user_owned_identity(Request::new(GetUserOwnedIdentityRequest { name }))
-                .await?
-                .into_inner();
-            let identity = response.identity.ok_or_else(|| {
-                anyhow::anyhow!("get current-user identity response missing identity")
-            })?;
-            print_info(&identity)?;
+            let identity = get_identity(app, target, name).await?;
+            print_info(&identity, target)?;
         }
         IdentityCommand::Remove { name } => {
+            delete_identity(app, target, &name).await?;
+            print_removed(&name, target);
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum IdentityTarget<'a> {
+    CurrentUser,
+    Workspace(&'a Workspace),
+}
+
+async fn create_identity(
+    app: &AppClient,
+    target: IdentityTarget<'_>,
+    name: String,
+    identity_spec_name: String,
+    token: String,
+) -> Result<Identity, anyhow::Error> {
+    let setup = Some(FixedTokenIdentitySetup { token });
+    let identity = match target {
+        IdentityTarget::CurrentUser => {
+            app.identity_client()
+                .create_user_owned_fixed_token_identity(Request::new(
+                    CreateUserOwnedFixedTokenIdentityRequest {
+                        name,
+                        identity_spec_name,
+                        setup,
+                    },
+                ))
+                .await?
+                .into_inner()
+                .identity
+        }
+        IdentityTarget::Workspace(workspace) => {
+            app.workspace_identity_client()
+                .create_workspace_owned_fixed_token_identity(Request::new(
+                    CreateWorkspaceOwnedFixedTokenIdentityRequest {
+                        workspace: Some(workspace.clone()),
+                        name,
+                        identity_spec_name,
+                        setup,
+                    },
+                ))
+                .await?
+                .into_inner()
+                .identity
+        }
+    };
+    identity.ok_or_else(|| anyhow::anyhow!("create identity response missing identity"))
+}
+
+async fn list_identities(
+    app: &AppClient,
+    target: IdentityTarget<'_>,
+) -> Result<Vec<Identity>, anyhow::Error> {
+    match target {
+        IdentityTarget::CurrentUser => Ok(app
+            .identity_client()
+            .list_user_owned_identities(Request::new(ListUserOwnedIdentitiesRequest {}))
+            .await?
+            .into_inner()
+            .identities),
+        IdentityTarget::Workspace(workspace) => Ok(app
+            .workspace_identity_client()
+            .list_workspace_owned_identities(Request::new(ListWorkspaceOwnedIdentitiesRequest {
+                workspace: Some(workspace.clone()),
+            }))
+            .await?
+            .into_inner()
+            .identities),
+    }
+}
+
+async fn get_identity(
+    app: &AppClient,
+    target: IdentityTarget<'_>,
+    name: String,
+) -> Result<Identity, anyhow::Error> {
+    let identity = match target {
+        IdentityTarget::CurrentUser => {
+            app.identity_client()
+                .get_user_owned_identity(Request::new(GetUserOwnedIdentityRequest { name }))
+                .await?
+                .into_inner()
+                .identity
+        }
+        IdentityTarget::Workspace(workspace) => {
+            app.workspace_identity_client()
+                .get_workspace_owned_identity(Request::new(GetWorkspaceOwnedIdentityRequest {
+                    workspace: Some(workspace.clone()),
+                    name,
+                }))
+                .await?
+                .into_inner()
+                .identity
+        }
+    };
+    identity.ok_or_else(|| anyhow::anyhow!("get identity response missing identity"))
+}
+
+async fn delete_identity(
+    app: &AppClient,
+    target: IdentityTarget<'_>,
+    name: &str,
+) -> Result<(), anyhow::Error> {
+    match target {
+        IdentityTarget::CurrentUser => {
             app.identity_client()
                 .delete_user_owned_identity(Request::new(DeleteUserOwnedIdentityRequest {
-                    name: name.clone(),
+                    name: name.to_string(),
                 }))
                 .await?;
-            println!("Removed current-user identity '{name}'.");
+        }
+        IdentityTarget::Workspace(workspace) => {
+            app.workspace_identity_client()
+                .delete_workspace_owned_identity(Request::new(
+                    DeleteWorkspaceOwnedIdentityRequest {
+                        workspace: Some(workspace.clone()),
+                        name: name.to_string(),
+                    },
+                ))
+                .await?;
         }
     }
     Ok(())
@@ -170,57 +294,109 @@ fn normalize_fixed_token(token: &str) -> Result<String, anyhow::Error> {
 }
 
 #[derive(Debug)]
-struct CurrentUserIdentity<'a> {
+struct IdentityView<'a> {
     identity_spec: &'a IdentitySpecReference,
+    owner: String,
+    spec_scope: String,
 }
 
-fn current_user_identity(identity: &Identity) -> Result<CurrentUserIdentity<'_>, anyhow::Error> {
-    match identity
+fn identity_view<'a>(
+    identity: &'a Identity,
+    target: IdentityTarget<'_>,
+) -> Result<IdentityView<'a>, anyhow::Error> {
+    let owner = identity
         .owner
         .as_ref()
-        .and_then(|owner| owner.value.as_ref())
-    {
-        Some(identity_owner::Value::CurrentUser(_)) => {}
-        Some(identity_owner::Value::Workspace(_)) => {
+        .and_then(|owner| owner.value.as_ref());
+    let owner = match (target, owner) {
+        (IdentityTarget::CurrentUser, Some(identity_owner::Value::CurrentUser(_))) => {
+            "current_user".to_string()
+        }
+        (IdentityTarget::CurrentUser, Some(identity_owner::Value::Workspace(_))) => {
             anyhow::bail!("current-user identity response has a workspace owner");
         }
-        None => anyhow::bail!("current-user identity response missing exact owner"),
-    }
-    let identity_spec = identity.identity_spec.as_ref().ok_or_else(|| {
-        anyhow::anyhow!("current-user identity response missing identity spec reference")
-    })?;
-    match identity_spec
+        (IdentityTarget::CurrentUser, None) => {
+            anyhow::bail!("current-user identity response missing exact owner");
+        }
+        (IdentityTarget::Workspace(expected), Some(identity_owner::Value::Workspace(actual)))
+            if actual.name == expected.name =>
+        {
+            format!("workspace:{}", actual.name)
+        }
+        (IdentityTarget::Workspace(_), Some(identity_owner::Value::CurrentUser(_))) => {
+            anyhow::bail!("workspace identity response has a current-user owner");
+        }
+        (IdentityTarget::Workspace(expected), Some(identity_owner::Value::Workspace(actual))) => {
+            anyhow::bail!(
+                "workspace identity response owner '{}' does not match selected workspace '{}'",
+                actual.name,
+                expected.name
+            )
+        }
+        (IdentityTarget::Workspace(_), None) => {
+            anyhow::bail!("workspace identity response missing exact owner");
+        }
+    };
+    let identity_spec = identity
+        .identity_spec
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("identity response missing identity spec reference"))?;
+    let scope = identity_spec
         .scope
         .as_ref()
         .and_then(|scope| scope.value.as_ref())
-    {
-        Some(identity_spec_scope::Value::Global(_)) => {}
-        Some(identity_spec_scope::Value::Workspace(_)) => {
+        .ok_or_else(|| anyhow::anyhow!("identity response missing exact identity-spec scope"))?;
+    let spec_scope = match (target, scope) {
+        (_, identity_spec_scope::Value::Global(_)) => "global".to_string(),
+        (IdentityTarget::Workspace(expected), identity_spec_scope::Value::Workspace(actual))
+            if actual.name == expected.name =>
+        {
+            format!("workspace:{}", actual.name)
+        }
+        (IdentityTarget::CurrentUser, identity_spec_scope::Value::Workspace(_)) => {
             anyhow::bail!("current-user identity response has a workspace identity-spec scope");
         }
-        None => anyhow::bail!("current-user identity response missing exact identity-spec scope"),
-    }
-    Ok(CurrentUserIdentity { identity_spec })
+        (IdentityTarget::Workspace(expected), identity_spec_scope::Value::Workspace(actual)) => {
+            anyhow::bail!(
+                "workspace identity response spec scope '{}' does not match selected workspace '{}'",
+                actual.name,
+                expected.name
+            )
+        }
+    };
+    Ok(IdentityView {
+        identity_spec,
+        owner,
+        spec_scope,
+    })
 }
 
-fn identity_row(identity: &Identity) -> Result<[String; 6], anyhow::Error> {
-    let view = current_user_identity(identity)?;
+#[cfg(test)]
+fn current_user_identity(identity: &Identity) -> Result<IdentityView<'_>, anyhow::Error> {
+    identity_view(identity, IdentityTarget::CurrentUser)
+}
+
+fn identity_row(
+    identity: &Identity,
+    target: IdentityTarget<'_>,
+) -> Result<[String; 6], anyhow::Error> {
+    let view = identity_view(identity, target)?;
     Ok([
         identity.name.clone(),
         view.identity_spec.name.clone(),
         view.identity_spec.issuer.clone(),
         identity_type_label(view.identity_spec.identity_type).to_string(),
         audience_label(view.identity_spec.audience.as_ref())?,
-        "global".to_string(),
+        view.spec_scope,
     ])
 }
 
-fn print_info(identity: &Identity) -> Result<(), anyhow::Error> {
-    let view = current_user_identity(identity)?;
+fn print_info(identity: &Identity, target: IdentityTarget<'_>) -> Result<(), anyhow::Error> {
+    let view = identity_view(identity, target)?;
     println!("{}", identity.name);
-    println!("  Owner:         current_user");
+    println!("  Owner:         {}", view.owner);
     println!("  Identity spec: {}", view.identity_spec.name);
-    println!("  Spec scope:    global");
+    println!("  Spec scope:    {}", view.spec_scope);
     println!("  Fingerprint:   {}", view.identity_spec.fingerprint);
     println!("  Issuer:        {}", view.identity_spec.issuer);
     println!(
@@ -232,6 +408,31 @@ fn print_info(identity: &Identity) -> Result<(), anyhow::Error> {
         audience_label(view.identity_spec.audience.as_ref())?
     );
     Ok(())
+}
+
+fn print_stored(identity: &Identity, view: &IdentityView<'_>, target: IdentityTarget<'_>) {
+    match target {
+        IdentityTarget::CurrentUser => println!(
+            "Stored current-user identity '{}' using global identity spec '{}'.",
+            identity.name, view.identity_spec.name
+        ),
+        IdentityTarget::Workspace(workspace) => println!(
+            "Stored workspace identity '{}' in '{}' using identity spec '{}' from {}.",
+            identity.name, workspace.name, view.identity_spec.name, view.spec_scope
+        ),
+    }
+}
+
+fn print_removed(name: &str, target: IdentityTarget<'_>) {
+    match target {
+        IdentityTarget::CurrentUser => println!("Removed current-user identity '{name}'."),
+        IdentityTarget::Workspace(workspace) => {
+            println!(
+                "Removed workspace identity '{name}' from '{}'.",
+                workspace.name
+            );
+        }
+    }
 }
 
 fn identity_type_label(value: i32) -> &'static str {
@@ -247,13 +448,13 @@ fn audience_label(audience: Option<&IdentityAudience>) -> Result<String, anyhow:
         return Ok("-".to_string());
     };
     if audience.host.trim().is_empty() {
-        anyhow::bail!("current-user identity response has an invalid empty audience host");
+        anyhow::bail!("identity response has an invalid empty audience host");
     }
     let Some(port) = audience.port else {
         return Ok(audience.host.clone());
     };
     if port == 0 || port > u32::from(u16::MAX) {
-        anyhow::bail!("current-user identity response has an invalid audience port");
+        anyhow::bail!("identity response has an invalid audience port");
     }
     let host = if audience.host.contains(':') {
         audience
@@ -276,10 +477,19 @@ mod tests {
     use clap::Parser as _;
     use coral_api::v1::{
         CurrentUserIdentityOwner, GlobalIdentitySpecScope, IdentityOwner, IdentitySpecScope,
+        Workspace,
     };
 
     use super::{audience_label, normalize_fixed_token};
-    use crate::{Cli, RequiredRuntime};
+    use crate::{Cli, Command, RequiredRuntime};
+
+    fn identity_args(args: &[&str]) -> super::IdentityArgs {
+        let cli = Cli::try_parse_from(args).expect("identity command parses");
+        let Command::Identity(args) = cli.command else {
+            panic!("expected identity command");
+        };
+        args
+    }
 
     #[test]
     fn command_requires_app_client_and_rejects_unsafe_or_incomplete_args() {
@@ -299,11 +509,22 @@ mod tests {
     }
 
     #[test]
-    fn current_user_commands_reject_an_explicit_workspace() {
-        super::IdentityArgs::validate_explicit_workspace(None)
+    fn identity_owner_selection_is_explicit_and_unambiguous() {
+        let current_user = identity_args(&["coral", "identity", "list"]);
+        current_user
+            .validate_workspace_selection(None)
             .expect("implicit workspace environment is ignored");
-        super::IdentityArgs::validate_explicit_workspace(Some("work"))
+        current_user
+            .validate_workspace_selection(Some("work"))
             .expect_err("explicit workspace must be rejected");
+
+        let workspace = identity_args(&["coral", "identity", "--workspace-owned", "list"]);
+        workspace
+            .validate_workspace_selection(None)
+            .expect_err("workspace ownership requires an explicit workspace");
+        workspace
+            .validate_workspace_selection(Some("work"))
+            .expect("both workspace selectors are accepted");
     }
 
     #[test]
@@ -369,5 +590,65 @@ mod tests {
             .scope = None;
         super::current_user_identity(&identity)
             .expect_err("missing identity-spec scope must be rejected");
+    }
+
+    #[test]
+    fn workspace_identity_requires_matching_owner_and_resolved_scope() {
+        let selected = Workspace {
+            name: "work".to_string(),
+        };
+        let mut identity = super::Identity {
+            owner: Some(IdentityOwner {
+                value: Some(super::identity_owner::Value::Workspace(selected.clone())),
+            }),
+            identity_spec: Some(super::IdentitySpecReference {
+                scope: Some(IdentitySpecScope {
+                    value: Some(super::identity_spec_scope::Value::Global(
+                        GlobalIdentitySpecScope {},
+                    )),
+                }),
+                ..super::IdentitySpecReference::default()
+            }),
+            ..super::Identity::default()
+        };
+        let global = super::identity_view(&identity, super::IdentityTarget::Workspace(&selected))
+            .expect("global fallback is valid");
+        assert_eq!(global.spec_scope, "global");
+
+        identity
+            .identity_spec
+            .as_mut()
+            .expect("identity spec")
+            .scope = Some(IdentitySpecScope {
+            value: Some(super::identity_spec_scope::Value::Workspace(
+                selected.clone(),
+            )),
+        });
+        let local = super::identity_view(&identity, super::IdentityTarget::Workspace(&selected))
+            .expect("matching workspace scope is valid");
+        assert_eq!(local.spec_scope, "workspace:work");
+
+        identity.owner = Some(IdentityOwner {
+            value: Some(super::identity_owner::Value::Workspace(Workspace {
+                name: "other".to_string(),
+            })),
+        });
+        super::identity_view(&identity, super::IdentityTarget::Workspace(&selected))
+            .expect_err("wrong workspace owner must be rejected");
+
+        identity.owner = Some(IdentityOwner {
+            value: Some(super::identity_owner::Value::Workspace(selected.clone())),
+        });
+        identity
+            .identity_spec
+            .as_mut()
+            .expect("identity spec")
+            .scope = Some(IdentitySpecScope {
+            value: Some(super::identity_spec_scope::Value::Workspace(Workspace {
+                name: "other".to_string(),
+            })),
+        });
+        super::identity_view(&identity, super::IdentityTarget::Workspace(&selected))
+            .expect_err("wrong workspace spec scope must be rejected");
     }
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -80,7 +80,7 @@ enum Command {
     SearchIndex(SearchIndexArgs),
     /// Manage data sources
     Source(SourceArgs),
-    /// Manage identities owned by the current Coral user
+    /// Manage current-user or explicitly selected workspace identities
     Identity(identity_ops::IdentityArgs),
     /// Manage installed identity specifications
     IdentitySpec(identity_spec_ops::IdentitySpecArgs),
@@ -536,6 +536,9 @@ impl Command {
     }
 
     fn uses_selected_workspace(&self) -> bool {
+        if let Command::Identity(args) = self {
+            return args.uses_selected_workspace();
+        }
         matches!(
             self,
             Command::Sql(_)
@@ -623,10 +626,8 @@ pub async fn run_from_env() -> Result<(), CliError> {
     let workspace_flag_present = workspace_selection.workspace.is_some();
     command.apply_workspace_flag_presence(workspace_flag_present);
     match &command {
-        Command::Identity(_) => {
-            identity_ops::IdentityArgs::validate_explicit_workspace(
-                workspace_selection.workspace.as_deref(),
-            )?;
+        Command::Identity(args) => {
+            args.validate_workspace_selection(workspace_selection.workspace.as_deref())?;
         }
         Command::IdentitySpec(args) => {
             args.validate_explicit_workspace(workspace_selection.workspace.as_deref())?;
@@ -900,7 +901,7 @@ async fn run_app_command(
         Command::Search(args) => run_search(&app, workspace, args).await?,
         Command::SearchIndex(args) => run_search_index(&app, workspace, args).await?,
         Command::Source(args) => run_source(&app, workspace, args).await?,
-        Command::Identity(args) => identity_ops::run(&app, args).await?,
+        Command::Identity(args) => identity_ops::run(&app, workspace, args).await?,
         Command::IdentitySpec(args) => identity_spec_ops::run(&app, workspace, args).await?,
         Command::Workspace(args) => run_workspace(&app, args).await?,
         Command::Function(args) => run_function(&app, workspace, args).await?,
@@ -2061,6 +2062,15 @@ mod tests {
         let source = Cli::try_parse_from(["coral", "source", "list"]).expect("source parses");
         let identity =
             Cli::try_parse_from(["coral", "identity", "list"]).expect("identity list parses");
+        let workspace_identity = Cli::try_parse_from([
+            "coral",
+            "--workspace",
+            "work",
+            "identity",
+            "--workspace-owned",
+            "list",
+        ])
+        .expect("workspace identity list parses");
         let identity_spec = Cli::try_parse_from(["coral", "identity-spec", "list"])
             .expect("identity-spec list parses");
         let functions =
@@ -2074,6 +2084,7 @@ mod tests {
         assert!(search.command.uses_selected_workspace());
         assert!(source.command.uses_selected_workspace());
         assert!(!identity.command.uses_selected_workspace());
+        assert!(workspace_identity.command.uses_selected_workspace());
         assert!(identity_spec.command.uses_selected_workspace());
         assert!(functions.command.uses_selected_workspace());
         assert!(onboard.command.uses_selected_workspace());


### PR DESCRIPTION
## Intent

Expose workspace-owned fixed-token identity lifecycle management without allowing ambient or accidental workspace selection to change identity ownership. Workspace ownership requires both an explicit `--workspace NAME` and `identity --workspace-owned`.

## What it enables

- Add, list, inspect, and remove identities owned independently by an explicitly selected workspace.
- Resolve a named identity spec server-side from the workspace with global fallback, then render the exact returned scope and fingerprint.
- Fail closed when returned owner or spec scope does not match the selected workspace.
- Preserve current-user command behavior, including ignoring `CORAL_WORKSPACE`, rejecting an unqualified `--workspace`, and keeping tokens write-only.

## Usage examples

```bash
coral --workspace work identity --workspace-owned add github-shared --identity-spec github-token
coral --workspace work identity --workspace-owned list
coral --workspace work identity --workspace-owned info github-shared
coral --workspace work identity --workspace-owned remove github-shared
```