### PR TITLE
test(cli): cover workspace identity commands

### DIFF
--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -812,6 +812,242 @@ async fn current_user_identity_malformed_responses_fail_closed() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn workspace_identity_add_reads_stdin_without_secret_egress_or_other_identity_rpc() {
+    let server = MockServer::start().await;
+    let token = "workspace-fixed-token-secret-sentinel";
+
+    let added = server
+        .cmd()
+        .env("CORAL_WORKSPACE", "ignored")
+        .args([
+            "--workspace",
+            "work",
+            "identity",
+            "--workspace-owned",
+            "add",
+            "github_shared",
+            "--identity-spec",
+            "workspace_token",
+            "--token-stdin",
+        ])
+        .write_stdin(format!("{token}\r\n"))
+        .assert()
+        .success()
+        .stdout(
+            "Stored workspace identity 'github_shared' in 'work' using identity spec 'workspace_token' from workspace:work.\n",
+        );
+    let stdout = String::from_utf8_lossy(&added.get_output().stdout);
+    let stderr = String::from_utf8_lossy(&added.get_output().stderr);
+    assert!(!stdout.contains(token), "secret leaked to stdout: {stdout}");
+    assert!(!stderr.contains(token), "secret leaked to stderr: {stderr}");
+
+    let requests = server.create_workspace_identity_requests();
+    assert_eq!(requests.len(), 1);
+    assert_workspace_name(requests[0].workspace.as_ref(), "work");
+    assert_eq!(requests[0].name, "github_shared");
+    assert_eq!(requests[0].identity_spec_name, "workspace_token");
+    assert_eq!(
+        requests[0].setup.as_ref().map(|setup| setup.token.as_str()),
+        Some(token)
+    );
+    assert_eq!(server.workspace_identity_request_count(), 1);
+    assert_eq!(server.current_user_identity_request_count(), 0);
+    assert_eq!(server.identity_spec_request_count(), 0);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_identity_list_and_info_render_exact_owner_and_resolved_scope() {
+    let server = MockServer::start().await;
+
+    let listed = server
+        .cmd()
+        .env("CORAL_WORKSPACE", "ignored")
+        .args([
+            "--workspace",
+            "work",
+            "identity",
+            "--workspace-owned",
+            "list",
+        ])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&listed.get_output().stdout);
+    let rows = nonempty_lines(&stdout);
+    for expected in [
+        [
+            "workspace_local",
+            "workspace_token",
+            "demo",
+            "fixed_token",
+            "api.example.com:443",
+            "workspace:work",
+        ],
+        [
+            "global_fallback",
+            "global_token",
+            "demo",
+            "fixed_token",
+            "api.example.com:443",
+            "global",
+        ],
+    ] {
+        assert!(
+            rows.iter().any(|row| row.split_whitespace().eq(expected)),
+            "missing row {expected:?}: {stdout}"
+        );
+    }
+    let lists = server.list_workspace_identities_requests();
+    assert_eq!(lists.len(), 1);
+    assert_workspace_name(lists[0].workspace.as_ref(), "work");
+
+    for (name, spec, scope) in [
+        ("workspace_local", "workspace_token", "workspace:work"),
+        ("global_fallback", "global_token", "global"),
+    ] {
+        let info = server
+            .cmd()
+            .env("CORAL_WORKSPACE", "ignored")
+            .args([
+                "--workspace",
+                "work",
+                "identity",
+                "--workspace-owned",
+                "info",
+                name,
+            ])
+            .assert()
+            .success();
+        let stdout = String::from_utf8_lossy(&info.get_output().stdout);
+        for expected in [
+            format!("Identity spec: {spec}"),
+            "Owner:         workspace:work".to_string(),
+            format!("Spec scope:    {scope}"),
+            format!("Fingerprint:   fingerprint-{spec}"),
+        ] {
+            assert!(stdout.contains(&expected), "missing {expected:?}: {stdout}");
+        }
+    }
+    let gets = server.get_workspace_identity_requests();
+    assert_eq!(gets.len(), 2);
+    for request in &gets {
+        assert_workspace_name(request.workspace.as_ref(), "work");
+    }
+    assert_eq!(server.workspace_identity_request_count(), 3);
+    assert_eq!(server.current_user_identity_request_count(), 0);
+    assert_eq!(server.identity_spec_request_count(), 0);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_identity_remove_sends_exact_request() {
+    let server = MockServer::start().await;
+
+    server
+        .cmd()
+        .env("CORAL_WORKSPACE", "ignored")
+        .args([
+            "--workspace",
+            "work",
+            "identity",
+            "--workspace-owned",
+            "remove",
+            "github_shared",
+        ])
+        .assert()
+        .success()
+        .stdout("Removed workspace identity 'github_shared' from 'work'.\n");
+    let requests = server.delete_workspace_identity_requests();
+    assert_eq!(requests.len(), 1);
+    assert_workspace_name(requests[0].workspace.as_ref(), "work");
+    assert_eq!(requests[0].name, "github_shared");
+    assert_eq!(server.workspace_identity_request_count(), 1);
+    assert_eq!(server.current_user_identity_request_count(), 0);
+    assert_eq!(server.identity_spec_request_count(), 0);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_identity_rejects_ambiguous_selection_without_rpc() {
+    let server = MockServer::start().await;
+
+    let current_user = server
+        .cmd()
+        .args(["--workspace", "work", "identity", "list"])
+        .assert()
+        .failure();
+    assert!(
+        String::from_utf8_lossy(&current_user.get_output().stderr)
+            .contains("add --workspace-owned")
+    );
+    let environment_only = server
+        .cmd()
+        .env("CORAL_WORKSPACE", "work")
+        .args(["identity", "--workspace-owned", "list"])
+        .assert()
+        .failure();
+    assert!(
+        String::from_utf8_lossy(&environment_only.get_output().stderr)
+            .contains("--workspace-owned requires an explicit --workspace NAME")
+    );
+    assert_eq!(server.workspace_identity_request_count(), 0);
+    assert_eq!(server.current_user_identity_request_count(), 0);
+    assert_eq!(server.identity_spec_request_count(), 0);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_identity_malformed_responses_fail_closed() {
+    let server = MockServer::start().await;
+    let cases = [
+        ("missing_owner", "missing exact owner"),
+        ("current_user_owner", "current-user owner"),
+        ("wrong_owner", "response owner 'other' does not match"),
+        ("missing_spec", "missing identity spec reference"),
+        ("missing_scope", "missing exact identity-spec scope"),
+        ("wrong_scope", "response spec scope 'other' does not match"),
+    ];
+
+    for (name, expected) in cases {
+        let result = server
+            .cmd()
+            .env("CORAL_WORKSPACE", "ignored")
+            .args([
+                "--workspace",
+                "work",
+                "identity",
+                "--workspace-owned",
+                "info",
+                name,
+            ])
+            .assert()
+            .failure()
+            .stdout("");
+        let stderr = String::from_utf8_lossy(&result.get_output().stderr);
+        assert!(stderr.contains(expected), "missing {expected:?}: {stderr}");
+    }
+    let gets = server.get_workspace_identity_requests();
+    assert_eq!(
+        gets.iter()
+            .map(|request| request.name.as_str())
+            .collect::<Vec<_>>(),
+        cases.map(|(name, _)| name).as_slice()
+    );
+    for request in &gets {
+        assert_workspace_name(request.workspace.as_ref(), "work");
+    }
+    assert_eq!(server.workspace_identity_request_count(), cases.len());
+    assert_eq!(server.current_user_identity_request_count(), 0);
+    assert_eq!(server.identity_spec_request_count(), 0);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn source_list_renders_configured_sources() {
     let server = MockServer::start().await;
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -22,6 +22,9 @@ use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::search_service_server::{SearchService, SearchServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::task_service_server::{TaskService, TaskServiceServer};
+use coral_api::v1::workspace_identity_service_server::{
+    WorkspaceIdentityService, WorkspaceIdentityServiceServer,
+};
 use coral_api::v1::workspace_service_server::{WorkspaceService, WorkspaceServiceServer};
 use coral_api::v1::{
     AddFunctionRequest, AddFunctionResponse, AddIdentitySpecRequest, AddIdentitySpecResponse,
@@ -29,34 +32,38 @@ use coral_api::v1::{
     ClearSearchDataRequest, ClearSearchDataResponse, Column, ColumnSearchResult,
     CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
     CreateBundledSourceWithOAuthResponse, CreateUserOwnedFixedTokenIdentityRequest,
-    CreateUserOwnedFixedTokenIdentityResponse, CreateWorkspaceRequest, CreateWorkspaceResponse,
-    CurrentUserIdentityOwner, DeleteFunctionRequest, DeleteFunctionResponse,
-    DeleteIdentitySpecRequest, DeleteIdentitySpecResponse, DeleteSourceRequest,
-    DeleteSourceResponse, DeleteUserOwnedIdentityRequest, DeleteUserOwnedIdentityResponse,
-    DeleteWorkspaceRequest, DeleteWorkspaceResponse, DescribeCatalogSurfaceRequest,
-    DescribeCatalogSurfaceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
-    DrainSearchQueueRequest, DrainSearchQueueResponse, EndTaskRequest, EndTaskResponse,
-    ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
+    CreateUserOwnedFixedTokenIdentityResponse, CreateWorkspaceOwnedFixedTokenIdentityRequest,
+    CreateWorkspaceOwnedFixedTokenIdentityResponse, CreateWorkspaceRequest,
+    CreateWorkspaceResponse, CurrentUserIdentityOwner, DeleteFunctionRequest,
+    DeleteFunctionResponse, DeleteIdentitySpecRequest, DeleteIdentitySpecResponse,
+    DeleteSourceRequest, DeleteSourceResponse, DeleteUserOwnedIdentityRequest,
+    DeleteUserOwnedIdentityResponse, DeleteWorkspaceOwnedIdentityRequest,
+    DeleteWorkspaceOwnedIdentityResponse, DeleteWorkspaceRequest, DeleteWorkspaceResponse,
+    DescribeCatalogSurfaceRequest, DescribeCatalogSurfaceResponse, DiscoverSourcesRequest,
+    DiscoverSourcesResponse, DrainSearchQueueRequest, DrainSearchQueueResponse, EndTaskRequest,
+    EndTaskResponse, ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
     GetIdentitySpecRequest, GetIdentitySpecResponse, GetSourceInfoRequest, GetSourceInfoResponse,
     GetSourceRequest, GetSourceResponse, GetUserOwnedIdentityRequest, GetUserOwnedIdentityResponse,
-    GlobalIdentitySpecScope, Identity, IdentityAudience, IdentityOwner, IdentitySpec,
-    IdentitySpecReference, IdentitySpecScope, IdentitySpecSummary, IdentitySpecType,
-    ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListCatalogResponse,
-    ListColumnsRequest, ListColumnsResponse, ListFunctionsRequest, ListFunctionsResponse,
-    ListIdentitySpecsRequest, ListIdentitySpecsResponse, ListSourcesRequest, ListSourcesResponse,
-    ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse, ListWorkspacesRequest,
-    ListWorkspacesResponse, MissingCatalogSurface, ObservedDrainResult, ObservedRebuildResult,
-    PaginationRequest, PaginationResponse, QueryPlan, RebuildSearchIndexRequest,
-    RebuildSearchIndexResponse, SearchCatalogRequest, SearchCatalogResponse, SearchField,
-    SearchMaintenanceResult, SearchMaintenanceState, SearchProvider, SearchProviderCoverage,
-    SearchProviderState, SearchRequest, SearchResponse, SearchResult, SearchResultTruncation,
-    SearchStorageCleanupResult, SearchSurfaceRef, SearchTableShape, Source,
-    SourceCredentialStorage, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput,
-    StartTaskRequest, StartTaskResponse, Table, TableFunction, TableSummary, Task as ProtoTask,
-    TaskEnd as ProtoTaskEnd, TaskStatus, ValidateSourceRequest, ValidateSourceResponse, Workspace,
-    catalog_item, create_bundled_source_with_o_auth_response, describe_catalog_surface_response,
-    identity_owner, identity_spec_scope, import_source_response, search_maintenance_result,
-    search_result, source_input_spec::Input as ProtoSourceInput,
+    GetWorkspaceOwnedIdentityRequest, GetWorkspaceOwnedIdentityResponse, GlobalIdentitySpecScope,
+    Identity, IdentityAudience, IdentityOwner, IdentitySpec, IdentitySpecReference,
+    IdentitySpecScope, IdentitySpecSummary, IdentitySpecType, ImportSourceRequest,
+    ImportSourceResponse, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
+    ListColumnsResponse, ListFunctionsRequest, ListFunctionsResponse, ListIdentitySpecsRequest,
+    ListIdentitySpecsResponse, ListSourcesRequest, ListSourcesResponse,
+    ListUserOwnedIdentitiesRequest, ListUserOwnedIdentitiesResponse,
+    ListWorkspaceOwnedIdentitiesRequest, ListWorkspaceOwnedIdentitiesResponse,
+    ListWorkspacesRequest, ListWorkspacesResponse, MissingCatalogSurface, ObservedDrainResult,
+    ObservedRebuildResult, PaginationRequest, PaginationResponse, QueryPlan,
+    RebuildSearchIndexRequest, RebuildSearchIndexResponse, SearchCatalogRequest,
+    SearchCatalogResponse, SearchField, SearchMaintenanceResult, SearchMaintenanceState,
+    SearchProvider, SearchProviderCoverage, SearchProviderState, SearchRequest, SearchResponse,
+    SearchResult, SearchResultTruncation, SearchStorageCleanupResult, SearchSurfaceRef,
+    SearchTableShape, Source, SourceCredentialStorage, SourceInfo, SourceInputSpec, SourceOrigin,
+    SourceSecretInput, StartTaskRequest, StartTaskResponse, Table, TableFunction, TableSummary,
+    Task as ProtoTask, TaskEnd as ProtoTaskEnd, TaskStatus, ValidateSourceRequest,
+    ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
+    describe_catalog_surface_response, identity_owner, identity_spec_scope, import_source_response,
+    search_maintenance_result, search_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_TASK_ID_METADATA_KEY,
@@ -74,6 +81,12 @@ use tonic_types::{ErrorDetail, StatusExt as _};
 fn workspace() -> Workspace {
     Workspace {
         name: "default".to_string(),
+    }
+}
+
+fn named_workspace(name: &str) -> Workspace {
+    Workspace {
+        name: name.to_string(),
     }
 }
 
@@ -170,6 +183,76 @@ fn mock_user_identity_for_get(name: &str) -> Identity {
         "workspace_scope" => {
             identity.identity_spec.as_mut().expect("spec").scope = Some(IdentitySpecScope {
                 value: Some(identity_spec_scope::Value::Workspace(workspace())),
+            });
+        }
+        _ => {}
+    }
+    identity
+}
+
+fn mock_workspace_identity(
+    name: &str,
+    spec_name: &str,
+    owner: Workspace,
+    scope: IdentitySpecScope,
+) -> Identity {
+    Identity {
+        name: name.to_string(),
+        owner: Some(IdentityOwner {
+            value: Some(identity_owner::Value::Workspace(owner)),
+        }),
+        identity_spec: Some(IdentitySpecReference {
+            name: spec_name.to_string(),
+            scope: Some(scope),
+            fingerprint: format!("fingerprint-{spec_name}"),
+            issuer: "demo".to_string(),
+            identity_type: IdentitySpecType::FixedToken as i32,
+            audience: Some(IdentityAudience {
+                host: "api.example.com".to_string(),
+                port: Some(443),
+            }),
+        }),
+        created_at_unix_nanos: 10,
+        updated_at_unix_nanos: 20,
+    }
+}
+
+fn mock_workspace_identity_for_get(name: &str, workspace: Workspace) -> Identity {
+    let mut identity = mock_workspace_identity(
+        name,
+        "workspace_token",
+        workspace.clone(),
+        IdentitySpecScope {
+            value: Some(identity_spec_scope::Value::Workspace(workspace)),
+        },
+    );
+    match name {
+        "global_fallback" => {
+            let spec = identity.identity_spec.as_mut().expect("spec");
+            spec.name = "global_token".to_string();
+            spec.fingerprint = "fingerprint-global_token".to_string();
+            spec.scope = Some(global_identity_spec_scope());
+        }
+        "missing_owner" => identity.owner = None,
+        "current_user_owner" => {
+            identity.owner = Some(IdentityOwner {
+                value: Some(identity_owner::Value::CurrentUser(
+                    CurrentUserIdentityOwner {},
+                )),
+            });
+        }
+        "wrong_owner" => {
+            identity.owner = Some(IdentityOwner {
+                value: Some(identity_owner::Value::Workspace(named_workspace("other"))),
+            });
+        }
+        "missing_spec" => identity.identity_spec = None,
+        "missing_scope" => identity.identity_spec.as_mut().expect("spec").scope = None,
+        "wrong_scope" => {
+            identity.identity_spec.as_mut().expect("spec").scope = Some(IdentitySpecScope {
+                value: Some(identity_spec_scope::Value::Workspace(named_workspace(
+                    "other",
+                ))),
             });
         }
         _ => {}
@@ -1021,6 +1104,10 @@ struct Captured {
     list_user_identities: Mutex<Vec<ListUserOwnedIdentitiesRequest>>,
     get_user_identity: Mutex<Vec<GetUserOwnedIdentityRequest>>,
     delete_user_identity: Mutex<Vec<DeleteUserOwnedIdentityRequest>>,
+    create_workspace_identity: Mutex<Vec<CreateWorkspaceOwnedFixedTokenIdentityRequest>>,
+    list_workspace_identities: Mutex<Vec<ListWorkspaceOwnedIdentitiesRequest>>,
+    get_workspace_identity: Mutex<Vec<GetWorkspaceOwnedIdentityRequest>>,
+    delete_workspace_identity: Mutex<Vec<DeleteWorkspaceOwnedIdentityRequest>>,
 }
 
 pub(crate) fn encode_arrow_ipc_stream(
@@ -1518,6 +1605,100 @@ impl IdentityService for MockIdentityService {
 }
 
 #[derive(Clone)]
+struct MockWorkspaceIdentityService {
+    captured: Arc<Captured>,
+}
+
+#[tonic::async_trait]
+impl WorkspaceIdentityService for MockWorkspaceIdentityService {
+    async fn create_workspace_owned_fixed_token_identity(
+        &self,
+        request: Request<CreateWorkspaceOwnedFixedTokenIdentityRequest>,
+    ) -> Result<Response<CreateWorkspaceOwnedFixedTokenIdentityResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .create_workspace_identity
+            .lock()
+            .expect("create_workspace_identity capture")
+            .push(request.clone());
+        let workspace = request.workspace.clone().unwrap_or_default();
+        Ok(Response::new(
+            CreateWorkspaceOwnedFixedTokenIdentityResponse {
+                identity: Some(mock_workspace_identity(
+                    &request.name,
+                    &request.identity_spec_name,
+                    workspace.clone(),
+                    IdentitySpecScope {
+                        value: Some(identity_spec_scope::Value::Workspace(workspace)),
+                    },
+                )),
+            },
+        ))
+    }
+
+    async fn list_workspace_owned_identities(
+        &self,
+        request: Request<ListWorkspaceOwnedIdentitiesRequest>,
+    ) -> Result<Response<ListWorkspaceOwnedIdentitiesResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .list_workspace_identities
+            .lock()
+            .expect("list_workspace_identities capture")
+            .push(request.clone());
+        let workspace = request.workspace.unwrap_or_default();
+        Ok(Response::new(ListWorkspaceOwnedIdentitiesResponse {
+            identities: vec![
+                mock_workspace_identity(
+                    "workspace_local",
+                    "workspace_token",
+                    workspace.clone(),
+                    IdentitySpecScope {
+                        value: Some(identity_spec_scope::Value::Workspace(workspace.clone())),
+                    },
+                ),
+                mock_workspace_identity(
+                    "global_fallback",
+                    "global_token",
+                    workspace,
+                    global_identity_spec_scope(),
+                ),
+            ],
+        }))
+    }
+
+    async fn get_workspace_owned_identity(
+        &self,
+        request: Request<GetWorkspaceOwnedIdentityRequest>,
+    ) -> Result<Response<GetWorkspaceOwnedIdentityResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .get_workspace_identity
+            .lock()
+            .expect("get_workspace_identity capture")
+            .push(request.clone());
+        Ok(Response::new(GetWorkspaceOwnedIdentityResponse {
+            identity: Some(mock_workspace_identity_for_get(
+                &request.name,
+                request.workspace.unwrap_or_default(),
+            )),
+        }))
+    }
+
+    async fn delete_workspace_owned_identity(
+        &self,
+        request: Request<DeleteWorkspaceOwnedIdentityRequest>,
+    ) -> Result<Response<DeleteWorkspaceOwnedIdentityResponse>, Status> {
+        self.captured
+            .delete_workspace_identity
+            .lock()
+            .expect("delete_workspace_identity capture")
+            .push(request.into_inner());
+        Ok(Response::new(DeleteWorkspaceOwnedIdentityResponse {}))
+    }
+}
+
+#[derive(Clone)]
 struct MockSourceService {
     config: Arc<MockServerConfig>,
     captured: Arc<Captured>,
@@ -1896,6 +2077,7 @@ impl MockServer {
         let search_captured = Arc::clone(&captured);
         let catalog_captured = Arc::clone(&captured);
         let identity_captured = Arc::clone(&captured);
+        let workspace_identity_captured = Arc::clone(&captured);
         let identity_spec_captured = Arc::clone(&captured);
         let source_captured = Arc::clone(&captured);
         let function_captured = Arc::clone(&captured);
@@ -1913,6 +2095,11 @@ impl MockServer {
                 .add_service(IdentityServiceServer::new(MockIdentityService {
                     captured: identity_captured,
                 }))
+                .add_service(WorkspaceIdentityServiceServer::new(
+                    MockWorkspaceIdentityService {
+                        captured: workspace_identity_captured,
+                    },
+                ))
                 .add_service(IdentitySpecServiceServer::new(MockIdentitySpecService {
                     captured: identity_spec_captured,
                 }))
@@ -2240,6 +2427,51 @@ impl MockServer {
             + self.list_user_identities_requests().len()
             + self.get_user_identity_requests().len()
             + self.delete_user_identity_requests().len()
+    }
+
+    pub(crate) fn create_workspace_identity_requests(
+        &self,
+    ) -> Vec<CreateWorkspaceOwnedFixedTokenIdentityRequest> {
+        self.captured
+            .create_workspace_identity
+            .lock()
+            .expect("create_workspace_identity capture")
+            .clone()
+    }
+
+    pub(crate) fn list_workspace_identities_requests(
+        &self,
+    ) -> Vec<ListWorkspaceOwnedIdentitiesRequest> {
+        self.captured
+            .list_workspace_identities
+            .lock()
+            .expect("list_workspace_identities capture")
+            .clone()
+    }
+
+    pub(crate) fn get_workspace_identity_requests(&self) -> Vec<GetWorkspaceOwnedIdentityRequest> {
+        self.captured
+            .get_workspace_identity
+            .lock()
+            .expect("get_workspace_identity capture")
+            .clone()
+    }
+
+    pub(crate) fn delete_workspace_identity_requests(
+        &self,
+    ) -> Vec<DeleteWorkspaceOwnedIdentityRequest> {
+        self.captured
+            .delete_workspace_identity
+            .lock()
+            .expect("delete_workspace_identity capture")
+            .clone()
+    }
+
+    pub(crate) fn workspace_identity_request_count(&self) -> usize {
+        self.create_workspace_identity_requests().len()
+            + self.list_workspace_identities_requests().len()
+            + self.get_workspace_identity_requests().len()
+            + self.delete_workspace_identity_requests().len()
     }
 
     pub(crate) fn endpoint_uri(&self) -> &str {


### PR DESCRIPTION
## Intent

Lock the workspace-owned identity CLI to its exact request, response, ownership, and secret-handling contracts.

## What it enables

Workspace identity commands now have end-to-end coverage for explicit workspace routing, workspace-local and global-fallback spec scopes, malformed response rejection, cross-service isolation, and token non-egress.

## Usage examples

Add: coral --workspace team identity --workspace-owned add github --identity-spec github_pat --token-stdin
List: coral --workspace team identity --workspace-owned list
Inspect: coral --workspace team identity --workspace-owned info github
Remove: coral --workspace team identity --workspace-owned remove github