### PR TITLE
chore(engine): update DataFusion to 54

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,14 +1687,13 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "datafusion"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93db0e623840612f7f2cd757f7e8a8922064192363732c88692e0870016e141b"
+checksum = "997a31e15872606a49478e670c58302094c97cb96abb0a7d60720f8e92170040"
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
- "bytes",
  "bzip2",
  "chrono",
  "datafusion-catalog",
@@ -1724,14 +1723,13 @@ dependencies = [
  "datafusion-sql",
  "flate2",
  "futures",
+ "indexmap",
  "itertools",
  "liblzma",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.5",
- "regex",
  "sqlparser",
  "tempfile",
  "tokio",
@@ -1742,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cefde60b26a7f4ff61e9d2ff2833322f91df2b568d7238afe67bde5bdffb66"
+checksum = "f7dd61161508f8f5fa1107774ea687bd753c22d83a32eebf963549f89de14139"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1767,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e112307715d6a7a331111a4c2330ff54bc237183511c319e3708a4cff431fb"
+checksum = "897c70f871277f9ce99aa38347be0d679bbe3e617156c4d2a8378cec8a2a0891"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1790,34 +1788,35 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d72a11ca44a95e1081870d3abb80c717496e8a7acb467a1d3e932bb636af5cc2"
+checksum = "121c9ded5d87d9172319e006f2afdb9928d72dbacd6a90a458d8acb1e3b43a65"
 dependencies = [
- "ahash",
  "arrow",
  "arrow-ipc",
+ "arrow-schema",
  "chrono",
+ "foldhash 0.2.0",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "itertools",
  "libc",
  "log",
  "object_store",
  "parquet",
- "paste",
  "recursive",
  "sqlparser",
  "tokio",
+ "uuid",
  "web-time",
 ]
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f4afaed29670ec4fd6053643adc749fe3f4bc9d1ce1b8c5679b22c67d12def"
+checksum = "981b9dae74f78ee3d9f714fb49b01919eab975461b56149510c3ba9ea11287d1"
 dependencies = [
  "futures",
  "log",
@@ -1826,9 +1825,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9fb386e1691355355a96419978a0022b7947b44d4a24a6ea99f00b6b485cbb6"
+checksum = "ffd7d295b2ec7c00d8a56562f41ed41062cf0af75549ed891c12a0a09eddfefe"
 dependencies = [
  "arrow",
  "async-compression",
@@ -1852,6 +1851,7 @@ dependencies = [
  "liblzma",
  "log",
  "object_store",
+ "parking_lot",
  "rand 0.9.5",
  "tokio",
  "tokio-util",
@@ -1861,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa6c52cfed0734c5f93754d1c0175f558175248bf686c944fb05c373e5fc096"
+checksum = "552b0b3f342f7ec41b3fbd70f6339dc82a30cfd0349e7f280e7852528085349f"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -1885,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503f29e0582c1fc189578d665ff57d9300da1f80c282777d7eb67bb79fb8cdca"
+checksum = "68850aa426b897e879c8b87e512ea8124f1d0a2869a4e51808ddaaddf1bc0ada"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1908,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33804749abc8d0c8cb7473228483cb8070e524c6f6086ee1b85a64debe2b3d2"
+checksum = "402f93242ae08ef99139ee2c528a49d087efe88d5c7b2c3ff5480855a40ce54f"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1925,16 +1925,15 @@ dependencies = [
  "datafusion-session",
  "futures",
  "object_store",
- "serde_json",
  "tokio",
  "tokio-stream",
 ]
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a8e0365e0e08e8ff94d912f0ababcf9065a1a304018ba90b1fc83c855b4997"
+checksum = "ffd2499c1bee0eeccf6a57156105700eeeb17bc701899ac719183c4e74231450"
 dependencies = [
  "arrow",
  "async-trait",
@@ -1944,6 +1943,7 @@ dependencies = [
  "datafusion-datasource",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-functions",
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-adapter",
@@ -1962,20 +1962,19 @@ dependencies = [
 
 [[package]]
 name = "datafusion-doc"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de6ac0df1662b9148ad3c987978b32cbec7c772f199b1d53520c8fa764a87ee"
+checksum = "cb9e7e5d11130c48c8bd4e80c79a9772dd28ce6dc330baca9246205d245b9e2e"
 
 [[package]]
 name = "datafusion-execution"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03c7fbdaefcca4ef6ffe425a5fc2325763bfb426599bb0bf4536466efabe709"
+checksum = "37a8643ab852eb68864e1b72ae789e8066282dce48eea6347ffb0aee33d1ccc0"
 dependencies = [
  "arrow",
  "arrow-buffer",
  "async-trait",
- "chrono",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
@@ -1991,11 +1990,12 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574b9b6977fedbd2a611cbff12e5caf90f31640ad9dc5870f152836d94bad0dd"
+checksum = "6932f4d71eed9c8d9341476a2b845aadfabde5495d08dbcd8fc23881f49fa7a0"
 dependencies = [
  "arrow",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -2006,7 +2006,6 @@ dependencies = [
  "datafusion-physical-expr-common",
  "indexmap",
  "itertools",
- "paste",
  "recursive",
  "serde_json",
  "sqlparser",
@@ -2014,22 +2013,21 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7c3adf3db8bf61e92eb90cb659c8e8b734593a8f7c8e12a843c7ddba24b87e"
+checksum = "0225491839a31b1f7d2cb8092c2d50792e2fe1c1724e4e6d08e011f5feaf4ed2"
 dependencies = [
  "arrow",
  "datafusion-common",
  "indexmap",
  "itertools",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28aa4e10384e782774b10e72aca4d93ef7b31aa653095d9d4536b0a3dbc51b6"
+checksum = "14872c47bfc3d21e53ec82f57074e6987a15941c1e2f43cde4ac6ae2746634e3"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2044,26 +2042,25 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-macros",
+ "datafusion-physical-expr-common",
  "hex",
  "itertools",
  "log",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "memchr",
  "num-traits",
  "rand 0.9.5",
  "regex",
- "sha2 0.10.9",
- "unicode-segmentation",
+ "sha2 0.11.0",
  "uuid",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00aa6217e56098ba84e0a338176fe52f0a84cca398021512c6c8c5eff806d0ad"
+checksum = "75a2ca14e1b609be21e657e2d3130b2f446456b08393b377bb721a33952d2e09"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-doc",
@@ -2073,19 +2070,18 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
+ "foldhash 0.2.0",
  "half",
  "log",
  "num-traits",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b511250349407db7c43832ab2de63f5557b19a20dfd236b39ca2c04468b50d47"
+checksum = "1ece74ba09092d2ef9c9b54a38445450aea292a1f8b04faf531936b723a24b3c"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
@@ -2094,21 +2090,22 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-json"
-version = "0.53.1"
+version = "0.54.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ff70cb2c1960f03ba647aa2813fb1efba4c33bc221d973dd4a462a6376359a"
+checksum = "ab80590f2e0c240fd14a8178b584941f5ced55ee90cd41a128e6c08176c0f7cc"
 dependencies = [
  "datafusion",
  "jiter",
  "log",
  "paste",
+ "serde_json",
 ]
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
+checksum = "3f3e3f9ee8ca59bf70518802107de6f1b88a9509efdc629fadc5de9d6b2d5ef5"
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -2122,34 +2119,34 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-macros",
  "datafusion-physical-expr-common",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itertools",
  "itoa",
  "log",
- "paste",
+ "memchr",
 ]
 
 [[package]]
 name = "datafusion-functions-table"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b40d3f5bbb3905f9ccb1ce9485a9595c77b69758a7c24d3ba79e334ff51e7e"
+checksum = "89161dffc22cf2b50f9f4b1bee83b5221d3b4ed7c2e37fd7aa2b22a5297b3a26"
 dependencies = [
  "arrow",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-physical-expr",
  "datafusion-physical-plan",
  "parking_lot",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e88ec9d57c9b685d02f58bfee7be62d72610430ddcedb82a08e5d9925dbfb6"
+checksum = "d7339345b226b3874037708bf5023ba1c2de705128f8457a095aae5ae9cb9c78"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2160,14 +2157,13 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8307bb93519b1a91913723a1130cfafeee3f72200d870d88e91a6fc5470ede5c"
+checksum = "fa84836dc2392df6f43d6a29d37fb56a8ebdc8b3f4e10ae8dc15861fd20278fb"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2175,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e367e6a71051d0ebdd29b2f85d12059b38b1d1f172c6906e80016da662226bd"
+checksum = "587164e03ad68732aa9e7bfe5686e3f25970d4c64fd4bd80790749840892dae5"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2186,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e929015451a67f77d9d8b727b2bf3a40c4445fdef6cdc53281d7d97c76888ace"
+checksum = "77f20e8cf9e8654d92f4c16b24c487353ee5bf153ffc12d5772cd399ab8cd281"
 dependencies = [
  "arrow",
  "chrono",
@@ -2206,11 +2202,10 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1e68aba7a4b350401cfdf25a3d6f989ad898a7410164afe9ca52080244cb59"
+checksum = "f015a4a82f6f7ff7e1d8d4bf3870a936752fa38b17705dfcc14adef95aa8922c"
 dependencies = [
- "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr",
@@ -2218,11 +2213,10 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "itertools",
  "parking_lot",
- "paste",
  "petgraph",
  "recursive",
  "tokio",
@@ -2230,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea22315f33cf2e0adc104e8ec42e285f6ed93998d565c65e82fec6a9ee9f9db4"
+checksum = "51e6ffff8acdfe54e0ea15ccf38115c4a9184433b0439f42907637928d00a235"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2245,26 +2239,26 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04b45ea8ad3ac2d78f2ea2a76053e06591c9629c7a603eda16c10649ecf4362"
+checksum = "7967a3e171c6a4bf09474b3f7a14f1a3db13ed1714ba12156f33fcce2bba54e8"
 dependencies = [
- "ahash",
  "arrow",
  "chrono",
  "datafusion-common",
  "datafusion-expr-common",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "itertools",
  "parking_lot",
+ "pin-project",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb13397809a425918f608dfe8653f332015a3e330004ab191b4404187238b95"
+checksum = "59ff803e2a96054cb6d83f35f9e60fd4f42eac515e1932bd1b2dbc91d5fcbf36"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2281,12 +2275,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edc023675791af9d5fb4cc4c24abf5f7bd3bd4dcf9e5bd90ea1eff6976dcc79"
+checksum = "776ee54d47d15bdb126452f9ca17b03761e3b004682914beaedd3f86eb507fbc"
 dependencies = [
- "ahash",
  "arrow",
+ "arrow-data",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "async-trait",
@@ -2301,7 +2296,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "itertools",
  "log",
@@ -2313,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8c76860e355616555081cab5968cec1af7a80701ff374510860bcd567e365a"
+checksum = "d5fb9e5774660aa69c3ba93c610f175f75b65cb8c3776edb3626de8f3a4f4ee3"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -2324,15 +2319,14 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
- "itertools",
  "log",
 ]
 
 [[package]]
 name = "datafusion-session"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5412111aa48e2424ba926112e192f7a6b7e4ccb450145d25ce5ede9f19dc491e"
+checksum = "15ce715fa2a61f4623cc234bcc14a3ef6a91f189128d5b14b468a6a17cdfc417"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2344,9 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "53.1.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
+checksum = "6094ad36a3ed6d7ac87b20b479b2d0b118250f66cf997603829fdc65b44a7099"
 dependencies = [
  "arrow",
  "bigdecimal",
@@ -2363,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-tracing"
-version = "53.0.2"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07de1239d9c1ff5a251848438a2ea03ae936e1613beeeea8bff8d3e88fb72fda"
+checksum = "a681122d1ff303ffa91dc0cec342c2f916cf08981b8a256f28129380dab637c9"
 dependencies = [
  "async-trait",
  "comfy-table",
@@ -2974,6 +2968,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -3411,9 +3410,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiter"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ba671987d7444d251d3ee5340be1bf4606cd6c0b53e6f4066b5a1ee376b22"
+checksum = "7866f284df68dbc242796251ed9768bde2b58ebc4d7d32cc07cc7fd993e3ed6c"
 dependencies = [
  "ahash",
  "bitvec",
@@ -5523,9 +5522,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.61.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
 dependencies = [
  "log",
  "recursive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,11 +55,11 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
 crossterm = { version = "0.29", default-features = false, features = ["events", "windows"] }
-datafusion = "53"
-datafusion-datasource = "53"
-datafusion-datasource-json = "53"
-datafusion-functions-json = "0.53"
-datafusion-tracing = "53.0.2"
+datafusion = "54"
+datafusion-datasource = "54"
+datafusion-datasource-json = "54"
+datafusion-functions-json = "0.54"
+datafusion-tracing = "54"
 dialoguer = "0.12"
 etcetera = "0.11"
 fs2 = "0.4"

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -40,7 +40,7 @@ impl FunctionServiceApi for FunctionService {
     ) -> Result<Response<AddFunctionResponse>, Status> {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
-        instrument_grpc(span, async move {
+        Box::pin(instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
             let runtime_function = queries
@@ -50,7 +50,7 @@ impl FunctionServiceApi for FunctionService {
             Ok(Response::new(AddFunctionResponse {
                 function: Some(runtime_function_to_proto(&workspace_name, runtime_function)),
             }))
-        })
+        }))
         .await
     }
 

--- a/crates/coral-engine/src/backends/file/json.rs
+++ b/crates/coral-engine/src/backends/file/json.rs
@@ -1,6 +1,5 @@
 //! JSON and JSONL file tables backed by `DataFusion` file scan primitives.
 
-use std::any::Any;
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::fmt;
 use std::io::{self, BufRead, BufReader, Read};
@@ -161,10 +160,6 @@ pub(super) fn requires_custom_provider(table: &FileTableSpec) -> Result<bool> {
 
 #[async_trait]
 impl TableProvider for JsonFileTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
@@ -358,10 +353,6 @@ impl FileSource for CoralJsonSource {
             opener,
             self.table_schema.file_schema(),
         )
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     fn table_schema(&self) -> &TableSchema {

--- a/crates/coral-engine/src/backends/file/provider.rs
+++ b/crates/coral-engine/src/backends/file/provider.rs
@@ -1,6 +1,5 @@
 //! Native file table providers built on `DataFusion` file scan primitives.
 
-use std::any::Any;
 use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
@@ -274,10 +273,6 @@ fn strip_partition_columns(
 
 #[async_trait]
 impl TableProvider for FileTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         match &self.inner {
             FileTableProviderInner::Listing(inner) => inner.schema(),

--- a/crates/coral-engine/src/backends/file/tests.rs
+++ b/crates/coral-engine/src/backends/file/tests.rs
@@ -240,12 +240,7 @@ async fn parquet_provider_reads_local_files_with_partitions() {
         .await
         .expect("table lookup should succeed")
         .expect("table should exist");
-    assert!(
-        provider
-            .as_any()
-            .downcast_ref::<FileTableProvider>()
-            .is_some()
-    );
+    assert!(provider.downcast_ref::<FileTableProvider>().is_some());
 
     let batches = ctx
         .sql("SELECT metric, value, date FROM otel.metrics ORDER BY metric")
@@ -449,10 +444,7 @@ async fn file_provider_reads_jsonl_with_listing_table() {
         .expect("table lookup should succeed")
         .expect("table should exist");
     assert!(
-        provider
-            .as_any()
-            .downcast_ref::<FileTableProvider>()
-            .is_some(),
+        provider.downcast_ref::<FileTableProvider>().is_some(),
         "plain JSONL should use DataFusion's native listing-table provider"
     );
 

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -7,7 +7,6 @@
 //! scanned later during execution, using the same `http_json_exec` path as
 //! manifest-backed tables.
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
@@ -117,10 +116,6 @@ impl fmt::Debug for HttpSourceFunctionCallTableProvider {
 
 #[async_trait::async_trait]
 impl TableProvider for HttpSourceFunctionCallTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.state.schema.clone()
     }

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -1,6 +1,5 @@
 //! `DataFusion` table provider for manifest-driven HTTP-backed tables.
 
-use std::any::Any;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -257,10 +256,6 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
 
 #[async_trait]
 impl TableProvider for HttpSourceTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/crates/coral-engine/src/backends/mcp/function.rs
+++ b/crates/coral-engine/src/backends/mcp/function.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
@@ -129,10 +128,6 @@ impl std::fmt::Debug for McpFunctionCallTableProvider {
 
 #[async_trait]
 impl TableProvider for McpFunctionCallTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.state.schema.clone()
     }

--- a/crates/coral-engine/src/backends/mcp/provider.rs
+++ b/crates/coral-engine/src/backends/mcp/provider.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -65,10 +64,6 @@ impl McpTableProvider {
 
 #[async_trait]
 impl TableProvider for McpTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }

--- a/crates/coral-engine/src/backends/shared/json_exec.rs
+++ b/crates/coral-engine/src/backends/shared/json_exec.rs
@@ -1,6 +1,5 @@
 //! Shared execution-plan adapter for backends that materialize rows as JSON values.
 
-use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
 
@@ -200,10 +199,6 @@ impl ExecutionPlan for JsonExec {
         "JsonExec"
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         self.projected_schema.clone()
     }
@@ -215,8 +210,10 @@ impl ExecutionPlan for JsonExec {
     fn partition_statistics(
         &self,
         _partition: Option<usize>,
-    ) -> Result<datafusion::common::Statistics> {
-        Ok(datafusion::common::Statistics::new_unknown(&self.schema()))
+    ) -> Result<Arc<datafusion::common::Statistics>> {
+        Ok(Arc::new(datafusion::common::Statistics::new_unknown(
+            &self.schema(),
+        )))
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {

--- a/crates/coral-engine/src/runtime/dependent_join/exec.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/exec.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
@@ -251,10 +250,6 @@ impl ExecutionPlan for DependentJoinExec {
         "DependentJoinExec"
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.output_schema)
     }
@@ -263,8 +258,8 @@ impl ExecutionPlan for DependentJoinExec {
         &self.props
     }
 
-    fn partition_statistics(&self, _partition: Option<usize>) -> Result<Statistics> {
-        Ok(Statistics::new_unknown(&self.schema()))
+    fn partition_statistics(&self, _partition: Option<usize>) -> Result<Arc<Statistics>> {
+        Ok(Arc::new(Statistics::new_unknown(&self.schema())))
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {

--- a/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
@@ -541,8 +541,12 @@ fn join_column_operand(expr: &Expr) -> Option<ParsedJoinOperand> {
             expr: Expr::Column(column.clone()),
             cast_type: None,
         }),
-        Expr::Cast(cast) => cast_join_column_operand(expr, cast.expr.as_ref(), &cast.data_type),
-        Expr::TryCast(cast) => cast_join_column_operand(expr, cast.expr.as_ref(), &cast.data_type),
+        Expr::Cast(cast) => {
+            cast_join_column_operand(expr, cast.expr.as_ref(), cast.field.data_type())
+        }
+        Expr::TryCast(cast) => {
+            cast_join_column_operand(expr, cast.expr.as_ref(), cast.field.data_type())
+        }
         _ => None,
     }
 }
@@ -642,7 +646,7 @@ fn peel_dependent_side(plan: &LogicalPlan) -> PeelOutcome {
             let Ok(provider) = source_as_provider(&scan.source) else {
                 return PeelOutcome::NotHttp;
             };
-            let Some(provider) = provider.as_any().downcast_ref::<HttpSourceTableProvider>() else {
+            let Some(provider) = provider.downcast_ref::<HttpSourceTableProvider>() else {
                 return PeelOutcome::NotHttp;
             };
             let Some(literal_filters) =

--- a/crates/coral-engine/src/runtime/dependent_join/planner.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/planner.rs
@@ -97,7 +97,6 @@ async fn resolve_http_provider(
         .ok_or_else(|| plan_datafusion_err!("dependent table '{}' is not registered", table_ref))?;
 
     let provider = provider
-        .as_any()
         .downcast_ref::<HttpSourceTableProvider>()
         .ok_or_else(|| {
             plan_datafusion_err!(

--- a/crates/coral-engine/src/runtime/json.rs
+++ b/crates/coral-engine/src/runtime/json.rs
@@ -73,7 +73,7 @@ fn optimise_json_get_cast(cast: &Cast) -> Option<Transformed<Expr>> {
     if scalar_func.func.name() != "json_get" {
         return None;
     }
-    let func = match &cast.data_type {
+    let func = match cast.field.data_type() {
         DataType::Boolean => json_get_bool_udf(),
         // Keep decimal casts on the normal cast path. Rewriting them to
         // `json_get_float` would erase the requested decimal precision/scale.

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -857,8 +857,8 @@ fn infer_cast_parameter_fields(
         node.apply_expressions(|expr| {
             expr.apply(|expr| {
                 let (cast_expr, data_type) = match expr {
-                    Expr::Cast(cast) => (cast.expr.as_ref(), cast.data_type.clone()),
-                    Expr::TryCast(cast) => (cast.expr.as_ref(), cast.data_type.clone()),
+                    Expr::Cast(cast) => (cast.expr.as_ref(), cast.field.data_type().clone()),
+                    Expr::TryCast(cast) => (cast.expr.as_ref(), cast.field.data_type().clone()),
                     _ => return Ok(TreeNodeRecursion::Continue),
                 };
                 let Expr::Placeholder(placeholder) = cast_expr else {

--- a/crates/coral-engine/src/runtime/schema_provider.rs
+++ b/crates/coral-engine/src/runtime/schema_provider.rs
@@ -1,6 +1,5 @@
 //! Static schema provider used for the source metadata schema.
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -25,10 +24,6 @@ impl StaticSchemaProvider {
 
 #[async_trait]
 impl SchemaProvider for StaticSchemaProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn table_names(&self) -> Vec<String> {
         let mut names: Vec<String> = self.tables.keys().cloned().collect();
         names.sort();

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -237,17 +237,15 @@ fn literal_scalar_value(expr: &Expr) -> DataFusionResult<Option<ScalarValue>> {
     match unalias(expr) {
         Expr::Literal(value, _) => Ok(Some(value.clone())),
         Expr::Cast(cast) => Ok(literal_scalar_value(&cast.expr)?
-            .map(|value| value.cast_to(&cast.data_type))
+            .map(|value| value.cast_to(cast.field.data_type()))
             .transpose()?),
         Expr::TryCast(cast) => {
             let Some(value) = literal_scalar_value(&cast.expr)? else {
                 return Ok(None);
             };
-            Ok(Some(
-                value
-                    .cast_to(&cast.data_type)
-                    .unwrap_or(ScalarValue::try_new_null(&cast.data_type)?),
-            ))
+            Ok(Some(value.cast_to(cast.field.data_type()).unwrap_or(
+                ScalarValue::try_new_null(cast.field.data_type())?,
+            )))
         }
         Expr::Negative(expr) => Ok(literal_scalar_value(expr)?
             .map(|value| value.arithmetic_negate())


### PR DESCRIPTION
## Why

Keep Coral on the current DataFusion release line and absorb the API changes in one migration rather than carrying compatibility code for DataFusion 53.

## What changed

- update the DataFusion workspace dependency family to 54
- migrate table providers, file sources, execution plans, and schema providers to native trait downcasting
- read cast targets from DataFusion's new `FieldRef` representation
- return shared partition statistics and box the enlarged function-service future

## Validation

- `make rust-checks` — 1,849 tests passed; 2 skipped
- performance check — `coral.tables` mean 243.2 ms against the 750 ms threshold

`make perf-check` built the release CLI but its wrapper could not find `target/release/coral` because this machine redirects Cargo outputs through `CARGO_TARGET_DIR`. Running the same xtask perf checker against the emitted release binary passed. The fake GitHub credential validation warning is expected by the benchmark setup.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
