### PR TITLE
refactor(search): extract provider orchestration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,7 @@ dependencies = [
  "apple-native-keyring-store",
  "arrow",
  "async-trait",
+ "async-lock",
  "axum",
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ print_stdout = "warn"
 assert_cmd = "2"
 anyhow = "1"
 arrow = "58.1.0"
+async-lock = "3"
 async-trait = "0.1"
 axum = { version = "0.8", default-features = false }
 base64 = "0.22"

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 arrow.workspace = true
 async-trait.workspace = true
+async-lock.workspace = true
 axum = { workspace = true, features = ["http1", "tokio"] }
 base64.workspace = true
 chrono.workspace = true

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -101,15 +101,22 @@ impl FunctionManager {
         revision: WorkspaceLifecycleRevision,
     ) -> Result<ValidatedFunctionInstall, AppError> {
         let function_name = validated_function_name(raw_sql, runtime_function)?;
-        let Some(_lifecycle_guard) = self.lifecycle_lock.lock_if_unchanged_async(revision).await
+        let manager = self.clone();
+        let operation_workspace_name = workspace_name.clone();
+        let raw_sql = raw_sql.to_string();
+        let Some(_) = self
+            .lifecycle_lock
+            .run_blocking_workspace_write_if_unchanged(revision, workspace_name, move || {
+                manager.install_user_function_artifact_with_lifecycle_lock(
+                    &operation_workspace_name,
+                    &function_name,
+                    &raw_sql,
+                )
+            })
+            .await?
         else {
             return Ok(ValidatedFunctionInstall::WorkspaceChanged);
         };
-        self.install_user_function_artifact_with_lifecycle_lock(
-            workspace_name,
-            &function_name,
-            raw_sql,
-        )?;
         Ok(ValidatedFunctionInstall::Installed)
     }
 
@@ -305,7 +312,21 @@ impl FunctionManager {
         workspace_name: &WorkspaceName,
         function_name: &FunctionName,
     ) -> Result<(), AppError> {
-        let _lifecycle_guard = self.lifecycle_lock.lock_async().await;
+        let manager = self.clone();
+        let workspace_name = workspace_name.clone();
+        let function_name = function_name.clone();
+        self.lifecycle_lock
+            .run_blocking_write(move || {
+                manager.remove_user_function_with_lifecycle_lock(&workspace_name, &function_name)
+            })
+            .await
+    }
+
+    fn remove_user_function_with_lifecycle_lock(
+        &self,
+        workspace_name: &WorkspaceName,
+        function_name: &FunctionName,
+    ) -> Result<(), AppError> {
         let _state_lock = self.config_store.state_lock_exclusive()?;
         self.config_store
             .get_function_unlocked(workspace_name, function_name)?;

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -93,7 +93,7 @@ impl FunctionManager {
         self.install_user_function_artifact(workspace_name, &function_name, raw_sql)
     }
 
-    pub(crate) fn install_validated_user_function_if_unchanged(
+    pub(crate) async fn install_validated_user_function_if_unchanged(
         &self,
         workspace_name: &WorkspaceName,
         raw_sql: &str,
@@ -101,7 +101,8 @@ impl FunctionManager {
         revision: WorkspaceLifecycleRevision,
     ) -> Result<ValidatedFunctionInstall, AppError> {
         let function_name = validated_function_name(raw_sql, runtime_function)?;
-        let Some(_lifecycle_guard) = self.lifecycle_lock.lock_if_unchanged(revision) else {
+        let Some(_lifecycle_guard) = self.lifecycle_lock.lock_if_unchanged_async(revision).await
+        else {
             return Ok(ValidatedFunctionInstall::WorkspaceChanged);
         };
         self.install_user_function_artifact_with_lifecycle_lock(
@@ -299,12 +300,12 @@ impl FunctionManager {
             .collect()
     }
 
-    pub(crate) fn remove_user_function(
+    pub(crate) async fn remove_user_function(
         &self,
         workspace_name: &WorkspaceName,
         function_name: &FunctionName,
     ) -> Result<(), AppError> {
-        let _lifecycle_guard = self.lifecycle_lock.lock();
+        let _lifecycle_guard = self.lifecycle_lock.lock_async().await;
         let _state_lock = self.config_store.state_lock_exclusive()?;
         self.config_store
             .get_function_unlocked(workspace_name, function_name)?;
@@ -664,6 +665,7 @@ select 1 as id
         assert!(error.contains("declares name 'renamed'"));
         manager
             .remove_user_function(&workspace, &installed.name)
+            .await
             .expect("inventory name remains removable");
     }
 
@@ -710,8 +712,8 @@ select 1 as id
         assert_eq!(runtime_function.result_columns.len(), 1);
     }
 
-    #[test]
-    fn remove_user_function_removes_inventory_and_artifacts() {
+    #[tokio::test]
+    async fn remove_user_function_removes_inventory_and_artifacts() {
         let (_temp, layout, config_store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql("review_queue");
@@ -719,6 +721,7 @@ select 1 as id
 
         manager
             .remove_user_function(&workspace, &installed.name)
+            .await
             .expect("remove function");
 
         assert!(
@@ -733,13 +736,14 @@ select 1 as id
         );
     }
 
-    #[test]
-    fn remove_user_function_reports_typed_missing_function() {
+    #[tokio::test]
+    async fn remove_user_function_reports_typed_missing_function() {
         let (_temp, _layout, _config_store, manager) = fixture();
         let function_name = FunctionName::parse("missing").expect("function name");
 
         let error = manager
             .remove_user_function(&workspace(), &function_name)
+            .await
             .expect_err("missing function should fail");
 
         assert!(matches!(

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -90,6 +90,7 @@ impl FunctionServiceApi for FunctionService {
             queries
                 .function_manager()
                 .remove_user_function(&workspace_name, &function_name)
+                .await
                 .map_err(app_status)?;
             Ok(Response::new(DeleteFunctionResponse {}))
         })

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -783,7 +783,7 @@ impl QueryManager {
         self.require_workspace(workspace_name)
             .await
             .map_err(QueryManagerError::App)?;
-        let _lifecycle_snapshot = self.lifecycle_lock.snapshot();
+        let _lifecycle_snapshot = self.lifecycle_lock.snapshot_async().await;
         let (loaded_sources, config) = self.load_function_validation_sources(workspace_name)?;
         self.validate_udf_sql_against_snapshot(workspace_name, raw_sql, &loaded_sources, &config)
             .await
@@ -795,12 +795,13 @@ impl QueryManager {
         raw_sql: &str,
     ) -> Result<UdfRuntimeDefinition, QueryManagerError> {
         for _ in 0..2 {
-            let revision = self.lifecycle_lock.snapshot().revision();
+            let revision = self.lifecycle_lock.snapshot_async().await.revision();
             self.require_workspace(workspace_name)
                 .await
                 .map_err(QueryManagerError::App)?;
-            let Some((loaded_sources, config)) =
-                self.function_validation_snapshot_if_unchanged(workspace_name, revision)?
+            let Some((loaded_sources, config)) = self
+                .function_validation_snapshot_if_unchanged(workspace_name, revision)
+                .await?
             else {
                 continue;
             };
@@ -820,6 +821,7 @@ impl QueryManager {
                     &runtime_function,
                     revision,
                 )
+                .await
                 .map_err(QueryManagerError::App)?
             {
                 ValidatedFunctionInstall::Installed => return Ok(runtime_function),
@@ -832,12 +834,12 @@ impl QueryManager {
         )))
     }
 
-    fn function_validation_snapshot_if_unchanged(
+    async fn function_validation_snapshot_if_unchanged(
         &self,
         workspace_name: &WorkspaceName,
         revision: WorkspaceLifecycleRevision,
     ) -> Result<Option<(Vec<LoadedQuerySource>, AppConfig)>, QueryManagerError> {
-        let lifecycle_snapshot = self.lifecycle_lock.snapshot();
+        let lifecycle_snapshot = self.lifecycle_lock.snapshot_async().await;
         if lifecycle_snapshot.revision() != revision {
             return Ok(None);
         }

--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -20,7 +20,7 @@ use crate::search::maintenance::{
     SearchDataScope, SearchMaintenanceDetail, SearchMaintenanceResult, SearchMaintenanceState,
     SearchProviderClearOutcome, SearchProviderClearRequest, SearchStorageCleanupResult,
 };
-use crate::search::provider::ProviderSearchOutcome;
+use crate::search::provider::{LocalSearchWriteCoordinator, ProviderSearchOutcome};
 use crate::search::result::{
     CatalogMetadataResult, ColumnHintResult, ProviderCoverage, ProviderStatus, SearchCandidate,
     SearchFieldRole, SearchManagerError, SearchPayload, SearchProviderKind, SearchProviderState,
@@ -54,11 +54,18 @@ struct CatalogProjectionState {
 #[derive(Clone)]
 pub(crate) struct CatalogMetadataProvider {
     layout: AppStateLayout,
+    write_coordinator: LocalSearchWriteCoordinator,
 }
 
 impl CatalogMetadataProvider {
-    pub(crate) fn new(layout: AppStateLayout) -> Self {
-        Self { layout }
+    pub(crate) fn with_write_coordinator(
+        layout: AppStateLayout,
+        write_coordinator: LocalSearchWriteCoordinator,
+    ) -> Self {
+        Self {
+            layout,
+            write_coordinator,
+        }
     }
 
     pub(crate) fn search(
@@ -70,6 +77,16 @@ impl CatalogMetadataProvider {
             Ok(resolution) => resolution,
             Err(error) => return catalog_query_error_outcome(error),
         };
+        self.write_coordinator.run(&request.workspace_name, || {
+            self.search_with_resolution(request, resolution)
+        })
+    }
+
+    fn search_with_resolution(
+        &self,
+        request: &SearchRequest,
+        resolution: &CatalogResolution,
+    ) -> ProviderSearchOutcome {
         let projection = match self.prepare_projection(request, resolution) {
             Ok(projection) => projection,
             Err(error) => return catalog_index_error_outcome(&error),

--- a/crates/coral-app/src/search/engine.rs
+++ b/crates/coral-app/src/search/engine.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 
+use tracing::Instrument as _;
+
 use crate::search::fusion;
 use crate::search::provider::{
     ProviderSearchOutcome, SearchExecutionContext, SearchProviderRegistration,
@@ -48,7 +50,10 @@ impl UniversalSearchEngine {
                     let provider = Arc::clone(provider);
                     let kind = provider.kind();
                     let context = Arc::clone(&context);
-                    let task = tokio::spawn(async move { provider.search(context).await });
+                    let span = tracing::Span::current();
+                    let task = tokio::spawn(
+                        async move { provider.search(context).await }.instrument(span),
+                    );
                     PendingProviderSearch::Provider { kind, task }
                 }
                 SearchProviderRegistration::StaticStatus(status) => {
@@ -153,14 +158,14 @@ mod tests {
 
     use tokio::sync::{Barrier, oneshot};
     use tokio::time::timeout;
+    use tracing::Instrument as _;
 
     use super::{UniversalSearchEngine, providers_have_more, truncation_note};
     use crate::bootstrap::AppError;
     use crate::query::manager::QueryManagerError;
     use crate::search::provider::{
-        ObservedValuesPolicyInput, ProviderSearchFuture, ProviderSearchOutcome,
-        SearchExecutionContext, SearchProvider, SearchProviderRegistration, SearchProviderRegistry,
-        provider_error_outcome,
+        ProviderSearchFuture, ProviderSearchOutcome, SearchExecutionContext, SearchProvider,
+        SearchProviderRegistration, SearchProviderRegistry, provider_error_outcome,
     };
     use crate::search::result::{
         ObservedValueResult, ProviderCoverage, ProviderStatus, SearchCandidate, SearchPayload,
@@ -318,6 +323,30 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn provider_future_inherits_the_search_request_span() {
+        let _subscriber = tracing::subscriber::set_default(tracing_subscriber::Registry::default());
+        let observed_span = Arc::new(Mutex::new(None));
+        let registry =
+            SearchProviderRegistry::from_ordered(vec![SearchProviderRegistration::Provider(
+                Arc::new(SpanCapturingProvider {
+                    observed_span: Arc::clone(&observed_span),
+                }),
+            )]);
+        let request_span = tracing::info_span!("universal_search_request");
+        let expected_span = request_span.id().expect("request span id");
+
+        UniversalSearchEngine::new(registry)
+            .search(test_context().await)
+            .instrument(request_span)
+            .await;
+
+        assert_eq!(
+            observed_span.lock().expect("observed span lock").as_ref(),
+            Some(&expected_span)
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cancelled_search_keeps_lifecycle_lease_until_blocking_provider_finishes() {
         let lifecycle = WorkspaceLifecycleLock::default();
@@ -410,6 +439,24 @@ mod tests {
         release: Mutex<Option<std_mpsc::Receiver<()>>>,
     }
 
+    struct SpanCapturingProvider {
+        observed_span: Arc<Mutex<Option<tracing::span::Id>>>,
+    }
+
+    impl SearchProvider for SpanCapturingProvider {
+        fn kind(&self) -> SearchProviderKind {
+            SearchProviderKind::CatalogMetadata
+        }
+
+        fn search(&self, _context: Arc<SearchExecutionContext>) -> ProviderSearchFuture {
+            let observed_span = Arc::clone(&self.observed_span);
+            Box::pin(async move {
+                *observed_span.lock().expect("observed span lock") = tracing::Span::current().id();
+                provider_error_outcome(SearchProviderKind::CatalogMetadata)
+            })
+        }
+    }
+
     impl SearchProvider for PausingBlockingProvider {
         fn kind(&self) -> SearchProviderKind {
             self.kind
@@ -481,7 +528,7 @@ mod tests {
             Err(QueryManagerError::App(AppError::Internal(
                 "catalog resolution is unused by test providers".to_string(),
             ))),
-            ObservedValuesPolicyInput::Disabled,
+            None,
         )
     }
 

--- a/crates/coral-app/src/search/engine.rs
+++ b/crates/coral-app/src/search/engine.rs
@@ -1,102 +1,124 @@
 //! Universal Search provider orchestration.
 
-use crate::bootstrap::AppError;
-use crate::catalog::model::CatalogResolution;
-use crate::query::QueryAttribution;
-use crate::query::manager::QueryManagerError;
-use crate::search::catalog::provider::CatalogMetadataProvider;
-use crate::search::observed::ObservedValuesRetrievalPolicy;
-use crate::search::observed::provider::ObservedValuesProvider;
-use crate::search::provider::ProviderSearchOutcome;
+use std::sync::Arc;
+
+use crate::search::fusion;
+use crate::search::provider::{
+    ProviderSearchOutcome, SearchExecutionContext, SearchProviderRegistry, provider_error_outcome,
+};
 use crate::search::result::{
-    ProviderStatus, SearchProviderKind, SearchProviderState, SearchRequest, SearchResponse,
-    SearchResult, SearchTruncation,
+    ProviderStatus, SearchProviderKind, SearchProviderState, SearchResponse, SearchResult,
+    SearchTruncation,
 };
 
 #[derive(Clone)]
 pub(crate) struct UniversalSearchEngine {
-    catalog: CatalogMetadataProvider,
-    observed: ObservedValuesProvider,
+    providers: SearchProviderRegistry,
 }
 
 impl UniversalSearchEngine {
-    pub(crate) fn new(catalog: CatalogMetadataProvider, observed: ObservedValuesProvider) -> Self {
-        Self { catalog, observed }
+    pub(crate) fn new(providers: SearchProviderRegistry) -> Self {
+        Self { providers }
     }
 
-    pub(crate) fn search(
-        &self,
-        request: &SearchRequest,
-        _attribution: &QueryAttribution,
-        catalog_resolution: Result<&CatalogResolution, &QueryManagerError>,
-        observed_policy: Option<Result<&ObservedValuesRetrievalPolicy, &AppError>>,
-    ) -> SearchResponse {
+    pub(crate) async fn search(&self, context: SearchExecutionContext) -> SearchResponse {
         tracing::debug!(
-            workspace = %request.workspace_name,
-            query_len_bytes = request.query.len(),
-            limit = request.limit,
+            workspace = %context.request.workspace_name,
+            query_len_bytes = context.request.query.len(),
+            limit = context.request.limit,
+            elapsed_ms = context.request_started_at.elapsed().as_millis(),
             "running Universal Search"
         );
-        let catalog = self.catalog.search(request, catalog_resolution);
-        let observed = observed_policy.map_or_else(observed_not_enabled_outcome, |policy| {
-            self.observed.search(request, policy)
-        });
-        let provider_has_more = providers_have_more(&[&catalog.status, &observed.status]);
-        let mut candidates = catalog.candidates;
-        candidates.extend(observed.candidates);
-        candidates.sort();
-
-        let total_count = candidates.len();
-        let max_results = usize::try_from(request.limit).unwrap_or(usize::MAX);
-        let truncated = total_count > max_results || provider_has_more;
-        let results = candidates
-            .into_iter()
-            .take(max_results)
-            .map(|candidate| SearchResult {
-                provider: candidate.provider,
-                payload: candidate.payload,
+        let context = Arc::new(context);
+        // Start every provider before awaiting any outcome. The registry still
+        // defines deterministic response order without serialising provider work.
+        let tasks = self
+            .providers
+            .iter()
+            .map(|provider| {
+                let provider = Arc::clone(provider);
+                let provider_kind = provider.kind();
+                let context = Arc::clone(&context);
+                let task = tokio::spawn(async move { provider.search(context).await });
+                (provider_kind, task)
             })
             .collect::<Vec<_>>();
-        let returned_count = u32::try_from(results.len()).unwrap_or(u32::MAX);
-
-        SearchResponse {
-            workspace_name: request.workspace_name.clone(),
-            results,
-            provider_statuses: vec![
-                catalog.status,
-                observed.status,
-                ProviderStatus {
-                    provider: SearchProviderKind::NativeFanout,
-                    state: SearchProviderState::NotEnabled,
-                    note: "provider-native fanout is not wired yet".to_string(),
-                    coverage: None,
-                },
-            ],
-            truncation: SearchTruncation {
-                truncated,
-                returned_count,
-                max_results: request.limit,
-                note: truncation_note(truncated, provider_has_more, total_count, max_results),
-            },
+        let mut outcomes = Vec::with_capacity(tasks.len());
+        for (provider_kind, task) in tasks {
+            let outcome = match task.await {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    tracing::error!(
+                        provider = ?provider_kind,
+                        ?error,
+                        "Universal Search provider future failed"
+                    );
+                    provider_error_outcome(provider_kind)
+                }
+            };
+            outcomes.push(outcome);
         }
+
+        assemble_response(&context, outcomes)
     }
 }
 
-fn observed_not_enabled_outcome() -> ProviderSearchOutcome {
-    ProviderSearchOutcome {
-        candidates: Vec::new(),
-        status: ProviderStatus {
-            provider: SearchProviderKind::ObservedValues,
-            state: SearchProviderState::NotEnabled,
-            note: "observed value search is disabled; enable `observed_values_search` to include values from earlier queries".to_string(),
-            coverage: None,
+fn assemble_response(
+    context: &SearchExecutionContext,
+    mut outcomes: Vec<ProviderSearchOutcome>,
+) -> SearchResponse {
+    let provider_has_more = providers_have_more(&outcomes);
+    let mut provider_statuses = outcomes
+        .iter()
+        .map(|outcome| outcome.status.clone())
+        .collect::<Vec<_>>();
+    if !provider_statuses
+        .iter()
+        .any(|status| status.provider == SearchProviderKind::NativeFanout)
+    {
+        provider_statuses.push(native_not_enabled_status());
+    }
+
+    let candidates = fusion::order_candidates(&mut outcomes);
+    let total_count = candidates.len();
+    let max_results = usize::try_from(context.request.limit).unwrap_or(usize::MAX);
+    let truncated = total_count > max_results || provider_has_more;
+    let results = candidates
+        .into_iter()
+        .take(max_results)
+        .map(|candidate| SearchResult {
+            provider: candidate.provider,
+            payload: candidate.payload,
+        })
+        .collect::<Vec<_>>();
+    let returned_count = u32::try_from(results.len()).unwrap_or(u32::MAX);
+
+    SearchResponse {
+        workspace_name: context.request.workspace_name.clone(),
+        results,
+        provider_statuses,
+        truncation: SearchTruncation {
+            truncated,
+            returned_count,
+            max_results: context.request.limit,
+            note: truncation_note(truncated, provider_has_more, total_count, max_results),
         },
     }
 }
 
-fn providers_have_more(statuses: &[&ProviderStatus]) -> bool {
-    statuses.iter().any(|status| {
-        status
+fn native_not_enabled_status() -> ProviderStatus {
+    ProviderStatus {
+        provider: SearchProviderKind::NativeFanout,
+        state: SearchProviderState::NotEnabled,
+        note: "provider-native fanout is not wired yet".to_string(),
+        coverage: None,
+    }
+}
+
+fn providers_have_more(outcomes: &[ProviderSearchOutcome]) -> bool {
+    outcomes.iter().any(|outcome| {
+        outcome
+            .status
             .coverage
             .as_ref()
             .is_some_and(|coverage| coverage.has_more)
@@ -122,21 +144,24 @@ fn truncation_note(
 
 #[cfg(test)]
 mod tests {
-    use super::{observed_not_enabled_outcome, providers_have_more, truncation_note};
-    use crate::search::result::{
-        ProviderCoverage, ProviderStatus, SearchProviderKind, SearchProviderState,
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    use tokio::sync::Barrier;
+    use tokio::time::timeout;
+
+    use super::{UniversalSearchEngine, providers_have_more, truncation_note};
+    use crate::bootstrap::AppError;
+    use crate::query::manager::QueryManagerError;
+    use crate::search::provider::{
+        ObservedValuesPolicyInput, ProviderSearchFuture, ProviderSearchOutcome,
+        SearchExecutionContext, SearchProvider, SearchProviderRegistry, provider_error_outcome,
     };
-
-    #[test]
-    fn disabled_observed_search_reports_not_enabled_without_candidates_or_coverage() {
-        let outcome = observed_not_enabled_outcome();
-
-        assert!(outcome.candidates.is_empty());
-        assert_eq!(outcome.status.provider, SearchProviderKind::ObservedValues);
-        assert_eq!(outcome.status.state, SearchProviderState::NotEnabled);
-        assert!(outcome.status.coverage.is_none());
-        assert!(outcome.status.note.contains("`observed_values_search`"));
-    }
+    use crate::search::result::{
+        ObservedValueResult, ProviderCoverage, ProviderStatus, SearchCandidate, SearchPayload,
+        SearchProviderKind, SearchProviderState, SearchRequest, SearchSurfaceKind,
+    };
+    use crate::workspaces::WorkspaceName;
 
     #[test]
     fn truncation_note_does_not_report_retrieved_count_as_total_when_provider_has_more() {
@@ -157,17 +182,179 @@ mod tests {
 
     #[test]
     fn stale_or_budget_exhausted_provider_does_not_imply_more_results() {
-        let status = ProviderStatus {
-            provider: SearchProviderKind::ObservedValues,
-            state: SearchProviderState::Partial,
-            note: String::new(),
-            coverage: Some(ProviderCoverage {
-                budget_exhausted: true,
-                stale_index: true,
-                ..ProviderCoverage::default()
-            }),
+        let outcome = ProviderSearchOutcome {
+            candidates: Vec::new(),
+            status: ProviderStatus {
+                provider: SearchProviderKind::ObservedValues,
+                state: SearchProviderState::Partial,
+                note: String::new(),
+                coverage: Some(ProviderCoverage {
+                    budget_exhausted: true,
+                    stale_index: true,
+                    ..ProviderCoverage::default()
+                }),
+            },
         };
 
-        assert!(!providers_have_more(&[&status]));
+        assert!(!providers_have_more(&[outcome]));
+    }
+
+    #[tokio::test]
+    async fn provider_failure_keeps_other_provider_candidates_and_status_order() {
+        let registry = SearchProviderRegistry::from_ordered(vec![
+            Arc::new(PanickingProvider {
+                kind: SearchProviderKind::CatalogMetadata,
+            }),
+            Arc::new(StaticProvider {
+                outcome: ProviderSearchOutcome {
+                    candidates: vec![observed_candidate("survivor")],
+                    status: ProviderStatus {
+                        provider: SearchProviderKind::ObservedValues,
+                        state: SearchProviderState::ResultsFound,
+                        note: String::new(),
+                        coverage: None,
+                    },
+                },
+            }),
+        ]);
+        let response = UniversalSearchEngine::new(registry)
+            .search(test_context())
+            .await;
+
+        assert_eq!(response.results.len(), 1);
+        assert_eq!(
+            response
+                .provider_statuses
+                .iter()
+                .map(|status| (status.provider, status.state))
+                .collect::<Vec<_>>(),
+            [
+                (
+                    SearchProviderKind::CatalogMetadata,
+                    SearchProviderState::Error,
+                ),
+                (
+                    SearchProviderKind::ObservedValues,
+                    SearchProviderState::ResultsFound,
+                ),
+                (
+                    SearchProviderKind::NativeFanout,
+                    SearchProviderState::NotEnabled,
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn providers_start_concurrently_but_keep_registry_response_order() {
+        let start_barrier = Arc::new(Barrier::new(3));
+        let registry = SearchProviderRegistry::from_ordered(vec![
+            Arc::new(BarrierProvider {
+                kind: SearchProviderKind::CatalogMetadata,
+                start_barrier: Arc::clone(&start_barrier),
+            }),
+            Arc::new(BarrierProvider {
+                kind: SearchProviderKind::ObservedValues,
+                start_barrier: Arc::clone(&start_barrier),
+            }),
+        ]);
+        let engine = UniversalSearchEngine::new(registry);
+        let search = tokio::spawn(async move { engine.search(test_context()).await });
+
+        timeout(Duration::from_secs(1), start_barrier.wait())
+            .await
+            .expect("all providers should start before any outcome is awaited");
+        let response = search.await.expect("search task");
+
+        assert_eq!(
+            response
+                .provider_statuses
+                .iter()
+                .map(|status| status.provider)
+                .collect::<Vec<_>>(),
+            [
+                SearchProviderKind::CatalogMetadata,
+                SearchProviderKind::ObservedValues,
+                SearchProviderKind::NativeFanout,
+            ]
+        );
+    }
+
+    struct StaticProvider {
+        outcome: ProviderSearchOutcome,
+    }
+
+    impl SearchProvider for StaticProvider {
+        fn kind(&self) -> SearchProviderKind {
+            self.outcome.status.provider
+        }
+
+        fn search(&self, _context: Arc<SearchExecutionContext>) -> ProviderSearchFuture {
+            let outcome = self.outcome.clone();
+            Box::pin(async move { outcome })
+        }
+    }
+
+    struct PanickingProvider {
+        kind: SearchProviderKind,
+    }
+
+    impl SearchProvider for PanickingProvider {
+        fn kind(&self) -> SearchProviderKind {
+            self.kind
+        }
+
+        fn search(&self, _context: Arc<SearchExecutionContext>) -> ProviderSearchFuture {
+            Box::pin(async move { panic!("provider panic") })
+        }
+    }
+
+    struct BarrierProvider {
+        kind: SearchProviderKind,
+        start_barrier: Arc<Barrier>,
+    }
+
+    impl SearchProvider for BarrierProvider {
+        fn kind(&self) -> SearchProviderKind {
+            self.kind
+        }
+
+        fn search(&self, _context: Arc<SearchExecutionContext>) -> ProviderSearchFuture {
+            let kind = self.kind;
+            let start_barrier = Arc::clone(&self.start_barrier);
+            Box::pin(async move {
+                start_barrier.wait().await;
+                provider_error_outcome(kind)
+            })
+        }
+    }
+
+    fn test_context() -> SearchExecutionContext {
+        SearchExecutionContext::new(
+            Instant::now(),
+            SearchRequest::new(WorkspaceName::default(), "issue", 10).expect("search request"),
+            Err(QueryManagerError::App(AppError::Internal(
+                "catalog resolution is unused by test providers".to_string(),
+            ))),
+            ObservedValuesPolicyInput::Disabled,
+        )
+    }
+
+    fn observed_candidate(key: &str) -> SearchCandidate {
+        SearchCandidate {
+            key: key.to_string(),
+            score: 1,
+            provider: SearchProviderKind::ObservedValues,
+            payload: SearchPayload::ObservedValue(ObservedValueResult {
+                value: key.to_string(),
+                schema_name: "github".to_string(),
+                surface_name: "issues".to_string(),
+                column_name: "title".to_string(),
+                surface_kind: SearchSurfaceKind::Table,
+                field_path: "title".to_string(),
+                observed_count: 1,
+                last_observed_at: "2026-07-16T00:00:00Z".to_string(),
+            }),
+        }
     }
 }

--- a/crates/coral-app/src/search/engine.rs
+++ b/crates/coral-app/src/search/engine.rs
@@ -4,16 +4,24 @@ use std::sync::Arc;
 
 use crate::search::fusion;
 use crate::search::provider::{
-    ProviderSearchOutcome, SearchExecutionContext, SearchProviderRegistry, provider_error_outcome,
+    ProviderSearchOutcome, SearchExecutionContext, SearchProviderRegistration,
+    SearchProviderRegistry, provider_error_outcome,
 };
 use crate::search::result::{
-    ProviderStatus, SearchProviderKind, SearchProviderState, SearchResponse, SearchResult,
-    SearchTruncation,
+    ProviderStatus, SearchProviderKind, SearchResponse, SearchResult, SearchTruncation,
 };
 
 #[derive(Clone)]
 pub(crate) struct UniversalSearchEngine {
     providers: SearchProviderRegistry,
+}
+
+enum PendingProviderSearch {
+    Provider {
+        kind: SearchProviderKind,
+        task: tokio::task::JoinHandle<ProviderSearchOutcome>,
+    },
+    StaticStatus(ProviderStatus),
 }
 
 impl UniversalSearchEngine {
@@ -35,26 +43,37 @@ impl UniversalSearchEngine {
         let tasks = self
             .providers
             .iter()
-            .map(|provider| {
-                let provider = Arc::clone(provider);
-                let provider_kind = provider.kind();
-                let context = Arc::clone(&context);
-                let task = tokio::spawn(async move { provider.search(context).await });
-                (provider_kind, task)
+            .map(|registration| match registration {
+                SearchProviderRegistration::Provider(provider) => {
+                    let provider = Arc::clone(provider);
+                    let kind = provider.kind();
+                    let context = Arc::clone(&context);
+                    let task = tokio::spawn(async move { provider.search(context).await });
+                    PendingProviderSearch::Provider { kind, task }
+                }
+                SearchProviderRegistration::StaticStatus(status) => {
+                    PendingProviderSearch::StaticStatus(status.clone())
+                }
             })
             .collect::<Vec<_>>();
         let mut outcomes = Vec::with_capacity(tasks.len());
-        for (provider_kind, task) in tasks {
-            let outcome = match task.await {
-                Ok(outcome) => outcome,
-                Err(error) => {
-                    tracing::error!(
-                        provider = ?provider_kind,
-                        ?error,
-                        "Universal Search provider future failed"
-                    );
-                    provider_error_outcome(provider_kind)
-                }
+        for pending in tasks {
+            let outcome = match pending {
+                PendingProviderSearch::Provider { kind, task } => match task.await {
+                    Ok(outcome) => outcome,
+                    Err(error) => {
+                        tracing::error!(
+                            provider = ?kind,
+                            ?error,
+                            "Universal Search provider future failed"
+                        );
+                        provider_error_outcome(kind)
+                    }
+                },
+                PendingProviderSearch::StaticStatus(status) => ProviderSearchOutcome {
+                    candidates: Vec::new(),
+                    status,
+                },
             };
             outcomes.push(outcome);
         }
@@ -68,16 +87,10 @@ fn assemble_response(
     mut outcomes: Vec<ProviderSearchOutcome>,
 ) -> SearchResponse {
     let provider_has_more = providers_have_more(&outcomes);
-    let mut provider_statuses = outcomes
+    let provider_statuses = outcomes
         .iter()
         .map(|outcome| outcome.status.clone())
         .collect::<Vec<_>>();
-    if !provider_statuses
-        .iter()
-        .any(|status| status.provider == SearchProviderKind::NativeFanout)
-    {
-        provider_statuses.push(native_not_enabled_status());
-    }
 
     let candidates = fusion::order_candidates(&mut outcomes);
     let total_count = candidates.len();
@@ -103,15 +116,6 @@ fn assemble_response(
             max_results: context.request.limit,
             note: truncation_note(truncated, provider_has_more, total_count, max_results),
         },
-    }
-}
-
-fn native_not_enabled_status() -> ProviderStatus {
-    ProviderStatus {
-        provider: SearchProviderKind::NativeFanout,
-        state: SearchProviderState::NotEnabled,
-        note: "provider-native fanout is not wired yet".to_string(),
-        coverage: None,
     }
 }
 
@@ -144,10 +148,10 @@ fn truncation_note(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex, mpsc as std_mpsc};
     use std::time::{Duration, Instant};
 
-    use tokio::sync::Barrier;
+    use tokio::sync::{Barrier, oneshot};
     use tokio::time::timeout;
 
     use super::{UniversalSearchEngine, providers_have_more, truncation_note};
@@ -155,13 +159,14 @@ mod tests {
     use crate::query::manager::QueryManagerError;
     use crate::search::provider::{
         ObservedValuesPolicyInput, ProviderSearchFuture, ProviderSearchOutcome,
-        SearchExecutionContext, SearchProvider, SearchProviderRegistry, provider_error_outcome,
+        SearchExecutionContext, SearchProvider, SearchProviderRegistration, SearchProviderRegistry,
+        provider_error_outcome,
     };
     use crate::search::result::{
         ObservedValueResult, ProviderCoverage, ProviderStatus, SearchCandidate, SearchPayload,
         SearchProviderKind, SearchProviderState, SearchRequest, SearchSurfaceKind,
     };
-    use crate::workspaces::WorkspaceName;
+    use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceLifecycleReadLease, WorkspaceName};
 
     #[test]
     fn truncation_note_does_not_report_retrieved_count_as_total_when_provider_has_more() {
@@ -202,10 +207,10 @@ mod tests {
     #[tokio::test]
     async fn provider_failure_keeps_other_provider_candidates_and_status_order() {
         let registry = SearchProviderRegistry::from_ordered(vec![
-            Arc::new(PanickingProvider {
+            SearchProviderRegistration::Provider(Arc::new(PanickingProvider {
                 kind: SearchProviderKind::CatalogMetadata,
-            }),
-            Arc::new(StaticProvider {
+            })),
+            SearchProviderRegistration::Provider(Arc::new(StaticProvider {
                 outcome: ProviderSearchOutcome {
                     candidates: vec![observed_candidate("survivor")],
                     status: ProviderStatus {
@@ -215,10 +220,14 @@ mod tests {
                         coverage: None,
                     },
                 },
-            }),
+            })),
+            static_status_registration(
+                SearchProviderKind::NativeFanout,
+                SearchProviderState::NotEnabled,
+            ),
         ]);
         let response = UniversalSearchEngine::new(registry)
-            .search(test_context())
+            .search(test_context().await)
             .await;
 
         assert_eq!(response.results.len(), 1);
@@ -246,20 +255,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn response_contains_only_registry_owned_statuses() {
+        let registry = SearchProviderRegistry::from_ordered(vec![static_status_registration(
+            SearchProviderKind::ObservedValues,
+            SearchProviderState::NotEnabled,
+        )]);
+
+        let response = UniversalSearchEngine::new(registry)
+            .search(test_context().await)
+            .await;
+
+        assert!(response.results.is_empty());
+        assert_eq!(
+            response
+                .provider_statuses
+                .iter()
+                .map(|status| (status.provider, status.state))
+                .collect::<Vec<_>>(),
+            [(
+                SearchProviderKind::ObservedValues,
+                SearchProviderState::NotEnabled,
+            )]
+        );
+    }
+
+    #[tokio::test]
     async fn providers_start_concurrently_but_keep_registry_response_order() {
         let start_barrier = Arc::new(Barrier::new(3));
         let registry = SearchProviderRegistry::from_ordered(vec![
-            Arc::new(BarrierProvider {
+            SearchProviderRegistration::Provider(Arc::new(BarrierProvider {
                 kind: SearchProviderKind::CatalogMetadata,
                 start_barrier: Arc::clone(&start_barrier),
-            }),
-            Arc::new(BarrierProvider {
+            })),
+            SearchProviderRegistration::Provider(Arc::new(BarrierProvider {
                 kind: SearchProviderKind::ObservedValues,
                 start_barrier: Arc::clone(&start_barrier),
-            }),
+            })),
+            static_status_registration(
+                SearchProviderKind::NativeFanout,
+                SearchProviderState::NotEnabled,
+            ),
         ]);
         let engine = UniversalSearchEngine::new(registry);
-        let search = tokio::spawn(async move { engine.search(test_context()).await });
+        let search = tokio::spawn(async move { engine.search(test_context().await).await });
 
         timeout(Duration::from_secs(1), start_barrier.wait())
             .await
@@ -278,6 +316,58 @@ mod tests {
                 SearchProviderKind::NativeFanout,
             ]
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancelled_search_keeps_lifecycle_lease_until_blocking_provider_finishes() {
+        let lifecycle = WorkspaceLifecycleLock::default();
+        let workspace = WorkspaceName::default();
+        let revision = lifecycle
+            .revision_if_active_async(&workspace)
+            .await
+            .expect("workspace is active");
+        let lifecycle_lease = lifecycle
+            .read_lease_if_unchanged(revision, &workspace)
+            .await
+            .expect("current lifecycle lease");
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = std_mpsc::channel();
+        let registry =
+            SearchProviderRegistry::from_ordered(vec![SearchProviderRegistration::Provider(
+                Arc::new(PausingBlockingProvider {
+                    kind: SearchProviderKind::CatalogMetadata,
+                    started: Mutex::new(Some(started_tx)),
+                    release: Mutex::new(Some(release_rx)),
+                }),
+            )]);
+        let engine = UniversalSearchEngine::new(registry);
+        let search = tokio::spawn(async move {
+            engine
+                .search(test_context_with_lease(lifecycle_lease))
+                .await
+        });
+
+        started_rx.await.expect("blocking provider should start");
+        search.abort();
+        assert!(
+            search
+                .await
+                .expect_err("search task should be cancelled")
+                .is_cancelled()
+        );
+
+        assert!(
+            timeout(Duration::from_millis(50), lifecycle.lock_async())
+                .await
+                .is_err(),
+            "detached provider work must retain the lifecycle read lease"
+        );
+
+        release_tx.send(()).expect("release blocking provider");
+        let guard = timeout(Duration::from_secs(1), lifecycle.lock_async())
+            .await
+            .expect("lifecycle writer should proceed after provider completion");
+        drop(guard);
     }
 
     struct StaticProvider {
@@ -314,6 +404,44 @@ mod tests {
         start_barrier: Arc<Barrier>,
     }
 
+    struct PausingBlockingProvider {
+        kind: SearchProviderKind,
+        started: Mutex<Option<oneshot::Sender<()>>>,
+        release: Mutex<Option<std_mpsc::Receiver<()>>>,
+    }
+
+    impl SearchProvider for PausingBlockingProvider {
+        fn kind(&self) -> SearchProviderKind {
+            self.kind
+        }
+
+        fn search(&self, context: Arc<SearchExecutionContext>) -> ProviderSearchFuture {
+            let kind = self.kind;
+            let started = self
+                .started
+                .lock()
+                .expect("started sender lock")
+                .take()
+                .expect("provider starts once");
+            let release = self
+                .release
+                .lock()
+                .expect("release receiver lock")
+                .take()
+                .expect("provider starts once");
+            Box::pin(async move {
+                tokio::task::spawn_blocking(move || {
+                    started.send(()).expect("signal provider start");
+                    release.recv().expect("wait for provider release");
+                    drop(context);
+                    provider_error_outcome(kind)
+                })
+                .await
+                .expect("blocking provider task")
+            })
+        }
+    }
+
     impl SearchProvider for BarrierProvider {
         fn kind(&self) -> SearchProviderKind {
             self.kind
@@ -329,15 +457,44 @@ mod tests {
         }
     }
 
-    fn test_context() -> SearchExecutionContext {
+    async fn test_context() -> SearchExecutionContext {
+        let lifecycle = WorkspaceLifecycleLock::default();
+        let workspace = WorkspaceName::default();
+        let revision = lifecycle
+            .revision_if_active_async(&workspace)
+            .await
+            .expect("workspace is active");
+        let lifecycle_lease = lifecycle
+            .read_lease_if_unchanged(revision, &workspace)
+            .await
+            .expect("current lifecycle lease");
+        test_context_with_lease(lifecycle_lease)
+    }
+
+    fn test_context_with_lease(
+        lifecycle_lease: WorkspaceLifecycleReadLease,
+    ) -> SearchExecutionContext {
         SearchExecutionContext::new(
             Instant::now(),
+            lifecycle_lease,
             SearchRequest::new(WorkspaceName::default(), "issue", 10).expect("search request"),
             Err(QueryManagerError::App(AppError::Internal(
                 "catalog resolution is unused by test providers".to_string(),
             ))),
             ObservedValuesPolicyInput::Disabled,
         )
+    }
+
+    fn static_status_registration(
+        provider: SearchProviderKind,
+        state: SearchProviderState,
+    ) -> SearchProviderRegistration {
+        SearchProviderRegistration::StaticStatus(ProviderStatus {
+            provider,
+            state,
+            note: String::new(),
+            coverage: None,
+        })
     }
 
     fn observed_candidate(key: &str) -> SearchCandidate {

--- a/crates/coral-app/src/search/fusion.rs
+++ b/crates/coral-app/src/search/fusion.rs
@@ -1,0 +1,220 @@
+//! Request-wide candidate ordering across Universal Search providers.
+
+use std::cmp::Reverse;
+
+use crate::search::provider::ProviderSearchOutcome;
+use crate::search::result::{SearchCandidate, SearchProviderKind};
+
+// Fixed-point scale preserves reciprocal-rank precision in the existing u32
+// score field.
+const RECIPROCAL_RANK_SCORE_SCALE: u64 = 1_000_000_000;
+// Standard RRF smoothing offset; changing it requires an explicit ranking
+// decision.
+const RECIPROCAL_RANK_SMOOTHING_OFFSET: u64 = 60;
+
+pub(crate) fn order_candidates(outcomes: &mut [ProviderSearchOutcome]) -> Vec<SearchCandidate> {
+    if outcomes.iter().any(|outcome| {
+        outcome.status.provider == SearchProviderKind::NativeFanout
+            && !outcome.candidates.is_empty()
+    }) {
+        reciprocal_rank_order(outcomes)
+    } else {
+        legacy_score_order(outcomes)
+    }
+}
+
+fn legacy_score_order(outcomes: &mut [ProviderSearchOutcome]) -> Vec<SearchCandidate> {
+    let mut candidates = outcomes
+        .iter_mut()
+        .flat_map(|outcome| std::mem::take(&mut outcome.candidates))
+        .collect::<Vec<_>>();
+    candidates.sort();
+    candidates
+}
+
+fn reciprocal_rank_order(outcomes: &mut [ProviderSearchOutcome]) -> Vec<SearchCandidate> {
+    let mut candidates = Vec::new();
+    for outcome in outcomes {
+        for (provider_rank, mut candidate) in std::mem::take(&mut outcome.candidates)
+            .into_iter()
+            .enumerate()
+        {
+            candidate.score = reciprocal_rank_score(provider_rank);
+            candidates.push(candidate);
+        }
+    }
+    candidates.sort_by(|left, right| {
+        (
+            Reverse(left.score),
+            provider_order(left.provider),
+            left.type_order(),
+            left.key.as_str(),
+        )
+            .cmp(&(
+                Reverse(right.score),
+                provider_order(right.provider),
+                right.type_order(),
+                right.key.as_str(),
+            ))
+    });
+    candidates
+}
+
+fn reciprocal_rank_score(provider_rank: usize) -> u32 {
+    let provider_rank = u64::try_from(provider_rank).unwrap_or(u64::MAX);
+    let denominator = RECIPROCAL_RANK_SMOOTHING_OFFSET
+        .saturating_add(provider_rank)
+        .saturating_add(1);
+    u32::try_from(RECIPROCAL_RANK_SCORE_SCALE / denominator).unwrap_or(u32::MAX)
+}
+
+fn provider_order(provider: SearchProviderKind) -> u8 {
+    match provider {
+        SearchProviderKind::CatalogMetadata => 0,
+        SearchProviderKind::ObservedValues => 1,
+        SearchProviderKind::NativeFanout => 2,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{order_candidates, reciprocal_rank_score};
+    use crate::search::provider::ProviderSearchOutcome;
+    use crate::search::result::{
+        ObservedValueResult, ProviderStatus, SearchCandidate, SearchPayload, SearchProviderKind,
+        SearchProviderState, SearchSurfaceKind,
+    };
+
+    #[test]
+    fn local_only_candidates_keep_legacy_scores_and_order() {
+        let mut outcomes = vec![outcome(
+            SearchProviderKind::CatalogMetadata,
+            vec![
+                candidate(SearchProviderKind::CatalogMetadata, "low", 1),
+                candidate(SearchProviderKind::CatalogMetadata, "high", 9),
+            ],
+        )];
+
+        let ordered = order_candidates(&mut outcomes);
+
+        assert_eq!(candidate_keys(&ordered), ["high", "low"]);
+        assert_eq!(ordered.first().expect("high candidate").score, 9);
+        assert_eq!(ordered.get(1).expect("low candidate").score, 1);
+    }
+
+    #[test]
+    fn empty_native_outcome_keeps_legacy_scores_and_order() {
+        let mut native = outcome(SearchProviderKind::NativeFanout, Vec::new());
+        native.status.state = SearchProviderState::Empty;
+        let mut outcomes = vec![
+            outcome(
+                SearchProviderKind::CatalogMetadata,
+                vec![candidate(SearchProviderKind::CatalogMetadata, "catalog", 9)],
+            ),
+            outcome(
+                SearchProviderKind::ObservedValues,
+                vec![candidate(
+                    SearchProviderKind::ObservedValues,
+                    "observed",
+                    11,
+                )],
+            ),
+            native,
+        ];
+
+        let ordered = order_candidates(&mut outcomes);
+
+        assert_eq!(candidate_keys(&ordered), ["observed", "catalog"]);
+        assert_eq!(ordered.first().expect("observed candidate").score, 11);
+        assert_eq!(ordered.get(1).expect("catalog candidate").score, 9);
+    }
+
+    #[test]
+    fn three_provider_fusion_uses_exact_rank_formula_and_provider_ties() {
+        let mut outcomes = vec![
+            outcome(
+                SearchProviderKind::CatalogMetadata,
+                vec![
+                    candidate(SearchProviderKind::CatalogMetadata, "catalog-0", 99),
+                    candidate(SearchProviderKind::CatalogMetadata, "catalog-1", 98),
+                ],
+            ),
+            outcome(
+                SearchProviderKind::ObservedValues,
+                vec![
+                    candidate(SearchProviderKind::ObservedValues, "observed-0", 7),
+                    candidate(SearchProviderKind::ObservedValues, "observed-1", 6),
+                ],
+            ),
+            outcome(
+                SearchProviderKind::NativeFanout,
+                vec![
+                    candidate(SearchProviderKind::NativeFanout, "native-0", 1),
+                    candidate(SearchProviderKind::NativeFanout, "native-1", 0),
+                ],
+            ),
+        ];
+
+        let ordered = order_candidates(&mut outcomes);
+
+        assert_eq!(
+            candidate_keys(&ordered),
+            [
+                "catalog-0",
+                "observed-0",
+                "native-0",
+                "catalog-1",
+                "observed-1",
+                "native-1",
+            ]
+        );
+        assert_eq!(
+            ordered.first().expect("first rank candidate").score,
+            reciprocal_rank_score(0)
+        );
+        assert_eq!(
+            ordered.get(3).expect("second rank candidate").score,
+            reciprocal_rank_score(1)
+        );
+    }
+
+    fn outcome(
+        provider: SearchProviderKind,
+        candidates: Vec<SearchCandidate>,
+    ) -> ProviderSearchOutcome {
+        ProviderSearchOutcome {
+            candidates,
+            status: ProviderStatus {
+                provider,
+                state: SearchProviderState::ResultsFound,
+                note: String::new(),
+                coverage: None,
+            },
+        }
+    }
+
+    fn candidate(provider: SearchProviderKind, key: &str, score: u32) -> SearchCandidate {
+        SearchCandidate {
+            key: key.to_string(),
+            score,
+            provider,
+            payload: SearchPayload::ObservedValue(ObservedValueResult {
+                value: key.to_string(),
+                schema_name: "github".to_string(),
+                surface_name: "issues".to_string(),
+                column_name: "title".to_string(),
+                surface_kind: SearchSurfaceKind::Table,
+                field_path: "title".to_string(),
+                observed_count: 1,
+                last_observed_at: "2026-07-16T00:00:00Z".to_string(),
+            }),
+        }
+    }
+
+    fn candidate_keys(candidates: &[SearchCandidate]) -> Vec<&str> {
+        candidates
+            .iter()
+            .map(|candidate| candidate.key.as_str())
+            .collect()
+    }
+}

--- a/crates/coral-app/src/search/fusion.rs
+++ b/crates/coral-app/src/search/fusion.rs
@@ -178,6 +178,41 @@ mod tests {
         );
     }
 
+    #[test]
+    fn equal_keys_from_different_providers_remain_distinct() {
+        let mut outcomes = vec![
+            outcome(
+                SearchProviderKind::CatalogMetadata,
+                vec![candidate(
+                    SearchProviderKind::CatalogMetadata,
+                    "provider-scoped-key",
+                    99,
+                )],
+            ),
+            outcome(
+                SearchProviderKind::NativeFanout,
+                vec![candidate(
+                    SearchProviderKind::NativeFanout,
+                    "provider-scoped-key",
+                    1,
+                )],
+            ),
+        ];
+
+        let ordered = order_candidates(&mut outcomes);
+
+        assert_eq!(
+            ordered
+                .iter()
+                .map(|candidate| (candidate.provider, candidate.key.as_str()))
+                .collect::<Vec<_>>(),
+            [
+                (SearchProviderKind::CatalogMetadata, "provider-scoped-key"),
+                (SearchProviderKind::NativeFanout, "provider-scoped-key"),
+            ]
+        );
+    }
+
     fn outcome(
         provider: SearchProviderKind,
         candidates: Vec<SearchCandidate>,

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -67,11 +67,6 @@ enum CatalogPreload {
     WorkspaceChanged,
 }
 
-enum SnapshotOperation<T> {
-    Complete(T),
-    WorkspaceChanged,
-}
-
 impl SearchManager {
     #[cfg(test)]
     pub(crate) fn new(
@@ -128,7 +123,6 @@ impl SearchManager {
         attribution: &QueryAttribution,
     ) -> Result<SearchResponse, SearchManagerError> {
         let request_started_at = Instant::now();
-        let runtime = tokio::runtime::Handle::current();
         for _ in 0..WORKSPACE_SNAPSHOT_ATTEMPTS {
             let CatalogPreload::Ready {
                 revision,
@@ -139,41 +133,34 @@ impl SearchManager {
             else {
                 continue;
             };
-            let search = self.clone();
-            let request = request.clone();
-            let runtime = runtime.clone();
-            let operation = run_blocking_search_operation(move || {
-                let Some(_snapshot) = search
-                    .lifecycle_lock
-                    .snapshot_if_unchanged(revision, &request.workspace_name)
-                else {
-                    return Ok(SnapshotOperation::WorkspaceChanged);
-                };
-                let observed_values_policy = if search.observed_values_search_enabled {
-                    ObservedValuesPolicyInput::Enabled(
-                        search.observed_retrieval_policy(&request.workspace_name),
-                    )
-                } else {
-                    ObservedValuesPolicyInput::Disabled
-                };
-                let context = SearchExecutionContext::new(
-                    request_started_at,
-                    request,
-                    resolution,
-                    observed_values_policy,
-                );
-                // Keep the non-Send lifecycle snapshot alive until every provider
-                // finishes, so workspace deletion or source changes cannot race
-                // this search. Drive the async engine from this blocking thread
-                // instead of carrying the snapshot guard across an async await.
-                Ok(SnapshotOperation::Complete(
-                    runtime.block_on(search.engine.search(context)),
-                ))
-            })
-            .await?;
-            if let SnapshotOperation::Complete(response) = operation {
-                return Ok(response);
-            }
+            let Some(lifecycle_lease) = self
+                .lifecycle_lock
+                .read_lease_if_unchanged(revision, &request.workspace_name)
+                .await
+            else {
+                continue;
+            };
+            let (observed_values_policy, lifecycle_lease) = if self.observed_values_search_enabled {
+                let search = self.clone();
+                let workspace_name = request.workspace_name.clone();
+                run_blocking_search_operation(move || {
+                    let policy = ObservedValuesPolicyInput::Enabled(
+                        search.observed_retrieval_policy(&workspace_name),
+                    );
+                    Ok((policy, lifecycle_lease))
+                })
+                .await?
+            } else {
+                (ObservedValuesPolicyInput::Disabled, lifecycle_lease)
+            };
+            let context = SearchExecutionContext::new(
+                request_started_at,
+                lifecycle_lease,
+                request.clone(),
+                resolution,
+                observed_values_policy,
+            );
+            return Ok(self.engine.search(context).await);
         }
         Err(workspace_changed_error("searching"))
     }
@@ -202,7 +189,8 @@ impl SearchManager {
             } else {
                 let Some(revision) = self
                     .lifecycle_lock
-                    .revision_if_active(&request.workspace_name)
+                    .revision_if_active_async(&request.workspace_name)
+                    .await
                 else {
                     continue;
                 };
@@ -211,15 +199,17 @@ impl SearchManager {
                     .await?;
                 (revision, None)
             };
+            let Some(lifecycle_lease) = self
+                .lifecycle_lock
+                .read_lease_if_unchanged(revision, &request.workspace_name)
+                .await
+            else {
+                continue;
+            };
             let search = self.clone();
             let request = request.clone();
-            let operation = run_blocking_search_operation(move || {
-                let Some(_snapshot) = search
-                    .lifecycle_lock
-                    .snapshot_if_unchanged(revision, &request.workspace_name)
-                else {
-                    return Ok(SnapshotOperation::WorkspaceChanged);
-                };
+            let response = run_blocking_search_operation(move || {
+                let _lifecycle_lease = lifecycle_lease;
                 let resolution = resolution
                     .map(|resolution| resolution.map_err(catalog_resolution_error))
                     .transpose()?;
@@ -245,14 +235,10 @@ impl SearchManager {
                         search.rebuild_observed_index(&request),
                     ],
                 };
-                Ok(SnapshotOperation::Complete(RebuildSearchIndexResponse {
-                    results,
-                }))
+                Ok(RebuildSearchIndexResponse { results })
             })
             .await?;
-            if let SnapshotOperation::Complete(response) = operation {
-                return Ok(response);
-            }
+            return Ok(response);
         }
         Err(workspace_changed_error("rebuilding the search index"))
     }
@@ -296,30 +282,29 @@ impl SearchManager {
         for _ in 0..WORKSPACE_SNAPSHOT_ATTEMPTS {
             let Some(revision) = self
                 .lifecycle_lock
-                .revision_if_active(&request.workspace_name)
+                .revision_if_active_async(&request.workspace_name)
+                .await
             else {
                 continue;
             };
             self.workspaces
                 .require_workspace(&request.workspace_name)
                 .await?;
+            let Some(lifecycle_lease) = self
+                .lifecycle_lock
+                .read_lease_if_unchanged(revision, &request.workspace_name)
+                .await
+            else {
+                continue;
+            };
             let search = self.clone();
             let request = request.clone();
-            let operation = run_blocking_search_operation(move || {
-                let Some(_snapshot) = search
-                    .lifecycle_lock
-                    .snapshot_if_unchanged(revision, &request.workspace_name)
-                else {
-                    return Ok(SnapshotOperation::WorkspaceChanged);
-                };
-                Ok(SnapshotOperation::Complete(
-                    search.clear_data_blocking(&request)?,
-                ))
+            let response = run_blocking_search_operation(move || {
+                let _lifecycle_lease = lifecycle_lease;
+                search.clear_data_blocking(&request)
             })
             .await?;
-            if let SnapshotOperation::Complete(response) = operation {
-                return Ok(response);
-            }
+            return Ok(response);
         }
         Err(workspace_changed_error("clearing search data"))
     }
@@ -472,7 +457,11 @@ impl SearchManager {
         workspace_name: &WorkspaceName,
         attribution: &QueryAttribution,
     ) -> Result<CatalogPreload, SearchManagerError> {
-        let Some(revision) = self.lifecycle_lock.revision_if_active(workspace_name) else {
+        let Some(revision) = self
+            .lifecycle_lock
+            .revision_if_active_async(workspace_name)
+            .await
+        else {
             return Ok(CatalogPreload::WorkspaceChanged);
         };
         self.workspaces.require_workspace(workspace_name).await?;

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -24,7 +24,7 @@ use crate::search::observed::{
     ObservedValuesRetrievalPolicy,
 };
 use crate::search::provider::{
-    ObservedValuesPolicyInput, SearchExecutionContext, SearchProviderRegistry,
+    LocalSearchWriteCoordinator, SearchExecutionContext, SearchProviderRegistry,
 };
 use crate::search::result::{
     SearchManagerError, SearchProviderKind, SearchRequest, SearchResponse,
@@ -97,8 +97,13 @@ impl SearchManager {
         catalog_discovery: CatalogDiscovery,
         lifecycle_lock: WorkspaceLifecycleLock,
     ) -> Self {
-        let catalog = CatalogMetadataProvider::new(layout.clone());
-        let observed = ObservedValuesProvider::new(layout.clone());
+        let write_coordinator = LocalSearchWriteCoordinator::default();
+        let catalog = CatalogMetadataProvider::with_write_coordinator(
+            layout.clone(),
+            write_coordinator.clone(),
+        );
+        let observed =
+            ObservedValuesProvider::with_write_coordinator(layout.clone(), write_coordinator);
         let observed_scope_loader = ObservedValuesLiveScopeLoader::new(
             layout.clone(),
             config_store.clone(),
@@ -110,7 +115,10 @@ impl SearchManager {
             observed: observed.clone(),
             observed_scope_loader,
             observed_values_search_enabled,
-            engine: UniversalSearchEngine::new(SearchProviderRegistry::local(catalog, observed)),
+            engine: UniversalSearchEngine::new(SearchProviderRegistry::local(
+                catalog,
+                observed_values_search_enabled.then(|| observed.clone()),
+            )),
             workspaces: workspace_manager,
             lifecycle_lock,
             layout,
@@ -144,14 +152,14 @@ impl SearchManager {
                 let search = self.clone();
                 let workspace_name = request.workspace_name.clone();
                 run_blocking_search_operation(move || {
-                    let policy = ObservedValuesPolicyInput::Enabled(
-                        search.observed_retrieval_policy(&workspace_name),
-                    );
-                    Ok((policy, lifecycle_lease))
+                    Ok((
+                        Some(search.observed_retrieval_policy(&workspace_name)),
+                        lifecycle_lease,
+                    ))
                 })
                 .await?
             } else {
-                (ObservedValuesPolicyInput::Disabled, lifecycle_lease)
+                (None, lifecycle_lease)
             };
             let context = SearchExecutionContext::new(
                 request_started_at,

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -23,6 +23,9 @@ use crate::search::observed::{
     ObservedValuesDrainBudget, ObservedValuesLiveScopeLoad, ObservedValuesLiveScopeLoader,
     ObservedValuesRetrievalPolicy,
 };
+use crate::search::provider::{
+    ObservedValuesPolicyInput, SearchExecutionContext, SearchProviderRegistry,
+};
 use crate::search::result::{
     SearchManagerError, SearchProviderKind, SearchRequest, SearchResponse,
 };
@@ -112,7 +115,7 @@ impl SearchManager {
             observed: observed.clone(),
             observed_scope_loader,
             observed_values_search_enabled,
-            engine: UniversalSearchEngine::new(catalog, observed),
+            engine: UniversalSearchEngine::new(SearchProviderRegistry::local(catalog, observed)),
             workspaces: workspace_manager,
             lifecycle_lock,
             layout,
@@ -124,6 +127,8 @@ impl SearchManager {
         request: &SearchRequest,
         attribution: &QueryAttribution,
     ) -> Result<SearchResponse, SearchManagerError> {
+        let request_started_at = Instant::now();
+        let runtime = tokio::runtime::Handle::current();
         for _ in 0..WORKSPACE_SNAPSHOT_ATTEMPTS {
             let CatalogPreload::Ready {
                 revision,
@@ -136,7 +141,7 @@ impl SearchManager {
             };
             let search = self.clone();
             let request = request.clone();
-            let attribution = attribution.clone();
+            let runtime = runtime.clone();
             let operation = run_blocking_search_operation(move || {
                 let Some(_snapshot) = search
                     .lifecycle_lock
@@ -144,15 +149,26 @@ impl SearchManager {
                 else {
                     return Ok(SnapshotOperation::WorkspaceChanged);
                 };
-                let observed_policy = search
-                    .observed_values_search_enabled
-                    .then(|| search.observed_retrieval_policy(&request.workspace_name));
-                Ok(SnapshotOperation::Complete(search.engine.search(
-                    &request,
-                    &attribution,
-                    resolution.as_ref(),
-                    observed_policy.as_ref().map(Result::as_ref),
-                )))
+                let observed_values_policy = if search.observed_values_search_enabled {
+                    ObservedValuesPolicyInput::Enabled(
+                        search.observed_retrieval_policy(&request.workspace_name),
+                    )
+                } else {
+                    ObservedValuesPolicyInput::Disabled
+                };
+                let context = SearchExecutionContext::new(
+                    request_started_at,
+                    request,
+                    resolution,
+                    observed_values_policy,
+                );
+                // Keep the non-Send lifecycle snapshot alive until every provider
+                // finishes, so workspace deletion or source changes cannot race
+                // this search. Drive the async engine from this blocking thread
+                // instead of carrying the snapshot guard across an async await.
+                Ok(SnapshotOperation::Complete(
+                    runtime.block_on(search.engine.search(context)),
+                ))
             })
             .await?;
             if let SnapshotOperation::Complete(response) = operation {

--- a/crates/coral-app/src/search/mod.rs
+++ b/crates/coral-app/src/search/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod catalog;
 pub(crate) mod engine;
+pub(crate) mod fusion;
 pub(crate) mod maintenance;
 pub(crate) mod manager;
 pub(crate) mod observed;

--- a/crates/coral-app/src/search/observed/provider.rs
+++ b/crates/coral-app/src/search/observed/provider.rs
@@ -17,7 +17,7 @@ use crate::search::observed::sqlite_projection::{
 };
 use crate::search::observed::sqlite_queue::ObservedValuesSurfaceKind;
 use crate::search::observed::sqlite_store::{ObservedValuesClearResult, SqliteObservedValuesStore};
-use crate::search::provider::ProviderSearchOutcome;
+use crate::search::provider::{LocalSearchWriteCoordinator, ProviderSearchOutcome};
 use crate::search::result::{
     ObservedValueResult, ProviderCoverage, ProviderStatus, SearchCandidate, SearchPayload,
     SearchProviderKind, SearchProviderState, SearchRequest, SearchSurfaceKind,
@@ -37,12 +37,22 @@ const OBSERVED_REBUILD_DRAIN_MS: u64 = 1_000;
 #[derive(Debug, Clone)]
 pub(crate) struct ObservedValuesProvider {
     store: SqliteObservedValuesStore,
+    write_coordinator: LocalSearchWriteCoordinator,
 }
 
 impl ObservedValuesProvider {
+    #[cfg(test)]
     pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self::with_write_coordinator(layout, LocalSearchWriteCoordinator::default())
+    }
+
+    pub(crate) fn with_write_coordinator(
+        layout: AppStateLayout,
+        write_coordinator: LocalSearchWriteCoordinator,
+    ) -> Self {
         Self {
             store: SqliteObservedValuesStore::new(layout),
+            write_coordinator,
         }
     }
 
@@ -55,6 +65,16 @@ impl ObservedValuesProvider {
             Ok(policy) => policy,
             Err(error) => return observed_policy_error_outcome(error),
         };
+        self.write_coordinator.run(&request.workspace_name, || {
+            self.search_with_policy(request, policy)
+        })
+    }
+
+    fn search_with_policy(
+        &self,
+        request: &SearchRequest,
+        policy: &ObservedValuesRetrievalPolicy,
+    ) -> ProviderSearchOutcome {
         let (drain, drain_error) = self.drain_before_search(&request.workspace_name);
         let retrieval_limit = usize::try_from(request.limit)
             .unwrap_or(usize::MAX)

--- a/crates/coral-app/src/search/provider.rs
+++ b/crates/coral-app/src/search/provider.rs
@@ -1,8 +1,9 @@
 //! Provider-facing Universal Search contracts and ordered registration.
 
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, Weak};
 use std::time::Instant;
 
 use tokio::task;
@@ -16,7 +17,7 @@ use crate::search::observed::provider::ObservedValuesProvider;
 use crate::search::result::{
     ProviderStatus, SearchCandidate, SearchProviderKind, SearchProviderState, SearchRequest,
 };
-use crate::workspaces::WorkspaceLifecycleReadLease;
+use crate::workspaces::{WorkspaceLifecycleReadLease, WorkspaceName};
 
 pub(crate) type ProviderSearchFuture =
     Pin<Box<dyn Future<Output = ProviderSearchOutcome> + Send + 'static>>;
@@ -27,10 +28,7 @@ pub(crate) struct ProviderSearchOutcome {
     pub(crate) status: ProviderStatus,
 }
 
-pub(crate) enum ObservedValuesPolicyInput {
-    Disabled,
-    Enabled(Result<ObservedValuesRetrievalPolicy, AppError>),
-}
+pub(crate) type ObservedValuesPolicyInput = Result<ObservedValuesRetrievalPolicy, AppError>;
 
 pub(crate) struct SearchExecutionContext {
     pub(crate) request_started_at: Instant,
@@ -40,7 +38,7 @@ pub(crate) struct SearchExecutionContext {
     _lifecycle_lease: WorkspaceLifecycleReadLease,
     pub(crate) request: SearchRequest,
     pub(crate) catalog_resolution: Result<CatalogResolution, QueryManagerError>,
-    pub(crate) observed_values_policy: ObservedValuesPolicyInput,
+    pub(crate) observed_values_policy: Option<ObservedValuesPolicyInput>,
 }
 
 impl SearchExecutionContext {
@@ -49,7 +47,7 @@ impl SearchExecutionContext {
         lifecycle_lease: WorkspaceLifecycleReadLease,
         request: SearchRequest,
         catalog_resolution: Result<CatalogResolution, QueryManagerError>,
-        observed_values_policy: ObservedValuesPolicyInput,
+        observed_values_policy: Option<ObservedValuesPolicyInput>,
     ) -> Self {
         Self {
             request_started_at,
@@ -58,6 +56,40 @@ impl SearchExecutionContext {
             catalog_resolution,
             observed_values_policy,
         }
+    }
+}
+
+/// Serializes local SQLite-backed provider work per workspace while leaving
+/// providers that do not use the coordinator free to run concurrently.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LocalSearchWriteCoordinator {
+    gates: Arc<Mutex<BTreeMap<WorkspaceName, Weak<Mutex<()>>>>>,
+}
+
+impl LocalSearchWriteCoordinator {
+    pub(crate) fn run<T>(
+        &self,
+        workspace_name: &WorkspaceName,
+        operation: impl FnOnce() -> T,
+    ) -> T {
+        let gate = {
+            let mut gates = self
+                .gates
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            gates.retain(|_, gate| gate.strong_count() > 0);
+            if let Some(gate) = gates.get(workspace_name).and_then(Weak::upgrade) {
+                gate
+            } else {
+                let gate = Arc::new(Mutex::new(()));
+                gates.insert(workspace_name.clone(), Arc::downgrade(&gate));
+                gate
+            }
+        };
+        let _guard = gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        operation()
     }
 }
 
@@ -84,13 +116,12 @@ pub(crate) enum SearchProviderRegistration {
 impl SearchProviderRegistry {
     pub(crate) fn local(
         catalog: CatalogMetadataProvider,
-        observed: ObservedValuesProvider,
+        observed: Option<ObservedValuesProvider>,
     ) -> Self {
-        let ordered = vec![
-            SearchProviderRegistration::Provider(Arc::new(catalog)),
-            SearchProviderRegistration::Provider(Arc::new(observed)),
-            SearchProviderRegistration::StaticStatus(native_not_enabled_status()),
-        ];
+        let ordered = local_registrations(
+            Arc::new(catalog),
+            observed.map(|provider| Arc::new(provider) as Arc<dyn SearchProvider>),
+        );
         Self {
             ordered: ordered.into(),
         }
@@ -106,6 +137,21 @@ impl SearchProviderRegistry {
             ordered: ordered.into(),
         }
     }
+}
+
+fn local_registrations(
+    catalog: Arc<dyn SearchProvider>,
+    observed: Option<Arc<dyn SearchProvider>>,
+) -> Vec<SearchProviderRegistration> {
+    let observed = observed.map_or_else(
+        || SearchProviderRegistration::StaticStatus(observed_not_enabled_status()),
+        SearchProviderRegistration::Provider,
+    );
+    vec![
+        SearchProviderRegistration::Provider(catalog),
+        observed,
+        SearchProviderRegistration::StaticStatus(native_not_enabled_status()),
+    ]
 }
 
 fn native_not_enabled_status() -> ProviderStatus {
@@ -141,21 +187,16 @@ impl SearchProvider for ObservedValuesProvider {
     fn search(&self, context: Arc<SearchExecutionContext>) -> ProviderSearchFuture {
         let provider = self.clone();
         Box::pin(async move {
-            if matches!(
-                &context.observed_values_policy,
-                ObservedValuesPolicyInput::Disabled
-            ) {
-                return observed_not_enabled_outcome();
+            if context.observed_values_policy.is_none() {
+                tracing::error!("enabled observed-values provider received no retrieval policy");
+                return provider_error_outcome(SearchProviderKind::ObservedValues);
             }
             run_blocking_provider(SearchProviderKind::ObservedValues, move || {
-                match &context.observed_values_policy {
-                    ObservedValuesPolicyInput::Enabled(policy) => {
-                        provider.search(&context.request, policy.as_ref())
-                    }
-                    ObservedValuesPolicyInput::Disabled => {
-                        unreachable!("disabled observed search returns before blocking offload")
-                    }
-                }
+                let policy = context
+                    .observed_values_policy
+                    .as_ref()
+                    .expect("registry enables observed provider only with a retrieval policy");
+                provider.search(&context.request, policy.as_ref())
             })
             .await
         })
@@ -191,45 +232,141 @@ pub(crate) fn provider_error_outcome(provider: SearchProviderKind) -> ProviderSe
     }
 }
 
-fn observed_not_enabled_outcome() -> ProviderSearchOutcome {
-    ProviderSearchOutcome {
-        candidates: Vec::new(),
-        status: ProviderStatus {
-            provider: SearchProviderKind::ObservedValues,
-            state: SearchProviderState::NotEnabled,
-            note: "observed value search is disabled; enable `observed_values_search` to include values from earlier queries".to_string(),
-            coverage: None,
-        },
+fn observed_not_enabled_status() -> ProviderStatus {
+    ProviderStatus {
+        provider: SearchProviderKind::ObservedValues,
+        state: SearchProviderState::NotEnabled,
+        note: "observed value search is disabled; enable `observed_values_search` to include values from earlier queries".to_string(),
+        coverage: None,
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::mpsc as std_mpsc;
     use std::thread;
 
-    use super::{observed_not_enabled_outcome, provider_error_outcome, run_blocking_provider};
+    use super::{
+        LocalSearchWriteCoordinator, ProviderSearchFuture, SearchExecutionContext, SearchProvider,
+        SearchProviderRegistration, local_registrations, provider_error_outcome,
+        run_blocking_provider,
+    };
     use crate::search::result::{SearchProviderKind, SearchProviderState};
+    use crate::workspaces::WorkspaceName;
 
     #[test]
-    fn disabled_observed_search_reports_not_enabled_without_candidates_or_coverage() {
-        let outcome = observed_not_enabled_outcome();
+    fn disabled_observed_search_is_registered_as_a_static_status() {
+        let registrations = local_registrations(
+            Arc::new(UnusedProvider(SearchProviderKind::CatalogMetadata)),
+            None,
+        );
 
-        assert!(outcome.candidates.is_empty());
-        assert_eq!(outcome.status.provider, SearchProviderKind::ObservedValues);
-        assert_eq!(outcome.status.state, SearchProviderState::NotEnabled);
-        assert!(outcome.status.coverage.is_none());
-        assert!(outcome.status.note.contains("`observed_values_search`"));
+        let SearchProviderRegistration::StaticStatus(status) =
+            registrations.get(1).expect("observed registration")
+        else {
+            panic!("disabled observed search must not register its provider");
+        };
+        assert_eq!(status.provider, SearchProviderKind::ObservedValues);
+        assert_eq!(status.state, SearchProviderState::NotEnabled);
+        assert!(status.coverage.is_none());
+        assert!(status.note.contains("`observed_values_search`"));
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn local_provider_work_runs_off_the_async_worker() {
         let async_thread = thread::current().id();
+        let (thread_tx, thread_rx) = std_mpsc::sync_channel(1);
         let outcome = run_blocking_provider(SearchProviderKind::CatalogMetadata, move || {
-            assert_ne!(thread::current().id(), async_thread);
+            thread_tx
+                .send(thread::current().id())
+                .expect("record blocking thread");
             provider_error_outcome(SearchProviderKind::CatalogMetadata)
         })
         .await;
 
+        assert_ne!(
+            thread_rx.recv().expect("blocking thread id"),
+            async_thread,
+            "provider work must leave the async worker thread"
+        );
         assert_eq!(outcome.status.provider, SearchProviderKind::CatalogMetadata);
+    }
+
+    #[test]
+    fn shared_local_writers_never_overlap_and_independent_work_still_runs() {
+        let coordinator = LocalSearchWriteCoordinator::default();
+        let workspace = WorkspaceName::default();
+        let active_writers = Arc::new(AtomicUsize::new(0));
+        let max_active_writers = Arc::new(AtomicUsize::new(0));
+        let (first_started_tx, first_started_rx) = std_mpsc::channel();
+        let (release_first_tx, release_first_rx) = std_mpsc::channel();
+
+        let first_coordinator = coordinator.clone();
+        let first_workspace = workspace.clone();
+        let first_active = Arc::clone(&active_writers);
+        let first_max = Arc::clone(&max_active_writers);
+        let first = thread::spawn(move || {
+            first_coordinator.run(&first_workspace, || {
+                record_active_writer(&first_active, &first_max);
+                first_started_tx.send(()).expect("signal first writer");
+                release_first_rx.recv().expect("release first writer");
+                first_active.fetch_sub(1, Ordering::SeqCst);
+            });
+        });
+        first_started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("first writer starts");
+
+        let second_active = Arc::clone(&active_writers);
+        let second_max = Arc::clone(&max_active_writers);
+        let (second_started_tx, second_started_rx) = std_mpsc::channel();
+        let second = thread::spawn(move || {
+            coordinator.run(&workspace, || {
+                record_active_writer(&second_active, &second_max);
+                second_started_tx.send(()).expect("signal second writer");
+                second_active.fetch_sub(1, Ordering::SeqCst);
+            });
+        });
+        assert!(matches!(
+            second_started_rx.recv_timeout(std::time::Duration::from_millis(100)),
+            Err(std_mpsc::RecvTimeoutError::Timeout)
+        ));
+
+        let (independent_tx, independent_rx) = std_mpsc::channel();
+        let independent = thread::spawn(move || independent_tx.send(()));
+        independent_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("independent provider work remains concurrent");
+
+        release_first_tx.send(()).expect("release first writer");
+        second_started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("second writer starts after first completes");
+        first.join().expect("first writer");
+        second.join().expect("second writer");
+        independent
+            .join()
+            .expect("independent worker")
+            .expect("signal independent work");
+        assert_eq!(max_active_writers.load(Ordering::SeqCst), 1);
+    }
+
+    fn record_active_writer(active: &AtomicUsize, max_active: &AtomicUsize) {
+        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+        max_active.fetch_max(current, Ordering::SeqCst);
+    }
+
+    struct UnusedProvider(SearchProviderKind);
+
+    impl SearchProvider for UnusedProvider {
+        fn kind(&self) -> SearchProviderKind {
+            self.0
+        }
+
+        fn search(&self, _context: Arc<SearchExecutionContext>) -> ProviderSearchFuture {
+            panic!("static registration must not invoke disabled provider")
+        }
     }
 }

--- a/crates/coral-app/src/search/provider.rs
+++ b/crates/coral-app/src/search/provider.rs
@@ -1,9 +1,209 @@
-//! Provider-facing Universal Search contracts.
+//! Provider-facing Universal Search contracts and ordered registration.
 
-use crate::search::result::{ProviderStatus, SearchCandidate};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Instant;
+
+use tokio::task;
+
+use crate::bootstrap::AppError;
+use crate::catalog::model::CatalogResolution;
+use crate::query::manager::QueryManagerError;
+use crate::search::catalog::provider::CatalogMetadataProvider;
+use crate::search::observed::ObservedValuesRetrievalPolicy;
+use crate::search::observed::provider::ObservedValuesProvider;
+use crate::search::result::{
+    ProviderStatus, SearchCandidate, SearchProviderKind, SearchProviderState, SearchRequest,
+};
+
+pub(crate) type ProviderSearchFuture =
+    Pin<Box<dyn Future<Output = ProviderSearchOutcome> + Send + 'static>>;
 
 #[derive(Debug, Clone)]
 pub(crate) struct ProviderSearchOutcome {
     pub(crate) candidates: Vec<SearchCandidate>,
     pub(crate) status: ProviderStatus,
+}
+
+pub(crate) enum ObservedValuesPolicyInput {
+    Disabled,
+    Enabled(Result<ObservedValuesRetrievalPolicy, AppError>),
+}
+
+pub(crate) struct SearchExecutionContext {
+    pub(crate) request_started_at: Instant,
+    pub(crate) request: SearchRequest,
+    pub(crate) catalog_resolution: Result<CatalogResolution, QueryManagerError>,
+    pub(crate) observed_values_policy: ObservedValuesPolicyInput,
+}
+
+impl SearchExecutionContext {
+    pub(crate) fn new(
+        request_started_at: Instant,
+        request: SearchRequest,
+        catalog_resolution: Result<CatalogResolution, QueryManagerError>,
+        observed_values_policy: ObservedValuesPolicyInput,
+    ) -> Self {
+        Self {
+            request_started_at,
+            request,
+            catalog_resolution,
+            observed_values_policy,
+        }
+    }
+}
+
+pub(crate) trait SearchProvider: Send + Sync {
+    fn kind(&self) -> SearchProviderKind;
+
+    /// Returns candidates in best-first provider-local order. When native
+    /// fanout contributes candidates, fusion treats each vector position as
+    /// that provider's rank instead of re-sorting provider-local evidence.
+    fn search(&self, context: Arc<SearchExecutionContext>) -> ProviderSearchFuture;
+}
+
+#[derive(Clone)]
+pub(crate) struct SearchProviderRegistry {
+    ordered: Arc<[Arc<dyn SearchProvider>]>,
+}
+
+impl SearchProviderRegistry {
+    pub(crate) fn local(
+        catalog: CatalogMetadataProvider,
+        observed: ObservedValuesProvider,
+    ) -> Self {
+        let ordered: Vec<Arc<dyn SearchProvider>> = vec![Arc::new(catalog), Arc::new(observed)];
+        Self {
+            ordered: ordered.into(),
+        }
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Arc<dyn SearchProvider>> {
+        self.ordered.iter()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_ordered(ordered: Vec<Arc<dyn SearchProvider>>) -> Self {
+        Self {
+            ordered: ordered.into(),
+        }
+    }
+}
+
+impl SearchProvider for CatalogMetadataProvider {
+    fn kind(&self) -> SearchProviderKind {
+        SearchProviderKind::CatalogMetadata
+    }
+
+    fn search(&self, context: Arc<SearchExecutionContext>) -> ProviderSearchFuture {
+        let provider = self.clone();
+        Box::pin(async move {
+            run_blocking_provider(SearchProviderKind::CatalogMetadata, move || {
+                provider.search(&context.request, context.catalog_resolution.as_ref())
+            })
+            .await
+        })
+    }
+}
+
+impl SearchProvider for ObservedValuesProvider {
+    fn kind(&self) -> SearchProviderKind {
+        SearchProviderKind::ObservedValues
+    }
+
+    fn search(&self, context: Arc<SearchExecutionContext>) -> ProviderSearchFuture {
+        let provider = self.clone();
+        Box::pin(async move {
+            if matches!(
+                &context.observed_values_policy,
+                ObservedValuesPolicyInput::Disabled
+            ) {
+                return observed_not_enabled_outcome();
+            }
+            run_blocking_provider(SearchProviderKind::ObservedValues, move || {
+                match &context.observed_values_policy {
+                    ObservedValuesPolicyInput::Enabled(policy) => {
+                        provider.search(&context.request, policy.as_ref())
+                    }
+                    ObservedValuesPolicyInput::Disabled => {
+                        unreachable!("disabled observed search returns before blocking offload")
+                    }
+                }
+            })
+            .await
+        })
+    }
+}
+
+async fn run_blocking_provider<F>(
+    provider: SearchProviderKind,
+    operation: F,
+) -> ProviderSearchOutcome
+where
+    F: FnOnce() -> ProviderSearchOutcome + Send + 'static,
+{
+    let span = tracing::Span::current();
+    match task::spawn_blocking(move || span.in_scope(operation)).await {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            tracing::error!(?provider, ?error, "Universal Search provider task failed");
+            provider_error_outcome(provider)
+        }
+    }
+}
+
+pub(crate) fn provider_error_outcome(provider: SearchProviderKind) -> ProviderSearchOutcome {
+    ProviderSearchOutcome {
+        candidates: Vec::new(),
+        status: ProviderStatus {
+            provider,
+            state: SearchProviderState::Error,
+            note: "search provider failed without affecting other providers".to_string(),
+            coverage: None,
+        },
+    }
+}
+
+fn observed_not_enabled_outcome() -> ProviderSearchOutcome {
+    ProviderSearchOutcome {
+        candidates: Vec::new(),
+        status: ProviderStatus {
+            provider: SearchProviderKind::ObservedValues,
+            state: SearchProviderState::NotEnabled,
+            note: "observed value search is disabled; enable `observed_values_search` to include values from earlier queries".to_string(),
+            coverage: None,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use super::{observed_not_enabled_outcome, provider_error_outcome, run_blocking_provider};
+    use crate::search::result::{SearchProviderKind, SearchProviderState};
+
+    #[test]
+    fn disabled_observed_search_reports_not_enabled_without_candidates_or_coverage() {
+        let outcome = observed_not_enabled_outcome();
+
+        assert!(outcome.candidates.is_empty());
+        assert_eq!(outcome.status.provider, SearchProviderKind::ObservedValues);
+        assert_eq!(outcome.status.state, SearchProviderState::NotEnabled);
+        assert!(outcome.status.coverage.is_none());
+        assert!(outcome.status.note.contains("`observed_values_search`"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn local_provider_work_runs_off_the_async_worker() {
+        let async_thread = thread::current().id();
+        let outcome = run_blocking_provider(SearchProviderKind::CatalogMetadata, move || {
+            assert_ne!(thread::current().id(), async_thread);
+            provider_error_outcome(SearchProviderKind::CatalogMetadata)
+        })
+        .await;
+
+        assert_eq!(outcome.status.provider, SearchProviderKind::CatalogMetadata);
+    }
 }

--- a/crates/coral-app/src/search/provider.rs
+++ b/crates/coral-app/src/search/provider.rs
@@ -16,6 +16,7 @@ use crate::search::observed::provider::ObservedValuesProvider;
 use crate::search::result::{
     ProviderStatus, SearchCandidate, SearchProviderKind, SearchProviderState, SearchRequest,
 };
+use crate::workspaces::WorkspaceLifecycleReadLease;
 
 pub(crate) type ProviderSearchFuture =
     Pin<Box<dyn Future<Output = ProviderSearchOutcome> + Send + 'static>>;
@@ -33,6 +34,10 @@ pub(crate) enum ObservedValuesPolicyInput {
 
 pub(crate) struct SearchExecutionContext {
     pub(crate) request_started_at: Instant,
+    // Keep the workspace lifecycle read lease attached to every provider task.
+    // Search request cancellation detaches spawned provider work, and blocking
+    // provider tasks cannot be cancelled once started.
+    _lifecycle_lease: WorkspaceLifecycleReadLease,
     pub(crate) request: SearchRequest,
     pub(crate) catalog_resolution: Result<CatalogResolution, QueryManagerError>,
     pub(crate) observed_values_policy: ObservedValuesPolicyInput,
@@ -41,12 +46,14 @@ pub(crate) struct SearchExecutionContext {
 impl SearchExecutionContext {
     pub(crate) fn new(
         request_started_at: Instant,
+        lifecycle_lease: WorkspaceLifecycleReadLease,
         request: SearchRequest,
         catalog_resolution: Result<CatalogResolution, QueryManagerError>,
         observed_values_policy: ObservedValuesPolicyInput,
     ) -> Self {
         Self {
             request_started_at,
+            _lifecycle_lease: lifecycle_lease,
             request,
             catalog_resolution,
             observed_values_policy,
@@ -65,7 +72,13 @@ pub(crate) trait SearchProvider: Send + Sync {
 
 #[derive(Clone)]
 pub(crate) struct SearchProviderRegistry {
-    ordered: Arc<[Arc<dyn SearchProvider>]>,
+    ordered: Arc<[SearchProviderRegistration]>,
+}
+
+#[derive(Clone)]
+pub(crate) enum SearchProviderRegistration {
+    Provider(Arc<dyn SearchProvider>),
+    StaticStatus(ProviderStatus),
 }
 
 impl SearchProviderRegistry {
@@ -73,21 +86,34 @@ impl SearchProviderRegistry {
         catalog: CatalogMetadataProvider,
         observed: ObservedValuesProvider,
     ) -> Self {
-        let ordered: Vec<Arc<dyn SearchProvider>> = vec![Arc::new(catalog), Arc::new(observed)];
+        let ordered = vec![
+            SearchProviderRegistration::Provider(Arc::new(catalog)),
+            SearchProviderRegistration::Provider(Arc::new(observed)),
+            SearchProviderRegistration::StaticStatus(native_not_enabled_status()),
+        ];
         Self {
             ordered: ordered.into(),
         }
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &Arc<dyn SearchProvider>> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &SearchProviderRegistration> {
         self.ordered.iter()
     }
 
     #[cfg(test)]
-    pub(crate) fn from_ordered(ordered: Vec<Arc<dyn SearchProvider>>) -> Self {
+    pub(crate) fn from_ordered(ordered: Vec<SearchProviderRegistration>) -> Self {
         Self {
             ordered: ordered.into(),
         }
+    }
+}
+
+fn native_not_enabled_status() -> ProviderStatus {
+    ProviderStatus {
+        provider: SearchProviderKind::NativeFanout,
+        state: SearchProviderState::NotEnabled,
+        note: "provider-native fanout is disabled".to_string(),
+        coverage: None,
     }
 }
 

--- a/crates/coral-app/src/search/result.rs
+++ b/crates/coral-app/src/search/result.rs
@@ -121,6 +121,8 @@ pub(crate) struct ProviderCoverage {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SearchCandidate {
+    /// Provider-scoped stable ordering key, not a cross-provider identity.
+    /// Equal keys emitted by different providers remain separate candidates.
     pub(crate) key: String,
     pub(crate) score: u32,
     pub(crate) provider: SearchProviderKind,

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -34,6 +34,7 @@ use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
 use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthCredentialSpec};
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tokio::sync::{mpsc, oneshot};
+use tokio::task;
 use tracing::warn;
 use uuid::Uuid;
 
@@ -307,7 +308,19 @@ impl SourceManager {
         Ok(candidates)
     }
 
-    pub(crate) fn create_bundled_source(
+    pub(crate) async fn create_bundled_source_async(
+        &self,
+        workspace_name: WorkspaceName,
+        command: CreateBundledSourceCommand,
+    ) -> Result<InstalledSource, AppError> {
+        let manager = self.clone();
+        self.run_blocking_lifecycle_write(move || {
+            manager.create_bundled_source_with_lifecycle_lock(&workspace_name, &command)
+        })
+        .await
+    }
+
+    fn create_bundled_source_with_lifecycle_lock(
         &self,
         workspace_name: &WorkspaceName,
         command: &CreateBundledSourceCommand,
@@ -345,7 +358,29 @@ impl SourceManager {
         .await
     }
 
+    #[cfg(test)]
     pub(crate) fn import_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: &ImportSourceCommand,
+    ) -> Result<InstalledSource, AppError> {
+        let _lifecycle_guard = self.lifecycle_lock.lock();
+        self.import_source_with_lifecycle_lock(workspace_name, command)
+    }
+
+    pub(crate) async fn import_source_async(
+        &self,
+        workspace_name: WorkspaceName,
+        command: ImportSourceCommand,
+    ) -> Result<InstalledSource, AppError> {
+        let manager = self.clone();
+        self.run_blocking_lifecycle_write(move || {
+            manager.import_source_with_lifecycle_lock(&workspace_name, &command)
+        })
+        .await
+    }
+
+    fn import_source_with_lifecycle_lock(
         &self,
         workspace_name: &WorkspaceName,
         command: &ImportSourceCommand,
@@ -402,7 +437,6 @@ impl SourceManager {
         materialization_manifest_yaml: &str,
         origin: SourceOrigin,
     ) -> Result<InstalledSource, AppError> {
-        let _lifecycle_guard = self.lifecycle_lock.lock();
         self.validate_runtime_schema_names_available(
             workspace_name,
             &candidate.name,
@@ -486,7 +520,7 @@ impl SourceManager {
                 events,
             )
             .await?;
-        let _lifecycle_guard = self.lifecycle_lock.lock();
+        let _lifecycle_guard = self.lifecycle_lock.lock_async().await;
         self.validate_runtime_schema_names_available(
             workspace_name,
             &candidate.name,
@@ -527,12 +561,33 @@ impl SourceManager {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn delete_source(
         &self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
         let _lifecycle_guard = self.lifecycle_lock.lock();
+        self.delete_source_with_lifecycle_lock(workspace_name, source_name)
+    }
+
+    pub(crate) async fn delete_source_async(
+        &self,
+        workspace_name: WorkspaceName,
+        source_name: SourceName,
+    ) -> Result<InstalledSource, AppError> {
+        let manager = self.clone();
+        self.run_blocking_lifecycle_write(move || {
+            manager.delete_source_with_lifecycle_lock(&workspace_name, &source_name)
+        })
+        .await
+    }
+
+    fn delete_source_with_lifecycle_lock(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<InstalledSource, AppError> {
         let source_dir = self.layout.source_dir(workspace_name, source_name);
         let credential_set_id = CredentialSetId::for_source(source_name);
         let credential_guard = self
@@ -1303,6 +1358,21 @@ impl SourceManager {
     ) -> InstalledSource {
         self.populate_source_version(workspace_name, source.clone())
             .unwrap_or(source)
+    }
+
+    async fn run_blocking_lifecycle_write<T, F>(&self, operation: F) -> Result<T, AppError>
+    where
+        T: Send + 'static,
+        F: FnOnce() -> Result<T, AppError> + Send + 'static,
+    {
+        let lifecycle_guard = self.lifecycle_lock.lock_async().await;
+        let span = tracing::Span::current();
+        task::spawn_blocking(move || {
+            let _lifecycle_guard = lifecycle_guard;
+            span.in_scope(operation)
+        })
+        .await
+        .map_err(AppError::from)?
     }
 }
 

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -30,11 +30,10 @@ use crate::sources::materialization::{
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs;
-use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
+use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceName};
 use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthCredentialSpec};
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tokio::sync::{mpsc, oneshot};
-use tokio::task;
 use tracing::warn;
 use uuid::Uuid;
 
@@ -157,6 +156,17 @@ struct PersistSourceRequest<'a> {
     bindings: ValidatedBindings,
     origin: SourceOrigin,
     materialization_tmp: Option<PathBuf>,
+}
+
+struct OAuthSourceInstallRequest {
+    workspace_name: WorkspaceName,
+    candidate: CandidateSource,
+    bindings: SourceBindings,
+    oauth_input_keys: BTreeSet<String>,
+    oauth_material: Vec<OAuthCredentialMaterial>,
+    manifest_yaml: Option<String>,
+    materialization_manifest_yaml: String,
+    origin: SourceOrigin,
 }
 
 struct SourceRollbackState {
@@ -311,11 +321,13 @@ impl SourceManager {
     pub(crate) async fn create_bundled_source_async(
         &self,
         workspace_name: WorkspaceName,
+        revision: WorkspaceLifecycleRevision,
         command: CreateBundledSourceCommand,
     ) -> Result<InstalledSource, AppError> {
         let manager = self.clone();
-        self.run_blocking_lifecycle_write(move || {
-            manager.create_bundled_source_with_lifecycle_lock(&workspace_name, &command)
+        let operation_workspace_name = workspace_name.clone();
+        self.run_blocking_lifecycle_write_if_unchanged(&workspace_name, revision, move || {
+            manager.create_bundled_source_with_lifecycle_lock(&operation_workspace_name, &command)
         })
         .await
     }
@@ -340,19 +352,21 @@ impl SourceManager {
     pub(crate) async fn create_bundled_source_with_oauth(
         &self,
         workspace_name: &WorkspaceName,
+        revision: WorkspaceLifecycleRevision,
         command: CreateBundledSourceWithOAuthCommand,
         events: ImportSourceEventSender,
     ) -> Result<InstalledSource, AppError> {
         let bundled = load_bundled_source(&command.name)?;
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
         self.install_source_with_oauth(
-            workspace_name,
-            &candidate,
-            &command.bindings,
+            workspace_name.clone(),
+            revision,
+            candidate,
+            command.bindings,
             command.oauth_credential_retrievals,
             events,
             None,
-            &bundled.manifest_yaml,
+            bundled.manifest_yaml,
             SourceOrigin::Bundled,
         )
         .await
@@ -371,11 +385,13 @@ impl SourceManager {
     pub(crate) async fn import_source_async(
         &self,
         workspace_name: WorkspaceName,
+        revision: WorkspaceLifecycleRevision,
         command: ImportSourceCommand,
     ) -> Result<InstalledSource, AppError> {
         let manager = self.clone();
-        self.run_blocking_lifecycle_write(move || {
-            manager.import_source_with_lifecycle_lock(&workspace_name, &command)
+        let operation_workspace_name = workspace_name.clone();
+        self.run_blocking_lifecycle_write_if_unchanged(&workspace_name, revision, move || {
+            manager.import_source_with_lifecycle_lock(&operation_workspace_name, &command)
         })
         .await
     }
@@ -403,6 +419,7 @@ impl SourceManager {
     pub(crate) async fn import_source_with_credentials(
         &self,
         workspace_name: &WorkspaceName,
+        revision: WorkspaceLifecycleRevision,
         command: ImportSourceWithCredentialsCommand,
         events: ImportSourceEventSender,
     ) -> Result<InstalledSource, AppError> {
@@ -412,13 +429,14 @@ impl SourceManager {
         let mut candidate = describe_manifest(&manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
         self.install_source_with_oauth(
-            workspace_name,
-            &candidate,
-            &command.bindings,
+            workspace_name.clone(),
+            revision,
+            candidate,
+            command.bindings,
             command.oauth_credential_retrievals,
             events,
-            Some(&manifest_yaml),
-            &manifest_yaml,
+            Some(manifest_yaml.clone()),
+            manifest_yaml,
             SourceOrigin::Imported,
         )
         .await
@@ -482,76 +500,107 @@ impl SourceManager {
     )]
     async fn install_source_with_oauth(
         &self,
-        workspace_name: &WorkspaceName,
-        candidate: &CandidateSource,
-        bindings: &SourceBindings,
+        workspace_name: WorkspaceName,
+        revision: WorkspaceLifecycleRevision,
+        candidate: CandidateSource,
+        bindings: SourceBindings,
         oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
         events: ImportSourceEventSender,
-        manifest_yaml: Option<&str>,
-        materialization_manifest_yaml: &str,
+        manifest_yaml: Option<String>,
+        materialization_manifest_yaml: String,
         origin: SourceOrigin,
     ) -> Result<InstalledSource, AppError> {
         self.validate_runtime_schema_names_available(
-            workspace_name,
+            &workspace_name,
             &candidate.name,
-            materialization_manifest_yaml,
+            &materialization_manifest_yaml,
         )?;
         let oauth_input_keys = oauth_credential_retrievals
             .iter()
             .map(|credential| credential.input_key.clone())
             .collect::<BTreeSet<_>>();
         let stored_material = self.source_stored_material_for_validation(
-            workspace_name,
-            candidate,
-            bindings,
+            &workspace_name,
+            &candidate,
+            &bindings,
             &oauth_input_keys,
         )?;
         let preflight_bindings = Self::validate_oauth_import_preflight(
-            candidate,
-            bindings,
+            &candidate,
+            &bindings,
             &stored_material,
             &oauth_credential_retrievals,
         )?;
         let oauth_material = self
             .retrieve_oauth_material(
-                candidate,
+                &candidate,
                 &preflight_bindings.variables,
                 oauth_credential_retrievals,
                 events,
             )
             .await?;
-        let _lifecycle_guard = self.lifecycle_lock.lock_async().await;
-        self.validate_runtime_schema_names_available(
-            workspace_name,
-            &candidate.name,
-            materialization_manifest_yaml,
-        )?;
-        let stored_material = self.source_stored_material_for_validation(
+        let guard_workspace_name = workspace_name.clone();
+        let manager = self.clone();
+        self.run_blocking_lifecycle_write_if_unchanged(&guard_workspace_name, revision, move || {
+            manager.install_oauth_source_with_lifecycle_lock(OAuthSourceInstallRequest {
+                workspace_name,
+                candidate,
+                bindings,
+                oauth_input_keys,
+                oauth_material,
+                manifest_yaml,
+                materialization_manifest_yaml,
+                origin,
+            })
+        })
+        .await
+    }
+
+    fn install_oauth_source_with_lifecycle_lock(
+        &self,
+        request: OAuthSourceInstallRequest,
+    ) -> Result<InstalledSource, AppError> {
+        let OAuthSourceInstallRequest {
             workspace_name,
             candidate,
             bindings,
+            oauth_input_keys,
+            oauth_material,
+            manifest_yaml,
+            materialization_manifest_yaml,
+            origin,
+        } = request;
+        self.validate_runtime_schema_names_available(
+            &workspace_name,
+            &candidate.name,
+            &materialization_manifest_yaml,
+        )?;
+        let stored_material = self.source_stored_material_for_validation(
+            &workspace_name,
+            &candidate,
+            &bindings,
             &oauth_input_keys,
         )?;
         let mut validation_material = stored_material.clone();
         for material in &oauth_material {
             validation_material.insert(material.input_key.clone(), material.access_token.clone());
         }
-        let mut bindings = validate_bindings(candidate, bindings, &validation_material)?;
+        let mut bindings = validate_bindings(&candidate, &bindings, &validation_material)?;
         merge_oauth_material_into_bindings(&mut bindings, oauth_material)?;
         let materialization_inputs =
             materialization_inputs_from_bindings(&bindings, &stored_material);
         self.persist_source(
-            workspace_name,
+            &workspace_name,
             PersistSourceRequest {
-                candidate,
-                manifest_yaml,
+                candidate: &candidate,
+                manifest_yaml: manifest_yaml.as_deref(),
                 bindings,
                 origin,
                 materialization_tmp: self
                     .prepare_v4_materialization(
-                        workspace_name,
-                        candidate,
-                        materialization_manifest_yaml,
+                        &workspace_name,
+                        &candidate,
+                        &materialization_manifest_yaml,
                         &materialization_inputs,
                         origin,
                         "tmp",
@@ -574,11 +623,13 @@ impl SourceManager {
     pub(crate) async fn delete_source_async(
         &self,
         workspace_name: WorkspaceName,
+        revision: WorkspaceLifecycleRevision,
         source_name: SourceName,
     ) -> Result<InstalledSource, AppError> {
         let manager = self.clone();
-        self.run_blocking_lifecycle_write(move || {
-            manager.delete_source_with_lifecycle_lock(&workspace_name, &source_name)
+        let operation_workspace_name = workspace_name.clone();
+        self.run_blocking_lifecycle_write_if_unchanged(&workspace_name, revision, move || {
+            manager.delete_source_with_lifecycle_lock(&operation_workspace_name, &source_name)
         })
         .await
     }
@@ -1360,19 +1411,24 @@ impl SourceManager {
             .unwrap_or(source)
     }
 
-    async fn run_blocking_lifecycle_write<T, F>(&self, operation: F) -> Result<T, AppError>
+    async fn run_blocking_lifecycle_write_if_unchanged<T, F>(
+        &self,
+        workspace_name: &WorkspaceName,
+        revision: WorkspaceLifecycleRevision,
+        operation: F,
+    ) -> Result<T, AppError>
     where
         T: Send + 'static,
         F: FnOnce() -> Result<T, AppError> + Send + 'static,
     {
-        let lifecycle_guard = self.lifecycle_lock.lock_async().await;
-        let span = tracing::Span::current();
-        task::spawn_blocking(move || {
-            let _lifecycle_guard = lifecycle_guard;
-            span.in_scope(operation)
-        })
-        .await
-        .map_err(AppError::from)?
+        self.lifecycle_lock
+            .run_blocking_workspace_write_if_unchanged(revision, workspace_name, operation)
+            .await?
+            .ok_or_else(|| {
+                AppError::FailedPrecondition(format!(
+                    "workspace '{workspace_name}' changed while a source lifecycle operation was pending; retry the operation"
+                ))
+            })
     }
 }
 
@@ -1714,11 +1770,22 @@ mod tests {
     use crate::sources::materialization::{FINGERPRINT_FILENAME, PROJECTIONS_FILENAME};
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
     use crate::state::{AppStateLayout, ConfigStore};
-    use crate::workspaces::WorkspaceName;
+    use crate::workspaces::{WorkspaceLifecycleRevision, WorkspaceName};
     use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
     fn default_workspace() -> WorkspaceName {
         WorkspaceName::default()
+    }
+
+    async fn active_revision(
+        manager: &SourceManager,
+        workspace_name: &WorkspaceName,
+    ) -> WorkspaceLifecycleRevision {
+        manager
+            .lifecycle_lock
+            .revision_if_active_async(workspace_name)
+            .await
+            .expect("workspace lifecycle revision")
     }
 
     fn manifest_with_secret() -> String {
@@ -3387,6 +3454,140 @@ surface:
     }
 
     #[tokio::test]
+    async fn announced_workspace_deletion_prevents_source_persistence() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let manager =
+            SourceManager::new_for_tests(config_store.clone(), credential_manager, layout.clone());
+        let workspace_name = default_workspace();
+        let revision = active_revision(&manager, &workspace_name).await;
+        let deletion_marker = manager
+            .lifecycle_lock
+            .mark_workspace_deleting(&workspace_name)
+            .await
+            .expect("mark workspace deleting");
+
+        let error = manager
+            .import_source_async(
+                workspace_name.clone(),
+                revision,
+                ImportSourceCommand {
+                    manifest_yaml: manifest_without_secrets(),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .await
+            .expect_err("deleting workspace must fail closed");
+        drop(deletion_marker);
+
+        assert!(
+            matches!(error, crate::bootstrap::AppError::FailedPrecondition(ref message) if message.contains("retry the operation"))
+        );
+        assert!(
+            config_store
+                .list_workspace_sources(&workspace_name)
+                .expect("list sources")
+                .is_empty()
+        );
+        let source_name = SourceName::parse("public_messages").expect("source");
+        assert!(!layout.source_dir(&workspace_name, &source_name).exists());
+    }
+
+    #[tokio::test]
+    async fn workspace_deletion_during_oauth_prevents_source_persistence() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let manager =
+            SourceManager::new_for_tests(config_store.clone(), credential_manager, layout.clone());
+        let fixture = OAuthFixture::new();
+        let redirect_port = free_loopback_port();
+        let (manifest_yaml, _) =
+            manifest_with_templated_oauth_endpoints(&fixture.token_url, redirect_port);
+        let (event_tx, mut event_rx) = import_event_channel();
+        let workspace_name = default_workspace();
+        let revision = active_revision(&manager, &workspace_name).await;
+        let lifecycle_lock = manager.lifecycle_lock.clone();
+        let deletion_workspace = workspace_name.clone();
+        let import = manager.import_source_with_credentials(
+            &workspace_name,
+            revision,
+            ImportSourceWithCredentialsCommand {
+                manifest_yaml,
+                bindings: oauth_import_bindings_with_tenant(),
+                oauth_credential_retrievals: vec![SourceOAuthCredentialRetrieval {
+                    input_key: "API_TOKEN".to_string(),
+                    method_index: 0,
+                    credential_inputs: Vec::new(),
+                }],
+            },
+            event_tx,
+        );
+        let delete_during_oauth = async {
+            let event = event_rx
+                .recv()
+                .await
+                .expect("authorization event")
+                .into_event();
+            let ImportSourceWithCredentialsEvent::Authorization {
+                authorization_url, ..
+            } = event
+            else {
+                panic!("unexpected import event");
+            };
+            let deletion_marker = lifecycle_lock
+                .mark_workspace_deleting(&deletion_workspace)
+                .await
+                .expect("mark workspace deleting");
+            callback(&authorization_url, redirect_port).await;
+
+            let event = event_rx
+                .recv()
+                .await
+                .expect("callback received event")
+                .into_event();
+            assert!(matches!(
+                event,
+                ImportSourceWithCredentialsEvent::CallbackReceived { .. }
+            ));
+            let event = event_rx
+                .recv()
+                .await
+                .expect("completion event")
+                .into_event();
+            assert!(matches!(
+                event,
+                ImportSourceWithCredentialsEvent::Completed { .. }
+            ));
+            deletion_marker
+        };
+
+        let (result, deletion_marker) = tokio::join!(import, delete_during_oauth);
+        let error = result.expect_err("OAuth import into deleting workspace must fail closed");
+        drop(deletion_marker);
+
+        assert!(
+            matches!(error, crate::bootstrap::AppError::FailedPrecondition(ref message) if message.contains("retry the operation"))
+        );
+        fixture.token_server.await.expect("token server");
+        assert!(
+            config_store
+                .list_workspace_sources(&workspace_name)
+                .expect("list sources")
+                .is_empty()
+        );
+        let source_name = SourceName::parse("secured_messages").expect("source");
+        assert!(!layout.source_dir(&workspace_name, &source_name).exists());
+    }
+
+    #[tokio::test]
     async fn import_with_oauth_persists_retrieved_material() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
@@ -3412,8 +3613,10 @@ surface:
         );
         let (event_tx, mut event_rx) = import_event_channel();
         let workspace_name = default_workspace();
+        let revision = active_revision(&manager, &workspace_name).await;
         let import = manager.import_source_with_credentials(
             &workspace_name,
+            revision,
             ImportSourceWithCredentialsCommand {
                 manifest_yaml,
                 bindings: oauth_import_bindings_with_tenant(),
@@ -3493,8 +3696,10 @@ surface:
         );
         let (event_tx, mut event_rx) = import_event_channel();
         let workspace_name = default_workspace();
+        let revision = active_revision(&manager, &workspace_name).await;
         let import = manager.import_source_with_credentials(
             &workspace_name,
+            revision,
             ImportSourceWithCredentialsCommand {
                 manifest_yaml,
                 bindings: oauth_import_bindings_with_tenant(),
@@ -3573,9 +3778,11 @@ surface:
         let redirect_port = free_loopback_port();
         let (event_tx, mut event_rx) = import_event_channel();
         let workspace_name = default_workspace();
+        let revision = active_revision(&manager, &workspace_name).await;
         let error = manager
             .import_source_with_credentials(
                 &workspace_name,
+                revision,
                 ImportSourceWithCredentialsCommand {
                     manifest_yaml: manifest_with_oauth_secret(
                         "http://127.0.0.1:1/token",
@@ -3630,10 +3837,13 @@ surface:
         let manager = SourceManager::new_for_tests(config_store, credential_manager, layout);
         let redirect_port = free_loopback_port();
         let (event_tx, mut event_rx) = import_event_channel();
+        let workspace_name = default_workspace();
+        let revision = active_revision(&manager, &workspace_name).await;
 
         let error = manager
             .import_source_with_credentials(
-                &default_workspace(),
+                &workspace_name,
+                revision,
                 ImportSourceWithCredentialsCommand {
                     manifest_yaml: manifest_with_oauth_secret(
                         "http://127.0.0.1:1/token",

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -329,7 +329,7 @@ impl SourceServiceApi for SourceService {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
         let workspaces = self.workspaces.clone();
-        instrument_grpc(span, async move {
+        Box::pin(instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             require_workspace(&workspaces, &workspace_name).await?;
@@ -345,7 +345,7 @@ impl SourceServiceApi for SourceService {
                 &workspace_name,
                 report,
             )))
-        })
+        }))
         .await
     }
 }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -48,7 +48,7 @@ use crate::transport::{
     grpc_span, instrument_grpc, query_status, validate_source_response_to_proto,
     workspace_name_from_proto, workspace_to_proto,
 };
-use crate::workspaces::{WorkspaceManager, WorkspaceName};
+use crate::workspaces::{WorkspaceLifecycleRevision, WorkspaceManager, WorkspaceName};
 use tokio::sync::mpsc;
 use tokio_stream::Stream;
 use tokio_stream::StreamExt as _;
@@ -177,7 +177,7 @@ impl SourceServiceApi for SourceService {
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            require_workspace(&workspaces, &workspace_name).await?;
+            let revision = require_active_workspace_revision(&workspaces, &workspace_name).await?;
             let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
             let command = CreateBundledSourceCommand {
                 name: bundled_name,
@@ -185,7 +185,7 @@ impl SourceServiceApi for SourceService {
             };
             let response_workspace_name = workspace_name.clone();
             let installed = sources
-                .create_bundled_source_async(workspace_name, command)
+                .create_bundled_source_async(workspace_name, revision, command)
                 .await
                 .map_err(app_status)?;
             Ok(Response::new(CreateBundledSourceResponse {
@@ -208,7 +208,7 @@ impl SourceServiceApi for SourceService {
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            require_workspace(&workspaces, &workspace_name).await?;
+            let revision = require_active_workspace_revision(&workspaces, &workspace_name).await?;
             let response_workspace_name = workspace_name.clone();
             let command = CreateBundledSourceWithOAuthCommand {
                 name: SourceName::parse(&request.name).map_err(app_status)?,
@@ -226,6 +226,7 @@ impl SourceServiceApi for SourceService {
                         sources
                             .create_bundled_source_with_oauth(
                                 &workspace_name,
+                                revision,
                                 command,
                                 event_sender,
                             )
@@ -251,7 +252,7 @@ impl SourceServiceApi for SourceService {
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            require_workspace(&workspaces, &workspace_name).await?;
+            let revision = require_active_workspace_revision(&workspaces, &workspace_name).await?;
             let response_workspace_name = workspace_name.clone();
             if request.oauth_credential_retrievals.is_empty() {
                 let command = ImportSourceCommand {
@@ -259,7 +260,7 @@ impl SourceServiceApi for SourceService {
                     bindings: source_bindings_from_proto(request.variables, request.secrets),
                 };
                 let installed = sources
-                    .import_source_async(workspace_name, command)
+                    .import_source_async(workspace_name, revision, command)
                     .await
                     .map_err(app_status)?;
                 let response = ImportSourceResponse {
@@ -285,7 +286,12 @@ impl SourceServiceApi for SourceService {
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
                         sources
-                            .import_source_with_credentials(&workspace_name, command, event_sender)
+                            .import_source_with_credentials(
+                                &workspace_name,
+                                revision,
+                                command,
+                                event_sender,
+                            )
                             .await
                             .map_err(app_status)
                     })
@@ -305,10 +311,10 @@ impl SourceServiceApi for SourceService {
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            require_workspace(&workspaces, &workspace_name).await?;
+            let revision = require_active_workspace_revision(&workspaces, &workspace_name).await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
             sources
-                .delete_source_async(workspace_name, source_name)
+                .delete_source_async(workspace_name, revision, source_name)
                 .await
                 .map_err(app_status)?;
             Ok(Response::new(DeleteSourceResponse {}))
@@ -350,6 +356,16 @@ async fn require_workspace(
 ) -> Result<(), Status> {
     workspaces
         .require_workspace(workspace_name)
+        .await
+        .map_err(app_status)
+}
+
+async fn require_active_workspace_revision(
+    workspaces: &WorkspaceManager,
+    workspace_name: &WorkspaceName,
+) -> Result<WorkspaceLifecycleRevision, Status> {
+    workspaces
+        .require_active_workspace_revision(workspace_name)
         .await
         .map_err(app_status)
 }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -50,7 +50,6 @@ use crate::transport::{
 };
 use crate::workspaces::{WorkspaceManager, WorkspaceName};
 use tokio::sync::mpsc;
-use tokio::task;
 use tokio_stream::Stream;
 use tokio_stream::StreamExt as _;
 
@@ -185,10 +184,10 @@ impl SourceServiceApi for SourceService {
                 bindings: source_bindings_from_proto(request.variables, request.secrets),
             };
             let response_workspace_name = workspace_name.clone();
-            let installed = run_blocking_source_operation(move || {
-                sources.create_bundled_source(&workspace_name, &command)
-            })
-            .await?;
+            let installed = sources
+                .create_bundled_source_async(workspace_name, command)
+                .await
+                .map_err(app_status)?;
             Ok(Response::new(CreateBundledSourceResponse {
                 source: Some(installed_source_to_proto(
                     &response_workspace_name,
@@ -259,10 +258,10 @@ impl SourceServiceApi for SourceService {
                     manifest_yaml: request.manifest_yaml,
                     bindings: source_bindings_from_proto(request.variables, request.secrets),
                 };
-                let installed = run_blocking_source_operation(move || {
-                    sources.import_source(&workspace_name, &command)
-                })
-                .await?;
+                let installed = sources
+                    .import_source_async(workspace_name, command)
+                    .await
+                    .map_err(app_status)?;
                 let response = ImportSourceResponse {
                     event: Some(import_source_response::Event::Source(
                         installed_source_to_proto(&response_workspace_name, installed),
@@ -308,10 +307,10 @@ impl SourceServiceApi for SourceService {
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             require_workspace(&workspaces, &workspace_name).await?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
-            run_blocking_source_operation(move || {
-                sources.delete_source(&workspace_name, &source_name)
-            })
-            .await?;
+            sources
+                .delete_source_async(workspace_name, source_name)
+                .await
+                .map_err(app_status)?;
             Ok(Response::new(DeleteSourceResponse {}))
         })
         .await
@@ -360,18 +359,6 @@ type CreateBundledSourceWithOAuthResponseStreamBox =
 type ImportSourceResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 type ImportSourceFuture = Pin<Box<dyn Future<Output = Result<InstalledSource, Status>> + Send>>;
-
-async fn run_blocking_source_operation<T, F>(operation: F) -> Result<T, Status>
-where
-    T: Send + 'static,
-    F: FnOnce() -> Result<T, AppError> + Send + 'static,
-{
-    let span = tracing::Span::current();
-    task::spawn_blocking(move || span.in_scope(operation))
-        .await
-        .map_err(|error| Status::internal(format!("source operation task failed: {error}")))?
-        .map_err(app_status)
-}
 
 fn import_source_response_stream<F, Fut>(
     response_workspace_name: WorkspaceName,

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -107,6 +107,7 @@ impl WorkspaceManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<WorkspaceRecord, AppError> {
+        let _lifecycle_guard = self.lifecycle_lock.lock_async().await;
         let mut tx = self.db.begin().await?;
         if tx
             .workspaces()
@@ -145,6 +146,7 @@ impl WorkspaceManager {
         let deletion_marker = self
             .lifecycle_lock
             .mark_workspace_deleting(workspace_name)
+            .await
             .ok_or_else(|| {
                 AppError::FailedPrecondition(format!(
                     "workspace '{workspace_name}' is already being deleted"

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -10,7 +10,8 @@ use crate::state::ConfigStore;
 use crate::state::db::{CoralDb, DbRepos, now_unix_nanos_i64};
 use crate::storage::fs::DirectoryBackup;
 use crate::workspaces::{
-    DeletedWorkspace, WorkspaceLifecycleLock, WorkspaceName, WorkspacePaths, WorkspaceRecord,
+    DeletedWorkspace, WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceName,
+    WorkspacePaths, WorkspaceRecord,
 };
 
 /// App-owned workspace lifecycle behavior.
@@ -98,6 +99,20 @@ impl WorkspaceManager {
         }
     }
 
+    /// Verifies the canonical workspace row while holding one active lifecycle
+    /// snapshot, then returns the revision a long-running writer must preserve.
+    pub(crate) async fn require_active_workspace_revision(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<WorkspaceLifecycleRevision, AppError> {
+        let snapshot = self.lifecycle_lock.snapshot_async().await;
+        if snapshot.workspace_is_deleting(workspace_name) {
+            return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
+        }
+        self.require_workspace(workspace_name).await?;
+        Ok(snapshot.revision())
+    }
+
     #[cfg(test)]
     pub(crate) fn lifecycle_lock(&self) -> WorkspaceLifecycleLock {
         self.lifecycle_lock.clone()
@@ -161,11 +176,9 @@ impl WorkspaceManager {
             else {
                 return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
             };
-            let deleted = {
-                let _lifecycle_guard = self.lifecycle_lock.lock();
-                self.config_store
-                    .remove_workspace_config_entries(workspace_name)
-            };
+            let deleted = self
+                .config_store
+                .remove_workspace_config_entries(workspace_name);
             let deleted = match deleted {
                 Ok(deleted) => deleted.unwrap_or_else(|| DeletedWorkspace {
                     workspace: WorkspaceRecord {

--- a/crates/coral-app/src/workspaces/mod.rs
+++ b/crates/coral-app/src/workspaces/mod.rs
@@ -6,7 +6,8 @@ pub(crate) mod service;
 
 pub(crate) use manager::WorkspaceManager;
 pub(crate) use model::{
-    DeletedWorkspace, WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceRecord,
+    DeletedWorkspace, WorkspaceLifecycleLock, WorkspaceLifecycleReadLease,
+    WorkspaceLifecycleRevision, WorkspaceRecord,
 };
 pub use name::DEFAULT_WORKSPACE_ID;
 pub(crate) use name::WorkspaceName;

--- a/crates/coral-app/src/workspaces/model.rs
+++ b/crates/coral-app/src/workspaces/model.rs
@@ -1,5 +1,9 @@
 use std::collections::BTreeSet;
-use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, Mutex};
+
+use async_lock::{RwLock, RwLockReadGuardArc, RwLockWriteGuardArc};
+#[cfg(test)]
+use async_lock::{RwLockReadGuard, RwLockWriteGuard};
 
 use crate::sources::model::InstalledSource;
 use crate::workspaces::WorkspaceName;
@@ -21,15 +25,16 @@ pub(crate) struct DeletedWorkspace {
 #[derive(Debug, Default)]
 struct WorkspaceLifecycleState {
     revision: u64,
-    deleting_workspaces: BTreeSet<WorkspaceName>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct WorkspaceLifecycleLock {
     inner: Arc<RwLock<WorkspaceLifecycleState>>,
+    deleting_workspaces: Arc<Mutex<BTreeSet<WorkspaceName>>>,
 }
 
 impl WorkspaceLifecycleLock {
+    #[cfg(test)]
     /// Serializes a workspace lifecycle write and advances the revision when
     /// the write guard is released.
     #[must_use = "bind the returned guard for the full critical section"]
@@ -39,23 +44,73 @@ impl WorkspaceLifecycleLock {
         }
     }
 
+    /// Serializes an asynchronous workspace lifecycle write without blocking
+    /// a Tokio worker while a search lease is active.
+    #[must_use = "bind the returned guard for the full critical section"]
+    pub(crate) async fn lock_async(&self) -> WorkspaceLifecycleOwnedGuard {
+        WorkspaceLifecycleOwnedGuard {
+            guard: self.inner.write_arc().await,
+        }
+    }
+
+    #[cfg(test)]
     #[must_use = "bind the returned snapshot while loading workspace state"]
     pub(crate) fn snapshot(&self) -> WorkspaceLifecycleSnapshot<'_> {
         WorkspaceLifecycleSnapshot {
             guard: self.read_inner(),
+            deleting_workspaces: Arc::clone(&self.deleting_workspaces),
         }
     }
 
+    #[must_use = "bind the returned snapshot while loading workspace state"]
+    pub(crate) async fn snapshot_async(&self) -> WorkspaceLifecycleReadLease {
+        WorkspaceLifecycleReadLease {
+            guard: self.inner.read_arc().await,
+            deleting_workspaces: Arc::clone(&self.deleting_workspaces),
+        }
+    }
+
+    #[cfg(test)]
     pub(crate) fn snapshot_if_unchanged(
         &self,
         revision: WorkspaceLifecycleRevision,
         workspace_name: &WorkspaceName,
     ) -> Option<WorkspaceLifecycleSnapshot<'_>> {
+        if self.workspace_is_deleting(workspace_name) {
+            return None;
+        }
         let guard = self.read_inner();
-        (guard.revision == revision.0 && !guard.deleting_workspaces.contains(workspace_name))
-            .then_some(WorkspaceLifecycleSnapshot { guard })
+        (guard.revision == revision.0 && !self.workspace_is_deleting(workspace_name)).then_some(
+            WorkspaceLifecycleSnapshot {
+                guard,
+                deleting_workspaces: Arc::clone(&self.deleting_workspaces),
+            },
+        )
     }
 
+    /// Acquires an owned read lease that can follow detached asynchronous work.
+    ///
+    /// Unlike [`Self::snapshot_if_unchanged`], the returned lease is
+    /// `Send + 'static`, so provider tasks can retain it after the request
+    /// future that started them is cancelled.
+    pub(crate) async fn read_lease_if_unchanged(
+        &self,
+        revision: WorkspaceLifecycleRevision,
+        workspace_name: &WorkspaceName,
+    ) -> Option<WorkspaceLifecycleReadLease> {
+        if self.workspace_is_deleting(workspace_name) {
+            return None;
+        }
+        let guard = self.inner.read_arc().await;
+        (guard.revision == revision.0 && !self.workspace_is_deleting(workspace_name)).then_some(
+            WorkspaceLifecycleReadLease {
+                guard,
+                deleting_workspaces: Arc::clone(&self.deleting_workspaces),
+            },
+        )
+    }
+
+    #[cfg(test)]
     pub(crate) fn revision_if_active(
         &self,
         workspace_name: &WorkspaceName,
@@ -64,21 +119,46 @@ impl WorkspaceLifecycleLock {
         (!snapshot.workspace_is_deleting(workspace_name)).then(|| snapshot.revision())
     }
 
-    pub(crate) fn mark_workspace_deleting(
+    pub(crate) async fn revision_if_active_async(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Option<WorkspaceLifecycleRevision> {
+        let snapshot = self.snapshot_async().await;
+        (!snapshot.workspace_is_deleting(workspace_name)).then(|| snapshot.revision())
+    }
+
+    /// Marks a workspace as deleting and drains outstanding lifecycle readers.
+    ///
+    /// The returned marker owns the global lifecycle write lease for the full
+    /// deletion. Workspace deletion spans shared database, configuration, and
+    /// credential state, so lifecycle work in every workspace stays excluded
+    /// until the marker is dropped.
+    pub(crate) async fn mark_workspace_deleting(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Option<WorkspaceDeletionMarker> {
-        let mut guard = self.write_inner();
-        if !guard.deleting_workspaces.insert(workspace_name.clone()) {
-            return None;
+        {
+            let mut deleting_workspaces = self.deleting_workspaces();
+            if !deleting_workspaces.insert(workspace_name.clone()) {
+                return None;
+            }
         }
-        guard.revision = guard.revision.wrapping_add(1);
-        Some(WorkspaceDeletionMarker {
-            lifecycle: self.clone(),
+
+        // Register deletion before waiting for outstanding readers so new
+        // search leases fail closed. The marker removes the registration if
+        // this future is cancelled while waiting for the write guard.
+        let mut marker = WorkspaceDeletionMarker {
+            deleting_workspaces: Arc::clone(&self.deleting_workspaces),
             workspace_name: workspace_name.clone(),
-        })
+            guard: None,
+        };
+        let mut guard = self.inner.write_arc().await;
+        guard.revision = guard.revision.wrapping_add(1);
+        marker.guard = Some(guard);
+        Some(marker)
     }
 
+    #[cfg(test)]
     pub(crate) fn lock_if_unchanged(
         &self,
         revision: WorkspaceLifecycleRevision,
@@ -91,31 +171,46 @@ impl WorkspaceLifecycleLock {
         }
     }
 
-    fn read_inner(&self) -> RwLockReadGuard<'_, WorkspaceLifecycleState> {
-        self.inner
-            .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
-
-    fn write_inner(&self) -> RwLockWriteGuard<'_, WorkspaceLifecycleState> {
-        self.inner
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
-
-    fn unmark_workspace_deleting(&self, workspace_name: &WorkspaceName) {
-        let mut guard = self.write_inner();
-        if guard.deleting_workspaces.remove(workspace_name) {
-            guard.revision = guard.revision.wrapping_add(1);
+    pub(crate) async fn lock_if_unchanged_async(
+        &self,
+        revision: WorkspaceLifecycleRevision,
+    ) -> Option<WorkspaceLifecycleOwnedGuard> {
+        let guard = self.inner.write_arc().await;
+        if guard.revision == revision.0 {
+            Some(WorkspaceLifecycleOwnedGuard { guard })
+        } else {
+            None
         }
+    }
+
+    #[cfg(test)]
+    fn read_inner(&self) -> RwLockReadGuard<'_, WorkspaceLifecycleState> {
+        self.inner.read_blocking()
+    }
+
+    #[cfg(test)]
+    fn write_inner(&self) -> RwLockWriteGuard<'_, WorkspaceLifecycleState> {
+        self.inner.write_blocking()
+    }
+
+    fn workspace_is_deleting(&self, workspace_name: &WorkspaceName) -> bool {
+        self.deleting_workspaces().contains(workspace_name)
+    }
+
+    fn deleting_workspaces(&self) -> std::sync::MutexGuard<'_, BTreeSet<WorkspaceName>> {
+        self.deleting_workspaces
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 
+#[cfg(test)]
 #[must_use]
 pub(crate) struct WorkspaceLifecycleGuard<'a> {
     guard: RwLockWriteGuard<'a, WorkspaceLifecycleState>,
 }
 
+#[cfg(test)]
 impl Drop for WorkspaceLifecycleGuard<'_> {
     fn drop(&mut self) {
         self.guard.revision = self.guard.revision.wrapping_add(1);
@@ -123,30 +218,78 @@ impl Drop for WorkspaceLifecycleGuard<'_> {
 }
 
 #[must_use]
-pub(crate) struct WorkspaceLifecycleSnapshot<'a> {
-    guard: RwLockReadGuard<'a, WorkspaceLifecycleState>,
+pub(crate) struct WorkspaceLifecycleOwnedGuard {
+    guard: RwLockWriteGuardArc<WorkspaceLifecycleState>,
 }
 
+impl Drop for WorkspaceLifecycleOwnedGuard {
+    fn drop(&mut self) {
+        self.guard.revision = self.guard.revision.wrapping_add(1);
+    }
+}
+
+#[cfg(test)]
+#[must_use]
+pub(crate) struct WorkspaceLifecycleSnapshot<'a> {
+    guard: RwLockReadGuard<'a, WorkspaceLifecycleState>,
+    deleting_workspaces: Arc<Mutex<BTreeSet<WorkspaceName>>>,
+}
+
+#[cfg(test)]
 impl WorkspaceLifecycleSnapshot<'_> {
     pub(crate) fn revision(&self) -> WorkspaceLifecycleRevision {
         WorkspaceLifecycleRevision(self.guard.revision)
     }
 
     pub(crate) fn workspace_is_deleting(&self, workspace_name: &WorkspaceName) -> bool {
-        self.guard.deleting_workspaces.contains(workspace_name)
+        self.deleting_workspaces
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(workspace_name)
+    }
+}
+
+/// Owned snapshot of workspace lifecycle state.
+///
+/// Validation uses the captured revision, while search providers retain the
+/// read lease so detached blocking work cannot overlap lifecycle mutations.
+#[must_use]
+pub(crate) struct WorkspaceLifecycleReadLease {
+    guard: RwLockReadGuardArc<WorkspaceLifecycleState>,
+    deleting_workspaces: Arc<Mutex<BTreeSet<WorkspaceName>>>,
+}
+
+impl WorkspaceLifecycleReadLease {
+    pub(crate) fn revision(&self) -> WorkspaceLifecycleRevision {
+        WorkspaceLifecycleRevision(self.guard.revision)
+    }
+
+    pub(crate) fn workspace_is_deleting(&self, workspace_name: &WorkspaceName) -> bool {
+        self.deleting_workspaces
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .contains(workspace_name)
     }
 }
 
 #[must_use]
 pub(crate) struct WorkspaceDeletionMarker {
-    lifecycle: WorkspaceLifecycleLock,
+    deleting_workspaces: Arc<Mutex<BTreeSet<WorkspaceName>>>,
     workspace_name: WorkspaceName,
+    guard: Option<RwLockWriteGuardArc<WorkspaceLifecycleState>>,
 }
 
 impl Drop for WorkspaceDeletionMarker {
     fn drop(&mut self) {
-        self.lifecycle
-            .unmark_workspace_deleting(&self.workspace_name);
+        let mut deleting_workspaces = self
+            .deleting_workspaces
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if deleting_workspaces.remove(&self.workspace_name)
+            && let Some(guard) = &mut self.guard
+        {
+            guard.revision = guard.revision.wrapping_add(1);
+        }
     }
 }
 
@@ -157,8 +300,8 @@ pub(crate) struct WorkspaceLifecycleRevision(u64);
 mod tests {
     use super::*;
 
-    #[test]
-    fn deletion_marker_marks_workspace_and_advances_revision_at_each_transition() {
+    #[tokio::test]
+    async fn deletion_marker_advances_revision_at_each_transition() {
         let lifecycle = WorkspaceLifecycleLock::default();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         let initial_revision = lifecycle
@@ -167,23 +310,26 @@ mod tests {
 
         let marker = lifecycle
             .mark_workspace_deleting(&workspace)
+            .await
             .expect("mark workspace deleting");
 
-        let deleting_snapshot = lifecycle.snapshot();
-        assert_eq!(
-            deleting_snapshot.revision().0,
-            initial_revision.0.wrapping_add(1)
+        assert!(lifecycle.workspace_is_deleting(&workspace));
+        assert!(
+            lifecycle.inner.try_read_arc().is_none(),
+            "workspace deletion intentionally excludes all lifecycle readers"
         );
-        assert!(deleting_snapshot.workspace_is_deleting(&workspace));
-        let deleting_revision = deleting_snapshot.revision();
-        drop(deleting_snapshot);
-        assert_eq!(lifecycle.revision_if_active(&workspace), None);
         assert!(
             lifecycle
-                .snapshot_if_unchanged(deleting_revision, &workspace)
+                .mark_workspace_deleting(&workspace)
+                .await
                 .is_none()
         );
-        assert!(lifecycle.mark_workspace_deleting(&workspace).is_none());
+        assert!(
+            lifecycle
+                .read_lease_if_unchanged(initial_revision, &workspace)
+                .await
+                .is_none()
+        );
 
         drop(marker);
 
@@ -193,6 +339,33 @@ mod tests {
             initial_revision.0.wrapping_add(2)
         );
         assert!(!active_snapshot.workspace_is_deleting(&workspace));
+    }
+
+    #[tokio::test]
+    async fn cancelling_pending_deletion_clears_marker() {
+        let lifecycle = WorkspaceLifecycleLock::default();
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let initial_revision = lifecycle
+            .revision_if_active_async(&workspace)
+            .await
+            .expect("workspace starts active");
+        let read_lease = lifecycle.snapshot_async().await;
+        let mut pending_deletion = Box::pin(lifecycle.mark_workspace_deleting(&workspace));
+
+        tokio::select! {
+            biased;
+            _ = &mut pending_deletion => panic!("deletion should wait for the read lease"),
+            () = tokio::task::yield_now() => {}
+        }
+        assert!(lifecycle.workspace_is_deleting(&workspace));
+
+        drop(pending_deletion);
+        assert!(!lifecycle.workspace_is_deleting(&workspace));
+        drop(read_lease);
+        assert_eq!(
+            lifecycle.revision_if_active_async(&workspace).await,
+            Some(initial_revision)
+        );
     }
 
     #[test]
@@ -224,7 +397,7 @@ mod tests {
         let lifecycle = WorkspaceLifecycleLock::default();
         let snapshot = lifecycle.snapshot();
         let initial_revision = snapshot.revision();
-        let Err(_write_error) = lifecycle.inner.try_write() else {
+        let None = lifecycle.inner.try_write() else {
             panic!("read snapshot should exclude lifecycle writes");
         };
 

--- a/crates/coral-app/src/workspaces/model.rs
+++ b/crates/coral-app/src/workspaces/model.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use async_lock::{RwLock, RwLockReadGuardArc, RwLockWriteGuardArc};
 #[cfg(test)]
 use async_lock::{RwLockReadGuard, RwLockWriteGuard};
+use tokio::task;
 
 use crate::sources::model::InstalledSource;
 use crate::workspaces::WorkspaceName;
@@ -51,6 +52,45 @@ impl WorkspaceLifecycleLock {
         WorkspaceLifecycleOwnedGuard {
             guard: self.inner.write_arc().await,
         }
+    }
+
+    /// Runs a blocking lifecycle write without occupying a Tokio worker.
+    ///
+    /// The owned guard moves into the blocking task so cancellation of the
+    /// awaiting request cannot release the lifecycle writer before the
+    /// synchronous persistence tail finishes.
+    pub(crate) async fn run_blocking_write<T, E, F>(&self, operation: F) -> Result<T, E>
+    where
+        T: Send + 'static,
+        E: From<task::JoinError> + Send + 'static,
+        F: FnOnce() -> Result<T, E> + Send + 'static,
+    {
+        let guard = self.lock_async().await;
+        Self::run_blocking_with_guard(guard, operation).await
+    }
+
+    /// Runs a blocking workspace write only when the workspace is still active
+    /// at the caller's captured lifecycle revision.
+    pub(crate) async fn run_blocking_workspace_write_if_unchanged<T, E, F>(
+        &self,
+        revision: WorkspaceLifecycleRevision,
+        workspace_name: &WorkspaceName,
+        operation: F,
+    ) -> Result<Option<T>, E>
+    where
+        T: Send + 'static,
+        E: From<task::JoinError> + Send + 'static,
+        F: FnOnce() -> Result<T, E> + Send + 'static,
+    {
+        let Some(guard) = self
+            .lock_workspace_if_unchanged_async(revision, workspace_name)
+            .await
+        else {
+            return Ok(None);
+        };
+        Self::run_blocking_with_guard(guard, operation)
+            .await
+            .map(Some)
     }
 
     #[cfg(test)]
@@ -171,16 +211,38 @@ impl WorkspaceLifecycleLock {
         }
     }
 
-    pub(crate) async fn lock_if_unchanged_async(
+    pub(crate) async fn lock_workspace_if_unchanged_async(
         &self,
         revision: WorkspaceLifecycleRevision,
+        workspace_name: &WorkspaceName,
     ) -> Option<WorkspaceLifecycleOwnedGuard> {
+        if self.workspace_is_deleting(workspace_name) {
+            return None;
+        }
         let guard = self.inner.write_arc().await;
-        if guard.revision == revision.0 {
+        if guard.revision == revision.0 && !self.workspace_is_deleting(workspace_name) {
             Some(WorkspaceLifecycleOwnedGuard { guard })
         } else {
             None
         }
+    }
+
+    async fn run_blocking_with_guard<T, E, F>(
+        guard: WorkspaceLifecycleOwnedGuard,
+        operation: F,
+    ) -> Result<T, E>
+    where
+        T: Send + 'static,
+        E: From<task::JoinError> + Send + 'static,
+        F: FnOnce() -> Result<T, E> + Send + 'static,
+    {
+        let span = tracing::Span::current();
+        task::spawn_blocking(move || {
+            let _guard = guard;
+            span.in_scope(operation)
+        })
+        .await
+        .map_err(E::from)?
     }
 
     #[cfg(test)]
@@ -298,6 +360,10 @@ pub(crate) struct WorkspaceLifecycleRevision(u64);
 
 #[cfg(test)]
 mod tests {
+    use std::thread;
+
+    use crate::bootstrap::AppError;
+
     use super::*;
 
     #[tokio::test]
@@ -327,6 +393,12 @@ mod tests {
         assert!(
             lifecycle
                 .read_lease_if_unchanged(initial_revision, &workspace)
+                .await
+                .is_none()
+        );
+        assert!(
+            lifecycle
+                .lock_workspace_if_unchanged_async(initial_revision, &workspace)
                 .await
                 .is_none()
         );
@@ -366,6 +438,59 @@ mod tests {
             lifecycle.revision_if_active_async(&workspace).await,
             Some(initial_revision)
         );
+    }
+
+    #[tokio::test]
+    async fn workspace_writer_fails_when_deletion_is_announced_while_waiting() {
+        let lifecycle = WorkspaceLifecycleLock::default();
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let revision = lifecycle
+            .revision_if_active_async(&workspace)
+            .await
+            .expect("workspace starts active");
+        let read_lease = lifecycle.snapshot_async().await;
+        let mut pending_writer =
+            Box::pin(lifecycle.lock_workspace_if_unchanged_async(revision, &workspace));
+
+        tokio::select! {
+            biased;
+            _ = &mut pending_writer => panic!("writer should wait for the read lease"),
+            () = tokio::task::yield_now() => {}
+        }
+
+        let deletion_lifecycle = lifecycle.clone();
+        let deletion_workspace = workspace.clone();
+        let deletion = tokio::spawn(async move {
+            let marker = deletion_lifecycle
+                .mark_workspace_deleting(&deletion_workspace)
+                .await
+                .expect("mark workspace deleting");
+            drop(marker);
+        });
+        while !lifecycle.workspace_is_deleting(&workspace) {
+            tokio::task::yield_now().await;
+        }
+        drop(read_lease);
+
+        let (writer, deletion) = tokio::join!(pending_writer, deletion);
+        deletion.expect("deletion marker task");
+        assert!(
+            writer.is_none(),
+            "announced workspace deletion must reject a writer after it acquires the gate"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn blocking_lifecycle_write_runs_off_the_async_worker() {
+        let lifecycle = WorkspaceLifecycleLock::default();
+        let async_thread = thread::current().id();
+
+        let blocking_thread = lifecycle
+            .run_blocking_write(|| Ok::<_, AppError>(thread::current().id()))
+            .await
+            .expect("blocking lifecycle write");
+
+        assert_ne!(blocking_thread, async_thread);
     }
 
     #[test]

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -434,6 +434,39 @@ async fn search_service_returns_structured_shell_response() {
     assert_no_coverage(native_status);
 }
 
+#[test]
+fn search_completes_with_one_blocking_thread() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .max_blocking_threads(1)
+        .enable_all()
+        .build()
+        .expect("build constrained Tokio runtime");
+    let search = runtime.block_on(async {
+        let harness = GrpcHarness::new().await;
+        let search = tokio::time::timeout(
+            Duration::from_secs(5),
+            harness.search_client().search(Request::new(SearchRequest {
+                workspace: Some(default_workspace()),
+                query: "github issue".to_string(),
+                limit: 10,
+            })),
+        )
+        .await;
+        drop(harness);
+        search
+    });
+    // A failed regression must not leave the test process waiting forever for
+    // a blocked task while Tokio tears down its constrained blocking pool.
+    runtime.shutdown_timeout(Duration::from_secs(1));
+
+    let response = search
+        .expect("search should not starve the blocking pool")
+        .expect("search")
+        .into_inner();
+    assert_eq!(response.provider_statuses.len(), 3);
+}
+
 #[tokio::test]
 async fn search_service_rejects_unknown_workspace() {
     let harness = GrpcHarness::new().await;


### PR DESCRIPTION
## Summary

- Introduces an async `SearchProvider` boundary and ordered provider registry for the existing catalog and observed-values providers. Registered providers start concurrently, while outcomes are consumed in registry order so response status ordering stays deterministic.
- Makes the registry the single owner of provider participation: disabled providers are registered as static statuses, and response assembly reports only registry-produced outcomes.
- Runs provider-local blocking work on blocking tasks while awaiting the async engine directly. This avoids nested blocking-pool starvation and keeps provider failures isolated from successful candidates.
- Retains an owned workspace lifecycle read lease through provider execution, detached provider tasks, and request cancellation. Lifecycle writers acquire their async lease before entering the blocking pool; workspace deletion records intent before draining readers and cleans that intent if the pending operation is cancelled.
- Centralizes request-wide response assembly, stable provider status order, truncation, and candidate ordering. Local-only searches retain the legacy score order; the dormant three-provider path uses deterministic reciprocal-rank fusion.
- Carries the request-scoped runtime catalog resolution through provider execution under the lifecycle lease, ready for a later native provider without adding a second manifest scan.

## Stack boundary

Stack 1/12, based on `main`. #1855 builds on this PR.

This establishes the stack's final provider scheduling and lifecycle-safety model at the orchestration boundary. Catalog and observed-values behavior stays local, existing relevance scores stay intact, native fanout remains absent and `NOT_ENABLED`, and Search makes no new upstream calls.

## Test plan

- `cargo check -p coral-app --all-targets`
- `cargo clippy -p coral-app --all-targets --all-features -- -D warnings`
- `cargo test -p coral-app search:: --lib` (209 passed)
- `cargo test -p coral-app --test grpc search_completes_with_one_blocking_thread -- --nocapture` (1 passed)
- `make rust-checks` on the restacked top branch (2,284 passed, 2 skipped)
- Regression coverage includes concurrent provider start with stable registry-order statuses, registry-owned disabled statuses, provider-failure isolation, cancellation retaining the lifecycle lease, pending-deletion cancellation cleanup, and a constrained gRPC runtime with one blocking thread.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
