### PR TITLE
feat(search): add native result and diagnostic contracts

### DIFF
--- a/crates/coral-api/proto/coral/v1/search.proto
+++ b/crates/coral-api/proto/coral/v1/search.proto
@@ -256,10 +256,10 @@ message SearchProviderStatus {
 
 // One bounded native fanout diagnostic.
 message NativeSearchDiagnostic {
-  // Installed source that owns the route.
-  string installed_source_name = 1;
-  // Query-visible schema when the route resolved to a runtime function.
-  optional string schema_name = 2;
+  // Source that owns the route and its query-visible function.
+  string source_name = 1;
+  reserved 2;
+  reserved "installed_source_name", "schema_name";
   // Query-visible function when the route resolved to a runtime function.
   optional string function_name = 3;
   // Source-authored route identifier when the source declared one.

--- a/crates/coral-api/proto/coral/v1/search.proto
+++ b/crates/coral-api/proto/coral/v1/search.proto
@@ -246,6 +246,98 @@ message SearchProviderStatus {
   string note = 3;
   // Structured provider-local coverage for this request. Absent when the provider is not enabled or skipped.
   SearchProviderCoverage coverage = 4;
+  // Bounded per-function or route-resolution diagnostics for native fanout.
+  repeated NativeSearchDiagnostic diagnostics = 5;
+  // Whether native fanout diagnostics were truncated.
+  bool diagnostics_truncated = 6;
+  // Number of native fanout diagnostics omitted after the diagnostic cap.
+  uint32 omitted_diagnostic_count = 7;
+}
+
+// One bounded native fanout diagnostic.
+message NativeSearchDiagnostic {
+  // Installed source that owns the route.
+  string installed_source_name = 1;
+  // Query-visible schema when the route resolved to a runtime function.
+  optional string schema_name = 2;
+  // Query-visible function when the route resolved to a runtime function.
+  optional string function_name = 3;
+  // Source-authored route identifier when the source declared one.
+  optional string authored_route_id = 4;
+  // Outcome state for this function or unresolved route.
+  NativeSearchDiagnosticState state = 5;
+  // Stable, provider-independent reason category.
+  NativeSearchDiagnosticReason reason = 6;
+  // Elapsed execution time in milliseconds.
+  uint64 elapsed_ms = 7;
+  // Safe display candidates produced by this function.
+  uint32 safe_candidate_count = 8;
+  // Whether upstream continuation or total metadata explicitly reported more results.
+  bool has_more = 9;
+}
+
+// Outcome state for one native fanout function or unresolved route.
+enum NativeSearchDiagnosticState {
+  // Unknown diagnostic state.
+  NATIVE_SEARCH_DIAGNOSTIC_STATE_UNSPECIFIED = 0;
+  // The function returned one or more safe display candidates.
+  NATIVE_SEARCH_DIAGNOSTIC_STATE_RESULTS_FOUND = 1;
+  // The function completed without a safe display candidate.
+  NATIVE_SEARCH_DIAGNOSTIC_STATE_EMPTY = 2;
+  // The route was not attempted.
+  NATIVE_SEARCH_DIAGNOSTIC_STATE_SKIPPED = 3;
+  // The function reached its deadline.
+  NATIVE_SEARCH_DIAGNOSTIC_STATE_TIMED_OUT = 4;
+  // The function was cancelled.
+  NATIVE_SEARCH_DIAGNOSTIC_STATE_CANCELLED = 5;
+  // The route or function failed.
+  NATIVE_SEARCH_DIAGNOSTIC_STATE_ERROR = 6;
+}
+
+// Stable reason category for one native fanout diagnostic.
+enum NativeSearchDiagnosticReason {
+  // Unknown diagnostic reason.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_UNSPECIFIED = 0;
+  // The source did not authorize this route.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_NOT_AUTHORIZED = 1;
+  // More than one route matched where exactly one was required.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_AMBIGUOUS_ROUTE = 2;
+  // The route's search limits were missing or invalid.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_INVALID_SEARCH_LIMITS = 3;
+  // The query could not be mapped to the selected input.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_QUERY_INPUT_UNMAPPABLE = 4;
+  // A required non-query argument had no valid default.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_MISSING_ARGUMENT_DEFAULT = 5;
+  // The resolved route no longer matched current installed source state.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_ROUTE_STALE = 6;
+  // The selected operation was not proven retrieval-only and idempotent.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_UNSAFE_OPERATION = 7;
+  // Returned rows contained no safe display fields.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_NO_SAFE_DISPLAY_FIELDS = 8;
+  // The route was omitted by the per-request fanout cap.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_FANOUT_LIMIT_REACHED = 9;
+  // Too little request budget remained to start the function.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_INSUFFICIENT_BUDGET = 10;
+  // The absolute native fanout budget expired.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_GLOBAL_BUDGET_EXHAUSTED = 11;
+  // The function reached its per-call timeout.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_CALL_TIMEOUT = 12;
+  // The function was cancelled before completion.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_CANCELLED = 13;
+  // The upstream provider rate-limited the call.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_RATE_LIMITED = 14;
+  // Authentication or permission checks rejected the call.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_AUTH_OR_PERMISSION_FAILED = 15;
+  // The upstream provider was unavailable.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_UPSTREAM_UNAVAILABLE = 16;
+  // The upstream response could not be decoded under the source contract.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_INVALID_RESPONSE = 17;
+  // The selected function failed during execution.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_EXECUTION_FAILED = 18;
+  // The backend could not satisfy the required cancellation contract.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_UNSUPPORTED_CANCELLATION = 19;
+  // Coral encountered an internal native fanout failure.
+  NATIVE_SEARCH_DIAGNOSTIC_REASON_INTERNAL_ERROR = 20;
 }
 
 // Structured provider-local coverage for one request.
@@ -310,7 +402,43 @@ message SearchResult {
     ColumnHint column_hint = 11;
     // Local observed-value hit. Reserved for the observed-value provider.
     ObservedValue observed_value = 12;
+    // Compact provider-native result preview.
+    NativeSearchResult native_result = 13;
   }
+}
+
+// Compact provider-native result preview.
+message NativeSearchResult {
+  // Query-visible source schema.
+  string schema_name = 1;
+  // Query-visible table-function name.
+  string function_name = 2;
+  // Zero-based provider result order.
+  uint32 row_ordinal = 3;
+  // Source-authored entity type when available.
+  optional string entity_type = 4;
+  // Safe provider identifier when available.
+  optional string provider_id = 5;
+  // Compact display title when available.
+  optional string title = 6;
+  // Sanitized absolute HTTP or HTTPS URL when available.
+  optional string url = 7;
+  // Compact display text when available.
+  optional string snippet = 8;
+  // Bounded source-authored display attributes.
+  repeated NativeSearchAttribute attributes = 9;
+  // Safe selected attributes omitted by count or size limits.
+  uint32 omitted_attribute_count = 10;
+  // Whether safe display content was truncated or omitted by count or size limits.
+  bool content_truncated = 11;
+}
+
+// One bounded provider-native display attribute.
+message NativeSearchAttribute {
+  // Safe display name.
+  string name = 1;
+  // Safe display value.
+  string display_value = 2;
 }
 
 // Table or table-function metadata hit with search-specific context.

--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -435,6 +435,9 @@ fn catalog_search_outcome(
                 stale_index: projection.stale_index || has_failures,
                 ..ProviderCoverage::default()
             }),
+            diagnostics: Vec::new(),
+            diagnostics_truncated: false,
+            omitted_diagnostic_count: 0,
         },
     }
 }
@@ -736,6 +739,9 @@ fn catalog_query_error_outcome(error: &QueryManagerError) -> ProviderSearchOutco
             state: SearchProviderState::Error,
             note: format!("Workspace catalog is unavailable: {detail}"),
             coverage: Some(ProviderCoverage::default()),
+            diagnostics: Vec::new(),
+            diagnostics_truncated: false,
+            omitted_diagnostic_count: 0,
         },
     }
 }
@@ -754,6 +760,9 @@ fn catalog_index_note_outcome(note: String) -> ProviderSearchOutcome {
             state: SearchProviderState::Error,
             note,
             coverage: Some(ProviderCoverage::default()),
+            diagnostics: Vec::new(),
+            diagnostics_truncated: false,
+            omitted_diagnostic_count: 0,
         },
     }
 }

--- a/crates/coral-app/src/search/engine.rs
+++ b/crates/coral-app/src/search/engine.rs
@@ -203,6 +203,9 @@ mod tests {
                     stale_index: true,
                     ..ProviderCoverage::default()
                 }),
+                diagnostics: Vec::new(),
+                diagnostics_truncated: false,
+                omitted_diagnostic_count: 0,
             },
         };
 
@@ -223,6 +226,9 @@ mod tests {
                         state: SearchProviderState::ResultsFound,
                         note: String::new(),
                         coverage: None,
+                        diagnostics: Vec::new(),
+                        diagnostics_truncated: false,
+                        omitted_diagnostic_count: 0,
                     },
                 },
             })),
@@ -541,6 +547,9 @@ mod tests {
             state,
             note: String::new(),
             coverage: None,
+            diagnostics: Vec::new(),
+            diagnostics_truncated: false,
+            omitted_diagnostic_count: 0,
         })
     }
 

--- a/crates/coral-app/src/search/fusion.rs
+++ b/crates/coral-app/src/search/fusion.rs
@@ -224,6 +224,9 @@ mod tests {
                 state: SearchProviderState::ResultsFound,
                 note: String::new(),
                 coverage: None,
+                diagnostics: Vec::new(),
+                diagnostics_truncated: false,
+                omitted_diagnostic_count: 0,
             },
         }
     }

--- a/crates/coral-app/src/search/observed/provider.rs
+++ b/crates/coral-app/src/search/observed/provider.rs
@@ -282,6 +282,9 @@ fn observed_search_outcome(
                     || drain_error.is_some()
                     || policy.has_load_failures(),
             }),
+            diagnostics: Vec::new(),
+            diagnostics_truncated: false,
+            omitted_diagnostic_count: 0,
         },
         candidates,
     }
@@ -416,6 +419,9 @@ fn observed_error_outcome(error: &SqliteSearchError) -> ProviderSearchOutcome {
                 failed_units: 1,
                 ..ProviderCoverage::default()
             }),
+            diagnostics: Vec::new(),
+            diagnostics_truncated: false,
+            omitted_diagnostic_count: 0,
         },
     }
 }
@@ -431,6 +437,9 @@ fn observed_policy_error_outcome(error: &AppError) -> ProviderSearchOutcome {
                 failed_units: 1,
                 ..ProviderCoverage::default()
             }),
+            diagnostics: Vec::new(),
+            diagnostics_truncated: false,
+            omitted_diagnostic_count: 0,
         },
     }
 }

--- a/crates/coral-app/src/search/provider.rs
+++ b/crates/coral-app/src/search/provider.rs
@@ -160,6 +160,9 @@ fn native_not_enabled_status() -> ProviderStatus {
         state: SearchProviderState::NotEnabled,
         note: "provider-native fanout is disabled".to_string(),
         coverage: None,
+        diagnostics: Vec::new(),
+        diagnostics_truncated: false,
+        omitted_diagnostic_count: 0,
     }
 }
 
@@ -228,6 +231,9 @@ pub(crate) fn provider_error_outcome(provider: SearchProviderKind) -> ProviderSe
             state: SearchProviderState::Error,
             note: "search provider failed without affecting other providers".to_string(),
             coverage: None,
+            diagnostics: Vec::new(),
+            diagnostics_truncated: false,
+            omitted_diagnostic_count: 0,
         },
     }
 }
@@ -238,6 +244,9 @@ fn observed_not_enabled_status() -> ProviderStatus {
         state: SearchProviderState::NotEnabled,
         note: "observed value search is disabled; enable `observed_values_search` to include values from earlier queries".to_string(),
         coverage: None,
+        diagnostics: Vec::new(),
+        diagnostics_truncated: false,
+        omitted_diagnostic_count: 0,
     }
 }
 

--- a/crates/coral-app/src/search/result.rs
+++ b/crates/coral-app/src/search/result.rs
@@ -213,8 +213,7 @@ pub(crate) struct NativeSearchAttribute {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct NativeSearchDiagnostic {
-    pub(crate) installed_source_name: String,
-    pub(crate) schema_name: Option<String>,
+    pub(crate) source_name: String,
     pub(crate) function_name: Option<String>,
     pub(crate) authored_route_id: Option<String>,
     pub(crate) state: NativeSearchDiagnosticState,

--- a/crates/coral-app/src/search/result.rs
+++ b/crates/coral-app/src/search/result.rs
@@ -82,6 +82,9 @@ pub(crate) struct ProviderStatus {
     pub(crate) state: SearchProviderState,
     pub(crate) note: String,
     pub(crate) coverage: Option<ProviderCoverage>,
+    pub(crate) diagnostics: Vec<NativeSearchDiagnostic>,
+    pub(crate) diagnostics_truncated: bool,
+    pub(crate) omitted_diagnostic_count: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -135,6 +138,7 @@ impl SearchCandidate {
             SearchPayload::CatalogMetadata(_) => 0,
             SearchPayload::ColumnHint(_) => 1,
             SearchPayload::ObservedValue(_) => 2,
+            SearchPayload::NativeResult(_) => 3,
         }
     }
 }
@@ -176,6 +180,96 @@ pub(crate) enum SearchPayload {
     CatalogMetadata(CatalogMetadataResult),
     ColumnHint(ColumnHintResult),
     ObservedValue(ObservedValueResult),
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the additive native result contract is populated by the follow-up fanout implementation"
+        )
+    )]
+    NativeResult(NativeSearchResult),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NativeSearchResult {
+    pub(crate) schema_name: String,
+    pub(crate) function_name: String,
+    pub(crate) row_ordinal: u32,
+    pub(crate) entity_type: Option<String>,
+    pub(crate) provider_id: Option<String>,
+    pub(crate) title: Option<String>,
+    pub(crate) url: Option<String>,
+    pub(crate) snippet: Option<String>,
+    pub(crate) attributes: Vec<NativeSearchAttribute>,
+    pub(crate) omitted_attribute_count: u32,
+    pub(crate) content_truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NativeSearchAttribute {
+    pub(crate) name: String,
+    pub(crate) display_value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NativeSearchDiagnostic {
+    pub(crate) installed_source_name: String,
+    pub(crate) schema_name: Option<String>,
+    pub(crate) function_name: Option<String>,
+    pub(crate) authored_route_id: Option<String>,
+    pub(crate) state: NativeSearchDiagnosticState,
+    pub(crate) reason: NativeSearchDiagnosticReason,
+    pub(crate) elapsed_ms: u64,
+    pub(crate) safe_candidate_count: u32,
+    pub(crate) has_more: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "native diagnostics are populated by the follow-up fanout implementation"
+    )
+)]
+pub(crate) enum NativeSearchDiagnosticState {
+    ResultsFound,
+    Empty,
+    Skipped,
+    TimedOut,
+    Cancelled,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "native diagnostics are populated by the follow-up fanout implementation"
+    )
+)]
+pub(crate) enum NativeSearchDiagnosticReason {
+    NotAuthorized,
+    AmbiguousRoute,
+    InvalidSearchLimits,
+    QueryInputUnmappable,
+    MissingArgumentDefault,
+    RouteStale,
+    UnsafeOperation,
+    NoSafeDisplayFields,
+    FanoutLimitReached,
+    InsufficientBudget,
+    GlobalBudgetExhausted,
+    CallTimeout,
+    Cancelled,
+    RateLimited,
+    AuthOrPermissionFailed,
+    UpstreamUnavailable,
+    InvalidResponse,
+    ExecutionFailed,
+    UnsupportedCancellation,
+    InternalError,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -526,8 +526,7 @@ fn provider_status_to_proto(status: ProviderStatus) -> SearchProviderStatus {
 
 fn native_diagnostic_to_proto(diagnostic: NativeSearchDiagnostic) -> ProtoNativeSearchDiagnostic {
     ProtoNativeSearchDiagnostic {
-        installed_source_name: diagnostic.installed_source_name,
-        schema_name: diagnostic.schema_name,
+        source_name: diagnostic.source_name,
         function_name: diagnostic.function_name,
         authored_route_id: diagnostic.authored_route_id,
         state: native_diagnostic_state_to_proto(diagnostic.state) as i32,
@@ -953,6 +952,20 @@ mod tests {
     }
 
     #[test]
+    fn native_diagnostic_tag_one_decodes_as_source_and_retired_tag_two_is_ignored() {
+        let diagnostic =
+            ProtoNativeSearchDiagnostic::decode(b"\x0a\x06github\x12\x06github".as_slice())
+                .expect("decode source name plus retired schema field");
+
+        assert_eq!(diagnostic.source_name, "github");
+        assert_eq!(
+            diagnostic.encode_to_vec(),
+            b"\x0a\x06github",
+            "prost should discard the retired tag-2 schema field"
+        );
+    }
+
+    #[test]
     fn native_diagnostics_preserve_resolution_absence_and_elapsed_width() {
         let proto = provider_status_to_proto(ProviderStatus {
             provider: SearchProviderKind::NativeFanout,
@@ -960,8 +973,7 @@ mod tests {
             note: "one route was unresolved".to_string(),
             coverage: Some(ProviderCoverage::default()),
             diagnostics: vec![NativeSearchDiagnostic {
-                installed_source_name: "github".to_string(),
-                schema_name: None,
+                source_name: "github".to_string(),
                 function_name: None,
                 authored_route_id: Some("issues".to_string()),
                 state: NativeSearchDiagnosticState::Skipped,
@@ -975,7 +987,7 @@ mod tests {
         });
 
         let diagnostic = proto.diagnostics.first().expect("diagnostic");
-        assert_eq!(diagnostic.schema_name, None);
+        assert_eq!(diagnostic.source_name, "github");
         assert_eq!(diagnostic.function_name, None);
         assert_eq!(diagnostic.authored_route_id.as_deref(), Some("issues"));
         assert_eq!(diagnostic.elapsed_ms, u64::MAX);

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -11,7 +11,11 @@ use coral_api::v1::{
     ClearSearchDataResponse as ProtoClearSearchDataResponse, ColumnHint,
     DrainSearchQueueRequest as ProtoDrainSearchQueueRequest,
     DrainSearchQueueResponse as ProtoDrainSearchQueueResponse,
-    ObservedClearResult as ProtoObservedClearResult,
+    NativeSearchAttribute as ProtoNativeSearchAttribute,
+    NativeSearchDiagnostic as ProtoNativeSearchDiagnostic,
+    NativeSearchDiagnosticReason as ProtoNativeSearchDiagnosticReason,
+    NativeSearchDiagnosticState as ProtoNativeSearchDiagnosticState,
+    NativeSearchResult as ProtoNativeSearchResult, ObservedClearResult as ProtoObservedClearResult,
     ObservedDrainResult as ProtoObservedDrainResult,
     ObservedRebuildResult as ProtoObservedRebuildResult, ObservedValue as ProtoObservedValue,
     RebuildSearchIndexRequest as ProtoRebuildSearchIndexRequest,
@@ -45,8 +49,9 @@ use crate::search::maintenance::{
 };
 use crate::search::manager::SearchManager;
 use crate::search::result::{
-    CatalogMetadataResult, ColumnHintResult, ObservedValueResult, ProviderCoverage, ProviderStatus,
-    SearchFieldRole, SearchManagerError, SearchPayload, SearchProviderKind,
+    CatalogMetadataResult, ColumnHintResult, NativeSearchDiagnostic, NativeSearchDiagnosticReason,
+    NativeSearchDiagnosticState, NativeSearchResult, ObservedValueResult, ProviderCoverage,
+    ProviderStatus, SearchFieldRole, SearchManagerError, SearchPayload, SearchProviderKind,
     SearchProviderState as DomainProviderState, SearchRequest, SearchResponse, SearchSurfaceKind,
     TableColumnPreview as DomainTableColumnPreview,
 };
@@ -408,6 +413,9 @@ fn search_payload_to_proto(
         SearchPayload::ObservedValue(result) => {
             Payload::ObservedValue(observed_value_to_proto(result))
         }
+        SearchPayload::NativeResult(result) => {
+            Payload::NativeResult(native_result_to_proto(result))
+        }
     }
 }
 
@@ -469,6 +477,29 @@ fn observed_value_to_proto(result: ObservedValueResult) -> ProtoObservedValue {
     }
 }
 
+fn native_result_to_proto(result: NativeSearchResult) -> ProtoNativeSearchResult {
+    ProtoNativeSearchResult {
+        schema_name: result.schema_name,
+        function_name: result.function_name,
+        row_ordinal: result.row_ordinal,
+        entity_type: result.entity_type,
+        provider_id: result.provider_id,
+        title: result.title,
+        url: result.url,
+        snippet: result.snippet,
+        attributes: result
+            .attributes
+            .into_iter()
+            .map(|attribute| ProtoNativeSearchAttribute {
+                name: attribute.name,
+                display_value: attribute.display_value,
+            })
+            .collect(),
+        omitted_attribute_count: result.omitted_attribute_count,
+        content_truncated: result.content_truncated,
+    }
+}
+
 fn provider_status_to_proto(status: ProviderStatus) -> SearchProviderStatus {
     let coverage = if matches!(
         status.state,
@@ -483,6 +514,99 @@ fn provider_status_to_proto(status: ProviderStatus) -> SearchProviderStatus {
         state: provider_state_to_proto(status.state) as i32,
         note: status.note,
         coverage,
+        diagnostics: status
+            .diagnostics
+            .into_iter()
+            .map(native_diagnostic_to_proto)
+            .collect(),
+        diagnostics_truncated: status.diagnostics_truncated,
+        omitted_diagnostic_count: status.omitted_diagnostic_count,
+    }
+}
+
+fn native_diagnostic_to_proto(diagnostic: NativeSearchDiagnostic) -> ProtoNativeSearchDiagnostic {
+    ProtoNativeSearchDiagnostic {
+        installed_source_name: diagnostic.installed_source_name,
+        schema_name: diagnostic.schema_name,
+        function_name: diagnostic.function_name,
+        authored_route_id: diagnostic.authored_route_id,
+        state: native_diagnostic_state_to_proto(diagnostic.state) as i32,
+        reason: native_diagnostic_reason_to_proto(diagnostic.reason) as i32,
+        elapsed_ms: diagnostic.elapsed_ms,
+        safe_candidate_count: diagnostic.safe_candidate_count,
+        has_more: diagnostic.has_more,
+    }
+}
+
+fn native_diagnostic_state_to_proto(
+    state: NativeSearchDiagnosticState,
+) -> ProtoNativeSearchDiagnosticState {
+    match state {
+        NativeSearchDiagnosticState::ResultsFound => ProtoNativeSearchDiagnosticState::ResultsFound,
+        NativeSearchDiagnosticState::Empty => ProtoNativeSearchDiagnosticState::Empty,
+        NativeSearchDiagnosticState::Skipped => ProtoNativeSearchDiagnosticState::Skipped,
+        NativeSearchDiagnosticState::TimedOut => ProtoNativeSearchDiagnosticState::TimedOut,
+        NativeSearchDiagnosticState::Cancelled => ProtoNativeSearchDiagnosticState::Cancelled,
+        NativeSearchDiagnosticState::Error => ProtoNativeSearchDiagnosticState::Error,
+    }
+}
+
+fn native_diagnostic_reason_to_proto(
+    reason: NativeSearchDiagnosticReason,
+) -> ProtoNativeSearchDiagnosticReason {
+    match reason {
+        NativeSearchDiagnosticReason::NotAuthorized => {
+            ProtoNativeSearchDiagnosticReason::NotAuthorized
+        }
+        NativeSearchDiagnosticReason::AmbiguousRoute => {
+            ProtoNativeSearchDiagnosticReason::AmbiguousRoute
+        }
+        NativeSearchDiagnosticReason::InvalidSearchLimits => {
+            ProtoNativeSearchDiagnosticReason::InvalidSearchLimits
+        }
+        NativeSearchDiagnosticReason::QueryInputUnmappable => {
+            ProtoNativeSearchDiagnosticReason::QueryInputUnmappable
+        }
+        NativeSearchDiagnosticReason::MissingArgumentDefault => {
+            ProtoNativeSearchDiagnosticReason::MissingArgumentDefault
+        }
+        NativeSearchDiagnosticReason::RouteStale => ProtoNativeSearchDiagnosticReason::RouteStale,
+        NativeSearchDiagnosticReason::UnsafeOperation => {
+            ProtoNativeSearchDiagnosticReason::UnsafeOperation
+        }
+        NativeSearchDiagnosticReason::NoSafeDisplayFields => {
+            ProtoNativeSearchDiagnosticReason::NoSafeDisplayFields
+        }
+        NativeSearchDiagnosticReason::FanoutLimitReached => {
+            ProtoNativeSearchDiagnosticReason::FanoutLimitReached
+        }
+        NativeSearchDiagnosticReason::InsufficientBudget => {
+            ProtoNativeSearchDiagnosticReason::InsufficientBudget
+        }
+        NativeSearchDiagnosticReason::GlobalBudgetExhausted => {
+            ProtoNativeSearchDiagnosticReason::GlobalBudgetExhausted
+        }
+        NativeSearchDiagnosticReason::CallTimeout => ProtoNativeSearchDiagnosticReason::CallTimeout,
+        NativeSearchDiagnosticReason::Cancelled => ProtoNativeSearchDiagnosticReason::Cancelled,
+        NativeSearchDiagnosticReason::RateLimited => ProtoNativeSearchDiagnosticReason::RateLimited,
+        NativeSearchDiagnosticReason::AuthOrPermissionFailed => {
+            ProtoNativeSearchDiagnosticReason::AuthOrPermissionFailed
+        }
+        NativeSearchDiagnosticReason::UpstreamUnavailable => {
+            ProtoNativeSearchDiagnosticReason::UpstreamUnavailable
+        }
+        NativeSearchDiagnosticReason::InvalidResponse => {
+            ProtoNativeSearchDiagnosticReason::InvalidResponse
+        }
+        NativeSearchDiagnosticReason::ExecutionFailed => {
+            ProtoNativeSearchDiagnosticReason::ExecutionFailed
+        }
+        NativeSearchDiagnosticReason::UnsupportedCancellation => {
+            ProtoNativeSearchDiagnosticReason::UnsupportedCancellation
+        }
+        NativeSearchDiagnosticReason::InternalError => {
+            ProtoNativeSearchDiagnosticReason::InternalError
+        }
     }
 }
 
@@ -539,17 +663,35 @@ fn field_role_to_proto(field_role: SearchFieldRole) -> ProtoSearchFieldRole {
 #[cfg(test)]
 mod tests {
     use coral_api::v1::{
+        NativeSearchDiagnostic as ProtoNativeSearchDiagnostic,
+        NativeSearchDiagnosticReason as ProtoNativeSearchDiagnosticReason,
+        NativeSearchDiagnosticState as ProtoNativeSearchDiagnosticState,
         SearchClearTarget as ProtoSearchClearTarget,
         SearchProviderState as ProtoSearchProviderState, search_clear_target,
     };
+    use prost::Message as _;
     use tonic::Code;
 
-    use super::{clear_target_from_proto, provider_status_to_proto};
+    use super::{
+        Payload, clear_target_from_proto, native_diagnostic_reason_to_proto,
+        native_diagnostic_state_to_proto, provider_status_to_proto, search_payload_to_proto,
+    };
     use crate::search::maintenance::SearchClearTarget;
     use crate::search::result::{
-        ProviderCoverage, ProviderStatus, SearchProviderKind,
-        SearchProviderState as DomainProviderState,
+        NativeSearchAttribute, NativeSearchDiagnostic, NativeSearchDiagnosticReason,
+        NativeSearchDiagnosticState, NativeSearchResult, ProviderCoverage, ProviderStatus,
+        SearchPayload, SearchProviderKind, SearchProviderState as DomainProviderState,
     };
+
+    fn round_trip_diagnostic(state: i32, reason: i32) -> ProtoNativeSearchDiagnostic {
+        let diagnostic = ProtoNativeSearchDiagnostic {
+            state,
+            reason,
+            ..ProtoNativeSearchDiagnostic::default()
+        };
+        ProtoNativeSearchDiagnostic::decode(diagnostic.encode_to_vec().as_slice())
+            .expect("native diagnostic protobuf round trip")
+    }
 
     #[test]
     fn skipped_provider_status_maps_without_coverage() {
@@ -558,6 +700,9 @@ mod tests {
             state: DomainProviderState::Skipped,
             note: "not eligible for this request".to_string(),
             coverage: Some(ProviderCoverage::default()),
+            diagnostics: Vec::new(),
+            diagnostics_truncated: false,
+            omitted_diagnostic_count: 0,
         });
 
         assert_eq!(
@@ -588,6 +733,96 @@ mod tests {
     }
 
     #[test]
+    fn native_result_mapping_preserves_optional_fields_and_attribute_order() {
+        let payload = search_payload_to_proto(
+            &crate::workspaces::WorkspaceName::default(),
+            SearchPayload::NativeResult(NativeSearchResult {
+                schema_name: "github".to_string(),
+                function_name: "search_issues".to_string(),
+                row_ordinal: 2,
+                entity_type: Some("issue".to_string()),
+                provider_id: None,
+                title: Some("Fix native search".to_string()),
+                url: None,
+                snippet: Some("Compact preview".to_string()),
+                attributes: vec![
+                    NativeSearchAttribute {
+                        name: "state".to_string(),
+                        display_value: "open".to_string(),
+                    },
+                    NativeSearchAttribute {
+                        name: "author".to_string(),
+                        display_value: "octocat".to_string(),
+                    },
+                ],
+                omitted_attribute_count: 3,
+                content_truncated: true,
+            }),
+        );
+        let Payload::NativeResult(proto) = payload else {
+            panic!("native result should map to the native protobuf payload");
+        };
+        let proto = coral_api::v1::NativeSearchResult::decode(proto.encode_to_vec().as_slice())
+            .expect("native result protobuf round trip");
+
+        assert_eq!(proto.schema_name, "github");
+        assert_eq!(proto.function_name, "search_issues");
+        assert_eq!(proto.row_ordinal, 2);
+        assert_eq!(proto.entity_type.as_deref(), Some("issue"));
+        assert_eq!(proto.provider_id, None);
+        assert_eq!(proto.title.as_deref(), Some("Fix native search"));
+        assert_eq!(proto.url, None);
+        assert_eq!(proto.snippet.as_deref(), Some("Compact preview"));
+        assert_eq!(
+            proto
+                .attributes
+                .iter()
+                .map(|attribute| attribute.name.as_str())
+                .collect::<Vec<_>>(),
+            ["state", "author"]
+        );
+        assert_eq!(proto.omitted_attribute_count, 3);
+        assert!(proto.content_truncated);
+    }
+
+    #[test]
+    fn every_native_diagnostic_state_maps_to_the_stable_wire_value() {
+        let cases = [
+            (
+                NativeSearchDiagnosticState::ResultsFound,
+                ProtoNativeSearchDiagnosticState::ResultsFound,
+            ),
+            (
+                NativeSearchDiagnosticState::Empty,
+                ProtoNativeSearchDiagnosticState::Empty,
+            ),
+            (
+                NativeSearchDiagnosticState::Skipped,
+                ProtoNativeSearchDiagnosticState::Skipped,
+            ),
+            (
+                NativeSearchDiagnosticState::TimedOut,
+                ProtoNativeSearchDiagnosticState::TimedOut,
+            ),
+            (
+                NativeSearchDiagnosticState::Cancelled,
+                ProtoNativeSearchDiagnosticState::Cancelled,
+            ),
+            (
+                NativeSearchDiagnosticState::Error,
+                ProtoNativeSearchDiagnosticState::Error,
+            ),
+        ];
+
+        for (index, (domain, expected)) in cases.into_iter().enumerate() {
+            let actual = native_diagnostic_state_to_proto(domain);
+            assert_eq!(actual, expected);
+            assert_eq!(actual as i32, i32::try_from(index + 1).expect("wire value"));
+            assert_eq!(round_trip_diagnostic(actual as i32, 0).state, actual as i32);
+        }
+    }
+
+    #[test]
     fn clear_source_target_rejects_unsafe_source_identities() {
         for source_name in [
             "",
@@ -611,5 +846,140 @@ mod tests {
                 "source={source_name:?}"
             );
         }
+    }
+
+    #[test]
+    fn every_native_diagnostic_reason_maps_to_the_stable_wire_value() {
+        let cases = [
+            (
+                NativeSearchDiagnosticReason::NotAuthorized,
+                ProtoNativeSearchDiagnosticReason::NotAuthorized,
+            ),
+            (
+                NativeSearchDiagnosticReason::AmbiguousRoute,
+                ProtoNativeSearchDiagnosticReason::AmbiguousRoute,
+            ),
+            (
+                NativeSearchDiagnosticReason::InvalidSearchLimits,
+                ProtoNativeSearchDiagnosticReason::InvalidSearchLimits,
+            ),
+            (
+                NativeSearchDiagnosticReason::QueryInputUnmappable,
+                ProtoNativeSearchDiagnosticReason::QueryInputUnmappable,
+            ),
+            (
+                NativeSearchDiagnosticReason::MissingArgumentDefault,
+                ProtoNativeSearchDiagnosticReason::MissingArgumentDefault,
+            ),
+            (
+                NativeSearchDiagnosticReason::RouteStale,
+                ProtoNativeSearchDiagnosticReason::RouteStale,
+            ),
+            (
+                NativeSearchDiagnosticReason::UnsafeOperation,
+                ProtoNativeSearchDiagnosticReason::UnsafeOperation,
+            ),
+            (
+                NativeSearchDiagnosticReason::NoSafeDisplayFields,
+                ProtoNativeSearchDiagnosticReason::NoSafeDisplayFields,
+            ),
+            (
+                NativeSearchDiagnosticReason::FanoutLimitReached,
+                ProtoNativeSearchDiagnosticReason::FanoutLimitReached,
+            ),
+            (
+                NativeSearchDiagnosticReason::InsufficientBudget,
+                ProtoNativeSearchDiagnosticReason::InsufficientBudget,
+            ),
+            (
+                NativeSearchDiagnosticReason::GlobalBudgetExhausted,
+                ProtoNativeSearchDiagnosticReason::GlobalBudgetExhausted,
+            ),
+            (
+                NativeSearchDiagnosticReason::CallTimeout,
+                ProtoNativeSearchDiagnosticReason::CallTimeout,
+            ),
+            (
+                NativeSearchDiagnosticReason::Cancelled,
+                ProtoNativeSearchDiagnosticReason::Cancelled,
+            ),
+            (
+                NativeSearchDiagnosticReason::RateLimited,
+                ProtoNativeSearchDiagnosticReason::RateLimited,
+            ),
+            (
+                NativeSearchDiagnosticReason::AuthOrPermissionFailed,
+                ProtoNativeSearchDiagnosticReason::AuthOrPermissionFailed,
+            ),
+            (
+                NativeSearchDiagnosticReason::UpstreamUnavailable,
+                ProtoNativeSearchDiagnosticReason::UpstreamUnavailable,
+            ),
+            (
+                NativeSearchDiagnosticReason::InvalidResponse,
+                ProtoNativeSearchDiagnosticReason::InvalidResponse,
+            ),
+            (
+                NativeSearchDiagnosticReason::ExecutionFailed,
+                ProtoNativeSearchDiagnosticReason::ExecutionFailed,
+            ),
+            (
+                NativeSearchDiagnosticReason::UnsupportedCancellation,
+                ProtoNativeSearchDiagnosticReason::UnsupportedCancellation,
+            ),
+            (
+                NativeSearchDiagnosticReason::InternalError,
+                ProtoNativeSearchDiagnosticReason::InternalError,
+            ),
+        ];
+
+        for (index, (domain, expected)) in cases.into_iter().enumerate() {
+            let actual = native_diagnostic_reason_to_proto(domain);
+            assert_eq!(actual, expected);
+            assert_eq!(actual as i32, i32::try_from(index + 1).expect("wire value"));
+            assert_eq!(
+                round_trip_diagnostic(0, actual as i32).reason,
+                actual as i32
+            );
+        }
+    }
+
+    #[test]
+    fn protobuf_round_trip_preserves_unknown_native_diagnostic_enums() {
+        let diagnostic = round_trip_diagnostic(999, 998);
+
+        assert_eq!(diagnostic.state, 999);
+        assert_eq!(diagnostic.reason, 998);
+    }
+
+    #[test]
+    fn native_diagnostics_preserve_resolution_absence_and_elapsed_width() {
+        let proto = provider_status_to_proto(ProviderStatus {
+            provider: SearchProviderKind::NativeFanout,
+            state: DomainProviderState::Partial,
+            note: "one route was unresolved".to_string(),
+            coverage: Some(ProviderCoverage::default()),
+            diagnostics: vec![NativeSearchDiagnostic {
+                installed_source_name: "github".to_string(),
+                schema_name: None,
+                function_name: None,
+                authored_route_id: Some("issues".to_string()),
+                state: NativeSearchDiagnosticState::Skipped,
+                reason: NativeSearchDiagnosticReason::AmbiguousRoute,
+                elapsed_ms: u64::MAX,
+                safe_candidate_count: 0,
+                has_more: false,
+            }],
+            diagnostics_truncated: true,
+            omitted_diagnostic_count: 7,
+        });
+
+        let diagnostic = proto.diagnostics.first().expect("diagnostic");
+        assert_eq!(diagnostic.schema_name, None);
+        assert_eq!(diagnostic.function_name, None);
+        assert_eq!(diagnostic.authored_route_id.as_deref(), Some("issues"));
+        assert_eq!(diagnostic.elapsed_ms, u64::MAX);
+        assert!(proto.diagnostics_truncated);
+        assert_eq!(proto.omitted_diagnostic_count, 7);
     }
 }

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -966,9 +966,9 @@ paths:
                     catalog_item::Item::TableFunction(_) | catalog_item::Item::Table(_) => None,
                 }
             }
-            search_result::Payload::ColumnHint(_) | search_result::Payload::ObservedValue(_) => {
-                None
-            }
+            search_result::Payload::ColumnHint(_)
+            | search_result::Payload::ObservedValue(_)
+            | search_result::Payload::NativeResult(_) => None,
         })
         .expect("eligible table function metadata");
     let authorization = function

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -1075,15 +1075,21 @@ async fn search_command_renders_native_results_and_bounded_diagnostics() {
     assert_eq!(result["native_result"]["attributes"][0]["name"], "state");
     assert_eq!(result["native_result"]["attributes"][1]["name"], "author");
     let status = &response["provider_statuses"][0];
-    assert_eq!(status["diagnostics"][0]["state"], "skipped");
-    assert_eq!(status["diagnostics"][0]["reason"], "fanout_limit_reached");
-    assert_eq!(status["diagnostics"][0]["elapsed_ms"], 0);
+    let diagnostic = &status["diagnostics"][0];
+    assert_eq!(diagnostic["source_name"], "github");
+    assert!(diagnostic.get("installed_source_name").is_none());
+    assert!(diagnostic.get("schema_name").is_none());
+    assert_eq!(diagnostic["state"], "skipped");
+    assert_eq!(diagnostic["reason"], "fanout_limit_reached");
+    assert_eq!(diagnostic["elapsed_ms"], 0);
     assert_eq!(status["omitted_diagnostic_count"], 2);
 
     let text_assert = server.cmd().args(["search", "native"]).assert().success();
     let text = String::from_utf8_lossy(&text_assert.get_output().stdout);
     assert!(text.contains("native result github.search_issues row 0"));
     assert!(text.contains("Attributes: state=open, author=octocat"));
+    assert!(text.contains("github.search_pull_requests: skipped/fanout_limit_reached"));
+    assert!(!text.contains("github (github.search_pull_requests)"));
     assert!(text.contains("skipped/fanout_limit_reached (0 ms, 0 candidate(s))"));
     assert!(text.contains("Diagnostics truncated: 2 omitted"));
 

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -29,7 +29,7 @@ use tonic::Code;
 
 use harness::{
     MockServer, MockServerConfig, assert_default_workspace, assert_workspace_name,
-    encode_arrow_ipc_stream,
+    encode_arrow_ipc_stream, mock_native_search_response,
 };
 
 #[cfg(feature = "embedded-ui")]
@@ -977,6 +977,10 @@ async fn search_command_renders_text_output_and_provider_statuses() {
         stdout.contains("- native_fanout: skipped"),
         "skipped provider should remain visible: {stdout}"
     );
+    assert!(
+        !stdout.contains("Diagnostics"),
+        "empty native diagnostics must not change existing text output: {stdout}"
+    );
 
     let requests = server.search_requests();
     assert_eq!(requests.len(), 1, "expected one search call");
@@ -1022,6 +1026,21 @@ async fn search_json_output_preserves_typed_payloads_and_statuses() {
     assert!(response["provider_statuses"][1]["coverage"].is_null());
     assert_eq!(response["provider_statuses"][2]["state"], "skipped");
     assert!(response["provider_statuses"][2]["coverage"].is_null());
+    assert!(
+        response["provider_statuses"][2]
+            .get("diagnostics")
+            .is_none()
+    );
+    assert!(
+        response["provider_statuses"][2]
+            .get("diagnostics_truncated")
+            .is_none()
+    );
+    assert!(
+        response["provider_statuses"][2]
+            .get("omitted_diagnostic_count")
+            .is_none()
+    );
     assert_eq!(response["truncation"]["returned_count"], 2);
 
     let requests = server.search_requests();
@@ -1029,6 +1048,44 @@ async fn search_json_output_preserves_typed_payloads_and_statuses() {
     assert_eq!(requests[0].query, "messages");
     assert_eq!(requests[0].limit, 5);
     assert_default_workspace(requests[0].workspace.as_ref());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn search_command_renders_native_results_and_bounded_diagnostics() {
+    let server = MockServer::start_with_config(
+        MockServerConfig::default().with_search_response(mock_native_search_response()),
+    )
+    .await;
+
+    let json_assert = server
+        .cmd()
+        .args(["search", "--json", "native"])
+        .assert()
+        .success();
+    let json_stdout = String::from_utf8_lossy(&json_assert.get_output().stdout);
+    let response: serde_json::Value =
+        serde_json::from_str(json_stdout.trim()).expect("native search JSON");
+    let result = &response["results"][0];
+    assert_eq!(result["kind"], "native_result");
+    assert_eq!(result["native_result"]["schema_name"], "github");
+    assert_eq!(result["native_result"]["function_name"], "search_issues");
+    assert!(result["native_result"].get("snippet").is_none());
+    assert_eq!(result["native_result"]["attributes"][0]["name"], "state");
+    assert_eq!(result["native_result"]["attributes"][1]["name"], "author");
+    let status = &response["provider_statuses"][0];
+    assert_eq!(status["diagnostics"][0]["state"], "skipped");
+    assert_eq!(status["diagnostics"][0]["reason"], "fanout_limit_reached");
+    assert_eq!(status["diagnostics"][0]["elapsed_ms"], 0);
+    assert_eq!(status["omitted_diagnostic_count"], 2);
+
+    let text_assert = server.cmd().args(["search", "native"]).assert().success();
+    let text = String::from_utf8_lossy(&text_assert.get_output().stdout);
+    assert!(text.contains("native result github.search_issues row 0"));
+    assert!(text.contains("Attributes: state=open, author=octocat"));
+    assert!(text.contains("skipped/fanout_limit_reached (0 ms, 0 candidate(s))"));
+    assert!(text.contains("Diagnostics truncated: 2 omitted"));
 
     server.shutdown().await;
 }

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -511,8 +511,7 @@ pub(crate) fn mock_native_search_response() -> SearchResponse {
                 stale_index: false,
             }),
             diagnostics: vec![NativeSearchDiagnostic {
-                installed_source_name: "github".to_string(),
-                schema_name: Some("github".to_string()),
+                source_name: "github".to_string(),
                 function_name: Some("search_pull_requests".to_string()),
                 authored_route_id: None,
                 state: NativeSearchDiagnosticState::Skipped as i32,

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -35,18 +35,20 @@ use coral_api::v1::{
     GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
     ImportSourceResponse, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
     ListColumnsResponse, ListFunctionsRequest, ListFunctionsResponse, ListSourcesRequest,
-    ListSourcesResponse, ListWorkspacesRequest, ListWorkspacesResponse, ObservedDrainResult,
-    ObservedRebuildResult, PaginationRequest, PaginationResponse, QueryPlan,
-    RebuildSearchIndexRequest, RebuildSearchIndexResponse, SearchCatalogRequest,
-    SearchCatalogResponse, SearchFieldRole, SearchMaintenanceResult, SearchMaintenanceState,
-    SearchProvider, SearchProviderCoverage, SearchProviderState, SearchRequest, SearchResponse,
-    SearchResult, SearchResultTruncation, SearchStorageCleanupResult, SearchSurfaceKind,
-    SearchTableColumnPreview, SearchTableColumnPreviewColumn, Source, SourceCredentialStorage,
-    SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, StartTaskRequest,
-    StartTaskResponse, Table, TableFunction, TableSummary, Task as ProtoTask,
-    TaskEnd as ProtoTaskEnd, TaskStatus, ValidateSourceRequest, ValidateSourceResponse, Workspace,
-    catalog_item, create_bundled_source_with_o_auth_response, import_source_response,
-    search_maintenance_result, search_result, source_input_spec::Input as ProtoSourceInput,
+    ListSourcesResponse, ListWorkspacesRequest, ListWorkspacesResponse, NativeSearchAttribute,
+    NativeSearchDiagnostic, NativeSearchDiagnosticReason, NativeSearchDiagnosticState,
+    NativeSearchResult, ObservedDrainResult, ObservedRebuildResult, PaginationRequest,
+    PaginationResponse, QueryPlan, RebuildSearchIndexRequest, RebuildSearchIndexResponse,
+    SearchCatalogRequest, SearchCatalogResponse, SearchFieldRole, SearchMaintenanceResult,
+    SearchMaintenanceState, SearchProvider, SearchProviderCoverage, SearchProviderState,
+    SearchRequest, SearchResponse, SearchResult, SearchResultTruncation,
+    SearchStorageCleanupResult, SearchSurfaceKind, SearchTableColumnPreview,
+    SearchTableColumnPreviewColumn, Source, SourceCredentialStorage, SourceInfo, SourceInputSpec,
+    SourceOrigin, SourceSecretInput, StartTaskRequest, StartTaskResponse, Table, TableFunction,
+    TableSummary, Task as ProtoTask, TaskEnd as ProtoTaskEnd, TaskStatus, ValidateSourceRequest,
+    ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
+    import_source_response, search_maintenance_result, search_result,
+    source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_TASK_ID_METADATA_KEY,
@@ -467,6 +469,65 @@ fn mock_search_response() -> SearchResponse {
     }
 }
 
+pub(crate) fn mock_native_search_response() -> SearchResponse {
+    SearchResponse {
+        results: vec![SearchResult {
+            provider: SearchProvider::NativeFanout as i32,
+            payload: Some(search_result::Payload::NativeResult(NativeSearchResult {
+                schema_name: "github".to_string(),
+                function_name: "search_issues".to_string(),
+                row_ordinal: 0,
+                entity_type: Some("issue".to_string()),
+                provider_id: Some("I_kwDO123".to_string()),
+                title: Some("Fix native search".to_string()),
+                url: Some("https://github.com/withcoral/coral/issues/1".to_string()),
+                snippet: None,
+                attributes: vec![
+                    NativeSearchAttribute {
+                        name: "state".to_string(),
+                        display_value: "open".to_string(),
+                    },
+                    NativeSearchAttribute {
+                        name: "author".to_string(),
+                        display_value: "octocat".to_string(),
+                    },
+                ],
+                omitted_attribute_count: 1,
+                content_truncated: true,
+            })),
+        }],
+        provider_statuses: vec![coral_api::v1::SearchProviderStatus {
+            provider: SearchProvider::NativeFanout as i32,
+            state: SearchProviderState::Partial as i32,
+            note: "one eligible route was not attempted".to_string(),
+            coverage: Some(SearchProviderCoverage {
+                eligible_units: 2,
+                searched_units: 1,
+                failed_units: 0,
+                returned_count: 1,
+                has_more: false,
+                budget_exhausted: true,
+                timed_out: false,
+                stale_index: false,
+            }),
+            diagnostics: vec![NativeSearchDiagnostic {
+                installed_source_name: "github".to_string(),
+                schema_name: Some("github".to_string()),
+                function_name: Some("search_pull_requests".to_string()),
+                authored_route_id: None,
+                state: NativeSearchDiagnosticState::Skipped as i32,
+                reason: NativeSearchDiagnosticReason::FanoutLimitReached as i32,
+                elapsed_ms: 0,
+                safe_candidate_count: 0,
+                has_more: false,
+            }],
+            diagnostics_truncated: true,
+            omitted_diagnostic_count: 2,
+        }],
+        truncation: None,
+    }
+}
+
 fn mock_rebuild_search_index_response() -> RebuildSearchIndexResponse {
     RebuildSearchIndexResponse {
         results: vec![
@@ -566,6 +627,9 @@ fn mock_provider_status(
         state: state as i32,
         note: note.to_string(),
         coverage,
+        diagnostics: Vec::new(),
+        diagnostics_truncated: false,
+        omitted_diagnostic_count: 0,
     }
 }
 
@@ -756,6 +820,11 @@ impl Default for MockServerConfig {
 }
 
 impl MockServerConfig {
+    pub(crate) fn with_search_response(mut self, response: SearchResponse) -> Self {
+        self.search = MockResult::ok(response);
+        self
+    }
+
     pub(crate) fn with_rebuild_search_index(
         mut self,
         response: RebuildSearchIndexResponse,

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -21,7 +21,10 @@ use coral_api::v1::{
 };
 use coral_app::{ServerBuilder, shutdown_tracing};
 use coral_client::{AppClient, default_workspace};
-use harness::{MockServer, MockServerConfig, assert_default_workspace, assert_workspace_name};
+use harness::{
+    MockServer, MockServerConfig, assert_default_workspace, assert_workspace_name,
+    mock_native_search_response,
+};
 use rmcp::{
     RoleClient, ServiceExt,
     model::{CallToolRequestParams, CallToolResult, ReadResourceRequestParams},
@@ -1294,6 +1297,47 @@ async fn mcp_stdio_sql_and_catalog_tools_return_structured_content()
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_search_returns_native_result_and_diagnostic_contracts()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start_with_config(
+        MockServerConfig::default().with_search_response(mock_native_search_response()),
+    )
+    .await;
+    let client = start_mcp_client(&server).await?;
+
+    let search = structured_tool_content(
+        &client,
+        CallToolRequestParams::new("search").with_arguments(json_object(&json!({
+            "query": "native",
+            "limit": 10
+        }))),
+    )
+    .await?;
+    assert_eq!(search["results"][0]["kind"], "native_result");
+    assert_eq!(
+        search["results"][0]["native_result"]["attributes"][0]["name"],
+        "state"
+    );
+    assert!(
+        search["results"][0]["native_result"]
+            .get("snippet")
+            .is_none()
+    );
+    assert_eq!(
+        search["provider_statuses"][0]["diagnostics"][0]["reason"],
+        "fanout_limit_reached"
+    );
+    assert_eq!(
+        search["provider_statuses"][0]["omitted_diagnostic_count"],
+        2
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
 async fn assert_list_catalog_tool(
     client: &RunningService<RoleClient, ()>,
     server: &MockServer,
@@ -1407,6 +1451,14 @@ async fn assert_search_tool(
     );
     assert_eq!(search["provider_statuses"][0]["state"], "results_found");
     assert!(search["provider_statuses"][1]["coverage"].is_null());
+    for status in search["provider_statuses"]
+        .as_array()
+        .expect("provider statuses")
+    {
+        assert!(status.get("diagnostics").is_none());
+        assert!(status.get("diagnostics_truncated").is_none());
+        assert!(status.get("omitted_diagnostic_count").is_none());
+    }
 
     let search_requests = server.search_requests();
     let request = search_requests.last().expect("search request");

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -1324,10 +1324,11 @@ async fn mcp_search_returns_native_result_and_diagnostic_contracts()
             .get("snippet")
             .is_none()
     );
-    assert_eq!(
-        search["provider_statuses"][0]["diagnostics"][0]["reason"],
-        "fanout_limit_reached"
-    );
+    let diagnostic = &search["provider_statuses"][0]["diagnostics"][0];
+    assert_eq!(diagnostic["source_name"], "github");
+    assert!(diagnostic.get("installed_source_name").is_none());
+    assert!(diagnostic.get("schema_name").is_none());
+    assert_eq!(diagnostic["reason"], "fanout_limit_reached");
     assert_eq!(
         search["provider_statuses"][0]["omitted_diagnostic_count"],
         2

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -1305,13 +1305,17 @@ async fn mcp_search_returns_native_result_and_diagnostic_contracts()
     )
     .await;
     let client = start_mcp_client(&server).await?;
+    let task_id = start_test_task(&client).await?;
 
     let search = structured_tool_content(
         &client,
-        CallToolRequestParams::new("search").with_arguments(json_object(&json!({
-            "query": "native",
-            "limit": 10
-        }))),
+        CallToolRequestParams::new("search").with_arguments(task_arguments(
+            &task_id,
+            &json!({
+                "query": "native",
+                "limit": 10
+            }),
+        )),
     )
     .await?;
     assert_eq!(search["results"][0]["kind"], "native_result");

--- a/crates/coral-client/src/search.rs
+++ b/crates/coral-client/src/search.rs
@@ -530,9 +530,7 @@ impl<'a> From<&'a coral_api::v1::SearchProviderStatus> for SearchProviderStatusV
 #[derive(Serialize, JsonSchema)]
 #[schemars(deny_unknown_fields)]
 struct NativeSearchDiagnosticValue<'a> {
-    installed_source_name: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    schema_name: Option<&'a str>,
+    source_name: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     function_name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -547,8 +545,7 @@ struct NativeSearchDiagnosticValue<'a> {
 impl<'a> From<&'a NativeSearchDiagnostic> for NativeSearchDiagnosticValue<'a> {
     fn from(diagnostic: &'a NativeSearchDiagnostic) -> Self {
         Self {
-            installed_source_name: &diagnostic.installed_source_name,
-            schema_name: diagnostic.schema_name.as_deref(),
+            source_name: &diagnostic.source_name,
             function_name: diagnostic.function_name.as_deref(),
             authored_route_id: diagnostic.authored_route_id.as_deref(),
             state: native_diagnostic_state_name(diagnostic.state),
@@ -910,15 +907,10 @@ fn provider_status_text(status: &coral_api::v1::SearchProviderStatus) -> String 
 }
 
 fn diagnostic_identity_text(diagnostic: &NativeSearchDiagnostic) -> String {
-    match (
-        diagnostic.schema_name.as_deref(),
-        diagnostic.function_name.as_deref(),
-    ) {
-        (Some(schema), Some(function)) => {
-            format!("{} ({schema}.{function})", diagnostic.installed_source_name)
-        }
-        _ => diagnostic.installed_source_name.clone(),
-    }
+    diagnostic.function_name.as_deref().map_or_else(
+        || diagnostic.source_name.clone(),
+        |function| format!("{}.{function}", diagnostic.source_name),
+    )
 }
 
 fn push_optional_fields_line(lines: &mut Vec<String>, label: &str, fields: &[String]) {
@@ -1153,8 +1145,7 @@ mod tests {
                 note: "one route was skipped".to_string(),
                 coverage: None,
                 diagnostics: vec![NativeSearchDiagnostic {
-                    installed_source_name: "github".to_string(),
-                    schema_name: None,
+                    source_name: "github".to_string(),
                     function_name: None,
                     authored_route_id: Some("issues".to_string()),
                     state: NativeSearchDiagnosticState::Skipped as i32,
@@ -1242,6 +1233,8 @@ mod tests {
         assert_eq!(result["attributes"][1]["name"], "author");
 
         let diagnostic = &json["provider_statuses"][0]["diagnostics"][0];
+        assert_eq!(diagnostic["source_name"], "github");
+        assert!(diagnostic.get("installed_source_name").is_none());
         assert!(diagnostic.get("schema_name").is_none());
         assert!(diagnostic.get("function_name").is_none());
         assert_eq!(diagnostic["authored_route_id"], "issues");
@@ -1267,6 +1260,21 @@ mod tests {
             )
         );
         assert!(text.contains("Diagnostics truncated: 3 omitted"));
+    }
+
+    #[test]
+    fn native_text_renders_resolved_diagnostic_as_source_and_function() {
+        let mut response = native_response();
+        response.provider_statuses[0].diagnostics[0].function_name =
+            Some("search_pull_requests".to_string());
+
+        let text = format_search_response_text(&response);
+
+        assert!(text.contains(
+            "github.search_pull_requests: skipped/insufficient_budget \
+             (19 ms, 0 candidate(s), route issues)"
+        ));
+        assert!(!text.contains("github (github."));
     }
 
     #[test]

--- a/crates/coral-client/src/search.rs
+++ b/crates/coral-client/src/search.rs
@@ -3,11 +3,12 @@
 use std::fmt::Write as _;
 
 use coral_api::v1::{
-    CatalogItem, CatalogMetadata, ColumnHint, ObservedValue, SearchFieldRole, SearchLimits,
-    SearchProvider, SearchProviderCoverage, SearchProviderState, SearchResponse, SearchResult,
-    SearchResultTruncation, SearchSurfaceKind, SearchTableColumnPreview,
-    SearchTableColumnPreviewColumn, TableFunction, TableFunctionArgument, TableFunctionKind,
-    TableFunctionResultColumn, TableSummary, catalog_item, search_result,
+    CatalogItem, CatalogMetadata, ColumnHint, NativeSearchAttribute, NativeSearchDiagnostic,
+    NativeSearchDiagnosticReason, NativeSearchDiagnosticState, NativeSearchResult, ObservedValue,
+    SearchFieldRole, SearchLimits, SearchProvider, SearchProviderCoverage, SearchProviderState,
+    SearchResponse, SearchResult, SearchResultTruncation, SearchSurfaceKind,
+    SearchTableColumnPreview, SearchTableColumnPreviewColumn, TableFunction, TableFunctionArgument,
+    TableFunctionKind, TableFunctionResultColumn, TableSummary, catalog_item, search_result,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -62,6 +63,11 @@ enum SearchResultValue<'a> {
         kind: &'static str,
         observed_value: ObservedValueValue<'a>,
     },
+    NativeResult {
+        provider: &'static str,
+        kind: &'static str,
+        native_result: NativeSearchResultValue<'a>,
+    },
     Unknown {
         provider: &'static str,
         kind: &'static str,
@@ -86,6 +92,11 @@ impl<'a> From<&'a SearchResult> for SearchResultValue<'a> {
                 provider,
                 kind: "observed_value",
                 observed_value: ObservedValueValue::from(observed),
+            },
+            Some(search_result::Payload::NativeResult(native)) => Self::NativeResult {
+                provider,
+                kind: "native_result",
+                native_result: NativeSearchResultValue::from(native),
             },
             None => Self::Unknown {
                 provider,
@@ -423,11 +434,76 @@ impl<'a> From<&'a ObservedValue> for ObservedValueValue<'a> {
 
 #[derive(Serialize, JsonSchema)]
 #[schemars(deny_unknown_fields)]
+struct NativeSearchResultValue<'a> {
+    schema_name: &'a str,
+    function_name: &'a str,
+    row_ordinal: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    entity_type: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    snippet: Option<&'a str>,
+    attributes: Vec<NativeSearchAttributeValue<'a>>,
+    omitted_attribute_count: u32,
+    content_truncated: bool,
+}
+
+impl<'a> From<&'a NativeSearchResult> for NativeSearchResultValue<'a> {
+    fn from(result: &'a NativeSearchResult) -> Self {
+        Self {
+            schema_name: &result.schema_name,
+            function_name: &result.function_name,
+            row_ordinal: result.row_ordinal,
+            entity_type: result.entity_type.as_deref(),
+            provider_id: result.provider_id.as_deref(),
+            title: result.title.as_deref(),
+            url: result.url.as_deref(),
+            snippet: result.snippet.as_deref(),
+            attributes: result
+                .attributes
+                .iter()
+                .map(NativeSearchAttributeValue::from)
+                .collect(),
+            omitted_attribute_count: result.omitted_attribute_count,
+            content_truncated: result.content_truncated,
+        }
+    }
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct NativeSearchAttributeValue<'a> {
+    name: &'a str,
+    display_value: &'a str,
+}
+
+impl<'a> From<&'a NativeSearchAttribute> for NativeSearchAttributeValue<'a> {
+    fn from(attribute: &'a NativeSearchAttribute) -> Self {
+        Self {
+            name: &attribute.name,
+            display_value: &attribute.display_value,
+        }
+    }
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 struct SearchProviderStatusValue<'a> {
     provider: &'static str,
     state: &'static str,
     note: &'a str,
     coverage: Option<SearchProviderCoverageValue>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    diagnostics: Vec<NativeSearchDiagnosticValue<'a>>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    diagnostics_truncated: bool,
+    #[serde(default, skip_serializing_if = "is_zero")]
+    omitted_diagnostic_count: u32,
 }
 
 impl<'a> From<&'a coral_api::v1::SearchProviderStatus> for SearchProviderStatusValue<'a> {
@@ -440,8 +516,64 @@ impl<'a> From<&'a coral_api::v1::SearchProviderStatus> for SearchProviderStatusV
                 .coverage
                 .as_ref()
                 .map(SearchProviderCoverageValue::from),
+            diagnostics: status
+                .diagnostics
+                .iter()
+                .map(NativeSearchDiagnosticValue::from)
+                .collect(),
+            diagnostics_truncated: status.diagnostics_truncated,
+            omitted_diagnostic_count: status.omitted_diagnostic_count,
         }
     }
+}
+
+#[derive(Serialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct NativeSearchDiagnosticValue<'a> {
+    installed_source_name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    function_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    authored_route_id: Option<&'a str>,
+    state: &'static str,
+    reason: &'static str,
+    elapsed_ms: u64,
+    safe_candidate_count: u32,
+    has_more: bool,
+}
+
+impl<'a> From<&'a NativeSearchDiagnostic> for NativeSearchDiagnosticValue<'a> {
+    fn from(diagnostic: &'a NativeSearchDiagnostic) -> Self {
+        Self {
+            installed_source_name: &diagnostic.installed_source_name,
+            schema_name: diagnostic.schema_name.as_deref(),
+            function_name: diagnostic.function_name.as_deref(),
+            authored_route_id: diagnostic.authored_route_id.as_deref(),
+            state: native_diagnostic_state_name(diagnostic.state),
+            reason: native_diagnostic_reason_name(diagnostic.reason),
+            elapsed_ms: diagnostic.elapsed_ms,
+            safe_candidate_count: diagnostic.safe_candidate_count,
+            has_more: diagnostic.has_more,
+        }
+    }
+}
+
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if callbacks receive a reference"
+)]
+fn is_false(value: &bool) -> bool {
+    !value
+}
+
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde skip_serializing_if callbacks receive a reference"
+)]
+fn is_zero(value: &u32) -> bool {
+    *value == 0
 }
 
 #[derive(Serialize, JsonSchema)]
@@ -573,6 +705,9 @@ fn result_text_lines(index: usize, result: &SearchResult) -> Vec<String> {
         Some(search_result::Payload::ObservedValue(observed)) => {
             observed_value_text_lines(index, provider, observed)
         }
+        Some(search_result::Payload::NativeResult(native)) => {
+            native_result_text_lines(index, provider, native)
+        }
         None => vec![format!("{index}. [{provider}] unknown result payload")],
     }
 }
@@ -678,6 +813,49 @@ fn observed_value_text_lines(
     lines
 }
 
+fn native_result_text_lines(
+    index: usize,
+    provider: &str,
+    result: &NativeSearchResult,
+) -> Vec<String> {
+    let mut lines = vec![format!(
+        "{index}. [{provider}] native result {}.{} row {}",
+        result.schema_name, result.function_name, result.row_ordinal
+    )];
+    for (label, value) in [
+        ("Entity type", result.entity_type.as_deref()),
+        ("Provider id", result.provider_id.as_deref()),
+        ("Title", result.title.as_deref()),
+        ("URL", result.url.as_deref()),
+        ("Snippet", result.snippet.as_deref()),
+    ] {
+        if let Some(value) = value {
+            lines.push(format!("   {label}: {value}"));
+        }
+    }
+    if !result.attributes.is_empty() {
+        lines.push(format!(
+            "   Attributes: {}",
+            result
+                .attributes
+                .iter()
+                .map(|attribute| format!("{}={}", attribute.name, attribute.display_value))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    if result.omitted_attribute_count > 0 {
+        lines.push(format!(
+            "   Omitted attributes: {}",
+            result.omitted_attribute_count
+        ));
+    }
+    if result.content_truncated {
+        lines.push("   Content truncated: true".to_string());
+    }
+    lines
+}
+
 fn provider_status_text(status: &coral_api::v1::SearchProviderStatus) -> String {
     let mut line = format!(
         "- {}: {}",
@@ -699,7 +877,48 @@ fn provider_status_text(status: &coral_api::v1::SearchProviderStatus) -> String 
         line.push_str(": ");
         line.push_str(&status.note);
     }
+    for diagnostic in &status.diagnostics {
+        write!(
+            line,
+            "\n  - {}: {}/{} ({} ms, {} candidate(s){}{})",
+            diagnostic_identity_text(diagnostic),
+            native_diagnostic_state_name(diagnostic.state),
+            native_diagnostic_reason_name(diagnostic.reason),
+            diagnostic.elapsed_ms,
+            diagnostic.safe_candidate_count,
+            if diagnostic.has_more {
+                ", has more"
+            } else {
+                ""
+            },
+            diagnostic
+                .authored_route_id
+                .as_deref()
+                .map_or_else(String::new, |route_id| format!(", route {route_id}"))
+        )
+        .expect("writing to string should not fail");
+    }
+    if status.diagnostics_truncated || status.omitted_diagnostic_count > 0 {
+        write!(
+            line,
+            "\n  Diagnostics truncated: {} omitted",
+            status.omitted_diagnostic_count
+        )
+        .expect("writing to string should not fail");
+    }
     line
+}
+
+fn diagnostic_identity_text(diagnostic: &NativeSearchDiagnostic) -> String {
+    match (
+        diagnostic.schema_name.as_deref(),
+        diagnostic.function_name.as_deref(),
+    ) {
+        (Some(schema), Some(function)) => {
+            format!("{} ({schema}.{function})", diagnostic.installed_source_name)
+        }
+        _ => diagnostic.installed_source_name.clone(),
+    }
 }
 
 fn push_optional_fields_line(lines: &mut Vec<String>, label: &str, fields: &[String]) {
@@ -829,6 +1048,44 @@ fn provider_state_name(state: i32) -> &'static str {
     }
 }
 
+fn native_diagnostic_state_name(state: i32) -> &'static str {
+    match NativeSearchDiagnosticState::try_from(state) {
+        Ok(NativeSearchDiagnosticState::ResultsFound) => "results_found",
+        Ok(NativeSearchDiagnosticState::Empty) => "empty",
+        Ok(NativeSearchDiagnosticState::Skipped) => "skipped",
+        Ok(NativeSearchDiagnosticState::TimedOut) => "timed_out",
+        Ok(NativeSearchDiagnosticState::Cancelled) => "cancelled",
+        Ok(NativeSearchDiagnosticState::Error) => "error",
+        Ok(NativeSearchDiagnosticState::Unspecified) | Err(_) => "unspecified",
+    }
+}
+
+fn native_diagnostic_reason_name(reason: i32) -> &'static str {
+    match NativeSearchDiagnosticReason::try_from(reason) {
+        Ok(NativeSearchDiagnosticReason::NotAuthorized) => "not_authorized",
+        Ok(NativeSearchDiagnosticReason::AmbiguousRoute) => "ambiguous_route",
+        Ok(NativeSearchDiagnosticReason::InvalidSearchLimits) => "invalid_search_limits",
+        Ok(NativeSearchDiagnosticReason::QueryInputUnmappable) => "query_input_unmappable",
+        Ok(NativeSearchDiagnosticReason::MissingArgumentDefault) => "missing_argument_default",
+        Ok(NativeSearchDiagnosticReason::RouteStale) => "route_stale",
+        Ok(NativeSearchDiagnosticReason::UnsafeOperation) => "unsafe_operation",
+        Ok(NativeSearchDiagnosticReason::NoSafeDisplayFields) => "no_safe_display_fields",
+        Ok(NativeSearchDiagnosticReason::FanoutLimitReached) => "fanout_limit_reached",
+        Ok(NativeSearchDiagnosticReason::InsufficientBudget) => "insufficient_budget",
+        Ok(NativeSearchDiagnosticReason::GlobalBudgetExhausted) => "global_budget_exhausted",
+        Ok(NativeSearchDiagnosticReason::CallTimeout) => "call_timeout",
+        Ok(NativeSearchDiagnosticReason::Cancelled) => "cancelled",
+        Ok(NativeSearchDiagnosticReason::RateLimited) => "rate_limited",
+        Ok(NativeSearchDiagnosticReason::AuthOrPermissionFailed) => "auth_or_permission_failed",
+        Ok(NativeSearchDiagnosticReason::UpstreamUnavailable) => "upstream_unavailable",
+        Ok(NativeSearchDiagnosticReason::InvalidResponse) => "invalid_response",
+        Ok(NativeSearchDiagnosticReason::ExecutionFailed) => "execution_failed",
+        Ok(NativeSearchDiagnosticReason::UnsupportedCancellation) => "unsupported_cancellation",
+        Ok(NativeSearchDiagnosticReason::InternalError) => "internal_error",
+        Ok(NativeSearchDiagnosticReason::Unspecified) | Err(_) => "unspecified",
+    }
+}
+
 fn surface_kind_name(kind: i32) -> &'static str {
     match SearchSurfaceKind::try_from(kind) {
         Ok(SearchSurfaceKind::Table) => "table",
@@ -856,8 +1113,62 @@ fn table_function_kind_name(kind: i32) -> &'static str {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::indexing_slicing,
+    reason = "unit test assertions use fixed fixture indexes for readability"
+)]
 mod tests {
     use super::*;
+
+    fn native_response() -> SearchResponse {
+        SearchResponse {
+            results: vec![SearchResult {
+                provider: SearchProvider::NativeFanout as i32,
+                payload: Some(search_result::Payload::NativeResult(NativeSearchResult {
+                    schema_name: "github".to_string(),
+                    function_name: "search_issues".to_string(),
+                    row_ordinal: 1,
+                    entity_type: Some("issue".to_string()),
+                    provider_id: None,
+                    title: Some("Fix native search".to_string()),
+                    url: None,
+                    snippet: Some("Compact preview".to_string()),
+                    attributes: vec![
+                        NativeSearchAttribute {
+                            name: "state".to_string(),
+                            display_value: "open".to_string(),
+                        },
+                        NativeSearchAttribute {
+                            name: "author".to_string(),
+                            display_value: "octocat".to_string(),
+                        },
+                    ],
+                    omitted_attribute_count: 2,
+                    content_truncated: true,
+                })),
+            }],
+            provider_statuses: vec![coral_api::v1::SearchProviderStatus {
+                provider: SearchProvider::NativeFanout as i32,
+                state: SearchProviderState::Partial as i32,
+                note: "one route was skipped".to_string(),
+                coverage: None,
+                diagnostics: vec![NativeSearchDiagnostic {
+                    installed_source_name: "github".to_string(),
+                    schema_name: None,
+                    function_name: None,
+                    authored_route_id: Some("issues".to_string()),
+                    state: NativeSearchDiagnosticState::Skipped as i32,
+                    reason: NativeSearchDiagnosticReason::InsufficientBudget as i32,
+                    elapsed_ms: 19,
+                    safe_candidate_count: 0,
+                    has_more: false,
+                }],
+                diagnostics_truncated: true,
+                omitted_diagnostic_count: 3,
+            }],
+            truncation: None,
+        }
+    }
 
     #[test]
     fn text_output_renders_table_function_guide() {
@@ -914,5 +1225,206 @@ mod tests {
             text.contains("Field path: labels.name"),
             "observed value text should include nested field path: {text}"
         );
+    }
+
+    #[test]
+    fn native_json_omits_absent_fields_and_preserves_attribute_order() {
+        let json = search_response_json_value(&native_response());
+        let result = &json["results"][0]["native_result"];
+
+        assert_eq!(result["schema_name"], "github");
+        assert_eq!(result["function_name"], "search_issues");
+        assert_eq!(result["row_ordinal"], 1);
+        assert_eq!(result["entity_type"], "issue");
+        assert!(result.get("provider_id").is_none());
+        assert!(result.get("url").is_none());
+        assert_eq!(result["attributes"][0]["name"], "state");
+        assert_eq!(result["attributes"][1]["name"], "author");
+
+        let diagnostic = &json["provider_statuses"][0]["diagnostics"][0];
+        assert!(diagnostic.get("schema_name").is_none());
+        assert!(diagnostic.get("function_name").is_none());
+        assert_eq!(diagnostic["authored_route_id"], "issues");
+        assert_eq!(diagnostic["state"], "skipped");
+        assert_eq!(diagnostic["reason"], "insufficient_budget");
+        assert_eq!(diagnostic["elapsed_ms"], 19);
+        assert_eq!(json["provider_statuses"][0]["omitted_diagnostic_count"], 3);
+    }
+
+    #[test]
+    fn native_text_renders_only_present_display_fields_and_diagnostics() {
+        let text = format_search_response_text(&native_response());
+
+        assert!(text.contains("native result github.search_issues row 1"));
+        assert!(text.contains("Entity type: issue"));
+        assert!(text.contains("Title: Fix native search"));
+        assert!(!text.contains("Provider id:"));
+        assert!(!text.contains("URL:"));
+        assert!(text.contains("Attributes: state=open, author=octocat"));
+        assert!(
+            text.contains(
+                "github: skipped/insufficient_budget (19 ms, 0 candidate(s), route issues)"
+            )
+        );
+        assert!(text.contains("Diagnostics truncated: 3 omitted"));
+    }
+
+    #[test]
+    fn native_diagnostic_enum_names_cover_every_stable_wire_value() {
+        let states = [
+            (NativeSearchDiagnosticState::ResultsFound, "results_found"),
+            (NativeSearchDiagnosticState::Empty, "empty"),
+            (NativeSearchDiagnosticState::Skipped, "skipped"),
+            (NativeSearchDiagnosticState::TimedOut, "timed_out"),
+            (NativeSearchDiagnosticState::Cancelled, "cancelled"),
+            (NativeSearchDiagnosticState::Error, "error"),
+        ];
+        for (state, expected) in states {
+            assert_eq!(native_diagnostic_state_name(state as i32), expected);
+        }
+
+        let reasons = [
+            (
+                NativeSearchDiagnosticReason::NotAuthorized,
+                "not_authorized",
+            ),
+            (
+                NativeSearchDiagnosticReason::AmbiguousRoute,
+                "ambiguous_route",
+            ),
+            (
+                NativeSearchDiagnosticReason::InvalidSearchLimits,
+                "invalid_search_limits",
+            ),
+            (
+                NativeSearchDiagnosticReason::QueryInputUnmappable,
+                "query_input_unmappable",
+            ),
+            (
+                NativeSearchDiagnosticReason::MissingArgumentDefault,
+                "missing_argument_default",
+            ),
+            (NativeSearchDiagnosticReason::RouteStale, "route_stale"),
+            (
+                NativeSearchDiagnosticReason::UnsafeOperation,
+                "unsafe_operation",
+            ),
+            (
+                NativeSearchDiagnosticReason::NoSafeDisplayFields,
+                "no_safe_display_fields",
+            ),
+            (
+                NativeSearchDiagnosticReason::FanoutLimitReached,
+                "fanout_limit_reached",
+            ),
+            (
+                NativeSearchDiagnosticReason::InsufficientBudget,
+                "insufficient_budget",
+            ),
+            (
+                NativeSearchDiagnosticReason::GlobalBudgetExhausted,
+                "global_budget_exhausted",
+            ),
+            (NativeSearchDiagnosticReason::CallTimeout, "call_timeout"),
+            (NativeSearchDiagnosticReason::Cancelled, "cancelled"),
+            (NativeSearchDiagnosticReason::RateLimited, "rate_limited"),
+            (
+                NativeSearchDiagnosticReason::AuthOrPermissionFailed,
+                "auth_or_permission_failed",
+            ),
+            (
+                NativeSearchDiagnosticReason::UpstreamUnavailable,
+                "upstream_unavailable",
+            ),
+            (
+                NativeSearchDiagnosticReason::InvalidResponse,
+                "invalid_response",
+            ),
+            (
+                NativeSearchDiagnosticReason::ExecutionFailed,
+                "execution_failed",
+            ),
+            (
+                NativeSearchDiagnosticReason::UnsupportedCancellation,
+                "unsupported_cancellation",
+            ),
+            (
+                NativeSearchDiagnosticReason::InternalError,
+                "internal_error",
+            ),
+        ];
+        for (reason, expected) in reasons {
+            assert_eq!(native_diagnostic_reason_name(reason as i32), expected);
+        }
+    }
+
+    #[test]
+    fn unknown_native_diagnostic_enums_are_rendered_as_unspecified() {
+        let mut response = native_response();
+        response.provider_statuses[0].diagnostics[0].state = 999;
+        response.provider_statuses[0].diagnostics[0].reason = 998;
+
+        let json = search_response_json_value(&response);
+        let diagnostic = &json["provider_statuses"][0]["diagnostics"][0];
+        assert_eq!(diagnostic["state"], "unspecified");
+        assert_eq!(diagnostic["reason"], "unspecified");
+    }
+
+    #[test]
+    fn feature_off_rendering_omits_all_new_diagnostic_fields() {
+        let response = SearchResponse {
+            results: Vec::new(),
+            provider_statuses: vec![coral_api::v1::SearchProviderStatus {
+                provider: SearchProvider::NativeFanout as i32,
+                state: SearchProviderState::NotEnabled as i32,
+                note: "search provider fanout disabled".to_string(),
+                coverage: None,
+                diagnostics: Vec::new(),
+                diagnostics_truncated: false,
+                omitted_diagnostic_count: 0,
+            }],
+            truncation: None,
+        };
+
+        let json = format_search_response_json(&response).expect("JSON response");
+        assert_eq!(
+            json,
+            r#"{
+  "results": [],
+  "provider_statuses": [
+    {
+      "provider": "native_fanout",
+      "state": "not_enabled",
+      "note": "search provider fanout disabled",
+      "coverage": null
+    }
+  ],
+  "truncation": null
+}"#
+        );
+        assert_eq!(
+            format_search_response_text(&response),
+            "Results\nNo results.\n\nProvider statuses\n- native_fanout: not_enabled: search provider fanout disabled\n"
+        );
+    }
+
+    #[test]
+    fn native_rendering_does_not_fabricate_internal_or_provider_details() {
+        let rendered = format_search_response_json(&native_response()).expect("JSON response");
+
+        for forbidden in [
+            "internal_key",
+            "rendered_sql",
+            "query_text",
+            "arguments",
+            "raw_error",
+            "response_body",
+            "request_url",
+        ] {
+            assert!(
+                !rendered.contains(forbidden),
+                "native rendering leaked forbidden field {forbidden}: {rendered}"
+            );
+        }
     }
 }

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -159,6 +159,74 @@ mod tests {
     }
 
     #[test]
+    fn search_output_schema_accepts_native_contract_and_feature_off_omission() {
+        let context = ToolDescriptionContext::new(1, 0, Vec::new());
+        let tools = available_tools(&context, BASE_TOOLS);
+        let search = tool_by_name(&tools, "search");
+        let schema = Value::Object(
+            search
+                .output_schema
+                .as_ref()
+                .expect("search output schema")
+                .as_ref()
+                .clone(),
+        );
+        let validator = jsonschema::validator_for(&schema).expect("valid search output schema");
+        let native = json!({
+            "results": [{
+                "provider": "native_fanout",
+                "kind": "native_result",
+                "native_result": {
+                    "schema_name": "github",
+                    "function_name": "search_issues",
+                    "row_ordinal": 0,
+                    "title": "Fix native search",
+                    "attributes": [{"name": "state", "display_value": "open"}],
+                    "omitted_attribute_count": 0,
+                    "content_truncated": false
+                }
+            }],
+            "provider_statuses": [{
+                "provider": "native_fanout",
+                "state": "partial",
+                "note": "one route skipped",
+                "coverage": null,
+                "diagnostics": [{
+                    "installed_source_name": "github",
+                    "authored_route_id": "issues",
+                    "state": "skipped",
+                    "reason": "fanout_limit_reached",
+                    "elapsed_ms": 0,
+                    "safe_candidate_count": 0,
+                    "has_more": false
+                }],
+                "diagnostics_truncated": true,
+                "omitted_diagnostic_count": 2
+            }],
+            "truncation": null
+        });
+        assert!(
+            validator.is_valid(&native),
+            "native response should match MCP output schema"
+        );
+
+        let feature_off = json!({
+            "results": [],
+            "provider_statuses": [{
+                "provider": "native_fanout",
+                "state": "not_enabled",
+                "note": "search provider fanout disabled",
+                "coverage": null
+            }],
+            "truncation": null
+        });
+        assert!(
+            validator.is_valid(&feature_off),
+            "feature-off response should not require default diagnostic fields"
+        );
+    }
+
+    #[test]
     fn available_tools_decorate_task_aware_tools() {
         let context = ToolDescriptionContext::new(1, 0, Vec::new());
         let tools = available_tools(&context, DEFAULT_TOOLS);

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -192,7 +192,7 @@ mod tests {
                 "note": "one route skipped",
                 "coverage": null,
                 "diagnostics": [{
-                    "installed_source_name": "github",
+                    "source_name": "github",
                     "authored_route_id": "issues",
                     "state": "skipped",
                     "reason": "fanout_limit_reached",
@@ -208,6 +208,29 @@ mod tests {
         assert!(
             validator.is_valid(&native),
             "native response should match MCP output schema"
+        );
+
+        let mut retired_installed_source = native.clone();
+        let retired_diagnostic = retired_installed_source
+            .pointer_mut("/provider_statuses/0/diagnostics/0")
+            .and_then(Value::as_object_mut)
+            .expect("native diagnostic object");
+        retired_diagnostic.remove("source_name");
+        retired_diagnostic.insert("installed_source_name".to_string(), json!("github"));
+        assert!(
+            !validator.is_valid(&retired_installed_source),
+            "retired installed_source_name must not match the MCP output schema"
+        );
+
+        let mut duplicated_schema = native.clone();
+        duplicated_schema
+            .pointer_mut("/provider_statuses/0/diagnostics/0")
+            .and_then(Value::as_object_mut)
+            .expect("native diagnostic object")
+            .insert("schema_name".to_string(), json!("github"));
+        assert!(
+            !validator.is_valid(&duplicated_schema),
+            "native diagnostics must not duplicate source_name as schema_name"
         );
 
         let feature_off = json!({

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -161,7 +161,7 @@ mod tests {
     #[test]
     fn search_output_schema_accepts_native_contract_and_feature_off_omission() {
         let context = ToolDescriptionContext::new(1, 0, Vec::new());
-        let tools = available_tools(&context, BASE_TOOLS);
+        let tools = available_tools(&context, DEFAULT_TOOLS);
         let search = tool_by_name(&tools, "search");
         let schema = Value::Object(
             search


### PR DESCRIPTION
## Summary

- Adds an additive NativeSearchResult protobuf payload with compact display fields, ordered name/value attributes, omission counts, and truncation metadata.
- Extends native provider status with bounded per-route diagnostics, truncation/count metadata, stable diagnostic states, and provider-independent reason codes.
- Maps the new contracts through app domain types and gRPC, then renders them consistently in client JSON/text, CLI, and MCP output.
- Omits absent and default diagnostic fields from machine-readable output so the existing feature-off NOT_ENABLED response remains unchanged; unknown protobuf enum values remain compatible and render safely as unspecified.

## Stack boundary

Stack 7/11. Depends on #1858; #1861 builds on this PR.

This PR adds transport and rendering contracts only; no provider emits a native result yet. The wire change is additive and public output never exposes internal identity keys, SQL, query text, arguments, raw provider errors, response bodies, or request URLs.

## Test plan

- make lint-proto
- cargo test -p coral-app native_
- cargo test -p coral-client native_
- cargo test -p coral-cli search_command_renders_native_results_and_bounded_diagnostics
- cargo test -p coral-cli mcp_search_returns_native_result_and_diagnostic_contracts
- make rust-checks

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
