### PR TITLE
feat(search): normalise native rows safely

### DIFF
--- a/crates/coral-app/src/search/content_safety.rs
+++ b/crates/coral-app/src/search/content_safety.rs
@@ -1,0 +1,270 @@
+//! Shared defense-in-depth filtering for untrusted search content.
+//!
+//! This is deliberately a narrow heuristic boundary. Callers still own their
+//! surface-specific validity and size policies.
+
+use serde_json::Value;
+
+const SENSITIVE_FIELD_NAMES: &[&str] = &[
+    "apikey",
+    "authorization",
+    "authtoken",
+    "cookie",
+    "credential",
+    "password",
+    "passwd",
+    "privatekey",
+    "refreshtoken",
+    "secret",
+    "session",
+    "token",
+];
+
+const SENSITIVE_AUTH_SCHEMES: &[&str] = &[
+    "api-key",
+    "apikey",
+    "basic",
+    "bearer",
+    "digest",
+    "negotiate",
+    "ntlm",
+    "token",
+];
+
+/// Result of removing recognized secret-bearing content from a JSON value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::search) enum JsonSanitization {
+    Unchanged,
+    Changed,
+    Drop,
+}
+
+/// Returns whether a field name resembles a credential-bearing field.
+pub(in crate::search) fn is_sensitive_name(field_name: &str) -> bool {
+    let normalized = field_name
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .collect::<String>()
+        .to_ascii_lowercase();
+    SENSITIVE_FIELD_NAMES
+        .iter()
+        .any(|name| normalized.contains(name))
+}
+
+/// Returns whether a value contains one of the obvious secret shapes we know.
+///
+/// A `false` result does not mean the value is generally non-sensitive.
+pub(in crate::search) fn is_sensitive_value(value: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.contains("-----BEGIN ") || trimmed.contains(" PRIVATE KEY-----") {
+        return true;
+    }
+    contains_sensitive_auth_scheme(trimmed)
+        || is_sensitive_token(trimmed)
+        || contains_sensitive_token(trimmed)
+        || contains_sensitive_key_value_pair(trimmed)
+}
+
+/// Returns whether either side of a decoded name/value pair is sensitive.
+pub(in crate::search) fn is_sensitive_pair(key: &str, value: &str) -> bool {
+    is_sensitive_name(key) || is_sensitive_value(value)
+}
+
+/// Removes recognized secret-bearing fields while preserving safe JSON siblings.
+pub(in crate::search) fn sanitize_json_value(value: &mut Value) -> JsonSanitization {
+    match value {
+        Value::Object(fields) => {
+            let mut changed = false;
+            fields.retain(|name, value| {
+                if is_sensitive_name(name) {
+                    changed = true;
+                    return false;
+                }
+                match sanitize_json_value(value) {
+                    JsonSanitization::Unchanged => true,
+                    JsonSanitization::Changed => {
+                        changed = true;
+                        true
+                    }
+                    JsonSanitization::Drop => {
+                        changed = true;
+                        false
+                    }
+                }
+            });
+            if !changed {
+                JsonSanitization::Unchanged
+            } else if fields.values().any(has_display_content) {
+                JsonSanitization::Changed
+            } else {
+                JsonSanitization::Drop
+            }
+        }
+        Value::Array(values) => {
+            let mut changed = false;
+            values.retain_mut(|value| match sanitize_json_value(value) {
+                JsonSanitization::Unchanged => true,
+                JsonSanitization::Changed => {
+                    changed = true;
+                    true
+                }
+                JsonSanitization::Drop => {
+                    changed = true;
+                    false
+                }
+            });
+            if !changed {
+                JsonSanitization::Unchanged
+            } else if values.iter().any(has_display_content) {
+                JsonSanitization::Changed
+            } else {
+                JsonSanitization::Drop
+            }
+        }
+        Value::String(value) if is_sensitive_value(value) => JsonSanitization::Drop,
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+            JsonSanitization::Unchanged
+        }
+    }
+}
+
+fn has_display_content(value: &Value) -> bool {
+    match value {
+        Value::Null => false,
+        Value::String(value) => !value.trim().is_empty(),
+        Value::Array(values) => values.iter().any(has_display_content),
+        Value::Object(fields) => fields.values().any(has_display_content),
+        Value::Bool(_) | Value::Number(_) => true,
+    }
+}
+
+fn is_sensitive_token(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    if (lower.starts_with("sk-") && value.len() >= 20)
+        || lower.starts_with("ghp_")
+        || lower.starts_with("github_pat_")
+        || lower.starts_with("xoxb-")
+        || lower.starts_with("xoxp-")
+        || lower.starts_with("xoxa-")
+        || lower.starts_with("ya29.")
+    {
+        return true;
+    }
+    looks_like_jwt(value)
+}
+
+fn contains_sensitive_token(value: &str) -> bool {
+    value
+        .split(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')))
+        .any(is_sensitive_token)
+}
+
+fn contains_sensitive_auth_scheme(value: &str) -> bool {
+    let mut words = value.split_whitespace();
+    let Some(mut previous) = words.next() else {
+        return false;
+    };
+    for current in words {
+        if is_sensitive_auth_scheme(previous) && current.len() >= 8 && is_auth_credential(current) {
+            return true;
+        }
+        previous = current;
+    }
+    false
+}
+
+fn is_sensitive_auth_scheme(value: &str) -> bool {
+    let scheme = value.trim_matches(|character: char| {
+        character.is_ascii_punctuation() && !matches!(character, '-' | '_')
+    });
+    SENSITIVE_AUTH_SCHEMES
+        .iter()
+        .any(|candidate| scheme.eq_ignore_ascii_case(candidate))
+}
+
+fn is_auth_credential(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().all(|character| {
+            character.is_ascii_alphanumeric()
+                || matches!(character, '-' | '_' | '.' | '~' | '+' | '/' | '=')
+        })
+}
+
+fn contains_sensitive_key_value_pair(value: &str) -> bool {
+    value
+        .char_indices()
+        .filter(|(_, character)| matches!(character, '=' | ':'))
+        .filter_map(|(separator_index, _)| sensitive_key_before(value, separator_index))
+        .any(is_sensitive_name)
+}
+
+fn sensitive_key_before(value: &str, separator_index: usize) -> Option<&str> {
+    let prefix = value
+        .get(..separator_index)?
+        .trim_end_matches(|character: char| {
+            character.is_whitespace() || matches!(character, '"' | '\'')
+        });
+    let key_start = prefix
+        .char_indices()
+        .rev()
+        .find(|(_, character)| !is_sensitive_key_character(*character))
+        .map_or(0, |(index, character)| index + character.len_utf8());
+    prefix.get(key_start..).filter(|key| !key.is_empty())
+}
+
+fn is_sensitive_key_character(character: char) -> bool {
+    character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
+}
+
+fn looks_like_jwt(value: &str) -> bool {
+    let mut parts = value.split('.');
+    let Some(header) = parts.next() else {
+        return false;
+    };
+    let Some(payload) = parts.next() else {
+        return false;
+    };
+    let Some(signature) = parts.next() else {
+        return false;
+    };
+    if parts.next().is_some() {
+        return false;
+    }
+    [header, payload, signature].iter().all(|part| {
+        part.len() >= 8
+            && part
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{JsonSanitization, is_sensitive_name, is_sensitive_value, sanitize_json_value};
+
+    #[test]
+    fn shared_policy_recognizes_names_embedded_tokens_and_nested_secrets() {
+        assert!(is_sensitive_name("api_key"));
+        assert!(is_sensitive_value(
+            "prefix sk-123456789012345678901234 suffix"
+        ));
+        assert!(is_sensitive_value("Bearer coral-secret-123456"));
+        assert!(is_sensitive_value(
+            "prefix bearer coral-secret-123456 suffix"
+        ));
+        assert!(is_sensitive_value("Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="));
+        assert!(!is_sensitive_value("bearer of bad news"));
+
+        let mut value = json!({
+            "name": "Ada",
+            "nested": { "refresh_token": "hidden", "project": "coral" }
+        });
+        assert_eq!(sanitize_json_value(&mut value), JsonSanitization::Changed);
+        assert_eq!(
+            value,
+            json!({ "name": "Ada", "nested": { "project": "coral" } })
+        );
+    }
+}

--- a/crates/coral-app/src/search/mod.rs
+++ b/crates/coral-app/src/search/mod.rs
@@ -1,10 +1,12 @@
 //! App-owned Universal Search orchestration.
 
 pub(crate) mod catalog;
+mod content_safety;
 pub(crate) mod engine;
 pub(crate) mod fusion;
 pub(crate) mod maintenance;
 pub(crate) mod manager;
+pub(crate) mod native;
 pub(crate) mod observed;
 pub(crate) mod provider;
 pub(crate) mod result;

--- a/crates/coral-app/src/search/native/dedupe.rs
+++ b/crates/coral-app/src/search/native/dedupe.rs
@@ -1,0 +1,136 @@
+//! Stable, route-scoped native candidate deduplication.
+
+use std::collections::HashMap;
+
+use crate::search::result::{NativeSearchAttribute, NativeSearchResult};
+
+use super::identity::NativeIdentity;
+use super::{
+    MAX_ATTRIBUTES, MAX_REQUEST_BYTES, MAX_RESULT_BYTES, MAX_RESULTS_PER_REQUEST, NativeCandidate,
+    result_payload_bytes,
+};
+
+pub(super) fn deduplicate(mut candidates: Vec<NativeCandidate>) -> Vec<NativeCandidate> {
+    candidates.sort_by_key(|candidate| (candidate.result.row_ordinal, candidate.identity));
+
+    let mut retained = Vec::<NativeCandidate>::with_capacity(candidates.len());
+    let mut identities = HashMap::<NativeIdentity, usize>::new();
+    for candidate in candidates {
+        let Some(identity) = candidate.identity else {
+            retained.push(candidate);
+            continue;
+        };
+        if let Some(index) = identities.get(&identity).copied() {
+            if let Some(existing) = retained.get_mut(index)
+                && candidate.result.row_ordinal > existing.result.row_ordinal
+            {
+                fill_missing_display(existing, candidate);
+            }
+        } else {
+            identities.insert(identity, retained.len());
+            retained.push(candidate);
+        }
+    }
+    retained.sort_by_key(|candidate| (candidate.result.row_ordinal, candidate.identity));
+    retained
+}
+
+pub(super) fn cap_request(candidates: Vec<NativeCandidate>) -> Vec<NativeCandidate> {
+    let mut retained = Vec::with_capacity(candidates.len().min(MAX_RESULTS_PER_REQUEST));
+    // Account for the enclosing public `results` array even when it is empty.
+    let mut payload_bytes = 2_usize;
+    for candidate in candidates {
+        if retained.len() == MAX_RESULTS_PER_REQUEST {
+            break;
+        }
+        let candidate_bytes = result_payload_bytes(&candidate.result);
+        let separator_bytes = usize::from(!retained.is_empty());
+        let next_payload_bytes = payload_bytes
+            .saturating_add(separator_bytes)
+            .saturating_add(candidate_bytes);
+        if next_payload_bytes > MAX_REQUEST_BYTES {
+            break;
+        }
+        payload_bytes = next_payload_bytes;
+        retained.push(candidate);
+    }
+    retained
+}
+
+fn fill_missing_display(existing: &mut NativeCandidate, later: NativeCandidate) {
+    let later_content_truncated = later.result.content_truncated;
+    let later_omitted_attribute_count = later.result.omitted_attribute_count;
+    let mut filled_from_later = false;
+    filled_from_later |=
+        fill_optional_field(&mut existing.result, later.result.entity_type, |result| {
+            &mut result.entity_type
+        });
+    filled_from_later |=
+        fill_optional_field(&mut existing.result, later.result.provider_id, |result| {
+            &mut result.provider_id
+        });
+    filled_from_later |= fill_optional_field(&mut existing.result, later.result.title, |result| {
+        &mut result.title
+    });
+    filled_from_later |= fill_optional_field(&mut existing.result, later.result.url, |result| {
+        &mut result.url
+    });
+    filled_from_later |=
+        fill_optional_field(&mut existing.result, later.result.snippet, |result| {
+            &mut result.snippet
+        });
+    for attribute in later.result.attributes {
+        if existing
+            .result
+            .attributes
+            .iter()
+            .any(|retained| retained.name == attribute.name)
+        {
+            continue;
+        }
+        if existing.result.attributes.len() == MAX_ATTRIBUTES
+            || !attribute_fits(&existing.result, &attribute)
+        {
+            existing.result.omitted_attribute_count =
+                existing.result.omitted_attribute_count.saturating_add(1);
+            existing.result.content_truncated = true;
+            continue;
+        }
+        existing.result.attributes.push(attribute);
+        filled_from_later = true;
+    }
+    if filled_from_later {
+        existing.result.content_truncated |= later_content_truncated;
+        existing.result.omitted_attribute_count = existing
+            .result
+            .omitted_attribute_count
+            .saturating_add(later_omitted_attribute_count);
+    }
+}
+
+fn fill_optional_field(
+    result: &mut NativeSearchResult,
+    value: Option<String>,
+    field: impl Fn(&mut NativeSearchResult) -> &mut Option<String>,
+) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    if field(result).is_some() {
+        return false;
+    }
+    *field(result) = Some(value);
+    if result_payload_bytes(result) > MAX_RESULT_BYTES {
+        *field(result) = None;
+        result.content_truncated = true;
+        false
+    } else {
+        true
+    }
+}
+
+fn attribute_fits(result: &NativeSearchResult, attribute: &NativeSearchAttribute) -> bool {
+    let mut trial = result.clone();
+    trial.attributes.push(attribute.clone());
+    result_payload_bytes(&trial) <= MAX_RESULT_BYTES
+}

--- a/crates/coral-app/src/search/native/identity.rs
+++ b/crates/coral-app/src/search/native/identity.rs
@@ -12,7 +12,7 @@ use coral_spec::ManifestDataType;
 use sha2::{Digest as _, Sha256};
 
 use crate::sources::universal_search::{
-    ResolvedUniversalSearchResultField, ResolvedUniversalSearchRoute, ResolvedUniversalSearchTarget,
+    ResolvedUniversalSearchResultField, ResolvedUniversalSearchRoute,
 };
 use crate::workspaces::WorkspaceName;
 
@@ -21,7 +21,6 @@ const TAG_WORKSPACE: u8 = 0x02;
 const TAG_SOURCE_NAME: u8 = 0x03;
 const TAG_INSTALLATION_REVISION: u8 = 0x04;
 const TAG_AUTHORED_ROUTE: u8 = 0x05;
-const TAG_INFERRED_V3_ROUTE: u8 = 0x06;
 const TAG_INFERRED_V4_OPERATION: u8 = 0x08;
 const TAG_ENTITY_TYPE: u8 = 0x09;
 const TAG_ABSENT: u8 = 0x0a;
@@ -104,18 +103,11 @@ fn identity_prefix(
     )?;
     match route.authored_route_id.as_deref() {
         Some(route_id) => append_component(&mut hasher, TAG_AUTHORED_ROUTE, route_id.as_bytes())?,
-        None => match &route.target {
-            ResolvedUniversalSearchTarget::V3 { function_name } => {
-                append_component(&mut hasher, TAG_INFERRED_V3_ROUTE, function_name.as_bytes())?;
-            }
-            ResolvedUniversalSearchTarget::V4 { operation_id } => {
-                append_component(
-                    &mut hasher,
-                    TAG_INFERRED_V4_OPERATION,
-                    operation_id.as_bytes(),
-                )?;
-            }
-        },
+        None => append_component(
+            &mut hasher,
+            TAG_INFERRED_V4_OPERATION,
+            route.target.operation_id.as_bytes(),
+        )?,
     }
     match route.result.entity_type.as_deref() {
         Some(entity_type) => {

--- a/crates/coral-app/src/search/native/identity.rs
+++ b/crates/coral-app/src/search/native/identity.rs
@@ -1,0 +1,487 @@
+//! Canonical internal identity for native provider rows.
+
+use arrow::array::{
+    Array, BooleanArray, Decimal128Array, Decimal256Array, Int8Array, Int16Array, Int32Array,
+    Int64Array, LargeStringArray, StringArray, StringViewArray, TimestampMicrosecondArray,
+    TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt8Array,
+    UInt16Array, UInt32Array, UInt64Array,
+};
+use arrow::datatypes::{DataType, TimeUnit};
+use arrow::record_batch::RecordBatch;
+use coral_spec::ManifestDataType;
+use sha2::{Digest as _, Sha256};
+
+use crate::sources::universal_search::{
+    ResolvedUniversalSearchResultField, ResolvedUniversalSearchRoute, ResolvedUniversalSearchTarget,
+};
+use crate::workspaces::WorkspaceName;
+
+const TAG_VERSION: u8 = 0x01;
+const TAG_WORKSPACE: u8 = 0x02;
+const TAG_SOURCE_NAME: u8 = 0x03;
+const TAG_INSTALLATION_REVISION: u8 = 0x04;
+const TAG_AUTHORED_ROUTE: u8 = 0x05;
+const TAG_INFERRED_V3_ROUTE: u8 = 0x06;
+const TAG_INFERRED_V4_OPERATION: u8 = 0x08;
+const TAG_ENTITY_TYPE: u8 = 0x09;
+const TAG_ABSENT: u8 = 0x0a;
+const TAG_IDENTITY_FIELDS: u8 = 0x0b;
+const TAG_PROVIDER_ID: u8 = 0x0c;
+const TAG_URL: u8 = 0x0d;
+
+const TAG_TEXT: u8 = 0x20;
+const TAG_BOOL: u8 = 0x21;
+const TAG_I8: u8 = 0x22;
+const TAG_I16: u8 = 0x23;
+const TAG_I32: u8 = 0x24;
+const TAG_I64: u8 = 0x25;
+const TAG_U8: u8 = 0x26;
+const TAG_U16: u8 = 0x27;
+const TAG_U32: u8 = 0x28;
+const TAG_U64: u8 = 0x29;
+const TAG_DECIMAL128: u8 = 0x2a;
+const TAG_DECIMAL256: u8 = 0x2b;
+const TAG_TIMESTAMP: u8 = 0x2c;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(in crate::search) struct NativeIdentity([u8; 32]);
+
+impl NativeIdentity {
+    pub(in crate::search) fn as_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+pub(super) fn identity_for_row(
+    workspace: &WorkspaceName,
+    route: &ResolvedUniversalSearchRoute,
+    batch: &RecordBatch,
+    row: usize,
+    provider_id: Option<&str>,
+    url: Option<&str>,
+) -> Option<NativeIdentity> {
+    let prefix = identity_prefix(workspace, route)?;
+    if !route.result.identity_fields.is_empty() {
+        let mut hasher = prefix.clone();
+        append_component(&mut hasher, TAG_IDENTITY_FIELDS, &[])?;
+        let valid =
+            route.result.identity_fields.iter().all(|field| {
+                append_identity_field(&mut hasher, batch, row, field).unwrap_or(false)
+            });
+        if valid {
+            return Some(finish(hasher));
+        }
+    }
+    if let Some(provider_id) = provider_id {
+        let mut hasher = prefix.clone();
+        append_component(&mut hasher, TAG_PROVIDER_ID, provider_id.as_bytes())?;
+        return Some(finish(hasher));
+    }
+    if let Some(url) = url {
+        let mut hasher = prefix;
+        append_component(&mut hasher, TAG_URL, url.as_bytes())?;
+        return Some(finish(hasher));
+    }
+    None
+}
+
+fn identity_prefix(
+    workspace: &WorkspaceName,
+    route: &ResolvedUniversalSearchRoute,
+) -> Option<Sha256> {
+    let mut hasher = Sha256::new();
+    append_component(&mut hasher, TAG_VERSION, b"native/v1")?;
+    append_component(&mut hasher, TAG_WORKSPACE, workspace.as_str().as_bytes())?;
+    append_component(
+        &mut hasher,
+        TAG_SOURCE_NAME,
+        route.owner_source_name.as_bytes(),
+    )?;
+    append_component(
+        &mut hasher,
+        TAG_INSTALLATION_REVISION,
+        route.installation_revision.as_bytes(),
+    )?;
+    match route.authored_route_id.as_deref() {
+        Some(route_id) => append_component(&mut hasher, TAG_AUTHORED_ROUTE, route_id.as_bytes())?,
+        None => match &route.target {
+            ResolvedUniversalSearchTarget::V3 { function_name } => {
+                append_component(&mut hasher, TAG_INFERRED_V3_ROUTE, function_name.as_bytes())?;
+            }
+            ResolvedUniversalSearchTarget::V4 { operation_id } => {
+                append_component(
+                    &mut hasher,
+                    TAG_INFERRED_V4_OPERATION,
+                    operation_id.as_bytes(),
+                )?;
+            }
+        },
+    }
+    match route.result.entity_type.as_deref() {
+        Some(entity_type) => {
+            append_component(&mut hasher, TAG_ENTITY_TYPE, entity_type.as_bytes())?;
+        }
+        None => append_component(&mut hasher, TAG_ABSENT, &[])?,
+    }
+    Some(hasher)
+}
+
+fn append_identity_field(
+    hasher: &mut Sha256,
+    batch: &RecordBatch,
+    row: usize,
+    field: &ResolvedUniversalSearchResultField,
+) -> Option<bool> {
+    let column = unique_column(batch, &field.column_name)?;
+    if !manifest_type_matches(column.data_type(), field.data_type) {
+        return Some(false);
+    }
+    Some(append_array_value(hasher, column.as_ref(), row))
+}
+
+fn unique_column<'a>(batch: &'a RecordBatch, name: &str) -> Option<&'a arrow::array::ArrayRef> {
+    let schema = batch.schema();
+    let mut matches = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| field.name() == name)
+        .map(|(index, _)| index);
+    let index = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+    batch.columns().get(index)
+}
+
+fn manifest_type_matches(data_type: &DataType, expected: ManifestDataType) -> bool {
+    match expected {
+        ManifestDataType::Utf8 => matches!(
+            data_type,
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
+        ),
+        ManifestDataType::Int64 => matches!(data_type, DataType::Int64),
+        ManifestDataType::Boolean => matches!(data_type, DataType::Boolean),
+        ManifestDataType::Timestamp => matches!(data_type, DataType::Timestamp(_, _)),
+        ManifestDataType::Float64 | ManifestDataType::Json => false,
+    }
+}
+
+macro_rules! append_primitive {
+    ($hasher:expr, $array:expr, $row:expr, $array_type:ty, $tag:expr) => {{
+        $array
+            .as_any()
+            .downcast_ref::<$array_type>()
+            .and_then(|array| append_component($hasher, $tag, &array.value($row).to_be_bytes()))
+            .is_some()
+    }};
+}
+
+fn append_array_value(hasher: &mut Sha256, array: &dyn Array, row: usize) -> bool {
+    if row >= array.len() || array.is_null(row) {
+        return false;
+    }
+    match array.data_type() {
+        DataType::Utf8 => append_downcast_value::<StringArray>(hasher, array, row, TAG_TEXT),
+        DataType::LargeUtf8 => {
+            append_downcast_value::<LargeStringArray>(hasher, array, row, TAG_TEXT)
+        }
+        DataType::Utf8View => {
+            append_downcast_value::<StringViewArray>(hasher, array, row, TAG_TEXT)
+        }
+        DataType::Boolean => array
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .and_then(|array| append_component(hasher, TAG_BOOL, &[u8::from(array.value(row))]))
+            .is_some(),
+        DataType::Int8 => append_primitive!(hasher, array, row, Int8Array, TAG_I8),
+        DataType::Int16 => append_primitive!(hasher, array, row, Int16Array, TAG_I16),
+        DataType::Int32 => append_primitive!(hasher, array, row, Int32Array, TAG_I32),
+        DataType::Int64 => append_primitive!(hasher, array, row, Int64Array, TAG_I64),
+        DataType::UInt8 => append_primitive!(hasher, array, row, UInt8Array, TAG_U8),
+        DataType::UInt16 => append_primitive!(hasher, array, row, UInt16Array, TAG_U16),
+        DataType::UInt32 => append_primitive!(hasher, array, row, UInt32Array, TAG_U32),
+        DataType::UInt64 => append_primitive!(hasher, array, row, UInt64Array, TAG_U64),
+        DataType::Decimal128(_, scale) => array
+            .as_any()
+            .downcast_ref::<Decimal128Array>()
+            .and_then(|array| {
+                let mut payload = Vec::with_capacity(17);
+                payload.push((*scale).cast_unsigned());
+                payload.extend_from_slice(&array.value(row).to_be_bytes());
+                append_component(hasher, TAG_DECIMAL128, &payload)
+            })
+            .is_some(),
+        DataType::Decimal256(_, scale) => array
+            .as_any()
+            .downcast_ref::<Decimal256Array>()
+            .and_then(|array| {
+                let mut payload = Vec::with_capacity(33);
+                payload.push((*scale).cast_unsigned());
+                payload.extend_from_slice(&array.value(row).to_be_bytes());
+                append_component(hasher, TAG_DECIMAL256, &payload)
+            })
+            .is_some(),
+        DataType::Timestamp(unit, timezone) => {
+            append_timestamp(hasher, array, row, *unit, timezone.as_deref())
+        }
+        _ => false,
+    }
+}
+
+fn append_downcast_value<T>(hasher: &mut Sha256, array: &dyn Array, row: usize, tag: u8) -> bool
+where
+    T: Array + StringValue + 'static,
+{
+    array
+        .as_any()
+        .downcast_ref::<T>()
+        .and_then(|array| append_component(hasher, tag, array.string_value(row).as_bytes()))
+        .is_some()
+}
+
+trait StringValue {
+    fn string_value(&self, row: usize) -> &str;
+}
+
+impl StringValue for StringArray {
+    fn string_value(&self, row: usize) -> &str {
+        self.value(row)
+    }
+}
+
+impl StringValue for LargeStringArray {
+    fn string_value(&self, row: usize) -> &str {
+        self.value(row)
+    }
+}
+
+impl StringValue for StringViewArray {
+    fn string_value(&self, row: usize) -> &str {
+        self.value(row)
+    }
+}
+
+fn append_timestamp(
+    hasher: &mut Sha256,
+    array: &dyn Array,
+    row: usize,
+    unit: TimeUnit,
+    timezone: Option<&str>,
+) -> bool {
+    let raw = match unit {
+        TimeUnit::Second => timestamp_value::<TimestampSecondArray>(array, row),
+        TimeUnit::Millisecond => timestamp_value::<TimestampMillisecondArray>(array, row),
+        TimeUnit::Microsecond => timestamp_value::<TimestampMicrosecondArray>(array, row),
+        TimeUnit::Nanosecond => timestamp_value::<TimestampNanosecondArray>(array, row),
+    };
+    let Some(raw) = raw else {
+        return false;
+    };
+    let multiplier = match unit {
+        TimeUnit::Second => 1_000_000_000_i128,
+        TimeUnit::Millisecond => 1_000_000_i128,
+        TimeUnit::Microsecond => 1_000_i128,
+        TimeUnit::Nanosecond => 1_i128,
+    };
+    let mut payload = Vec::with_capacity(25 + timezone.map_or(0, str::len));
+    payload.extend_from_slice(&(i128::from(raw) * multiplier).to_be_bytes());
+    match timezone {
+        Some(timezone) => {
+            payload.push(1);
+            let Ok(length) = u64::try_from(timezone.len()) else {
+                return false;
+            };
+            payload.extend_from_slice(&length.to_be_bytes());
+            payload.extend_from_slice(timezone.as_bytes());
+        }
+        None => payload.push(0),
+    }
+    append_component(hasher, TAG_TIMESTAMP, &payload).is_some()
+}
+
+fn timestamp_value<T>(array: &dyn Array, row: usize) -> Option<i64>
+where
+    T: Array + TimestampValue + 'static,
+{
+    array
+        .as_any()
+        .downcast_ref::<T>()
+        .map(|array| array.timestamp_value(row))
+}
+
+trait TimestampValue {
+    fn timestamp_value(&self, row: usize) -> i64;
+}
+
+macro_rules! impl_timestamp_value {
+    ($($array_type:ty),+ $(,)?) => {
+        $(
+            impl TimestampValue for $array_type {
+                fn timestamp_value(&self, row: usize) -> i64 {
+                    self.value(row)
+                }
+            }
+        )+
+    };
+}
+
+impl_timestamp_value!(
+    TimestampSecondArray,
+    TimestampMillisecondArray,
+    TimestampMicrosecondArray,
+    TimestampNanosecondArray,
+);
+
+fn append_component(hasher: &mut Sha256, tag: u8, value: &[u8]) -> Option<()> {
+    let length = u64::try_from(value.len()).ok()?;
+    hasher.update([tag]);
+    hasher.update(length.to_be_bytes());
+    hasher.update(value);
+    Some(())
+}
+
+fn finish(hasher: Sha256) -> NativeIdentity {
+    NativeIdentity(hasher.finalize().into())
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::array::{
+        BinaryArray, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, ListArray,
+        StringArray, StringViewArray, TimestampMicrosecondArray, TimestampMillisecondArray,
+        TimestampNanosecondArray, TimestampSecondArray, UInt8Array, UInt16Array, UInt32Array,
+        UInt64Array,
+    };
+    use arrow::datatypes::{Int64Type, i256};
+    use sha2::{Digest as _, Sha256};
+
+    use super::{append_array_value, finish};
+
+    fn digest(array: &dyn arrow::array::Array) -> Option<[u8; 32]> {
+        let mut hasher = Sha256::new();
+        append_array_value(&mut hasher, array, 0).then(|| finish(hasher).as_bytes())
+    }
+
+    #[test]
+    fn logical_types_and_framed_text_do_not_collide() {
+        assert_ne!(
+            digest(&Int64Array::from(vec![1])),
+            digest(&UInt64Array::from(vec![1]))
+        );
+        assert_ne!(
+            digest(&Int64Array::from(vec![1])),
+            digest(&StringArray::from(vec!["1"]))
+        );
+
+        let mut left = Sha256::new();
+        assert!(append_array_value(
+            &mut left,
+            &StringArray::from(vec!["ab"]),
+            0
+        ));
+        assert!(append_array_value(
+            &mut left,
+            &StringArray::from(vec!["c"]),
+            0
+        ));
+        let mut right = Sha256::new();
+        assert!(append_array_value(
+            &mut right,
+            &StringArray::from(vec!["a"]),
+            0
+        ));
+        assert!(append_array_value(
+            &mut right,
+            &StringArray::from(vec!["bc"]),
+            0
+        ));
+        assert_ne!(finish(left), finish(right));
+
+        let integer_digests = [
+            digest(&Int8Array::from(vec![1])),
+            digest(&Int16Array::from(vec![1])),
+            digest(&Int32Array::from(vec![1])),
+            digest(&Int64Array::from(vec![1])),
+            digest(&UInt8Array::from(vec![1])),
+            digest(&UInt16Array::from(vec![1])),
+            digest(&UInt32Array::from(vec![1])),
+            digest(&UInt64Array::from(vec![1])),
+        ];
+        assert_eq!(
+            integer_digests
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            8
+        );
+    }
+
+    #[test]
+    fn strings_preserve_exact_unicode_without_storage_or_normalization_drift() {
+        assert_eq!(
+            digest(&StringArray::from(vec!["é"])),
+            digest(&StringViewArray::from(vec!["é"]))
+        );
+        assert_ne!(
+            digest(&StringArray::from(vec!["é"])),
+            digest(&StringArray::from(vec!["e\u{301}"]))
+        );
+        assert_eq!(
+            digest(&StringArray::from(vec!["é"])),
+            Some([
+                150, 45, 189, 33, 200, 91, 78, 134, 48, 205, 221, 235, 237, 48, 217, 191, 78, 201,
+                111, 37, 223, 75, 116, 157, 232, 254, 169, 141, 251, 177, 66, 243,
+            ])
+        );
+    }
+
+    #[test]
+    fn decimals_include_width_scale_sign_and_unscaled_value() {
+        let decimal128 = arrow::array::Decimal128Array::from(vec![12_345_i128])
+            .with_precision_and_scale(10, 2)
+            .expect("decimal128");
+        let other_scale = arrow::array::Decimal128Array::from(vec![12_345_i128])
+            .with_precision_and_scale(10, 3)
+            .expect("decimal128 scale");
+        let negative = arrow::array::Decimal128Array::from(vec![-12_345_i128])
+            .with_precision_and_scale(10, 2)
+            .expect("negative decimal128");
+        let decimal256 = arrow::array::Decimal256Array::from(vec![i256::from_i128(12_345)])
+            .with_precision_and_scale(40, 2)
+            .expect("decimal256");
+
+        assert_ne!(digest(&decimal128), digest(&other_scale));
+        assert_ne!(digest(&decimal128), digest(&negative));
+        assert_ne!(digest(&decimal128), digest(&decimal256));
+    }
+
+    #[test]
+    fn timestamps_normalize_units_but_preserve_explicit_timezone_metadata() {
+        let seconds = TimestampSecondArray::from(vec![2]).with_timezone("UTC");
+        let millis = TimestampMillisecondArray::from(vec![2_000]).with_timezone("UTC");
+        let micros = TimestampMicrosecondArray::from(vec![2_000_000]).with_timezone("UTC");
+        let nanos = TimestampNanosecondArray::from(vec![2_000_000_000]).with_timezone("UTC");
+        assert_eq!(digest(&seconds), digest(&millis));
+        assert_eq!(digest(&seconds), digest(&micros));
+        assert_eq!(digest(&seconds), digest(&nanos));
+        assert_ne!(
+            digest(&seconds),
+            digest(&TimestampSecondArray::from(vec![2]).with_timezone("+00:00"))
+        );
+        assert_ne!(
+            digest(&seconds),
+            digest(&TimestampSecondArray::from(vec![2]))
+        );
+        assert!(digest(&TimestampSecondArray::from(vec![i64::MAX])).is_some());
+    }
+
+    #[test]
+    fn null_float_binary_and_nested_values_invalidate_identity() {
+        let nested = ListArray::from_iter_primitive::<Int64Type, _, _>([Some(vec![Some(1)])]);
+        assert_eq!(digest(&Int64Array::from(vec![None])), None);
+        assert_eq!(digest(&Float64Array::from(vec![1.0])), None);
+        assert_eq!(digest(&BinaryArray::from(vec![b"one".as_slice()])), None);
+        assert_eq!(digest(&nested), None);
+    }
+}

--- a/crates/coral-app/src/search/native/identity.rs
+++ b/crates/coral-app/src/search/native/identity.rs
@@ -91,11 +91,7 @@ fn identity_prefix(
     let mut hasher = Sha256::new();
     append_component(&mut hasher, TAG_VERSION, b"native/v1")?;
     append_component(&mut hasher, TAG_WORKSPACE, workspace.as_str().as_bytes())?;
-    append_component(
-        &mut hasher,
-        TAG_SOURCE_NAME,
-        route.owner_source_name.as_bytes(),
-    )?;
+    append_component(&mut hasher, TAG_SOURCE_NAME, route.source_name.as_bytes())?;
     append_component(
         &mut hasher,
         TAG_INSTALLATION_REVISION,

--- a/crates/coral-app/src/search/native/mod.rs
+++ b/crates/coral-app/src/search/native/mod.rs
@@ -1,0 +1,118 @@
+//! Pure native-row security, identity, deduplication, and rank-input boundary.
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the follow-up fanout provider wires these reviewed pure helpers into Search"
+    )
+)]
+
+mod dedupe;
+mod identity;
+mod normalize;
+mod rank;
+mod redaction;
+
+use serde::Serialize;
+
+use crate::search::result::{NativeSearchAttribute, NativeSearchResult};
+
+pub(super) const MAX_RESULTS_PER_FUNCTION: usize = 5;
+pub(super) const MAX_RESULTS_PER_REQUEST: usize = 20;
+pub(super) const MAX_RESULT_BYTES: usize = 8 * 1_024;
+pub(super) const MAX_REQUEST_BYTES: usize = 256 * 1_024;
+pub(super) const MAX_ATTRIBUTES: usize = 8;
+
+#[derive(Debug, Clone)]
+pub(super) struct NativeCandidate {
+    pub(super) result: NativeSearchResult,
+    pub(super) identity: Option<identity::NativeIdentity>,
+    pub(super) rank_input: rank::NativeRankInput,
+}
+
+/// Conservative accounting for one public native `SearchResult` JSON envelope.
+///
+/// Serializing the locked public shape counts JSON escaping, field names, and
+/// collection/object framing. Serialization failure returns the largest value
+/// so budget enforcement fails closed.
+pub(super) fn result_payload_bytes(result: &NativeSearchResult) -> usize {
+    serde_json::to_vec(&PublicSearchResultEnvelope::from(result))
+        .map_or(usize::MAX, |payload| payload.len())
+}
+
+#[derive(Serialize)]
+struct PublicSearchResultEnvelope<'a> {
+    provider: &'static str,
+    kind: &'static str,
+    native_result: PublicNativeSearchResult<'a>,
+}
+
+impl<'a> From<&'a NativeSearchResult> for PublicSearchResultEnvelope<'a> {
+    fn from(result: &'a NativeSearchResult) -> Self {
+        Self {
+            provider: "native_fanout",
+            kind: "native_result",
+            native_result: PublicNativeSearchResult::from(result),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct PublicNativeSearchResult<'a> {
+    schema_name: &'a str,
+    function_name: &'a str,
+    row_ordinal: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    entity_type: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    snippet: Option<&'a str>,
+    attributes: Vec<PublicNativeSearchAttribute<'a>>,
+    omitted_attribute_count: u32,
+    content_truncated: bool,
+}
+
+impl<'a> From<&'a NativeSearchResult> for PublicNativeSearchResult<'a> {
+    fn from(result: &'a NativeSearchResult) -> Self {
+        Self {
+            schema_name: &result.schema_name,
+            function_name: &result.function_name,
+            row_ordinal: result.row_ordinal,
+            entity_type: result.entity_type.as_deref(),
+            provider_id: result.provider_id.as_deref(),
+            title: result.title.as_deref(),
+            url: result.url.as_deref(),
+            snippet: result.snippet.as_deref(),
+            attributes: result
+                .attributes
+                .iter()
+                .map(PublicNativeSearchAttribute::from)
+                .collect(),
+            omitted_attribute_count: result.omitted_attribute_count,
+            content_truncated: result.content_truncated,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct PublicNativeSearchAttribute<'a> {
+    name: &'a str,
+    display_value: &'a str,
+}
+
+impl<'a> From<&'a NativeSearchAttribute> for PublicNativeSearchAttribute<'a> {
+    fn from(attribute: &'a NativeSearchAttribute) -> Self {
+        Self {
+            name: &attribute.name,
+            display_value: &attribute.display_value,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coral-app/src/search/native/normalize.rs
+++ b/crates/coral-app/src/search/native/normalize.rs
@@ -1,0 +1,372 @@
+//! Typed Arrow row normalization into the compact native result contract.
+
+use std::collections::HashSet;
+
+use arrow::array::{Array, LargeStringArray, StringArray, StringViewArray};
+use arrow::datatypes::DataType;
+use arrow::record_batch::RecordBatch;
+use arrow::util::display::array_value_to_string;
+use coral_spec::ManifestDataType;
+
+use crate::search::result::{NativeSearchAttribute, NativeSearchResult};
+use crate::sources::universal_search::{
+    ResolvedUniversalSearchResultField, ResolvedUniversalSearchRoute,
+};
+use crate::workspaces::WorkspaceName;
+
+use super::identity::identity_for_row;
+use super::rank::NativeRankInput;
+use super::redaction::{
+    ATTRIBUTE_VALUE_BYTES, OverflowPolicy, PROVIDER_ID_BYTES, SNIPPET_BYTES, Sanitized,
+    TITLE_BYTES, sanitize_attribute_name, sanitize_canonical_json, sanitize_text, sanitize_url,
+};
+use super::{
+    MAX_ATTRIBUTES, MAX_RESULT_BYTES, MAX_RESULTS_PER_FUNCTION, NativeCandidate,
+    result_payload_bytes,
+};
+
+const PROVIDER_ID_NAMES: &[&str] = &["id", "node_id", "global_id"];
+const TITLE_NAMES: &[&str] = &["title", "name"];
+const URL_NAMES: &[&str] = &["url", "html_url", "web_url"];
+const SNIPPET_NAMES: &[&str] = &["snippet", "summary", "description"];
+
+pub(super) fn normalize_batches(
+    workspace: &WorkspaceName,
+    route: &ResolvedUniversalSearchRoute,
+    batches: &[RecordBatch],
+) -> Vec<NativeCandidate> {
+    let mut candidates = Vec::new();
+    let mut row_ordinal = 0_usize;
+    for batch in batches {
+        for row in 0..batch.num_rows() {
+            if row_ordinal == MAX_RESULTS_PER_FUNCTION {
+                return candidates;
+            }
+            let ordinal = u32::try_from(row_ordinal).unwrap_or(u32::MAX);
+            if let Some(candidate) = normalize_row(workspace, route, batch, row, ordinal) {
+                candidates.push(candidate);
+            }
+            row_ordinal = row_ordinal.saturating_add(1);
+        }
+    }
+    candidates
+}
+
+fn normalize_row(
+    workspace: &WorkspaceName,
+    route: &ResolvedUniversalSearchRoute,
+    batch: &RecordBatch,
+    row: usize,
+    row_ordinal: u32,
+) -> Option<NativeCandidate> {
+    let mapped = route.result.authored_mapping;
+    let provider = mapped_value(
+        batch,
+        row,
+        mapped
+            .then_some(route.result.provider_id.as_ref())
+            .flatten(),
+        (!mapped).then_some(PROVIDER_ID_NAMES),
+    );
+    let title = mapped_value(
+        batch,
+        row,
+        mapped.then_some(route.result.title.as_ref()).flatten(),
+        (!mapped).then_some(TITLE_NAMES),
+    );
+    let url = mapped_value(
+        batch,
+        row,
+        mapped.then_some(route.result.url.as_ref()).flatten(),
+        (!mapped).then_some(URL_NAMES),
+    );
+    let snippet = mapped_value(
+        batch,
+        row,
+        mapped.then_some(route.result.snippet.as_ref()).flatten(),
+        (!mapped).then_some(SNIPPET_NAMES),
+    );
+
+    let (provider_id, provider_limited) =
+        sanitize_optional_text(provider.as_ref(), PROVIDER_ID_BYTES, OverflowPolicy::Omit);
+    let (title, title_limited) =
+        sanitize_optional_text(title.as_ref(), TITLE_BYTES, OverflowPolicy::Truncate);
+    let (url, url_limited) = sanitize_optional_url(url.as_ref());
+    let (snippet, snippet_limited) =
+        sanitize_optional_text(snippet.as_ref(), SNIPPET_BYTES, OverflowPolicy::Truncate);
+    let content_truncated = provider_limited || title_limited || url_limited || snippet_limited;
+
+    let identity = identity_for_row(
+        workspace,
+        route,
+        batch,
+        row,
+        provider_id.as_deref(),
+        url.as_deref(),
+    );
+    let entity_type = route.result.entity_type.as_deref().and_then(|value| {
+        match sanitize_text("entity_type", value, usize::MAX, OverflowPolicy::Omit) {
+            Sanitized::Safe(value) => Some(value),
+            Sanitized::SizeLimited(_) | Sanitized::Rejected => None,
+        }
+    });
+    let mut result = NativeSearchResult {
+        schema_name: route.locator.schema_name.clone(),
+        function_name: route.locator.function_name.clone(),
+        row_ordinal,
+        entity_type,
+        provider_id,
+        title,
+        url,
+        snippet,
+        attributes: Vec::new(),
+        omitted_attribute_count: 0,
+        content_truncated,
+    };
+
+    if mapped {
+        append_attributes(&mut result, batch, row, &route.result.attributes);
+    }
+    enforce_result_budget(&mut result)?;
+
+    has_row_display_content(&result).then_some(NativeCandidate {
+        result,
+        identity,
+        rank_input: NativeRankInput::from_provider_ordinal(row_ordinal),
+    })
+}
+
+fn mapped_value(
+    batch: &RecordBatch,
+    row: usize,
+    explicit: Option<&ResolvedUniversalSearchResultField>,
+    inference_names: Option<&[&str]>,
+) -> Option<MappedValue> {
+    if let Some(field) = explicit {
+        let column = unique_column(batch, &field.column_name)?;
+        if !display_type_matches(column.data_type(), field.data_type) {
+            return None;
+        }
+        return raw_scalar(column.as_ref(), row).map(|value| MappedValue {
+            field_name: field.column_name.clone(),
+            value,
+        });
+    }
+    inference_names?.iter().find_map(|name| {
+        let column = unique_column(batch, name)?;
+        raw_scalar(column.as_ref(), row).map(|value| MappedValue {
+            field_name: (*name).to_string(),
+            value,
+        })
+    })
+}
+
+fn append_attributes(
+    result: &mut NativeSearchResult,
+    batch: &RecordBatch,
+    row: usize,
+    fields: &[ResolvedUniversalSearchResultField],
+) {
+    let mut names = HashSet::new();
+    for field in fields {
+        let name = match sanitize_attribute_name(&field.column_name) {
+            Sanitized::Safe(name) => name,
+            Sanitized::SizeLimited(_) => {
+                omit_safe_attribute(result);
+                continue;
+            }
+            Sanitized::Rejected => continue,
+        };
+        let Some(column) = unique_column(batch, &field.column_name) else {
+            continue;
+        };
+        if !display_type_matches(column.data_type(), field.data_type) || column.is_null(row) {
+            continue;
+        }
+        let sanitized = if field.data_type == ManifestDataType::Json {
+            raw_string(column.as_ref(), row).map_or(Sanitized::Rejected, |value| {
+                sanitize_canonical_json(&field.column_name, value)
+            })
+        } else {
+            raw_scalar(column.as_ref(), row).map_or(Sanitized::Rejected, |value| {
+                sanitize_text(
+                    &field.column_name,
+                    &value,
+                    ATTRIBUTE_VALUE_BYTES,
+                    OverflowPolicy::Truncate,
+                )
+            })
+        };
+        let display_value = match sanitized {
+            Sanitized::Safe(value) => value,
+            Sanitized::SizeLimited(Some(value)) => {
+                result.content_truncated = true;
+                value
+            }
+            Sanitized::SizeLimited(None) => {
+                omit_safe_attribute(result);
+                continue;
+            }
+            Sanitized::Rejected => continue,
+        };
+        if !names.insert(name.clone()) || result.attributes.len() == MAX_ATTRIBUTES {
+            omit_safe_attribute(result);
+            continue;
+        }
+        let attribute = NativeSearchAttribute {
+            name,
+            display_value,
+        };
+        let mut trial = result.clone();
+        trial.attributes.push(attribute.clone());
+        if result_payload_bytes(&trial) > MAX_RESULT_BYTES {
+            omit_safe_attribute(result);
+        } else {
+            result.attributes.push(attribute);
+        }
+    }
+}
+
+fn enforce_result_budget(result: &mut NativeSearchResult) -> Option<()> {
+    if result_payload_bytes(result) <= MAX_RESULT_BYTES {
+        return Some(());
+    }
+    for field_index in 0..5 {
+        let removed = match field_index {
+            0 => result.entity_type.take(),
+            1 => result.snippet.take(),
+            2 => result.url.take(),
+            3 => result.title.take(),
+            4 => result.provider_id.take(),
+            _ => None,
+        };
+        if removed.is_some() {
+            result.content_truncated = true;
+        }
+        if result_payload_bytes(result) <= MAX_RESULT_BYTES {
+            return Some(());
+        }
+    }
+    None
+}
+
+fn has_row_display_content(result: &NativeSearchResult) -> bool {
+    result.provider_id.is_some()
+        || result.title.is_some()
+        || result.url.is_some()
+        || result.snippet.is_some()
+        || !result.attributes.is_empty()
+}
+
+fn sanitize_optional_text(
+    value: Option<&MappedValue>,
+    max_bytes: usize,
+    overflow: OverflowPolicy,
+) -> (Option<String>, bool) {
+    let Some(value) = value else {
+        return (None, false);
+    };
+    match sanitize_text(&value.field_name, &value.value, max_bytes, overflow) {
+        Sanitized::Safe(value) => (Some(value), false),
+        Sanitized::SizeLimited(value) => (value, true),
+        Sanitized::Rejected => (None, false),
+    }
+}
+
+fn sanitize_optional_url(value: Option<&MappedValue>) -> (Option<String>, bool) {
+    let Some(value) = value else {
+        return (None, false);
+    };
+    match sanitize_url(&value.field_name, &value.value) {
+        Sanitized::Safe(value) => (Some(value), false),
+        Sanitized::SizeLimited(value) => (value, true),
+        Sanitized::Rejected => (None, false),
+    }
+}
+
+fn omit_safe_attribute(result: &mut NativeSearchResult) {
+    result.omitted_attribute_count = result.omitted_attribute_count.saturating_add(1);
+    result.content_truncated = true;
+}
+
+fn unique_column<'a>(batch: &'a RecordBatch, name: &str) -> Option<&'a arrow::array::ArrayRef> {
+    let schema = batch.schema();
+    let mut matches = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| field.name() == name)
+        .map(|(index, _)| index);
+    let index = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+    batch.columns().get(index)
+}
+
+fn display_type_matches(data_type: &DataType, expected: ManifestDataType) -> bool {
+    match expected {
+        ManifestDataType::Utf8 | ManifestDataType::Json => matches!(
+            data_type,
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
+        ),
+        ManifestDataType::Int64 => matches!(data_type, DataType::Int64),
+        ManifestDataType::Boolean => matches!(data_type, DataType::Boolean),
+        ManifestDataType::Float64 => matches!(data_type, DataType::Float64),
+        ManifestDataType::Timestamp => matches!(data_type, DataType::Timestamp(_, _)),
+    }
+}
+
+fn raw_scalar(column: &dyn Array, row: usize) -> Option<String> {
+    if row >= column.len() || column.is_null(row) || is_unsupported_display_type(column.data_type())
+    {
+        return None;
+    }
+    raw_string(column, row)
+        .map(str::to_string)
+        .or_else(|| array_value_to_string(column, row).ok())
+}
+
+fn raw_string(column: &dyn Array, row: usize) -> Option<&str> {
+    match column.data_type() {
+        DataType::Utf8 => column
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .map(|array| array.value(row)),
+        DataType::LargeUtf8 => column
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .map(|array| array.value(row)),
+        DataType::Utf8View => column
+            .as_any()
+            .downcast_ref::<StringViewArray>()
+            .map(|array| array.value(row)),
+        _ => None,
+    }
+}
+
+fn is_unsupported_display_type(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Null
+            | DataType::Binary
+            | DataType::LargeBinary
+            | DataType::BinaryView
+            | DataType::FixedSizeBinary(_)
+            | DataType::List(_)
+            | DataType::ListView(_)
+            | DataType::LargeList(_)
+            | DataType::LargeListView(_)
+            | DataType::FixedSizeList(_, _)
+            | DataType::Struct(_)
+            | DataType::Map(_, _)
+            | DataType::Union(_, _)
+            | DataType::Dictionary(_, _)
+            | DataType::RunEndEncoded(_, _)
+    )
+}
+
+struct MappedValue {
+    field_name: String,
+    value: String,
+}

--- a/crates/coral-app/src/search/native/rank.rs
+++ b/crates/coral-app/src/search/native/rank.rs
@@ -1,0 +1,16 @@
+//! Provider-local rank input for native rows.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::search) struct NativeRankInput {
+    provider_ordinal: u32,
+}
+
+impl NativeRankInput {
+    pub(in crate::search) const fn from_provider_ordinal(provider_ordinal: u32) -> Self {
+        Self { provider_ordinal }
+    }
+
+    pub(in crate::search) const fn provider_ordinal(self) -> u32 {
+        self.provider_ordinal
+    }
+}

--- a/crates/coral-app/src/search/native/redaction.rs
+++ b/crates/coral-app/src/search/native/redaction.rs
@@ -1,0 +1,453 @@
+//! Sanitisation for provider-authored native search display content.
+
+use serde_json::{Map, Value};
+use url::Url;
+
+use crate::search::content_safety::{
+    JsonSanitization, is_sensitive_name, is_sensitive_pair, is_sensitive_value, sanitize_json_value,
+};
+
+pub(super) const PROVIDER_ID_BYTES: usize = 512;
+pub(super) const TITLE_BYTES: usize = 512;
+pub(super) const URL_BYTES: usize = 2_048;
+pub(super) const SNIPPET_BYTES: usize = 1_024;
+pub(super) const ATTRIBUTE_NAME_BYTES: usize = 128;
+pub(super) const ATTRIBUTE_VALUE_BYTES: usize = 1_024;
+
+const MAX_PERCENT_DECODE_PASSES: usize = 4;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Sanitized<T> {
+    Safe(T),
+    SizeLimited(Option<T>),
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum OverflowPolicy {
+    Omit,
+    Truncate,
+}
+
+pub(super) fn sanitize_text(
+    field_name: &str,
+    value: &str,
+    max_bytes: usize,
+    overflow: OverflowPolicy,
+) -> Sanitized<String> {
+    if is_sensitive_name(field_name) {
+        return Sanitized::Rejected;
+    }
+    let cleaned = clean_display_text(value);
+    if cleaned.trim().is_empty() || is_sensitive_value(&cleaned) {
+        return Sanitized::Rejected;
+    }
+    if cleaned.len() <= max_bytes {
+        return Sanitized::Safe(cleaned);
+    }
+    match overflow {
+        OverflowPolicy::Omit => Sanitized::SizeLimited(None),
+        OverflowPolicy::Truncate => {
+            Sanitized::SizeLimited(Some(truncate_utf8(&cleaned, max_bytes)))
+        }
+    }
+}
+
+pub(super) fn sanitize_attribute_name(field_name: &str) -> Sanitized<String> {
+    if is_sensitive_name(field_name) {
+        return Sanitized::Rejected;
+    }
+    let cleaned = clean_display_text(field_name);
+    if cleaned.trim().is_empty() || is_sensitive_name(&cleaned) {
+        return Sanitized::Rejected;
+    }
+    if cleaned.len() > ATTRIBUTE_NAME_BYTES {
+        Sanitized::SizeLimited(None)
+    } else {
+        Sanitized::Safe(cleaned)
+    }
+}
+
+pub(super) fn sanitize_url(field_name: &str, value: &str) -> Sanitized<String> {
+    if is_sensitive_name(field_name) {
+        return Sanitized::Rejected;
+    }
+    let cleaned = clean_display_text(value);
+    if cleaned.trim().is_empty() {
+        return Sanitized::Rejected;
+    }
+    let Ok(mut url) = Url::parse(&cleaned) else {
+        return Sanitized::Rejected;
+    };
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || !safe_decoded_path(&url)
+    {
+        return Sanitized::Rejected;
+    }
+
+    url.set_fragment(None);
+    let pairs = url.query_pairs().into_owned().collect::<Vec<_>>();
+    let retained = pairs
+        .into_iter()
+        .filter_map(|(name, value)| {
+            let decoded_name = fixed_point_percent_decode(&name)?;
+            let decoded_value = fixed_point_percent_decode(&value)?;
+            let cleaned_name = clean_display_text(&decoded_name);
+            let cleaned_value = clean_display_text(&decoded_value);
+            if (!name.is_empty() && cleaned_name.is_empty())
+                || (!value.is_empty() && cleaned_value.is_empty())
+                || is_sensitive_pair(&cleaned_name, &cleaned_value)
+            {
+                None
+            } else {
+                Some((cleaned_name, cleaned_value))
+            }
+        })
+        .collect::<Vec<_>>();
+    url.set_query(None);
+    if !retained.is_empty() {
+        url.query_pairs_mut().extend_pairs(
+            retained
+                .iter()
+                .map(|(name, value)| (name.as_str(), value.as_str())),
+        );
+    }
+
+    let sanitized = url.to_string();
+    if is_sensitive_value(&sanitized) {
+        Sanitized::Rejected
+    } else if sanitized.len() > URL_BYTES {
+        Sanitized::SizeLimited(None)
+    } else {
+        Sanitized::Safe(sanitized)
+    }
+}
+
+pub(super) fn sanitize_canonical_json(field_name: &str, value: &str) -> Sanitized<String> {
+    if is_sensitive_name(field_name) {
+        return Sanitized::Rejected;
+    }
+    let Ok(mut value) = serde_json::from_str::<Value>(value) else {
+        return Sanitized::Rejected;
+    };
+    if sanitize_json_value(&mut value) == JsonSanitization::Drop {
+        return Sanitized::Rejected;
+    }
+    if !clean_and_canonicalize_json(&mut value) {
+        return Sanitized::Rejected;
+    }
+    let Ok(serialized) = serde_json::to_string(&value) else {
+        return Sanitized::Rejected;
+    };
+    if serialized.trim().is_empty() || is_sensitive_value(&serialized) {
+        return Sanitized::Rejected;
+    }
+    if serialized.len() > ATTRIBUTE_VALUE_BYTES {
+        Sanitized::SizeLimited(None)
+    } else {
+        Sanitized::Safe(serialized)
+    }
+}
+
+pub(super) fn clean_display_text(value: &str) -> String {
+    let mut cleaned = String::with_capacity(value.len());
+    let mut characters = value.chars().peekable();
+    while let Some(character) = characters.next() {
+        match character {
+            '\u{1b}' => consume_escape_sequence(&mut characters),
+            '\u{9b}' => consume_control_sequence(&mut characters),
+            '\u{9d}' => consume_operating_system_command(&mut characters),
+            character if character.is_control() || is_bidi_control(character) => {}
+            character => cleaned.push(character),
+        }
+    }
+    cleaned
+}
+
+pub(super) fn truncate_utf8(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_string();
+    }
+    let mut boundary = max_bytes;
+    while boundary > 0 && !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    value.get(..boundary).unwrap_or_default().to_string()
+}
+
+fn consume_escape_sequence(characters: &mut std::iter::Peekable<std::str::Chars<'_>>) {
+    match characters.next() {
+        Some('[') => consume_control_sequence(characters),
+        Some(']') => consume_operating_system_command(characters),
+        Some(_) | None => {}
+    }
+}
+
+fn consume_control_sequence(characters: &mut std::iter::Peekable<std::str::Chars<'_>>) {
+    for character in characters.by_ref() {
+        if ('@'..='~').contains(&character) {
+            break;
+        }
+    }
+}
+
+fn consume_operating_system_command(characters: &mut std::iter::Peekable<std::str::Chars<'_>>) {
+    while let Some(character) = characters.next() {
+        if character == '\u{7}' {
+            break;
+        }
+        if character == '\u{1b}' && characters.next_if_eq(&'\\').is_some() {
+            break;
+        }
+    }
+}
+
+fn safe_decoded_path(url: &Url) -> bool {
+    let Some(decoded) = fixed_point_percent_decode(url.path()) else {
+        return false;
+    };
+    clean_display_text(&decoded) == decoded && !is_sensitive_value(&decoded)
+}
+
+fn fixed_point_percent_decode(value: &str) -> Option<String> {
+    let mut decoded = value.to_string();
+    for _ in 0..MAX_PERCENT_DECODE_PASSES {
+        let next = percent_decode_utf8_once(&decoded)?;
+        if next == decoded {
+            return Some(decoded);
+        }
+        decoded = next;
+    }
+
+    // Do not classify content while another valid encoded layer remains. This
+    // bounds adversarial work without permitting a deeper decoder to reveal a
+    // secret or control character after this safety boundary accepted it.
+    let next = percent_decode_utf8_once(&decoded)?;
+    (next == decoded).then_some(decoded)
+}
+
+fn percent_decode_utf8_once(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0_usize;
+    while index < bytes.len() {
+        if bytes.get(index) == Some(&b'%') {
+            let high = bytes
+                .get(index.saturating_add(1))
+                .copied()
+                .and_then(hex_value);
+            let low = bytes
+                .get(index.saturating_add(2))
+                .copied()
+                .and_then(hex_value);
+            if let (Some(high), Some(low)) = (high, low) {
+                decoded.push((high << 4) | low);
+                index = index.saturating_add(3);
+                continue;
+            }
+        }
+        decoded.push(*bytes.get(index)?);
+        index = index.saturating_add(1);
+    }
+    String::from_utf8(decoded).ok()
+}
+
+const fn hex_value(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn is_bidi_control(character: char) -> bool {
+    matches!(
+        character,
+        '\u{061c}'
+            | '\u{200e}'
+            | '\u{200f}'
+            | '\u{202a}'..='\u{202e}'
+            | '\u{2066}'..='\u{2069}'
+    )
+}
+
+fn clean_and_canonicalize_json(value: &mut Value) -> bool {
+    match value {
+        Value::Object(fields) => {
+            let mut entries = std::mem::take(fields).into_iter().collect::<Vec<_>>();
+            entries = entries
+                .into_iter()
+                .filter_map(|(name, mut value)| {
+                    let name = clean_display_text(&name);
+                    if name.trim().is_empty()
+                        || is_sensitive_name(&name)
+                        || !clean_and_canonicalize_json(&mut value)
+                    {
+                        None
+                    } else {
+                        Some((name, value))
+                    }
+                })
+                .collect();
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            let mut ordered = Map::new();
+            for (name, value) in entries {
+                if !ordered.contains_key(&name) {
+                    ordered.insert(name, value);
+                }
+            }
+            *fields = ordered;
+            !fields.is_empty()
+        }
+        Value::Array(values) => {
+            values.retain_mut(clean_and_canonicalize_json);
+            !values.is_empty()
+        }
+        Value::String(text) => {
+            *text = clean_display_text(text);
+            !text.trim().is_empty() && !is_sensitive_value(text)
+        }
+        Value::Null => false,
+        Value::Bool(_) | Value::Number(_) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        OverflowPolicy, Sanitized, clean_display_text, sanitize_canonical_json, sanitize_text,
+        sanitize_url, truncate_utf8,
+    };
+
+    #[test]
+    fn cleaning_removes_ansi_controls_and_bidi_controls() {
+        assert_eq!(
+            clean_display_text("a\0\u{1b}[31mred\u{1b}[0m\n\u{202e}b"),
+            "aredb"
+        );
+        assert_eq!(clean_display_text("x\u{1b}]0;title\u{7}y"), "xy");
+    }
+
+    #[test]
+    fn text_truncation_never_splits_utf8() {
+        assert_eq!(truncate_utf8("aéz", 2), "a");
+        assert_eq!(
+            sanitize_text("title", "aéz", 3, OverflowPolicy::Truncate),
+            Sanitized::SizeLimited(Some("aé".to_string()))
+        );
+    }
+
+    #[test]
+    fn strict_urls_drop_userinfo_fragments_and_every_sensitive_pair() {
+        assert_eq!(
+            sanitize_url(
+                "url",
+                "HTTPS://Example.TEST/path?token=one&safe=yes&api%5Fkey=two&token=three#secret"
+            ),
+            Sanitized::Safe("https://example.test/path?safe=yes".to_string())
+        );
+        assert_eq!(
+            sanitize_url("url", "https://user:pass@example.test/path"),
+            Sanitized::Rejected
+        );
+        assert_eq!(sanitize_url("url", "/relative"), Sanitized::Rejected);
+        assert_eq!(sanitize_url("url", "file:///tmp/a"), Sanitized::Rejected);
+    }
+
+    #[test]
+    fn canonical_json_sorts_keys_and_uses_the_shared_secret_policy() {
+        assert_eq!(
+            sanitize_canonical_json(
+                "metadata",
+                r#"{"z":2,"api_key":"hidden","a":{"y":2,"x":1}}"#
+            ),
+            Sanitized::Safe(r#"{"a":{"x":1,"y":2},"z":2}"#.to_string())
+        );
+    }
+
+    #[test]
+    fn canonical_json_cleans_nested_strings_keys_and_emptied_content() {
+        assert_eq!(
+            sanitize_canonical_json(
+                "metadata",
+                "{\"b\\u0000\":\"safe\\u202etext\",\"empty\":\"\\u0000\",\"nested\":[\"\\u001b[31mred\\u001b[0m\",null]}"
+            ),
+            Sanitized::Safe("{\"b\":\"safetext\",\"nested\":[\"red\"]}".to_string())
+        );
+        assert_eq!(
+            sanitize_canonical_json("metadata", "{\"only\":\"\\u0000\"}"),
+            Sanitized::Rejected
+        );
+    }
+
+    #[test]
+    fn urls_clean_decoded_query_controls_before_redaction_and_reencoding() {
+        assert_eq!(
+            sanitize_url(
+                "url",
+                "https://example.test/path?safe%00name=value%00x&to%E2%80%AEken=hidden&ansi=%1B%5B31mred%1B%5B0m"
+            ),
+            Sanitized::Safe("https://example.test/path?safename=valuex&ansi=red".to_string())
+        );
+    }
+
+    #[test]
+    fn urls_classify_double_encoded_query_names_values_and_controls() {
+        assert_eq!(
+            sanitize_url(
+                "url",
+                "https://example.test/path?to%256ben=hidden&safe=sk%252D12345678901234567890&na%2500me=va%2500lue&ok=yes"
+            ),
+            Sanitized::Safe("https://example.test/path?name=value&ok=yes".to_string())
+        );
+    }
+
+    #[test]
+    fn urls_drop_query_pairs_when_bounded_decoding_does_not_reach_a_fixed_point() {
+        assert_eq!(
+            sanitize_url(
+                "url",
+                "https://example.test/path?to%2525252525256ben=hidden&ok=yes"
+            ),
+            Sanitized::Safe("https://example.test/path?ok=yes".to_string())
+        );
+    }
+
+    #[test]
+    fn urls_reject_encoded_unsafe_or_secret_shaped_paths() {
+        for url in [
+            "https://example.test/a%00b",
+            "https://example.test/%1B%5B31mred%1B%5B0m",
+            "https://example.test/a%E2%80%AEb",
+            "https://example.test/sk%2D12345678901234567890",
+            "https://example.test/a%2500b",
+            "https://example.test/sk%252D12345678901234567890",
+            "https://example.test/to%2525252525256ben",
+        ] {
+            assert_eq!(sanitize_url("url", url), Sanitized::Rejected, "{url}");
+        }
+        assert_eq!(
+            sanitize_url("url", "https://example.test/caf%C3%A9"),
+            Sanitized::Safe("https://example.test/caf%C3%A9".to_string())
+        );
+    }
+
+    #[test]
+    fn url_limit_is_exact_and_empty_safe_query_values_are_preserved() {
+        let prefix = "https://example.test/";
+        let exact = format!("{prefix}{}", "a".repeat(super::URL_BYTES - prefix.len()));
+        assert_eq!(sanitize_url("url", &exact), Sanitized::Safe(exact.clone()));
+        assert_eq!(
+            sanitize_url("url", &format!("{exact}a")),
+            Sanitized::SizeLimited(None)
+        );
+        assert_eq!(
+            sanitize_url("url", "https://example.test/path?flag=&safe=yes"),
+            Sanitized::Safe("https://example.test/path?flag=&safe=yes".to_string())
+        );
+    }
+}

--- a/crates/coral-app/src/search/native/tests.rs
+++ b/crates/coral-app/src/search/native/tests.rs
@@ -40,8 +40,8 @@ fn route(mapping: ResolvedUniversalSearchResultMapping) -> ResolvedUniversalSear
         owner_source_name: "github".to_string(),
         installation_revision: Uuid::from_u128(1),
         authored_route_id: Some("issues".to_string()),
-        target: ResolvedUniversalSearchTarget::V3 {
-            function_name: "search_issues".to_string(),
+        target: ResolvedUniversalSearchTarget {
+            operation_id: "search_issues".to_string(),
         },
         locator: UniversalSearchFunctionLocator {
             schema_name: "github".to_string(),

--- a/crates/coral-app/src/search/native/tests.rs
+++ b/crates/coral-app/src/search/native/tests.rs
@@ -3,7 +3,7 @@
     reason = "focused native fixtures assert result shape immediately before indexed access"
 )]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, BinaryArray, Float64Array, Int64Array, StringArray};
@@ -37,7 +37,7 @@ fn resolved_field(name: &str, data_type: ManifestDataType) -> ResolvedUniversalS
 
 fn route(mapping: ResolvedUniversalSearchResultMapping) -> ResolvedUniversalSearchRoute {
     ResolvedUniversalSearchRoute {
-        owner_source_name: "github".to_string(),
+        source_name: "github".to_string(),
         installation_revision: Uuid::from_u128(1),
         authored_route_id: Some("issues".to_string()),
         target: ResolvedUniversalSearchTarget {
@@ -99,9 +99,12 @@ fn explicit_mapping_wins_and_attributes_are_never_inferred() {
         ("arbitrary", string_column(vec![Some("must not appear")])),
     ]);
 
-    let candidates = normalize_batches(&workspace(), &route(mapping), &[batch]);
+    let route = route(mapping);
+    let candidates = normalize_batches(&workspace(), &route, &[batch]);
     assert_eq!(candidates.len(), 1);
     let result = &candidates[0].result;
+    assert_eq!(result.schema_name, route.source_name);
+    assert_eq!(result.function_name, route.locator.function_name);
     assert_eq!(result.provider_id.as_deref(), Some("N1"));
     assert_eq!(result.title.as_deref(), Some("Mapped title"));
     assert_eq!(result.entity_type.as_deref(), Some("issue"));
@@ -459,6 +462,35 @@ fn identity_is_stable_across_display_changes_and_absent_for_title_only_rows() {
 }
 
 #[test]
+fn native_v1_full_route_and_row_identity_digest_is_stable() {
+    let mapping = ResolvedUniversalSearchResultMapping {
+        authored_mapping: true,
+        entity_type: Some("issue".to_string()),
+        identity_fields: vec![resolved_field("id", ManifestDataType::Int64)],
+        title: Some(resolved_field("title", ManifestDataType::Utf8)),
+        ..ResolvedUniversalSearchResultMapping::default()
+    };
+    let route = route(mapping);
+    let row = batch(vec![
+        ("id", Arc::new(Int64Array::from(vec![7])) as ArrayRef),
+        ("title", string_column(vec![Some("Pinned identity")])),
+    ]);
+
+    let candidates = normalize_batches(&workspace(), &route, &[row]);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(
+        candidates[0]
+            .identity
+            .expect("complete route and row produce an identity")
+            .as_bytes(),
+        [
+            230, 38, 248, 94, 37, 184, 69, 70, 3, 3, 160, 116, 224, 246, 162, 78, 193, 194, 11,
+            122, 139, 183, 202, 4, 85, 24, 7, 21, 48, 184, 152, 153,
+        ]
+    );
+}
+
+#[test]
 fn invalid_authored_identity_falls_back_to_safe_provider_id_then_url() {
     let mapping = ResolvedUniversalSearchResultMapping {
         authored_mapping: true,
@@ -542,9 +574,11 @@ fn dedupe_keeps_lowest_ordinal_fills_missing_fields_and_never_crosses_scope() {
     let mut other_route = route(mapping.clone());
     other_route.authored_route_id = Some("pull_requests".to_string());
     let mut other_source = route(mapping);
-    other_source.owner_source_name = "gitlab".to_string();
+    other_source.source_name = "github_mcp_v4".to_string();
+    other_source.locator.schema_name = "github_mcp_v4".to_string();
     let mut other_installation = primary_route.clone();
     other_installation.installation_revision = Uuid::from_u128(2);
+    let other_workspace = WorkspaceName::parse("secondary").expect("valid workspace");
     let candidates =
         normalize_batches(&workspace(), &primary_route, std::slice::from_ref(&one_row))
             .into_iter()
@@ -561,10 +595,25 @@ fn dedupe_keeps_lowest_ordinal_fills_missing_fields_and_never_crosses_scope() {
             .chain(normalize_batches(
                 &workspace(),
                 &other_installation,
+                std::slice::from_ref(&one_row),
+            ))
+            .chain(normalize_batches(
+                &other_workspace,
+                &primary_route,
                 &[one_row],
             ))
-            .collect();
-    assert_eq!(deduplicate(candidates).len(), 4);
+            .collect::<Vec<_>>();
+    assert!(
+        candidates
+            .iter()
+            .all(|candidate| candidate.identity.is_some())
+    );
+    let identities = candidates
+        .iter()
+        .filter_map(|candidate| candidate.identity)
+        .collect::<HashSet<_>>();
+    assert_eq!(identities.len(), candidates.len());
+    assert_eq!(deduplicate(candidates).len(), 5);
 }
 
 #[test]

--- a/crates/coral-app/src/search/native/tests.rs
+++ b/crates/coral-app/src/search/native/tests.rs
@@ -1,0 +1,653 @@
+#![expect(
+    clippy::indexing_slicing,
+    reason = "focused native fixtures assert result shape immediately before indexed access"
+)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, BinaryArray, Float64Array, Int64Array, StringArray};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use coral_spec::{DO_NOT_INDEX_COLUMN_METADATA_KEY, ManifestDataType, SearchLimitsSpec};
+use uuid::Uuid;
+
+use super::dedupe::{cap_request, deduplicate};
+use super::normalize::normalize_batches;
+use super::rank::NativeRankInput;
+use super::{
+    MAX_REQUEST_BYTES, MAX_RESULT_BYTES, MAX_RESULTS_PER_FUNCTION, MAX_RESULTS_PER_REQUEST,
+    NativeCandidate, PublicSearchResultEnvelope, result_payload_bytes,
+};
+use crate::search::result::{NativeSearchAttribute, NativeSearchResult};
+use crate::sources::runtime_package::RuntimeContractFingerprint;
+use crate::sources::universal_search::{
+    ResolvedUniversalSearchArgument, ResolvedUniversalSearchResultField,
+    ResolvedUniversalSearchResultMapping, ResolvedUniversalSearchRoute,
+    ResolvedUniversalSearchTarget, UniversalSearchFunctionLocator, UniversalSearchResolutionOrigin,
+};
+use crate::workspaces::WorkspaceName;
+
+fn resolved_field(name: &str, data_type: ManifestDataType) -> ResolvedUniversalSearchResultField {
+    ResolvedUniversalSearchResultField {
+        column_name: name.to_string(),
+        data_type,
+    }
+}
+
+fn route(mapping: ResolvedUniversalSearchResultMapping) -> ResolvedUniversalSearchRoute {
+    ResolvedUniversalSearchRoute {
+        owner_source_name: "github".to_string(),
+        installation_revision: Uuid::from_u128(1),
+        authored_route_id: Some("issues".to_string()),
+        target: ResolvedUniversalSearchTarget::V3 {
+            function_name: "search_issues".to_string(),
+        },
+        locator: UniversalSearchFunctionLocator {
+            schema_name: "github".to_string(),
+            function_name: "search_issues".to_string(),
+        },
+        query_argument: ResolvedUniversalSearchArgument {
+            name: "query".to_string(),
+            data_type: ManifestDataType::Utf8,
+        },
+        default_arguments: Vec::new(),
+        search_limits: SearchLimitsSpec {
+            default_top_k: 5,
+            max_top_k: 5,
+            max_calls_per_query: 1,
+        },
+        result: mapping,
+        origin: UniversalSearchResolutionOrigin::Explicit,
+        runtime_contract_fingerprint: RuntimeContractFingerprint::for_test("v1:test"),
+    }
+}
+
+fn string_column(values: Vec<Option<&str>>) -> ArrayRef {
+    Arc::new(StringArray::from(values))
+}
+
+fn batch(columns: Vec<(&str, ArrayRef)>) -> RecordBatch {
+    RecordBatch::try_from_iter(columns).expect("valid native test batch")
+}
+
+fn workspace() -> WorkspaceName {
+    WorkspaceName::default()
+}
+
+#[test]
+fn explicit_mapping_wins_and_attributes_are_never_inferred() {
+    let mapping = ResolvedUniversalSearchResultMapping {
+        authored_mapping: true,
+        entity_type: Some("issue".to_string()),
+        identity_fields: vec![resolved_field("node", ManifestDataType::Utf8)],
+        provider_id: Some(resolved_field("node", ManifestDataType::Utf8)),
+        title: Some(resolved_field("headline", ManifestDataType::Utf8)),
+        url: Some(resolved_field("link", ManifestDataType::Utf8)),
+        snippet: None,
+        attributes: vec![resolved_field("state", ManifestDataType::Utf8)],
+    };
+    let batch = batch(vec![
+        ("node", string_column(vec![Some("N1")])),
+        ("headline", string_column(vec![Some("Mapped title")])),
+        ("title", string_column(vec![Some("Inferred title")])),
+        (
+            "link",
+            string_column(vec![Some("https://example.test/issues/1")]),
+        ),
+        ("state", string_column(vec![Some("open")])),
+        ("arbitrary", string_column(vec![Some("must not appear")])),
+    ]);
+
+    let candidates = normalize_batches(&workspace(), &route(mapping), &[batch]);
+    assert_eq!(candidates.len(), 1);
+    let result = &candidates[0].result;
+    assert_eq!(result.provider_id.as_deref(), Some("N1"));
+    assert_eq!(result.title.as_deref(), Some("Mapped title"));
+    assert_eq!(result.entity_type.as_deref(), Some("issue"));
+    assert_eq!(
+        result.attributes,
+        vec![NativeSearchAttribute {
+            name: "state".to_string(),
+            display_value: "open".to_string(),
+        }]
+    );
+}
+
+#[test]
+fn conservative_inference_uses_only_locked_names_in_priority_order() {
+    let batch = batch(vec![
+        ("node_id", string_column(vec![Some("node-1")])),
+        ("global_id", string_column(vec![Some("global-1")])),
+        ("name", string_column(vec![Some("Ada")])),
+        (
+            "html_url",
+            string_column(vec![Some("https://example.test/ada")]),
+        ),
+        ("description", string_column(vec![Some("Researcher")])),
+        ("status", string_column(vec![Some("active")])),
+    ]);
+    let candidates = normalize_batches(
+        &workspace(),
+        &route(ResolvedUniversalSearchResultMapping::default()),
+        &[batch],
+    );
+    let result = &candidates[0].result;
+    assert_eq!(result.provider_id.as_deref(), Some("node-1"));
+    assert_eq!(result.title.as_deref(), Some("Ada"));
+    assert_eq!(result.url.as_deref(), Some("https://example.test/ada"));
+    assert_eq!(result.snippet.as_deref(), Some("Researcher"));
+    assert!(result.attributes.is_empty());
+}
+
+#[test]
+fn direct_display_does_not_overload_do_not_index_metadata() {
+    let field = Field::new("title", DataType::Utf8, false).with_metadata(HashMap::from([(
+        DO_NOT_INDEX_COLUMN_METADATA_KEY.to_string(),
+        "true".to_string(),
+    )]));
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![field])),
+        vec![string_column(vec![Some("Still displayable")])],
+    )
+    .expect("metadata batch");
+
+    let candidates = normalize_batches(
+        &workspace(),
+        &route(ResolvedUniversalSearchResultMapping::default()),
+        &[batch],
+    );
+    assert_eq!(
+        candidates[0].result.title.as_deref(),
+        Some("Still displayable")
+    );
+}
+
+#[test]
+fn source_authored_entity_type_uses_the_display_safety_boundary() {
+    let mapping = ResolvedUniversalSearchResultMapping {
+        entity_type: Some("sk-12345678901234567890".to_string()),
+        ..ResolvedUniversalSearchResultMapping::default()
+    };
+    let batch = batch(vec![("title", string_column(vec![Some("Safe title")]))]);
+    let candidates = normalize_batches(&workspace(), &route(mapping), &[batch]);
+
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].result.entity_type, None);
+}
+
+#[test]
+fn secrets_binary_and_invalid_urls_are_dropped_while_explicit_json_is_canonical() {
+    let mapping = ResolvedUniversalSearchResultMapping {
+        authored_mapping: true,
+        title: Some(resolved_field("api_token", ManifestDataType::Utf8)),
+        url: Some(resolved_field("link", ManifestDataType::Utf8)),
+        attributes: vec![
+            resolved_field("binary", ManifestDataType::Utf8),
+            resolved_field("metadata", ManifestDataType::Json),
+        ],
+        ..ResolvedUniversalSearchResultMapping::default()
+    };
+    let batch = batch(vec![
+        ("api_token", string_column(vec![Some("visible-looking")])),
+        ("link", string_column(vec![Some("javascript:alert(1)")])),
+        (
+            "binary",
+            Arc::new(BinaryArray::from(vec![b"bytes".as_slice()])) as ArrayRef,
+        ),
+        (
+            "metadata",
+            string_column(vec![Some(
+                r#"{"z":2,"password":"hidden","a":{"y":2,"x":1}}"#,
+            )]),
+        ),
+    ]);
+    let candidates = normalize_batches(&workspace(), &route(mapping), &[batch]);
+    assert_eq!(candidates.len(), 1);
+    let result = &candidates[0].result;
+    assert_eq!(result.title, None);
+    assert_eq!(result.url, None);
+    assert_eq!(
+        result.attributes,
+        vec![NativeSearchAttribute {
+            name: "metadata".to_string(),
+            display_value: r#"{"a":{"x":1,"y":2},"z":2}"#.to_string(),
+        }]
+    );
+    assert_eq!(result.omitted_attribute_count, 0);
+    assert!(!result.content_truncated);
+}
+
+#[test]
+fn redaction_does_not_count_but_safe_attribute_omissions_and_truncation_do() {
+    let oversized_name = "n".repeat(129);
+    let mut attributes = vec![
+        resolved_field("api_key", ManifestDataType::Utf8),
+        resolved_field("\0", ManifestDataType::Utf8),
+        resolved_field("a\0b", ManifestDataType::Utf8),
+        resolved_field("ab", ManifestDataType::Utf8),
+        resolved_field(&oversized_name, ManifestDataType::Utf8),
+        resolved_field("long", ManifestDataType::Utf8),
+    ];
+    attributes.extend(
+        (0..9).map(|index| resolved_field(&format!("safe_{index}"), ManifestDataType::Utf8)),
+    );
+    let mapping = ResolvedUniversalSearchResultMapping {
+        authored_mapping: true,
+        attributes,
+        ..ResolvedUniversalSearchResultMapping::default()
+    };
+    let mut columns = vec![
+        ("api_key", string_column(vec![Some("hidden")])),
+        ("\0", string_column(vec![Some("safe but nameless")])),
+        ("a\0b", string_column(vec![Some("first")])),
+        ("ab", string_column(vec![Some("second")])),
+        (oversized_name.as_str(), string_column(vec![Some("safe")])),
+        ("long", string_column(vec![Some(&"é".repeat(513))])),
+    ];
+    let safe_names = (0..9)
+        .map(|index| format!("safe_{index}"))
+        .collect::<Vec<_>>();
+    for name in &safe_names {
+        columns.push((name.as_str(), string_column(vec![Some("value")])));
+    }
+    let batch = batch(columns);
+
+    let candidates = normalize_batches(&workspace(), &route(mapping), &[batch]);
+    let result = &candidates[0].result;
+    assert_eq!(result.attributes[0].name, "ab");
+    assert_eq!(result.attributes[0].display_value, "first");
+    assert!(
+        result
+            .attributes
+            .iter()
+            .all(|attribute| attribute.name != "api_key")
+    );
+    assert_eq!(result.attributes.len(), 8);
+    assert_eq!(result.omitted_attribute_count, 5);
+    assert!(result.content_truncated);
+    assert!(
+        result
+            .attributes
+            .iter()
+            .find(|attribute| attribute.name == "long")
+            .is_some_and(|attribute| attribute.display_value.len() == 1_024)
+    );
+}
+
+#[test]
+fn utf8_field_limits_and_total_result_budget_are_exact_and_safe() {
+    let mut attributes = Vec::new();
+    let mut columns = vec![
+        ("id", string_column(vec![Some(&"i".repeat(513))])),
+        ("title", string_column(vec![Some(&"é".repeat(257))])),
+        ("snippet", string_column(vec![Some(&"s".repeat(1_025))])),
+    ];
+    let attribute_names = (0..8)
+        .map(|index| format!("attr_{index}"))
+        .collect::<Vec<_>>();
+    for name in &attribute_names {
+        attributes.push(resolved_field(name, ManifestDataType::Utf8));
+        columns.push((name.as_str(), string_column(vec![Some(&"x".repeat(1_024))])));
+    }
+    let mapping = ResolvedUniversalSearchResultMapping {
+        authored_mapping: true,
+        provider_id: Some(resolved_field("id", ManifestDataType::Utf8)),
+        title: Some(resolved_field("title", ManifestDataType::Utf8)),
+        snippet: Some(resolved_field("snippet", ManifestDataType::Utf8)),
+        attributes,
+        ..ResolvedUniversalSearchResultMapping::default()
+    };
+    let candidates = normalize_batches(&workspace(), &route(mapping), &[batch(columns)]);
+    let result = &candidates[0].result;
+    assert_eq!(result.provider_id, None);
+    assert_eq!(result.title.as_ref().map(String::len), Some(512));
+    assert_eq!(result.snippet.as_ref().map(String::len), Some(1_024));
+    assert!(
+        result
+            .title
+            .as_deref()
+            .is_some_and(|title| title.is_char_boundary(title.len()))
+    );
+    assert!(result_payload_bytes(result) <= MAX_RESULT_BYTES);
+    assert!(result.omitted_attribute_count > 0);
+    assert!(result.content_truncated);
+}
+
+#[test]
+fn payload_accounting_matches_public_json_with_escaping_and_utf8() {
+    let result = NativeSearchResult {
+        schema_name: "sch\"\\\u{0001}éma".to_string(),
+        function_name: "fun\n\\\"雪".to_string(),
+        row_ordinal: u32::MAX,
+        entity_type: Some("entity\t😀".to_string()),
+        provider_id: Some("id\"\\\u{0008}é".to_string()),
+        title: Some("title\r\n\"\\東京".to_string()),
+        url: Some("https://example.test/a?quoted=\"&slash=\\".to_string()),
+        snippet: Some("snippet\u{000c}\"\\🪸".to_string()),
+        attributes: vec![NativeSearchAttribute {
+            name: "na\"\\\u{0002}me".to_string(),
+            display_value: "va\"\\\u{0003}lueé".to_string(),
+        }],
+        omitted_attribute_count: u32::MAX,
+        content_truncated: true,
+    };
+    let public_json = serde_json::json!({
+        "provider": "native_fanout",
+        "kind": "native_result",
+        "native_result": {
+            "schema_name": &result.schema_name,
+            "function_name": &result.function_name,
+            "row_ordinal": result.row_ordinal,
+            "entity_type": result.entity_type.as_deref(),
+            "provider_id": result.provider_id.as_deref(),
+            "title": result.title.as_deref(),
+            "url": result.url.as_deref(),
+            "snippet": result.snippet.as_deref(),
+            "attributes": [{
+                "name": &result.attributes[0].name,
+                "display_value": &result.attributes[0].display_value,
+            }],
+            "omitted_attribute_count": result.omitted_attribute_count,
+            "content_truncated": result.content_truncated,
+        },
+    });
+    let serialized = serde_json::to_vec(&public_json).expect("public JSON serializes");
+
+    assert_eq!(result_payload_bytes(&result), serialized.len());
+    let serialized = String::from_utf8(serialized).expect("JSON is UTF-8");
+    assert!(serialized.contains(r#"\""#));
+    assert!(serialized.contains(r"\\"));
+    assert!(serialized.contains(r"\u0001"));
+    assert!(serialized.contains('é'));
+    assert!(serialized.contains('😀'));
+}
+
+#[test]
+fn escaped_attribute_values_stay_within_the_public_json_result_budget() {
+    let attribute_names = (0..8)
+        .map(|index| format!("attr_{index}"))
+        .collect::<Vec<_>>();
+    let mut mapping = ResolvedUniversalSearchResultMapping {
+        authored_mapping: true,
+        title: Some(resolved_field("title", ManifestDataType::Utf8)),
+        ..ResolvedUniversalSearchResultMapping::default()
+    };
+    mapping.attributes.extend(
+        attribute_names
+            .iter()
+            .map(|name| resolved_field(name, ManifestDataType::Utf8)),
+    );
+    let escaped = "\"\\".repeat(512);
+    let mut columns = vec![("title", string_column(vec![Some(&"é".repeat(256))]))];
+    for name in &attribute_names {
+        columns.push((name.as_str(), string_column(vec![Some(&escaped)])));
+    }
+
+    let normalized = normalize_batches(&workspace(), &route(mapping), &[batch(columns)]);
+    let result = &normalized[0].result;
+    assert!(result_payload_bytes(result) <= MAX_RESULT_BYTES);
+    assert!(result.omitted_attribute_count > 0);
+    assert!(result.content_truncated);
+}
+
+#[test]
+fn per_function_and_request_result_caps_preserve_provider_order() {
+    let ids = (0..6)
+        .map(|index| Some(format!("id-{index}")))
+        .collect::<Vec<_>>();
+    let id_refs = ids.iter().map(|value| value.as_deref()).collect::<Vec<_>>();
+    let batch = batch(vec![("id", string_column(id_refs))]);
+    let route = route(ResolvedUniversalSearchResultMapping::default());
+    let normalized = normalize_batches(&workspace(), &route, &[batch]);
+    assert_eq!(normalized.len(), MAX_RESULTS_PER_FUNCTION);
+    assert_eq!(normalized[4].result.row_ordinal, 4);
+
+    let many = (0..25)
+        .map(|ordinal| candidate(ordinal, Some(format!("id-{ordinal}")), None))
+        .collect::<Vec<_>>();
+    let capped = cap_request(many);
+    assert_eq!(capped.len(), MAX_RESULTS_PER_REQUEST);
+    assert_eq!(capped[19].result.row_ordinal, 19);
+    let accounted_bytes = 2_usize
+        .saturating_add(capped.len().saturating_sub(1))
+        .saturating_add(
+            capped
+                .iter()
+                .map(|candidate| result_payload_bytes(&candidate.result))
+                .sum::<usize>(),
+        );
+    let public_results = capped
+        .iter()
+        .map(|candidate| PublicSearchResultEnvelope::from(&candidate.result))
+        .collect::<Vec<_>>();
+    let serialized_bytes =
+        serde_json::to_vec(&public_results).expect("public native result array serializes");
+    assert_eq!(accounted_bytes, serialized_bytes.len());
+    assert!(serialized_bytes.len() <= MAX_REQUEST_BYTES);
+}
+
+#[test]
+fn identity_is_stable_across_display_changes_and_absent_for_title_only_rows() {
+    let mapping = ResolvedUniversalSearchResultMapping {
+        authored_mapping: true,
+        identity_fields: vec![resolved_field("id", ManifestDataType::Int64)],
+        title: Some(resolved_field("title", ManifestDataType::Utf8)),
+        ..ResolvedUniversalSearchResultMapping::default()
+    };
+    let identity_route = route(mapping);
+    let first = batch(vec![
+        ("id", Arc::new(Int64Array::from(vec![7])) as ArrayRef),
+        ("title", string_column(vec![Some("First title")])),
+    ]);
+    let second = batch(vec![
+        ("id", Arc::new(Int64Array::from(vec![7])) as ArrayRef),
+        ("title", string_column(vec![Some("Changed title")])),
+    ]);
+    let first = normalize_batches(&workspace(), &identity_route, &[first]);
+    let second = normalize_batches(&workspace(), &identity_route, &[second]);
+    assert_eq!(first[0].identity, second[0].identity);
+
+    let title_only = batch(vec![("title", string_column(vec![Some("Only title")]))]);
+    let title_only = normalize_batches(
+        &workspace(),
+        &route(ResolvedUniversalSearchResultMapping::default()),
+        &[title_only],
+    );
+    assert_eq!(title_only.len(), 1);
+    assert_eq!(title_only[0].identity, None);
+}
+
+#[test]
+fn invalid_authored_identity_falls_back_to_safe_provider_id_then_url() {
+    let mapping = ResolvedUniversalSearchResultMapping {
+        authored_mapping: true,
+        identity_fields: vec![resolved_field("score", ManifestDataType::Float64)],
+        provider_id: Some(resolved_field("id", ManifestDataType::Utf8)),
+        url: Some(resolved_field("url", ManifestDataType::Utf8)),
+        title: Some(resolved_field("title", ManifestDataType::Utf8)),
+        ..ResolvedUniversalSearchResultMapping::default()
+    };
+    let route = route(mapping);
+    let with_fallback = batch(vec![
+        ("score", Arc::new(Float64Array::from(vec![1.0])) as ArrayRef),
+        ("id", string_column(vec![Some("provider-1")])),
+        (
+            "url",
+            string_column(vec![Some("https://example.test/1?token=hidden&safe=1")]),
+        ),
+        ("title", string_column(vec![Some("Title")])),
+    ]);
+    let normalized = normalize_batches(&workspace(), &route, &[with_fallback]);
+    assert!(normalized[0].identity.is_some());
+    assert_eq!(
+        normalized[0].result.url.as_deref(),
+        Some("https://example.test/1?safe=1")
+    );
+
+    let no_fallback = batch(vec![
+        ("score", Arc::new(Float64Array::from(vec![1.0])) as ArrayRef),
+        ("id", string_column(vec![None])),
+        ("url", string_column(vec![None])),
+        ("title", string_column(vec![Some("Title")])),
+    ]);
+    let normalized = normalize_batches(&workspace(), &route, &[no_fallback]);
+    assert_eq!(normalized[0].identity, None);
+}
+
+#[test]
+fn dedupe_keeps_lowest_ordinal_fills_missing_fields_and_never_crosses_scope() {
+    let mapping = ResolvedUniversalSearchResultMapping {
+        authored_mapping: true,
+        identity_fields: vec![resolved_field("id", ManifestDataType::Utf8)],
+        title: Some(resolved_field("title", ManifestDataType::Utf8)),
+        snippet: Some(resolved_field("snippet", ManifestDataType::Utf8)),
+        attributes: vec![resolved_field("state", ManifestDataType::Utf8)],
+        ..ResolvedUniversalSearchResultMapping::default()
+    };
+    let primary_route = route(mapping.clone());
+    let duplicate_rows = batch(vec![
+        ("id", string_column(vec![Some("same"), Some("same")])),
+        ("title", string_column(vec![Some("First"), Some("Later")])),
+        (
+            "snippet",
+            string_column(vec![None, Some(&"s".repeat(1_025))]),
+        ),
+        ("state", string_column(vec![None, Some("open")])),
+    ]);
+    let normalized = normalize_batches(&workspace(), &primary_route, &[duplicate_rows]);
+    let deduped = deduplicate(normalized.into_iter().rev().collect());
+    assert_eq!(deduped.len(), 1);
+    assert_eq!(deduped[0].result.row_ordinal, 0);
+    assert_eq!(deduped[0].result.title.as_deref(), Some("First"));
+    assert_eq!(
+        deduped[0].result.snippet.as_ref().map(String::len),
+        Some(1_024)
+    );
+    assert!(deduped[0].result.content_truncated);
+    assert_eq!(
+        deduped[0].result.attributes,
+        vec![NativeSearchAttribute {
+            name: "state".to_string(),
+            display_value: "open".to_string(),
+        }]
+    );
+
+    let one_row = batch(vec![
+        ("id", string_column(vec![Some("same")])),
+        ("title", string_column(vec![Some("Title")])),
+        ("snippet", string_column(vec![None])),
+        ("state", string_column(vec![None])),
+    ]);
+    let mut other_route = route(mapping.clone());
+    other_route.authored_route_id = Some("pull_requests".to_string());
+    let mut other_source = route(mapping);
+    other_source.owner_source_name = "gitlab".to_string();
+    let mut other_installation = primary_route.clone();
+    other_installation.installation_revision = Uuid::from_u128(2);
+    let candidates =
+        normalize_batches(&workspace(), &primary_route, std::slice::from_ref(&one_row))
+            .into_iter()
+            .chain(normalize_batches(
+                &workspace(),
+                &other_route,
+                std::slice::from_ref(&one_row),
+            ))
+            .chain(normalize_batches(
+                &workspace(),
+                &other_source,
+                std::slice::from_ref(&one_row),
+            ))
+            .chain(normalize_batches(
+                &workspace(),
+                &other_installation,
+                &[one_row],
+            ))
+            .collect();
+    assert_eq!(deduplicate(candidates).len(), 4);
+}
+
+#[test]
+fn dedupe_orders_unsorted_identities_and_fills_from_the_nearest_higher_row() {
+    let mapping = ResolvedUniversalSearchResultMapping {
+        authored_mapping: true,
+        identity_fields: vec![resolved_field("id", ManifestDataType::Utf8)],
+        title: Some(resolved_field("title", ManifestDataType::Utf8)),
+        snippet: Some(resolved_field("snippet", ManifestDataType::Utf8)),
+        ..ResolvedUniversalSearchResultMapping::default()
+    };
+    let rows = batch(vec![
+        (
+            "id",
+            string_column(vec![Some("a"), Some("b"), Some("a"), Some("c")]),
+        ),
+        (
+            "title",
+            string_column(vec![Some("A first"), Some("B"), Some("A later"), Some("C")]),
+        ),
+        (
+            "snippet",
+            string_column(vec![None, None, Some("filled from row two"), None]),
+        ),
+    ]);
+    let mut normalized = normalize_batches(&workspace(), &route(mapping), &[rows]);
+    normalized.reverse();
+
+    let deduped = deduplicate(normalized);
+    assert_eq!(
+        deduped
+            .iter()
+            .map(|candidate| candidate.result.row_ordinal)
+            .collect::<Vec<_>>(),
+        vec![0, 1, 3]
+    );
+    assert_eq!(deduped[0].result.title.as_deref(), Some("A first"));
+    assert_eq!(
+        deduped[0].result.snippet.as_deref(),
+        Some("filled from row two")
+    );
+}
+
+#[test]
+fn rank_input_is_exact_provider_ordinal_and_upstream_score_is_ignored() {
+    let batch = batch(vec![
+        ("title", string_column(vec![Some("First"), Some("Second")])),
+        (
+            "score",
+            Arc::new(Float64Array::from(vec![0.01, 999.0])) as ArrayRef,
+        ),
+    ]);
+    let candidates = normalize_batches(
+        &workspace(),
+        &route(ResolvedUniversalSearchResultMapping::default()),
+        &[batch],
+    );
+    assert_eq!(candidates[0].rank_input.provider_ordinal(), 0);
+    assert_eq!(candidates[1].rank_input.provider_ordinal(), 1);
+    assert_eq!(candidates[0].result.title.as_deref(), Some("First"));
+    assert_eq!(candidates[1].result.title.as_deref(), Some("Second"));
+}
+
+fn candidate(
+    row_ordinal: u32,
+    provider_id: Option<String>,
+    title: Option<String>,
+) -> NativeCandidate {
+    NativeCandidate {
+        result: NativeSearchResult {
+            schema_name: "github".to_string(),
+            function_name: "search".to_string(),
+            row_ordinal,
+            entity_type: None,
+            provider_id,
+            title,
+            url: None,
+            snippet: None,
+            attributes: Vec::new(),
+            omitted_attribute_count: 0,
+            content_truncated: false,
+        },
+        identity: None,
+        rank_input: NativeRankInput::from_provider_ordinal(row_ordinal),
+    }
+}

--- a/crates/coral-app/src/search/observed/sensitive.rs
+++ b/crates/coral-app/src/search/observed/sensitive.rs
@@ -7,44 +7,20 @@
 use serde_json::Value;
 use url::{Url, form_urlencoded};
 
-const SENSITIVE_COLUMN_NAMES: &[&str] = &[
-    "apikey",
-    "authorization",
-    "authtoken",
-    "cookie",
-    "credential",
-    "password",
-    "passwd",
-    "privatekey",
-    "refreshtoken",
-    "secret",
-    "session",
-    "token",
-];
+use crate::search::content_safety::{
+    JsonSanitization, is_sensitive_name, is_sensitive_pair, sanitize_json_value,
+};
 
 /// Returns whether a field name resembles a credential-bearing field.
 pub(super) fn is_sensitive_column(column_name: &str) -> bool {
-    let normalized = column_name
-        .chars()
-        .filter(char::is_ascii_alphanumeric)
-        .collect::<String>()
-        .to_ascii_lowercase();
-    SENSITIVE_COLUMN_NAMES
-        .iter()
-        .any(|name| normalized.contains(name))
+    is_sensitive_name(column_name)
 }
 
 /// Returns whether a value contains one of the obvious secret shapes we know.
 ///
 /// A `false` result does not mean the value is generally non-sensitive.
 pub(super) fn is_sensitive_value(value: &str) -> bool {
-    let trimmed = value.trim();
-    if trimmed.contains("-----BEGIN ") || trimmed.contains(" PRIVATE KEY-----") {
-        return true;
-    }
-    is_sensitive_token(trimmed)
-        || contains_sensitive_token(trimmed)
-        || contains_sensitive_key_value_pair(trimmed)
+    crate::search::content_safety::is_sensitive_value(value)
 }
 
 /// Removes recognized secret-bearing fields while preserving safe structured content.
@@ -87,69 +63,6 @@ fn sanitize_json(value: &str) -> Option<SanitizedValue> {
                 .map_or(SanitizedValue::Drop, SanitizedValue::Changed),
         ),
         JsonSanitization::Drop => Some(SanitizedValue::Drop),
-    }
-}
-
-enum JsonSanitization {
-    Unchanged,
-    Changed,
-    Drop,
-}
-
-fn sanitize_json_value(value: &mut Value) -> JsonSanitization {
-    match value {
-        Value::Object(fields) => {
-            let mut changed = false;
-            fields.retain(|name, value| {
-                if is_sensitive_column(name) {
-                    changed = true;
-                    return false;
-                }
-                match sanitize_json_value(value) {
-                    JsonSanitization::Unchanged => true,
-                    JsonSanitization::Changed => {
-                        changed = true;
-                        true
-                    }
-                    JsonSanitization::Drop => {
-                        changed = true;
-                        false
-                    }
-                }
-            });
-            if !changed {
-                JsonSanitization::Unchanged
-            } else if fields.values().any(has_observable_content) {
-                JsonSanitization::Changed
-            } else {
-                JsonSanitization::Drop
-            }
-        }
-        Value::Array(values) => {
-            let mut changed = false;
-            values.retain_mut(|value| match sanitize_json_value(value) {
-                JsonSanitization::Unchanged => true,
-                JsonSanitization::Changed => {
-                    changed = true;
-                    true
-                }
-                JsonSanitization::Drop => {
-                    changed = true;
-                    false
-                }
-            });
-            if !changed {
-                JsonSanitization::Unchanged
-            } else if values.iter().any(has_observable_content) {
-                JsonSanitization::Changed
-            } else {
-                JsonSanitization::Drop
-            }
-        }
-        Value::String(value) if is_sensitive_value(value) => JsonSanitization::Drop,
-        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
-            JsonSanitization::Unchanged
-        }
     }
 }
 
@@ -250,89 +163,6 @@ fn sanitize_form(value: &str) -> Option<SanitizedValue> {
             .map(|(key, value)| (key.as_str(), value.as_str())),
     );
     Some(SanitizedValue::Changed(serializer.finish()))
-}
-
-fn is_sensitive_pair(key: &str, value: &str) -> bool {
-    is_sensitive_column(key) || is_sensitive_value(value)
-}
-
-fn has_observable_content(value: &Value) -> bool {
-    match value {
-        Value::Null => false,
-        Value::String(value) => !value.trim().is_empty(),
-        Value::Array(values) => values.iter().any(has_observable_content),
-        Value::Object(fields) => fields.values().any(has_observable_content),
-        Value::Bool(_) | Value::Number(_) => true,
-    }
-}
-
-fn is_sensitive_token(value: &str) -> bool {
-    let lower = value.to_ascii_lowercase();
-    if (lower.starts_with("sk-") && value.len() >= 20)
-        || lower.starts_with("ghp_")
-        || lower.starts_with("github_pat_")
-        || lower.starts_with("xoxb-")
-        || lower.starts_with("xoxp-")
-        || lower.starts_with("xoxa-")
-        || lower.starts_with("ya29.")
-    {
-        return true;
-    }
-    looks_like_jwt(value)
-}
-
-fn contains_sensitive_token(value: &str) -> bool {
-    value
-        .split(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')))
-        .any(is_sensitive_token)
-}
-
-fn contains_sensitive_key_value_pair(value: &str) -> bool {
-    value
-        .char_indices()
-        .filter(|(_, character)| matches!(character, '=' | ':'))
-        .filter_map(|(separator_index, _)| sensitive_key_before(value, separator_index))
-        .any(is_sensitive_column)
-}
-
-fn sensitive_key_before(value: &str, separator_index: usize) -> Option<&str> {
-    let prefix = value
-        .get(..separator_index)?
-        .trim_end_matches(|character: char| {
-            character.is_whitespace() || matches!(character, '"' | '\'')
-        });
-    let key_start = prefix
-        .char_indices()
-        .rev()
-        .find(|(_, character)| !is_sensitive_key_character(*character))
-        .map_or(0, |(index, character)| index + character.len_utf8());
-    prefix.get(key_start..).filter(|key| !key.is_empty())
-}
-
-fn is_sensitive_key_character(character: char) -> bool {
-    character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
-}
-
-fn looks_like_jwt(value: &str) -> bool {
-    let mut parts = value.split('.');
-    let Some(header) = parts.next() else {
-        return false;
-    };
-    let Some(payload) = parts.next() else {
-        return false;
-    };
-    let Some(signature) = parts.next() else {
-        return false;
-    };
-    if parts.next().is_some() {
-        return false;
-    }
-    [header, payload, signature].iter().all(|part| {
-        part.len() >= 8
-            && part
-                .chars()
-                .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
-    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Adds pure native-row modules for Arrow-row normalization, content redaction, canonical identity, same-route deduplication, request capping, and provider-order rank input.
- Prefers explicit source-authored result mappings; otherwise infers only the locked provider ID, title, URL, and snippet names. Arbitrary attributes are never inferred, binary values are omitted, and nested values render only when explicitly mapped as bounded canonical JSON.
- Extracts the existing observed-value secret heuristics into shared search content-safety helpers, then applies them to credential-like names, secret-shaped values, nested JSON, and decoded URL paths and query parameters.
- Enforces exact per-field and payload budgets: five rows per function, twenty per request, eight attributes, 8 KiB per result, and 256 KiB per native result array, with UTF-8-safe truncation and JSON-envelope byte accounting.
- Builds typed, length-framed native/v1 identities scoped to workspace, source installation, route, and entity. Identity uses authored fields, then safe provider ID, then sanitized URL; title, snippet, and row ordinal are never identity inputs.

## Stack boundary

Stack 8/11. Depends on #1859; #1863 builds on this PR.

These helpers are pure and are not reachable from public Search in this PR. Dedupe never crosses source, installation, or route scope; do_not_index remains an observation-persistence policy rather than direct-display suppression.

## Test plan

- cargo test -p coral-app search::native
- cargo test -p coral-app search::content_safety
- make rust-checks

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
