### PR TITLE
fix(cli): show table functions after source add

### DIFF
--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -969,21 +969,20 @@ pub(crate) fn print_validation_pretty(
         source_credential_storage_label(source.credential_storage)
     );
 
-    print_schema_items(
-        response
-            .tables
-            .iter()
-            .map(|table| (table.schema_name.as_str(), table.name.as_str())),
+    print_source_items(
+        &source.name,
+        response.tables.iter().map(|table| table.name.as_str()),
         "table",
         "tables",
         "",
         limit,
     );
-    print_schema_items(
+    print_source_items(
+        &source.name,
         response
             .table_functions
             .iter()
-            .map(|function| (function.schema_name.as_str(), function.name.as_str())),
+            .map(|function| function.name.as_str()),
         "table function",
         "table functions",
         "()",
@@ -1034,52 +1033,49 @@ pub(crate) fn print_validation_pretty(
     Ok(())
 }
 
-fn print_schema_items<'a>(
-    items: impl IntoIterator<Item = (&'a str, &'a str)>,
+fn print_source_items<'a>(
+    source_name: &str,
+    items: impl IntoIterator<Item = &'a str>,
     singular: &str,
     plural: &str,
     suffix: &str,
     limit: TableDisplayLimit,
 ) {
-    let mut by_schema: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
-    for (schema, name) in items {
-        by_schema.entry(schema).or_default().push(name);
+    let mut names = items.into_iter().collect::<Vec<_>>();
+    if names.is_empty() {
+        return;
     }
-    for names in by_schema.values_mut() {
-        names.sort_unstable();
+    names.sort_unstable();
+
+    let count = names.len();
+    println!();
+    println!(
+        "    {}",
+        style(format!(
+            "{source_name} ({count} {})",
+            if count == 1 { singular } else { plural }
+        ))
+        .bold()
+    );
+
+    let show_count = match limit {
+        TableDisplayLimit::All => names.len(),
+        TableDisplayLimit::Max(max) => names.len().min(max),
+    };
+    let remaining = names.len() - show_count;
+
+    for (i, name) in names.iter().take(show_count).enumerate() {
+        let is_last = i == show_count - 1 && remaining == 0;
+        let branch = if is_last { "└─" } else { "├─" };
+        println!("    {} {name}{suffix}", style(branch).dim());
     }
 
-    for (schema, names) in &by_schema {
-        let count = names.len();
-        println!();
+    if remaining > 0 {
         println!(
-            "    {}",
-            style(format!(
-                "{schema} ({count} {})",
-                if count == 1 { singular } else { plural }
-            ))
-            .bold()
+            "    {} {}",
+            style("└─").dim(),
+            style(format!("... and {remaining} more")).dim()
         );
-
-        let show_count = match limit {
-            TableDisplayLimit::All => names.len(),
-            TableDisplayLimit::Max(max) => names.len().min(max),
-        };
-        let remaining = names.len() - show_count;
-
-        for (i, name) in names.iter().take(show_count).enumerate() {
-            let is_last = i == show_count - 1 && remaining == 0;
-            let branch = if is_last { "└─" } else { "├─" };
-            println!("    {} {name}{suffix}", style(branch).dim());
-        }
-
-        if remaining > 0 {
-            println!(
-                "    {} {}",
-                style("└─").dim(),
-                style(format!("... and {remaining} more")).dim()
-            );
-        }
     }
 }
 

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -969,52 +969,26 @@ pub(crate) fn print_validation_pretty(
         source_credential_storage_label(source.credential_storage)
     );
 
-    // Group tables by schema, sorted.
-    let mut by_schema: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
-    for table in &response.tables {
-        by_schema
-            .entry(&table.schema_name)
-            .or_default()
-            .push(&table.name);
-    }
-    for tables in by_schema.values_mut() {
-        tables.sort_unstable();
-    }
-
-    for (schema, tables) in &by_schema {
-        let count = tables.len();
-        println!();
-        println!(
-            "    {}",
-            style(format!(
-                "{schema} ({count} {})",
-                if count == 1 { "table" } else { "tables" }
-            ))
-            .bold()
-        );
-
-        let show_count = match limit {
-            TableDisplayLimit::All => tables.len(),
-            TableDisplayLimit::Max(max) => tables.len().min(max),
-        };
-        let remaining = tables.len() - show_count;
-
-        for (i, table) in tables.iter().take(show_count).enumerate() {
-            let is_last = i == show_count - 1 && remaining == 0;
-            let branch = if is_last { "└─" } else { "├─" };
-            println!("    {} {}", style(branch).dim(), table);
-        }
-
-        if remaining > 0 {
-            println!(
-                "    {} {}",
-                style("└─").dim(),
-                style(format!("... and {remaining} more")).dim()
-            );
-        }
-    }
-
-    print_table_functions_pretty(response, limit);
+    print_schema_items(
+        response
+            .tables
+            .iter()
+            .map(|table| (table.schema_name.as_str(), table.name.as_str())),
+        "table",
+        "tables",
+        "",
+        limit,
+    );
+    print_schema_items(
+        response
+            .table_functions
+            .iter()
+            .map(|function| (function.schema_name.as_str(), function.name.as_str())),
+        "table function",
+        "table functions",
+        "()",
+        limit,
+    );
 
     let query_test_counts = query_test_counts(response);
     if query_test_counts.declared > 0 {
@@ -1060,46 +1034,43 @@ pub(crate) fn print_validation_pretty(
     Ok(())
 }
 
-fn print_table_functions_pretty(response: &ValidateSourceResponse, limit: TableDisplayLimit) {
-    // Keep table functions separate so the existing table summary remains
-    // stable while making callable source surfaces equally visible.
+fn print_schema_items<'a>(
+    items: impl IntoIterator<Item = (&'a str, &'a str)>,
+    singular: &str,
+    plural: &str,
+    suffix: &str,
+    limit: TableDisplayLimit,
+) {
     let mut by_schema: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
-    for function in &response.table_functions {
-        by_schema
-            .entry(&function.schema_name)
-            .or_default()
-            .push(&function.name);
+    for (schema, name) in items {
+        by_schema.entry(schema).or_default().push(name);
     }
-    for functions in by_schema.values_mut() {
-        functions.sort_unstable();
+    for names in by_schema.values_mut() {
+        names.sort_unstable();
     }
 
-    for (schema, functions) in &by_schema {
-        let count = functions.len();
+    for (schema, names) in &by_schema {
+        let count = names.len();
         println!();
         println!(
             "    {}",
             style(format!(
                 "{schema} ({count} {})",
-                if count == 1 {
-                    "table function"
-                } else {
-                    "table functions"
-                }
+                if count == 1 { singular } else { plural }
             ))
             .bold()
         );
 
         let show_count = match limit {
-            TableDisplayLimit::All => functions.len(),
-            TableDisplayLimit::Max(max) => functions.len().min(max),
+            TableDisplayLimit::All => names.len(),
+            TableDisplayLimit::Max(max) => names.len().min(max),
         };
-        let remaining = functions.len() - show_count;
+        let remaining = names.len() - show_count;
 
-        for (i, function) in functions.iter().take(show_count).enumerate() {
+        for (i, name) in names.iter().take(show_count).enumerate() {
             let is_last = i == show_count - 1 && remaining == 0;
             let branch = if is_last { "└─" } else { "├─" };
-            println!("    {} {}()", style(branch).dim(), function);
+            println!("    {} {name}{suffix}", style(branch).dim());
         }
 
         if remaining > 0 {

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -37,12 +37,14 @@ use url::{Host, Url};
 
 const MAX_TABLES_PER_SCHEMA: usize = 9;
 
-/// How many tables to show per schema when pretty-printing validation results.
+/// How many tables or table functions to show per schema when pretty-printing
+/// validation results.
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum TableDisplayLimit {
-    /// Show every table the source exposes.
+    /// Show every table and table function the source exposes.
     All,
-    /// Show at most this many tables per schema, with a summary for the rest.
+    /// Show at most this many items of each kind per schema, with a summary for
+    /// the rest.
     Max(usize),
 }
 
@@ -1012,6 +1014,8 @@ pub(crate) fn print_validation_pretty(
         }
     }
 
+    print_table_functions_pretty(response, limit);
+
     let query_test_counts = query_test_counts(response);
     if query_test_counts.declared > 0 {
         println!("    {}", style("Query tests").bold());
@@ -1054,6 +1058,58 @@ pub(crate) fn print_validation_pretty(
     println!();
 
     Ok(())
+}
+
+fn print_table_functions_pretty(response: &ValidateSourceResponse, limit: TableDisplayLimit) {
+    // Keep table functions separate so the existing table summary remains
+    // stable while making callable source surfaces equally visible.
+    let mut by_schema: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for function in &response.table_functions {
+        by_schema
+            .entry(&function.schema_name)
+            .or_default()
+            .push(&function.name);
+    }
+    for functions in by_schema.values_mut() {
+        functions.sort_unstable();
+    }
+
+    for (schema, functions) in &by_schema {
+        let count = functions.len();
+        println!();
+        println!(
+            "    {}",
+            style(format!(
+                "{schema} ({count} {})",
+                if count == 1 {
+                    "table function"
+                } else {
+                    "table functions"
+                }
+            ))
+            .bold()
+        );
+
+        let show_count = match limit {
+            TableDisplayLimit::All => functions.len(),
+            TableDisplayLimit::Max(max) => functions.len().min(max),
+        };
+        let remaining = functions.len() - show_count;
+
+        for (i, function) in functions.iter().take(show_count).enumerate() {
+            let is_last = i == show_count - 1 && remaining == 0;
+            let branch = if is_last { "└─" } else { "├─" };
+            println!("    {} {}()", style(branch).dim(), function);
+        }
+
+        if remaining > 0 {
+            println!(
+                "    {} {}",
+                style("└─").dim(),
+                style(format!("... and {remaining} more")).dim()
+            );
+        }
+    }
 }
 
 fn validation_follow_up(

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -974,7 +974,6 @@ pub(crate) fn print_validation_pretty(
         response.tables.iter().map(|table| table.name.as_str()),
         "table",
         "tables",
-        "",
         limit,
     );
     print_source_items(
@@ -985,7 +984,6 @@ pub(crate) fn print_validation_pretty(
             .map(|function| function.name.as_str()),
         "table function",
         "table functions",
-        "()",
         limit,
     );
 
@@ -1038,7 +1036,6 @@ fn print_source_items<'a>(
     items: impl IntoIterator<Item = &'a str>,
     singular: &str,
     plural: &str,
-    suffix: &str,
     limit: TableDisplayLimit,
 ) {
     let mut names = items.into_iter().collect::<Vec<_>>();
@@ -1067,7 +1064,7 @@ fn print_source_items<'a>(
     for (i, name) in names.iter().take(show_count).enumerate() {
         let is_last = i == show_count - 1 && remaining == 0;
         let branch = if is_last { "└─" } else { "├─" };
-        println!("    {} {name}{suffix}", style(branch).dim());
+        println!("    {} {name}", style(branch).dim());
     }
 
     if remaining > 0 {

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -725,8 +725,12 @@ async fn source_test_renders_validation_summary() {
         "expected table-function schema summary: {stdout}"
     );
     assert!(
-        stdout.contains("search_issues()"),
-        "expected callable table-function name: {stdout}"
+        stdout.contains("search_issues"),
+        "expected table-function name: {stdout}"
+    );
+    assert!(
+        !stdout.contains("search_issues()"),
+        "table-function summary must not imply a zero-argument signature: {stdout}"
     );
 
     let requests = server.validate_source_requests();
@@ -1355,8 +1359,12 @@ surface:
         "expected table-function schema summary after source add: {stdout}"
     );
     assert!(
-        stdout.contains("search_issues()"),
-        "expected callable table-function name after source add: {stdout}"
+        stdout.contains("search_issues"),
+        "expected table-function name after source add: {stdout}"
+    );
+    assert!(
+        !stdout.contains("search_issues()"),
+        "table-function summary must not imply a zero-argument signature after source add: {stdout}"
     );
 
     let requests = server.import_source_requests();

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -720,6 +720,14 @@ async fn source_test_renders_validation_summary() {
         stdout.contains("pull_requests"),
         "expected pull_requests table: {stdout}"
     );
+    assert!(
+        stdout.contains("github (1 table function)"),
+        "expected table-function schema summary: {stdout}"
+    );
+    assert!(
+        stdout.contains("search_issues()"),
+        "expected callable table-function name: {stdout}"
+    );
 
     let requests = server.validate_source_requests();
     assert_eq!(requests.len(), 1, "expected one validate_source call");
@@ -1330,7 +1338,7 @@ surface:
     )
     .expect("write manifest");
 
-    server
+    let assert = server
         .cmd()
         .args([
             "source",
@@ -1340,6 +1348,16 @@ surface:
         ])
         .assert()
         .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("github (1 table function)"),
+        "expected table-function schema summary after source add: {stdout}"
+    );
+    assert!(
+        stdout.contains("search_issues()"),
+        "expected callable table-function name after source add: {stdout}"
+    );
 
     let requests = server.import_source_requests();
     assert_eq!(requests.len(), 1, "expected one import_source call");

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -38,8 +38,8 @@ use coral_api::v1::{
     SearchProvider, SearchProviderCoverage, SearchProviderState, SearchRequest, SearchResponse,
     SearchResult, SearchResultTruncation, SearchStorageCleanupResult, SearchSurfaceKind,
     SearchTableColumnPreview, SearchTableColumnPreviewColumn, Source, SourceCredentialStorage,
-    SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableSummary,
-    ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
+    SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableFunction,
+    TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
     create_bundled_source_with_o_auth_response, import_source_response, search_maintenance_result,
     search_result, source_input_spec::Input as ProtoSourceInput,
 };
@@ -354,7 +354,16 @@ fn mock_validate_response() -> ValidateSourceResponse {
             mock_table("github", "issues"),
             mock_table("github", "pull_requests"),
         ],
-        table_functions: Vec::new(),
+        table_functions: vec![TableFunction {
+            workspace: Some(workspace()),
+            schema_name: "github".to_string(),
+            name: "search_issues".to_string(),
+            description: "Search issues".to_string(),
+            arguments: Vec::new(),
+            result_columns: Vec::new(),
+            kind: 0,
+            search_limits: None,
+        }],
         query_tests: Vec::new(),
     }
 }


### PR DESCRIPTION
## Summary

- show table functions alongside tables in source validation summaries
- remove logic for grouping by schema; all Coral sources are single-schema now
- preserve the existing table output and add CLI regression coverage for both `source add` and `source test`

## Why

`ValidateSourceResponse` already includes table-function metadata, but the CLI renderer only consumed its tables. Sources backed by function-oriented surfaces, including DSL v4 OpenAPI sources, therefore appeared to expose little or nothing after installation.

## User impact

After `coral source add`, users can now see the table functions made available by the installed source. Large function catalogs remain concise because the existing default display limit is applied independently to table functions.

### Before

```
Added source github_v4 (secrets: file (plaintext))
Validating source...

  ✓ github_v4 connected successfully
  Secrets: file (plaintext)

    github_v4 (56 tables)
    ├─ activity_get_feeds
    ├─ activity_list_notifications_for_authenticated_user
    ├─ activity_list_public_events
    ├─ activity_list_repos_starred_by_authenticated_user
    ├─ activity_list_watched_repos_for_authenticated_user
    ├─ agent_tasks_list_tasks
    ├─ apps_get_authenticated
    ├─ apps_get_webhook_config_for_app
    ├─ apps_list_installation_requests_for_authenticated_app
    └─ ... and 47 more
    Query tests
    3 declared · 3 passed · 0 failed

    ✓ SELECT total_count, incomplete_results, search_type FROM github_v4.search_issues_and_pull_requests(q => 'repo:octocat/Hello-World is:issue') LIMIT 1
      1 row

    ✓ SELECT id, number, title, state FROM github_v4.issues_list_for_repo(owner => 'octocat', repo => 'Hello-World') LIMIT 5
      5 rows

    ✓ SELECT id, number, title FROM github_v4.issues_get(owner => 'octocat', repo => 'Hello-World', issue_number => 1)
      1 row
```

### After

```
Added source github_v4 (secrets: file (plaintext))
Validating source...

  ✓ github_v4 connected successfully
  Secrets: file (plaintext)

    github_v4 (56 tables)
    ├─ activity_get_feeds
    ├─ activity_list_notifications_for_authenticated_user
    ├─ activity_list_public_events
    ├─ activity_list_repos_starred_by_authenticated_user
    ├─ activity_list_watched_repos_for_authenticated_user
    ├─ agent_tasks_list_tasks
    ├─ apps_get_authenticated
    ├─ apps_get_webhook_config_for_app
    ├─ apps_list_installation_requests_for_authenticated_app
    └─ ... and 47 more

    github_v4 (548 table functions)
    ├─ actions_get_actions_cache_list
    ├─ actions_get_actions_cache_retention_limit_for_enterprise
    ├─ actions_get_actions_cache_retention_limit_for_organization
    ├─ actions_get_actions_cache_retention_limit_for_repository
    ├─ actions_get_actions_cache_storage_limit_for_enterprise
    ├─ actions_get_actions_cache_storage_limit_for_organization
    ├─ actions_get_actions_cache_storage_limit_for_repository
    ├─ actions_get_actions_cache_usage
    ├─ actions_get_actions_cache_usage_by_repo_for_org
    └─ ... and 539 more
    Query tests
    3 declared · 3 passed · 0 failed

    ✓ SELECT total_count, incomplete_results, search_type FROM github_v4.search_issues_and_pull_requests(q => 'repo:octocat/Hello-World is:issue') LIMIT 1
      1 row

    ✓ SELECT id, number, title, state FROM github_v4.issues_list_for_repo(owner => 'octocat', repo => 'Hello-World') LIMIT 5
      5 rows

    ✓ SELECT id, number, title FROM github_v4.issues_get(owner => 'octocat', repo => 'Hello-World', issue_number => 1)
      1 row
```

## Validation

- `make rust-checks`
  - formatting and workspace Clippy passed
  - 1,841 tests passed, 2 skipped
  - workspace documentation built with warnings denied
- focused `source add` and `source test` CLI regressions passed