### PR TITLE
feat(search): orchestrate bounded native fanout

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -431,6 +431,7 @@ impl ServerBuilder {
             diagnostic_reporter,
             CatalogDiscovery::new(query_manager.clone()),
             workspace_lifecycle_lock,
+            None,
         );
         let trace_components = trace_components_for_store(active_trace_store);
         start_server(
@@ -1115,6 +1116,7 @@ enabled = false
             true,
             CatalogDiscovery::new(query_manager),
             lifecycle_lock,
+            None,
         );
         let workspace = WorkspaceName::default();
         let store = SqliteObservedValuesStore::new(layout.clone());
@@ -1687,6 +1689,7 @@ backend = "unsupported"
             true,
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
+            None,
         );
         let trace_service =
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
@@ -2139,6 +2142,7 @@ tables:
             true,
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
+            None,
         );
         let running = start_server(
             ServerDependencies {
@@ -2266,6 +2270,7 @@ tables:
             true,
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
+            None,
         );
         let running = start_server(
             ServerDependencies {
@@ -2393,6 +2398,7 @@ tables:
             true,
             CatalogDiscovery::new(query_manager.clone()),
             lifecycle_lock,
+            None,
         );
         let running = start_server(
             ServerDependencies {

--- a/crates/coral-app/src/catalog/model.rs
+++ b/crates/coral-app/src/catalog/model.rs
@@ -14,9 +14,5 @@ pub(crate) struct CatalogResolution {
     /// Runtime schema name to canonical installed source owner.
     pub(crate) runtime_schema_owners: BTreeMap<String, String>,
     /// Passive route decisions derived from the exact runtime source snapshot.
-    #[expect(
-        dead_code,
-        reason = "native fanout consumes passive route decisions later in the child stack"
-    )]
     pub(crate) universal_search_resolutions: Vec<UniversalSearchResolution>,
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -7,18 +7,21 @@ use std::time::{Duration, Instant};
 
 use chrono::DateTime;
 use coral_engine::{
-    CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, PreparedQueryRuntime,
-    QueryCancellationToken, QueryExecution, QueryExecutionControls, QueryExecutionFailureKind,
-    QueryExecutionProvenance, QueryParameterValue, QueryParameters, QueryPlan, QueryRuntimeConfig,
-    QueryRuntimeContext, QuerySource, ResolvedQueryResources, SourceDecorator,
-    SourceDecoratorError, SourceFailurePolicy, SourceInputResolver, SourceTables,
-    SourceValidationReport, StatusCode, TableInfo, UdfRuntimeDefinition,
+    CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, PreparedQueryRuntime, QueryExecution,
+    QueryExecutionControls, QueryExecutionFailureKind, QueryExecutionProvenance,
+    QueryParameterValue, QueryParameters, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
+    QuerySource, ResolvedQueryResources, SourceDecorator, SourceDecoratorError,
+    SourceFailurePolicy, SourceInputResolver, SourceTables, SourceValidationReport, StatusCode,
+    TableInfo, UdfRuntimeDefinition,
 };
 use coral_spec::{ManifestDataType, ManifestInputKind, ManifestInputSpec};
 use opentelemetry::trace::Status as OtelStatus;
 use serde_json::json;
 use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+#[cfg(test)]
+use coral_engine::QueryCancellationToken;
 
 use crate::bootstrap::AppError;
 use crate::catalog::model::CatalogResolution;
@@ -80,8 +83,8 @@ pub(crate) struct ExecuteSelectedTableFunction {
     pub(crate) workspace_name: WorkspaceName,
     pub(crate) route: ResolvedUniversalSearchRoute,
     pub(crate) query: String,
-    pub(crate) deadline: tokio::time::Instant,
-    pub(crate) cancellation: QueryCancellationToken,
+    pub(crate) controls: QueryExecutionControls,
+    pub(crate) search_origin: uuid::Uuid,
     pub(crate) row_limit: usize,
 }
 
@@ -522,7 +525,9 @@ impl QueryManager {
                         &source_load.loaded,
                         &config,
                         CredentialResolutionMode::Refreshing,
-                        SourceObservationMode::Enabled,
+                        SourceObservationMode::Enabled {
+                            search_origin: None,
+                        },
                     )
                     .await?;
                 let prepared = runtime
@@ -568,13 +573,6 @@ impl QueryManager {
 
     /// Executes one previously resolved source table function under fanout
     /// controls without accepting caller-authored SQL.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "native fanout calls this seam in the next stacked PR"
-        )
-    )]
     #[expect(
         clippy::too_many_lines,
         reason = "the audited freshness, credential, runtime, and telemetry ordering stays linear"
@@ -584,8 +582,7 @@ impl QueryManager {
         command: ExecuteSelectedTableFunction,
     ) -> Result<SelectedTableFunctionExecution, SelectedTableFunctionExecutionError> {
         let started_at = Instant::now();
-        let controls =
-            QueryExecutionControls::for_fanout(command.deadline, command.cancellation.clone());
+        let controls = command.controls.clone();
         let span = tracing::info_span!(
             "coral.query.selected_table_function",
             otel.name = "coral.query.selected_table_function",
@@ -739,7 +736,9 @@ impl QueryManager {
                     std::slice::from_ref(&selected_source),
                     &config,
                     CredentialResolutionMode::StoredOnly,
-                    SourceObservationMode::Enabled,
+                    SourceObservationMode::Enabled {
+                        search_origin: Some(command.search_origin),
+                    },
                 )
                 .map_err(|_error| SelectedTableFunctionExecutionError::internal(&controls))?;
             let runtime = controls
@@ -991,7 +990,9 @@ impl QueryManager {
             selected_sources,
             config,
             CredentialResolutionMode::Refreshing,
-            SourceObservationMode::Enabled,
+            SourceObservationMode::Enabled {
+                search_origin: None,
+            },
         )
     }
 
@@ -1021,7 +1022,7 @@ impl QueryManager {
         let query_sources = query_sources_from_loaded(selected_sources);
         let mut extensions =
             engine_extensions_for_providers(&self.engine_extensions_providers, &query_sources);
-        if matches!(source_observation_mode, SourceObservationMode::Enabled)
+        if let SourceObservationMode::Enabled { search_origin } = source_observation_mode
             && let Some(search_observations) = &self.search_observations
         {
             let observation_sources = selected_sources
@@ -1034,8 +1035,11 @@ impl QueryManager {
                     )
                 })
                 .collect::<Vec<_>>();
-            let observed_extensions =
-                search_observations.extensions_for(workspace_name, &observation_sources);
+            let observed_extensions = search_observations.extensions_for(
+                workspace_name,
+                &observation_sources,
+                search_origin,
+            );
             extensions
                 .source_observation_publishers
                 .extend(observed_extensions.source_observation_publishers);
@@ -1494,7 +1498,7 @@ enum QueryOperation {
 
 #[derive(Clone, Copy)]
 enum SourceObservationMode {
-    Enabled,
+    Enabled { search_origin: Option<uuid::Uuid> },
     Disabled,
 }
 
@@ -4246,8 +4250,11 @@ surface:
                 workspace_name: WorkspaceName::default(),
                 route,
                 query: query.to_string(),
-                deadline: tokio::time::Instant::now() + Duration::from_secs(2),
-                cancellation: QueryCancellationToken::new(),
+                controls: QueryExecutionControls::for_fanout(
+                    tokio::time::Instant::now() + Duration::from_secs(2),
+                    QueryCancellationToken::new(),
+                ),
+                search_origin: uuid::Uuid::from_u128(1),
                 row_limit,
             })
             .await
@@ -4583,8 +4590,11 @@ surface:
                 workspace_name: WorkspaceName::default(),
                 route: route.clone(),
                 query: "query".to_string(),
-                deadline: tokio::time::Instant::now() + Duration::from_secs(1),
-                cancellation,
+                controls: QueryExecutionControls::for_fanout(
+                    tokio::time::Instant::now() + Duration::from_secs(1),
+                    cancellation,
+                ),
+                search_origin: uuid::Uuid::from_u128(2),
                 row_limit: 5,
             })
             .await
@@ -4601,8 +4611,11 @@ surface:
                 workspace_name: WorkspaceName::default(),
                 route,
                 query: "query".to_string(),
-                deadline: tokio::time::Instant::now(),
-                cancellation: QueryCancellationToken::new(),
+                controls: QueryExecutionControls::for_fanout(
+                    tokio::time::Instant::now(),
+                    QueryCancellationToken::new(),
+                ),
+                search_origin: uuid::Uuid::from_u128(3),
                 row_limit: 5,
             })
             .await
@@ -4704,6 +4717,11 @@ surface:
             payloads.join("\n").contains("observable selected value"),
             "selected function rows should flow through source observations"
         );
+        assert!(payloads.iter().all(|payload| {
+            serde_json::from_str::<Value>(payload).is_ok_and(|payload| {
+                payload.get("search_origin") == Some(&json!(uuid::Uuid::from_u128(1)))
+            })
+        }));
     }
 
     fn selected_route_with_defaults(

--- a/crates/coral-app/src/query/mod.rs
+++ b/crates/coral-app/src/query/mod.rs
@@ -7,10 +7,6 @@ pub(crate) mod manager;
 pub(crate) mod service;
 
 pub(crate) use attribution::QueryAttribution;
-#[expect(
-    unused_imports,
-    reason = "native fanout consumes this internal execution seam in the next stacked PR"
-)]
 pub(crate) use manager::{
     ExecuteSelectedTableFunction, SelectedTableFunctionExecution,
     SelectedTableFunctionExecutionError, SelectedTableFunctionFailureKind,

--- a/crates/coral-app/src/search/engine.rs
+++ b/crates/coral-app/src/search/engine.rs
@@ -154,11 +154,12 @@ fn truncation_note(
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex, mpsc as std_mpsc};
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     use tokio::sync::{Barrier, oneshot};
-    use tokio::time::timeout;
+    use tokio::time::{Instant, timeout};
     use tracing::Instrument as _;
+    use uuid::Uuid;
 
     use super::{UniversalSearchEngine, providers_have_more, truncation_note};
     use crate::bootstrap::AppError;
@@ -405,6 +406,38 @@ mod tests {
         drop(guard);
     }
 
+    #[tokio::test]
+    async fn native_failure_keeps_local_results_and_reports_native_error() {
+        let registry = SearchProviderRegistry::from_ordered(vec![
+            SearchProviderRegistration::Provider(Arc::new(StaticProvider {
+                outcome: ProviderSearchOutcome {
+                    candidates: vec![observed_candidate("local-survivor")],
+                    status: ProviderStatus {
+                        provider: SearchProviderKind::ObservedValues,
+                        state: SearchProviderState::ResultsFound,
+                        note: String::new(),
+                        coverage: None,
+                        diagnostics: Vec::new(),
+                        diagnostics_truncated: false,
+                        omitted_diagnostic_count: 0,
+                    },
+                },
+            })),
+            SearchProviderRegistration::Provider(Arc::new(PanickingProvider {
+                kind: SearchProviderKind::NativeFanout,
+            })),
+        ]);
+        let response = UniversalSearchEngine::new(registry)
+            .search(test_context().await)
+            .await;
+
+        assert_eq!(response.results.len(), 1);
+        assert!(response.provider_statuses.iter().any(|status| {
+            status.provider == SearchProviderKind::NativeFanout
+                && status.state == SearchProviderState::Error
+        }));
+    }
+
     struct StaticProvider {
         outcome: ProviderSearchOutcome,
     }
@@ -530,6 +563,8 @@ mod tests {
         SearchExecutionContext::new(
             Instant::now(),
             lifecycle_lease,
+            None,
+            Uuid::nil(),
             SearchRequest::new(WorkspaceName::default(), "issue", 10).expect("search request"),
             Err(QueryManagerError::App(AppError::Internal(
                 "catalog resolution is unused by test providers".to_string(),

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -1,8 +1,10 @@
 //! App-level Universal Search manager.
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
+use chrono::Utc;
 use tokio::task;
+use tokio::time::Instant;
 
 use crate::bootstrap::AppError;
 use crate::catalog::discovery::CatalogDiscovery;
@@ -18,6 +20,7 @@ use crate::search::maintenance::{
     SearchMaintenanceState, SearchProviderClearRequest, SearchProviderRebuildRequest,
     SearchStorageCleanupResult,
 };
+use crate::search::native::provider::NativeFanoutRegistration;
 use crate::search::observed::provider::{ObservedValuesProvider, observed_clear_provider_result};
 use crate::search::observed::{
     ObservedValuesDrainBudget, ObservedValuesLiveScopeLoad, ObservedValuesLiveScopeLoader,
@@ -45,6 +48,7 @@ pub(crate) struct SearchManager {
     observed: ObservedValuesProvider,
     observed_scope_loader: ObservedValuesLiveScopeLoader,
     observed_values_search_enabled: bool,
+    native_fanout_present: bool,
     engine: UniversalSearchEngine,
     workspaces: WorkspaceManager,
     lifecycle_lock: WorkspaceLifecycleLock,
@@ -76,6 +80,7 @@ impl SearchManager {
         observed_values_search_enabled: bool,
         catalog_discovery: CatalogDiscovery,
         lifecycle_lock: WorkspaceLifecycleLock,
+        native_fanout: Option<NativeFanoutRegistration>,
     ) -> Self {
         Self::with_diagnostic_reporter(
             layout,
@@ -85,6 +90,7 @@ impl SearchManager {
             SourceDiagnosticReporter::default(),
             catalog_discovery,
             lifecycle_lock,
+            native_fanout,
         )
     }
 
@@ -96,6 +102,7 @@ impl SearchManager {
         diagnostic_reporter: SourceDiagnosticReporter,
         catalog_discovery: CatalogDiscovery,
         lifecycle_lock: WorkspaceLifecycleLock,
+        native_fanout: Option<NativeFanoutRegistration>,
     ) -> Self {
         let write_coordinator = LocalSearchWriteCoordinator::default();
         let catalog = CatalogMetadataProvider::with_write_coordinator(
@@ -104,6 +111,8 @@ impl SearchManager {
         );
         let observed =
             ObservedValuesProvider::with_write_coordinator(layout.clone(), write_coordinator);
+        let native_fanout_present = native_fanout.is_some();
+        let native_provider = native_fanout.map(|registration| registration.provider);
         let observed_scope_loader = ObservedValuesLiveScopeLoader::new(
             layout.clone(),
             config_store.clone(),
@@ -115,9 +124,11 @@ impl SearchManager {
             observed: observed.clone(),
             observed_scope_loader,
             observed_values_search_enabled,
+            native_fanout_present,
             engine: UniversalSearchEngine::new(SearchProviderRegistry::local(
                 catalog,
                 observed_values_search_enabled.then(|| observed.clone()),
+                native_provider,
             )),
             workspaces: workspace_manager,
             lifecycle_lock,
@@ -131,6 +142,10 @@ impl SearchManager {
         attribution: &QueryAttribution,
     ) -> Result<SearchResponse, SearchManagerError> {
         let request_started_at = Instant::now();
+        let observed_values_cutoff = self
+            .native_fanout_present
+            .then(|| Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string());
+        let search_origin = uuid::Uuid::new_v4();
         for _ in 0..WORKSPACE_SNAPSHOT_ATTEMPTS {
             let CatalogPreload::Ready {
                 revision,
@@ -164,6 +179,8 @@ impl SearchManager {
             let context = SearchExecutionContext::new(
                 request_started_at,
                 lifecycle_lease,
+                observed_values_cutoff.clone(),
+                search_origin,
                 request.clone(),
                 resolution,
                 observed_values_policy,

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -94,6 +94,10 @@ impl SearchManager {
         )
     }
 
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the composition root passes search providers, lifecycle state, and diagnostics explicitly"
+    )]
     pub(crate) fn with_diagnostic_reporter(
         layout: AppStateLayout,
         config_store: &ConfigStore,

--- a/crates/coral-app/src/search/native/diagnostics.rs
+++ b/crates/coral-app/src/search/native/diagnostics.rs
@@ -156,11 +156,7 @@ pub(super) fn skipped_route(
 
 pub(super) fn explicit_denial(denial: &ResolvedUniversalSearchDenial) -> NativeSearchDiagnostic {
     NativeSearchDiagnostic {
-        installed_source_name: denial.owner_source_name.clone(),
-        schema_name: denial
-            .locator
-            .as_ref()
-            .map(|locator| locator.schema_name.clone()),
+        source_name: denial.source_name.clone(),
         function_name: denial
             .locator
             .as_ref()
@@ -179,8 +175,7 @@ pub(super) fn resolution_failure(
 ) -> NativeSearchDiagnostic {
     let locator = diagnostic.locator.as_ref();
     NativeSearchDiagnostic {
-        installed_source_name: diagnostic.owner_source_name.clone(),
-        schema_name: locator.map(|locator| locator.schema_name.clone()),
+        source_name: diagnostic.source_name.clone(),
         function_name: locator.map(|locator| locator.function_name.clone()),
         authored_route_id: diagnostic.authored_route_id.clone(),
         state: NativeSearchDiagnosticState::Skipped,
@@ -240,8 +235,7 @@ fn route_diagnostic(
     has_more: bool,
 ) -> NativeSearchDiagnostic {
     NativeSearchDiagnostic {
-        installed_source_name: route.owner_source_name.clone(),
-        schema_name: Some(route.locator.schema_name.clone()),
+        source_name: route.source_name.clone(),
         function_name: Some(route.locator.function_name.clone()),
         authored_route_id: route.authored_route_id.clone(),
         state,
@@ -291,8 +285,23 @@ fn execution_failure(
 
 #[cfg(test)]
 mod tests {
-    use super::{NativeProviderSummary, provider_state};
-    use crate::search::result::SearchProviderState;
+    use coral_spec::{ManifestDataType, SearchLimitsSpec};
+    use uuid::Uuid;
+
+    use super::{
+        NativeProviderSummary, explicit_denial, provider_state, resolution_failure, skipped_route,
+    };
+    use crate::search::result::{
+        NativeSearchDiagnosticReason, NativeSearchDiagnosticState, SearchProviderState,
+    };
+    use crate::sources::runtime_package::RuntimeContractFingerprint;
+    use crate::sources::universal_search::{
+        ResolvedUniversalSearchArgument, ResolvedUniversalSearchDenial,
+        ResolvedUniversalSearchResultMapping, ResolvedUniversalSearchRoute,
+        ResolvedUniversalSearchTarget, UniversalSearchFunctionLocator,
+        UniversalSearchResolutionDiagnostic, UniversalSearchResolutionOrigin,
+        UniversalSearchResolutionReason,
+    };
 
     #[test]
     fn aggregate_state_table_is_deterministic() {
@@ -312,5 +321,106 @@ mod tests {
         assert_eq!(state(2, 1, 1, 1, false), SearchProviderState::Partial);
         assert_eq!(state(4, 4, 0, 4, true), SearchProviderState::Partial);
         assert_eq!(state(2, 0, 2, 0, false), SearchProviderState::Error);
+    }
+
+    #[test]
+    fn diagnostics_use_canonical_source_and_only_the_locator_function() {
+        let route = route_with_locator_schema("legacy_runtime_component");
+        let route_diagnostic =
+            skipped_route(&route, NativeSearchDiagnosticReason::FanoutLimitReached);
+        assert_eq!(route_diagnostic.source_name, "github");
+        assert_eq!(
+            route_diagnostic.function_name.as_deref(),
+            Some("search_issues")
+        );
+        assert_eq!(route_diagnostic.state, NativeSearchDiagnosticState::Skipped);
+
+        let denial = ResolvedUniversalSearchDenial {
+            source_name: "linear".to_string(),
+            authored_route_id: "denied".to_string(),
+            target: ResolvedUniversalSearchTarget {
+                operation_id: "search_tasks".to_string(),
+            },
+            locator: Some(UniversalSearchFunctionLocator {
+                schema_name: "ignored_runtime_component".to_string(),
+                function_name: "search_tasks".to_string(),
+            }),
+        };
+        let denial_diagnostic = explicit_denial(&denial);
+        assert_eq!(denial_diagnostic.source_name, "linear");
+        assert_eq!(
+            denial_diagnostic.function_name.as_deref(),
+            Some("search_tasks")
+        );
+        assert_eq!(
+            denial_diagnostic.reason,
+            NativeSearchDiagnosticReason::NotAuthorized
+        );
+
+        let failure = UniversalSearchResolutionDiagnostic {
+            source_name: "salesforce".to_string(),
+            authored_route_id: Some("unsafe".to_string()),
+            locator: Some(UniversalSearchFunctionLocator {
+                schema_name: "ignored_failure_component".to_string(),
+                function_name: "search_accounts".to_string(),
+            }),
+            reason: UniversalSearchResolutionReason::UnsafeOperation,
+        };
+        let failure_diagnostic = resolution_failure(&failure);
+        assert_eq!(failure_diagnostic.source_name, "salesforce");
+        assert_eq!(
+            failure_diagnostic.function_name.as_deref(),
+            Some("search_accounts")
+        );
+        assert_eq!(
+            failure_diagnostic.reason,
+            NativeSearchDiagnosticReason::UnsafeOperation
+        );
+    }
+
+    #[test]
+    fn resolution_failure_without_locator_has_no_function_name() {
+        let failure = UniversalSearchResolutionDiagnostic {
+            source_name: "github".to_string(),
+            authored_route_id: None,
+            locator: None,
+            reason: UniversalSearchResolutionReason::AmbiguousRoute,
+        };
+
+        let diagnostic = resolution_failure(&failure);
+
+        assert_eq!(diagnostic.source_name, "github");
+        assert_eq!(diagnostic.function_name, None);
+        assert_eq!(diagnostic.authored_route_id, None);
+    }
+
+    fn route_with_locator_schema(locator_schema_name: &str) -> ResolvedUniversalSearchRoute {
+        ResolvedUniversalSearchRoute {
+            source_name: "github".to_string(),
+            installation_revision: Uuid::from_u128(1),
+            authored_route_id: Some("issues".to_string()),
+            target: ResolvedUniversalSearchTarget {
+                operation_id: "search_issues".to_string(),
+            },
+            locator: UniversalSearchFunctionLocator {
+                schema_name: locator_schema_name.to_string(),
+                function_name: "search_issues".to_string(),
+            },
+            query_argument: ResolvedUniversalSearchArgument {
+                name: "query".to_string(),
+                data_type: ManifestDataType::Utf8,
+            },
+            default_arguments: Vec::new(),
+            search_limits: SearchLimitsSpec {
+                default_top_k: 5,
+                max_top_k: 5,
+                max_calls_per_query: 1,
+            },
+            result: ResolvedUniversalSearchResultMapping::default(),
+            origin: UniversalSearchResolutionOrigin::Explicit,
+            runtime_contract_fingerprint: RuntimeContractFingerprint::for_test(
+                "v1:diagnostic-test",
+            ),
+        }
     }
 }

--- a/crates/coral-app/src/search/native/diagnostics.rs
+++ b/crates/coral-app/src/search/native/diagnostics.rs
@@ -1,0 +1,316 @@
+//! Stable, bounded diagnostics and aggregate state for native fanout.
+
+use std::time::Duration;
+
+use coral_engine::QueryExecutionFailureKind;
+
+use crate::query::SelectedTableFunctionFailureKind;
+use crate::search::result::{
+    NativeSearchDiagnostic, NativeSearchDiagnosticReason, NativeSearchDiagnosticState,
+    SearchProviderState,
+};
+use crate::sources::universal_search::{
+    ResolvedUniversalSearchDenial, ResolvedUniversalSearchRoute,
+    UniversalSearchResolutionDiagnostic, UniversalSearchResolutionReason,
+};
+
+const MAX_NATIVE_DIAGNOSTICS: usize = 16;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum NativeCallFailure {
+    Selected(SelectedTableFunctionFailureKind),
+    GlobalBudgetExhausted,
+    CallTimeout,
+    UnsupportedCancellation,
+    Internal,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct NativeProviderSummary {
+    pub(super) attempted_calls: usize,
+    pub(super) successful_calls: usize,
+    pub(super) failed_calls: usize,
+    pub(super) safe_candidate_count: usize,
+    pub(super) omitted_by_budget_or_cap: bool,
+}
+
+#[derive(Debug)]
+pub(super) struct BoundedDiagnostics {
+    pub(super) diagnostics: Vec<NativeSearchDiagnostic>,
+    pub(super) truncated: bool,
+    pub(super) omitted_count: u32,
+}
+
+pub(super) fn provider_state(summary: NativeProviderSummary) -> SearchProviderState {
+    if summary.attempted_calls == 0 {
+        return SearchProviderState::Skipped;
+    }
+    if summary.successful_calls == 0 {
+        return SearchProviderState::Error;
+    }
+    if summary.failed_calls > 0 || summary.omitted_by_budget_or_cap {
+        return SearchProviderState::Partial;
+    }
+    if summary.safe_candidate_count == 0 {
+        SearchProviderState::Empty
+    } else {
+        SearchProviderState::ResultsFound
+    }
+}
+
+pub(super) fn successful_call(
+    route: &ResolvedUniversalSearchRoute,
+    elapsed: Duration,
+    raw_row_count: usize,
+    safe_candidate_count: usize,
+    has_more: bool,
+) -> NativeSearchDiagnostic {
+    let (state, reason) = if safe_candidate_count > 0 {
+        (
+            NativeSearchDiagnosticState::ResultsFound,
+            NativeSearchDiagnosticReason::Unspecified,
+        )
+    } else if raw_row_count > 0 {
+        (
+            NativeSearchDiagnosticState::Empty,
+            NativeSearchDiagnosticReason::NoSafeDisplayFields,
+        )
+    } else {
+        (
+            NativeSearchDiagnosticState::Empty,
+            NativeSearchDiagnosticReason::Unspecified,
+        )
+    };
+    route_diagnostic(
+        route,
+        state,
+        reason,
+        elapsed,
+        safe_candidate_count,
+        has_more,
+    )
+}
+
+pub(super) fn failed_call(
+    route: &ResolvedUniversalSearchRoute,
+    elapsed: Duration,
+    failure: NativeCallFailure,
+    timed_out: bool,
+    cleanup_settled: bool,
+) -> NativeSearchDiagnostic {
+    if !cleanup_settled {
+        return route_diagnostic(
+            route,
+            if timed_out {
+                NativeSearchDiagnosticState::TimedOut
+            } else {
+                NativeSearchDiagnosticState::Error
+            },
+            NativeSearchDiagnosticReason::UnsupportedCancellation,
+            elapsed,
+            0,
+            false,
+        );
+    }
+    let (state, reason) = match failure {
+        NativeCallFailure::Selected(SelectedTableFunctionFailureKind::RouteStale) => (
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::RouteStale,
+        ),
+        NativeCallFailure::Selected(SelectedTableFunctionFailureKind::Execution(kind)) => {
+            execution_failure(kind)
+        }
+        NativeCallFailure::GlobalBudgetExhausted => (
+            NativeSearchDiagnosticState::TimedOut,
+            NativeSearchDiagnosticReason::GlobalBudgetExhausted,
+        ),
+        NativeCallFailure::CallTimeout => (
+            NativeSearchDiagnosticState::TimedOut,
+            NativeSearchDiagnosticReason::CallTimeout,
+        ),
+        NativeCallFailure::UnsupportedCancellation => (
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::UnsupportedCancellation,
+        ),
+        NativeCallFailure::Internal => (
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::InternalError,
+        ),
+    };
+    route_diagnostic(route, state, reason, elapsed, 0, false)
+}
+
+pub(super) fn skipped_route(
+    route: &ResolvedUniversalSearchRoute,
+    reason: NativeSearchDiagnosticReason,
+) -> NativeSearchDiagnostic {
+    route_diagnostic(
+        route,
+        NativeSearchDiagnosticState::Skipped,
+        reason,
+        Duration::ZERO,
+        0,
+        false,
+    )
+}
+
+pub(super) fn explicit_denial(denial: &ResolvedUniversalSearchDenial) -> NativeSearchDiagnostic {
+    NativeSearchDiagnostic {
+        installed_source_name: denial.owner_source_name.clone(),
+        schema_name: denial
+            .locator
+            .as_ref()
+            .map(|locator| locator.schema_name.clone()),
+        function_name: denial
+            .locator
+            .as_ref()
+            .map(|locator| locator.function_name.clone()),
+        authored_route_id: Some(denial.authored_route_id.clone()),
+        state: NativeSearchDiagnosticState::Skipped,
+        reason: NativeSearchDiagnosticReason::NotAuthorized,
+        elapsed_ms: 0,
+        safe_candidate_count: 0,
+        has_more: false,
+    }
+}
+
+pub(super) fn resolution_failure(
+    diagnostic: &UniversalSearchResolutionDiagnostic,
+) -> NativeSearchDiagnostic {
+    let locator = diagnostic.locator.as_ref();
+    NativeSearchDiagnostic {
+        installed_source_name: diagnostic.owner_source_name.clone(),
+        schema_name: locator.map(|locator| locator.schema_name.clone()),
+        function_name: locator.map(|locator| locator.function_name.clone()),
+        authored_route_id: diagnostic.authored_route_id.clone(),
+        state: NativeSearchDiagnosticState::Skipped,
+        reason: match diagnostic.reason {
+            UniversalSearchResolutionReason::AmbiguousRoute => {
+                NativeSearchDiagnosticReason::AmbiguousRoute
+            }
+            UniversalSearchResolutionReason::InvalidSearchLimits => {
+                NativeSearchDiagnosticReason::InvalidSearchLimits
+            }
+            UniversalSearchResolutionReason::MissingArgumentDefault => {
+                NativeSearchDiagnosticReason::MissingArgumentDefault
+            }
+            UniversalSearchResolutionReason::QueryInputUnmappable => {
+                NativeSearchDiagnosticReason::QueryInputUnmappable
+            }
+            UniversalSearchResolutionReason::RouteStale => NativeSearchDiagnosticReason::RouteStale,
+            UniversalSearchResolutionReason::UnsafeOperation => {
+                NativeSearchDiagnosticReason::UnsafeOperation
+            }
+        },
+        elapsed_ms: 0,
+        safe_candidate_count: 0,
+        has_more: false,
+    }
+}
+
+pub(super) fn bound_diagnostics(
+    attempted: Vec<NativeSearchDiagnostic>,
+    unattempted: Vec<NativeSearchDiagnostic>,
+    resolution: Vec<NativeSearchDiagnostic>,
+    already_omitted: usize,
+) -> BoundedDiagnostics {
+    let mut diagnostics = Vec::with_capacity(MAX_NATIVE_DIAGNOSTICS);
+    let mut locally_omitted = 0_usize;
+    for diagnostic in attempted.into_iter().chain(unattempted).chain(resolution) {
+        if diagnostics.len() < MAX_NATIVE_DIAGNOSTICS {
+            diagnostics.push(diagnostic);
+        } else {
+            locally_omitted = locally_omitted.saturating_add(1);
+        }
+    }
+    let omitted = already_omitted.saturating_add(locally_omitted);
+    BoundedDiagnostics {
+        diagnostics,
+        truncated: omitted > 0,
+        omitted_count: u32::try_from(omitted).unwrap_or(u32::MAX),
+    }
+}
+
+fn route_diagnostic(
+    route: &ResolvedUniversalSearchRoute,
+    state: NativeSearchDiagnosticState,
+    reason: NativeSearchDiagnosticReason,
+    elapsed: Duration,
+    safe_candidate_count: usize,
+    has_more: bool,
+) -> NativeSearchDiagnostic {
+    NativeSearchDiagnostic {
+        installed_source_name: route.owner_source_name.clone(),
+        schema_name: Some(route.locator.schema_name.clone()),
+        function_name: Some(route.locator.function_name.clone()),
+        authored_route_id: route.authored_route_id.clone(),
+        state,
+        reason,
+        elapsed_ms: u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX),
+        safe_candidate_count: u32::try_from(safe_candidate_count).unwrap_or(u32::MAX),
+        has_more,
+    }
+}
+
+fn execution_failure(
+    failure: QueryExecutionFailureKind,
+) -> (NativeSearchDiagnosticState, NativeSearchDiagnosticReason) {
+    match failure {
+        QueryExecutionFailureKind::Timeout => (
+            NativeSearchDiagnosticState::TimedOut,
+            NativeSearchDiagnosticReason::CallTimeout,
+        ),
+        QueryExecutionFailureKind::Cancelled => (
+            NativeSearchDiagnosticState::Cancelled,
+            NativeSearchDiagnosticReason::Cancelled,
+        ),
+        QueryExecutionFailureKind::RateLimited => (
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::RateLimited,
+        ),
+        QueryExecutionFailureKind::Authentication | QueryExecutionFailureKind::PermissionDenied => {
+            (
+                NativeSearchDiagnosticState::Error,
+                NativeSearchDiagnosticReason::AuthOrPermissionFailed,
+            )
+        }
+        QueryExecutionFailureKind::UpstreamUnavailable => (
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::UpstreamUnavailable,
+        ),
+        QueryExecutionFailureKind::InvalidResponse => (
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::InvalidResponse,
+        ),
+        _ => (
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::ExecutionFailed,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NativeProviderSummary, provider_state};
+    use crate::search::result::SearchProviderState;
+
+    #[test]
+    fn aggregate_state_table_is_deterministic() {
+        let state = |attempted, succeeded, failed, returned, omitted| {
+            provider_state(NativeProviderSummary {
+                attempted_calls: attempted,
+                successful_calls: succeeded,
+                failed_calls: failed,
+                safe_candidate_count: returned,
+                omitted_by_budget_or_cap: omitted,
+            })
+        };
+
+        assert_eq!(state(0, 0, 0, 0, false), SearchProviderState::Skipped);
+        assert_eq!(state(1, 1, 0, 0, false), SearchProviderState::Empty);
+        assert_eq!(state(1, 1, 0, 1, false), SearchProviderState::ResultsFound);
+        assert_eq!(state(2, 1, 1, 1, false), SearchProviderState::Partial);
+        assert_eq!(state(4, 4, 0, 4, true), SearchProviderState::Partial);
+        assert_eq!(state(2, 0, 2, 0, false), SearchProviderState::Error);
+    }
+}

--- a/crates/coral-app/src/search/native/identity.rs
+++ b/crates/coral-app/src/search/native/identity.rs
@@ -27,6 +27,7 @@ const TAG_ABSENT: u8 = 0x0a;
 const TAG_IDENTITY_FIELDS: u8 = 0x0b;
 const TAG_PROVIDER_ID: u8 = 0x0c;
 const TAG_URL: u8 = 0x0d;
+const TAG_ROW_ORDINAL: u8 = 0x0e;
 
 const TAG_TEXT: u8 = 0x20;
 const TAG_BOOL: u8 = 0x21;
@@ -49,6 +50,66 @@ impl NativeIdentity {
     pub(in crate::search) fn as_bytes(self) -> [u8; 32] {
         self.0
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(in crate::search) struct NativeSortKey([u8; 32]);
+
+impl NativeSortKey {
+    pub(in crate::search) fn as_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+/// Returns an internal ordering key without making content-only rows eligible
+/// for deduplication.
+pub(super) fn sort_key_for_row(
+    workspace: &WorkspaceName,
+    route: &ResolvedUniversalSearchRoute,
+    row_ordinal: u32,
+    identity: Option<NativeIdentity>,
+) -> NativeSortKey {
+    if let Some(identity) = identity {
+        return NativeSortKey(identity.as_bytes());
+    }
+    let mut hasher = Sha256::new();
+    append_component(&mut hasher, TAG_VERSION, b"native-route-row/v1")
+        .expect("fixed version length fits u64");
+    append_component(&mut hasher, TAG_WORKSPACE, workspace.as_str().as_bytes())
+        .expect("workspace length fits u64");
+    append_component(
+        &mut hasher,
+        TAG_SOURCE_NAME,
+        route.owner_source_name.as_bytes(),
+    )
+    .expect("source name length fits u64");
+    append_component(
+        &mut hasher,
+        TAG_INSTALLATION_REVISION,
+        route.installation_revision.as_bytes(),
+    )
+    .expect("installation revision length fits u64");
+    match route.authored_route_id.as_deref() {
+        Some(route_id) => append_component(&mut hasher, TAG_AUTHORED_ROUTE, route_id.as_bytes())
+            .expect("route id length fits u64"),
+        None => match &route.target {
+            ResolvedUniversalSearchTarget::V3 { function_name } => {
+                append_component(&mut hasher, TAG_INFERRED_V3_ROUTE, function_name.as_bytes())
+                    .expect("function name length fits u64");
+            }
+            ResolvedUniversalSearchTarget::V4 { operation_id } => {
+                append_component(
+                    &mut hasher,
+                    TAG_INFERRED_V4_OPERATION,
+                    operation_id.as_bytes(),
+                )
+                .expect("operation id length fits u64");
+            }
+        },
+    }
+    append_component(&mut hasher, TAG_ROW_ORDINAL, &row_ordinal.to_be_bytes())
+        .expect("fixed row ordinal length fits u64");
+    NativeSortKey(hasher.finalize().into())
 }
 
 pub(super) fn identity_for_row(

--- a/crates/coral-app/src/search/native/identity.rs
+++ b/crates/coral-app/src/search/native/identity.rs
@@ -77,12 +77,8 @@ pub(super) fn sort_key_for_row(
         .expect("fixed version length fits u64");
     append_component(&mut hasher, TAG_WORKSPACE, workspace.as_str().as_bytes())
         .expect("workspace length fits u64");
-    append_component(
-        &mut hasher,
-        TAG_SOURCE_NAME,
-        route.owner_source_name.as_bytes(),
-    )
-    .expect("source name length fits u64");
+    append_component(&mut hasher, TAG_SOURCE_NAME, route.source_name.as_bytes())
+        .expect("source name length fits u64");
     append_component(
         &mut hasher,
         TAG_INSTALLATION_REVISION,

--- a/crates/coral-app/src/search/native/identity.rs
+++ b/crates/coral-app/src/search/native/identity.rs
@@ -92,20 +92,12 @@ pub(super) fn sort_key_for_row(
     match route.authored_route_id.as_deref() {
         Some(route_id) => append_component(&mut hasher, TAG_AUTHORED_ROUTE, route_id.as_bytes())
             .expect("route id length fits u64"),
-        None => match &route.target {
-            ResolvedUniversalSearchTarget::V3 { function_name } => {
-                append_component(&mut hasher, TAG_INFERRED_V3_ROUTE, function_name.as_bytes())
-                    .expect("function name length fits u64");
-            }
-            ResolvedUniversalSearchTarget::V4 { operation_id } => {
-                append_component(
-                    &mut hasher,
-                    TAG_INFERRED_V4_OPERATION,
-                    operation_id.as_bytes(),
-                )
-                .expect("operation id length fits u64");
-            }
-        },
+        None => append_component(
+            &mut hasher,
+            TAG_INFERRED_V4_OPERATION,
+            route.target.operation_id.as_bytes(),
+        )
+        .expect("operation id length fits u64"),
     }
     append_component(&mut hasher, TAG_ROW_ORDINAL, &row_ordinal.to_be_bytes())
         .expect("fixed row ordinal length fits u64");

--- a/crates/coral-app/src/search/native/mod.rs
+++ b/crates/coral-app/src/search/native/mod.rs
@@ -1,15 +1,9 @@
 //! Pure native-row security, identity, deduplication, and rank-input boundary.
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the follow-up fanout provider wires these reviewed pure helpers into Search"
-    )
-)]
-
 mod dedupe;
+mod diagnostics;
 mod identity;
 mod normalize;
+pub(crate) mod provider;
 mod rank;
 mod redaction;
 
@@ -27,6 +21,7 @@ pub(super) const MAX_ATTRIBUTES: usize = 8;
 pub(super) struct NativeCandidate {
     pub(super) result: NativeSearchResult,
     pub(super) identity: Option<identity::NativeIdentity>,
+    pub(super) sort_key: identity::NativeSortKey,
     pub(super) rank_input: rank::NativeRankInput,
 }
 

--- a/crates/coral-app/src/search/native/normalize.rs
+++ b/crates/coral-app/src/search/native/normalize.rs
@@ -14,7 +14,7 @@ use crate::sources::universal_search::{
 };
 use crate::workspaces::WorkspaceName;
 
-use super::identity::identity_for_row;
+use super::identity::{identity_for_row, sort_key_for_row};
 use super::rank::NativeRankInput;
 use super::redaction::{
     ATTRIBUTE_VALUE_BYTES, OverflowPolicy, PROVIDER_ID_BYTES, SNIPPET_BYTES, Sanitized,
@@ -129,9 +129,11 @@ fn normalize_row(
     }
     enforce_result_budget(&mut result)?;
 
+    let sort_key = sort_key_for_row(workspace, route, row_ordinal, identity);
     has_row_display_content(&result).then_some(NativeCandidate {
         result,
         identity,
+        sort_key,
         rank_input: NativeRankInput::from_provider_ordinal(row_ordinal),
     })
 }

--- a/crates/coral-app/src/search/native/provider.rs
+++ b/crates/coral-app/src/search/native/provider.rs
@@ -24,8 +24,7 @@ use crate::search::result::{
     SearchCandidate, SearchPayload, SearchProviderKind,
 };
 use crate::sources::universal_search::{
-    ResolvedUniversalSearchRoute, ResolvedUniversalSearchTarget, UniversalSearchResolution,
-    UniversalSearchResolutionOrigin,
+    ResolvedUniversalSearchRoute, UniversalSearchResolution, UniversalSearchResolutionOrigin,
 };
 use crate::workspaces::WorkspaceName;
 
@@ -574,17 +573,11 @@ fn route_sort_key(route: &ResolvedUniversalSearchRoute) -> (u8, String, String, 
         UniversalSearchResolutionOrigin::Explicit => 0,
         UniversalSearchResolutionOrigin::Inferred => 1,
     };
-    let (surface, operation) = match &route.target {
-        ResolvedUniversalSearchTarget::V3 { function_name } => {
-            (String::new(), function_name.clone())
-        }
-        ResolvedUniversalSearchTarget::V4 { operation_id } => (String::new(), operation_id.clone()),
-    };
     (
         origin,
         route.authored_route_id.clone().unwrap_or_default(),
-        surface,
-        operation,
+        String::new(),
+        route.target.operation_id.clone(),
         format!(
             "{}.{}",
             route.locator.schema_name, route.locator.function_name

--- a/crates/coral-app/src/search/native/provider.rs
+++ b/crates/coral-app/src/search/native/provider.rs
@@ -429,14 +429,14 @@ struct RouteInventory {
 impl RouteInventory {
     fn from_reports(reports: &[UniversalSearchResolution]) -> Self {
         let mut reports = reports.to_vec();
-        reports.sort_by(|left, right| left.owner_source_name.cmp(&right.owner_source_name));
+        reports.sort_by(|left, right| left.source_name.cmp(&right.source_name));
         let mut grouped = BTreeMap::<String, Vec<ResolvedUniversalSearchRoute>>::new();
         let mut resolution_diagnostics = Vec::new();
         let mut already_omitted_diagnostics = 0_usize;
         for mut report in reports {
             report.eligible_routes.sort_by_key(route_sort_key);
             grouped
-                .entry(report.owner_source_name.clone())
+                .entry(report.source_name.clone())
                 .or_default()
                 .extend(report.eligible_routes);
             report.explicit_denials.sort_by_key(|denial| {
@@ -478,22 +478,24 @@ impl RouteInventory {
         resolution_diagnostics.sort_by_key(resolution_diagnostic_sort_key);
 
         let all = grouped
-            .into_values()
-            .flat_map(|mut routes| {
+            .into_iter()
+            .flat_map(|(source_name, mut routes)| {
                 routes.sort_by_key(route_sort_key);
                 routes
+                    .into_iter()
+                    .map(move |route| (source_name.clone(), route))
             })
             .enumerate()
-            .map(|(order, route)| SelectedRoute { order, route })
+            .map(|(order, (source_name, route))| (source_name, SelectedRoute { order, route }))
             .collect::<Vec<_>>();
         let eligible_count = all.len();
         let mut selected_indices = Vec::new();
         let mut selected_sources = BTreeSet::new();
-        for (index, route) in all.iter().enumerate() {
+        for (index, (source_name, _route)) in all.iter().enumerate() {
             if selected_indices.len() == MAX_SELECTED_FUNCTIONS {
                 break;
             }
-            if selected_sources.insert(route.route.owner_source_name.clone()) {
+            if selected_sources.insert(source_name.clone()) {
                 selected_indices.push(index);
             }
         }
@@ -505,7 +507,10 @@ impl RouteInventory {
                 selected_indices.push(index);
             }
         }
-        let mut slots = all.into_iter().map(Some).collect::<Vec<_>>();
+        let mut slots = all
+            .into_iter()
+            .map(|(_source_name, route)| Some(route))
+            .collect::<Vec<_>>();
         let selected = selected_indices
             .into_iter()
             .enumerate()
@@ -531,12 +536,11 @@ impl RouteInventory {
 
 fn resolution_diagnostic_sort_key(
     diagnostic: &NativeSearchDiagnostic,
-) -> (String, u8, String, String, String, u8) {
+) -> (String, u8, String, String, u8) {
     (
-        diagnostic.installed_source_name.clone(),
+        diagnostic.source_name.clone(),
         u8::from(diagnostic.authored_route_id.is_none()),
         diagnostic.authored_route_id.clone().unwrap_or_default(),
-        diagnostic.schema_name.clone().unwrap_or_default(),
         diagnostic.function_name.clone().unwrap_or_default(),
         native_reason_order(diagnostic.reason),
     )
@@ -776,7 +780,7 @@ fn attempt_from_join(
         Ok(attempt) => attempt,
         Err(error) => {
             tracing::error!(
-                source = %call.selected.route.owner_source_name,
+                source = %call.selected.route.source_name,
                 route_id = call.selected.route.authored_route_id.as_deref().unwrap_or(""),
                 cancelled = error.is_cancelled(),
                 panicked = error.is_panic(),

--- a/crates/coral-app/src/search/native/provider.rs
+++ b/crates/coral-app/src/search/native/provider.rs
@@ -1,0 +1,1064 @@
+//! Bounded, failure-isolated provider-native Universal Search fanout.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use coral_engine::{QueryCancellationToken, QueryExecutionControls, QueryExecutionFailureKind};
+use tokio::task;
+use tokio::time::Instant;
+
+use crate::query::manager::QueryManager;
+use crate::query::{
+    ExecuteSelectedTableFunction, SelectedTableFunctionExecution,
+    SelectedTableFunctionExecutionError,
+};
+use crate::search::provider::{
+    ProviderSearchFuture, ProviderSearchOutcome, SearchExecutionContext, SearchProvider,
+};
+use crate::search::result::{
+    NativeSearchDiagnostic, NativeSearchDiagnosticReason, ProviderCoverage, ProviderStatus,
+    SearchCandidate, SearchPayload, SearchProviderKind,
+};
+use crate::sources::universal_search::{
+    ResolvedUniversalSearchRoute, ResolvedUniversalSearchTarget, UniversalSearchResolution,
+    UniversalSearchResolutionOrigin,
+};
+use crate::workspaces::WorkspaceName;
+
+use super::dedupe::{cap_request, deduplicate};
+use super::diagnostics::{
+    NativeCallFailure, NativeProviderSummary, bound_diagnostics, explicit_denial, failed_call,
+    provider_state, resolution_failure, skipped_route, successful_call,
+};
+use super::normalize::normalize_batches;
+use super::{MAX_RESULTS_PER_FUNCTION, NativeCandidate};
+
+const GLOBAL_FANOUT_BUDGET: Duration = Duration::from_millis(750);
+const PER_CALL_BUDGET: Duration = Duration::from_millis(600);
+const MINIMUM_START_BUDGET: Duration = Duration::from_millis(100);
+const CANCELLATION_CLEANUP_GRACE: Duration = Duration::from_millis(25);
+const MAX_SELECTED_FUNCTIONS: usize = 4;
+
+type SelectedFunctionFuture = Pin<
+    Box<
+        dyn Future<
+                Output = Result<
+                    SelectedTableFunctionExecution,
+                    SelectedTableFunctionExecutionError,
+                >,
+            > + Send
+            + 'static,
+    >,
+>;
+
+trait SelectedFunctionExecutor: Send + Sync {
+    fn execute(&self, command: ExecuteSelectedTableFunction) -> SelectedFunctionFuture;
+}
+
+impl SelectedFunctionExecutor for QueryManager {
+    fn execute(&self, command: ExecuteSelectedTableFunction) -> SelectedFunctionFuture {
+        let manager = self.clone();
+        Box::pin(async move { manager.execute_selected_table_function(command).await })
+    }
+}
+
+/// Executes only source-authorised routes under the request-wide native budget.
+#[derive(Clone)]
+pub(crate) struct NativeFanoutProvider {
+    executor: Arc<dyn SelectedFunctionExecutor>,
+    limits: NativeFanoutLimits,
+}
+
+pub(crate) struct NativeFanoutRegistration {
+    pub(crate) provider: Arc<dyn SearchProvider>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NativeFanoutLimits {
+    global_budget: Duration,
+    per_call_budget: Duration,
+    minimum_start_budget: Duration,
+    cleanup_grace: Duration,
+}
+
+impl Default for NativeFanoutLimits {
+    fn default() -> Self {
+        Self {
+            global_budget: GLOBAL_FANOUT_BUDGET,
+            per_call_budget: PER_CALL_BUDGET,
+            minimum_start_budget: MINIMUM_START_BUDGET,
+            cleanup_grace: CANCELLATION_CLEANUP_GRACE,
+        }
+    }
+}
+
+impl NativeFanoutProvider {
+    #[expect(
+        dead_code,
+        reason = "the follow-up feature gate installs this registration in production"
+    )]
+    pub(crate) fn registration(executor: QueryManager) -> NativeFanoutRegistration {
+        let provider: Arc<dyn SearchProvider> = Arc::new(Self {
+            executor: Arc::new(executor),
+            limits: NativeFanoutLimits::default(),
+        });
+        NativeFanoutRegistration { provider }
+    }
+
+    #[cfg(test)]
+    fn for_test(executor: Arc<dyn SelectedFunctionExecutor>, limits: NativeFanoutLimits) -> Self {
+        Self { executor, limits }
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the bounded wave, accounting, and diagnostic ordering remain auditable together"
+    )]
+    async fn search_native(&self, context: Arc<SearchExecutionContext>) -> ProviderSearchOutcome {
+        let global_deadline = context
+            .request_started_at
+            .checked_add(self.limits.global_budget)
+            .unwrap_or(context.request_started_at);
+        if Instant::now() >= global_deadline {
+            return empty_outcome(
+                0,
+                true,
+                Vec::new(),
+                "native fanout budget expired before route setup completed",
+            );
+        }
+        let reports = match context.catalog_resolution.as_ref() {
+            Ok(resolution) => &resolution.universal_search_resolutions,
+            Err(_error) => {
+                tracing::error!("failed to resolve native Universal Search routes");
+                return provider_failure_outcome();
+            }
+        };
+        let inventory = RouteInventory::from_reports(reports);
+        let wave_cancellation = QueryCancellationToken::new();
+        let eligible_count = inventory.eligible_count;
+        let mut resolution_diagnostics = inventory.resolution_diagnostics;
+        let already_omitted = inventory.already_omitted_diagnostics;
+        let mut unattempted_diagnostics = inventory
+            .unselected
+            .iter()
+            .map(|route| {
+                skipped_route(
+                    &route.route,
+                    NativeSearchDiagnosticReason::FanoutLimitReached,
+                )
+            })
+            .collect::<Vec<_>>();
+        unattempted_diagnostics.sort_by_key(resolution_diagnostic_sort_key);
+
+        if inventory.selected.is_empty() {
+            let bounded = bound_diagnostics(
+                Vec::new(),
+                unattempted_diagnostics,
+                resolution_diagnostics,
+                already_omitted,
+            );
+            return outcome_from_parts(
+                Vec::new(),
+                ProviderCoverage {
+                    eligible_units: u32_count(eligible_count),
+                    ..ProviderCoverage::default()
+                },
+                NativeProviderSummary {
+                    attempted_calls: 0,
+                    successful_calls: 0,
+                    failed_calls: 0,
+                    safe_candidate_count: 0,
+                    omitted_by_budget_or_cap: false,
+                },
+                bounded,
+            );
+        }
+
+        let remaining = global_deadline.saturating_duration_since(Instant::now());
+        if remaining < self.limits.minimum_start_budget {
+            let mut selected_skips = inventory
+                .selected
+                .iter()
+                .map(|route| {
+                    skipped_route(
+                        &route.route,
+                        NativeSearchDiagnosticReason::InsufficientBudget,
+                    )
+                })
+                .collect::<Vec<_>>();
+            selected_skips.append(&mut unattempted_diagnostics);
+            selected_skips.sort_by_key(resolution_diagnostic_sort_key);
+            let bounded = bound_diagnostics(
+                Vec::new(),
+                selected_skips,
+                resolution_diagnostics,
+                already_omitted,
+            );
+            return outcome_from_parts(
+                Vec::new(),
+                ProviderCoverage {
+                    eligible_units: u32_count(eligible_count),
+                    budget_exhausted: true,
+                    ..ProviderCoverage::default()
+                },
+                NativeProviderSummary {
+                    attempted_calls: 0,
+                    successful_calls: 0,
+                    failed_calls: 0,
+                    safe_candidate_count: 0,
+                    omitted_by_budget_or_cap: true,
+                },
+                bounded,
+            );
+        }
+
+        let requested_rows = usize::try_from(context.request.limit)
+            .unwrap_or(usize::MAX)
+            .min(MAX_RESULTS_PER_FUNCTION);
+        let mut tasks = Vec::with_capacity(inventory.selected.len());
+        for selected in inventory.selected {
+            let spawned_at = Instant::now();
+            let per_call_deadline = spawned_at
+                .checked_add(self.limits.per_call_budget)
+                .unwrap_or(global_deadline)
+                .min(global_deadline);
+            let executor = Arc::clone(&self.executor);
+            let workspace_name = context.request.workspace_name.clone();
+            let query = context.request.query.clone();
+            let route = selected.route.clone();
+            let controls = QueryExecutionControls::for_fanout(
+                per_call_deadline,
+                wave_cancellation.child_token(),
+            );
+            let command = ExecuteSelectedTableFunction {
+                workspace_name: workspace_name.clone(),
+                route: route.clone(),
+                query,
+                controls: controls.clone(),
+                row_limit: requested_rows,
+                search_origin: context.search_origin,
+            };
+            let cleanup_grace = self.limits.cleanup_grace;
+            let minimum_start_budget = self.limits.minimum_start_budget;
+            let order = selected.order;
+            let task_controls = controls.clone();
+            let deadline_state = CallDeadlineState::new(if per_call_deadline == global_deadline {
+                TimeoutScope::Global
+            } else {
+                TimeoutScope::Call
+            });
+            let task_deadline_state = deadline_state.clone();
+            let task = tokio::spawn(async move {
+                run_selected_call(
+                    executor,
+                    command,
+                    workspace_name,
+                    route,
+                    order,
+                    task_controls,
+                    per_call_deadline,
+                    global_deadline,
+                    minimum_start_budget,
+                    cleanup_grace,
+                    task_deadline_state,
+                )
+                .await
+            });
+            tasks.push(CallTask {
+                selected,
+                controls,
+                spawned_at,
+                deadline_state,
+                task,
+            });
+        }
+
+        let mut attempts = collect_attempts(
+            tasks,
+            &wave_cancellation,
+            global_deadline,
+            self.limits.cleanup_grace,
+        )
+        .await;
+        attempts.sort_by_key(|attempt| attempt.selected.order);
+
+        let mut attempted_diagnostics = Vec::with_capacity(attempts.len());
+        let mut skipped_diagnostics = Vec::new();
+        let mut ordered_candidates = Vec::new();
+        let mut successful_calls = 0_usize;
+        let mut failed_calls = 0_usize;
+        let mut searched_calls = 0_usize;
+        let mut returned_count = 0_usize;
+        let mut has_more = false;
+        let mut timed_out = false;
+        let mut time_budget_exhausted = false;
+        let mut omitted_for_start_budget = false;
+        for attempt in attempts {
+            searched_calls = searched_calls.saturating_add(usize::from(attempt.upstream_started));
+            match attempt.outcome {
+                AttemptOutcome::Success {
+                    mut candidates,
+                    raw_row_count,
+                    continuation,
+                } => {
+                    successful_calls = successful_calls.saturating_add(1);
+                    let safe_candidate_count = candidates.len();
+                    returned_count = returned_count.saturating_add(safe_candidate_count);
+                    has_more |= continuation;
+                    attempted_diagnostics.push(successful_call(
+                        &attempt.selected.route,
+                        attempt.elapsed,
+                        raw_row_count,
+                        safe_candidate_count,
+                        continuation,
+                    ));
+                    candidates = deduplicate(candidates);
+                    ordered_candidates.extend(candidates.into_iter().map(|candidate| {
+                        OrderedNativeCandidate {
+                            selected_order: attempt.selected.order,
+                            candidate,
+                        }
+                    }));
+                }
+                AttemptOutcome::Failure(failure) => {
+                    failed_calls = failed_calls.saturating_add(1);
+                    timed_out |= attempt.timeout_scope.is_some();
+                    time_budget_exhausted |= attempt.timeout_scope.is_some();
+                    attempted_diagnostics.push(failed_call(
+                        &attempt.selected.route,
+                        attempt.elapsed,
+                        failure,
+                        attempt.timeout_scope.is_some(),
+                        attempt.cleanup_settled,
+                    ));
+                }
+                AttemptOutcome::Skipped(reason) => {
+                    omitted_for_start_budget = true;
+                    skipped_diagnostics.push(skipped_route(&attempt.selected.route, reason));
+                }
+            }
+        }
+        skipped_diagnostics.append(&mut unattempted_diagnostics);
+        attempted_diagnostics.sort_by_key(resolution_diagnostic_sort_key);
+        skipped_diagnostics.sort_by_key(resolution_diagnostic_sort_key);
+
+        ordered_candidates.sort_by(|left, right| {
+            (
+                left.candidate.rank_input.provider_ordinal(),
+                left.selected_order,
+                candidate_sort_key(&left.candidate),
+            )
+                .cmp(&(
+                    right.candidate.rank_input.provider_ordinal(),
+                    right.selected_order,
+                    candidate_sort_key(&right.candidate),
+                ))
+        });
+        let candidates = ordered_candidates
+            .into_iter()
+            .map(|ordered| ordered.candidate)
+            .collect::<Vec<_>>();
+        let candidates = cap_request(candidates)
+            .into_iter()
+            .map(native_search_candidate)
+            .collect::<Vec<_>>();
+        let omitted_by_cap = eligible_count > MAX_SELECTED_FUNCTIONS;
+        let bounded = bound_diagnostics(
+            attempted_diagnostics,
+            skipped_diagnostics,
+            std::mem::take(&mut resolution_diagnostics),
+            already_omitted,
+        );
+        outcome_from_parts(
+            candidates,
+            ProviderCoverage {
+                eligible_units: u32_count(eligible_count),
+                searched_units: u32_count(searched_calls),
+                failed_units: u32_count(failed_calls),
+                returned_count: u32_count(returned_count),
+                has_more,
+                budget_exhausted: omitted_by_cap
+                    || omitted_for_start_budget
+                    || time_budget_exhausted,
+                timed_out,
+                stale_index: false,
+            },
+            NativeProviderSummary {
+                attempted_calls: successful_calls.saturating_add(failed_calls),
+                successful_calls,
+                failed_calls,
+                safe_candidate_count: returned_count,
+                omitted_by_budget_or_cap: omitted_by_cap
+                    || omitted_for_start_budget
+                    || time_budget_exhausted,
+            },
+            bounded,
+        )
+    }
+}
+
+impl SearchProvider for NativeFanoutProvider {
+    fn kind(&self) -> SearchProviderKind {
+        SearchProviderKind::NativeFanout
+    }
+
+    fn search(&self, context: Arc<SearchExecutionContext>) -> ProviderSearchFuture {
+        let provider = self.clone();
+        Box::pin(async move { provider.search_native(context).await })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SelectedRoute {
+    order: usize,
+    route: ResolvedUniversalSearchRoute,
+}
+
+struct RouteInventory {
+    selected: Vec<SelectedRoute>,
+    unselected: Vec<SelectedRoute>,
+    eligible_count: usize,
+    resolution_diagnostics: Vec<NativeSearchDiagnostic>,
+    already_omitted_diagnostics: usize,
+}
+
+impl RouteInventory {
+    fn from_reports(reports: &[UniversalSearchResolution]) -> Self {
+        let mut reports = reports.to_vec();
+        reports.sort_by(|left, right| left.owner_source_name.cmp(&right.owner_source_name));
+        let mut grouped = BTreeMap::<String, Vec<ResolvedUniversalSearchRoute>>::new();
+        let mut resolution_diagnostics = Vec::new();
+        let mut already_omitted_diagnostics = 0_usize;
+        for mut report in reports {
+            report.eligible_routes.sort_by_key(route_sort_key);
+            grouped
+                .entry(report.owner_source_name.clone())
+                .or_default()
+                .extend(report.eligible_routes);
+            report.explicit_denials.sort_by_key(|denial| {
+                (
+                    denial.authored_route_id.clone(),
+                    denial
+                        .locator
+                        .as_ref()
+                        .map(|locator| locator.schema_name.clone())
+                        .unwrap_or_default(),
+                    denial
+                        .locator
+                        .as_ref()
+                        .map(|locator| locator.function_name.clone())
+                        .unwrap_or_default(),
+                )
+            });
+            resolution_diagnostics.extend(report.explicit_denials.iter().map(explicit_denial));
+            report.diagnostics.sort_by_key(|diagnostic| {
+                (
+                    diagnostic.authored_route_id.clone().unwrap_or_default(),
+                    diagnostic
+                        .locator
+                        .as_ref()
+                        .map(|locator| locator.schema_name.clone())
+                        .unwrap_or_default(),
+                    diagnostic
+                        .locator
+                        .as_ref()
+                        .map(|locator| locator.function_name.clone())
+                        .unwrap_or_default(),
+                    resolution_reason_order(diagnostic.reason),
+                )
+            });
+            resolution_diagnostics.extend(report.diagnostics.iter().map(resolution_failure));
+            already_omitted_diagnostics =
+                already_omitted_diagnostics.saturating_add(report.omitted_diagnostic_count);
+        }
+        resolution_diagnostics.sort_by_key(resolution_diagnostic_sort_key);
+
+        let all = grouped
+            .into_values()
+            .flat_map(|mut routes| {
+                routes.sort_by_key(route_sort_key);
+                routes
+            })
+            .enumerate()
+            .map(|(order, route)| SelectedRoute { order, route })
+            .collect::<Vec<_>>();
+        let eligible_count = all.len();
+        let mut selected_indices = Vec::new();
+        let mut selected_sources = BTreeSet::new();
+        for (index, route) in all.iter().enumerate() {
+            if selected_indices.len() == MAX_SELECTED_FUNCTIONS {
+                break;
+            }
+            if selected_sources.insert(route.route.owner_source_name.clone()) {
+                selected_indices.push(index);
+            }
+        }
+        for index in 0..all.len() {
+            if selected_indices.len() == MAX_SELECTED_FUNCTIONS {
+                break;
+            }
+            if !selected_indices.contains(&index) {
+                selected_indices.push(index);
+            }
+        }
+        let mut slots = all.into_iter().map(Some).collect::<Vec<_>>();
+        let selected = selected_indices
+            .into_iter()
+            .enumerate()
+            .map(|(selection_order, index)| {
+                let mut selected = slots
+                    .get_mut(index)
+                    .and_then(Option::take)
+                    .expect("selected route index is unique and in bounds");
+                selected.order = selection_order;
+                selected
+            })
+            .collect();
+        let unselected = slots.into_iter().flatten().collect();
+        Self {
+            selected,
+            unselected,
+            eligible_count,
+            resolution_diagnostics,
+            already_omitted_diagnostics,
+        }
+    }
+}
+
+fn resolution_diagnostic_sort_key(
+    diagnostic: &NativeSearchDiagnostic,
+) -> (String, u8, String, String, String, u8) {
+    (
+        diagnostic.installed_source_name.clone(),
+        u8::from(diagnostic.authored_route_id.is_none()),
+        diagnostic.authored_route_id.clone().unwrap_or_default(),
+        diagnostic.schema_name.clone().unwrap_or_default(),
+        diagnostic.function_name.clone().unwrap_or_default(),
+        native_reason_order(diagnostic.reason),
+    )
+}
+
+fn native_reason_order(reason: NativeSearchDiagnosticReason) -> u8 {
+    match reason {
+        NativeSearchDiagnosticReason::Unspecified => 0,
+        NativeSearchDiagnosticReason::NotAuthorized => 1,
+        NativeSearchDiagnosticReason::AmbiguousRoute => 2,
+        NativeSearchDiagnosticReason::InvalidSearchLimits => 3,
+        NativeSearchDiagnosticReason::QueryInputUnmappable => 4,
+        NativeSearchDiagnosticReason::MissingArgumentDefault => 5,
+        NativeSearchDiagnosticReason::RouteStale => 6,
+        NativeSearchDiagnosticReason::UnsafeOperation => 7,
+        NativeSearchDiagnosticReason::NoSafeDisplayFields => 8,
+        NativeSearchDiagnosticReason::FanoutLimitReached => 9,
+        NativeSearchDiagnosticReason::InsufficientBudget => 10,
+        NativeSearchDiagnosticReason::GlobalBudgetExhausted => 11,
+        NativeSearchDiagnosticReason::CallTimeout => 12,
+        NativeSearchDiagnosticReason::Cancelled => 13,
+        NativeSearchDiagnosticReason::RateLimited => 14,
+        NativeSearchDiagnosticReason::AuthOrPermissionFailed => 15,
+        NativeSearchDiagnosticReason::UpstreamUnavailable => 16,
+        NativeSearchDiagnosticReason::InvalidResponse => 17,
+        NativeSearchDiagnosticReason::ExecutionFailed => 18,
+        NativeSearchDiagnosticReason::UnsupportedCancellation => 19,
+        NativeSearchDiagnosticReason::InternalError => 20,
+    }
+}
+
+fn route_sort_key(route: &ResolvedUniversalSearchRoute) -> (u8, String, String, String, String) {
+    let origin = match route.origin {
+        UniversalSearchResolutionOrigin::Explicit => 0,
+        UniversalSearchResolutionOrigin::Inferred => 1,
+    };
+    let (surface, operation) = match &route.target {
+        ResolvedUniversalSearchTarget::V3 { function_name } => {
+            (String::new(), function_name.clone())
+        }
+        ResolvedUniversalSearchTarget::V4 { operation_id } => (String::new(), operation_id.clone()),
+    };
+    (
+        origin,
+        route.authored_route_id.clone().unwrap_or_default(),
+        surface,
+        operation,
+        format!(
+            "{}.{}",
+            route.locator.schema_name, route.locator.function_name
+        ),
+    )
+}
+
+fn resolution_reason_order(
+    reason: crate::sources::universal_search::UniversalSearchResolutionReason,
+) -> u8 {
+    use crate::sources::universal_search::UniversalSearchResolutionReason;
+
+    match reason {
+        UniversalSearchResolutionReason::AmbiguousRoute => 0,
+        UniversalSearchResolutionReason::InvalidSearchLimits => 1,
+        UniversalSearchResolutionReason::MissingArgumentDefault => 2,
+        UniversalSearchResolutionReason::QueryInputUnmappable => 3,
+        UniversalSearchResolutionReason::RouteStale => 4,
+        UniversalSearchResolutionReason::UnsafeOperation => 5,
+    }
+}
+
+struct OrderedNativeCandidate {
+    selected_order: usize,
+    candidate: NativeCandidate,
+}
+
+struct CallTask {
+    selected: SelectedRoute,
+    controls: QueryExecutionControls,
+    spawned_at: Instant,
+    deadline_state: CallDeadlineState,
+    task: task::JoinHandle<AttemptResult>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TimeoutScope {
+    Call,
+    Global,
+}
+
+#[derive(Clone)]
+struct CallDeadlineState {
+    fired: Arc<AtomicBool>,
+    scope: TimeoutScope,
+}
+
+impl CallDeadlineState {
+    fn new(scope: TimeoutScope) -> Self {
+        Self {
+            fired: Arc::new(AtomicBool::new(false)),
+            scope,
+        }
+    }
+
+    fn mark_fired(&self) {
+        self.fired.store(true, Ordering::SeqCst);
+    }
+
+    fn fired_scope(&self) -> Option<TimeoutScope> {
+        self.fired.load(Ordering::SeqCst).then_some(self.scope)
+    }
+}
+
+struct AttemptResult {
+    selected: SelectedRoute,
+    elapsed: Duration,
+    upstream_started: bool,
+    timeout_scope: Option<TimeoutScope>,
+    cleanup_settled: bool,
+    outcome: AttemptOutcome,
+}
+
+enum AttemptOutcome {
+    Success {
+        candidates: Vec<NativeCandidate>,
+        raw_row_count: usize,
+        continuation: bool,
+    },
+    Failure(NativeCallFailure),
+    Skipped(NativeSearchDiagnosticReason),
+}
+
+impl AttemptResult {
+    fn failure(selected: SelectedRoute, elapsed: Duration, failure: NativeCallFailure) -> Self {
+        Self {
+            selected,
+            elapsed,
+            upstream_started: false,
+            timeout_scope: None,
+            cleanup_settled: true,
+            outcome: AttemptOutcome::Failure(failure),
+        }
+    }
+
+    fn skipped(selected: SelectedRoute, reason: NativeSearchDiagnosticReason) -> Self {
+        Self {
+            selected,
+            elapsed: Duration::ZERO,
+            upstream_started: false,
+            timeout_scope: None,
+            cleanup_settled: true,
+            outcome: AttemptOutcome::Skipped(reason),
+        }
+    }
+
+    fn with_timeout(mut self, scope: TimeoutScope, cleanup_settled: bool) -> Self {
+        self.timeout_scope = Some(scope);
+        self.cleanup_settled = cleanup_settled;
+        self
+    }
+}
+
+async fn collect_attempts(
+    mut tasks: Vec<CallTask>,
+    wave_cancellation: &QueryCancellationToken,
+    global_deadline: Instant,
+    cleanup_grace: Duration,
+) -> Vec<AttemptResult> {
+    let mut attempts = Vec::with_capacity(tasks.len());
+    let global_cutoff = tokio::time::sleep_until(global_deadline);
+    tokio::pin!(global_cutoff);
+    while !tasks.is_empty() {
+        let mut call = tasks.remove(0);
+        let joined = tokio::select! {
+            biased;
+            () = &mut global_cutoff => None,
+            joined = &mut call.task => Some(joined),
+        };
+        let Some(joined) = joined else {
+            let mut pending = vec![call];
+            pending.append(&mut tasks);
+            let mut unfinished = Vec::with_capacity(pending.len());
+            for mut pending_call in pending {
+                if pending_call.task.is_finished() {
+                    let joined = (&mut pending_call.task).await;
+                    attempts.push(attempt_from_join(pending_call, joined));
+                } else {
+                    unfinished.push(pending_call);
+                }
+            }
+            wave_cancellation.cancel();
+            collect_after_global_cutoff(&mut attempts, unfinished, global_deadline, cleanup_grace)
+                .await;
+            return attempts;
+        };
+        attempts.push(attempt_from_join(call, joined));
+    }
+    attempts
+}
+
+async fn collect_after_global_cutoff(
+    attempts: &mut Vec<AttemptResult>,
+    pending: Vec<CallTask>,
+    global_deadline: Instant,
+    cleanup_grace: Duration,
+) {
+    let cleanup_deadline = global_deadline
+        .checked_add(cleanup_grace)
+        .unwrap_or(global_deadline);
+    for mut call in pending {
+        match tokio::time::timeout_at(cleanup_deadline, &mut call.task).await {
+            Ok(joined) => attempts.push(force_global_timeout(attempt_from_join(call, joined))),
+            Err(_elapsed) => {
+                call.task.abort();
+                let upstream_started = call.controls.upstream_started();
+                let mut attempt = AttemptResult::failure(
+                    call.selected,
+                    call.spawned_at.elapsed(),
+                    NativeCallFailure::UnsupportedCancellation,
+                )
+                .with_timeout(TimeoutScope::Global, false);
+                attempt.upstream_started = upstream_started;
+                attempts.push(attempt);
+            }
+        }
+    }
+}
+
+fn force_global_timeout(mut attempt: AttemptResult) -> AttemptResult {
+    attempt.timeout_scope = Some(TimeoutScope::Global);
+    if attempt.cleanup_settled {
+        attempt.outcome = AttemptOutcome::Failure(NativeCallFailure::GlobalBudgetExhausted);
+    } else {
+        attempt.outcome = AttemptOutcome::Failure(NativeCallFailure::UnsupportedCancellation);
+    }
+    attempt
+}
+
+fn attempt_from_join(
+    call: CallTask,
+    joined: Result<AttemptResult, task::JoinError>,
+) -> AttemptResult {
+    let upstream_started = call.controls.upstream_started();
+    let mut attempt = match joined {
+        Ok(attempt) => attempt,
+        Err(error) => {
+            tracing::error!(
+                source = %call.selected.route.owner_source_name,
+                route_id = call.selected.route.authored_route_id.as_deref().unwrap_or(""),
+                cancelled = error.is_cancelled(),
+                panicked = error.is_panic(),
+                "native fanout call task failed"
+            );
+            if let Some(scope) = call.deadline_state.fired_scope() {
+                let failure = match scope {
+                    TimeoutScope::Call => NativeCallFailure::CallTimeout,
+                    TimeoutScope::Global => NativeCallFailure::GlobalBudgetExhausted,
+                };
+                AttemptResult::failure(call.selected, call.spawned_at.elapsed(), failure)
+                    .with_timeout(scope, true)
+            } else {
+                AttemptResult::failure(
+                    call.selected,
+                    call.spawned_at.elapsed(),
+                    NativeCallFailure::Internal,
+                )
+            }
+        }
+    };
+    attempt.upstream_started = upstream_started;
+    attempt
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "one task receives the complete immutable execution and stop contract"
+)]
+async fn run_selected_call(
+    executor: Arc<dyn SelectedFunctionExecutor>,
+    command: ExecuteSelectedTableFunction,
+    workspace_name: WorkspaceName,
+    route: ResolvedUniversalSearchRoute,
+    selected_order: usize,
+    controls: QueryExecutionControls,
+    deadline: Instant,
+    global_deadline: Instant,
+    minimum_start_budget: Duration,
+    cleanup_grace: Duration,
+    deadline_state: CallDeadlineState,
+) -> AttemptResult {
+    let started_at = Instant::now();
+    let selected = SelectedRoute {
+        order: selected_order,
+        route: route.clone(),
+    };
+    if global_deadline.saturating_duration_since(Instant::now()) < minimum_start_budget {
+        return AttemptResult::skipped(selected, NativeSearchDiagnosticReason::InsufficientBudget);
+    }
+    let mut execution = executor.execute(command);
+    let deadline_elapsed = tokio::time::sleep_until(deadline);
+    tokio::pin!(deadline_elapsed);
+    let result = tokio::select! {
+        biased;
+        () = &mut deadline_elapsed => None,
+        result = &mut execution => Some(result),
+    };
+    if let Some(result) = result {
+        return finish_selected_call(
+            selected,
+            &workspace_name,
+            started_at,
+            result,
+            deadline,
+            global_deadline,
+        );
+    }
+
+    deadline_state.mark_fired();
+    controls.cancellation().cancel();
+    let timeout_scope = deadline_state.scope;
+    let cleanup_deadline = deadline.checked_add(cleanup_grace).unwrap_or(deadline);
+    let cleanup_settled = tokio::time::timeout_at(cleanup_deadline, &mut execution)
+        .await
+        .is_ok();
+    let failure = if cleanup_settled {
+        match timeout_scope {
+            TimeoutScope::Call => NativeCallFailure::CallTimeout,
+            TimeoutScope::Global => NativeCallFailure::GlobalBudgetExhausted,
+        }
+    } else {
+        NativeCallFailure::UnsupportedCancellation
+    };
+    AttemptResult::failure(selected, started_at.elapsed(), failure)
+        .with_timeout(timeout_scope, cleanup_settled)
+}
+
+fn finish_selected_call(
+    selected: SelectedRoute,
+    workspace_name: &WorkspaceName,
+    started_at: Instant,
+    result: Result<SelectedTableFunctionExecution, SelectedTableFunctionExecutionError>,
+    deadline: Instant,
+    global_deadline: Instant,
+) -> AttemptResult {
+    match result {
+        Ok(execution) => {
+            let raw_row_count = execution.execution.row_count();
+            let candidates = normalize_batches(
+                workspace_name,
+                &selected.route,
+                execution.execution.batches(),
+            );
+            let elapsed = started_at.elapsed();
+            // Controlled HTTP/MCP execution caps decoded responses at 64 KiB
+            // and this path reads at most five rows, so normalization work is
+            // bounded. Still reject the batch when that bounded work crosses
+            // the absolute call/global deadline.
+            if Instant::now() >= deadline {
+                let timeout_scope = if deadline == global_deadline {
+                    TimeoutScope::Global
+                } else {
+                    TimeoutScope::Call
+                };
+                let failure = match timeout_scope {
+                    TimeoutScope::Call => NativeCallFailure::CallTimeout,
+                    TimeoutScope::Global => NativeCallFailure::GlobalBudgetExhausted,
+                };
+                return AttemptResult::failure(selected, elapsed, failure)
+                    .with_timeout(timeout_scope, true);
+            }
+            AttemptResult {
+                selected,
+                elapsed,
+                upstream_started: false,
+                timeout_scope: None,
+                cleanup_settled: true,
+                outcome: AttemptOutcome::Success {
+                    candidates,
+                    raw_row_count,
+                    continuation: execution.has_more,
+                },
+            }
+        }
+        Err(error) => {
+            let elapsed = started_at.elapsed();
+            let timeout_scope = matches!(
+                error.kind,
+                crate::query::SelectedTableFunctionFailureKind::Execution(
+                    QueryExecutionFailureKind::Timeout
+                )
+            )
+            .then(|| {
+                if Instant::now() >= deadline && deadline == global_deadline {
+                    TimeoutScope::Global
+                } else {
+                    TimeoutScope::Call
+                }
+            });
+            let attempt =
+                AttemptResult::failure(selected, elapsed, NativeCallFailure::Selected(error.kind));
+            if let Some(scope) = timeout_scope {
+                attempt.with_timeout(scope, true)
+            } else {
+                attempt
+            }
+        }
+    }
+}
+
+fn candidate_sort_key(candidate: &NativeCandidate) -> String {
+    hex_key(candidate.sort_key.as_bytes())
+}
+
+fn native_search_candidate(candidate: NativeCandidate) -> SearchCandidate {
+    SearchCandidate {
+        key: candidate_sort_key(&candidate),
+        score: 0,
+        provider: SearchProviderKind::NativeFanout,
+        payload: SearchPayload::NativeResult(candidate.result),
+    }
+}
+
+fn hex_key(bytes: [u8; 32]) -> String {
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(hex_digit(byte >> 4));
+        output.push(hex_digit(byte & 0x0f));
+    }
+    output
+}
+
+fn hex_digit(nibble: u8) -> char {
+    char::from(if nibble < 10 {
+        b'0' + nibble
+    } else {
+        b'a' + (nibble - 10)
+    })
+}
+
+fn outcome_from_parts(
+    candidates: Vec<SearchCandidate>,
+    coverage: ProviderCoverage,
+    summary: NativeProviderSummary,
+    diagnostics: super::diagnostics::BoundedDiagnostics,
+) -> ProviderSearchOutcome {
+    let state = provider_state(summary);
+    ProviderSearchOutcome {
+        candidates,
+        status: ProviderStatus {
+            provider: SearchProviderKind::NativeFanout,
+            state,
+            note: provider_note(state),
+            coverage: Some(coverage),
+            diagnostics: diagnostics.diagnostics,
+            diagnostics_truncated: diagnostics.truncated,
+            omitted_diagnostic_count: diagnostics.omitted_count,
+        },
+    }
+}
+
+fn empty_outcome(
+    eligible_count: usize,
+    budget_exhausted: bool,
+    diagnostics: Vec<NativeSearchDiagnostic>,
+    note: &str,
+) -> ProviderSearchOutcome {
+    ProviderSearchOutcome {
+        candidates: Vec::new(),
+        status: ProviderStatus {
+            provider: SearchProviderKind::NativeFanout,
+            state: crate::search::result::SearchProviderState::Skipped,
+            note: note.to_string(),
+            coverage: Some(ProviderCoverage {
+                eligible_units: u32_count(eligible_count),
+                budget_exhausted,
+                ..ProviderCoverage::default()
+            }),
+            diagnostics,
+            diagnostics_truncated: false,
+            omitted_diagnostic_count: 0,
+        },
+    }
+}
+
+fn provider_failure_outcome() -> ProviderSearchOutcome {
+    ProviderSearchOutcome {
+        candidates: Vec::new(),
+        status: ProviderStatus {
+            provider: SearchProviderKind::NativeFanout,
+            state: crate::search::result::SearchProviderState::Error,
+            note: "native fanout route setup failed without affecting local search".to_string(),
+            coverage: Some(ProviderCoverage::default()),
+            diagnostics: Vec::new(),
+            diagnostics_truncated: false,
+            omitted_diagnostic_count: 0,
+        },
+    }
+}
+
+fn provider_note(state: crate::search::result::SearchProviderState) -> String {
+    match state {
+        crate::search::result::SearchProviderState::ResultsFound => {
+            "provider-native fanout returned results".to_string()
+        }
+        crate::search::result::SearchProviderState::Empty => {
+            "provider-native fanout completed without safe display results".to_string()
+        }
+        crate::search::result::SearchProviderState::Skipped => {
+            "provider-native fanout had no executable work".to_string()
+        }
+        crate::search::result::SearchProviderState::Partial => {
+            "provider-native fanout returned partial results".to_string()
+        }
+        crate::search::result::SearchProviderState::Error => {
+            "provider-native fanout failed without affecting local search".to_string()
+        }
+        crate::search::result::SearchProviderState::NotEnabled => String::new(),
+    }
+}
+
+fn u32_count(value: usize) -> u32 {
+    u32::try_from(value).unwrap_or(u32::MAX)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coral-app/src/search/native/provider.rs
+++ b/crates/coral-app/src/search/native/provider.rs
@@ -428,56 +428,13 @@ struct RouteInventory {
 
 impl RouteInventory {
     fn from_reports(reports: &[UniversalSearchResolution]) -> Self {
-        let mut reports = reports.to_vec();
-        reports.sort_by(|left, right| left.source_name.cmp(&right.source_name));
-        let mut grouped = BTreeMap::<String, Vec<ResolvedUniversalSearchRoute>>::new();
-        let mut resolution_diagnostics = Vec::new();
-        let mut already_omitted_diagnostics = 0_usize;
-        for mut report in reports {
-            report.eligible_routes.sort_by_key(route_sort_key);
-            grouped
-                .entry(report.source_name.clone())
-                .or_default()
-                .extend(report.eligible_routes);
-            report.explicit_denials.sort_by_key(|denial| {
-                (
-                    denial.authored_route_id.clone(),
-                    denial
-                        .locator
-                        .as_ref()
-                        .map(|locator| locator.schema_name.clone())
-                        .unwrap_or_default(),
-                    denial
-                        .locator
-                        .as_ref()
-                        .map(|locator| locator.function_name.clone())
-                        .unwrap_or_default(),
-                )
-            });
-            resolution_diagnostics.extend(report.explicit_denials.iter().map(explicit_denial));
-            report.diagnostics.sort_by_key(|diagnostic| {
-                (
-                    diagnostic.authored_route_id.clone().unwrap_or_default(),
-                    diagnostic
-                        .locator
-                        .as_ref()
-                        .map(|locator| locator.schema_name.clone())
-                        .unwrap_or_default(),
-                    diagnostic
-                        .locator
-                        .as_ref()
-                        .map(|locator| locator.function_name.clone())
-                        .unwrap_or_default(),
-                    resolution_reason_order(diagnostic.reason),
-                )
-            });
-            resolution_diagnostics.extend(report.diagnostics.iter().map(resolution_failure));
-            already_omitted_diagnostics =
-                already_omitted_diagnostics.saturating_add(report.omitted_diagnostic_count);
-        }
-        resolution_diagnostics.sort_by_key(resolution_diagnostic_sort_key);
+        let CollectedResolutionReports {
+            routes_by_source,
+            diagnostics: resolution_diagnostics,
+            omitted_diagnostic_count: already_omitted_diagnostics,
+        } = collect_resolution_reports(reports);
 
-        let all = grouped
+        let all = routes_by_source
             .into_iter()
             .flat_map(|(source_name, mut routes)| {
                 routes.sort_by_key(route_sort_key);
@@ -531,6 +488,68 @@ impl RouteInventory {
             resolution_diagnostics,
             already_omitted_diagnostics,
         }
+    }
+}
+
+struct CollectedResolutionReports {
+    routes_by_source: BTreeMap<String, Vec<ResolvedUniversalSearchRoute>>,
+    diagnostics: Vec<NativeSearchDiagnostic>,
+    omitted_diagnostic_count: usize,
+}
+
+fn collect_resolution_reports(reports: &[UniversalSearchResolution]) -> CollectedResolutionReports {
+    let mut reports = reports.to_vec();
+    reports.sort_by(|left, right| left.source_name.cmp(&right.source_name));
+    let mut routes_by_source = BTreeMap::<String, Vec<ResolvedUniversalSearchRoute>>::new();
+    let mut diagnostics = Vec::new();
+    let mut omitted_diagnostic_count = 0_usize;
+    for mut report in reports {
+        report.eligible_routes.sort_by_key(route_sort_key);
+        routes_by_source
+            .entry(report.source_name.clone())
+            .or_default()
+            .extend(report.eligible_routes);
+        report.explicit_denials.sort_by_key(|denial| {
+            (
+                denial.authored_route_id.clone(),
+                denial
+                    .locator
+                    .as_ref()
+                    .map(|locator| locator.schema_name.clone())
+                    .unwrap_or_default(),
+                denial
+                    .locator
+                    .as_ref()
+                    .map(|locator| locator.function_name.clone())
+                    .unwrap_or_default(),
+            )
+        });
+        diagnostics.extend(report.explicit_denials.iter().map(explicit_denial));
+        report.diagnostics.sort_by_key(|diagnostic| {
+            (
+                diagnostic.authored_route_id.clone().unwrap_or_default(),
+                diagnostic
+                    .locator
+                    .as_ref()
+                    .map(|locator| locator.schema_name.clone())
+                    .unwrap_or_default(),
+                diagnostic
+                    .locator
+                    .as_ref()
+                    .map(|locator| locator.function_name.clone())
+                    .unwrap_or_default(),
+                resolution_reason_order(diagnostic.reason),
+            )
+        });
+        diagnostics.extend(report.diagnostics.iter().map(resolution_failure));
+        omitted_diagnostic_count =
+            omitted_diagnostic_count.saturating_add(report.omitted_diagnostic_count);
+    }
+    diagnostics.sort_by_key(resolution_diagnostic_sort_key);
+    CollectedResolutionReports {
+        routes_by_source,
+        diagnostics,
+        omitted_diagnostic_count,
     }
 }
 

--- a/crates/coral-app/src/search/native/provider/tests.rs
+++ b/crates/coral-app/src/search/native/provider/tests.rs
@@ -14,7 +14,7 @@ use arrow::array::{ArrayRef, StringArray};
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use coral_engine::{
-    CatalogInfo, QueryExecution, QueryExecutionFailureKind, QueryExecutionProvenance,
+    CatalogInfo, QueryExecution, QueryExecutionFailureKind, ResolvedQueryResources,
 };
 use coral_spec::{ManifestDataType, SearchLimitsSpec};
 use tokio::sync::Barrier;
@@ -151,12 +151,8 @@ fn successful_execution(
         execution: QueryExecution::new(
             arrow_schema,
             batches,
-            QueryExecutionProvenance::new(
-                "sensitive SQL sentinel",
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
-            ),
+            "sensitive SQL sentinel",
+            ResolvedQueryResources::new(Vec::new(), Vec::new(), Vec::new()),
         ),
         has_more,
         upstream_started: controls.upstream_started(),

--- a/crates/coral-app/src/search/native/provider/tests.rs
+++ b/crates/coral-app/src/search/native/provider/tests.rs
@@ -35,7 +35,7 @@ use crate::query::{
     ExecuteSelectedTableFunction, SelectedTableFunctionExecution,
     SelectedTableFunctionExecutionError, SelectedTableFunctionFailureKind,
 };
-use crate::search::provider::{ObservedValuesPolicyInput, SearchExecutionContext};
+use crate::search::provider::SearchExecutionContext;
 use crate::search::result::{
     NativeSearchDiagnosticReason, NativeSearchDiagnosticState, SearchPayload, SearchProviderState,
     SearchRequest,
@@ -191,6 +191,7 @@ fn context(
                 table_functions: Vec::new(),
             },
             failed_source_names: BTreeSet::new(),
+            runtime_schema_owners: BTreeMap::new(),
             universal_search_resolutions: reports,
         }),
     )
@@ -211,7 +212,7 @@ fn context_with_resolution(
         Uuid::from_u128(99),
         SearchRequest::new(workspace, "payment", limit).expect("request"),
         catalog_resolution,
-        ObservedValuesPolicyInput::Disabled,
+        None,
     ))
 }
 

--- a/crates/coral-app/src/search/native/provider/tests.rs
+++ b/crates/coral-app/src/search/native/provider/tests.rs
@@ -1,0 +1,1357 @@
+//! Focused bounded-fanout orchestration tests.
+
+#![expect(
+    clippy::indexing_slicing,
+    reason = "focused provider fixtures assert exact bounded diagnostic and result shapes"
+)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::future;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use arrow::array::{ArrayRef, StringArray};
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatch;
+use coral_engine::{
+    CatalogInfo, QueryExecution, QueryExecutionFailureKind, QueryExecutionProvenance,
+};
+use coral_spec::{ManifestDataType, SearchLimitsSpec};
+use tokio::sync::Barrier;
+use tokio::time::Instant;
+use uuid::Uuid;
+
+use super::super::diagnostics::{NativeCallFailure, failed_call};
+use super::super::normalize::normalize_batches;
+use super::{
+    AttemptOutcome, AttemptResult, CallDeadlineState, CallTask, NativeFanoutLimits,
+    NativeFanoutProvider, RouteInventory, SelectedFunctionExecutor, SelectedFunctionFuture,
+    SelectedRoute, TimeoutScope, candidate_sort_key, collect_attempts,
+};
+use crate::bootstrap::AppError;
+use crate::catalog::model::CatalogResolution;
+use crate::query::manager::QueryManagerError;
+use crate::query::{
+    ExecuteSelectedTableFunction, SelectedTableFunctionExecution,
+    SelectedTableFunctionExecutionError, SelectedTableFunctionFailureKind,
+};
+use crate::search::provider::{ObservedValuesPolicyInput, SearchExecutionContext};
+use crate::search::result::{
+    NativeSearchDiagnosticReason, NativeSearchDiagnosticState, SearchPayload, SearchProviderState,
+    SearchRequest,
+};
+use crate::sources::runtime_package::RuntimeContractFingerprint;
+use crate::sources::universal_search::{
+    ResolvedUniversalSearchArgument, ResolvedUniversalSearchResultMapping,
+    ResolvedUniversalSearchRoute, ResolvedUniversalSearchTarget, UniversalSearchFunctionLocator,
+    UniversalSearchResolution, UniversalSearchResolutionDiagnostic,
+    UniversalSearchResolutionOrigin, UniversalSearchResolutionReason,
+};
+use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
+
+#[derive(Clone)]
+enum Behaviour {
+    Immediate {
+        batches: Vec<RecordBatch>,
+        has_more: bool,
+    },
+    Barrier(Arc<Barrier>),
+    WaitForCancellation,
+    NeverSettles,
+    EarlyTimeout,
+    PanicAfter(Duration),
+    PanicAfterCancellation(Duration),
+}
+
+#[derive(Clone)]
+struct ScriptedExecutor {
+    behaviours: Arc<BTreeMap<String, Behaviour>>,
+    starts: Arc<Mutex<Vec<String>>>,
+}
+
+impl ScriptedExecutor {
+    fn same(behaviour: Behaviour) -> Self {
+        Self {
+            behaviours: Arc::new(BTreeMap::from([("*".to_string(), behaviour)])),
+            starts: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn starts(&self) -> Vec<String> {
+        self.starts.lock().expect("starts lock").clone()
+    }
+
+    fn scripted(behaviours: impl IntoIterator<Item = (String, Behaviour)>) -> Self {
+        Self {
+            behaviours: Arc::new(behaviours.into_iter().collect()),
+            starts: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl SelectedFunctionExecutor for ScriptedExecutor {
+    fn execute(&self, command: ExecuteSelectedTableFunction) -> SelectedFunctionFuture {
+        let behaviour = self
+            .behaviours
+            .get(&command.route.locator.function_name)
+            .or_else(|| self.behaviours.get("*"))
+            .expect("scripted behaviour")
+            .clone();
+        let starts = Arc::clone(&self.starts);
+        Box::pin(async move {
+            let controls = command.controls.clone();
+            controls.mark_upstream_started();
+            starts
+                .lock()
+                .expect("starts lock")
+                .push(command.route.locator.function_name.clone());
+            match behaviour {
+                Behaviour::Immediate { batches, has_more } => {
+                    Ok(successful_execution(batches, has_more, &controls))
+                }
+                Behaviour::Barrier(barrier) => {
+                    barrier.wait().await;
+                    Ok(successful_execution(Vec::new(), false, &controls))
+                }
+                Behaviour::WaitForCancellation => {
+                    controls.cancellation().cancelled().await;
+                    Err(execution_error(
+                        QueryExecutionFailureKind::Cancelled,
+                        &controls,
+                    ))
+                }
+                Behaviour::NeverSettles => future::pending().await,
+                Behaviour::EarlyTimeout => Err(execution_error(
+                    QueryExecutionFailureKind::Timeout,
+                    &controls,
+                )),
+                Behaviour::PanicAfter(delay) => {
+                    tokio::time::sleep(delay).await;
+                    panic!("sanitised fake executor panic")
+                }
+                Behaviour::PanicAfterCancellation(delay) => {
+                    controls.cancellation().cancelled().await;
+                    tokio::time::sleep(delay).await;
+                    panic!("sanitised cleanup panic")
+                }
+            }
+        })
+    }
+}
+
+fn successful_execution(
+    batches: Vec<RecordBatch>,
+    has_more: bool,
+    controls: &coral_engine::QueryExecutionControls,
+) -> SelectedTableFunctionExecution {
+    let arrow_schema = batches
+        .first()
+        .map_or_else(|| Arc::new(Schema::empty()), RecordBatch::schema);
+    SelectedTableFunctionExecution {
+        execution: QueryExecution::new(
+            arrow_schema,
+            batches,
+            QueryExecutionProvenance::new(
+                "sensitive SQL sentinel",
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            ),
+        ),
+        has_more,
+        upstream_started: controls.upstream_started(),
+    }
+}
+
+fn execution_error(
+    kind: QueryExecutionFailureKind,
+    controls: &coral_engine::QueryExecutionControls,
+) -> SelectedTableFunctionExecutionError {
+    SelectedTableFunctionExecutionError {
+        kind: SelectedTableFunctionFailureKind::Execution(kind),
+        upstream_started: controls.upstream_started(),
+    }
+}
+
+fn provider(executor: ScriptedExecutor) -> NativeFanoutProvider {
+    NativeFanoutProvider::for_test(Arc::new(executor), NativeFanoutLimits::default())
+}
+
+fn context(
+    started_at: Instant,
+    limit: u32,
+    reports: Vec<UniversalSearchResolution>,
+) -> Arc<SearchExecutionContext> {
+    context_with_resolution(
+        started_at,
+        limit,
+        Ok(CatalogResolution {
+            catalog: CatalogInfo {
+                tables: Vec::new(),
+                table_functions: Vec::new(),
+            },
+            failed_source_names: BTreeSet::new(),
+            runtime_schema_owners: BTreeMap::new(),
+            universal_search_resolutions: reports,
+        }),
+    )
+}
+
+fn context_with_resolution(
+    started_at: Instant,
+    limit: u32,
+    catalog_resolution: Result<CatalogResolution, QueryManagerError>,
+) -> Arc<SearchExecutionContext> {
+    let workspace = WorkspaceName::default();
+    let lifecycle = WorkspaceLifecycleLock::default();
+    let lifecycle_lease = lifecycle.snapshot_for_test(&workspace);
+    Arc::new(SearchExecutionContext::new(
+        started_at,
+        lifecycle_lease,
+        Some("2026-07-20T00:00:00.000Z".to_string()),
+        Uuid::from_u128(99),
+        SearchRequest::new(workspace, "payment", limit).expect("request"),
+        catalog_resolution,
+        ObservedValuesPolicyInput::Disabled,
+    ))
+}
+
+fn report(source: &str, routes: Vec<ResolvedUniversalSearchRoute>) -> UniversalSearchResolution {
+    UniversalSearchResolution {
+        owner_source_name: source.to_string(),
+        eligible_routes: routes,
+        explicit_denials: Vec::new(),
+        diagnostics: Vec::new(),
+        diagnostics_truncated: false,
+        omitted_diagnostic_count: 0,
+    }
+}
+
+fn resolution_diagnostic(
+    source: &str,
+    route_id: Option<&str>,
+    locator: Option<(&str, &str)>,
+    reason: UniversalSearchResolutionReason,
+) -> UniversalSearchResolutionDiagnostic {
+    UniversalSearchResolutionDiagnostic {
+        owner_source_name: source.to_string(),
+        authored_route_id: route_id.map(str::to_string),
+        locator: locator.map(
+            |(schema_name, function_name)| UniversalSearchFunctionLocator {
+                schema_name: schema_name.to_string(),
+                function_name: function_name.to_string(),
+            },
+        ),
+        reason,
+    }
+}
+
+fn route(
+    source: &str,
+    route_name: &str,
+    origin: UniversalSearchResolutionOrigin,
+) -> ResolvedUniversalSearchRoute {
+    ResolvedUniversalSearchRoute {
+        owner_source_name: source.to_string(),
+        installation_revision: Uuid::from_u128(source.bytes().map(u128::from).sum()),
+        authored_route_id: matches!(origin, UniversalSearchResolutionOrigin::Explicit)
+            .then(|| route_name.to_string()),
+        target: ResolvedUniversalSearchTarget::V3 {
+            function_name: route_name.to_string(),
+        },
+        locator: UniversalSearchFunctionLocator {
+            schema_name: format!("{source}_runtime"),
+            function_name: route_name.to_string(),
+        },
+        query_argument: ResolvedUniversalSearchArgument {
+            name: "query".to_string(),
+            data_type: ManifestDataType::Utf8,
+        },
+        default_arguments: Vec::new(),
+        search_limits: SearchLimitsSpec {
+            default_top_k: 5,
+            max_top_k: 5,
+            max_calls_per_query: 1,
+        },
+        result: ResolvedUniversalSearchResultMapping::default(),
+        origin,
+        runtime_contract_fingerprint: RuntimeContractFingerprint::for_test("v1:fanout-test"),
+    }
+}
+
+fn empty_success() -> Behaviour {
+    Behaviour::Immediate {
+        batches: Vec::new(),
+        has_more: false,
+    }
+}
+
+fn coverage(
+    outcome: &crate::search::provider::ProviderSearchOutcome,
+) -> &crate::search::result::ProviderCoverage {
+    outcome.status.coverage.as_ref().expect("native coverage")
+}
+
+async fn wait_for_starts(executor: &ScriptedExecutor, count: usize) {
+    for _ in 0..100 {
+        if executor.starts().len() >= count {
+            return;
+        }
+        tokio::task::yield_now().await;
+    }
+    panic!(
+        "expected {count} executor start(s), got {:?}",
+        executor.starts()
+    );
+}
+
+#[test]
+fn route_selection_is_deterministic_explicit_first_and_one_per_source() {
+    let reports = vec![
+        report(
+            "zeta",
+            vec![
+                route(
+                    "zeta",
+                    "inferred",
+                    UniversalSearchResolutionOrigin::Inferred,
+                ),
+                route(
+                    "zeta",
+                    "explicit",
+                    UniversalSearchResolutionOrigin::Explicit,
+                ),
+            ],
+        ),
+        report(
+            "alpha",
+            vec![route(
+                "alpha",
+                "a",
+                UniversalSearchResolutionOrigin::Explicit,
+            )],
+        ),
+        report(
+            "delta",
+            vec![route(
+                "delta",
+                "d",
+                UniversalSearchResolutionOrigin::Explicit,
+            )],
+        ),
+        report(
+            "beta",
+            vec![route(
+                "beta",
+                "b",
+                UniversalSearchResolutionOrigin::Explicit,
+            )],
+        ),
+        report(
+            "charlie",
+            vec![route(
+                "charlie",
+                "c",
+                UniversalSearchResolutionOrigin::Explicit,
+            )],
+        ),
+    ];
+
+    let inventory = RouteInventory::from_reports(&reports);
+    let selected = inventory
+        .selected
+        .iter()
+        .map(|selected| {
+            (
+                selected.route.owner_source_name.as_str(),
+                selected.route.locator.function_name.as_str(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(inventory.eligible_count, 6);
+    assert_eq!(
+        selected,
+        [
+            ("alpha", "a"),
+            ("beta", "b"),
+            ("charlie", "c"),
+            ("delta", "d")
+        ]
+    );
+    assert_eq!(inventory.unselected.len(), 2);
+}
+
+#[test]
+fn route_selection_golden_is_a1_b1_a2_a3() {
+    let inventory = RouteInventory::from_reports(&[
+        report(
+            "alpha",
+            ["a3", "a1", "a2"]
+                .into_iter()
+                .map(|name| route("alpha", name, UniversalSearchResolutionOrigin::Explicit))
+                .collect(),
+        ),
+        report(
+            "beta",
+            vec![route(
+                "beta",
+                "b1",
+                UniversalSearchResolutionOrigin::Explicit,
+            )],
+        ),
+    ]);
+
+    assert_eq!(
+        inventory
+            .selected
+            .iter()
+            .map(|selected| selected.route.locator.function_name.as_str())
+            .collect::<Vec<_>>(),
+        ["a1", "b1", "a2", "a3"]
+    );
+}
+
+#[tokio::test]
+async fn native_results_round_robin_by_row_then_selected_route_before_digest() {
+    fn result_batch(prefix: &str, seed: usize) -> RecordBatch {
+        let first_id = format!("{prefix}-{seed}-0");
+        let second_id = format!("{prefix}-{seed}-1");
+        let first_title = format!("{prefix}0");
+        let second_title = format!("{prefix}1");
+        RecordBatch::try_from_iter([
+            (
+                "id",
+                Arc::new(StringArray::from(vec![
+                    first_id.as_str(),
+                    second_id.as_str(),
+                ])) as ArrayRef,
+            ),
+            (
+                "title",
+                Arc::new(StringArray::from(vec![
+                    first_title.as_str(),
+                    second_title.as_str(),
+                ])) as ArrayRef,
+            ),
+        ])
+        .expect("result batch")
+    }
+
+    let route_a = route("alpha", "a", UniversalSearchResolutionOrigin::Explicit);
+    let route_b = route("beta", "b", UniversalSearchResolutionOrigin::Explicit);
+    let workspace = WorkspaceName::default();
+    let (batch_a, batch_b) = (0..1_024)
+        .find_map(|seed| {
+            let batch_a = result_batch("A", seed);
+            let batch_b = result_batch("B", seed);
+            let a = normalize_batches(&workspace, &route_a, std::slice::from_ref(&batch_a));
+            let b = normalize_batches(&workspace, &route_b, std::slice::from_ref(&batch_b));
+            (candidate_sort_key(&a[0]) > candidate_sort_key(&b[0])).then_some((batch_a, batch_b))
+        })
+        .expect("find a digest order opposed to selected route order");
+    let executor = ScriptedExecutor::scripted([
+        (
+            "a".to_string(),
+            Behaviour::Immediate {
+                batches: vec![batch_a],
+                has_more: false,
+            },
+        ),
+        (
+            "b".to_string(),
+            Behaviour::Immediate {
+                batches: vec![batch_b],
+                has_more: false,
+            },
+        ),
+    ]);
+    let reports = vec![
+        report("alpha", vec![route_a]),
+        report("beta", vec![route_b]),
+    ];
+    let outcome = provider(executor)
+        .search_native(context(Instant::now(), 10, reports))
+        .await;
+    let titles = outcome
+        .candidates
+        .iter()
+        .map(|candidate| match &candidate.payload {
+            SearchPayload::NativeResult(result) => result.title.as_deref(),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(titles, [Some("A0"), Some("B0"), Some("A1"), Some("B1")]);
+    assert!(outcome.candidates[0].key > outcome.candidates[1].key);
+}
+
+#[tokio::test]
+async fn four_calls_enter_one_wave_and_a_fifth_never_starts() {
+    let reports = ["a", "b", "c", "d", "e"]
+        .into_iter()
+        .map(|source| {
+            report(
+                source,
+                vec![route(
+                    source,
+                    source,
+                    UniversalSearchResolutionOrigin::Explicit,
+                )],
+            )
+        })
+        .collect::<Vec<_>>();
+    let executor = ScriptedExecutor::same(Behaviour::Barrier(Arc::new(Barrier::new(4))));
+
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(1),
+        provider(executor.clone()).search_native(context(Instant::now(), 10, reports)),
+    )
+    .await
+    .expect("four-way barrier completes");
+
+    assert_eq!(executor.starts().len(), 4);
+    assert!(!executor.starts().iter().any(|name| name == "e"));
+    assert_eq!(outcome.status.state, SearchProviderState::Partial);
+    assert_eq!(coverage(&outcome).eligible_units, 5);
+    assert_eq!(coverage(&outcome).searched_units, 4);
+    assert_eq!(coverage(&outcome).failed_units, 0);
+    assert!(coverage(&outcome).budget_exhausted);
+}
+
+#[tokio::test]
+async fn mixed_and_all_failure_states_follow_provider_state_table() {
+    let reports = || {
+        vec![
+            report(
+                "alpha",
+                vec![route(
+                    "alpha",
+                    "a",
+                    UniversalSearchResolutionOrigin::Explicit,
+                )],
+            ),
+            report(
+                "beta",
+                vec![route(
+                    "beta",
+                    "b",
+                    UniversalSearchResolutionOrigin::Explicit,
+                )],
+            ),
+        ]
+    };
+    let mixed = ScriptedExecutor::scripted([
+        ("a".to_string(), empty_success()),
+        ("b".to_string(), Behaviour::EarlyTimeout),
+    ]);
+    let mixed = provider(mixed)
+        .search_native(context(Instant::now(), 10, reports()))
+        .await;
+    assert_eq!(mixed.status.state, SearchProviderState::Partial);
+    assert_eq!(coverage(&mixed).searched_units, 2);
+    assert_eq!(coverage(&mixed).failed_units, 1);
+
+    let failed = ScriptedExecutor::same(Behaviour::EarlyTimeout);
+    let failed = provider(failed)
+        .search_native(context(Instant::now(), 10, reports()))
+        .await;
+    assert_eq!(failed.status.state, SearchProviderState::Error);
+    assert_eq!(coverage(&failed).searched_units, 2);
+    assert_eq!(coverage(&failed).failed_units, 2);
+}
+
+#[test]
+fn selected_failures_map_to_stable_public_reason_codes() {
+    let route = route("alpha", "a", UniversalSearchResolutionOrigin::Explicit);
+    let cases = [
+        (
+            NativeCallFailure::Selected(SelectedTableFunctionFailureKind::RouteStale),
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::RouteStale,
+        ),
+        (
+            NativeCallFailure::Selected(SelectedTableFunctionFailureKind::Execution(
+                QueryExecutionFailureKind::Timeout,
+            )),
+            NativeSearchDiagnosticState::TimedOut,
+            NativeSearchDiagnosticReason::CallTimeout,
+        ),
+        (
+            NativeCallFailure::Selected(SelectedTableFunctionFailureKind::Execution(
+                QueryExecutionFailureKind::Cancelled,
+            )),
+            NativeSearchDiagnosticState::Cancelled,
+            NativeSearchDiagnosticReason::Cancelled,
+        ),
+        (
+            NativeCallFailure::Selected(SelectedTableFunctionFailureKind::Execution(
+                QueryExecutionFailureKind::RateLimited,
+            )),
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::RateLimited,
+        ),
+        (
+            NativeCallFailure::Selected(SelectedTableFunctionFailureKind::Execution(
+                QueryExecutionFailureKind::Authentication,
+            )),
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::AuthOrPermissionFailed,
+        ),
+        (
+            NativeCallFailure::Selected(SelectedTableFunctionFailureKind::Execution(
+                QueryExecutionFailureKind::PermissionDenied,
+            )),
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::AuthOrPermissionFailed,
+        ),
+        (
+            NativeCallFailure::Selected(SelectedTableFunctionFailureKind::Execution(
+                QueryExecutionFailureKind::UpstreamUnavailable,
+            )),
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::UpstreamUnavailable,
+        ),
+        (
+            NativeCallFailure::Selected(SelectedTableFunctionFailureKind::Execution(
+                QueryExecutionFailureKind::InvalidResponse,
+            )),
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::InvalidResponse,
+        ),
+        (
+            NativeCallFailure::Selected(SelectedTableFunctionFailureKind::Execution(
+                QueryExecutionFailureKind::Execution,
+            )),
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::ExecutionFailed,
+        ),
+        (
+            NativeCallFailure::GlobalBudgetExhausted,
+            NativeSearchDiagnosticState::TimedOut,
+            NativeSearchDiagnosticReason::GlobalBudgetExhausted,
+        ),
+        (
+            NativeCallFailure::CallTimeout,
+            NativeSearchDiagnosticState::TimedOut,
+            NativeSearchDiagnosticReason::CallTimeout,
+        ),
+        (
+            NativeCallFailure::UnsupportedCancellation,
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::UnsupportedCancellation,
+        ),
+        (
+            NativeCallFailure::Internal,
+            NativeSearchDiagnosticState::Error,
+            NativeSearchDiagnosticReason::InternalError,
+        ),
+    ];
+
+    for (failure, state, reason) in cases {
+        let diagnostic = failed_call(&route, Duration::from_millis(7), failure, false, true);
+        assert_eq!(diagnostic.state, state, "failure {failure:?}");
+        assert_eq!(diagnostic.reason, reason, "failure {failure:?}");
+        assert_eq!(diagnostic.elapsed_ms, 7);
+    }
+}
+
+#[tokio::test]
+async fn zero_one_and_four_routes_have_exact_state_and_coverage() {
+    let zero = provider(ScriptedExecutor::same(empty_success()))
+        .search_native(context(Instant::now(), 10, Vec::new()))
+        .await;
+    assert_eq!(zero.status.state, SearchProviderState::Skipped);
+    assert_eq!(coverage(&zero).eligible_units, 0);
+    assert_eq!(coverage(&zero).searched_units, 0);
+
+    let one_report = vec![report(
+        "alpha",
+        vec![route(
+            "alpha",
+            "a",
+            UniversalSearchResolutionOrigin::Explicit,
+        )],
+    )];
+    let one = provider(ScriptedExecutor::same(empty_success()))
+        .search_native(context(Instant::now(), 10, one_report))
+        .await;
+    assert_eq!(one.status.state, SearchProviderState::Empty);
+    assert_eq!(coverage(&one).eligible_units, 1);
+    assert_eq!(coverage(&one).searched_units, 1);
+
+    let four_reports = ["alpha", "beta", "charlie", "delta"]
+        .into_iter()
+        .map(|source| {
+            report(
+                source,
+                vec![route(
+                    source,
+                    source,
+                    UniversalSearchResolutionOrigin::Explicit,
+                )],
+            )
+        })
+        .collect();
+    let four = provider(ScriptedExecutor::same(empty_success()))
+        .search_native(context(Instant::now(), 10, four_reports))
+        .await;
+    assert_eq!(four.status.state, SearchProviderState::Empty);
+    assert_eq!(coverage(&four).eligible_units, 4);
+    assert_eq!(coverage(&four).searched_units, 4);
+    assert_eq!(coverage(&four).failed_units, 0);
+    assert!(!coverage(&four).budget_exhausted);
+}
+
+#[tokio::test]
+async fn diagnostics_are_capped_by_tier_then_explicit_source_route_order() {
+    let mut alpha = report(
+        "alpha",
+        vec![
+            route("alpha", "a2", UniversalSearchResolutionOrigin::Explicit),
+            route("alpha", "i2", UniversalSearchResolutionOrigin::Inferred),
+            route("alpha", "a1", UniversalSearchResolutionOrigin::Explicit),
+            route("alpha", "i1", UniversalSearchResolutionOrigin::Inferred),
+        ],
+    );
+    alpha.omitted_diagnostic_count = 3;
+    alpha.diagnostics = (0..14)
+        .map(|index| {
+            resolution_diagnostic(
+                &format!("z{index:02}"),
+                Some(&format!("r{index:02}")),
+                Some(("safe_schema", "safe_function")),
+                UniversalSearchResolutionReason::RouteStale,
+            )
+        })
+        .collect();
+    let beta = report(
+        "beta",
+        vec![route(
+            "beta",
+            "b1",
+            UniversalSearchResolutionOrigin::Explicit,
+        )],
+    );
+    let outcome = provider(ScriptedExecutor::same(empty_success()))
+        .search_native(context(Instant::now(), 10, vec![beta, alpha]))
+        .await;
+
+    assert_eq!(outcome.status.diagnostics.len(), 16);
+    assert!(outcome.status.diagnostics_truncated);
+    assert_eq!(outcome.status.omitted_diagnostic_count, 6);
+    assert_eq!(
+        outcome.status.diagnostics[..4]
+            .iter()
+            .map(|diagnostic| {
+                (
+                    diagnostic.installed_source_name.as_str(),
+                    diagnostic.function_name.as_deref(),
+                )
+            })
+            .collect::<Vec<_>>(),
+        [
+            ("alpha", Some("a1")),
+            ("alpha", Some("a2")),
+            ("alpha", Some("i1")),
+            ("beta", Some("b1")),
+        ]
+    );
+    assert_eq!(
+        outcome.status.diagnostics[4].reason,
+        NativeSearchDiagnosticReason::FanoutLimitReached
+    );
+    assert_eq!(
+        outcome.status.diagnostics[4].function_name.as_deref(),
+        Some("i2")
+    );
+    assert_eq!(outcome.status.diagnostics[5].installed_source_name, "z00");
+}
+
+#[tokio::test]
+async fn resolved_diagnostic_keeps_locator_and_unresolved_diagnostic_omits_it() {
+    let mut report = report("alpha", Vec::new());
+    report.diagnostics = vec![
+        resolution_diagnostic(
+            "alpha",
+            Some("resolved"),
+            Some(("safe_schema", "safe_function")),
+            UniversalSearchResolutionReason::UnsafeOperation,
+        ),
+        resolution_diagnostic(
+            "alpha",
+            Some("unresolved"),
+            None,
+            UniversalSearchResolutionReason::AmbiguousRoute,
+        ),
+    ];
+    let outcome = provider(ScriptedExecutor::same(empty_success()))
+        .search_native(context(Instant::now(), 10, vec![report]))
+        .await;
+    let resolved = outcome
+        .status
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.authored_route_id.as_deref() == Some("resolved"))
+        .expect("resolved diagnostic");
+    assert_eq!(resolved.schema_name.as_deref(), Some("safe_schema"));
+    assert_eq!(resolved.function_name.as_deref(), Some("safe_function"));
+    let unresolved = outcome
+        .status
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.authored_route_id.as_deref() == Some("unresolved"))
+        .expect("unresolved diagnostic");
+    assert_eq!(unresolved.schema_name, None);
+    assert_eq!(unresolved.function_name, None);
+}
+
+#[tokio::test(start_paused = true)]
+async fn call_timeout_fires_at_600ms_and_cancellable_work_is_released() {
+    let executor = ScriptedExecutor::same(Behaviour::WaitForCancellation);
+    let reports = vec![report(
+        "a",
+        vec![route("a", "a", UniversalSearchResolutionOrigin::Explicit)],
+    )];
+    let provider = provider(executor.clone());
+    let task = tokio::spawn(async move {
+        provider
+            .search_native(context(Instant::now(), 10, reports))
+            .await
+    });
+    wait_for_starts(&executor, 1).await;
+
+    tokio::time::advance(Duration::from_millis(599)).await;
+    assert!(!task.is_finished());
+    tokio::time::advance(Duration::from_millis(1)).await;
+    let outcome = task.await.expect("provider task");
+
+    assert!(coverage(&outcome).timed_out);
+    assert!(coverage(&outcome).budget_exhausted);
+    assert_eq!(coverage(&outcome).searched_units, 1);
+    assert_eq!(coverage(&outcome).failed_units, 1);
+    assert_eq!(
+        outcome.status.diagnostics[0].reason,
+        NativeSearchDiagnosticReason::CallTimeout
+    );
+    assert_eq!(
+        outcome.status.diagnostics[0].state,
+        NativeSearchDiagnosticState::TimedOut
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn non_settling_cleanup_preserves_timeout_facts_and_stops_at_625ms() {
+    let executor = ScriptedExecutor::same(Behaviour::NeverSettles);
+    let reports = vec![report(
+        "a",
+        vec![route("a", "a", UniversalSearchResolutionOrigin::Explicit)],
+    )];
+    let provider = provider(executor.clone());
+    let started_at = Instant::now();
+    let task = tokio::spawn(async move {
+        provider
+            .search_native(context(started_at, 10, reports))
+            .await
+    });
+    wait_for_starts(&executor, 1).await;
+
+    tokio::time::advance(Duration::from_millis(624)).await;
+    assert!(!task.is_finished());
+    tokio::time::advance(Duration::from_millis(1)).await;
+    let outcome = task.await.expect("provider task");
+
+    assert_eq!(
+        Instant::now().duration_since(started_at),
+        Duration::from_millis(625)
+    );
+    assert!(coverage(&outcome).timed_out);
+    assert!(coverage(&outcome).budget_exhausted);
+    assert_eq!(
+        outcome.status.diagnostics[0].reason,
+        NativeSearchDiagnosticReason::UnsupportedCancellation
+    );
+    assert_eq!(
+        outcome.status.diagnostics[0].state,
+        NativeSearchDiagnosticState::TimedOut
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn request_relative_global_cutoff_wins_when_setup_consumed_200ms() {
+    let executor = ScriptedExecutor::same(Behaviour::NeverSettles);
+    let reports = vec![report(
+        "a",
+        vec![route("a", "a", UniversalSearchResolutionOrigin::Explicit)],
+    )];
+    let provider = provider(executor.clone());
+    let request_started_at = Instant::now() - Duration::from_millis(200);
+    let task = tokio::spawn(async move {
+        provider
+            .search_native(context(request_started_at, 10, reports))
+            .await
+    });
+    wait_for_starts(&executor, 1).await;
+
+    tokio::time::advance(Duration::from_millis(574)).await;
+    assert!(!task.is_finished());
+    tokio::time::advance(Duration::from_millis(1)).await;
+    let outcome = task.await.expect("provider task");
+
+    assert_eq!(
+        Instant::now().duration_since(request_started_at),
+        Duration::from_millis(775)
+    );
+    assert_eq!(
+        outcome.status.diagnostics[0].reason,
+        NativeSearchDiagnosticReason::UnsupportedCancellation
+    );
+    assert!(coverage(&outcome).timed_out);
+    assert!(coverage(&outcome).budget_exhausted);
+}
+
+#[tokio::test(start_paused = true)]
+async fn success_settling_during_global_grace_is_discarded() {
+    let wave_cancellation = coral_engine::QueryCancellationToken::new();
+    let global_deadline = Instant::now() + Duration::from_millis(750);
+    let selected = SelectedRoute {
+        order: 0,
+        route: route("alpha", "a", UniversalSearchResolutionOrigin::Explicit),
+    };
+    let controls = coral_engine::QueryExecutionControls::for_fanout(
+        global_deadline,
+        wave_cancellation.child_token(),
+    );
+    let task_selected = selected.clone();
+    let task = tokio::spawn(async move {
+        tokio::time::sleep_until(global_deadline + Duration::from_millis(10)).await;
+        AttemptResult {
+            selected: task_selected,
+            elapsed: Duration::from_millis(760),
+            upstream_started: true,
+            timeout_scope: None,
+            cleanup_settled: true,
+            outcome: AttemptOutcome::Success {
+                candidates: Vec::new(),
+                raw_row_count: 1,
+                continuation: false,
+            },
+        }
+    });
+    let collector = tokio::spawn(async move {
+        collect_attempts(
+            vec![CallTask {
+                selected,
+                controls,
+                spawned_at: Instant::now(),
+                deadline_state: CallDeadlineState::new(TimeoutScope::Global),
+                task,
+            }],
+            &wave_cancellation,
+            global_deadline,
+            Duration::from_millis(25),
+        )
+        .await
+    });
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(760)).await;
+    let attempts = collector.await.expect("collector task");
+
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(attempts[0].timeout_scope, Some(TimeoutScope::Global));
+    assert!(matches!(
+        attempts[0].outcome,
+        AttemptOutcome::Failure(super::NativeCallFailure::GlobalBudgetExhausted)
+    ));
+}
+
+#[tokio::test(start_paused = true)]
+async fn post_global_grace_abort_is_not_awaited() {
+    let started_at = Instant::now();
+    let wave_cancellation = coral_engine::QueryCancellationToken::new();
+    let global_deadline = started_at + Duration::from_millis(750);
+    let selected = SelectedRoute {
+        order: 0,
+        route: route("alpha", "a", UniversalSearchResolutionOrigin::Explicit),
+    };
+    let controls = coral_engine::QueryExecutionControls::for_fanout(
+        global_deadline,
+        wave_cancellation.child_token(),
+    );
+    let task = tokio::spawn(future::pending::<AttemptResult>());
+    let collector = tokio::spawn(async move {
+        collect_attempts(
+            vec![CallTask {
+                selected,
+                controls,
+                spawned_at: started_at,
+                deadline_state: CallDeadlineState::new(TimeoutScope::Global),
+                task,
+            }],
+            &wave_cancellation,
+            global_deadline,
+            Duration::from_millis(25),
+        )
+        .await
+    });
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(750)).await;
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(25)).await;
+    let attempts = collector.await.expect("collector task");
+
+    assert_eq!(
+        Instant::now().duration_since(started_at),
+        Duration::from_millis(775)
+    );
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(attempts[0].timeout_scope, Some(TimeoutScope::Global));
+    assert!(!attempts[0].cleanup_settled);
+    assert!(matches!(
+        attempts[0].outcome,
+        AttemptOutcome::Failure(NativeCallFailure::UnsupportedCancellation)
+    ));
+}
+
+#[tokio::test(start_paused = true)]
+async fn remaining_99ms_skips_but_exactly_100ms_starts() {
+    let reports = || {
+        vec![report(
+            "a",
+            vec![route("a", "a", UniversalSearchResolutionOrigin::Explicit)],
+        )]
+    };
+    let skipped_executor = ScriptedExecutor::same(empty_success());
+    let skipped = provider(skipped_executor.clone())
+        .search_native(context(
+            Instant::now() - Duration::from_millis(651),
+            10,
+            reports(),
+        ))
+        .await;
+    assert!(skipped_executor.starts().is_empty());
+    assert_eq!(skipped.status.state, SearchProviderState::Skipped);
+    assert!(coverage(&skipped).budget_exhausted);
+
+    let started_executor = ScriptedExecutor::same(empty_success());
+    let started = provider(started_executor.clone())
+        .search_native(context(
+            Instant::now() - Duration::from_millis(650),
+            10,
+            reports(),
+        ))
+        .await;
+    assert_eq!(started_executor.starts(), ["a"]);
+    assert_eq!(coverage(&started).searched_units, 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn early_source_timeout_under_global_capped_deadline_is_call_timeout() {
+    let executor = ScriptedExecutor::same(Behaviour::EarlyTimeout);
+    let reports = vec![report(
+        "a",
+        vec![route("a", "a", UniversalSearchResolutionOrigin::Explicit)],
+    )];
+    let outcome = provider(executor)
+        .search_native(context(
+            Instant::now() - Duration::from_millis(200),
+            10,
+            reports,
+        ))
+        .await;
+
+    assert_eq!(
+        outcome.status.diagnostics[0].reason,
+        NativeSearchDiagnosticReason::CallTimeout
+    );
+    assert!(coverage(&outcome).timed_out);
+    assert!(coverage(&outcome).budget_exhausted);
+}
+
+#[tokio::test(start_paused = true)]
+async fn panic_after_upstream_start_keeps_exact_search_accounting() {
+    let executor = ScriptedExecutor::same(Behaviour::PanicAfter(Duration::from_millis(10)));
+    let reports = vec![report(
+        "a",
+        vec![route("a", "a", UniversalSearchResolutionOrigin::Explicit)],
+    )];
+    let provider = provider(executor.clone());
+    let task = tokio::spawn(async move {
+        provider
+            .search_native(context(Instant::now(), 10, reports))
+            .await
+    });
+    wait_for_starts(&executor, 1).await;
+    tokio::time::advance(Duration::from_millis(10)).await;
+    let outcome = task.await.expect("provider task");
+
+    assert_eq!(coverage(&outcome).searched_units, 1);
+    assert_eq!(coverage(&outcome).failed_units, 1);
+    assert!(outcome.status.diagnostics[0].elapsed_ms >= 10);
+    assert_eq!(
+        outcome.status.diagnostics[0].reason,
+        NativeSearchDiagnosticReason::InternalError
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn panic_during_call_cleanup_preserves_timeout_classification() {
+    let executor =
+        ScriptedExecutor::same(Behaviour::PanicAfterCancellation(Duration::from_millis(10)));
+    let reports = vec![report(
+        "alpha",
+        vec![route(
+            "alpha",
+            "a",
+            UniversalSearchResolutionOrigin::Explicit,
+        )],
+    )];
+    let provider = provider(executor.clone());
+    let task = tokio::spawn(async move {
+        provider
+            .search_native(context(Instant::now(), 10, reports))
+            .await
+    });
+    wait_for_starts(&executor, 1).await;
+    tokio::time::advance(Duration::from_millis(600)).await;
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(10)).await;
+    let outcome = task.await.expect("provider task");
+
+    assert!(coverage(&outcome).timed_out);
+    assert!(coverage(&outcome).budget_exhausted);
+    assert_eq!(coverage(&outcome).searched_units, 1);
+    assert_eq!(coverage(&outcome).failed_units, 1);
+    assert_eq!(
+        outcome.status.diagnostics[0].reason,
+        NativeSearchDiagnosticReason::CallTimeout
+    );
+    assert_eq!(
+        outcome.status.diagnostics[0].state,
+        NativeSearchDiagnosticState::TimedOut
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn early_panic_reaped_after_another_deadline_remains_internal() {
+    let executor = ScriptedExecutor::scripted([
+        ("a".to_string(), Behaviour::NeverSettles),
+        (
+            "b".to_string(),
+            Behaviour::PanicAfter(Duration::from_millis(5)),
+        ),
+    ]);
+    let reports = vec![
+        report(
+            "alpha",
+            vec![route(
+                "alpha",
+                "a",
+                UniversalSearchResolutionOrigin::Explicit,
+            )],
+        ),
+        report(
+            "beta",
+            vec![route(
+                "beta",
+                "b",
+                UniversalSearchResolutionOrigin::Explicit,
+            )],
+        ),
+    ];
+    let provider = provider(executor.clone());
+    let task = tokio::spawn(async move {
+        provider
+            .search_native(context(Instant::now(), 10, reports))
+            .await
+    });
+    wait_for_starts(&executor, 2).await;
+    tokio::time::advance(Duration::from_millis(5)).await;
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(595)).await;
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(25)).await;
+    let outcome = task.await.expect("provider task");
+    let beta = outcome
+        .status
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.installed_source_name == "beta")
+        .expect("beta diagnostic");
+
+    assert_eq!(beta.reason, NativeSearchDiagnosticReason::InternalError);
+    assert_eq!(beta.state, NativeSearchDiagnosticState::Error);
+}
+
+#[tokio::test]
+async fn exactly_five_rows_without_continuation_does_not_claim_more() {
+    let batch = RecordBatch::try_from_iter([(
+        "title",
+        Arc::new(StringArray::from(vec![
+            "one", "two", "three", "four", "five",
+        ])) as ArrayRef,
+    )])
+    .expect("batch");
+    let reports = vec![report(
+        "alpha",
+        vec![route(
+            "alpha",
+            "a",
+            UniversalSearchResolutionOrigin::Explicit,
+        )],
+    )];
+    let outcome = provider(ScriptedExecutor::same(Behaviour::Immediate {
+        batches: vec![batch],
+        has_more: false,
+    }))
+    .search_native(context(Instant::now(), 10, reports))
+    .await;
+
+    assert_eq!(outcome.candidates.len(), 5);
+    assert_eq!(coverage(&outcome).returned_count, 5);
+    assert!(!coverage(&outcome).has_more);
+}
+
+#[tokio::test]
+async fn contentless_rows_report_no_safe_fields_without_counting_a_result() {
+    let batch = RecordBatch::try_from_iter([(
+        "unmapped_field",
+        Arc::new(StringArray::from(vec!["safe but not displayable"])) as ArrayRef,
+    )])
+    .expect("batch");
+    let reports = vec![report(
+        "alpha",
+        vec![route(
+            "alpha",
+            "a",
+            UniversalSearchResolutionOrigin::Explicit,
+        )],
+    )];
+    let outcome = provider(ScriptedExecutor::same(Behaviour::Immediate {
+        batches: vec![batch],
+        has_more: false,
+    }))
+    .search_native(context(Instant::now(), 10, reports))
+    .await;
+
+    assert!(outcome.candidates.is_empty());
+    assert_eq!(outcome.status.state, SearchProviderState::Empty);
+    assert_eq!(coverage(&outcome).returned_count, 0);
+    assert_eq!(
+        outcome.status.diagnostics[0].reason,
+        NativeSearchDiagnosticReason::NoSafeDisplayFields
+    );
+}
+
+#[tokio::test]
+async fn returned_count_is_measured_before_native_deduplication() {
+    let batch = RecordBatch::try_from_iter([
+        (
+            "id",
+            Arc::new(StringArray::from(vec!["same-id", "same-id"])) as ArrayRef,
+        ),
+        (
+            "title",
+            Arc::new(StringArray::from(vec!["same result", "same result"])) as ArrayRef,
+        ),
+    ])
+    .expect("batch");
+    let reports = vec![report(
+        "alpha",
+        vec![route(
+            "alpha",
+            "a",
+            UniversalSearchResolutionOrigin::Explicit,
+        )],
+    )];
+    let outcome = provider(ScriptedExecutor::same(Behaviour::Immediate {
+        batches: vec![batch],
+        has_more: false,
+    }))
+    .search_native(context(Instant::now(), 10, reports))
+    .await;
+
+    assert_eq!(coverage(&outcome).returned_count, 2);
+    assert_eq!(outcome.candidates.len(), 1);
+}
+
+#[tokio::test]
+async fn catalog_resolution_failure_marks_native_provider_error_without_starting_calls() {
+    let executor = ScriptedExecutor::same(empty_success());
+    let outcome = provider(executor.clone())
+        .search_native(context_with_resolution(
+            Instant::now(),
+            10,
+            Err(QueryManagerError::App(AppError::Unavailable(
+                "catalog unavailable".to_string(),
+            ))),
+        ))
+        .await;
+
+    assert!(executor.starts().is_empty());
+    assert!(outcome.candidates.is_empty());
+    assert_eq!(outcome.status.state, SearchProviderState::Error);
+    assert_eq!(coverage(&outcome).eligible_units, 0);
+    assert_eq!(coverage(&outcome).searched_units, 0);
+    assert_eq!(coverage(&outcome).failed_units, 0);
+}
+
+#[tokio::test]
+async fn contentless_rows_are_empty_and_safe_rows_never_expose_raw_sentinels() {
+    let batch = RecordBatch::try_from_iter([
+        (
+            "id",
+            Arc::new(StringArray::from(vec![
+                Some("safe-1"),
+                Some("sk-12345678901234567890"),
+            ])) as ArrayRef,
+        ),
+        (
+            "title",
+            Arc::new(StringArray::from(vec![
+                Some("Safe issue"),
+                Some("Bearer secret-secret-secret"),
+            ])) as ArrayRef,
+        ),
+        (
+            "url",
+            Arc::new(StringArray::from(vec![
+                Some("https://example.test/issue?%74oken=raw-url-secret&safe=1"),
+                Some("javascript:raw-password"),
+            ])) as ArrayRef,
+        ),
+    ])
+    .expect("batch");
+    let executor = ScriptedExecutor::same(Behaviour::Immediate {
+        batches: vec![batch],
+        has_more: false,
+    });
+    let reports = vec![report(
+        "a",
+        vec![route("a", "a", UniversalSearchResolutionOrigin::Explicit)],
+    )];
+    let outcome = provider(executor)
+        .search_native(context(Instant::now(), 10, reports))
+        .await;
+
+    assert_eq!(coverage(&outcome).returned_count, 1);
+    assert_eq!(outcome.candidates.len(), 1);
+    let SearchPayload::NativeResult(result) = &outcome.candidates[0].payload else {
+        panic!("native result");
+    };
+    assert_eq!(result.title.as_deref(), Some("Safe issue"));
+    assert_eq!(
+        result.url.as_deref(),
+        Some("https://example.test/issue?safe=1")
+    );
+    let rendered = format!("{outcome:?}");
+    for sentinel in [
+        "sensitive SQL sentinel",
+        "raw-url-secret",
+        "raw-password",
+        "Bearer secret-secret-secret",
+        "sk-12345678901234567890",
+    ] {
+        assert!(!rendered.contains(sentinel), "leaked sentinel {sentinel}");
+    }
+}

--- a/crates/coral-app/src/search/native/provider/tests.rs
+++ b/crates/coral-app/src/search/native/provider/tests.rs
@@ -191,7 +191,6 @@ fn context(
                 table_functions: Vec::new(),
             },
             failed_source_names: BTreeSet::new(),
-            runtime_schema_owners: BTreeMap::new(),
             universal_search_resolutions: reports,
         }),
     )
@@ -218,7 +217,7 @@ fn context_with_resolution(
 
 fn report(source: &str, routes: Vec<ResolvedUniversalSearchRoute>) -> UniversalSearchResolution {
     UniversalSearchResolution {
-        owner_source_name: source.to_string(),
+        source_name: source.to_string(),
         eligible_routes: routes,
         explicit_denials: Vec::new(),
         diagnostics: Vec::new(),
@@ -234,7 +233,7 @@ fn resolution_diagnostic(
     reason: UniversalSearchResolutionReason,
 ) -> UniversalSearchResolutionDiagnostic {
     UniversalSearchResolutionDiagnostic {
-        owner_source_name: source.to_string(),
+        source_name: source.to_string(),
         authored_route_id: route_id.map(str::to_string),
         locator: locator.map(
             |(schema_name, function_name)| UniversalSearchFunctionLocator {
@@ -252,7 +251,7 @@ fn route(
     origin: UniversalSearchResolutionOrigin,
 ) -> ResolvedUniversalSearchRoute {
     ResolvedUniversalSearchRoute {
-        owner_source_name: source.to_string(),
+        source_name: source.to_string(),
         installation_revision: Uuid::from_u128(source.bytes().map(u128::from).sum()),
         authored_route_id: matches!(origin, UniversalSearchResolutionOrigin::Explicit)
             .then(|| route_name.to_string()),
@@ -260,7 +259,7 @@ fn route(
             operation_id: route_name.to_string(),
         },
         locator: UniversalSearchFunctionLocator {
-            schema_name: format!("{source}_runtime"),
+            schema_name: source.to_string(),
             function_name: route_name.to_string(),
         },
         query_argument: ResolvedUniversalSearchArgument {
@@ -363,7 +362,7 @@ fn route_selection_is_deterministic_explicit_first_and_one_per_source() {
         .iter()
         .map(|selected| {
             (
-                selected.route.owner_source_name.as_str(),
+                selected.route.source_name.as_str(),
                 selected.route.locator.function_name.as_str(),
             )
         })
@@ -406,9 +405,19 @@ fn route_selection_golden_is_a1_b1_a2_a3() {
         inventory
             .selected
             .iter()
-            .map(|selected| selected.route.locator.function_name.as_str())
+            .map(|selected| {
+                (
+                    selected.route.source_name.as_str(),
+                    selected.route.locator.function_name.as_str(),
+                )
+            })
             .collect::<Vec<_>>(),
-        ["a1", "b1", "a2", "a3"]
+        [
+            ("alpha", "a1"),
+            ("beta", "b1"),
+            ("alpha", "a2"),
+            ("alpha", "a3"),
+        ]
     );
 }
 
@@ -473,16 +482,28 @@ async fn native_results_round_robin_by_row_then_selected_route_before_digest() {
     let outcome = provider(executor)
         .search_native(context(Instant::now(), 10, reports))
         .await;
-    let titles = outcome
+    let results = outcome
         .candidates
         .iter()
         .map(|candidate| match &candidate.payload {
-            SearchPayload::NativeResult(result) => result.title.as_deref(),
-            _ => None,
+            SearchPayload::NativeResult(result) => (
+                result.schema_name.as_str(),
+                result.function_name.as_str(),
+                result.title.as_deref(),
+            ),
+            _ => unreachable!("native fanout returns only native results"),
         })
         .collect::<Vec<_>>();
 
-    assert_eq!(titles, [Some("A0"), Some("B0"), Some("A1"), Some("B1")]);
+    assert_eq!(
+        results,
+        [
+            ("alpha", "a", Some("A0")),
+            ("beta", "b", Some("B0")),
+            ("alpha", "a", Some("A1")),
+            ("beta", "b", Some("B1")),
+        ]
+    );
     assert!(outcome.candidates[0].key > outcome.candidates[1].key);
 }
 
@@ -715,16 +736,6 @@ async fn diagnostics_are_capped_by_tier_then_explicit_source_route_order() {
         ],
     );
     alpha.omitted_diagnostic_count = 3;
-    alpha.diagnostics = (0..14)
-        .map(|index| {
-            resolution_diagnostic(
-                &format!("z{index:02}"),
-                Some(&format!("r{index:02}")),
-                Some(("safe_schema", "safe_function")),
-                UniversalSearchResolutionReason::RouteStale,
-            )
-        })
-        .collect();
     let beta = report(
         "beta",
         vec![route(
@@ -733,8 +744,21 @@ async fn diagnostics_are_capped_by_tier_then_explicit_source_route_order() {
             UniversalSearchResolutionOrigin::Explicit,
         )],
     );
+    let mut reports = vec![beta, alpha];
+    reports.extend((0..14).map(|index| {
+        let source_name = format!("z{index:02}");
+        let route_id = format!("r{index:02}");
+        let mut report = report(&source_name, Vec::new());
+        report.diagnostics = vec![resolution_diagnostic(
+            &source_name,
+            Some(&route_id),
+            Some((&source_name, "safe_function")),
+            UniversalSearchResolutionReason::RouteStale,
+        )];
+        report
+    }));
     let outcome = provider(ScriptedExecutor::same(empty_success()))
-        .search_native(context(Instant::now(), 10, vec![beta, alpha]))
+        .search_native(context(Instant::now(), 10, reports))
         .await;
 
     assert_eq!(outcome.status.diagnostics.len(), 16);
@@ -745,7 +769,7 @@ async fn diagnostics_are_capped_by_tier_then_explicit_source_route_order() {
             .iter()
             .map(|diagnostic| {
                 (
-                    diagnostic.installed_source_name.as_str(),
+                    diagnostic.source_name.as_str(),
                     diagnostic.function_name.as_deref(),
                 )
             })
@@ -765,17 +789,17 @@ async fn diagnostics_are_capped_by_tier_then_explicit_source_route_order() {
         outcome.status.diagnostics[4].function_name.as_deref(),
         Some("i2")
     );
-    assert_eq!(outcome.status.diagnostics[5].installed_source_name, "z00");
+    assert_eq!(outcome.status.diagnostics[5].source_name, "z00");
 }
 
 #[tokio::test]
-async fn resolved_diagnostic_keeps_locator_and_unresolved_diagnostic_omits_it() {
+async fn resolved_diagnostic_keeps_function_and_unresolved_diagnostic_omits_it() {
     let mut report = report("alpha", Vec::new());
     report.diagnostics = vec![
         resolution_diagnostic(
             "alpha",
             Some("resolved"),
-            Some(("safe_schema", "safe_function")),
+            Some(("alpha", "safe_function")),
             UniversalSearchResolutionReason::UnsafeOperation,
         ),
         resolution_diagnostic(
@@ -794,7 +818,7 @@ async fn resolved_diagnostic_keeps_locator_and_unresolved_diagnostic_omits_it() 
         .iter()
         .find(|diagnostic| diagnostic.authored_route_id.as_deref() == Some("resolved"))
         .expect("resolved diagnostic");
-    assert_eq!(resolved.schema_name.as_deref(), Some("safe_schema"));
+    assert_eq!(resolved.source_name, "alpha");
     assert_eq!(resolved.function_name.as_deref(), Some("safe_function"));
     let unresolved = outcome
         .status
@@ -802,7 +826,7 @@ async fn resolved_diagnostic_keeps_locator_and_unresolved_diagnostic_omits_it() 
         .iter()
         .find(|diagnostic| diagnostic.authored_route_id.as_deref() == Some("unresolved"))
         .expect("unresolved diagnostic");
-    assert_eq!(unresolved.schema_name, None);
+    assert_eq!(unresolved.source_name, "alpha");
     assert_eq!(unresolved.function_name, None);
 }
 
@@ -1176,7 +1200,7 @@ async fn early_panic_reaped_after_another_deadline_remains_internal() {
         .status
         .diagnostics
         .iter()
-        .find(|diagnostic| diagnostic.installed_source_name == "beta")
+        .find(|diagnostic| diagnostic.source_name == "beta")
         .expect("beta diagnostic");
 
     assert_eq!(beta.reason, NativeSearchDiagnosticReason::InternalError);

--- a/crates/coral-app/src/search/native/provider/tests.rs
+++ b/crates/coral-app/src/search/native/provider/tests.rs
@@ -256,8 +256,8 @@ fn route(
         installation_revision: Uuid::from_u128(source.bytes().map(u128::from).sum()),
         authored_route_id: matches!(origin, UniversalSearchResolutionOrigin::Explicit)
             .then(|| route_name.to_string()),
-        target: ResolvedUniversalSearchTarget::V3 {
-            function_name: route_name.to_string(),
+        target: ResolvedUniversalSearchTarget {
+            operation_id: route_name.to_string(),
         },
         locator: UniversalSearchFunctionLocator {
             schema_name: format!("{source}_runtime"),

--- a/crates/coral-app/src/search/native/tests.rs
+++ b/crates/coral-app/src/search/native/tests.rs
@@ -697,6 +697,12 @@ fn candidate(
             content_truncated: false,
         },
         identity: None,
+        sort_key: super::identity::sort_key_for_row(
+            &workspace(),
+            &route(ResolvedUniversalSearchResultMapping::default()),
+            row_ordinal,
+            None,
+        ),
         rank_input: NativeRankInput::from_provider_ordinal(row_ordinal),
     }
 }

--- a/crates/coral-app/src/search/observed/provider.rs
+++ b/crates/coral-app/src/search/observed/provider.rs
@@ -2,6 +2,8 @@
 
 use std::time::Duration;
 
+use uuid::Uuid;
+
 use crate::bootstrap::AppError;
 use crate::search::maintenance::{
     ObservedClearMaintenanceResult, ObservedDrainMaintenanceResult,
@@ -56,17 +58,28 @@ impl ObservedValuesProvider {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn search(
         &self,
         request: &SearchRequest,
         policy: Result<&ObservedValuesRetrievalPolicy, &AppError>,
+    ) -> ProviderSearchOutcome {
+        self.search_with_origin(request, policy, None, None)
+    }
+
+    pub(crate) fn search_with_origin(
+        &self,
+        request: &SearchRequest,
+        policy: Result<&ObservedValuesRetrievalPolicy, &AppError>,
+        search_origin: Option<Uuid>,
+        observed_values_cutoff: Option<&str>,
     ) -> ProviderSearchOutcome {
         let policy = match policy {
             Ok(policy) => policy,
             Err(error) => return observed_policy_error_outcome(error),
         };
         self.write_coordinator.run(&request.workspace_name, || {
-            self.search_with_policy(request, policy)
+            self.search_with_policy(request, policy, search_origin, observed_values_cutoff)
         })
     }
 
@@ -74,17 +87,20 @@ impl ObservedValuesProvider {
         &self,
         request: &SearchRequest,
         policy: &ObservedValuesRetrievalPolicy,
+        search_origin: Option<Uuid>,
+        observed_values_cutoff: Option<&str>,
     ) -> ProviderSearchOutcome {
-        let (drain, drain_error) = self.drain_before_search(&request.workspace_name);
+        let (drain, drain_error) = self.drain_before_search(&request.workspace_name, search_origin);
         let retrieval_limit = usize::try_from(request.limit)
             .unwrap_or(usize::MAX)
             .saturating_mul(OBSERVED_PROVIDER_RETRIEVAL_MULTIPLIER)
             .max(OBSERVED_PROVIDER_MIN_RETRIEVAL_LIMIT);
-        let hits = match self.store.search(
+        let hits = match self.store.search_before(
             &request.workspace_name,
             &request.terms,
             retrieval_limit,
             policy,
+            observed_values_cutoff,
         ) {
             Ok(hits) => hits,
             Err(error) => return observed_error_outcome(&error),
@@ -116,8 +132,12 @@ impl ObservedValuesProvider {
     fn drain_before_search(
         &self,
         workspace_name: &WorkspaceName,
+        search_origin: Option<Uuid>,
     ) -> (ObservedValuesDrainResult, Option<String>) {
-        let pending_queue_depth = match self.store.pending_queue_job_count(workspace_name) {
+        let pending_queue_depth = match self
+            .store
+            .pending_queue_job_count_before_search(workspace_name, search_origin)
+        {
             Ok(0) => return (ObservedValuesDrainResult::default(), None),
             Ok(count) => u32::try_from(count).unwrap_or(u32::MAX),
             Err(error) => {
@@ -132,12 +152,13 @@ impl ObservedValuesProvider {
                 );
             }
         };
-        match self.store.drain_queue(
+        match self.store.drain_queue_before_search(
             workspace_name,
             ObservedValuesDrainBudget::new(
                 OBSERVED_DRAIN_BEFORE_SEARCH_MAX_JOBS,
                 Duration::from_millis(OBSERVED_DRAIN_BEFORE_SEARCH_MS),
             ),
+            search_origin,
         ) {
             Ok(drain) => {
                 log_storage_drops(workspace_name, &drain);

--- a/crates/coral-app/src/search/observed/publisher.rs
+++ b/crates/coral-app/src/search/observed/publisher.rs
@@ -18,7 +18,7 @@ use crate::search::observed::sqlite_queue::{ObservedValuesEpoch, ObservedValuesS
 use crate::search::observed::sqlite_store::SqliteObservedValuesStore;
 use crate::search::observed::writer::{
     ObservedValuesTryReserveError, ObservedValuesWrite, ObservedValuesWriter,
-    payload_json_with_budget,
+    payload_json_with_budget_and_origin,
 };
 use crate::search::sqlite_store::SqliteSearchError;
 use crate::state::AppStateLayout;
@@ -72,6 +72,7 @@ impl SearchObservationHandle {
         &self,
         workspace_name: &WorkspaceName,
         selected_sources: &[SearchObservationSource<'_>],
+        search_origin: Option<Uuid>,
     ) -> EngineExtensions {
         let epochs = match self.store.capture_epochs_for_sources(
             workspace_name,
@@ -113,6 +114,7 @@ impl SearchObservationHandle {
                 writer: self.writer.clone(),
                 collector: self.collector.clone(),
                 scopes,
+                search_origin,
             },
         ));
         extensions
@@ -163,6 +165,7 @@ struct SourceScanObservedValuesPublisher {
     writer: ObservedValuesWriter,
     collector: ObservedValuesCollector,
     scopes: HashMap<SurfaceKey, RegisteredSurface>,
+    search_origin: Option<Uuid>,
 }
 
 struct RegisteredSurface {
@@ -223,9 +226,10 @@ impl SourceScanObservedValuesPublisher {
         if payload.is_empty() {
             return;
         }
-        let payload_json = match payload_json_with_budget(
+        let payload_json = match payload_json_with_budget_and_origin(
             payload,
             self.collector.budget().job_bytes_limit,
+            self.search_origin,
         ) {
             Ok(Some(payload_json)) => payload_json,
             Ok(None) => {
@@ -351,8 +355,11 @@ mod tests {
         let workspace = WorkspaceName::default();
         let handle = SearchObservationHandle::new(layout.clone());
         let source = secret_input_query_source();
-        let extensions =
-            handle.extensions_for(&workspace, &[SearchObservationSource::for_test(&source)]);
+        let extensions = handle.extensions_for(
+            &workspace,
+            &[SearchObservationSource::for_test(&source)],
+            None,
+        );
         let publisher = extensions
             .source_observation_publishers
             .first()
@@ -399,8 +406,11 @@ mod tests {
         let workspace = WorkspaceName::default();
         let handle = SearchObservationHandle::new(layout.clone());
         let source = secret_input_query_source();
-        let extensions =
-            handle.extensions_for(&workspace, &[SearchObservationSource::for_test(&source)]);
+        let extensions = handle.extensions_for(
+            &workspace,
+            &[SearchObservationSource::for_test(&source)],
+            None,
+        );
         let publisher = extensions
             .source_observation_publishers
             .first()
@@ -442,8 +452,11 @@ mod tests {
         let workspace = WorkspaceName::default();
         let handle = SearchObservationHandle::new(layout.clone());
         let source = multi_surface_v4_query_source();
-        let extensions =
-            handle.extensions_for(&workspace, &[SearchObservationSource::for_test(&source)]);
+        let extensions = handle.extensions_for(
+            &workspace,
+            &[SearchObservationSource::for_test(&source)],
+            None,
+        );
         let publisher = extensions
             .source_observation_publishers
             .first()
@@ -504,8 +517,11 @@ mod tests {
         let workspace = WorkspaceName::default();
         let handle = SearchObservationHandle::new(layout.clone());
         let source = secret_input_query_source();
-        let extensions =
-            handle.extensions_for(&workspace, &[SearchObservationSource::for_test(&source)]);
+        let extensions = handle.extensions_for(
+            &workspace,
+            &[SearchObservationSource::for_test(&source)],
+            None,
+        );
         let publisher = extensions
             .source_observation_publishers
             .first()

--- a/crates/coral-app/src/search/observed/sqlite_projection.rs
+++ b/crates/coral-app/src/search/observed/sqlite_projection.rs
@@ -6,14 +6,15 @@ use std::time::{Duration, Instant};
 
 use rusqlite::types::{Type, Value};
 use rusqlite::{Connection, OptionalExtension as _, Transaction, TransactionBehavior, params};
+use uuid::Uuid;
 
 use crate::search::observed::ObservedValuesRetrievalPolicy;
 use crate::search::observed::governance::{
     ObservedValuesProjectionReclamation, observed_fts_mergeable_segments_exist,
 };
 use crate::search::observed::sqlite_queue::{
-    ObservedValueCandidate, ObservedValuesEpoch, ObservedValuesQueuePayload,
-    ObservedValuesSurfaceKind,
+    ObservedValueCandidate, ObservedValuesEpoch, ObservedValuesQueueEnvelope,
+    ObservedValuesQueuePayload, ObservedValuesSurfaceKind,
 };
 use crate::search::sqlite_store::SqliteSearchError;
 use crate::workspaces::WorkspaceName;
@@ -281,9 +282,59 @@ pub(crate) fn drain_observed_queue(
     )
         -> Result<ObservedValuesProjectionReclamation, SqliteSearchError>,
 ) -> Result<ObservedValuesDrainResult, SqliteSearchError> {
+    drain_observed_queue_excluding_origin(
+        connection,
+        workspace_name,
+        budget,
+        None,
+        storage_limit_reached,
+        &mut reclaim_storage,
+    )
+}
+
+pub(crate) fn drain_observed_queue_before_search(
+    connection: &mut Connection,
+    workspace_name: &WorkspaceName,
+    budget: ObservedValuesDrainBudget,
+    search_origin: Option<Uuid>,
+    storage_limit_reached: impl Fn(&Connection) -> Result<bool, SqliteSearchError>,
+    mut reclaim_storage: impl FnMut(
+        &mut Connection,
+        Duration,
+    )
+        -> Result<ObservedValuesProjectionReclamation, SqliteSearchError>,
+) -> Result<ObservedValuesDrainResult, SqliteSearchError> {
+    drain_observed_queue_excluding_origin(
+        connection,
+        workspace_name,
+        budget,
+        search_origin,
+        storage_limit_reached,
+        &mut reclaim_storage,
+    )
+}
+
+fn drain_observed_queue_excluding_origin<F, R>(
+    connection: &mut Connection,
+    workspace_name: &WorkspaceName,
+    budget: ObservedValuesDrainBudget,
+    search_origin: Option<Uuid>,
+    storage_limit_reached: F,
+    reclaim_storage: &mut R,
+) -> Result<ObservedValuesDrainResult, SqliteSearchError>
+where
+    F: Fn(&Connection) -> Result<bool, SqliteSearchError>,
+    R: FnMut(
+        &mut Connection,
+        Duration,
+    ) -> Result<ObservedValuesProjectionReclamation, SqliteSearchError>,
+{
+    let excluded_search_origin = search_origin.map(|origin| origin.to_string());
+    let excluded_search_origin = excluded_search_origin.as_deref();
     let mut result = ObservedValuesDrainResult::default();
     let Some(deadline) = deadline_for(budget.time_budget) else {
-        result.remaining_queue_depth = pending_queue_job_count(connection, workspace_name)?;
+        result.remaining_queue_depth =
+            pending_queue_job_count(connection, workspace_name, excluded_search_origin)?;
         result.budget_exhausted = result.remaining_queue_depth > 0;
         return Ok(result);
     };
@@ -310,6 +361,7 @@ pub(crate) fn drain_observed_queue(
             connection,
             workspace_name,
             last_seen_job_id,
+            excluded_search_origin,
             &storage_limit_reached,
         )? {
             DrainOneResult::Empty => break,
@@ -357,7 +409,8 @@ pub(crate) fn drain_observed_queue(
         }
     }
 
-    result.remaining_queue_depth = pending_queue_job_count(connection, workspace_name)?;
+    result.remaining_queue_depth =
+        pending_queue_job_count(connection, workspace_name, excluded_search_origin)?;
     let max_jobs_reached = drain_steps >= max_drain_steps;
     if result.remaining_queue_depth > 0 && (max_jobs_reached || storage_reclamation_stalled) {
         result.budget_exhausted = true;
@@ -1481,6 +1534,7 @@ fn observed_fts_rebuild_no_progress_error() -> SqliteSearchError {
     io::Error::other("observed-value FTS rebuild batch made no keyset progress").into()
 }
 
+#[cfg(test)]
 pub(crate) fn search_observed_values(
     connection: &Connection,
     workspace_name: &WorkspaceName,
@@ -1488,8 +1542,20 @@ pub(crate) fn search_observed_values(
     limit: usize,
     policy: &ObservedValuesRetrievalPolicy,
 ) -> Result<ObservedValuesSearchHits, SqliteSearchError> {
+    search_observed_values_before(connection, workspace_name, terms, limit, policy, None)
+}
+
+pub(crate) fn search_observed_values_before(
+    connection: &Connection,
+    workspace_name: &WorkspaceName,
+    terms: &[String],
+    limit: usize,
+    policy: &ObservedValuesRetrievalPolicy,
+    observed_values_cutoff: Option<&str>,
+) -> Result<ObservedValuesSearchHits, SqliteSearchError> {
     prepare_live_scope_table(connection, policy)?;
-    let value_count = eligible_observed_value_count(connection, workspace_name, policy)?;
+    let value_count =
+        eligible_observed_value_count(connection, workspace_name, policy, observed_values_cutoff)?;
     if terms.is_empty() || limit == 0 {
         return Ok(ObservedValuesSearchHits {
             hits: Vec::new(),
@@ -1511,6 +1577,7 @@ pub(crate) fn search_observed_values(
             &fts_terms,
             probe_limit(limit),
             policy,
+            observed_values_cutoff,
         )?;
         retrieval_limited |= truncate_probe_hits(&mut fts_hits, limit);
         hits.extend(fts_hits);
@@ -1527,6 +1594,7 @@ pub(crate) fn search_observed_values(
             &short_terms,
             probe_limit(limit),
             policy,
+            observed_values_cutoff,
         )?;
         retrieval_limited |= truncate_probe_hits(&mut short_hits, limit);
         hits.extend(short_hits);
@@ -1547,6 +1615,7 @@ fn search_observed_values_fts(
     terms: &[String],
     limit: usize,
     policy: &ObservedValuesRetrievalPolicy,
+    observed_values_cutoff: Option<&str>,
 ) -> Result<Vec<ObservedValuesSearchHit>, SqliteSearchError> {
     let match_query = fts_match_query(terms);
     let mut statement = connection.prepare(
@@ -1580,6 +1649,7 @@ fn search_observed_values_fts(
         WHERE f.workspace = ?
             AND observed_values_fts MATCH ?
             AND v.last_observed_at >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', ?)
+            AND (? IS NULL OR v.last_observed_at < ?)
         ORDER BY bm25(observed_values_fts, 1.0, 1.0) ASC,
             v.last_observed_at DESC,
             v.source_name ASC,
@@ -1594,6 +1664,8 @@ fn search_observed_values_fts(
             workspace_name.as_str(),
             match_query,
             sqlite_retention_modifier(policy),
+            observed_values_cutoff,
+            observed_values_cutoff,
             i64::try_from(limit).unwrap_or(i64::MAX),
         ],
         observed_search_hit_from_row,
@@ -1608,6 +1680,7 @@ fn search_observed_values_short_terms(
     terms: &[&str],
     limit: usize,
     policy: &ObservedValuesRetrievalPolicy,
+    observed_values_cutoff: Option<&str>,
 ) -> Result<Vec<ObservedValuesSearchHit>, SqliteSearchError> {
     let mut hits = Vec::new();
     let retention_modifier = sqlite_retention_modifier(policy);
@@ -1633,6 +1706,7 @@ fn search_observed_values_short_terms(
             AND s.surface_name = v.surface_name
         WHERE v.workspace = ?
             AND v.last_observed_at >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', ?)
+            AND (? IS NULL OR v.last_observed_at < ?)
             AND (
                 v.search_text = ?
                 OR v.value_key = ?
@@ -1657,6 +1731,8 @@ fn search_observed_values_short_terms(
             params![
                 workspace_name.as_str(),
                 &retention_modifier,
+                observed_values_cutoff,
+                observed_values_cutoff,
                 term,
                 term,
                 term,
@@ -1678,13 +1754,20 @@ fn drain_one_observed_job<F>(
     connection: &mut Connection,
     workspace_name: &WorkspaceName,
     after_job_id: i64,
+    excluded_search_origin: Option<&str>,
     storage_limit_reached: &F,
 ) -> Result<DrainOneResult, SqliteSearchError>
 where
     F: Fn(&Connection) -> Result<bool, SqliteSearchError>,
 {
     let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-    let Some(raw_job) = next_queue_job(&transaction, workspace_name, after_job_id)? else {
+    let Some(raw_job) = next_queue_job(
+        &transaction,
+        workspace_name,
+        after_job_id,
+        excluded_search_origin,
+    )?
+    else {
         transaction.commit()?;
         return Ok(DrainOneResult::Empty);
     };
@@ -1710,8 +1793,8 @@ where
         return Ok(DrainOneResult::Stale { job_id });
     }
 
-    let payload = match serde_json::from_str::<ObservedValuesQueuePayload>(&job.payload_json) {
-        Ok(payload) => payload,
+    let payload = match serde_json::from_str::<ObservedValuesQueueEnvelope>(&job.payload_json) {
+        Ok(envelope) => envelope.payload,
         Err(error) => {
             mark_queue_job_failed(&transaction, job.id, &error.to_string())?;
             let job_id = job.id;
@@ -1945,6 +2028,7 @@ fn next_queue_job(
     transaction: &Transaction<'_>,
     workspace_name: &WorkspaceName,
     after_job_id: i64,
+    excluded_search_origin: Option<&str>,
 ) -> Result<Option<RawObservedQueueJobRow>, SqliteSearchError> {
     transaction
         .query_row(
@@ -1963,13 +2047,22 @@ fn next_queue_job(
             WHERE workspace = ?1
                 AND id > ?2
                 AND attempts < ?3
+                AND CASE
+                    WHEN ?4 IS NULL THEN 1
+                    WHEN json_valid(payload_json) = 0 THEN 1
+                    ELSE COALESCE(
+                        json_extract(payload_json, '$.search_origin') <> ?4,
+                        1
+                    )
+                END
             ORDER BY id
             LIMIT 1
             ",
             params![
                 workspace_name.as_str(),
                 after_job_id,
-                MAX_OBSERVED_QUEUE_JOB_ATTEMPTS
+                MAX_OBSERVED_QUEUE_JOB_ATTEMPTS,
+                excluded_search_origin,
             ],
             observed_queue_job_from_row,
         )
@@ -2157,10 +2250,28 @@ fn mark_queue_job_failed_on_connection(
 fn pending_queue_job_count(
     connection: &Connection,
     workspace_name: &WorkspaceName,
+    excluded_search_origin: Option<&str>,
 ) -> Result<u32, SqliteSearchError> {
     let count: i64 = connection.query_row(
-        "SELECT COUNT(*) FROM observed_queue_jobs WHERE workspace = ?1 AND attempts < ?2",
-        params![workspace_name.as_str(), MAX_OBSERVED_QUEUE_JOB_ATTEMPTS],
+        "
+        SELECT COUNT(*)
+        FROM observed_queue_jobs
+        WHERE workspace = ?1
+            AND attempts < ?2
+            AND CASE
+                WHEN ?3 IS NULL THEN 1
+                WHEN json_valid(payload_json) = 0 THEN 1
+                ELSE COALESCE(
+                    json_extract(payload_json, '$.search_origin') <> ?3,
+                    1
+                )
+            END
+        ",
+        params![
+            workspace_name.as_str(),
+            MAX_OBSERVED_QUEUE_JOB_ATTEMPTS,
+            excluded_search_origin,
+        ],
         |row| row.get(0),
     )?;
     Ok(u32::try_from(count).unwrap_or(u32::MAX))
@@ -2323,6 +2434,7 @@ fn eligible_observed_value_count(
     connection: &Connection,
     workspace_name: &WorkspaceName,
     policy: &ObservedValuesRetrievalPolicy,
+    observed_values_cutoff: Option<&str>,
 ) -> Result<u32, SqliteSearchError> {
     let count: i64 = connection.query_row(
         "
@@ -2336,8 +2448,14 @@ fn eligible_observed_value_count(
             AND s.surface_name = v.surface_name
         WHERE v.workspace = ?
             AND v.last_observed_at >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', ?)
+            AND (? IS NULL OR v.last_observed_at < ?)
         ",
-        params![workspace_name.as_str(), sqlite_retention_modifier(policy)],
+        params![
+            workspace_name.as_str(),
+            sqlite_retention_modifier(policy),
+            observed_values_cutoff,
+            observed_values_cutoff,
+        ],
         |row| row.get(0),
     )?;
     Ok(u32::try_from(count).unwrap_or(u32::MAX))
@@ -2451,10 +2569,11 @@ mod tests {
 
     use rusqlite::params;
     use tempfile::tempdir;
+    use uuid::Uuid;
 
     use super::{
-        ObservedValuesDrainBudget, drain_observed_queue, search_observed_values,
-        sqlite_retention_modifier,
+        ObservedValuesDrainBudget, drain_observed_queue, drain_observed_queue_before_search,
+        search_observed_values, search_observed_values_before, sqlite_retention_modifier,
     };
     use crate::search::observed::governance::ObservedValuesProjectionReclamation;
     use crate::search::observed::sqlite_queue::{
@@ -2927,6 +3046,98 @@ mod tests {
     }
 
     #[test]
+    fn before_search_excludes_current_origin_and_cutoff_hides_later_projection() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::default();
+        let store = SqliteObservedValuesStore::new(layout.clone());
+        let generation = store
+            .capture_epoch(&workspace, "github")
+            .expect("generation");
+        let current_origin = Uuid::from_u128(2);
+        let mut previous_job =
+            test_job_with_identity("github", "github", "previous", "Previous payment");
+        previous_job.payload_json =
+            payload_json_with_origin("Previous payment", "previous-payment", Uuid::from_u128(1));
+        let mut current_job =
+            test_job_with_identity("github", "github", "current", "Current payment");
+        current_job.payload_json =
+            payload_json_with_origin("Current payment", "current-payment", current_origin);
+        store
+            .enqueue_if_current(&workspace, &previous_job, generation)
+            .expect("enqueue previous job");
+        store
+            .enqueue_if_current(&workspace, &current_job, generation)
+            .expect("enqueue current job");
+        let backing = SqliteSearchStore::open_workspace(&layout, &workspace).expect("store");
+        let mut connection = backing.connect_for_test().expect("connection");
+
+        let result = drain_observed_queue_before_search(
+            &mut connection,
+            &workspace,
+            ObservedValuesDrainBudget::new(10, Duration::from_secs(1)),
+            Some(current_origin),
+            |_| Ok(false),
+            |_, _| Ok(ObservedValuesProjectionReclamation::default()),
+        )
+        .expect("drain before search");
+
+        assert_eq!(result.queue_jobs_processed, 1);
+        assert_eq!(result.remaining_queue_depth, 0);
+        let physical_queue_depth: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM observed_queue_jobs WHERE workspace = ?1",
+                params![workspace.as_str()],
+                |row| row.get(0),
+            )
+            .expect("physical queue depth");
+        assert_eq!(physical_queue_depth, 1);
+
+        drain_observed_queue(
+            &mut connection,
+            &workspace,
+            ObservedValuesDrainBudget::new(10, Duration::from_secs(1)),
+            |_| Ok(false),
+            |_, _| Ok(ObservedValuesProjectionReclamation::default()),
+        )
+        .expect("later drain");
+        let policy = ObservedValuesRetrievalPolicy::new(
+            ["previous", "current"]
+                .into_iter()
+                .map(|source_scope_id| ObservedValuesLiveScope {
+                    owner_source_name: "github".to_string(),
+                    source_name: "github".to_string(),
+                    source_scope_id: source_scope_id.to_string(),
+                    surface_kind: ObservedValuesSurfaceKind::Table,
+                    surface_name: "issues".to_string(),
+                })
+                .collect(),
+            30,
+        );
+        let current_request_hits = search_observed_values_before(
+            &connection,
+            &workspace,
+            &[String::from("payment")],
+            10,
+            &policy,
+            Some("1970-01-01T00:00:00.000Z"),
+        )
+        .expect("search at request cutoff");
+        assert!(current_request_hits.hits.is_empty());
+        let next_request_hits = search_observed_values_before(
+            &connection,
+            &workspace,
+            &[String::from("payment")],
+            10,
+            &policy,
+            Some("9999-12-31T23:59:59.999Z"),
+        )
+        .expect("search after request cutoff");
+        assert_eq!(next_request_hits.hits.len(), 2);
+    }
+
+    #[test]
     fn retention_modifier_formats_sqlite_datetime_modifier() {
         let policy = ObservedValuesRetrievalPolicy::new(
             vec![ObservedValuesLiveScope {
@@ -2963,6 +3174,23 @@ mod tests {
                 r#"{{"values":[{{"column_name":"title","display_value":"{display_value}","search_text":"payment outage","value_key":"{value_key}"}}]}}"#,
             ),
         }
+    }
+
+    fn payload_json_with_origin(
+        display_value: &str,
+        value_key: &str,
+        search_origin: Uuid,
+    ) -> String {
+        serde_json::to_string(&serde_json::json!({
+            "search_origin": search_origin,
+            "values": [{
+                "column_name": "title",
+                "display_value": display_value,
+                "search_text": display_value.to_ascii_lowercase(),
+                "value_key": value_key,
+            }],
+        }))
+        .expect("serialize origin-aware payload")
     }
 
     fn enqueue_multi_surface_identity_fixture(

--- a/crates/coral-app/src/search/observed/sqlite_queue.rs
+++ b/crates/coral-app/src/search/observed/sqlite_queue.rs
@@ -1,6 +1,7 @@
 //! Durable observed-values queue records.
 
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// Snapshot of the workspace-wide and source-local invalidation counters.
 ///
@@ -50,6 +51,20 @@ impl ObservedValuesQueuePayload {
     pub(crate) fn is_empty(&self) -> bool {
         self.values.is_empty()
     }
+}
+
+/// JSON envelope persisted in `observed_queue_jobs.payload_json`.
+///
+/// The optional origin is deliberately stored in the existing payload rather
+/// than a schema column. Legacy jobs deserialize with no origin, and ordinary
+/// SQL keeps producing the byte-for-byte-compatible `{ "values": ... }`
+/// shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ObservedValuesQueueEnvelope {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) search_origin: Option<Uuid>,
+    #[serde(flatten)]
+    pub(crate) payload: ObservedValuesQueuePayload,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/coral-app/src/search/observed/sqlite_store.rs
+++ b/crates/coral-app/src/search/observed/sqlite_store.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
 use rusqlite::{Connection, OptionalExtension as _, Transaction, TransactionBehavior, params};
+use uuid::Uuid;
 
 use crate::search::observed::ObservedValuesRetrievalPolicy;
 use crate::search::observed::governance::{
@@ -139,6 +140,25 @@ impl SqliteObservedValuesStore {
         workspace_name: &WorkspaceName,
         budget: ObservedValuesDrainBudget,
     ) -> Result<ObservedValuesDrainResult, SqliteSearchError> {
+        self.drain_queue_with_origin(workspace_name, budget, None, false)
+    }
+
+    pub(crate) fn drain_queue_before_search(
+        &self,
+        workspace_name: &WorkspaceName,
+        budget: ObservedValuesDrainBudget,
+        search_origin: Option<Uuid>,
+    ) -> Result<ObservedValuesDrainResult, SqliteSearchError> {
+        self.drain_queue_with_origin(workspace_name, budget, search_origin, true)
+    }
+
+    fn drain_queue_with_origin(
+        &self,
+        workspace_name: &WorkspaceName,
+        budget: ObservedValuesDrainBudget,
+        search_origin: Option<Uuid>,
+        before_search: bool,
+    ) -> Result<ObservedValuesDrainResult, SqliteSearchError> {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let mut connection = store.connect()?;
         configure_drain_busy_timeout(&connection, budget)?;
@@ -164,27 +184,37 @@ impl SqliteObservedValuesStore {
             .policy
             .maintenance_batch_rows
             .saturating_sub(pre_projection_evicted_rows);
-        let mut result = sqlite_projection::drain_observed_queue(
-            &mut connection,
-            workspace_name,
-            projection_budget,
-            |connection| storage_limit_reached(connection, self.policy),
-            |connection, time_budget| {
-                let max_rows =
-                    remaining_projection_eviction_rows.min(PROJECTION_RECLAMATION_BATCH_ROWS);
-                let reclamation = evict_oldest_observed_values_for_projection(
-                    connection,
-                    workspace_name,
-                    max_rows,
-                    time_budget,
-                )?;
-                remaining_projection_eviction_rows = remaining_projection_eviction_rows
-                    .saturating_sub(
-                        usize::try_from(reclamation.evicted_rows).unwrap_or(usize::MAX),
-                    );
-                Ok(reclamation)
-            },
-        )?;
+        let mut reclaim_storage = |connection: &mut Connection, time_budget: Duration| {
+            let max_rows =
+                remaining_projection_eviction_rows.min(PROJECTION_RECLAMATION_BATCH_ROWS);
+            let reclamation = evict_oldest_observed_values_for_projection(
+                connection,
+                workspace_name,
+                max_rows,
+                time_budget,
+            )?;
+            remaining_projection_eviction_rows = remaining_projection_eviction_rows
+                .saturating_sub(usize::try_from(reclamation.evicted_rows).unwrap_or(usize::MAX));
+            Ok(reclamation)
+        };
+        let mut result = if before_search {
+            sqlite_projection::drain_observed_queue_before_search(
+                &mut connection,
+                workspace_name,
+                projection_budget,
+                search_origin,
+                |connection| storage_limit_reached(connection, self.policy),
+                &mut reclaim_storage,
+            )?
+        } else {
+            sqlite_projection::drain_observed_queue(
+                &mut connection,
+                workspace_name,
+                projection_budget,
+                |connection| storage_limit_reached(connection, self.policy),
+                &mut reclaim_storage,
+            )?
+        };
         let governance = if let Some(governance) = pre_projection_governance {
             governance
         } else {
@@ -267,6 +297,7 @@ impl SqliteObservedValuesStore {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn search(
         &self,
         workspace_name: &WorkspaceName,
@@ -274,9 +305,27 @@ impl SqliteObservedValuesStore {
         limit: usize,
         policy: &ObservedValuesRetrievalPolicy,
     ) -> Result<ObservedValuesSearchHits, SqliteSearchError> {
+        self.search_before(workspace_name, terms, limit, policy, None)
+    }
+
+    pub(crate) fn search_before(
+        &self,
+        workspace_name: &WorkspaceName,
+        terms: &[String],
+        limit: usize,
+        policy: &ObservedValuesRetrievalPolicy,
+        observed_values_cutoff: Option<&str>,
+    ) -> Result<ObservedValuesSearchHits, SqliteSearchError> {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let connection = store.connect()?;
-        sqlite_projection::search_observed_values(&connection, workspace_name, terms, limit, policy)
+        sqlite_projection::search_observed_values_before(
+            &connection,
+            workspace_name,
+            terms,
+            limit,
+            policy,
+            observed_values_cutoff,
+        )
     }
 
     pub(crate) fn compact_after_clear(
@@ -287,6 +336,7 @@ impl SqliteObservedValuesStore {
         Ok(store.compact_after_clear())
     }
 
+    #[cfg(test)]
     pub(crate) fn pending_queue_job_count(
         &self,
         workspace_name: &WorkspaceName,
@@ -294,6 +344,18 @@ impl SqliteObservedValuesStore {
         let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
         let connection = store.connect()?;
         let count = pending_queue_job_count(&connection, workspace_name)?;
+        Ok(usize::try_from(count).unwrap_or(usize::MAX))
+    }
+
+    pub(crate) fn pending_queue_job_count_before_search(
+        &self,
+        workspace_name: &WorkspaceName,
+        search_origin: Option<Uuid>,
+    ) -> Result<usize, SqliteSearchError> {
+        let store = SqliteSearchStore::open_workspace(&self.layout, workspace_name)?;
+        let connection = store.connect()?;
+        let count =
+            pending_queue_job_count_before_search(&connection, workspace_name, search_origin)?;
         Ok(usize::try_from(count).unwrap_or(usize::MAX))
     }
 
@@ -518,6 +580,38 @@ fn pending_queue_job_count(
         .query_row(
             "SELECT COUNT(*) FROM observed_queue_jobs WHERE workspace = ?1 AND attempts < ?2",
             params![workspace_name.as_str(), MAX_OBSERVED_QUEUE_JOB_ATTEMPTS],
+            |row| row.get(0),
+        )
+        .map_err(SqliteSearchError::from)
+}
+
+fn pending_queue_job_count_before_search(
+    connection: &Connection,
+    workspace_name: &WorkspaceName,
+    search_origin: Option<Uuid>,
+) -> Result<i64, SqliteSearchError> {
+    let excluded_search_origin = search_origin.map(|origin| origin.to_string());
+    connection
+        .query_row(
+            "
+            SELECT COUNT(*)
+            FROM observed_queue_jobs
+            WHERE workspace = ?1
+              AND attempts < ?2
+              AND CASE
+                  WHEN ?3 IS NULL THEN 1
+                  WHEN json_valid(payload_json) = 0 THEN 1
+                  ELSE COALESCE(
+                      json_extract(payload_json, '$.search_origin') <> ?3,
+                      1
+                  )
+              END
+            ",
+            params![
+                workspace_name.as_str(),
+                MAX_OBSERVED_QUEUE_JOB_ATTEMPTS,
+                excluded_search_origin.as_deref(),
+            ],
             |row| row.get(0),
         )
         .map_err(SqliteSearchError::from)

--- a/crates/coral-app/src/search/observed/sqlite_store/tests.rs
+++ b/crates/coral-app/src/search/observed/sqlite_store/tests.rs
@@ -28,6 +28,7 @@ use crate::search::sqlite_store::{SqliteSearchError, SqliteSearchStore};
 use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
 use tempfile::tempdir;
+use uuid::Uuid;
 
 #[test]
 fn queue_job_is_durable_across_store_reopen() {
@@ -478,6 +479,240 @@ fn drain_queue_projects_observed_values_into_searchable_fts() {
     assert_eq!(hit.column_name, "title");
     assert_eq!(hit.display_value, "Payment outage");
     assert_eq!(hit.observation_count, 1);
+}
+
+#[test]
+fn before_search_drain_defers_new_current_origin_job_until_next_request() {
+    let temp = tempdir().expect("tempdir");
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+    let workspace = WorkspaceName::default();
+    let store = SqliteObservedValuesStore::new(layout);
+    let epoch = store.capture_epoch(&workspace, "github").expect("epoch");
+    let current_origin = Uuid::from_u128(101);
+    let mut previous_job = test_job_with("previous", "issues", "Previous payment");
+    previous_job.payload_json = payload_json_with_origin("Previous payment", Uuid::from_u128(100));
+    let mut current_job = test_job_with("current", "issues", "Current payment");
+    current_job.payload_json = payload_json_with_origin("Current payment", current_origin);
+    store
+        .enqueue_if_current(&workspace, &previous_job, epoch)
+        .expect("enqueue previous observation");
+    store
+        .enqueue_if_current(&workspace, &current_job, epoch)
+        .expect("enqueue current observation");
+
+    let current_drain = store
+        .drain_queue_before_search(&workspace, drain_budget(), Some(current_origin))
+        .expect("drain before current search");
+
+    assert_eq!(current_drain.queue_jobs_processed, 1);
+    assert_eq!(current_drain.failed_jobs, 0);
+    assert_eq!(current_drain.remaining_queue_depth, 0);
+    assert!(!current_drain.budget_exhausted);
+    assert_eq!(
+        store
+            .pending_queue_job_count(&workspace)
+            .expect("physical queue depth"),
+        1,
+        "the current-origin job stays durable but is not eligible work"
+    );
+    assert_eq!(
+        store
+            .projected_value_count(&workspace)
+            .expect("projected value count"),
+        1
+    );
+    let current_search_hits = store
+        .search(
+            &workspace,
+            &["payment".to_string()],
+            10,
+            &test_policy(&[("previous", "issues"), ("current", "issues")]),
+        )
+        .expect("search after current-origin drain");
+    let current_search_values = current_search_hits
+        .hits
+        .iter()
+        .map(|hit| hit.display_value.as_str())
+        .collect::<Vec<_>>();
+    assert!(current_search_values.contains(&"Previous payment"));
+    assert!(!current_search_values.contains(&"Current payment"));
+
+    let next_drain = store
+        .drain_queue_before_search(&workspace, drain_budget(), Some(Uuid::from_u128(102)))
+        .expect("drain before next search");
+    assert_eq!(next_drain.queue_jobs_processed, 1);
+    assert_eq!(next_drain.remaining_queue_depth, 0);
+    assert_eq!(
+        store
+            .pending_queue_job_count(&workspace)
+            .expect("empty physical queue"),
+        0
+    );
+    assert_eq!(
+        store
+            .projected_value_count(&workspace)
+            .expect("projected value count"),
+        2
+    );
+    let next_search_hits = store
+        .search(
+            &workspace,
+            &["payment".to_string()],
+            10,
+            &test_policy(&[("previous", "issues"), ("current", "issues")]),
+        )
+        .expect("search after next-origin drain");
+    let next_search_values = next_search_hits
+        .hits
+        .iter()
+        .map(|hit| hit.display_value.as_str())
+        .collect::<Vec<_>>();
+    assert!(next_search_values.contains(&"Previous payment"));
+    assert!(next_search_values.contains(&"Current payment"));
+}
+
+#[test]
+fn before_search_drain_defers_same_scope_upsert_with_current_origin() {
+    let temp = tempdir().expect("tempdir");
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+    let workspace = WorkspaceName::default();
+    let store = SqliteObservedValuesStore::new(layout);
+    let epoch = store.capture_epoch(&workspace, "github").expect("epoch");
+    let current_origin = Uuid::from_u128(201);
+    let mut superseded_job = test_job_with("same-scope", "issues", "Superseded value");
+    superseded_job.payload_json =
+        payload_json_with_origin("Superseded value", Uuid::from_u128(200));
+    let mut current_job = test_job_with("same-scope", "issues", "Current value");
+    current_job.payload_json = payload_json_with_origin("Current value", current_origin);
+    store
+        .enqueue_if_current(&workspace, &superseded_job, epoch)
+        .expect("enqueue superseded observation");
+    store
+        .enqueue_if_current(&workspace, &current_job, epoch)
+        .expect("upsert current observation into same queue row");
+    assert_eq!(
+        store
+            .pending_queue_job_count(&workspace)
+            .expect("deduplicated queue depth"),
+        1
+    );
+
+    let current_drain = store
+        .drain_queue_before_search(&workspace, drain_budget(), Some(current_origin))
+        .expect("drain before current search");
+
+    assert_eq!(current_drain.queue_jobs_processed, 0);
+    assert_eq!(current_drain.failed_jobs, 0);
+    assert_eq!(current_drain.remaining_queue_depth, 0);
+    assert!(!current_drain.budget_exhausted);
+    assert_eq!(
+        store
+            .pending_queue_job_count(&workspace)
+            .expect("physical queue depth"),
+        1
+    );
+    assert_eq!(
+        store
+            .projected_value_count(&workspace)
+            .expect("projected value count"),
+        0
+    );
+
+    let next_drain = store
+        .drain_queue_before_search(&workspace, drain_budget(), Some(Uuid::from_u128(202)))
+        .expect("drain before next search");
+    assert_eq!(next_drain.queue_jobs_processed, 1);
+    assert_eq!(next_drain.failed_jobs, 0);
+    assert_eq!(next_drain.remaining_queue_depth, 0);
+    assert_eq!(
+        store
+            .projected_value_count(&workspace)
+            .expect("projected value count"),
+        1
+    );
+    let next_search_hits = store
+        .search(
+            &workspace,
+            &["value".to_string()],
+            10,
+            &test_policy(&[("same-scope", "issues")]),
+        )
+        .expect("search projected same-scope value");
+    assert_eq!(next_search_hits.hits.len(), 1);
+    assert_eq!(
+        next_search_hits
+            .hits
+            .first()
+            .expect("current same-scope hit")
+            .display_value,
+        "Current value"
+    );
+    assert!(
+        next_search_hits
+            .hits
+            .iter()
+            .all(|hit| hit.display_value != "Superseded value")
+    );
+    assert!(
+        store
+            .queue_payloads(&workspace)
+            .expect("empty queue")
+            .is_empty()
+    );
+}
+
+#[test]
+fn request_cutoff_excludes_current_origin_even_after_concurrent_drain() {
+    let temp = tempdir().expect("tempdir");
+    let layout = AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+    let workspace = WorkspaceName::default();
+    let store = SqliteObservedValuesStore::new(layout);
+    let epoch = store.capture_epoch(&workspace, "github").expect("epoch");
+    let current_origin = Uuid::from_u128(301);
+    let mut current_job = test_job_with("current", "issues", "Current payment");
+    current_job.payload_json = payload_json_with_origin("Current payment", current_origin);
+    store
+        .enqueue_if_current(&workspace, &current_job, epoch)
+        .expect("enqueue current native observation");
+
+    // Model another Search or maintenance worker draining after this
+    // request captured its cutoff but before its observed SELECT.
+    store
+        .drain_queue(&workspace, drain_budget())
+        .expect("concurrent drainer projects current observation");
+
+    let policy = test_policy(&[("current", "issues")]);
+    let current_hits = store
+        .search_before(
+            &workspace,
+            &["payment".to_string()],
+            10,
+            &policy,
+            Some("1970-01-01T00:00:00.000Z"),
+        )
+        .expect("current request search");
+    assert_eq!(current_hits.value_count, 0);
+    assert!(current_hits.hits.is_empty());
+
+    let next_hits = store
+        .search_before(
+            &workspace,
+            &["payment".to_string()],
+            10,
+            &policy,
+            Some("9999-12-31T23:59:59.999Z"),
+        )
+        .expect("next request search");
+    assert_eq!(next_hits.value_count, 1);
+    assert_eq!(next_hits.hits.len(), 1);
+    assert_eq!(
+        next_hits
+            .hits
+            .first()
+            .expect("future request finds projected value")
+            .display_value,
+        "Current payment"
+    );
 }
 
 #[test]
@@ -3139,6 +3374,20 @@ fn payload_json(display_value: &str) -> String {
         r#"{{"values":[{{"column_name":"title","display_value":"{display_value}","search_text":"{}","value_key":"{value_key}"}}]}}"#,
         display_value.to_ascii_lowercase()
     )
+}
+
+fn payload_json_with_origin(display_value: &str, search_origin: Uuid) -> String {
+    let value_key = display_value.to_ascii_lowercase().replace(' ', "-");
+    serde_json::to_string(&serde_json::json!({
+        "search_origin": search_origin,
+        "values": [{
+            "column_name": "title",
+            "display_value": display_value,
+            "search_text": display_value.to_ascii_lowercase(),
+            "value_key": value_key,
+        }],
+    }))
+    .expect("serialize origin-aware test payload")
 }
 
 fn test_policy(scopes: &[(&str, &str)]) -> ObservedValuesRetrievalPolicy {

--- a/crates/coral-app/src/search/observed/writer.rs
+++ b/crates/coral-app/src/search/observed/writer.rs
@@ -5,6 +5,7 @@ use std::thread::JoinHandle;
 
 use serde::Serialize;
 use tokio::sync::mpsc::{self, Receiver, Sender, error::TrySendError};
+use uuid::Uuid;
 
 use crate::search::observed::sqlite_queue::{
     ObservedValueCandidate, ObservedValuesEnqueueResult, ObservedValuesEpoch,
@@ -182,18 +183,29 @@ fn run_observed_values_writer(
 
 #[derive(Serialize)]
 struct ObservedValuesQueuePayloadRef<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    search_origin: Option<Uuid>,
     values: &'a [ObservedValueCandidate],
 }
 
+#[cfg(test)]
 pub(super) fn payload_json_with_budget(
     payload: ObservedValuesQueuePayload,
     max_job_bytes: usize,
+) -> Result<Option<String>, String> {
+    payload_json_with_budget_and_origin(payload, max_job_bytes, None)
+}
+
+pub(super) fn payload_json_with_budget_and_origin(
+    payload: ObservedValuesQueuePayload,
+    max_job_bytes: usize,
+    search_origin: Option<Uuid>,
 ) -> Result<Option<String>, String> {
     if payload.is_empty() {
         return Ok(None);
     }
     let values = payload.values;
-    let payload_json = payload_json_for_values(&values)?;
+    let payload_json = payload_json_for_values(&values, search_origin)?;
     if payload_json.len() <= max_job_bytes {
         return Ok(Some(payload_json));
     }
@@ -206,7 +218,7 @@ pub(super) fn payload_json_with_budget(
         let candidate_values = values
             .get(..candidate_len)
             .expect("binary-search prefix length stays within observed-values payload bounds");
-        let candidate_json = payload_json_for_values(candidate_values)?;
+        let candidate_json = payload_json_for_values(candidate_values, search_origin)?;
         if candidate_json.len() <= max_job_bytes {
             best = Some(candidate_json);
             low = candidate_len;
@@ -217,20 +229,31 @@ pub(super) fn payload_json_with_budget(
     Ok(best)
 }
 
-fn payload_json_for_values(values: &[ObservedValueCandidate]) -> Result<String, String> {
-    serde_json::to_string(&ObservedValuesQueuePayloadRef { values })
-        .map_err(|error| error.to_string())
+fn payload_json_for_values(
+    values: &[ObservedValueCandidate],
+    search_origin: Option<Uuid>,
+) -> Result<String, String> {
+    serde_json::to_string(&ObservedValuesQueuePayloadRef {
+        search_origin,
+        values,
+    })
+    .map_err(|error| error.to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
 
+    use uuid::Uuid;
+
     use super::{
         ObservedValuesTryReserveError, ObservedValuesWrite, ObservedValuesWriter,
-        ObservedValuesWriterShared,
+        ObservedValuesWriterShared, payload_json_with_budget, payload_json_with_budget_and_origin,
     };
-    use crate::search::observed::sqlite_queue::{ObservedValuesEpoch, ObservedValuesSurfaceKind};
+    use crate::search::observed::sqlite_queue::{
+        ObservedValueCandidate, ObservedValuesEpoch, ObservedValuesQueueEnvelope,
+        ObservedValuesQueuePayload, ObservedValuesSurfaceKind,
+    };
     use crate::workspaces::WorkspaceName;
 
     #[test]
@@ -258,6 +281,47 @@ mod tests {
         writer
             .try_reserve()
             .expect("capacity should return after dequeue");
+    }
+
+    #[test]
+    fn ordinary_queue_payload_omits_origin_and_legacy_json_defaults_to_none() {
+        let payload_json = payload_json_with_budget(test_payload(), usize::MAX)
+            .expect("serialize payload")
+            .expect("non-empty payload");
+
+        assert_eq!(
+            payload_json,
+            r#"{"values":[{"column_name":"title","display_value":"Payment outage","search_text":"payment outage","value_key":"payment-outage"}]}"#
+        );
+        let envelope = serde_json::from_str::<ObservedValuesQueueEnvelope>(&payload_json)
+            .expect("deserialize legacy-compatible envelope");
+        assert_eq!(envelope.search_origin, None);
+        assert_eq!(envelope.payload.values.len(), 1);
+    }
+
+    #[test]
+    fn selected_queue_payload_serializes_search_origin() {
+        let search_origin = Uuid::from_u128(42);
+        let payload_json =
+            payload_json_with_budget_and_origin(test_payload(), usize::MAX, Some(search_origin))
+                .expect("serialize payload")
+                .expect("non-empty payload");
+
+        let envelope = serde_json::from_str::<ObservedValuesQueueEnvelope>(&payload_json)
+            .expect("deserialize origin envelope");
+        assert_eq!(envelope.search_origin, Some(search_origin));
+        assert_eq!(envelope.payload.values.len(), 1);
+    }
+
+    fn test_payload() -> ObservedValuesQueuePayload {
+        ObservedValuesQueuePayload {
+            values: vec![ObservedValueCandidate {
+                column_name: "title".to_string(),
+                display_value: "Payment outage".to_string(),
+                search_text: "payment outage".to_string(),
+                value_key: "payment-outage".to_string(),
+            }],
+        }
     }
 
     fn test_write() -> ObservedValuesWrite {

--- a/crates/coral-app/src/search/provider.rs
+++ b/crates/coral-app/src/search/provider.rs
@@ -4,9 +4,10 @@ use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex, Weak};
-use std::time::Instant;
 
 use tokio::task;
+use tokio::time::Instant;
+use uuid::Uuid;
 
 use crate::bootstrap::AppError;
 use crate::catalog::model::CatalogResolution;
@@ -36,6 +37,12 @@ pub(crate) struct SearchExecutionContext {
     // Search request cancellation detaches spawned provider work, and blocking
     // provider tasks cannot be cancelled once started.
     _lifecycle_lease: WorkspaceLifecycleReadLease,
+    /// UTC wall-clock cutoff in `SQLite`'s millisecond timestamp format.
+    ///
+    /// Observed rows projected at or after this instant belong to this or a
+    /// concurrent request and must not enter this response.
+    pub(crate) observed_values_cutoff: Option<String>,
+    pub(crate) search_origin: Uuid,
     pub(crate) request: SearchRequest,
     pub(crate) catalog_resolution: Result<CatalogResolution, QueryManagerError>,
     pub(crate) observed_values_policy: Option<ObservedValuesPolicyInput>,
@@ -45,6 +52,8 @@ impl SearchExecutionContext {
     pub(crate) fn new(
         request_started_at: Instant,
         lifecycle_lease: WorkspaceLifecycleReadLease,
+        observed_values_cutoff: Option<String>,
+        search_origin: Uuid,
         request: SearchRequest,
         catalog_resolution: Result<CatalogResolution, QueryManagerError>,
         observed_values_policy: Option<ObservedValuesPolicyInput>,
@@ -52,6 +61,8 @@ impl SearchExecutionContext {
         Self {
             request_started_at,
             _lifecycle_lease: lifecycle_lease,
+            observed_values_cutoff,
+            search_origin,
             request,
             catalog_resolution,
             observed_values_policy,
@@ -117,10 +128,12 @@ impl SearchProviderRegistry {
     pub(crate) fn local(
         catalog: CatalogMetadataProvider,
         observed: Option<ObservedValuesProvider>,
+        native: Option<Arc<dyn SearchProvider>>,
     ) -> Self {
         let ordered = local_registrations(
             Arc::new(catalog),
             observed.map(|provider| Arc::new(provider) as Arc<dyn SearchProvider>),
+            native,
         );
         Self {
             ordered: ordered.into(),
@@ -142,6 +155,7 @@ impl SearchProviderRegistry {
 fn local_registrations(
     catalog: Arc<dyn SearchProvider>,
     observed: Option<Arc<dyn SearchProvider>>,
+    native: Option<Arc<dyn SearchProvider>>,
 ) -> Vec<SearchProviderRegistration> {
     let observed = observed.map_or_else(
         || SearchProviderRegistration::StaticStatus(observed_not_enabled_status()),
@@ -150,7 +164,10 @@ fn local_registrations(
     vec![
         SearchProviderRegistration::Provider(catalog),
         observed,
-        SearchProviderRegistration::StaticStatus(native_not_enabled_status()),
+        native.map_or_else(
+            || SearchProviderRegistration::StaticStatus(native_not_enabled_status()),
+            SearchProviderRegistration::Provider,
+        ),
     ]
 }
 
@@ -199,7 +216,15 @@ impl SearchProvider for ObservedValuesProvider {
                     .observed_values_policy
                     .as_ref()
                     .expect("registry enables observed provider only with a retrieval policy");
-                provider.search(&context.request, policy.as_ref())
+                provider.search_with_origin(
+                    &context.request,
+                    policy.as_ref(),
+                    context
+                        .observed_values_cutoff
+                        .as_ref()
+                        .map(|_| context.search_origin),
+                    context.observed_values_cutoff.as_deref(),
+                )
             })
             .await
         })
@@ -269,6 +294,7 @@ mod tests {
     fn disabled_observed_search_is_registered_as_a_static_status() {
         let registrations = local_registrations(
             Arc::new(UnusedProvider(SearchProviderKind::CatalogMetadata)),
+            None,
             None,
         );
 

--- a/crates/coral-app/src/search/result.rs
+++ b/crates/coral-app/src/search/result.rs
@@ -180,13 +180,6 @@ pub(crate) enum SearchPayload {
     CatalogMetadata(CatalogMetadataResult),
     ColumnHint(ColumnHintResult),
     ObservedValue(ObservedValueResult),
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "the additive native result contract is populated by the follow-up fanout implementation"
-        )
-    )]
     NativeResult(NativeSearchResult),
 }
 
@@ -224,13 +217,6 @@ pub(crate) struct NativeSearchDiagnostic {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "native diagnostics are populated by the follow-up fanout implementation"
-    )
-)]
 pub(crate) enum NativeSearchDiagnosticState {
     ResultsFound,
     Empty,
@@ -241,14 +227,8 @@ pub(crate) enum NativeSearchDiagnosticState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "native diagnostics are populated by the follow-up fanout implementation"
-    )
-)]
 pub(crate) enum NativeSearchDiagnosticReason {
+    Unspecified,
     NotAuthorized,
     AmbiguousRoute,
     InvalidSearchLimits,

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -554,6 +554,7 @@ fn native_diagnostic_reason_to_proto(
     reason: NativeSearchDiagnosticReason,
 ) -> ProtoNativeSearchDiagnosticReason {
     match reason {
+        NativeSearchDiagnosticReason::Unspecified => ProtoNativeSearchDiagnosticReason::Unspecified,
         NativeSearchDiagnosticReason::NotAuthorized => {
             ProtoNativeSearchDiagnosticReason::NotAuthorized
         }

--- a/crates/coral-app/src/workspaces/model.rs
+++ b/crates/coral-app/src/workspaces/model.rs
@@ -111,6 +111,24 @@ impl WorkspaceLifecycleLock {
     }
 
     #[cfg(test)]
+    pub(crate) fn snapshot_for_test(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> WorkspaceLifecycleReadLease {
+        assert!(
+            !self.workspace_is_deleting(workspace_name),
+            "fresh test workspace should be active"
+        );
+        WorkspaceLifecycleReadLease {
+            guard: self
+                .inner
+                .try_read_arc()
+                .expect("fresh test lifecycle lock should be readable"),
+            deleting_workspaces: Arc::clone(&self.deleting_workspaces),
+        }
+    }
+
+    #[cfg(test)]
     pub(crate) fn snapshot_if_unchanged(
         &self,
         revision: WorkspaceLifecycleRevision,

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -271,7 +271,13 @@ impl QueryExecutionControls {
         self.signals.explicit_continuation.load(Ordering::SeqCst)
     }
 
-    pub(crate) fn mark_upstream_started(&self) {
+    /// Records that this execution crossed an upstream transport boundary.
+    ///
+    /// Backend and orchestration adapters use this shared signal for exact
+    /// fanout coverage accounting, including when the execution future
+    /// subsequently panics or is aborted.
+    #[doc(hidden)]
+    pub fn mark_upstream_started(&self) {
         self.signals.upstream_started.store(true, Ordering::SeqCst);
     }
 


### PR DESCRIPTION
## Summary

- Adds `NativeFanoutProvider`, consuming the request-scoped runtime `CatalogResolution` held under the workspace lifecycle snapshot. Native routing performs no separate manifest scan and maintains no route cache.
- Selects at most four source-authorized DSL v4 routes deterministically, with one route per source in the first pass, and executes them concurrently in one wave.
- Uses exact DSL v4 operation identity for stable ordering and row identity; no DSL v3 route or identity branch exists.
- Enforces the request-relative fanout contract: 750 ms global cutoff, 600 ms per call, 100 ms minimum start budget, 25 ms cancellation cleanup, five rows per route, no retries, and no pagination.
- Normalizes, deduplicates, and fuses safe native previews while emitting bounded stable diagnostics and coverage. Provider failures, timeouts, cancellation, and panics do not discard local catalog or observed-value results.
- Tags observations produced by native calls with a Search origin and cutoff so successfully decoded batches can enter the existing observed-values pipeline only for later Search requests.

## Stack boundary

Stack 9/11. Depends on #1861; #1864 builds on this PR.

Production bootstrap still supplies no native provider. This PR cannot introduce upstream calls from public Search; activation is isolated to #1864.

## Test plan

- `cargo test -p coral-app search::native::provider::tests --lib`
- `cargo test -p coral-app search::engine::tests --lib`
- `cargo test -p coral-app search::observed::sqlite_store::tests --lib`
- `cargo test -p coral-app search_paused_in_catalog_resolution_does_not_recreate_deleted_workspace_storage`
- `cargo check -p coral-app --all-targets`
- `make rust-checks` on the cumulative top branch: 2,275 passed, 2 skipped

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
