### PR TITLE
docs(search): document native provider fanout

### DIFF
--- a/apps/docs/guides/search-with-coral.mdx
+++ b/apps/docs/guides/search-with-coral.mdx
@@ -65,17 +65,102 @@ Observed-value collection, search, and maintenance are experimental and disabled
 
 ## Search connected sources
 
-Provider fanout is experimental and disabled by default. Enable it persistently, then restart long-running Coral processes such as `coral mcp-stdio`:
+Provider fanout is experimental and disabled by default. It adds live provider
+matches to the local catalog and observed-value matches described above; it
+does not replace either local provider.
+
+### Enable fanout and authorize a route
+
+Enable fanout persistently, then restart long-running Coral processes such as
+`coral mcp-stdio`:
 
 ```shellscript
 coral features enable search_provider_fanout
 ```
 
-For one process, use `--enable-search-provider-fanout`; use the matching `--disable-search-provider-fanout` override to roll back immediately. Disabling fanout leaves catalog and observed-value search available.
+For one process, put `--enable-search-provider-fanout` before the command:
 
-Enabling the feature is only one gate. A source must also expose a valid `kind: search` function that its [Universal Search authorization policy](/reference/source-spec-reference#universal-search-authorization) allows. Search can start at most four eligible functions in one wave, requests at most five rows from each, applies a 750 ms fanout cutoff and a 600 ms per-call timeout, and does not retry or paginate.
+```shellscript
+coral --enable-search-provider-fanout search github issues cancellation timeout
+```
 
-Connected-source results are compact, sanitized previews rather than raw rows. A failed or timed-out call is reported through bounded status and diagnostic fields; successful local results remain available, so a response can be partial. When `observed_values_search` is also enabled, successfully decoded source batches may be queued for the same best-effort local observation pipeline used by SQL queries. New observations can affect only later searches, not the response currently being assembled.
+The runtime feature is only one gate. A source must also expose a valid
+`kind: search` function that its [Universal Search authorization
+policy](/reference/source-spec-reference#universal-search-authorization) makes
+eligible. Explicit policy is strongest; without one, Coral infers a route only
+when the source has one unambiguous, safe search function. Enabling the feature
+never authorizes an ordinary or ambiguous function.
+
+For each selected route, Coral sends the current Search text through the
+source-designated query input, along with source-authored default arguments and
+the credentials that route normally requires, to the configured upstream
+provider.
+
+When a route returns safe display fields, the normal output might include:
+
+```text
+3. [native_fanout] native result github.search_issues row 0
+   Entity type: issue
+   Provider id: 12345
+   Title: Cancel provider work at the fanout deadline
+   URL: https://github.com/withcoral/coral/issues/12345
+   Attributes: state=open
+```
+
+This is a compact preview for choosing what to inspect next. Use the named
+table function or another source table with `coral sql` when you need the full
+record.
+
+### Limits and partial results
+
+Fanout uses one concurrent wave. It selects at most four eligible functions,
+requests at most five rows from each, and returns at most 20 native previews
+before the overall Search result limit is applied. It does not retry or
+paginate.
+
+The 750 ms fanout cutoff starts when the Search request starts, not when an
+upstream call starts. Each call gets at most 600 ms, and Coral will not start a
+call with less than 100 ms left. At the cutoff Coral signals cancellation and
+allows at most 25 ms for cleanup. A remote server may still finish work it
+already accepted.
+
+Each native preview is capped at 8 KiB and all native result previews in one
+response at 256 KiB. A preview has at most eight selected attributes. Provider
+status includes at most 16 stable per-route diagnostics; excess diagnostics
+are reported only as an omitted count.
+
+Local matches remain in the response when native work times out, fails, or is
+skipped. In those cases `provider_statuses` reports partial coverage and safe
+reason categories such as `call_timeout` or `rate_limited`, never raw provider
+errors, request URLs, credentials, query arguments, or response bodies.
+
+### Observation is not a fanout cache
+
+When `observed_values_search` is also enabled, successfully decoded source
+batches enter the existing best-effort observation pipeline before native
+preview normalization and the five-row preview cap. A batch can therefore be
+queued even if a later stage omits its rows or fails. It can affect only a
+later Search request after asynchronous projection, never the response being
+assembled.
+
+<Note>
+Provider fanout runs only because you made a Search request. Coral does not
+crawl sources in the background, cache provider responses, return raw source
+rows, upload observed values, or use observed data for Coral's own purposes.
+</Note>
+
+### Roll back
+
+Disable the stored feature and restart long-running Coral processes:
+
+```shellscript
+coral features disable search_provider_fanout
+```
+
+For a single invocation, use `--disable-search-provider-fanout`. The disable
+override wins over stored enablement. Rolling back does not require a database
+migration, observed-value purge, or source reinstall; catalog and
+observed-value search remain available.
 
 ## Use search over MCP
 

--- a/apps/docs/guides/search-with-coral.mdx
+++ b/apps/docs/guides/search-with-coral.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Search with Coral"
-description: "Find relevant data from Coral's local search state and, optionally, authorized connected-source search routes."
+description: "Find relevant data from Coral's local search state and, optionally, authorized DSL v4 connected-source search routes."
 ---
 
 `coral search` helps you find where to query before you write SQL. Describe a table, table function, column, filter, or value in natural language, and Coral ranks matching locations in your current workspace.
 
 Catalog search prepares the current workspace query runtime and catalog, then searches a local index. Runtime preparation can read stored credentials, initialize source providers, and inspect file metadata in local or object storage, but it does not execute your data query or return source rows. Optional observed-value search can also match samples collected while executing earlier queries; it only reads Coral's local search state.
 
-Experimental provider fanout can additionally make bounded, read-only calls to connected-source search routes. It is disabled by default: both the `search_provider_fanout` runtime feature and an eligible source-authored route must allow a call.
+Experimental provider fanout can additionally make bounded, read-only calls to eligible DSL v4 connected-source routes. It is disabled by default: both the `search_provider_fanout` runtime feature and a source-authored DSL v4 route must allow a call.
 
 ## Search the catalog
 
@@ -69,6 +69,14 @@ Provider fanout is experimental and disabled by default. It adds live provider
 matches to the local catalog and observed-value matches described above; it
 does not replace either local provider.
 
+<Note>
+Provider fanout is available only for DSL v4 sources. DSL v3 sources remain
+queryable through SQL and discoverable through local catalog and observed-value
+search, but Search never executes their functions as fanout routes. Migrate the
+source to DSL v4 and author a top-level `universal_search` route to enable
+fanout.
+</Note>
+
 ### Enable fanout and authorize a route
 
 Enable fanout persistently, then restart long-running Coral processes such as
@@ -84,12 +92,12 @@ For one process, put `--enable-search-provider-fanout` before the command:
 coral --enable-search-provider-fanout search github issues cancellation timeout
 ```
 
-The runtime feature is only one gate. A source must also expose a valid
-`kind: search` function that its [Universal Search authorization
-policy](/reference/source-spec-reference#universal-search-authorization) makes
-eligible. Explicit policy is strongest; without one, Coral infers a route only
-when the source has one unambiguous, safe search function. Enabling the feature
-never authorizes an ordinary or ambiguous function.
+The runtime feature is only one gate. A DSL v4 source must also authorize an
+imported operation through its top-level [Universal Search authorization
+policy](/reference/source-spec-reference#universal-search-authorization).
+Explicit policy is strongest; without one, Coral infers a route only when the
+source has one unambiguous, safe generated search route. Enabling the feature
+never authorizes an ordinary or ambiguous operation.
 
 For each selected route, Coral sends the current Search text through the
 source-designated query input, along with source-authored default arguments and
@@ -113,7 +121,7 @@ record.
 
 ### Limits and partial results
 
-Fanout uses one concurrent wave. It selects at most four eligible functions,
+Fanout uses one concurrent wave. It selects at most four eligible DSL v4 routes,
 requests at most five rows from each, and returns at most 20 native previews
 before the overall Search result limit is applied. It does not retry or
 paginate.
@@ -166,7 +174,7 @@ observed-value search remain available.
 
 Coral exposes the same search through its MCP `search` tool. Catalog results are always available. When observed-value search is enabled for the MCP server process, the agent also receives typed observed-value matches and can use the matching table and column to write SQL.
 
-The MCP server derives the tool description and annotations from the app's current Search capabilities. It says that no source-authored search function is called when fanout is disabled or has no eligible routes, and warns that Search may call connected sources when eligible routes exist or capability lookup is unavailable. Fanout is marked open-world; when observed-value collection is also enabled, successful source batches can enqueue local observations, so the tool is not described as read-only or idempotent.
+The MCP server derives the tool description and annotations from the app's current Search capabilities. It says that no DSL v4 connected-source route is executed when fanout is disabled or has no eligible routes, and warns that Search may call connected sources through eligible DSL v4 routes when routes exist or capability lookup is unavailable. Fanout is marked open-world; when observed-value collection is also enabled, successful source batches can enqueue local observations, so the tool is not described as read-only or idempotent.
 
 Ask for the result you want; you do not need to name the `search` tool:
 

--- a/apps/docs/guides/use-coral-over-mcp.mdx
+++ b/apps/docs/guides/use-coral-over-mcp.mdx
@@ -229,13 +229,58 @@ When your agent has many tools available, name Coral explicitly:
 
 > "Use Coral to find where `payments-api` appeared, then query the matching data."
 
-When the right table or table function is not obvious, ask the agent to [search with Coral](/guides/search-with-coral). The `search` tool always searches local catalog metadata and can optionally search locally observed values. With experimental provider fanout enabled and an eligible source-authorized DSL v4 route, it can also make bounded, read-only calls to connected sources.
+> "Use Coral Search to find GitHub issues about cancellation. If it returns a
+> connected-source preview, query the full issue through the best matching
+> table or table function."
+
+When the right table or table function is not obvious, ask the agent to
+[search with Coral](/guides/search-with-coral). The `search` tool always
+searches local catalog metadata and can optionally search locally observed
+values. With experimental provider fanout enabled and an eligible
+source-authorized DSL v4 route, the same request can make bounded, read-only
+calls to connected sources. Local results remain available if an upstream route
+fails or times out.
 
 ### Search behavior
 
-Coral asks the app for Search capabilities before MCP initialization and refreshes them when the client lists tools or reads dynamic guide resources. Tool descriptions say that no DSL v4 connected-source route is executed when fanout is disabled or no route is eligible. When fanout can run, they name a bounded set of eligible DSL v4 source surfaces and say that Search may call them. If capability lookup fails while fanout may be enabled, the description conservatively says the capability is unknown and calls through eligible DSL v4 source routes may occur.
+Coral asks the app for Search capabilities before MCP initialization and
+refreshes them when the client lists tools or reads dynamic guide resources.
+The description therefore follows source installation, removal, and reimport
+without claiming that every installed source can be searched. It says that no
+DSL v4 connected-source route is executed when fanout is disabled or no route
+is eligible. When fanout can run, it names a bounded set of eligible DSL v4
+source surfaces and says that Search may call them. If capability lookup fails
+while fanout may be enabled, it conservatively says the capability is unknown
+and calls through eligible DSL v4 source routes may occur:
 
-Fanout-enabled Search is annotated as open-world. If observed-value collection is disabled, authorized upstream search operations remain read-only and idempotent. When `observed_values_search` is also enabled, successful source batches can enqueue new local observations, so Search is not annotated as read-only or idempotent. These observations can become searchable only on a later request.
+| Effective behavior | Search tool description |
+| --- | --- |
+| Fanout disabled | Does not execute DSL v4 connected-source routes |
+| Fanout enabled, no eligible route | Does not execute DSL v4 connected-source routes; no eligible route is resolved |
+| Fanout enabled, eligible routes | May call a capped inventory of named generated functions and authored DSL v4 routes |
+| Capability lookup unavailable while fanout may be enabled | Capability unknown; calls through eligible DSL v4 source routes may occur |
+
+MCP annotations are conservative as capabilities change:
+
+| Effective behavior | Read-only | Idempotent | Open-world |
+| --- | --- | --- | --- |
+| Fanout disabled | Yes | Yes | No |
+| Fanout enabled, observed-value collection disabled | Yes | Yes | Yes |
+| Fanout enabled, observed-value collection enabled | No | No | Yes |
+| Capability unknown and fanout may be enabled | No | No | Yes |
+
+With observation enabled, a successfully decoded provider batch can enqueue
+new local observations before final Search normalization. Those observations
+can become searchable only on a later request. The upstream operation remains
+source-authorized, and its source policy asserts that it is retrieval-only and
+idempotent; the annotation changes because the Search call may mutate Coral's
+local observation state.
+
+Connected-source results are sanitized previews, not raw rows. The Search
+response can be partial and reports bounded safe diagnostics instead of raw
+provider errors. See [Search connected
+sources](/guides/search-with-coral#search-connected-sources) for the execution
+budgets, caps, observation boundary, and rollback command.
 
 If an answer needs data from multiple connected sources, ask the agent to combine the data in Coral when possible.
 

--- a/apps/docs/project/security.mdx
+++ b/apps/docs/project/security.mdx
@@ -32,9 +32,12 @@ clients can route source-specific requests to Coral during discovery.
 Secret values are not returned through `coral.inputs`; secret rows show only
 whether a value is configured.
 
-Search reads local catalog metadata by default. Its experimental provider
-fanout is disabled by default and can make upstream calls only when both the
-runtime feature and a source-authored DSL v4 route policy allow them. DSL v3
+Search prepares the current workspace runtime and catalog, then searches a
+local index. Preparation can read stored credentials, initialize source
+providers, and inspect file metadata in local or object storage, but it does
+not execute a data query or return source rows. Experimental provider fanout
+is disabled by default and calls eligible DSL v4 source routes only when both
+the runtime feature and source-authored DSL v4 route policy allow them. DSL v3
 functions are never provider-fanout routes.
 
 ## What Coral protects against
@@ -64,25 +67,48 @@ trust boundary:
 ## Provider fanout boundaries
 
 When `search_provider_fanout` is enabled, one Search request can start at most
-four authorized, retrieval-only and idempotent DSL v4 source routes in one
-wave. Coral requests at most five rows per route, applies a 750 ms fanout cutoff
-and a 600 ms per-call timeout, and does not retry or paginate. A DSL v4 source
-policy is a separate gate: enabling the runtime feature does not authorize a
-route, and invalid or ambiguous routes fail closed.
+four DSL v4 routes in one wave that installed source policy authorizes and
+asserts are retrieval-only and idempotent. Coral requests at most five rows per
+route, applies a 750 ms fanout cutoff from the beginning of the Search request,
+and gives each call at most 600 ms. It does not start a call with less than 100
+ms remaining, does not retry or paginate, and allows at most 25 ms for
+cancellation cleanup after the cutoff. Coral stops its own request work, but an
+arbitrary remote server may still finish work it already accepted. A DSL v4
+source policy is a separate gate: enabling the runtime feature does not
+authorize a route, and invalid or ambiguous routes fail closed.
+
+For each selected route, Coral sends the current Search text through the
+source-designated query input, plus source-authored default arguments and the
+credentials that route normally requires, to the configured upstream provider.
+This is the principal data-flow difference from local catalog and
+observed-value search.
 
 Search returns only bounded, sanitized display fields from connected-source
 results, not raw rows or provider response bodies. It removes credential-like
 fields, secret-shaped values, unsafe URL parameters, and unsafe control
-characters, and reports failures through bounded reason categories rather than
-raw provider errors. Local catalog and observed-value results remain available
-when upstream work fails or times out.
+characters. Native output is capped at five previews per function, 20 per
+request, eight selected attributes per preview, 8 KiB per preview, and 256 KiB
+across native result previews in the response.
+
+Native provider status includes at most 16 bounded diagnostics with stable
+state and reason categories. Those diagnostics do not include raw provider
+errors, request URLs, rendered SQL, query text, arguments, credentials,
+headers, tokens, or provider bodies. Native previews contain only the bounded,
+sanitized fields selected from returned rows. Local catalog and observed-value
+results remain available when upstream work fails or times out.
 
 If `observed_values_search` is also enabled, successfully decoded source
 batches can enter Coral's existing best-effort local observation pipeline
 before Search normalizes the preview. Those observations remain subject to the
 same source scope, `do_not_index`, secret suppression, retention, and storage
 limits as SQL query observations. They can affect only later searches. Coral
-does not add a fanout cache or background crawl.
+does not add a fanout cache or background crawl, upload observed values, or use
+observed user data for Coral's own purposes.
+
+Disable `search_provider_fanout` to stop new provider calls. This rollback
+leaves local catalog and observed-value search intact and requires no database
+migration, observed-value purge, or source reinstall. See [Search connected
+sources](/guides/search-with-coral#search-connected-sources) for the commands.
 
 ## Secret storage configuration
 

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -71,6 +71,7 @@ has observed during earlier queries.
 ```shellscript
 coral search github issues assigned to me
 coral search --limit 5 --json slack messages text
+coral --enable-search-provider-fanout search github issues cancellation timeout
 ```
 
 Search prepares the current workspace query runtime and catalog, then searches a
@@ -86,10 +87,12 @@ Experimental connected-source fanout is disabled by default. When
 `search_provider_fanout` is enabled and a source authorizes an eligible
 top-level DSL v4 `universal_search` route, Search may make bounded, read-only
 upstream calls. It starts at most four routes in one wave, requests at most five
-rows from each, applies a 750 ms fanout cutoff and 600 ms per-call timeout, and
-does not retry or paginate. DSL v3 functions are never fanout routes. Local
-matches survive native failures, and status fields report partial, skipped,
-timed-out, or failed work without returning raw provider errors.
+rows from each, applies a 750 ms fanout cutoff and 600 ms per-call timeout, and does not
+retry or paginate. Calls do not start with less than 100 ms remaining; after
+the cutoff, Coral allows at most 25 ms for cancellation cleanup. Local matches
+survive native failures. Aggregate status reports partial, skipped, or failed
+work, while per-route diagnostics identify timeouts without returning raw
+provider errors. DSL v3 functions are never fanout routes.
 
 Observed-value collection, retrieval, and maintenance are disabled by default.
 Enable them persistently using Coral [runtime features](/reference/configuration#runtime-features).
@@ -120,10 +123,15 @@ provider statuses report whether each provider found matches, completed with no
 matches, returned partial coverage, was skipped, or failed. Native results
 contain compact, sanitized display fields rather than raw source rows, plus
 bounded per-route diagnostics that distinguish timeouts and other safe failure
-categories. An empty observed-value result only
-describes Coral's local observations; it does not prove that the value is absent
-from a connected source. `truncation` reports when more matches were available
-than returned.
+categories. Native output is capped at 20 previews, 8 KiB per preview, 256 KiB
+across native result previews, and 16 diagnostics. An empty observed-value
+result only describes Coral's local observations; it does not prove that the
+value is absent from a connected source. `truncation` reports when more matches
+were available than returned.
+
+See [Search connected
+sources](/guides/search-with-coral#search-connected-sources) for an annotated
+native result example, the source-policy gate, and rollback behavior.
 
 ## `coral search-index`
 
@@ -538,7 +546,7 @@ By default, this server exposes:
 | -------- | ---------------- | ----------- |
 | Tool     | `sql`            | Execute read-only SQL against the Coral database |
 | Tool     | `add_function`   | Create a reusable table function in the current workspace |
-| Tool     | `search`         | Find relevant catalog entries and, when enabled, locally observed values |
+| Tool     | `search`         | Search local catalog state and effective optional Search providers |
 | Tool     | `list_catalog`   | List database tables and table functions with pagination |
 | Tool     | `describe_table` | Show compact metadata for one database table |
 | Tool     | `list_columns`   | List columns for one database table with pagination |
@@ -549,10 +557,18 @@ By default, this server exposes:
 
 When the `feedback` feature is enabled, the server also exposes a non-read-only `feedback` tool for blocked-agent reports. Feedback reports are stored locally and anonymous copies may be uploaded to Coral.
 
-When `observed_values_search` is disabled, the `search` tool and
-`coral://guide` advertise catalog discovery only. Enable observed-value search
-for one MCP server process with
-`coral --enable-observed-values-search mcp-stdio`.
+The `search` tool description and annotations follow effective capabilities.
+When `observed_values_search` is disabled, observed values are omitted from the
+advertised local scope. Enable observed-value search for one MCP server process
+with `coral --enable-observed-values-search mcp-stdio`.
+
+When `search_provider_fanout` is enabled but no route is eligible, the
+description says that Search does not call source-authored search functions;
+otherwise it names a capped inventory of connected-source routes that Search
+may call. Enable fanout for one MCP server process with
+`coral --enable-search-provider-fanout mcp-stdio`. See [Use Coral over
+MCP](/guides/use-coral-over-mcp#search-behavior) for dynamic descriptions and
+annotations.
 
 Discovery helpers include the `coral` system schema, so `search`,
 `list_catalog`, `describe_table`, `list_columns`, and `coral://tables` can

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -562,10 +562,10 @@ When `observed_values_search` is disabled, observed values are omitted from the
 advertised local scope. Enable observed-value search for one MCP server process
 with `coral --enable-observed-values-search mcp-stdio`.
 
-When `search_provider_fanout` is enabled but no route is eligible, the
-description says that Search does not call source-authored search functions;
-otherwise it names a capped inventory of connected-source routes that Search
-may call. Enable fanout for one MCP server process with
+When `search_provider_fanout` is enabled but no DSL v4 route is eligible, the
+description says that Search does not execute DSL v4 connected-source routes;
+otherwise it names a capped inventory of eligible DSL v4 routes that Search may
+call. Enable fanout for one MCP server process with
 `coral --enable-search-provider-fanout mcp-stdio`. See [Use Coral over
 MCP](/guides/use-coral-over-mcp#search-behavior) for dynamic descriptions and
 annotations.

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -132,6 +132,13 @@ an eligible top-level DSL v4 `universal_search` route. Enabling the feature does
 not authorize a source by itself. DSL v3 functions are never provider-fanout
 routes.
 
+The persisted setting is:
+
+```toml
+[features]
+search_provider_fanout = true
+```
+
 ```shellscript
 coral features enable search_provider_fanout
 coral features disable search_provider_fanout
@@ -144,6 +151,10 @@ override it for one process with `--enable-search-provider-fanout` or
 enablement. Disabling fanout stops request-triggered provider calls without a
 database migration, observed-value purge, or source reinstall. Local catalog
 and observed-value search remain available.
+
+See [Search connected
+sources](/guides/search-with-coral#search-connected-sources) for the separate
+source-policy gate, execution limits, and partial-result behavior.
 
 ## OpenTelemetry
 

--- a/apps/docs/reference/source-spec-reference.mdx
+++ b/apps/docs/reference/source-spec-reference.mdx
@@ -674,13 +674,18 @@ query. Values must be positive. `default_top_k` and `max_top_k` are capped at
 
 ### Universal Search authorization
 
-Universal Search fan-out is available only for DSL v4 sources. DSL v3 sources
-cannot author `functions[].universal_search` and do not participate in native
-fan-out. To make a provider available, define a DSL v4 imported-surface source.
-Universal Search authorization is source-authored policy for a `kind: search`
-route. It does not replace `kind` or `search_limits`, and result display
-metadata does not grant authorization. Authorize only an upstream operation
-that you have verified is retrieval-only and idempotent.
+Provider fanout is available only for DSL v4 sources. DSL v3 sources remain
+queryable through SQL and discoverable through local catalog and observed-value
+search, but Search never executes their functions as fanout routes. DSL v3
+sources cannot author `functions[].universal_search`. To make a provider
+eligible for fanout, migrate the source to DSL v4 and author a top-level
+`universal_search` route over an imported operation.
+
+Universal Search authorization is source-authored policy over an imported DSL
+v4 operation. It does not replace the imported operation's generated search
+classification or limits, and result display metadata does not grant
+authorization. Authorize only an upstream operation that you have verified is
+retrieval-only and idempotent.
 
 Authorization only makes a route eligible. Coral executes eligible routes from
 Search only when the experimental `search_provider_fanout` [runtime

--- a/apps/docs/reference/source-spec-reference.mdx
+++ b/apps/docs/reference/source-spec-reference.mdx
@@ -558,7 +558,16 @@ Function args accept an optional `type` field using Coral manifest data type
 names. It defaults to `Utf8`; set it when the provider argument is numeric,
 boolean, timestamp-shaped, or JSON-shaped.
 
+The following complete DSL v3 manifest declares one provider-ranked search
+function for direct SQL use. It remains ineligible for Universal Search
+provider fan-out:
+
 ```yaml
+name: issue_search_v3
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://api.example.com
 functions:
   - name: search_issues
     kind: search
@@ -630,7 +639,7 @@ when calling table functions:
 
 ```sql
 SELECT id, title, html_url
-FROM github.search_issues(q => 'repo:withcoral/coral source functions')
+FROM issue_search_v3.search_issues(q => 'cancellation cleanup')
 LIMIT 10;
 ```
 
@@ -668,6 +677,10 @@ query. Values must be positive. `default_top_k` and `max_top_k` are capped at
 Universal Search fan-out is available only for DSL v4 sources. DSL v3 sources
 cannot author `functions[].universal_search` and do not participate in native
 fan-out. To make a provider available, define a DSL v4 imported-surface source.
+Universal Search authorization is source-authored policy for a `kind: search`
+route. It does not replace `kind` or `search_limits`, and result display
+metadata does not grant authorization. Authorize only an upstream operation
+that you have verified is retrieval-only and idempotent.
 
 Authorization only makes a route eligible. Coral executes eligible routes from
 Search only when the experimental `search_provider_fanout` [runtime
@@ -677,14 +690,15 @@ ordinary SQL execution, catalog search, observed-value search, or the installed
 source.
 
 DSL v4 table functions are generated from one imported surface. Author routes
-at the top level and bind them to the original imported operation identity:
+at the top level and bind them to the original imported operation identity.
+This complete parser-valid manifest uses a URL-backed OpenAPI descriptor:
 
 ```yaml
-name: github_v4
+name: issue_search_v4
 dsl_version: 4
 surface:
   type: openapi
-  url: https://example.com/openapi.json
+  url: https://api.example.com/openapi.json
 
 universal_search:
   routes:
@@ -705,11 +719,13 @@ universal_search:
         attributes: [/state, /author/login]
 ```
 
-The route map key, such as `issue_search`, is the authored authorization ID and
-must match `[a-z][a-z0-9_]*`. Because each DSL v4 source has exactly one
-surface, `operation_id` is its exact current target. Generated schema and
-function names are not authorization identities. `query_input.location` must
-be `path`, `query`, or `tool_arg`;
+The route map key, such as `issue_search`, is the stable authored authorization
+ID and must match `[a-z][a-z0-9_]*`. Because each DSL v4 source has exactly one
+imported surface, its target is the exact
+`operation_id: search_issues_and_pull_requests` from that descriptor. Generated
+schema and function names are query-visible projections, not authorization
+identities, and must never replace the authored route ID and exact target.
+`query_input.location` must be `path`, `query`, or `tool_arg`;
 header, cookie, and body inputs cannot be selected.
 
 Coral derives route arguments and defaults from the imported OpenAPI or MCP


### PR DESCRIPTION
## Summary

- Expands the Search guide with the default-off enablement flow, the independent DSL v4 source-policy gate, a native preview example, execution budgets, response caps, partial-result behavior, and rollback.
- States the compatibility boundary explicitly: provider fanout is DSL v4-only. DSL v3 sources remain queryable through SQL and discoverable through local catalog and observed-value search, but Search never executes their functions as fanout routes.
- Keeps the complete DSL v3 provider-ranked function example for direct SQL use while documenting migration to a DSL v4 imported surface plus top-level `universal_search` route for fanout.
- Documents exact DSL v4 imported `operation_id` targets and authored route IDs; generated schema and function names are query-visible projections, not authorization identities.
- Explains that provider fanout is request-triggered read-only upstream work: it adds no background crawl, provider-response cache, or raw-row Search response.
- Documents how successfully decoded provider batches can feed the existing best-effort observed-values pipeline when enabled, while remaining unavailable to the Search response currently being assembled.
- Adds the MCP capability/annotation matrix and expands CLI, configuration, and security references with the 750/600/100/25 ms timing contract, route/row limits, bounded diagnostics, and data-flow boundaries.

## Stack boundary

Stack 11/11. Depends on #1864.

This PR changes documentation only. It describes the default-off, source-authorized DSL v4 capability implemented below it without implying any DSL v3 fanout compatibility.

## Test plan

- `make docs-check`
- `make schema-check`
- `make lint-proto`
- `make rust-checks`: 2,275 passed, 2 skipped

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
