### PR TITLE
feat(reef): add hosted login and callback routes

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -348,6 +348,8 @@ describe('Architectural Tests', () => {
     it('app shell should wrap only top-level app routes', () => {
       const routeConfig = fs.readFileSync(ROUTE_CONFIG_FILE, 'utf-8')
 
+      expect(routeConfig).toContain("route('login', 'routes/login.tsx')")
+      expect(routeConfig).toContain("route('auth/callback', 'routes/auth.callback.tsx')")
       expect(routeConfig).toContain("layout('routes/_protected.tsx', [")
       expect(routeConfig).toContain(
         "route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts')",
@@ -374,8 +376,9 @@ describe('Architectural Tests', () => {
 
       // Structural check: the same-origin resource route and onboarding stay
       // outside the app shell while sharing its request authentication boundary.
+      // Reef login and callback stay public so they can establish that session.
       expect(routeConfig).toMatch(
-        /export default \[\s*layout\(\s*'routes\/_protected\.tsx',\s*\[\s*(?:\/\/[^\n]*\n\s*)*route\(`\$\{routePattern\('workspaceSource'\)\}\/oauth-install`, 'routes\/source-oauth-install\.ts'\),\s*route\('onboarding', 'routes\/onboarding\.tsx'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\]\s*\),?\s*\] satisfies RouteConfig/,
+        /export default \[\s*route\('login', 'routes\/login\.tsx'\),\s*route\('auth\/callback', 'routes\/auth\.callback\.tsx'\),\s*layout\(\s*'routes\/_protected\.tsx',\s*\[\s*(?:\/\/[^\n]*\n\s*)*route\(`\$\{routePattern\('workspaceSource'\)\}\/oauth-install`, 'routes\/source-oauth-install\.ts'\),\s*route\('onboarding', 'routes\/onboarding\.tsx'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\]\s*\),?\s*\] satisfies RouteConfig/,
       )
     })
 

--- a/apps/reef/app/auth/response.server.ts
+++ b/apps/reef/app/auth/response.server.ts
@@ -1,0 +1,16 @@
+export function authPrivateHeaders(): Headers {
+  return new Headers({
+    'Cache-Control': 'private, no-store',
+    Vary: 'Cookie',
+  })
+}
+
+export function markAuthResponsePrivate(response: Response): Response {
+  response.headers.set('Cache-Control', 'private, no-store')
+  const varies = response.headers
+    .get('Vary')
+    ?.split(',')
+    .map((value) => value.trim().toLowerCase())
+  if (!varies?.includes('cookie')) response.headers.append('Vary', 'Cookie')
+  return response
+}

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -7,6 +7,8 @@ import { routePattern } from './routing/routemap'
 const isDesktopApp = process.env.CORAL_DESKTOP_APP === '1'
 
 export default [
+  route('login', 'routes/login.tsx'),
+  route('auth/callback', 'routes/auth.callback.tsx'),
   layout('routes/_protected.tsx', [
     // Action-only resource route: OAuth/device-code install streams progress over
     // same-origin fetch. It and onboarding share the auth boundary but do not

--- a/apps/reef/app/routes/_protected.tsx
+++ b/apps/reef/app/routes/_protected.tsx
@@ -3,14 +3,10 @@ import { Outlet, redirect } from 'react-router'
 import type { Route } from './+types/_protected'
 
 import { reefAuthConfig } from '@/auth/config.server'
+import { markAuthResponsePrivate } from '@/auth/response.server'
 import { requestAuthContext } from '@/auth/server-context'
 import { clearReefSession, readReefSession } from '@/auth/session.server'
 import type { RequiredAuthConfig } from '@/auth/types'
-
-const PRIVATE_RESPONSE_HEADERS = {
-  'Cache-Control': 'private, no-store',
-  Vary: 'Cookie',
-} as const
 
 export const middleware: Route.MiddlewareFunction[] = [
   async ({ context, request }, next) => {
@@ -31,10 +27,9 @@ export const middleware: Route.MiddlewareFunction[] = [
 
     try {
       const response = await next()
-      applyPrivateHeaders(response)
-      return response
+      return markAuthResponsePrivate(response)
     } catch (error) {
-      if (error instanceof Response) applyPrivateHeaders(error)
+      if (error instanceof Response) markAuthResponsePrivate(error)
       throw error
     }
   },
@@ -53,16 +48,10 @@ async function loginRedirect(request: Request, config: RequiredAuthConfig): Prom
   }
 
   const response = redirect(`/login?returnTo=${encodeURIComponent(returnTo)}`, { headers })
-  applyPrivateHeaders(response)
-  return response
+  return markAuthResponsePrivate(response)
 }
 
 function hasSessionCookie(request: Request, name: string): boolean {
   const cookie = request.headers.get('cookie')
   return cookie?.split(';').some((part) => part.trim().startsWith(`${name}=`)) ?? false
-}
-
-function applyPrivateHeaders(response: Response): void {
-  response.headers.set('Cache-Control', PRIVATE_RESPONSE_HEADERS['Cache-Control'])
-  response.headers.append('Vary', PRIVATE_RESPONSE_HEADERS.Vary)
 }

--- a/apps/reef/app/routes/auth.callback.server.test.tsx
+++ b/apps/reef/app/routes/auth.callback.server.test.tsx
@@ -1,0 +1,101 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RequiredAuthConfig } from '@/auth/types'
+
+const authMocks = vi.hoisted(() => ({
+  completeCoralOAuthLogin: vi.fn(),
+  reefAuthConfig: vi.fn(),
+}))
+
+vi.mock('@/auth/config.server', () => ({ reefAuthConfig: authMocks.reefAuthConfig }))
+vi.mock('@/auth/coral-oauth.server', () => ({
+  completeCoralOAuthLogin: authMocks.completeCoralOAuthLogin,
+}))
+
+import { ErrorBoundary, loader } from './auth.callback'
+
+const requiredConfig: RequiredAuthConfig = {
+  clientId: 'coral-cloud-ui',
+  cookieName: 'reef_session',
+  cookieSecure: true,
+  issuer: 'https://login.example.test',
+  mode: 'required',
+  redirectUri: 'https://reef.example.test/auth/callback',
+  scope: 'coral:mcp',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+
+describe('auth callback route', () => {
+  beforeEach(() => {
+    authMocks.completeCoralOAuthLogin.mockReset()
+    authMocks.reefAuthConfig.mockReset()
+  })
+
+  it('is unavailable when local or desktop auth is disabled', async () => {
+    authMocks.reefAuthConfig.mockReturnValue({ mode: 'disabled' })
+
+    const thrown = await runLoader().catch((error: unknown) => error)
+
+    expect(thrown).toBeInstanceOf(Response)
+    expect((thrown as Response).status).toBe(404)
+    expect(authMocks.completeCoralOAuthLogin).not.toHaveBeenCalled()
+  })
+
+  it('preserves the hosted callback redirect and session cookie response', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    const callbackResponse = new Response(null, {
+      headers: [
+        ['location', '/workspaces/analytics/sources'],
+        ['Set-Cookie', 'reef_oauth=; Max-Age=0; Path=/; HttpOnly'],
+        ['Set-Cookie', 'reef_session=encrypted; Path=/; HttpOnly; Secure'],
+      ],
+      status: 302,
+    })
+    authMocks.completeCoralOAuthLogin.mockResolvedValue(callbackResponse)
+    const request = new Request('https://reef.example.test/auth/callback?code=code&state=state')
+
+    const response = await loader({ request } as never)
+
+    expect(authMocks.completeCoralOAuthLogin).toHaveBeenCalledWith(request, requiredConfig)
+    expect(response).toBe(callbackResponse)
+    expect(response.headers.get('location')).toBe('/workspaces/analytics/sources')
+    expect(response.headers.getSetCookie()).toHaveLength(2)
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+  })
+
+  it('marks expected callback failures private before the error boundary handles them', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    const callbackError = new Response('provider detail', { status: 400 })
+    authMocks.completeCoralOAuthLogin.mockRejectedValue(callbackError)
+
+    const thrown = await runLoader().catch((error: unknown) => error)
+
+    expect(thrown).toBe(callbackError)
+    expect(callbackError.headers.get('Cache-Control')).toBe('private, no-store')
+    expect(callbackError.headers.get('Vary')).toContain('Cookie')
+  })
+
+  it('renders an accessible generic error without provider or token details', () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter initialEntries={['/auth/callback']}>
+        <ErrorBoundary />
+      </MemoryRouter>,
+    )
+
+    expect(markup).toContain('aria-labelledby="auth-error-title"')
+    expect(markup).toContain('Sign-in failed')
+    expect(markup).toContain('href="/login"')
+    expect(markup).toContain('Try again')
+    expect(markup).not.toContain('provider detail')
+    expect(markup).not.toContain('access_token')
+  })
+})
+
+async function runLoader() {
+  return loader({
+    request: new Request('https://reef.example.test/auth/callback?code=code&state=state'),
+  } as never)
+}

--- a/apps/reef/app/routes/auth.callback.tsx
+++ b/apps/reef/app/routes/auth.callback.tsx
@@ -1,0 +1,43 @@
+import type { Route } from './+types/auth.callback'
+
+import { reefAuthConfig } from '@/auth/config.server'
+import { completeCoralOAuthLogin } from '@/auth/coral-oauth.server'
+import { markAuthResponsePrivate } from '@/auth/response.server'
+import * as Button from '@/wax/components/button'
+import { Typography } from '@/wax/components/typography'
+
+import * as styles from './login.css'
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const config = reefAuthConfig()
+  if (config.mode === 'disabled') throw new Response('Not Found', { status: 404 })
+
+  try {
+    return markAuthResponsePrivate(await completeCoralOAuthLogin(request, config))
+  } catch (error) {
+    if (error instanceof Response) markAuthResponsePrivate(error)
+    throw error
+  }
+}
+
+export default function AuthCallback() {
+  return null
+}
+
+export function ErrorBoundary() {
+  return (
+    <main className={styles.page}>
+      <section className={styles.content} aria-labelledby="auth-error-title">
+        <Typography.HeadingLarge as="h1" id="auth-error-title">
+          Sign-in failed
+        </Typography.HeadingLarge>
+        <Typography.Body>
+          Try signing in again. If the problem continues, contact your administrator.
+        </Typography.Body>
+        <div className={styles.actions}>
+          <Button.InternalLink to="/login">Try again</Button.InternalLink>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/apps/reef/app/routes/login.css.ts
+++ b/apps/reef/app/routes/login.css.ts
@@ -1,0 +1,27 @@
+import { style } from '@vanilla-extract/css'
+
+import { theme } from '@/wax/theme/theme.css'
+
+export const page = style({
+  alignItems: 'center',
+  backgroundColor: theme.surface.mainContent,
+  boxSizing: 'border-box',
+  display: 'flex',
+  minHeight: '100vh',
+  padding: '24px',
+})
+
+export const content = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+  margin: '0 auto',
+  maxWidth: '420px',
+  textAlign: 'center',
+})
+
+export const actions = style({
+  display: 'flex',
+  justifyContent: 'center',
+  paddingTop: '8px',
+})

--- a/apps/reef/app/routes/login.server.test.tsx
+++ b/apps/reef/app/routes/login.server.test.tsx
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RequiredAuthConfig } from '@/auth/types'
+
+const authMocks = vi.hoisted(() => ({
+  readReefSession: vi.fn(),
+  reefAuthConfig: vi.fn(),
+  startCoralOAuthLogin: vi.fn(),
+}))
+
+vi.mock('@/auth/config.server', () => ({ reefAuthConfig: authMocks.reefAuthConfig }))
+vi.mock('@/auth/coral-oauth.server', () => ({
+  startCoralOAuthLogin: authMocks.startCoralOAuthLogin,
+}))
+vi.mock('@/auth/session.server', () => ({ readReefSession: authMocks.readReefSession }))
+
+import { headers, loader } from './login'
+
+const requiredConfig: RequiredAuthConfig = {
+  clientId: 'coral-cloud-ui',
+  cookieName: 'reef_session',
+  cookieSecure: true,
+  issuer: 'https://login.example.test',
+  mode: 'required',
+  redirectUri: 'https://reef.example.test/auth/callback',
+  scope: 'coral:mcp',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+
+describe('login route', () => {
+  beforeEach(() => {
+    authMocks.readReefSession.mockReset()
+    authMocks.reefAuthConfig.mockReset()
+    authMocks.startCoralOAuthLogin.mockReset()
+  })
+
+  it('marks rendered login responses private at the route boundary', () => {
+    const responseHeaders = new Headers(headers())
+
+    expect(responseHeaders.get('Cache-Control')).toBe('private, no-store')
+    expect(responseHeaders.get('Vary')).toBe('Cookie')
+  })
+
+  it('returns disabled local and desktop requests home without reading auth state', async () => {
+    authMocks.reefAuthConfig.mockReturnValue({ mode: 'disabled' })
+
+    const response = await runLoader('http://localhost:5173/login')
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('/')
+    expect(authMocks.readReefSession).not.toHaveBeenCalled()
+    expect(authMocks.startCoralOAuthLogin).not.toHaveBeenCalled()
+  })
+
+  it('returns an existing hosted session home instead of restarting OAuth', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue({
+      accessToken: 'server-only-token',
+      expiresAt: 4_102_444_800,
+      tokenType: 'Bearer',
+    })
+
+    const response = await runLoader('https://reef.example.test/login')
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('/')
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+    expect(authMocks.startCoralOAuthLogin).not.toHaveBeenCalled()
+  })
+
+  it('renders the signed-out interstitial without immediately restarting SSO', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(null)
+
+    await expect(runLoaderValue('https://reef.example.test/login?signedOut=1')).resolves.toBeNull()
+    expect(authMocks.startCoralOAuthLogin).not.toHaveBeenCalled()
+  })
+
+  it('starts hosted OAuth and preserves its redirect and transaction cookie', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(null)
+    const upstream = new Response(null, {
+      headers: {
+        location: 'https://login.example.test/authorize',
+        'Set-Cookie': 'reef_oauth=transaction; Path=/; HttpOnly',
+      },
+      status: 302,
+    })
+    authMocks.startCoralOAuthLogin.mockResolvedValue(upstream)
+    const request = new Request('https://reef.example.test/login?returnTo=%2Fworkspaces')
+
+    const response = (await loader({ request } as never)) as Response
+
+    expect(authMocks.startCoralOAuthLogin).toHaveBeenCalledWith(request, requiredConfig)
+    expect(response).toBe(upstream)
+    expect(response.headers.get('location')).toBe('https://login.example.test/authorize')
+    expect(response.headers.get('Set-Cookie')).toContain('reef_oauth=transaction')
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+    expect(response.headers.get('Vary')).toContain('Cookie')
+  })
+})
+
+async function runLoader(url: string): Promise<Response> {
+  const result = await runLoaderValue(url)
+  expect(result).toBeInstanceOf(Response)
+  return result as Response
+}
+
+async function runLoaderValue(url: string) {
+  return loader({ request: new Request(url) } as never)
+}

--- a/apps/reef/app/routes/login.tsx
+++ b/apps/reef/app/routes/login.tsx
@@ -1,0 +1,50 @@
+import { Form, redirect } from 'react-router'
+
+import type { Route } from './+types/login'
+
+import { reefAuthConfig } from '@/auth/config.server'
+import { startCoralOAuthLogin } from '@/auth/coral-oauth.server'
+import { authPrivateHeaders, markAuthResponsePrivate } from '@/auth/response.server'
+import { readReefSession } from '@/auth/session.server'
+import { getMeta } from '@/meta'
+import * as Button from '@/wax/components/button'
+import { Typography } from '@/wax/components/typography'
+
+import * as styles from './login.css'
+
+export function meta(_args: Route.MetaArgs) {
+  return getMeta('Sign in')
+}
+
+export function headers() {
+  return authPrivateHeaders()
+}
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const config = reefAuthConfig()
+  if (config.mode === 'disabled') return redirect('/')
+
+  const session = await readReefSession(request, config)
+  if (session) return markAuthResponsePrivate(redirect('/'))
+
+  const url = new URL(request.url)
+  if (url.searchParams.has('signedOut')) return null
+
+  return markAuthResponsePrivate(await startCoralOAuthLogin(request, config))
+}
+
+export default function Login() {
+  return (
+    <main className={styles.page}>
+      <section className={styles.content} aria-labelledby="login-title">
+        <Typography.HeadingLarge as="h1" id="login-title">
+          Coral 🪸
+        </Typography.HeadingLarge>
+        <Typography.Body>You have been signed out.</Typography.Body>
+        <Form action="/login" className={styles.actions} method="get">
+          <Button.TextButton type="submit">Sign in with Coral Cloud</Button.TextButton>
+        </Form>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
Constraint: Desktop and local Reef must never contact an auth issuer, while hosted Reef needs public routes that can establish the protected-route session.
Rejected: Client-side login effects or WorkOS-specific UI state | loaders prevent hydration flashes and Coral Cloud remains the provider-neutral upstream boundary.
Confidence: high
Scope-risk: moderate
Directive: Add logout and CSRF protection in the next branch; do not place login or callback beneath _protected.
Tested: npm run check --prefix apps/reef; npm run typecheck --prefix apps/reef; npm test --prefix apps/reef (91 files, 400 tests); npm run build --prefix apps/reef; client secret scan
Not-tested: Production Coral Cloud identity-provider integration and packaged desktop smoke testing are deferred.