### PR TITLE
feat(reef): add Wax textarea input

### DIFF
--- a/apps/reef/app/wax/components/inputs/text/index.ts
+++ b/apps/reef/app/wax/components/inputs/text/index.ts
@@ -1,2 +1,4 @@
+export { TextArea } from './text-area'
+export type { TextAreaProps } from './text-area'
 export { TextInput } from './text-input'
 export type { TextInputProps } from './text-input'

--- a/apps/reef/app/wax/components/inputs/text/text-area.css.ts
+++ b/apps/reef/app/wax/components/inputs/text/text-area.css.ts
@@ -1,0 +1,34 @@
+import { style } from '@vanilla-extract/css'
+
+import { input } from '@/wax/components/inputs/base-input.css'
+import { animation, theme } from '@/wax/theme/theme.css'
+
+export const textArea = style([
+  input,
+  {
+    border: 0,
+    borderRadius: 'inherit',
+    display: 'block',
+    minHeight: 72,
+    resize: 'vertical',
+  },
+])
+
+export const textAreaContainer = style({
+  border: `1px solid ${theme.input.stroke.default}`,
+  borderRadius: 8,
+  transition: animation.colorTransition,
+  width: '100%',
+  selectors: {
+    '&:has(textarea:disabled)': {
+      borderColor: theme.input.stroke.disabled,
+      cursor: 'not-allowed',
+    },
+    '&:focus-within': {
+      borderColor: theme.input.stroke.focus,
+    },
+    '&:hover:not(:focus-within):not(:has(textarea:disabled))': {
+      borderColor: theme.input.stroke.hover,
+    },
+  },
+})

--- a/apps/reef/app/wax/components/inputs/text/text-area.stories.tsx
+++ b/apps/reef/app/wax/components/inputs/text/text-area.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import { expect, fireEvent, waitFor } from 'storybook/test'
+
+import { TextArea } from './text-area'
+
+const meta = {
+  args: {
+    placeholder: 'Describe this source…',
+  },
+  component: TextArea,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 360 }}>
+        <Story />
+      </div>
+    ),
+  ],
+  title: 'Wax/Inputs/TextArea',
+} satisfies Meta<typeof TextArea>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  play: async ({ canvas, userEvent }) => {
+    const textArea = canvas.getByRole('textbox')
+
+    await expect(textArea).toHaveAttribute('tabindex', '0')
+    await userEvent.type(textArea, 'Editable text')
+    await expect(textArea).toHaveValue('Editable text')
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    value: 'This description cannot be edited.',
+  },
+  play: async ({ canvas }) => {
+    const textArea = canvas.getByRole('textbox')
+
+    await expect(textArea).toBeDisabled()
+    await expect(textArea).toHaveAttribute('data-disabled')
+  },
+}
+
+export const Controlled: Story = {
+  render: () => {
+    const [value, setValue] = useState('A longer description that can span multiple lines.')
+    return <TextArea onChange={setValue} value={value} />
+  },
+}
+
+export const Overflow: Story = {
+  args: {
+    rows: 4,
+    value: Array.from(
+      { length: 12 },
+      (_, index) => `Line ${index + 1}: Source descriptions can contain detailed setup guidance.`,
+    ).join('\n'),
+  },
+  play: async ({ canvas }) => {
+    const textArea = canvas.getByRole('textbox')
+
+    await waitFor(() => expect(textArea.scrollHeight).toBeGreaterThan(textArea.clientHeight))
+    await expect(getComputedStyle(textArea).overflowX).toBe('hidden')
+    await expect(textArea).toHaveAttribute('data-overflow-y-end')
+    await expect(getComputedStyle(textArea).maskImage).toContain('linear-gradient')
+
+    textArea.scrollTop = textArea.scrollHeight
+    await fireEvent.scroll(textArea)
+    await waitFor(() => expect(textArea).toHaveAttribute('data-overflow-y-start'))
+  },
+}

--- a/apps/reef/app/wax/components/inputs/text/text-area.tsx
+++ b/apps/reef/app/wax/components/inputs/text/text-area.tsx
@@ -1,0 +1,73 @@
+import { Field } from '@base-ui/react/field'
+import classNames from 'classnames'
+
+import { Container as ScrollArea } from '@/wax/components/scroll-area'
+
+import * as styles from './text-area.css'
+
+export interface TextAreaProps {
+  ariaLabel?: string
+  autoFocus?: boolean
+  className?: string
+  disabled?: boolean
+  id?: string
+  name?: string
+  onBlur?: () => void
+  onChange?: (value: string) => void
+  onFocus?: () => void
+  onKeyDown?: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void
+  placeholder?: string
+  ref?: React.Ref<HTMLTextAreaElement>
+  rows?: number
+  value?: string
+}
+
+export function TextArea({
+  ariaLabel,
+  autoFocus,
+  className,
+  disabled,
+  id,
+  name,
+  onBlur,
+  onChange,
+  onFocus,
+  onKeyDown,
+  placeholder,
+  ref,
+  rows = 3,
+  value,
+}: TextAreaProps) {
+  return (
+    <Field.Root disabled={disabled}>
+      <ScrollArea
+        className={styles.textAreaContainer}
+        height="auto"
+        scrollDirection="vertical"
+        renderViewport={
+          <Field.Control
+            aria-label={ariaLabel}
+            autoFocus={autoFocus}
+            id={id}
+            name={name}
+            onBlur={onBlur}
+            onFocus={onFocus}
+            onValueChange={onChange}
+            placeholder={placeholder}
+            render={
+              <textarea
+                className={classNames(styles.textArea, className)}
+                onKeyDown={onKeyDown}
+                ref={ref}
+                role="textbox"
+                rows={rows}
+                tabIndex={0}
+              />
+            }
+            value={value}
+          />
+        }
+      />
+    </Field.Root>
+  )
+}

--- a/apps/reef/app/wax/components/scroll-area/scroll-area.css.ts
+++ b/apps/reef/app/wax/components/scroll-area/scroll-area.css.ts
@@ -2,7 +2,7 @@ import { style, styleVariants } from '@vanilla-extract/css'
 
 import { theme, zIndex } from '@/wax/theme/theme.css'
 
-const FADE_HEIGHT_PX = 40
+const FADE_SIZE_PX = 40
 
 export const root = style({
   overflow: 'hidden',
@@ -37,7 +37,7 @@ const fadeTop = style({
   selectors: {
     '&::before': {
       background: `linear-gradient(to bottom, ${fadeColor}, transparent)`,
-      height: `min(${FADE_HEIGHT_PX}px, var(--scroll-area-overflow-y-start))`,
+      height: `min(${FADE_SIZE_PX}px, var(--scroll-area-overflow-y-start))`,
       top: 0,
       vars: {
         '--scroll-area-overflow-y-start': 'inherit',
@@ -51,7 +51,7 @@ const fadeBottom = style({
     '&::after': {
       background: `linear-gradient(to top, ${fadeColor}, transparent)`,
       bottom: 0,
-      height: `min(${FADE_HEIGHT_PX}px, var(--scroll-area-overflow-y-end, ${FADE_HEIGHT_PX}px))`,
+      height: `min(${FADE_SIZE_PX}px, var(--scroll-area-overflow-y-end, ${FADE_SIZE_PX}px))`,
       vars: {
         '--scroll-area-overflow-y-end': 'inherit',
       },
@@ -59,11 +59,107 @@ const fadeBottom = style({
   },
 })
 
+const horizontalFadeBase = style({
+  selectors: {
+    '&::before, &::after': {
+      content: '""',
+      display: 'block',
+      height: '100%',
+      pointerEvents: 'none',
+      position: 'absolute',
+      top: 0,
+      transition: 'width 0.1s ease-out',
+      zIndex: zIndex.raised,
+    },
+  },
+})
+
+const fadeLeft = style({
+  selectors: {
+    '&::before': {
+      background: `linear-gradient(to right, ${fadeColor}, transparent)`,
+      left: 0,
+      vars: {
+        '--scroll-area-overflow-x-start': 'inherit',
+      },
+      width: `min(${FADE_SIZE_PX}px, var(--scroll-area-overflow-x-start))`,
+    },
+  },
+})
+
+const fadeRight = style({
+  selectors: {
+    '&::after': {
+      background: `linear-gradient(to left, ${fadeColor}, transparent)`,
+      right: 0,
+      vars: {
+        '--scroll-area-overflow-x-end': 'inherit',
+      },
+      width: `min(${FADE_SIZE_PX}px, var(--scroll-area-overflow-x-end, ${FADE_SIZE_PX}px))`,
+    },
+  },
+})
+
 export const viewportFade = styleVariants({
   both: [fadeBase, fadeTop, fadeBottom],
   bottom: [fadeBase, fadeBottom],
+  horizontal: [horizontalFadeBase, fadeLeft, fadeRight],
   none: [],
   top: [fadeBase, fadeTop],
+})
+
+const nativeFadeTop = style({
+  maskImage: `linear-gradient(
+    to bottom,
+    transparent 0,
+    black min(${FADE_SIZE_PX}px, var(--scroll-area-overflow-y-start)),
+    black 100%
+  )`,
+  maskRepeat: 'no-repeat',
+  scrollPaddingBlockStart: FADE_SIZE_PX,
+})
+
+const nativeFadeBottom = style({
+  maskImage: `linear-gradient(
+    to bottom,
+    black 0,
+    black calc(100% - min(${FADE_SIZE_PX}px, var(--scroll-area-overflow-y-end, ${FADE_SIZE_PX}px))),
+    transparent 100%
+  )`,
+  maskRepeat: 'no-repeat',
+  scrollPaddingBlockEnd: FADE_SIZE_PX,
+})
+
+const nativeFadeBoth = style({
+  maskImage: `linear-gradient(
+    to bottom,
+    transparent 0,
+    black min(${FADE_SIZE_PX}px, var(--scroll-area-overflow-y-start)),
+    black calc(100% - min(${FADE_SIZE_PX}px, var(--scroll-area-overflow-y-end, ${FADE_SIZE_PX}px))),
+    transparent 100%
+  )`,
+  maskRepeat: 'no-repeat',
+  scrollPaddingBlock: FADE_SIZE_PX,
+})
+
+const nativeFadeHorizontal = style({
+  maskImage: `linear-gradient(
+    to right,
+    transparent 0,
+    black min(${FADE_SIZE_PX}px, var(--scroll-area-overflow-x-start)),
+    black calc(100% - min(${FADE_SIZE_PX}px, var(--scroll-area-overflow-x-end, ${FADE_SIZE_PX}px))),
+    transparent 100%
+  )`,
+  maskRepeat: 'no-repeat',
+  scrollPaddingInline: FADE_SIZE_PX,
+})
+
+export const nativeViewportFade = styleVariants({
+  both: [nativeFadeBoth],
+  bottom: [nativeFadeBottom],
+  horizontal: [nativeFadeHorizontal],
+  none: {},
+  top: [nativeFadeTop],
 })
 
 export const content = style({

--- a/apps/reef/app/wax/components/scroll-area/scroll-area.stories.tsx
+++ b/apps/reef/app/wax/components/scroll-area/scroll-area.stories.tsx
@@ -19,7 +19,11 @@ const meta: Meta<typeof Container> = {
     },
     fade: {
       control: 'select',
-      options: [undefined, 'top', 'bottom', 'both', 'none'],
+      options: [undefined, 'top', 'bottom', 'both', 'horizontal', 'none'],
+    },
+    scrollDirection: {
+      control: 'select',
+      options: [undefined, 'both', 'horizontal', 'vertical'],
     },
   },
   component: Container,
@@ -41,12 +45,13 @@ export default meta
 type Story = StoryObj<typeof Container>
 
 export const Default: Story = {
-  render: ({ constrainWidth, fade, horizontal }) => (
+  render: ({ constrainWidth, fade, horizontal, scrollDirection }) => (
     <Container
       constrainWidth={constrainWidth}
       fade={fade}
       height="200px"
       horizontal={horizontal}
+      scrollDirection={scrollDirection}
       width="300px"
     >
       <div

--- a/apps/reef/app/wax/components/scroll-area/scroll-area.tsx
+++ b/apps/reef/app/wax/components/scroll-area/scroll-area.tsx
@@ -4,23 +4,38 @@ import classNames from 'classnames'
 import * as styles from './scroll-area.css'
 
 interface ScrollAreaBaseProps extends React.HTMLAttributes<HTMLDivElement> {
-  children: React.ReactNode
   /** Constrains content width to viewport. Useful when you don't need horizontal scrolling. Defaults to false. */
   constrainWidth?: boolean
   /** Makes the internal content wrapper at least as tall as the scroll viewport. Defaults to false. */
   fillContent?: boolean
-  /** Adds gradient fade effect at scroll edges. */
-  fade?: 'both' | 'bottom' | 'none' | 'top'
+  /** Adds a gradient fade effect at the selected scroll edges. */
+  fade?: 'both' | 'bottom' | 'horizontal' | 'none' | 'top'
   /** Whether to show the horizontal scrollbar. Defaults to false. */
   horizontal?: boolean
   ref?: React.Ref<HTMLDivElement>
+  /** Axes that may scroll. Defaults to 'both'. */
+  scrollDirection?: 'both' | 'horizontal' | 'vertical'
   /** Ref to the scrollable viewport element. Useful for virtualization libraries. */
   viewportRef?: React.Ref<HTMLDivElement>
+  /** Class name applied to the scrollable viewport element. */
+  viewportClassName?: string
   /** Defaults to '100%'. */
   width?: string
 }
 
-type ScrollAreaProps = ScrollAreaWithHeight | ScrollAreaWithMaxHeight
+type ScrollAreaProps = (ScrollAreaWithHeight | ScrollAreaWithMaxHeight) &
+  (ScrollAreaContentProps | ScrollAreaNativeViewportProps)
+
+interface ScrollAreaContentProps {
+  children: React.ReactNode
+  renderViewport?: never
+}
+
+interface ScrollAreaNativeViewportProps {
+  children?: never
+  /** Native element that owns its own scrollable content, such as a textarea. */
+  renderViewport: React.ReactElement
+}
 
 interface ScrollAreaWithHeight extends ScrollAreaBaseProps {
   /** Fixed height. Defaults to '100%'. */
@@ -58,7 +73,10 @@ export function Container({
   horizontal = false,
   maxHeight,
   ref,
+  renderViewport,
+  scrollDirection = 'both',
   style,
+  viewportClassName,
   viewportRef,
   width = '100%',
   ...rest
@@ -71,6 +89,25 @@ export function Container({
         }
       : undefined
 
+  const viewport = renderViewport ? (
+    <BaseScrollArea.Viewport
+      className={classNames(styles.viewport, styles.nativeViewportFade[fade], viewportClassName)}
+      ref={viewportRef}
+      render={renderViewport}
+      style={getViewportStyle(scrollDirection)}
+    />
+  ) : (
+    <BaseScrollArea.Viewport
+      className={classNames(styles.viewport, styles.viewportFade[fade], viewportClassName)}
+      ref={viewportRef}
+      style={getViewportStyle(scrollDirection)}
+    >
+      <BaseScrollArea.Content className={styles.content} style={contentStyle}>
+        {children}
+      </BaseScrollArea.Content>
+    </BaseScrollArea.Viewport>
+  )
+
   return (
     <BaseScrollArea.Root
       className={classNames(styles.root, className)}
@@ -78,23 +115,30 @@ export function Container({
       style={{ height: maxHeight ? undefined : height, maxHeight, width, ...style }}
       {...rest}
     >
-      <BaseScrollArea.Viewport
-        className={classNames(styles.viewport, styles.viewportFade[fade])}
-        ref={viewportRef}
-      >
-        <BaseScrollArea.Content className={styles.content} style={contentStyle}>
-          {children}
-        </BaseScrollArea.Content>
-      </BaseScrollArea.Viewport>
-      <BaseScrollArea.Scrollbar className={styles.scrollbar} orientation="vertical">
-        <BaseScrollArea.Thumb className={styles.thumb} />
-      </BaseScrollArea.Scrollbar>
-      {horizontal && (
+      {viewport}
+      {scrollDirection !== 'horizontal' && (
+        <BaseScrollArea.Scrollbar className={styles.scrollbar} orientation="vertical">
+          <BaseScrollArea.Thumb className={styles.thumb} />
+        </BaseScrollArea.Scrollbar>
+      )}
+      {horizontal && scrollDirection !== 'vertical' && (
         <BaseScrollArea.Scrollbar className={styles.scrollbar} orientation="horizontal">
           <BaseScrollArea.Thumb className={styles.thumb} />
         </BaseScrollArea.Scrollbar>
       )}
-      {horizontal && <BaseScrollArea.Corner className={styles.corner} />}
+      {horizontal && scrollDirection === 'both' && (
+        <BaseScrollArea.Corner className={styles.corner} />
+      )}
     </BaseScrollArea.Root>
   )
+}
+
+function getViewportStyle(scrollDirection: NonNullable<ScrollAreaBaseProps['scrollDirection']>) {
+  if (scrollDirection === 'horizontal') {
+    return { overflowY: 'hidden' } as const
+  }
+  if (scrollDirection === 'vertical') {
+    return { overflowX: 'hidden' } as const
+  }
+  return undefined
 }

--- a/apps/reef/app/wax/components/tabs/list.tsx
+++ b/apps/reef/app/wax/components/tabs/list.tsx
@@ -1,7 +1,8 @@
-import { ScrollArea as BaseScrollArea } from '@base-ui/react/scroll-area'
 import { Tabs as BaseTabs } from '@base-ui/react/tabs'
 import classNames from 'classnames'
 import { useEffect, useRef } from 'react'
+
+import { Container as ScrollArea } from '@/wax/components/scroll-area'
 
 import * as styles from './tabs.css'
 
@@ -36,12 +37,14 @@ export function List({
   }, [])
 
   return (
-    <BaseScrollArea.Root className={styles.listRoot}>
-      <BaseScrollArea.Viewport className={styles.listViewport}>
-        <BaseScrollArea.Content>
-          <BaseTabs.List className={classNames(styles.list, className)} ref={listRef} {...props} />
-        </BaseScrollArea.Content>
-      </BaseScrollArea.Viewport>
-    </BaseScrollArea.Root>
+    <ScrollArea
+      className={styles.listRoot}
+      fade="horizontal"
+      height="auto"
+      scrollDirection="horizontal"
+      viewportClassName={styles.listViewport}
+    >
+      <BaseTabs.List className={classNames(styles.list, className)} ref={listRef} {...props} />
+    </ScrollArea>
   )
 }

--- a/apps/reef/app/wax/components/tabs/tabs.css.ts
+++ b/apps/reef/app/wax/components/tabs/tabs.css.ts
@@ -3,8 +3,6 @@ import { style } from '@vanilla-extract/css'
 import { breakpoints } from '@/styles/theme.css'
 import { theme, zIndex } from '@/wax/theme/theme.css'
 
-const FADE_WIDTH_PX = 40
-
 export const listRoot = style({
   maxWidth: '100%',
   minWidth: 0,
@@ -18,15 +16,6 @@ export const listViewport = style({
       scrollPaddingInline: '16px',
     },
   },
-  maskImage: `linear-gradient(
-    to right,
-    transparent 0,
-    black min(${FADE_WIDTH_PX}px, var(--scroll-area-overflow-x-start)),
-    black calc(100% - min(${FADE_WIDTH_PX}px, var(--scroll-area-overflow-x-end, ${FADE_WIDTH_PX}px))),
-    transparent 100%
-  )`,
-  maskRepeat: 'no-repeat',
-  overscrollBehavior: 'contain',
   scrollPaddingInline: '32px',
   width: '100%',
 })

--- a/apps/reef/app/wax/components/tabs/tabs.stories.tsx
+++ b/apps/reef/app/wax/components/tabs/tabs.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 
-import { fn } from 'storybook/test'
+import { expect, fn } from 'storybook/test'
 
 import { Tabs } from '@/wax/components'
 
@@ -75,6 +75,14 @@ export const HorizontalScroll: StoryObj<DefaultArgs> = {
       </Tabs.Root>
     </div>
   ),
+  play: async ({ canvas }) => {
+    const list = canvas.getByRole('tablist')
+    const viewport = list.closest<HTMLElement>('[data-id$="-viewport"]')
+
+    await expect(viewport).toBeDefined()
+    await expect(viewport?.scrollWidth).toBeGreaterThan(viewport?.clientWidth ?? 0)
+    await expect(getComputedStyle(viewport!).overflowY).toBe('hidden')
+  },
 }
 
 export const HorizontalScrollLastSelected: StoryObj<DefaultArgs> = {


### PR DESCRIPTION
## Summary

- add a reusable Wax `TextArea` that remains a native textarea for form, editing, selection, and accessibility behavior
- let Wax ScrollArea render native intrinsic scrollports so TextArea overflow state and scrollbar behavior come from the shared primitive
- show directional top/bottom fades only where content remains hidden
- preserve focus, hover, disabled, resize, controlled, and uncontrolled behavior
- add default, controlled, disabled, and overflowing Storybook coverage

## Stack

- stacked on the SourceField label-association parent in [#1866](https://github.com/withcoral/coral/pull/1866)
- provides the ScrollArea viewport seam consumed by Wax Radio in [#1869](https://github.com/withcoral/coral/pull/1869)
- consumed by the source-creation flow in [#1800](https://github.com/withcoral/coral/pull/1800)

## Validation

- `npm run check --prefix apps/reef`
- `npm run typecheck --prefix apps/reef`
- `npm test --prefix apps/reef` (86 files, 364 tests)
- `npm run build --prefix apps/reef`
- combined TextArea/Radio/ScrollArea stories (3 files, 10 tests)
- source-creator integration tests (2 files, 13 tests)
- Playwright Storybook checks for native editing, focusability, scroll metrics, resize style, stable border, and directional overflow fades