### PR TITLE
feat(reef): add Wax radio group

### DIFF
--- a/apps/reef/app/wax/components/index.ts
+++ b/apps/reef/app/wax/components/index.ts
@@ -8,6 +8,7 @@ export * as Inputs from './inputs'
 export * as KeyboardShortcut from './keyboard-shortcut'
 export * as List from './list'
 export * as Menu from './menu'
+export * as Radio from './radio'
 export * as ScrollArea from './scroll-area'
 export * as Tabs from './tabs'
 export { Card }

--- a/apps/reef/app/wax/components/radio/group.tsx
+++ b/apps/reef/app/wax/components/radio/group.tsx
@@ -1,0 +1,32 @@
+import { RadioGroup as BaseRadioGroup } from '@base-ui/react/radio-group'
+import classNames from 'classnames'
+
+import { Container as ScrollArea } from '@/wax/components/scroll-area'
+
+import * as styles from './radio.css'
+
+export type GroupProps<Value> = Omit<BaseRadioGroup.Props<Value>, 'className' | 'onValueChange'> & {
+  className?: string
+  onValueChange?: (value: Value) => void
+}
+
+export function Group<Value>({
+  children,
+  className,
+  onValueChange,
+  ref,
+  ...props
+}: GroupProps<Value>) {
+  return (
+    <ScrollArea fade="horizontal" height="auto" scrollDirection="horizontal">
+      <BaseRadioGroup
+        className={classNames(styles.group, className)}
+        onValueChange={(value) => onValueChange?.(value)}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </BaseRadioGroup>
+    </ScrollArea>
+  )
+}

--- a/apps/reef/app/wax/components/radio/index.ts
+++ b/apps/reef/app/wax/components/radio/index.ts
@@ -1,0 +1,4 @@
+export { Group } from './group'
+export type { GroupProps } from './group'
+export { Item } from './item'
+export type { ItemProps } from './item'

--- a/apps/reef/app/wax/components/radio/item.tsx
+++ b/apps/reef/app/wax/components/radio/item.tsx
@@ -1,0 +1,20 @@
+import { Radio as BaseRadio } from '@base-ui/react/radio'
+import classNames from 'classnames'
+
+import * as styles from './radio.css'
+
+export type ItemProps<Value> = Omit<React.ComponentPropsWithoutRef<'label'>, 'value'> & {
+  disabled?: boolean
+  value: Value
+}
+
+export function Item<Value>({ children, className, disabled, value, ...props }: ItemProps<Value>) {
+  return (
+    <label className={classNames(styles.item, className)} {...props}>
+      <BaseRadio.Root className={styles.control} disabled={disabled} value={value}>
+        <BaseRadio.Indicator className={styles.indicator} />
+      </BaseRadio.Root>
+      <span className={styles.label}>{children}</span>
+    </label>
+  )
+}

--- a/apps/reef/app/wax/components/radio/radio.css.ts
+++ b/apps/reef/app/wax/components/radio/radio.css.ts
@@ -1,0 +1,76 @@
+import { style } from '@vanilla-extract/css'
+
+import { animation, theme } from '@/wax/theme/theme.css'
+
+export const group = style({
+  alignItems: 'center',
+  display: 'flex',
+  gap: 20,
+  minWidth: 'max-content',
+  paddingBlock: 4,
+  paddingInline: 4,
+})
+
+export const item = style({
+  alignItems: 'center',
+  color: theme.content.secondary,
+  cursor: 'pointer',
+  display: 'inline-flex',
+  flexShrink: 0,
+  gap: 8,
+  userSelect: 'none',
+  whiteSpace: 'nowrap',
+  ...theme.typography.body,
+  selectors: {
+    '&:hover:not(:has([data-disabled]))': {
+      color: theme.content.primary,
+    },
+    '&:has([data-checked])': {
+      color: theme.content.primary,
+    },
+    '&:has([data-disabled])': {
+      color: theme.content.disabled,
+      cursor: 'not-allowed',
+    },
+    '&:has([role="radio"]:focus-visible)': {
+      borderRadius: 4,
+      outline: `2px solid ${theme.stroke.focused}`,
+      outlineOffset: 2,
+    },
+  },
+})
+
+export const control = style({
+  alignItems: 'center',
+  backgroundColor: 'transparent',
+  border: `2px solid ${theme.content.tertiary}`,
+  borderRadius: '50%',
+  cursor: 'inherit',
+  display: 'inline-flex',
+  flexShrink: 0,
+  height: 18,
+  justifyContent: 'center',
+  outline: 'none',
+  padding: 0,
+  transition: animation.colorTransition,
+  width: 18,
+  selectors: {
+    '&[data-checked]': {
+      borderColor: theme.stroke.focused,
+    },
+    '&[data-disabled]': {
+      borderColor: theme.input.stroke.disabled,
+    },
+  },
+})
+
+export const indicator = style({
+  backgroundColor: theme.stroke.focused,
+  borderRadius: '50%',
+  height: 8,
+  width: 8,
+})
+
+export const label = style({
+  pointerEvents: 'none',
+})

--- a/apps/reef/app/wax/components/radio/radio.stories.tsx
+++ b/apps/reef/app/wax/components/radio/radio.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import { expect, waitFor } from 'storybook/test'
+
+import { Radio } from '@/wax/components'
+
+const meta = {
+  parameters: {
+    layout: 'centered',
+  },
+  title: 'Wax/Radio',
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState('openapi')
+    return (
+      <Radio.Group aria-label="Source type" value={value} onValueChange={setValue}>
+        <Radio.Item value="openapi">REST API (OpenAPI)</Radio.Item>
+        <Radio.Item value="mcp">MCP server</Radio.Item>
+      </Radio.Group>
+    )
+  },
+  play: async ({ canvas, userEvent }) => {
+    await expect(canvas.getByRole('radiogroup', { name: 'Source type' })).toBeInTheDocument()
+
+    const openapi = canvas.getByRole('radio', { name: 'REST API (OpenAPI)' })
+    const mcp = canvas.getByRole('radio', { name: 'MCP server' })
+    await expect(openapi).toBeChecked()
+    await expect(openapi.getBoundingClientRect().width).toBe(18)
+
+    openapi.focus()
+    await expect(getComputedStyle(openapi.closest('label')!).outlineStyle).toBe('solid')
+    await userEvent.keyboard('{ArrowRight}')
+    await expect(mcp).toBeChecked()
+  },
+}
+
+export const DisabledItem: Story = {
+  render: () => (
+    <Radio.Group aria-label="Authentication" defaultValue="none">
+      <Radio.Item value="none">None</Radio.Item>
+      <Radio.Item value="bearer">Bearer token</Radio.Item>
+      <Radio.Item disabled value="header">
+        Custom header
+      </Radio.Item>
+    </Radio.Group>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    const none = canvas.getByRole('radio', { name: 'None' })
+    const bearer = canvas.getByRole('radio', { name: 'Bearer token' })
+    const header = canvas.getByRole('radio', { name: 'Custom header' })
+
+    await expect(none).toBeChecked()
+    await userEvent.click(header)
+    await expect(none).toBeChecked()
+    await expect(header).not.toBeChecked()
+
+    await userEvent.click(bearer)
+    await expect(bearer).toBeChecked()
+  },
+}
+
+const authenticationOptions = [
+  'None',
+  'API key',
+  'Bearer token',
+  'Basic auth',
+  'OAuth 2.0',
+  'Custom header',
+  'AWS SigV4',
+]
+
+export const ManyOptions: Story = {
+  render: () => (
+    <div style={{ width: 320 }}>
+      <ManyOptionsExample />
+    </div>
+  ),
+  play: async ({ canvas, userEvent }) => {
+    const group = canvas.getByRole('radiogroup', { name: 'Authentication type' })
+    const viewport = group.closest<HTMLElement>('[data-id$="-viewport"]')
+
+    await expect(viewport).toBeDefined()
+    await expect(viewport?.scrollWidth).toBeGreaterThan(viewport?.clientWidth ?? 0)
+    await expect(getComputedStyle(viewport!).overflowY).toBe('hidden')
+    await expect(getComputedStyle(viewport!, '::after').backgroundImage).toContain(
+      'linear-gradient',
+    )
+
+    const none = canvas.getByRole('radio', { name: 'None' })
+    const sigV4 = canvas.getByRole('radio', { name: 'AWS SigV4' })
+    none.focus()
+    await userEvent.keyboard(
+      '{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}{ArrowRight}',
+    )
+    await expect(sigV4).toBeChecked()
+    await waitFor(() => expect(viewport?.scrollLeft).toBeGreaterThan(0))
+  },
+}
+
+function ManyOptionsExample() {
+  const [value, setValue] = useState(authenticationOptions[0])
+  return (
+    <Radio.Group aria-label="Authentication type" onValueChange={setValue} value={value}>
+      {authenticationOptions.map((option) => (
+        <Radio.Item key={option} value={option}>
+          {option}
+        </Radio.Item>
+      ))}
+    </Radio.Group>
+  )
+}


### PR DESCRIPTION
## ![image.png](https://app.graphite.com/user-attachments/assets/048a54ae-08f0-4c71-a546-4a77c52b39be.png)

![image.png](https://app.graphite.com/user-attachments/assets/ed22cba7-56ff-40cd-ac53-cdc53ab132b1.png)

![CleanShot 2026-07-21 at 12.57.07@2x.png](https://app.graphite.com/user-attachments/assets/bd6fe745-a295-435a-a40f-c4f5b29b27aa.png)





##   
  
Summary

- add reusable Wax `Radio.Group` and `Radio.Item` components backed by Base UI
- preserve native radio semantics, focus management, form behavior, disabled behavior, and arrow-key navigation
- render one aria-hidden selection background that slides and resizes between options and wrapped rows
- support `overflow="wrap"` by default and `overflow="scroll"` through Wax ScrollArea when height must remain fixed
- show horizontal edge fades and automatically scroll the selected option into view
- honor `prefers-reduced-motion`
- cover default, disabled, wrapped-many-option, and scrolling-many-option behavior in Storybook

## Stack

- stacked on the Wax textarea parent in [#1868](https://github.com/withcoral/coral/pull/1868)
- consumed by the source-creation flow in [#1800](https://github.com/withcoral/coral/pull/1800)

## Validation

- `npm run check --prefix apps/reef`
- `npm run typecheck --prefix apps/reef`
- `npm test --prefix apps/reef` (87 files, 367 tests)
- `npm run build --prefix apps/reef`
- Playwright Storybook checks for wrap dimensions, ScrollArea overflow, auto-scroll, pointer access, animated selection, reduced motion, and both edge fades