### PR TITLE
feat(reef): move settings into workspace menu

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -46,10 +46,9 @@ npm run dev --prefix apps/desktop
 
 The desktop dev command starts the Reef dev server first, then launches Electron
 with `ELECTRON_RENDERER_URL` pointed at that server, so Reef's dependencies must
-be installed too. The dev server receives `CORAL_DESKTOP_APP=1`,
-`VITE_CORAL_DESKTOP_APP=1`, and a fixed `CORAL_ENDPOINT` for server-side loaders;
-Electron waits for the sidecar before loading the first document so initial SSR
-does not race the local Coral process.
+be installed too. The dev server receives `VITE_CORAL_DESKTOP_APP=1` and a fixed
+`CORAL_ENDPOINT` for server-side loaders; Electron waits for the sidecar before
+loading the first document so initial SSR does not race the local Coral process.
 
 In development, the sidecar is started through Cargo so the app uses the local
 Rust code (run from the repo root):

--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -123,7 +123,6 @@ const appDevServer = spawnChild('npm', ['run', 'dev', '--prefix', 'apps/reef'], 
   cwd: repoRoot,
   env: {
     ...process.env,
-    CORAL_DESKTOP_APP: '1',
     CORAL_ENDPOINT: `http://127.0.0.1:${sidecarPort}`,
     VITE_CORAL_DESKTOP_APP: '1',
   },

--- a/apps/desktop/scripts/stage-coral.mjs
+++ b/apps/desktop/scripts/stage-coral.mjs
@@ -36,7 +36,6 @@ await run('npm', ['ci', '--prefix', 'apps/reef'])
 await run('npm', ['run', 'build', '--prefix', 'apps/reef'], {
   env: {
     ...process.env,
-    CORAL_DESKTOP_APP: '1',
     VITE_CORAL_DESKTOP_APP: '1',
   },
 })

--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -368,7 +368,7 @@ describe('Architectural Tests', () => {
       expect(routeConfig).toContain("route(':schemaName/:tableName', 'routes/schema-table.tsx')")
       expect(routeConfig).toContain("route(routePattern('workspaceTraces'), 'routes/traces.tsx', [")
       expect(routeConfig).toContain("route(':traceId', 'routes/trace-detail.tsx')")
-      // Settings is gated to the desktop build, but the route entry is still present.
+      // Settings stays in the shared app shell; desktop-only sections are gated in the route.
       expect(routeConfig).toContain("route(routePattern('settings'), 'routes/settings.tsx')")
 
       // Structural check: the same-origin resource route and onboarding stay

--- a/apps/reef/app/components/sidebar/sidebar.css.ts
+++ b/apps/reef/app/components/sidebar/sidebar.css.ts
@@ -41,39 +41,15 @@ export const workspaceSelectorRow = style({
   alignItems: 'center',
   display: 'flex',
   gap: '4px',
+  minHeight: '32px',
   minWidth: 0,
 })
 
 export const workspaceSelector = style({
-  alignItems: 'center',
-  background: 'transparent',
-  border: 'none',
-  borderRadius: '8px',
-  color: theme.content.primary,
-  display: 'flex',
   flex: '1 1 auto',
-  gap: '8px',
-  minHeight: '32px',
+  justifyContent: 'flex-start',
   minWidth: 0,
   overflow: 'hidden',
-  paddingInline: '8px',
-  textDecoration: 'none',
-  transition: animation.colorTransition,
-  selectors: {
-    '&[data-popup-open], &:hover': {
-      backgroundColor: theme.surface.onMainContent,
-    },
-    '&:focus-visible': {
-      outline: `1px solid ${theme.button.primary.focus}`,
-      outlineOffset: '2px',
-    },
-  },
-})
-
-export const settingsBackIcon = style({
-  alignItems: 'center',
-  display: 'flex',
-  flexShrink: 0,
 })
 
 export const workspaceSelectorLabel = style({

--- a/apps/reef/app/components/sidebar/sidebar.css.ts
+++ b/apps/reef/app/components/sidebar/sidebar.css.ts
@@ -57,6 +57,7 @@ export const workspaceSelector = style({
   minWidth: 0,
   overflow: 'hidden',
   paddingInline: '8px',
+  textDecoration: 'none',
   transition: animation.colorTransition,
   selectors: {
     '&[data-popup-open], &:hover': {
@@ -67,6 +68,12 @@ export const workspaceSelector = style({
       outlineOffset: '2px',
     },
   },
+})
+
+export const settingsBackIcon = style({
+  alignItems: 'center',
+  display: 'flex',
+  flexShrink: 0,
 })
 
 export const workspaceSelectorLabel = style({
@@ -123,12 +130,4 @@ export const nav = style({
   gap: '4px',
   marginBlockStart: '24px',
   minHeight: 0,
-})
-
-export const footer = style({
-  display: 'flex',
-  flexDirection: 'column',
-  flexShrink: 0,
-  gap: '4px',
-  marginTop: 'auto',
 })

--- a/apps/reef/app/components/sidebar/sidebar.stories.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.stories.tsx
@@ -13,7 +13,10 @@ const meta = {
     (Story, context) => {
       const RoutesStub = createRoutesStub([
         {
-          children: [{ index: true, Component: () => null }],
+          children: [
+            { index: true, Component: () => null },
+            { Component: () => null, path: 'settings' },
+          ],
           Component: () => <Story />,
           path: '/',
         },
@@ -53,9 +56,12 @@ export const Default: Story = {
   },
 }
 
-export const Minimized: Story = {
+export const Settings: Story = {
   args: {
-    initialIsMinimized: true,
+    initialIsMinimized: false,
     workspaces: [{ name: 'default' }, { name: 'analytics' }],
+  },
+  parameters: {
+    initialEntry: '/settings',
   },
 }

--- a/apps/reef/app/components/sidebar/sidebar.test.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { createMemoryRouter, data, RouterProvider } from 'react-router'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 import { render } from 'vitest-browser-react'
 
@@ -71,6 +71,7 @@ describe('Sidebar', () => {
   })
 
   afterEach(async () => {
+    vi.unstubAllEnvs()
     document.cookie = `${SIDEBAR_COOKIE_NAME}=; Max-Age=0; Path=/`
     await page.viewport(1024, 768)
   })
@@ -188,6 +189,51 @@ describe('Sidebar', () => {
       .not.toBeInTheDocument()
   })
 
+  it('opens desktop settings after a divider below create workspace', async () => {
+    vi.stubEnv('VITE_CORAL_DESKTOP_APP', '1')
+    const screen = await renderSidebar(false, '/workspaces/analytics/sources', WORKSPACES)
+
+    await screen.getByRole('button', { name: 'Open workspace menu' }).click()
+    const createWorkspace = screen.getByRole('menuitem', { name: 'Create workspace' }).element()
+    const settings = screen.getByRole('menuitem', { name: 'Settings' })
+    const settingsElement = settings.element()
+    const separatorBetween = [...document.querySelectorAll('[role="separator"]')].some(
+      (separator) =>
+        Boolean(
+          createWorkspace.compareDocumentPosition(separator) & Node.DOCUMENT_POSITION_FOLLOWING,
+        ) &&
+        Boolean(
+          separator.compareDocumentPosition(settingsElement) & Node.DOCUMENT_POSITION_FOLLOWING,
+        ),
+    )
+
+    expect(separatorBetween).toBe(true)
+
+    await settings.click()
+    await expect.poll(() => screen.router.state.location.pathname).toBe(routePath('settings'))
+    await expect
+      .element(screen.getByRole('link', { name: 'Back to Coral' }))
+      .toHaveAttribute('href', routePath('home'))
+  })
+
+  it('shows settings navigation instead of workspace navigation on the settings route', async () => {
+    vi.stubEnv('VITE_CORAL_DESKTOP_APP', '1')
+    const screen = await renderSidebar(false, routePath('settings'), WORKSPACES)
+
+    const backToCoral = screen.getByRole('link', { name: 'Back to Coral' })
+    await expect.element(backToCoral).toHaveAttribute('href', routePath('home'))
+    await expect
+      .element(screen.getByRole('button', { name: 'Open workspace menu' }))
+      .not.toBeInTheDocument()
+    await expect.element(screen.getByRole('link', { name: 'MCP Clients' })).toBeVisible()
+    await expect.element(screen.getByRole('link', { name: 'Sources' })).not.toBeInTheDocument()
+    await expect.element(screen.getByRole('link', { name: 'Schema' })).not.toBeInTheDocument()
+    await expect.element(screen.getByRole('link', { name: 'Traces' })).not.toBeInTheDocument()
+
+    await backToCoral.click()
+    await expect.poll(() => screen.router.state.location.pathname).toBe(routePath('home'))
+  })
+
   it('keeps the create workspace dialog closed after back and forward navigation', async () => {
     const tracesPath = routePath('workspaceTraces', { workspaceId: 'analytics' })
     const sourcesPath = routePath('workspaceSources', { workspaceId: 'analytics' })
@@ -267,7 +313,7 @@ describe('Sidebar', () => {
   })
 
   it('falls back to the first workspace outside a canonical workspace route', async () => {
-    const screen = await renderSidebar(false, routePath('settings'), WORKSPACES)
+    const screen = await renderSidebar(false, routePath('home'), WORKSPACES)
 
     await expect.element(screen.getByText('default', { exact: true })).toBeVisible()
     await expect

--- a/apps/reef/app/components/sidebar/sidebar.test.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.test.tsx
@@ -189,8 +189,7 @@ describe('Sidebar', () => {
       .not.toBeInTheDocument()
   })
 
-  it('opens desktop settings after a divider below create workspace', async () => {
-    vi.stubEnv('VITE_CORAL_DESKTOP_APP', '1')
+  it('always shows settings in the workspace menu', async () => {
     const screen = await renderSidebar(false, '/workspaces/analytics/sources', WORKSPACES)
 
     await screen.getByRole('button', { name: 'Open workspace menu' }).click()
@@ -213,22 +212,24 @@ describe('Sidebar', () => {
     await expect.poll(() => screen.router.state.location.pathname).toBe(routePath('settings'))
   })
 
-  it('shows settings navigation instead of workspace navigation on the settings route', async () => {
-    vi.stubEnv('VITE_CORAL_DESKTOP_APP', '1')
+  it('shows no settings navigation items on the web', async () => {
     const screen = await renderSidebar(false, routePath('settings'), WORKSPACES)
 
-    const homeLink = screen.getByRole('link', { name: 'Home' })
-    await expect.element(homeLink).toHaveAttribute('href', routePath('home'))
+    await expect.element(screen.getByRole('link', { name: 'Home' })).toBeVisible()
     await expect
       .element(screen.getByRole('button', { name: 'Open workspace menu' }))
       .not.toBeInTheDocument()
-    await expect.element(screen.getByRole('link', { name: 'MCP Clients' })).toBeVisible()
+    await expect.element(screen.getByRole('link', { name: 'MCP Clients' })).not.toBeInTheDocument()
     await expect.element(screen.getByRole('link', { name: 'Sources' })).not.toBeInTheDocument()
     await expect.element(screen.getByRole('link', { name: 'Schema' })).not.toBeInTheDocument()
     await expect.element(screen.getByRole('link', { name: 'Traces' })).not.toBeInTheDocument()
+  })
 
-    await homeLink.click()
-    await expect.poll(() => screen.router.state.location.pathname).toBe(routePath('home'))
+  it('shows MCP Clients in desktop settings navigation', async () => {
+    vi.stubEnv('VITE_CORAL_DESKTOP_APP', '1')
+    const screen = await renderSidebar(false, routePath('settings'), WORKSPACES)
+
+    await expect.element(screen.getByRole('link', { name: 'MCP Clients' })).toBeVisible()
   })
 
   it('keeps the create workspace dialog closed after back and forward navigation', async () => {

--- a/apps/reef/app/components/sidebar/sidebar.test.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.test.tsx
@@ -211,17 +211,14 @@ describe('Sidebar', () => {
 
     await settings.click()
     await expect.poll(() => screen.router.state.location.pathname).toBe(routePath('settings'))
-    await expect
-      .element(screen.getByRole('link', { name: 'Back to Coral' }))
-      .toHaveAttribute('href', routePath('home'))
   })
 
   it('shows settings navigation instead of workspace navigation on the settings route', async () => {
     vi.stubEnv('VITE_CORAL_DESKTOP_APP', '1')
     const screen = await renderSidebar(false, routePath('settings'), WORKSPACES)
 
-    const backToCoral = screen.getByRole('link', { name: 'Back to Coral' })
-    await expect.element(backToCoral).toHaveAttribute('href', routePath('home'))
+    const homeLink = screen.getByRole('link', { name: 'Home' })
+    await expect.element(homeLink).toHaveAttribute('href', routePath('home'))
     await expect
       .element(screen.getByRole('button', { name: 'Open workspace menu' }))
       .not.toBeInTheDocument()
@@ -230,7 +227,7 @@ describe('Sidebar', () => {
     await expect.element(screen.getByRole('link', { name: 'Schema' })).not.toBeInTheDocument()
     await expect.element(screen.getByRole('link', { name: 'Traces' })).not.toBeInTheDocument()
 
-    await backToCoral.click()
+    await homeLink.click()
     await expect.poll(() => screen.router.state.location.pathname).toBe(routePath('home'))
   })
 

--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import { useEffect, useRef, useState } from 'react'
-import { Link, NavLink, useLocation, useParams } from 'react-router'
+import { Link, NavLink, useLocation, useMatch, useParams } from 'react-router'
 
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
 import {
@@ -29,6 +29,8 @@ interface SidebarProps {
   workspaces: ReadonlyArray<Pick<Workspace, 'name'>>
 }
 
+type NavItem = { icon: IconName; label: string; paths: string[]; to: string }
+
 export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
   const location = useLocation()
   const { workspaceId } = useParams()
@@ -53,17 +55,13 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
     { icon: 'Plug', label: 'Sources', paths: [routePath('home'), sourcesPath], to: sourcesPath },
     { icon: 'Database', label: 'Schema', paths: [schemaPath], to: schemaPath },
     { icon: 'Activity', label: 'Traces', paths: [tracesPath], to: tracesPath },
-  ] satisfies Array<{ icon: IconName; label: string; paths: string[]; to: string }>
+  ] satisfies NavItem[]
   const settingsPath = routePath('settings')
-  const isSettingsRoute =
-    location.pathname === settingsPath || location.pathname.startsWith(`${settingsPath}/`)
-  const settingsNavItems = [
-    { icon: 'Settings', label: 'MCP Clients', paths: [settingsPath], to: settingsPath },
-  ] satisfies Array<{ icon: IconName; label: string; paths: string[]; to: string }>
+  const isSettingsRoute = Boolean(useMatch({ end: false, path: settingsPath }))
+  const settingsNavItems: NavItem[] = isCoralDesktopBuild()
+    ? [{ icon: 'Settings', label: 'MCP Clients', paths: [settingsPath], to: settingsPath }]
+    : []
   const navItems = isSettingsRoute ? settingsNavItems : workspaceNavItems
-  // Build-time detection keeps desktop-only navigation stable across SSR and
-  // hydration; bridge availability is checked by the Settings page itself.
-  const isDesktopApp = isCoralDesktopBuild()
   const settingsHomeButton = (
     <ButtonContainer ariaLabel="Home" as={Link} size="22" to={routePath('home')} variant="bare">
       <ButtonIcon name="ChevronLeft" />
@@ -134,7 +132,6 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
               <Menu.Container>
                 <Menu.Trigger
                   className={styles.workspaceSelector}
-                  nativeButton
                   render={
                     <ButtonContainer ariaLabel="Open workspace menu" size="32" variant="bare" />
                   }
@@ -184,14 +181,10 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
                   >
                     Create workspace
                   </Menu.Item>
-                  {isDesktopApp && (
-                    <>
-                      <Menu.Separator />
-                      <Menu.Item icon="Settings" to={settingsPath}>
-                        Settings
-                      </Menu.Item>
-                    </>
-                  )}
+                  <Menu.Separator />
+                  <Menu.Item icon="Settings" to={settingsPath}>
+                    Settings
+                  </Menu.Item>
                 </Menu.Content>
               </Menu.Container>
 

--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -3,7 +3,11 @@ import { useEffect, useRef, useState } from 'react'
 import { Link, NavLink, useLocation, useParams } from 'react-router'
 
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
-import { IconButton } from '@/wax/components/button'
+import {
+  Container as ButtonContainer,
+  Icon as ButtonIcon,
+  IconButton,
+} from '@/wax/components/button'
 import { Icon } from '@/wax/components/icon'
 import { SidebarButton } from '@/wax/components/sidebar-button/sidebar-button'
 import { Tooltip } from '@/wax/components/tooltip'
@@ -60,6 +64,27 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
   // Build-time detection keeps desktop-only navigation stable across SSR and
   // hydration; bridge availability is checked by the Settings page itself.
   const isDesktopApp = isCoralDesktopBuild()
+  const settingsHomeButton = (
+    <ButtonContainer ariaLabel="Home" as={Link} size="22" to={routePath('home')} variant="bare">
+      <ButtonIcon name="ChevronLeft" />
+    </ButtonContainer>
+  )
+  const settingsHeader = (
+    <>
+      {isMinimized ? (
+        <Tooltip content="Home" side="right">
+          {settingsHomeButton}
+        </Tooltip>
+      ) : (
+        settingsHomeButton
+      )}
+      {!isMinimized && (
+        <span className={styles.workspaceSelectorLabel}>
+          <Typography.Body>Settings</Typography.Body>
+        </span>
+      )}
+    </>
+  )
 
   const handleToggleSidebar = (event: KeyboardEvent) => {
     event.preventDefault()
@@ -103,26 +128,16 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
 
         <div className={styles.workspaceSelectorRow}>
           {isSettingsRoute ? (
-            <Link
-              aria-label="Back to Coral home"
-              className={styles.workspaceSelector}
-              to={routePath('home')}
-            >
-              <span className={styles.settingsBackIcon}>
-                <Icon color="secondary" name="ArrowLeft" size="18" />
-              </span>
-              {!isMinimized && (
-                <span className={styles.workspaceSelectorLabel}>
-                  <Typography.Body>Settings</Typography.Body>
-                </span>
-              )}
-            </Link>
+            settingsHeader
           ) : (
             <>
               <Menu.Container>
                 <Menu.Trigger
                   className={styles.workspaceSelector}
-                  render={<button aria-label="Open workspace menu" type="button" />}
+                  nativeButton
+                  render={
+                    <ButtonContainer ariaLabel="Open workspace menu" size="32" variant="bare" />
+                  }
                 >
                   <span
                     className={styles.workspaceSelectorMark({ color: workspaceSelectorMarkColor })}

--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -45,31 +45,21 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
   const tracesPath = workspaceNavTarget
     ? routePath('workspaceTraces', { workspaceId: workspaceNavTarget.name })
     : routePath('home')
-  const navItems = [
+  const workspaceNavItems = [
     { icon: 'Plug', label: 'Sources', paths: [routePath('home'), sourcesPath], to: sourcesPath },
     { icon: 'Database', label: 'Schema', paths: [schemaPath], to: schemaPath },
     { icon: 'Activity', label: 'Traces', paths: [tracesPath], to: tracesPath },
   ] satisfies Array<{ icon: IconName; label: string; paths: string[]; to: string }>
-  const isSettingsActive =
-    location.pathname === routePath('settings') ||
-    location.pathname.startsWith(`${routePath('settings')}/`)
-  // Keep the desktop-only settings link stable across SSR and hydration. The
-  // actual bridge can only be detected on the client, but the route is included
-  // at build time for Electron and omitted from the web build.
+  const settingsPath = routePath('settings')
+  const isSettingsRoute =
+    location.pathname === settingsPath || location.pathname.startsWith(`${settingsPath}/`)
+  const settingsNavItems = [
+    { icon: 'Settings', label: 'MCP Clients', paths: [settingsPath], to: settingsPath },
+  ] satisfies Array<{ icon: IconName; label: string; paths: string[]; to: string }>
+  const navItems = isSettingsRoute ? settingsNavItems : workspaceNavItems
+  // Build-time detection keeps desktop-only navigation stable across SSR and
+  // hydration; bridge availability is checked by the Settings page itself.
   const isDesktopApp = isCoralDesktopBuild()
-
-  const settingsButton = (
-    <SidebarButton
-      aria-label="Settings"
-      as={NavLink}
-      icon="Settings"
-      isActive={isSettingsActive}
-      isMinimized={isMinimized}
-      to={routePath('settings')}
-    >
-      Settings
-    </SidebarButton>
-  )
 
   const handleToggleSidebar = (event: KeyboardEvent) => {
     event.preventDefault()
@@ -112,59 +102,91 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
         )}
 
         <div className={styles.workspaceSelectorRow}>
-          <Menu.Container>
-            <Menu.Trigger
+          {isSettingsRoute ? (
+            <Link
+              aria-label="Back to Coral home"
               className={styles.workspaceSelector}
-              render={<button aria-label="Open workspace menu" type="button" />}
+              to={routePath('home')}
             >
-              <span className={styles.workspaceSelectorMark({ color: workspaceSelectorMarkColor })}>
-                <Icon color="inherit" name="Coral" size="18" />
+              <span className={styles.settingsBackIcon}>
+                <Icon color="secondary" name="ArrowLeft" size="18" />
               </span>
               {!isMinimized && (
-                <>
-                  <Tooltip content={workspaceSelectorLabel} showOnlyWhenTruncated side="bottom">
-                    <span className={styles.workspaceSelectorLabel}>
-                      <Typography.Body>{workspaceSelectorLabel}</Typography.Body>
-                    </span>
-                  </Tooltip>
-                  <span className={styles.workspaceSelectorChevron}>
-                    <Icon color="tertiary" name="ChevronDown" size="16" />
-                  </span>
-                </>
+                <span className={styles.workspaceSelectorLabel}>
+                  <Typography.Body>Settings</Typography.Body>
+                </span>
               )}
-            </Menu.Trigger>
-            <Menu.Content align="start" side="bottom" sideOffset={6}>
-              <Menu.Group>
-                <Menu.GroupLabel>Workspaces</Menu.GroupLabel>
-                {workspaces.length === 0 ? (
-                  <Menu.Item disabled>No workspaces</Menu.Item>
-                ) : (
-                  <Menu.RadioGroup value={workspaceNavTarget?.name}>
-                    {workspaces.map((workspace) => (
-                      <Menu.RadioItem
-                        as={Link}
-                        key={workspace.name}
-                        to={workspacePathForCurrentSection(workspace.name, location.pathname)}
-                        value={workspace.name}
-                      >
-                        {workspace.name}
-                      </Menu.RadioItem>
-                    ))}
-                  </Menu.RadioGroup>
-                )}
-              </Menu.Group>
-              <Menu.Separator />
-              <Menu.Item icon="Plus" onClick={() => handleCreateWorkspaceDialogOpenChange(true)}>
-                Create workspace
-              </Menu.Item>
-            </Menu.Content>
-          </Menu.Container>
+            </Link>
+          ) : (
+            <>
+              <Menu.Container>
+                <Menu.Trigger
+                  className={styles.workspaceSelector}
+                  render={<button aria-label="Open workspace menu" type="button" />}
+                >
+                  <span
+                    className={styles.workspaceSelectorMark({ color: workspaceSelectorMarkColor })}
+                  >
+                    <Icon color="inherit" name="Coral" size="18" />
+                  </span>
+                  {!isMinimized && (
+                    <>
+                      <Tooltip content={workspaceSelectorLabel} showOnlyWhenTruncated side="bottom">
+                        <span className={styles.workspaceSelectorLabel}>
+                          <Typography.Body>{workspaceSelectorLabel}</Typography.Body>
+                        </span>
+                      </Tooltip>
+                      <span className={styles.workspaceSelectorChevron}>
+                        <Icon color="tertiary" name="ChevronDown" size="16" />
+                      </span>
+                    </>
+                  )}
+                </Menu.Trigger>
+                <Menu.Content align="start" side="bottom" sideOffset={6}>
+                  <Menu.Group>
+                    <Menu.GroupLabel>Workspaces</Menu.GroupLabel>
+                    {workspaces.length === 0 ? (
+                      <Menu.Item disabled>No workspaces</Menu.Item>
+                    ) : (
+                      <Menu.RadioGroup value={workspaceNavTarget?.name}>
+                        {workspaces.map((workspace) => (
+                          <Menu.RadioItem
+                            as={Link}
+                            key={workspace.name}
+                            to={workspacePathForCurrentSection(workspace.name, location.pathname)}
+                            value={workspace.name}
+                          >
+                            {workspace.name}
+                          </Menu.RadioItem>
+                        ))}
+                      </Menu.RadioGroup>
+                    )}
+                  </Menu.Group>
+                  <Menu.Separator />
+                  <Menu.Item
+                    icon="Plus"
+                    onClick={() => handleCreateWorkspaceDialogOpenChange(true)}
+                  >
+                    Create workspace
+                  </Menu.Item>
+                  {isDesktopApp && (
+                    <>
+                      <Menu.Separator />
+                      <Menu.Item icon="Settings" to={settingsPath}>
+                        Settings
+                      </Menu.Item>
+                    </>
+                  )}
+                </Menu.Content>
+              </Menu.Container>
 
-          <WorkspaceCreationDialog
-            fetcherKey={createWorkspaceFetcherKey}
-            onOpenChange={handleCreateWorkspaceDialogOpenChange}
-            open={createWorkspaceDialogOpen}
-          />
+              <WorkspaceCreationDialog
+                fetcherKey={createWorkspaceFetcherKey}
+                onOpenChange={handleCreateWorkspaceDialogOpenChange}
+                open={createWorkspaceDialogOpen}
+              />
+            </>
+          )}
 
           {!isMinimized && (
             <div className={styles.toggleButton}>
@@ -215,18 +237,6 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
             button
           )
         })}
-      </div>
-
-      <div className={styles.footer}>
-        {isDesktopApp &&
-          // Collapsed sidebar hides the label, so surface it on hover instead.
-          (isMinimized ? (
-            <Tooltip content="Settings" side="right">
-              {settingsButton}
-            </Tooltip>
-          ) : (
-            settingsButton
-          ))}
       </div>
     </nav>
   )

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -2,10 +2,6 @@ import { type RouteConfig, index, layout, route } from '@react-router/dev/routes
 
 import { routePattern } from './routing/routemap'
 
-// Settings is a desktop-only surface (it drives the Electron MCP bridge); the
-// web build omits it so browser users don't hit a dead "bridge unavailable" page.
-const isDesktopApp = process.env.CORAL_DESKTOP_APP === '1'
-
 export default [
   // Action-only resource route: OAuth/device-code install streams progress over
   // same-origin fetch. It intentionally sits outside the app shell and does not
@@ -25,6 +21,6 @@ export default [
     route(routePattern('workspaceTraces'), 'routes/traces.tsx', [
       route(':traceId', 'routes/trace-detail.tsx'),
     ]),
-    ...(isDesktopApp ? [route(routePattern('settings'), 'routes/settings.tsx')] : []),
+    route(routePattern('settings'), 'routes/settings.tsx'),
   ]),
 ] satisfies RouteConfig

--- a/apps/reef/app/routes/settings.css.ts
+++ b/apps/reef/app/routes/settings.css.ts
@@ -46,27 +46,6 @@ export const section = style({
   gap: '16px',
 })
 
-export const sectionHead = style({
-  alignItems: 'baseline',
-  display: 'flex',
-  gap: '8px',
-})
-
-export const sectionCount = style({
-  alignItems: 'center',
-  background: theme.surface.onMainContent,
-  border: `1px solid ${theme.stroke.secondary}`,
-  borderRadius: '999px',
-  color: theme.content.secondary,
-  display: 'inline-flex',
-  fontSize: '11px',
-  fontWeight: 600,
-  height: '18px',
-  justifyContent: 'center',
-  minWidth: '22px',
-  paddingInline: '6px',
-})
-
 export const cardGrid = style({
   display: 'grid',
   gap: '16px',

--- a/apps/reef/app/routes/settings.test.tsx
+++ b/apps/reef/app/routes/settings.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import SettingsRoute from './settings'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  delete window.coralDesktop
+})
+
+describe('SettingsRoute', () => {
+  it('does not show desktop-only MCP clients on the web', async () => {
+    vi.stubEnv('VITE_CORAL_DESKTOP_APP', '')
+
+    const screen = await render(<SettingsRoute />)
+
+    await expect.element(screen.getByRole('heading', { level: 1, name: 'Settings' })).toBeVisible()
+    await expect
+      .element(screen.getByRole('heading', { name: 'MCP Clients' }))
+      .not.toBeInTheDocument()
+    await expect.element(screen.getByText('Desktop bridge unavailable.')).not.toBeInTheDocument()
+  })
+
+  it('shows MCP clients in the desktop build', async () => {
+    vi.stubEnv('VITE_CORAL_DESKTOP_APP', '1')
+    const listMcpClients = vi
+      .fn()
+      .mockResolvedValue([
+        { configPath: '/tmp/codex-config.toml', id: 'codex' as const, name: 'Codex' },
+      ])
+    window.coralDesktop = {
+      configureMcp: vi.fn(),
+      listMcpClients,
+    }
+
+    const screen = await render(<SettingsRoute />)
+
+    await expect
+      .element(screen.getByRole('heading', { level: 2, name: 'MCP Clients' }))
+      .toBeVisible()
+    await expect.element(screen.getByText('Codex', { exact: true })).toBeVisible()
+    expect(listMcpClients).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/reef/app/routes/settings.tsx
+++ b/apps/reef/app/routes/settings.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react'
 import {
   coralDesktopApi,
   desktopErrorMessage,
+  isCoralDesktopBuild,
   type McpClientDescriptor,
   type McpClientId,
 } from '@/lib/coral-desktop'
@@ -29,6 +30,20 @@ function isPending(pending: PendingAction, kind: PendingKind, clientId?: McpClie
 }
 
 export default function SettingsRoute() {
+  return (
+    <main className={styles.page}>
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <Typography.HeadingLarge as="h1">Settings</Typography.HeadingLarge>
+        </header>
+
+        {isCoralDesktopBuild() && <McpClientsSettings />}
+      </div>
+    </main>
+  )
+}
+
+function McpClientsSettings() {
   const desktop = useMemo(() => coralDesktopApi(), [])
   const [clients, setClients] = useState<McpClientDescriptor[]>([])
   const [clientStatus, setClientStatus] = useState<ClientStatus>({})
@@ -83,62 +98,58 @@ export default function SettingsRoute() {
   }
 
   return (
-    <main className={styles.page}>
-      <div className={styles.container}>
-        <header className={styles.header}>
-          <Typography.HeadingLarge as="h1">MCP Clients</Typography.HeadingLarge>
-          <Typography.Body variant="secondary">
-            Configure Coral as an MCP server for supported clients on this device.
-          </Typography.Body>
-        </header>
+    <section className={styles.section}>
+      <header className={styles.header}>
+        <Typography.HeadingXSmall as="h2">MCP Clients</Typography.HeadingXSmall>
+        <Typography.Body variant="secondary">
+          Configure Coral as an MCP server for supported clients on this device.
+        </Typography.Body>
+      </header>
 
-        <section className={styles.section}>
-          {loadError && (
-            <Typography.BodySmall className={styles.status} variant="error">
-              {loadError}
-            </Typography.BodySmall>
-          )}
+      {loadError && (
+        <Typography.BodySmall className={styles.status} variant="error">
+          {loadError}
+        </Typography.BodySmall>
+      )}
 
-          <div className={styles.cardGrid}>
-            {clients.map((client) => {
-              const connectedPath = clientStatus[client.id]
-              const configPath = connectedPath ?? client.configPath
-              const connectPending = isPending(pending, 'connect', client.id)
+      <div className={styles.cardGrid}>
+        {clients.map((client) => {
+          const connectedPath = clientStatus[client.id]
+          const configPath = connectedPath ?? client.configPath
+          const connectPending = isPending(pending, 'connect', client.id)
 
-              return (
-                <article className={styles.clientCard} key={client.id}>
-                  <div className={styles.cardHeader}>
-                    <div className={styles.clientLogo}>
-                      <Icon color="tertiary" name={CLIENT_ICONS[client.id]} size="18" />
-                    </div>
-                    <Typography.BodyLargeStrong className={styles.cardTitle} truncate>
-                      {client.name}
-                    </Typography.BodyLargeStrong>
-                  </div>
+          return (
+            <article className={styles.clientCard} key={client.id}>
+              <div className={styles.cardHeader}>
+                <div className={styles.clientLogo}>
+                  <Icon color="tertiary" name={CLIENT_ICONS[client.id]} size="18" />
+                </div>
+                <Typography.BodyLargeStrong className={styles.cardTitle} truncate>
+                  {client.name}
+                </Typography.BodyLargeStrong>
+              </div>
 
-                  <Typography.CodeSmallInline className={styles.path} title={configPath}>
-                    {configPath}
-                  </Typography.CodeSmallInline>
+              <Typography.CodeSmallInline className={styles.path} title={configPath}>
+                {configPath}
+              </Typography.CodeSmallInline>
 
-                  <div className={styles.cardFooter}>
-                    <div className={styles.cardActions}>
-                      <Button.Container
-                        disabled={!isDesktopAvailable || hasPendingAction}
-                        onClick={() => handleConnectMcp(client)}
-                        size="32"
-                        variant="secondary"
-                      >
-                        <Button.Icon name="Link" />
-                        <Button.Text>{connectPending ? 'Connecting' : 'Connect'}</Button.Text>
-                      </Button.Container>
-                    </div>
-                  </div>
-                </article>
-              )
-            })}
-          </div>
-        </section>
+              <div className={styles.cardFooter}>
+                <div className={styles.cardActions}>
+                  <Button.Container
+                    disabled={!isDesktopAvailable || hasPendingAction}
+                    onClick={() => handleConnectMcp(client)}
+                    size="32"
+                    variant="secondary"
+                  >
+                    <Button.Icon name="Link" />
+                    <Button.Text>{connectPending ? 'Connecting' : 'Connect'}</Button.Text>
+                  </Button.Container>
+                </div>
+              </div>
+            </article>
+          )
+        })}
       </div>
-    </main>
+    </section>
   )
 }

--- a/apps/reef/app/routes/settings.tsx
+++ b/apps/reef/app/routes/settings.tsx
@@ -86,15 +86,13 @@ export default function SettingsRoute() {
     <main className={styles.page}>
       <div className={styles.container}>
         <header className={styles.header}>
-          <Typography.HeadingLarge as="h1">Settings</Typography.HeadingLarge>
+          <Typography.HeadingLarge as="h1">MCP Clients</Typography.HeadingLarge>
+          <Typography.Body variant="secondary">
+            Configure Coral as an MCP server for supported clients on this device.
+          </Typography.Body>
         </header>
 
         <section className={styles.section}>
-          <div className={styles.sectionHead}>
-            <Typography.HeadingXSmall as="h2">MCP clients</Typography.HeadingXSmall>
-            <span className={styles.sectionCount}>{clients.length}</span>
-          </div>
-
           {loadError && (
             <Typography.BodySmall className={styles.status} variant="error">
               {loadError}

--- a/apps/reef/app/wax/components/menu/trigger.tsx
+++ b/apps/reef/app/wax/components/menu/trigger.tsx
@@ -1,22 +1,21 @@
 import { Menu as BaseMenu } from '@base-ui/react/menu'
 import classNames from 'classnames'
 
+import { Container as ButtonContainer } from '@/wax/components/button/container'
+
 import * as styles from './menu.css'
 
 export interface TriggerProps {
   children: React.ReactNode
   className?: string
-  nativeButton?: boolean
   render?: React.ReactElement<Record<string, unknown>>
 }
 
-export function Trigger({
-  children,
-  className,
-  nativeButton: nativeButtonProp,
-  render,
-}: TriggerProps) {
-  const nativeButton = nativeButtonProp ?? (!render || render.type === 'button')
+export function Trigger({ children, className, render }: TriggerProps) {
+  const nativeButton =
+    !render ||
+    render.type === 'button' ||
+    (render.type === ButtonContainer && (!render.props.as || render.props.as === 'button'))
   return (
     <BaseMenu.Trigger
       className={classNames(styles.trigger, className)}

--- a/apps/reef/app/wax/components/menu/trigger.tsx
+++ b/apps/reef/app/wax/components/menu/trigger.tsx
@@ -6,11 +6,17 @@ import * as styles from './menu.css'
 export interface TriggerProps {
   children: React.ReactNode
   className?: string
+  nativeButton?: boolean
   render?: React.ReactElement<Record<string, unknown>>
 }
 
-export function Trigger({ children, className, render }: TriggerProps) {
-  const nativeButton = !render || render.type === 'button'
+export function Trigger({
+  children,
+  className,
+  nativeButton: nativeButtonProp,
+  render,
+}: TriggerProps) {
+  const nativeButton = nativeButtonProp ?? (!render || render.type === 'button')
   return (
     <BaseMenu.Trigger
       className={classNames(styles.trigger, className)}


### PR DESCRIPTION
## Summary

- Moving the settings out of the bottom of the Sidebar
- Sidebar now conditionally renders per-workspace items (e.g. sources), or global settings (MCP clients at the moment, subject to change near term)


## Test plan

<img width="218" height="259" alt="image" src="https://github.com/user-attachments/assets/88e3b534-3551-4db2-a428-8cb2c71446cf" /> 


https://github.com/user-attachments/assets/3bf411d3-9007-4a48-a65a-53b2f9276afb


Web will be empty for the moment:

<img width="1517" height="735" alt="image" src="https://github.com/user-attachments/assets/9053e194-9872-41e7-b6b6-187940233849" />
