### PR TITLE
ci: reduce release PR validation churn

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,11 +50,6 @@ jobs:
         if: steps.rp.outputs.pr
         run: rustup show
 
-      - name: Record release PR head
-        id: release_pr_head
-        if: steps.rp.outputs.pr
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Sync Cargo.lock to new workspace version
         if: steps.rp.outputs.pr
         run: |
@@ -87,21 +82,7 @@ jobs:
           git add apps/docs/project/changelog.mdx apps/docs/docs.json
           git commit -m "chore: regenerate changelog docs"
 
-      - name: Check for regenerated commits
-        id: regenerated_commits
-        if: steps.rp.outputs.pr
-        env:
-          RELEASE_PR_HEAD: ${{ steps.release_pr_head.outputs.sha }}
-        run: |
-          set -euo pipefail
-          if [ "$(git rev-parse HEAD)" != "$RELEASE_PR_HEAD" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Push regenerated changes
-        if: steps.regenerated_commits.outputs.changed == 'true'
         env:
           PR_BRANCH: ${{ fromJSON(steps.rp.outputs.pr || '{}').headBranchName }}
           GH_APP_TOKEN: ${{ steps.github-app-token.outputs.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -50,11 +50,13 @@ jobs:
         if: steps.rp.outputs.pr
         run: rustup show
 
+      - name: Record release PR head
+        id: release_pr_head
+        if: steps.rp.outputs.pr
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Sync Cargo.lock to new workspace version
         if: steps.rp.outputs.pr
-        env:
-          PR_BRANCH: ${{ fromJSON(steps.rp.outputs.pr || '{}').headBranchName }}
-          GH_APP_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
           set -euo pipefail
           cargo update --workspace
@@ -66,7 +68,6 @@ jobs:
           git config user.email "release-please[bot]@users.noreply.github.com"
           git add Cargo.lock
           git commit -m "chore: sync Cargo.lock"
-          git push "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${PR_BRANCH}"
 
       # release-please updates CHANGELOG.md on the release PR, so this
       # is the right place to regenerate the docs page that mirrors it.
@@ -74,9 +75,6 @@ jobs:
       # so docs on `main` do not lag CHANGELOG.md.
       - name: Regenerate changelog docs
         if: steps.rp.outputs.pr
-        env:
-          PR_BRANCH: ${{ fromJSON(steps.rp.outputs.pr || '{}').headBranchName }}
-          GH_APP_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
           set -euo pipefail
           make docs-generate
@@ -88,4 +86,25 @@ jobs:
           git config user.email "release-please[bot]@users.noreply.github.com"
           git add apps/docs/project/changelog.mdx apps/docs/docs.json
           git commit -m "chore: regenerate changelog docs"
+
+      - name: Check for regenerated commits
+        id: regenerated_commits
+        if: steps.rp.outputs.pr
+        env:
+          RELEASE_PR_HEAD: ${{ steps.release_pr_head.outputs.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$(git rev-parse HEAD)" != "$RELEASE_PR_HEAD" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push regenerated changes
+        if: steps.regenerated_commits.outputs.changed == 'true'
+        env:
+          PR_BRANCH: ${{ fromJSON(steps.rp.outputs.pr || '{}').headBranchName }}
+          GH_APP_TOKEN: ${{ steps.github-app-token.outputs.token }}
+        run: |
+          set -euo pipefail
           git push "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${PR_BRANCH}"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -49,6 +49,16 @@ jobs:
       performance-regression: ${{ steps.filter.outputs.performance-regression }}
 
     steps:
+      # Release Please updates its candidate branch before this repository's
+      # generation steps add their final commit. Give those writes time to
+      # coalesce so concurrency cancellation stops obsolete runs before the
+      # expensive validation jobs fan out.
+      - name: Let release automation settle
+        if: >-
+          github.event_name == 'pull_request' &&
+          startsWith(github.head_ref, 'release-please--')
+        run: sleep 120
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,12 @@
   replacement skipped run cancels any in-progress validation for the PR branch.
   Keep that draft gate aligned between the initial change detector and final
   aggregate `validate` job.
+- Keep Release Please branch updates coalesced and cheap to supersede. The
+  `release-please` workflow may create multiple local regeneration commits, but
+  must push them together through its final push step. `Validate` intentionally
+  gives `release-please--*` pull requests a 120-second settle period before
+  checkout and change detection so concurrency cancellation stops intermediate
+  branch states before expensive jobs fan out.
 - `make rust-checks` is the Rust-only local gate and should keep using
   `--all-features`; the embedded UI feature is a normal CLI build surface.
 - The built UI artifact is produced by repo/CI orchestration (`make ui-build`


### PR DESCRIPTION
## Summary

- coalesce generated `Cargo.lock` and changelog commits into a single release-branch push
- give Release Please PRs a 120-second settle period before expensive validation fans out
- document the CI invariant in `AGENTS.md`

## Why

Release Please updates its candidate branch, then the repository generation steps previously pushed two more times. Every new HEAD triggered a full `Validate` run, repeatedly cancelling work and consuming runner capacity.

Coalescing generated commits removes one unnecessary trigger. The settle barrier lets the existing concurrency cancellation stop intermediate branch states before expensive jobs begin.

## Validation

- `actionlint .github/workflows/release-please.yml .github/workflows/validate.yml`
- `git diff --check`