### PR TITLE
feat(traces): project Query Stream operation summaries

### DIFF
--- a/apps/reef/app/routes/trace-detail-loader.server.test.ts
+++ b/apps/reef/app/routes/trace-detail-loader.server.test.ts
@@ -1,7 +1,11 @@
 import { create } from '@bufbuild/protobuf'
 
 import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
-import { TraceStatus } from '@/generated/coral/v1/traces_pb'
+import {
+  TraceInvocationKind,
+  TraceOperationKind,
+  TraceStatus,
+} from '@/generated/coral/v1/traces_pb'
 import type { TraceDetailData } from '@/views/traces/trace-utils'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -14,6 +18,9 @@ function detail(traceId: string): TraceDetailData {
       durationNanos: '1000000',
       endTimeUnixNanos: '2000000',
       name: 'coral.query',
+      invocationKind: TraceInvocationKind.UNSPECIFIED,
+      operationKind: TraceOperationKind.UNSPECIFIED,
+      operationName: '',
       query: 'select 1',
       rootSpanId: 'root',
       rowCount: '1',

--- a/apps/reef/app/routes/traces-loader.server.test.ts
+++ b/apps/reef/app/routes/traces-loader.server.test.ts
@@ -1,7 +1,11 @@
 import { create } from '@bufbuild/protobuf'
 
 import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
-import { TraceStatus } from '@/generated/coral/v1/traces_pb'
+import {
+  TraceInvocationKind,
+  TraceOperationKind,
+  TraceStatus,
+} from '@/generated/coral/v1/traces_pb'
 import type { TraceSummaryData } from '@/views/traces/trace-utils'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -12,6 +16,9 @@ function summary(traceId: string, query = `select '${traceId}'`): TraceSummaryDa
     durationNanos: '1000000',
     endTimeUnixNanos: '2000000',
     name: query ? 'coral.query' : 'http.request',
+    invocationKind: TraceInvocationKind.UNSPECIFIED,
+    operationKind: TraceOperationKind.UNSPECIFIED,
+    operationName: '',
     query,
     rootSpanId: `root-${traceId}`,
     rowCount: '1',

--- a/apps/reef/app/views/traces/trace-detail.test.tsx
+++ b/apps/reef/app/views/traces/trace-detail.test.tsx
@@ -1,5 +1,9 @@
 import { createMemoryRouter, Outlet, RouterProvider, useParams } from 'react-router'
-import { TraceStatus } from '@/generated/coral/v1/traces_pb'
+import {
+  TraceInvocationKind,
+  TraceOperationKind,
+  TraceStatus,
+} from '@/generated/coral/v1/traces_pb'
 import { describe, expect, it } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { render } from 'vitest-browser-react'
@@ -17,6 +21,9 @@ function detail(): TraceDetailData {
       durationNanos: '12000000',
       endTimeUnixNanos: '13000000',
       name: 'coral.query',
+      invocationKind: TraceInvocationKind.UNSPECIFIED,
+      operationKind: TraceOperationKind.UNSPECIFIED,
+      operationName: '',
       query: 'select * from github.pull_requests',
       rootSpanId: 'root',
       rowCount: '7',

--- a/apps/reef/app/views/traces/trace-list.server.test.tsx
+++ b/apps/reef/app/views/traces/trace-list.server.test.tsx
@@ -1,6 +1,10 @@
 import { renderToString } from 'react-dom/server'
 import { MemoryRouter } from 'react-router'
-import { TraceStatus } from '@/generated/coral/v1/traces_pb'
+import {
+  TraceInvocationKind,
+  TraceOperationKind,
+  TraceStatus,
+} from '@/generated/coral/v1/traces_pb'
 import { describe, expect, it, vi } from 'vitest'
 
 import { TraceList } from './trace-list'
@@ -10,6 +14,9 @@ const trace: TraceSummaryData = {
   durationNanos: '1000000',
   endTimeUnixNanos: '1700000001000000000',
   name: 'coral.query',
+  invocationKind: TraceInvocationKind.UNSPECIFIED,
+  operationKind: TraceOperationKind.UNSPECIFIED,
+  operationName: '',
   query: 'select 1',
   rootSpanId: 'root',
   rowCount: '1',

--- a/apps/reef/app/views/traces/trace-list.test.tsx
+++ b/apps/reef/app/views/traces/trace-list.test.tsx
@@ -1,5 +1,9 @@
 import { createMemoryRouter, RouterProvider } from 'react-router'
-import { TraceStatus } from '@/generated/coral/v1/traces_pb'
+import {
+  TraceInvocationKind,
+  TraceOperationKind,
+  TraceStatus,
+} from '@/generated/coral/v1/traces_pb'
 import { describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-react'
 
@@ -11,6 +15,9 @@ function summary(traceId: string): TraceSummaryData {
     durationNanos: '1000000',
     endTimeUnixNanos: '2000000',
     name: 'coral.query',
+    invocationKind: TraceInvocationKind.UNSPECIFIED,
+    operationKind: TraceOperationKind.UNSPECIFIED,
+    operationName: '',
     query: `select '${traceId}'`,
     rootSpanId: `root-${traceId}`,
     rowCount: '1',

--- a/apps/reef/app/views/traces/traces-index.test.tsx
+++ b/apps/reef/app/views/traces/traces-index.test.tsx
@@ -4,7 +4,11 @@ import {
   useLoaderData,
   type LoaderFunction,
 } from 'react-router'
-import { TraceStatus } from '@/generated/coral/v1/traces_pb'
+import {
+  TraceInvocationKind,
+  TraceOperationKind,
+  TraceStatus,
+} from '@/generated/coral/v1/traces_pb'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { render } from 'vitest-browser-react'
@@ -30,6 +34,9 @@ function summary(traceId: string): TraceSummaryData {
     durationNanos: '1000000',
     endTimeUnixNanos: '2000000',
     name: 'coral.query',
+    invocationKind: TraceInvocationKind.UNSPECIFIED,
+    operationKind: TraceOperationKind.UNSPECIFIED,
+    operationName: '',
     query: `select '${traceId}'`,
     rootSpanId: `root-${traceId}`,
     rowCount: '1',

--- a/crates/coral-api/proto/coral/v1/traces.proto
+++ b/crates/coral-api/proto/coral/v1/traces.proto
@@ -14,31 +14,81 @@ enum TraceStatus {
   TRACE_STATUS_ERROR = 2;
 }
 
+// Server-side projection used when reading locally captured traces.
+enum TraceView {
+  // Returns one summary per distributed trace for diagnostic callers.
+  TRACE_VIEW_UNSPECIFIED = 0;
+  // Returns at most one summary per distributed trace, classified by its outer
+  // user-visible operation for Query Stream. Traces without a completed outer
+  // user-visible operation are omitted. A completed operation beneath a local
+  // parent is not projected until its owning local ancestry has also completed
+  // and been exported.
+  TRACE_VIEW_QUERY_STREAM = 1;
+}
+
+// Semantic operation represented by a Query Stream summary.
+enum TraceOperationKind {
+  // The operation kind was not recorded or could not be inferred.
+  TRACE_OPERATION_KIND_UNSPECIFIED = 0;
+  // A SQL query operation.
+  TRACE_OPERATION_KIND_QUERY = 1;
+  // A Search operation.
+  TRACE_OPERATION_KIND_SEARCH = 2;
+  // A tool operation not represented by a more specific kind.
+  TRACE_OPERATION_KIND_TOOL = 3;
+  // Another explicitly marked user-visible operation.
+  TRACE_OPERATION_KIND_OTHER = 4;
+}
+
+// Invocation path for an operation represented by a Query Stream summary.
+enum TraceInvocationKind {
+  // The invocation path was not recorded or could not be inferred.
+  TRACE_INVOCATION_KIND_UNSPECIFIED = 0;
+  // The operation was invoked directly through a Coral surface.
+  TRACE_INVOCATION_KIND_DIRECT = 1;
+  // The operation was invoked through MCP.
+  TRACE_INVOCATION_KIND_MCP = 2;
+}
+
 // Compact trace row for list views.
 message TraceSummary {
   // W3C trace identifier.
   string trace_id = 1;
-  // Span used as the display root for this trace.
+  // Span used as the display root. In Query Stream this identifies the
+  // selected operation within a distributed trace.
   string root_span_id = 2;
-  // Display name, usually `coral.query` for query traces.
+  // Display name of the trace primary span, or the operation span in Query
+  // Stream.
   string name = 3;
-  // SQL text when the trace includes a Coral query span.
+  // SQL text for a trace or Query operation, or locally retained Search text
+  // for a Query Stream Search operation.
   string query = 4;
-  // Derived trace status.
+  // Derived trace status, or selected operation status in Query Stream.
   TraceStatus status = 5;
-  // Earliest span start time in Unix nanoseconds.
+  // Earliest trace span start time, or operation start time in Query Stream,
+  // in Unix nanoseconds.
   int64 start_time_unix_nanos = 6 [jstype = JS_STRING];
-  // Latest span end time in Unix nanoseconds.
+  // Latest trace span end time, or operation end time in Query Stream, in Unix
+  // nanoseconds.
   int64 end_time_unix_nanos = 7 [jstype = JS_STRING];
-  // Wall-clock duration between the first span start and last span end.
+  // Trace wall-clock duration, or selected operation duration in Query Stream.
   int64 duration_nanos = 8 [jstype = JS_STRING];
-  // Number of spans captured for this trace.
+  // Number of spans captured for this trace, or spans owned by the selected
+  // operation in Query Stream.
   uint32 span_count = 9;
-  // Query row count when the trace includes a completed Coral query span.
+  // Query row count when the trace or selected operation includes a completed
+  // Coral query span.
   uint64 row_count = 10 [jstype = JS_STRING];
   // Whether `row_count` was recorded. This distinguishes an unknown count from
   // a valid zero-row query.
   bool row_count_recorded = 11;
+  // Semantic operation kind for Query Stream entries.
+  TraceOperationKind operation_kind = 12;
+  // Privacy-safe operation label, such as `sql`, `search`, or an MCP tool name.
+  string operation_name = 13;
+  // Invocation path for the Query Stream entry, independent of its semantic
+  // operation kind.
+  TraceInvocationKind invocation_kind = 14;
 }
 
 // Lists locally captured traces.
@@ -67,6 +117,10 @@ message GetTraceRequest {
   // Optional workspace that the trace must belong to. Omit for the global
   // trace lookup.
   Workspace workspace = 2;
+  // Projection used for the returned summary. The default preserves the
+  // diagnostic trace summary while Query Stream classifies the full trace by
+  // its outer user-visible operation.
+  TraceView view = 3;
 }
 
 // One stored trace span.

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -1,5 +1,7 @@
 //! JSONL-backed span export for local trace capture.
 
+mod query_stream;
+
 use std::collections::{HashMap, HashSet, hash_map::Entry};
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, BufWriter, Write};
@@ -427,6 +429,24 @@ pub(crate) enum StoredTraceStatus {
     Error,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum StoredTraceOperationKind {
+    #[default]
+    Unspecified,
+    Query,
+    Search,
+    Tool,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum StoredTraceInvocationKind {
+    #[default]
+    Unspecified,
+    Direct,
+    Mcp,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TraceSummaryRecord {
     pub(crate) trace_id: String,
@@ -440,6 +460,9 @@ pub(crate) struct TraceSummaryRecord {
     pub(crate) span_count: u32,
     pub(crate) row_count: u64,
     pub(crate) row_count_recorded: bool,
+    pub(crate) operation_kind: StoredTraceOperationKind,
+    pub(crate) operation_name: String,
+    pub(crate) invocation_kind: StoredTraceInvocationKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -525,6 +548,8 @@ struct TraceListSpanRecord {
     trace_id: String,
     span_id: String,
     parent_span_id: Option<String>,
+    #[serde(default)]
+    parent_span_is_remote: bool,
     name: String,
     #[serde(default)]
     status: StoredTraceStatus,
@@ -635,6 +660,19 @@ impl TraceStore {
         let traces = self.clone();
         task::spawn_blocking(move || {
             traces.get_trace_for_workspace_sync(&trace_id, &workspace_name)
+        })
+        .await
+        .map_err(|source| TraceStoreError::Worker { source })?
+    }
+
+    pub(crate) async fn get_query_stream_trace(
+        &self,
+        trace_id: String,
+        workspace_name: Option<String>,
+    ) -> Result<TraceDetailRecord, TraceStoreError> {
+        let traces = self.clone();
+        task::spawn_blocking(move || {
+            traces.get_query_stream_trace_sync(&trace_id, workspace_name.as_deref())
         })
         .await
         .map_err(|source| TraceStoreError::Worker { source })?
@@ -779,6 +817,19 @@ impl TraceStore {
         } else {
             Err(TraceStoreError::NotFound(trace_id.to_string()))
         }
+    }
+
+    fn get_query_stream_trace_sync(
+        &self,
+        trace_id: &str,
+        workspace_name: Option<&str>,
+    ) -> Result<TraceDetailRecord, TraceStoreError> {
+        let mut detail = self.get_trace_sync(trace_id)?;
+        let Some(summary) = query_stream::summary(&detail.spans, workspace_name) else {
+            return Err(TraceStoreError::NotFound(trace_id.to_string()));
+        };
+        detail.summary = summary;
+        Ok(detail)
     }
 
     pub(crate) fn list_query_history_sync(
@@ -1605,6 +1656,9 @@ fn summary_from_list_aggregate(
             span_count: aggregate.span_count,
             row_count: 0,
             row_count_recorded: false,
+            operation_kind: StoredTraceOperationKind::Unspecified,
+            operation_name: String::new(),
+            invocation_kind: StoredTraceInvocationKind::Unspecified,
         },
         |primary| {
             let attributes = parse_attributes(&primary.attributes_json);
@@ -1628,6 +1682,9 @@ fn summary_from_list_aggregate(
                 span_count: aggregate.span_count,
                 row_count: row_count.unwrap_or_default(),
                 row_count_recorded: row_count.is_some(),
+                operation_kind: StoredTraceOperationKind::Unspecified,
+                operation_name: String::new(),
+                invocation_kind: StoredTraceInvocationKind::Unspecified,
             }
         },
     )
@@ -1659,6 +1716,9 @@ fn summary_from_aggregate(
             span_count: aggregate.span_count,
             row_count: 0,
             row_count_recorded: false,
+            operation_kind: StoredTraceOperationKind::Unspecified,
+            operation_name: String::new(),
+            invocation_kind: StoredTraceInvocationKind::Unspecified,
         },
         |primary| {
             let attributes = parse_attributes(&primary.attributes_json);
@@ -1682,6 +1742,9 @@ fn summary_from_aggregate(
                 span_count: aggregate.span_count,
                 row_count: row_count.unwrap_or_default(),
                 row_count_recorded: row_count.is_some(),
+                operation_kind: StoredTraceOperationKind::Unspecified,
+                operation_name: String::new(),
+                invocation_kind: StoredTraceInvocationKind::Unspecified,
             }
         },
     )
@@ -1764,6 +1827,15 @@ fn attr_string(attributes: &JsonValue, key: &str) -> Option<String> {
         JsonValue::String(value) => Some(value.clone()),
         JsonValue::Number(value) => Some(value.to_string()),
         JsonValue::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn attr_bool(attributes: &JsonValue, key: &str) -> Option<bool> {
+    match attributes.get(key)? {
+        JsonValue::Bool(value) => Some(*value),
+        JsonValue::String(value) => value.parse().ok(),
+        JsonValue::Number(value) => value.as_i64().map(|value| value != 0),
         _ => None,
     }
 }
@@ -2881,7 +2953,7 @@ mod tests {
             .expect("set trace file modified time");
     }
 
-    fn trace_record(trace_id: &str, span_id: &str) -> TraceSpanRecord {
+    pub(super) fn trace_record(trace_id: &str, span_id: &str) -> TraceSpanRecord {
         TraceSpanRecord {
             trace_id: trace_id.to_string(),
             span_id: span_id.to_string(),

--- a/crates/coral-app/src/telemetry/local_store/query_stream.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream.rs
@@ -1,0 +1,435 @@
+//! Query Stream operation projection over locally captured spans.
+
+use std::collections::{HashMap, HashSet};
+
+mod classification;
+
+use classification::{
+    QueryStreamMetadata, QueryStreamPrimaryOperation, QueryStreamWorkspaceEvidence,
+    is_unmarked_mcp_protocol_attributes, operation_text_from_attributes,
+    operation_text_is_semantic, query_stream_metadata,
+};
+
+use super::{
+    StoredTraceOperationKind, StoredTraceStatus, TraceListSpanRecord, TraceSpanRecord,
+    TraceSummaryRecord, attr_string, attr_u64, parse_attributes, status_from_attributes,
+    usize_to_u32,
+};
+use coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE;
+
+fn sort_and_deduplicate_query_stream_summaries(summaries: &mut Vec<TraceSummaryRecord>) {
+    summaries.sort_by(|left, right| {
+        right
+            .end_time_unix_nanos
+            .cmp(&left.end_time_unix_nanos)
+            .then_with(|| left.trace_id.cmp(&right.trace_id))
+            .then_with(|| left.root_span_id.cmp(&right.root_span_id))
+    });
+    let mut seen_trace_ids = HashSet::new();
+    summaries.retain(|summary| seen_trace_ids.insert(summary.trace_id.clone()));
+}
+
+pub(super) fn summary(
+    spans: &[TraceSpanRecord],
+    workspace_name: Option<&str>,
+) -> Option<TraceSummaryRecord> {
+    summaries(spans, workspace_name).into_iter().next()
+}
+
+fn summaries(spans: &[TraceSpanRecord], workspace_name: Option<&str>) -> Vec<TraceSummaryRecord> {
+    let records = spans
+        .iter()
+        .map(|span| TraceListSpanRecord {
+            trace_id: span.trace_id.clone(),
+            span_id: span.span_id.clone(),
+            parent_span_id: span.parent_span_id.clone(),
+            parent_span_is_remote: span.parent_span_is_remote,
+            name: span.name.clone(),
+            status: span.status,
+            start_time_unix_nanos: span.start_time_unix_nanos,
+            end_time_unix_nanos: span.end_time_unix_nanos,
+            attributes_json: span.attributes_json.clone(),
+        })
+        .collect();
+    let mut projector = QueryStreamProjector::new(workspace_name);
+    projector.record_file(records);
+    projector.finish();
+    projector.into_summaries()
+}
+
+type QueryStreamSpanKey = (String, String);
+
+#[derive(Debug)]
+struct ProjectedQueryStreamSpan {
+    trace_id: String,
+    span_id: String,
+    parent_span_id: Option<String>,
+    parent_span_is_remote: bool,
+    name: String,
+    status: StoredTraceStatus,
+    start_time_unix_nanos: i64,
+    end_time_unix_nanos: i64,
+    metadata: Option<QueryStreamMetadata>,
+    protocol: bool,
+    workspace: Option<String>,
+    operation_text: Option<String>,
+    row_count: Option<u64>,
+}
+
+impl ProjectedQueryStreamSpan {
+    fn from_record(span: TraceListSpanRecord) -> Self {
+        let attributes = parse_attributes(&span.attributes_json);
+        let metadata = query_stream_metadata(&span.name, attributes.as_ref());
+        let protocol = attributes
+            .as_ref()
+            .is_some_and(is_unmarked_mcp_protocol_attributes);
+        let status = status_from_attributes(attributes.as_ref()).unwrap_or(span.status);
+        let workspace = attributes
+            .as_ref()
+            .and_then(|attributes| attr_string(attributes, WORKSPACE_SPAN_ATTRIBUTE));
+        let operation_text = metadata.as_ref().and_then(|metadata| {
+            attributes
+                .as_ref()
+                .and_then(|attributes| operation_text_from_attributes(metadata.kind, attributes))
+        });
+        let row_count = attributes
+            .as_ref()
+            .and_then(|attributes| attr_u64(attributes, "row_count"));
+        Self {
+            trace_id: span.trace_id,
+            span_id: span.span_id,
+            parent_span_id: span.parent_span_id,
+            parent_span_is_remote: span.parent_span_is_remote,
+            name: span.name,
+            status,
+            start_time_unix_nanos: span.start_time_unix_nanos,
+            end_time_unix_nanos: span.end_time_unix_nanos,
+            metadata,
+            protocol,
+            workspace,
+            operation_text,
+            row_count,
+        }
+    }
+
+    fn key(&self) -> QueryStreamSpanKey {
+        (self.trace_id.clone(), self.span_id.clone())
+    }
+
+    fn parent_key(&self) -> Option<QueryStreamSpanKey> {
+        self.parent_span_id
+            .as_ref()
+            .map(|parent_span_id| (self.trace_id.clone(), parent_span_id.clone()))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct QueryStreamNodeState {
+    owner: Option<u64>,
+    owner_depth: Option<usize>,
+    suppresses_entries: bool,
+}
+
+#[derive(Debug)]
+struct QueryStreamEntrySnapshot {
+    trace_id: String,
+    span_id: String,
+    name: String,
+    status: StoredTraceStatus,
+    start_time_unix_nanos: i64,
+    end_time_unix_nanos: i64,
+    metadata: QueryStreamMetadata,
+    workspace: Option<String>,
+    operation_text: Option<String>,
+    row_count: Option<u64>,
+}
+
+impl QueryStreamEntrySnapshot {
+    fn from_span(span: &ProjectedQueryStreamSpan, metadata: QueryStreamMetadata) -> Self {
+        Self {
+            trace_id: span.trace_id.clone(),
+            span_id: span.span_id.clone(),
+            name: span.name.clone(),
+            status: span.status,
+            start_time_unix_nanos: span.start_time_unix_nanos,
+            end_time_unix_nanos: span.end_time_unix_nanos,
+            metadata,
+            workspace: span.workspace.clone(),
+            operation_text: span.operation_text.clone(),
+            row_count: span.row_count,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct QueryStreamTextEnrichment {
+    kind: StoredTraceOperationKind,
+    depth: usize,
+    start_time_unix_nanos: i64,
+    span_id: String,
+    text: String,
+    row_count: Option<u64>,
+}
+
+impl QueryStreamTextEnrichment {
+    fn sort_key(&self) -> (usize, i64, &str) {
+        (self.depth, self.start_time_unix_nanos, &self.span_id)
+    }
+}
+
+#[derive(Debug)]
+struct StreamingQueryStreamAggregate {
+    entry: QueryStreamEntrySnapshot,
+    span_count: usize,
+    primary_descendant_operation: Option<QueryStreamPrimaryOperation>,
+    text_enrichment: Option<QueryStreamTextEnrichment>,
+    workspace_evidence: QueryStreamWorkspaceEvidence,
+}
+
+impl StreamingQueryStreamAggregate {
+    fn new(entry: QueryStreamEntrySnapshot) -> Self {
+        Self {
+            entry,
+            span_count: 0,
+            primary_descendant_operation: None,
+            text_enrichment: None,
+            workspace_evidence: QueryStreamWorkspaceEvidence::default(),
+        }
+    }
+
+    fn record_span(&mut self, span: &ProjectedQueryStreamSpan, depth: usize) {
+        self.span_count = self.span_count.saturating_add(1);
+        self.workspace_evidence.record(span.workspace.as_deref());
+        let Some(metadata) = span.metadata.as_ref() else {
+            return;
+        };
+        if depth > 0 {
+            let operation = QueryStreamPrimaryOperation::new(
+                metadata.kind,
+                depth,
+                span.start_time_unix_nanos,
+                &span.span_id,
+            );
+            if self
+                .primary_descendant_operation
+                .as_ref()
+                .is_none_or(|current| operation.sort_key() < current.sort_key())
+            {
+                self.primary_descendant_operation = Some(operation);
+            }
+        }
+        let Some(text) = span.operation_text.as_deref() else {
+            return;
+        };
+        let enrichment = QueryStreamTextEnrichment {
+            kind: metadata.kind,
+            depth,
+            start_time_unix_nanos: span.start_time_unix_nanos,
+            span_id: span.span_id.clone(),
+            text: text.to_string(),
+            row_count: (metadata.kind == StoredTraceOperationKind::Query)
+                .then_some(span.row_count)
+                .flatten(),
+        };
+        if self
+            .text_enrichment
+            .as_ref()
+            .is_none_or(|current| enrichment.sort_key() < current.sort_key())
+        {
+            self.text_enrichment = Some(enrichment);
+        }
+    }
+
+    fn workspace(&self) -> Option<&str> {
+        self.entry
+            .workspace
+            .as_deref()
+            .or_else(|| self.workspace_evidence.unique())
+    }
+
+    fn into_summary(self) -> TraceSummaryRecord {
+        let text_enrichment = self.text_enrichment.as_ref().filter(|enrichment| {
+            operation_text_is_semantic(
+                self.entry.metadata.kind,
+                enrichment.kind,
+                self.primary_descendant_operation.as_ref(),
+            )
+        });
+        let query = self
+            .entry
+            .operation_text
+            .or_else(|| text_enrichment.map(|enrichment| enrichment.text.clone()));
+        let row_count = (self.entry.metadata.kind == StoredTraceOperationKind::Query)
+            .then_some(self.entry.row_count)
+            .flatten()
+            .or_else(|| text_enrichment.and_then(|enrichment| enrichment.row_count));
+        TraceSummaryRecord {
+            trace_id: self.entry.trace_id,
+            root_span_id: self.entry.span_id,
+            name: self.entry.name,
+            query: query.unwrap_or_default(),
+            status: self.entry.status,
+            start_time_unix_nanos: self.entry.start_time_unix_nanos,
+            end_time_unix_nanos: self.entry.end_time_unix_nanos,
+            duration_nanos: self
+                .entry
+                .end_time_unix_nanos
+                .saturating_sub(self.entry.start_time_unix_nanos),
+            span_count: usize_to_u32(self.span_count),
+            row_count: row_count.unwrap_or_default(),
+            row_count_recorded: row_count.is_some(),
+            operation_kind: self.entry.metadata.kind,
+            operation_name: self.entry.metadata.name,
+            invocation_kind: self.entry.metadata.invocation_kind,
+        }
+    }
+}
+
+/// Projects completed spans into their outer Query Stream operations.
+///
+/// A completed child with an unresolved local parent remains hidden until that
+/// owning ancestry is available, avoiding an incomplete row that would later
+/// need to be replaced by its outer operation.
+struct QueryStreamProjector {
+    workspace_name: Option<String>,
+    nodes: HashMap<QueryStreamSpanKey, QueryStreamNodeState>,
+    aggregates: HashMap<u64, StreamingQueryStreamAggregate>,
+    finalized: Vec<TraceSummaryRecord>,
+    next_operation_id: u64,
+}
+
+impl QueryStreamProjector {
+    fn new(workspace_name: Option<&str>) -> Self {
+        Self {
+            workspace_name: workspace_name.map(str::to_string),
+            nodes: HashMap::new(),
+            aggregates: HashMap::new(),
+            finalized: Vec::new(),
+            next_operation_id: 0,
+        }
+    }
+
+    fn record_file(&mut self, spans: Vec<TraceListSpanRecord>) {
+        let mut pending = spans
+            .into_iter()
+            .map(ProjectedQueryStreamSpan::from_record)
+            .map(|span| (span.key(), span))
+            .collect::<HashMap<_, _>>();
+
+        while let Some(start_key) = pending.keys().next().cloned() {
+            if self.nodes.contains_key(&start_key) {
+                pending.remove(&start_key);
+                continue;
+            }
+
+            let mut chain = Vec::new();
+            let mut current_key = start_key;
+            loop {
+                if self.nodes.contains_key(&current_key) {
+                    break;
+                }
+                let Some(span) = pending.remove(&current_key) else {
+                    break;
+                };
+                let parent_key = span.parent_key();
+                chain.push(span);
+                let Some(parent_key) = parent_key else {
+                    break;
+                };
+                if self.nodes.contains_key(&parent_key) || !pending.contains_key(&parent_key) {
+                    break;
+                }
+                current_key = parent_key;
+            }
+
+            for span in chain.into_iter().rev() {
+                self.record_span(&span);
+            }
+        }
+    }
+
+    fn record_span(&mut self, span: &ProjectedQueryStreamSpan) {
+        let key = span.key();
+        if self.nodes.contains_key(&key) {
+            return;
+        }
+        let parent = span
+            .parent_key()
+            .as_ref()
+            .and_then(|parent_key| self.nodes.get(parent_key))
+            .copied();
+        let unresolved_local_parent =
+            span.parent_span_id.is_some() && !span.parent_span_is_remote && parent.is_none();
+        let ancestor_suppresses_entries = parent.is_some_and(|parent| parent.suppresses_entries);
+        let visible_metadata = (!ancestor_suppresses_entries && !unresolved_local_parent)
+            .then(|| span.metadata.clone())
+            .flatten();
+        let (owner, owner_depth) = if let Some(metadata) = visible_metadata {
+            let operation_id = self.next_operation_id;
+            self.next_operation_id = self.next_operation_id.saturating_add(1);
+            self.aggregates.insert(
+                operation_id,
+                StreamingQueryStreamAggregate::new(QueryStreamEntrySnapshot::from_span(
+                    span, metadata,
+                )),
+            );
+            (Some(operation_id), Some(0))
+        } else {
+            (
+                parent.and_then(|parent| parent.owner),
+                parent
+                    .and_then(|parent| parent.owner_depth)
+                    .map(|depth| depth.saturating_add(1)),
+            )
+        };
+        let suppresses_entries = ancestor_suppresses_entries
+            || unresolved_local_parent
+            || span.protocol
+            || span
+                .metadata
+                .as_ref()
+                .is_some_and(|metadata| metadata.explicit);
+        let node = QueryStreamNodeState {
+            owner,
+            owner_depth,
+            suppresses_entries,
+        };
+        self.nodes.insert(key, node);
+        if let Some((owner, depth)) = owner.zip(owner_depth)
+            && let Some(aggregate) = self.aggregates.get_mut(&owner)
+        {
+            aggregate.record_span(span, depth);
+        }
+    }
+
+    fn finish(&mut self) {
+        let operation_ids = self.aggregates.keys().copied().collect::<Vec<_>>();
+        for operation_id in operation_ids {
+            self.finalize_operation(operation_id);
+        }
+        self.nodes.clear();
+    }
+
+    fn finalize_operation(&mut self, operation_id: u64) {
+        let Some(aggregate) = self.aggregates.remove(&operation_id) else {
+            return;
+        };
+        if self
+            .workspace_name
+            .as_deref()
+            .is_none_or(|workspace_name| aggregate.workspace() == Some(workspace_name))
+        {
+            self.finalized.push(aggregate.into_summary());
+        }
+    }
+
+    fn into_summaries(mut self) -> Vec<TraceSummaryRecord> {
+        sort_and_deduplicate_query_stream_summaries(&mut self.finalized);
+        self.finalized
+    }
+}
+
+#[cfg(test)]
+mod semantics_tests;
+#[cfg(test)]
+mod test_support;

--- a/crates/coral-app/src/telemetry/local_store/query_stream/classification.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/classification.rs
@@ -1,0 +1,252 @@
+//! Shared Query Stream operation classification and aggregation policy.
+
+use coral_telemetry::{
+    QUERY_STREAM_ENTRY_ATTRIBUTE, QUERY_STREAM_KIND_ATTRIBUTE, QUERY_STREAM_KIND_QUERY,
+    QUERY_STREAM_KIND_SEARCH, QUERY_STREAM_KIND_TOOL, QUERY_STREAM_NAME_ATTRIBUTE,
+    QUERY_STREAM_SEARCH_QUERY_ATTRIBUTE,
+};
+use serde_json::Value as JsonValue;
+
+use super::super::{StoredTraceInvocationKind, StoredTraceOperationKind, attr_bool, attr_string};
+
+const MCP_METHOD_ATTRIBUTE: &str = "mcp.method";
+const MCP_TOOL_NAME_ATTRIBUTE: &str = "mcp.tool.name";
+const MCP_CALL_TOOL_METHOD: &str = "tools/call";
+pub(super) const UNKNOWN_TOOL_OPERATION_NAME: &str = "unknown_tool";
+pub(super) const MAX_LEGACY_TOOL_OPERATION_NAME_LEN: usize = 128;
+
+// Shared operation semantics used by the Query Stream projector.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct QueryStreamMetadata {
+    pub(super) explicit: bool,
+    pub(super) kind: StoredTraceOperationKind,
+    pub(super) name: String,
+    pub(super) invocation_kind: StoredTraceInvocationKind,
+}
+
+pub(super) fn query_stream_metadata(
+    span_name: &str,
+    attributes: Option<&JsonValue>,
+) -> Option<QueryStreamMetadata> {
+    match attributes.and_then(|attributes| attr_bool(attributes, QUERY_STREAM_ENTRY_ATTRIBUTE)) {
+        Some(false) => None,
+        Some(true) => {
+            let kind_name = attributes
+                .and_then(|attributes| attr_string(attributes, QUERY_STREAM_KIND_ATTRIBUTE));
+            let raw_kind = operation_kind_from_name(kind_name.as_deref());
+            let name = attributes
+                .and_then(|attributes| attr_string(attributes, QUERY_STREAM_NAME_ATTRIBUTE))
+                .filter(|name| !name.trim().is_empty())
+                .unwrap_or_else(|| fallback_operation_name(span_name, attributes, raw_kind));
+            let invocation_kind = invocation_kind_from_attributes(attributes);
+            let kind = normalize_legacy_mcp_capability(raw_kind, invocation_kind, &name);
+            Some(QueryStreamMetadata {
+                explicit: true,
+                kind,
+                name,
+                invocation_kind,
+            })
+        }
+        None => legacy_query_stream_metadata(span_name, attributes),
+    }
+}
+
+fn legacy_query_stream_metadata(
+    span_name: &str,
+    attributes: Option<&JsonValue>,
+) -> Option<QueryStreamMetadata> {
+    if let Some(tool_name) = attributes
+        .filter(|attributes| {
+            attr_string(attributes, MCP_METHOD_ATTRIBUTE).as_deref() == Some(MCP_CALL_TOOL_METHOD)
+        })
+        .and_then(|attributes| attr_string(attributes, MCP_TOOL_NAME_ATTRIBUTE))
+        .filter(|tool_name| !tool_name.trim().is_empty())
+    {
+        let name = privacy_safe_tool_operation_name(tool_name);
+        return Some(QueryStreamMetadata {
+            explicit: true,
+            kind: normalize_legacy_mcp_capability(
+                StoredTraceOperationKind::Tool,
+                StoredTraceInvocationKind::Mcp,
+                &name,
+            ),
+            name,
+            invocation_kind: StoredTraceInvocationKind::Mcp,
+        });
+    }
+    let (kind, default_name) = match span_name {
+        "coral.query" => (StoredTraceOperationKind::Query, "sql"),
+        "coral.search" => (StoredTraceOperationKind::Search, "search"),
+        _ => return None,
+    };
+    let name = attributes
+        .and_then(|attributes| attr_string(attributes, "operation"))
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or_else(|| default_name.to_string());
+    Some(QueryStreamMetadata {
+        explicit: false,
+        kind,
+        name,
+        invocation_kind: StoredTraceInvocationKind::Direct,
+    })
+}
+
+fn invocation_kind_from_attributes(attributes: Option<&JsonValue>) -> StoredTraceInvocationKind {
+    if attributes.is_some_and(|attributes| {
+        attr_string(attributes, MCP_METHOD_ATTRIBUTE)
+            .is_some_and(|method| !method.trim().is_empty())
+    }) {
+        StoredTraceInvocationKind::Mcp
+    } else {
+        StoredTraceInvocationKind::Direct
+    }
+}
+
+/// Normalizes spans retained before capability and invocation were separated.
+/// New MCP producers record SQL and Search as semantic kinds on the outer span,
+/// while older producers recorded every MCP operation as `tool`.
+fn normalize_legacy_mcp_capability(
+    kind: StoredTraceOperationKind,
+    invocation_kind: StoredTraceInvocationKind,
+    operation_name: &str,
+) -> StoredTraceOperationKind {
+    if kind != StoredTraceOperationKind::Tool || invocation_kind != StoredTraceInvocationKind::Mcp {
+        return kind;
+    }
+    match operation_name {
+        "sql" => StoredTraceOperationKind::Query,
+        "search" => StoredTraceOperationKind::Search,
+        _ => kind,
+    }
+}
+
+fn operation_kind_from_name(kind: Option<&str>) -> StoredTraceOperationKind {
+    match kind {
+        Some(QUERY_STREAM_KIND_QUERY) => StoredTraceOperationKind::Query,
+        Some(QUERY_STREAM_KIND_SEARCH) => StoredTraceOperationKind::Search,
+        Some(QUERY_STREAM_KIND_TOOL) => StoredTraceOperationKind::Tool,
+        _ => StoredTraceOperationKind::Other,
+    }
+}
+
+pub(super) fn privacy_safe_tool_operation_name(tool_name: String) -> String {
+    let has_identifier_shape = !tool_name.is_empty()
+        && tool_name.len() <= MAX_LEGACY_TOOL_OPERATION_NAME_LEN
+        && tool_name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'));
+    if has_identifier_shape {
+        tool_name
+    } else {
+        UNKNOWN_TOOL_OPERATION_NAME.to_string()
+    }
+}
+
+fn fallback_operation_name(
+    span_name: &str,
+    attributes: Option<&JsonValue>,
+    kind: StoredTraceOperationKind,
+) -> String {
+    match kind {
+        StoredTraceOperationKind::Query => attributes
+            .and_then(|attributes| attr_string(attributes, "operation"))
+            .unwrap_or_else(|| "sql".to_string()),
+        StoredTraceOperationKind::Search => "search".to_string(),
+        StoredTraceOperationKind::Tool => privacy_safe_tool_operation_name(
+            attributes
+                .and_then(|attributes| attr_string(attributes, MCP_TOOL_NAME_ATTRIBUTE))
+                .unwrap_or_else(|| span_name.to_string()),
+        ),
+        StoredTraceOperationKind::Other | StoredTraceOperationKind::Unspecified => {
+            span_name.to_string()
+        }
+    }
+}
+
+pub(super) fn is_unmarked_mcp_protocol_attributes(attributes: &JsonValue) -> bool {
+    let is_marked = attr_bool(attributes, QUERY_STREAM_ENTRY_ATTRIBUTE).unwrap_or(false);
+    !is_marked
+        && attributes.get(MCP_METHOD_ATTRIBUTE).is_some()
+        && attributes.get(MCP_TOOL_NAME_ATTRIBUTE).is_none()
+}
+
+pub(super) fn operation_text_from_attributes(
+    kind: StoredTraceOperationKind,
+    attributes: &JsonValue,
+) -> Option<String> {
+    let attribute = match kind {
+        StoredTraceOperationKind::Query => "sql",
+        StoredTraceOperationKind::Search => QUERY_STREAM_SEARCH_QUERY_ATTRIBUTE,
+        StoredTraceOperationKind::Tool
+        | StoredTraceOperationKind::Other
+        | StoredTraceOperationKind::Unspecified => return None,
+    };
+    attr_string(attributes, attribute).filter(|text| !text.trim().is_empty())
+}
+
+pub(super) fn operation_text_is_semantic(
+    entry_kind: StoredTraceOperationKind,
+    text_kind: StoredTraceOperationKind,
+    primary_descendant: Option<&QueryStreamPrimaryOperation>,
+) -> bool {
+    entry_kind == text_kind
+        || (entry_kind == StoredTraceOperationKind::Tool
+            && primary_descendant.is_some_and(|operation| operation.kind == text_kind))
+}
+
+#[derive(Debug)]
+pub(super) struct QueryStreamPrimaryOperation {
+    kind: StoredTraceOperationKind,
+    depth: usize,
+    start_time_unix_nanos: i64,
+    span_id: String,
+}
+
+impl QueryStreamPrimaryOperation {
+    pub(super) fn new(
+        kind: StoredTraceOperationKind,
+        depth: usize,
+        start_time_unix_nanos: i64,
+        span_id: &str,
+    ) -> Self {
+        Self {
+            kind,
+            depth,
+            start_time_unix_nanos,
+            span_id: span_id.to_string(),
+        }
+    }
+
+    pub(super) fn sort_key(&self) -> (usize, i64, &str) {
+        (self.depth, self.start_time_unix_nanos, &self.span_id)
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) enum QueryStreamWorkspaceEvidence {
+    #[default]
+    None,
+    One(String),
+    Conflict,
+}
+
+impl QueryStreamWorkspaceEvidence {
+    pub(super) fn record(&mut self, workspace: Option<&str>) {
+        let Some(workspace) = workspace.filter(|workspace| !workspace.trim().is_empty()) else {
+            return;
+        };
+        match self {
+            Self::None => *self = Self::One(workspace.to_string()),
+            Self::One(current) if current != workspace => *self = Self::Conflict,
+            Self::One(_) | Self::Conflict => {}
+        }
+    }
+
+    pub(super) fn unique(&self) -> Option<&str> {
+        match self {
+            Self::One(workspace) => Some(workspace),
+            Self::None | Self::Conflict => None,
+        }
+    }
+}

--- a/crates/coral-app/src/telemetry/local_store/query_stream/semantics_tests.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/semantics_tests.rs
@@ -1,0 +1,462 @@
+use serde_json::json;
+
+use super::super::tests::trace_record;
+use super::super::{StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus};
+use super::classification::{
+    MAX_LEGACY_TOOL_OPERATION_NAME_LEN, UNKNOWN_TOOL_OPERATION_NAME,
+    privacy_safe_tool_operation_name,
+};
+use super::test_support::{project, span};
+
+// Shared classification and ownership behavior.
+
+#[test]
+fn query_stream_projects_outer_operations() {
+    let sql_tool = span("shared-trace", "sql-tool")
+        .named("coral.mcp.call_tool")
+        .remote_root()
+        .entry("tool", "sql", "alpha")
+        .attrs(json!({
+            "mcp.method": "tools/call",
+            "mcp.tool.name": "sql",
+            "status": "error",
+        }))
+        .status(StoredTraceStatus::Error)
+        .times(10, 40)
+        .build();
+    let nested_query = span("shared-trace", "nested-query")
+        .child_of(&sql_tool)
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "SELECT 42", "row_count": 7, "status": "ok"}))
+        .times(20, 30)
+        .build();
+
+    let summaries = project(&[sql_tool, nested_query], None);
+    assert_eq!(summaries.len(), 1);
+    let sql_summary = summaries.first().expect("SQL summary");
+    assert_eq!(sql_summary.root_span_id, "sql-tool");
+    assert_eq!(sql_summary.operation_kind, StoredTraceOperationKind::Query);
+    assert_eq!(sql_summary.operation_name, "sql");
+    assert_eq!(sql_summary.invocation_kind, StoredTraceInvocationKind::Mcp);
+    assert_eq!(sql_summary.query, "SELECT 42");
+    assert_eq!(sql_summary.row_count, 7);
+    assert!(sql_summary.row_count_recorded);
+    assert_eq!(sql_summary.status, StoredTraceStatus::Error);
+    assert_eq!(sql_summary.start_time_unix_nanos, 10);
+    assert_eq!(sql_summary.end_time_unix_nanos, 40);
+    assert_eq!(sql_summary.duration_nanos, 30);
+    assert_eq!(sql_summary.span_count, 2);
+}
+
+#[test]
+fn query_stream_projects_search_text_for_mcp_operation() {
+    let tool = span("search-trace", "search-tool")
+        .named("coral.mcp.call_tool")
+        .remote_root()
+        .entry("search", "search", "beta")
+        .attrs(json!({
+            "mcp.method": "tools/call",
+            "mcp.tool.name": "search",
+        }))
+        .times(1, 30)
+        .build();
+    let search = span("search-trace", "search-operation")
+        .named("coral.search")
+        .child_of(&tool)
+        .entry("search", "search", "beta")
+        .attrs(json!({"coral.local.search.query": "find customer churn"}))
+        .times(10, 20)
+        .build();
+    let internal_query = span("search-trace", "search-catalog-query")
+        .child_of(&search)
+        .entry("query", "list_catalog", "beta")
+        .attrs(json!({"sql": "LIST CATALOG", "row_count": 99}))
+        .times(12, 15)
+        .build();
+
+    let summaries = project(&[tool, search, internal_query], Some("beta"));
+    let summary = summaries.first().expect("tool search summary");
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summary.root_span_id, "search-tool");
+    assert_eq!(summary.operation_kind, StoredTraceOperationKind::Search);
+    assert_eq!(summary.operation_name, "search");
+    assert_eq!(summary.invocation_kind, StoredTraceInvocationKind::Mcp);
+    assert_eq!(summary.query, "find customer churn");
+    assert!(!summary.row_count_recorded);
+}
+
+#[test]
+fn query_stream_projects_search_text_for_direct_operation() {
+    let search = span("direct-search-trace", "direct-search")
+        .named("coral.search")
+        .remote_root()
+        .entry("search", "search", "gamma")
+        .attrs(json!({"coral.local.search.query": "direct search phrase"}))
+        .build();
+
+    let summaries = project(&[search], Some("gamma"));
+    let summary = summaries.first().expect("direct search summary");
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summary.root_span_id, "direct-search");
+    assert_eq!(summary.operation_kind, StoredTraceOperationKind::Search);
+    assert_eq!(summary.invocation_kind, StoredTraceInvocationKind::Direct);
+    assert_eq!(summary.query, "direct search phrase");
+}
+
+#[test]
+fn query_stream_projects_bare_legacy_root_query() {
+    let mut query = trace_record("legacy-query-trace", "legacy-query");
+    query.attributes_json = json!({
+        "workspace": "alpha",
+        "sql": "SELECT 42",
+        "row_count": 7,
+    })
+    .to_string();
+
+    let summaries = project(&[query], Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    let summary = summaries.first().expect("legacy query summary");
+    assert_eq!(summary.root_span_id, "legacy-query");
+    assert_eq!(summary.operation_kind, StoredTraceOperationKind::Query);
+    assert_eq!(summary.operation_name, "sql");
+    assert_eq!(summary.invocation_kind, StoredTraceInvocationKind::Direct);
+    assert_eq!(summary.query, "SELECT 42");
+    assert_eq!(summary.row_count, 7);
+    assert!(summary.row_count_recorded);
+}
+
+#[test]
+fn query_stream_ignores_row_count_on_non_query_entry() {
+    let search = span("search-row-count-trace", "search")
+        .named("coral.search")
+        .entry("search", "search", "alpha")
+        .attrs(json!({
+            "coral.local.search.query": "find customer churn",
+            "row_count": 99,
+        }))
+        .build();
+
+    let summaries = project(&[search], Some("alpha"));
+    let summary = summaries.first().expect("search summary");
+    assert_eq!(summary.operation_kind, StoredTraceOperationKind::Search);
+    assert_eq!(summary.query, "find customer churn");
+    assert_eq!(summary.row_count, 0);
+    assert!(!summary.row_count_recorded);
+}
+
+#[test]
+fn query_stream_entry_false_overrides_legacy_tool_shape() {
+    let mut suppressed = trace_record("suppressed-trace", "suppressed-tool");
+    suppressed.parent_span_id = Some("remote-parent".to_string());
+    suppressed.parent_span_is_remote = true;
+    suppressed.name = "coral.mcp.call_tool".to_string();
+    suppressed.attributes_json = json!({
+        "coral.stream.entry": false,
+        "mcp.method": "tools/call",
+        "mcp.tool.name": "list_catalog",
+        "workspace": "alpha",
+    })
+    .to_string();
+
+    let summaries = project(&[suppressed], Some("alpha"));
+    assert!(summaries.is_empty());
+}
+
+#[test]
+fn query_stream_entry_without_kind_is_other() {
+    let mut entry = trace_record("other-trace", "other-entry");
+    entry.parent_span_id = Some("remote-parent".to_string());
+    entry.parent_span_is_remote = true;
+    entry.name = "coral.vector_lookup".to_string();
+    entry.attributes_json = json!({
+        "coral.stream.entry": true,
+        "coral.stream.name": "semantic_lookup",
+        "workspace": "alpha",
+    })
+    .to_string();
+
+    let summaries = project(&[entry], Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    let summary = summaries.first().expect("other summary");
+    assert_eq!(summary.operation_kind, StoredTraceOperationKind::Other);
+    assert_eq!(summary.operation_name, "semantic_lookup");
+    assert_eq!(summary.invocation_kind, StoredTraceInvocationKind::Direct);
+    assert!(summary.query.is_empty());
+}
+
+#[test]
+fn query_stream_hides_entries_with_unfinished_local_parents() {
+    let mut unfinished_child = trace_record("unfinished-trace", "unfinished-query");
+    unfinished_child.parent_span_id = Some("unfinished-protocol-parent".to_string());
+    unfinished_child.parent_span_is_remote = false;
+    unfinished_child.attributes_json = json!({
+        "coral.stream.entry": true,
+        "coral.stream.kind": "query",
+        "coral.stream.name": "sql",
+        "workspace": "alpha",
+        "sql": "SELECT 'unfinished'",
+    })
+    .to_string();
+
+    let mut remote_root = trace_record("remote-root-trace", "remote-query");
+    remote_root.parent_span_id = Some("remote-parent".to_string());
+    remote_root.parent_span_is_remote = true;
+    remote_root.attributes_json = json!({
+        "coral.stream.entry": true,
+        "coral.stream.kind": "query",
+        "coral.stream.name": "sql",
+        "workspace": "alpha",
+        "sql": "SELECT 'remote'",
+    })
+    .to_string();
+
+    let summaries = project(&[unfinished_child, remote_root], Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(
+        summaries.first().expect("remote summary").root_span_id,
+        "remote-query"
+    );
+}
+
+#[test]
+fn query_stream_keeps_one_operation_when_a_remote_parent_is_reused() {
+    let mut records = Vec::new();
+
+    for index in 0..128 {
+        let tool_span_id = format!("tool-{index:03}");
+        let tool = span("shared-trace", &tool_span_id)
+            .named("coral.mcp.call_tool")
+            .remote_root()
+            .entry("tool", "sql", "alpha")
+            .attrs(json!({
+                "mcp.method": "tools/call",
+                "mcp.tool.name": "sql",
+            }))
+            .times(index * 10, index * 10 + 9)
+            .build();
+        let query = span("shared-trace", &format!("query-{index:03}"))
+            .child_of(&tool)
+            .entry("query", "sql", "alpha")
+            .attrs(json!({"sql": format!("SELECT {index}"), "row_count": index}))
+            .times(index * 10 + 1, index * 10 + 8)
+            .build();
+        records.extend([tool, query]);
+    }
+
+    let summaries = project(&records, Some("alpha"));
+    let summary = summaries.first().expect("newest operation");
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summary.root_span_id, "tool-127");
+    assert_eq!(summary.operation_kind, StoredTraceOperationKind::Query);
+    assert_eq!(summary.invocation_kind, StoredTraceInvocationKind::Mcp);
+    assert_eq!(summary.span_count, 2);
+    assert_eq!(summary.query, "SELECT 127");
+}
+
+#[test]
+fn query_stream_suppresses_protocol_descendants_without_method_enumeration() {
+    let mut protocol = trace_record("future-trace", "protocol");
+    protocol.name = "coral.mcp.future_protocol".to_string();
+    protocol.attributes_json = r#"{"mcp.method":"future/negotiate"}"#.to_string();
+
+    let mut protocol_child = trace_record("future-trace", "protocol-child");
+    protocol_child.parent_span_id = Some(protocol.span_id.clone());
+    protocol_child.name = "coral.vector_lookup".to_string();
+    protocol_child.attributes_json = json!({
+        "coral.stream.entry": true,
+        "coral.stream.kind": "vector_lookup",
+        "coral.stream.name": "semantic_lookup",
+        "workspace": "alpha",
+    })
+    .to_string();
+
+    let mut direct_future = trace_record("future-trace", "direct-future");
+    direct_future.parent_span_id = Some("remote-parent".to_string());
+    direct_future.parent_span_is_remote = true;
+    direct_future.name = "coral.vector_lookup".to_string();
+    direct_future.attributes_json = json!({
+        "coral.stream.entry": true,
+        "coral.stream.kind": "vector_lookup",
+        "coral.stream.name": "semantic_lookup",
+        "workspace": "alpha",
+    })
+    .to_string();
+    direct_future.start_time_unix_nanos = 10;
+    direct_future.end_time_unix_nanos = 11;
+
+    let summaries = project(&[protocol, protocol_child, direct_future], Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    let summary = summaries.first().expect("future summary");
+    assert_eq!(summary.root_span_id, "direct-future");
+    assert_eq!(summary.operation_kind, StoredTraceOperationKind::Other);
+    assert_eq!(summary.operation_name, "semantic_lookup");
+    assert_eq!(summary.invocation_kind, StoredTraceInvocationKind::Direct);
+}
+
+#[test]
+fn query_stream_supports_legacy_operations_and_protocol_suppression() {
+    let mut protocol = trace_record("legacy-trace", "protocol");
+    protocol.name = "coral.mcp.protocol".to_string();
+    protocol.attributes_json = r#"{"mcp.method":"some/future_method"}"#.to_string();
+
+    let mut hidden_query = trace_record("legacy-trace", "hidden-query");
+    hidden_query.parent_span_id = Some(protocol.span_id.clone());
+    hidden_query.attributes_json = r#"{"workspace":"alpha","sql":"LIST CATALOG"}"#.to_string();
+
+    let mut legacy_tool = trace_record("legacy-trace", "legacy-tool");
+    legacy_tool.name = "coral.mcp.call_tool".to_string();
+    legacy_tool.attributes_json =
+        r#"{"mcp.method":"tools/call","mcp.tool.name":"list_catalog"}"#.to_string();
+    legacy_tool.start_time_unix_nanos = 10;
+    legacy_tool.end_time_unix_nanos = 13;
+
+    let mut visible_query = trace_record("legacy-trace", "visible-query");
+    visible_query.parent_span_id = Some(legacy_tool.span_id.clone());
+    visible_query.attributes_json =
+        r#"{"workspace":"alpha","operation":"list_catalog","sql":"LIST CATALOG"}"#.to_string();
+    visible_query.start_time_unix_nanos = 11;
+    visible_query.end_time_unix_nanos = 12;
+
+    let mut search_tool = trace_record("search-trace", "legacy-search-tool");
+    search_tool.name = "coral.mcp.call_tool".to_string();
+    search_tool.attributes_json =
+        r#"{"mcp.method":"tools/call","mcp.tool.name":"search"}"#.to_string();
+    search_tool.start_time_unix_nanos = 20;
+    search_tool.end_time_unix_nanos = 25;
+
+    let mut search = trace_record("search-trace", "legacy-search");
+    search.parent_span_id = Some(search_tool.span_id.clone());
+    search.name = "coral.search".to_string();
+    search.attributes_json = r#"{"workspace":"alpha","operation":"search"}"#.to_string();
+    search.start_time_unix_nanos = 21;
+    search.end_time_unix_nanos = 24;
+
+    let mut search_catalog_query = trace_record("search-trace", "legacy-search-catalog-query");
+    search_catalog_query.parent_span_id = Some(search.span_id.clone());
+    search_catalog_query.attributes_json =
+        r#"{"workspace":"alpha","operation":"list_catalog","sql":"LIST CATALOG"}"#.to_string();
+    search_catalog_query.start_time_unix_nanos = 22;
+    search_catalog_query.end_time_unix_nanos = 23;
+
+    let summaries = project(
+        &[
+            protocol,
+            hidden_query,
+            legacy_tool,
+            visible_query,
+            search_tool,
+            search,
+            search_catalog_query,
+        ],
+        Some("alpha"),
+    );
+    assert_eq!(summaries.len(), 2);
+    let search_summary = summaries.first().expect("legacy search summary");
+    assert_eq!(search_summary.root_span_id, "legacy-search-tool");
+    assert_eq!(
+        search_summary.operation_kind,
+        StoredTraceOperationKind::Search
+    );
+    assert_eq!(search_summary.operation_name, "search");
+    assert_eq!(
+        search_summary.invocation_kind,
+        StoredTraceInvocationKind::Mcp
+    );
+    assert!(search_summary.query.is_empty());
+    let tool_summary = summaries.get(1).expect("legacy tool summary");
+    assert_eq!(tool_summary.root_span_id, "legacy-tool");
+    assert_eq!(tool_summary.operation_kind, StoredTraceOperationKind::Tool);
+    assert_eq!(tool_summary.operation_name, "list_catalog");
+    assert_eq!(tool_summary.invocation_kind, StoredTraceInvocationKind::Mcp);
+    assert_eq!(tool_summary.query, "LIST CATALOG");
+}
+
+#[test]
+fn query_stream_legacy_tool_requires_consistent_descendant_workspace() {
+    let mut tool = trace_record("legacy-conflict", "legacy-tool");
+    tool.name = "coral.mcp.call_tool".to_string();
+    tool.attributes_json =
+        r#"{"mcp.method":"tools/call","mcp.tool.name":"future_tool"}"#.to_string();
+    tool.start_time_unix_nanos = 10;
+    tool.end_time_unix_nanos = 30;
+
+    let mut alpha = trace_record("legacy-conflict", "alpha-child");
+    alpha.parent_span_id = Some(tool.span_id.clone());
+    alpha.name = "internal.alpha".to_string();
+    alpha.attributes_json = r#"{"workspace":"alpha"}"#.to_string();
+    alpha.start_time_unix_nanos = 15;
+    alpha.end_time_unix_nanos = 16;
+
+    let mut beta = trace_record("legacy-conflict", "beta-child");
+    beta.parent_span_id = Some(tool.span_id.clone());
+    beta.name = "internal.beta".to_string();
+    beta.attributes_json = r#"{"workspace":"beta"}"#.to_string();
+    beta.start_time_unix_nanos = 20;
+    beta.end_time_unix_nanos = 21;
+
+    let records = [tool, alpha, beta];
+    assert!(project(&records, Some("alpha")).is_empty());
+    let global = project(&records, None);
+    assert_eq!(global.len(), 1);
+    assert_eq!(
+        global.first().expect("legacy tool").operation_name,
+        "future_tool"
+    );
+}
+
+#[test]
+fn query_stream_redacts_prose_shaped_legacy_tool_name() {
+    let sentinel = "SENSITIVE prose-shaped legacy tool";
+
+    let mut tool = trace_record("legacy-private-trace", "legacy-private-tool");
+    tool.name = "coral.mcp.call_tool".to_string();
+    tool.attributes_json = json!({
+        "mcp.method": "tools/call",
+        "mcp.tool.name": sentinel,
+    })
+    .to_string();
+
+    let summaries = project(&[tool], None);
+    assert_eq!(summaries.len(), 1);
+    let summary = summaries.first().expect("legacy tool summary");
+    assert_eq!(summary.operation_kind, StoredTraceOperationKind::Tool);
+    assert_eq!(summary.operation_name, UNKNOWN_TOOL_OPERATION_NAME);
+    assert_eq!(summary.invocation_kind, StoredTraceInvocationKind::Mcp);
+    assert!(!format!("{summary:?}").contains(sentinel));
+}
+
+#[test]
+fn query_stream_redacts_prose_shaped_explicit_tool_fallback_name() {
+    let sentinel = "SENSITIVE prose-shaped explicit tool";
+
+    let mut tool = trace_record("explicit-private-trace", "explicit-private-tool");
+    tool.name = "coral.mcp.call_tool".to_string();
+    tool.attributes_json = json!({
+        "coral.stream.entry": true,
+        "coral.stream.kind": "tool",
+        "mcp.tool.name": sentinel,
+    })
+    .to_string();
+
+    let summaries = project(&[tool], None);
+    assert_eq!(summaries.len(), 1);
+    let summary = summaries.first().expect("explicit tool summary");
+    assert_eq!(summary.operation_kind, StoredTraceOperationKind::Tool);
+    assert_eq!(summary.operation_name, UNKNOWN_TOOL_OPERATION_NAME);
+    assert!(!format!("{summary:?}").contains(sentinel));
+}
+
+#[test]
+fn tool_operation_name_policy_bounds_identifiers() {
+    let longest_valid = format!("2.{}", "a".repeat(MAX_LEGACY_TOOL_OPERATION_NAME_LEN - 2));
+    assert_eq!(
+        privacy_safe_tool_operation_name(longest_valid.clone()),
+        longest_valid
+    );
+
+    let overlong = format!("2.{}", "a".repeat(MAX_LEGACY_TOOL_OPERATION_NAME_LEN - 1));
+    assert_eq!(
+        privacy_safe_tool_operation_name(overlong),
+        UNKNOWN_TOOL_OPERATION_NAME
+    );
+}

--- a/crates/coral-app/src/telemetry/local_store/query_stream/test_support.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/test_support.rs
@@ -1,0 +1,80 @@
+use serde_json::{Map, Value, json};
+
+use super::super::tests::trace_record;
+use super::super::{StoredTraceStatus, TraceSpanRecord, TraceSummaryRecord};
+
+pub(super) fn span(trace_id: &str, span_id: &str) -> TestSpan {
+    TestSpan {
+        record: trace_record(trace_id, span_id),
+        attributes: Map::new(),
+    }
+}
+
+pub(super) struct TestSpan {
+    record: TraceSpanRecord,
+    attributes: Map<String, Value>,
+}
+
+impl TestSpan {
+    pub(super) fn named(mut self, name: &str) -> Self {
+        self.record.name = name.to_string();
+        self
+    }
+
+    pub(super) fn remote_root(mut self) -> Self {
+        self.record.parent_span_id = Some("remote-parent".to_string());
+        self.record.parent_span_is_remote = true;
+        self
+    }
+
+    pub(super) fn child_of(mut self, parent: &TraceSpanRecord) -> Self {
+        self.record.parent_span_id = Some(parent.span_id.clone());
+        self
+    }
+
+    pub(super) fn entry(mut self, kind: &str, operation_name: &str, workspace: &str) -> Self {
+        self.attributes.extend(
+            json!({
+                "coral.stream.entry": true,
+                "coral.stream.kind": kind,
+                "coral.stream.name": operation_name,
+                "workspace": workspace,
+            })
+            .as_object()
+            .expect("stream entry attributes")
+            .clone(),
+        );
+        self
+    }
+
+    pub(super) fn attrs(mut self, attributes: Value) -> Self {
+        let Value::Object(attributes) = attributes else {
+            panic!("additional span attributes must be an object");
+        };
+        self.attributes.extend(attributes);
+        self
+    }
+
+    pub(super) fn status(mut self, status: StoredTraceStatus) -> Self {
+        self.record.status = status;
+        self
+    }
+
+    pub(super) fn times(mut self, start_time_unix_nanos: i64, end_time_unix_nanos: i64) -> Self {
+        self.record.start_time_unix_nanos = start_time_unix_nanos;
+        self.record.end_time_unix_nanos = end_time_unix_nanos;
+        self
+    }
+
+    pub(super) fn build(mut self) -> TraceSpanRecord {
+        self.record.attributes_json = Value::Object(self.attributes).to_string();
+        self.record
+    }
+}
+
+pub(super) fn project(
+    records: &[TraceSpanRecord],
+    workspace_name: Option<&str>,
+) -> Vec<TraceSummaryRecord> {
+    super::summaries(records, workspace_name)
+}

--- a/crates/coral-app/src/telemetry/manager.rs
+++ b/crates/coral-app/src/telemetry/manager.rs
@@ -6,6 +6,12 @@ use std::time::Duration;
 use super::local_store::{TraceDetailRecord, TraceStore, TraceStoreError, TraceSummaryRecord};
 use crate::workspaces::WorkspaceName;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TraceListView {
+    All,
+    QueryStream,
+}
+
 #[derive(Debug)]
 pub(crate) struct ListTracesQuery {
     pub(crate) workspace: Option<WorkspaceName>,
@@ -23,6 +29,7 @@ pub(crate) struct TraceListPage {
 pub(crate) struct GetTraceQuery {
     pub(crate) trace_id: String,
     pub(crate) workspace: Option<WorkspaceName>,
+    pub(crate) view: TraceListView,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -89,14 +96,23 @@ impl TraceManager {
         let GetTraceQuery {
             trace_id,
             workspace,
+            view,
         } = query;
-        match workspace {
-            Some(workspace) => {
+        let workspace = workspace.map(|workspace| workspace.as_str().to_string());
+        match view {
+            TraceListView::All => match workspace {
+                Some(workspace) => {
+                    self.traces
+                        .get_trace_for_workspace(trace_id, workspace)
+                        .await
+                }
+                None => self.traces.get_trace(trace_id).await,
+            },
+            TraceListView::QueryStream => {
                 self.traces
-                    .get_trace_for_workspace(trace_id, workspace.as_str().to_string())
+                    .get_query_stream_trace(trace_id, workspace)
                     .await
             }
-            None => self.traces.get_trace(trace_id).await,
         }
         .map_err(TraceManagerError::from)
     }
@@ -109,7 +125,7 @@ mod tests {
     use serde_json::json;
     use tempfile::TempDir;
 
-    use super::{GetTraceQuery, ListTracesQuery, TraceManager, TraceManagerError};
+    use super::{GetTraceQuery, ListTracesQuery, TraceListView, TraceManager, TraceManagerError};
     use crate::workspaces::WorkspaceName;
 
     #[tokio::test]
@@ -156,6 +172,7 @@ mod tests {
             .get_trace(GetTraceQuery {
                 trace_id: "beta".to_string(),
                 workspace: None,
+                view: TraceListView::All,
             })
             .await
             .expect("unscoped beta trace");
@@ -165,6 +182,7 @@ mod tests {
             .get_trace(GetTraceQuery {
                 trace_id: "beta".to_string(),
                 workspace: Some(WorkspaceName::parse("alpha").expect("alpha workspace")),
+                view: TraceListView::All,
             })
             .await
             .expect_err("beta trace must not match alpha workspace");

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -2,16 +2,19 @@
 
 use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
 use coral_api::v1::{
-    GetTraceRequest, GetTraceResponse, ListTracesRequest, ListTracesResponse, TraceSpan,
-    TraceStatus, TraceSummary, Workspace,
+    GetTraceRequest, GetTraceResponse, ListTracesRequest, ListTracesResponse, TraceInvocationKind,
+    TraceOperationKind, TraceSpan, TraceStatus, TraceSummary, TraceView, Workspace,
 };
 use tonic::{Code, Request, Response, Status};
 
 use crate::bootstrap::app_status;
 use crate::telemetry::local_store::{
-    StoredTraceStatus, TraceDetailRecord, TraceSpanRecord, TraceSummaryRecord,
+    StoredTraceInvocationKind, StoredTraceOperationKind, StoredTraceStatus, TraceDetailRecord,
+    TraceSpanRecord, TraceSummaryRecord,
 };
-use crate::telemetry::manager::{GetTraceQuery, ListTracesQuery, TraceManager, TraceManagerError};
+use crate::telemetry::manager::{
+    GetTraceQuery, ListTracesQuery, TraceListView, TraceManager, TraceManagerError,
+};
 use crate::transport::{grpc_span, instrument_grpc};
 use crate::workspaces::WorkspaceName;
 
@@ -81,10 +84,12 @@ impl TraceServiceApi for TraceService {
                 ));
             }
             let workspace = workspace_filter_from_proto(request.workspace.as_ref())?;
+            let view = trace_list_view_from_proto(request.view)?;
             let trace = traces
                 .get_trace(GetTraceQuery {
                     trace_id: request.trace_id,
                     workspace,
+                    view,
                 })
                 .await
                 .map_err(trace_manager_status)?;
@@ -114,6 +119,17 @@ fn parse_page_token(page_token: &str) -> Result<usize, Status> {
             "invalid input: page_token must be returned by ListTraces",
         )
     })
+}
+
+fn trace_list_view_from_proto(view: i32) -> Result<TraceListView, Status> {
+    match TraceView::try_from(view) {
+        Ok(TraceView::Unspecified) => Ok(TraceListView::All),
+        Ok(TraceView::QueryStream) => Ok(TraceListView::QueryStream),
+        Err(_unknown_view) => Err(Status::new(
+            Code::InvalidArgument,
+            "invalid input: unknown trace view",
+        )),
+    }
 }
 
 fn workspace_filter_from_proto(
@@ -153,6 +169,9 @@ fn trace_summary_to_proto(summary: TraceSummaryRecord) -> TraceSummary {
         span_count: summary.span_count,
         row_count: summary.row_count,
         row_count_recorded: summary.row_count_recorded,
+        operation_kind: trace_operation_kind_to_proto(summary.operation_kind) as i32,
+        operation_name: summary.operation_name,
+        invocation_kind: trace_invocation_kind_to_proto(summary.invocation_kind) as i32,
     }
 }
 
@@ -191,18 +210,41 @@ fn trace_status_to_proto(status: StoredTraceStatus) -> TraceStatus {
     }
 }
 
+fn trace_operation_kind_to_proto(kind: StoredTraceOperationKind) -> TraceOperationKind {
+    match kind {
+        StoredTraceOperationKind::Unspecified => TraceOperationKind::Unspecified,
+        StoredTraceOperationKind::Query => TraceOperationKind::Query,
+        StoredTraceOperationKind::Search => TraceOperationKind::Search,
+        StoredTraceOperationKind::Tool => TraceOperationKind::Tool,
+        StoredTraceOperationKind::Other => TraceOperationKind::Other,
+    }
+}
+
+fn trace_invocation_kind_to_proto(kind: StoredTraceInvocationKind) -> TraceInvocationKind {
+    match kind {
+        StoredTraceInvocationKind::Unspecified => TraceInvocationKind::Unspecified,
+        StoredTraceInvocationKind::Direct => TraceInvocationKind::Direct,
+        StoredTraceInvocationKind::Mcp => TraceInvocationKind::Mcp,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
     use coral_api::v1::trace_service_server::TraceService as TraceServiceApi;
-    use coral_api::v1::{GetTraceRequest, ListTracesRequest, Workspace};
+    use coral_api::v1::{
+        GetTraceRequest, ListTracesRequest, TraceInvocationKind, TraceOperationKind, TraceView,
+        Workspace,
+    };
     use serde_json::json;
     use tempfile::TempDir;
     use tonic::{Code, Request};
 
-    use super::{TraceService, normalize_page_size, parse_page_token};
-    use crate::telemetry::TraceManager;
+    use super::{
+        TraceService, normalize_page_size, parse_page_token, trace_invocation_kind_to_proto,
+    };
+    use crate::telemetry::{TraceManager, local_store::StoredTraceInvocationKind};
 
     #[test]
     fn page_size_defaults_and_caps() {
@@ -217,6 +259,22 @@ mod tests {
         assert_eq!(parse_page_token("").expect("empty token"), 0);
         assert_eq!(parse_page_token("25").expect("offset token"), 25);
         parse_page_token("not-an-offset").unwrap_err();
+    }
+
+    #[test]
+    fn invocation_kinds_map_to_wire_values() {
+        assert_eq!(
+            trace_invocation_kind_to_proto(StoredTraceInvocationKind::Unspecified),
+            TraceInvocationKind::Unspecified
+        );
+        assert_eq!(
+            trace_invocation_kind_to_proto(StoredTraceInvocationKind::Direct),
+            TraceInvocationKind::Direct
+        );
+        assert_eq!(
+            trace_invocation_kind_to_proto(StoredTraceInvocationKind::Mcp),
+            TraceInvocationKind::Mcp
+        );
     }
 
     #[tokio::test]
@@ -250,12 +308,33 @@ mod tests {
             response.traces.first().expect("alpha trace").trace_id,
             "alpha-trace"
         );
+        assert_eq!(
+            response.traces.first().expect("alpha trace").operation_kind,
+            TraceOperationKind::Unspecified as i32
+        );
+        assert!(
+            response
+                .traces
+                .first()
+                .expect("alpha trace")
+                .operation_name
+                .is_empty()
+        );
+        assert_eq!(
+            response
+                .traces
+                .first()
+                .expect("alpha trace")
+                .invocation_kind,
+            TraceInvocationKind::Unspecified as i32
+        );
 
         let detail = TraceServiceApi::get_trace(
             &service,
             Request::new(GetTraceRequest {
                 trace_id: "alpha-trace".to_string(),
                 workspace: Some(workspace("alpha")),
+                view: TraceView::Unspecified as i32,
             }),
         )
         .await
@@ -268,11 +347,54 @@ mod tests {
             Request::new(GetTraceRequest {
                 trace_id: "beta-trace".to_string(),
                 workspace: Some(workspace("alpha")),
+                view: TraceView::Unspecified as i32,
             }),
         )
         .await
         .expect_err("beta trace should not match alpha workspace");
         assert_eq!(status.code(), Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn trace_service_projects_query_stream_entries() {
+        let temp = TempDir::new().expect("temp dir");
+        let trace_store = temp.path().join("trace-store");
+        std::fs::create_dir_all(&trace_store).expect("trace store dir");
+        write_query_stream_trace_fixture(&trace_store);
+        let service = TraceService::new(TraceManager::new(trace_store, Duration::from_mins(1)));
+
+        let detail = TraceServiceApi::get_trace(
+            &service,
+            Request::new(GetTraceRequest {
+                trace_id: "shared-trace".to_string(),
+                workspace: Some(workspace("alpha")),
+                view: TraceView::QueryStream as i32,
+            }),
+        )
+        .await
+        .expect("get query stream trace")
+        .into_inner();
+        let summary = detail.summary.expect("query stream detail summary");
+        assert_eq!(summary.root_span_id, "tool-span");
+        assert_eq!(summary.operation_kind, TraceOperationKind::Query as i32);
+        assert_eq!(summary.operation_name, "sql");
+        assert_eq!(summary.invocation_kind, TraceInvocationKind::Mcp as i32);
+        assert_eq!(summary.query, "SELECT 42");
+        assert_eq!(summary.start_time_unix_nanos, 10);
+        assert_eq!(summary.end_time_unix_nanos, 40);
+        assert_eq!(detail.spans.len(), 2);
+
+        let unknown_view = TraceServiceApi::get_trace(
+            &service,
+            Request::new(GetTraceRequest {
+                trace_id: "shared-trace".to_string(),
+                workspace: None,
+                view: 999,
+            }),
+        )
+        .await
+        .expect_err("unknown view is rejected");
+        assert_eq!(unknown_view.code(), Code::InvalidArgument);
     }
 
     fn workspace(name: &str) -> Workspace {
@@ -288,6 +410,49 @@ mod tests {
             lines.push('\n');
         }
         std::fs::write(dir.join("spans-test.jsonl"), lines).expect("write trace records");
+    }
+
+    fn write_query_stream_trace_fixture(trace_store: &std::path::Path) {
+        let mut tool = trace_record_json("shared-trace", "tool-span", "alpha", 10, 40);
+        let tool_object = tool.as_object_mut().expect("tool record object");
+        tool_object.insert("parent_span_id".to_string(), json!("remote-parent"));
+        tool_object.insert("parent_span_is_remote".to_string(), json!(true));
+        tool_object.insert("name".to_string(), json!("coral.mcp.call_tool"));
+        tool_object.insert(
+            "attributes_json".to_string(),
+            json!(
+                json!({
+                    "coral.stream.entry": true,
+                    "coral.stream.kind": "tool",
+                    "coral.stream.name": "sql",
+                    "mcp.method": "tools/call",
+                    "mcp.tool.name": "sql",
+                    "workspace": "alpha",
+                    "status": "ok",
+                })
+                .to_string()
+            ),
+        );
+
+        let mut nested = trace_record_json("shared-trace", "nested-query", "alpha", 20, 30);
+        let nested_object = nested.as_object_mut().expect("nested record object");
+        nested_object.insert("parent_span_id".to_string(), json!("tool-span"));
+        nested_object.insert(
+            "attributes_json".to_string(),
+            json!(
+                json!({
+                    "coral.stream.entry": true,
+                    "coral.stream.kind": "query",
+                    "coral.stream.name": "sql",
+                    "workspace": "alpha",
+                    "sql": "SELECT 42",
+                    "row_count": 1,
+                    "status": "ok",
+                })
+                .to_string()
+            ),
+        );
+        write_trace_records(trace_store, &[tool, nested]);
     }
 
     fn trace_record_json(

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -55,12 +55,13 @@ pub(crate) fn call_tool_span(
     workspace: &str,
     trace_parent: Option<&str>,
 ) -> tracing::Span {
+    let operation_kind = query_stream_kind_for_tool(tool_name);
     let tool_name = tool_name.map_or(UNKNOWN_TOOL_NAME, ToolName::as_str);
     let span = tracing::info_span!(
         target: "coral_mcp::server",
         "coral.mcp.call_tool",
         coral.stream.entry = true,
-        coral.stream.kind = coral_telemetry::QUERY_STREAM_KIND_TOOL,
+        coral.stream.kind = operation_kind,
         coral.stream.name = tool_name,
         error.type = field::Empty,
         exception.message = field::Empty,
@@ -75,6 +76,23 @@ pub(crate) fn call_tool_span(
     span.record(coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE, workspace);
     apply_trace_parent(&span, trace_parent);
     span
+}
+
+fn query_stream_kind_for_tool(tool_name: Option<ToolName>) -> &'static str {
+    match tool_name {
+        Some(ToolName::Sql) => coral_telemetry::QUERY_STREAM_KIND_QUERY,
+        Some(ToolName::Search) => coral_telemetry::QUERY_STREAM_KIND_SEARCH,
+        Some(
+            ToolName::AddFunction
+            | ToolName::ListCatalog
+            | ToolName::DescribeTable
+            | ToolName::ListColumns
+            | ToolName::StartTask
+            | ToolName::EndTask
+            | ToolName::Feedback,
+        )
+        | None => coral_telemetry::QUERY_STREAM_KIND_TOOL,
+    }
 }
 
 pub(crate) fn list_resources_span(trace_parent: Option<&str>) -> tracing::Span {
@@ -174,8 +192,8 @@ mod tests {
     use tracing_subscriber::layer::SubscriberExt as _;
 
     use super::{
-        MCP_TOOL_ERROR_MESSAGE, call_tool_span, list_resources_span, list_tools_span,
-        read_resource_span, record_tonic_status,
+        MCP_TOOL_ERROR_MESSAGE, UNKNOWN_TOOL_NAME, call_tool_span, list_resources_span,
+        list_tools_span, read_resource_span, record_tonic_status,
     };
     use crate::surface::ToolName;
 
@@ -222,6 +240,54 @@ mod tests {
                 .iter()
                 .all(|attribute| !attribute.key.as_str().contains("argument"))
         );
+
+        provider.shutdown().expect("provider shutdown");
+    }
+
+    #[test]
+    fn tool_call_span_records_semantic_capability() {
+        let (exporter, provider, subscriber) = telemetry_fixture();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        for tool_name in [
+            Some(ToolName::Sql),
+            Some(ToolName::Search),
+            Some(ToolName::ListCatalog),
+            None,
+        ] {
+            let span = call_tool_span(tool_name, "alpha", None);
+            span.in_scope(|| {});
+        }
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let expected = [
+            ("sql", coral_telemetry::QUERY_STREAM_KIND_QUERY),
+            ("search", coral_telemetry::QUERY_STREAM_KIND_SEARCH),
+            ("list_catalog", coral_telemetry::QUERY_STREAM_KIND_TOOL),
+            (UNKNOWN_TOOL_NAME, coral_telemetry::QUERY_STREAM_KIND_TOOL),
+        ];
+        for (tool_name, expected_kind) in expected {
+            let tool_call = spans
+                .iter()
+                .find(|span| {
+                    span.name == "coral.mcp.call_tool"
+                        && string_attribute(span, coral_telemetry::QUERY_STREAM_NAME_ATTRIBUTE)
+                            .as_deref()
+                            == Some(tool_name)
+                })
+                .unwrap_or_else(|| panic!("missing {tool_name} tool span"));
+            assert_eq!(
+                string_attribute(tool_call, coral_telemetry::QUERY_STREAM_KIND_ATTRIBUTE)
+                    .as_deref(),
+                Some(expected_kind),
+                "unexpected Query Stream capability for {tool_name}"
+            );
+            assert_eq!(
+                string_attribute(tool_call, "mcp.method").as_deref(),
+                Some("tools/call")
+            );
+        }
 
         provider.shutdown().expect("provider shutdown");
     }

--- a/crates/coral-telemetry/src/lib.rs
+++ b/crates/coral-telemetry/src/lib.rs
@@ -43,11 +43,11 @@ pub const QUERY_STREAM_KIND_ATTRIBUTE: &str = "coral.stream.kind";
 /// Span attribute containing the privacy-safe Query Stream operation name.
 pub const QUERY_STREAM_NAME_ATTRIBUTE: &str = "coral.stream.name";
 
-/// Semantic Query Stream kind for direct SQL and catalog query operations.
+/// Semantic Query Stream kind for SQL and catalog query operations.
 pub const QUERY_STREAM_KIND_QUERY: &str = "query";
-/// Semantic Query Stream kind for direct Universal Search operations.
+/// Semantic Query Stream kind for Universal Search operations.
 pub const QUERY_STREAM_KIND_SEARCH: &str = "search";
-/// Semantic Query Stream kind for MCP tool invocations.
+/// Semantic Query Stream kind for tool operations without a more specific kind.
 pub const QUERY_STREAM_KIND_TOOL: &str = "tool";
 /// Semantic Query Stream kind for another explicitly marked user-visible operation.
 pub const QUERY_STREAM_KIND_OTHER: &str = "other";


### PR DESCRIPTION
## TL;DR

PR #1876 defines the Query Stream operation contract and applies it to trace detail.

SQL remains a Query and Search remains Search whether it was invoked directly through Coral or through MCP. `operation_kind` describes the capability; `invocation_kind` separately records whether the operation was direct or MCP.

For example, an MCP Search for `refund policy` is returned as `SEARCH + MCP`, while its internal `LIST CATALOG` and SQL work remains visible only in the full trace timeline.

## Summary

- add typed Query Stream capability, invocation provenance, and privacy-safe operation name metadata to `TraceSummary`
- classify direct and MCP SQL as Query, and direct and MCP Search as Search
- keep generic MCP calls as Tool even when their implementation contains Query spans
- emit semantic Query/Search markers from new MCP SQL and Search spans
- normalize already-retained and legacy MCP `sql` and `search` spans at read time without a storage migration
- support legacy unmarked Query, Search, and MCP tool spans
- keep explicit and legacy tool-name fallbacks privacy-safe
- project locally retained Search text for direct and MCP Search operations
- prevent Search from inheriting internal `LIST CATALOG` SQL or row counts, ignore row counts attached directly to non-Query operations, and prevent unrelated tools from inheriting nested Search text
- return the projected summary from `GetTrace(view = QUERY_STREAM)` while preserving every trace span in the detail timeline
- preserve the existing diagnostic summary, with unspecified operation and invocation metadata, when no view is requested

## Product contract

- `operation_kind` says what the user did: Query, Search, Tool, or another marked operation.
- `invocation_kind` says how it entered Coral: direct or MCP.
- `operation_name` is a privacy-safe display label; consumers do not need to infer capability from it.
- Query Stream identity remains the distributed `trace_id`.
- Detail returns the full trace timeline, but its summary describes the selected outer operation. Summary duration, status, span count, and text therefore belong to that operation, and `detail.spans.length` can be larger than `summary.span_count`.
- If one remote trace context contains several unrelated visible operations, the newest operation is selected deterministically.

## Stack boundary

- Layer 2 of 4 in the Query Stream stack
- Depends on: #2043
- Next: #2053
- This PR owns operation semantics, invocation provenance, compatibility classification, and Query Stream detail projection. Bounded listing is in #2053; Reef consumption and presentation are in #1904.

## Validation

- `make rust-checks` at the stack tip: passed (format, Clippy, 2,485 tests, rustdoc)
- `make lint-proto`: passed
- `cargo test --locked -p coral-mcp telemetry::tests --lib`: passed (5 tests)
- `cargo test --locked -p coral-app telemetry::local_store::query_stream --lib`: passed (15 tests at this layer; 25 at the stack tip)
- `cargo test --locked -p coral-app telemetry::service::tests --lib`: passed (5 tests)
- `npm run check --prefix apps/reef` at the stack tip: passed
- `npm run typecheck --prefix apps/reef` at the stack tip: passed
- `git diff --check`: passed
