### PR TITLE
ci: gate release automation on validated main

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,9 +52,6 @@ jobs:
 
       - name: Sync Cargo.lock to new workspace version
         if: steps.rp.outputs.pr
-        env:
-          PR_BRANCH: ${{ fromJSON(steps.rp.outputs.pr || '{}').headBranchName }}
-          GH_APP_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
           set -euo pipefail
           cargo update --workspace
@@ -66,7 +63,6 @@ jobs:
           git config user.email "release-please[bot]@users.noreply.github.com"
           git add Cargo.lock
           git commit -m "chore: sync Cargo.lock"
-          git push "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${PR_BRANCH}"
 
       # release-please updates CHANGELOG.md on the release PR, so this
       # is the right place to regenerate the docs page that mirrors it.
@@ -74,9 +70,6 @@ jobs:
       # so docs on `main` do not lag CHANGELOG.md.
       - name: Regenerate changelog docs
         if: steps.rp.outputs.pr
-        env:
-          PR_BRANCH: ${{ fromJSON(steps.rp.outputs.pr || '{}').headBranchName }}
-          GH_APP_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |
           set -euo pipefail
           make docs-generate
@@ -88,4 +81,12 @@ jobs:
           git config user.email "release-please[bot]@users.noreply.github.com"
           git add apps/docs/project/changelog.mdx apps/docs/docs.json
           git commit -m "chore: regenerate changelog docs"
+
+      - name: Push changes
+        if: steps.rp.outputs.pr
+        env:
+          PR_BRANCH: ${{ fromJSON(steps.rp.outputs.pr || '{}').headBranchName }}
+          GH_APP_TOKEN: ${{ steps.github-app-token.outputs.token }}
+        run: |
+          set -euo pipefail
           git push "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${PR_BRANCH}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,7 @@
 name: release-please
 on:
-  push:
-    branches: [main]
+  repository_dispatch:
+    types: [main-validated]
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -31,6 +31,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
+      release_candidate: ${{ steps.release-candidate.outputs.release_candidate }}
       github_actions: ${{ steps.filter.outputs.github_actions }}
       rust_checks: ${{ steps.filter.outputs.rust_checks }}
       postgres_database_tests: ${{ steps.filter.outputs.postgres_database_tests }}
@@ -53,8 +54,32 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Detect changes
+      - name: Detect release candidate changes
+        id: release-filter
+        if: >-
+          ${{ github.event_name == 'pull_request' &&
+              github.event.pull_request.user.login == 'coral-release-bot[bot]' &&
+              github.event.pull_request.base.ref == 'main' &&
+              github.event.pull_request.head.ref == 'release-please--branches--main--components--coral' &&
+              github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            non_release_candidate_artifacts:
+              - '**'
+              - '!{.release-please-manifest.json,CHANGELOG.md,Cargo.lock,Cargo.toml}'
+              - '!apps/desktop/package{,-lock}.json'
+              - '!apps/docs/{docs.json,project/changelog.mdx}'
+
+      - name: Classify Release Please candidate
+        id: release-candidate
+        env:
+          RELEASE_CANDIDATE: ${{ steps.release-filter.outputs.non_release_candidate_artifacts == 'false' }}
+        run: echo "release_candidate=$RELEASE_CANDIDATE" >> "$GITHUB_OUTPUT"
+
+      - name: Detect ordinary changes
         id: filter
+        if: steps.release-candidate.outputs.release_candidate != 'true'
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
@@ -744,12 +769,58 @@ jobs:
             --coral-bin target/release/coral \
             --max-mean-seconds 0.75
 
+  release-candidate-integrity:
+    name: Release candidate integrity
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.release_candidate == 'true' }}
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Verify exact base commit passed Validate on main
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          count="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow validate.yml \
+            --branch main --commit "$BASE_SHA" --event push --status success \
+            --limit 1 --json databaseId --jq length)"
+          if [ "$count" -eq 0 ]; then
+            echo "Base commit $BASE_SHA has not passed Validate on main." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Verify locked Cargo metadata
+        run: |
+          version="$(sed -n 's/^version = "\([^"]*\)" # x-release-please-version$/\1/p' Cargo.toml)"
+          cargo metadata --locked --no-deps --format-version 1 |
+            jq -e --arg version "$version" 'all(.packages[]; .version == $version)' >/dev/null
+          jq -e --arg version "$version" '.["."] == $version' .release-please-manifest.json >/dev/null
+          jq -e --arg version "$version" '.version == $version' apps/desktop/package.json >/dev/null
+          jq -e --arg version "$version" \
+            '.version == $version and .packages[""].version == $version' \
+            apps/desktop/package-lock.json >/dev/null
+
+      - name: Verify generated docs are fresh
+        run: make docs-check
+
   validate:
     runs-on: ubuntu-latest
     needs:
       [
         changes,
+        release-candidate-integrity,
         rust-checks,
+        postgres-database-tests,
         windows-rust-smoke,
         install-script,
         ui-build,
@@ -773,7 +844,9 @@ jobs:
       - name: Check all job results
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
+          RELEASE_CANDIDATE_INTEGRITY_RESULT: ${{ needs.release-candidate-integrity.result }}
           RUST_CHECKS_RESULT: ${{ needs.rust-checks.result }}
+          POSTGRES_DATABASE_TESTS_RESULT: ${{ needs.postgres-database-tests.result }}
           WINDOWS_RUST_SMOKE_RESULT: ${{ needs.windows-rust-smoke.result }}
           INSTALL_SCRIPT_RESULT: ${{ needs.install-script.result }}
           UI_BUILD_RESULT: ${{ needs.ui-build.result }}
@@ -792,7 +865,9 @@ jobs:
         run: |
           jobs=(
             "changes:$CHANGES_RESULT"
+            "release-candidate-integrity:$RELEASE_CANDIDATE_INTEGRITY_RESULT"
             "rust-checks:$RUST_CHECKS_RESULT"
+            "postgres-database-tests:$POSTGRES_DATABASE_TESTS_RESULT"
             "windows-rust-smoke:$WINDOWS_RUST_SMOKE_RESULT"
             "install-script:$INSTALL_SCRIPT_RESULT"
             "ui-build:$UI_BUILD_RESULT"
@@ -830,3 +905,16 @@ jobs:
           if [ $failed -eq 1 ]; then
             exit 1
           fi
+
+  dispatch-release-please:
+    name: Dispatch Release Please
+    runs-on: ubuntu-latest
+    needs: validate
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.validate.result == 'success' }}
+    permissions:
+      contents: write
+    steps:
+      - name: Dispatch validated main commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh api --method POST "repos/${GITHUB_REPOSITORY}/dispatches" -f event_type=main-validated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,14 @@
   replacement skipped run cancels any in-progress validation for the PR branch.
   Keep that draft gate aligned between the initial change detector and final
   aggregate `validate` job.
+- Release Please is dispatched only after the aggregate `Validate` job succeeds
+  for a push to `main`; it does not also poll or re-check the mutable branch tip.
+- Trusted Release Please PRs use a fail-closed validation fast path only when
+  their author, same-repository branch, base branch, and changed-file allowlist
+  all match. The fast path must prove that the exact PR base SHA passed Validate
+  on `main`, check that release versions agree and generated docs are fresh, and
+  remain part of the aggregate required `validate` job. Any classifier mismatch
+  must run the ordinary validation path.
 - `make rust-checks` is the Rust-only local gate and should keep using
   `--all-features`; the embedded UI feature is a normal CLI build surface.
 - The built UI artifact is produced by repo/CI orchestration (`make ui-build`


### PR DESCRIPTION
> [!WARNING]
> This PR has a fundamental flaw. 😢 `release-please` always operates on the head of main, so we hit a race condition if PR A merges, passed validation and triggers `release-please`, but then PR B merges and has not yet completed validation when `release-please` runs. The unvalidated contents of PR B will be included in the release PR, and the release PR could be merged even if PR B subsequently fails to validate.
>
> We could add a SHA guard: pass the SHA of the validated commit in the `main-validated` signal, and abort `release-please` if the current head of main is not that commit. But then we're back to the problem of back-pressure, where a regular drumbeat of merges to main, combined with a slow validate workflow, leads to releases being unmergeable for long periods of time. In that world, we're not materially better off than when we just run the full validate flow on release PRs, except now the workflows are more complex and harder to reason about.

## Summary

Release Please currently starts in parallel with `Validate` after every push to `main`. It can therefore update the release candidate before the corresponding main commit has passed validation, while the generated version files also cause that release PR to repeat expensive Rust, Windows, performance, and desktop packaging checks.

This change makes the ordering explicit: the aggregate `validate` job dispatches Release Please only after a successful push run on `main`, and the Release Please workflow listens for that dispatch instead of the original push.

Trusted Release Please PRs now take a fail-closed integrity path when the bot identity, repository, branch, base branch, and changed-file allowlist all match. That path verifies that the exact PR base SHA has a successful main Validate run, checks that Cargo, Release Please, and desktop versions agree, verifies locked Cargo metadata, and runs the existing generated-docs freshness check. Any classifier mismatch runs the ordinary path-filtered validation instead.

The aggregate `validate` job also now includes the existing Postgres database test job. Without that dependency, downstream automation could be dispatched while Postgres validation was still running or after it had failed.

### Before

<img width="1656" height="738" alt="image" src="https://github.com/user-attachments/assets/723fcebf-ab12-47ca-a951-d9cf2f5142a1" />

### After

<img width="2147" height="1008" alt="image" src="https://github.com/user-attachments/assets/4228c9d7-d301-40b9-a60c-8d241dd9f22a" />


## Validation

- `actionlint`
- `zizmor --no-progress .github/workflows/validate.yml .github/workflows/release-please.yml`
- `git diff --check`
- Exact-base successful-run lookup against PR #1759's main base SHA
- Release-candidate version coherence, locked Cargo metadata, and `make docs-check` against the actual PR #1759 checkout
