### PR TITLE
feat(reef): authenticate server-side Coral requests

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -596,6 +596,10 @@ describe('Architectural Tests', () => {
       expect(extractImports(requestClient)).toContain('@connectrpc/connect-web')
       expect(requestClient).toMatch(/export function sourceClientForRequest\s*\(/)
       expect(requestClient).toMatch(/export function traceClientForRequest\s*\(/)
+      expect(requestClient).toMatch(/interceptors:\s*accessToken\s*\?\s*\[bearerAuthInterceptor/)
+      expect(requestClient).toContain(
+        "rpcRequest.header.set('Authorization', `Bearer ${accessToken}`)",
+      )
     })
 
     it('retains root sidebar hydration without warming a browser Coral runtime', () => {

--- a/apps/reef/app/auth/server-context.test-helper.ts
+++ b/apps/reef/app/auth/server-context.test-helper.ts
@@ -1,0 +1,37 @@
+import { RouterContextProvider } from 'react-router'
+
+import { requestAuthContext } from './server-context'
+
+export function authTestContext(accessToken: string | null = 'test-coral-token') {
+  const context = new RouterContextProvider()
+  if (!accessToken) {
+    context.set(requestAuthContext, { accessToken: null, mode: 'disabled' })
+    return context
+  }
+
+  context.set(requestAuthContext, {
+    accessToken,
+    mode: 'required',
+    session: {
+      accessToken,
+      expiresAt: 4_102_444_800,
+      tokenType: 'Bearer',
+    },
+  })
+  return context
+}
+
+export function authRouteTestArgs<Params>(
+  request: Request,
+  params: Params,
+  accessToken: string | null = 'test-coral-token',
+) {
+  const url = new URL(request.url)
+  return {
+    context: authTestContext(accessToken),
+    params,
+    pattern: url.pathname,
+    request,
+    url,
+  }
+}

--- a/apps/reef/app/lib/coral-request.server.test.ts
+++ b/apps/reef/app/lib/coral-request.server.test.ts
@@ -1,0 +1,85 @@
+import type { Interceptor } from '@connectrpc/connect'
+import type { GrpcWebTransportOptions } from '@connectrpc/connect-web'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const transportMocks = vi.hoisted(() => ({
+  createClient: vi.fn((_service, transport) => transport),
+  createGrpcWebTransport: vi.fn((options) => options),
+}))
+
+vi.mock('@connectrpc/connect', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@connectrpc/connect')>()),
+  createClient: transportMocks.createClient,
+}))
+vi.mock('@connectrpc/connect-web', () => ({
+  createGrpcWebTransport: transportMocks.createGrpcWebTransport,
+}))
+
+import {
+  catalogClientForRequest,
+  queryClientForRequest,
+  sourceClientForRequest,
+  traceClientForRequest,
+  workspaceClientForRequest,
+} from './coral-request.server'
+
+const request = new Request('http://localhost:5173/workspaces/analytics/sources')
+const clientFactories = [
+  catalogClientForRequest,
+  queryClientForRequest,
+  sourceClientForRequest,
+  traceClientForRequest,
+  workspaceClientForRequest,
+]
+
+describe('request-scoped Coral transport authentication', () => {
+  beforeEach(() => {
+    vi.stubEnv('CORAL_ENDPOINT', 'https://coral.example.test')
+    transportMocks.createClient.mockClear()
+    transportMocks.createGrpcWebTransport.mockClear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('adds the server-held bearer token to every Coral RPC', async () => {
+    for (const clientFactory of clientFactories) {
+      const transport = clientFactory(
+        request,
+        'coral-access-token',
+      ) as unknown as GrpcWebTransportOptions
+      const [interceptor] = transport.interceptors ?? []
+
+      expect(interceptor).toBeTypeOf('function')
+      expect(await authorizationHeader(interceptor)).toBe('Bearer coral-access-token')
+    }
+  })
+
+  it('keeps local and desktop Coral RPCs unauthenticated', () => {
+    vi.stubEnv('CORAL_ENDPOINT', 'http://127.0.0.1:50051')
+
+    for (const clientFactory of clientFactories) {
+      const transport = clientFactory(request, null) as unknown as GrpcWebTransportOptions
+
+      expect(transport.interceptors).toBeUndefined()
+    }
+  })
+
+  it('rejects cleartext Coral endpoints before attaching a bearer token', () => {
+    vi.stubEnv('CORAL_ENDPOINT', 'http://coral.example.test')
+
+    expect(() => sourceClientForRequest(request, 'coral-access-token')).toThrow(
+      'CORAL_ENDPOINT must use HTTPS when Coral authentication is enabled',
+    )
+    expect(transportMocks.createGrpcWebTransport).not.toHaveBeenCalled()
+  })
+})
+
+async function authorizationHeader(interceptor: Interceptor): Promise<string | null> {
+  const next = vi.fn(async (rpcRequest) => rpcRequest)
+  const rpcRequest = { header: new Headers() }
+
+  await interceptor(next as never)(rpcRequest as never)
+  return rpcRequest.header.get('Authorization')
+}

--- a/apps/reef/app/lib/coral-request.server.ts
+++ b/apps/reef/app/lib/coral-request.server.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@connectrpc/connect'
+import { createClient, type Interceptor } from '@connectrpc/connect'
 import { createGrpcWebTransport } from '@connectrpc/connect-web'
 
 import { CatalogService } from '@/generated/coral/v1/catalog_pb'
@@ -10,30 +10,24 @@ import { WorkspaceService } from '@/generated/coral/v1/workspaces_pb'
 import { DEFAULT_DEV_CORAL_ENDPOINT } from './constants'
 import { isLocalDevOrigin, trimTrailingSlash } from './utils'
 
-export function sourceClientForRequest(request: Request) {
-  return createClient(SourceService, coralTransportForRequest(request))
+export function sourceClientForRequest(request: Request, accessToken: string | null) {
+  return createClient(SourceService, coralTransportForRequest(request, accessToken))
 }
 
-export function workspaceClientForRequest(request: Request) {
-  return createClient(WorkspaceService, coralTransportForRequest(request))
+export function workspaceClientForRequest(request: Request, accessToken: string | null) {
+  return createClient(WorkspaceService, coralTransportForRequest(request, accessToken))
 }
 
-export function catalogClientForRequest(request: Request) {
-  return createClient(
-    CatalogService,
-    createGrpcWebTransport({ baseUrl: coralEndpointForRequest(request) }),
-  )
+export function catalogClientForRequest(request: Request, accessToken: string | null) {
+  return createClient(CatalogService, coralTransportForRequest(request, accessToken))
 }
 
-export function queryClientForRequest(request: Request) {
-  return createClient(
-    QueryService,
-    createGrpcWebTransport({ baseUrl: coralEndpointForRequest(request) }),
-  )
+export function queryClientForRequest(request: Request, accessToken: string | null) {
+  return createClient(QueryService, coralTransportForRequest(request, accessToken))
 }
 
-export function traceClientForRequest(request: Request) {
-  return createClient(TraceService, coralTransportForRequest(request))
+export function traceClientForRequest(request: Request, accessToken: string | null) {
+  return createClient(TraceService, coralTransportForRequest(request, accessToken))
 }
 
 export function coralEndpointForRequest(request: Request): string {
@@ -49,6 +43,21 @@ export function coralEndpointForRequest(request: Request): string {
   return url.origin
 }
 
-function coralTransportForRequest(request: Request) {
-  return createGrpcWebTransport({ baseUrl: coralEndpointForRequest(request) })
+function coralTransportForRequest(request: Request, accessToken: string | null) {
+  const baseUrl = coralEndpointForRequest(request)
+  if (accessToken && new URL(baseUrl).protocol !== 'https:') {
+    throw new Error('CORAL_ENDPOINT must use HTTPS when Coral authentication is enabled')
+  }
+
+  return createGrpcWebTransport({
+    baseUrl,
+    interceptors: accessToken ? [bearerAuthInterceptor(accessToken)] : undefined,
+  })
+}
+
+function bearerAuthInterceptor(accessToken: string): Interceptor {
+  return (next) => async (rpcRequest) => {
+    rpcRequest.header.set('Authorization', `Bearer ${accessToken}`)
+    return next(rpcRequest)
+  }
 }

--- a/apps/reef/app/lib/onboarding-query.server.test.ts
+++ b/apps/reef/app/lib/onboarding-query.server.test.ts
@@ -1,10 +1,16 @@
 import { tableFromArrays, tableToIPC } from 'apache-arrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { executeSql } = vi.hoisted(() => ({ executeSql: vi.fn() }))
+const { executeSql, queryClientForRequest } = vi.hoisted(() => {
+  const executeSqlMock = vi.fn()
+  return {
+    executeSql: executeSqlMock,
+    queryClientForRequest: vi.fn(() => ({ executeSql: executeSqlMock })),
+  }
+})
 
 vi.mock('@/lib/coral-request.server', () => ({
-  queryClientForRequest: () => ({ executeSql }),
+  queryClientForRequest,
 }))
 
 import { ONBOARDING_SAMPLE_QUERY } from './onboarding-query'
@@ -13,7 +19,10 @@ import {
   loadOnboardingSampleQuery,
 } from './onboarding-query.server'
 
-beforeEach(() => executeSql.mockReset())
+beforeEach(() => {
+  executeSql.mockReset()
+  queryClientForRequest.mockClear()
+})
 
 describe('decodeOnboardingSampleQueryRows', () => {
   it('decodes the source counts returned by the onboarding query', () => {
@@ -48,12 +57,17 @@ describe('loadOnboardingSampleQuery', () => {
     })
 
     await expect(
-      loadOnboardingSampleQuery(new Request('http://reef.test/onboarding?step=query'), 'analytics'),
+      loadOnboardingSampleQuery(
+        new Request('http://reef.test/onboarding?step=query'),
+        'coral-access-token',
+        'analytics',
+      ),
     ).resolves.toEqual({
       rows: [{ source: 'github', tables: '3' }],
       status: 'success',
     })
     expect(executeSql).toHaveBeenCalledOnce()
+    expect(queryClientForRequest).toHaveBeenCalledWith(expect.any(Request), 'coral-access-token')
     expect(executeSql.mock.calls[0]?.[0]).toMatchObject({
       sql: ONBOARDING_SAMPLE_QUERY,
       workspace: { name: 'analytics' },
@@ -66,7 +80,11 @@ describe('loadOnboardingSampleQuery', () => {
     })
 
     await expect(
-      loadOnboardingSampleQuery(new Request('http://reef.test/onboarding?step=query'), 'analytics'),
+      loadOnboardingSampleQuery(
+        new Request('http://reef.test/onboarding?step=query'),
+        'coral-access-token',
+        'analytics',
+      ),
     ).resolves.toEqual({
       message: 'The sample query returned an unexpected result shape.',
       status: 'error',

--- a/apps/reef/app/lib/onboarding-query.server.ts
+++ b/apps/reef/app/lib/onboarding-query.server.ts
@@ -14,10 +14,11 @@ import { errorMessage } from './utils'
 
 export async function loadOnboardingSampleQuery(
   request: Request,
+  accessToken: string | null,
   workspaceId: string,
 ): Promise<OnboardingSampleQueryResult> {
   try {
-    const response = await queryClientForRequest(request).executeSql(
+    const response = await queryClientForRequest(request, accessToken).executeSql(
       create(ExecuteSqlRequestSchema, {
         sql: ONBOARDING_SAMPLE_QUERY,
         workspace: create(WorkspaceSchema, { name: workspaceId }),

--- a/apps/reef/app/lib/workspace-redirect.server.test.ts
+++ b/apps/reef/app/lib/workspace-redirect.server.test.ts
@@ -17,9 +17,11 @@ describe('redirectToFirstWorkspaceSources', () => {
   it('redirects the app index to the first workspace sources and preserves its query', async () => {
     const response = await redirectToFirstWorkspaceSources(
       new Request('http://localhost/?from=index'),
+      'coral-access-token',
     )
 
     expect(response.status).toBe(302)
     expect(response.headers.get('location')).toBe('/workspaces/team%20alpha/sources?from=index')
+    expect(firstWorkspaceForRequest).toHaveBeenCalledWith(expect.any(Request), 'coral-access-token')
   })
 })

--- a/apps/reef/app/lib/workspace-redirect.server.ts
+++ b/apps/reef/app/lib/workspace-redirect.server.ts
@@ -3,8 +3,11 @@ import { redirect } from 'react-router'
 import { firstWorkspaceForRequest } from '@/lib/workspaces.server'
 import { routePath } from '@/routing/routemap'
 
-export async function redirectToFirstWorkspaceSources(request: Request): Promise<Response> {
-  const workspace = await firstWorkspaceForRequest(request)
+export async function redirectToFirstWorkspaceSources(
+  request: Request,
+  accessToken: string | null,
+): Promise<Response> {
+  const workspace = await firstWorkspaceForRequest(request, accessToken)
   const search = new URL(request.url).search
   return redirect(`${routePath('workspaceSources', { workspaceId: workspace.name })}${search}`)
 }

--- a/apps/reef/app/lib/workspaces.server.test.ts
+++ b/apps/reef/app/lib/workspaces.server.test.ts
@@ -22,18 +22,22 @@ describe('local workspaces', () => {
       workspaces: [{ name: 'default' }, { name: 'analytics' }],
     })
 
-    await expect(listWorkspacesForRequest(request)).resolves.toEqual([
+    await expect(listWorkspacesForRequest(request, 'coral-access-token')).resolves.toEqual([
       { name: 'default' },
       { name: 'analytics' },
     ])
-    await expect(firstWorkspaceForRequest(request)).resolves.toEqual({ name: 'default' })
-    expect(workspaceClientForRequest).toHaveBeenCalledWith(request)
+    await expect(firstWorkspaceForRequest(request, 'coral-access-token')).resolves.toEqual({
+      name: 'default',
+    })
+    expect(workspaceClientForRequest).toHaveBeenCalledWith(request, 'coral-access-token')
   })
 
   it('returns a clear route error when no local workspace exists', async () => {
     listWorkspaces.mockResolvedValue({ workspaces: [] })
 
-    await expect(firstWorkspaceForRequest(new Request('http://localhost/'))).rejects.toMatchObject({
+    await expect(
+      firstWorkspaceForRequest(new Request('http://localhost/'), null),
+    ).rejects.toMatchObject({
       status: 404,
       statusText: 'Workspace Not Found',
     })

--- a/apps/reef/app/lib/workspaces.server.ts
+++ b/apps/reef/app/lib/workspaces.server.ts
@@ -5,13 +5,19 @@ import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { CreateWorkspaceRequestSchema } from '@/generated/coral/v1/workspaces_pb'
 import { workspaceClientForRequest } from '@/lib/coral-request.server'
 
-export async function listWorkspacesForRequest(request: Request): Promise<Workspace[]> {
-  const response = await workspaceClientForRequest(request).listWorkspaces({})
+export async function listWorkspacesForRequest(
+  request: Request,
+  accessToken: string | null,
+): Promise<Workspace[]> {
+  const response = await workspaceClientForRequest(request, accessToken).listWorkspaces({})
   return response.workspaces
 }
 
-export async function firstWorkspaceForRequest(request: Request): Promise<Workspace> {
-  const [workspace] = await listWorkspacesForRequest(request)
+export async function firstWorkspaceForRequest(
+  request: Request,
+  accessToken: string | null,
+): Promise<Workspace> {
+  const [workspace] = await listWorkspacesForRequest(request, accessToken)
   if (workspace) return workspace
 
   throw new Response('No Coral workspace is configured.', {
@@ -22,9 +28,10 @@ export async function firstWorkspaceForRequest(request: Request): Promise<Worksp
 
 export async function createWorkspaceForRequest(
   request: Request,
+  accessToken: string | null,
   name: string,
 ): Promise<Workspace> {
-  const response = await workspaceClientForRequest(request).createWorkspace(
+  const response = await workspaceClientForRequest(request, accessToken).createWorkspace(
     create(CreateWorkspaceRequestSchema, {
       workspace: create(WorkspaceSchema, { name }),
     }),

--- a/apps/reef/app/routes/app-shell.server.test.ts
+++ b/apps/reef/app/routes/app-shell.server.test.ts
@@ -6,6 +6,7 @@ const { listWorkspacesForRequest } = vi.hoisted(() => ({
 
 vi.mock('@/lib/workspaces.server', () => ({ listWorkspacesForRequest }))
 
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
 import { routePath } from '@/routing/routemap'
 
 import { loader } from './app-shell'
@@ -24,18 +25,16 @@ describe('app shell loader', () => {
     const workspaces = [{ name: 'default' }, { name: 'analytics' }]
     listWorkspacesForRequest.mockResolvedValue(workspaces)
 
-    await expect(loader({ request } as Parameters<typeof loader>[0])).resolves.toEqual({
+    await expect(loader(authRouteTestArgs(request, {}, 'coral-access-token'))).resolves.toEqual({
       workspaces,
     })
     expect(listWorkspacesForRequest).toHaveBeenCalledOnce()
-    expect(listWorkspacesForRequest).toHaveBeenCalledWith(request)
+    expect(listWorkspacesForRequest).toHaveBeenCalledWith(request, 'coral-access-token')
   })
 
   it('leaves workspace lookup to the index redirect loader', async () => {
     await expect(
-      loader({
-        request: new Request(`http://reef.test${routePath('home')}`),
-      } as Parameters<typeof loader>[0]),
+      loader(authRouteTestArgs(new Request(`http://reef.test${routePath('home')}`), {})),
     ).resolves.toEqual({ workspaces: [] })
     expect(listWorkspacesForRequest).not.toHaveBeenCalled()
   })
@@ -46,9 +45,7 @@ describe('app shell loader', () => {
     listWorkspacesForRequest.mockRejectedValue(error)
 
     await expect(
-      loader({
-        request: new Request('http://reef.test/workspaces/default/sources'),
-      } as Parameters<typeof loader>[0]),
+      loader(authRouteTestArgs(new Request('http://reef.test/workspaces/default/sources'), {})),
     ).resolves.toEqual({ workspaces: [] })
     expect(consoleError).toHaveBeenCalledWith('Failed to load sidebar workspaces:', error)
   })

--- a/apps/reef/app/routes/app-shell.tsx
+++ b/apps/reef/app/routes/app-shell.tsx
@@ -4,6 +4,7 @@ import type { Route } from './+types/app-shell'
 
 import { ContentContainer } from '@/components/content-container'
 import { Sidebar } from '@/components/sidebar'
+import { requestAuthContext } from '@/auth/server-context'
 import { listWorkspacesForRequest } from '@/lib/workspaces.server'
 import { routePath } from '@/routing/routemap'
 import { ToastContainer } from '@/wax/components/toast'
@@ -14,11 +15,16 @@ interface RootLoaderData {
   sidebarIsMinimized: boolean
 }
 
-export async function loader({ request }: Route.LoaderArgs) {
+export async function loader({ context, request }: Route.LoaderArgs) {
   if (isWorkspaceRedirectRoute(request)) return { workspaces: [] }
 
   try {
-    return { workspaces: await listWorkspacesForRequest(request) }
+    return {
+      workspaces: await listWorkspacesForRequest(
+        request,
+        context.get(requestAuthContext).accessToken,
+      ),
+    }
   } catch (error) {
     console.error('Failed to load sidebar workspaces:', error)
     return { workspaces: [] }

--- a/apps/reef/app/routes/index.tsx
+++ b/apps/reef/app/routes/index.tsx
@@ -1,9 +1,10 @@
 import type { Route } from './+types/index'
 
+import { requestAuthContext } from '@/auth/server-context'
 import { redirectToFirstWorkspaceSources } from '@/lib/workspace-redirect.server'
 
-export async function loader({ request }: Route.LoaderArgs) {
-  return redirectToFirstWorkspaceSources(request)
+export async function loader({ context, request }: Route.LoaderArgs) {
+  return redirectToFirstWorkspaceSources(request, context.get(requestAuthContext).accessToken)
 }
 
 export default function AppIndex() {

--- a/apps/reef/app/routes/onboarding.server.test.ts
+++ b/apps/reef/app/routes/onboarding.server.test.ts
@@ -1,0 +1,75 @@
+import { create } from '@bufbuild/protobuf'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  firstWorkspaceForRequest,
+  loadOnboardingSampleQuery,
+  loadSourcesRouteData,
+  runSourcesAction,
+} = vi.hoisted(() => ({
+  firstWorkspaceForRequest: vi.fn(),
+  loadOnboardingSampleQuery: vi.fn(),
+  loadSourcesRouteData: vi.fn(),
+  runSourcesAction: vi.fn(),
+}))
+
+vi.mock('@/lib/workspaces.server', () => ({ firstWorkspaceForRequest }))
+vi.mock('@/lib/onboarding-query.server', () => ({ loadOnboardingSampleQuery }))
+vi.mock('./sources-loader', () => ({ loadSourcesRouteData }))
+vi.mock('./sources-action', () => ({ runSourcesAction }))
+
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
+import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
+
+import { action, loader } from './onboarding'
+
+const workspace = create(WorkspaceSchema, { name: 'analytics' })
+
+describe('onboarding route authentication', () => {
+  beforeEach(() => {
+    firstWorkspaceForRequest.mockReset()
+    loadOnboardingSampleQuery.mockReset()
+    loadSourcesRouteData.mockReset()
+    runSourcesAction.mockReset()
+    firstWorkspaceForRequest.mockResolvedValue(workspace)
+    loadSourcesRouteData.mockResolvedValue({
+      entries: [{ installed: true, name: 'github' }],
+      loadError: null,
+    })
+    loadOnboardingSampleQuery.mockResolvedValue({ rows: [], status: 'success' })
+  })
+
+  it('passes the hosted token through workspace, source, and query loading', async () => {
+    const request = new Request('http://reef.test/onboarding?step=query')
+
+    await loader(authRouteTestArgs(request, {}, 'coral-access-token'))
+
+    expect(firstWorkspaceForRequest).toHaveBeenCalledWith(request, 'coral-access-token')
+    expect(loadSourcesRouteData).toHaveBeenCalledWith(request, workspace, 'coral-access-token')
+    expect(loadOnboardingSampleQuery).toHaveBeenCalledWith(
+      request,
+      'coral-access-token',
+      'analytics',
+    )
+  })
+
+  it('keeps local onboarding requests unauthenticated', async () => {
+    const request = new Request('http://reef.test/onboarding?step=sources')
+
+    await loader(authRouteTestArgs(request, {}, null))
+
+    expect(firstWorkspaceForRequest).toHaveBeenCalledWith(request, null)
+    expect(loadSourcesRouteData).toHaveBeenCalledWith(request, workspace, null)
+    expect(loadOnboardingSampleQuery).not.toHaveBeenCalled()
+  })
+
+  it('passes the hosted token through source actions', async () => {
+    const request = new Request('http://reef.test/onboarding', { method: 'POST' })
+    runSourcesAction.mockResolvedValue({ ok: true })
+
+    await action(authRouteTestArgs(request, {}, 'coral-access-token'))
+
+    expect(firstWorkspaceForRequest).toHaveBeenCalledWith(request, 'coral-access-token')
+    expect(runSourcesAction).toHaveBeenCalledWith(request, workspace, 'coral-access-token')
+  })
+})

--- a/apps/reef/app/routes/onboarding.tsx
+++ b/apps/reef/app/routes/onboarding.tsx
@@ -1,6 +1,7 @@
 import type { Route } from './+types/onboarding'
 import type { SourcesActionData } from './sources-action'
 
+import { requestAuthContext } from '@/auth/server-context'
 import { getOnboardingStepState } from '@/components/onboarding/onboarding-steps'
 import { loadOnboardingSampleQuery } from '@/lib/onboarding-query.server'
 import { firstWorkspaceForRequest } from '@/lib/workspaces.server'
@@ -9,9 +10,10 @@ import { OnboardingView } from '@/views/onboarding/onboarding'
 import { runSourcesAction } from './sources-action'
 import { loadSourcesRouteData } from './sources-loader'
 
-export async function loader({ request }: Route.LoaderArgs) {
-  const workspace = await firstWorkspaceForRequest(request)
-  const sources = await loadSourcesRouteData(request, workspace)
+export async function loader({ context, request }: Route.LoaderArgs) {
+  const accessToken = context.get(requestAuthContext).accessToken
+  const workspace = await firstWorkspaceForRequest(request, accessToken)
+  const sources = await loadSourcesRouteData(request, workspace, accessToken)
   const step = getOnboardingStepState(new URL(request.url).searchParams.get('step'))
   const shouldRunSampleQuery =
     step.step === 'query' &&
@@ -20,14 +22,21 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   return {
     ...sources,
-    sampleQuery: shouldRunSampleQuery ? loadOnboardingSampleQuery(request, workspace.name) : null,
+    sampleQuery: shouldRunSampleQuery
+      ? loadOnboardingSampleQuery(request, accessToken, workspace.name)
+      : null,
     step,
     workspaceId: workspace.name,
   }
 }
 
-export async function action({ request }: Route.ActionArgs): Promise<SourcesActionData> {
-  return runSourcesAction(request, await firstWorkspaceForRequest(request))
+export async function action({ context, request }: Route.ActionArgs): Promise<SourcesActionData> {
+  const accessToken = context.get(requestAuthContext).accessToken
+  return runSourcesAction(
+    request,
+    await firstWorkspaceForRequest(request, accessToken),
+    accessToken,
+  )
 }
 
 export default function OnboardingRoute({ actionData, loaderData }: Route.ComponentProps) {

--- a/apps/reef/app/routes/schema-loaders.server.test.ts
+++ b/apps/reef/app/routes/schema-loaders.server.test.ts
@@ -11,6 +11,8 @@ const { catalogClientForRequest, fetchSchemaFromCoral, fetchTableColumnsFromCora
 vi.mock('@/lib/coral-request.server', () => ({ catalogClientForRequest }))
 vi.mock('@/lib/schema-explorer', () => ({ fetchSchemaFromCoral, fetchTableColumnsFromCoral }))
 
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
+
 import { loader as schemaLoader } from './schema'
 import { loader as schemaTableLoader } from './schema-table'
 
@@ -28,15 +30,14 @@ describe('schema loaders', () => {
     fetchSchemaFromCoral.mockResolvedValue(schema)
 
     await expect(
-      schemaLoader({ params: { workspaceId: 'analytics' }, request } as Parameters<
-        typeof schemaLoader
-      >[0]),
+      schemaLoader(authRouteTestArgs(request, { workspaceId: 'analytics' })),
     ).resolves.toEqual({ schema })
     expect(fetchSchemaFromCoral).toHaveBeenCalledWith(
       catalogClient,
       expect.objectContaining({ name: 'analytics' }),
       request.signal,
     )
+    expect(catalogClientForRequest).toHaveBeenCalledWith(request, 'test-coral-token')
   })
 
   it('lists table columns for the workspace route parameter', async () => {
@@ -44,14 +45,13 @@ describe('schema loaders', () => {
     fetchTableColumnsFromCoral.mockResolvedValue([])
 
     await expect(
-      schemaTableLoader({
-        params: {
+      schemaTableLoader(
+        authRouteTestArgs(request, {
           schemaName: 'github',
           tableName: 'issues',
           workspaceId: 'analytics',
-        },
-        request,
-      } as Parameters<typeof schemaTableLoader>[0]),
+        }),
+      ),
     ).resolves.toEqual({ columns: [] })
     expect(fetchTableColumnsFromCoral).toHaveBeenCalledWith(
       catalogClient,
@@ -60,5 +60,6 @@ describe('schema loaders', () => {
       'issues',
       request.signal,
     )
+    expect(catalogClientForRequest).toHaveBeenCalledWith(request, 'test-coral-token')
   })
 })

--- a/apps/reef/app/routes/schema-table.tsx
+++ b/apps/reef/app/routes/schema-table.tsx
@@ -1,4 +1,5 @@
 import { fetchTableColumnsFromCoral } from '@/lib/schema-explorer'
+import { requestAuthContext } from '@/auth/server-context'
 import { catalogClientForRequest } from '@/lib/coral-request.server'
 import { workspaceFromParams } from '@/lib/workspace-routing'
 import { SchemaTableError, SchemaTableView } from '@/views/schema-explorer/schema-table'
@@ -12,11 +13,11 @@ import type { Route } from './+types/schema-table'
 // The abort signal matters: large tables fan out concurrent paginated
 // ListColumns calls, so switching tables quickly would otherwise pile up
 // orphaned requests.
-export async function loader({ params, request }: Route.LoaderArgs) {
+export async function loader({ context, params, request }: Route.LoaderArgs) {
   const workspace = workspaceFromParams(params)
   return {
     columns: await fetchTableColumnsFromCoral(
-      catalogClientForRequest(request),
+      catalogClientForRequest(request, context.get(requestAuthContext).accessToken),
       workspace,
       params.schemaName,
       params.tableName,

--- a/apps/reef/app/routes/schema.tsx
+++ b/apps/reef/app/routes/schema.tsx
@@ -1,4 +1,5 @@
 import { fetchSchemaFromCoral } from '@/lib/schema-explorer'
+import { requestAuthContext } from '@/auth/server-context'
 import { catalogClientForRequest } from '@/lib/coral-request.server'
 import { workspaceFromParams } from '@/lib/workspace-routing'
 import { SchemaExplorer, SchemaExplorerError } from '@/views/schema-explorer/schema'
@@ -9,10 +10,14 @@ import type { Route } from './+types/schema'
 // global navigation progress bar is the pending UI and a failure lands in the
 // route ErrorBoundary. The abort signal cancels the catalog request when the
 // navigation is superseded.
-export async function loader({ params, request }: Route.LoaderArgs) {
+export async function loader({ context, params, request }: Route.LoaderArgs) {
   const workspace = workspaceFromParams(params)
   return {
-    schema: await fetchSchemaFromCoral(catalogClientForRequest(request), workspace, request.signal),
+    schema: await fetchSchemaFromCoral(
+      catalogClientForRequest(request, context.get(requestAuthContext).accessToken),
+      workspace,
+      request.signal,
+    ),
   }
 }
 

--- a/apps/reef/app/routes/source-detail.server.test.tsx
+++ b/apps/reef/app/routes/source-detail.server.test.tsx
@@ -1,0 +1,52 @@
+import { create } from '@bufbuild/protobuf'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSource, getSourceInfo, sourceClientForRequest } = vi.hoisted(() => {
+  const getSourceMock = vi.fn()
+  const getSourceInfoMock = vi.fn()
+  return {
+    getSource: getSourceMock,
+    getSourceInfo: getSourceInfoMock,
+    sourceClientForRequest: vi.fn(() => ({
+      getSource: getSourceMock,
+      getSourceInfo: getSourceInfoMock,
+    })),
+  }
+})
+
+vi.mock('@/lib/coral-request.server', () => ({ sourceClientForRequest }))
+
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
+import { SourceInfoSchema, SourceOrigin } from '@/generated/coral/v1/sources_pb'
+
+import { loader } from './source-detail'
+
+describe('source detail loader authentication', () => {
+  beforeEach(() => {
+    getSource.mockReset()
+    getSourceInfo.mockReset()
+    sourceClientForRequest.mockClear()
+    getSource.mockResolvedValue({ source: undefined })
+    getSourceInfo.mockResolvedValue({
+      sourceInfo: create(SourceInfoSchema, {
+        installed: false,
+        name: 'github',
+        origin: SourceOrigin.BUNDLED,
+      }),
+    })
+  })
+
+  it.each([
+    ['hosted', 'coral-access-token'],
+    ['local', null],
+  ])('passes the %s request token to Coral', async (_mode, accessToken) => {
+    const request = new Request('http://reef.test/workspaces/analytics/sources/github')
+
+    const result = await loader(
+      authRouteTestArgs(request, { sourceName: 'github', workspaceId: 'analytics' }, accessToken),
+    )
+
+    expect(sourceClientForRequest).toHaveBeenCalledWith(request, accessToken)
+    expect(result.entry).toMatchObject({ installed: false, name: 'github' })
+  })
+})

--- a/apps/reef/app/routes/source-detail.tsx
+++ b/apps/reef/app/routes/source-detail.tsx
@@ -3,6 +3,7 @@ import { create } from '@bufbuild/protobuf'
 import type { Route } from './+types/source-detail'
 import { action as sourcesAction, type SourcesActionData } from './sources-action'
 
+import { requestAuthContext } from '@/auth/server-context'
 import {
   GetSourceInfoRequestSchema,
   GetSourceRequestSchema,
@@ -28,6 +29,7 @@ interface SourceDetailRouteData {
 }
 
 export async function loader({
+  context,
   params,
   request,
 }: Route.LoaderArgs): Promise<SourceDetailRouteData> {
@@ -40,7 +42,7 @@ export async function loader({
     }
   }
 
-  const sourceClient = sourceClientForRequest(request)
+  const sourceClient = sourceClientForRequest(request, context.get(requestAuthContext).accessToken)
   const [sourceResult, infoResult] = await Promise.allSettled([
     getInstalledSource(sourceClient, workspace, name),
     getSourceInfo(sourceClient, workspace, name),

--- a/apps/reef/app/routes/source-oauth-install.server.test.ts
+++ b/apps/reef/app/routes/source-oauth-install.server.test.ts
@@ -24,6 +24,7 @@ import {
   type CreateBundledSourceWithOAuthResponse,
 } from '@/generated/coral/v1/sources_pb'
 import type { OAuthInstallStreamEvent } from '@/lib/source-oauth-install-stream'
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
 
 import { action, relayOAuthInstallStreamEvents } from './source-oauth-install'
 
@@ -83,10 +84,9 @@ describe('action', () => {
       },
     )
 
-    const response = await action({
-      params: { sourceName: 'github', workspaceId: 'analytics' },
-      request,
-    } as Parameters<typeof action>[0])
+    const response = await action(
+      authRouteTestArgs(request, { sourceName: 'github', workspaceId: 'analytics' }),
+    )
     await response.text()
 
     expect(getSourceInfo).toHaveBeenCalledWith(

--- a/apps/reef/app/routes/source-oauth-install.ts
+++ b/apps/reef/app/routes/source-oauth-install.ts
@@ -2,6 +2,7 @@ import { create } from '@bufbuild/protobuf'
 
 import type { Route } from './+types/source-oauth-install'
 
+import { requestAuthContext } from '@/auth/server-context'
 import {
   CreateBundledSourceWithOAuthRequestSchema,
   GetSourceInfoRequestSchema,
@@ -35,7 +36,7 @@ const NDJSON_HEADERS = {
 // interactive OAuth/device-code installs need browser-visible server-streaming
 // progress. The browser fetches this same-origin endpoint; it never imports or
 // calls Coral's gRPC-Web client directly.
-export async function action({ params, request }: Route.ActionArgs): Promise<Response> {
+export async function action({ context, params, request }: Route.ActionArgs): Promise<Response> {
   const formData = await request.formData()
   let name: string
   try {
@@ -46,7 +47,7 @@ export async function action({ params, request }: Route.ActionArgs): Promise<Res
     return ndjsonErrorResponse(errorMessage(error), 400)
   }
 
-  const sourceClient = sourceClientForRequest(request)
+  const sourceClient = sourceClientForRequest(request, context.get(requestAuthContext).accessToken)
   try {
     const workspace = workspaceFromParams(params)
     const info = await getSourceInfo(sourceClient, name, workspace)

--- a/apps/reef/app/routes/sources-action.server.test.ts
+++ b/apps/reef/app/routes/sources-action.server.test.ts
@@ -1,10 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { deleteSource } = vi.hoisted(() => ({ deleteSource: vi.fn() }))
+const { deleteSource, sourceClientForRequest } = vi.hoisted(() => {
+  const deleteSourceMock = vi.fn()
+  return {
+    deleteSource: deleteSourceMock,
+    sourceClientForRequest: vi.fn(() => ({ deleteSource: deleteSourceMock })),
+  }
+})
 
 vi.mock('@/lib/coral-request.server', () => ({
-  sourceClientForRequest: () => ({ deleteSource }),
+  sourceClientForRequest,
 }))
+
+import { authTestContext } from '@/auth/server-context.test-helper'
 
 import { action } from './sources-action'
 
@@ -20,7 +28,11 @@ describe('sources action workspace routing', () => {
       method: 'POST',
     })
 
-    const response = await action({ params: { workspaceId: 'analytics' }, request })
+    const response = await action({
+      context: authTestContext('coral-access-token'),
+      params: { workspaceId: 'analytics' },
+      request,
+    })
 
     expect(deleteSource).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -28,6 +40,7 @@ describe('sources action workspace routing', () => {
         workspace: expect.objectContaining({ name: 'analytics' }),
       }),
     )
+    expect(sourceClientForRequest).toHaveBeenCalledWith(request, 'coral-access-token')
     expect(response).toBeInstanceOf(Response)
     expect((response as Response).headers.get('location')).toBe('/workspaces/analytics/sources')
   })

--- a/apps/reef/app/routes/sources-action.ts
+++ b/apps/reef/app/routes/sources-action.ts
@@ -1,6 +1,7 @@
 import { create } from '@bufbuild/protobuf'
-import { redirect } from 'react-router'
+import { redirect, type RouterContextProvider } from 'react-router'
 
+import { requestAuthContext } from '@/auth/server-context'
 import {
   CreateBundledSourceRequestSchema,
   DeleteSourceRequestSchema,
@@ -49,16 +50,22 @@ export type SourcesActionData =
   | undefined
 
 interface SourcesActionArgs {
+  context: Readonly<RouterContextProvider>
   params: { workspaceId?: string }
   request: Request
 }
 
 export async function action({
+  context,
   params,
   request,
 }: SourcesActionArgs): Promise<SourcesActionData | Response> {
   const workspace = workspaceFromParams(params)
-  const result = await runSourcesAction(request, workspace)
+  const result = await runSourcesAction(
+    request,
+    workspace,
+    context.get(requestAuthContext).accessToken,
+  )
   return result.status === 'success'
     ? redirect(routePath('workspaceSources', { workspaceId: workspace.name }))
     : result
@@ -69,13 +76,14 @@ type SourceActionResult = Exclude<SourcesActionData, undefined>
 export async function runSourcesAction(
   request: Request,
   workspace: Workspace,
+  accessToken: string | null,
 ): Promise<SourceActionResult> {
   const formData = await request.formData()
   const intent = formValue(formData, '_intent')
   const name = formValue(formData, 'name')
   if (!name) return actionError('install', '', 'Missing source name')
 
-  const sourceClient = sourceClientForRequest(request)
+  const sourceClient = sourceClientForRequest(request, accessToken)
   try {
     if (intent === 'install') {
       const info = await getSourceInfo(sourceClient, workspace, name)

--- a/apps/reef/app/routes/sources-loader.ts
+++ b/apps/reef/app/routes/sources-loader.ts
@@ -2,6 +2,7 @@ import { create } from '@bufbuild/protobuf'
 
 import type { Route } from './+types/sources'
 
+import { requestAuthContext } from '@/auth/server-context'
 import {
   DiscoverSourcesRequestSchema,
   ListSourcesRequestSchema,
@@ -17,16 +18,28 @@ export interface SourcesRouteData {
   loadError: string | null
 }
 
-export async function loader({ params, request }: Route.LoaderArgs): Promise<SourcesRouteData> {
-  return loadSourcesRouteData(request, workspaceFromParams(params))
+export async function loader({
+  context,
+  params,
+  request,
+}: Route.LoaderArgs): Promise<SourcesRouteData> {
+  return loadSourcesRouteData(
+    request,
+    workspaceFromParams(params),
+    context.get(requestAuthContext).accessToken,
+  )
 }
 
 export async function loadSourcesRouteData(
   request: Request,
   workspace: Workspace,
+  accessToken: string | null,
 ): Promise<SourcesRouteData> {
   try {
-    return { entries: await listCatalogForRequest(request, workspace), loadError: null }
+    return {
+      entries: await listCatalogForRequest(request, workspace, accessToken),
+      loadError: null,
+    }
   } catch (error) {
     return { entries: [], loadError: errorMessage(error) }
   }
@@ -35,8 +48,9 @@ export async function loadSourcesRouteData(
 export async function listCatalogForRequest(
   request: Request,
   workspace: Workspace,
+  accessToken: string | null,
 ): Promise<CatalogEntry[]> {
-  const sourceClient = sourceClientForRequest(request)
+  const sourceClient = sourceClientForRequest(request, accessToken)
   const [discovered, installed] = await Promise.all([
     sourceClient.discoverSources(create(DiscoverSourcesRequestSchema, { workspace })),
     sourceClient.listSources(create(ListSourcesRequestSchema, { workspace })),

--- a/apps/reef/app/routes/trace-detail-loader.server.test.ts
+++ b/apps/reef/app/routes/trace-detail-loader.server.test.ts
@@ -34,15 +34,26 @@ describe('trace detail loader', () => {
     const getTrace = vi.fn().mockResolvedValue(detail('trace/with?reserved'))
 
     await expect(
-      loadTraceDetailRouteData(request, 'trace/with?reserved', workspace, getTrace),
+      loadTraceDetailRouteData(
+        request,
+        'trace/with?reserved',
+        workspace,
+        'coral-access-token',
+        getTrace,
+      ),
     ).resolves.toEqual({ detail: detail('trace/with?reserved'), loadError: null })
-    expect(getTrace).toHaveBeenCalledWith(request, 'trace/with?reserved', workspace)
+    expect(getTrace).toHaveBeenCalledWith(
+      request,
+      'trace/with?reserved',
+      workspace,
+      'coral-access-token',
+    )
   })
 
   it('returns an inline error for a missing trace ID', async () => {
     const getTrace = vi.fn()
     await expect(
-      loadTraceDetailRouteData(request, undefined, workspace, getTrace),
+      loadTraceDetailRouteData(request, undefined, workspace, 'coral-access-token', getTrace),
     ).resolves.toEqual({
       detail: null,
       loadError: 'Missing trace ID',
@@ -56,6 +67,7 @@ describe('trace detail loader', () => {
         request,
         'trace-07',
         workspace,
+        'coral-access-token',
         vi.fn().mockRejectedValue(new Error('HTTP 404 from TraceService')),
       ),
     ).resolves.toMatchObject({
@@ -69,6 +81,7 @@ describe('trace detail loader', () => {
         request,
         'trace-07',
         workspace,
+        'coral-access-token',
         vi.fn().mockRejectedValue(new Error('trace lookup failed')),
       ),
     ).resolves.toEqual({ detail: null, loadError: 'trace lookup failed' })
@@ -81,13 +94,13 @@ describe('trace detail loader', () => {
       .mockRejectedValueOnce(new Error('trace-b failed'))
 
     await expect(
-      loadTraceDetailRouteData(request, 'trace-a', workspace, getTrace),
+      loadTraceDetailRouteData(request, 'trace-a', workspace, 'coral-access-token', getTrace),
     ).resolves.toEqual({
       detail: detail('trace-a'),
       loadError: null,
     })
     await expect(
-      loadTraceDetailRouteData(request, 'trace-b', workspace, getTrace),
+      loadTraceDetailRouteData(request, 'trace-b', workspace, 'coral-access-token', getTrace),
     ).resolves.toEqual({
       detail: null,
       loadError: 'trace-b failed',

--- a/apps/reef/app/routes/trace-detail-loader.ts
+++ b/apps/reef/app/routes/trace-detail-loader.ts
@@ -2,6 +2,7 @@ import { create } from '@bufbuild/protobuf'
 
 import type { Route } from './+types/trace-detail'
 
+import { requestAuthContext } from '@/auth/server-context'
 import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { GetTraceRequestSchema } from '@/generated/coral/v1/traces_pb'
 import { traceClientForRequest } from '@/lib/coral-request.server'
@@ -18,22 +19,33 @@ export type GetTraceForRequest = (
   request: Request,
   traceId: string,
   workspace: Workspace,
+  accessToken: string | null,
 ) => Promise<TraceDetailData>
 
-export async function loader({ params, request }: Route.LoaderArgs): Promise<TraceDetailRouteData> {
-  return loadTraceDetailRouteData(request, params.traceId, workspaceFromParams(params))
+export async function loader({
+  context,
+  params,
+  request,
+}: Route.LoaderArgs): Promise<TraceDetailRouteData> {
+  return loadTraceDetailRouteData(
+    request,
+    params.traceId,
+    workspaceFromParams(params),
+    context.get(requestAuthContext).accessToken,
+  )
 }
 
 export async function loadTraceDetailRouteData(
   request: Request,
   traceId: string | undefined,
   workspace: Workspace,
+  accessToken: string | null,
   getTrace: GetTraceForRequest = getTraceForRequest,
 ): Promise<TraceDetailRouteData> {
   if (!traceId) return { detail: null, loadError: 'Missing trace ID' }
 
   try {
-    return { detail: await getTrace(request, traceId, workspace), loadError: null }
+    return { detail: await getTrace(request, traceId, workspace, accessToken), loadError: null }
   } catch (error) {
     return { detail: null, loadError: formatTraceError(errorMessage(error)) }
   }
@@ -43,8 +55,9 @@ async function getTraceForRequest(
   request: Request,
   traceId: string,
   workspace: Workspace,
+  accessToken: string | null,
 ): Promise<TraceDetailData> {
-  return traceClientForRequest(request).getTrace(
+  return traceClientForRequest(request, accessToken).getTrace(
     create(GetTraceRequestSchema, { traceId, workspace }),
   )
 }

--- a/apps/reef/app/routes/traces-loader.server.test.ts
+++ b/apps/reef/app/routes/traces-loader.server.test.ts
@@ -34,13 +34,15 @@ describe('traces list loader', () => {
       traces: [summary('query'), summary('http', '')],
     })
 
-    await expect(loadTracesRouteData(request, workspace, listPage)).resolves.toEqual({
+    await expect(
+      loadTracesRouteData(request, workspace, 'coral-access-token', listPage),
+    ).resolves.toEqual({
       endpointLabel: 'reef.test',
       loadError: null,
       referenceTimeMs: 123_456,
       traces: [summary('query')],
     })
-    expect(listPage).toHaveBeenCalledWith(request, workspace, 100, '')
+    expect(listPage).toHaveBeenCalledWith(request, workspace, 100, '', 'coral-access-token')
   })
 
   it('loads at most two pages, preserves ordering, and caps query traces at 80', async () => {
@@ -51,10 +53,17 @@ describe('traces list loader', () => {
       .mockResolvedValueOnce({ nextPageToken: 'page-2', traces: firstPage })
       .mockResolvedValueOnce({ nextPageToken: 'page-3', traces: secondPage })
 
-    const traces = await listQueryTraces(request, workspace, listPage)
+    const traces = await listQueryTraces(request, workspace, 'coral-access-token', listPage)
 
     expect(listPage).toHaveBeenCalledTimes(2)
-    expect(listPage).toHaveBeenNthCalledWith(2, request, workspace, 100, 'page-2')
+    expect(listPage).toHaveBeenNthCalledWith(
+      2,
+      request,
+      workspace,
+      100,
+      'page-2',
+      'coral-access-token',
+    )
     expect(traces).toHaveLength(80)
     expect(traces.map(({ traceId }) => traceId)).toEqual(
       Array.from({ length: 80 }, (_, index) => `trace-${index}`),
@@ -63,14 +72,18 @@ describe('traces list loader', () => {
 
   it('maps unavailable and generic failures into route data', async () => {
     const unavailable = vi.fn().mockRejectedValue(new Error('rpc unimplemented'))
-    await expect(loadTracesRouteData(request, workspace, unavailable)).resolves.toMatchObject({
+    await expect(
+      loadTracesRouteData(request, workspace, 'coral-access-token', unavailable),
+    ).resolves.toMatchObject({
       loadError:
         'Trace storage is not enabled for this Coral server. Enable [local_traces].enabled = true, restart the Coral server, then run a query.',
       traces: [],
     })
 
     const generic = vi.fn().mockRejectedValue(new Error('sidecar unavailable'))
-    await expect(loadTracesRouteData(request, workspace, generic)).resolves.toMatchObject({
+    await expect(
+      loadTracesRouteData(request, workspace, 'coral-access-token', generic),
+    ).resolves.toMatchObject({
       loadError: 'sidecar unavailable',
       traces: [],
     })

--- a/apps/reef/app/routes/traces-loader.ts
+++ b/apps/reef/app/routes/traces-loader.ts
@@ -2,6 +2,7 @@ import { create } from '@bufbuild/protobuf'
 
 import type { Route } from './+types/traces'
 
+import { requestAuthContext } from '@/auth/server-context'
 import type { Workspace } from '@/generated/coral/v1/resources_pb'
 import { ListTracesRequestSchema } from '@/generated/coral/v1/traces_pb'
 import { traceClientForRequest } from '@/lib/coral-request.server'
@@ -25,15 +26,25 @@ export type ListTracePage = (
   workspace: Workspace,
   pageSize: number,
   pageToken: string,
+  accessToken: string | null,
 ) => Promise<{ nextPageToken: string; traces: TraceSummaryData[] }>
 
-export async function loader({ params, request }: Route.LoaderArgs): Promise<TracesRouteData> {
-  return loadTracesRouteData(request, workspaceFromParams(params))
+export async function loader({
+  context,
+  params,
+  request,
+}: Route.LoaderArgs): Promise<TracesRouteData> {
+  return loadTracesRouteData(
+    request,
+    workspaceFromParams(params),
+    context.get(requestAuthContext).accessToken,
+  )
 }
 
 export async function loadTracesRouteData(
   request: Request,
   workspace: Workspace,
+  accessToken: string | null,
   listPage: ListTracePage = listTracePageForRequest,
 ): Promise<TracesRouteData> {
   const referenceTimeMs = Date.now()
@@ -42,7 +53,7 @@ export async function loadTracesRouteData(
       endpointLabel: traceEndpointLabel(request),
       loadError: null,
       referenceTimeMs,
-      traces: await listQueryTraces(request, workspace, listPage),
+      traces: await listQueryTraces(request, workspace, accessToken, listPage),
     }
   } catch (error) {
     return {
@@ -57,6 +68,7 @@ export async function loadTracesRouteData(
 export async function listQueryTraces(
   request: Request,
   workspace: Workspace,
+  accessToken: string | null,
   listPage: ListTracePage = listTracePageForRequest,
 ): Promise<TraceSummaryData[]> {
   const queryTraces: TraceSummaryData[] = []
@@ -67,7 +79,13 @@ export async function listQueryTraces(
     page < MAX_TRACE_LIST_PAGES && queryTraces.length < MAX_QUERY_TRACES;
     page += 1
   ) {
-    const response = await listPage(request, workspace, TRACE_LIST_PAGE_SIZE, pageToken)
+    const response = await listPage(
+      request,
+      workspace,
+      TRACE_LIST_PAGE_SIZE,
+      pageToken,
+      accessToken,
+    )
     queryTraces.push(...response.traces.filter(isQueryTrace))
     pageToken = response.nextPageToken
     if (!pageToken) break
@@ -89,8 +107,9 @@ async function listTracePageForRequest(
   workspace: Workspace,
   pageSize: number,
   pageToken: string,
+  accessToken: string | null,
 ): Promise<{ nextPageToken: string; traces: TraceSummaryData[] }> {
-  return traceClientForRequest(request).listTraces(
+  return traceClientForRequest(request, accessToken).listTraces(
     create(ListTracesRequestSchema, { pageSize, pageToken, workspace }),
   )
 }

--- a/apps/reef/app/routes/workspaces-action.server.test.ts
+++ b/apps/reef/app/routes/workspaces-action.server.test.ts
@@ -1,13 +1,20 @@
 import { create } from '@bufbuild/protobuf'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { createWorkspace } = vi.hoisted(() => ({ createWorkspace: vi.fn() }))
+const { createWorkspace, workspaceClientForRequest } = vi.hoisted(() => {
+  const createWorkspaceMock = vi.fn()
+  return {
+    createWorkspace: createWorkspaceMock,
+    workspaceClientForRequest: vi.fn(() => ({ createWorkspace: createWorkspaceMock })),
+  }
+})
 
 vi.mock('@/lib/coral-request.server', () => ({
-  workspaceClientForRequest: () => ({ createWorkspace }),
+  workspaceClientForRequest,
 }))
 
 import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
 
 import { action } from './workspaces-action'
 
@@ -21,12 +28,11 @@ function createRequest(name: string, intent = 'create') {
 describe('create workspace action', () => {
   beforeEach(() => {
     createWorkspace.mockReset()
+    workspaceClientForRequest.mockClear()
   })
 
   it('rejects unsupported intents before mutation', async () => {
-    const result = await action({
-      request: createRequest('analytics', 'rename'),
-    } as Parameters<typeof action>[0])
+    const result = await action(authRouteTestArgs(createRequest('analytics', 'rename'), {}))
 
     expect(result).toMatchObject({
       data: { error: 'Unsupported workspace action.', name: '' },
@@ -43,7 +49,7 @@ describe('create workspace action', () => {
     ['team-', 'Workspace name must not start or end with a hyphen'],
     ['a'.repeat(64), 'Workspace name must be 63 characters or fewer'],
   ])('rejects invalid workspace name %j before mutation', async (name, error) => {
-    const result = await action({ request: createRequest(name) } as Parameters<typeof action>[0])
+    const result = await action(authRouteTestArgs(createRequest(name), {}))
 
     expect(result).toMatchObject({
       data: { error, name },
@@ -58,9 +64,8 @@ describe('create workspace action', () => {
       workspace: create(WorkspaceSchema, { name: 'analytics' }),
     })
 
-    const result = await action({
-      request: createRequest('analytics'),
-    } as Parameters<typeof action>[0])
+    const request = createRequest('analytics')
+    const result = await action(authRouteTestArgs(request, {}))
 
     expect(createWorkspace).toHaveBeenCalledOnce()
     expect(createWorkspace).toHaveBeenCalledWith(
@@ -68,17 +73,27 @@ describe('create workspace action', () => {
         workspace: expect.objectContaining({ name: 'analytics' }),
       }),
     )
+    expect(workspaceClientForRequest).toHaveBeenCalledWith(request, 'test-coral-token')
     expect(result).toBeInstanceOf(Response)
     expect((result as Response).status).toBe(302)
     expect((result as Response).headers.get('Location')).toBe('/workspaces/analytics/sources')
   })
 
+  it('keeps local workspace creation unauthenticated', async () => {
+    createWorkspace.mockResolvedValue({
+      workspace: create(WorkspaceSchema, { name: 'analytics' }),
+    })
+
+    const request = createRequest('analytics')
+    await action(authRouteTestArgs(request, {}, null))
+
+    expect(workspaceClientForRequest).toHaveBeenCalledWith(request, null)
+  })
+
   it('returns service errors to the dialog without redirecting', async () => {
     createWorkspace.mockRejectedValue(new Error('workspace already exists'))
 
-    await expect(
-      action({ request: createRequest('analytics') } as Parameters<typeof action>[0]),
-    ).resolves.toMatchObject({
+    await expect(action(authRouteTestArgs(createRequest('analytics'), {}))).resolves.toMatchObject({
       data: { error: 'workspace already exists', name: 'analytics' },
       init: { status: 502 },
     })

--- a/apps/reef/app/routes/workspaces-action.ts
+++ b/apps/reef/app/routes/workspaces-action.ts
@@ -2,12 +2,13 @@ import { data, redirect } from 'react-router'
 
 import type { Route } from './+types/workspaces-action'
 
+import { requestAuthContext } from '@/auth/server-context'
 import { errorMessage } from '@/lib/utils'
 import { type CreateWorkspaceActionData, validateWorkspaceName } from '@/lib/workspace-name'
 import { createWorkspaceForRequest } from '@/lib/workspaces.server'
 import { routePath } from '@/routing/routemap'
 
-export async function action({ request }: Route.ActionArgs) {
+export async function action({ context, request }: Route.ActionArgs) {
   const formData = await request.formData()
   const intent = formData.get('intent')
 
@@ -20,7 +21,11 @@ export async function action({ request }: Route.ActionArgs) {
       if (validationError) return actionError(name, validationError, 400)
 
       try {
-        const workspace = await createWorkspaceForRequest(request, name)
+        const workspace = await createWorkspaceForRequest(
+          request,
+          context.get(requestAuthContext).accessToken,
+          name,
+        )
         return redirect(routePath('workspaceSources', { workspaceId: workspace.name }))
       } catch (error) {
         return actionError(name, errorMessage(error), 502)


### PR DESCRIPTION
Constraint: Reef must keep the Coral access token server-only while desktop and local transports remain unauthenticated.

Rejected: Forwarding the browser Authorization header | the browser never owns the Coral token and must not be able to spoof Reef credentials.

Confidence: high

Scope-risk: moderate

Directive: Keep bearer injection centralized in coral-request.server.ts and source tokens only from protected-route request context.

Tested: npm run check --prefix apps/reef; npm run typecheck --prefix apps/reef; npm test --prefix apps/reef (92 files, 406 tests); npm run build --prefix apps/reef; client token scan

Not-tested: Production Coral Cloud token acceptance, expiry refresh, and packaged desktop smoke testing are deferred.