### PR TITLE
test(desktop): exercise packaging smoke lane

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -2,7 +2,21 @@ name: Desktop macOS package
 
 on:
   workflow_call:
+    inputs:
+      mode:
+        description: Packaging validation mode (smoke or universal)
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      mode:
+        description: Packaging validation mode
+        required: true
+        default: universal
+        type: choice
+        options:
+          - universal
+          - smoke
 
 permissions:
   contents: read
@@ -17,17 +31,34 @@ env:
 
 jobs:
   package:
-    name: Build unsigned package
-    runs-on: macos-latest
+    name: Validate desktop package (${{ inputs.mode }})
+    # The smoke lane must match the published aarch64 sidecar. Universal lipo
+    # builds also work on the ARM runner.
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
+      - name: Validate packaging mode
+        env:
+          PACKAGE_MODE: ${{ inputs.mode }}
+        run: |
+          case "$PACKAGE_MODE" in
+            smoke|universal) ;;
+            *)
+              echo "Unsupported desktop packaging mode: $PACKAGE_MODE" >&2
+              echo "Expected one of: smoke, universal" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Install Rust toolchain
+        if: ${{ inputs.mode == 'universal' }}
         run: rustup show
 
       - name: Cache Rust artifacts
+        if: ${{ inputs.mode == 'universal' }}
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: coral-desktop-macos-universal
@@ -58,17 +89,122 @@ jobs:
             apps/desktop/resources/entitlements.mac.plist \
             apps/desktop/resources/entitlements.mac.inherit.plist
 
-      - name: Package desktop app
+      - name: Check desktop
+        run: npm run check --prefix apps/desktop
+
+      - name: Test desktop
+        run: npm test --prefix apps/desktop
+
+      - name: Resolve and verify published ARM sidecar
+        if: ${{ inputs.mode == 'smoke' }}
+        id: smoke-sidecar
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          runner_arch="$(uname -m)"
+          if [ "$runner_arch" != "arm64" ]; then
+            echo "Desktop package smoke requires an arm64 runner; found: $runner_arch" >&2
+            exit 1
+          fi
+
+          archive_name="coral-aarch64-apple-darwin.tar.gz"
+          download_dir="$(mktemp -d "$RUNNER_TEMP/coral-desktop-smoke-download.XXXXXX")"
+          extract_dir="$(mktemp -d "$RUNNER_TEMP/coral-desktop-smoke-sidecar.XXXXXX")"
+
+          release_tag="$(gh api "repos/${REPOSITORY}/releases/latest" --jq '.tag_name')"
+          if [ -z "$release_tag" ]; then
+            echo "Could not resolve the latest published Coral release tag" >&2
+            exit 1
+          fi
+          echo "Using published Coral release: $release_tag"
+
+          gh release download "$release_tag" \
+            --repo "$REPOSITORY" \
+            --dir "$download_dir" \
+            --pattern "$archive_name" \
+            --pattern checksums.sha256
+
+          archive_path="$download_dir/$archive_name"
+          checksums_path="$download_dir/checksums.sha256"
+          if [ ! -s "$archive_path" ]; then
+            echo "Downloaded Coral archive is missing or empty: $archive_path" >&2
+            exit 1
+          fi
+          if [ ! -s "$checksums_path" ]; then
+            echo "Downloaded checksum file is missing or empty: $checksums_path" >&2
+            exit 1
+          fi
+
+          checksum_matches="$download_dir/checksum-matches"
+          awk -v name="$archive_name" \
+            '($2 == name || $2 == ("*" name)) && length($1) == 64 { print $1 }' \
+            "$checksums_path" > "$checksum_matches"
+          checksum_count="$(wc -l < "$checksum_matches" | tr -d '[:space:]')"
+          if [ "$checksum_count" != "1" ]; then
+            echo "Expected exactly one checksum for $archive_name; found $checksum_count" >&2
+            exit 1
+          fi
+
+          expected_checksum="$(tr '[:upper:]' '[:lower:]' < "$checksum_matches")"
+          actual_checksum="$(shasum -a 256 "$archive_path" | awk '{ print $1 }')"
+          if [ "$actual_checksum" != "$expected_checksum" ]; then
+            echo "Checksum verification failed for $archive_name" >&2
+            echo "Expected: $expected_checksum" >&2
+            echo "Actual:   $actual_checksum" >&2
+            exit 1
+          fi
+          echo "Verified checksum for $archive_name"
+
+          tar -xzf "$archive_path" -C "$extract_dir"
+          coral_path="$extract_dir/coral"
+          if [ ! -f "$coral_path" ]; then
+            echo "Published archive did not contain the expected coral executable" >&2
+            exit 1
+          fi
+          if [ ! -s "$coral_path" ]; then
+            echo "Published coral executable is empty: $coral_path" >&2
+            exit 1
+          fi
+          if [ ! -x "$coral_path" ]; then
+            echo "Published coral executable is not executable: $coral_path" >&2
+            exit 1
+          fi
+
+          file "$coral_path"
+          sidecar_archs="$(lipo -archs "$coral_path")"
+          if [ "$sidecar_archs" != "arm64" ]; then
+            echo "Expected a thin arm64 Coral sidecar; found: $sidecar_archs" >&2
+            exit 1
+          fi
+          echo "Verified thin arm64 sidecar: $coral_path"
+          echo "coral-path=$coral_path" >> "$GITHUB_OUTPUT"
+
+      - name: Package native unpacked desktop app
+        if: ${{ inputs.mode == 'smoke' }}
+        env:
+          CORAL_DESKTOP_PREBUILT_CORAL: ${{ steps.smoke-sidecar.outputs.coral-path }}
+        run: npm run package:mac:smoke --prefix apps/desktop
+
+      - name: Verify native unpacked desktop app
+        if: ${{ inputs.mode == 'smoke' }}
+        run: node apps/desktop/scripts/verify-package-dir.mjs apps/desktop/dist
+
+      - name: Package universal desktop app
+        if: ${{ inputs.mode == 'universal' }}
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
         run: npm run package:mac --prefix apps/desktop
 
-      - name: Verify desktop package artifacts
+      - name: Verify universal desktop package artifacts
+        if: ${{ inputs.mode == 'universal' }}
         run: node apps/desktop/scripts/verify-dist.mjs apps/desktop/dist
 
       # PR and manual builds are available for inspection for one week.
       - name: Upload desktop package artifact
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ inputs.mode == 'universal' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coral-desktop-macos-unsigned

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: macos-unsigned-${{ matrix.target }}
+          if-no-files-found: error
           path: unsigned-${{ matrix.target }}/coral
 
   sign-notarize-macos:
@@ -323,6 +324,7 @@ jobs:
   build-desktop-macos:
     needs:
       - validate-release-ref
+      - build
     environment: release
     runs-on: macos-latest
     env:
@@ -345,18 +347,135 @@ jobs:
       - name: Install desktop dependencies
         run: npm ci --prefix apps/desktop
 
+      - name: Download unsigned x86_64 macOS binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: macos-unsigned-x86_64-apple-darwin
+          path: ${{ runner.temp }}/coral-desktop-cli/x86_64
+
+      - name: Download unsigned arm64 macOS binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: macos-unsigned-aarch64-apple-darwin
+          path: ${{ runner.temp }}/coral-desktop-cli/arm64
+
+      - name: Validate and combine macOS binaries
+        id: universal-coral
+        shell: bash
+        env:
+          RELEASE_COMMIT_SHA: ${{ needs.validate-release-ref.outputs.commit-sha }}
+          X86_64_ARTIFACT_DIR: ${{ runner.temp }}/coral-desktop-cli/x86_64
+          ARM64_ARTIFACT_DIR: ${{ runner.temp }}/coral-desktop-cli/arm64
+          UNIVERSAL_DIR: ${{ runner.temp }}/coral-desktop-cli/universal
+        run: |
+          set -euo pipefail
+
+          checked_out_commit="$(git rev-parse HEAD)"
+          if [ "$checked_out_commit" != "$RELEASE_COMMIT_SHA" ]; then
+            echo "Checked-out commit ${checked_out_commit} does not match validated release commit ${RELEASE_COMMIT_SHA}." >&2
+            exit 1
+          fi
+
+          require_single_coral() {
+            local artifact_dir="$1"
+            local expected_arch="$2"
+            local label="$3"
+            local files=()
+            while IFS= read -r -d '' file_path; do
+              files+=("$file_path")
+            done < <(find "$artifact_dir" -type f -print0)
+
+            if [ "${#files[@]}" -ne 1 ]; then
+              echo "${label} artifact must contain exactly one file; found ${#files[@]}." >&2
+              find "$artifact_dir" -maxdepth 3 -print >&2
+              exit 1
+            fi
+
+            local binary="${files[0]}"
+            if [ "$(basename "$binary")" != "coral" ]; then
+              echo "${label} artifact contains unexpected filename: ${binary}." >&2
+              exit 1
+            fi
+            if [ ! -s "$binary" ]; then
+              echo "${label} artifact contains an empty coral binary: ${binary}." >&2
+              exit 1
+            fi
+            chmod 755 "$binary"
+
+            local actual_archs
+            actual_archs="$(lipo -archs "$binary")"
+            if [ "$actual_archs" != "$expected_arch" ]; then
+              echo "${label} coral must be thin ${expected_arch}; lipo reported '${actual_archs}'." >&2
+              exit 1
+            fi
+            if ! file "$binary" | grep -Eq "Mach-O 64-bit executable ${expected_arch}([, ]|$)"; then
+              echo "${label} coral is not the expected ${expected_arch} Mach-O executable:" >&2
+              file "$binary" >&2
+              exit 1
+            fi
+
+            printf '%s\n' "$binary"
+          }
+
+          x86_64_binary="$(require_single_coral "$X86_64_ARTIFACT_DIR" x86_64 x86_64)"
+          arm64_binary="$(require_single_coral "$ARM64_ARTIFACT_DIR" arm64 arm64)"
+
+          mkdir -p "$UNIVERSAL_DIR"
+          universal_binary="$UNIVERSAL_DIR/coral"
+          lipo -create "$x86_64_binary" "$arm64_binary" -output "$universal_binary"
+          chmod 755 "$universal_binary"
+
+          universal_archs="$(lipo -archs "$universal_binary")"
+          if [ "$universal_archs" != "x86_64 arm64" ] && [ "$universal_archs" != "arm64 x86_64" ]; then
+            echo "Universal coral must contain exactly x86_64 and arm64; lipo reported '${universal_archs}'." >&2
+            exit 1
+          fi
+
+          expected_version="${TAG_NAME#v}"
+          expected_commit="$(git rev-parse --short "$RELEASE_COMMIT_SHA")"
+          expected_output="coral ${expected_version}+${expected_commit}"
+          version_output="$("$universal_binary" --version)"
+          if [ "$version_output" != "$expected_output" ]; then
+            echo "Universal coral version mismatch: expected '${expected_output}', got '${version_output}'." >&2
+            exit 1
+          fi
+
+          checksum="$(shasum -a 256 "$universal_binary" | awk '{print $1}')"
+          echo "Combined same-run macOS artifacts for ${RELEASE_COMMIT_SHA}."
+          echo "Universal coral architectures: ${universal_archs}"
+          echo "Universal coral SHA-256: ${checksum}"
+          echo "path=${universal_binary}" >> "$GITHUB_OUTPUT"
+
       - name: Build xtask
         run: cargo build --locked -p xtask
 
       # Build before Apple credentials enter the environment: the desktop
-      # build installs UI and Reef dependencies and executes Rust build scripts.
-      # The release flag is compiled into the main process to enable updates;
-      # signing and notarization still happen only in the credentialed step.
+      # build installs and compiles Reef, then stages the already-built universal
+      # CLI from this run's matrix artifacts. The release flag is compiled into
+      # the main process to enable updates; signing and notarization still happen
+      # only in the credentialed step.
       - name: Build universal desktop inputs
         env:
           CORAL_DESKTOP_RELEASE: "1"
-          CORAL_DESKTOP_UNIVERSAL: "1"
+          CORAL_DESKTOP_PREBUILT_CORAL: ${{ steps.universal-coral.outputs.path }}
         run: npm run build --prefix apps/desktop
+
+      - name: Verify staged universal sidecar
+        shell: bash
+        env:
+          UNIVERSAL_CORAL: ${{ steps.universal-coral.outputs.path }}
+        run: |
+          set -euo pipefail
+          staged_coral="apps/desktop/resources/coral/coral"
+          test -s "$staged_coral"
+          test -x "$staged_coral"
+          cmp "$UNIVERSAL_CORAL" "$staged_coral"
+          staged_archs="$(lipo -archs "$staged_coral")"
+          if [ "$staged_archs" != "x86_64 arm64" ] && [ "$staged_archs" != "arm64 x86_64" ]; then
+            echo "Staged desktop sidecar must contain exactly x86_64 and arm64; lipo reported '${staged_archs}'." >&2
+            exit 1
+          fi
+          echo "Staged desktop sidecar architectures: ${staged_archs}"
 
       - name: Verify release updater bundle
         run: npm run verify:release-build --prefix apps/desktop
@@ -375,6 +494,32 @@ jobs:
           ./target/debug/xtask release-desktop-macos-package \
             --tag "$TAG_NAME" \
             --work-dir "$RUNNER_TEMP/coral-desktop-release"
+
+      - name: Verify packaged universal sidecar
+        shell: bash
+        run: |
+          set -euo pipefail
+          packaged_sidecars=()
+          while IFS= read -r -d '' sidecar; do
+            packaged_sidecars+=("$sidecar")
+          done < <(find apps/desktop/dist -type f \
+            -path '*/Coral.app/Contents/Resources/coral/coral' -print0)
+
+          if [ "${#packaged_sidecars[@]}" -ne 1 ]; then
+            echo "Expected exactly one packaged Coral.app sidecar; found ${#packaged_sidecars[@]}." >&2
+            find apps/desktop/dist -maxdepth 5 -print >&2
+            exit 1
+          fi
+
+          packaged_coral="${packaged_sidecars[0]}"
+          test -s "$packaged_coral"
+          test -x "$packaged_coral"
+          packaged_archs="$(lipo -archs "$packaged_coral")"
+          if [ "$packaged_archs" != "x86_64 arm64" ] && [ "$packaged_archs" != "arm64 x86_64" ]; then
+            echo "Packaged desktop sidecar must contain exactly x86_64 and arm64; lipo reported '${packaged_archs}'." >&2
+            exit 1
+          fi
+          echo "Packaged desktop sidecar architectures: ${packaged_archs}"
 
       - name: Upload desktop artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,8 @@ jobs:
       ui-tests: ${{ steps.filter.outputs.ui-tests }}
       reef-checks: ${{ steps.filter.outputs.reef-checks }}
       desktop-checks: ${{ steps.filter.outputs.desktop-checks }}
-      desktop-package-macos: ${{ steps.filter.outputs.desktop-package-macos }}
+      desktop-package-smoke: ${{ steps.filter.outputs.desktop-package-smoke == 'true' || steps.desktop-package-source-filter.outputs.desktop-source == 'true' || steps.desktop-package-source-filter.outputs.reef-source == 'true' }}
+      desktop-package-universal: ${{ steps.filter.outputs.desktop-package-universal }}
       proto-lint: ${{ steps.filter.outputs.proto-lint }}
       source-lint: ${{ steps.filter.outputs.source-lint }}
       docs-freshness: ${{ steps.filter.outputs.docs-freshness }}
@@ -97,7 +98,14 @@ jobs:
             desktop-checks:
               - '.github/workflows/validate.yml'
               - 'apps/desktop/**'
-            desktop-package-macos:
+            desktop-package-smoke:
+              - 'apps/desktop/electron.vite.config.ts'
+              - 'apps/desktop/tsconfig.json'
+              # Reef's production client and server outputs are embedded in
+              # Coral.app, so runtime changes need the same assembly smoke.
+              - 'apps/reef/public/**'
+              - 'crates/coral-api/proto/**'
+            desktop-package-universal:
               - '.github/workflows/validate.yml'
               - '.github/workflows/release.yml'
               - '.github/workflows/desktop-package.yml'
@@ -108,7 +116,27 @@ jobs:
               - 'rust-toolchain'
               - 'crates/**/Cargo.toml'
               - 'crates/**/build.rs'
-              - 'apps/desktop/**'
+              - 'apps/desktop/.node-version'
+              - 'apps/desktop/package.json'
+              - 'apps/desktop/package-lock.json'
+              - 'apps/desktop/electron-builder.config.ts'
+              - 'apps/desktop/resources/**'
+              - 'apps/desktop/scripts/stage-coral.mjs'
+              - 'apps/desktop/scripts/stage-coral-plan.mjs'
+              - 'apps/desktop/scripts/clean-dist.mjs'
+              - 'apps/desktop/scripts/copy-reef-server.mjs'
+              - 'apps/desktop/scripts/verify-dist.mjs'
+              - 'apps/desktop/scripts/verify-release-build.mjs'
+              - 'apps/desktop/scripts/verify-package-dir.mjs'
+              # These inputs control the Reef dependency graph, generated
+              # client, or build layout that Electron packages.
+              - 'apps/reef/.node-version'
+              - 'apps/reef/package.json'
+              - 'apps/reef/package-lock.json'
+              - 'apps/reef/buf.gen.yaml'
+              - 'apps/reef/react-router.config.ts'
+              - 'apps/reef/tsconfig.json'
+              - 'apps/reef/vite.config.ts'
             proto-lint:
               - '.github/workflows/validate.yml'
               - 'Makefile'
@@ -161,6 +189,36 @@ jobs:
               - 'xtask/src/main.rs'
               - 'xtask/src/perf.rs'
               - 'sources/core/github/**'
+
+      # Keep test and Storybook-only source changes out of packaging. This
+      # separate filter uses `every` so each file must match its source tree
+      # and all exclusion rules; the main filter uses the default OR behavior.
+      - name: Detect package source changes
+        id: desktop-package-source-filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          predicate-quantifier: every
+          filters: |
+            desktop-source:
+              - 'apps/desktop/src/**'
+              - '!**/*.test'
+              - '!**/*.test.*'
+              - '!**/*.spec'
+              - '!**/*.spec.*'
+              - '!**/*.stories'
+              - '!**/*.stories.*'
+              - '!apps/desktop/src/**/__tests__/**'
+              - '!apps/desktop/src/**/__stories__/**'
+            reef-source:
+              - 'apps/reef/app/**'
+              - '!**/*.test'
+              - '!**/*.test.*'
+              - '!**/*.spec'
+              - '!**/*.spec.*'
+              - '!**/*.stories'
+              - '!**/*.stories.*'
+              - '!apps/reef/app/**/__tests__/**'
+              - '!apps/reef/app/**/__stories__/**'
 
   rust-checks:
     name: Rust checks
@@ -523,13 +581,25 @@ jobs:
       - name: Test desktop
         run: npm test --prefix apps/desktop
 
-  desktop-package-macos:
-    name: Desktop macOS package
+  desktop-package-universal:
+    name: Desktop macOS universal package
     needs: changes
-    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.desktop-package-macos == 'true' }}
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.desktop-package-universal == 'true' }}
     permissions:
       contents: read
     uses: ./.github/workflows/desktop-package.yml
+    with:
+      mode: universal
+
+  desktop-package-smoke:
+    name: Desktop macOS package smoke
+    needs: changes
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.desktop-package-smoke == 'true' && needs.changes.outputs.desktop-package-universal != 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/desktop-package.yml
+    with:
+      mode: smoke
 
   proto-lint:
     name: Lint protobuf API
@@ -756,7 +826,8 @@ jobs:
         ui-tests,
         reef-checks,
         desktop-checks,
-        desktop-package-macos,
+        desktop-package-universal,
+        desktop-package-smoke,
         proto-lint,
         gha-security-audit-pr,
         gha-security-audit-sarif,
@@ -780,7 +851,8 @@ jobs:
           UI_TESTS_RESULT: ${{ needs.ui-tests.result }}
           REEF_CHECKS_RESULT: ${{ needs.reef-checks.result }}
           DESKTOP_CHECKS_RESULT: ${{ needs.desktop-checks.result }}
-          DESKTOP_PACKAGE_MACOS_RESULT: ${{ needs.desktop-package-macos.result }}
+          DESKTOP_PACKAGE_UNIVERSAL_RESULT: ${{ needs.desktop-package-universal.result }}
+          DESKTOP_PACKAGE_SMOKE_RESULT: ${{ needs.desktop-package-smoke.result }}
           PROTO_LINT_RESULT: ${{ needs.proto-lint.result }}
           GHA_SECURITY_AUDIT_PR_RESULT: ${{ needs.gha-security-audit-pr.result }}
           GHA_SECURITY_AUDIT_SARIF_RESULT: ${{ needs.gha-security-audit-sarif.result }}
@@ -799,7 +871,8 @@ jobs:
             "ui-tests:$UI_TESTS_RESULT"
             "reef-checks:$REEF_CHECKS_RESULT"
             "desktop-checks:$DESKTOP_CHECKS_RESULT"
-            "desktop-package-macos:$DESKTOP_PACKAGE_MACOS_RESULT"
+            "desktop-package-universal:$DESKTOP_PACKAGE_UNIVERSAL_RESULT"
+            "desktop-package-smoke:$DESKTOP_PACKAGE_SMOKE_RESULT"
             "proto-lint:$PROTO_LINT_RESULT"
             "gha-security-audit-pr:$GHA_SECURITY_AUDIT_PR_RESULT"
             "gha-security-audit-sarif:$GHA_SECURITY_AUDIT_SARIF_RESULT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,15 +51,20 @@
   latency. CI installs the bundled `github` source with fake credentials and
   fails when release `coral sql "select * from coral.tables"` has a hyperfine
   mean above 750 ms.
-- Desktop distribution-sensitive PRs must exercise the release-shaped macOS
-  package path, not only the desktop type-check. Validate calls the reusable
-  desktop packaging workflow for desktop, packaging-workflow, release-workflow,
-  Cargo workspace/toolchain, crate-manifest, and build-script changes. Ordinary
-  Rust, Reef, and UI changes use their existing checks. Use manual dispatch as
-  an unsigned packaging preflight for distribution-sensitive changes outside
-  the automatic paths. Validation artifacts stay unsigned and must not be
-  reused for a release; desktop release publishing must rebuild from a clean
-  checkout with signing and notarization.
+- Ordinary source-only desktop application and embedded Reef runtime PRs must
+  exercise the native unpacked macOS packaging smoke in addition to their
+  normal checks. Changes that can affect dependency resolution, sidecar
+  staging or architecture, entitlements, electron-builder inputs, bundle
+  layout, artifacts, or workflow behavior must instead exercise the full
+  release-shaped universal DMG/ZIP workflow. The smoke and universal lanes are
+  mutually exclusive; use manual dispatch for an unsigned universal packaging
+  preflight outside the automatic paths. Validation artifacts stay unsigned
+  and must not be reused for a release. Desktop release packaging must reuse
+  the clean, same-run x86_64 and
+  arm64 CLI build artifacts, combine them into its universal sidecar, and then
+  retain the existing signing and notarization flow. PR descriptions for changes
+  to this proportional gate or artifact-reuse rule must call out the resulting
+  contributor or agent behavior change.
 - The `Validate` workflow intentionally skips draft pull request runs, starts
   again on `ready_for_review`, and still triggers on `converted_to_draft` so the
   replacement skipped run cancels any in-progress validation for the PR branch.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -64,12 +64,26 @@ cargo run --locked -p coral-cli -- ui --no-open --port 0
 npm run build --prefix apps/desktop
 ```
 
-The build script compiles the release Coral binary, builds Reef in React Router
-framework mode, stages Reef's server bundle under `apps/desktop/out/reef-server/`,
-and stages the Coral binary under `apps/desktop/resources/coral/` for Electron
-packaging. The packaged app serves document, data, action, and route-discovery
-requests through the staged server bundle; static assets are copied from
-`apps/reef/build/client/` into the app resources.
+By default, the build script builds the embedded UI and release Coral binary,
+builds Reef in React Router framework mode, stages Reef's server bundle under
+`apps/desktop/out/reef-server/`, and stages the Coral binary under
+`apps/desktop/resources/coral/` for Electron packaging. The packaged app serves
+document, data, action, and route-discovery requests through the staged server
+bundle; static assets are copied from `apps/reef/build/client/` into the app
+resources.
+
+CI packaging can explicitly stage an existing Coral executable instead:
+
+```shell
+CORAL_DESKTOP_PREBUILT_CORAL=/absolute/path/to/coral npm run build --prefix apps/desktop
+```
+
+The prebuilt path must be absolute, readable, non-empty, and outside the staging
+directory. This mode skips the embedded UI build and all Cargo, rustup, and lipo
+commands; Reef and Electron still build normally. It is used by the native
+packaging smoke and to reuse same-run release binaries, cannot be combined with
+`CORAL_DESKTOP_UNIVERSAL=1`, and never falls back to compiling Coral when the
+input is invalid.
 
 ```shell
 npm run package:dir --prefix apps/desktop

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -1,6 +1,8 @@
+import { execFileSync } from 'node:child_process'
 import { accessSync, constants, statSync } from 'node:fs'
+import { join } from 'node:path'
 
-import type { Configuration } from 'electron-builder'
+import type { AfterPackContext, Configuration } from 'electron-builder'
 
 const API_KEY_NOTARIZATION_ENV = [
   'APPLE_API_KEY',
@@ -36,6 +38,49 @@ function requireNotarizationCredentials(env: NodeJS.ProcessEnv): void {
   }
 }
 
+export function verifyUniversalReleaseSidecar(context: AfterPackContext): void {
+  const appName = `${context.packager.appInfo.productFilename}.app`
+  const sidecarPath = join(
+    context.appOutDir,
+    appName,
+    'Contents',
+    'Resources',
+    'coral',
+    'coral',
+  )
+
+  let sidecarMetadata
+  try {
+    sidecarMetadata = statSync(sidecarPath)
+    accessSync(sidecarPath, constants.R_OK | constants.X_OK)
+  } catch {
+    throw new Error(`release desktop sidecar must be a readable, executable file: ${sidecarPath}`)
+  }
+  if (!sidecarMetadata.isFile() || sidecarMetadata.size === 0) {
+    throw new Error(`release desktop sidecar must be a readable, executable file: ${sidecarPath}`)
+  }
+
+  const architectures = execFileSync('lipo', ['-archs', sidecarPath], {
+    encoding: 'utf8',
+  })
+    .trim()
+    .split(/\s+/)
+    .sort()
+  if (
+    architectures.length !== 2 ||
+    architectures[0] !== 'arm64' ||
+    architectures[1] !== 'x86_64'
+  ) {
+    throw new Error(
+      `release desktop sidecar must contain exactly arm64 and x86_64; lipo reported '${architectures.join(' ')}'`,
+    )
+  }
+
+  console.info(
+    `[desktop-package] verified pre-sign sidecar architectures: ${architectures.join(' ')}`,
+  )
+}
+
 export function createConfig(env: NodeJS.ProcessEnv = process.env): Configuration {
   const releaseBuild = env.CORAL_DESKTOP_RELEASE === '1'
   if (releaseBuild) requireNotarizationCredentials(env)
@@ -56,6 +101,10 @@ export function createConfig(env: NodeJS.ProcessEnv = process.env): Configuratio
       output: 'dist',
       buildResources: 'resources',
     },
+    // afterPack runs after Coral.app is assembled but before electron-builder
+    // signs it, so release packaging fails before signing begins if the staged
+    // sidecar lost either architecture.
+    afterPack: releaseBuild ? verifyUniversalReleaseSidecar : undefined,
     files: ['out/**/*', 'package.json'],
     extraResources: [
       {

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -31,6 +31,7 @@
         "tinykeys": "4.0.0"
       },
       "devDependencies": {
+        "@electron/asar": "3.4.1",
         "@types/node": "^22.19.2",
         "electron": "^42.3.3",
         "electron-builder": "^26.15.2",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,7 +14,7 @@
     "postbuild": "node ./scripts/copy-reef-server.mjs",
     "type-check": "tsc --noEmit",
     "check": "npm run type-check && npm run test:config",
-    "test:config": "node --test scripts/electron-builder-config.test.mjs scripts/electron-vite-config.test.mjs",
+    "test:config": "node --test scripts/electron-builder-config.test.mjs scripts/electron-vite-config.test.mjs scripts/stage-coral.test.mjs scripts/verify-package-dir.test.mjs",
     "test": "vitest run",
     "verify:release-build": "node ./scripts/verify-release-build.mjs",
     "prepackage": "npm run build",
@@ -26,6 +26,8 @@
     "prepackage:mac": "CORAL_DESKTOP_UNIVERSAL=1 npm run build",
     "package:mac": "npm run package:mac:prepared",
     "package:mac:prepared": "electron-builder --mac --universal --publish never --config electron-builder.config.ts",
+    "prepackage:mac:smoke": "node -e \"if (!process.env.CORAL_DESKTOP_PREBUILT_CORAL?.trim()) throw new Error('package:mac:smoke requires CORAL_DESKTOP_PREBUILT_CORAL')\" && npm run build",
+    "package:mac:smoke": "CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --dir --config electron-builder.config.ts",
     "stage:coral": "node ./scripts/stage-coral.mjs"
   },
   "dependencies": {
@@ -52,6 +54,7 @@
     "tinykeys": "4.0.0"
   },
   "devDependencies": {
+    "@electron/asar": "3.4.1",
     "@types/node": "^22.19.2",
     "electron": "^42.3.3",
     "electron-builder": "^26.15.2",

--- a/apps/desktop/scripts/electron-builder-config.test.mjs
+++ b/apps/desktop/scripts/electron-builder-config.test.mjs
@@ -34,6 +34,7 @@ test('non-release packages are explicitly unsigned', () => {
   const config = createConfig({})
 
   assert.equal(config.forceCodeSigning, false)
+  assert.equal(config.afterPack, undefined)
   assert.equal(config.mac?.identity, null)
   assert.equal(config.mac?.hardenedRuntime, false)
   assert.equal(config.mac?.entitlements, null)
@@ -48,6 +49,7 @@ test('release packages enable strict signing and notarization', () => {
   })
 
   assert.equal(config.forceCodeSigning, true)
+  assert.equal(typeof config.afterPack, 'function')
   assert.equal(config.mac?.identity, undefined)
   assert.equal(config.mac?.hardenedRuntime, true)
   assert.equal(config.mac?.entitlements, 'resources/entitlements.mac.plist')

--- a/apps/desktop/scripts/stage-coral-plan.mjs
+++ b/apps/desktop/scripts/stage-coral-plan.mjs
@@ -1,6 +1,6 @@
 import { constants } from 'node:fs'
-import { access, chmod, copyFile, mkdir, rm, stat } from 'node:fs/promises'
-import { isAbsolute, relative, resolve, sep } from 'node:path'
+import { access, chmod, copyFile, mkdir, realpath, rm, stat } from 'node:fs/promises'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 export const PREBUILT_CORAL_ENV = 'CORAL_DESKTOP_PREBUILT_CORAL'
 
@@ -43,6 +43,46 @@ function requirePrebuiltOutsideOutputDirectory(sourceBinary, outputDir) {
       `${PREBUILT_CORAL_ENV} must point outside the staging output directory ${outputDir}; that directory is cleared before copying.`,
     )
   }
+}
+
+async function canonicalizePotentialPath(path, realpathFile) {
+  let existingAncestor = resolve(path)
+  const missingSegments = []
+
+  while (true) {
+    try {
+      const canonicalAncestor = await realpathFile(existingAncestor)
+      return join(canonicalAncestor, ...missingSegments.reverse())
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error
+
+      const parent = dirname(existingAncestor)
+      if (parent === existingAncestor) throw error
+      missingSegments.push(basename(existingAncestor))
+      existingAncestor = parent
+    }
+  }
+}
+
+async function requireCanonicalPrebuiltOutsideOutputDirectory(
+  sourceBinary,
+  outputDir,
+  realpathFile,
+) {
+  let canonicalPaths
+  try {
+    canonicalPaths = await Promise.all([
+      realpathFile(sourceBinary),
+      canonicalizePotentialPath(outputDir, realpathFile),
+    ])
+  } catch (error) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} or its staging output directory could not be resolved.`,
+      { cause: error },
+    )
+  }
+
+  requirePrebuiltOutsideOutputDirectory(...canonicalPaths)
 }
 
 export function createStageCoralPlan({
@@ -140,7 +180,7 @@ export function createStageCoralPlan({
 
 export async function validatePrebuiltCoral(
   sourceBinary,
-  { statFile = stat, accessFile = access } = {},
+  { statFile = stat, accessFile = access, realpathFile = realpath, outputDir } = {},
 ) {
   let metadata
   try {
@@ -171,12 +211,20 @@ export async function validatePrebuiltCoral(
       { cause: error },
     )
   }
+
+  if (outputDir) {
+    await requireCanonicalPrebuiltOutsideOutputDirectory(
+      sourceBinary,
+      outputDir,
+      realpathFile,
+    )
+  }
 }
 
 export async function stageCoralBinary(plan) {
   if (plan.mode === 'prebuilt') {
     requirePrebuiltOutsideOutputDirectory(plan.sourceBinary, plan.outputDir)
-    await validatePrebuiltCoral(plan.sourceBinary)
+    await validatePrebuiltCoral(plan.sourceBinary, { outputDir: plan.outputDir })
   }
 
   await rm(plan.outputDir, { recursive: true, force: true })

--- a/apps/desktop/scripts/stage-coral-plan.mjs
+++ b/apps/desktop/scripts/stage-coral-plan.mjs
@@ -1,0 +1,189 @@
+import { constants } from 'node:fs'
+import { access, chmod, copyFile, mkdir, rm, stat } from 'node:fs/promises'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
+
+export const PREBUILT_CORAL_ENV = 'CORAL_DESKTOP_PREBUILT_CORAL'
+
+const macTargets = ['x86_64-apple-darwin', 'aarch64-apple-darwin']
+
+function npmCommand(args, env) {
+  return {
+    command: 'npm',
+    args,
+    ...(env ? { env } : {}),
+  }
+}
+
+function commonBuildCommands(includeUi) {
+  return [
+    ...(includeUi
+      ? [
+          npmCommand(['ci', '--prefix', 'apps/ui']),
+          npmCommand(['run', 'build', '--prefix', 'apps/ui']),
+        ]
+      : []),
+    npmCommand(['ci', '--prefix', 'apps/reef']),
+    npmCommand(['run', 'build', '--prefix', 'apps/reef'], {
+      CORAL_DESKTOP_APP: '1',
+      VITE_CORAL_DESKTOP_APP: '1',
+    }),
+  ]
+}
+
+function requirePrebuiltOutsideOutputDirectory(sourceBinary, outputDir) {
+  const relativeSource = relative(outputDir, sourceBinary)
+  const sourceIsInsideOutput =
+    relativeSource === '' ||
+    (relativeSource !== '..' &&
+      !relativeSource.startsWith(`..${sep}`) &&
+      !isAbsolute(relativeSource))
+
+  if (sourceIsInsideOutput) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} must point outside the staging output directory ${outputDir}; that directory is cleared before copying.`,
+    )
+  }
+}
+
+export function createStageCoralPlan({
+  env = process.env,
+  platform = process.platform,
+  repoRoot,
+  desktopRoot,
+}) {
+  const outputDir = resolve(desktopRoot, 'resources', 'coral')
+  const binaryName = platform === 'win32' ? 'coral.exe' : 'coral'
+  const destinationBinary = resolve(outputDir, binaryName)
+  const universalMac = env.CORAL_DESKTOP_UNIVERSAL === '1'
+  const prebuiltInput = env[PREBUILT_CORAL_ENV]
+  const prebuiltSelected = prebuiltInput !== undefined
+
+  if (prebuiltSelected && universalMac) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} cannot be combined with CORAL_DESKTOP_UNIVERSAL=1.`,
+    )
+  }
+
+  if (prebuiltSelected) {
+    if (typeof prebuiltInput !== 'string' || !isAbsolute(prebuiltInput)) {
+      throw new Error(
+        `${PREBUILT_CORAL_ENV} must be an absolute path; received ${JSON.stringify(prebuiltInput)}.`,
+      )
+    }
+
+    const sourceBinary = resolve(prebuiltInput)
+    requirePrebuiltOutsideOutputDirectory(sourceBinary, outputDir)
+
+    return {
+      mode: 'prebuilt',
+      commands: commonBuildCommands(false),
+      sourceBinary,
+      destinationBinary,
+      outputDir,
+      platform,
+    }
+  }
+
+  const commands = commonBuildCommands(true)
+  if (!universalMac) {
+    commands.push({
+      command: 'cargo',
+      args: ['build', '--locked', '-p', 'coral-cli', '--release'],
+    })
+    return {
+      mode: 'native',
+      commands,
+      sourceBinary: resolve(repoRoot, 'target', 'release', binaryName),
+      destinationBinary,
+      outputDir,
+      platform,
+    }
+  }
+
+  if (platform !== 'darwin') {
+    throw new Error('CORAL_DESKTOP_UNIVERSAL=1 is only supported on macOS.')
+  }
+
+  commands.push(
+    {
+      command: 'rustup',
+      args: ['target', 'add', ...macTargets],
+    },
+    ...macTargets.map((target) => ({
+      command: 'cargo',
+      args: ['build', '--locked', '-p', 'coral-cli', '--release', '--target', target],
+    })),
+  )
+
+  const universalBinary = resolve(repoRoot, 'target', 'release', 'coral-universal')
+  commands.push({
+    command: 'lipo',
+    args: [
+      '-create',
+      ...macTargets.map((target) =>
+        resolve(repoRoot, 'target', target, 'release', binaryName),
+      ),
+      '-output',
+      universalBinary,
+    ],
+  })
+
+  return {
+    mode: 'universal',
+    commands,
+    sourceBinary: universalBinary,
+    destinationBinary,
+    outputDir,
+    platform,
+  }
+}
+
+export async function validatePrebuiltCoral(
+  sourceBinary,
+  { statFile = stat, accessFile = access } = {},
+) {
+  let metadata
+  try {
+    metadata = await statFile(sourceBinary)
+  } catch (error) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} does not exist or cannot be inspected: ${sourceBinary}.`,
+      { cause: error },
+    )
+  }
+
+  if (!metadata.isFile()) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} must point to a regular file: ${sourceBinary}.`,
+    )
+  }
+  if (metadata.size === 0) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} must point to a non-empty file: ${sourceBinary}.`,
+    )
+  }
+
+  try {
+    await accessFile(sourceBinary, constants.R_OK)
+  } catch (error) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} must point to a readable file: ${sourceBinary}.`,
+      { cause: error },
+    )
+  }
+}
+
+export async function stageCoralBinary(plan) {
+  if (plan.mode === 'prebuilt') {
+    requirePrebuiltOutsideOutputDirectory(plan.sourceBinary, plan.outputDir)
+    await validatePrebuiltCoral(plan.sourceBinary)
+  }
+
+  await rm(plan.outputDir, { recursive: true, force: true })
+  await mkdir(plan.outputDir, { recursive: true })
+  await copyFile(plan.sourceBinary, plan.destinationBinary)
+
+  if (plan.platform !== 'win32') {
+    await chmod(plan.destinationBinary, 0o755)
+  }
+}

--- a/apps/desktop/scripts/stage-coral.mjs
+++ b/apps/desktop/scripts/stage-coral.mjs
@@ -1,23 +1,22 @@
-import { chmod, copyFile, mkdir, rm } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
 import { spawn } from 'node:child_process'
+import { resolve } from 'node:path'
+
+import {
+  createStageCoralPlan,
+  stageCoralBinary,
+  validatePrebuiltCoral,
+} from './stage-coral-plan.mjs'
 
 const desktopRoot = resolve(import.meta.dirname, '..')
 const repoRoot = resolve(desktopRoot, '..', '..')
-const outputDir = resolve(desktopRoot, 'resources', 'coral')
-const binaryName = process.platform === 'win32' ? 'coral.exe' : 'coral'
-const targetBinary = resolve(repoRoot, 'target', 'release', binaryName)
-const universalMacBinary = resolve(repoRoot, 'target', 'release', 'coral-universal')
-const universalMac = process.env.CORAL_DESKTOP_UNIVERSAL === '1'
-const macTargets = ['x86_64-apple-darwin', 'aarch64-apple-darwin']
 
-function run(command, args, options = {}) {
+function run({ command, args, env }) {
   return new Promise((resolveRun, rejectRun) => {
     const child = spawn(command, args, {
       cwd: repoRoot,
       stdio: 'inherit',
       shell: process.platform === 'win32',
-      ...options,
+      ...(env ? { env: { ...process.env, ...env } } : {}),
     })
     child.on('error', rejectRun)
     child.on('exit', (code) => {
@@ -30,48 +29,24 @@ function run(command, args, options = {}) {
   })
 }
 
-await run('npm', ['ci', '--prefix', 'apps/ui'])
-await run('npm', ['run', 'build', '--prefix', 'apps/ui'])
-await run('npm', ['ci', '--prefix', 'apps/reef'])
-await run('npm', ['run', 'build', '--prefix', 'apps/reef'], {
-  env: {
-    ...process.env,
-    CORAL_DESKTOP_APP: '1',
-    VITE_CORAL_DESKTOP_APP: '1',
-  },
+const plan = createStageCoralPlan({
+  env: process.env,
+  platform: process.platform,
+  repoRoot,
+  desktopRoot,
 })
 
-async function buildCoralCli() {
-  if (!universalMac) {
-    await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release'])
-    return targetBinary
-  }
-
-  if (process.platform !== 'darwin') {
-    throw new Error('CORAL_DESKTOP_UNIVERSAL=1 is only supported on macOS.')
-  }
-
-  await run('rustup', ['target', 'add', ...macTargets])
-  for (const target of macTargets) {
-    await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release', '--target', target])
-  }
-  await run('lipo', [
-    '-create',
-    ...macTargets.map((target) => resolve(repoRoot, 'target', target, 'release', binaryName)),
-    '-output',
-    universalMacBinary,
-  ])
-  return universalMacBinary
+if (plan.mode === 'prebuilt') {
+  console.log('[stage-coral] prebuilt mode selected')
+  console.log(`[stage-coral] prebuilt source: ${plan.sourceBinary}`)
+  console.log(`[stage-coral] prebuilt destination: ${plan.destinationBinary}`)
+  await validatePrebuiltCoral(plan.sourceBinary)
 }
 
-const builtBinary = await buildCoralCli()
-
-await rm(outputDir, { recursive: true, force: true })
-await mkdir(outputDir, { recursive: true })
-await copyFile(builtBinary, join(outputDir, binaryName))
-
-if (process.platform !== 'win32') {
-  await chmod(join(outputDir, binaryName), 0o755)
+for (const command of plan.commands) {
+  await run(command)
 }
 
-console.log(`[stage-coral] staged ${builtBinary} -> ${join(outputDir, binaryName)}`)
+await stageCoralBinary(plan)
+
+console.log(`[stage-coral] staged ${plan.sourceBinary} -> ${plan.destinationBinary}`)

--- a/apps/desktop/scripts/stage-coral.mjs
+++ b/apps/desktop/scripts/stage-coral.mjs
@@ -40,7 +40,7 @@ if (plan.mode === 'prebuilt') {
   console.log('[stage-coral] prebuilt mode selected')
   console.log(`[stage-coral] prebuilt source: ${plan.sourceBinary}`)
   console.log(`[stage-coral] prebuilt destination: ${plan.destinationBinary}`)
-  await validatePrebuiltCoral(plan.sourceBinary)
+  await validatePrebuiltCoral(plan.sourceBinary, { outputDir: plan.outputDir })
 }
 
 for (const command of plan.commands) {

--- a/apps/desktop/scripts/stage-coral.test.mjs
+++ b/apps/desktop/scripts/stage-coral.test.mjs
@@ -1,0 +1,276 @@
+import assert from 'node:assert/strict'
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+
+import {
+  createStageCoralPlan,
+  PREBUILT_CORAL_ENV,
+  stageCoralBinary,
+  validatePrebuiltCoral,
+} from './stage-coral-plan.mjs'
+
+async function createFixture(t) {
+  const root = await mkdtemp(join(tmpdir(), 'coral-desktop-stage-'))
+  t.after(() => rm(root, { recursive: true, force: true }))
+
+  const repoRoot = join(root, 'repo')
+  const desktopRoot = join(repoRoot, 'apps', 'desktop')
+  await mkdir(desktopRoot, { recursive: true })
+  return { root, repoRoot, desktopRoot }
+}
+
+function createPlan(fixture, env, platform = 'darwin') {
+  return createStageCoralPlan({
+    env,
+    platform,
+    repoRoot: fixture.repoRoot,
+    desktopRoot: fixture.desktopRoot,
+  })
+}
+
+test('stages a valid prebuilt Coral file and makes the output executable', async (t) => {
+  const fixture = await createFixture(t)
+  const sourceBinary = join(fixture.root, 'prebuilt', 'coral')
+  await mkdir(dirname(sourceBinary), { recursive: true })
+  await writeFile(sourceBinary, 'prebuilt coral')
+  await chmod(sourceBinary, 0o644)
+
+  const plan = createPlan(fixture, {
+    [PREBUILT_CORAL_ENV]: sourceBinary,
+  })
+  await mkdir(plan.outputDir, { recursive: true })
+  const staleOutput = join(plan.outputDir, 'stale')
+  await writeFile(staleOutput, 'remove me')
+  await stageCoralBinary(plan)
+
+  assert.equal(plan.mode, 'prebuilt')
+  assert.equal(await readFile(plan.destinationBinary, 'utf8'), 'prebuilt coral')
+  assert.notEqual((await stat(plan.destinationBinary)).mode & 0o111, 0)
+  await assert.rejects(stat(staleOutput), { code: 'ENOENT' })
+})
+
+test('rejects a prebuilt Coral file inside the staging output before cleanup', async (t) => {
+  const fixture = await createFixture(t)
+  const outputDir = join(fixture.desktopRoot, 'resources', 'coral')
+  const sourceBinary = join(outputDir, 'coral')
+  await mkdir(outputDir, { recursive: true })
+  await writeFile(sourceBinary, 'already staged coral')
+
+  assert.throws(
+    () => createPlan(fixture, { [PREBUILT_CORAL_ENV]: sourceBinary }),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point outside the staging output directory`),
+  )
+  assert.equal(await readFile(sourceBinary, 'utf8'), 'already staged coral')
+
+  await assert.rejects(
+    stageCoralBinary({
+      mode: 'prebuilt',
+      sourceBinary,
+      destinationBinary: sourceBinary,
+      outputDir,
+      platform: 'darwin',
+    }),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point outside the staging output directory`),
+  )
+  assert.equal(await readFile(sourceBinary, 'utf8'), 'already staged coral')
+})
+
+test('rejects relative, missing, empty, directory, and unreadable prebuilt inputs', async (t) => {
+  const fixture = await createFixture(t)
+
+  assert.throws(
+    () => createPlan(fixture, { [PREBUILT_CORAL_ENV]: 'relative/coral' }),
+    new RegExp(`${PREBUILT_CORAL_ENV} must be an absolute path`),
+  )
+
+  const missing = join(fixture.root, 'missing-coral')
+  await assert.rejects(
+    validatePrebuiltCoral(missing),
+    new RegExp(`${PREBUILT_CORAL_ENV} does not exist or cannot be inspected`),
+  )
+
+  const empty = join(fixture.root, 'empty-coral')
+  await writeFile(empty, '')
+  await assert.rejects(
+    validatePrebuiltCoral(empty),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point to a non-empty file`),
+  )
+
+  const directory = join(fixture.root, 'coral-directory')
+  await mkdir(directory)
+  await assert.rejects(
+    validatePrebuiltCoral(directory),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point to a regular file`),
+  )
+
+  const unreadable = join(fixture.root, 'unreadable-coral')
+  await writeFile(unreadable, 'coral')
+  await assert.rejects(
+    validatePrebuiltCoral(unreadable, {
+      accessFile: async () => {
+        const error = new Error('permission denied')
+        error.code = 'EACCES'
+        throw error
+      },
+    }),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point to a readable file`),
+  )
+})
+
+test('rejects prebuilt and universal modes together', async (t) => {
+  const fixture = await createFixture(t)
+  const sourceBinary = join(fixture.root, 'coral')
+  await writeFile(sourceBinary, 'coral')
+
+  assert.throws(
+    () =>
+      createPlan(fixture, {
+        [PREBUILT_CORAL_ENV]: sourceBinary,
+        CORAL_DESKTOP_UNIVERSAL: '1',
+      }),
+    /cannot be combined with CORAL_DESKTOP_UNIVERSAL=1/,
+  )
+})
+
+test('prebuilt mode builds Reef without scheduling UI or Rust toolchain commands', async (t) => {
+  const fixture = await createFixture(t)
+  const sourceBinary = join(fixture.root, 'coral')
+  await writeFile(sourceBinary, 'coral')
+
+  const plan = createPlan(fixture, { [PREBUILT_CORAL_ENV]: sourceBinary })
+
+  assert.deepEqual(plan.commands, [
+    {
+      command: 'npm',
+      args: ['ci', '--prefix', 'apps/reef'],
+    },
+    {
+      command: 'npm',
+      args: ['run', 'build', '--prefix', 'apps/reef'],
+      env: {
+        CORAL_DESKTOP_APP: '1',
+        VITE_CORAL_DESKTOP_APP: '1',
+      },
+    },
+  ])
+  assert.equal(
+    plan.commands.some(
+      ({ command, args }) =>
+        ['cargo', 'rustup', 'lipo'].includes(command) || args.includes('apps/ui'),
+    ),
+    false,
+  )
+})
+
+test('native mode preserves the existing UI, Reef, and Cargo command plan', async (t) => {
+  const fixture = await createFixture(t)
+  const plan = createPlan(fixture, {}, 'linux')
+
+  assert.equal(plan.mode, 'native')
+  assert.deepEqual(plan.commands, [
+    {
+      command: 'npm',
+      args: ['ci', '--prefix', 'apps/ui'],
+    },
+    {
+      command: 'npm',
+      args: ['run', 'build', '--prefix', 'apps/ui'],
+    },
+    {
+      command: 'npm',
+      args: ['ci', '--prefix', 'apps/reef'],
+    },
+    {
+      command: 'npm',
+      args: ['run', 'build', '--prefix', 'apps/reef'],
+      env: {
+        CORAL_DESKTOP_APP: '1',
+        VITE_CORAL_DESKTOP_APP: '1',
+      },
+    },
+    {
+      command: 'cargo',
+      args: ['build', '--locked', '-p', 'coral-cli', '--release'],
+    },
+  ])
+  assert.equal(plan.sourceBinary, join(fixture.repoRoot, 'target', 'release', 'coral'))
+})
+
+test('universal mode preserves the existing UI, Reef, Rust, and lipo command plan', async (t) => {
+  const fixture = await createFixture(t)
+  const plan = createPlan(fixture, { CORAL_DESKTOP_UNIVERSAL: '1' })
+  const x86Binary = join(
+    fixture.repoRoot,
+    'target',
+    'x86_64-apple-darwin',
+    'release',
+    'coral',
+  )
+  const armBinary = join(
+    fixture.repoRoot,
+    'target',
+    'aarch64-apple-darwin',
+    'release',
+    'coral',
+  )
+  const universalBinary = join(fixture.repoRoot, 'target', 'release', 'coral-universal')
+
+  assert.equal(plan.mode, 'universal')
+  assert.deepEqual(plan.commands, [
+    {
+      command: 'npm',
+      args: ['ci', '--prefix', 'apps/ui'],
+    },
+    {
+      command: 'npm',
+      args: ['run', 'build', '--prefix', 'apps/ui'],
+    },
+    {
+      command: 'npm',
+      args: ['ci', '--prefix', 'apps/reef'],
+    },
+    {
+      command: 'npm',
+      args: ['run', 'build', '--prefix', 'apps/reef'],
+      env: {
+        CORAL_DESKTOP_APP: '1',
+        VITE_CORAL_DESKTOP_APP: '1',
+      },
+    },
+    {
+      command: 'rustup',
+      args: ['target', 'add', 'x86_64-apple-darwin', 'aarch64-apple-darwin'],
+    },
+    {
+      command: 'cargo',
+      args: [
+        'build',
+        '--locked',
+        '-p',
+        'coral-cli',
+        '--release',
+        '--target',
+        'x86_64-apple-darwin',
+      ],
+    },
+    {
+      command: 'cargo',
+      args: [
+        'build',
+        '--locked',
+        '-p',
+        'coral-cli',
+        '--release',
+        '--target',
+        'aarch64-apple-darwin',
+      ],
+    },
+    {
+      command: 'lipo',
+      args: ['-create', x86Binary, armBinary, '-output', universalBinary],
+    },
+  ])
+  assert.equal(plan.sourceBinary, universalBinary)
+})

--- a/apps/desktop/scripts/stage-coral.test.mjs
+++ b/apps/desktop/scripts/stage-coral.test.mjs
@@ -1,5 +1,14 @@
 import assert from 'node:assert/strict'
-import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import test from 'node:test'
@@ -40,6 +49,7 @@ test('stages a valid prebuilt Coral file and makes the output executable', async
   const plan = createPlan(fixture, {
     [PREBUILT_CORAL_ENV]: sourceBinary,
   })
+  await validatePrebuiltCoral(sourceBinary, { outputDir: plan.outputDir })
   await mkdir(plan.outputDir, { recursive: true })
   const staleOutput = join(plan.outputDir, 'stale')
   await writeFile(staleOutput, 'remove me')
@@ -75,6 +85,34 @@ test('rejects a prebuilt Coral file inside the staging output before cleanup', a
     new RegExp(`${PREBUILT_CORAL_ENV} must point outside the staging output directory`),
   )
   assert.equal(await readFile(sourceBinary, 'utf8'), 'already staged coral')
+})
+
+test('rejects a prebuilt path whose symlinked parent resolves inside staging', async (t) => {
+  const fixture = await createFixture(t)
+  const outputDir = join(fixture.desktopRoot, 'resources', 'coral')
+  const stagedBinary = join(outputDir, 'coral')
+  const aliasedOutputDir = join(fixture.root, 'prebuilt-alias')
+  await mkdir(outputDir, { recursive: true })
+  await writeFile(stagedBinary, 'already staged coral')
+  await symlink(
+    outputDir,
+    aliasedOutputDir,
+    process.platform === 'win32' ? 'junction' : 'dir',
+  )
+
+  const plan = createPlan(fixture, {
+    [PREBUILT_CORAL_ENV]: join(aliasedOutputDir, 'coral'),
+  })
+
+  await assert.rejects(
+    validatePrebuiltCoral(plan.sourceBinary, { outputDir: plan.outputDir }),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point outside the staging output directory`),
+  )
+  await assert.rejects(
+    stageCoralBinary(plan),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point outside the staging output directory`),
+  )
+  assert.equal(await readFile(stagedBinary, 'utf8'), 'already staged coral')
 })
 
 test('rejects relative, missing, empty, directory, and unreadable prebuilt inputs', async (t) => {

--- a/apps/desktop/scripts/verify-package-dir.mjs
+++ b/apps/desktop/scripts/verify-package-dir.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+import { statFile } from '@electron/asar'
+import { constants } from 'node:fs'
+import { access, open, readdir, stat } from 'node:fs/promises'
+import { basename, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const MACH_64_MAGIC = 0xfeedfacf
+const MACH_32_MAGIC = 0xfeedface
+const FAT_MAGICS = new Set([0xcafebabe, 0xcafebabf, 0xbebafeca, 0xbfbafeca])
+const CPU_TYPE_ARM64 = 0x0100000c
+const CPU_TYPE_X86_64 = 0x01000007
+
+async function requireDirectory(path, description) {
+  let metadata
+  try {
+    metadata = await stat(path)
+  } catch {
+    throw new Error(`missing ${description}: ${path}`)
+  }
+  if (!metadata.isDirectory()) throw new Error(`${description} is not a directory: ${path}`)
+}
+
+async function requireNonEmptyFile(path, description) {
+  let metadata
+  try {
+    metadata = await stat(path)
+  } catch {
+    throw new Error(`missing ${description}: ${path}`)
+  }
+  if (!metadata.isFile() || metadata.size === 0) {
+    throw new Error(`${description} must be a non-empty regular file: ${path}`)
+  }
+  return metadata
+}
+
+async function requireExecutable(path, description, metadata) {
+  if ((metadata.mode & 0o111) === 0) throw new Error(`${description} is not executable: ${path}`)
+  try {
+    await access(path, constants.X_OK)
+  } catch {
+    throw new Error(`${description} is not executable: ${path}`)
+  }
+}
+
+async function findTopLevelAppBundles(directory) {
+  await requireDirectory(directory, 'unpacked package directory')
+  const found = []
+
+  async function visit(current) {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      const path = join(current, entry.name)
+      if (entry.name.endsWith('.app')) {
+        found.push(path)
+      } else {
+        await visit(path)
+      }
+    }
+  }
+
+  await visit(directory)
+  return found
+}
+
+function requireArchiveFile(archivePath, entry, description) {
+  let metadata
+  try {
+    metadata = statFile(archivePath, entry)
+  } catch {
+    throw new Error(`missing ${description} in app.asar: ${entry}`)
+  }
+  if (!Number.isSafeInteger(metadata.size) || metadata.size <= 0) {
+    throw new Error(`${description} must be a non-empty file in app.asar: ${entry}`)
+  }
+}
+
+async function containsNonEmptyFile(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory() && (await containsNonEmptyFile(path))) return true
+    if (entry.isFile() && (await stat(path)).size > 0) return true
+  }
+  return false
+}
+
+export async function readThinMachOArchitecture(path) {
+  const handle = await open(path, 'r')
+  try {
+    const header = Buffer.alloc(8)
+    const { bytesRead } = await handle.read(header, 0, header.length, 0)
+    if (bytesRead < header.length) throw new Error('file is too small to contain a Mach-O header')
+
+    const magicLittleEndian = header.readUInt32LE(0)
+    const magicBigEndian = header.readUInt32BE(0)
+    if (FAT_MAGICS.has(magicLittleEndian) || FAT_MAGICS.has(magicBigEndian)) {
+      throw new Error('binary is universal; expected a thin arm64 Mach-O executable')
+    }
+
+    let cpuType
+    if (magicLittleEndian === MACH_64_MAGIC || magicLittleEndian === MACH_32_MAGIC) {
+      cpuType = header.readUInt32LE(4)
+    } else if (magicBigEndian === MACH_64_MAGIC || magicBigEndian === MACH_32_MAGIC) {
+      cpuType = header.readUInt32BE(4)
+    } else {
+      throw new Error('file is not a Mach-O executable')
+    }
+
+    if (cpuType === CPU_TYPE_ARM64) return 'arm64'
+    if (cpuType === CPU_TYPE_X86_64) return 'x86_64'
+    return `unknown CPU type 0x${cpuType.toString(16)}`
+  } finally {
+    await handle.close()
+  }
+}
+
+export async function verifyPackageDir(packageDirectory) {
+  const distDir = resolve(packageDirectory)
+  const appBundles = await findTopLevelAppBundles(distDir)
+  if (appBundles.length !== 1 || basename(appBundles[0]) !== 'Coral.app') {
+    const found = appBundles.length === 0 ? 'none' : appBundles.map((path) => basename(path)).join(', ')
+    throw new Error(`expected exactly one Coral.app in ${distDir}; found ${found}`)
+  }
+
+  const appPath = appBundles[0]
+  const contentsPath = join(appPath, 'Contents')
+  const resourcesPath = join(contentsPath, 'Resources')
+  await requireDirectory(contentsPath, 'Electron app Contents directory')
+  await requireDirectory(join(contentsPath, 'Frameworks'), 'Electron app Frameworks directory')
+  await requireDirectory(resourcesPath, 'Electron app Resources directory')
+  await requireNonEmptyFile(join(contentsPath, 'Info.plist'), 'Electron app Info.plist')
+
+  const electronExecutablePath = join(contentsPath, 'MacOS', 'Coral')
+  const electronExecutable = await requireNonEmptyFile(
+    electronExecutablePath,
+    'Electron app executable',
+  )
+  await requireExecutable(electronExecutablePath, 'Electron app executable', electronExecutable)
+
+  const archivePath = join(resourcesPath, 'app.asar')
+  await requireNonEmptyFile(archivePath, 'packaged app archive')
+  requireArchiveFile(archivePath, 'out/main/index.js', 'Electron main output')
+  requireArchiveFile(archivePath, 'out/preload/index.cjs', 'Electron preload output')
+  requireArchiveFile(archivePath, 'out/reef-server/index.js', 'Reef server output')
+
+  const reefAssetsPath = join(resourcesPath, 'app', 'assets')
+  await requireDirectory(reefAssetsPath, 'Reef client assets directory')
+  if (!(await containsNonEmptyFile(reefAssetsPath))) {
+    throw new Error(`Reef client assets directory contains no non-empty files: ${reefAssetsPath}`)
+  }
+
+  const sidecarPath = join(resourcesPath, 'coral', 'coral')
+  const sidecar = await requireNonEmptyFile(sidecarPath, 'packaged Coral sidecar')
+  await requireExecutable(sidecarPath, 'packaged Coral sidecar', sidecar)
+  let architecture
+  try {
+    architecture = await readThinMachOArchitecture(sidecarPath)
+  } catch (error) {
+    throw new Error(`packaged Coral sidecar is not thin arm64: ${error.message}`)
+  }
+  if (architecture !== 'arm64') {
+    throw new Error(`packaged Coral sidecar must be thin arm64; found ${architecture}`)
+  }
+
+  return { appPath, archivePath, sidecarPath, architecture }
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  const packageDirectory = process.argv[2] ?? fileURLToPath(new URL('../dist', import.meta.url))
+  try {
+    const result = await verifyPackageDir(packageDirectory)
+    console.log(
+      `[verify-package-dir] ok: ${result.appPath}; main, preload, Reef client/server, and ${result.architecture} Coral sidecar verified`,
+    )
+  } catch (error) {
+    console.error(`[verify-package-dir] ${error.message}`)
+    process.exitCode = 1
+  }
+}

--- a/apps/desktop/scripts/verify-package-dir.test.mjs
+++ b/apps/desktop/scripts/verify-package-dir.test.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test, { afterEach } from 'node:test'
+
+import { createPackage } from '@electron/asar'
+
+import { verifyPackageDir } from './verify-package-dir.mjs'
+
+const fixtures = new Set()
+
+afterEach(async () => {
+  await Promise.all(
+    [...fixtures].map((fixture) => rm(fixture, { recursive: true, force: true })),
+  )
+  fixtures.clear()
+})
+
+function thinMachO(cpuType = 0x0100000c) {
+  const header = Buffer.alloc(32)
+  header.writeUInt32LE(0xfeedfacf, 0)
+  header.writeUInt32LE(cpuType, 4)
+  return header
+}
+
+async function createFixture(options = {}) {
+  const root = await mkdtemp(join(tmpdir(), 'coral-package-dir-fixture-'))
+  fixtures.add(root)
+  const distDir = join(root, 'dist')
+  await mkdir(distDir, { recursive: true })
+  if (options.missingApp) return { root, distDir }
+
+  const appPath = join(distDir, 'mac-arm64', 'Coral.app')
+  const contentsPath = join(appPath, 'Contents')
+  const resourcesPath = join(contentsPath, 'Resources')
+  const electronExecutablePath = join(contentsPath, 'MacOS', 'Coral')
+  const sidecarPath = join(resourcesPath, 'coral', 'coral')
+  const reefAssetsPath = join(resourcesPath, 'app', 'assets')
+  await Promise.all([
+    mkdir(join(contentsPath, 'Frameworks'), { recursive: true }),
+    mkdir(join(contentsPath, 'MacOS'), { recursive: true }),
+    mkdir(join(resourcesPath, 'coral'), { recursive: true }),
+    mkdir(reefAssetsPath, { recursive: true }),
+  ])
+  await Promise.all([
+    writeFile(join(contentsPath, 'Info.plist'), '<plist/>'),
+    writeFile(electronExecutablePath, 'electron'),
+    writeFile(sidecarPath, thinMachO(options.cpuType)),
+    writeFile(join(reefAssetsPath, 'entry.js'), 'reef client'),
+  ])
+  await Promise.all([chmod(electronExecutablePath, 0o755), chmod(sidecarPath, 0o755)])
+
+  const archiveSource = join(root, 'archive-source')
+  const archiveEntries = {
+    'out/main/index.js': 'main',
+    'out/preload/index.cjs': 'preload',
+    'out/reef-server/index.js': 'reef server',
+  }
+  for (const [entry, contents] of Object.entries(archiveEntries)) {
+    if (options.omitArchiveEntry === entry) continue
+    const path = join(archiveSource, entry)
+    if (options.directoryArchiveEntry === entry) {
+      await mkdir(path, { recursive: true })
+      continue
+    }
+    await mkdir(join(path, '..'), { recursive: true })
+    await writeFile(path, contents)
+  }
+  await createPackage(archiveSource, join(resourcesPath, 'app.asar'))
+
+  return {
+    root,
+    distDir,
+    appPath,
+    electronExecutablePath,
+    reefAssetsPath,
+    resourcesPath,
+    sidecarPath,
+  }
+}
+
+test('accepts an unpacked app with Electron, Reef, and a thin arm64 sidecar', async () => {
+  const fixture = await createFixture()
+
+  const result = await verifyPackageDir(fixture.distDir)
+
+  assert.equal(result.appPath, fixture.appPath)
+  assert.equal(result.sidecarPath, fixture.sidecarPath)
+  assert.equal(result.architecture, 'arm64')
+})
+
+test('rejects missing app output', async () => {
+  const fixture = await createFixture({ missingApp: true })
+
+  await assert.rejects(() => verifyPackageDir(fixture.distDir), /expected exactly one Coral\.app/)
+})
+
+test('rejects a missing packaged sidecar', async () => {
+  const fixture = await createFixture()
+  await rm(fixture.sidecarPath)
+
+  await assert.rejects(() => verifyPackageDir(fixture.distDir), /missing packaged Coral sidecar/)
+})
+
+test('rejects a sidecar without executable permission', async () => {
+  const fixture = await createFixture()
+  await chmod(fixture.sidecarPath, 0o644)
+
+  await assert.rejects(() => verifyPackageDir(fixture.distDir), /sidecar is not executable/)
+})
+
+test('rejects missing Electron main and preload outputs', async (t) => {
+  for (const [entry, description] of [
+    ['out/main/index.js', 'Electron main output'],
+    ['out/preload/index.cjs', 'Electron preload output'],
+  ]) {
+    await t.test(description, async () => {
+      const fixture = await createFixture({ omitArchiveEntry: entry })
+      await assert.rejects(() => verifyPackageDir(fixture.distDir), new RegExp(description))
+    })
+  }
+})
+
+test('rejects an ASAR directory masquerading as an Electron output file', async () => {
+  const fixture = await createFixture({ directoryArchiveEntry: 'out/main/index.js' })
+
+  await assert.rejects(
+    () => verifyPackageDir(fixture.distDir),
+    /Electron main output must be a non-empty file/,
+  )
+})
+
+test('rejects missing Reef client assets', async () => {
+  const fixture = await createFixture()
+  await rm(fixture.reefAssetsPath, { recursive: true })
+
+  await assert.rejects(() => verifyPackageDir(fixture.distDir), /missing Reef client assets directory/)
+})
+
+test('rejects missing Reef server assets', async () => {
+  const fixture = await createFixture({ omitArchiveEntry: 'out/reef-server/index.js' })
+
+  await assert.rejects(() => verifyPackageDir(fixture.distDir), /missing Reef server output/)
+})
+
+test('rejects a non-arm64 sidecar', async () => {
+  const fixture = await createFixture({ cpuType: 0x01000007 })
+
+  await assert.rejects(() => verifyPackageDir(fixture.distDir), /must be thin arm64; found x86_64/)
+})

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -12,6 +12,7 @@ import {
 import { killAllTrackedChildren, startCoralSidecar, type CoralSidecar } from './sidecar'
 import { checkForDesktopUpdates, desktopUpdatesSupported, installAutoUpdater } from './auto-update'
 
+// Temporary no-op edit used to exercise the native macOS packaging smoke lane.
 const SHUTDOWN_TIMEOUT_MS = 6000
 
 let mainWindow: BrowserWindow | null = null


### PR DESCRIPTION
## Purpose

Temporary stacked PR against #1879 to measure the new source-only desktop packaging path.

This deliberately adds one comment under `apps/desktop/src/**` and makes no behavior change. The expected gate behavior is:

- native unpacked macOS smoke packaging runs
- universal DMG/ZIP packaging is skipped
- the aggregate Validate gate includes the selected smoke result

Please do not merge this probe PR.

## Local validation

- `npm run check --prefix apps/desktop`
- `npm test --prefix apps/desktop`