### PR TITLE
ci(desktop): disable packaging during PR validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,6 @@ jobs:
       ui-tests: ${{ steps.filter.outputs.ui-tests }}
       reef-checks: ${{ steps.filter.outputs.reef-checks }}
       desktop-checks: ${{ steps.filter.outputs.desktop-checks }}
-      desktop-package-macos: ${{ steps.filter.outputs.desktop-package-macos }}
       proto-lint: ${{ steps.filter.outputs.proto-lint }}
       source-lint: ${{ steps.filter.outputs.source-lint }}
       docs-freshness: ${{ steps.filter.outputs.docs-freshness }}
@@ -106,18 +105,6 @@ jobs:
               - 'apps/desktop/src/shared/types.ts'
             desktop-checks:
               - '.github/workflows/validate.yml'
-              - 'apps/desktop/**'
-            desktop-package-macos:
-              - '.github/workflows/validate.yml'
-              - '.github/workflows/release.yml'
-              - '.github/workflows/desktop-package.yml'
-              - '.cargo/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - 'rust-toolchain.toml'
-              - 'rust-toolchain'
-              - 'crates/**/Cargo.toml'
-              - 'crates/**/build.rs'
               - 'apps/desktop/**'
             proto-lint:
               - '.github/workflows/validate.yml'
@@ -534,14 +521,6 @@ jobs:
       - name: Test desktop
         run: npm test --prefix apps/desktop
 
-  desktop-package-macos:
-    name: Desktop macOS package
-    needs: changes
-    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.desktop-package-macos == 'true' }}
-    permissions:
-      contents: read
-    uses: ./.github/workflows/desktop-package.yml
-
   proto-lint:
     name: Lint protobuf API
     runs-on: ubuntu-latest
@@ -767,7 +746,6 @@ jobs:
         ui-tests,
         reef-checks,
         desktop-checks,
-        desktop-package-macos,
         proto-lint,
         gha-security-audit-pr,
         gha-security-audit-sarif,
@@ -791,7 +769,6 @@ jobs:
           UI_TESTS_RESULT: ${{ needs.ui-tests.result }}
           REEF_CHECKS_RESULT: ${{ needs.reef-checks.result }}
           DESKTOP_CHECKS_RESULT: ${{ needs.desktop-checks.result }}
-          DESKTOP_PACKAGE_MACOS_RESULT: ${{ needs.desktop-package-macos.result }}
           PROTO_LINT_RESULT: ${{ needs.proto-lint.result }}
           GHA_SECURITY_AUDIT_PR_RESULT: ${{ needs.gha-security-audit-pr.result }}
           GHA_SECURITY_AUDIT_SARIF_RESULT: ${{ needs.gha-security-audit-sarif.result }}
@@ -810,7 +787,6 @@ jobs:
             "ui-tests:$UI_TESTS_RESULT"
             "reef-checks:$REEF_CHECKS_RESULT"
             "desktop-checks:$DESKTOP_CHECKS_RESULT"
-            "desktop-package-macos:$DESKTOP_PACKAGE_MACOS_RESULT"
             "proto-lint:$PROTO_LINT_RESULT"
             "gha-security-audit-pr:$GHA_SECURITY_AUDIT_PR_RESULT"
             "gha-security-audit-sarif:$GHA_SECURITY_AUDIT_SARIF_RESULT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,14 +51,10 @@
   latency. CI installs the bundled `github` source with fake credentials and
   fails when release `coral sql "select * from coral.tables"` has a hyperfine
   mean above 750 ms.
-- Desktop distribution-sensitive PRs must exercise the release-shaped macOS
-  package path, not only the desktop type-check. Validate calls the reusable
-  desktop packaging workflow for desktop, packaging-workflow, release-workflow,
-  Cargo workspace/toolchain, crate-manifest, and build-script changes. Ordinary
-  Rust, Reef, and UI changes use their existing checks. Use manual dispatch as
-  an unsigned packaging preflight for distribution-sensitive changes outside
-  the automatic paths. Validation artifacts stay unsigned and must not be
-  reused for a release; desktop release publishing must rebuild from a clean
+- Pull requests do not automatically build macOS Desktop packages. Use manual
+  dispatch for an unsigned packaging preflight when a distribution-sensitive
+  change warrants one. Validation artifacts stay unsigned and must not be
+  reused for a release; Desktop release publishing must rebuild from a clean
   checkout with signing and notarization.
 - The `Validate` workflow intentionally skips draft pull request runs, starts
   again on `ready_for_review`, and still triggers on `converted_to_draft` so the


### PR DESCRIPTION
## Summary

PRs that touch Desktop packaging currently kick off a full, release-shaped macOS package build. That job regularly takes 40+ minutes, and the unsigned artifacts it produces are never reused for a release.

This PR removes that packaging job from automatic PR validation. The normal Desktop checks and tests still run, and the existing packaging workflow is still available through manual dispatch when we want an unsigned preflight.

Actual release packaging, signing, and notarization are unchanged.

The contributor behavior change is simply: run the manual Desktop packaging workflow when a distribution-sensitive PR needs a full packaging preflight.

## Test plan

- Parsed `.github/workflows/validate.yml` and `.github/workflows/desktop-package.yml` as YAML.
- Verified `validate.yml` no longer references the Desktop packaging job or result.
- Verified `desktop-package.yml` still supports manual dispatch.
