### PR TITLE
feat(desktop): support prebuilt Coral sidecars

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,6 @@ jobs:
       ui-tests: ${{ steps.filter.outputs.ui-tests }}
       reef-checks: ${{ steps.filter.outputs.reef-checks }}
       desktop-checks: ${{ steps.filter.outputs.desktop-checks }}
-      desktop-package-macos: ${{ steps.filter.outputs.desktop-package-macos }}
       proto-lint: ${{ steps.filter.outputs.proto-lint }}
       source-lint: ${{ steps.filter.outputs.source-lint }}
       docs-freshness: ${{ steps.filter.outputs.docs-freshness }}
@@ -106,18 +105,6 @@ jobs:
               - 'apps/desktop/src/shared/types.ts'
             desktop-checks:
               - '.github/workflows/validate.yml'
-              - 'apps/desktop/**'
-            desktop-package-macos:
-              - '.github/workflows/validate.yml'
-              - '.github/workflows/release.yml'
-              - '.github/workflows/desktop-package.yml'
-              - '.cargo/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - 'rust-toolchain.toml'
-              - 'rust-toolchain'
-              - 'crates/**/Cargo.toml'
-              - 'crates/**/build.rs'
               - 'apps/desktop/**'
             proto-lint:
               - '.github/workflows/validate.yml'
@@ -534,14 +521,6 @@ jobs:
       - name: Test desktop
         run: npm test --prefix apps/desktop
 
-  desktop-package-macos:
-    name: Desktop macOS package
-    needs: changes
-    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.desktop-package-macos == 'true' }}
-    permissions:
-      contents: read
-    uses: ./.github/workflows/desktop-package.yml
-
   proto-lint:
     name: Lint protobuf API
     runs-on: ubuntu-latest
@@ -767,7 +746,6 @@ jobs:
         ui-tests,
         reef-checks,
         desktop-checks,
-        desktop-package-macos,
         proto-lint,
         gha-security-audit-pr,
         gha-security-audit-sarif,
@@ -791,7 +769,6 @@ jobs:
           UI_TESTS_RESULT: ${{ needs.ui-tests.result }}
           REEF_CHECKS_RESULT: ${{ needs.reef-checks.result }}
           DESKTOP_CHECKS_RESULT: ${{ needs.desktop-checks.result }}
-          DESKTOP_PACKAGE_MACOS_RESULT: ${{ needs.desktop-package-macos.result }}
           PROTO_LINT_RESULT: ${{ needs.proto-lint.result }}
           GHA_SECURITY_AUDIT_PR_RESULT: ${{ needs.gha-security-audit-pr.result }}
           GHA_SECURITY_AUDIT_SARIF_RESULT: ${{ needs.gha-security-audit-sarif.result }}
@@ -810,7 +787,6 @@ jobs:
             "ui-tests:$UI_TESTS_RESULT"
             "reef-checks:$REEF_CHECKS_RESULT"
             "desktop-checks:$DESKTOP_CHECKS_RESULT"
-            "desktop-package-macos:$DESKTOP_PACKAGE_MACOS_RESULT"
             "proto-lint:$PROTO_LINT_RESULT"
             "gha-security-audit-pr:$GHA_SECURITY_AUDIT_PR_RESULT"
             "gha-security-audit-sarif:$GHA_SECURITY_AUDIT_SARIF_RESULT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,14 +51,10 @@
   latency. CI installs the bundled `github` source with fake credentials and
   fails when release `coral sql "select * from coral.tables"` has a hyperfine
   mean above 750 ms.
-- Desktop distribution-sensitive PRs must exercise the release-shaped macOS
-  package path, not only the desktop type-check. Validate calls the reusable
-  desktop packaging workflow for desktop, packaging-workflow, release-workflow,
-  Cargo workspace/toolchain, crate-manifest, and build-script changes. Ordinary
-  Rust, Reef, and UI changes use their existing checks. Use manual dispatch as
-  an unsigned packaging preflight for distribution-sensitive changes outside
-  the automatic paths. Validation artifacts stay unsigned and must not be
-  reused for a release; desktop release publishing must rebuild from a clean
+- Pull requests do not automatically build macOS Desktop packages. Use manual
+  dispatch for an unsigned packaging preflight when a distribution-sensitive
+  change warrants one. Validation artifacts stay unsigned and must not be
+  reused for a release; Desktop release publishing must rebuild from a clean
   checkout with signing and notarization.
 - The `Validate` workflow intentionally skips draft pull request runs, starts
   again on `ready_for_review`, and still triggers on `converted_to_draft` so the

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -63,12 +63,25 @@ cargo run --locked -p coral-cli -- ui --no-open --port 0
 npm run build --prefix apps/desktop
 ```
 
-The build script compiles the release Coral binary, builds Reef in React Router
-framework mode, stages Reef's server bundle under `apps/desktop/out/reef-server/`,
-and stages the Coral binary under `apps/desktop/resources/coral/` for Electron
-packaging. The packaged app serves document, data, action, and route-discovery
-requests through the staged server bundle; static assets are copied from
-`apps/reef/build/client/` into the app resources.
+By default, the build script builds the embedded UI and release Coral binary,
+builds Reef in React Router framework mode, stages Reef's server bundle under
+`apps/desktop/out/reef-server/`, and stages the Coral binary under
+`apps/desktop/resources/coral/` for Electron packaging. The packaged app serves
+document, data, action, and route-discovery requests through the staged server
+bundle; static assets are copied from `apps/reef/build/client/` into the app
+resources.
+
+CI packaging can explicitly stage an existing Coral executable instead:
+
+```shell
+CORAL_DESKTOP_PREBUILT_CORAL=/absolute/path/to/coral npm run build --prefix apps/desktop
+```
+
+The prebuilt path must be absolute, readable, non-empty, and outside the staging
+directory. This mode skips the embedded UI build and all Cargo, rustup, and lipo
+commands; Reef and Electron still build normally. It is intended for trusted CI
+artifacts, cannot be combined with `CORAL_DESKTOP_UNIVERSAL=1`, and never falls
+back to compiling Coral when the input is invalid.
 
 ```shell
 npm run package:dir --prefix apps/desktop

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,7 +14,7 @@
     "postbuild": "node ./scripts/copy-reef-server.mjs",
     "type-check": "tsc --noEmit",
     "check": "npm run type-check && npm run test:config",
-    "test:config": "node --test scripts/electron-builder-config.test.mjs scripts/electron-vite-config.test.mjs scripts/reef-runtime-dependencies.test.mjs",
+    "test:config": "node --test scripts/electron-builder-config.test.mjs scripts/electron-vite-config.test.mjs scripts/reef-runtime-dependencies.test.mjs scripts/stage-coral.test.mjs",
     "test": "vitest run",
     "verify:release-build": "node ./scripts/verify-release-build.mjs",
     "prepackage": "npm run build",

--- a/apps/desktop/scripts/stage-coral-plan.mjs
+++ b/apps/desktop/scripts/stage-coral-plan.mjs
@@ -1,0 +1,236 @@
+import { constants } from 'node:fs'
+import { access, chmod, copyFile, mkdir, realpath, rm, stat } from 'node:fs/promises'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+
+export const PREBUILT_CORAL_ENV = 'CORAL_DESKTOP_PREBUILT_CORAL'
+
+const macTargets = ['x86_64-apple-darwin', 'aarch64-apple-darwin']
+
+function npmCommand(args, env) {
+  return {
+    command: 'npm',
+    args,
+    ...(env ? { env } : {}),
+  }
+}
+
+function commonBuildCommands(includeUi) {
+  return [
+    ...(includeUi
+      ? [
+          npmCommand(['ci', '--prefix', 'apps/ui']),
+          npmCommand(['run', 'build', '--prefix', 'apps/ui']),
+        ]
+      : []),
+    npmCommand(['ci', '--prefix', 'apps/reef']),
+    npmCommand(['run', 'build', '--prefix', 'apps/reef'], {
+      VITE_CORAL_DESKTOP_APP: '1',
+    }),
+  ]
+}
+
+function requirePrebuiltOutsideOutputDirectory(sourceBinary, outputDir) {
+  const relativeSource = relative(outputDir, sourceBinary)
+  const sourceIsInsideOutput =
+    relativeSource === '' ||
+    (relativeSource !== '..' &&
+      !relativeSource.startsWith(`..${sep}`) &&
+      !isAbsolute(relativeSource))
+
+  if (sourceIsInsideOutput) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} must point outside the staging output directory ${outputDir}; that directory is cleared before copying.`,
+    )
+  }
+}
+
+async function canonicalizePotentialPath(path, realpathFile) {
+  let existingAncestor = resolve(path)
+  const missingSegments = []
+
+  while (true) {
+    try {
+      const canonicalAncestor = await realpathFile(existingAncestor)
+      return join(canonicalAncestor, ...missingSegments.reverse())
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error
+
+      const parent = dirname(existingAncestor)
+      if (parent === existingAncestor) throw error
+      missingSegments.push(basename(existingAncestor))
+      existingAncestor = parent
+    }
+  }
+}
+
+async function requireCanonicalPrebuiltOutsideOutputDirectory(
+  sourceBinary,
+  outputDir,
+  realpathFile,
+) {
+  let canonicalPaths
+  try {
+    canonicalPaths = await Promise.all([
+      realpathFile(sourceBinary),
+      canonicalizePotentialPath(outputDir, realpathFile),
+    ])
+  } catch (error) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} or its staging output directory could not be resolved.`,
+      { cause: error },
+    )
+  }
+
+  requirePrebuiltOutsideOutputDirectory(...canonicalPaths)
+}
+
+export function createStageCoralPlan({
+  env = process.env,
+  platform = process.platform,
+  repoRoot,
+  desktopRoot,
+}) {
+  const outputDir = resolve(desktopRoot, 'resources', 'coral')
+  const binaryName = platform === 'win32' ? 'coral.exe' : 'coral'
+  const destinationBinary = resolve(outputDir, binaryName)
+  const universalMac = env.CORAL_DESKTOP_UNIVERSAL === '1'
+  const prebuiltInput = env[PREBUILT_CORAL_ENV]
+  const prebuiltSelected = prebuiltInput !== undefined
+
+  if (prebuiltSelected && universalMac) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} cannot be combined with CORAL_DESKTOP_UNIVERSAL=1.`,
+    )
+  }
+
+  if (prebuiltSelected) {
+    if (typeof prebuiltInput !== 'string' || !isAbsolute(prebuiltInput)) {
+      throw new Error(
+        `${PREBUILT_CORAL_ENV} must be an absolute path; received ${JSON.stringify(prebuiltInput)}.`,
+      )
+    }
+
+    const sourceBinary = resolve(prebuiltInput)
+    requirePrebuiltOutsideOutputDirectory(sourceBinary, outputDir)
+
+    return {
+      mode: 'prebuilt',
+      commands: commonBuildCommands(false),
+      sourceBinary,
+      destinationBinary,
+      outputDir,
+      platform,
+    }
+  }
+
+  const commands = commonBuildCommands(true)
+  if (!universalMac) {
+    commands.push({
+      command: 'cargo',
+      args: ['build', '--locked', '-p', 'coral-cli', '--release'],
+    })
+    return {
+      mode: 'native',
+      commands,
+      sourceBinary: resolve(repoRoot, 'target', 'release', binaryName),
+      destinationBinary,
+      outputDir,
+      platform,
+    }
+  }
+
+  if (platform !== 'darwin') {
+    throw new Error('CORAL_DESKTOP_UNIVERSAL=1 is only supported on macOS.')
+  }
+
+  commands.push(
+    {
+      command: 'rustup',
+      args: ['target', 'add', ...macTargets],
+    },
+    ...macTargets.map((target) => ({
+      command: 'cargo',
+      args: ['build', '--locked', '-p', 'coral-cli', '--release', '--target', target],
+    })),
+  )
+
+  const universalBinary = resolve(repoRoot, 'target', 'release', 'coral-universal')
+  commands.push({
+    command: 'lipo',
+    args: [
+      '-create',
+      ...macTargets.map((target) =>
+        resolve(repoRoot, 'target', target, 'release', binaryName),
+      ),
+      '-output',
+      universalBinary,
+    ],
+  })
+
+  return {
+    mode: 'universal',
+    commands,
+    sourceBinary: universalBinary,
+    destinationBinary,
+    outputDir,
+    platform,
+  }
+}
+
+export async function validatePrebuiltCoral(
+  sourceBinary,
+  { statFile = stat, accessFile = access, realpathFile = realpath, outputDir } = {},
+) {
+  let metadata
+  try {
+    metadata = await statFile(sourceBinary)
+  } catch (error) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} does not exist or cannot be inspected: ${sourceBinary}.`,
+      { cause: error },
+    )
+  }
+
+  if (!metadata.isFile()) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} must point to a regular file: ${sourceBinary}.`,
+    )
+  }
+  if (metadata.size === 0) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} must point to a non-empty file: ${sourceBinary}.`,
+    )
+  }
+
+  try {
+    await accessFile(sourceBinary, constants.R_OK)
+  } catch (error) {
+    throw new Error(
+      `${PREBUILT_CORAL_ENV} must point to a readable file: ${sourceBinary}.`,
+      { cause: error },
+    )
+  }
+
+  if (outputDir) {
+    await requireCanonicalPrebuiltOutsideOutputDirectory(
+      sourceBinary,
+      outputDir,
+      realpathFile,
+    )
+  }
+}
+
+export async function stageCoralBinary(plan) {
+  if (plan.mode === 'prebuilt') {
+    requirePrebuiltOutsideOutputDirectory(plan.sourceBinary, plan.outputDir)
+    await validatePrebuiltCoral(plan.sourceBinary, { outputDir: plan.outputDir })
+  }
+
+  await rm(plan.outputDir, { recursive: true, force: true })
+  await mkdir(plan.outputDir, { recursive: true })
+  await copyFile(plan.sourceBinary, plan.destinationBinary)
+
+  if (plan.platform !== 'win32') {
+    await chmod(plan.destinationBinary, 0o755)
+  }
+}

--- a/apps/desktop/scripts/stage-coral.mjs
+++ b/apps/desktop/scripts/stage-coral.mjs
@@ -1,23 +1,22 @@
-import { chmod, copyFile, mkdir, rm } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
 import { spawn } from 'node:child_process'
+import { resolve } from 'node:path'
+
+import {
+  createStageCoralPlan,
+  stageCoralBinary,
+  validatePrebuiltCoral,
+} from './stage-coral-plan.mjs'
 
 const desktopRoot = resolve(import.meta.dirname, '..')
 const repoRoot = resolve(desktopRoot, '..', '..')
-const outputDir = resolve(desktopRoot, 'resources', 'coral')
-const binaryName = process.platform === 'win32' ? 'coral.exe' : 'coral'
-const targetBinary = resolve(repoRoot, 'target', 'release', binaryName)
-const universalMacBinary = resolve(repoRoot, 'target', 'release', 'coral-universal')
-const universalMac = process.env.CORAL_DESKTOP_UNIVERSAL === '1'
-const macTargets = ['x86_64-apple-darwin', 'aarch64-apple-darwin']
 
-function run(command, args, options = {}) {
+function run({ command, args, env }) {
   return new Promise((resolveRun, rejectRun) => {
     const child = spawn(command, args, {
       cwd: repoRoot,
       stdio: 'inherit',
       shell: process.platform === 'win32',
-      ...options,
+      ...(env ? { env: { ...process.env, ...env } } : {}),
     })
     child.on('error', rejectRun)
     child.on('exit', (code) => {
@@ -30,47 +29,24 @@ function run(command, args, options = {}) {
   })
 }
 
-await run('npm', ['ci', '--prefix', 'apps/ui'])
-await run('npm', ['run', 'build', '--prefix', 'apps/ui'])
-await run('npm', ['ci', '--prefix', 'apps/reef'])
-await run('npm', ['run', 'build', '--prefix', 'apps/reef'], {
-  env: {
-    ...process.env,
-    VITE_CORAL_DESKTOP_APP: '1',
-  },
+const plan = createStageCoralPlan({
+  env: process.env,
+  platform: process.platform,
+  repoRoot,
+  desktopRoot,
 })
 
-async function buildCoralCli() {
-  if (!universalMac) {
-    await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release'])
-    return targetBinary
-  }
-
-  if (process.platform !== 'darwin') {
-    throw new Error('CORAL_DESKTOP_UNIVERSAL=1 is only supported on macOS.')
-  }
-
-  await run('rustup', ['target', 'add', ...macTargets])
-  for (const target of macTargets) {
-    await run('cargo', ['build', '--locked', '-p', 'coral-cli', '--release', '--target', target])
-  }
-  await run('lipo', [
-    '-create',
-    ...macTargets.map((target) => resolve(repoRoot, 'target', target, 'release', binaryName)),
-    '-output',
-    universalMacBinary,
-  ])
-  return universalMacBinary
+if (plan.mode === 'prebuilt') {
+  console.log('[stage-coral] prebuilt mode selected')
+  console.log(`[stage-coral] prebuilt source: ${plan.sourceBinary}`)
+  console.log(`[stage-coral] prebuilt destination: ${plan.destinationBinary}`)
+  await validatePrebuiltCoral(plan.sourceBinary, { outputDir: plan.outputDir })
 }
 
-const builtBinary = await buildCoralCli()
-
-await rm(outputDir, { recursive: true, force: true })
-await mkdir(outputDir, { recursive: true })
-await copyFile(builtBinary, join(outputDir, binaryName))
-
-if (process.platform !== 'win32') {
-  await chmod(join(outputDir, binaryName), 0o755)
+for (const command of plan.commands) {
+  await run(command)
 }
 
-console.log(`[stage-coral] staged ${builtBinary} -> ${join(outputDir, binaryName)}`)
+await stageCoralBinary(plan)
+
+console.log(`[stage-coral] staged ${plan.sourceBinary} -> ${plan.destinationBinary}`)

--- a/apps/desktop/scripts/stage-coral.test.mjs
+++ b/apps/desktop/scripts/stage-coral.test.mjs
@@ -1,0 +1,311 @@
+import assert from 'node:assert/strict'
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import test from 'node:test'
+
+import {
+  createStageCoralPlan,
+  PREBUILT_CORAL_ENV,
+  stageCoralBinary,
+  validatePrebuiltCoral,
+} from './stage-coral-plan.mjs'
+
+async function createFixture(t) {
+  const root = await mkdtemp(join(tmpdir(), 'coral-desktop-stage-'))
+  t.after(() => rm(root, { recursive: true, force: true }))
+
+  const repoRoot = join(root, 'repo')
+  const desktopRoot = join(repoRoot, 'apps', 'desktop')
+  await mkdir(desktopRoot, { recursive: true })
+  return { root, repoRoot, desktopRoot }
+}
+
+function createPlan(fixture, env, platform = 'darwin') {
+  return createStageCoralPlan({
+    env,
+    platform,
+    repoRoot: fixture.repoRoot,
+    desktopRoot: fixture.desktopRoot,
+  })
+}
+
+test('stages a valid prebuilt Coral file and makes the output executable', async (t) => {
+  const fixture = await createFixture(t)
+  const sourceBinary = join(fixture.root, 'prebuilt', 'coral')
+  await mkdir(dirname(sourceBinary), { recursive: true })
+  await writeFile(sourceBinary, 'prebuilt coral')
+  await chmod(sourceBinary, 0o644)
+
+  const plan = createPlan(fixture, {
+    [PREBUILT_CORAL_ENV]: sourceBinary,
+  })
+  await validatePrebuiltCoral(sourceBinary, { outputDir: plan.outputDir })
+  await mkdir(plan.outputDir, { recursive: true })
+  const staleOutput = join(plan.outputDir, 'stale')
+  await writeFile(staleOutput, 'remove me')
+  await stageCoralBinary(plan)
+
+  assert.equal(plan.mode, 'prebuilt')
+  assert.equal(await readFile(plan.destinationBinary, 'utf8'), 'prebuilt coral')
+  assert.notEqual((await stat(plan.destinationBinary)).mode & 0o111, 0)
+  await assert.rejects(stat(staleOutput), { code: 'ENOENT' })
+})
+
+test('rejects a prebuilt Coral file inside the staging output before cleanup', async (t) => {
+  const fixture = await createFixture(t)
+  const outputDir = join(fixture.desktopRoot, 'resources', 'coral')
+  const sourceBinary = join(outputDir, 'coral')
+  await mkdir(outputDir, { recursive: true })
+  await writeFile(sourceBinary, 'already staged coral')
+
+  assert.throws(
+    () => createPlan(fixture, { [PREBUILT_CORAL_ENV]: sourceBinary }),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point outside the staging output directory`),
+  )
+  assert.equal(await readFile(sourceBinary, 'utf8'), 'already staged coral')
+
+  await assert.rejects(
+    stageCoralBinary({
+      mode: 'prebuilt',
+      sourceBinary,
+      destinationBinary: sourceBinary,
+      outputDir,
+      platform: 'darwin',
+    }),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point outside the staging output directory`),
+  )
+  assert.equal(await readFile(sourceBinary, 'utf8'), 'already staged coral')
+})
+
+test('rejects a prebuilt path whose symlinked parent resolves inside staging', async (t) => {
+  const fixture = await createFixture(t)
+  const outputDir = join(fixture.desktopRoot, 'resources', 'coral')
+  const stagedBinary = join(outputDir, 'coral')
+  const aliasedOutputDir = join(fixture.root, 'prebuilt-alias')
+  await mkdir(outputDir, { recursive: true })
+  await writeFile(stagedBinary, 'already staged coral')
+  await symlink(
+    outputDir,
+    aliasedOutputDir,
+    process.platform === 'win32' ? 'junction' : 'dir',
+  )
+
+  const plan = createPlan(fixture, {
+    [PREBUILT_CORAL_ENV]: join(aliasedOutputDir, 'coral'),
+  })
+
+  await assert.rejects(
+    validatePrebuiltCoral(plan.sourceBinary, { outputDir: plan.outputDir }),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point outside the staging output directory`),
+  )
+  await assert.rejects(
+    stageCoralBinary(plan),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point outside the staging output directory`),
+  )
+  assert.equal(await readFile(stagedBinary, 'utf8'), 'already staged coral')
+})
+
+test('rejects relative, missing, empty, directory, and unreadable prebuilt inputs', async (t) => {
+  const fixture = await createFixture(t)
+
+  assert.throws(
+    () => createPlan(fixture, { [PREBUILT_CORAL_ENV]: 'relative/coral' }),
+    new RegExp(`${PREBUILT_CORAL_ENV} must be an absolute path`),
+  )
+
+  const missing = join(fixture.root, 'missing-coral')
+  await assert.rejects(
+    validatePrebuiltCoral(missing),
+    new RegExp(`${PREBUILT_CORAL_ENV} does not exist or cannot be inspected`),
+  )
+
+  const empty = join(fixture.root, 'empty-coral')
+  await writeFile(empty, '')
+  await assert.rejects(
+    validatePrebuiltCoral(empty),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point to a non-empty file`),
+  )
+
+  const directory = join(fixture.root, 'coral-directory')
+  await mkdir(directory)
+  await assert.rejects(
+    validatePrebuiltCoral(directory),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point to a regular file`),
+  )
+
+  const unreadable = join(fixture.root, 'unreadable-coral')
+  await writeFile(unreadable, 'coral')
+  await assert.rejects(
+    validatePrebuiltCoral(unreadable, {
+      accessFile: async () => {
+        const error = new Error('permission denied')
+        error.code = 'EACCES'
+        throw error
+      },
+    }),
+    new RegExp(`${PREBUILT_CORAL_ENV} must point to a readable file`),
+  )
+})
+
+test('rejects prebuilt and universal modes together', async (t) => {
+  const fixture = await createFixture(t)
+  const sourceBinary = join(fixture.root, 'coral')
+  await writeFile(sourceBinary, 'coral')
+
+  assert.throws(
+    () =>
+      createPlan(fixture, {
+        [PREBUILT_CORAL_ENV]: sourceBinary,
+        CORAL_DESKTOP_UNIVERSAL: '1',
+      }),
+    /cannot be combined with CORAL_DESKTOP_UNIVERSAL=1/,
+  )
+})
+
+test('prebuilt mode builds Reef without scheduling UI or Rust toolchain commands', async (t) => {
+  const fixture = await createFixture(t)
+  const sourceBinary = join(fixture.root, 'coral')
+  await writeFile(sourceBinary, 'coral')
+
+  const plan = createPlan(fixture, { [PREBUILT_CORAL_ENV]: sourceBinary })
+
+  assert.deepEqual(plan.commands, [
+    {
+      command: 'npm',
+      args: ['ci', '--prefix', 'apps/reef'],
+    },
+    {
+      command: 'npm',
+      args: ['run', 'build', '--prefix', 'apps/reef'],
+      env: {
+        VITE_CORAL_DESKTOP_APP: '1',
+      },
+    },
+  ])
+  assert.equal(
+    plan.commands.some(
+      ({ command, args }) =>
+        ['cargo', 'rustup', 'lipo'].includes(command) || args.includes('apps/ui'),
+    ),
+    false,
+  )
+})
+
+test('native mode preserves the existing UI, Reef, and Cargo command plan', async (t) => {
+  const fixture = await createFixture(t)
+  const plan = createPlan(fixture, {}, 'linux')
+
+  assert.equal(plan.mode, 'native')
+  assert.deepEqual(plan.commands, [
+    {
+      command: 'npm',
+      args: ['ci', '--prefix', 'apps/ui'],
+    },
+    {
+      command: 'npm',
+      args: ['run', 'build', '--prefix', 'apps/ui'],
+    },
+    {
+      command: 'npm',
+      args: ['ci', '--prefix', 'apps/reef'],
+    },
+    {
+      command: 'npm',
+      args: ['run', 'build', '--prefix', 'apps/reef'],
+      env: {
+        VITE_CORAL_DESKTOP_APP: '1',
+      },
+    },
+    {
+      command: 'cargo',
+      args: ['build', '--locked', '-p', 'coral-cli', '--release'],
+    },
+  ])
+  assert.equal(plan.sourceBinary, join(fixture.repoRoot, 'target', 'release', 'coral'))
+})
+
+test('universal mode preserves the existing UI, Reef, Rust, and lipo command plan', async (t) => {
+  const fixture = await createFixture(t)
+  const plan = createPlan(fixture, { CORAL_DESKTOP_UNIVERSAL: '1' })
+  const x86Binary = join(
+    fixture.repoRoot,
+    'target',
+    'x86_64-apple-darwin',
+    'release',
+    'coral',
+  )
+  const armBinary = join(
+    fixture.repoRoot,
+    'target',
+    'aarch64-apple-darwin',
+    'release',
+    'coral',
+  )
+  const universalBinary = join(fixture.repoRoot, 'target', 'release', 'coral-universal')
+
+  assert.equal(plan.mode, 'universal')
+  assert.deepEqual(plan.commands, [
+    {
+      command: 'npm',
+      args: ['ci', '--prefix', 'apps/ui'],
+    },
+    {
+      command: 'npm',
+      args: ['run', 'build', '--prefix', 'apps/ui'],
+    },
+    {
+      command: 'npm',
+      args: ['ci', '--prefix', 'apps/reef'],
+    },
+    {
+      command: 'npm',
+      args: ['run', 'build', '--prefix', 'apps/reef'],
+      env: {
+        VITE_CORAL_DESKTOP_APP: '1',
+      },
+    },
+    {
+      command: 'rustup',
+      args: ['target', 'add', 'x86_64-apple-darwin', 'aarch64-apple-darwin'],
+    },
+    {
+      command: 'cargo',
+      args: [
+        'build',
+        '--locked',
+        '-p',
+        'coral-cli',
+        '--release',
+        '--target',
+        'x86_64-apple-darwin',
+      ],
+    },
+    {
+      command: 'cargo',
+      args: [
+        'build',
+        '--locked',
+        '-p',
+        'coral-cli',
+        '--release',
+        '--target',
+        'aarch64-apple-darwin',
+      ],
+    },
+    {
+      command: 'lipo',
+      args: ['-create', x86Binary, armBinary, '-output', universalBinary],
+    },
+  ])
+  assert.equal(plan.sourceBinary, universalBinary)
+})


### PR DESCRIPTION
> Stacked on #1885. This PR contains one additional commit and should be reviewed against `am-disable-desktop-pr-packaging`.

## Summary

Desktop staging currently always builds the Coral CLI itself. This PR adds an opt-in `CORAL_DESKTOP_PREBUILT_CORAL` input so a trusted CI job can supply an existing executable instead.

When that input is set, staging still builds Reef and Electron normally, but skips the embedded UI build and all Cargo, rustup, and lipo commands. The existing native and universal build paths are unchanged.

The supplied path must be absolute and point to a readable, non-empty regular file outside the staging output directory. We check both lexical and resolved paths so a symlink cannot hide the source inside a directory that staging is about to clear.

Nothing in CI uses this mode yet. A later stacked PR will use it for the lightweight Desktop packaging smoke.

## Test plan

- `npm run check --prefix apps/desktop`
- `npm test --prefix apps/desktop`
- Added coverage for valid prebuilt staging, cleanup safety, symlink aliases, invalid inputs, mode conflicts, and unchanged native/universal command plans.
