### PR TITLE
ci(desktop): add macOS packaging smoke

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -2,7 +2,21 @@ name: Desktop macOS package
 
 on:
   workflow_call:
+    inputs:
+      mode:
+        description: Packaging validation mode (smoke or universal)
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      mode:
+        description: Packaging validation mode
+        required: true
+        default: universal
+        type: choice
+        options:
+          - universal
+          - smoke
 
 permissions:
   contents: read
@@ -17,17 +31,34 @@ env:
 
 jobs:
   package:
-    name: Build unsigned package
-    runs-on: macos-latest
+    name: Validate desktop package (${{ inputs.mode }})
+    # The smoke lane must match the published aarch64 sidecar. Universal lipo
+    # builds also work on the ARM runner.
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
+      - name: Validate packaging mode
+        env:
+          PACKAGE_MODE: ${{ inputs.mode }}
+        run: |
+          case "$PACKAGE_MODE" in
+            smoke|universal) ;;
+            *)
+              echo "Unsupported desktop packaging mode: $PACKAGE_MODE" >&2
+              echo "Expected one of: smoke, universal" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Install Rust toolchain
+        if: ${{ inputs.mode == 'universal' }}
         run: rustup show
 
       - name: Cache Rust artifacts
+        if: ${{ inputs.mode == 'universal' }}
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: coral-desktop-macos-universal
@@ -58,17 +89,122 @@ jobs:
             apps/desktop/resources/entitlements.mac.plist \
             apps/desktop/resources/entitlements.mac.inherit.plist
 
-      - name: Package desktop app
+      - name: Check desktop
+        run: npm run check --prefix apps/desktop
+
+      - name: Test desktop
+        run: npm test --prefix apps/desktop
+
+      - name: Resolve and verify published ARM sidecar
+        if: ${{ inputs.mode == 'smoke' }}
+        id: smoke-sidecar
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          runner_arch="$(uname -m)"
+          if [ "$runner_arch" != "arm64" ]; then
+            echo "Desktop package smoke requires an arm64 runner; found: $runner_arch" >&2
+            exit 1
+          fi
+
+          archive_name="coral-aarch64-apple-darwin.tar.gz"
+          download_dir="$(mktemp -d "$RUNNER_TEMP/coral-desktop-smoke-download.XXXXXX")"
+          extract_dir="$(mktemp -d "$RUNNER_TEMP/coral-desktop-smoke-sidecar.XXXXXX")"
+
+          release_tag="$(gh api "repos/${REPOSITORY}/releases/latest" --jq '.tag_name')"
+          if [ -z "$release_tag" ]; then
+            echo "Could not resolve the latest published Coral release tag" >&2
+            exit 1
+          fi
+          echo "Using published Coral release: $release_tag"
+
+          gh release download "$release_tag" \
+            --repo "$REPOSITORY" \
+            --dir "$download_dir" \
+            --pattern "$archive_name" \
+            --pattern checksums.sha256
+
+          archive_path="$download_dir/$archive_name"
+          checksums_path="$download_dir/checksums.sha256"
+          if [ ! -s "$archive_path" ]; then
+            echo "Downloaded Coral archive is missing or empty: $archive_path" >&2
+            exit 1
+          fi
+          if [ ! -s "$checksums_path" ]; then
+            echo "Downloaded checksum file is missing or empty: $checksums_path" >&2
+            exit 1
+          fi
+
+          checksum_matches="$download_dir/checksum-matches"
+          awk -v name="$archive_name" \
+            '($2 == name || $2 == ("*" name)) && length($1) == 64 { print $1 }' \
+            "$checksums_path" > "$checksum_matches"
+          checksum_count="$(wc -l < "$checksum_matches" | tr -d '[:space:]')"
+          if [ "$checksum_count" != "1" ]; then
+            echo "Expected exactly one checksum for $archive_name; found $checksum_count" >&2
+            exit 1
+          fi
+
+          expected_checksum="$(tr '[:upper:]' '[:lower:]' < "$checksum_matches")"
+          actual_checksum="$(shasum -a 256 "$archive_path" | awk '{ print $1 }')"
+          if [ "$actual_checksum" != "$expected_checksum" ]; then
+            echo "Checksum verification failed for $archive_name" >&2
+            echo "Expected: $expected_checksum" >&2
+            echo "Actual:   $actual_checksum" >&2
+            exit 1
+          fi
+          echo "Verified checksum for $archive_name"
+
+          tar -xzf "$archive_path" -C "$extract_dir"
+          coral_path="$extract_dir/coral"
+          if [ ! -f "$coral_path" ]; then
+            echo "Published archive did not contain the expected coral executable" >&2
+            exit 1
+          fi
+          if [ ! -s "$coral_path" ]; then
+            echo "Published coral executable is empty: $coral_path" >&2
+            exit 1
+          fi
+          if [ ! -x "$coral_path" ]; then
+            echo "Published coral executable is not executable: $coral_path" >&2
+            exit 1
+          fi
+
+          file "$coral_path"
+          sidecar_archs="$(lipo -archs "$coral_path")"
+          if [ "$sidecar_archs" != "arm64" ]; then
+            echo "Expected a thin arm64 Coral sidecar; found: $sidecar_archs" >&2
+            exit 1
+          fi
+          echo "Verified thin arm64 sidecar: $coral_path"
+          echo "coral-path=$coral_path" >> "$GITHUB_OUTPUT"
+
+      - name: Package native unpacked desktop app
+        if: ${{ inputs.mode == 'smoke' }}
+        env:
+          CORAL_DESKTOP_PREBUILT_CORAL: ${{ steps.smoke-sidecar.outputs.coral-path }}
+        run: npm run package:mac:smoke --prefix apps/desktop
+
+      - name: Verify native unpacked desktop app
+        if: ${{ inputs.mode == 'smoke' }}
+        run: node apps/desktop/scripts/verify-package-dir.mjs apps/desktop/dist
+
+      - name: Package universal desktop app
+        if: ${{ inputs.mode == 'universal' }}
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
         run: npm run package:mac --prefix apps/desktop
 
-      - name: Verify desktop package artifacts
+      - name: Verify universal desktop package artifacts
+        if: ${{ inputs.mode == 'universal' }}
         run: node apps/desktop/scripts/verify-dist.mjs apps/desktop/dist
 
-      # PR and manual builds are available for inspection for one week.
+      # Manual universal preflights are available for inspection for one week.
       - name: Upload desktop package artifact
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ inputs.mode == 'universal' && github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coral-desktop-macos-unsigned

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,6 +40,7 @@ jobs:
       ui-tests: ${{ steps.filter.outputs.ui-tests }}
       reef-checks: ${{ steps.filter.outputs.reef-checks }}
       desktop-checks: ${{ steps.filter.outputs.desktop-checks }}
+      desktop-package-smoke: ${{ steps.filter.outputs.desktop-package-smoke == 'true' || steps.desktop-package-source-filter.outputs.desktop == 'true' || steps.desktop-package-source-filter.outputs.reef-source == 'true' }}
       proto-lint: ${{ steps.filter.outputs.proto-lint }}
       source-lint: ${{ steps.filter.outputs.source-lint }}
       docs-freshness: ${{ steps.filter.outputs.docs-freshness }}
@@ -106,6 +107,21 @@ jobs:
             desktop-checks:
               - '.github/workflows/validate.yml'
               - 'apps/desktop/**'
+            desktop-package-smoke:
+              - '.github/workflows/validate.yml'
+              - '.github/workflows/release.yml'
+              - '.github/workflows/desktop-package.yml'
+              # Reef's production client and server outputs are embedded in
+              # Coral.app, so runtime changes need the same assembly smoke.
+              - 'apps/reef/.node-version'
+              - 'apps/reef/package.json'
+              - 'apps/reef/package-lock.json'
+              - 'apps/reef/buf.gen.yaml'
+              - 'apps/reef/public/**'
+              - 'apps/reef/react-router.config.ts'
+              - 'apps/reef/tsconfig.json'
+              - 'apps/reef/vite.config.ts'
+              - 'crates/coral-api/proto/**'
             proto-lint:
               - '.github/workflows/validate.yml'
               - 'Makefile'
@@ -158,6 +174,39 @@ jobs:
               - 'xtask/src/main.rs'
               - 'xtask/src/perf.rs'
               - 'sources/core/github/**'
+
+      # Keep docs, test, and Storybook-only Desktop/Reef changes out of
+      # packaging. This separate filter uses `every` so each file must match
+      # its source tree and all exclusion rules; the main filter uses the
+      # default OR behavior.
+      - name: Detect package source changes
+        id: desktop-package-source-filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          predicate-quantifier: every
+          filters: |
+            desktop:
+              - 'apps/desktop/**'
+              - '!**/*.md'
+              - '!**/*.test'
+              - '!**/*.test.*'
+              - '!**/*.spec'
+              - '!**/*.spec.*'
+              - '!**/*.stories'
+              - '!**/*.stories.*'
+              - '!apps/desktop/**/__tests__/**'
+              - '!apps/desktop/**/__stories__/**'
+            reef-source:
+              - 'apps/reef/app/**'
+              - '!**/*.md'
+              - '!**/*.test'
+              - '!**/*.test.*'
+              - '!**/*.spec'
+              - '!**/*.spec.*'
+              - '!**/*.stories'
+              - '!**/*.stories.*'
+              - '!apps/reef/app/**/__tests__/**'
+              - '!apps/reef/app/**/__stories__/**'
 
   rust-checks:
     name: Rust checks
@@ -521,6 +570,16 @@ jobs:
       - name: Test desktop
         run: npm test --prefix apps/desktop
 
+  desktop-package-smoke:
+    name: Desktop macOS package smoke
+    needs: changes
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.desktop-package-smoke == 'true' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/desktop-package.yml
+    with:
+      mode: smoke
+
   proto-lint:
     name: Lint protobuf API
     runs-on: ubuntu-latest
@@ -746,6 +805,7 @@ jobs:
         ui-tests,
         reef-checks,
         desktop-checks,
+        desktop-package-smoke,
         proto-lint,
         gha-security-audit-pr,
         gha-security-audit-sarif,
@@ -769,6 +829,7 @@ jobs:
           UI_TESTS_RESULT: ${{ needs.ui-tests.result }}
           REEF_CHECKS_RESULT: ${{ needs.reef-checks.result }}
           DESKTOP_CHECKS_RESULT: ${{ needs.desktop-checks.result }}
+          DESKTOP_PACKAGE_SMOKE_RESULT: ${{ needs.desktop-package-smoke.result }}
           PROTO_LINT_RESULT: ${{ needs.proto-lint.result }}
           GHA_SECURITY_AUDIT_PR_RESULT: ${{ needs.gha-security-audit-pr.result }}
           GHA_SECURITY_AUDIT_SARIF_RESULT: ${{ needs.gha-security-audit-sarif.result }}
@@ -787,6 +848,7 @@ jobs:
             "ui-tests:$UI_TESTS_RESULT"
             "reef-checks:$REEF_CHECKS_RESULT"
             "desktop-checks:$DESKTOP_CHECKS_RESULT"
+            "desktop-package-smoke:$DESKTOP_PACKAGE_SMOKE_RESULT"
             "proto-lint:$PROTO_LINT_RESULT"
             "gha-security-audit-pr:$GHA_SECURITY_AUDIT_PR_RESULT"
             "gha-security-audit-sarif:$GHA_SECURITY_AUDIT_SARIF_RESULT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,11 +51,15 @@
   latency. CI installs the bundled `github` source with fake credentials and
   fails when release `coral sql "select * from coral.tables"` has a hyperfine
   mean above 750 ms.
-- Pull requests do not automatically build macOS Desktop packages. Use manual
-  dispatch for an unsigned packaging preflight when a distribution-sensitive
-  change warrants one. Validation artifacts stay unsigned and must not be
-  reused for a release; Desktop release publishing must rebuild from a clean
-  checkout with signing and notarization.
+- Package-relevant Desktop application and embedded Reef PRs must exercise the
+  native unpacked macOS packaging smoke in addition to their normal checks.
+  Automatic PR validation does not build the release-shaped universal DMG/ZIP;
+  use manual dispatch for an unsigned universal packaging preflight when a
+  distribution-sensitive change warrants one. Validation artifacts stay
+  unsigned and must not be reused for a release; Desktop release publishing
+  must rebuild from a clean checkout with signing and notarization. PR
+  descriptions for changes to this gate must call out the resulting contributor
+  or agent behavior change.
 - The `Validate` workflow intentionally skips draft pull request runs, starts
   again on `ready_for_review`, and still triggers on `converted_to_draft` so the
   replacement skipped run cancels any in-progress validation for the PR branch.

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -32,6 +32,7 @@
         "tinykeys": "4.0.0"
       },
       "devDependencies": {
+        "@electron/asar": "3.4.1",
         "@types/node": "^22.19.2",
         "electron": "^42.3.3",
         "electron-builder": "^26.15.2",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -14,7 +14,7 @@
     "postbuild": "node ./scripts/copy-reef-server.mjs",
     "type-check": "tsc --noEmit",
     "check": "npm run type-check && npm run test:config",
-    "test:config": "node --test scripts/electron-builder-config.test.mjs scripts/electron-vite-config.test.mjs scripts/reef-runtime-dependencies.test.mjs scripts/stage-coral.test.mjs",
+    "test:config": "node --test scripts/electron-builder-config.test.mjs scripts/electron-vite-config.test.mjs scripts/reef-runtime-dependencies.test.mjs scripts/stage-coral.test.mjs scripts/verify-package-dir.test.mjs",
     "test": "vitest run",
     "verify:release-build": "node ./scripts/verify-release-build.mjs",
     "prepackage": "npm run build",
@@ -26,6 +26,8 @@
     "prepackage:mac": "CORAL_DESKTOP_UNIVERSAL=1 npm run build",
     "package:mac": "npm run package:mac:prepared",
     "package:mac:prepared": "electron-builder --mac --universal --publish never --config electron-builder.config.ts",
+    "prepackage:mac:smoke": "node -e \"if (!process.env.CORAL_DESKTOP_PREBUILT_CORAL?.trim()) throw new Error('package:mac:smoke requires CORAL_DESKTOP_PREBUILT_CORAL')\" && npm run build",
+    "package:mac:smoke": "CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --dir --config electron-builder.config.ts",
     "stage:coral": "node ./scripts/stage-coral.mjs"
   },
   "dependencies": {
@@ -53,6 +55,7 @@
     "tinykeys": "4.0.0"
   },
   "devDependencies": {
+    "@electron/asar": "3.4.1",
     "@types/node": "^22.19.2",
     "electron": "^42.3.3",
     "electron-builder": "^26.15.2",

--- a/apps/desktop/scripts/verify-package-dir.mjs
+++ b/apps/desktop/scripts/verify-package-dir.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+import { statFile } from '@electron/asar'
+import { constants } from 'node:fs'
+import { access, open, readdir, stat } from 'node:fs/promises'
+import { basename, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const MACH_64_MAGIC = 0xfeedfacf
+const MACH_32_MAGIC = 0xfeedface
+const FAT_MAGICS = new Set([0xcafebabe, 0xcafebabf, 0xbebafeca, 0xbfbafeca])
+const CPU_TYPE_ARM64 = 0x0100000c
+const CPU_TYPE_X86_64 = 0x01000007
+
+async function requireDirectory(path, description) {
+  let metadata
+  try {
+    metadata = await stat(path)
+  } catch {
+    throw new Error(`missing ${description}: ${path}`)
+  }
+  if (!metadata.isDirectory()) throw new Error(`${description} is not a directory: ${path}`)
+}
+
+async function requireNonEmptyFile(path, description) {
+  let metadata
+  try {
+    metadata = await stat(path)
+  } catch {
+    throw new Error(`missing ${description}: ${path}`)
+  }
+  if (!metadata.isFile() || metadata.size === 0) {
+    throw new Error(`${description} must be a non-empty regular file: ${path}`)
+  }
+  return metadata
+}
+
+async function requireExecutable(path, description, metadata) {
+  if ((metadata.mode & 0o111) === 0) throw new Error(`${description} is not executable: ${path}`)
+  try {
+    await access(path, constants.X_OK)
+  } catch {
+    throw new Error(`${description} is not executable: ${path}`)
+  }
+}
+
+async function findTopLevelAppBundles(directory) {
+  await requireDirectory(directory, 'unpacked package directory')
+  const found = []
+
+  async function visit(current) {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      const path = join(current, entry.name)
+      if (entry.name.endsWith('.app')) {
+        found.push(path)
+      } else {
+        await visit(path)
+      }
+    }
+  }
+
+  await visit(directory)
+  return found
+}
+
+function requireArchiveFile(archivePath, entry, description) {
+  let metadata
+  try {
+    metadata = statFile(archivePath, entry)
+  } catch {
+    throw new Error(`missing ${description} in app.asar: ${entry}`)
+  }
+  if (!Number.isSafeInteger(metadata.size) || metadata.size <= 0) {
+    throw new Error(`${description} must be a non-empty file in app.asar: ${entry}`)
+  }
+}
+
+async function containsNonEmptyFile(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory() && (await containsNonEmptyFile(path))) return true
+    if (entry.isFile() && (await stat(path)).size > 0) return true
+  }
+  return false
+}
+
+export async function readThinMachOArchitecture(path) {
+  const handle = await open(path, 'r')
+  try {
+    const header = Buffer.alloc(8)
+    const { bytesRead } = await handle.read(header, 0, header.length, 0)
+    if (bytesRead < header.length) throw new Error('file is too small to contain a Mach-O header')
+
+    const magicLittleEndian = header.readUInt32LE(0)
+    const magicBigEndian = header.readUInt32BE(0)
+    if (FAT_MAGICS.has(magicLittleEndian) || FAT_MAGICS.has(magicBigEndian)) {
+      throw new Error('binary is universal; expected a thin arm64 Mach-O executable')
+    }
+
+    let cpuType
+    if (magicLittleEndian === MACH_64_MAGIC || magicLittleEndian === MACH_32_MAGIC) {
+      cpuType = header.readUInt32LE(4)
+    } else if (magicBigEndian === MACH_64_MAGIC || magicBigEndian === MACH_32_MAGIC) {
+      cpuType = header.readUInt32BE(4)
+    } else {
+      throw new Error('file is not a Mach-O executable')
+    }
+
+    if (cpuType === CPU_TYPE_ARM64) return 'arm64'
+    if (cpuType === CPU_TYPE_X86_64) return 'x86_64'
+    return `unknown CPU type 0x${cpuType.toString(16)}`
+  } finally {
+    await handle.close()
+  }
+}
+
+export async function verifyPackageDir(packageDirectory) {
+  const distDir = resolve(packageDirectory)
+  const appBundles = await findTopLevelAppBundles(distDir)
+  if (appBundles.length !== 1 || basename(appBundles[0]) !== 'Coral.app') {
+    const found = appBundles.length === 0 ? 'none' : appBundles.map((path) => basename(path)).join(', ')
+    throw new Error(`expected exactly one Coral.app in ${distDir}; found ${found}`)
+  }
+
+  const appPath = appBundles[0]
+  const contentsPath = join(appPath, 'Contents')
+  const resourcesPath = join(contentsPath, 'Resources')
+  await requireDirectory(contentsPath, 'Electron app Contents directory')
+  await requireDirectory(join(contentsPath, 'Frameworks'), 'Electron app Frameworks directory')
+  await requireDirectory(resourcesPath, 'Electron app Resources directory')
+  await requireNonEmptyFile(join(contentsPath, 'Info.plist'), 'Electron app Info.plist')
+
+  const electronExecutablePath = join(contentsPath, 'MacOS', 'Coral')
+  const electronExecutable = await requireNonEmptyFile(
+    electronExecutablePath,
+    'Electron app executable',
+  )
+  await requireExecutable(electronExecutablePath, 'Electron app executable', electronExecutable)
+
+  const archivePath = join(resourcesPath, 'app.asar')
+  await requireNonEmptyFile(archivePath, 'packaged app archive')
+  requireArchiveFile(archivePath, 'out/main/index.js', 'Electron main output')
+  requireArchiveFile(archivePath, 'out/preload/index.cjs', 'Electron preload output')
+  requireArchiveFile(archivePath, 'out/reef-server/index.js', 'Reef server output')
+
+  const reefAssetsPath = join(resourcesPath, 'app', 'assets')
+  await requireDirectory(reefAssetsPath, 'Reef client assets directory')
+  if (!(await containsNonEmptyFile(reefAssetsPath))) {
+    throw new Error(`Reef client assets directory contains no non-empty files: ${reefAssetsPath}`)
+  }
+
+  const sidecarPath = join(resourcesPath, 'coral', 'coral')
+  const sidecar = await requireNonEmptyFile(sidecarPath, 'packaged Coral sidecar')
+  await requireExecutable(sidecarPath, 'packaged Coral sidecar', sidecar)
+  let architecture
+  try {
+    architecture = await readThinMachOArchitecture(sidecarPath)
+  } catch (error) {
+    throw new Error(`packaged Coral sidecar is not thin arm64: ${error.message}`)
+  }
+  if (architecture !== 'arm64') {
+    throw new Error(`packaged Coral sidecar must be thin arm64; found ${architecture}`)
+  }
+
+  return { appPath, archivePath, sidecarPath, architecture }
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  const packageDirectory = process.argv[2] ?? fileURLToPath(new URL('../dist', import.meta.url))
+  try {
+    const result = await verifyPackageDir(packageDirectory)
+    console.log(
+      `[verify-package-dir] ok: ${result.appPath}; main, preload, Reef client/server, and ${result.architecture} Coral sidecar verified`,
+    )
+  } catch (error) {
+    console.error(`[verify-package-dir] ${error.message}`)
+    process.exitCode = 1
+  }
+}

--- a/apps/desktop/scripts/verify-package-dir.test.mjs
+++ b/apps/desktop/scripts/verify-package-dir.test.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test, { afterEach } from 'node:test'
+
+import { createPackage } from '@electron/asar'
+
+import { verifyPackageDir } from './verify-package-dir.mjs'
+
+const fixtures = new Set()
+
+afterEach(async () => {
+  await Promise.all(
+    [...fixtures].map((fixture) => rm(fixture, { recursive: true, force: true })),
+  )
+  fixtures.clear()
+})
+
+function thinMachO(cpuType = 0x0100000c) {
+  const header = Buffer.alloc(32)
+  header.writeUInt32LE(0xfeedfacf, 0)
+  header.writeUInt32LE(cpuType, 4)
+  return header
+}
+
+async function createFixture(options = {}) {
+  const root = await mkdtemp(join(tmpdir(), 'coral-package-dir-fixture-'))
+  fixtures.add(root)
+  const distDir = join(root, 'dist')
+  await mkdir(distDir, { recursive: true })
+  if (options.missingApp) return { root, distDir }
+
+  const appPath = join(distDir, 'mac-arm64', 'Coral.app')
+  const contentsPath = join(appPath, 'Contents')
+  const resourcesPath = join(contentsPath, 'Resources')
+  const electronExecutablePath = join(contentsPath, 'MacOS', 'Coral')
+  const sidecarPath = join(resourcesPath, 'coral', 'coral')
+  const reefAssetsPath = join(resourcesPath, 'app', 'assets')
+  await Promise.all([
+    mkdir(join(contentsPath, 'Frameworks'), { recursive: true }),
+    mkdir(join(contentsPath, 'MacOS'), { recursive: true }),
+    mkdir(join(resourcesPath, 'coral'), { recursive: true }),
+    mkdir(reefAssetsPath, { recursive: true }),
+  ])
+  await Promise.all([
+    writeFile(join(contentsPath, 'Info.plist'), '<plist/>'),
+    writeFile(electronExecutablePath, 'electron'),
+    writeFile(sidecarPath, thinMachO(options.cpuType)),
+    writeFile(join(reefAssetsPath, 'entry.js'), 'reef client'),
+  ])
+  await Promise.all([chmod(electronExecutablePath, 0o755), chmod(sidecarPath, 0o755)])
+
+  const archiveSource = join(root, 'archive-source')
+  const archiveEntries = {
+    'out/main/index.js': 'main',
+    'out/preload/index.cjs': 'preload',
+    'out/reef-server/index.js': 'reef server',
+  }
+  for (const [entry, contents] of Object.entries(archiveEntries)) {
+    if (options.omitArchiveEntry === entry) continue
+    const path = join(archiveSource, entry)
+    if (options.directoryArchiveEntry === entry) {
+      await mkdir(path, { recursive: true })
+      continue
+    }
+    await mkdir(join(path, '..'), { recursive: true })
+    await writeFile(path, contents)
+  }
+  await createPackage(archiveSource, join(resourcesPath, 'app.asar'))
+
+  return {
+    root,
+    distDir,
+    appPath,
+    electronExecutablePath,
+    reefAssetsPath,
+    resourcesPath,
+    sidecarPath,
+  }
+}
+
+test('accepts an unpacked app with Electron, Reef, and a thin arm64 sidecar', async () => {
+  const fixture = await createFixture()
+
+  const result = await verifyPackageDir(fixture.distDir)
+
+  assert.equal(result.appPath, fixture.appPath)
+  assert.equal(result.sidecarPath, fixture.sidecarPath)
+  assert.equal(result.architecture, 'arm64')
+})
+
+test('rejects missing app output', async () => {
+  const fixture = await createFixture({ missingApp: true })
+
+  await assert.rejects(() => verifyPackageDir(fixture.distDir), /expected exactly one Coral\.app/)
+})
+
+test('rejects a missing packaged sidecar', async () => {
+  const fixture = await createFixture()
+  await rm(fixture.sidecarPath)
+
+  await assert.rejects(() => verifyPackageDir(fixture.distDir), /missing packaged Coral sidecar/)
+})
+
+test('rejects a sidecar without executable permission', async () => {
+  const fixture = await createFixture()
+  await chmod(fixture.sidecarPath, 0o644)
+
+  await assert.rejects(() => verifyPackageDir(fixture.distDir), /sidecar is not executable/)
+})
+
+test('rejects missing Electron main and preload outputs', async (t) => {
+  for (const [entry, description] of [
+    ['out/main/index.js', 'Electron main output'],
+    ['out/preload/index.cjs', 'Electron preload output'],
+  ]) {
+    await t.test(description, async () => {
+      const fixture = await createFixture({ omitArchiveEntry: entry })
+      await assert.rejects(() => verifyPackageDir(fixture.distDir), new RegExp(description))
+    })
+  }
+})
+
+test('rejects an ASAR directory masquerading as an Electron output file', async () => {
+  const fixture = await createFixture({ directoryArchiveEntry: 'out/main/index.js' })
+
+  await assert.rejects(
+    () => verifyPackageDir(fixture.distDir),
+    /Electron main output must be a non-empty file/,
+  )
+})
+
+test('rejects missing Reef client assets', async () => {
+  const fixture = await createFixture()
+  await rm(fixture.reefAssetsPath, { recursive: true })
+
+  await assert.rejects(() => verifyPackageDir(fixture.distDir), /missing Reef client assets directory/)
+})
+
+test('rejects missing Reef server assets', async () => {
+  const fixture = await createFixture({ omitArchiveEntry: 'out/reef-server/index.js' })
+
+  await assert.rejects(() => verifyPackageDir(fixture.distDir), /missing Reef server output/)
+})
+
+test('rejects a non-arm64 sidecar', async () => {
+  const fixture = await createFixture({ cpuType: 0x01000007 })
+
+  await assert.rejects(() => verifyPackageDir(fixture.distDir), /must be thin arm64; found x86_64/)
+})


### PR DESCRIPTION
 ## Summary

  #1885 stopped running the 40+ minute universal Desktop package build on every relevant PR. This PR adds packaging validation back as a much lighter smoke test.

  For package-relevant Desktop and Reef changes, we now download and verify the latest published arm64 Coral CLI, build Reef and Electron, and package a native unpacked `Coral.app`. We then inspect the app to make sure the Electron main/preload code,
  Reef client/server assets, and executable arm64 sidecar are all present.

  This skips the Rust build, x86_64 build, lipo step, DMG/ZIP generation, and artifact upload. Docs, tests, and Storybook-only changes also stay out of the packaging lane.

  The full unsigned universal packaging workflow remains available through manual dispatch. Release packaging, signing, and notarization are unchanged.

  The contributor behavior change is: package-relevant Desktop and Reef PRs automatically get the lighter smoke test; use the manual universal workflow when a change needs a full packaging preflight.

  ## Test plan

  - `npm run check --prefix apps/desktop`
  - `npm test --prefix apps/desktop`
  - Ran `actionlint` against the changed workflows.
  - Parsed both changed workflows as YAML.
  - Ran the complete smoke locally on arm64 using the latest published Coral sidecar and verified the resulting unpacked app.