### PR TITLE
ci(desktop): reuse CLI artifacts for release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: macos-unsigned-${{ matrix.target }}
+          if-no-files-found: error
           path: unsigned-${{ matrix.target }}/coral
 
   sign-notarize-macos:
@@ -323,6 +324,7 @@ jobs:
   build-desktop-macos:
     needs:
       - validate-release-ref
+      - build
     environment: release
     runs-on: macos-latest
     env:
@@ -345,18 +347,135 @@ jobs:
       - name: Install desktop dependencies
         run: npm ci --prefix apps/desktop
 
+      - name: Download unsigned x86_64 macOS binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: macos-unsigned-x86_64-apple-darwin
+          path: ${{ runner.temp }}/coral-desktop-cli/x86_64
+
+      - name: Download unsigned arm64 macOS binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: macos-unsigned-aarch64-apple-darwin
+          path: ${{ runner.temp }}/coral-desktop-cli/arm64
+
+      - name: Validate and combine macOS binaries
+        id: universal-coral
+        shell: bash
+        env:
+          RELEASE_COMMIT_SHA: ${{ needs.validate-release-ref.outputs.commit-sha }}
+          X86_64_ARTIFACT_DIR: ${{ runner.temp }}/coral-desktop-cli/x86_64
+          ARM64_ARTIFACT_DIR: ${{ runner.temp }}/coral-desktop-cli/arm64
+          UNIVERSAL_DIR: ${{ runner.temp }}/coral-desktop-cli/universal
+        run: |
+          set -euo pipefail
+
+          checked_out_commit="$(git rev-parse HEAD)"
+          if [ "$checked_out_commit" != "$RELEASE_COMMIT_SHA" ]; then
+            echo "Checked-out commit ${checked_out_commit} does not match validated release commit ${RELEASE_COMMIT_SHA}." >&2
+            exit 1
+          fi
+
+          require_single_coral() {
+            local artifact_dir="$1"
+            local expected_arch="$2"
+            local label="$3"
+            local files=()
+            while IFS= read -r -d '' file_path; do
+              files+=("$file_path")
+            done < <(find "$artifact_dir" -type f -print0)
+
+            if [ "${#files[@]}" -ne 1 ]; then
+              echo "${label} artifact must contain exactly one file; found ${#files[@]}." >&2
+              find "$artifact_dir" -maxdepth 3 -print >&2
+              exit 1
+            fi
+
+            local binary="${files[0]}"
+            if [ "$(basename "$binary")" != "coral" ]; then
+              echo "${label} artifact contains unexpected filename: ${binary}." >&2
+              exit 1
+            fi
+            if [ ! -s "$binary" ]; then
+              echo "${label} artifact contains an empty coral binary: ${binary}." >&2
+              exit 1
+            fi
+            chmod 755 "$binary"
+
+            local actual_archs
+            actual_archs="$(lipo -archs "$binary")"
+            if [ "$actual_archs" != "$expected_arch" ]; then
+              echo "${label} coral must be thin ${expected_arch}; lipo reported '${actual_archs}'." >&2
+              exit 1
+            fi
+            if ! file "$binary" | grep -Eq "Mach-O 64-bit executable ${expected_arch}([, ]|$)"; then
+              echo "${label} coral is not the expected ${expected_arch} Mach-O executable:" >&2
+              file "$binary" >&2
+              exit 1
+            fi
+
+            printf '%s\n' "$binary"
+          }
+
+          x86_64_binary="$(require_single_coral "$X86_64_ARTIFACT_DIR" x86_64 x86_64)"
+          arm64_binary="$(require_single_coral "$ARM64_ARTIFACT_DIR" arm64 arm64)"
+
+          mkdir -p "$UNIVERSAL_DIR"
+          universal_binary="$UNIVERSAL_DIR/coral"
+          lipo -create "$x86_64_binary" "$arm64_binary" -output "$universal_binary"
+          chmod 755 "$universal_binary"
+
+          universal_archs="$(lipo -archs "$universal_binary")"
+          if [ "$universal_archs" != "x86_64 arm64" ] && [ "$universal_archs" != "arm64 x86_64" ]; then
+            echo "Universal coral must contain exactly x86_64 and arm64; lipo reported '${universal_archs}'." >&2
+            exit 1
+          fi
+
+          expected_version="${TAG_NAME#v}"
+          expected_commit="$(git rev-parse --short "$RELEASE_COMMIT_SHA")"
+          expected_output="coral ${expected_version}+${expected_commit}"
+          version_output="$("$universal_binary" --version)"
+          if [ "$version_output" != "$expected_output" ]; then
+            echo "Universal coral version mismatch: expected '${expected_output}', got '${version_output}'." >&2
+            exit 1
+          fi
+
+          checksum="$(shasum -a 256 "$universal_binary" | awk '{print $1}')"
+          echo "Combined same-run macOS artifacts for ${RELEASE_COMMIT_SHA}."
+          echo "Universal coral architectures: ${universal_archs}"
+          echo "Universal coral SHA-256: ${checksum}"
+          echo "path=${universal_binary}" >> "$GITHUB_OUTPUT"
+
       - name: Build xtask
         run: cargo build --locked -p xtask
 
       # Build before Apple credentials enter the environment: the desktop
-      # build installs UI and Reef dependencies and executes Rust build scripts.
-      # The release flag is compiled into the main process to enable updates;
-      # signing and notarization still happen only in the credentialed step.
+      # build installs and compiles Reef, then stages the already-built universal
+      # CLI from this run's matrix artifacts. The release flag is compiled into
+      # the main process to enable updates; signing and notarization still happen
+      # only in the credentialed step.
       - name: Build universal desktop inputs
         env:
           CORAL_DESKTOP_RELEASE: "1"
-          CORAL_DESKTOP_UNIVERSAL: "1"
+          CORAL_DESKTOP_PREBUILT_CORAL: ${{ steps.universal-coral.outputs.path }}
         run: npm run build --prefix apps/desktop
+
+      - name: Verify staged universal sidecar
+        shell: bash
+        env:
+          UNIVERSAL_CORAL: ${{ steps.universal-coral.outputs.path }}
+        run: |
+          set -euo pipefail
+          staged_coral="apps/desktop/resources/coral/coral"
+          test -s "$staged_coral"
+          test -x "$staged_coral"
+          cmp "$UNIVERSAL_CORAL" "$staged_coral"
+          staged_archs="$(lipo -archs "$staged_coral")"
+          if [ "$staged_archs" != "x86_64 arm64" ] && [ "$staged_archs" != "arm64 x86_64" ]; then
+            echo "Staged desktop sidecar must contain exactly x86_64 and arm64; lipo reported '${staged_archs}'." >&2
+            exit 1
+          fi
+          echo "Staged desktop sidecar architectures: ${staged_archs}"
 
       - name: Verify release updater bundle
         run: npm run verify:release-build --prefix apps/desktop
@@ -375,6 +494,32 @@ jobs:
           ./target/debug/xtask release-desktop-macos-package \
             --tag "$TAG_NAME" \
             --work-dir "$RUNNER_TEMP/coral-desktop-release"
+
+      - name: Verify packaged universal sidecar
+        shell: bash
+        run: |
+          set -euo pipefail
+          packaged_sidecars=()
+          while IFS= read -r -d '' sidecar; do
+            packaged_sidecars+=("$sidecar")
+          done < <(find apps/desktop/dist -type f \
+            -path '*/Coral.app/Contents/Resources/coral/coral' -print0)
+
+          if [ "${#packaged_sidecars[@]}" -ne 1 ]; then
+            echo "Expected exactly one packaged Coral.app sidecar; found ${#packaged_sidecars[@]}." >&2
+            find apps/desktop/dist -maxdepth 5 -print >&2
+            exit 1
+          fi
+
+          packaged_coral="${packaged_sidecars[0]}"
+          test -s "$packaged_coral"
+          test -x "$packaged_coral"
+          packaged_archs="$(lipo -archs "$packaged_coral")"
+          if [ "$packaged_archs" != "x86_64 arm64" ] && [ "$packaged_archs" != "arm64 x86_64" ]; then
+            echo "Packaged desktop sidecar must contain exactly x86_64 and arm64; lipo reported '${packaged_archs}'." >&2
+            exit 1
+          fi
+          echo "Packaged desktop sidecar architectures: ${packaged_archs}"
 
       - name: Upload desktop artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,10 +56,11 @@
   Automatic PR validation does not build the release-shaped universal DMG/ZIP;
   use manual dispatch for an unsigned universal packaging preflight when a
   distribution-sensitive change warrants one. Validation artifacts stay
-  unsigned and must not be reused for a release; Desktop release publishing
-  must rebuild from a clean checkout with signing and notarization. PR
-  descriptions for changes to this gate must call out the resulting contributor
-  or agent behavior change.
+  unsigned and must not be reused for a release. Desktop release packaging must
+  reuse the clean, same-run x86_64 and arm64 CLI build artifacts, combine them
+  into its universal sidecar, and then retain the existing signing and
+  notarization flow. PR descriptions for changes to this gate or artifact-reuse
+  rule must call out the resulting contributor or agent behavior change.
 - The `Validate` workflow intentionally skips draft pull request runs, starts
   again on `ready_for_review`, and still triggers on `converted_to_draft` so the
   replacement skipped run cancels any in-progress validation for the PR branch.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -79,9 +79,10 @@ CORAL_DESKTOP_PREBUILT_CORAL=/absolute/path/to/coral npm run build --prefix apps
 
 The prebuilt path must be absolute, readable, non-empty, and outside the staging
 directory. This mode skips the embedded UI build and all Cargo, rustup, and lipo
-commands; Reef and Electron still build normally. It is intended for trusted CI
-artifacts, cannot be combined with `CORAL_DESKTOP_UNIVERSAL=1`, and never falls
-back to compiling Coral when the input is invalid.
+commands; Reef and Electron still build normally. It is used by the native
+packaging smoke and to reuse same-run release binaries, cannot be combined with
+`CORAL_DESKTOP_UNIVERSAL=1`, and never falls back to compiling Coral when the
+input is invalid.
 
 ```shell
 npm run package:dir --prefix apps/desktop

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -1,6 +1,8 @@
+import { execFileSync } from 'node:child_process'
 import { accessSync, constants, statSync } from 'node:fs'
+import { join } from 'node:path'
 
-import type { Configuration } from 'electron-builder'
+import type { AfterPackContext, Configuration } from 'electron-builder'
 
 const API_KEY_NOTARIZATION_ENV = [
   'APPLE_API_KEY',
@@ -36,6 +38,49 @@ function requireNotarizationCredentials(env: NodeJS.ProcessEnv): void {
   }
 }
 
+export function verifyUniversalReleaseSidecar(context: AfterPackContext): void {
+  const appName = `${context.packager.appInfo.productFilename}.app`
+  const sidecarPath = join(
+    context.appOutDir,
+    appName,
+    'Contents',
+    'Resources',
+    'coral',
+    'coral',
+  )
+
+  let sidecarMetadata
+  try {
+    sidecarMetadata = statSync(sidecarPath)
+    accessSync(sidecarPath, constants.R_OK | constants.X_OK)
+  } catch {
+    throw new Error(`release desktop sidecar must be a readable, executable file: ${sidecarPath}`)
+  }
+  if (!sidecarMetadata.isFile() || sidecarMetadata.size === 0) {
+    throw new Error(`release desktop sidecar must be a readable, executable file: ${sidecarPath}`)
+  }
+
+  const architectures = execFileSync('lipo', ['-archs', sidecarPath], {
+    encoding: 'utf8',
+  })
+    .trim()
+    .split(/\s+/)
+    .sort()
+  if (
+    architectures.length !== 2 ||
+    architectures[0] !== 'arm64' ||
+    architectures[1] !== 'x86_64'
+  ) {
+    throw new Error(
+      `release desktop sidecar must contain exactly arm64 and x86_64; lipo reported '${architectures.join(' ')}'`,
+    )
+  }
+
+  console.info(
+    `[desktop-package] verified pre-sign sidecar architectures: ${architectures.join(' ')}`,
+  )
+}
+
 export function createConfig(env: NodeJS.ProcessEnv = process.env): Configuration {
   const releaseBuild = env.CORAL_DESKTOP_RELEASE === '1'
   if (releaseBuild) requireNotarizationCredentials(env)
@@ -56,6 +101,10 @@ export function createConfig(env: NodeJS.ProcessEnv = process.env): Configuratio
       output: 'dist',
       buildResources: 'resources',
     },
+    // afterPack runs after Coral.app is assembled but before electron-builder
+    // signs it, so release packaging fails before signing begins if the staged
+    // sidecar lost either architecture.
+    afterPack: releaseBuild ? verifyUniversalReleaseSidecar : undefined,
     files: ['out/**/*', 'package.json'],
     extraResources: [
       {

--- a/apps/desktop/scripts/electron-builder-config.test.mjs
+++ b/apps/desktop/scripts/electron-builder-config.test.mjs
@@ -34,6 +34,7 @@ test('non-release packages are explicitly unsigned', () => {
   const config = createConfig({})
 
   assert.equal(config.forceCodeSigning, false)
+  assert.equal(config.afterPack, undefined)
   assert.equal(config.mac?.identity, null)
   assert.equal(config.mac?.hardenedRuntime, false)
   assert.equal(config.mac?.entitlements, null)
@@ -48,6 +49,7 @@ test('release packages enable strict signing and notarization', () => {
   })
 
   assert.equal(config.forceCodeSigning, true)
+  assert.equal(typeof config.afterPack, 'function')
   assert.equal(config.mac?.identity, undefined)
   assert.equal(config.mac?.hardenedRuntime, true)
   assert.equal(config.mac?.entitlements, 'resources/entitlements.mac.plist')


### PR DESCRIPTION
## Summary

  The release workflow already builds clean x86_64 and arm64 Coral CLI binaries, but Desktop packaging currently builds both of them again just to create its universal sidecar.

  This PR reuses the two CLI artifacts produced earlier in the same release run. We validate their filenames, architectures, version, and commit, combine them with `lipo`, and pass the resulting universal binary through the prebuilt-sidecar support
  from #1886.

  There are checks at each part of the handoff: the combined binary must contain exactly x86_64 and arm64, the staged copy must match it, and the packaged app must still contain both architectures. An `afterPack` check also catches a bad sidecar
  before Apple signing begins.

  The release still builds Reef and Electron normally and still produces, signs, and notarizes the same universal DMG/ZIP. We are only removing the duplicate Rust builds from the Desktop release job. PR validation artifacts are never reused.

  The contributor behavior change is: Desktop release packaging now treats the clean, same-run CLI build artifacts as its source of truth rather than rebuilding the CLI itself.

  ## Test plan

  - `npm run check --prefix apps/desktop`
  - `npm test --prefix apps/desktop`
  - Ran `actionlint` against `.github/workflows/release.yml`.
  - Parsed the release workflow as YAML.
  - Exercised the pre-sign verifier locally against a real arm64 + x86_64 Mach-O fixture.