### PR TITLE
ci: guard release-please push step behind PR output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -83,6 +83,7 @@ jobs:
           git commit -m "chore: regenerate changelog docs"
 
       - name: Push regenerated changes
+        if: steps.rp.outputs.pr
         env:
           PR_BRANCH: ${{ fromJSON(steps.rp.outputs.pr || '{}').headBranchName }}
           GH_APP_TOKEN: ${{ steps.github-app-token.outputs.token }}


### PR DESCRIPTION
The "Push regenerated changes" step introduced in #1874 lost the `if: steps.rp.outputs.pr` condition that its parent steps carried, so it ran even on runs where release-please created no release PR. On those runs checkout is also skipped, so the push failed with `fatal: not a git repository` (see [this run](https://github.com/withcoral/coral/actions/runs/29826444013/job/88620755349)).

This adds the missing guard so the push step skips alongside the other release-PR-only steps.