### PR TITLE
feat(reef): add secure hosted logout

### DIFF
--- a/apps/reef/README.md
+++ b/apps/reef/README.md
@@ -27,6 +27,10 @@ session values documented in `.env.example`. A non-desktop production server
 without an explicit mode fails closed rather than accidentally publishing an
 unauthenticated app.
 
+Hosted sessions can be cleared from the Sidebar's CSRF-protected **Sign out**
+action. Logout currently clears Reef's local session; Coral Cloud does not yet
+advertise a provider-neutral browser logout or token-revocation endpoint.
+
 Run checks:
 
 ```bash

--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -350,6 +350,7 @@ describe('Architectural Tests', () => {
 
       expect(routeConfig).toContain("route('login', 'routes/login.tsx')")
       expect(routeConfig).toContain("route('auth/callback', 'routes/auth.callback.tsx')")
+      expect(routeConfig).toContain("route('logout', 'routes/logout.tsx')")
       expect(routeConfig).toContain("layout('routes/_protected.tsx', [")
       expect(routeConfig).toContain(
         "route(`${routePattern('workspaceSource')}/oauth-install`, 'routes/source-oauth-install.ts')",
@@ -376,9 +377,10 @@ describe('Architectural Tests', () => {
 
       // Structural check: the same-origin resource route and onboarding stay
       // outside the app shell while sharing its request authentication boundary.
-      // Reef login and callback stay public so they can establish that session.
+      // Reef login, callback, and logout stay public so they can establish or
+      // clear the hosted session.
       expect(routeConfig).toMatch(
-        /export default \[\s*route\('login', 'routes\/login\.tsx'\),\s*route\('auth\/callback', 'routes\/auth\.callback\.tsx'\),\s*layout\(\s*'routes\/_protected\.tsx',\s*\[\s*(?:\/\/[^\n]*\n\s*)*route\(`\$\{routePattern\('workspaceSource'\)\}\/oauth-install`, 'routes\/source-oauth-install\.ts'\),\s*route\('onboarding', 'routes\/onboarding\.tsx'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\]\s*\),?\s*\] satisfies RouteConfig/,
+        /export default \[\s*route\('login', 'routes\/login\.tsx'\),\s*route\('auth\/callback', 'routes\/auth\.callback\.tsx'\),\s*route\('logout', 'routes\/logout\.tsx'\),\s*layout\(\s*'routes\/_protected\.tsx',\s*\[\s*(?:\/\/[^\n]*\n\s*)*route\(`\$\{routePattern\('workspaceSource'\)\}\/oauth-install`, 'routes\/source-oauth-install\.ts'\),\s*route\('onboarding', 'routes\/onboarding\.tsx'\),\s*layout\(\s*'routes\/app-shell\.tsx',\s*\[[\s\S]*\]\s*\),?\s*\]\s*\),?\s*\] satisfies RouteConfig/,
       )
     })
 

--- a/apps/reef/app/auth/csrf.server.test.ts
+++ b/apps/reef/app/auth/csrf.server.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { clearCsrfToken, csrfTokenForRequest, validateCsrfToken } from './csrf.server'
+import type { RequiredAuthConfig } from './types'
+
+const config: RequiredAuthConfig = {
+  clientId: 'coral-cloud-ui',
+  cookieName: 'reef_session',
+  cookieSecure: true,
+  issuer: 'https://login.example.test',
+  mode: 'required',
+  redirectUri: 'https://reef.example.test/auth/callback',
+  scope: 'coral:mcp',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+
+describe('Reef CSRF tokens', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('creates and reuses a signed, HTTP-only token cookie', async () => {
+    const created = await csrfTokenForRequest(new Request('https://reef.example.test/'), config)
+
+    expect(created.token).toBeTruthy()
+    expect(created.setCookie).toContain('reef_csrf=')
+    expect(created.setCookie).toContain('HttpOnly')
+    expect(created.setCookie).toContain('SameSite=Lax')
+    expect(created.setCookie).toContain('Secure')
+
+    const reused = await csrfTokenForRequest(requestWithCookie(created.setCookie!), config)
+    expect(reused).toEqual({ setCookie: null, token: created.token })
+  })
+
+  it('accepts only a fresh form token matching the signed cookie', async () => {
+    const created = await csrfTokenForRequest(new Request('https://reef.example.test/'), config)
+
+    await expect(
+      validateCsrfToken(postRequest(created.setCookie!, created.token), config),
+    ).resolves.toBe(true)
+    await expect(
+      validateCsrfToken(postRequest(created.setCookie!, 'wrong-token'), config),
+    ).resolves.toBe(false)
+    await expect(
+      validateCsrfToken(postRequest('reef_csrf=tampered', created.token), config),
+    ).resolves.toBe(false)
+
+    vi.advanceTimersByTime((config.sessionMaxAgeSeconds + 1) * 1000)
+    await expect(
+      validateCsrfToken(postRequest(created.setCookie!, created.token), config),
+    ).resolves.toBe(false)
+  })
+
+  it('clears the token cookie with matching security attributes', async () => {
+    const cookie = await clearCsrfToken(config)
+
+    expect(cookie).toContain('reef_csrf=')
+    expect(cookie).toContain('Max-Age=0')
+    expect(cookie).toContain('HttpOnly')
+    expect(cookie).toContain('Secure')
+  })
+})
+
+function requestWithCookie(setCookie: string): Request {
+  return new Request('https://reef.example.test/', {
+    headers: { cookie: setCookie.split(';', 1)[0] },
+  })
+}
+
+function postRequest(setCookie: string, csrf: string): Request {
+  return new Request('https://reef.example.test/logout', {
+    body: new URLSearchParams({ csrf }),
+    headers: { cookie: setCookie.split(';', 1)[0] },
+    method: 'POST',
+  })
+}

--- a/apps/reef/app/auth/csrf.server.ts
+++ b/apps/reef/app/auth/csrf.server.ts
@@ -1,0 +1,104 @@
+import { timingSafeEqual } from 'node:crypto'
+
+import { createCookie } from 'react-router'
+
+import { randomToken } from './session.server'
+import type { RequiredAuthConfig } from './types'
+
+const CSRF_COOKIE_NAME = 'reef_csrf'
+const CLOCK_SKEW_SECONDS = 30
+
+interface CsrfCookieValue {
+  createdAt: number
+  token: string
+}
+
+interface CsrfTokenResult {
+  setCookie: string | null
+  token: string
+}
+
+export async function csrfTokenForRequest(
+  request: Request,
+  config: RequiredAuthConfig,
+): Promise<CsrfTokenResult> {
+  const existing = await readCsrfCookie(request, config)
+  if (existing && isFresh(existing, config)) return { setCookie: null, token: existing.token }
+
+  const value = { createdAt: unixTimestamp(), token: randomToken(32) } satisfies CsrfCookieValue
+  return {
+    setCookie: await csrfCookie(config).serialize(value),
+    token: value.token,
+  }
+}
+
+export async function validateCsrfToken(
+  request: Request,
+  config: RequiredAuthConfig,
+): Promise<boolean> {
+  const cookie = await readCsrfCookie(request, config)
+  if (!cookie || !isFresh(cookie, config)) return false
+
+  let formData: FormData
+  try {
+    formData = await request.clone().formData()
+  } catch {
+    return false
+  }
+
+  const submitted = formData.get('csrf')
+  return typeof submitted === 'string' && safeEqual(submitted, cookie.token)
+}
+
+export async function clearCsrfToken(config: RequiredAuthConfig): Promise<string> {
+  return csrfCookie(config).serialize('', { maxAge: 0 })
+}
+
+function csrfCookie(config: RequiredAuthConfig) {
+  return createCookie(CSRF_COOKIE_NAME, {
+    httpOnly: true,
+    maxAge: config.sessionMaxAgeSeconds,
+    path: '/',
+    sameSite: 'lax',
+    secrets: [config.sessionSecret],
+    secure: config.cookieSecure,
+  })
+}
+
+async function readCsrfCookie(
+  request: Request,
+  config: RequiredAuthConfig,
+): Promise<CsrfCookieValue | null> {
+  const value = await csrfCookie(config).parse(request.headers.get('cookie'))
+  if (!isCsrfCookieValue(value)) return null
+  return value
+}
+
+function isCsrfCookieValue(value: unknown): value is CsrfCookieValue {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<CsrfCookieValue>
+  return (
+    typeof candidate.createdAt === 'number' &&
+    Number.isFinite(candidate.createdAt) &&
+    typeof candidate.token === 'string' &&
+    candidate.token.length > 0
+  )
+}
+
+function isFresh(value: CsrfCookieValue, config: RequiredAuthConfig): boolean {
+  const now = unixTimestamp()
+  return (
+    value.createdAt <= now + CLOCK_SKEW_SECONDS &&
+    now - value.createdAt <= config.sessionMaxAgeSeconds
+  )
+}
+
+function safeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left)
+  const rightBuffer = Buffer.from(right)
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer)
+}
+
+function unixTimestamp(): number {
+  return Math.floor(Date.now() / 1000)
+}

--- a/apps/reef/app/auth/server-context.test-helper.ts
+++ b/apps/reef/app/auth/server-context.test-helper.ts
@@ -11,6 +11,7 @@ export function authTestContext(accessToken: string | null = 'test-coral-token')
 
   context.set(requestAuthContext, {
     accessToken,
+    csrfToken: 'test-csrf-token',
     mode: 'required',
     session: {
       accessToken,

--- a/apps/reef/app/auth/types.ts
+++ b/apps/reef/app/auth/types.ts
@@ -24,6 +24,8 @@ export interface AuthSession {
   tokenType: string
 }
 
+export type BrowserAuth = { mode: 'disabled' } | { csrfToken: string; mode: 'required' }
+
 export type RequestAuth =
   | { accessToken: null; mode: 'disabled' }
-  | { accessToken: string; mode: 'required'; session: AuthSession }
+  | { accessToken: string; csrfToken: string; mode: 'required'; session: AuthSession }

--- a/apps/reef/app/components/sidebar/sidebar.stories.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.stories.tsx
@@ -59,3 +59,11 @@ export const Minimized: Story = {
     workspaces: [{ name: 'default' }, { name: 'analytics' }],
   },
 }
+
+export const Hosted: Story = {
+  args: {
+    auth: { csrfToken: 'storybook-csrf-token', mode: 'required' },
+    initialIsMinimized: false,
+    workspaces: [{ name: 'default' }, { name: 'analytics' }],
+  },
+}

--- a/apps/reef/app/components/sidebar/sidebar.test.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.test.tsx
@@ -7,6 +7,7 @@ import { Sidebar } from './sidebar'
 import { SIDEBAR_COOKIE_NAME } from './sidebar-state'
 import { validateWorkspaceName } from '@/lib/workspace-name'
 import { routePath, routePattern } from '@/routing/routemap'
+import type { BrowserAuth } from '@/auth/types'
 
 const WORKSPACES = [{ name: 'default' }, { name: 'analytics' }]
 
@@ -14,6 +15,7 @@ async function renderSidebar(
   initialIsMinimized: boolean,
   initialEntry = routePath('home'),
   workspaces: Array<{ name: string }> = [],
+  auth: BrowserAuth = { mode: 'disabled' },
 ) {
   const router = createMemoryRouter(
     [
@@ -31,31 +33,45 @@ async function renderSidebar(
         path: routePattern('workspaces'),
       },
       {
-        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        element: (
+          <Sidebar auth={auth} initialIsMinimized={initialIsMinimized} workspaces={workspaces} />
+        ),
         path: routePattern('workspaceSource'),
       },
       {
-        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        element: (
+          <Sidebar auth={auth} initialIsMinimized={initialIsMinimized} workspaces={workspaces} />
+        ),
         path: routePattern('workspaceSources'),
       },
       {
-        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        element: (
+          <Sidebar auth={auth} initialIsMinimized={initialIsMinimized} workspaces={workspaces} />
+        ),
         path: routePattern('workspaceSchemaTable'),
       },
       {
-        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        element: (
+          <Sidebar auth={auth} initialIsMinimized={initialIsMinimized} workspaces={workspaces} />
+        ),
         path: routePattern('workspaceSchema'),
       },
       {
-        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        element: (
+          <Sidebar auth={auth} initialIsMinimized={initialIsMinimized} workspaces={workspaces} />
+        ),
         path: routePattern('workspaceTrace'),
       },
       {
-        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        element: (
+          <Sidebar auth={auth} initialIsMinimized={initialIsMinimized} workspaces={workspaces} />
+        ),
         path: routePattern('workspaceTraces'),
       },
       {
-        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        element: (
+          <Sidebar auth={auth} initialIsMinimized={initialIsMinimized} workspaces={workspaces} />
+        ),
         path: '*',
       },
     ],
@@ -293,5 +309,24 @@ describe('Sidebar', () => {
     await expect
       .poll(() => document.querySelector('[data-base-ui-portal]')?.textContent)
       .toContain('Sources')
+  })
+
+  it('shows logout only for hosted auth and submits its CSRF token', async () => {
+    const local = await renderSidebar(false, '/workspaces/analytics/sources', WORKSPACES)
+    await expect.element(local.getByRole('button', { name: 'Sign out' })).not.toBeInTheDocument()
+
+    const hosted = await renderSidebar(false, '/workspaces/analytics/sources', WORKSPACES, {
+      csrfToken: 'hosted-csrf-token',
+      mode: 'required',
+    })
+    const signOut = hosted.getByRole('button', { name: 'Sign out' })
+    const form = signOut.element().closest('form')
+
+    await expect.element(signOut).toBeVisible()
+    expect(form?.getAttribute('action')).toBe('/logout')
+    expect(form?.getAttribute('method')).toBe('post')
+    expect(form?.querySelector<HTMLInputElement>('input[name="csrf"]')?.value).toBe(
+      'hosted-csrf-token',
+    )
   })
 })

--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import { useEffect, useRef, useState } from 'react'
-import { Link, NavLink, useLocation, useParams } from 'react-router'
+import { Form, Link, NavLink, useLocation, useParams } from 'react-router'
 
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
 import { IconButton } from '@/wax/components/button'
@@ -12,6 +12,7 @@ import type { IconName } from '@/wax/components/icon'
 import * as Menu from '@/wax/components/menu'
 import { getAvatarColorFromSeed } from '@/wax/components/avatar/utils/get-avatar-color'
 import type { Workspace } from '@/generated/coral/v1/resources_pb'
+import type { BrowserAuth } from '@/auth/types'
 import { WorkspaceCreationDialog } from '@/components/workspaces'
 import { isCoralDesktopBuild } from '@/lib/coral-desktop'
 import { workspacePathForCurrentSection } from '@/lib/workspace-routing'
@@ -21,11 +22,16 @@ import * as styles from './sidebar.css'
 import { useSidebarState } from './use-sidebar-state'
 
 interface SidebarProps {
+  auth?: BrowserAuth
   initialIsMinimized: boolean
   workspaces: ReadonlyArray<Pick<Workspace, 'name'>>
 }
 
-export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
+export function Sidebar({
+  auth = { mode: 'disabled' },
+  initialIsMinimized,
+  workspaces,
+}: SidebarProps) {
   const location = useLocation()
   const { workspaceId } = useParams()
   const { isMinimized, toggleSidebar } = useSidebarState(initialIsMinimized)
@@ -218,6 +224,22 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
       </div>
 
       <div className={styles.footer}>
+        {auth.mode === 'required' && (
+          <Form action="/logout" method="post">
+            <input name="csrf" type="hidden" value={auth.csrfToken} />
+            {isMinimized ? (
+              <Tooltip content="Sign out" side="right">
+                <SidebarButton aria-label="Sign out" icon="LogOut" isMinimized type="submit">
+                  Sign out
+                </SidebarButton>
+              </Tooltip>
+            ) : (
+              <SidebarButton aria-label="Sign out" icon="LogOut" type="submit">
+                Sign out
+              </SidebarButton>
+            )}
+          </Form>
+        )}
         {isDesktopApp &&
           // Collapsed sidebar hides the label, so surface it on hover instead.
           (isMinimized ? (

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -9,6 +9,7 @@ const isDesktopApp = process.env.CORAL_DESKTOP_APP === '1'
 export default [
   route('login', 'routes/login.tsx'),
   route('auth/callback', 'routes/auth.callback.tsx'),
+  route('logout', 'routes/logout.tsx'),
   layout('routes/_protected.tsx', [
     // Action-only resource route: OAuth/device-code install streams progress over
     // same-origin fetch. It and onboarding share the auth boundary but do not

--- a/apps/reef/app/routes/_protected.server.test.tsx
+++ b/apps/reef/app/routes/_protected.server.test.tsx
@@ -5,11 +5,13 @@ import type { RequiredAuthConfig } from '@/auth/types'
 
 const authMocks = vi.hoisted(() => ({
   clearReefSession: vi.fn(async () => 'reef_session=; Max-Age=0; Path=/; HttpOnly'),
+  csrfTokenForRequest: vi.fn(),
   readReefSession: vi.fn(),
   reefAuthConfig: vi.fn(),
 }))
 
 vi.mock('@/auth/config.server', () => ({ reefAuthConfig: authMocks.reefAuthConfig }))
+vi.mock('@/auth/csrf.server', () => ({ csrfTokenForRequest: authMocks.csrfTokenForRequest }))
 vi.mock('@/auth/session.server', () => ({
   clearReefSession: authMocks.clearReefSession,
   readReefSession: authMocks.readReefSession,
@@ -90,6 +92,8 @@ const handlerBuild = {
 describe('optional auth boundary', () => {
   beforeEach(() => {
     authMocks.clearReefSession.mockClear()
+    authMocks.csrfTokenForRequest.mockReset()
+    authMocks.csrfTokenForRequest.mockResolvedValue({ setCookie: null, token: 'csrf-token' })
     authMocks.readReefSession.mockReset()
     authMocks.reefAuthConfig.mockReset()
     descendantAction.mockClear()
@@ -108,6 +112,7 @@ describe('optional auth boundary', () => {
     expect(next).toHaveBeenCalledOnce()
     expect(authMocks.readReefSession).not.toHaveBeenCalled()
     expect(authMocks.clearReefSession).not.toHaveBeenCalled()
+    expect(authMocks.csrfTokenForRequest).not.toHaveBeenCalled()
     expect(context.get(requestAuthContext)).toEqual({ accessToken: null, mode: 'disabled' })
     expect(response.headers.has('Cache-Control')).toBe(false)
   })
@@ -196,9 +201,32 @@ describe('optional auth boundary', () => {
 
     expect(context.get(requestAuthContext)).toEqual({
       accessToken: 'server-only-token',
+      csrfToken: 'csrf-token',
       mode: 'required',
       session,
     })
+  })
+
+  it('commits a fresh CSRF cookie on the protected response', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.readReefSession.mockResolvedValue(session)
+    authMocks.csrfTokenForRequest.mockResolvedValue({
+      setCookie: 'reef_csrf=signed; Path=/; HttpOnly; SameSite=Lax',
+      token: 'fresh-csrf-token',
+    })
+
+    const response = await runMiddleware(
+      new Request('https://reef.example.test/'),
+      async () => new Response('ok'),
+    )
+
+    expect(response.headers.get('Set-Cookie')).toContain('reef_csrf=signed')
+
+    const childError = new Response('failed', { status: 500 })
+    const thrown = await runMiddleware(new Request('https://reef.example.test/'), async () => {
+      throw childError
+    }).catch((error: unknown) => error)
+    expect((thrown as Response).headers.get('Set-Cookie')).toContain('reef_csrf=signed')
   })
 
   it('marks normal and thrown hosted responses private and non-cacheable', async () => {

--- a/apps/reef/app/routes/_protected.tsx
+++ b/apps/reef/app/routes/_protected.tsx
@@ -3,6 +3,7 @@ import { Outlet, redirect } from 'react-router'
 import type { Route } from './+types/_protected'
 
 import { reefAuthConfig } from '@/auth/config.server'
+import { csrfTokenForRequest } from '@/auth/csrf.server'
 import { markAuthResponsePrivate } from '@/auth/response.server'
 import { requestAuthContext } from '@/auth/server-context'
 import { clearReefSession, readReefSession } from '@/auth/session.server'
@@ -19,17 +20,23 @@ export const middleware: Route.MiddlewareFunction[] = [
 
     const session = await readReefSession(request, config)
     if (!session) throw await loginRedirect(request, config)
+    const csrf = await csrfTokenForRequest(request, config)
     context.set(requestAuthContext, {
       accessToken: session.accessToken,
+      csrfToken: csrf.token,
       mode: 'required',
       session,
     })
 
     try {
       const response = await next()
+      appendSetCookie(response, csrf.setCookie)
       return markAuthResponsePrivate(response)
     } catch (error) {
-      if (error instanceof Response) markAuthResponsePrivate(error)
+      if (error instanceof Response) {
+        appendSetCookie(error, csrf.setCookie)
+        markAuthResponsePrivate(error)
+      }
       throw error
     }
   },
@@ -54,4 +61,8 @@ async function loginRedirect(request: Request, config: RequiredAuthConfig): Prom
 function hasSessionCookie(request: Request, name: string): boolean {
   const cookie = request.headers.get('cookie')
   return cookie?.split(';').some((part) => part.trim().startsWith(`${name}=`)) ?? false
+}
+
+function appendSetCookie(response: Response, value: string | null): void {
+  if (value) response.headers.append('Set-Cookie', value)
 }

--- a/apps/reef/app/routes/app-shell.server.test.ts
+++ b/apps/reef/app/routes/app-shell.server.test.ts
@@ -20,12 +20,13 @@ describe('app shell loader', () => {
     vi.restoreAllMocks()
   })
 
-  it('loads the local workspace list once for the sidebar', async () => {
+  it('loads the hosted workspace list and browser-safe auth state for the sidebar', async () => {
     const request = new Request('http://reef.test/workspaces/default/sources')
     const workspaces = [{ name: 'default' }, { name: 'analytics' }]
     listWorkspacesForRequest.mockResolvedValue(workspaces)
 
     await expect(loader(authRouteTestArgs(request, {}, 'coral-access-token'))).resolves.toEqual({
+      auth: { csrfToken: 'test-csrf-token', mode: 'required' },
       workspaces,
     })
     expect(listWorkspacesForRequest).toHaveBeenCalledOnce()
@@ -35,7 +36,10 @@ describe('app shell loader', () => {
   it('leaves workspace lookup to the index redirect loader', async () => {
     await expect(
       loader(authRouteTestArgs(new Request(`http://reef.test${routePath('home')}`), {})),
-    ).resolves.toEqual({ workspaces: [] })
+    ).resolves.toEqual({
+      auth: { csrfToken: 'test-csrf-token', mode: 'required' },
+      workspaces: [],
+    })
     expect(listWorkspacesForRequest).not.toHaveBeenCalled()
   })
 
@@ -46,7 +50,21 @@ describe('app shell loader', () => {
 
     await expect(
       loader(authRouteTestArgs(new Request('http://reef.test/workspaces/default/sources'), {})),
-    ).resolves.toEqual({ workspaces: [] })
+    ).resolves.toEqual({
+      auth: { csrfToken: 'test-csrf-token', mode: 'required' },
+      workspaces: [],
+    })
     expect(consoleError).toHaveBeenCalledWith('Failed to load sidebar workspaces:', error)
+  })
+
+  it('keeps local sidebar auth disabled', async () => {
+    const request = new Request('http://reef.test/workspaces/default/sources')
+    listWorkspacesForRequest.mockResolvedValue([{ name: 'default' }])
+
+    await expect(loader(authRouteTestArgs(request, {}, null))).resolves.toEqual({
+      auth: { mode: 'disabled' },
+      workspaces: [{ name: 'default' }],
+    })
+    expect(listWorkspacesForRequest).toHaveBeenCalledWith(request, null)
   })
 })

--- a/apps/reef/app/routes/app-shell.tsx
+++ b/apps/reef/app/routes/app-shell.tsx
@@ -8,6 +8,7 @@ import { requestAuthContext } from '@/auth/server-context'
 import { listWorkspacesForRequest } from '@/lib/workspaces.server'
 import { routePath } from '@/routing/routemap'
 import { ToastContainer } from '@/wax/components/toast'
+import type { BrowserAuth, RequestAuth } from '@/auth/types'
 
 import * as styles from './app-shell.css'
 
@@ -16,10 +17,12 @@ interface RootLoaderData {
 }
 
 export async function loader({ context, request }: Route.LoaderArgs) {
-  if (isWorkspaceRedirectRoute(request)) return { workspaces: [] }
+  const auth = browserAuth(context.get(requestAuthContext))
+  if (isWorkspaceRedirectRoute(request)) return { auth, workspaces: [] }
 
   try {
     return {
+      auth,
       workspaces: await listWorkspacesForRequest(
         request,
         context.get(requestAuthContext).accessToken,
@@ -27,8 +30,14 @@ export async function loader({ context, request }: Route.LoaderArgs) {
     }
   } catch (error) {
     console.error('Failed to load sidebar workspaces:', error)
-    return { workspaces: [] }
+    return { auth, workspaces: [] }
   }
+}
+
+function browserAuth(auth: RequestAuth): BrowserAuth {
+  return auth.mode === 'required'
+    ? { csrfToken: auth.csrfToken, mode: 'required' }
+    : { mode: 'disabled' }
 }
 
 function isWorkspaceRedirectRoute(request: Request): boolean {
@@ -41,6 +50,7 @@ export default function AppShell({ loaderData }: Route.ComponentProps) {
   return (
     <div className={styles.layout}>
       <Sidebar
+        auth={loaderData.auth}
         initialIsMinimized={rootData?.sidebarIsMinimized ?? false}
         workspaces={loaderData.workspaces}
       />

--- a/apps/reef/app/routes/logout.server.test.tsx
+++ b/apps/reef/app/routes/logout.server.test.tsx
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authMocks = vi.hoisted(() => ({
+  clearCsrfToken: vi.fn(),
+  clearOAuthTransaction: vi.fn(),
+  clearReefSession: vi.fn(),
+  reefAuthConfig: vi.fn(),
+  validateCsrfToken: vi.fn(),
+}))
+
+vi.mock('@/auth/config.server', () => ({ reefAuthConfig: authMocks.reefAuthConfig }))
+vi.mock('@/auth/csrf.server', () => ({
+  clearCsrfToken: authMocks.clearCsrfToken,
+  validateCsrfToken: authMocks.validateCsrfToken,
+}))
+vi.mock('@/auth/session.server', () => ({
+  clearOAuthTransaction: authMocks.clearOAuthTransaction,
+  clearReefSession: authMocks.clearReefSession,
+}))
+
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
+import type { RequiredAuthConfig } from '@/auth/types'
+
+import { action, loader } from './logout'
+
+const requiredConfig: RequiredAuthConfig = {
+  clientId: 'coral-cloud-ui',
+  cookieName: 'reef_session',
+  cookieSecure: true,
+  issuer: 'https://login.example.test',
+  mode: 'required',
+  redirectUri: 'https://reef.example.test/auth/callback',
+  scope: 'coral:mcp',
+  sessionMaxAgeSeconds: 3600,
+  sessionSecret: '0123456789abcdef0123456789abcdef',
+}
+
+describe('logout route', () => {
+  beforeEach(() => {
+    authMocks.clearCsrfToken.mockReset()
+    authMocks.clearOAuthTransaction.mockReset()
+    authMocks.clearReefSession.mockReset()
+    authMocks.reefAuthConfig.mockReset()
+    authMocks.validateCsrfToken.mockReset()
+    authMocks.clearCsrfToken.mockResolvedValue('reef_csrf=; Max-Age=0; Path=/')
+    authMocks.clearOAuthTransaction.mockResolvedValue('reef_oauth=; Max-Age=0; Path=/')
+    authMocks.clearReefSession.mockResolvedValue('reef_session=; Max-Age=0; Path=/')
+  })
+
+  it('redirects GET requests home without clearing a session', async () => {
+    const response = await loader()
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('Location')).toBe('/')
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+    expect(authMocks.clearReefSession).not.toHaveBeenCalled()
+  })
+
+  it('keeps disabled local and desktop logout inert', async () => {
+    authMocks.reefAuthConfig.mockReturnValue({ mode: 'disabled' })
+    const request = logoutRequest('local-token')
+
+    const response = await action(authRouteTestArgs(request, {}, null))
+
+    expect(response.headers.get('Location')).toBe('/')
+    expect(authMocks.validateCsrfToken).not.toHaveBeenCalled()
+    expect(authMocks.clearReefSession).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-POST mutations', async () => {
+    const request = new Request('https://reef.example.test/logout', { method: 'DELETE' })
+
+    await expect(action(authRouteTestArgs(request, {}))).rejects.toMatchObject({ status: 405 })
+    expect(authMocks.reefAuthConfig).not.toHaveBeenCalled()
+  })
+
+  it('rejects a hosted logout with an invalid CSRF token', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.validateCsrfToken.mockResolvedValue(false)
+    const request = logoutRequest('invalid-token')
+
+    await expect(action(authRouteTestArgs(request, {}))).rejects.toMatchObject({ status: 403 })
+    expect(authMocks.validateCsrfToken).toHaveBeenCalledWith(request, requiredConfig)
+    expect(authMocks.clearReefSession).not.toHaveBeenCalled()
+  })
+
+  it('clears hosted auth cookies and lands on the signed-out screen', async () => {
+    authMocks.reefAuthConfig.mockReturnValue(requiredConfig)
+    authMocks.validateCsrfToken.mockResolvedValue(true)
+    const request = logoutRequest('valid-token')
+
+    const response = await action(authRouteTestArgs(request, {}))
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('Location')).toBe('/login?signedOut=1')
+    expect(response.headers.getSetCookie()).toEqual([
+      'reef_csrf=; Max-Age=0; Path=/',
+      'reef_oauth=; Max-Age=0; Path=/',
+      'reef_session=; Max-Age=0; Path=/',
+    ])
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+  })
+})
+
+function logoutRequest(csrf: string): Request {
+  return new Request('https://reef.example.test/logout', {
+    body: new URLSearchParams({ csrf }),
+    method: 'POST',
+  })
+}

--- a/apps/reef/app/routes/logout.tsx
+++ b/apps/reef/app/routes/logout.tsx
@@ -1,0 +1,38 @@
+import { redirect } from 'react-router'
+
+import type { Route } from './+types/logout'
+
+import { reefAuthConfig } from '@/auth/config.server'
+import { clearCsrfToken, validateCsrfToken } from '@/auth/csrf.server'
+import { markAuthResponsePrivate } from '@/auth/response.server'
+import { clearOAuthTransaction, clearReefSession } from '@/auth/session.server'
+
+export async function loader() {
+  return markAuthResponsePrivate(redirect('/'))
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  if (request.method !== 'POST') {
+    throw markAuthResponsePrivate(new Response('Method Not Allowed', { status: 405 }))
+  }
+
+  const config = reefAuthConfig()
+  if (config.mode === 'disabled') return markAuthResponsePrivate(redirect('/'))
+  if (!(await validateCsrfToken(request, config))) {
+    throw markAuthResponsePrivate(new Response('Invalid CSRF token', { status: 403 }))
+  }
+
+  const headers = new Headers()
+  headers.append('Set-Cookie', await clearCsrfToken(config))
+  headers.append('Set-Cookie', await clearOAuthTransaction(config))
+  headers.append('Set-Cookie', await clearReefSession(config))
+
+  // Coral Cloud does not currently advertise a provider-neutral browser logout
+  // or revocation endpoint. Keep logout local and stop automatic SSO bounce by
+  // landing on the signed-out login screen.
+  return markAuthResponsePrivate(redirect('/login?signedOut=1', { headers }))
+}
+
+export default function Logout() {
+  return null
+}


### PR DESCRIPTION
Expose a hosted-only Sidebar sign-out action backed by a signed CSRF cookie, require POST for logout, and clear Reef session, OAuth transaction, and CSRF cookies before landing on the signed-out screen. Local and desktop Reef remain auth-control free.

Constraint: Logout must remain invisible and inert when Reef authentication is disabled.
Rejected: GET logout or cookie-only POST logout | both permit cross-site logout without an explicit user-bound CSRF token.
Confidence: high
Scope-risk: moderate
Directive: Reuse csrf.server.ts when extending CSRF validation to other hosted mutation routes.
Tested: npm run check --prefix apps/reef; npm run typecheck --prefix apps/reef; npm test --prefix apps/reef (96 files, 425 tests); npm run build --prefix apps/reef; client bundle auth-secret scan; ccc index
Not-tested: Upstream Coral Cloud logout/revocation and packaged desktop smoke testing