### PR TITLE
refactor(engine): distinguish SQL catalogs from schemas

### DIFF
--- a/apps/docs/reference/source-spec-reference.mdx
+++ b/apps/docs/reference/source-spec-reference.mdx
@@ -1457,7 +1457,8 @@ secret has been configured.
 
 | Column | Description |
 | ------ | ----------- |
-| `schema_name` | Source schema that owns the input |
+| `schema_name` | Source schema that owns the input; empty for database sources |
+| `catalog_name` | SQL catalog that owns the input; empty for schema-addressed sources |
 | `key` | Input key from the manifest |
 | `kind` | `variable` or `secret` |
 | `value` | Variable value when available; `NULL` for secrets |
@@ -1466,14 +1467,27 @@ secret has been configured.
 | `required` | Whether the input must be configured |
 | `is_set` | Whether Coral has a saved value for that input |
 
+Sources whose tables are addressed as `schema_name.table_name` populate
+`schema_name` and leave `catalog_name` empty. Database sources are addressed by
+catalog instead, so their input rows invert that: `schema_name` is empty and
+`catalog_name` carries the source name. Neither column is ever `NULL` — the
+absent side is the empty string, so match it with `= ''` rather than `IS NULL`.
+A query that should cover either shape filters on both columns.
+
+The same pair appears on `coral.tables`, `coral.columns`, `coral.filters`, and
+`coral.table_functions`, with one difference: on those tables `schema_name` stays
+populated for database sources because it names the schema inside the database
+(such as `public`), while `catalog_name` names the source.
+
 Example queries:
 
 ```sql
--- Look up a variable value
+-- Look up a variable value, whichever way the source is addressed
 SELECT value FROM coral.inputs
-WHERE schema_name = 'datadog' AND kind = 'variable' AND key = 'DD_SITE';
+WHERE (schema_name = 'datadog' OR catalog_name = 'datadog')
+  AND kind = 'variable' AND key = 'DD_SITE';
 
 -- Check which secrets are configured without revealing them
-SELECT schema_name, key FROM coral.inputs
+SELECT catalog_name, schema_name, key FROM coral.inputs
 WHERE kind = 'secret' AND is_set;
 ```

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -147,6 +147,7 @@ impl McpQueryHistoryEntry {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct McpQueryTableUsage {
     source: String,
+    catalog: Option<String>,
     schema: String,
     table: String,
 }
@@ -156,6 +157,14 @@ impl McpQueryTableUsage {
     #[must_use]
     pub fn source_name(&self) -> &str {
         &self.source
+    }
+
+    /// SQL catalog used in the query, or `None` for a table addressed as
+    /// `schema.table`. Two catalogs can expose the same `schema.table`, so this
+    /// is part of the table's identity.
+    #[must_use]
+    pub fn catalog_name(&self) -> Option<&str> {
+        self.catalog.as_deref()
     }
 
     /// SQL schema name used in the query.
@@ -173,6 +182,7 @@ impl McpQueryTableUsage {
     fn from_trace(usage: TraceQueryTableUsage) -> Self {
         Self {
             source: usage.source,
+            catalog: usage.catalog,
             schema: usage.schema,
             table: usage.table,
         }
@@ -413,6 +423,7 @@ mod tests {
             tables: (0..table_count)
                 .map(|index| McpQueryTableUsage {
                     source: table_source.to_string(),
+                    catalog: None,
                     schema: "schema".to_string(),
                     table: format!("table_{index}"),
                 })

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -594,7 +594,7 @@ mod tests {
 
     fn table(required_filters: Vec<String>) -> TableInfo {
         TableInfo {
-            catalog_name: String::new(),
+            catalog_name: None,
             schema_name: "github".to_string(),
             table_name: "Pull.Requests".to_string(),
             description: "Pull request table".to_string(),

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -594,6 +594,7 @@ mod tests {
 
     fn table(required_filters: Vec<String>) -> TableInfo {
         TableInfo {
+            catalog_name: String::new(),
             schema_name: "github".to_string(),
             table_name: "Pull.Requests".to_string(),
             description: "Pull request table".to_string(),

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -428,8 +428,13 @@ impl QueryManager {
                     .await
                     .map_err(QueryManagerError::Core)?;
                 if let Some(shown_guide_ids) = shown_guide_ids {
-                    let required_guides =
-                        required_query_guides(&runtime.list_catalog(None), prepared.resources());
+                    // Unfiltered on both qualifiers: a required guide has to be
+                    // found wherever the query's tables live, including
+                    // catalog-backed sources.
+                    let required_guides = required_query_guides(
+                        &runtime.list_catalog(None, None),
+                        prepared.resources(),
+                    );
                     let unseen_guides = required_guides
                         .into_iter()
                         .filter(|guide| !shown_guide_ids.contains(&guide.guide_id))

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -285,7 +285,7 @@ impl QueryManager {
                         SourceObservationMode::Disabled,
                     )
                     .await?;
-                Ok(runtime.list_tables(schema_filter, table_filter))
+                Ok(runtime.list_tables(None, schema_filter, table_filter))
             },
             |tables| Some(u64::try_from(tables.len()).unwrap_or(u64::MAX)),
             |_, _| {},
@@ -336,7 +336,7 @@ impl QueryManager {
                 let runtime_schema_owners =
                     runtime_schema_owners(&source_load.loaded).map_err(QueryManagerError::App)?;
                 Ok(CatalogResolution {
-                    catalog: runtime.list_catalog(schema_filter),
+                    catalog: runtime.list_catalog(None, schema_filter),
                     failed_source_names,
                     runtime_schema_owners,
                 })
@@ -385,7 +385,7 @@ impl QueryManager {
                         SourceObservationMode::Disabled,
                     )
                     .await?;
-                Ok(runtime.describe_table(schema_name, table_name))
+                Ok(runtime.describe_table(None, schema_name, table_name))
             },
             |_| None,
             |_, _| {},

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1170,6 +1170,7 @@ fn record_query_provenance(span: &tracing::Span, provenance: &QueryExecutionProv
             .map(|table| {
                 json!({
                     "source_name": table.source_name(),
+                    "catalog_name": table.catalog_name(),
                     "schema_name": table.schema_name(),
                     "table_name": table.table_name(),
                 })
@@ -1605,7 +1606,10 @@ mod tests {
         );
         let resources = ResolvedQueryResources::new(
             vec!["github".to_string()],
-            vec![QueryTableUsage::new("github", "github", "issues")],
+            vec![
+                QueryTableUsage::new("github", None, "github", "issues"),
+                QueryTableUsage::new("warehouse", Some("warehouse"), "public", "users"),
+            ],
             vec![QueryTableFunctionUsage::new(
                 "github",
                 "github",
@@ -1628,10 +1632,12 @@ mod tests {
             span_attr(query_span, crate::telemetry::QUERY_TRACE_SOURCES_ATTR),
             Some(r#"["github"]"#.to_string())
         );
+        // A catalog-backed table records its catalog: `(schema, table)` alone
+        // would merge two databases that both expose `public.users`.
         assert_eq!(
             span_attr(query_span, crate::telemetry::QUERY_TRACE_TABLES_ATTR),
             Some(
-                r#"[{"source_name":"github","schema_name":"github","table_name":"issues"}]"#
+                r#"[{"source_name":"github","catalog_name":null,"schema_name":"github","table_name":"issues"},{"source_name":"warehouse","catalog_name":"warehouse","schema_name":"public","table_name":"users"}]"#
                     .to_string()
             )
         );

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -142,6 +142,10 @@ impl SourceDecorator for CatalogFailureRecorder {
         "catalog_failure_recorder"
     }
 
+    fn supports_catalog_sources(&self) -> bool {
+        true
+    }
+
     fn decorate_source(
         &mut self,
         _source: &QuerySource,

--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -1055,6 +1055,7 @@ mod tests {
     fn column_cap_catalog(column_count: usize) -> CatalogInfo {
         CatalogInfo {
             tables: vec![TableInfo {
+                catalog_name: String::new(),
                 schema_name: "fixture".to_string(),
                 table_name: "payments".to_string(),
                 description: "Payments".to_string(),

--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -1055,7 +1055,7 @@ mod tests {
     fn column_cap_catalog(column_count: usize) -> CatalogInfo {
         CatalogInfo {
             tables: vec![TableInfo {
-                catalog_name: String::new(),
+                catalog_name: None,
                 schema_name: "fixture".to_string(),
                 table_name: "payments".to_string(),
                 description: "Payments".to_string(),

--- a/crates/coral-app/src/search/catalog/snapshot.rs
+++ b/crates/coral-app/src/search/catalog/snapshot.rs
@@ -574,7 +574,7 @@ mod tests {
     fn catalog_with_table(table_name: &str) -> CatalogInfo {
         CatalogInfo {
             tables: vec![TableInfo {
-                catalog_name: String::new(),
+                catalog_name: None,
                 schema_name: "fixture".to_string(),
                 table_name: table_name.to_string(),
                 description: format!("Fixture {table_name}"),

--- a/crates/coral-app/src/search/catalog/snapshot.rs
+++ b/crates/coral-app/src/search/catalog/snapshot.rs
@@ -574,6 +574,7 @@ mod tests {
     fn catalog_with_table(table_name: &str) -> CatalogInfo {
         CatalogInfo {
             tables: vec![TableInfo {
+                catalog_name: String::new(),
                 schema_name: "fixture".to_string(),
                 table_name: table_name.to_string(),
                 description: format!("Fixture {table_name}"),

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -491,6 +491,10 @@ pub(crate) struct TraceQueryHistoryEntry {
 pub(crate) struct TraceQueryTableUsage {
     #[serde(rename = "source_name")]
     pub(crate) source: String,
+    /// Absent on spans recorded before query provenance carried the catalog, so
+    /// historical rows still parse.
+    #[serde(rename = "catalog_name", default)]
+    pub(crate) catalog: Option<String>,
     #[serde(rename = "schema_name")]
     pub(crate) schema: String,
     #[serde(rename = "table_name")]

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -905,7 +905,7 @@ mod tests {
     fn table_to_proto_preserves_table_metadata() {
         let workspace_name = WorkspaceName::parse("default").expect("workspace");
         let table = TableInfo {
-            catalog_name: String::new(),
+            catalog_name: None,
             schema_name: "demo".to_string(),
             table_name: "users".to_string(),
             description: "User records".to_string(),
@@ -945,7 +945,7 @@ mod tests {
     fn table_summary_to_proto_preserves_table_metadata_without_columns() {
         let workspace_name = WorkspaceName::parse("default").expect("workspace");
         let table = TableInfo {
-            catalog_name: String::new(),
+            catalog_name: None,
             schema_name: "demo".to_string(),
             table_name: "users".to_string(),
             description: "User records".to_string(),

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -905,6 +905,7 @@ mod tests {
     fn table_to_proto_preserves_table_metadata() {
         let workspace_name = WorkspaceName::parse("default").expect("workspace");
         let table = TableInfo {
+            catalog_name: String::new(),
             schema_name: "demo".to_string(),
             table_name: "users".to_string(),
             description: "User records".to_string(),
@@ -944,6 +945,7 @@ mod tests {
     fn table_summary_to_proto_preserves_table_metadata_without_columns() {
         let workspace_name = WorkspaceName::parse("default").expect("workspace");
         let table = TableInfo {
+            catalog_name: String::new(),
             schema_name: "demo".to_string(),
             table_name: "users".to_string(),
             description: "User records".to_string(),

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -50,6 +50,10 @@ impl SourceDecorator for PausingCatalogDecorator {
         "pausing_catalog_resolution"
     }
 
+    fn supports_catalog_sources(&self) -> bool {
+        true
+    }
+
     fn prepare(&mut self, _selected_sources: &[QuerySource]) -> Result<(), SourceDecoratorError> {
         let Some(pause) = self.pause.take() else {
             return Ok(());

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -14,6 +14,7 @@ use coral_spec::{
     SourceTableFunctionSpec, TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::catalog::CatalogProvider;
 use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
 use datafusion::prelude::SessionContext;
@@ -62,6 +63,9 @@ pub(crate) struct RegisteredColumn {
 
 #[derive(Debug, Clone)]
 pub(crate) struct RegisteredTable {
+    /// SQL schema containing this table when it differs from the source's
+    /// default schema. Database tables set this to their remote schema.
+    pub(crate) schema_name: Option<String>,
     pub(crate) table_name: String,
     pub(crate) description: String,
     pub(crate) guide: String,
@@ -125,9 +129,33 @@ pub(crate) struct RegisteredInput {
     pub(crate) is_set: bool,
 }
 
+/// The source's portion of a fully qualified table name
+/// (`catalog.schema.table`): which position its name occupies and what that
+/// name is. Names for all selected sources share one flat namespace
+/// regardless of variant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SourceQualifiedName {
+    /// Two-part source: tables resolve as `datafusion.<name>.<table>`.
+    Schema(String),
+}
+
+impl SourceQualifiedName {
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            Self::Schema(name) => name,
+        }
+    }
+
+    pub(crate) fn catalog_name(&self) -> Option<&str> {
+        match self {
+            Self::Schema(_) => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct RegisteredSource {
-    pub(crate) schema_name: String,
+    pub(crate) qualified_name: SourceQualifiedName,
     pub(crate) tables: Vec<RegisteredTable>,
     pub(crate) table_functions: Vec<RegisteredTableFunction>,
     pub(crate) inputs: Vec<RegisteredInput>,
@@ -135,10 +163,16 @@ pub(crate) struct RegisteredSource {
 
 pub(crate) struct BackendRegistration {
     pub(crate) schemas: Vec<BackendSchemaRegistration>,
+    pub(crate) catalogs: Vec<BackendCatalogRegistration>,
 }
 
 pub(crate) struct BackendSchemaRegistration {
     pub(crate) tables: HashMap<String, Arc<dyn TableProvider>>,
+    pub(crate) source: RegisteredSource,
+}
+
+pub(crate) struct BackendCatalogRegistration {
+    pub(crate) catalog: Arc<dyn CatalogProvider>,
     pub(crate) source: RegisteredSource,
 }
 
@@ -186,7 +220,9 @@ impl BackendRegistrationContext {
 
 #[async_trait]
 pub(crate) trait CompiledBackendSource: Send + Sync {
-    fn schema_name(&self) -> &str;
+    /// Runtime qualified name: the SQL schema for two-part sources, the SQL
+    /// catalog for catalog-backed sources.
+    fn qualified_name(&self) -> &str;
 
     fn source_name(&self) -> &str;
 
@@ -349,6 +385,7 @@ pub(crate) fn build_registered_table(
     required_filters: Vec<String>,
 ) -> RegisteredTable {
     RegisteredTable {
+        schema_name: None,
         table_name: common.name.clone(),
         description: common.description.clone(),
         guide: common.guide.clone(),

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -222,7 +222,7 @@ impl BackendRegistrationContext {
 pub(crate) trait CompiledBackendSource: Send + Sync {
     /// Runtime qualified name: the SQL schema for two-part sources, the SQL
     /// catalog for catalog-backed sources.
-    fn qualified_name(&self) -> &str;
+    fn qualified_name(&self) -> SourceQualifiedName;
 
     fn source_name(&self) -> &str;
 

--- a/crates/coral-engine/src/backends/composite.rs
+++ b/crates/coral-engine/src/backends/composite.rs
@@ -9,9 +9,9 @@ use datafusion::error::DataFusionError;
 use datafusion::prelude::SessionContext;
 
 use crate::backends::{
-    BackendRegistration, BackendRegistrationContext, BackendSchemaRegistration,
-    CompiledBackendSource, RegisteredInput, RegisteredSource, RegisteredTable,
-    RegisteredTableFunction,
+    BackendCatalogRegistration, BackendRegistration, BackendRegistrationContext,
+    BackendSchemaRegistration, CompiledBackendSource, RegisteredInput, RegisteredSource,
+    RegisteredTable, RegisteredTableFunction, SourceQualifiedName,
 };
 
 struct CompositeCompiledSource {
@@ -31,7 +31,7 @@ pub(crate) fn compile_source(
 
 #[async_trait]
 impl CompiledBackendSource for CompositeCompiledSource {
-    fn schema_name(&self) -> &str {
+    fn qualified_name(&self) -> &str {
         &self.source_name
     }
 
@@ -52,11 +52,13 @@ impl CompiledBackendSource for CompositeCompiledSource {
         registration_context: &BackendRegistrationContext,
     ) -> datafusion::error::Result<BackendRegistration> {
         let mut schemas: BTreeMap<String, CompositeSchemaRegistration> = BTreeMap::new();
+        let mut catalogs: Vec<BackendCatalogRegistration> = Vec::new();
 
         for component in &self.components {
             let registration = component.register(ctx, registration_context).await?;
+            catalogs.extend(registration.catalogs);
             for schema in registration.schemas {
-                let schema_name = schema.source.schema_name.clone();
+                let schema_name = schema.source.qualified_name.name().to_string();
                 let target = schemas
                     .entry(schema_name.clone())
                     .or_insert_with(|| CompositeSchemaRegistration::new(schema_name.clone()));
@@ -92,6 +94,7 @@ impl CompiledBackendSource for CompositeCompiledSource {
                 .into_values()
                 .map(CompositeSchemaRegistration::into_registration)
                 .collect(),
+            catalogs,
         })
     }
 }
@@ -123,7 +126,7 @@ impl CompositeSchemaRegistration {
         BackendSchemaRegistration {
             tables: self.tables,
             source: RegisteredSource {
-                schema_name: self.schema_name,
+                qualified_name: SourceQualifiedName::Schema(self.schema_name),
                 tables: self.registered_tables,
                 table_functions: self.registered_functions,
                 inputs: self.inputs,

--- a/crates/coral-engine/src/backends/composite.rs
+++ b/crates/coral-engine/src/backends/composite.rs
@@ -31,8 +31,8 @@ pub(crate) fn compile_source(
 
 #[async_trait]
 impl CompiledBackendSource for CompositeCompiledSource {
-    fn qualified_name(&self) -> &str {
-        &self.source_name
+    fn qualified_name(&self) -> SourceQualifiedName {
+        SourceQualifiedName::Schema(self.source_name.clone())
     }
 
     fn source_name(&self) -> &str {

--- a/crates/coral-engine/src/backends/file/mod.rs
+++ b/crates/coral-engine/src/backends/file/mod.rs
@@ -71,8 +71,8 @@ pub(crate) fn compile_manifest(
 
 #[async_trait]
 impl CompiledBackendSource for FileCompiledSource {
-    fn qualified_name(&self) -> &str {
-        &self.manifest.common.name
+    fn qualified_name(&self) -> SourceQualifiedName {
+        SourceQualifiedName::Schema(self.manifest.common.name.clone())
     }
 
     fn source_name(&self) -> &str {

--- a/crates/coral-engine/src/backends/file/mod.rs
+++ b/crates/coral-engine/src/backends/file/mod.rs
@@ -25,8 +25,8 @@ use datafusion::prelude::SessionContext;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
     BackendSchemaRegistration, CompiledBackendSource, RegisteredSource, RegisteredTable,
-    build_registered_inputs, build_registered_table, registered_columns_from_schema,
-    registered_columns_from_specs, required_filter_names,
+    SourceQualifiedName, build_registered_inputs, build_registered_table,
+    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
     validate_lookup_key_filter_backend_support,
 };
 use coral_spec::SourceBackend;
@@ -71,7 +71,7 @@ pub(crate) fn compile_manifest(
 
 #[async_trait]
 impl CompiledBackendSource for FileCompiledSource {
-    fn schema_name(&self) -> &str {
+    fn qualified_name(&self) -> &str {
         &self.manifest.common.name
     }
 
@@ -145,17 +145,17 @@ impl CompiledBackendSource for FileCompiledSource {
             &secret_keys,
         );
 
-        let schema_name = self.manifest.common.name.clone();
         Ok(BackendRegistration {
             schemas: vec![BackendSchemaRegistration {
                 tables,
                 source: RegisteredSource {
-                    schema_name,
+                    qualified_name: SourceQualifiedName::Schema(self.manifest.common.name.clone()),
                     tables: table_infos,
                     table_functions: vec![],
                     inputs,
                 },
             }],
+            catalogs: Vec::new(),
         })
     }
 }

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -81,8 +81,8 @@ pub(crate) fn compile_manifest(
 
 #[async_trait]
 impl CompiledBackendSource for HttpCompiledSource {
-    fn qualified_name(&self) -> &str {
-        &self.manifest.common.name
+    fn qualified_name(&self) -> SourceQualifiedName {
+        SourceQualifiedName::Schema(self.manifest.common.name.clone())
     }
 
     fn source_name(&self) -> &str {

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -15,9 +15,9 @@ use crate::backends::shared::source_observation::{
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
     BackendSchemaRegistration, CompiledBackendSource, RegisteredSource, RegisteredTable,
-    SourceFunctionProviderFactory, build_registered_inputs, build_registered_table,
-    build_registered_table_function, registered_columns_from_specs, required_filter_names,
-    validate_lookup_key_filter_backend_support,
+    SourceFunctionProviderFactory, SourceQualifiedName, build_registered_inputs,
+    build_registered_table, build_registered_table_function, registered_columns_from_specs,
+    required_filter_names, validate_lookup_key_filter_backend_support,
 };
 use crate::{
     BoundRequestIdentityHttpAuthenticator, RequestAuthenticator, SourceInputResolutionContext,
@@ -81,7 +81,7 @@ pub(crate) fn compile_manifest(
 
 #[async_trait]
 impl CompiledBackendSource for HttpCompiledSource {
-    fn schema_name(&self) -> &str {
+    fn qualified_name(&self) -> &str {
         &self.manifest.common.name
     }
 
@@ -167,17 +167,17 @@ impl CompiledBackendSource for HttpCompiledSource {
             &secret_keys,
         );
 
-        let schema_name = self.manifest.common.name.clone();
         Ok(BackendRegistration {
             schemas: vec![BackendSchemaRegistration {
                 tables,
                 source: RegisteredSource {
-                    schema_name,
+                    qualified_name: SourceQualifiedName::Schema(self.manifest.common.name.clone()),
                     tables: table_infos,
                     table_functions: table_function_infos,
                     inputs,
                 },
             }],
+            catalogs: Vec::new(),
         })
     }
 }

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -32,9 +32,9 @@ use crate::backends::shared::source_observation::{
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
     BackendSchemaRegistration, CompiledBackendSource, RegisteredSource,
-    SourceFunctionProviderFactory, build_registered_inputs, build_registered_table,
-    build_registered_table_function, registered_columns_from_specs, required_filter_names,
-    validate_lookup_key_filter_backend_support,
+    SourceFunctionProviderFactory, SourceQualifiedName, build_registered_inputs,
+    build_registered_table, build_registered_table_function, registered_columns_from_specs,
+    required_filter_names, validate_lookup_key_filter_backend_support,
 };
 use crate::runtime::error::datafusion_to_core;
 use crate::{
@@ -178,7 +178,7 @@ fn compile_source_with_caller(
 
 #[async_trait]
 impl CompiledBackendSource for McpCompiledSource {
-    fn schema_name(&self) -> &str {
+    fn qualified_name(&self) -> &str {
         &self.manifest.common.name
     }
 
@@ -252,17 +252,17 @@ impl CompiledBackendSource for McpCompiledSource {
             &secret_keys,
         );
 
-        let schema_name = self.manifest.common.name.clone();
         Ok(BackendRegistration {
             schemas: vec![BackendSchemaRegistration {
                 tables,
                 source: RegisteredSource {
-                    schema_name,
+                    qualified_name: SourceQualifiedName::Schema(self.manifest.common.name.clone()),
                     tables: table_infos,
                     table_functions: table_function_infos,
                     inputs,
                 },
             }],
+            catalogs: Vec::new(),
         })
     }
 }

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -178,8 +178,8 @@ fn compile_source_with_caller(
 
 #[async_trait]
 impl CompiledBackendSource for McpCompiledSource {
-    fn qualified_name(&self) -> &str {
-        &self.manifest.common.name
+    fn qualified_name(&self) -> SourceQualifiedName {
+        SourceQualifiedName::Schema(self.manifest.common.name.clone())
     }
 
     fn source_name(&self) -> &str {

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -80,13 +80,14 @@ use coral_spec::ValidatedSourceManifest;
 pub(crate) mod common;
 mod composite;
 pub(crate) use common::{
-    BackendCompileRequest, BackendRegistration, BackendRegistrationContext,
-    BackendSchemaRegistration, BoundSourceFunctionArg, BoundSourceFunctionValue,
-    CompiledBackendSource, RegisteredInput, RegisteredSource, RegisteredTable,
-    RegisteredTableFunction, RegisteredTableFunctionArgument, SourceFunctionProviderFactory,
-    build_registered_inputs, build_registered_table, build_registered_table_function,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
-    schema_from_columns, validate_lookup_key_filter_backend_support,
+    BackendCatalogRegistration, BackendCompileRequest, BackendRegistration,
+    BackendRegistrationContext, BackendSchemaRegistration, BoundSourceFunctionArg,
+    BoundSourceFunctionValue, CompiledBackendSource, RegisteredInput, RegisteredSource,
+    RegisteredTable, RegisteredTableFunction, RegisteredTableFunctionArgument,
+    SourceFunctionProviderFactory, SourceQualifiedName, build_registered_inputs,
+    build_registered_table, build_registered_table_function, registered_columns_from_schema,
+    registered_columns_from_specs, required_filter_names, schema_from_columns,
+    validate_lookup_key_filter_backend_support,
 };
 
 pub(crate) mod file;

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -541,6 +541,17 @@ pub trait SourceDecorator: Send + Sync {
     /// Stable decorator name used in diagnostics.
     fn name(&self) -> &'static str;
 
+    /// Whether this decorator supports sources registered as `SQL` catalogs.
+    ///
+    /// Catalog-backed sources expose table providers lazily, so
+    /// [`SourceDecorator::decorate_source`] is not called for them. Decorators
+    /// should return `true` only when their guarantees remain intact without
+    /// decorating those table providers, such as when they only observe
+    /// registration lifecycle events.
+    fn supports_catalog_sources(&self) -> bool {
+        false
+    }
+
     /// Performs one-time setup before any sources are registered.
     ///
     /// # Errors

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -24,6 +24,8 @@ pub struct ColumnInfo {
 /// Describes one queryable table.
 #[derive(Debug, Clone)]
 pub struct TableInfo {
+    /// `SQL` catalog name. Empty for two-part table references.
+    pub catalog_name: String,
     /// `SQL` schema name.
     pub schema_name: String,
     /// Table name within the schema.

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -24,8 +24,8 @@ pub struct ColumnInfo {
 /// Describes one queryable table.
 #[derive(Debug, Clone)]
 pub struct TableInfo {
-    /// `SQL` catalog name. Empty for two-part table references.
-    pub catalog_name: String,
+    /// `SQL` catalog name. Absent for two-part table references.
+    pub catalog_name: Option<String>,
     /// `SQL` schema name.
     pub schema_name: String,
     /// Table name within the schema.

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -1087,9 +1087,14 @@ impl QueryExecutionProvenance {
 }
 
 /// One source table referenced by a query.
+///
+/// `(schema, table)` alone does not identify a table once catalog-backed sources
+/// are registered: two databases can each expose `public.users`. The catalog is
+/// part of the identity, so consumers keying on this entry must include it.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct QueryTableUsage {
     source: String,
+    catalog: Option<String>,
     schema: String,
     table: String,
 }
@@ -1097,13 +1102,18 @@ pub struct QueryTableUsage {
 impl QueryTableUsage {
     #[must_use]
     /// Builds one source table usage entry.
+    ///
+    /// `catalog_name` is `None` for a table addressed as `schema.table`, and the
+    /// SQL catalog for one addressed as `catalog.schema.table`.
     pub fn new(
         source_name: impl Into<String>,
+        catalog_name: Option<&str>,
         schema_name: impl Into<String>,
         table_name: impl Into<String>,
     ) -> Self {
         Self {
             source: source_name.into(),
+            catalog: catalog_name.map(ToString::to_string),
             schema: schema_name.into(),
             table: table_name.into(),
         }
@@ -1113,6 +1123,13 @@ impl QueryTableUsage {
     /// Returns the installed source name that owns this table.
     pub fn source_name(&self) -> &str {
         &self.source
+    }
+
+    #[must_use]
+    /// Returns the SQL catalog for this table, or `None` when it is addressed as
+    /// `schema.table`.
+    pub fn catalog_name(&self) -> Option<&str> {
+        self.catalog.as_deref()
     }
 
     #[must_use]

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -191,19 +191,27 @@ impl QuerySource {
     }
 
     #[must_use]
-    /// Returns the SQL schemas published by this selected source.
+    /// Returns the SQL schema names published by this selected source.
     pub fn schema_names(&self) -> Vec<&str> {
-        let mut schemas = Vec::new();
+        let mut names = Vec::new();
         for component in &self.components {
-            let schema = component.source_name();
-            if !schemas.contains(&schema) {
-                schemas.push(schema);
+            let name = component.source_name();
+            if !names.contains(&name) {
+                names.push(name);
             }
         }
-        if schemas.is_empty() {
-            schemas.push(self.source_name());
+        if names.is_empty() {
+            names.push(self.source_name());
         }
-        schemas
+        names
+    }
+
+    #[must_use]
+    /// Returns the SQL catalog names published by this selected source.
+    /// Catalog-backed runtime components are introduced separately from the
+    /// generic qualified-table identity model.
+    pub fn catalog_names(&self) -> Vec<&str> {
+        Vec::new()
     }
 
     #[must_use]

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -601,7 +601,9 @@ fn sql_string_literal(value: &str) -> String {
 /// Either a truly unqualified `FROM X` or a qualified `FROM schema.table`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ParsedTableRef {
-    Unqualified { table: String },
+    Unqualified {
+        table: String,
+    },
     Qualified {
         qualifier: ParsedQualifier,
         table: String,
@@ -1071,8 +1073,7 @@ mod tests {
     #[test]
     fn table_not_found_schema_reference_has_no_catalog_metadata() {
         let tables = vec![table("hockey", "master")];
-        let err =
-            StructuredQueryError::table_not_found(&tr(&["hockey", "missing_table"]), &tables);
+        let err = StructuredQueryError::table_not_found(&tr(&["hockey", "missing_table"]), &tables);
 
         assert_eq!(err.metadata().get("catalog"), None);
         assert_eq!(

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -177,30 +177,52 @@ impl StructuredQueryError {
     /// `missing_ref` preserves the SQL object-name components for the missing
     /// table. `known_tables` is consulted to (a) distinguish `DataFusion`'s
     /// synthetic `public` schema from a real user source also named `public`,
-    /// and (b) recover a correct `(schema, table)` split when the source
-    /// name itself contains a dot.
+    /// (b) recover a correct `(schema, table)` split when the source name
+    /// itself contains a dot, and (c) split a catalog-backed reference into its
+    /// catalog and schema.
+    ///
+    /// Metadata reports `catalog` and `schema` as separate keys, never a
+    /// compound `catalog.schema` string: clients recover from this error by
+    /// feeding those values back into catalog lookups that take the catalog and
+    /// the schema as distinct arguments, and those match the schema on its own.
     pub(crate) fn table_not_found(missing_ref: &TableRefParts, known_tables: &[TableInfo]) -> Self {
         let parsed = parse_table_ref(missing_ref, known_tables);
 
-        let (schema, table) = match &parsed {
+        let (qualifier, table) = match &parsed {
             ParsedTableRef::Unqualified { table } => (None, table.clone()),
-            ParsedTableRef::Qualified { schema, table } => (Some(schema.clone()), table.clone()),
+            ParsedTableRef::Qualified { qualifier, table } => (Some(qualifier), table.clone()),
         };
 
-        let display_ref = match &schema {
-            Some(schema) => format!("{schema}.{table}"),
+        let display_ref = match qualifier {
+            Some(qualifier) => format!("{}.{table}", qualifier.written),
             None => table.clone(),
         };
-        let hint = table_not_found_hint(schema.as_deref(), &table, known_tables);
+        let hint = table_not_found_hint(
+            qualifier.map(|qualifier| qualifier.written.as_str()),
+            &table,
+            known_tables,
+        );
 
         let mut metadata = HashMap::new();
-        if let Some(schema) = &schema {
-            metadata.insert("schema".to_string(), schema.clone());
+        if let Some(qualifier) = qualifier {
+            if let Some(catalog) = qualifier.catalog() {
+                metadata.insert("catalog".to_string(), catalog.to_string());
+            }
+            metadata.insert("schema".to_string(), qualifier.schema().to_string());
         }
         metadata.insert("table".to_string(), table.clone());
 
-        let detail = match schema.as_deref() {
-            Some(schema) => format!("No table `{table}` exists in schema `{schema}`."),
+        let detail = match qualifier {
+            Some(qualifier) => match qualifier.catalog() {
+                Some(catalog) => format!(
+                    "No table `{table}` exists in catalog `{catalog}` schema `{}`.",
+                    qualifier.schema()
+                ),
+                None => format!(
+                    "No table `{table}` exists in schema `{}`.",
+                    qualifier.written
+                ),
+            },
             None => format!("No table `{table}` exists in any registered schema."),
         };
 
@@ -410,10 +432,9 @@ fn table_not_found_hint(
         ));
     };
 
-    let schema_lower = schema.to_lowercase();
     let tables_in_schema: Vec<&TableInfo> = known_tables
         .iter()
-        .filter(|info| table_schema_matches(info, &schema_lower))
+        .filter(|info| table_schema_matches(info, schema))
         .collect();
 
     if tables_in_schema.is_empty() {
@@ -467,7 +488,7 @@ fn quoted_qualified_table_match<'a>(
 
     let mut matches = known_tables
         .iter()
-        .filter(|info| raw_schema_table_name(info).eq_ignore_ascii_case(table));
+        .filter(|info| raw_schema_table_matches(info, table));
     let first = matches.next()?;
     matches.next().is_none().then_some(first)
 }
@@ -498,6 +519,29 @@ fn raw_schema_table_name(info: &TableInfo) -> String {
         format!("{}.{}.{}", catalog_name, info.schema_name, info.table_name)
     } else {
         format!("{}.{}", info.schema_name, info.table_name)
+    }
+}
+
+/// Case-insensitive match of a whole unquoted reference against this table's
+/// dotted raw name. Shares [`eq_folded`]'s folding so a non-ASCII source name
+/// matches here too, and compares in place instead of building the joined name
+/// per table.
+fn raw_schema_table_matches(info: &TableInfo, reference: &str) -> bool {
+    match info.catalog_name.as_deref() {
+        None => eq_folded(
+            reference,
+            &[&info.schema_name, ".", info.table_name.as_str()],
+        ),
+        Some(catalog_name) => eq_folded(
+            reference,
+            &[
+                catalog_name,
+                ".",
+                &info.schema_name,
+                ".",
+                info.table_name.as_str(),
+            ],
+        ),
     }
 }
 
@@ -558,7 +602,57 @@ fn sql_string_literal(value: &str) -> String {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ParsedTableRef {
     Unqualified { table: String },
-    Qualified { schema: String, table: String },
+    Qualified {
+        qualifier: ParsedQualifier,
+        table: String,
+    },
+}
+
+/// The qualifier recovered from a missing table reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedQualifier {
+    /// The qualifier exactly as the query spelled it. Error text echoes this so
+    /// the message names what the caller actually wrote.
+    written: String,
+    /// The registered catalog/schema pair this qualifier resolved to, when it
+    /// resolved at all.
+    registered: Option<RegisteredQualifier>,
+}
+
+/// A catalog/schema pair as the runtime has it registered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RegisteredQualifier {
+    catalog: Option<String>,
+    schema: String,
+}
+
+impl RegisteredQualifier {
+    fn from_table(info: &TableInfo) -> Self {
+        Self {
+            catalog: info.catalog_name.clone(),
+            schema: info.schema_name.clone(),
+        }
+    }
+}
+
+impl ParsedQualifier {
+    /// The catalog this qualifier resolved to, if it named a catalog-backed
+    /// table.
+    fn catalog(&self) -> Option<&str> {
+        self.registered
+            .as_ref()
+            .and_then(|registered| registered.catalog.as_deref())
+    }
+
+    /// The schema to report on its own: the registered spelling when the
+    /// qualifier resolved, otherwise the caller's own spelling.
+    fn schema(&self) -> &str {
+        self.registered
+            .as_ref()
+            .map_or(self.written.as_str(), |registered| {
+                registered.schema.as_str()
+            })
+    }
 }
 
 /// Recovers the user's intent from a parsed missing table reference.
@@ -621,9 +715,12 @@ fn parse_table_ref(reference: &TableRefParts, known_tables: &[TableInfo]) -> Par
                     body.get(..schema_len)
                         .expect("schema range is bounded by loop"),
                 );
-                if schema_is_registered(&candidate_schema, known_tables) {
+                if let Some(registered) = matched_qualifier(&candidate_schema, known_tables) {
                     return ParsedTableRef::Qualified {
-                        schema: candidate_schema,
+                        qualifier: ParsedQualifier {
+                            written: candidate_schema,
+                            registered: Some(registered),
+                        },
                         table: join_ref_parts(
                             body.get(schema_len..)
                                 .expect("table range is bounded by loop"),
@@ -641,7 +738,10 @@ fn parse_table_ref(reference: &TableRefParts, known_tables: &[TableInfo]) -> Par
                 .split_last()
                 .expect("multi-part body is guaranteed by match arm");
             ParsedTableRef::Qualified {
-                schema: join_ref_parts(schema),
+                qualifier: ParsedQualifier {
+                    written: join_ref_parts(schema),
+                    registered: None,
+                },
                 table: table.clone(),
             }
         }
@@ -653,19 +753,45 @@ fn join_ref_parts(parts: &[String]) -> String {
 }
 
 fn schema_is_registered(candidate: &str, known_tables: &[TableInfo]) -> bool {
-    let lowered = candidate.to_lowercase();
-    known_tables
-        .iter()
-        .any(|info| table_schema_matches(info, &lowered))
+    matched_qualifier(candidate, known_tables).is_some()
 }
 
-fn table_schema_matches(info: &TableInfo, schema_lower: &str) -> bool {
+/// Finds the registered qualifier a schema candidate names, so a caller can
+/// report the catalog and schema separately instead of echoing the compound
+/// string back.
+fn matched_qualifier(candidate: &str, known_tables: &[TableInfo]) -> Option<RegisteredQualifier> {
+    known_tables
+        .iter()
+        .find(|info| table_schema_matches(info, candidate))
+        .map(RegisteredQualifier::from_table)
+}
+
+/// Whether `candidate` names this table's qualifier: the bare schema for a
+/// schema-backed table, or `catalog.schema` for a catalog-backed one. A
+/// catalog-backed table deliberately does not match its bare schema, because a
+/// database's internal `public` schema is not a top-level source name.
+fn table_schema_matches(info: &TableInfo, candidate: &str) -> bool {
     match info.catalog_name.as_deref() {
-        None => info.schema_name.eq_ignore_ascii_case(schema_lower),
-        Some(catalog_name) => {
-            format!("{catalog_name}.{}", info.schema_name).to_lowercase() == schema_lower
-        }
+        None => eq_folded(candidate, &[info.schema_name.as_str()]),
+        Some(catalog_name) => eq_folded(candidate, &[catalog_name, ".", &info.schema_name]),
     }
+}
+
+/// Case-insensitive equality between `candidate` and `segments` joined end to
+/// end.
+///
+/// Both sides fold through `char::to_lowercase`, so identifiers outside ASCII
+/// compare correctly: legacy (pre-v4) manifests are not charset-restricted, so
+/// a source named `CAFÉ` still has to match `FROM café.orders`. Folding the
+/// segments in place also keeps the catalog-backed arm from allocating a joined
+/// `catalog.schema` string per table, and callers run this once per prefix
+/// length per table.
+fn eq_folded(candidate: &str, segments: &[&str]) -> bool {
+    folded_chars(candidate).eq(segments.iter().copied().flat_map(folded_chars))
+}
+
+fn folded_chars(value: &str) -> impl Iterator<Item = char> + '_ {
+    value.chars().flat_map(char::to_lowercase)
 }
 
 // ---------------------------------------------------------------------------
@@ -903,25 +1029,75 @@ mod tests {
     }
 
     #[test]
-    fn table_not_found_catalog_reference_uses_compound_schema() {
+    fn table_not_found_catalog_reference_splits_catalog_from_schema() {
         let tables = vec![catalog_table("coral_db", "main", "users")];
         let err = StructuredQueryError::table_not_found(
             &tr(&["datafusion", "coral_db", "main", "usrs"]),
             &tables,
         );
 
+        // Metadata reaches MCP clients verbatim and is what they feed back into
+        // catalog lookups, which match the schema on its own — so `schema` must
+        // stay bare and the catalog must travel in its own key.
+        assert_eq!(
+            err.metadata().get("catalog").map(String::as_str),
+            Some("coral_db")
+        );
         assert_eq!(
             err.metadata().get("schema").map(String::as_str),
-            Some("coral_db.main")
+            Some("main")
         );
         assert_eq!(
             err.metadata().get("table").map(String::as_str),
             Some("usrs")
         );
+        assert_eq!(
+            err.detail(),
+            "No table `usrs` exists in catalog `coral_db` schema `main`."
+        );
+        // The summary still echoes the reference as written.
+        assert!(
+            err.summary().contains("coral_db.main.usrs"),
+            "got: {}",
+            err.summary()
+        );
         let hint = err.hint().expect("hint should be present");
         assert!(
             hint.contains("coral_db.main.users"),
             "namespaced miss should suggest the queryable table reference, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn table_not_found_schema_reference_has_no_catalog_metadata() {
+        let tables = vec![table("hockey", "master")];
+        let err =
+            StructuredQueryError::table_not_found(&tr(&["hockey", "missing_table"]), &tables);
+
+        assert_eq!(err.metadata().get("catalog"), None);
+        assert_eq!(
+            err.metadata().get("schema").map(String::as_str),
+            Some("hockey")
+        );
+    }
+
+    #[test]
+    fn table_not_found_matches_non_ascii_schema_case_insensitively() {
+        // Legacy (pre-v4) source names are not charset-restricted, so folding
+        // has to be Unicode-aware on both sides: `CAFÉ` must resolve to the
+        // registered `café` instead of falling through to the generic
+        // "schema not registered" hint.
+        let tables = vec![table("café", "orders")];
+        let err = StructuredQueryError::table_not_found(&tr(&["CAFÉ", "ordrs"]), &tables);
+
+        assert_eq!(
+            err.metadata().get("schema").map(String::as_str),
+            Some("café")
+        );
+        let hint = err.hint().expect("hint should be present");
+        assert!(
+            hint.contains("orders"),
+            "registered schema should drive the table suggestion, got: {hint}"
         );
     }
 
@@ -953,8 +1129,12 @@ mod tests {
         );
 
         assert_eq!(
+            err.metadata().get("catalog").map(String::as_str),
+            Some("warehouse")
+        );
+        assert_eq!(
             err.metadata().get("schema").map(String::as_str),
-            Some("warehouse.public")
+            Some("public")
         );
         assert_eq!(
             err.metadata().get("table").map(String::as_str),

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -411,7 +411,7 @@ fn table_not_found_hint(
     let schema_lower = schema.to_lowercase();
     let tables_in_schema: Vec<&TableInfo> = known_tables
         .iter()
-        .filter(|info| info.schema_name.to_lowercase() == schema_lower)
+        .filter(|info| table_schema_matches(info, &schema_lower))
         .collect();
 
     if tables_in_schema.is_empty() {
@@ -478,35 +478,65 @@ fn quoted_qualified_table_hint(missing: &str, info: &TableInfo) -> String {
     } else {
         format!("`{reference}` or `{fully_quoted_reference}`")
     };
+    let reference_shape = if info.catalog_name.is_empty() {
+        "schema.table"
+    } else {
+        "catalog.schema.table"
+    };
 
     format!(
         "`\"{missing}\"` is one quoted identifier, so SQL looks for a table literally named \
          `{missing}`. Use {suggestions} in `FROM`/`JOIN` clauses; do not quote the whole \
-         `schema.table` string.",
+         `{reference_shape}` string.",
     )
 }
 
 fn raw_schema_table_name(info: &TableInfo) -> String {
-    format!("{}.{}", info.schema_name, info.table_name)
+    if info.catalog_name.is_empty() {
+        format!("{}.{}", info.schema_name, info.table_name)
+    } else {
+        format!(
+            "{}.{}.{}",
+            info.catalog_name, info.schema_name, info.table_name
+        )
+    }
 }
 
 /// Renders `schema.table` with per-component SQL quoting (dotted source
 /// names stay one quoted identifier; case-preserving names are quoted
 /// only when they would otherwise round-trip wrong).
 fn format_schema_table(info: &TableInfo) -> String {
-    format!(
-        "{}.{}",
-        quote_dotted_identifier(&info.schema_name),
-        quote_identifier(&info.table_name)
-    )
+    if info.catalog_name.is_empty() {
+        format!(
+            "{}.{}",
+            quote_dotted_identifier(&info.schema_name),
+            quote_identifier(&info.table_name)
+        )
+    } else {
+        format!(
+            "{}.{}.{}",
+            quote_dotted_identifier(&info.catalog_name),
+            quote_identifier(&info.schema_name),
+            quote_identifier(&info.table_name)
+        )
+    }
 }
 
 fn format_schema_table_fully_quoted(info: &TableInfo) -> String {
-    format!(
-        "{}.{}",
-        quote_identifier_always(&info.schema_name),
-        quote_identifier_always(&info.table_name)
-    )
+    if info.catalog_name.is_empty() {
+        format!(
+            "{}.{}",
+            quote_identifier_always(&info.schema_name),
+            quote_identifier_always(&info.table_name)
+        )
+    } else {
+        format!(
+            "{}.{}.{}",
+            quote_identifier_always(&info.catalog_name),
+            quote_identifier_always(&info.schema_name),
+            quote_identifier_always(&info.table_name)
+        )
+    }
 }
 
 fn format_schema_function(info: &TableFunctionInfo) -> String {
@@ -586,8 +616,7 @@ fn parse_table_ref(reference: &TableRefParts, known_tables: &[TableInfo]) -> Par
             }
 
             // Pick the longest contiguous prefix of `body` that matches a
-            // registered schema (case-insensitive). This recovers dotted
-            // source names like `"foo.bar"` from their exploded form.
+            // registered schema or catalog.schema pair (case-insensitive).
             for schema_len in (1..body.len()).rev() {
                 let candidate_schema = join_ref_parts(
                     body.get(..schema_len)
@@ -628,7 +657,15 @@ fn schema_is_registered(candidate: &str, known_tables: &[TableInfo]) -> bool {
     let lowered = candidate.to_lowercase();
     known_tables
         .iter()
-        .any(|info| info.schema_name.to_lowercase() == lowered)
+        .any(|info| table_schema_matches(info, &lowered))
+}
+
+fn table_schema_matches(info: &TableInfo, schema_lower: &str) -> bool {
+    if info.schema_name.to_lowercase() == schema_lower {
+        return true;
+    }
+    !info.catalog_name.is_empty()
+        && format!("{}.{}", info.catalog_name, info.schema_name).to_lowercase() == schema_lower
 }
 
 // ---------------------------------------------------------------------------
@@ -657,6 +694,7 @@ mod tests {
 
     fn table(schema: &str, name: &str) -> TableInfo {
         TableInfo {
+            catalog_name: String::new(),
             schema_name: schema.to_string(),
             table_name: name.to_string(),
             description: String::new(),
@@ -664,6 +702,13 @@ mod tests {
             require_guide_read: false,
             columns: vec![],
             required_filters: vec![],
+        }
+    }
+
+    fn catalog_table(catalog: &str, schema: &str, name: &str) -> TableInfo {
+        TableInfo {
+            catalog_name: catalog.to_string(),
+            ..table(schema, name)
         }
     }
 
@@ -855,6 +900,29 @@ mod tests {
     }
 
     #[test]
+    fn table_not_found_catalog_reference_uses_compound_schema() {
+        let tables = vec![catalog_table("coral_db", "main", "users")];
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["datafusion", "coral_db", "main", "usrs"]),
+            &tables,
+        );
+
+        assert_eq!(
+            err.metadata().get("schema").map(String::as_str),
+            Some("coral_db.main")
+        );
+        assert_eq!(
+            err.metadata().get("table").map(String::as_str),
+            Some("usrs")
+        );
+        let hint = err.hint().expect("hint should be present");
+        assert!(
+            hint.contains("coral_db.main.users"),
+            "namespaced miss should suggest the queryable table reference, got: {hint}"
+        );
+    }
+
+    #[test]
     fn table_not_found_strips_datafusion_catalog_prefix_from_display() {
         let tables = vec![table("hockey", "Master")];
         let err = StructuredQueryError::table_not_found(
@@ -932,7 +1000,7 @@ mod tests {
     }
 
     #[test]
-    fn table_not_found_quoted_qualified_name_suggests_sql_reference() {
+    fn table_not_found_quoted_qualified_names_suggest_sql_references() {
         // `FROM "github.pulls"` reaches the planner as a single bare
         // identifier under the synthetic `public` schema. When that flat
         // string exactly matches a visible `schema_name.table_name`, point
@@ -963,6 +1031,38 @@ mod tests {
         );
         assert!(
             hint.contains("do not quote the whole `schema.table` string"),
+            "hint should explicitly reject whole-reference quoting, got: {hint}"
+        );
+
+        // `FROM "coral_db.main.users"` is one bare table name under the
+        // synthetic `public` schema. For database surfaces, the flat string
+        // must match catalog.schema.table, not just schema.table.
+        let tables = vec![catalog_table("coral_db", "main", "users")];
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["datafusion", "public", "coral_db.main.users"]),
+            &tables,
+        );
+
+        assert_eq!(err.metadata().get("schema"), None);
+        assert_eq!(
+            err.metadata().get("table").map(String::as_str),
+            Some("coral_db.main.users")
+        );
+        let hint = err.hint().expect("hint should be present");
+        assert!(
+            hint.contains("`\"coral_db.main.users\"` is one quoted identifier"),
+            "hint should explain whole-reference quoting, got: {hint}"
+        );
+        assert!(
+            hint.contains("`coral_db.main.users`"),
+            "hint should suggest the SQL-safe three-part reference, got: {hint}"
+        );
+        assert!(
+            hint.contains("`\"coral_db\".\"main\".\"users\"`"),
+            "hint should show per-identifier quoting as the alternative, got: {hint}"
+        );
+        assert!(
+            hint.contains("do not quote the whole `catalog.schema.table` string"),
             "hint should explicitly reject whole-reference quoting, got: {hint}"
         );
     }

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -660,12 +660,12 @@ fn schema_is_registered(candidate: &str, known_tables: &[TableInfo]) -> bool {
 }
 
 fn table_schema_matches(info: &TableInfo, schema_lower: &str) -> bool {
-    if info.schema_name.to_lowercase() == schema_lower {
-        return true;
+    match info.catalog_name.as_deref() {
+        None => info.schema_name.eq_ignore_ascii_case(schema_lower),
+        Some(catalog_name) => {
+            format!("{catalog_name}.{}", info.schema_name).to_lowercase() == schema_lower
+        }
     }
-    info.catalog_name.as_deref().is_some_and(|catalog_name| {
-        format!("{catalog_name}.{}", info.schema_name).to_lowercase() == schema_lower
-    })
 }
 
 // ---------------------------------------------------------------------------
@@ -922,6 +922,45 @@ mod tests {
         assert!(
             hint.contains("coral_db.main.users"),
             "namespaced miss should suggest the queryable table reference, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn catalog_internal_public_schema_does_not_qualify_bare_table_miss() {
+        let tables = vec![catalog_table("warehouse", "public", "users")];
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["datafusion", "public", "missing"]),
+            &tables,
+        );
+
+        assert_eq!(err.metadata().get("schema"), None);
+        assert_eq!(
+            err.metadata().get("table").map(String::as_str),
+            Some("missing")
+        );
+        assert!(
+            err.detail()
+                .contains("does not exist in any registered schema"),
+            "unexpected detail: {}",
+            err.detail()
+        );
+    }
+
+    #[test]
+    fn catalog_internal_schema_matches_compound_catalog_schema() {
+        let tables = vec![catalog_table("warehouse", "public", "users")];
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["warehouse", "public", "missing"]),
+            &tables,
+        );
+
+        assert_eq!(
+            err.metadata().get("schema").map(String::as_str),
+            Some("warehouse.public")
+        );
+        assert_eq!(
+            err.metadata().get("table").map(String::as_str),
+            Some("missing")
         );
     }
 

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -938,11 +938,9 @@ mod tests {
             err.metadata().get("table").map(String::as_str),
             Some("missing")
         );
-        assert!(
-            err.detail()
-                .contains("does not exist in any registered schema"),
-            "unexpected detail: {}",
-            err.detail()
+        assert_eq!(
+            err.detail(),
+            "No table `missing` exists in any registered schema."
         );
     }
 

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -26,6 +26,9 @@ pub(crate) const TABLE_FUNCTION_NOT_TABLE_REASON: &str = "TABLE_FUNCTION_NOT_TAB
 /// this only if we have data justifying divergence from that baseline.
 const DID_YOU_MEAN_SIMILARITY: f64 = 0.5;
 
+const LIST_AVAILABLE_TABLES_SQL: &str =
+    "SELECT catalog_name, schema_name, table_name FROM coral.tables";
+
 /// Structure-preserving column reference used by `unknown_column`.
 ///
 /// Keeping the qualifier components separate from the bare name means the
@@ -402,10 +405,9 @@ fn table_not_found_hint(
         if let Some((winner, _score)) = best {
             return Some(did_you_mean_hint(&format_schema_table(winner)));
         }
-        return Some(
-            "List available tables with `SELECT schema_name, table_name FROM coral.tables`."
-                .to_string(),
-        );
+        return Some(format!(
+            "List available tables with `{LIST_AVAILABLE_TABLES_SQL}`."
+        ));
     };
 
     let schema_lower = schema.to_lowercase();
@@ -424,8 +426,8 @@ fn table_not_found_hint(
         // enrich the hint at their layer.
         return Some(format!(
             "Schema `{schema}` is not currently registered. \
-             Query `SELECT DISTINCT schema_name FROM coral.tables` \
-             to see available schemas."
+             Query `{LIST_AVAILABLE_TABLES_SQL}` \
+             to see available catalogs, schemas, and tables."
         ));
     }
 
@@ -829,6 +831,9 @@ mod tests {
         assert_eq!(err.status(), StatusCode::NotFound);
         let hint = err.hint().expect("hint should be present");
         assert!(hint.contains("coral.tables"), "got: {hint}");
+        assert!(hint.contains("catalog_name"), "got: {hint}");
+        assert!(hint.contains("schema_name"), "got: {hint}");
+        assert!(hint.contains("table_name"), "got: {hint}");
         assert!(
             !hint.contains("coral source"),
             "hint must stay transport-neutral (no CLI-specific commands), got: {hint}"
@@ -1181,6 +1186,9 @@ mod tests {
 
         let hint = err.hint().expect("hint should be present");
         assert!(hint.contains("coral.tables"), "got: {hint}");
+        assert!(hint.contains("catalog_name"), "got: {hint}");
+        assert!(hint.contains("schema_name"), "got: {hint}");
+        assert!(hint.contains("table_name"), "got: {hint}");
     }
 
     #[test]

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -478,7 +478,7 @@ fn quoted_qualified_table_hint(missing: &str, info: &TableInfo) -> String {
     } else {
         format!("`{reference}` or `{fully_quoted_reference}`")
     };
-    let reference_shape = if info.catalog_name.is_empty() {
+    let reference_shape = if info.catalog_name.is_none() {
         "schema.table"
     } else {
         "catalog.schema.table"
@@ -492,13 +492,10 @@ fn quoted_qualified_table_hint(missing: &str, info: &TableInfo) -> String {
 }
 
 fn raw_schema_table_name(info: &TableInfo) -> String {
-    if info.catalog_name.is_empty() {
-        format!("{}.{}", info.schema_name, info.table_name)
+    if let Some(catalog_name) = info.catalog_name.as_deref() {
+        format!("{}.{}.{}", catalog_name, info.schema_name, info.table_name)
     } else {
-        format!(
-            "{}.{}.{}",
-            info.catalog_name, info.schema_name, info.table_name
-        )
+        format!("{}.{}", info.schema_name, info.table_name)
     }
 }
 
@@ -506,33 +503,33 @@ fn raw_schema_table_name(info: &TableInfo) -> String {
 /// names stay one quoted identifier; case-preserving names are quoted
 /// only when they would otherwise round-trip wrong).
 fn format_schema_table(info: &TableInfo) -> String {
-    if info.catalog_name.is_empty() {
+    if let Some(catalog_name) = info.catalog_name.as_deref() {
         format!(
-            "{}.{}",
-            quote_dotted_identifier(&info.schema_name),
+            "{}.{}.{}",
+            quote_dotted_identifier(catalog_name),
+            quote_identifier(&info.schema_name),
             quote_identifier(&info.table_name)
         )
     } else {
         format!(
-            "{}.{}.{}",
-            quote_dotted_identifier(&info.catalog_name),
-            quote_identifier(&info.schema_name),
+            "{}.{}",
+            quote_dotted_identifier(&info.schema_name),
             quote_identifier(&info.table_name)
         )
     }
 }
 
 fn format_schema_table_fully_quoted(info: &TableInfo) -> String {
-    if info.catalog_name.is_empty() {
+    if let Some(catalog_name) = info.catalog_name.as_deref() {
         format!(
-            "{}.{}",
+            "{}.{}.{}",
+            quote_identifier_always(catalog_name),
             quote_identifier_always(&info.schema_name),
             quote_identifier_always(&info.table_name)
         )
     } else {
         format!(
-            "{}.{}.{}",
-            quote_identifier_always(&info.catalog_name),
+            "{}.{}",
             quote_identifier_always(&info.schema_name),
             quote_identifier_always(&info.table_name)
         )
@@ -664,8 +661,9 @@ fn table_schema_matches(info: &TableInfo, schema_lower: &str) -> bool {
     if info.schema_name.to_lowercase() == schema_lower {
         return true;
     }
-    !info.catalog_name.is_empty()
-        && format!("{}.{}", info.catalog_name, info.schema_name).to_lowercase() == schema_lower
+    info.catalog_name.as_deref().is_some_and(|catalog_name| {
+        format!("{catalog_name}.{}", info.schema_name).to_lowercase() == schema_lower
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -694,7 +692,7 @@ mod tests {
 
     fn table(schema: &str, name: &str) -> TableInfo {
         TableInfo {
-            catalog_name: String::new(),
+            catalog_name: None,
             schema_name: schema.to_string(),
             table_name: name.to_string(),
             description: String::new(),
@@ -707,7 +705,7 @@ mod tests {
 
     fn catalog_table(catalog: &str, schema: &str, name: &str) -> TableInfo {
         TableInfo {
-            catalog_name: catalog.to_string(),
+            catalog_name: Some(catalog.to_string()),
             ..table(schema, name)
         }
     }

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -41,7 +41,14 @@
 //! # async fn demo(
 //! #     sources: &[QuerySource],
 //! # ) -> Result<(), Box<dyn std::error::Error>> {
-//! let _ = CoralQuery::list_tables(sources, QueryRuntimeConfig::default(), None, None).await?;
+//! let _ = CoralQuery::list_tables(
+//!     sources,
+//!     QueryRuntimeConfig::default(),
+//!     None,
+//!     None,
+//!     None,
+//! )
+//! .await?;
 //! # Ok(())
 //! # }
 //! # Ok(())
@@ -125,22 +132,34 @@ impl PreparedQueryRuntime {
     #[must_use]
     pub fn list_tables(
         &self,
+        catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
     ) -> Vec<TableInfo> {
-        self.inner.list_tables(schema_filter, table_filter)
+        self.inner
+            .list_tables(catalog_filter, schema_filter, table_filter)
     }
 
     /// Lists queryable catalog metadata from this prepared runtime.
     #[must_use]
-    pub fn list_catalog(&self, schema_filter: Option<&str>) -> CatalogInfo {
-        self.inner.catalog_info(schema_filter)
+    pub fn list_catalog(
+        &self,
+        catalog_filter: Option<&str>,
+        schema_filter: Option<&str>,
+    ) -> CatalogInfo {
+        self.inner.catalog_info(catalog_filter, schema_filter)
     }
 
     /// Describes one table from this prepared runtime.
     #[must_use]
-    pub fn describe_table(&self, schema_name: &str, table_name: &str) -> DescribeTableInfo {
-        self.inner.describe_table(schema_name, table_name)
+    pub fn describe_table(
+        &self,
+        catalog_name: Option<&str>,
+        schema_name: &str,
+        table_name: &str,
+    ) -> DescribeTableInfo {
+        self.inner
+            .describe_table(catalog_name, schema_name, table_name)
     }
 
     /// Infers typed signatures for multiple UDFs against this runtime.
@@ -289,12 +308,15 @@ impl CoralQuery {
     pub async fn list_tables(
         sources: &[QuerySource],
         runtime: QueryRuntimeConfig,
+        catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, CoreError> {
-        Ok(Self::prepare(sources, runtime)
-            .await?
-            .list_tables(schema_filter, table_filter))
+        Ok(Self::prepare(sources, runtime).await?.list_tables(
+            catalog_filter,
+            schema_filter,
+            table_filter,
+        ))
     }
 
     /// Lists queryable catalog metadata from the provided source set.
@@ -312,11 +334,12 @@ impl CoralQuery {
     pub async fn list_catalog(
         sources: &[QuerySource],
         runtime: QueryRuntimeConfig,
+        catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
     ) -> Result<CatalogInfo, CoreError> {
         Ok(Self::prepare(sources, runtime)
             .await?
-            .list_catalog(schema_filter))
+            .list_catalog(catalog_filter, schema_filter))
     }
 
     /// Describes one table or returns lightweight table metadata for missing-table help.
@@ -332,12 +355,15 @@ impl CoralQuery {
     pub async fn describe_table(
         sources: &[QuerySource],
         runtime: QueryRuntimeConfig,
+        catalog_name: Option<&str>,
         schema_name: &str,
         table_name: &str,
     ) -> Result<DescribeTableInfo, CoreError> {
-        Ok(Self::prepare(sources, runtime)
-            .await?
-            .describe_table(schema_name, table_name))
+        Ok(Self::prepare(sources, runtime).await?.describe_table(
+            catalog_name,
+            schema_name,
+            table_name,
+        ))
     }
 
     /// Executes one `SQL` statement over the provided source set.
@@ -489,13 +515,14 @@ impl CoralQuery {
             runtime::query::build_runtime(std::slice::from_ref(source), runtime).await?;
         let source_name = source.source_name();
         let schema_names = source.schema_names();
-        let catalog = query_runtime.catalog_info_for_schemas(&schema_names);
+        let catalog_names = source.catalog_names();
+        let catalog = query_runtime.catalog_info_for_sources(&schema_names, &catalog_names);
         if catalog.tables.is_empty() && catalog.table_functions.is_empty() {
             if let Some(failure) = query_runtime.registration_failure(source_name) {
                 return Err(CoreError::FailedPrecondition(failure.detail.clone()));
             }
-            for schema_name in schema_names {
-                if let Some(failure) = query_runtime.registration_failure(schema_name) {
+            for name in schema_names.into_iter().chain(catalog_names) {
+                if let Some(failure) = query_runtime.registration_failure(name) {
                     return Err(CoreError::FailedPrecondition(failure.detail.clone()));
                 }
             }

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -11,7 +11,7 @@ use datafusion::error::{DataFusionError, Result};
 use datafusion::prelude::SessionContext;
 use serde::Serialize;
 
-use crate::backends::RegisteredSource;
+use crate::backends::{RegisteredSource, SourceQualifiedName};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
     ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
@@ -257,6 +257,12 @@ const TABLES_COLUMNS: &[SystemColumnDefinition] = &[
         nullable: true,
         description: "JSON search-limit metadata when the table declares provider search limits.",
     },
+    SystemColumnDefinition {
+        name: "catalog_name",
+        data_type: "Utf8",
+        nullable: false,
+        description: "SQL catalog containing the table. Empty for tables queried as schema_name.table_name.",
+    },
 ];
 
 const COLUMNS_COLUMNS: &[SystemColumnDefinition] = &[
@@ -320,6 +326,12 @@ const COLUMNS_COLUMNS: &[SystemColumnDefinition] = &[
         nullable: true,
         description: "Filter matching mode for virtual filter columns.",
     },
+    SystemColumnDefinition {
+        name: "catalog_name",
+        data_type: "Utf8",
+        nullable: false,
+        description: "SQL catalog containing the table. Empty for tables queried as schema_name.table_name.",
+    },
 ];
 
 const FILTERS_COLUMNS: &[SystemColumnDefinition] = &[
@@ -365,6 +377,12 @@ const FILTERS_COLUMNS: &[SystemColumnDefinition] = &[
         nullable: false,
         description: "Human-readable filter description.",
     },
+    SystemColumnDefinition {
+        name: "catalog_name",
+        data_type: "Utf8",
+        nullable: false,
+        description: "SQL catalog containing the filtered table. Empty for tables queried as schema_name.table_name.",
+    },
 ];
 
 const INPUTS_COLUMNS: &[SystemColumnDefinition] = &[
@@ -372,7 +390,7 @@ const INPUTS_COLUMNS: &[SystemColumnDefinition] = &[
         name: "schema_name",
         data_type: "Utf8",
         nullable: false,
-        description: "SQL schema for the source that declares the input.",
+        description: "SQL schema of the source that declares the input. Empty for database sources, which are addressed by catalog_name.",
     },
     SystemColumnDefinition {
         name: "key",
@@ -415,6 +433,12 @@ const INPUTS_COLUMNS: &[SystemColumnDefinition] = &[
         data_type: "Boolean",
         nullable: false,
         description: "Whether Coral resolved a value for the input.",
+    },
+    SystemColumnDefinition {
+        name: "catalog_name",
+        data_type: "Utf8",
+        nullable: false,
+        description: "SQL catalog of the database source that declares the input. Empty for sources addressed by schema_name.",
     },
 ];
 
@@ -506,6 +530,7 @@ fn system_table_infos() -> Vec<TableInfo> {
     SYSTEM_TABLE_DEFINITIONS
         .iter()
         .map(|table| TableInfo {
+            catalog_name: String::new(),
             schema_name: SYSTEM_SCHEMA.to_string(),
             table_name: table.table_name.to_string(),
             description: table.description.to_string(),
@@ -536,7 +561,15 @@ pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableIn
     let mut tables = system_table_infos();
     tables.extend(active_sources.iter().flat_map(|source| {
         source.tables.iter().map(move |table| TableInfo {
-            schema_name: source.schema_name.clone(),
+            catalog_name: source
+                .qualified_name
+                .catalog_name()
+                .unwrap_or_default()
+                .to_string(),
+            schema_name: table
+                .schema_name
+                .clone()
+                .unwrap_or_else(|| source.qualified_name.name().to_string()),
             table_name: table.table_name.clone(),
             description: table.description.clone(),
             guide: table.guide.clone(),
@@ -559,7 +592,11 @@ pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableIn
         })
     }));
     tables.sort_by(|left, right| {
-        (&left.schema_name, &left.table_name).cmp(&(&right.schema_name, &right.table_name))
+        (&left.catalog_name, &left.schema_name, &left.table_name).cmp(&(
+            &right.catalog_name,
+            &right.schema_name,
+            &right.table_name,
+        ))
     });
     tables
 }
@@ -651,6 +688,7 @@ fn catalog_table_functions(
 }
 
 struct CatalogTable {
+    catalog_name: String,
     schema_name: String,
     table_name: String,
     description: String,
@@ -667,11 +705,13 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
         Field::new("guide", DataType::Utf8, false),
         Field::new("required_filters", DataType::Utf8, false),
         Field::new("search_limits_json", DataType::Utf8, true),
+        Field::new("catalog_name", DataType::Utf8, false),
     ]));
 
     let mut rows = SYSTEM_TABLE_DEFINITIONS
         .iter()
         .map(|table| CatalogTable {
+            catalog_name: String::new(),
             schema_name: SYSTEM_SCHEMA.to_string(),
             table_name: table.table_name.to_string(),
             description: table.description.to_string(),
@@ -681,7 +721,15 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
         })
         .chain(active_sources.iter().flat_map(|source| {
             source.tables.iter().map(move |table| CatalogTable {
-                schema_name: source.schema_name.clone(),
+                catalog_name: source
+                    .qualified_name
+                    .catalog_name()
+                    .unwrap_or_default()
+                    .to_string(),
+                schema_name: table
+                    .schema_name
+                    .clone()
+                    .unwrap_or_else(|| source.qualified_name.name().to_string()),
                 table_name: table.table_name.clone(),
                 description: table.description.clone(),
                 guide: table.guide.clone(),
@@ -692,7 +740,11 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
         .collect::<Vec<_>>();
 
     rows.sort_by(|left, right| {
-        (&left.schema_name, &left.table_name).cmp(&(&right.schema_name, &right.table_name))
+        (&left.catalog_name, &left.schema_name, &left.table_name).cmp(&(
+            &right.catalog_name,
+            &right.schema_name,
+            &right.table_name,
+        ))
     });
 
     let search_limits_json = rows
@@ -709,6 +761,7 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
             utf8_column(rows.iter().map(|row| Some(row.guide.as_str()))),
             utf8_column(rows.iter().map(|row| Some(row.required_filters.as_str()))),
             utf8_column(search_limits_json.iter().map(|value| value.as_deref())),
+            utf8_column(rows.iter().map(|row| Some(row.catalog_name.as_str()))),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
@@ -717,6 +770,7 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
 }
 
 struct CatalogFilter {
+    catalog_name: String,
     schema_name: String,
     table_name: String,
     filter_name: String,
@@ -735,32 +789,10 @@ fn build_filters_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
         Field::new("is_required", DataType::Boolean, false),
         Field::new("data_type", DataType::Utf8, false),
         Field::new("description", DataType::Utf8, false),
+        Field::new("catalog_name", DataType::Utf8, false),
     ]));
 
-    let mut rows = active_sources
-        .iter()
-        .flat_map(|source| {
-            source.tables.iter().flat_map(move |table| {
-                table.filters.iter().map(move |filter| CatalogFilter {
-                    schema_name: source.schema_name.clone(),
-                    table_name: table.table_name.clone(),
-                    filter_name: filter.name.clone(),
-                    filter_mode: filter.mode.clone(),
-                    is_required: filter.required,
-                    data_type: filter.data_type.clone(),
-                    description: filter.description.clone(),
-                })
-            })
-        })
-        .collect::<Vec<_>>();
-
-    rows.sort_by(|left, right| {
-        (&left.schema_name, &left.table_name, &left.filter_name).cmp(&(
-            &right.schema_name,
-            &right.table_name,
-            &right.filter_name,
-        ))
-    });
+    let rows = catalog_filter_rows(active_sources);
 
     let batch = RecordBatch::try_new(
         schema.clone(),
@@ -776,6 +808,7 @@ fn build_filters_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
             ),
             utf8_column(rows.iter().map(|row| Some(row.data_type.as_str()))),
             utf8_column(rows.iter().map(|row| Some(row.description.as_str()))),
+            utf8_column(rows.iter().map(|row| Some(row.catalog_name.as_str()))),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
@@ -783,8 +816,52 @@ fn build_filters_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
     MemTable::try_new(schema, vec![vec![batch]])
 }
 
+fn catalog_filter_rows(active_sources: &[RegisteredSource]) -> Vec<CatalogFilter> {
+    let mut rows = active_sources
+        .iter()
+        .flat_map(|source| {
+            source.tables.iter().flat_map(move |table| {
+                table.filters.iter().map(move |filter| CatalogFilter {
+                    catalog_name: source
+                        .qualified_name
+                        .catalog_name()
+                        .unwrap_or_default()
+                        .to_string(),
+                    schema_name: table
+                        .schema_name
+                        .clone()
+                        .unwrap_or_else(|| source.qualified_name.name().to_string()),
+                    table_name: table.table_name.clone(),
+                    filter_name: filter.name.clone(),
+                    filter_mode: filter.mode.clone(),
+                    is_required: filter.required,
+                    data_type: filter.data_type.clone(),
+                    description: filter.description.clone(),
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+
+    rows.sort_by(|left, right| {
+        (
+            &left.catalog_name,
+            &left.schema_name,
+            &left.table_name,
+            &left.filter_name,
+        )
+            .cmp(&(
+                &right.catalog_name,
+                &right.schema_name,
+                &right.table_name,
+                &right.filter_name,
+            ))
+    });
+    rows
+}
+
 struct CatalogInput {
     schema_name: String,
+    catalog_name: String,
     key: String,
     kind: &'static str,
     value: Option<String>,
@@ -795,23 +872,19 @@ struct CatalogInput {
     is_set: bool,
 }
 
-fn build_inputs_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
-    let schema = Arc::new(Schema::new(vec![
-        Field::new("schema_name", DataType::Utf8, false),
-        Field::new("key", DataType::Utf8, false),
-        Field::new("kind", DataType::Utf8, false),
-        Field::new("value", DataType::Utf8, true),
-        Field::new("default_value", DataType::Utf8, true),
-        Field::new("hint", DataType::Utf8, true),
-        Field::new("required", DataType::Boolean, false),
-        Field::new("is_set", DataType::Boolean, false),
-    ]));
-
+fn catalog_input_rows(active_sources: &[RegisteredSource]) -> Vec<CatalogInput> {
     let mut rows: Vec<CatalogInput> = active_sources
         .iter()
         .flat_map(|source| {
             source.inputs.iter().map(move |input| CatalogInput {
-                schema_name: source.schema_name.clone(),
+                schema_name: match &source.qualified_name {
+                    SourceQualifiedName::Schema(name) => name.clone(),
+                },
+                catalog_name: source
+                    .qualified_name
+                    .catalog_name()
+                    .unwrap_or_default()
+                    .to_string(),
                 key: input.key.clone(),
                 kind: match input.kind {
                     ManifestInputKind::Variable => "variable",
@@ -827,8 +900,29 @@ fn build_inputs_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
         .collect();
 
     rows.sort_by(|left, right| {
-        (&left.schema_name, &left.key).cmp(&(&right.schema_name, &right.key))
+        (&left.catalog_name, &left.schema_name, &left.key).cmp(&(
+            &right.catalog_name,
+            &right.schema_name,
+            &right.key,
+        ))
     });
+    rows
+}
+
+fn build_inputs_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("schema_name", DataType::Utf8, false),
+        Field::new("key", DataType::Utf8, false),
+        Field::new("kind", DataType::Utf8, false),
+        Field::new("value", DataType::Utf8, true),
+        Field::new("default_value", DataType::Utf8, true),
+        Field::new("hint", DataType::Utf8, true),
+        Field::new("required", DataType::Boolean, false),
+        Field::new("is_set", DataType::Boolean, false),
+        Field::new("catalog_name", DataType::Utf8, false),
+    ]));
+
+    let rows = catalog_input_rows(active_sources);
 
     let batch = RecordBatch::try_new(
         schema.clone(),
@@ -879,6 +973,11 @@ fn build_inputs_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
                     .map(|row| Some(row.is_set))
                     .collect::<BooleanArray>(),
             ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.catalog_name.as_str()))
+                    .collect::<StringArray>(),
+            ),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
@@ -887,6 +986,7 @@ fn build_inputs_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
 }
 
 struct CatalogColumn {
+    catalog_name: String,
     schema_name: String,
     table_name: String,
     column_name: String,
@@ -911,6 +1011,7 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
         Field::new("is_required_filter", DataType::Boolean, false),
         Field::new("description", DataType::Utf8, false),
         Field::new("filter_mode", DataType::Utf8, true),
+        Field::new("catalog_name", DataType::Utf8, false),
     ]));
 
     let rows = catalog_column_rows(active_sources);
@@ -923,11 +1024,18 @@ fn catalog_column_rows(active_sources: &[RegisteredSource]) -> Vec<CatalogColumn
     let mut rows = system_catalog_column_rows();
     rows.extend(source_catalog_column_rows(active_sources));
     rows.sort_by(|left, right| {
-        (&left.schema_name, &left.table_name, left.ordinal_position).cmp(&(
-            &right.schema_name,
-            &right.table_name,
-            right.ordinal_position,
-        ))
+        (
+            &left.catalog_name,
+            &left.schema_name,
+            &left.table_name,
+            left.ordinal_position,
+        )
+            .cmp(&(
+                &right.catalog_name,
+                &right.schema_name,
+                &right.table_name,
+                right.ordinal_position,
+            ))
     });
     rows
 }
@@ -941,6 +1049,7 @@ fn system_catalog_column_rows() -> Vec<CatalogColumn> {
                 .iter()
                 .enumerate()
                 .map(move |(position, column)| CatalogColumn {
+                    catalog_name: String::new(),
                     schema_name: SYSTEM_SCHEMA.to_string(),
                     table_name: table.table_name.to_string(),
                     column_name: column.name.to_string(),
@@ -961,12 +1070,22 @@ fn source_catalog_column_rows(active_sources: &[RegisteredSource]) -> Vec<Catalo
         .iter()
         .flat_map(|source| {
             source.tables.iter().flat_map(move |table| {
+                let catalog_name = source
+                    .qualified_name
+                    .catalog_name()
+                    .unwrap_or_default()
+                    .to_string();
+                let schema_name = table
+                    .schema_name
+                    .clone()
+                    .unwrap_or_else(|| source.qualified_name.name().to_string());
                 table
                     .columns
                     .iter()
                     .enumerate()
                     .map(move |(position, column)| CatalogColumn {
-                        schema_name: source.schema_name.clone(),
+                        catalog_name: catalog_name.clone(),
+                        schema_name: schema_name.clone(),
                         table_name: table.table_name.clone(),
                         column_name: column.name.clone(),
                         data_type: column.data_type.clone(),
@@ -1032,6 +1151,11 @@ fn catalog_columns_batch(schema: Arc<Schema>, rows: &[CatalogColumn]) -> Result<
                     .collect::<StringArray>(),
             ),
             utf8_column(rows.iter().map(|row| row.filter_mode.as_deref())),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.catalog_name.as_str()))
+                    .collect::<StringArray>(),
+            ),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))
@@ -1042,7 +1166,7 @@ mod tests {
     use std::sync::Arc;
 
     use crate::backends::common::test_support::StubSourceFunctionFactory;
-    use crate::backends::{RegisteredSource, RegisteredTableFunction};
+    use crate::backends::{RegisteredSource, RegisteredTableFunction, SourceQualifiedName};
 
     use super::collect_table_functions;
 
@@ -1050,7 +1174,7 @@ mod tests {
     fn collect_table_functions_preserves_registered_function_schema() {
         let functions = collect_table_functions(
             &[RegisteredSource {
-                schema_name: "source_schema".to_string(),
+                qualified_name: SourceQualifiedName::Schema("source_schema".to_string()),
                 tables: Vec::new(),
                 table_functions: vec![RegisteredTableFunction {
                     schema_name: "function_schema".to_string(),

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -530,7 +530,7 @@ fn system_table_infos() -> Vec<TableInfo> {
     SYSTEM_TABLE_DEFINITIONS
         .iter()
         .map(|table| TableInfo {
-            catalog_name: String::new(),
+            catalog_name: None,
             schema_name: SYSTEM_SCHEMA.to_string(),
             table_name: table.table_name.to_string(),
             description: table.description.to_string(),
@@ -564,8 +564,7 @@ pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableIn
             catalog_name: source
                 .qualified_name
                 .catalog_name()
-                .unwrap_or_default()
-                .to_string(),
+                .map(ToString::to_string),
             schema_name: table
                 .schema_name
                 .clone()

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -10,13 +10,12 @@ use crate::TableFunctionInfo;
 use crate::backends::http::ProviderQueryError;
 use crate::backends::mcp::McpProviderQueryError;
 use crate::contracts::{ColumnParts, StructuredQueryError, TableRefParts};
+use crate::runtime::DATAFUSION_DEFAULT_CATALOG;
 use crate::runtime::dependent_join::error::DependentJoinError;
 use crate::{
     CoreError, QueryResultObserverError, RequestIdentityHttpAuthenticatorError,
     RequestIdentitySelectionError, SourceDecoratorError, SourceInputResolverError, TableInfo,
 };
-
-const DATAFUSION_DEFAULT_CATALOG: &str = "datafusion";
 
 pub(crate) fn datafusion_to_core(error: &DataFusionError, tables: &[TableInfo]) -> CoreError {
     datafusion_to_core_with_sql(error, tables, None)

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -8,7 +8,7 @@ use datafusion::logical_expr::Expr;
 pub(crate) const DATAFUSION_DEFAULT_CATALOG: &str = "datafusion";
 
 /// Removes `DataFusion`'s synthetic default catalog from a table qualifier.
-/// Schema-backed Coral tables store an empty catalog name in metadata, even
+/// Schema-backed Coral tables store no catalog name in metadata, even
 /// when `DataFusion` expands an explicit reference to `datafusion.schema.table`.
 pub(crate) fn non_default_catalog_name(catalog_name: Option<&str>) -> Option<&str> {
     catalog_name.filter(|name| !name.eq_ignore_ascii_case(DATAFUSION_DEFAULT_CATALOG))

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -5,6 +5,15 @@ use datafusion::common::ScalarValue;
 use datafusion::error::Result;
 use datafusion::logical_expr::Expr;
 
+pub(crate) const DATAFUSION_DEFAULT_CATALOG: &str = "datafusion";
+
+/// Removes `DataFusion`'s synthetic default catalog from a table qualifier.
+/// Schema-backed Coral tables store an empty catalog name in metadata, even
+/// when `DataFusion` expands an explicit reference to `datafusion.schema.table`.
+pub(crate) fn non_default_catalog_name(catalog_name: Option<&str>) -> Option<&str> {
+    catalog_name.filter(|name| !name.eq_ignore_ascii_case(DATAFUSION_DEFAULT_CATALOG))
+}
+
 pub(crate) mod catalog;
 pub(crate) mod dependent_join;
 pub(crate) mod error;

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -1473,6 +1473,7 @@ mod tests {
                 schema_name: "demo".to_string(),
                 function_name: "search_events".to_string(),
                 description: "Search events.".to_string(),
+                guide: String::new(),
                 arguments: Vec::new(),
                 result_columns: Vec::new(),
                 kind: coral_spec::SourceTableFunctionKind::Table,

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -30,6 +30,7 @@ use crate::runtime::error::{
     query_result_observer_error_to_core,
 };
 use crate::runtime::json::register_json_support;
+use crate::runtime::non_default_catalog_name;
 use crate::runtime::pattern_validator::register_pattern_validator;
 use crate::runtime::query_planner::CoralQueryPlanner;
 use crate::runtime::registry::{
@@ -65,7 +66,9 @@ pub(crate) struct QueryRuntimeAdapter {
     tables: Vec<TableInfo>,
     table_functions: Vec<TableFunctionInfo>,
     failures: Vec<SourceRegistrationFailure>,
-    schema_to_source: HashMap<String, String>,
+    /// Source name keyed by top-level SQL name (schema for two-part sources,
+    /// catalog for database sources).
+    name_to_source: HashMap<String, String>,
     query_result_observers: Vec<Arc<dyn QueryResultObserver>>,
 }
 
@@ -215,7 +218,7 @@ async fn build_runtime_inner(
         tables: primary.tables,
         table_functions: primary.table_functions,
         failures: primary.failures,
-        schema_to_source: schema_to_source_names(sources),
+        name_to_source: name_to_source_names(sources),
         query_result_observers: extensions.query_result_observers,
     })
 }
@@ -499,6 +502,24 @@ async fn register_runtime_sources(
     register_sources(ctx, source_candidates, source_decorators).await
 }
 
+fn table_qualifier_matches(
+    table: &TableInfo,
+    catalog_filter: Option<&str>,
+    schema_filter: Option<&str>,
+) -> bool {
+    catalog_filter.is_none_or(|value| table.catalog_name == value)
+        && schema_filter.is_none_or(|value| table.schema_name == value)
+}
+
+fn table_reference_matches(
+    table: &TableInfo,
+    catalog_name: Option<&str>,
+    schema_name: &str,
+) -> bool {
+    table.catalog_name == non_default_catalog_name(catalog_name).unwrap_or_default()
+        && table.schema_name == schema_name
+}
+
 impl QueryRuntimeAdapter {
     pub(crate) async fn install_udfs(
         &mut self,
@@ -549,12 +570,13 @@ impl QueryRuntimeAdapter {
 
     pub(crate) fn list_tables(
         &self,
-        source_filter: Option<&str>,
+        catalog_filter: Option<&str>,
+        schema_filter: Option<&str>,
         table_filter: Option<&str>,
     ) -> Vec<TableInfo> {
         self.tables
             .iter()
-            .filter(|table| source_filter.is_none_or(|value| table.schema_name == value))
+            .filter(|table| table_qualifier_matches(table, catalog_filter, schema_filter))
             .filter(|table| table_filter.is_none_or(|value| table.table_name == value))
             .cloned()
             .collect()
@@ -573,43 +595,64 @@ impl QueryRuntimeAdapter {
             .collect()
     }
 
-    pub(crate) fn catalog_info(&self, source_filter: Option<&str>) -> CatalogInfo {
+    pub(crate) fn catalog_info(
+        &self,
+        catalog_filter: Option<&str>,
+        schema_filter: Option<&str>,
+    ) -> CatalogInfo {
         CatalogInfo {
-            tables: self.list_tables(source_filter, None),
-            table_functions: self.list_table_functions(source_filter, None),
+            tables: self.list_tables(catalog_filter, schema_filter, None),
+            table_functions: if catalog_filter.is_none() {
+                self.list_table_functions(schema_filter, None)
+            } else {
+                Vec::new()
+            },
         }
     }
 
-    pub(crate) fn catalog_info_for_schemas(&self, schema_filters: &[&str]) -> CatalogInfo {
+    /// Catalog metadata restricted to the sources publishing the given
+    /// schema and catalog names. Schema names never match database-internal
+    /// schemas, which are addressed through their catalog.
+    pub(crate) fn catalog_info_for_sources(
+        &self,
+        schema_names: &[&str],
+        catalog_names: &[&str],
+    ) -> CatalogInfo {
         CatalogInfo {
             tables: self
                 .tables
                 .iter()
                 .filter(|table| {
-                    schema_filters
-                        .iter()
-                        .any(|schema| table.schema_name == *schema)
+                    if table.catalog_name.is_empty() {
+                        schema_names.contains(&table.schema_name.as_str())
+                    } else {
+                        catalog_names.contains(&table.catalog_name.as_str())
+                    }
                 })
                 .cloned()
                 .collect(),
             table_functions: self
                 .table_functions
                 .iter()
-                .filter(|function| {
-                    schema_filters
-                        .iter()
-                        .any(|schema| function.schema_name == *schema)
-                })
+                .filter(|function| schema_names.contains(&function.schema_name.as_str()))
                 .cloned()
                 .collect(),
         }
     }
 
-    pub(crate) fn describe_table(&self, schema_name: &str, table_name: &str) -> DescribeTableInfo {
+    pub(crate) fn describe_table(
+        &self,
+        catalog_name: Option<&str>,
+        schema_name: &str,
+        table_name: &str,
+    ) -> DescribeTableInfo {
         if let Some(table) = self
             .tables
             .iter()
-            .find(|table| table.schema_name == schema_name && table.table_name == table_name)
+            .find(|table| {
+                table_reference_matches(table, catalog_name, schema_name)
+                    && table.table_name == table_name
+            })
             .cloned()
         {
             return DescribeTableInfo {
@@ -866,7 +909,7 @@ impl QueryRuntimeAdapter {
         sources.extend(
             table_functions
                 .iter()
-                .filter(|usage| self.schema_to_source.contains_key(usage.schema_name()))
+                .filter(|usage| self.name_to_source.contains_key(usage.schema_name()))
                 .map(|usage| usage.source_name().to_string()),
         );
 
@@ -921,13 +964,14 @@ impl QueryRuntimeAdapter {
         let Some((schema_name, table_name)) = relation_parts(table_reference) else {
             return;
         };
-        if self
-            .tables
-            .iter()
-            .any(|table| table.schema_name == schema_name && table.table_name == table_name)
-        {
+        let catalog_name = non_default_catalog_name(table_reference.catalog());
+        if self.tables.iter().any(|table| {
+            table.catalog_name == catalog_name.unwrap_or_default()
+                && table.schema_name == schema_name
+                && table.table_name == table_name
+        }) {
             tables.insert(QueryTableUsage::new(
-                self.source_name_for_schema(schema_name),
+                self.source_name_for(catalog_name.unwrap_or(schema_name)),
                 schema_name,
                 table_name,
             ));
@@ -959,18 +1003,19 @@ impl QueryRuntimeAdapter {
             return false;
         };
         table_functions.insert(QueryTableFunctionUsage::new(
-            self.source_name_for_schema(schema_name),
+            self.source_name_for(schema_name),
             schema_name,
             function_name,
         ));
         true
     }
 
-    fn source_name_for_schema(&self, schema_name: &str) -> String {
-        self.schema_to_source
-            .get(schema_name)
+    /// Resolves the source owning a top-level SQL name (schema or catalog).
+    fn source_name_for(&self, name: &str) -> String {
+        self.name_to_source
+            .get(name)
             .cloned()
-            .unwrap_or_else(|| schema_name.to_string())
+            .unwrap_or_else(|| name.to_string())
     }
 
     pub(crate) async fn explain_sql(
@@ -1339,7 +1384,7 @@ pub(crate) fn read_only_sql_options() -> SQLOptions {
         .with_allow_statements(false)
 }
 
-fn schema_to_source_names(sources: &[QuerySource]) -> HashMap<String, String> {
+fn name_to_source_names(sources: &[QuerySource]) -> HashMap<String, String> {
     sources
         .iter()
         .flat_map(|source| {
@@ -1347,7 +1392,8 @@ fn schema_to_source_names(sources: &[QuerySource]) -> HashMap<String, String> {
             source
                 .schema_names()
                 .into_iter()
-                .map(move |schema_name| (schema_name.to_string(), source_name.clone()))
+                .chain(source.catalog_names())
+                .map(move |name| (name.to_string(), source_name.clone()))
         })
         .collect()
 }
@@ -1359,6 +1405,7 @@ fn relation_parts(table_reference: &TableReference) -> Option<(&str, &str)> {
 
 fn table_metadata_without_columns(table: &TableInfo) -> TableInfo {
     TableInfo {
+        catalog_name: table.catalog_name.clone(),
         schema_name: table.schema_name.clone(),
         table_name: table.table_name.clone(),
         description: table.description.clone(),
@@ -1405,6 +1452,7 @@ mod tests {
             source_function_names: HashSet::new(),
             udfs_installed: false,
             tables: vec![TableInfo {
+                catalog_name: String::new(),
                 schema_name: "demo".to_string(),
                 table_name: "events".to_string(),
                 description: "Event rows".to_string(),
@@ -1423,14 +1471,14 @@ mod tests {
             }],
             table_functions: Vec::new(),
             failures: Vec::new(),
-            schema_to_source: HashMap::from([("demo".to_string(), "demo".to_string())]),
+            name_to_source: HashMap::from([("demo".to_string(), "demo".to_string())]),
             query_result_observers: Vec::new(),
         }
     }
 
     #[test]
     fn describe_table_hit_returns_full_table_without_missing_context() {
-        let result = adapter_with_table().describe_table("demo", "events");
+        let result = adapter_with_table().describe_table(None, "demo", "events");
 
         let table = result.table.expect("exact table");
         assert_eq!(table.columns.len(), 1);
@@ -1439,7 +1487,7 @@ mod tests {
 
     #[test]
     fn describe_table_miss_returns_columnless_context_tables() {
-        let result = adapter_with_table().describe_table("demo", "missing");
+        let result = adapter_with_table().describe_table(None, "demo", "missing");
 
         assert!(result.table.is_none());
         assert_eq!(result.missing_context_tables.len(), 1);

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -507,7 +507,7 @@ fn table_qualifier_matches(
     catalog_filter: Option<&str>,
     schema_filter: Option<&str>,
 ) -> bool {
-    catalog_filter.is_none_or(|value| table.catalog_name == value)
+    catalog_filter.is_none_or(|value| table.catalog_name.as_deref() == Some(value))
         && schema_filter.is_none_or(|value| table.schema_name == value)
 }
 
@@ -516,7 +516,7 @@ fn table_reference_matches(
     catalog_name: Option<&str>,
     schema_name: &str,
 ) -> bool {
-    table.catalog_name == non_default_catalog_name(catalog_name).unwrap_or_default()
+    table.catalog_name.as_deref() == non_default_catalog_name(catalog_name)
         && table.schema_name == schema_name
 }
 
@@ -622,12 +622,9 @@ impl QueryRuntimeAdapter {
             tables: self
                 .tables
                 .iter()
-                .filter(|table| {
-                    if table.catalog_name.is_empty() {
-                        schema_names.contains(&table.schema_name.as_str())
-                    } else {
-                        catalog_names.contains(&table.catalog_name.as_str())
-                    }
+                .filter(|table| match table.catalog_name.as_deref() {
+                    None => schema_names.contains(&table.schema_name.as_str()),
+                    Some(catalog_name) => catalog_names.contains(&catalog_name),
                 })
                 .cloned()
                 .collect(),
@@ -966,7 +963,7 @@ impl QueryRuntimeAdapter {
         };
         let catalog_name = non_default_catalog_name(table_reference.catalog());
         if self.tables.iter().any(|table| {
-            table.catalog_name == catalog_name.unwrap_or_default()
+            table.catalog_name.as_deref() == catalog_name
                 && table.schema_name == schema_name
                 && table.table_name == table_name
         }) {
@@ -1452,7 +1449,7 @@ mod tests {
             source_function_names: HashSet::new(),
             udfs_installed: false,
             tables: vec![TableInfo {
-                catalog_name: String::new(),
+                catalog_name: None,
                 schema_name: "demo".to_string(),
                 table_name: "events".to_string(),
                 description: "Event rows".to_string(),

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -790,7 +790,7 @@ impl QueryRuntimeAdapter {
             .sources()
             .iter()
             .filter(|source_name| {
-                self.schema_to_source
+                self.name_to_source
                     .values()
                     .any(|installed_name| installed_name == *source_name)
             })
@@ -1475,6 +1475,7 @@ mod tests {
                 function_name: "search_events".to_string(),
                 description: "Search events.".to_string(),
                 guide: String::new(),
+                require_guide_read: false,
                 arguments: Vec::new(),
                 result_columns: Vec::new(),
                 kind: coral_spec::SourceTableFunctionKind::Table,

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -972,6 +972,7 @@ impl QueryRuntimeAdapter {
         }) {
             tables.insert(QueryTableUsage::new(
                 self.source_name_for(catalog_name.unwrap_or(schema_name)),
+                catalog_name,
                 schema_name,
                 table_name,
             ));

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -507,7 +507,8 @@ fn table_qualifier_matches(
     catalog_filter: Option<&str>,
     schema_filter: Option<&str>,
 ) -> bool {
-    catalog_filter.is_none_or(|value| table.catalog_name.as_deref() == Some(value))
+    catalog_filter
+        .is_none_or(|value| table.catalog_name.as_deref() == non_default_catalog_name(Some(value)))
         && schema_filter.is_none_or(|value| table.schema_name == value)
 }
 
@@ -600,9 +601,11 @@ impl QueryRuntimeAdapter {
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
     ) -> CatalogInfo {
+        let includes_schema_sources =
+            catalog_filter.is_none_or(|value| non_default_catalog_name(Some(value)).is_none());
         CatalogInfo {
             tables: self.list_tables(catalog_filter, schema_filter, None),
-            table_functions: if catalog_filter.is_none() {
+            table_functions: if includes_schema_sources {
                 self.list_table_functions(schema_filter, None)
             } else {
                 Vec::new()
@@ -1466,7 +1469,15 @@ mod tests {
                 }],
                 required_filters: vec!["owner".to_string()],
             }],
-            table_functions: Vec::new(),
+            table_functions: vec![TableFunctionInfo {
+                schema_name: "demo".to_string(),
+                function_name: "search_events".to_string(),
+                description: "Search events.".to_string(),
+                arguments: Vec::new(),
+                result_columns: Vec::new(),
+                kind: coral_spec::SourceTableFunctionKind::Table,
+                search_limits: None,
+            }],
             failures: Vec::new(),
             name_to_source: HashMap::from([("demo".to_string(), "demo".to_string())]),
             query_result_observers: Vec::new(),
@@ -1494,6 +1505,25 @@ mod tests {
             .expect("missing context table");
         assert!(context_table.columns.is_empty());
         assert_eq!(context_table.required_filters, ["owner".to_string()]);
+    }
+
+    #[test]
+    fn explicit_datafusion_catalog_filters_schema_metadata() {
+        let adapter = adapter_with_table();
+
+        let tables = adapter.list_tables(
+            Some(crate::runtime::DATAFUSION_DEFAULT_CATALOG),
+            Some("demo"),
+            None,
+        );
+        assert_eq!(tables.len(), 1);
+
+        let catalog = adapter.catalog_info(
+            Some(crate::runtime::DATAFUSION_DEFAULT_CATALOG),
+            Some("demo"),
+        );
+        assert_eq!(catalog.tables.len(), 1);
+        assert_eq!(catalog.table_functions.len(), 1);
     }
 
     #[test]

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -8,14 +8,14 @@ use datafusion::prelude::SessionContext;
 use tracing::{Instrument as _, info_span};
 
 use crate::backends::{
-    BackendRegistration, BackendRegistrationContext, BackendSchemaRegistration,
-    CompiledBackendSource, RegisteredSource,
+    BackendCatalogRegistration, BackendRegistration, BackendRegistrationContext,
+    BackendSchemaRegistration, CompiledBackendSource, RegisteredSource,
 };
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy};
 
-const RESERVED_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin", "public"];
+const RESERVED_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin", "datafusion", "public"];
 
 /// One selected query source together with its compiled backend artifact.
 ///
@@ -72,7 +72,7 @@ fn is_reserved_schema(schema: &str) -> bool {
 }
 
 fn reserved_schema_detail(schema: &str) -> String {
-    format!("source schema '{schema}' is reserved and cannot be used by manifests")
+    format!("source SQL name '{schema}' is reserved and cannot be used by manifests")
 }
 
 /// Register all configured source manifests into the active `SessionContext`.
@@ -110,11 +110,12 @@ async fn register_sources_inner(
         .iter()
         .map(|selected| selected.source().clone())
         .collect::<Vec<_>>();
-    validate_selected_source_schema_names(&selected_sources)?;
+    validate_selected_source_names(&selected_sources)?;
     prepare_source_decorators(source_decorators, &selected_sources)?;
 
     let mut result = SourceRegistrationResult::default();
     let mut seen_schemas = catalog.schema_names().into_iter().collect();
+    let mut seen_catalogs = ctx.catalog_names().into_iter().collect();
     let registration_context = BackendRegistrationContext::default();
 
     for source in sources {
@@ -128,12 +129,14 @@ async fn register_sources_inner(
                     ctx,
                     &registration_context,
                     &mut seen_schemas,
+                    &mut seen_catalogs,
                     compiled_source.as_ref(),
                 )
                 .await
                 {
                     Ok(registration) => {
                         register_backend_registration(
+                            ctx,
                             catalog.as_ref(),
                             source_decorators,
                             query_source,
@@ -154,7 +157,7 @@ async fn register_sources_inner(
                         push_source_failure(
                             &mut result,
                             &source_name,
-                            compiled_source.schema_name(),
+                            compiled_source.qualified_name(),
                             core_error.to_string(),
                         );
                     }
@@ -179,20 +182,28 @@ async fn register_sources_inner(
     Ok(result)
 }
 
-fn validate_selected_source_schema_names(
-    sources: &[QuerySource],
-) -> std::result::Result<(), CoreError> {
-    let mut owner_by_schema = HashMap::new();
+fn validate_selected_source_names(sources: &[QuerySource]) -> std::result::Result<(), CoreError> {
+    let mut owner_by_name = HashMap::new();
     for source in sources {
-        for schema_name in source.schema_names() {
-            if is_reserved_schema(schema_name) {
-                return Err(CoreError::InvalidInput(reserved_schema_detail(schema_name)));
+        let names = source
+            .schema_names()
+            .into_iter()
+            .map(|name| (name, "schema"))
+            .chain(
+                source
+                    .catalog_names()
+                    .into_iter()
+                    .map(|name| (name, "catalog")),
+            );
+        for (name, kind) in names {
+            if is_reserved_schema(name) {
+                return Err(CoreError::InvalidInput(reserved_schema_detail(name)));
             }
             if let Some(existing_source) =
-                owner_by_schema.insert(schema_name.to_string(), source.source_name().to_string())
+                owner_by_name.insert(name.to_string(), source.source_name().to_string())
             {
                 return Err(CoreError::InvalidInput(format!(
-                    "source '{}' runtime schema name '{schema_name}' conflicts with selected source '{existing_source}'",
+                    "source '{}' runtime {kind} name '{name}' conflicts with selected source '{existing_source}'",
                     source.source_name()
                 )));
             }
@@ -221,27 +232,62 @@ async fn register_source(
     ctx: &SessionContext,
     registration_context: &BackendRegistrationContext,
     seen_schemas: &mut std::collections::HashSet<String>,
+    seen_catalogs: &mut std::collections::HashSet<String>,
     source: &dyn CompiledBackendSource,
 ) -> DataFusionResult<BackendRegistration> {
     source.validate_runtime_capabilities()?;
+
     let registration = source.register(ctx, registration_context).await?;
+    claim_registration_schemas(&registration, seen_schemas)?;
+    claim_registration_catalogs(&registration, seen_catalogs)?;
+
+    Ok(registration)
+}
+
+fn claim_registration_schemas(
+    registration: &BackendRegistration,
+    seen_schemas: &mut std::collections::HashSet<String>,
+) -> DataFusionResult<()> {
     let mut registration_schemas = std::collections::HashSet::new();
     for schema in &registration.schemas {
-        let schema_name = &schema.source.schema_name;
+        let schema_name = schema.source.qualified_name.name();
         check_reserved_schema(schema_name)?;
 
-        if !registration_schemas.insert(schema_name.clone()) || seen_schemas.contains(schema_name) {
+        if !registration_schemas.insert(schema_name.to_string())
+            || seen_schemas.contains(schema_name)
+        {
             return Err(DataFusionError::Execution(format!(
                 "duplicate source schema '{schema_name}'"
             )));
         }
     }
     seen_schemas.extend(registration_schemas);
+    Ok(())
+}
 
-    Ok(registration)
+fn claim_registration_catalogs(
+    registration: &BackendRegistration,
+    seen_catalogs: &mut std::collections::HashSet<String>,
+) -> DataFusionResult<()> {
+    let mut registration_catalogs = std::collections::HashSet::new();
+    for catalog in &registration.catalogs {
+        let catalog_name = catalog.source.qualified_name.name();
+        check_reserved_schema(catalog_name)?;
+
+        if !registration_catalogs.insert(catalog_name.to_string())
+            || seen_catalogs.contains(catalog_name)
+        {
+            return Err(DataFusionError::Execution(format!(
+                "duplicate source catalog '{catalog_name}'"
+            )));
+        }
+    }
+    seen_catalogs.extend(registration_catalogs);
+    Ok(())
 }
 
 fn register_backend_registration(
+    ctx: &SessionContext,
     catalog: &dyn datafusion::catalog::CatalogProvider,
     source_decorators: &mut [Box<dyn SourceDecorator>],
     query_source: &QuerySource,
@@ -249,13 +295,35 @@ fn register_backend_registration(
     registration: BackendRegistration,
     result: &mut SourceRegistrationResult,
 ) -> std::result::Result<(), CoreError> {
+    // Source decorators wrap table providers at registration time, but catalog
+    // registrations expose providers lazily through the catalog itself, so
+    // decorators cannot be applied to them. Fail the source instead of
+    // silently bypassing an embedder's policy/observability hook.
+    if !registration.catalogs.is_empty() && !source_decorators.is_empty() {
+        let core_error = CoreError::FailedPrecondition(format!(
+            "source '{source_name}' registers database catalogs, which do not support source decorators"
+        ));
+        if handle_source_registration_failure(source_decorators, query_source, &core_error)? {
+            return Err(core_error);
+        }
+        push_source_failure(result, source_name, source_name, core_error.to_string());
+        return Ok(());
+    }
+
     let mut staged = Vec::with_capacity(registration.schemas.len());
+    let mut catalog_staged = Vec::with_capacity(registration.catalogs.len());
+    for catalog_registration in registration.catalogs {
+        let BackendCatalogRegistration { catalog, source } = catalog_registration;
+        let catalog_name = source.qualified_name.name().to_string();
+        catalog_staged.push((catalog_name, catalog, source));
+    }
+
     for schema_registration in registration.schemas {
         let BackendSchemaRegistration {
             tables,
             source: registered_source,
         } = schema_registration;
-        let schema_name = registered_source.schema_name.clone();
+        let schema_name = registered_source.qualified_name.name().to_string();
         let decorated_tables = decorate_source_tables(source_decorators, query_source, tables)?;
         staged.push((schema_name, decorated_tables, registered_source));
     }
@@ -282,7 +350,14 @@ fn register_backend_registration(
         }
     }
 
+    for (catalog_name, registered_catalog, _registered_source) in &catalog_staged {
+        ctx.register_catalog(catalog_name, Arc::clone(registered_catalog));
+    }
+
     for (_schema_name, _decorated_tables, registered_source) in staged {
+        result.active_sources.push(registered_source);
+    }
+    for (_catalog_name, _registered_catalog, registered_source) in catalog_staged {
         result.active_sources.push(registered_source);
     }
     Ok(())
@@ -395,7 +470,7 @@ mod tests {
 
     use crate::{CoreError, QuerySource, RuntimeSourcePackage};
 
-    use super::{check_reserved_schema, validate_selected_source_schema_names};
+    use super::{check_reserved_schema, validate_selected_source_names};
 
     #[test]
     fn reserved_schema_coral_is_rejected() {
@@ -443,14 +518,14 @@ mod tests {
         )
         .expect("runtime package");
 
-        let error = validate_selected_source_schema_names(&[source])
+        let error = validate_selected_source_names(&[source])
             .expect_err("reserved source schema should fail selected-source preflight");
 
         let CoreError::InvalidInput(detail) = error else {
             panic!("expected invalid input, got {error:?}");
         };
         assert!(
-            detail.contains("source schema 'public' is reserved"),
+            detail.contains("source SQL name 'public' is reserved"),
             "unexpected error: {detail}"
         );
     }

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -15,6 +15,9 @@ use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy};
 
+/// Source SQL names the runtime owns. Mirrored by `RESERVED_SOURCE_SCHEMA_NAMES`
+/// in `coral-spec`, which rejects the same names during manifest validation so a
+/// source cannot pass validation and then fail here.
 const RESERVED_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin", "datafusion", "public"];
 
 /// One selected query source together with its compiled backend artifact.
@@ -68,7 +71,12 @@ fn check_reserved_schema(schema: &str) -> DataFusionResult<()> {
 }
 
 fn is_reserved_schema(schema: &str) -> bool {
-    RESERVED_SCHEMA_NAMES.contains(&schema)
+    // Case-insensitive so this agrees with `non_default_catalog_name`, which
+    // folds the default catalog the same way: `DataFusion` must not register as
+    // a source while catalog filters read that spelling as the default catalog.
+    RESERVED_SCHEMA_NAMES
+        .iter()
+        .any(|reserved| reserved.eq_ignore_ascii_case(schema))
 }
 
 fn reserved_schema_detail(schema: &str) -> String {
@@ -497,6 +505,29 @@ mod tests {
             msg.contains("public"),
             "error message should mention the schema name"
         );
+    }
+
+    #[test]
+    fn reserved_schema_datafusion_is_rejected() {
+        let result = check_reserved_schema("datafusion");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("datafusion"),
+            "error message should mention the schema name"
+        );
+    }
+
+    #[test]
+    fn reserved_schema_rejection_ignores_case() {
+        // `non_default_catalog_name` folds the default catalog
+        // case-insensitively, so an exact-match reservation would let
+        // `DataFusion` register and then be read as the default catalog by
+        // every catalog filter. Legacy manifests are not restricted to
+        // lowercase names, so this is reachable.
+        check_reserved_schema("DataFusion").expect_err("DataFusion is reserved");
+        check_reserved_schema("Coral").expect_err("Coral is reserved");
+        check_reserved_schema("PUBLIC").expect_err("PUBLIC is reserved");
     }
 
     #[test]

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -154,10 +154,11 @@ async fn register_sources_inner(
                         )? {
                             return Err(core_error);
                         }
+                        let qualified_name = compiled_source.qualified_name();
                         push_source_failure(
                             &mut result,
                             &source_name,
-                            compiled_source.qualified_name(),
+                            qualified_name.name(),
                             core_error.to_string(),
                         );
                     }

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -297,12 +297,16 @@ fn register_backend_registration(
     result: &mut SourceRegistrationResult,
 ) -> std::result::Result<(), CoreError> {
     // Source decorators wrap table providers at registration time, but catalog
-    // registrations expose providers lazily through the catalog itself, so
-    // decorators cannot be applied to them. Fail the source instead of
-    // silently bypassing an embedder's policy/observability hook.
-    if !registration.catalogs.is_empty() && !source_decorators.is_empty() {
+    // registrations expose providers lazily through the catalog itself.
+    // Decorators must explicitly allow that their table-decoration hook is
+    // skipped so policy decorators fail closed while lifecycle observers can
+    // still participate.
+    if let Some(decorator) = source_decorators.iter().find(|decorator| {
+        !registration.catalogs.is_empty() && !decorator.supports_catalog_sources()
+    }) {
         let core_error = CoreError::FailedPrecondition(format!(
-            "source '{source_name}' registers database catalogs, which do not support source decorators"
+            "source '{source_name}' registers database catalogs, which source decorator '{}' does not support",
+            decorator.name()
         ));
         if handle_source_registration_failure(source_decorators, query_source, &core_error)? {
             return Err(core_error);

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -191,7 +191,7 @@ async fn coral_columns_default_row_order_matches_ordinal_position() {
 async fn list_tables_matches_catalog() {
     let (_temp, sources) = build_catalog_sources();
 
-    let listed = CoralQuery::list_tables(&sources, test_runtime(), None, None)
+    let listed = CoralQuery::list_tables(&sources, test_runtime(), None, None, None)
         .await
         .expect("list_tables should succeed");
     let catalog_rows = execution_to_rows(
@@ -224,7 +224,7 @@ async fn list_tables_matches_catalog() {
 
 #[tokio::test]
 async fn list_tables_returns_system_catalog_when_no_sources() {
-    let tables = CoralQuery::list_tables(&[], test_runtime(), None, None)
+    let tables = CoralQuery::list_tables(&[], test_runtime(), None, None, None)
         .await
         .expect("source-free catalog should succeed");
 
@@ -663,6 +663,7 @@ async fn coral_search_metadata_appends_columns_without_shifting_existing_ordinal
             "is_required_filter",
             "description",
             "filter_mode",
+            "catalog_name",
         ]
     );
 }
@@ -701,7 +702,7 @@ async fn coral_filters_lists_filter_metadata() {
         &CoralQuery::execute_sql(
             &sources,
             test_runtime(),
-            "SELECT table_name, filter_name, filter_mode, is_required, data_type, description \
+            "SELECT table_name, filter_name, filter_mode, is_required, data_type, description, catalog_name \
              FROM coral.filters WHERE schema_name = 'searchy' AND filter_mode = 'contains'",
         )
         .await
@@ -717,6 +718,7 @@ async fn coral_filters_lists_filter_metadata() {
             "is_required": false,
             "data_type": "Utf8",
             "description": "Provider-native placeholder search text",
+            "catalog_name": "",
         })]
     );
 }
@@ -752,7 +754,7 @@ async fn coral_columns_exposes_filter_mode_for_virtual_filters() {
 async fn list_catalog_matches_table_function_metadata() {
     let sources = vec![build_source(http_manifest_with_function())];
 
-    let catalog = CoralQuery::list_catalog(&sources, test_runtime(), Some("searchy"))
+    let catalog = CoralQuery::list_catalog(&sources, test_runtime(), None, Some("searchy"))
         .await
         .expect("list_catalog should succeed");
 
@@ -782,7 +784,7 @@ async fn list_catalog_matches_table_function_metadata() {
 async fn list_catalog_collects_tables_and_functions_together() {
     let sources = vec![build_source(http_manifest_with_function())];
 
-    let catalog = CoralQuery::list_catalog(&sources, test_runtime(), Some("searchy"))
+    let catalog = CoralQuery::list_catalog(&sources, test_runtime(), None, Some("searchy"))
         .await
         .expect("list_catalog should succeed");
 

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -260,7 +260,7 @@ async fn validate_source_reports_only_component_schemas_for_multi_schema_source(
 async fn identity_gated_source_requires_request_identity_selector() {
     let source = identity_runtime_source(identity_http_component());
 
-    let error = CoralQuery::list_catalog(&[source], test_runtime(), None)
+    let error = CoralQuery::list_catalog(&[source], test_runtime(), None, None)
         .await
         .expect_err("identity-gated source should require a selector");
 
@@ -278,7 +278,7 @@ async fn identity_gated_source_requires_request_identity_authenticator_factory()
     let runtime =
         test_runtime().with_request_identity_selector(Some(Arc::new(UnexpectedIdentitySelector)));
 
-    let error = CoralQuery::list_catalog(&[source], runtime, None)
+    let error = CoralQuery::list_catalog(&[source], runtime, None, None)
         .await
         .expect_err("identity-gated source should require an authenticator factory");
 
@@ -303,7 +303,7 @@ async fn identity_gated_sources_reject_duplicate_source_names_before_binding() {
             &factory_called,
         ))));
 
-    let error = CoralQuery::list_catalog(&sources, runtime, None)
+    let error = CoralQuery::list_catalog(&sources, runtime, None, None)
         .await
         .expect_err("duplicate gated source names should fail before identity binding");
 
@@ -335,7 +335,7 @@ async fn identity_gated_source_binds_identity_once_for_all_http_components() {
         Arc::clone(&factory_called),
     );
 
-    let catalog = CoralQuery::list_catalog(&[source], runtime, None)
+    let catalog = CoralQuery::list_catalog(&[source], runtime, None, None)
         .await
         .expect("one source identity should authenticate every HTTP component");
 
@@ -370,7 +370,7 @@ async fn identity_gated_source_rejects_selected_identity_type_mismatch() {
         Arc::clone(&factory_called),
     );
 
-    let error = CoralQuery::list_catalog(&[source], runtime, None)
+    let error = CoralQuery::list_catalog(&[source], runtime, None, None)
         .await
         .expect_err("JSON type mismatch should reject selected identity");
 
@@ -400,7 +400,7 @@ async fn identity_gated_source_accepts_spec_id_and_audience_subset() {
         Arc::clone(&factory_called),
     );
 
-    let catalog = CoralQuery::list_catalog(&[source], runtime, None)
+    let catalog = CoralQuery::list_catalog(&[source], runtime, None, None)
         .await
         .expect("matching identity should build runtime");
 

--- a/crates/coral-engine/tests/engine/composite_tests.rs
+++ b/crates/coral-engine/tests/engine/composite_tests.rs
@@ -206,7 +206,7 @@ async fn selected_sources_reject_runtime_schema_collisions() {
     )
     .expect("second runtime package");
 
-    let error = CoralQuery::list_catalog(&[first, second], test_runtime(), None)
+    let error = CoralQuery::list_catalog(&[first, second], test_runtime(), None, None)
         .await
         .expect_err("duplicate selected schemas should fail");
 

--- a/crates/coral-engine/tests/engine/query_result_observer_tests.rs
+++ b/crates/coral-engine/tests/engine/query_result_observer_tests.rs
@@ -195,6 +195,34 @@ async fn execution_and_observer_include_table_provenance() {
 }
 
 #[tokio::test]
+async fn explicit_datafusion_catalog_keeps_schema_table_provenance() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
+    let source = build_source(jsonl_manifest("observer_qualified", temp.path()));
+    let observer = Arc::new(ProvenanceObserver::default());
+    let runtime = runtime_with_observer(observer.clone());
+    let sql = "SELECT id FROM datafusion.observer_qualified.users WHERE id >= 2 ORDER BY id";
+
+    let execution = CoralQuery::execute_sql(&[source], runtime, sql)
+        .await
+        .expect("query should succeed");
+
+    let expected = ObservedProvenance {
+        sql: sql.to_string(),
+        sources: vec!["observer_qualified".to_string()],
+        tables: vec![(
+            "observer_qualified".to_string(),
+            "observer_qualified".to_string(),
+            "users".to_string(),
+        )],
+        table_functions: Vec::new(),
+        row_count: 2,
+    };
+    assert_eq!(ObservedProvenance::from(execution.provenance()), expected);
+    assert_eq!(observer.calls(), vec![expected]);
+}
+
+#[tokio::test]
 async fn observer_called_after_successful_query_and_sees_final_batches() {
     let temp = tempfile::tempdir().expect("tempdir");
     write_jsonl_file(temp.path(), "users.jsonl", &users_rows());

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -1075,7 +1075,7 @@ async fn published_udf_table_function_is_cataloged() {
     udf.publish.table_function.guide = "Use this function for review queue lookups.".to_string();
     let runtime = test_runtime().with_udfs(vec![udf]);
 
-    let catalog = CoralQuery::list_catalog(&[source], runtime, Some("udfs"))
+    let catalog = CoralQuery::list_catalog(&[source], runtime, None, Some("udfs"))
         .await
         .expect("catalog should include udf function");
 
@@ -1111,7 +1111,7 @@ async fn published_udf_table_function_catalog_uses_normalized_publish_identifier
         "catalog_mixed_case_udf_events",
     )]);
 
-    let catalog = CoralQuery::list_catalog(&[source], runtime, Some("udfs"))
+    let catalog = CoralQuery::list_catalog(&[source], runtime, None, Some("udfs"))
         .await
         .expect("catalog should include normalized udf function");
 

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -1011,7 +1011,7 @@ async fn mcp_catalog_helpers_expose_coral_system_tables_from_sql_catalog() {
         .expect("structured describe");
     assert_eq!(described["found"], true);
     assert_eq!(described["name"], "coral.columns");
-    assert_eq!(described["column_count"], 10);
+    assert_eq!(described["column_count"], 11);
 
     let columns = client
         .call_tool(
@@ -1027,7 +1027,7 @@ async fn mcp_catalog_helpers_expose_coral_system_tables_from_sql_catalog() {
         .expect("list system columns")
         .structured_content
         .expect("structured columns");
-    assert_eq!(columns["total"], 6);
+    assert_eq!(columns["total"], 7);
     assert_eq!(columns["rows"][0][0], "schema_name");
 
     session.shutdown().await;

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -19,7 +19,11 @@ use serde_json::Value;
 
 use crate::{ManifestError, ParsedTemplate, Result};
 
-const RESERVED_SOURCE_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin", "public"];
+/// Source SQL names the runtime owns. Kept in step with `RESERVED_SCHEMA_NAMES`
+/// in `coral-engine`'s registry: a name the engine refuses at registration has
+/// to fail manifest validation too, or the manifest validator accepts a source
+/// that can never register.
+const RESERVED_SOURCE_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin", "datafusion", "public"];
 
 /// Arrow field metadata key marking a source-authored column as excluded from
 /// observed-value indexing.
@@ -58,7 +62,13 @@ pub(crate) fn validate_source_name(name: &str) -> Result<()> {
 }
 
 pub(crate) fn validate_reserved_source_schema_name(name: &str, label: &str) -> Result<()> {
-    if RESERVED_SOURCE_SCHEMA_NAMES.contains(&name) {
+    // Case-insensitive: legacy (pre-v4) manifests are not held to v4's
+    // `[a-z][a-z0-9_]*` rule, so `DataFusion` would otherwise pass validation
+    // while the runtime still treats that spelling as its default catalog.
+    if RESERVED_SOURCE_SCHEMA_NAMES
+        .iter()
+        .any(|reserved| reserved.eq_ignore_ascii_case(name))
+    {
         return Err(ManifestError::validation(format!(
             "{label} '{name}' is reserved and cannot be used by manifests"
         )));

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -358,6 +358,41 @@ tables:
     }
 
     #[test]
+    fn reserved_datafusion_source_name_is_rejected_in_any_case() {
+        // The engine refuses to register `datafusion` (it is `DataFusion`'s
+        // default catalog) and folds that name case-insensitively. Validation
+        // has to reject the same spellings, or a legacy manifest passes lint and
+        // then fails at runtime with "cannot be used by manifests".
+        for name in ["datafusion", "DataFusion"] {
+            let error = parse_source_manifest_yaml(&format!(
+                r"
+name: {name}
+version: 1.0.0
+dsl_version: 3
+backend: file
+tables:
+  - name: messages
+    description: Demo messages
+    format: jsonl
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+"
+            ))
+            .expect_err("reserved source name should fail");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("source name '{name}' is reserved")),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[test]
     fn lookup_key_on_file_jsonl_rejects_at_spec_layer() {
         let error = parse_source_manifest_yaml(
             r"

--- a/plugins/coral/skills/coral-create-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-create-source-spec/SKILL.md
@@ -168,12 +168,19 @@ Use this loop during authoring:
 coral source lint ./my-source.yaml
 coral source add --file ./my-source.yaml
 coral source test my_source
-coral sql "SELECT schema_name, table_name, description, required_filters FROM coral.tables WHERE schema_name = 'my_source' ORDER BY schema_name, table_name LIMIT 50 OFFSET 0"
-coral sql "SELECT function_name, kind, arguments_json, result_columns_json, search_limits_json FROM coral.table_functions WHERE schema_name = 'my_source' ORDER BY function_name LIMIT 50 OFFSET 0"
-coral sql "SELECT table_name, filter_name, filter_mode, is_required, data_type, description FROM coral.filters WHERE schema_name = 'my_source' ORDER BY table_name, filter_name LIMIT 100 OFFSET 0"
-coral sql "SELECT table_name, column_name, data_type, is_virtual, is_required_filter, filter_mode, description FROM coral.columns WHERE schema_name = 'my_source' ORDER BY table_name, ordinal_position LIMIT 100 OFFSET 0"
-coral sql "SELECT key, kind, value, default_value, hint, required, is_set FROM coral.inputs WHERE schema_name = 'my_source' ORDER BY key"
+coral sql "SELECT catalog_name, schema_name, table_name, description, required_filters FROM coral.tables WHERE schema_name = 'my_source' OR catalog_name = 'my_source' ORDER BY catalog_name, schema_name, table_name LIMIT 50 OFFSET 0"
+coral sql "SELECT function_name, kind, arguments_json, result_columns_json, search_limits_json FROM coral.table_functions WHERE schema_name = 'my_source' OR catalog_name = 'my_source' ORDER BY function_name LIMIT 50 OFFSET 0"
+coral sql "SELECT table_name, filter_name, filter_mode, is_required, data_type, description FROM coral.filters WHERE schema_name = 'my_source' OR catalog_name = 'my_source' ORDER BY table_name, filter_name LIMIT 100 OFFSET 0"
+coral sql "SELECT table_name, column_name, data_type, is_virtual, is_required_filter, filter_mode, description FROM coral.columns WHERE schema_name = 'my_source' OR catalog_name = 'my_source' ORDER BY table_name, ordinal_position LIMIT 100 OFFSET 0"
+coral sql "SELECT catalog_name, key, kind, value, default_value, hint, required, is_set FROM coral.inputs WHERE schema_name = 'my_source' OR catalog_name = 'my_source' ORDER BY key"
 ```
+
+Each `WHERE` clause matches on both qualifiers because a source is addressed
+either by schema or by catalog. Schema-addressed sources carry the source name in
+`schema_name` and leave `catalog_name` empty; database sources put the source name
+in `catalog_name`, and their `coral.inputs` rows have an empty `schema_name`.
+Filtering on `schema_name` alone returns zero rows for a database source without
+reporting an error, which reads as "this source declares nothing".
 
 For repo sources or already-named sources, add `test_queries` for a basic smoke/connection check and run:
 

--- a/plugins/coral/skills/coral-create-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-create-source-spec/SKILL.md
@@ -169,7 +169,7 @@ coral source lint ./my-source.yaml
 coral source add --file ./my-source.yaml
 coral source test my_source
 coral sql "SELECT catalog_name, schema_name, table_name, description, required_filters FROM coral.tables WHERE schema_name = 'my_source' OR catalog_name = 'my_source' ORDER BY catalog_name, schema_name, table_name LIMIT 50 OFFSET 0"
-coral sql "SELECT function_name, kind, arguments_json, result_columns_json, search_limits_json FROM coral.table_functions WHERE schema_name = 'my_source' OR catalog_name = 'my_source' ORDER BY function_name LIMIT 50 OFFSET 0"
+coral sql "SELECT function_name, kind, arguments_json, result_columns_json, search_limits_json FROM coral.table_functions WHERE schema_name = 'my_source' ORDER BY function_name LIMIT 50 OFFSET 0"
 coral sql "SELECT table_name, filter_name, filter_mode, is_required, data_type, description FROM coral.filters WHERE schema_name = 'my_source' OR catalog_name = 'my_source' ORDER BY table_name, filter_name LIMIT 100 OFFSET 0"
 coral sql "SELECT table_name, column_name, data_type, is_virtual, is_required_filter, filter_mode, description FROM coral.columns WHERE schema_name = 'my_source' OR catalog_name = 'my_source' ORDER BY table_name, ordinal_position LIMIT 100 OFFSET 0"
 coral sql "SELECT catalog_name, key, kind, value, default_value, hint, required, is_set FROM coral.inputs WHERE schema_name = 'my_source' OR catalog_name = 'my_source' ORDER BY key"


### PR DESCRIPTION
## Summary

- represent installed source identity with an explicit schema or catalog qualifier
- preserve schema-backed behavior while enabling catalog-backed database sources
- normalize DataFusion default-catalog handling in provenance and query matching

## Idiot's guide (for Simon)

A fully-qualified table name is, for example, `datafusion.github.pull_requests`

* `datafusion` is the catalog (or database) name
* `github` is the schema
* `pull_requests` is the table name

This won't work for database sources, which already have database name, schema name and table name; if we always use `datafusion` as the catalog name, we'd need four levels of hierarchy for SQL sources. So instead, SQL sources, the name of the source becomes the **catalog** name, rather than the schema name.

> github REST source -> `datafusion.github.users`
> postgres source -> `postgres.my_application.my_users`

## Stack

- Base: main
- Next: #1894

This is PR 1 of 7 in the relational database source MVP stack.

## Notes

- **Breaking:** `datafusion` is now a reserved source SQL name (case-insensitive, as are `coral`/`coral_admin`/`public`). An existing source named `datafusion` no longer passes manifest validation.
- The catalog registration path (`claim_registration_catalogs` and the fail-closed decorator gate) is unreachable here: every backend still returns no catalogs. It first gets test coverage at #2028, which replaces both with `catalog_publications` / `supports_lazy_schemas`.
