### PR TITLE
feat(catalog): expose catalog-qualified table discovery

### DIFF
--- a/apps/docs/guides/use-coral-over-mcp.mdx
+++ b/apps/docs/guides/use-coral-over-mcp.mdx
@@ -197,7 +197,10 @@ The `coral://tables` resource exposes `catalog_name`, `schema_name`, and
 
 Tables with an empty `catalog_name` use two-part `schema.table` names. Database
 tables have a catalog and use three-part `catalog.schema.table` names. Use the
-provided `sql_reference`, which quotes each identifier when required.
+provided `sql_reference`, which quotes each identifier when required. When
+calling `list_catalog`, `describe_table`, or `list_columns` for a database
+table, pass its catalog separately from its schema; omit the catalog for
+two-part tables.
 
 ## What your agent can do
 

--- a/apps/docs/guides/use-coral-over-mcp.mdx
+++ b/apps/docs/guides/use-coral-over-mcp.mdx
@@ -189,6 +189,16 @@ Once your client is connected, ask the agent to list available Coral tables or r
 
 If it works, the agent should return installed schemas and tables. You do not need to know the MCP tool names; the agent gets discovery helpers and a read-only SQL interface to the same sources you use from `coral sql`.
 
+### Catalog-qualified table names
+
+The `coral://tables` resource exposes `catalog_name`, `schema_name`, and
+`table_name` separately for every table. It also provides `name` for display and
+`sql_reference` for use in `FROM` and `JOIN` clauses.
+
+Tables with an empty `catalog_name` use two-part `schema.table` names. Database
+tables have a catalog and use three-part `catalog.schema.table` names. Use the
+provided `sql_reference`, which quotes each identifier when required.
+
 ## What your agent can do
 
 Coral gives your agent a read-only SQL view over the sources you have installed locally. That means your agent can:

--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -256,8 +256,7 @@ message DescribeTableResponse {
   Table table = 1;
   // Suggested nearby tables when the exact table is missing.
   repeated TableSummary suggestions = 2;
-  // Query-visible table namespaces available in this workspace: a schema
-  // name, or the composite `catalog.schema` for database sources.
+  // Query-visible raw schema names available in this workspace.
   repeated string available_schemas = 3;
   // Tables in the requested schema, capped for user-facing missing-table help.
   repeated TableSummary same_schema_tables = 4;

--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -61,6 +61,9 @@ message Table {
   repeated string required_filters = 6;
   // User-facing query guidance.
   string guide = 7;
+  // SQL catalog containing the schema. Empty for two-part tables; otherwise
+  // the table is addressed as catalog_name.schema_name.name.
+  string catalog_name = 8;
 }
 
 // Table metadata without full column definitions.
@@ -78,6 +81,9 @@ message TableSummary {
   repeated string required_filters = 5;
   // User-facing query guidance.
   string guide = 6;
+  // SQL catalog containing the schema. Empty for two-part tables; otherwise
+  // the table is addressed as catalog_name.schema_name.name.
+  string catalog_name = 7;
 }
 
 // An argument accepted by a query-visible table function.
@@ -184,6 +190,8 @@ message ListCatalogRequest {
   CatalogItemKind kind = 3;
   // Optional page request. Missing or zero limit keeps the unbounded behavior.
   PaginationRequest pagination = 4;
+  // Optional exact SQL catalog name. Empty matches tables in every catalog.
+  string catalog_name = 5;
 }
 
 // Returns queryable catalog items in one workspace.
@@ -210,6 +218,8 @@ message SearchCatalogRequest {
   CatalogItemKind kind = 5;
   // Optional page request. Missing or zero limit applies the search default.
   PaginationRequest pagination = 6;
+  // Optional exact SQL catalog name. Empty searches tables in every catalog.
+  string catalog_name = 7;
 }
 
 // One catalog search match.
@@ -236,6 +246,8 @@ message DescribeTableRequest {
   string schema_name = 2;
   // Exact table name.
   string table_name = 3;
+  // SQL catalog containing the schema. Empty for two-part tables.
+  string catalog_name = 4;
 }
 
 // Returns one table, or app-owned missing-table discovery context.
@@ -244,7 +256,8 @@ message DescribeTableResponse {
   Table table = 1;
   // Suggested nearby tables when the exact table is missing.
   repeated TableSummary suggestions = 2;
-  // Query-visible schemas available in this workspace.
+  // Query-visible table namespaces available in this workspace: a schema
+  // name, or the composite `catalog.schema` for database sources.
   repeated string available_schemas = 3;
   // Tables in the requested schema, capped for user-facing missing-table help.
   repeated TableSummary same_schema_tables = 4;
@@ -266,6 +279,8 @@ message ListColumnsRequest {
   bool required_only = 6;
   // Optional page request. Missing or zero limit applies the column-list default.
   PaginationRequest pagination = 7;
+  // SQL catalog containing the schema. Empty for two-part tables.
+  string catalog_name = 8;
 }
 
 // One column search match.

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -389,7 +389,7 @@ impl CatalogDiscovery {
 fn catalog_item_sort_key(item: &CatalogItem) -> (&str, &str, &str, &'static str) {
     match item {
         CatalogItem::Table(table) => (
-            &table.catalog_name,
+            table.catalog_name.as_deref().unwrap_or_default(),
             &table.schema_name,
             &table.table_name,
             "table",
@@ -465,7 +465,10 @@ fn table_matched_fields(table: &TableInfo, regex: &Regex) -> Vec<CatalogMetadata
     let addressable_schema = table_addressable_schema_name(table);
     let name = table_addressable_name(table);
     let mut matches = Vec::new();
-    let catalog_matched = !table.catalog_name.is_empty() && regex.is_match(&table.catalog_name);
+    let catalog_matched = table
+        .catalog_name
+        .as_deref()
+        .is_some_and(|catalog_name| regex.is_match(catalog_name));
     let schema_matched = regex.is_match(&table.schema_name);
     if catalog_matched {
         matches.push(CatalogMetadataField::CatalogName);
@@ -601,17 +604,18 @@ fn table_metadata_contains_literal(table: &TableInfo, literal: &str) -> bool {
     let literal = literal.to_lowercase();
     let schema_name = table_addressable_schema_name(table);
     let name = table_addressable_name(table);
-    let candidates = [
-        table.catalog_name.as_str(),
-        table.schema_name.as_str(),
-        schema_name.as_str(),
-        table.table_name.as_str(),
-        name.as_str(),
-        table.description.as_str(),
-        table.guide.as_str(),
-    ];
-    candidates
+    table
+        .catalog_name
+        .as_deref()
         .into_iter()
+        .chain([
+            table.schema_name.as_str(),
+            schema_name.as_str(),
+            table.table_name.as_str(),
+            name.as_str(),
+            table.description.as_str(),
+            table.guide.as_str(),
+        ])
         .any(|value| value.to_lowercase().contains(&literal))
         || table
             .required_filters
@@ -620,10 +624,9 @@ fn table_metadata_contains_literal(table: &TableInfo, literal: &str) -> bool {
 }
 
 fn table_addressable_schema_name(table: &TableInfo) -> String {
-    if table.catalog_name.is_empty() {
-        table.schema_name.clone()
-    } else {
-        format!("{}.{}", table.catalog_name, table.schema_name)
+    match table.catalog_name.as_deref() {
+        Some(catalog_name) => format!("{catalog_name}.{}", table.schema_name),
+        None => table.schema_name.clone(),
     }
 }
 
@@ -640,7 +643,7 @@ fn table_matches_ref(table: &TableInfo, table_ref: CatalogTableRef<'_>) -> bool 
 }
 
 fn table_qualifier_matches(table: &TableInfo, table_ref: CatalogTableRef<'_>) -> bool {
-    table.catalog_name == table_ref.catalog_name.unwrap_or_default()
+    table.catalog_name.as_deref() == table_ref.catalog_name
         && table.schema_name == table_ref.schema_name
 }
 
@@ -694,7 +697,7 @@ mod tests {
 
     fn database_table(schema_name: &str, table_name: &str) -> TableInfo {
         let mut table = table(Vec::new());
-        table.catalog_name = "coral_db".to_string();
+        table.catalog_name = Some("coral_db".to_string());
         table.schema_name = schema_name.to_string();
         table.table_name = table_name.to_string();
         table
@@ -773,7 +776,7 @@ mod tests {
         );
         assert_eq!(same_schema.len(), 1);
         let same_schema_table = same_schema.first().expect("same schema table");
-        assert_eq!(same_schema_table.catalog_name, "coral_db");
+        assert_eq!(same_schema_table.catalog_name.as_deref(), Some("coral_db"));
         assert_eq!(same_schema_table.schema_name, "main");
         assert_eq!(same_schema_table.table_name, "users");
 
@@ -784,7 +787,7 @@ mod tests {
         );
         assert_eq!(suggestions.len(), 1);
         let suggestion = suggestions.first().expect("suggestion");
-        assert_eq!(suggestion.catalog_name, "coral_db");
+        assert_eq!(suggestion.catalog_name.as_deref(), Some("coral_db"));
         assert_eq!(suggestion.schema_name, "main");
         assert_eq!(suggestion.table_name, "users");
         assert!(table_metadata_contains_literal(

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -148,11 +148,19 @@ pub(crate) struct CatalogTableRef<'a> {
 }
 
 impl<'a> CatalogTableRef<'a> {
+    /// Builds a table reference with the catalog reduced to its meaning:
+    /// `catalog_name` is `None` exactly when the table is addressed as two
+    /// parts. Blank and whitespace-only catalogs are absent, and the
+    /// default-catalog sentinel names schema-backed tables, so callers do not
+    /// have to trim before constructing one.
     pub(crate) fn new(
         catalog_name: Option<&'a str>,
         schema_name: &'a str,
         table_name: &'a str,
     ) -> Self {
+        let catalog_name = catalog_name
+            .map(str::trim)
+            .filter(|catalog_name| !catalog_name.is_empty());
         Self {
             catalog_name: normalize_catalog_name(catalog_name),
             schema_name,
@@ -231,7 +239,11 @@ impl CatalogDiscovery {
         schema_name: Option<&str>,
         attribution: &QueryAttribution,
     ) -> Result<CatalogInfo, QueryManagerError> {
-        let catalog_name = normalize_catalog_name(catalog_name);
+        // Pass the filter through untouched. `None` here means "every catalog",
+        // so normalizing `datafusion` to `None` would widen an exact-match
+        // request into a wildcard, contradicting both the proto contract and
+        // `describe_table`, which resolves the same value to two-part tables.
+        // The engine normalizes the sentinel on the value side instead.
         self.queries
             .list_catalog(workspace_name, catalog_name, schema_name, attribution)
             .await

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet;
 
-use coral_engine::{CatalogInfo, ColumnInfo, TableFunctionInfo, TableInfo};
+use coral_engine::{CatalogInfo, ColumnInfo, TableFunctionInfo, TableInfo, normalize_catalog_name};
 use regex::{Regex, RegexBuilder};
 
 use crate::bootstrap::AppError;
@@ -18,7 +18,6 @@ const MAX_COLUMN_LIMIT: u32 = 200;
 const MAX_METADATA_PATTERN_BYTES: usize = 256;
 const REGEX_SIZE_LIMIT_BYTES: usize = 1 << 20;
 const MISSING_TABLE_SUGGESTION_LIMIT: usize = 10;
-const DATAFUSION_DEFAULT_CATALOG: &str = "datafusion";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct Pagination {
@@ -155,8 +154,7 @@ impl<'a> CatalogTableRef<'a> {
         table_name: &'a str,
     ) -> Self {
         Self {
-            catalog_name: catalog_name
-                .filter(|name| !name.eq_ignore_ascii_case(DATAFUSION_DEFAULT_CATALOG)),
+            catalog_name: normalize_catalog_name(catalog_name),
             schema_name,
             table_name,
         }
@@ -233,6 +231,7 @@ impl CatalogDiscovery {
         schema_name: Option<&str>,
         attribution: &QueryAttribution,
     ) -> Result<CatalogInfo, QueryManagerError> {
+        let catalog_name = normalize_catalog_name(catalog_name);
         self.queries
             .list_catalog(workspace_name, catalog_name, schema_name, attribution)
             .await

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -18,6 +18,7 @@ const MAX_COLUMN_LIMIT: u32 = 200;
 const MAX_METADATA_PATTERN_BYTES: usize = 256;
 const REGEX_SIZE_LIMIT_BYTES: usize = 1 << 20;
 const MISSING_TABLE_SUGGESTION_LIMIT: usize = 10;
+const DATAFUSION_DEFAULT_CATALOG: &str = "datafusion";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct Pagination {
@@ -67,7 +68,11 @@ pub(crate) struct CatalogSearchResult {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum CatalogMetadataField {
+    CatalogName,
     SchemaName,
+    /// The composite `catalog.schema` reference of a database table, when a
+    /// match spans the catalog/schema boundary rather than either part alone.
+    QualifiedSchema,
     TableName,
     FunctionName,
     Name,
@@ -81,7 +86,9 @@ pub(crate) enum CatalogMetadataField {
 impl CatalogMetadataField {
     pub(crate) fn as_proto_name(self) -> &'static str {
         match self {
+            Self::CatalogName => "catalog_name",
             Self::SchemaName => "schema_name",
+            Self::QualifiedSchema => "qualified_schema",
             Self::TableName => "table_name",
             Self::FunctionName => "function_name",
             Self::Name => "name",
@@ -131,14 +138,25 @@ impl ColumnMetadataField {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[expect(
+    clippy::struct_field_names,
+    reason = "explicit SQL qualifier names keep catalog, schema, and table semantics unambiguous"
+)]
 pub(crate) struct CatalogTableRef<'a> {
+    pub(crate) catalog_name: Option<&'a str>,
     pub(crate) schema_name: &'a str,
     pub(crate) table_name: &'a str,
 }
 
 impl<'a> CatalogTableRef<'a> {
-    pub(crate) fn new(schema_name: &'a str, table_name: &'a str) -> Self {
+    pub(crate) fn new(
+        catalog_name: Option<&'a str>,
+        schema_name: &'a str,
+        table_name: &'a str,
+    ) -> Self {
         Self {
+            catalog_name: catalog_name
+                .filter(|name| !name.eq_ignore_ascii_case(DATAFUSION_DEFAULT_CATALOG)),
             schema_name,
             table_name,
         }
@@ -155,6 +173,7 @@ pub(crate) struct ListColumnsQuery<'a> {
 
 pub(crate) struct SearchCatalogQuery<'a> {
     pub(crate) pattern: &'a str,
+    pub(crate) catalog_name: Option<&'a str>,
     pub(crate) schema_name: Option<&'a str>,
     pub(crate) kind: Option<CatalogItemKind>,
     pub(crate) ignore_case: bool,
@@ -176,13 +195,14 @@ impl CatalogDiscovery {
     pub(crate) async fn list_catalog(
         &self,
         workspace_name: &WorkspaceName,
+        catalog_name: Option<&str>,
         schema_name: Option<&str>,
         kind: Option<CatalogItemKind>,
         pagination: Pagination,
         attribution: &QueryAttribution,
     ) -> Result<CatalogPage, QueryManagerError> {
         let catalog = self
-            .catalog_info(workspace_name, schema_name, attribution)
+            .catalog_info(workspace_name, catalog_name, schema_name, attribution)
             .await?;
         let counts = catalog_counts(&catalog);
         let items = catalog_items(catalog, kind);
@@ -195,12 +215,13 @@ impl CatalogDiscovery {
     async fn catalog_items(
         &self,
         workspace_name: &WorkspaceName,
+        catalog_name: Option<&str>,
         schema_name: Option<&str>,
         kind: Option<CatalogItemKind>,
         attribution: &QueryAttribution,
     ) -> Result<Vec<CatalogItem>, QueryManagerError> {
         let catalog = self
-            .catalog_info(workspace_name, schema_name, attribution)
+            .catalog_info(workspace_name, catalog_name, schema_name, attribution)
             .await?;
         Ok(catalog_items(catalog, kind))
     }
@@ -208,11 +229,12 @@ impl CatalogDiscovery {
     pub(crate) async fn catalog_info(
         &self,
         workspace_name: &WorkspaceName,
+        catalog_name: Option<&str>,
         schema_name: Option<&str>,
         attribution: &QueryAttribution,
     ) -> Result<CatalogInfo, QueryManagerError> {
         self.queries
-            .list_catalog(workspace_name, schema_name, attribution)
+            .list_catalog(workspace_name, catalog_name, schema_name, attribution)
             .await
     }
 
@@ -222,7 +244,7 @@ impl CatalogDiscovery {
         attribution: &QueryAttribution,
     ) -> Result<CatalogResolution, QueryManagerError> {
         self.queries
-            .resolve_catalog(workspace_name, None, attribution)
+            .resolve_catalog(workspace_name, None, None, attribution)
             .await
     }
 
@@ -236,6 +258,7 @@ impl CatalogDiscovery {
             .queries
             .describe_table(
                 workspace_name,
+                table_ref.catalog_name,
                 table_ref.schema_name,
                 table_ref.table_name,
                 attribution,
@@ -246,18 +269,8 @@ impl CatalogDiscovery {
         }
 
         let tables = table_lookup.missing_context_tables;
-        let available_schemas = tables
-            .iter()
-            .map(|table| table.schema_name.clone())
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .collect();
-        let same_schema_tables = tables
-            .iter()
-            .filter(|table| table.schema_name == table_ref.schema_name)
-            .take(MISSING_TABLE_SUGGESTION_LIMIT)
-            .cloned()
-            .collect::<Vec<_>>();
+        let available_schemas = available_table_schemas(&tables);
+        let same_schema_tables = same_schema_tables(&tables, table_ref);
         let suggestions = missing_table_suggestions(&tables, table_ref, &same_schema_tables);
         Ok(DescribeTableResult::Missing(MissingTableContext {
             suggestions,
@@ -304,7 +317,13 @@ impl CatalogDiscovery {
         let regex = compile_metadata_regex(query.pattern, query.ignore_case)
             .map_err(QueryManagerError::App)?;
         let matches = self
-            .catalog_items(workspace_name, query.schema_name, query.kind, attribution)
+            .catalog_items(
+                workspace_name,
+                query.catalog_name,
+                query.schema_name,
+                query.kind,
+                attribution,
+            )
             .await?
             .into_iter()
             .filter_map(|item| {
@@ -328,16 +347,14 @@ impl CatalogDiscovery {
             .queries
             .list_tables(
                 workspace_name,
+                query.table_ref.catalog_name,
                 Some(query.table_ref.schema_name),
                 Some(query.table_ref.table_name),
                 attribution,
             )
             .await?
             .into_iter()
-            .find(|table| {
-                table.schema_name == query.table_ref.schema_name
-                    && table.table_name == query.table_ref.table_name
-            });
+            .find(|table| table_matches_ref(table, query.table_ref));
         let Some(table) = table else {
             return Ok(None);
         };
@@ -369,10 +386,16 @@ impl CatalogDiscovery {
     }
 }
 
-fn catalog_item_sort_key(item: &CatalogItem) -> (&str, &str, &'static str) {
+fn catalog_item_sort_key(item: &CatalogItem) -> (&str, &str, &str, &'static str) {
     match item {
-        CatalogItem::Table(table) => (&table.schema_name, &table.table_name, "table"),
+        CatalogItem::Table(table) => (
+            &table.catalog_name,
+            &table.schema_name,
+            &table.table_name,
+            "table",
+        ),
         CatalogItem::TableFunction(function) => (
+            "",
             &function.schema_name,
             &function.function_name,
             "table_function",
@@ -439,21 +462,36 @@ fn catalog_item_matched_fields(item: &CatalogItem, regex: &Regex) -> Vec<Catalog
 }
 
 fn table_matched_fields(table: &TableInfo, regex: &Regex) -> Vec<CatalogMetadataField> {
-    let name = format!("{}.{}", table.schema_name, table.table_name);
-    let candidates = [
-        (CatalogMetadataField::SchemaName, table.schema_name.as_str()),
-        (CatalogMetadataField::TableName, table.table_name.as_str()),
-        (CatalogMetadataField::Name, name.as_str()),
-        (
-            CatalogMetadataField::Description,
-            table.description.as_str(),
-        ),
-        (CatalogMetadataField::Guide, table.guide.as_str()),
-    ];
-    let mut matches = candidates
-        .into_iter()
-        .filter_map(|(field, value)| regex.is_match(value).then_some(field))
-        .collect::<Vec<_>>();
+    let addressable_schema = table_addressable_schema_name(table);
+    let name = table_addressable_name(table);
+    let mut matches = Vec::new();
+    let catalog_matched = !table.catalog_name.is_empty() && regex.is_match(&table.catalog_name);
+    let schema_matched = regex.is_match(&table.schema_name);
+    if catalog_matched {
+        matches.push(CatalogMetadataField::CatalogName);
+    }
+    if schema_matched {
+        matches.push(CatalogMetadataField::SchemaName);
+    }
+    if !catalog_matched
+        && !schema_matched
+        && addressable_schema != table.schema_name
+        && regex.is_match(&addressable_schema)
+    {
+        matches.push(CatalogMetadataField::QualifiedSchema);
+    }
+    if regex.is_match(&table.table_name) {
+        matches.push(CatalogMetadataField::TableName);
+    }
+    if regex.is_match(&name) {
+        matches.push(CatalogMetadataField::Name);
+    }
+    if regex.is_match(&table.description) {
+        matches.push(CatalogMetadataField::Description);
+    }
+    if regex.is_match(&table.guide) {
+        matches.push(CatalogMetadataField::Guide);
+    }
     if table
         .required_filters
         .iter()
@@ -519,15 +557,32 @@ fn column_matched_fields(column: &ColumnInfo, regex: &Regex) -> Vec<ColumnMetada
         .collect()
 }
 
+fn available_table_schemas(tables: &[TableInfo]) -> Vec<String> {
+    tables
+        .iter()
+        .map(table_addressable_schema_name)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn same_schema_tables(tables: &[TableInfo], table_ref: CatalogTableRef<'_>) -> Vec<TableInfo> {
+    tables
+        .iter()
+        .filter(|table| table_qualifier_matches(table, table_ref))
+        .take(MISSING_TABLE_SUGGESTION_LIMIT)
+        .cloned()
+        .collect()
+}
+
 fn missing_table_suggestions(
     all_tables: &[TableInfo],
     table_ref: CatalogTableRef<'_>,
     same_schema_tables: &[TableInfo],
 ) -> Vec<TableInfo> {
-    let suggestion_schema = (!same_schema_tables.is_empty()).then_some(table_ref.schema_name);
     let mut suggestions = all_tables
         .iter()
-        .filter(|table| suggestion_schema.is_none_or(|schema| table.schema_name == schema))
+        .filter(|table| same_schema_tables.is_empty() || table_qualifier_matches(table, table_ref))
         .filter(|table| table_metadata_contains_literal(table, table_ref.table_name))
         .take(MISSING_TABLE_SUGGESTION_LIMIT)
         .cloned()
@@ -544,9 +599,12 @@ fn table_metadata_contains_literal(table: &TableInfo, literal: &str) -> bool {
         return false;
     }
     let literal = literal.to_lowercase();
-    let name = format!("{}.{}", table.schema_name, table.table_name);
+    let schema_name = table_addressable_schema_name(table);
+    let name = table_addressable_name(table);
     let candidates = [
+        table.catalog_name.as_str(),
         table.schema_name.as_str(),
+        schema_name.as_str(),
         table.table_name.as_str(),
         name.as_str(),
         table.description.as_str(),
@@ -559,6 +617,31 @@ fn table_metadata_contains_literal(table: &TableInfo, literal: &str) -> bool {
             .required_filters
             .iter()
             .any(|filter| filter.to_lowercase().contains(&literal))
+}
+
+fn table_addressable_schema_name(table: &TableInfo) -> String {
+    if table.catalog_name.is_empty() {
+        table.schema_name.clone()
+    } else {
+        format!("{}.{}", table.catalog_name, table.schema_name)
+    }
+}
+
+fn table_addressable_name(table: &TableInfo) -> String {
+    format!(
+        "{}.{}",
+        table_addressable_schema_name(table),
+        table.table_name
+    )
+}
+
+fn table_matches_ref(table: &TableInfo, table_ref: CatalogTableRef<'_>) -> bool {
+    table.table_name == table_ref.table_name && table_qualifier_matches(table, table_ref)
+}
+
+fn table_qualifier_matches(table: &TableInfo, table_ref: CatalogTableRef<'_>) -> bool {
+    table.catalog_name == table_ref.catalog_name.unwrap_or_default()
+        && table.schema_name == table_ref.schema_name
 }
 
 pub(crate) fn page_items<T>(items: Vec<T>, pagination: Pagination) -> Page<T> {
@@ -589,7 +672,11 @@ pub(crate) fn page_items<T>(items: Vec<T>, pagination: Pagination) -> Page<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CatalogMetadataField, compile_metadata_regex, table_matched_fields};
+    use super::{
+        CatalogMetadataField, CatalogTableRef, available_table_schemas, compile_metadata_regex,
+        missing_table_suggestions, same_schema_tables, table_matched_fields, table_matches_ref,
+        table_metadata_contains_literal,
+    };
     use coral_engine::TableInfo;
 
     fn table(required_filters: Vec<String>) -> TableInfo {
@@ -603,6 +690,14 @@ mod tests {
             columns: Vec::new(),
             required_filters,
         }
+    }
+
+    fn database_table(schema_name: &str, table_name: &str) -> TableInfo {
+        let mut table = table(Vec::new());
+        table.catalog_name = "coral_db".to_string();
+        table.schema_name = schema_name.to_string();
+        table.table_name = table_name.to_string();
+        table
     }
 
     #[test]
@@ -621,5 +716,80 @@ mod tests {
     #[test]
     fn empty_metadata_pattern_is_invalid() {
         compile_metadata_regex(" ", true).expect_err("empty pattern should fail");
+    }
+
+    #[test]
+    fn database_catalog_and_schema_match_catalog_discovery_metadata() {
+        let main = database_table("main", "users");
+        let analytics = database_table("analytics", "events");
+        let tables = vec![main, analytics];
+        let main_table = tables.first().expect("main table");
+
+        assert!(table_matches_ref(
+            main_table,
+            CatalogTableRef::new(Some("coral_db"), "main", "users")
+        ));
+        assert!(!table_matches_ref(
+            main_table,
+            CatalogTableRef::new(Some("coral_db"), "analytics", "users")
+        ));
+        assert_eq!(
+            table_matched_fields(
+                main_table,
+                &regex::Regex::new("^coral_db\\.main\\.users$").expect("regex")
+            ),
+            vec![CatalogMetadataField::Name]
+        );
+        assert_eq!(
+            table_matched_fields(main_table, &regex::Regex::new("^main$").expect("regex")),
+            vec![CatalogMetadataField::SchemaName]
+        );
+        assert_eq!(
+            table_matched_fields(
+                main_table,
+                &regex::Regex::new("^coral_db\\.main$").expect("regex")
+            ),
+            vec![CatalogMetadataField::QualifiedSchema]
+        );
+        assert_eq!(
+            table_matched_fields(main_table, &regex::Regex::new("db\\.ma").expect("regex")),
+            vec![
+                CatalogMetadataField::QualifiedSchema,
+                CatalogMetadataField::Name
+            ]
+        );
+        assert_eq!(
+            table_matched_fields(main_table, &regex::Regex::new("^coral_db$").expect("regex")),
+            vec![CatalogMetadataField::CatalogName]
+        );
+
+        assert_eq!(
+            available_table_schemas(&tables),
+            vec!["coral_db.analytics", "coral_db.main"]
+        );
+        let same_schema = same_schema_tables(
+            &tables,
+            CatalogTableRef::new(Some("coral_db"), "main", "missing"),
+        );
+        assert_eq!(same_schema.len(), 1);
+        let same_schema_table = same_schema.first().expect("same schema table");
+        assert_eq!(same_schema_table.catalog_name, "coral_db");
+        assert_eq!(same_schema_table.schema_name, "main");
+        assert_eq!(same_schema_table.table_name, "users");
+
+        let suggestions = missing_table_suggestions(
+            &tables,
+            CatalogTableRef::new(Some("coral_db"), "main", "user"),
+            &same_schema,
+        );
+        assert_eq!(suggestions.len(), 1);
+        let suggestion = suggestions.first().expect("suggestion");
+        assert_eq!(suggestion.catalog_name, "coral_db");
+        assert_eq!(suggestion.schema_name, "main");
+        assert_eq!(suggestion.table_name, "users");
+        assert!(table_metadata_contains_literal(
+            same_schema_table,
+            "coral_db.main.users"
+        ));
     }
 }

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -562,7 +562,7 @@ fn column_matched_fields(column: &ColumnInfo, regex: &Regex) -> Vec<ColumnMetada
 fn available_table_schemas(tables: &[TableInfo]) -> Vec<String> {
     tables
         .iter()
-        .map(table_addressable_schema_name)
+        .map(|table| table.schema_name.clone())
         .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
@@ -765,10 +765,7 @@ mod tests {
             vec![CatalogMetadataField::CatalogName]
         );
 
-        assert_eq!(
-            available_table_schemas(&tables),
-            vec!["coral_db.analytics", "coral_db.main"]
-        );
+        assert_eq!(available_table_schemas(&tables), vec!["analytics", "main"]);
         let same_schema = same_schema_tables(
             &tables,
             CatalogTableRef::new(Some("coral_db"), "main", "missing"),

--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -583,7 +583,7 @@ fn available_table_schemas(tables: &[TableInfo]) -> Vec<String> {
 fn same_schema_tables(tables: &[TableInfo], table_ref: CatalogTableRef<'_>) -> Vec<TableInfo> {
     tables
         .iter()
-        .filter(|table| table_qualifier_matches(table, table_ref))
+        .filter(|table| schema_qualifier_matches(table, table_ref))
         .take(MISSING_TABLE_SUGGESTION_LIMIT)
         .cloned()
         .collect()
@@ -596,7 +596,7 @@ fn missing_table_suggestions(
 ) -> Vec<TableInfo> {
     let mut suggestions = all_tables
         .iter()
-        .filter(|table| same_schema_tables.is_empty() || table_qualifier_matches(table, table_ref))
+        .filter(|table| same_schema_tables.is_empty() || schema_qualifier_matches(table, table_ref))
         .filter(|table| table_metadata_contains_literal(table, table_ref.table_name))
         .take(MISSING_TABLE_SUGGESTION_LIMIT)
         .cloned()
@@ -655,6 +655,17 @@ fn table_matches_ref(table: &TableInfo, table_ref: CatalogTableRef<'_>) -> bool 
 
 fn table_qualifier_matches(table: &TableInfo, table_ref: CatalogTableRef<'_>) -> bool {
     table.catalog_name.as_deref() == table_ref.catalog_name
+        && table.schema_name == table_ref.schema_name
+}
+
+/// Matches recovery hints rather than lookups: an absent catalog matches every
+/// catalog, so a two-part miss still surfaces its three-part neighbors. Lookups
+/// keep using [`table_qualifier_matches`], which stays an exact match so a bare
+/// reference never resolves into a catalog-backed table.
+fn schema_qualifier_matches(table: &TableInfo, table_ref: CatalogTableRef<'_>) -> bool {
+    table_ref
+        .catalog_name
+        .is_none_or(|catalog| table.catalog_name.as_deref() == Some(catalog))
         && table.schema_name == table_ref.schema_name
 }
 

--- a/crates/coral-app/src/catalog/service.rs
+++ b/crates/coral-app/src/catalog/service.rs
@@ -56,10 +56,18 @@ impl CatalogServiceApi for CatalogService {
             let pagination = pagination_from_proto(request.pagination.unwrap_or_default());
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
+            let catalog_name = optional_trimmed(&request.catalog_name);
             let schema_name = optional_trimmed(&request.schema_name);
             let kind = catalog_item_kind_from_proto(request.kind)?;
             let catalog_page = catalog
-                .list_catalog(&workspace_name, schema_name, kind, pagination, &attribution)
+                .list_catalog(
+                    &workspace_name,
+                    catalog_name,
+                    schema_name,
+                    kind,
+                    pagination,
+                    &attribution,
+                )
                 .await
                 .map_err(query_status)?;
             let page = catalog_page.items;
@@ -98,6 +106,7 @@ impl CatalogServiceApi for CatalogService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
+            let catalog_name = optional_trimmed(&request.catalog_name);
             let schema_name = optional_trimmed(&request.schema_name);
             let kind = catalog_item_kind_from_proto(request.kind)?;
             let pagination = search_pagination(request.pagination.map(pagination_from_proto))
@@ -107,6 +116,7 @@ impl CatalogServiceApi for CatalogService {
                     &workspace_name,
                     SearchCatalogQuery {
                         pattern: &request.pattern,
+                        catalog_name,
                         schema_name,
                         kind,
                         ignore_case: request.ignore_case,
@@ -147,12 +157,13 @@ impl CatalogServiceApi for CatalogService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
+            let catalog_name = optional_trimmed(&request.catalog_name);
             let schema_name = required_trimmed(&request.schema_name, "schema_name")?;
             let table_name = required_trimmed(&request.table_name, "table_name")?;
             let result = catalog
                 .describe_table(
                     &workspace_name,
-                    CatalogTableRef::new(&schema_name, &table_name),
+                    CatalogTableRef::new(catalog_name, &schema_name, &table_name),
                     &attribution,
                 )
                 .await
@@ -177,6 +188,7 @@ impl CatalogServiceApi for CatalogService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let attribution = query_attribution(&tasks, &workspace_name, &request_context).await?;
+            let catalog_name = optional_trimmed(&request.catalog_name);
             let schema_name = required_trimmed(&request.schema_name, "schema_name")?;
             let table_name = required_trimmed(&request.table_name, "table_name")?;
             let pagination = column_pagination(request.pagination.map(pagination_from_proto))
@@ -185,7 +197,7 @@ impl CatalogServiceApi for CatalogService {
                 .list_columns(
                     &workspace_name,
                     ListColumnsQuery {
-                        table_ref: CatalogTableRef::new(&schema_name, &table_name),
+                        table_ref: CatalogTableRef::new(catalog_name, &schema_name, &table_name),
                         pattern: request.pattern.as_deref(),
                         ignore_case: request.ignore_case,
                         required_only: request.required_only,
@@ -196,7 +208,11 @@ impl CatalogServiceApi for CatalogService {
                 .await
                 .map_err(query_status)?
                 .ok_or_else(|| {
-                    Status::not_found(format!("table '{schema_name}.{table_name}' not found"))
+                    let qualifier = catalog_name.map_or_else(
+                        || schema_name.clone(),
+                        |catalog| format!("{catalog}.{schema_name}"),
+                    );
+                    Status::not_found(format!("table '{qualifier}.{table_name}' not found"))
                 })?;
             let pagination = pagination_to_proto(
                 page.total,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -265,11 +265,12 @@ impl QueryManager {
     pub(crate) async fn list_tables(
         &self,
         workspace_name: &WorkspaceName,
+        catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
         attribution: &QueryAttribution,
     ) -> Result<Vec<TableInfo>, QueryManagerError> {
-        let trace_sql = list_tables_trace_sql(schema_filter, table_filter);
+        let trace_sql = list_tables_trace_sql(catalog_filter, schema_filter, table_filter);
         run_query_operation(
             QueryOperation::ListTables,
             workspace_name,
@@ -289,7 +290,7 @@ impl QueryManager {
                         SourceObservationMode::Disabled,
                     )
                     .await?;
-                Ok(runtime.list_tables(None, schema_filter, table_filter))
+                Ok(runtime.list_tables(catalog_filter, schema_filter, table_filter))
             },
             |tables| Some(u64::try_from(tables.len()).unwrap_or(u64::MAX)),
             |_, _| {},
@@ -300,11 +301,12 @@ impl QueryManager {
     pub(crate) async fn list_catalog(
         &self,
         workspace_name: &WorkspaceName,
+        catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
         attribution: &QueryAttribution,
     ) -> Result<CatalogInfo, QueryManagerError> {
         Ok(self
-            .resolve_catalog(workspace_name, schema_filter, attribution)
+            .resolve_catalog(workspace_name, catalog_filter, schema_filter, attribution)
             .await?
             .catalog)
     }
@@ -312,10 +314,11 @@ impl QueryManager {
     pub(crate) async fn resolve_catalog(
         &self,
         workspace_name: &WorkspaceName,
+        catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
         attribution: &QueryAttribution,
     ) -> Result<CatalogResolution, QueryManagerError> {
-        let trace_sql = list_catalog_trace_sql(schema_filter);
+        let trace_sql = list_catalog_trace_sql(catalog_filter, schema_filter);
         run_query_operation(
             QueryOperation::ListCatalog,
             workspace_name,
@@ -340,7 +343,7 @@ impl QueryManager {
                 let runtime_schema_owners =
                     runtime_schema_owners(&source_load.loaded).map_err(QueryManagerError::App)?;
                 Ok(CatalogResolution {
-                    catalog: runtime.list_catalog(None, schema_filter),
+                    catalog: runtime.list_catalog(catalog_filter, schema_filter),
                     failed_source_names,
                     runtime_schema_owners,
                 })
@@ -365,11 +368,12 @@ impl QueryManager {
     pub(crate) async fn describe_table(
         &self,
         workspace_name: &WorkspaceName,
+        catalog_name: Option<&str>,
         schema_name: &str,
         table_name: &str,
         attribution: &QueryAttribution,
     ) -> Result<DescribeTableInfo, QueryManagerError> {
-        let trace_sql = describe_table_trace_sql(schema_name, table_name);
+        let trace_sql = describe_table_trace_sql(catalog_name, schema_name, table_name);
         run_query_operation(
             QueryOperation::DescribeTable,
             workspace_name,
@@ -389,7 +393,7 @@ impl QueryManager {
                         SourceObservationMode::Disabled,
                     )
                     .await?;
-                Ok(runtime.describe_table(None, schema_name, table_name))
+                Ok(runtime.describe_table(catalog_name, schema_name, table_name))
             },
             |_| None,
             |_, _| {},
@@ -1062,24 +1066,43 @@ impl QueryOperation {
     }
 }
 
-fn list_tables_trace_sql(schema_filter: Option<&str>, table_filter: Option<&str>) -> String {
-    match (schema_filter, table_filter) {
-        (Some(schema), Some(table)) => format!("LIST TABLES {schema}.{table}"),
-        (Some(schema), None) => format!("LIST TABLES {schema}.*"),
-        (None, Some(table)) => format!("LIST TABLES *.{table}"),
-        (None, None) => "LIST TABLES *.*".to_string(),
+fn list_tables_trace_sql(
+    catalog_filter: Option<&str>,
+    schema_filter: Option<&str>,
+    table_filter: Option<&str>,
+) -> String {
+    match (catalog_filter, schema_filter, table_filter) {
+        (Some(catalog), Some(schema), Some(table)) => {
+            format!("LIST TABLES {catalog}.{schema}.{table}")
+        }
+        (Some(catalog), Some(schema), None) => format!("LIST TABLES {catalog}.{schema}.*"),
+        (None, Some(schema), Some(table)) => format!("LIST TABLES {schema}.{table}"),
+        (None, Some(schema), None) => format!("LIST TABLES {schema}.*"),
+        (Some(catalog), None, Some(table)) => format!("LIST TABLES {catalog}.*.{table}"),
+        (Some(catalog), None, None) => format!("LIST TABLES {catalog}.*.*"),
+        (None, None, Some(table)) => format!("LIST TABLES *.{table}"),
+        (None, None, None) => "LIST TABLES *.*".to_string(),
     }
 }
 
-fn list_catalog_trace_sql(schema_filter: Option<&str>) -> String {
-    match schema_filter {
-        Some(schema) => format!("LIST CATALOG {schema}"),
-        None => "LIST CATALOG".to_string(),
+fn list_catalog_trace_sql(catalog_filter: Option<&str>, schema_filter: Option<&str>) -> String {
+    match (catalog_filter, schema_filter) {
+        (Some(catalog), Some(schema)) => format!("LIST CATALOG {catalog}.{schema}"),
+        (Some(catalog), None) => format!("LIST CATALOG {catalog}.*"),
+        (None, Some(schema)) => format!("LIST CATALOG {schema}"),
+        (None, None) => "LIST CATALOG".to_string(),
     }
 }
 
-fn describe_table_trace_sql(schema_name: &str, table_name: &str) -> String {
-    format!("DESCRIBE TABLE {schema_name}.{table_name}")
+fn describe_table_trace_sql(
+    catalog_name: Option<&str>,
+    schema_name: &str,
+    table_name: &str,
+) -> String {
+    catalog_name.map_or_else(
+        || format!("DESCRIBE TABLE {schema_name}.{table_name}"),
+        |catalog| format!("DESCRIBE TABLE {catalog}.{schema_name}.{table_name}"),
+    )
 }
 
 async fn run_query_operation<T, Fut, RowCount>(
@@ -1673,6 +1696,7 @@ mod tests {
                 request_context,
                 ListCatalogRequest {
                     workspace: Some(default_workspace_proto()),
+                    catalog_name: String::new(),
                     schema_name: String::new(),
                     kind: 0,
                     pagination: Some(PaginationRequest {
@@ -1687,6 +1711,7 @@ mod tests {
                 request_context,
                 SearchCatalogRequest {
                     workspace: Some(default_workspace_proto()),
+                    catalog_name: String::new(),
                     pattern: "tables".to_string(),
                     ignore_case: true,
                     schema_name: String::new(),
@@ -1703,6 +1728,7 @@ mod tests {
                 request_context,
                 DescribeTableRequest {
                     workspace: Some(default_workspace_proto()),
+                    catalog_name: String::new(),
                     schema_name: "coral".to_string(),
                     table_name: "tables".to_string(),
                 },
@@ -1713,6 +1739,7 @@ mod tests {
                 request_context,
                 ListColumnsRequest {
                     workspace: Some(default_workspace_proto()),
+                    catalog_name: String::new(),
                     schema_name: "coral".to_string(),
                     table_name: "tables".to_string(),
                     pattern: None,
@@ -2679,6 +2706,7 @@ where type = $kind
             .manager
             .list_catalog(
                 &workspace_name,
+                None,
                 Some("functions"),
                 &QueryAttribution::default(),
             )
@@ -2920,7 +2948,7 @@ tables:
 
         let resolution = fixture
             .manager
-            .resolve_catalog(&workspace_name, None, &QueryAttribution::default())
+            .resolve_catalog(&workspace_name, None, None, &QueryAttribution::default())
             .await
             .expect("healthy catalog should survive one source load failure");
 
@@ -2951,7 +2979,7 @@ tables:
 
         let resolution = fixture
             .manager
-            .resolve_catalog(&workspace_name, None, &QueryAttribution::default())
+            .resolve_catalog(&workspace_name, None, None, &QueryAttribution::default())
             .await
             .expect("healthy catalog should survive one registration failure");
 

--- a/crates/coral-app/src/search/catalog/snapshot.rs
+++ b/crates/coral-app/src/search/catalog/snapshot.rs
@@ -194,7 +194,7 @@ fn normalized_runtime_schema_owners(
 
 fn table_documents(table: &TableInfo, documents: &mut Vec<CatalogDocument>) {
     debug_assert!(
-        table.catalog_name.is_empty(),
+        table.catalog_name.is_none(),
         "catalog search documents do not yet support catalog-qualified tables"
     );
     let qualified_name = qualified_name(&table.schema_name, &table.table_name);

--- a/crates/coral-app/src/search/catalog/snapshot.rs
+++ b/crates/coral-app/src/search/catalog/snapshot.rs
@@ -193,6 +193,10 @@ fn normalized_runtime_schema_owners(
 }
 
 fn table_documents(table: &TableInfo, documents: &mut Vec<CatalogDocument>) {
+    debug_assert!(
+        table.catalog_name.is_empty(),
+        "catalog search documents do not yet support catalog-qualified tables"
+    );
     let qualified_name = qualified_name(&table.schema_name, &table.table_name);
     documents.push(CatalogDocument {
         doc_id: format!("catalog:table:{qualified_name}"),

--- a/crates/coral-app/src/search/catalog/snapshot.rs
+++ b/crates/coral-app/src/search/catalog/snapshot.rs
@@ -193,11 +193,11 @@ fn normalized_runtime_schema_owners(
 }
 
 fn table_documents(table: &TableInfo, documents: &mut Vec<CatalogDocument>) {
-    debug_assert!(
-        table.catalog_name.is_none(),
-        "catalog search documents do not yet support catalog-qualified tables"
+    let qualified_name = qualified_name(
+        table.catalog_name.as_deref(),
+        &table.schema_name,
+        &table.table_name,
     );
-    let qualified_name = qualified_name(&table.schema_name, &table.table_name);
     documents.push(CatalogDocument {
         doc_id: format!("catalog:table:{qualified_name}"),
         doc_kind: CatalogDocumentKind::CatalogTable,
@@ -233,7 +233,11 @@ fn table_column_document(
     column: &ColumnInfo,
     documents: &mut Vec<CatalogDocument>,
 ) {
-    let surface_qualified_name = qualified_name(&table.schema_name, &table.table_name);
+    let surface_qualified_name = qualified_name(
+        table.catalog_name.as_deref(),
+        &table.schema_name,
+        &table.table_name,
+    );
     documents.push(CatalogDocument {
         doc_id: format!("column:table:{surface_qualified_name}:{}", column.name),
         doc_kind: CatalogDocumentKind::ColumnHint,
@@ -261,7 +265,11 @@ fn table_required_filter_document(
     filter: &str,
     documents: &mut Vec<CatalogDocument>,
 ) {
-    let surface_qualified_name = qualified_name(&table.schema_name, &table.table_name);
+    let surface_qualified_name = qualified_name(
+        table.catalog_name.as_deref(),
+        &table.schema_name,
+        &table.table_name,
+    );
     documents.push(CatalogDocument {
         doc_id: format!("filter:table:{surface_qualified_name}:{filter}"),
         doc_kind: CatalogDocumentKind::ColumnHint,
@@ -284,7 +292,7 @@ fn table_required_filter_document(
 }
 
 fn table_function_documents(function: &TableFunctionInfo, documents: &mut Vec<CatalogDocument>) {
-    let qualified_name = qualified_name(&function.schema_name, &function.function_name);
+    let qualified_name = qualified_name(None, &function.schema_name, &function.function_name);
     let source_native_search_keywords = if function.kind == SourceTableFunctionKind::Search {
         "source native search provider route fanout"
     } else {
@@ -340,7 +348,8 @@ fn table_function_argument_document(
     argument: &TableFunctionArgumentInfo,
     documents: &mut Vec<CatalogDocument>,
 ) {
-    let surface_qualified_name = qualified_name(&function.schema_name, &function.function_name);
+    let surface_qualified_name =
+        qualified_name(None, &function.schema_name, &function.function_name);
     let values = argument.values.join(" ");
     documents.push(CatalogDocument {
         doc_id: format!(
@@ -372,7 +381,8 @@ fn table_function_result_column_document(
     column: &TableFunctionResultColumnInfo,
     documents: &mut Vec<CatalogDocument>,
 ) {
-    let surface_qualified_name = qualified_name(&function.schema_name, &function.function_name);
+    let surface_qualified_name =
+        qualified_name(None, &function.schema_name, &function.function_name);
     documents.push(CatalogDocument {
         doc_id: format!(
             "result_column:function:{surface_qualified_name}:{}",
@@ -399,8 +409,14 @@ fn table_function_result_column_document(
     });
 }
 
-fn qualified_name(schema_name: &str, surface_name: &str) -> String {
-    format!("{schema_name}.{surface_name}")
+/// Renders the addressable name a document is keyed and searched by. Two-part
+/// surfaces keep `schema.surface`; catalog-backed tables carry the catalog so
+/// two catalogs exposing the same `schema.table` stay distinct documents.
+fn qualified_name(catalog_name: Option<&str>, schema_name: &str, surface_name: &str) -> String {
+    match catalog_name {
+        Some(catalog_name) => format!("{catalog_name}.{schema_name}.{surface_name}"),
+        None => format!("{schema_name}.{surface_name}"),
+    }
 }
 
 fn join_search_text<const N: usize>(parts: [&str; N]) -> String {

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -378,7 +378,7 @@ pub(crate) fn table_to_proto(
 
     Table {
         workspace: Some(workspace_to_proto(workspace_name)),
-        catalog_name: table.catalog_name,
+        catalog_name: table.catalog_name.unwrap_or_default(),
         schema_name: table.schema_name,
         name: table.table_name,
         description: table.description,
@@ -394,7 +394,7 @@ pub(crate) fn table_summary_to_proto(
 ) -> TableSummary {
     TableSummary {
         workspace: Some(workspace_to_proto(workspace_name)),
-        catalog_name: table.catalog_name,
+        catalog_name: table.catalog_name.unwrap_or_default(),
         schema_name: table.schema_name,
         name: table.table_name,
         description: table.description,

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -378,6 +378,7 @@ pub(crate) fn table_to_proto(
 
     Table {
         workspace: Some(workspace_to_proto(workspace_name)),
+        catalog_name: table.catalog_name,
         schema_name: table.schema_name,
         name: table.table_name,
         description: table.description,
@@ -393,6 +394,7 @@ pub(crate) fn table_summary_to_proto(
 ) -> TableSummary {
     TableSummary {
         workspace: Some(workspace_to_proto(workspace_name)),
+        catalog_name: table.catalog_name,
         schema_name: table.schema_name,
         name: table.table_name,
         description: table.description,

--- a/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
+++ b/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
@@ -30,6 +30,7 @@ async fn search_catalog_matches_metadata_and_paginates_after_filtering() {
         .catalog_client()
         .search_catalog(Request::new(SearchCatalogRequest {
             workspace: Some(default_workspace()),
+            catalog_name: String::new(),
             pattern: "Issue".to_string(),
             ignore_case: true,
             schema_name: "searchy".to_string(),
@@ -90,6 +91,7 @@ async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagina
         .catalog_client()
         .list_catalog(Request::new(ListCatalogRequest {
             workspace: Some(default_workspace()),
+            catalog_name: String::new(),
             schema_name: "searchy".to_string(),
             kind: 0,
             pagination: Some(PaginationRequest {
@@ -130,6 +132,7 @@ async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagina
         .catalog_client()
         .list_catalog(Request::new(ListCatalogRequest {
             workspace: Some(default_workspace()),
+            catalog_name: String::new(),
             schema_name: "searchy".to_string(),
             kind: 2,
             pagination: Some(PaginationRequest {
@@ -208,6 +211,7 @@ async fn list_columns_filters_required_columns_and_patterns() {
         .catalog_client()
         .list_columns(Request::new(ListColumnsRequest {
             workspace: Some(default_workspace()),
+            catalog_name: String::new(),
             schema_name: "filtered_messages".to_string(),
             table_name: "messages".to_string(),
             pattern: None,
@@ -228,6 +232,7 @@ async fn list_columns_filters_required_columns_and_patterns() {
         .catalog_client()
         .list_columns(Request::new(ListColumnsRequest {
             workspace: Some(default_workspace()),
+            catalog_name: String::new(),
             schema_name: "filtered_messages".to_string(),
             table_name: "messages".to_string(),
             pattern: Some("TEXT".to_string()),
@@ -276,6 +281,7 @@ async fn describe_missing_table_returns_catalog_suggestions() {
         .catalog_client()
         .describe_table(Request::new(DescribeTableRequest {
             workspace: Some(default_workspace()),
+            catalog_name: String::new(),
             schema_name: "local_messages".to_string(),
             table_name: "messeges".to_string(),
         }))
@@ -305,6 +311,7 @@ async fn describe_missing_table_name_does_not_apply_regex_limits() {
         .catalog_client()
         .describe_table(Request::new(DescribeTableRequest {
             workspace: Some(default_workspace()),
+            catalog_name: String::new(),
             schema_name: "local_messages".to_string(),
             table_name: "missing_table_".repeat(40),
         }))
@@ -332,6 +339,7 @@ async fn list_columns_missing_table_takes_precedence_over_invalid_pattern() {
         .catalog_client()
         .list_columns(Request::new(ListColumnsRequest {
             workspace: Some(default_workspace()),
+            catalog_name: String::new(),
             schema_name: "local_messages".to_string(),
             table_name: "missing".to_string(),
             pattern: Some("[".to_string()),
@@ -353,6 +361,7 @@ async fn invalid_regex_returns_invalid_argument() {
         .catalog_client()
         .search_catalog(Request::new(SearchCatalogRequest {
             workspace: Some(default_workspace()),
+            catalog_name: String::new(),
             pattern: "[".to_string(),
             ignore_case: true,
             schema_name: String::new(),
@@ -375,6 +384,7 @@ async fn invalid_regex_returns_invalid_argument() {
         .catalog_client()
         .list_columns(Request::new(ListColumnsRequest {
             workspace: Some(default_workspace()),
+            catalog_name: String::new(),
             schema_name: "filtered_messages".to_string(),
             table_name: "messages".to_string(),
             pattern: Some("[".to_string()),

--- a/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
+++ b/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
@@ -179,6 +179,7 @@ async fn search_catalog_matches_table_function_guide() {
             workspace: Some(default_workspace()),
             pattern: "exact issue lookup".to_string(),
             ignore_case: true,
+            catalog_name: String::new(),
             schema_name: "searchy".to_string(),
             kind: 2,
             pagination: None,

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -185,6 +185,7 @@ impl GrpcHarness {
         self.catalog_client()
             .list_catalog(Request::new(ListCatalogRequest {
                 workspace: Some(default_workspace()),
+                catalog_name: String::new(),
                 schema_name: String::new(),
                 kind: 1,
                 pagination: Some(PaginationRequest {

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -145,6 +145,7 @@ async fn list_catalog_item(
         .catalog_client()
         .list_catalog(Request::new(ListCatalogRequest {
             workspace: Some(workspace.clone()),
+            catalog_name: String::new(),
             schema_name: schema_name.to_string(),
             kind: kind as i32,
             pagination: Some(PaginationRequest {

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -288,6 +288,7 @@ async fn list_catalog_supports_table_kind_and_pagination() {
         .catalog_client()
         .list_catalog(Request::new(ListCatalogRequest {
             workspace: Some(default_workspace()),
+            catalog_name: String::new(),
             schema_name: "local_messages".to_string(),
             kind: 1,
             pagination: Some(PaginationRequest {
@@ -322,6 +323,7 @@ async fn list_catalog_supports_table_kind_and_pagination() {
         .catalog_client()
         .list_catalog(Request::new(ListCatalogRequest {
             workspace: Some(default_workspace()),
+            catalog_name: String::new(),
             schema_name: "missing".to_string(),
             kind: 1,
             pagination: Some(PaginationRequest {
@@ -1458,6 +1460,7 @@ async fn rejects_invalid_workspace_and_source_names() {
             workspace: Some(Workspace {
                 name: r"bad\workspace".to_string(),
             }),
+            catalog_name: String::new(),
             schema_name: String::new(),
             kind: 1,
             pagination: None,

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -95,6 +95,7 @@ fn mock_table(schema_name: &str, name: &str) -> Table {
     Table {
         workspace: Some(workspace()),
         schema_name: schema_name.to_string(),
+        catalog_name: String::new(),
         name: name.to_string(),
         description: String::new(),
         guide: String::new(),
@@ -107,6 +108,7 @@ fn mock_visible_table() -> Table {
     Table {
         workspace: Some(workspace()),
         schema_name: "local_messages".to_string(),
+        catalog_name: String::new(),
         name: "messages".to_string(),
         description: "Fixture messages".to_string(),
         guide: "Query fixture messages.".to_string(),
@@ -160,6 +162,7 @@ fn table_summary(table: &Table) -> TableSummary {
     TableSummary {
         workspace: table.workspace.clone(),
         schema_name: table.schema_name.clone(),
+        catalog_name: table.catalog_name.clone(),
         name: table.name.clone(),
         description: table.description.clone(),
         required_filters: table.required_filters.clone(),

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -48,8 +48,8 @@ pub use error::{ClientError, QueryResultError};
 pub use propagation::{BearerToken, with_task_metadata};
 pub use search::{
     SearchResponseValue, format_schema_table_equivalent, format_search_response_json,
-    format_search_response_text, format_sql_identifier, minimal_table_function_call_example,
-    search_response_json_value,
+    format_search_response_text, format_sql_identifier, format_table_name,
+    minimal_table_function_call_example, search_response_json_value,
 };
 pub use sources::{SourceInputDecodeError, manifest_input_from_proto};
 pub use status_error::{

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -49,7 +49,7 @@ pub use propagation::{BearerToken, with_task_metadata};
 pub use search::{
     SearchResponseValue, format_schema_table_equivalent, format_search_response_json,
     format_search_response_text, format_sql_identifier, format_table_name,
-    minimal_table_function_call_example, search_response_json_value,
+    minimal_table_function_call_example, optional_catalog_name, search_response_json_value,
 };
 pub use sources::{SourceInputDecodeError, manifest_input_from_proto};
 pub use status_error::{

--- a/crates/coral-client/src/search.rs
+++ b/crates/coral-client/src/search.rs
@@ -155,7 +155,11 @@ impl<'a> From<&'a TableSummary> for TableSummaryValue<'a> {
             kind: "table",
             catalog_name: &table.catalog_name,
             schema_name: &table.schema_name,
-            name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
+            name: format_table_name(
+                optional_catalog_name(&table.catalog_name),
+                &table.schema_name,
+                &table.name,
+            ),
             sql_reference: format_schema_table_equivalent(
                 optional_catalog_name(&table.catalog_name),
                 &table.schema_name,
@@ -582,7 +586,11 @@ fn catalog_metadata_text_lines(
         Some(catalog_item::Item::Table(table)) => vec![
             format!(
                 "{index}. [{provider}] table {}",
-                format_table_name(&table.catalog_name, &table.schema_name, &table.name)
+                format_table_name(
+                    optional_catalog_name(&table.catalog_name),
+                    &table.schema_name,
+                    &table.name,
+                )
             ),
             format!(
                 "   SQL: {}",
@@ -737,11 +745,14 @@ pub fn minimal_table_function_call_example(function: &TableFunction) -> String {
 
 /// Formats a display table name with its query-visible schema and optional catalog.
 #[must_use]
-pub fn format_table_name(catalog_name: &str, schema_name: &str, table_name: &str) -> String {
-    if catalog_name.is_empty() {
-        format!("{schema_name}.{table_name}")
-    } else {
-        format!("{catalog_name}.{schema_name}.{table_name}")
+pub fn format_table_name(
+    catalog_name: Option<&str>,
+    schema_name: &str,
+    table_name: &str,
+) -> String {
+    match catalog_name {
+        Some(catalog_name) => format!("{catalog_name}.{schema_name}.{table_name}"),
+        None => format!("{schema_name}.{table_name}"),
     }
 }
 

--- a/crates/coral-client/src/search.rs
+++ b/crates/coral-client/src/search.rs
@@ -157,7 +157,7 @@ impl<'a> From<&'a TableSummary> for TableSummaryValue<'a> {
             schema_name: &table.schema_name,
             name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
             sql_reference: format_schema_table_equivalent(
-                &table.catalog_name,
+                optional_catalog_name(&table.catalog_name),
                 &table.schema_name,
                 &table.name,
             ),
@@ -204,7 +204,7 @@ impl<'a> From<&'a TableFunction> for TableFunctionValue<'a> {
             schema_name: &function.schema_name,
             name: format!("{}.{}", function.schema_name, function.name),
             sql_reference: format_schema_table_equivalent(
-                "",
+                None,
                 &function.schema_name,
                 &function.name,
             ),
@@ -369,7 +369,7 @@ impl<'a> From<&'a ColumnHint> for ColumnHintValue<'a> {
             surface_name: &hint.surface_name,
             surface_kind: surface_kind_name(hint.surface_kind),
             surface_sql_reference: format_schema_table_equivalent(
-                "",
+                None,
                 &hint.schema_name,
                 &hint.surface_name,
             ),
@@ -405,7 +405,7 @@ impl<'a> From<&'a ObservedValue> for ObservedValueValue<'a> {
             surface_name: &observed.surface_name,
             surface_kind: surface_kind_name(observed.surface_kind),
             surface_sql_reference: format_schema_table_equivalent(
-                "",
+                None,
                 &observed.schema_name,
                 &observed.surface_name,
             ),
@@ -587,7 +587,7 @@ fn catalog_metadata_text_lines(
             format!(
                 "   SQL: {}",
                 format_schema_table_equivalent(
-                    &table.catalog_name,
+                    optional_catalog_name(&table.catalog_name),
                     &table.schema_name,
                     &table.name
                 )
@@ -601,7 +601,7 @@ fn catalog_metadata_text_lines(
                 ),
                 format!(
                     "   SQL reference: {}",
-                    format_schema_table_equivalent("", &function.schema_name, &function.name)
+                    format_schema_table_equivalent(None, &function.schema_name, &function.name)
                 ),
                 format!("   Call: {}", minimal_table_function_call_example(function)),
             ];
@@ -635,7 +635,7 @@ fn column_hint_text_lines(index: usize, provider: &str, hint: &ColumnHint) -> Ve
         format!(
             "   Surface: {} {}",
             surface_kind_name(hint.surface_kind),
-            format_schema_table_equivalent("", &hint.schema_name, &hint.surface_name)
+            format_schema_table_equivalent(None, &hint.schema_name, &hint.surface_name)
         ),
     ];
     if !hint.data_type.is_empty() {
@@ -724,7 +724,7 @@ fn preview_text(preview: &SearchTableColumnPreview) -> Option<String> {
 /// Formats the shortest SQL call example for a table function.
 #[must_use]
 pub fn minimal_table_function_call_example(function: &TableFunction) -> String {
-    let reference = format_schema_table_equivalent("", &function.schema_name, &function.name);
+    let reference = format_schema_table_equivalent(None, &function.schema_name, &function.name);
     let required_arguments = function
         .arguments
         .iter()
@@ -746,28 +746,34 @@ pub fn format_table_name(catalog_name: &str, schema_name: &str, table_name: &str
 }
 
 /// Formats a SQL table or table-function reference, qualified by schema and, when
-/// `catalog_name` is non-empty, by catalog. Pass `""` for a two-part reference —
+/// `catalog_name` is `Some`, by catalog. Pass `None` for a two-part reference —
 /// table functions and the surfaces whose protos carry no catalog field.
 #[must_use]
 pub fn format_schema_table_equivalent(
-    catalog_name: &str,
+    catalog_name: Option<&str>,
     schema_name: &str,
     table_name: &str,
 ) -> String {
-    if catalog_name.is_empty() {
-        format!(
-            "{}.{}",
-            format_sql_identifier(schema_name),
-            format_sql_identifier(table_name)
-        )
-    } else {
-        format!(
+    match catalog_name {
+        Some(catalog_name) => format!(
             "{}.{}.{}",
             format_sql_identifier(catalog_name),
             format_sql_identifier(schema_name),
             format_sql_identifier(table_name)
-        )
+        ),
+        None => format!(
+            "{}.{}",
+            format_sql_identifier(schema_name),
+            format_sql_identifier(table_name)
+        ),
     }
+}
+
+/// Reads a catalog qualifier off a proto message, where an empty field means the
+/// surface is two-part and carries no catalog.
+#[must_use]
+pub fn optional_catalog_name(catalog_name: &str) -> Option<&str> {
+    (!catalog_name.is_empty()).then_some(catalog_name)
 }
 
 /// Formats one SQL identifier, quoting it only when required.

--- a/crates/coral-client/src/search.rs
+++ b/crates/coral-client/src/search.rs
@@ -735,7 +735,9 @@ pub fn minimal_table_function_call_example(function: &TableFunction) -> String {
     format!("{reference}({required_arguments})")
 }
 
-fn format_table_name(catalog_name: &str, schema_name: &str, table_name: &str) -> String {
+/// Formats a display table name with its query-visible schema and optional catalog.
+#[must_use]
+pub fn format_table_name(catalog_name: &str, schema_name: &str, table_name: &str) -> String {
     if catalog_name.is_empty() {
         format!("{schema_name}.{table_name}")
     } else {

--- a/crates/coral-client/src/search.rs
+++ b/crates/coral-client/src/search.rs
@@ -141,6 +141,7 @@ impl<'a> CatalogItemValue<'a> {
 #[schemars(deny_unknown_fields)]
 struct TableSummaryValue<'a> {
     kind: &'static str,
+    catalog_name: &'a str,
     schema_name: &'a str,
     name: String,
     sql_reference: String,
@@ -152,9 +153,14 @@ impl<'a> From<&'a TableSummary> for TableSummaryValue<'a> {
     fn from(table: &'a TableSummary) -> Self {
         Self {
             kind: "table",
+            catalog_name: &table.catalog_name,
             schema_name: &table.schema_name,
-            name: format!("{}.{}", table.schema_name, table.name),
-            sql_reference: format_schema_table_equivalent(&table.schema_name, &table.name),
+            name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
+            sql_reference: format_schema_table_equivalent(
+                &table.catalog_name,
+                &table.schema_name,
+                &table.name,
+            ),
             description: &table.description,
             table: TableSummaryDetailsValue::from(table),
         }
@@ -197,7 +203,11 @@ impl<'a> From<&'a TableFunction> for TableFunctionValue<'a> {
             kind: "table_function",
             schema_name: &function.schema_name,
             name: format!("{}.{}", function.schema_name, function.name),
-            sql_reference: format_schema_table_equivalent(&function.schema_name, &function.name),
+            sql_reference: format_schema_table_equivalent(
+                "",
+                &function.schema_name,
+                &function.name,
+            ),
             sql_call_example: minimal_table_function_call_example(function),
             description: &function.description,
             table_function: TableFunctionDetailsValue::from(function),
@@ -359,6 +369,7 @@ impl<'a> From<&'a ColumnHint> for ColumnHintValue<'a> {
             surface_name: &hint.surface_name,
             surface_kind: surface_kind_name(hint.surface_kind),
             surface_sql_reference: format_schema_table_equivalent(
+                "",
                 &hint.schema_name,
                 &hint.surface_name,
             ),
@@ -394,6 +405,7 @@ impl<'a> From<&'a ObservedValue> for ObservedValueValue<'a> {
             surface_name: &observed.surface_name,
             surface_kind: surface_kind_name(observed.surface_kind),
             surface_sql_reference: format_schema_table_equivalent(
+                "",
                 &observed.schema_name,
                 &observed.surface_name,
             ),
@@ -569,12 +581,16 @@ fn catalog_metadata_text_lines(
     let mut lines = match metadata.item.as_ref().and_then(|item| item.item.as_ref()) {
         Some(catalog_item::Item::Table(table)) => vec![
             format!(
-                "{index}. [{provider}] table {}.{}",
-                table.schema_name, table.name
+                "{index}. [{provider}] table {}",
+                format_table_name(&table.catalog_name, &table.schema_name, &table.name)
             ),
             format!(
                 "   SQL: {}",
-                format_schema_table_equivalent(&table.schema_name, &table.name)
+                format_schema_table_equivalent(
+                    &table.catalog_name,
+                    &table.schema_name,
+                    &table.name
+                )
             ),
         ],
         Some(catalog_item::Item::TableFunction(function)) => {
@@ -585,7 +601,7 @@ fn catalog_metadata_text_lines(
                 ),
                 format!(
                     "   SQL reference: {}",
-                    format_schema_table_equivalent(&function.schema_name, &function.name)
+                    format_schema_table_equivalent("", &function.schema_name, &function.name)
                 ),
                 format!("   Call: {}", minimal_table_function_call_example(function)),
             ];
@@ -619,7 +635,7 @@ fn column_hint_text_lines(index: usize, provider: &str, hint: &ColumnHint) -> Ve
         format!(
             "   Surface: {} {}",
             surface_kind_name(hint.surface_kind),
-            format_schema_table_equivalent(&hint.schema_name, &hint.surface_name)
+            format_schema_table_equivalent("", &hint.schema_name, &hint.surface_name)
         ),
     ];
     if !hint.data_type.is_empty() {
@@ -708,7 +724,7 @@ fn preview_text(preview: &SearchTableColumnPreview) -> Option<String> {
 /// Formats the shortest SQL call example for a table function.
 #[must_use]
 pub fn minimal_table_function_call_example(function: &TableFunction) -> String {
-    let reference = format_schema_table_equivalent(&function.schema_name, &function.name);
+    let reference = format_schema_table_equivalent("", &function.schema_name, &function.name);
     let required_arguments = function
         .arguments
         .iter()
@@ -719,14 +735,35 @@ pub fn minimal_table_function_call_example(function: &TableFunction) -> String {
     format!("{reference}({required_arguments})")
 }
 
+fn format_table_name(catalog_name: &str, schema_name: &str, table_name: &str) -> String {
+    if catalog_name.is_empty() {
+        format!("{schema_name}.{table_name}")
+    } else {
+        format!("{catalog_name}.{schema_name}.{table_name}")
+    }
+}
+
 /// Formats a schema-qualified SQL table or table-function reference.
 #[must_use]
-pub fn format_schema_table_equivalent(schema_name: &str, table_name: &str) -> String {
-    format!(
-        "{}.{}",
-        format_sql_identifier(schema_name),
-        format_sql_identifier(table_name)
-    )
+pub fn format_schema_table_equivalent(
+    catalog_name: &str,
+    schema_name: &str,
+    table_name: &str,
+) -> String {
+    if catalog_name.is_empty() {
+        format!(
+            "{}.{}",
+            format_sql_identifier(schema_name),
+            format_sql_identifier(table_name)
+        )
+    } else {
+        format!(
+            "{}.{}.{}",
+            format_sql_identifier(catalog_name),
+            format_sql_identifier(schema_name),
+            format_sql_identifier(table_name)
+        )
+    }
 }
 
 /// Formats one SQL identifier, quoting it only when required.

--- a/crates/coral-client/src/search.rs
+++ b/crates/coral-client/src/search.rs
@@ -745,7 +745,9 @@ pub fn format_table_name(catalog_name: &str, schema_name: &str, table_name: &str
     }
 }
 
-/// Formats a schema-qualified SQL table or table-function reference.
+/// Formats a SQL table or table-function reference, qualified by schema and, when
+/// `catalog_name` is non-empty, by catalog. Pass `""` for a two-part reference —
+/// table functions and the surfaces whose protos carry no catalog field.
 #[must_use]
 pub fn format_schema_table_equivalent(
     catalog_name: &str,

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -90,6 +90,7 @@ pub use contracts::{
     UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn, UdfRuntimeSignature,
     UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
 };
+pub use runtime::normalize_catalog_name;
 
 /// High-level query operations for the local query engine.
 pub struct CoralQuery;

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -10,6 +10,14 @@ pub(crate) const DATAFUSION_DEFAULT_CATALOG: &str = "datafusion";
 /// Removes `DataFusion`'s synthetic default catalog from a table qualifier.
 /// Schema-backed Coral tables store no catalog name in metadata, even
 /// when `DataFusion` expands an explicit reference to `datafusion.schema.table`.
+///
+/// This normalizes a table *reference*. Do not apply it to a catalog *filter*
+/// before handing that filter to the engine: a filter's `None` means "every
+/// catalog", so folding the sentinel to `None` turns an exact match on the
+/// default catalog into a wildcard. The engine's own filter comparison already
+/// normalizes the sentinel on the value side, where it correctly selects
+/// schema-backed tables.
+#[must_use]
 pub fn normalize_catalog_name(catalog_name: Option<&str>) -> Option<&str> {
     catalog_name.filter(|name| !name.eq_ignore_ascii_case(DATAFUSION_DEFAULT_CATALOG))
 }

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -10,7 +10,7 @@ pub(crate) const DATAFUSION_DEFAULT_CATALOG: &str = "datafusion";
 /// Removes `DataFusion`'s synthetic default catalog from a table qualifier.
 /// Schema-backed Coral tables store no catalog name in metadata, even
 /// when `DataFusion` expands an explicit reference to `datafusion.schema.table`.
-pub(crate) fn non_default_catalog_name(catalog_name: Option<&str>) -> Option<&str> {
+pub fn normalize_catalog_name(catalog_name: Option<&str>) -> Option<&str> {
     catalog_name.filter(|name| !name.eq_ignore_ascii_case(DATAFUSION_DEFAULT_CATALOG))
 }
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -30,7 +30,6 @@ use crate::runtime::error::{
     query_result_observer_error_to_core,
 };
 use crate::runtime::json::register_json_support;
-use crate::runtime::non_default_catalog_name;
 use crate::runtime::pattern_validator::register_pattern_validator;
 use crate::runtime::query_planner::CoralQueryPlanner;
 use crate::runtime::registry::{
@@ -53,7 +52,7 @@ use crate::{
     RequestIdentityHttpAuthenticatorFactory, RequestIdentitySelectionContext,
     RequestIdentitySelectionError, RequestIdentitySelector, ResolvedQueryResources,
     SelectedRequestIdentity, SourceDecorator, SourceInputResolver, SourceObservationPublisher,
-    TableFunctionInfo, TableInfo, UdfRuntimeDefinition,
+    TableFunctionInfo, TableInfo, UdfRuntimeDefinition, normalize_catalog_name,
 };
 
 pub(crate) struct QueryRuntimeAdapter {
@@ -508,7 +507,7 @@ fn table_qualifier_matches(
     schema_filter: Option<&str>,
 ) -> bool {
     catalog_filter
-        .is_none_or(|value| table.catalog_name.as_deref() == non_default_catalog_name(Some(value)))
+        .is_none_or(|value| table.catalog_name.as_deref() == normalize_catalog_name(Some(value)))
         && schema_filter.is_none_or(|value| table.schema_name == value)
 }
 
@@ -517,7 +516,7 @@ fn table_reference_matches(
     catalog_name: Option<&str>,
     schema_name: &str,
 ) -> bool {
-    table.catalog_name.as_deref() == non_default_catalog_name(catalog_name)
+    table.catalog_name.as_deref() == normalize_catalog_name(catalog_name)
         && table.schema_name == schema_name
 }
 
@@ -602,7 +601,7 @@ impl QueryRuntimeAdapter {
         schema_filter: Option<&str>,
     ) -> CatalogInfo {
         let includes_schema_sources =
-            catalog_filter.is_none_or(|value| non_default_catalog_name(Some(value)).is_none());
+            catalog_filter.is_none_or(|value| normalize_catalog_name(Some(value)).is_none());
         CatalogInfo {
             tables: self.list_tables(catalog_filter, schema_filter, None),
             table_functions: if includes_schema_sources {
@@ -964,7 +963,7 @@ impl QueryRuntimeAdapter {
         let Some((schema_name, table_name)) = relation_parts(table_reference) else {
             return;
         };
-        let catalog_name = non_default_catalog_name(table_reference.catalog());
+        let catalog_name = normalize_catalog_name(table_reference.catalog());
         if self.tables.iter().any(|table| {
             table.catalog_name.as_deref() == catalog_name
                 && table.schema_name == schema_name

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -88,8 +88,9 @@ Each distinct placeholder becomes a required named argument. Coral infers its ty
 - Joins across schemas work with standard SQL after table scans complete.
 - Use `LIKE` or `ILIKE` for SQL wildcard matching with `%` and `_`. `SIMILAR TO` uses regex-shaped patterns, so write `.*` instead of `%`, `.` instead of `_`, or escape literal percent/underscore characters as `\%` and `\_`.
 - Regex operators such as `~` and `~*` treat `%` and `_` as ordinary literal characters.
-- `list_catalog` shows queryable tables and parameterized table functions in pages; pass `schema`, `kind`, `limit`, and `offset` to narrow large catalogs. Omit `kind` or pass `null` to list all item kinds.
+- `list_catalog` shows queryable tables and parameterized table functions in pages; pass `catalog`, `schema`, `kind`, `limit`, and `offset` to narrow large catalogs. Omit `kind` or pass `null` to list all item kinds.
 {{SEARCH_TOOL_GUIDANCE}}
 - `describe_table` returns one compact table detail with guide text, required filters, and column count; use `coral.columns` when you need full column details.
 - `list_columns` lists columns for one table; pass `pattern`, `required_only`, `limit`, and `offset` to inspect large schemas progressively. Existing tables return field names once in `fields` and positional values in `rows`, plus `total`, `has_more`, and optional `next_offset`; use each field's index to read corresponding row values, including regex `matched_fields`. Missing tables return `found: false` with suggested recovery calls instead of an empty page.
+- For database tables, pass `catalog` separately from `schema` to `describe_table` and `list_columns`; omit `catalog` for two-part tables.
 - `coral://tables` shows table summaries for query-visible source tables and Coral catalog tables, including `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs`; those catalog tables provide richer SQL metadata.

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -38,7 +38,15 @@ SELECT schema_name, key FROM coral.inputs
 WHERE kind = 'secret' AND is_set;
 ```
 
-Database source inputs are addressed by catalog instead: their rows have an empty `schema_name` and set `catalog_name`. When joining `coral.inputs` to `coral.tables`, join on `schema_name` for two-part sources and on `catalog_name` for database sources.
+Database source inputs are addressed by catalog instead: their rows have an empty `schema_name` and set `catalog_name`. Both columns use `''` rather than NULL for the side that does not apply, so joining `coral.inputs` to `coral.tables` on either column alone matches every two-part row against every other one via `'' = ''`. Guard each side:
+
+```sql
+SELECT t.catalog_name, t.schema_name, t.table_name, i.key
+FROM coral.tables t
+JOIN coral.inputs i
+  ON (i.catalog_name <> '' AND i.catalog_name = t.catalog_name)
+  OR (i.catalog_name = '' AND t.catalog_name = '' AND i.schema_name = t.schema_name);
+```
 
 ## JSON Columns
 

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -10,7 +10,7 @@ Prefer one SQL statement with `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates
 
 ```sql
 -- List visible tables, descriptions, and required filters
-SELECT schema_name, table_name, description, required_filters FROM coral.tables ORDER BY schema_name, table_name;
+SELECT catalog_name, schema_name, table_name, description, required_filters FROM coral.tables ORDER BY catalog_name, schema_name, table_name;
 
 -- List parameterized table functions
 SELECT schema_name, function_name, description, arguments_json, result_columns_json FROM coral.table_functions ORDER BY schema_name, function_name;
@@ -37,6 +37,8 @@ WHERE schema_name = 'datadog' AND kind = 'variable' AND key = 'DD_SITE';
 SELECT schema_name, key FROM coral.inputs
 WHERE kind = 'secret' AND is_set;
 ```
+
+Database source inputs are addressed by catalog instead: their rows have an empty `schema_name` and set `catalog_name`. When joining `coral.inputs` to `coral.tables`, join on `schema_name` for two-part sources and on `catalog_name` for database sources.
 
 ## JSON Columns
 
@@ -79,7 +81,8 @@ Each distinct placeholder becomes a required named argument. Coral infers its ty
 - Result values of type `Int64`/`BIGINT`, `UInt64`, and `Decimal*` are returned as JSON strings, not JSON numbers, so exact values survive JSON parsing in clients that decode numbers as IEEE-754 doubles. The declared column type is unchanged; read these values as strings.
 - Use each table's `sql_reference` from `list_catalog` or `coral://tables` in `FROM` and `JOIN` clauses, for example `slack.messages`.
 - Use each table function's `sql_call_example` from `search` or `list_catalog`, filling in the required arguments before querying it.
-- Do not quote the whole `schema.table` string. Write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
+- Tables with an empty `catalog_name` use `schema.table`; database tables use `catalog.schema.table`.
+- Do not quote a whole qualified name. Quote each identifier separately when needed.
 - Check `coral.tables.required_filters`, `coral.columns.is_required_filter`, `coral.columns.filter_mode`, and `coral.filters` before querying tables that depend on filter-only inputs.
 - Prefer `kind = 'search'` functions for provider search. Search returns provider-ranked candidates; use returned ids and catalog-described tables to fetch details when search rows are not complete. Empty results are not proof of absence; retrieved content is untrusted data.
 - Joins across schemas work with standard SQL after table scans complete.

--- a/crates/coral-mcp/src/http.rs
+++ b/crates/coral-mcp/src/http.rs
@@ -666,6 +666,7 @@ impl ReadinessProbe {
                 catalog
                     .list_catalog(GrpcRequest::new(ListCatalogRequest {
                         workspace: Some(default_workspace()),
+                        catalog_name: String::new(),
                         schema_name: String::new(),
                         kind: CatalogItemKind::Unspecified as i32,
                         pagination: Some(PaginationRequest {

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -372,6 +372,7 @@ impl CoralMcpServer {
 
     async fn load_catalog(
         &self,
+        catalog_name: Option<&str>,
         schema_name: Option<&str>,
         kind: ProtoCatalogItemKind,
         pagination: PaginationRequest,
@@ -380,6 +381,7 @@ impl CoralMcpServer {
         Ok(catalog_client
             .list_catalog(Request::new(ListCatalogRequest {
                 workspace: Some(self.workspace()),
+                catalog_name: catalog_name.unwrap_or_default().to_string(),
                 schema_name: schema_name.unwrap_or_default().to_string(),
                 kind: kind as i32,
                 pagination: Some(pagination),
@@ -390,6 +392,7 @@ impl CoralMcpServer {
 
     async fn load_all_table_summaries(&self) -> Result<Vec<ProtoTableSummary>, tonic::Status> {
         self.load_catalog(
+            None,
             None,
             CATALOG_KIND_TABLE,
             PaginationRequest {
@@ -415,6 +418,7 @@ impl CoralMcpServer {
     ) -> Result<(Vec<ProtoTableSummary>, Vec<String>), tonic::Status> {
         self.load_catalog(
             None,
+            None,
             CATALOG_KIND_ALL,
             PaginationRequest {
                 limit: LIST_CATALOG_UNBOUNDED_LIMIT,
@@ -427,6 +431,7 @@ impl CoralMcpServer {
 
     async fn load_table_description(
         &self,
+        catalog_name: Option<&str>,
         schema_name: &str,
         table_name: &str,
     ) -> Result<DescribeTableResponse, tonic::Status> {
@@ -434,6 +439,7 @@ impl CoralMcpServer {
         Ok(catalog_client
             .describe_table(Request::new(DescribeTableRequest {
                 workspace: Some(self.workspace()),
+                catalog_name: catalog_name.unwrap_or_default().to_string(),
                 schema_name: schema_name.to_string(),
                 table_name: table_name.to_string(),
             }))
@@ -445,6 +451,7 @@ impl CoralMcpServer {
         // One item is enough: the app returns per-kind counts before pagination.
         let response = self
             .load_catalog(
+                None,
                 None,
                 CATALOG_KIND_ALL,
                 PaginationRequest {
@@ -709,6 +716,7 @@ impl CoralMcpServer {
         let result = catalog_client
             .list_catalog(Request::new(ListCatalogRequest {
                 workspace: Some(self.workspace()),
+                catalog_name: arguments.catalog.unwrap_or_default(),
                 schema_name: arguments.schema.unwrap_or_default(),
                 kind: catalog_item_kind_from_tool(arguments.kind) as i32,
                 pagination: Some(PaginationRequest {
@@ -730,10 +738,15 @@ impl CoralMcpServer {
     ) -> Result<ToolCallOutcome, ErrorData> {
         let arguments = describe_table_arguments(request_arguments)?;
         match self
-            .load_table_description(&arguments.schema, &arguments.table)
+            .load_table_description(
+                arguments.catalog.as_deref(),
+                &arguments.schema,
+                &arguments.table,
+            )
             .await
         {
             Ok(response) => Ok(ToolCallOutcome::success(describe_table_value(
+                arguments.catalog.as_deref(),
                 &arguments.schema,
                 &arguments.table,
                 &response,
@@ -845,6 +858,7 @@ impl CoralMcpServer {
         match catalog_client
             .list_columns(Request::new(ListColumnsRequest {
                 workspace: Some(self.workspace()),
+                catalog_name: arguments.catalog.clone().unwrap_or_default(),
                 schema_name: arguments.schema.clone(),
                 table_name: arguments.table.clone(),
                 pattern: arguments.pattern.clone(),
@@ -858,6 +872,7 @@ impl CoralMcpServer {
             .await
         {
             Ok(response) => Ok(ToolCallOutcome::success(list_columns_value(
+                arguments.catalog.as_deref(),
                 &arguments.schema,
                 &arguments.table,
                 &response.into_inner(),
@@ -867,11 +882,16 @@ impl CoralMcpServer {
             }
             Err(status) if status.code() == tonic::Code::NotFound => {
                 match self
-                    .load_table_description(&arguments.schema, &arguments.table)
+                    .load_table_description(
+                        arguments.catalog.as_deref(),
+                        &arguments.schema,
+                        &arguments.table,
+                    )
                     .await
                 {
                     Ok(response) => {
                         Ok(ToolCallOutcome::success(list_columns_table_fallback_value(
+                            arguments.catalog.as_deref(),
                             &arguments.schema,
                             &arguments.table,
                             &response,

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -788,7 +788,7 @@ mod tests {
             }),
         };
 
-        let value = list_columns_value("github", "issues", &response);
+        let value = list_columns_value(None, "github", "issues", &response);
         let fields = value.get("fields").expect("fields");
         let first_row = value
             .get("rows")

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -23,7 +23,10 @@ use super::context::ToolDescriptionContext;
 use super::discovery::{DefaultPaginationInput, Pagination, parse_pagination};
 use super::schema::{tool_input_schema, tool_output_schema};
 use super::tool_names::ToolName;
-use super::values::{MissingTableSummaryValue, format_schema_table_equivalent, format_table_name};
+use super::values::{
+    MissingTableSummaryValue, format_schema_table_equivalent, format_table_name,
+    optional_catalog_name,
+};
 
 const DEFAULT_IGNORE_CASE: bool = true;
 const DEFAULT_REQUIRED_ONLY: bool = false;
@@ -578,7 +581,7 @@ impl<'a> From<&'a ProtoTableSummary> for CatalogTableItemValue<'a> {
             schema_name: &table.schema_name,
             name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
             sql_reference: format_schema_table_equivalent(
-                &table.catalog_name,
+                optional_catalog_name(&table.catalog_name),
                 &table.schema_name,
                 &table.name,
             ),
@@ -625,7 +628,7 @@ impl<'a> From<&'a ProtoTableFunction> for CatalogTableFunctionItemValue<'a> {
             schema_name: &function.schema_name,
             name: format!("{}.{}", function.schema_name, function.name),
             sql_reference: format_schema_table_equivalent(
-                "",
+                None,
                 &function.schema_name,
                 &function.name,
             ),

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -505,7 +505,11 @@ impl<'a> From<&'a ProtoTable> for FoundTableValue<'a> {
             catalog_name: &table.catalog_name,
             schema_name: &table.schema_name,
             table_name: &table.name,
-            name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
+            name: format_table_name(
+                optional_catalog_name(&table.catalog_name),
+                &table.schema_name,
+                &table.name,
+            ),
             description: &table.description,
             guide: &table.guide,
             required_filters: &table.required_filters,
@@ -579,7 +583,11 @@ impl<'a> From<&'a ProtoTableSummary> for CatalogTableItemValue<'a> {
             kind: CatalogTableKind::Table,
             catalog_name: &table.catalog_name,
             schema_name: &table.schema_name,
-            name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
+            name: format_table_name(
+                optional_catalog_name(&table.catalog_name),
+                &table.schema_name,
+                &table.name,
+            ),
             sql_reference: format_schema_table_equivalent(
                 optional_catalog_name(&table.catalog_name),
                 &table.schema_name,

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -155,7 +155,7 @@ pub(crate) fn list_catalog_arguments(
     arguments: Option<&Map<String, Value>>,
 ) -> Result<ListCatalogArguments, ErrorData> {
     Ok(ListCatalogArguments {
-        catalog: optional_string_argument(arguments, "catalog")?,
+        catalog: optional_non_empty_string_argument(arguments, "catalog")?,
         schema: optional_string_argument(arguments, "schema")?,
         kind: optional_catalog_kind_argument(arguments)?,
         pagination: parse_pagination(arguments)?,
@@ -166,7 +166,7 @@ pub(crate) fn describe_table_arguments(
     arguments: Option<&Map<String, Value>>,
 ) -> Result<DescribeTableArguments, ErrorData> {
     Ok(DescribeTableArguments {
-        catalog: optional_string_argument(arguments, "catalog")?,
+        catalog: optional_non_empty_string_argument(arguments, "catalog")?,
         schema: required_string_argument(arguments, "schema")?,
         table: required_string_argument(arguments, "table")?,
     })
@@ -176,7 +176,7 @@ pub(crate) fn list_columns_arguments(
     arguments: Option<&Map<String, Value>>,
 ) -> Result<ListColumnsArguments, ErrorData> {
     Ok(ListColumnsArguments {
-        catalog: optional_string_argument(arguments, "catalog")?,
+        catalog: optional_non_empty_string_argument(arguments, "catalog")?,
         schema: required_string_argument(arguments, "schema")?,
         table: required_string_argument(arguments, "table")?,
         pattern: optional_non_empty_string_argument(arguments, "pattern")?,

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -23,7 +23,7 @@ use super::context::ToolDescriptionContext;
 use super::discovery::{DefaultPaginationInput, Pagination, parse_pagination};
 use super::schema::{tool_input_schema, tool_output_schema};
 use super::tool_names::ToolName;
-use super::values::{MissingTableSummaryValue, format_schema_table_equivalent};
+use super::values::{MissingTableSummaryValue, format_schema_table_equivalent, format_table_name};
 
 const DEFAULT_IGNORE_CASE: bool = true;
 const DEFAULT_REQUIRED_ONLY: bool = false;
@@ -47,6 +47,8 @@ pub(crate) enum CatalogToolKind {
 
 #[derive(JsonSchema)]
 pub(crate) struct ListCatalogArguments {
+    #[schemars(description = "Optional exact SQL catalog name to list.")]
+    pub(crate) catalog: Option<String>,
     #[schemars(description = "Optional exact SQL schema name to list.")]
     pub(crate) schema: Option<String>,
     #[schemars(
@@ -59,6 +61,8 @@ pub(crate) struct ListCatalogArguments {
 
 #[derive(JsonSchema)]
 pub(crate) struct DescribeTableArguments {
+    #[schemars(description = "Optional SQL catalog name. Omit for two-part tables.")]
+    pub(crate) catalog: Option<String>,
     #[schemars(length(min = 1), description = "Exact SQL schema name.")]
     pub(crate) schema: String,
     #[schemars(
@@ -70,6 +74,8 @@ pub(crate) struct DescribeTableArguments {
 
 #[derive(JsonSchema)]
 pub(crate) struct ListColumnsArguments {
+    #[schemars(description = "Optional SQL catalog name. Omit for two-part tables.")]
+    pub(crate) catalog: Option<String>,
     #[schemars(length(min = 1), description = "Exact SQL schema name.")]
     pub(crate) schema: String,
     #[schemars(
@@ -149,6 +155,7 @@ pub(crate) fn list_catalog_arguments(
     arguments: Option<&Map<String, Value>>,
 ) -> Result<ListCatalogArguments, ErrorData> {
     Ok(ListCatalogArguments {
+        catalog: optional_string_argument(arguments, "catalog")?,
         schema: optional_string_argument(arguments, "schema")?,
         kind: optional_catalog_kind_argument(arguments)?,
         pagination: parse_pagination(arguments)?,
@@ -159,6 +166,7 @@ pub(crate) fn describe_table_arguments(
     arguments: Option<&Map<String, Value>>,
 ) -> Result<DescribeTableArguments, ErrorData> {
     Ok(DescribeTableArguments {
+        catalog: optional_string_argument(arguments, "catalog")?,
         schema: required_string_argument(arguments, "schema")?,
         table: required_string_argument(arguments, "table")?,
     })
@@ -168,6 +176,7 @@ pub(crate) fn list_columns_arguments(
     arguments: Option<&Map<String, Value>>,
 ) -> Result<ListColumnsArguments, ErrorData> {
     Ok(ListColumnsArguments {
+        catalog: optional_string_argument(arguments, "catalog")?,
         schema: required_string_argument(arguments, "schema")?,
         table: required_string_argument(arguments, "table")?,
         pattern: optional_non_empty_string_argument(arguments, "pattern")?,
@@ -199,15 +208,17 @@ fn default_required_only() -> bool {
 }
 
 pub(crate) fn describe_table_value(
+    catalog: Option<&str>,
     schema: &str,
     table: &str,
     response: &DescribeTableResponse,
 ) -> Value {
-    serde_json::to_value(describe_table_output(schema, table, response))
+    serde_json::to_value(describe_table_output(catalog, schema, table, response))
         .expect("describe table output value serializes")
 }
 
 fn describe_table_output<'a>(
+    catalog: Option<&'a str>,
     schema: &'a str,
     table: &'a str,
     response: &'a DescribeTableResponse,
@@ -216,6 +227,7 @@ fn describe_table_output<'a>(
         return DescribeTableOutput::Found(FoundTableValue::from(table));
     }
     DescribeTableOutput::Missing(missing_table_value(
+        catalog,
         schema,
         table,
         &response.available_schemas,
@@ -225,15 +237,19 @@ fn describe_table_output<'a>(
 }
 
 pub(crate) fn list_columns_table_fallback_value(
+    catalog: Option<&str>,
     schema: &str,
     table: &str,
     response: &DescribeTableResponse,
 ) -> Value {
-    serde_json::to_value(list_columns_table_fallback_output(schema, table, response))
-        .expect("list columns table fallback output value serializes")
+    serde_json::to_value(list_columns_table_fallback_output(
+        catalog, schema, table, response,
+    ))
+    .expect("list columns table fallback output value serializes")
 }
 
 fn list_columns_table_fallback_output<'a>(
+    catalog: Option<&'a str>,
     schema: &'a str,
     table: &'a str,
     response: &'a DescribeTableResponse,
@@ -242,6 +258,7 @@ fn list_columns_table_fallback_output<'a>(
         return ListColumnsOutput::Found(FoundTableValue::from(table));
     }
     ListColumnsOutput::Missing(missing_table_value(
+        catalog,
         schema,
         table,
         &response.available_schemas,
@@ -251,6 +268,7 @@ fn list_columns_table_fallback_output<'a>(
 }
 
 fn missing_table_value<'a>(
+    catalog: Option<&'a str>,
     schema: &'a str,
     table: &'a str,
     available_schemas: &'a [String],
@@ -265,17 +283,33 @@ fn missing_table_value<'a>(
         .iter()
         .map(MissingTableSummaryValue::from)
         .collect::<Vec<_>>();
-    let suggested_calls = vec![SuggestedCall {
+    let mut suggested_calls = vec![SuggestedCall {
         tool: CatalogSuggestedTool::ListCatalog,
         arguments: SuggestedCallArguments {
+            catalog,
             schema: (!same_schema_tables.is_empty()).then_some(schema),
             kind: Some(CatalogToolKind::Table),
             limit: Some(10),
         },
     }];
+    if catalog.is_some() && same_schema_tables.is_empty() {
+        suggested_calls.push(SuggestedCall {
+            tool: CatalogSuggestedTool::ListCatalog,
+            arguments: SuggestedCallArguments {
+                catalog: None,
+                schema: None,
+                kind: Some(CatalogToolKind::Table),
+                limit: Some(10),
+            },
+        });
+    }
     MissingTableValue {
         found: false,
-        requested: RequestedTable { schema, table },
+        requested: RequestedTable {
+            catalog,
+            schema,
+            table,
+        },
         available_schemas,
         same_schema_tables,
         suggestions,
@@ -312,6 +346,7 @@ fn catalog_item_value(item: &coral_api::v1::CatalogItem) -> Option<CatalogItemVa
 }
 
 pub(crate) fn list_columns_value(
+    catalog: Option<&str>,
     schema: &str,
     table: &str,
     response: &ListColumnsResponse,
@@ -323,6 +358,7 @@ pub(crate) fn list_columns_value(
         .filter_map(column_search_result_row)
         .collect::<Vec<_>>();
     serde_json::to_value(ListColumnsOutput::Page(ListColumnsPageValue::new(
+        catalog,
         schema,
         table,
         rows,
@@ -397,6 +433,8 @@ impl<'a> CatalogPageValue<'a> {
 #[derive(Serialize, JsonSchema)]
 #[schemars(deny_unknown_fields)]
 struct ListColumnsPageValue<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    catalog_name: Option<&'a str>,
     schema_name: &'a str,
     table_name: &'a str,
     fields: &'static [&'static str; LIST_COLUMNS_FIELDS.len()],
@@ -414,12 +452,14 @@ struct ListColumnsPageValue<'a> {
 
 impl<'a> ListColumnsPageValue<'a> {
     fn new(
+        catalog_name: Option<&'a str>,
         schema_name: &'a str,
         table_name: &'a str,
         rows: Vec<ColumnSearchRowValue<'a>>,
         pagination: &PaginationResponse,
     ) -> Self {
         Self {
+            catalog_name,
             schema_name,
             table_name,
             fields: &LIST_COLUMNS_FIELDS,
@@ -444,6 +484,7 @@ enum CatalogItemValue<'a> {
 #[schemars(deny_unknown_fields)]
 struct FoundTableValue<'a> {
     found: bool,
+    catalog_name: &'a str,
     schema_name: &'a str,
     table_name: &'a str,
     name: String,
@@ -458,9 +499,10 @@ impl<'a> From<&'a ProtoTable> for FoundTableValue<'a> {
     fn from(table: &'a ProtoTable) -> Self {
         Self {
             found: true,
+            catalog_name: &table.catalog_name,
             schema_name: &table.schema_name,
             table_name: &table.name,
-            name: format!("{}.{}", table.schema_name, table.name),
+            name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
             description: &table.description,
             guide: &table.guide,
             required_filters: &table.required_filters,
@@ -484,6 +526,8 @@ struct MissingTableValue<'a> {
 #[derive(Serialize, JsonSchema)]
 #[schemars(deny_unknown_fields)]
 struct RequestedTable<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    catalog: Option<&'a str>,
     schema: &'a str,
     table: &'a str,
 }
@@ -505,6 +549,8 @@ enum CatalogSuggestedTool {
 #[schemars(deny_unknown_fields)]
 struct SuggestedCallArguments<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
+    catalog: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     schema: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     kind: Option<CatalogToolKind>,
@@ -516,6 +562,7 @@ struct SuggestedCallArguments<'a> {
 #[schemars(deny_unknown_fields)]
 struct CatalogTableItemValue<'a> {
     kind: CatalogTableKind,
+    catalog_name: &'a str,
     schema_name: &'a str,
     name: String,
     sql_reference: String,
@@ -527,9 +574,14 @@ impl<'a> From<&'a ProtoTableSummary> for CatalogTableItemValue<'a> {
     fn from(table: &'a ProtoTableSummary) -> Self {
         Self {
             kind: CatalogTableKind::Table,
+            catalog_name: &table.catalog_name,
             schema_name: &table.schema_name,
-            name: format!("{}.{}", table.schema_name, table.name),
-            sql_reference: format_schema_table_equivalent(&table.schema_name, &table.name),
+            name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
+            sql_reference: format_schema_table_equivalent(
+                &table.catalog_name,
+                &table.schema_name,
+                &table.name,
+            ),
             description: &table.description,
             table: CatalogTableValue {
                 table_name: &table.name,
@@ -572,7 +624,11 @@ impl<'a> From<&'a ProtoTableFunction> for CatalogTableFunctionItemValue<'a> {
             kind: CatalogTableFunctionKind::TableFunction,
             schema_name: &function.schema_name,
             name: format!("{}.{}", function.schema_name, function.name),
-            sql_reference: format_schema_table_equivalent(&function.schema_name, &function.name),
+            sql_reference: format_schema_table_equivalent(
+                "",
+                &function.schema_name,
+                &function.name,
+            ),
             sql_call_example: minimal_table_function_call_example(function),
             description: &function.description,
             table_function: CatalogTableFunctionValue {

--- a/crates/coral-mcp/src/surface/function.rs
+++ b/crates/coral-mcp/src/surface/function.rs
@@ -157,7 +157,7 @@ pub(crate) fn function_added_value(function: &Function) -> Result<Value, tonic::
         .as_ref()
         .ok_or_else(|| tonic::Status::internal("add function response missing publish target"))?;
     let sql_reference =
-        format_schema_table_equivalent("", &table_function.schema_name, &table_function.name);
+        format_schema_table_equivalent(None, &table_function.schema_name, &table_function.name);
     let arguments = ready
         .arguments
         .iter()

--- a/crates/coral-mcp/src/surface/function.rs
+++ b/crates/coral-mcp/src/surface/function.rs
@@ -157,7 +157,7 @@ pub(crate) fn function_added_value(function: &Function) -> Result<Value, tonic::
         .as_ref()
         .ok_or_else(|| tonic::Status::internal("add function response missing publish target"))?;
     let sql_reference =
-        format_schema_table_equivalent(&table_function.schema_name, &table_function.name);
+        format_schema_table_equivalent("", &table_function.schema_name, &table_function.name);
     let arguments = ready
         .arguments
         .iter()

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -80,7 +80,7 @@ pub(crate) fn guide_resource_content(
     );
     let mut schemas = tables
         .iter()
-        .filter(|table| table.schema_name != "coral")
+        .filter(|table| !is_coral_system_schema(table))
         .map(addressable_schema_name)
         .collect::<BTreeSet<_>>();
     schemas.extend(
@@ -181,7 +181,7 @@ fn sql_string_literal(value: &str) -> String {
 fn first_visible_table(tables: &[TableSummary]) -> Option<(&str, &str, &str)> {
     tables
         .iter()
-        .filter(|table| table.schema_name != "coral")
+        .filter(|table| !is_coral_system_schema(table))
         .min_by(|left, right| {
             (&left.catalog_name, &left.schema_name, &left.name).cmp(&(
                 &right.catalog_name,
@@ -198,11 +198,16 @@ fn first_visible_table(tables: &[TableSummary]) -> Option<(&str, &str, &str)> {
         })
 }
 
+fn is_coral_system_schema(table: &TableSummary) -> bool {
+    table.catalog_name.is_empty() && table.schema_name == "coral"
+}
+
 fn addressable_schema_name(table: &TableSummary) -> String {
+    let schema_name = prompt_safe_text(&table.schema_name);
     if table.catalog_name.is_empty() {
-        table.schema_name.clone()
+        schema_name
     } else {
-        format!("{}.{}", table.catalog_name, table.schema_name)
+        format!("{}.{schema_name}", prompt_safe_text(&table.catalog_name))
     }
 }
 

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -109,15 +109,18 @@ FROM coral.columns WHERE schema_name = '<schema>' AND table_name = '<table>' ORD
                 .to_string()
         },
         |(catalog_name, schema_name, table_name)| {
+            let schema_name = sql_string_literal(schema_name);
+            let table_name = sql_string_literal(table_name);
             if catalog_name.is_empty() {
                 format!(
                     "SELECT column_name, data_type, is_nullable, is_virtual, is_required_filter, filter_mode, description \
-FROM coral.columns WHERE schema_name = '{schema_name}' AND table_name = '{table_name}' ORDER BY ordinal_position;"
+FROM coral.columns WHERE schema_name = {schema_name} AND table_name = {table_name} ORDER BY ordinal_position;"
                 )
             } else {
+                let catalog_name = sql_string_literal(catalog_name);
                 format!(
                     "SELECT column_name, data_type, is_nullable, is_virtual, is_required_filter, filter_mode, description \
-FROM coral.columns WHERE catalog_name = '{catalog_name}' AND schema_name = '{schema_name}' AND table_name = '{table_name}' ORDER BY ordinal_position;"
+FROM coral.columns WHERE catalog_name = {catalog_name} AND schema_name = {schema_name} AND table_name = {table_name} ORDER BY ordinal_position;"
                 )
             }
         },
@@ -169,6 +172,10 @@ fn guide_resource_description(
 
 fn tables_resource_description(visible_table_count: usize) -> String {
     format!("Fully qualified database tables in Coral ({visible_table_count} table(s)).")
+}
+
+fn sql_string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
 }
 
 fn first_visible_table(tables: &[TableSummary]) -> Option<(&str, &str, &str)> {

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -310,6 +310,13 @@ mod tests {
         }
     }
 
+    fn catalog_table(catalog_name: &str, schema_name: &str, name: &str) -> TableSummary {
+        TableSummary {
+            catalog_name: catalog_name.to_string(),
+            ..table(schema_name, name)
+        }
+    }
+
     fn query(sql: impl Into<String>) -> McpQueryExample {
         McpQueryExample::new(sql)
     }
@@ -539,6 +546,22 @@ WHERE title LIKE '%bug%'",
                 "Use each table's `sql_reference` from `list_catalog` or `coral://tables`"
             )
         );
+    }
+
+    #[test]
+    fn guide_content_qualifies_catalog_schema_and_column_example() {
+        let content = guide_resource_content(
+            &[source("warehouse")],
+            &[catalog_table("warehouse", "public", "orders")],
+            &[],
+            false,
+        );
+
+        assert!(content.contains("Visible schemas:\n- warehouse.public"));
+        assert!(content.contains(
+            "FROM coral.columns WHERE catalog_name = 'warehouse' AND schema_name = 'public' \
+             AND table_name = 'orders' ORDER BY ordinal_position;"
+        ));
     }
 
     #[test]

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -617,23 +617,23 @@ WHERE title LIKE '%bug%'",
     #[test]
     fn sql_reference_quotes_each_identifier_independently() {
         assert_eq!(
-            format_schema_table_equivalent("", "github", "pulls"),
+            format_schema_table_equivalent(None, "github", "pulls"),
             "github.pulls"
         );
         assert_eq!(
-            format_schema_table_equivalent("", "github", "Pull.Requests"),
+            format_schema_table_equivalent(None, "github", "Pull.Requests"),
             "github.\"Pull.Requests\""
         );
         assert_eq!(
-            format_schema_table_equivalent("", "git.hub", "pulls"),
+            format_schema_table_equivalent(None, "git.hub", "pulls"),
             "\"git.hub\".pulls"
         );
         assert_eq!(
-            format_schema_table_equivalent("", "git\"hub", "pulls"),
+            format_schema_table_equivalent(None, "git\"hub", "pulls"),
             "\"git\"\"hub\".pulls"
         );
         assert_eq!(
-            format_schema_table_equivalent("coral_db", "Main.Schema", "users"),
+            format_schema_table_equivalent(Some("coral_db"), "Main.Schema", "users"),
             "coral_db.\"Main.Schema\".users"
         );
     }

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -81,13 +81,13 @@ pub(crate) fn guide_resource_content(
     let mut schemas = tables
         .iter()
         .filter(|table| table.schema_name != "coral")
-        .map(|table| table.schema_name.as_str())
+        .map(addressable_schema_name)
         .collect::<BTreeSet<_>>();
     schemas.extend(
         table_function_schema_names
             .iter()
-            .map(String::as_str)
-            .filter(|schema| *schema != "coral"),
+            .filter(|schema| *schema != "coral")
+            .cloned(),
     );
     if schemas.is_empty() {
         if sources.is_empty() {
@@ -108,11 +108,18 @@ pub(crate) fn guide_resource_content(
 FROM coral.columns WHERE schema_name = '<schema>' AND table_name = '<table>' ORDER BY ordinal_position;"
                 .to_string()
         },
-        |(schema_name, table_name)| {
-            format!(
-                "SELECT column_name, data_type, is_nullable, is_virtual, is_required_filter, filter_mode, description \
+        |(catalog_name, schema_name, table_name)| {
+            if catalog_name.is_empty() {
+                format!(
+                    "SELECT column_name, data_type, is_nullable, is_virtual, is_required_filter, filter_mode, description \
 FROM coral.columns WHERE schema_name = '{schema_name}' AND table_name = '{table_name}' ORDER BY ordinal_position;"
-            )
+                )
+            } else {
+                format!(
+                    "SELECT column_name, data_type, is_nullable, is_virtual, is_required_filter, filter_mode, description \
+FROM coral.columns WHERE catalog_name = '{catalog_name}' AND schema_name = '{schema_name}' AND table_name = '{table_name}' ORDER BY ordinal_position;"
+                )
+            }
         },
     );
 
@@ -164,14 +171,32 @@ fn tables_resource_description(visible_table_count: usize) -> String {
     format!("Fully qualified database tables in Coral ({visible_table_count} table(s)).")
 }
 
-fn first_visible_table(tables: &[TableSummary]) -> Option<(&str, &str)> {
+fn first_visible_table(tables: &[TableSummary]) -> Option<(&str, &str, &str)> {
     tables
         .iter()
         .filter(|table| table.schema_name != "coral")
         .min_by(|left, right| {
-            (&left.schema_name, &left.name).cmp(&(&right.schema_name, &right.name))
+            (&left.catalog_name, &left.schema_name, &left.name).cmp(&(
+                &right.catalog_name,
+                &right.schema_name,
+                &right.name,
+            ))
         })
-        .map(|table| (table.schema_name.as_str(), table.name.as_str()))
+        .map(|table| {
+            (
+                table.catalog_name.as_str(),
+                table.schema_name.as_str(),
+                table.name.as_str(),
+            )
+        })
+}
+
+fn addressable_schema_name(table: &TableSummary) -> String {
+    if table.catalog_name.is_empty() {
+        table.schema_name.clone()
+    } else {
+        format!("{}.{}", table.catalog_name, table.schema_name)
+    }
 }
 
 struct RenderedQueryExample {
@@ -277,6 +302,7 @@ mod tests {
                 name: "default".to_string(),
             }),
             schema_name: schema_name.to_string(),
+            catalog_name: String::new(),
             name: name.to_string(),
             description: format!("{name} description"),
             required_filters: Vec::new(),
@@ -543,20 +569,24 @@ WHERE title LIKE '%bug%'",
     #[test]
     fn sql_reference_quotes_each_identifier_independently() {
         assert_eq!(
-            format_schema_table_equivalent("github", "pulls"),
+            format_schema_table_equivalent("", "github", "pulls"),
             "github.pulls"
         );
         assert_eq!(
-            format_schema_table_equivalent("github", "Pull.Requests"),
+            format_schema_table_equivalent("", "github", "Pull.Requests"),
             "github.\"Pull.Requests\""
         );
         assert_eq!(
-            format_schema_table_equivalent("git.hub", "pulls"),
+            format_schema_table_equivalent("", "git.hub", "pulls"),
             "\"git.hub\".pulls"
         );
         assert_eq!(
-            format_schema_table_equivalent("git\"hub", "pulls"),
+            format_schema_table_equivalent("", "git\"hub", "pulls"),
             "\"git\"\"hub\".pulls"
+        );
+        assert_eq!(
+            format_schema_table_equivalent("coral_db", "Main.Schema", "users"),
+            "coral_db.\"Main.Schema\".users"
         );
     }
 }

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -81,13 +81,16 @@ pub(crate) fn guide_resource_content(
     let mut schemas = tables
         .iter()
         .filter(|table| !is_coral_system_schema(table))
-        .map(addressable_schema_name)
+        .map(visible_schema_entry)
         .collect::<BTreeSet<_>>();
+    // Sanitized like the table schemas above: source names are only validated
+    // as path segments, so a schema publishing table functions could otherwise
+    // carry a newline and break out of its `Visible schemas:` bullet.
     schemas.extend(
         table_function_schema_names
             .iter()
             .filter(|schema| *schema != "coral")
-            .cloned(),
+            .map(|schema| prompt_safe_text(schema)),
     );
     if schemas.is_empty() {
         if sources.is_empty() {
@@ -97,7 +100,7 @@ pub(crate) fn guide_resource_content(
         }
     } else {
         sources_section.push_str("\nVisible schemas:\n");
-        for schema in schemas {
+        for schema in &schemas {
             writeln!(sources_section, "- {schema}").expect("writing to String is infallible");
         }
     }
@@ -202,12 +205,22 @@ fn is_coral_system_schema(table: &TableSummary) -> bool {
     table.catalog_name.is_empty() && table.schema_name == "coral"
 }
 
-fn addressable_schema_name(table: &TableSummary) -> String {
+/// Renders one entry for the visible-schema list.
+///
+/// A catalog-backed table names its catalog separately rather than joining the
+/// two into `catalog.schema`: this list is labelled as schemas, and
+/// `warehouse.public` is not a schema — the schema is `public` and the catalog
+/// is `warehouse`. Keeping them apart is also what the `coral.*` metadata
+/// tables expect, since they filter on `catalog_name` and `schema_name`.
+fn visible_schema_entry(table: &TableSummary) -> String {
     let schema_name = prompt_safe_text(&table.schema_name);
     if table.catalog_name.is_empty() {
         schema_name
     } else {
-        format!("{}.{schema_name}", prompt_safe_text(&table.catalog_name))
+        format!(
+            "{schema_name} (catalog: {})",
+            prompt_safe_text(&table.catalog_name)
+        )
     }
 }
 
@@ -569,7 +582,7 @@ WHERE title LIKE '%bug%'",
             false,
         );
 
-        assert!(content.contains("Visible schemas:\n- warehouse.public"));
+        assert!(content.contains("Visible schemas:\n- public (catalog: warehouse)"));
         assert!(content.contains(
             "FROM coral.columns WHERE catalog_name = 'warehouse' AND schema_name = 'public' \
              AND table_name = 'orders' ORDER BY ordinal_position;"

--- a/crates/coral-mcp/src/surface/values.rs
+++ b/crates/coral-mcp/src/surface/values.rs
@@ -42,7 +42,11 @@ impl<'a> From<&'a TableSummary> for QueryableTableSummaryValue<'a> {
             catalog_name: &table.catalog_name,
             schema_name: &table.schema_name,
             table_name: &table.name,
-            name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
+            name: format_table_name(
+                optional_catalog_name(&table.catalog_name),
+                &table.schema_name,
+                &table.name,
+            ),
             sql_reference: format_schema_table_equivalent(
                 optional_catalog_name(&table.catalog_name),
                 &table.schema_name,
@@ -72,7 +76,11 @@ impl<'a> From<&'a TableSummary> for MissingTableSummaryValue<'a> {
             catalog_name: &table.catalog_name,
             schema_name: &table.schema_name,
             table_name: &table.name,
-            name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
+            name: format_table_name(
+                optional_catalog_name(&table.catalog_name),
+                &table.schema_name,
+                &table.name,
+            ),
             description: &table.description,
             required_filters: &table.required_filters,
         }

--- a/crates/coral-mcp/src/surface/values.rs
+++ b/crates/coral-mcp/src/surface/values.rs
@@ -1,5 +1,5 @@
 use coral_api::v1::TableSummary;
-pub(crate) use coral_client::format_schema_table_equivalent;
+pub(crate) use coral_client::{format_schema_table_equivalent, format_table_name};
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::Value;
@@ -74,13 +74,5 @@ impl<'a> From<&'a TableSummary> for MissingTableSummaryValue<'a> {
             description: &table.description,
             required_filters: &table.required_filters,
         }
-    }
-}
-
-pub(crate) fn format_table_name(catalog_name: &str, schema_name: &str, table_name: &str) -> String {
-    if catalog_name.is_empty() {
-        format!("{schema_name}.{table_name}")
-    } else {
-        format!("{catalog_name}.{schema_name}.{table_name}")
     }
 }

--- a/crates/coral-mcp/src/surface/values.rs
+++ b/crates/coral-mcp/src/surface/values.rs
@@ -24,6 +24,7 @@ pub(crate) fn queryable_table_summary_values(tables: &[TableSummary]) -> Vec<Val
 
 #[derive(Serialize)]
 struct QueryableTableSummaryValue<'a> {
+    catalog_name: &'a str,
     schema_name: &'a str,
     table_name: &'a str,
     name: String,
@@ -36,10 +37,15 @@ struct QueryableTableSummaryValue<'a> {
 impl<'a> From<&'a TableSummary> for QueryableTableSummaryValue<'a> {
     fn from(table: &'a TableSummary) -> Self {
         Self {
+            catalog_name: &table.catalog_name,
             schema_name: &table.schema_name,
             table_name: &table.name,
-            name: format!("{}.{}", table.schema_name, table.name),
-            sql_reference: format_schema_table_equivalent(&table.schema_name, &table.name),
+            name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
+            sql_reference: format_schema_table_equivalent(
+                &table.catalog_name,
+                &table.schema_name,
+                &table.name,
+            ),
             description: &table.description,
             guide: &table.guide,
             required_filters: &table.required_filters,
@@ -50,6 +56,7 @@ impl<'a> From<&'a TableSummary> for QueryableTableSummaryValue<'a> {
 #[derive(Serialize, JsonSchema)]
 #[schemars(deny_unknown_fields)]
 pub(crate) struct MissingTableSummaryValue<'a> {
+    pub(crate) catalog_name: &'a str,
     pub(crate) schema_name: &'a str,
     pub(crate) table_name: &'a str,
     pub(crate) name: String,
@@ -60,11 +67,20 @@ pub(crate) struct MissingTableSummaryValue<'a> {
 impl<'a> From<&'a TableSummary> for MissingTableSummaryValue<'a> {
     fn from(table: &'a TableSummary) -> Self {
         Self {
+            catalog_name: &table.catalog_name,
             schema_name: &table.schema_name,
             table_name: &table.name,
-            name: format!("{}.{}", table.schema_name, table.name),
+            name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
             description: &table.description,
             required_filters: &table.required_filters,
         }
+    }
+}
+
+pub(crate) fn format_table_name(catalog_name: &str, schema_name: &str, table_name: &str) -> String {
+    if catalog_name.is_empty() {
+        format!("{schema_name}.{table_name}")
+    } else {
+        format!("{catalog_name}.{schema_name}.{table_name}")
     }
 }

--- a/crates/coral-mcp/src/surface/values.rs
+++ b/crates/coral-mcp/src/surface/values.rs
@@ -1,5 +1,7 @@
 use coral_api::v1::TableSummary;
-pub(crate) use coral_client::{format_schema_table_equivalent, format_table_name};
+pub(crate) use coral_client::{
+    format_schema_table_equivalent, format_table_name, optional_catalog_name,
+};
 use schemars::JsonSchema;
 use serde::Serialize;
 use serde_json::Value;
@@ -42,7 +44,7 @@ impl<'a> From<&'a TableSummary> for QueryableTableSummaryValue<'a> {
             table_name: &table.name,
             name: format_table_name(&table.catalog_name, &table.schema_name, &table.name),
             sql_reference: format_schema_table_equivalent(
-                &table.catalog_name,
+                optional_catalog_name(&table.catalog_name),
                 &table.schema_name,
                 &table.name,
             ),

--- a/plugins/coral/skills/coral/SKILL.md
+++ b/plugins/coral/skills/coral/SKILL.md
@@ -23,7 +23,7 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 ## Workflow
 
 1. Identify the needed source, entity, and scope from the user request.
-2. Discover relevant tables, table functions, columns, and filters with `search`; use `list_catalog` when you need a paged catalog view narrowed by schema or kind.
+2. Discover relevant tables, table functions, columns, and filters with `search`; use `list_catalog` when you need a paged catalog view narrowed by catalog, schema, or kind.
 3. Read `search` or `list_catalog` for `sql_reference`, `sql_call_example`, `guide`, and `required_filters`; use `coral://guide` for query patterns and `coral://tables` for table summaries.
 4. Inspect `coral.columns` for table columns, required filters, virtual columns, and descriptions.
 5. Inspect `coral.table_functions` for source-scoped function guides, arguments, and result columns.
@@ -33,7 +33,7 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 
 ## Query Rules
 
-- Use each table's `sql_reference` when available. If building a reference from `schema_name` and `table_name`, write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
+- Use each table's `sql_reference` when available. Empty `catalog_name` means `schema_name.table_name`; otherwise use `catalog_name.schema_name.table_name`. Quote identifiers separately, never the whole qualified reference.
 - Use each table function's `sql_call_example`, filling in required arguments before querying it.
 - Keep metadata discovery bounded: page catalog discovery, query `coral.columns` for one table or `coral.table_functions` for one source when possible, and add `LIMIT` when reading broad metadata directly.
 - Virtual columns are filter-only and return `NULL`; check `is_virtual`.


### PR DESCRIPTION
## Summary

- carry catalog names through discovery, API, CLI, search, and MCP surfaces
- keep describe-table and list-columns behavior consistent for DataFusion-qualified input
- format three-part catalog, schema, and table names where public surfaces expose qualified names

## Stack

- Depends on: #1893
- Next: #1927

This is PR 2 of 7 in the relational database source MVP stack.