### PR TITLE
feat(engine): add relational database catalog backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -141,6 +152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,7 +222,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
@@ -350,6 +370,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
+ "serde",
  "serde_core",
  "serde_json",
 ]
@@ -360,7 +381,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -534,6 +555,28 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -779,6 +822,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bb8"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457d7ed3f888dfd2c7af56d4975cade43c622f74bdcddfed6d4352f57acc6310"
+dependencies = [
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "tokio",
+]
+
+[[package]]
+name = "bb8-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e570e6557cd0f88d28d32afa76644873271a70dc22656df565b2021c4036aa9c"
+dependencies = [
+ "bb8",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +963,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,10 +1019,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytecount"
@@ -1022,8 +1143,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1034,7 +1157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -1393,6 +1516,7 @@ dependencies = [
  "datafusion-datasource",
  "datafusion-datasource-json",
  "datafusion-functions-json",
+ "datafusion-table-providers",
  "datafusion-tracing",
  "futures",
  "httpdate",
@@ -1402,6 +1526,7 @@ dependencies = [
  "parquet",
  "reqwest 0.13.4",
  "rmcp",
+ "rusqlite",
  "serde",
  "serde_json",
  "strsim",
@@ -1542,6 +1667,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2067,6 +2216,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-federation"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31c9f6439e96c06a56d6fe8ff33bdf9d74a7336d4e6937e6862699df2596187"
+dependencies = [
+ "arrow-json",
+ "async-stream",
+ "async-trait",
+ "datafusion",
+ "futures",
+]
+
+[[package]]
 name = "datafusion-functions"
 version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2561,146 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-table-providers"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33884dd4df7006e31ec923b1d362a0b4c75615ba6bea6b3ee9c41b20b06b4da"
+dependencies = [
+ "arrow",
+ "datafusion",
+ "datafusion-table-providers-common",
+ "datafusion-table-providers-mysql",
+ "datafusion-table-providers-postgres",
+ "datafusion-table-providers-sqlite",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-table-providers-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b4ed5748078e8ddb61405557f54051ae85b025ba226d4f58f58aea1eaf7faf"
+dependencies = [
+ "arrow",
+ "arrow-json",
+ "async-trait",
+ "bigdecimal",
+ "byteorder",
+ "chrono",
+ "dashmap",
+ "datafusion",
+ "datafusion-federation",
+ "fallible-iterator 0.3.0",
+ "fundu",
+ "futures",
+ "geo-types",
+ "hickory-resolver",
+ "itertools",
+ "num-bigint",
+ "rand 0.10.2",
+ "regex",
+ "sea-query",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "snafu",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "datafusion-table-providers-mysql"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b9e9e79a4cf6942b78cc08e4b16426632d5394916a5563dd49c3b83e5174abd"
+dependencies = [
+ "arrow",
+ "async-stream",
+ "async-trait",
+ "bigdecimal",
+ "chrono",
+ "datafusion",
+ "datafusion-federation",
+ "datafusion-table-providers-common",
+ "futures",
+ "mysql_async",
+ "num-bigint",
+ "sea-query",
+ "secrecy",
+ "snafu",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "datafusion-table-providers-postgres"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2a7910defd5971ca5503d2bf25bea4ae5875c5a4355e7caead246a34db6be7"
+dependencies = [
+ "arrow",
+ "arrow-json",
+ "arrow-schema",
+ "async-stream",
+ "async-trait",
+ "bb8",
+ "bb8-postgres",
+ "bigdecimal",
+ "byteorder",
+ "chrono",
+ "datafusion",
+ "datafusion-federation",
+ "datafusion-table-providers-common",
+ "fallible-iterator 0.3.0",
+ "futures",
+ "geo-types",
+ "logos",
+ "native-tls",
+ "pem",
+ "postgres-native-tls",
+ "rust_decimal",
+ "sea-query",
+ "secrecy",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-table-providers-sqlite"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6c9a43b09b71717309f6cd5db04fe8a73a49c5923aa5fc4b02c8c7d9e8e796"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "async-trait",
+ "chrono",
+ "datafusion",
+ "datafusion-federation",
+ "datafusion-table-providers-common",
+ "fundu",
+ "futures",
+ "rusqlite",
+ "sea-query",
+ "secrecy",
+ "snafu",
+ "tokio",
+ "tokio-rusqlite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "datafusion-tracing"
 version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,6 +2941,12 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
@@ -2706,6 +3014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
+ "libz-sys",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -2751,6 +3060,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2784,6 +3108,21 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fundu"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce12752fc64f35be3d53e0a57017cd30970f0cffd73f62c791837d8845badbd"
+dependencies = [
+ "fundu-core",
+]
+
+[[package]]
+name = "fundu-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e463452e2d8b7600d38dcea1ed819773a57f0d710691bfc78db3961bd3f4c3ba"
 
 [[package]]
 name = "funty"
@@ -2914,6 +3253,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo-types"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
+dependencies = [
+ "approx",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2922,7 +3272,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2989,6 +3339,15 @@ dependencies = [
  "crunchy",
  "num-traits",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -3069,6 +3428,76 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.2",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.2",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -3256,7 +3685,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3436,10 +3865,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.5",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3468,7 +3913,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7866f284df68dbc242796251ed9768bde2b58ebc4d7d32cc07cc7fd993e3ed6c"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bitvec",
  "lexical-parse-float",
  "num-bigint",
@@ -3553,7 +3998,7 @@ version = "0.46.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "bytecount",
  "data-encoding",
  "email_address",
@@ -3597,6 +4042,15 @@ dependencies = [
  "serde_json",
  "signature",
  "zeroize",
+]
+
+[[package]]
+name = "keyed_priority_queue"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee7893dab2e44ae5f9d0173f26ff4aa327c10b01b06a72b52dd9405b628640d"
+dependencies = [
+ "indexmap",
 ]
 
 [[package]]
@@ -3710,10 +4164,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3754,6 +4228,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3766,6 +4281,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -3858,8 +4396,25 @@ checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -3867,6 +4422,107 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "mysql-common-derive"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4db8a44120571277accfaa3f3d91e7d3989d601d817c2fc01a9391b86135666"
+dependencies = [
+ "darling 0.23.0",
+ "heck 0.5.0",
+ "manyhow",
+ "num-bigint",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "termcolor",
+ "thiserror",
+]
+
+[[package]]
+name = "mysql_async"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d9585dc9058886ff3a1f48a23024dd1d054264dee7c5ae0e4bd640c953bee5"
+dependencies = [
+ "bytes",
+ "crossbeam-queue",
+ "flate2",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "keyed_priority_queue",
+ "lru",
+ "mysql_common",
+ "native-tls",
+ "pem",
+ "percent-encoding",
+ "rand 0.9.5",
+ "serde",
+ "serde_json",
+ "socket2 0.5.10",
+ "thiserror",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "twox-hash",
+ "url",
+]
+
+[[package]]
+name = "mysql_common"
+version = "0.35.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbb9f371618ce723f095c61fbcdc36e8936956d2b62832f9c7648689b338e052"
+dependencies = [
+ "base64",
+ "bigdecimal",
+ "bitflags",
+ "btoi",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc32fast",
+ "flate2",
+ "getrandom 0.3.4",
+ "mysql-common-derive",
+ "num-bigint",
+ "num-traits",
+ "regex",
+ "saturating",
+ "serde",
+ "serde_json",
+ "sha1 0.10.7",
+ "sha2 0.10.9",
+ "thiserror",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -3985,6 +4641,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4036,6 +4710,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4044,10 +4722,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -4195,7 +4910,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -4238,6 +4953,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,7 +4986,17 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -4269,6 +5004,15 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -4343,6 +5087,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
+name = "postgres-native-tls"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef4de47bb81477e0c3deaf153a1b10ae176484713ff1640969f4cb96b653ebc"
+dependencies = [
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.2",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "chrono",
+ "fallible-iterator 0.2.0",
+ "geo-types",
+ "postgres-protocol",
+ "serde_core",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4394,6 +5184,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4410,6 +5211,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -4563,6 +5375,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4665,7 +5497,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.5",
  "thiserror",
  "tokio",
  "tracing",
@@ -4704,7 +5536,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -4738,11 +5570,22 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -4755,6 +5598,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4855,7 +5708,7 @@ version = "0.46.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "fluent-uri",
  "getrandom 0.3.4",
  "hashbrown 0.16.1",
@@ -4894,6 +5747,15 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "reqwest"
@@ -4984,6 +5846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4995,6 +5863,35 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5050,7 +5947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
  "bitflags",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink 0.10.0",
  "libsqlite3-sys",
@@ -5091,6 +5988,24 @@ dependencies = [
  "mime_guess",
  "sha2 0.11.0",
  "walkdir",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "postgres-types",
+ "rand 0.8.7",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5220,6 +6135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "saturating"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5266,7 +6187,12 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d190cfb3bcceb8a8d7d04dee5a0c77f60c7627979cdcb47fdcb8934f009badf"
 dependencies = [
+ "bigdecimal",
+ "chrono",
+ "itoa",
+ "rust_decimal",
  "sea-query-derive",
+ "time",
 ]
 
 [[package]]
@@ -5291,6 +6217,21 @@ checksum = "4eaa419cdb9157da1361186b1959983eb2ea0dcb9a3c69dc45c449ecb2af8fef"
 dependencies = [
  "sea-query",
  "sqlx",
+]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -5449,6 +6390,17 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -5591,10 +6543,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "snafu"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "snap"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -5657,8 +6640,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64",
+ "bigdecimal",
  "bytes",
  "cfg-if",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -5673,12 +6658,14 @@ dependencies = [
  "log",
  "memchr",
  "percent-encoding",
+ "rust_decimal",
  "rustls",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
  "thiserror",
+ "time",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5716,6 +6703,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sqlx-core",
+ "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.119",
@@ -5730,9 +6718,11 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
+ "bigdecimal",
  "bitflags",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest 0.11.3",
  "dotenvy",
@@ -5742,11 +6732,13 @@ dependencies = [
  "generic-array",
  "log",
  "percent-encoding",
+ "rust_decimal",
  "serde",
- "sha1",
+ "sha1 0.11.0",
  "sha2 0.11.0",
  "sqlx-core",
  "thiserror",
+ "time",
  "tracing",
 ]
 
@@ -5758,8 +6750,10 @@ checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
+ "bigdecimal",
  "bitflags",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -5773,7 +6767,9 @@ dependencies = [
  "log",
  "md-5 0.11.0",
  "memchr",
+ "num-bigint",
  "rand 0.10.2",
+ "rust_decimal",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -5781,6 +6777,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
+ "time",
  "tracing",
  "whoami",
 ]
@@ -5792,6 +6789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "form_urlencoded",
  "futures-channel",
@@ -5805,6 +6803,7 @@ dependencies = [
  "serde",
  "sqlx-core",
  "thiserror",
+ "time",
  "tracing",
  "url",
 ]
@@ -5863,6 +6862,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -5928,6 +6938,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5950,6 +6966,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -6089,7 +7114,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -6104,6 +7129,53 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf 0.13.1",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.10.2",
+ "socket2 0.6.5",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
+name = "tokio-rusqlite"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302563ae4a2127f3d2c105f4f2f0bd7cae3609371755600ebc148e0ccd8510d6"
+dependencies = [
+ "crossbeam-channel",
+ "rusqlite",
+ "tokio",
 ]
 
 [[package]]
@@ -6222,7 +7294,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2",
+ "socket2 0.6.5",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -6662,12 +7734,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -6679,6 +7769,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -6794,6 +7885,19 @@ name = "whoami"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
+]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,8 @@ serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.9"
 schemars = "1.2.1"
 sea-query = { version = "1", default-features = false, features = ["backend-postgres", "backend-sqlite", "derive", "thread-safe"] }
+# Keep SQLx bind support aligned with SeaQuery value variants enabled
+# transitively by datafusion-table-providers.
 sea-query-sqlx = { version = "0.9", default-features = false, features = [
   "postgres-array",
   "sqlx-postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ datafusion = "54"
 datafusion-datasource = "54"
 datafusion-datasource-json = "54"
 datafusion-functions-json = "0.54"
+# The 0.13 PostgreSQL/MySQL adapters hard-enable native-tls (OpenSSL on Linux)
+# and expose no rustls feature. Accept this for the database MVP and revisit it
+# when upstream provides a rustls-compatible configuration.
+datafusion-table-providers = { version = "0.13.0", default-features = false }
 datafusion-tracing = "54"
 dialoguer = "0.12"
 etcetera = "0.11"
@@ -93,7 +97,15 @@ serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.9"
 schemars = "1.2.1"
 sea-query = { version = "1", default-features = false, features = ["backend-postgres", "backend-sqlite", "derive", "thread-safe"] }
-sea-query-sqlx = { version = "0.9", default-features = false, features = ["sqlx-postgres", "sqlx-sqlite"] }
+sea-query-sqlx = { version = "0.9", default-features = false, features = [
+  "postgres-array",
+  "sqlx-postgres",
+  "sqlx-sqlite",
+  "with-bigdecimal",
+  "with-chrono",
+  "with-rust_decimal",
+  "with-time",
+] }
 sha2 = "0.10"
 sqlx = { version = "0.9", default-features = false, features = ["macros", "migrate", "postgres", "runtime-tokio", "sqlite", "tls-rustls"] }
 sqlparser = "0.59.0"

--- a/crates/coral-app/src/functions/validation.rs
+++ b/crates/coral-app/src/functions/validation.rs
@@ -69,6 +69,9 @@ fn record_source_component_sql_targets(
     targets: &mut SqlPublishTargets,
 ) {
     match component {
+        RuntimeSourceComponent::Database(_) => {
+            // Database tables are discovered at registration and have no static publish targets.
+        }
         RuntimeSourceComponent::Http(manifest) => {
             for table in &manifest.tables {
                 targets.insert(SqlPublishTarget::new(&manifest.common.name, table.name()));

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -417,6 +417,8 @@ impl QueryManager {
         shown_guide_ids: Option<&HashSet<String>>,
         attribution: &QueryAttribution,
     ) -> Result<ExecuteSqlOutcome, QueryManagerError> {
+        // Keep the database-enabled operation future off this async state machine: on Linux it
+        // exceeds Clippy's `large_futures` threshold when awaited inline.
         Box::pin(run_query_operation(
             QueryOperation::ExecuteSql,
             workspace_name,

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -417,7 +417,7 @@ impl QueryManager {
         shown_guide_ids: Option<&HashSet<String>>,
         attribution: &QueryAttribution,
     ) -> Result<ExecuteSqlOutcome, QueryManagerError> {
-        run_query_operation(
+        Box::pin(run_query_operation(
             QueryOperation::ExecuteSql,
             workspace_name,
             sql,
@@ -474,7 +474,7 @@ impl QueryManager {
                     record_query_provenance(span, execution.provenance());
                 }
             },
-        )
+        ))
         .await
     }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -444,10 +444,11 @@ impl QueryManager {
                     // Unfiltered on both qualifiers: a required guide has to be
                     // found wherever the query's tables live, including
                     // catalog-backed sources.
-                    let required_guides = required_query_guides(
-                        &runtime.list_catalog(None, None),
-                        prepared.resources(),
-                    );
+                    let catalog = runtime
+                        .list_catalog(None, None)
+                        .await
+                        .map_err(QueryManagerError::Core)?;
+                    let required_guides = required_query_guides(&catalog, prepared.resources());
                     let unseen_guides = required_guides
                         .into_iter()
                         .filter(|guide| !shown_guide_ids.contains(&guide.guide_id))

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -290,7 +290,10 @@ impl QueryManager {
                         SourceObservationMode::Disabled,
                     )
                     .await?;
-                Ok(runtime.list_tables(catalog_filter, schema_filter, table_filter))
+                runtime
+                    .list_tables(catalog_filter, schema_filter, table_filter)
+                    .await
+                    .map_err(QueryManagerError::Core)
             },
             |tables| Some(u64::try_from(tables.len()).unwrap_or(u64::MAX)),
             |_, _| {},
@@ -343,7 +346,10 @@ impl QueryManager {
                 let runtime_schema_owners =
                     runtime_schema_owners(&source_load.loaded).map_err(QueryManagerError::App)?;
                 Ok(CatalogResolution {
-                    catalog: runtime.list_catalog(catalog_filter, schema_filter),
+                    catalog: runtime
+                        .list_catalog(catalog_filter, schema_filter)
+                        .await
+                        .map_err(QueryManagerError::Core)?,
                     failed_source_names,
                     runtime_schema_owners,
                 })
@@ -393,7 +399,10 @@ impl QueryManager {
                         SourceObservationMode::Disabled,
                     )
                     .await?;
-                Ok(runtime.describe_table(catalog_name, schema_name, table_name))
+                runtime
+                    .describe_table(catalog_name, schema_name, table_name)
+                    .await
+                    .map_err(QueryManagerError::Core)
             },
             |_| None,
             |_, _| {},

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -56,15 +56,14 @@ impl QueryServiceApi for QueryService {
                     .await
                     .map_err(task_manager_status)?,
             );
-            let outcome = queries
-                .execute_sql(
-                    &workspace_name,
-                    &inner.sql,
-                    shown_guide_ids.as_ref(),
-                    &attribution,
-                )
-                .await
-                .map_err(query_status)?;
+            let outcome = Box::pin(queries.execute_sql(
+                &workspace_name,
+                &inner.sql,
+                shown_guide_ids.as_ref(),
+                &attribution,
+            ))
+            .await
+            .map_err(query_status)?;
             let response = match outcome {
                 ExecuteSqlOutcome::Executed(execution) => ExecuteSqlResponse {
                     arrow_ipc_stream: encode_arrow_ipc_stream(

--- a/crates/coral-app/src/search/observed/source_scope.rs
+++ b/crates/coral-app/src/search/observed/source_scope.rs
@@ -81,6 +81,9 @@ pub(super) fn source_surface_scopes(
     let mut scopes = Vec::new();
     for component in source.components() {
         match component {
+            RuntimeSourceComponent::Database(_) => {
+                // Database tables do not declare HTTP/MCP observation surfaces.
+            }
             RuntimeSourceComponent::Http(manifest) => {
                 scopes.extend(manifest.tables.iter().map(|table| {
                     surface_scope(

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -91,6 +91,13 @@ pub(crate) fn runtime_contract_fingerprint(
                 "DSL v4 runtime fingerprint received a file component".to_string(),
             ));
         }
+        // The engine models database components here, but no app path installs
+        // one until DSL v4 database sources are connected.
+        Some(RuntimeSourceComponent::Database(_)) => {
+            return Err(AppError::Internal(
+                "DSL v4 runtime fingerprint received a database component".to_string(),
+            ));
+        }
         None => None,
     };
     let input = RuntimeContractFingerprintInput {

--- a/crates/coral-engine/Cargo.toml
+++ b/crates/coral-engine/Cargo.toml
@@ -19,6 +19,11 @@ datafusion.workspace = true
 datafusion-datasource.workspace = true
 datafusion-datasource-json.workspace = true
 datafusion-functions-json.workspace = true
+datafusion-table-providers = { workspace = true, features = [
+  "mysql",
+  "postgres",
+  "sqlite",
+] }
 datafusion-tracing.workspace = true
 futures.workspace = true
 httpdate.workspace = true
@@ -46,6 +51,7 @@ arrow.workspace = true
 coral-spec.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 parquet.workspace = true
+rusqlite.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 tokio.workspace = true

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -137,17 +137,21 @@ pub(crate) struct RegisteredInput {
 pub(crate) enum SourceQualifiedName {
     /// Two-part source: tables resolve as `datafusion.<name>.<table>`.
     Schema(String),
+    /// Catalog-backed source: tables resolve as `<name>.<db_schema>.<table>`,
+    /// with the SQL schema recorded per table.
+    Catalog(String),
 }
 
 impl SourceQualifiedName {
     pub(crate) fn name(&self) -> &str {
         match self {
-            Self::Schema(name) => name,
+            Self::Schema(name) | Self::Catalog(name) => name,
         }
     }
 
     pub(crate) fn catalog_name(&self) -> Option<&str> {
         match self {
+            Self::Catalog(name) => Some(name),
             Self::Schema(_) => None,
         }
     }

--- a/crates/coral-engine/src/backends/database.rs
+++ b/crates/coral-engine/src/backends/database.rs
@@ -1,0 +1,747 @@
+//! Relational database backend registration through `datafusion-table-providers`.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use coral_spec::backends::database::{
+    DatabaseConnectionSpec, DatabaseSourceManifest, MySqlConnectionSpec, PostgresConnectionSpec,
+    SqliteConnectionSpec,
+};
+use coral_spec::{ParsedTemplate, SourceManifestCommon};
+use datafusion::arrow::array::StringArray;
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::catalog::{CatalogProvider, SchemaProvider};
+use datafusion::datasource::TableProvider;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::logical_expr::TableType;
+use datafusion::prelude::SessionContext;
+use datafusion::sql::TableReference;
+use datafusion::sql::unparser::dialect::{Dialect, MySqlDialect, PostgreSqlDialect, SqliteDialect};
+use datafusion_table_providers::UnsupportedTypeAction;
+use datafusion_table_providers::sql::db_connection_pool::dbconnection::query_arrow;
+use datafusion_table_providers::sql::db_connection_pool::mysqlpool::MySQLConnectionPool;
+use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
+use datafusion_table_providers::sql::db_connection_pool::sqlitepool::SqliteConnectionPoolFactory;
+use datafusion_table_providers::sql::db_connection_pool::{DbConnectionPool, Mode};
+use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
+use datafusion_table_providers::util::secrets::to_secret_map;
+use futures::TryStreamExt as _;
+
+use crate::backends::shared::template::{RenderContext, render_template};
+use crate::backends::{
+    BackendCatalogRegistration, BackendCompileRequest, BackendRegistration,
+    BackendRegistrationContext, CompiledBackendSource, RegisteredSource, RegisteredTable,
+    SourceQualifiedName, build_registered_inputs,
+};
+
+const REMOTE_DATABASE_REGISTRATION_TIMEOUT: Duration = Duration::from_secs(10);
+const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub(crate) fn compile_manifest(
+    manifest: &DatabaseSourceManifest,
+    request: &BackendCompileRequest<'_>,
+) -> Box<dyn CompiledBackendSource> {
+    Box::new(CompiledDatabaseSource {
+        manifest: manifest.clone(),
+        source_secrets: request.source_secrets.clone(),
+        source_variables: request.source_variables.clone(),
+    })
+}
+
+struct CompiledDatabaseSource {
+    manifest: DatabaseSourceManifest,
+    source_secrets: BTreeMap<String, String>,
+    source_variables: BTreeMap<String, String>,
+}
+
+#[async_trait]
+trait DatabaseCatalogStrategy: Send + Sync {
+    fn provider_name(&self) -> &'static str;
+
+    fn registration_timeout(&self) -> Option<Duration> {
+        Some(REMOTE_DATABASE_REGISTRATION_TIMEOUT)
+    }
+
+    async fn build_catalog(&self, context: &RenderContext<'_>)
+    -> DataFusionResult<DatabaseCatalog>;
+}
+
+fn database_strategy(connection: &DatabaseConnectionSpec) -> &dyn DatabaseCatalogStrategy {
+    match connection {
+        DatabaseConnectionSpec::Postgres(connection) => connection,
+        DatabaseConnectionSpec::MySql(connection) => connection,
+        DatabaseConnectionSpec::Sqlite(connection) => connection,
+    }
+}
+
+#[async_trait]
+impl CompiledBackendSource for CompiledDatabaseSource {
+    fn qualified_name(&self) -> &str {
+        &self.manifest.common.name
+    }
+
+    fn source_name(&self) -> &str {
+        &self.manifest.common.name
+    }
+
+    fn validate_runtime_capabilities(&self) -> DataFusionResult<()> {
+        Ok(())
+    }
+
+    async fn register(
+        &self,
+        _ctx: &SessionContext,
+        _registration: &BackendRegistrationContext,
+    ) -> DataFusionResult<BackendRegistration> {
+        let resolved_inputs = coral_spec::resolve_inputs(
+            &self.manifest.declared_inputs,
+            &self.source_secrets,
+            &self.source_variables,
+        );
+        let context = RenderContext::source_scoped(&resolved_inputs);
+        let strategy = database_strategy(&self.manifest.connection);
+        let provider_name = strategy.provider_name();
+        let registration_timeout = strategy.registration_timeout();
+        let registration = async {
+            let database_catalog = strategy.build_catalog(&context).await?;
+            let source = registered_source_for_catalog(
+                &self.manifest.common,
+                &self.manifest.declared_inputs,
+                &self.source_secrets,
+                &self.source_variables,
+                &database_catalog.relations,
+            );
+
+            Ok(BackendRegistration {
+                schemas: Vec::new(),
+                catalogs: vec![BackendCatalogRegistration {
+                    catalog: database_catalog.provider,
+                    source,
+                }],
+            })
+        };
+
+        match registration_timeout {
+            Some(timeout) => {
+                timed_database_registration(
+                    &self.manifest.common.name,
+                    provider_name,
+                    timeout,
+                    registration,
+                )
+                .await
+            }
+            None => registration.await,
+        }
+    }
+}
+
+async fn timed_database_registration<T>(
+    source_name: &str,
+    provider: &str,
+    timeout: Duration,
+    registration: impl Future<Output = DataFusionResult<T>>,
+) -> DataFusionResult<T> {
+    tokio::time::timeout(timeout, registration)
+        .await
+        .map_err(|_elapsed| {
+            DataFusionError::Execution(format!(
+                "database source '{source_name}' ({provider}) registration timed out after {} seconds",
+                timeout.as_secs()
+            ))
+        })?
+}
+
+#[async_trait]
+impl DatabaseCatalogStrategy for PostgresConnectionSpec {
+    fn provider_name(&self) -> &'static str {
+        "postgres"
+    }
+
+    async fn build_catalog(
+        &self,
+        context: &RenderContext<'_>,
+    ) -> DataFusionResult<DatabaseCatalog> {
+        let mut params = render_connection_params(
+            [
+                ("host", &self.host),
+                ("port", &self.port),
+                ("db", &self.database),
+                ("user", &self.user),
+                ("pass", &self.password),
+            ],
+            context,
+        )?;
+        if let Some(sslmode) = self.sslmode.as_ref() {
+            params.insert("sslmode".to_string(), render_template(sslmode, context)?);
+        }
+        let pool = PostgresConnectionPool::new(to_secret_map(params))
+            .await
+            .map_err(provider_error)?
+            // The MySQL adapter has no equivalent unsupported-type policy.
+            .with_unsupported_type_action(UnsupportedTypeAction::String);
+        database_catalog(
+            Arc::new(pool),
+            POSTGRES_RELATIONS_SQL,
+            Arc::new(PostgreSqlDialect {}),
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl DatabaseCatalogStrategy for MySqlConnectionSpec {
+    fn provider_name(&self) -> &'static str {
+        "mysql"
+    }
+
+    async fn build_catalog(
+        &self,
+        context: &RenderContext<'_>,
+    ) -> DataFusionResult<DatabaseCatalog> {
+        let mut params = render_connection_params(
+            [
+                ("host", &self.host),
+                ("db", &self.database),
+                ("user", &self.user),
+                ("pass", &self.password),
+            ],
+            context,
+        )?;
+        let raw_port = render_template(&self.port, context)?;
+        let tcp_port = match raw_port.trim().parse::<u16>() {
+            Ok(port) if port != 0 => port,
+            _ => {
+                return Err(DataFusionError::Execution(
+                    "MySQL connection.port is invalid; expected an integer between 1 and 65535"
+                        .to_string(),
+                ));
+            }
+        };
+        params.insert("tcp_port".to_string(), tcp_port.to_string());
+        let pool = MySQLConnectionPool::new(to_secret_map(params))
+            .await
+            .map_err(provider_error)?;
+        database_catalog(
+            Arc::new(pool),
+            MYSQL_RELATIONS_SQL,
+            Arc::new(MySqlDialect {}),
+        )
+        .await
+    }
+}
+
+fn render_connection_params<const N: usize>(
+    fields: [(&str, &ParsedTemplate); N],
+    context: &RenderContext<'_>,
+) -> DataFusionResult<HashMap<String, String>> {
+    fields
+        .into_iter()
+        .map(|(key, template)| Ok((key.to_string(), render_template(template, context)?)))
+        .collect()
+}
+
+#[async_trait]
+impl DatabaseCatalogStrategy for SqliteConnectionSpec {
+    fn provider_name(&self) -> &'static str {
+        "sqlite"
+    }
+
+    fn registration_timeout(&self) -> Option<Duration> {
+        None
+    }
+
+    async fn build_catalog(
+        &self,
+        context: &RenderContext<'_>,
+    ) -> DataFusionResult<DatabaseCatalog> {
+        let path = render_template(&self.path, context)?;
+        let pool = SqliteConnectionPoolFactory::new(&path, Mode::File, SQLITE_BUSY_TIMEOUT)
+            .build()
+            .await
+            .map_err(boxed_provider_error)?;
+        database_catalog(
+            Arc::new(pool),
+            SQLITE_RELATIONS_SQL,
+            Arc::new(SqliteDialect {}),
+        )
+        .await
+    }
+}
+
+const POSTGRES_RELATIONS_SQL: &str = "
+SELECT table_schema AS schema_name,
+       table_name,
+       table_type AS relation_type
+FROM information_schema.tables
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')";
+
+const MYSQL_RELATIONS_SQL: &str = "
+SELECT TABLE_SCHEMA AS schema_name,
+       TABLE_NAME AS table_name,
+       TABLE_TYPE AS relation_type
+FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')";
+
+const SQLITE_RELATIONS_SQL: &str = "
+SELECT 'main' AS schema_name,
+       name AS table_name,
+       CASE type WHEN 'view' THEN 'VIEW' ELSE 'BASE TABLE' END AS relation_type
+FROM sqlite_master
+WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'";
+
+type Pool<T, P> = Arc<dyn DbConnectionPool<T, P> + Send + Sync>;
+
+struct DatabaseCatalog {
+    provider: Arc<dyn CatalogProvider>,
+    relations: Vec<DatabaseRelation>,
+}
+
+#[derive(Clone, Debug)]
+struct DatabaseRelation {
+    schema_name: String,
+    table_name: String,
+    table_type: TableType,
+}
+
+type SqlDialect = Arc<dyn Dialect + Send + Sync>;
+
+async fn database_catalog<T: 'static, P: 'static>(
+    pool: Pool<T, P>,
+    inventory_sql: &str,
+    dialect: SqlDialect,
+) -> DataFusionResult<DatabaseCatalog> {
+    let relations = load_database_inventory(&pool, inventory_sql).await?;
+    let provider = Arc::new(CoralDatabaseCatalogProvider::new(
+        &pool, &relations, &dialect,
+    )) as Arc<dyn CatalogProvider>;
+    Ok(DatabaseCatalog {
+        provider,
+        relations,
+    })
+}
+
+async fn load_database_inventory<T: 'static, P: 'static>(
+    pool: &Pool<T, P>,
+    inventory_sql: &str,
+) -> DataFusionResult<Vec<DatabaseRelation>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("schema_name", DataType::Utf8, false),
+        Field::new("table_name", DataType::Utf8, false),
+        Field::new("relation_type", DataType::Utf8, false),
+    ]));
+    let connection = pool.connect().await.map_err(boxed_provider_error)?;
+    let batches = query_arrow(connection, inventory_sql.to_string(), Some(schema))
+        .await
+        .map_err(provider_error)?
+        .try_collect::<Vec<_>>()
+        .await?;
+    let mut relations = Vec::new();
+    for batch in batches {
+        let schema_names = database_inventory_column(&batch, "schema_name")?;
+        let table_names = database_inventory_column(&batch, "table_name")?;
+        let relation_types = database_inventory_column(&batch, "relation_type")?;
+        for row in 0..batch.num_rows() {
+            relations.push(DatabaseRelation {
+                schema_name: schema_names.value(row).to_string(),
+                table_name: table_names.value(row).to_string(),
+                table_type: relation_table_type(relation_types.value(row)),
+            });
+        }
+    }
+    relations.sort_by(|left, right| {
+        (&left.schema_name, &left.table_name).cmp(&(&right.schema_name, &right.table_name))
+    });
+    relations.dedup_by(|left, right| {
+        left.schema_name == right.schema_name && left.table_name == right.table_name
+    });
+    Ok(relations)
+}
+
+fn database_inventory_column<'a>(
+    batch: &'a datafusion::arrow::record_batch::RecordBatch,
+    name: &str,
+) -> DataFusionResult<&'a StringArray> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref::<StringArray>())
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!("database inventory column '{name}' is not Utf8"))
+        })
+}
+
+fn relation_table_type(value: &str) -> TableType {
+    if value.eq_ignore_ascii_case("VIEW") || value.eq_ignore_ascii_case("MATERIALIZED VIEW") {
+        TableType::View
+    } else {
+        TableType::Base
+    }
+}
+
+struct CoralDatabaseCatalogProvider {
+    schemas: HashMap<String, Arc<dyn SchemaProvider>>,
+}
+
+impl CoralDatabaseCatalogProvider {
+    fn new<T: 'static, P: 'static>(
+        pool: &Pool<T, P>,
+        relations: &[DatabaseRelation],
+        dialect: &SqlDialect,
+    ) -> Self {
+        let mut by_schema = BTreeMap::<String, BTreeMap<String, TableType>>::new();
+        for relation in relations {
+            by_schema
+                .entry(relation.schema_name.clone())
+                .or_default()
+                .insert(relation.table_name.clone(), relation.table_type);
+        }
+        let schemas = by_schema
+            .into_iter()
+            .map(|(schema_name, tables)| {
+                let provider = CoralDatabaseSchemaProvider {
+                    schema_name: schema_name.clone(),
+                    tables,
+                    pool: Arc::clone(pool),
+                    dialect: Arc::clone(dialect),
+                };
+                (schema_name, Arc::new(provider) as Arc<dyn SchemaProvider>)
+            })
+            .collect();
+        Self { schemas }
+    }
+}
+
+impl fmt::Debug for CoralDatabaseCatalogProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CoralDatabaseCatalogProvider")
+            .field("schemas", &self.schemas.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl CatalogProvider for CoralDatabaseCatalogProvider {
+    fn schema_names(&self) -> Vec<String> {
+        self.schemas.keys().cloned().collect()
+    }
+
+    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        self.schemas.get(name).cloned()
+    }
+}
+
+struct CoralDatabaseSchemaProvider<T: 'static, P: 'static> {
+    schema_name: String,
+    tables: BTreeMap<String, TableType>,
+    pool: Pool<T, P>,
+    dialect: SqlDialect,
+}
+
+impl<T: 'static, P: 'static> fmt::Debug for CoralDatabaseSchemaProvider<T, P> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CoralDatabaseSchemaProvider")
+            .field("schema_name", &self.schema_name)
+            .field("tables", &self.tables)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl<T: 'static, P: 'static> SchemaProvider for CoralDatabaseSchemaProvider<T, P> {
+    fn table_names(&self) -> Vec<String> {
+        self.tables.keys().cloned().collect()
+    }
+
+    async fn table(&self, name: &str) -> DataFusionResult<Option<Arc<dyn TableProvider>>> {
+        if !self.tables.contains_key(name) {
+            return Ok(None);
+        }
+        SqlTable::new(
+            &self.schema_name,
+            &self.pool,
+            TableReference::partial(self.schema_name.clone(), name.to_string()),
+        )
+        .await
+        .map(|table| {
+            let table = table.with_dialect(Arc::clone(&self.dialect));
+            Some(Arc::new(table) as Arc<dyn TableProvider>)
+        })
+        .map_err(provider_error)
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        self.tables.contains_key(name)
+    }
+
+    async fn table_type(&self, name: &str) -> DataFusionResult<Option<TableType>> {
+        Ok(self.tables.get(name).copied())
+    }
+}
+
+fn registered_source_for_catalog(
+    common: &SourceManifestCommon,
+    declared_inputs: &[coral_spec::ManifestInputSpec],
+    source_secrets: &BTreeMap<String, String>,
+    source_variables: &BTreeMap<String, String>,
+    relations: &[DatabaseRelation],
+) -> RegisteredSource {
+    let secret_keys = source_secrets.keys().cloned().collect::<BTreeSet<_>>();
+    RegisteredSource {
+        qualified_name: SourceQualifiedName::Catalog(common.name.clone()),
+        tables: database_relation_inventory(relations),
+        table_functions: Vec::new(),
+        inputs: build_registered_inputs(declared_inputs, source_variables, &secret_keys),
+    }
+}
+
+/// Project the Coral-owned relation inventory into public catalog metadata
+/// without constructing table providers or fetching column schemas.
+fn database_relation_inventory(relations: &[DatabaseRelation]) -> Vec<RegisteredTable> {
+    relations
+        .iter()
+        .map(|relation| RegisteredTable {
+            schema_name: Some(relation.schema_name.clone()),
+            table_name: relation.table_name.clone(),
+            description: String::new(),
+            guide: String::new(),
+            columns: Vec::new(),
+            filters: Vec::new(),
+            required_filters: Vec::new(),
+            search_limits: None,
+        })
+        .collect()
+}
+
+fn provider_error(error: impl std::error::Error + Send + Sync + 'static) -> DataFusionError {
+    DataFusionError::External(Box::new(error))
+}
+
+fn boxed_provider_error(error: Box<dyn std::error::Error + Send + Sync>) -> DataFusionError {
+    DataFusionError::External(error)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use coral_spec::{
+        DatabaseConnectionSpec, DatabaseSourceManifest, MySqlConnectionSpec, ParsedTemplate,
+        SourceManifestCommon, SqliteConnectionSpec,
+    };
+
+    use super::DatabaseCatalogStrategy;
+    use crate::backends::shared::template::RenderContext;
+    use crate::{
+        CoralQuery, QueryRuntimeConfig, QuerySource, RuntimeSourceComponent, RuntimeSourcePackage,
+        SourceDecorator, SourceDecoratorError, SourceFailurePolicy, SourceTables,
+    };
+
+    struct AbortOnSourceFailureDecorator;
+
+    impl SourceDecorator for AbortOnSourceFailureDecorator {
+        fn name(&self) -> &'static str {
+            "abort-on-source-failure"
+        }
+
+        fn decorate_source(
+            &mut self,
+            _source: &QuerySource,
+            tables: SourceTables,
+        ) -> Result<SourceTables, SourceDecoratorError> {
+            Ok(tables)
+        }
+
+        fn source_failed(
+            &mut self,
+            _source: &QuerySource,
+            _error: &crate::CoreError,
+        ) -> Result<SourceFailurePolicy, SourceDecoratorError> {
+            Ok(SourceFailurePolicy::Abort)
+        }
+    }
+
+    fn template(value: &str) -> ParsedTemplate {
+        ParsedTemplate::parse(value.to_string()).expect("template")
+    }
+
+    fn mysql_connection(port: &str) -> MySqlConnectionSpec {
+        MySqlConnectionSpec {
+            host: template("localhost"),
+            port: template(port),
+            database: template("coral"),
+            user: template("root"),
+            password: template("password"),
+        }
+    }
+
+    fn sqlite_source(path: String) -> QuerySource {
+        let database = DatabaseSourceManifest {
+            common: SourceManifestCommon {
+                dsl_version: 4,
+                name: "coral_db".to_string(),
+                version: String::new(),
+                description: "Coral test database".to_string(),
+                test_queries: Vec::new(),
+            },
+            connection: DatabaseConnectionSpec::Sqlite(SqliteConnectionSpec {
+                path: ParsedTemplate::parse(path).expect("sqlite path template"),
+            }),
+            declared_inputs: Vec::new(),
+        };
+        QuerySource::from_runtime_components(
+            RuntimeSourcePackage {
+                source_name: "coral_db".to_string(),
+                authored_version: None,
+                description: String::new(),
+                declared_inputs: Vec::new(),
+                test_queries: Vec::new(),
+                components: vec![RuntimeSourceComponent::Database(database)],
+            },
+            BTreeMap::new(),
+            BTreeMap::new(),
+        )
+        .expect("database runtime source")
+    }
+
+    #[tokio::test]
+    async fn mysql_strategy_rejects_ports_that_provider_would_default() {
+        let cases = [
+            ("not-a-port", BTreeMap::new()),
+            ("70000", BTreeMap::new()),
+            ("0", BTreeMap::new()),
+            (
+                "{{input.DB_PORT}}",
+                BTreeMap::from([("DB_PORT".to_string(), "not-a-port".to_string())]),
+            ),
+        ];
+
+        for (port, resolved_inputs) in cases {
+            let connection = mysql_connection(port);
+            let context = RenderContext::source_scoped(&resolved_inputs);
+            let Err(error) = connection.build_catalog(&context).await else {
+                panic!("invalid MySQL port should fail before provider fallback");
+            };
+            let message = error.to_string();
+            assert!(
+                message.contains("MySQL connection.port is invalid"),
+                "unexpected error: {message}"
+            );
+            assert!(
+                message.contains("between 1 and 65535"),
+                "unexpected error: {message}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn sqlite_database_source_registers_catalog_and_queries_three_part_table() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let db_path = temp.path().join("coral.sqlite");
+        let conn = rusqlite::Connection::open(&db_path).expect("sqlite db");
+        conn.execute_batch(
+            "
+            CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+            INSERT INTO users (id, name) VALUES (1, 'Ada'), (2, 'Lin');
+            ",
+        )
+        .expect("sqlite fixture");
+        drop(conn);
+
+        let sources = vec![sqlite_source(db_path.to_string_lossy().into_owned())];
+
+        let tables = CoralQuery::list_tables(
+            &sources,
+            QueryRuntimeConfig::default(),
+            Some("coral_db"),
+            Some("main"),
+            Some("users"),
+        )
+        .await
+        .expect("list tables");
+        assert_eq!(tables.len(), 1);
+        let table = tables.first().expect("table metadata");
+        assert_eq!(table.catalog_name.as_deref(), Some("coral_db"));
+        assert_eq!(table.schema_name, "main");
+        assert_eq!(table.table_name, "users");
+
+        let result = CoralQuery::execute_sql(
+            &sources,
+            QueryRuntimeConfig::default(),
+            "SELECT id FROM coral_db.main.users WHERE name = 'Lin'",
+        )
+        .await
+        .expect("query sqlite table");
+        assert_eq!(result.row_count(), 1);
+        let scanned_sources = result
+            .provenance()
+            .tables()
+            .iter()
+            .map(|usage| usage.source_name().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            scanned_sources,
+            ["coral_db"],
+            "scan attributes to the source"
+        );
+
+        let catalog_result = CoralQuery::execute_sql(
+            &sources,
+            QueryRuntimeConfig::default(),
+            "SELECT catalog_name, schema_name, table_name FROM coral.tables \
+             WHERE catalog_name = 'coral_db' AND schema_name = 'main' AND table_name = 'users'",
+        )
+        .await
+        .expect("query coral tables");
+        assert_eq!(catalog_result.row_count(), 1);
+
+        let tables = CoralQuery::list_tables(
+            &sources,
+            QueryRuntimeConfig::default(),
+            Some("coral_db"),
+            Some("main"),
+            Some("users"),
+        )
+        .await
+        .expect("list tables by catalog and schema");
+        assert_eq!(tables.len(), 1);
+
+        let source = sources.first().expect("source");
+        CoralQuery::validate_source(source, QueryRuntimeConfig::default(), &[])
+            .await
+            .expect("database source validates");
+    }
+
+    #[tokio::test]
+    async fn database_catalog_registration_rejects_source_decorators() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let db_path = temp.path().join("coral.sqlite");
+        drop(rusqlite::Connection::open(&db_path).expect("sqlite db"));
+        let sources = vec![sqlite_source(db_path.to_string_lossy().into_owned())];
+
+        let mut decorated_config = QueryRuntimeConfig::default();
+        decorated_config
+            .extensions
+            .source_decorators
+            .push(Box::new(AbortOnSourceFailureDecorator));
+        let error = CoralQuery::list_tables(
+            &sources,
+            decorated_config,
+            Some("coral_db"),
+            Some("main"),
+            Some("users"),
+        )
+        .await
+        .expect_err("catalog registrations must reject source decorators");
+        assert!(
+            error
+                .to_string()
+                .contains("registers database catalogs, which do not support source decorators"),
+            "unexpected error: {error}"
+        );
+    }
+}

--- a/crates/coral-engine/src/backends/database.rs
+++ b/crates/coral-engine/src/backends/database.rs
@@ -668,6 +668,15 @@ mod tests {
         assert_eq!(table.catalog_name.as_deref(), Some("coral_db"));
         assert_eq!(table.schema_name, "main");
         assert_eq!(table.table_name, "users");
+        assert_eq!(
+            table
+                .columns
+                .iter()
+                .map(|column| column.name.as_str())
+                .collect::<Vec<_>>(),
+            ["id", "name"],
+            "database columns flow through coral.columns"
+        );
 
         let result = CoralQuery::execute_sql(
             &sources,
@@ -699,16 +708,13 @@ mod tests {
         .expect("query coral tables");
         assert_eq!(catalog_result.row_count(), 1);
 
-        let tables = CoralQuery::list_tables(
+        CoralQuery::execute_sql(
             &sources,
             QueryRuntimeConfig::default(),
-            Some("coral_db"),
-            Some("main"),
-            Some("users"),
+            "SELECT * FROM coral._columns_static",
         )
         .await
-        .expect("list tables by catalog and schema");
-        assert_eq!(tables.len(), 1);
+        .expect_err("the internal columns staging table must not be queryable");
 
         let source = sources.first().expect("source");
         CoralQuery::validate_source(source, QueryRuntimeConfig::default(), &[])

--- a/crates/coral-engine/src/backends/database.rs
+++ b/crates/coral-engine/src/backends/database.rs
@@ -80,8 +80,8 @@ fn database_strategy(connection: &DatabaseConnectionSpec) -> &dyn DatabaseCatalo
 
 #[async_trait]
 impl CompiledBackendSource for CompiledDatabaseSource {
-    fn qualified_name(&self) -> &str {
-        &self.manifest.common.name
+    fn qualified_name(&self) -> SourceQualifiedName {
+        SourceQualifiedName::Catalog(self.manifest.common.name.clone())
     }
 
     fn source_name(&self) -> &str {

--- a/crates/coral-engine/src/backends/database/catalog.rs
+++ b/crates/coral-engine/src/backends/database/catalog.rs
@@ -1,0 +1,191 @@
+//! DataFusion catalog adapter for a normalized relational database inventory.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::arrow::array::StringArray;
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider, SchemaProvider};
+use datafusion::datasource::TableProvider;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::logical_expr::TableType;
+use datafusion::sql::TableReference;
+use datafusion::sql::unparser::dialect::Dialect;
+use datafusion_table_providers::sql::db_connection_pool::DbConnectionPool;
+use datafusion_table_providers::sql::db_connection_pool::dbconnection::query_arrow;
+use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
+use futures::TryStreamExt as _;
+
+type Pool<T, P> = Arc<dyn DbConnectionPool<T, P> + Send + Sync>;
+type SqlDialect = Arc<dyn Dialect + Send + Sync>;
+
+pub(super) struct DatabaseCatalog {
+    pub(super) provider: Arc<dyn CatalogProvider>,
+    pub(super) relations: Vec<DatabaseRelation>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct DatabaseRelation {
+    pub(super) schema_name: String,
+    pub(super) table_name: String,
+    table_type: TableType,
+}
+
+pub(super) async fn build_database_catalog<T: 'static, P: 'static>(
+    pool: Pool<T, P>,
+    inventory_sql: &str,
+    dialect: SqlDialect,
+) -> DataFusionResult<DatabaseCatalog> {
+    let relations = load_database_inventory(&pool, inventory_sql).await?;
+    let provider = Arc::new(MemoryCatalogProvider::new());
+    register_database_schemas(provider.as_ref(), &pool, &relations, &dialect)?;
+    Ok(DatabaseCatalog {
+        provider,
+        relations,
+    })
+}
+
+fn register_database_schemas<T: 'static, P: 'static>(
+    catalog: &MemoryCatalogProvider,
+    pool: &Pool<T, P>,
+    relations: &[DatabaseRelation],
+    dialect: &SqlDialect,
+) -> DataFusionResult<()> {
+    let mut relations_by_schema = BTreeMap::<String, BTreeMap<String, TableType>>::new();
+    for relation in relations {
+        relations_by_schema
+            .entry(relation.schema_name.clone())
+            .or_default()
+            .insert(relation.table_name.clone(), relation.table_type);
+    }
+    for (schema_name, tables) in relations_by_schema {
+        let schema = LazyDatabaseSchemaProvider {
+            schema_name: schema_name.clone(),
+            tables,
+            pool: Arc::clone(pool),
+            dialect: Arc::clone(dialect),
+        };
+        catalog.register_schema(&schema_name, Arc::new(schema))?;
+    }
+    Ok(())
+}
+
+async fn load_database_inventory<T: 'static, P: 'static>(
+    pool: &Pool<T, P>,
+    inventory_sql: &str,
+) -> DataFusionResult<Vec<DatabaseRelation>> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("schema_name", DataType::Utf8, false),
+        Field::new("table_name", DataType::Utf8, false),
+        Field::new("relation_type", DataType::Utf8, false),
+    ]));
+    let connection = pool.connect().await.map_err(boxed_provider_error)?;
+    let batches = query_arrow(connection, inventory_sql.to_string(), Some(schema))
+        .await
+        .map_err(provider_error)?
+        .try_collect::<Vec<_>>()
+        .await?;
+    let mut relations = Vec::new();
+    for batch in batches {
+        let schema_names = inventory_column(&batch, "schema_name")?;
+        let table_names = inventory_column(&batch, "table_name")?;
+        let relation_types = inventory_column(&batch, "relation_type")?;
+        for row in 0..batch.num_rows() {
+            relations.push(DatabaseRelation {
+                schema_name: schema_names.value(row).to_string(),
+                table_name: table_names.value(row).to_string(),
+                table_type: relation_table_type(relation_types.value(row)),
+            });
+        }
+    }
+    relations.sort_by(|left, right| {
+        (&left.schema_name, &left.table_name).cmp(&(&right.schema_name, &right.table_name))
+    });
+    relations.dedup_by(|left, right| {
+        left.schema_name == right.schema_name && left.table_name == right.table_name
+    });
+    Ok(relations)
+}
+
+fn inventory_column<'a>(
+    batch: &'a datafusion::arrow::record_batch::RecordBatch,
+    name: &str,
+) -> DataFusionResult<&'a StringArray> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref::<StringArray>())
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!("database inventory column '{name}' is not Utf8"))
+        })
+}
+
+fn relation_table_type(value: &str) -> TableType {
+    if value.eq_ignore_ascii_case("VIEW") || value.eq_ignore_ascii_case("MATERIALIZED VIEW") {
+        TableType::View
+    } else {
+        TableType::Base
+    }
+}
+
+struct LazyDatabaseSchemaProvider<T: 'static, P: 'static> {
+    schema_name: String,
+    tables: BTreeMap<String, TableType>,
+    pool: Pool<T, P>,
+    dialect: SqlDialect,
+}
+
+impl<T: 'static, P: 'static> fmt::Debug for LazyDatabaseSchemaProvider<T, P> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LazyDatabaseSchemaProvider")
+            .field("schema_name", &self.schema_name)
+            .field("tables", &self.tables)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl<T: 'static, P: 'static> SchemaProvider for LazyDatabaseSchemaProvider<T, P> {
+    fn table_names(&self) -> Vec<String> {
+        self.tables.keys().cloned().collect()
+    }
+
+    async fn table(&self, name: &str) -> DataFusionResult<Option<Arc<dyn TableProvider>>> {
+        if !self.tables.contains_key(name) {
+            return Ok(None);
+        }
+        SqlTable::new(
+            &self.schema_name,
+            &self.pool,
+            TableReference::partial(self.schema_name.clone(), name.to_string()),
+        )
+        .await
+        .map(|table| {
+            let table = table.with_dialect(Arc::clone(&self.dialect));
+            Some(Arc::new(table) as Arc<dyn TableProvider>)
+        })
+        .map_err(provider_error)
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        self.tables.contains_key(name)
+    }
+
+    async fn table_type(&self, name: &str) -> DataFusionResult<Option<TableType>> {
+        Ok(self.tables.get(name).copied())
+    }
+}
+
+pub(super) fn provider_error(
+    error: impl std::error::Error + Send + Sync + 'static,
+) -> DataFusionError {
+    DataFusionError::External(Box::new(error))
+}
+
+pub(super) fn boxed_provider_error(
+    error: Box<dyn std::error::Error + Send + Sync>,
+) -> DataFusionError {
+    DataFusionError::External(error)
+}

--- a/crates/coral-engine/src/backends/database/catalog.rs
+++ b/crates/coral-engine/src/backends/database/catalog.rs
@@ -1,4 +1,4 @@
-//! DataFusion catalog adapter for a normalized relational database inventory.
+//! `DataFusion` catalog adapter for a normalized relational database inventory.
 
 use std::collections::BTreeMap;
 use std::fmt;

--- a/crates/coral-engine/src/backends/database/mod.rs
+++ b/crates/coral-engine/src/backends/database/mod.rs
@@ -399,6 +399,7 @@ mod tests {
                 description: String::new(),
                 declared_inputs: Vec::new(),
                 test_queries: Vec::new(),
+                identity_requirements: None,
                 components: vec![RuntimeSourceComponent::Database(database)],
             },
             BTreeMap::new(),

--- a/crates/coral-engine/src/backends/database/mod.rs
+++ b/crates/coral-engine/src/backends/database/mod.rs
@@ -542,9 +542,10 @@ mod tests {
         .await
         .expect_err("catalog registrations must reject source decorators");
         assert!(
-            error
-                .to_string()
-                .contains("registers database catalogs, which do not support source decorators"),
+            error.to_string().contains(
+                "registers database catalogs, which source decorator \
+                     'abort-on-source-failure' does not support"
+            ),
             "unexpected error: {error}"
         );
     }

--- a/crates/coral-engine/src/backends/database/mod.rs
+++ b/crates/coral-engine/src/backends/database/mod.rs
@@ -1,7 +1,8 @@
 //! Relational database backend registration through `datafusion-table-providers`.
 
+mod catalog;
+
 use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::fmt;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
@@ -12,25 +13,19 @@ use coral_spec::backends::database::{
     SqliteConnectionSpec,
 };
 use coral_spec::{ParsedTemplate, SourceManifestCommon};
-use datafusion::arrow::array::StringArray;
-use datafusion::arrow::datatypes::{DataType, Field, Schema};
-use datafusion::catalog::{CatalogProvider, SchemaProvider};
-use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
-use datafusion::logical_expr::TableType;
 use datafusion::prelude::SessionContext;
-use datafusion::sql::TableReference;
-use datafusion::sql::unparser::dialect::{Dialect, MySqlDialect, PostgreSqlDialect, SqliteDialect};
+use datafusion::sql::unparser::dialect::{MySqlDialect, PostgreSqlDialect, SqliteDialect};
 use datafusion_table_providers::UnsupportedTypeAction;
-use datafusion_table_providers::sql::db_connection_pool::dbconnection::query_arrow;
+use datafusion_table_providers::sql::db_connection_pool::Mode;
 use datafusion_table_providers::sql::db_connection_pool::mysqlpool::MySQLConnectionPool;
 use datafusion_table_providers::sql::db_connection_pool::postgrespool::PostgresConnectionPool;
 use datafusion_table_providers::sql::db_connection_pool::sqlitepool::SqliteConnectionPoolFactory;
-use datafusion_table_providers::sql::db_connection_pool::{DbConnectionPool, Mode};
-use datafusion_table_providers::sql::sql_provider_datafusion::SqlTable;
 use datafusion_table_providers::util::secrets::to_secret_map;
-use futures::TryStreamExt as _;
 
+use self::catalog::{
+    DatabaseCatalog, DatabaseRelation, boxed_provider_error, build_database_catalog, provider_error,
+};
 use crate::backends::shared::template::{RenderContext, render_template};
 use crate::backends::{
     BackendCatalogRegistration, BackendCompileRequest, BackendRegistration,
@@ -184,7 +179,7 @@ impl DatabaseCatalogStrategy for PostgresConnectionSpec {
             .map_err(provider_error)?
             // The MySQL adapter has no equivalent unsupported-type policy.
             .with_unsupported_type_action(UnsupportedTypeAction::String);
-        database_catalog(
+        build_database_catalog(
             Arc::new(pool),
             POSTGRES_RELATIONS_SQL,
             Arc::new(PostgreSqlDialect {}),
@@ -226,7 +221,7 @@ impl DatabaseCatalogStrategy for MySqlConnectionSpec {
         let pool = MySQLConnectionPool::new(to_secret_map(params))
             .await
             .map_err(provider_error)?;
-        database_catalog(
+        build_database_catalog(
             Arc::new(pool),
             MYSQL_RELATIONS_SQL,
             Arc::new(MySqlDialect {}),
@@ -264,7 +259,7 @@ impl DatabaseCatalogStrategy for SqliteConnectionSpec {
             .build()
             .await
             .map_err(boxed_provider_error)?;
-        database_catalog(
+        build_database_catalog(
             Arc::new(pool),
             SQLITE_RELATIONS_SQL,
             Arc::new(SqliteDialect {}),
@@ -293,195 +288,6 @@ SELECT 'main' AS schema_name,
        CASE type WHEN 'view' THEN 'VIEW' ELSE 'BASE TABLE' END AS relation_type
 FROM sqlite_master
 WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'";
-
-type Pool<T, P> = Arc<dyn DbConnectionPool<T, P> + Send + Sync>;
-
-struct DatabaseCatalog {
-    provider: Arc<dyn CatalogProvider>,
-    relations: Vec<DatabaseRelation>,
-}
-
-#[derive(Clone, Debug)]
-struct DatabaseRelation {
-    schema_name: String,
-    table_name: String,
-    table_type: TableType,
-}
-
-type SqlDialect = Arc<dyn Dialect + Send + Sync>;
-
-async fn database_catalog<T: 'static, P: 'static>(
-    pool: Pool<T, P>,
-    inventory_sql: &str,
-    dialect: SqlDialect,
-) -> DataFusionResult<DatabaseCatalog> {
-    let relations = load_database_inventory(&pool, inventory_sql).await?;
-    let provider = Arc::new(CoralDatabaseCatalogProvider::new(
-        &pool, &relations, &dialect,
-    )) as Arc<dyn CatalogProvider>;
-    Ok(DatabaseCatalog {
-        provider,
-        relations,
-    })
-}
-
-async fn load_database_inventory<T: 'static, P: 'static>(
-    pool: &Pool<T, P>,
-    inventory_sql: &str,
-) -> DataFusionResult<Vec<DatabaseRelation>> {
-    let schema = Arc::new(Schema::new(vec![
-        Field::new("schema_name", DataType::Utf8, false),
-        Field::new("table_name", DataType::Utf8, false),
-        Field::new("relation_type", DataType::Utf8, false),
-    ]));
-    let connection = pool.connect().await.map_err(boxed_provider_error)?;
-    let batches = query_arrow(connection, inventory_sql.to_string(), Some(schema))
-        .await
-        .map_err(provider_error)?
-        .try_collect::<Vec<_>>()
-        .await?;
-    let mut relations = Vec::new();
-    for batch in batches {
-        let schema_names = database_inventory_column(&batch, "schema_name")?;
-        let table_names = database_inventory_column(&batch, "table_name")?;
-        let relation_types = database_inventory_column(&batch, "relation_type")?;
-        for row in 0..batch.num_rows() {
-            relations.push(DatabaseRelation {
-                schema_name: schema_names.value(row).to_string(),
-                table_name: table_names.value(row).to_string(),
-                table_type: relation_table_type(relation_types.value(row)),
-            });
-        }
-    }
-    relations.sort_by(|left, right| {
-        (&left.schema_name, &left.table_name).cmp(&(&right.schema_name, &right.table_name))
-    });
-    relations.dedup_by(|left, right| {
-        left.schema_name == right.schema_name && left.table_name == right.table_name
-    });
-    Ok(relations)
-}
-
-fn database_inventory_column<'a>(
-    batch: &'a datafusion::arrow::record_batch::RecordBatch,
-    name: &str,
-) -> DataFusionResult<&'a StringArray> {
-    batch
-        .column_by_name(name)
-        .and_then(|column| column.as_any().downcast_ref::<StringArray>())
-        .ok_or_else(|| {
-            DataFusionError::Execution(format!("database inventory column '{name}' is not Utf8"))
-        })
-}
-
-fn relation_table_type(value: &str) -> TableType {
-    if value.eq_ignore_ascii_case("VIEW") || value.eq_ignore_ascii_case("MATERIALIZED VIEW") {
-        TableType::View
-    } else {
-        TableType::Base
-    }
-}
-
-struct CoralDatabaseCatalogProvider {
-    schemas: HashMap<String, Arc<dyn SchemaProvider>>,
-}
-
-impl CoralDatabaseCatalogProvider {
-    fn new<T: 'static, P: 'static>(
-        pool: &Pool<T, P>,
-        relations: &[DatabaseRelation],
-        dialect: &SqlDialect,
-    ) -> Self {
-        let mut by_schema = BTreeMap::<String, BTreeMap<String, TableType>>::new();
-        for relation in relations {
-            by_schema
-                .entry(relation.schema_name.clone())
-                .or_default()
-                .insert(relation.table_name.clone(), relation.table_type);
-        }
-        let schemas = by_schema
-            .into_iter()
-            .map(|(schema_name, tables)| {
-                let provider = CoralDatabaseSchemaProvider {
-                    schema_name: schema_name.clone(),
-                    tables,
-                    pool: Arc::clone(pool),
-                    dialect: Arc::clone(dialect),
-                };
-                (schema_name, Arc::new(provider) as Arc<dyn SchemaProvider>)
-            })
-            .collect();
-        Self { schemas }
-    }
-}
-
-impl fmt::Debug for CoralDatabaseCatalogProvider {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("CoralDatabaseCatalogProvider")
-            .field("schemas", &self.schemas.keys().collect::<Vec<_>>())
-            .finish()
-    }
-}
-
-impl CatalogProvider for CoralDatabaseCatalogProvider {
-    fn schema_names(&self) -> Vec<String> {
-        self.schemas.keys().cloned().collect()
-    }
-
-    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
-        self.schemas.get(name).cloned()
-    }
-}
-
-struct CoralDatabaseSchemaProvider<T: 'static, P: 'static> {
-    schema_name: String,
-    tables: BTreeMap<String, TableType>,
-    pool: Pool<T, P>,
-    dialect: SqlDialect,
-}
-
-impl<T: 'static, P: 'static> fmt::Debug for CoralDatabaseSchemaProvider<T, P> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("CoralDatabaseSchemaProvider")
-            .field("schema_name", &self.schema_name)
-            .field("tables", &self.tables)
-            .finish_non_exhaustive()
-    }
-}
-
-#[async_trait]
-impl<T: 'static, P: 'static> SchemaProvider for CoralDatabaseSchemaProvider<T, P> {
-    fn table_names(&self) -> Vec<String> {
-        self.tables.keys().cloned().collect()
-    }
-
-    async fn table(&self, name: &str) -> DataFusionResult<Option<Arc<dyn TableProvider>>> {
-        if !self.tables.contains_key(name) {
-            return Ok(None);
-        }
-        SqlTable::new(
-            &self.schema_name,
-            &self.pool,
-            TableReference::partial(self.schema_name.clone(), name.to_string()),
-        )
-        .await
-        .map(|table| {
-            let table = table.with_dialect(Arc::clone(&self.dialect));
-            Some(Arc::new(table) as Arc<dyn TableProvider>)
-        })
-        .map_err(provider_error)
-    }
-
-    fn table_exist(&self, name: &str) -> bool {
-        self.tables.contains_key(name)
-    }
-
-    async fn table_type(&self, name: &str) -> DataFusionResult<Option<TableType>> {
-        Ok(self.tables.get(name).copied())
-    }
-}
 
 fn registered_source_for_catalog(
     common: &SourceManifestCommon,
@@ -515,14 +321,6 @@ fn database_relation_inventory(relations: &[DatabaseRelation]) -> Vec<Registered
             search_limits: None,
         })
         .collect()
-}
-
-fn provider_error(error: impl std::error::Error + Send + Sync + 'static) -> DataFusionError {
-    DataFusionError::External(Box::new(error))
-}
-
-fn boxed_provider_error(error: Box<dyn std::error::Error + Send + Sync>) -> DataFusionError {
-    DataFusionError::External(error)
 }
 
 #[cfg(test)]

--- a/crates/coral-engine/src/backends/database/mod.rs
+++ b/crates/coral-engine/src/backends/database/mod.rs
@@ -316,6 +316,9 @@ fn database_relation_inventory(relations: &[DatabaseRelation]) -> Vec<Registered
             table_name: relation.table_name.clone(),
             description: String::new(),
             guide: String::new(),
+            // Discovered from the remote database rather than authored, so
+            // there is no guide to require reading.
+            require_guide_read: false,
             columns: Vec::new(),
             filters: Vec::new(),
             required_filters: Vec::new(),

--- a/crates/coral-engine/src/backends/database/mod.rs
+++ b/crates/coral-engine/src/backends/database/mod.rs
@@ -273,7 +273,8 @@ SELECT table_schema AS schema_name,
        table_name,
        table_type AS relation_type
 FROM information_schema.tables
-WHERE table_schema NOT IN ('pg_catalog', 'information_schema')";
+WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+  AND table_type IN ('BASE TABLE', 'VIEW')";
 
 const MYSQL_RELATIONS_SQL: &str = "
 SELECT TABLE_SCHEMA AS schema_name,

--- a/crates/coral-engine/src/backends/file/tests.rs
+++ b/crates/coral-engine/src/backends/file/tests.rs
@@ -271,6 +271,7 @@ async fn parquet_provider_exposes_inferred_schema_in_coral_columns() {
     let active_sources = register_sources_blocking(&ctx, compile_sources(vec![manifest]))
         .expect("file source should register");
     catalog::register(&ctx, &active_sources.active_sources, &[])
+        .await
         .expect("metadata tables should register");
 
     let batches = ctx

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -572,9 +572,14 @@ fn register_test_sources(ctx: &SessionContext, sources: Vec<CompiledQuerySource>
         .expect("source function planner should register");
 }
 
-fn register_test_sources_with_catalog(ctx: &SessionContext, sources: Vec<CompiledQuerySource>) {
+async fn register_test_sources_with_catalog(
+    ctx: &SessionContext,
+    sources: Vec<CompiledQuerySource>,
+) {
     let registration = register_sources_blocking(ctx, sources).expect("mcp source should register");
-    catalog::register(ctx, &registration.active_sources, &[]).expect("catalog should register");
+    catalog::register(ctx, &registration.active_sources, &[])
+        .await
+        .expect("catalog should register");
     let source_functions = SourceFunctionRegistry::new(
         registration
             .active_sources
@@ -1735,7 +1740,7 @@ async fn mcp_table_appears_in_catalog_metadata() {
     let caller = Arc::new(FakeMcpTableCaller {
         calls: Mutex::new(Vec::new()),
     });
-    register_test_sources_with_catalog(&ctx, compile_sources(mcp_table_manifest(), caller));
+    register_test_sources_with_catalog(&ctx, compile_sources(mcp_table_manifest(), caller)).await;
 
     let batches = ctx
         .sql(

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -90,6 +90,7 @@ pub(crate) use common::{
     validate_lookup_key_filter_backend_support,
 };
 
+pub(crate) mod database;
 pub(crate) mod file;
 pub(crate) mod http;
 pub(crate) mod mcp;
@@ -135,6 +136,9 @@ fn compile_component(
     request: &BackendCompileRequest<'_>,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     match component {
+        RuntimeSourceComponent::Database(manifest) => {
+            Ok(database::compile_manifest(manifest, request))
+        }
         RuntimeSourceComponent::Http(manifest) => {
             let request_identity_http_authenticator = request
                 .source

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -80,7 +80,7 @@ impl fmt::Debug for QuerySource {
             .field("components", &self.components)
             .field("variables", &self.variables)
             .field("secret_count", &self.secrets.len())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -99,9 +99,18 @@ impl fmt::Debug for RuntimeSourceComponent {
                     .field("provider", &provider)
                     .finish_non_exhaustive()
             }
-            Self::Http(manifest) => formatter.debug_tuple("Http").field(manifest).finish(),
-            Self::File(manifest) => formatter.debug_tuple("File").field(manifest).finish(),
-            Self::Mcp(manifest) => formatter.debug_tuple("Mcp").field(manifest).finish(),
+            Self::Http(manifest) => formatter
+                .debug_struct("Http")
+                .field("source_name", &manifest.common.name)
+                .finish_non_exhaustive(),
+            Self::File(manifest) => formatter
+                .debug_struct("File")
+                .field("source_name", &manifest.common.name)
+                .finish_non_exhaustive(),
+            Self::Mcp(manifest) => formatter
+                .debug_struct("Mcp")
+                .field("source_name", &manifest.common.name)
+                .finish_non_exhaustive(),
         }
     }
 }

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
+use coral_spec::backends::database::DatabaseSourceManifest;
 use coral_spec::backends::file::FileSourceManifest;
 use coral_spec::backends::http::HttpSourceManifest;
 use coral_spec::backends::mcp::McpSourceManifest;
@@ -57,6 +58,8 @@ pub struct RuntimeSourcePackage {
 /// One backend-ready component inside an app-assembled query source package.
 #[derive(Debug, Clone)]
 pub enum RuntimeSourceComponent {
+    /// Relational database-backed runtime component.
+    Database(DatabaseSourceManifest),
     /// HTTP-backed runtime component.
     Http(HttpSourceManifest),
     /// File-backed runtime component.
@@ -191,27 +194,44 @@ impl QuerySource {
     }
 
     #[must_use]
-    /// Returns the SQL schema names published by this selected source.
+    /// Returns the SQL schema names published by this source's two-part
+    /// components. Database components publish catalogs instead; see
+    /// [`Self::catalog_names`]. A source with no components claims its source
+    /// name as a schema. Schema and catalog names of all selected sources
+    /// share one flat namespace.
     pub fn schema_names(&self) -> Vec<&str> {
         let mut names = Vec::new();
         for component in &self.components {
+            if matches!(component, RuntimeSourceComponent::Database(_)) {
+                continue;
+            }
             let name = component.source_name();
             if !names.contains(&name) {
                 names.push(name);
             }
         }
-        if names.is_empty() {
+        if self.components.is_empty() {
             names.push(self.source_name());
         }
         names
     }
 
     #[must_use]
-    /// Returns the SQL catalog names published by this selected source.
-    /// Catalog-backed runtime components are introduced separately from the
-    /// generic qualified-table identity model.
+    /// Returns the SQL catalog names published by this source's database
+    /// components. Tables of these components resolve as
+    /// `catalog.schema.table`, with schemas discovered at registration time.
     pub fn catalog_names(&self) -> Vec<&str> {
-        Vec::new()
+        let mut names = Vec::new();
+        for component in &self.components {
+            let RuntimeSourceComponent::Database(manifest) = component else {
+                continue;
+            };
+            let name = manifest.common.name.as_str();
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+        names
     }
 
     #[must_use]
@@ -229,9 +249,11 @@ impl QuerySource {
 
 impl RuntimeSourceComponent {
     #[must_use]
-    /// Returns the runtime schema name declared by this component.
+    /// Returns the name this component publishes at runtime: a schema name,
+    /// or a catalog name for database components.
     pub fn source_name(&self) -> &str {
         match self {
+            Self::Database(manifest) => &manifest.common.name,
             Self::Http(manifest) => &manifest.common.name,
             Self::File(manifest) => &manifest.common.name,
             Self::Mcp(manifest) => &manifest.common.name,

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
-use coral_spec::backends::database::DatabaseSourceManifest;
+use coral_spec::backends::database::{DatabaseConnectionSpec, DatabaseSourceManifest};
 use coral_spec::backends::file::FileSourceManifest;
 use coral_spec::backends::http::HttpSourceManifest;
 use coral_spec::backends::mcp::McpSourceManifest;
@@ -23,7 +23,7 @@ use crate::{
 };
 
 /// One managed source selected into the current query runtime.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct QuerySource {
     source_name: String,
     authored_version: Option<String>,
@@ -56,7 +56,7 @@ pub struct RuntimeSourcePackage {
 }
 
 /// One backend-ready component inside an app-assembled query source package.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum RuntimeSourceComponent {
     /// Relational database-backed runtime component.
     Database(DatabaseSourceManifest),
@@ -66,6 +66,44 @@ pub enum RuntimeSourceComponent {
     File(FileSourceManifest),
     /// MCP-backed runtime component.
     Mcp(McpSourceManifest),
+}
+
+impl fmt::Debug for QuerySource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("QuerySource")
+            .field("source_name", &self.source_name)
+            .field("authored_version", &self.authored_version)
+            .field("description", &self.description)
+            .field("declared_inputs", &self.declared_inputs)
+            .field("test_queries", &self.test_queries)
+            .field("components", &self.components)
+            .field("variables", &self.variables)
+            .field("secret_count", &self.secrets.len())
+            .finish()
+    }
+}
+
+impl fmt::Debug for RuntimeSourceComponent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Database(manifest) => {
+                let provider = match &manifest.connection {
+                    DatabaseConnectionSpec::Postgres(_) => "postgres",
+                    DatabaseConnectionSpec::MySql(_) => "mysql",
+                    DatabaseConnectionSpec::Sqlite(_) => "sqlite",
+                };
+                formatter
+                    .debug_struct("Database")
+                    .field("source_name", &manifest.common.name)
+                    .field("provider", &provider)
+                    .finish_non_exhaustive()
+            }
+            Self::Http(manifest) => formatter.debug_tuple("Http").field(manifest).finish(),
+            Self::File(manifest) => formatter.debug_tuple("File").field(manifest).finish(),
+            Self::Mcp(manifest) => formatter.debug_tuple("Mcp").field(manifest).finish(),
+        }
+    }
 }
 
 impl QuerySource {

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -130,37 +130,52 @@ impl PreparedQuery<'_> {
 
 impl PreparedQueryRuntime {
     /// Lists queryable tables from this prepared runtime.
-    #[must_use]
-    pub fn list_tables(
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if live catalog metadata cannot be collected.
+    pub async fn list_tables(
         &self,
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
-    ) -> Vec<TableInfo> {
-        self.inner
-            .list_tables(catalog_filter, schema_filter, table_filter)
+    ) -> Result<Vec<TableInfo>, CoreError> {
+        Box::pin(
+            self.inner
+                .list_tables(catalog_filter, schema_filter, table_filter),
+        )
+        .await
     }
 
     /// Lists queryable catalog metadata from this prepared runtime.
-    #[must_use]
-    pub fn list_catalog(
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if live catalog metadata cannot be collected.
+    pub async fn list_catalog(
         &self,
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
-    ) -> CatalogInfo {
-        self.inner.catalog_info(catalog_filter, schema_filter)
+    ) -> Result<CatalogInfo, CoreError> {
+        Box::pin(self.inner.catalog_info(catalog_filter, schema_filter)).await
     }
 
     /// Describes one table from this prepared runtime.
-    #[must_use]
-    pub fn describe_table(
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if live catalog metadata cannot be collected.
+    pub async fn describe_table(
         &self,
         catalog_name: Option<&str>,
         schema_name: &str,
         table_name: &str,
-    ) -> DescribeTableInfo {
-        self.inner
-            .describe_table(catalog_name, schema_name, table_name)
+    ) -> Result<DescribeTableInfo, CoreError> {
+        Box::pin(
+            self.inner
+                .describe_table(catalog_name, schema_name, table_name),
+        )
+        .await
     }
 
     /// Infers typed signatures for multiple UDFs against this runtime.
@@ -313,11 +328,10 @@ impl CoralQuery {
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, CoreError> {
-        Ok(Self::prepare(sources, runtime).await?.list_tables(
-            catalog_filter,
-            schema_filter,
-            table_filter,
-        ))
+        Self::prepare(sources, runtime)
+            .await?
+            .list_tables(catalog_filter, schema_filter, table_filter)
+            .await
     }
 
     /// Lists queryable catalog metadata from the provided source set.
@@ -338,9 +352,10 @@ impl CoralQuery {
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
     ) -> Result<CatalogInfo, CoreError> {
-        Ok(Self::prepare(sources, runtime)
+        Self::prepare(sources, runtime)
             .await?
-            .list_catalog(catalog_filter, schema_filter))
+            .list_catalog(catalog_filter, schema_filter)
+            .await
     }
 
     /// Describes one table or returns lightweight table metadata for missing-table help.
@@ -360,11 +375,10 @@ impl CoralQuery {
         schema_name: &str,
         table_name: &str,
     ) -> Result<DescribeTableInfo, CoreError> {
-        Ok(Self::prepare(sources, runtime).await?.describe_table(
-            catalog_name,
-            schema_name,
-            table_name,
-        ))
+        Self::prepare(sources, runtime)
+            .await?
+            .describe_table(catalog_name, schema_name, table_name)
+            .await
     }
 
     /// Executes one `SQL` statement over the provided source set.
@@ -517,7 +531,9 @@ impl CoralQuery {
         let source_name = source.source_name();
         let schema_names = source.schema_names();
         let catalog_names = source.catalog_names();
-        let catalog = query_runtime.catalog_info_for_sources(&schema_names, &catalog_names);
+        let catalog = query_runtime
+            .catalog_info_for_sources(&schema_names, &catalog_names)
+            .await?;
         if catalog.tables.is_empty() && catalog.table_functions.is_empty() {
             if let Some(failure) = query_runtime.registration_failure(source_name) {
                 return Err(CoreError::FailedPrecondition(failure.detail.clone()));

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -96,6 +96,9 @@ pub(crate) async fn register(
         .filter_map(|source| source.qualified_name.catalog_name())
         .collect::<Vec<_>>();
     let columns_view = view_table_for_sql(ctx, &columns_view_sql(&catalog_names)).await?;
+    // The view retains its resolved plan; the staging table must not remain a
+    // queryable, undocumented member of the final `coral` schema.
+    let _ = meta_tables.remove(STATIC_COLUMNS_TABLE);
     meta_tables.insert("columns".to_string(), Arc::new(columns_view));
 
     catalog.register_schema(

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -767,6 +767,11 @@ fn collect_table_infos_from_batches(batches: &[RecordBatch]) -> Result<Vec<Table
                 table_name: table_names.value(row).to_string(),
                 description: descriptions.value(row).to_string(),
                 guide: guides.value(row).to_string(),
+                // `coral.tables` publishes `guide` but not `require_guide_read`,
+                // so this SQL-backed path cannot recover the flag. Tables
+                // collected here are therefore never guide-gated; closing that
+                // gap means publishing the column on `coral.tables`.
+                require_guide_read: false,
                 columns: Vec::new(),
                 required_filters: split_required_filters(required_filters.value(row)),
             });
@@ -1459,6 +1464,7 @@ mod tests {
                 table_name: "orders".to_string(),
                 description: String::new(),
                 guide: String::new(),
+                require_guide_read: false,
                 columns: vec![RegisteredColumn {
                     name: "id".to_string(),
                     data_type: "Int64".to_string(),

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -13,7 +13,7 @@ use datafusion::prelude::SessionContext;
 use serde::Serialize;
 
 use crate::backends::{RegisteredSource, RegisteredTable, SourceQualifiedName};
-use crate::runtime::non_default_catalog_name;
+use crate::runtime::normalize_catalog_name;
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
     ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
@@ -736,7 +736,7 @@ fn append_catalog_filter(
 ) {
     let mut predicates = Vec::new();
     if let Some(value) = catalog_filter {
-        let value = non_default_catalog_name(Some(value)).unwrap_or_default();
+        let value = normalize_catalog_name(Some(value)).unwrap_or_default();
         predicates.push(format!("catalog_name = {}", sql_string_literal(value)));
     }
     if let Some(value) = schema_filter {

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -6,12 +6,14 @@ use std::sync::Arc;
 use coral_spec::{ManifestInputKind, SearchLimitsSpec, SourceTableFunctionKind};
 use datafusion::arrow::array::{ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
-use datafusion::datasource::MemTable;
+use datafusion::catalog::{MemorySchemaProvider, SchemaProvider};
+use datafusion::datasource::{MemTable, ViewTable};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::prelude::SessionContext;
 use serde::Serialize;
 
-use crate::backends::{RegisteredSource, SourceQualifiedName};
+use crate::backends::{RegisteredSource, RegisteredTable, SourceQualifiedName};
+use crate::runtime::non_default_catalog_name;
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
     ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
@@ -20,6 +22,7 @@ use crate::{
 
 /// Schema name for source metadata tables such as `coral.tables`.
 pub(crate) const SYSTEM_SCHEMA: &str = "coral";
+const STATIC_COLUMNS_TABLE: &str = "_columns_static";
 
 /// Catalog-only metadata for one SQL table-function surface.
 #[derive(Debug, Clone)]
@@ -56,7 +59,7 @@ pub(crate) struct CatalogTableFunctionResultColumn {
 ///
 /// Returns a `DataFusionError` if the catalog is missing or the metadata
 /// tables cannot be materialized.
-pub(crate) fn register(
+pub(crate) async fn register(
     ctx: &SessionContext,
     active_sources: &[RegisteredSource],
     catalog_only_table_functions: &[CatalogTableFunction],
@@ -71,7 +74,7 @@ pub(crate) fn register(
     let mut meta_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
         HashMap::new();
     meta_tables.insert("tables".to_string(), Arc::new(tables_table));
-    meta_tables.insert("columns".to_string(), Arc::new(columns_table));
+    meta_tables.insert(STATIC_COLUMNS_TABLE.to_string(), Arc::new(columns_table));
     meta_tables.insert("filters".to_string(), Arc::new(filters_table));
     meta_tables.insert("inputs".to_string(), Arc::new(inputs_table));
     meta_tables.insert(
@@ -82,12 +85,65 @@ pub(crate) fn register(
     let catalog = ctx
         .catalog("datafusion")
         .ok_or_else(|| DataFusionError::Plan("catalog 'datafusion' not found".to_string()))?;
+    let planning_schema = Arc::new(MemorySchemaProvider::new());
+    for (name, table) in &meta_tables {
+        planning_schema.register_table(name.clone(), table.clone())?;
+    }
+    catalog.register_schema(SYSTEM_SCHEMA, planning_schema)?;
+
+    let catalog_names = active_sources
+        .iter()
+        .filter_map(|source| source.qualified_name.catalog_name())
+        .collect::<Vec<_>>();
+    let columns_view = view_table_for_sql(ctx, &columns_view_sql(&catalog_names)).await?;
+    meta_tables.insert("columns".to_string(), Arc::new(columns_view));
+
     catalog.register_schema(
         SYSTEM_SCHEMA,
         Arc::new(StaticSchemaProvider::new(meta_tables)),
     )?;
 
     Ok(())
+}
+
+async fn view_table_for_sql(ctx: &SessionContext, sql: &str) -> Result<ViewTable> {
+    let df = ctx.sql(sql).await?;
+    let (_state, plan) = df.into_parts();
+    Ok(ViewTable::new(plan, Some(sql.to_string())))
+}
+
+fn columns_view_sql(catalog_names: &[&str]) -> String {
+    let static_sql = format!(
+        "SELECT schema_name, table_name, ordinal_position, column_name, data_type, \
+         is_nullable, is_virtual, is_required_filter, description, filter_mode, catalog_name \
+         FROM {SYSTEM_SCHEMA}.{STATIC_COLUMNS_TABLE}"
+    );
+    if catalog_names.is_empty() {
+        return static_sql;
+    }
+    format!(
+        "{static_sql} UNION ALL \
+         SELECT table_schema AS schema_name, table_name, \
+         CAST(ordinal_position AS INT) AS ordinal_position, column_name, data_type, \
+         is_nullable = 'YES' AS is_nullable, false AS is_virtual, \
+         false AS is_required_filter, '' AS description, '' AS filter_mode, \
+         table_catalog AS catalog_name \
+         FROM information_schema.columns \
+         WHERE table_catalog IN ({}) AND table_schema <> 'information_schema'",
+        sql_string_list(catalog_names)
+    )
+}
+
+fn sql_string_list(values: &[&str]) -> String {
+    values
+        .iter()
+        .map(|value| sql_string_literal(value))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn sql_string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
 }
 
 fn build_table_functions_table(
@@ -555,9 +611,9 @@ fn system_table_infos() -> Vec<TableInfo> {
         .collect()
 }
 
-/// Collect typed query-visible table metadata for the active source set.
+/// Collect static query-visible table metadata for the active source set.
 #[must_use]
-pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableInfo> {
+pub(crate) fn collect_static_tables(active_sources: &[RegisteredSource]) -> Vec<TableInfo> {
     let mut tables = system_table_infos();
     tables.extend(active_sources.iter().flat_map(|source| {
         source.tables.iter().map(move |table| TableInfo {
@@ -565,10 +621,7 @@ pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableIn
                 .qualified_name
                 .catalog_name()
                 .map(ToString::to_string),
-            schema_name: table
-                .schema_name
-                .clone()
-                .unwrap_or_else(|| source.qualified_name.name().to_string()),
+            schema_name: registered_table_schema_name(source, table),
             table_name: table.table_name.clone(),
             description: table.description.clone(),
             guide: table.guide.clone(),
@@ -598,6 +651,230 @@ pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableIn
         ))
     });
     tables
+}
+
+/// Collect typed table metadata by querying the public `coral` catalog views.
+pub(crate) async fn collect_tables(
+    ctx: &SessionContext,
+    catalog_filter: Option<&str>,
+    schema_filter: Option<&str>,
+    table_filter: Option<&str>,
+) -> Result<Vec<TableInfo>> {
+    let mut tables = collect_table_metadata(ctx, catalog_filter, schema_filter, table_filter)
+        .await?
+        .into_iter()
+        .map(|table| {
+            (
+                (
+                    table.catalog_name.clone(),
+                    table.schema_name.clone(),
+                    table.table_name.clone(),
+                ),
+                table,
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    let sql = catalog_columns_query(catalog_filter, schema_filter, table_filter);
+    let batches = ctx.sql(&sql).await?.collect().await?;
+    apply_column_infos_from_batches(&mut tables, &batches)?;
+    let mut tables = tables.into_values().collect::<Vec<_>>();
+    sort_tables(&mut tables);
+    for table in &mut tables {
+        table.columns.sort_by_key(|column| column.ordinal_position);
+    }
+    Ok(tables)
+}
+
+/// Collect table metadata without forcing lazy column discovery.
+pub(crate) async fn collect_table_metadata(
+    ctx: &SessionContext,
+    catalog_filter: Option<&str>,
+    schema_filter: Option<&str>,
+    table_filter: Option<&str>,
+) -> Result<Vec<TableInfo>> {
+    let sql = catalog_tables_query(catalog_filter, schema_filter, table_filter);
+    let batches = ctx.sql(&sql).await?.collect().await?;
+    let mut tables = collect_table_infos_from_batches(&batches)?;
+    sort_tables(&mut tables);
+    Ok(tables)
+}
+
+fn catalog_tables_query(
+    catalog_filter: Option<&str>,
+    schema_filter: Option<&str>,
+    table_filter: Option<&str>,
+) -> String {
+    let mut sql = "SELECT catalog_name, schema_name, table_name, description, guide, \
+                   required_filters FROM coral.tables"
+        .to_string();
+    append_catalog_filter(&mut sql, catalog_filter, schema_filter, table_filter);
+    sql
+}
+
+fn catalog_columns_query(
+    catalog_filter: Option<&str>,
+    schema_filter: Option<&str>,
+    table_filter: Option<&str>,
+) -> String {
+    let mut sql = "SELECT catalog_name, schema_name, table_name, ordinal_position, column_name, \
+                   data_type, is_nullable, is_virtual, is_required_filter, description \
+                   FROM coral.columns"
+        .to_string();
+    append_catalog_filter(&mut sql, catalog_filter, schema_filter, table_filter);
+    sql
+}
+
+fn append_catalog_filter(
+    sql: &mut String,
+    catalog_filter: Option<&str>,
+    schema_filter: Option<&str>,
+    table_filter: Option<&str>,
+) {
+    let mut predicates = Vec::new();
+    if let Some(value) = catalog_filter {
+        let value = non_default_catalog_name(Some(value)).unwrap_or_default();
+        predicates.push(format!("catalog_name = {}", sql_string_literal(value)));
+    }
+    if let Some(value) = schema_filter {
+        predicates.push(format!("schema_name = {}", sql_string_literal(value)));
+    }
+    if let Some(value) = table_filter {
+        predicates.push(format!("table_name = {}", sql_string_literal(value)));
+    }
+    if !predicates.is_empty() {
+        sql.push_str(" WHERE ");
+        sql.push_str(&predicates.join(" AND "));
+    }
+}
+
+fn collect_table_infos_from_batches(batches: &[RecordBatch]) -> Result<Vec<TableInfo>> {
+    let mut tables = Vec::new();
+    for batch in batches {
+        let catalog_names = string_array(batch, "catalog_name")?;
+        let schema_names = string_array(batch, "schema_name")?;
+        let table_names = string_array(batch, "table_name")?;
+        let descriptions = string_array(batch, "description")?;
+        let guides = string_array(batch, "guide")?;
+        let required_filters = string_array(batch, "required_filters")?;
+        for row in 0..batch.num_rows() {
+            tables.push(TableInfo {
+                catalog_name: optional_catalog_name(catalog_names.value(row)),
+                schema_name: schema_names.value(row).to_string(),
+                table_name: table_names.value(row).to_string(),
+                description: descriptions.value(row).to_string(),
+                guide: guides.value(row).to_string(),
+                columns: Vec::new(),
+                required_filters: split_required_filters(required_filters.value(row)),
+            });
+        }
+    }
+    Ok(tables)
+}
+
+fn optional_catalog_name(catalog_name: &str) -> Option<String> {
+    (!catalog_name.is_empty()).then(|| catalog_name.to_string())
+}
+
+type TableInfoByKey = HashMap<(Option<String>, String, String), TableInfo>;
+
+fn apply_column_infos_from_batches(
+    tables: &mut TableInfoByKey,
+    batches: &[RecordBatch],
+) -> Result<()> {
+    for batch in batches {
+        let catalog_names = string_array(batch, "catalog_name")?;
+        let schema_names = string_array(batch, "schema_name")?;
+        let table_names = string_array(batch, "table_name")?;
+        let positions = int32_array(batch, "ordinal_position")?;
+        let column_names = string_array(batch, "column_name")?;
+        let data_types = string_array(batch, "data_type")?;
+        let is_nullable = bool_array(batch, "is_nullable")?;
+        let is_virtual = bool_array(batch, "is_virtual")?;
+        let is_required_filter = bool_array(batch, "is_required_filter")?;
+        let descriptions = string_array(batch, "description")?;
+        for row in 0..batch.num_rows() {
+            let key = (
+                optional_catalog_name(catalog_names.value(row)),
+                schema_names.value(row).to_string(),
+                table_names.value(row).to_string(),
+            );
+            let Some(table) = tables.get_mut(&key) else {
+                continue;
+            };
+            table.columns.push(ColumnInfo {
+                name: column_names.value(row).to_string(),
+                data_type: data_types.value(row).to_string(),
+                nullable: is_nullable.value(row),
+                is_virtual: is_virtual.value(row),
+                is_required_filter: is_required_filter.value(row),
+                description: descriptions.value(row).to_string(),
+                ordinal_position: u32::try_from(positions.value(row)).unwrap_or_default(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn string_array<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a StringArray> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref::<StringArray>())
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!("coral catalog column '{name}' is not Utf8"))
+        })
+}
+
+fn int32_array<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a Int32Array> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref::<Int32Array>())
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!("coral catalog column '{name}' is not Int32"))
+        })
+}
+
+fn bool_array<'a>(batch: &'a RecordBatch, name: &str) -> Result<&'a BooleanArray> {
+    batch
+        .column_by_name(name)
+        .and_then(|column| column.as_any().downcast_ref::<BooleanArray>())
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!("coral catalog column '{name}' is not Boolean"))
+        })
+}
+
+fn split_required_filters(value: &str) -> Vec<String> {
+    if value.is_empty() {
+        Vec::new()
+    } else {
+        value.split(',').map(ToString::to_string).collect()
+    }
+}
+
+fn sort_tables(tables: &mut [TableInfo]) {
+    tables.sort_by(|left, right| {
+        (&left.catalog_name, &left.schema_name, &left.table_name).cmp(&(
+            &right.catalog_name,
+            &right.schema_name,
+            &right.table_name,
+        ))
+    });
+}
+
+fn registered_table_schema_name(source: &RegisteredSource, table: &RegisteredTable) -> String {
+    match (&source.qualified_name, &table.schema_name) {
+        (_, Some(schema_name)) | (SourceQualifiedName::Schema(schema_name), None) => {
+            schema_name.clone()
+        }
+        (SourceQualifiedName::Catalog(catalog_name), None) => {
+            debug_assert!(
+                false,
+                "catalog-backed table '{}.{}' must record its SQL schema",
+                catalog_name, table.table_name
+            );
+            catalog_name.clone()
+        }
+    }
 }
 
 /// Collect typed table function metadata for the active runtime.
@@ -725,10 +1002,7 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
                     .catalog_name()
                     .unwrap_or_default()
                     .to_string(),
-                schema_name: table
-                    .schema_name
-                    .clone()
-                    .unwrap_or_else(|| source.qualified_name.name().to_string()),
+                schema_name: registered_table_schema_name(source, table),
                 table_name: table.table_name.clone(),
                 description: table.description.clone(),
                 guide: table.guide.clone(),
@@ -826,10 +1100,7 @@ fn catalog_filter_rows(active_sources: &[RegisteredSource]) -> Vec<CatalogFilter
                         .catalog_name()
                         .unwrap_or_default()
                         .to_string(),
-                    schema_name: table
-                        .schema_name
-                        .clone()
-                        .unwrap_or_else(|| source.qualified_name.name().to_string()),
+                    schema_name: registered_table_schema_name(source, table),
                     table_name: table.table_name.clone(),
                     filter_name: filter.name.clone(),
                     filter_mode: filter.mode.clone(),
@@ -878,6 +1149,7 @@ fn catalog_input_rows(active_sources: &[RegisteredSource]) -> Vec<CatalogInput> 
             source.inputs.iter().map(move |input| CatalogInput {
                 schema_name: match &source.qualified_name {
                     SourceQualifiedName::Schema(name) => name.clone(),
+                    SourceQualifiedName::Catalog(_) => String::new(),
                 },
                 catalog_name: source
                     .qualified_name
@@ -1074,10 +1346,7 @@ fn source_catalog_column_rows(active_sources: &[RegisteredSource]) -> Vec<Catalo
                     .catalog_name()
                     .unwrap_or_default()
                     .to_string();
-                let schema_name = table
-                    .schema_name
-                    .clone()
-                    .unwrap_or_else(|| source.qualified_name.name().to_string());
+                let schema_name = registered_table_schema_name(source, table);
                 table
                     .columns
                     .iter()
@@ -1164,10 +1433,90 @@ fn catalog_columns_batch(schema: Arc<Schema>, rows: &[CatalogColumn]) -> Result<
 mod tests {
     use std::sync::Arc;
 
-    use crate::backends::common::test_support::StubSourceFunctionFactory;
-    use crate::backends::{RegisteredSource, RegisteredTableFunction, SourceQualifiedName};
+    use coral_spec::ManifestInputKind;
 
-    use super::collect_table_functions;
+    use crate::backends::common::{
+        RegisteredColumn, RegisteredFilter, test_support::StubSourceFunctionFactory,
+    };
+    use crate::backends::{
+        RegisteredInput, RegisteredSource, RegisteredTable, RegisteredTableFunction,
+        SourceQualifiedName,
+    };
+
+    use super::{
+        catalog_filter_rows, catalog_input_rows, collect_static_tables, collect_table_functions,
+        source_catalog_column_rows,
+    };
+
+    fn catalog_source() -> RegisteredSource {
+        RegisteredSource {
+            qualified_name: SourceQualifiedName::Catalog("warehouse".to_string()),
+            tables: vec![RegisteredTable {
+                schema_name: Some("public".to_string()),
+                table_name: "orders".to_string(),
+                description: String::new(),
+                guide: String::new(),
+                columns: vec![RegisteredColumn {
+                    name: "id".to_string(),
+                    data_type: "Int64".to_string(),
+                    nullable: false,
+                    is_virtual: false,
+                    is_required_filter: true,
+                    filter_mode: Some("exact".to_string()),
+                    description: String::new(),
+                }],
+                filters: vec![RegisteredFilter {
+                    name: "id".to_string(),
+                    mode: "exact".to_string(),
+                    required: true,
+                    data_type: "Int64".to_string(),
+                    description: String::new(),
+                }],
+                required_filters: vec!["id".to_string()],
+                search_limits: None,
+            }],
+            table_functions: Vec::new(),
+            inputs: vec![RegisteredInput {
+                key: "REGION".to_string(),
+                kind: ManifestInputKind::Variable,
+                required: false,
+                default_value: "eu".to_string(),
+                hint: None,
+                resolved_value: Some("us".to_string()),
+                is_set: true,
+            }],
+        }
+    }
+
+    #[test]
+    fn catalog_source_metadata_keeps_catalog_and_schema_separate() {
+        let sources = [catalog_source()];
+
+        let table = collect_static_tables(&sources)
+            .into_iter()
+            .find(|table| table.table_name == "orders")
+            .expect("catalog table metadata");
+        assert_eq!(table.catalog_name.as_deref(), Some("warehouse"));
+        assert_eq!(table.schema_name, "public");
+
+        let columns = source_catalog_column_rows(&sources);
+        assert_eq!(columns.len(), 1);
+        let column = columns.first().expect("catalog column metadata");
+        assert_eq!(column.catalog_name, "warehouse");
+        assert_eq!(column.schema_name, "public");
+
+        let filters = catalog_filter_rows(&sources);
+        assert_eq!(filters.len(), 1);
+        let filter = filters.first().expect("catalog filter metadata");
+        assert_eq!(filter.catalog_name, "warehouse");
+        assert_eq!(filter.schema_name, "public");
+
+        let inputs = catalog_input_rows(&sources);
+        assert_eq!(inputs.len(), 1);
+        let input = inputs.first().expect("catalog input metadata");
+        assert_eq!(input.catalog_name, "warehouse");
+        assert_eq!(input.schema_name, "");
+    }
 
     #[test]
     fn collect_table_functions_preserves_registered_function_schema() {

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -305,6 +305,12 @@ const TABLES_COLUMNS: &[SystemColumnDefinition] = &[
         description: "Query guidance for the table.",
     },
     SystemColumnDefinition {
+        name: "require_guide_read",
+        data_type: "Boolean",
+        nullable: false,
+        description: "Whether the table guide must be read before querying the table.",
+    },
+    SystemColumnDefinition {
         name: "required_filters",
         data_type: "Utf8",
         nullable: false,
@@ -709,7 +715,7 @@ fn catalog_tables_query(
     table_filter: Option<&str>,
 ) -> String {
     let mut sql = "SELECT catalog_name, schema_name, table_name, description, guide, \
-                   required_filters FROM coral.tables"
+                   require_guide_read, required_filters FROM coral.tables"
         .to_string();
     append_catalog_filter(&mut sql, catalog_filter, schema_filter, table_filter);
     sql
@@ -759,6 +765,7 @@ fn collect_table_infos_from_batches(batches: &[RecordBatch]) -> Result<Vec<Table
         let table_names = string_array(batch, "table_name")?;
         let descriptions = string_array(batch, "description")?;
         let guides = string_array(batch, "guide")?;
+        let require_guide_reads = bool_array(batch, "require_guide_read")?;
         let required_filters = string_array(batch, "required_filters")?;
         for row in 0..batch.num_rows() {
             tables.push(TableInfo {
@@ -767,11 +774,7 @@ fn collect_table_infos_from_batches(batches: &[RecordBatch]) -> Result<Vec<Table
                 table_name: table_names.value(row).to_string(),
                 description: descriptions.value(row).to_string(),
                 guide: guides.value(row).to_string(),
-                // `coral.tables` publishes `guide` but not `require_guide_read`,
-                // so this SQL-backed path cannot recover the flag. Tables
-                // collected here are therefore never guide-gated; closing that
-                // gap means publishing the column on `coral.tables`.
-                require_guide_read: false,
+                require_guide_read: require_guide_reads.value(row),
                 columns: Vec::new(),
                 required_filters: split_required_filters(required_filters.value(row)),
             });
@@ -977,6 +980,7 @@ struct CatalogTable {
     table_name: String,
     description: String,
     guide: String,
+    require_guide_read: bool,
     required_filters: String,
     search_limits: Option<SearchLimitsSpec>,
 }
@@ -987,6 +991,7 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
         Field::new("table_name", DataType::Utf8, false),
         Field::new("description", DataType::Utf8, false),
         Field::new("guide", DataType::Utf8, false),
+        Field::new("require_guide_read", DataType::Boolean, false),
         Field::new("required_filters", DataType::Utf8, false),
         Field::new("search_limits_json", DataType::Utf8, true),
         Field::new("catalog_name", DataType::Utf8, false),
@@ -1000,6 +1005,7 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
             table_name: table.table_name.to_string(),
             description: table.description.to_string(),
             guide: table.guide.to_string(),
+            require_guide_read: false,
             required_filters: String::new(),
             search_limits: None,
         })
@@ -1014,6 +1020,7 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
                 table_name: table.table_name.clone(),
                 description: table.description.clone(),
                 guide: table.guide.clone(),
+                require_guide_read: table.require_guide_read,
                 required_filters: table.required_filters.join(","),
                 search_limits: table.search_limits.clone(),
             })
@@ -1040,6 +1047,11 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
             utf8_column(rows.iter().map(|row| Some(row.table_name.as_str()))),
             utf8_column(rows.iter().map(|row| Some(row.description.as_str()))),
             utf8_column(rows.iter().map(|row| Some(row.guide.as_str()))),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.require_guide_read))
+                    .collect::<BooleanArray>(),
+            ),
             utf8_column(rows.iter().map(|row| Some(row.required_filters.as_str()))),
             utf8_column(search_limits_json.iter().map(|value| value.as_deref())),
             utf8_column(rows.iter().map(|row| Some(row.catalog_name.as_str()))),

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -80,6 +80,16 @@ pub(crate) fn datafusion_to_core_with_sql_and_table_functions(
     }
 }
 
+pub(crate) fn missing_table_reference(
+    error: &DataFusionError,
+    sql: Option<&str>,
+) -> Option<TableRefParts> {
+    let DataFusionError::Plan(detail) = error.find_root() else {
+        return None;
+    };
+    table_not_found_ref(error, detail, sql)
+}
+
 pub(crate) fn source_decorator_error_to_core(error: &SourceDecoratorError) -> CoreError {
     match error {
         SourceDecoratorError::InvalidInput(detail) => CoreError::InvalidInput(detail.clone()),

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -726,7 +726,9 @@ impl QueryRuntimeAdapter {
 
                 let prepared = match self.prepare_sql_once(&fallback.ctx, &sql, params).await {
                     Ok(prepared) => prepared,
-                    Err(error) => return Err(self.sql_execution_failure_to_core(error, &sql).await),
+                    Err(error) => {
+                        return Err(self.sql_execution_failure_to_core(error, &sql).await);
+                    }
                 };
                 match self.execute_prepared_once(prepared).await {
                     Ok(execution) => Ok(execution),
@@ -734,8 +736,7 @@ impl QueryRuntimeAdapter {
                         if is_missing_required_filter_failure(&error) {
                             return Err(cap_core_error);
                         }
-                        let fallback_error =
-                            self.sql_execution_failure_to_core(error, &sql).await;
+                        let fallback_error = self.sql_execution_failure_to_core(error, &sql).await;
                         Err(fallback_error)
                     }
                 }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -683,9 +683,10 @@ impl QueryRuntimeAdapter {
         sql: &str,
         params: QueryParameters,
     ) -> Result<PreparedSql, CoreError> {
-        self.prepare_sql_once(&self.ctx, sql, params)
-            .await
-            .map_err(|error| self.sql_execution_failure_to_core(error, sql))
+        match self.prepare_sql_once(&self.ctx, sql, params).await {
+            Ok(prepared) => Ok(prepared),
+            Err(error) => Err(self.sql_execution_failure_to_core(error, sql).await),
+        }
     }
 
     pub(crate) async fn execute_prepared(
@@ -723,10 +724,10 @@ impl QueryRuntimeAdapter {
                     .get_or_build_without_dependent_join()
                     .await?;
 
-                let prepared = self
-                    .prepare_sql_once(&fallback.ctx, &sql, params)
-                    .await
-                    .map_err(|error| self.sql_execution_failure_to_core(error, &sql))?;
+                let prepared = match self.prepare_sql_once(&fallback.ctx, &sql, params).await {
+                    Ok(prepared) => prepared,
+                    Err(error) => return Err(self.sql_execution_failure_to_core(error, &sql).await),
+                };
                 match self.execute_prepared_once(prepared).await {
                     Ok(execution) => Ok(execution),
                     Err(error) => {

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -26,7 +26,7 @@ use crate::runtime::dependent_join::error::resolver_rows_exceeded;
 use crate::runtime::dependent_join::optimizer;
 use crate::runtime::dependent_join::planner::DependentJoinExtensionPlanner;
 use crate::runtime::error::{
-    datafusion_to_core, datafusion_to_core_with_sql_and_table_functions,
+    datafusion_to_core, datafusion_to_core_with_sql_and_table_functions, missing_table_reference,
     query_result_observer_error_to_core,
 };
 use crate::runtime::json::register_json_support;
@@ -148,7 +148,7 @@ pub(crate) async fn build_runtime(
     runtime: QueryRuntimeConfig,
 ) -> Result<QueryRuntimeAdapter, CoreError> {
     let span = info_span!("coral.engine.runtime.build", source.count = sources.len());
-    build_runtime_inner(sources, runtime).instrument(span).await
+    Box::pin(build_runtime_inner(sources, runtime).instrument(span)).await
 }
 
 async fn build_runtime_inner(
@@ -343,8 +343,9 @@ async fn build_registered_runtime(
     let udf_table_functions = published_table_functions(config.udfs, &source_function_names)
         .map_err(|err| datafusion_to_core(&err, &[]))?;
     catalog::register(&ctx, &registration.active_sources, &udf_table_functions)
+        .await
         .map_err(|err| datafusion_to_core(&err, &[]))?;
-    let tables = catalog::collect_tables(&registration.active_sources);
+    let tables = catalog::collect_static_tables(&registration.active_sources);
     let table_functions =
         catalog::collect_table_functions(&registration.active_sources, &udf_table_functions);
     install_table_function_call_planners(
@@ -501,25 +502,6 @@ async fn register_runtime_sources(
     register_sources(ctx, source_candidates, source_decorators).await
 }
 
-fn table_qualifier_matches(
-    table: &TableInfo,
-    catalog_filter: Option<&str>,
-    schema_filter: Option<&str>,
-) -> bool {
-    catalog_filter
-        .is_none_or(|value| table.catalog_name.as_deref() == normalize_catalog_name(Some(value)))
-        && schema_filter.is_none_or(|value| table.schema_name == value)
-}
-
-fn table_reference_matches(
-    table: &TableInfo,
-    catalog_name: Option<&str>,
-    schema_name: &str,
-) -> bool {
-    table.catalog_name.as_deref() == normalize_catalog_name(catalog_name)
-        && table.schema_name == schema_name
-}
-
 impl QueryRuntimeAdapter {
     pub(crate) async fn install_udfs(
         &mut self,
@@ -554,6 +536,7 @@ impl QueryRuntimeAdapter {
         .await
         .map_err(|err| datafusion_to_core(&err, &self.tables))?;
         catalog::register(&self.ctx, &self.active_sources, &udf_table_functions)
+            .await
             .map_err(|err| datafusion_to_core(&err, &self.tables))?;
         udf_calls
             .install(&self.ctx)
@@ -568,18 +551,15 @@ impl QueryRuntimeAdapter {
         Ok(())
     }
 
-    pub(crate) fn list_tables(
+    pub(crate) async fn list_tables(
         &self,
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
-    ) -> Vec<TableInfo> {
-        self.tables
-            .iter()
-            .filter(|table| table_qualifier_matches(table, catalog_filter, schema_filter))
-            .filter(|table| table_filter.is_none_or(|value| table.table_name == value))
-            .cloned()
-            .collect()
+    ) -> Result<Vec<TableInfo>, CoreError> {
+        catalog::collect_tables(&self.ctx, catalog_filter, schema_filter, table_filter)
+            .await
+            .map_err(|err| datafusion_to_core(&err, &self.tables))
     }
 
     fn list_table_functions(
@@ -595,80 +575,89 @@ impl QueryRuntimeAdapter {
             .collect()
     }
 
-    pub(crate) fn catalog_info(
+    pub(crate) async fn catalog_info(
         &self,
         catalog_filter: Option<&str>,
         schema_filter: Option<&str>,
-    ) -> CatalogInfo {
+    ) -> Result<CatalogInfo, CoreError> {
         let includes_schema_sources =
             catalog_filter.is_none_or(|value| normalize_catalog_name(Some(value)).is_none());
-        CatalogInfo {
-            tables: self.list_tables(catalog_filter, schema_filter, None),
+        Ok(CatalogInfo {
+            tables: self
+                .list_tables(catalog_filter, schema_filter, None)
+                .await?,
             table_functions: if includes_schema_sources {
                 self.list_table_functions(schema_filter, None)
             } else {
                 Vec::new()
             },
-        }
+        })
     }
 
     /// Catalog metadata restricted to the sources publishing the given
     /// schema and catalog names. Schema names never match database-internal
     /// schemas, which are addressed through their catalog.
-    pub(crate) fn catalog_info_for_sources(
+    pub(crate) async fn catalog_info_for_sources(
         &self,
         schema_names: &[&str],
         catalog_names: &[&str],
-    ) -> CatalogInfo {
-        CatalogInfo {
-            tables: self
-                .tables
-                .iter()
-                .filter(|table| match table.catalog_name.as_deref() {
-                    None => schema_names.contains(&table.schema_name.as_str()),
-                    Some(catalog_name) => catalog_names.contains(&catalog_name),
-                })
-                .cloned()
-                .collect(),
+    ) -> Result<CatalogInfo, CoreError> {
+        let mut tables = Vec::new();
+        for schema_name in schema_names {
+            tables.extend(self.list_tables(None, Some(schema_name), None).await?);
+        }
+        for catalog_name in catalog_names {
+            tables.extend(self.list_tables(Some(catalog_name), None, None).await?);
+        }
+        tables.sort_by(|left, right| {
+            (&left.catalog_name, &left.schema_name, &left.table_name).cmp(&(
+                &right.catalog_name,
+                &right.schema_name,
+                &right.table_name,
+            ))
+        });
+        tables.dedup_by(|left, right| {
+            left.catalog_name == right.catalog_name
+                && left.schema_name == right.schema_name
+                && left.table_name == right.table_name
+        });
+        Ok(CatalogInfo {
+            tables,
             table_functions: self
                 .table_functions
                 .iter()
                 .filter(|function| schema_names.contains(&function.schema_name.as_str()))
                 .cloned()
                 .collect(),
-        }
+        })
     }
 
-    pub(crate) fn describe_table(
+    pub(crate) async fn describe_table(
         &self,
         catalog_name: Option<&str>,
         schema_name: &str,
         table_name: &str,
-    ) -> DescribeTableInfo {
-        if let Some(table) = self
-            .tables
-            .iter()
-            .find(|table| {
-                table_reference_matches(table, catalog_name, schema_name)
-                    && table.table_name == table_name
-            })
-            .cloned()
-        {
-            return DescribeTableInfo {
+    ) -> Result<DescribeTableInfo, CoreError> {
+        let mut tables = self
+            .list_tables(catalog_name, Some(schema_name), Some(table_name))
+            .await?;
+        if let Some(table) = tables.pop() {
+            return Ok(DescribeTableInfo {
                 table: Some(table),
                 missing_context_tables: Vec::new(),
-            };
+            });
         }
 
-        let missing_context_tables = self
-            .tables
+        let missing_context_tables = catalog::collect_table_metadata(&self.ctx, None, None, None)
+            .await
+            .map_err(|err| datafusion_to_core(&err, &self.tables))?
             .iter()
             .map(table_metadata_without_columns)
             .collect();
-        DescribeTableInfo {
+        Ok(DescribeTableInfo {
             table: None,
             missing_context_tables,
-        }
+        })
     }
 
     pub(crate) fn registration_failure(
@@ -744,12 +733,13 @@ impl QueryRuntimeAdapter {
                         if is_missing_required_filter_failure(&error) {
                             return Err(cap_core_error);
                         }
-                        let fallback_error = self.sql_execution_failure_to_core(error, &sql);
+                        let fallback_error =
+                            self.sql_execution_failure_to_core(error, &sql).await;
                         Err(fallback_error)
                     }
                 }
             }
-            Err(error) => Err(self.sql_execution_failure_to_core(error, &sql)),
+            Err(error) => Err(self.sql_execution_failure_to_core(error, &sql).await),
         }
     }
 
@@ -856,12 +846,17 @@ impl QueryRuntimeAdapter {
         Ok(execution)
     }
 
-    fn sql_execution_failure_to_core(&self, error: SqlExecutionFailure, sql: &str) -> CoreError {
+    async fn sql_execution_failure_to_core(
+        &self,
+        error: SqlExecutionFailure,
+        sql: &str,
+    ) -> CoreError {
         match error {
             SqlExecutionFailure::Planning(error) => {
+                let tables = self.table_context_for_planning_error(&error, sql).await;
                 datafusion_to_core_with_sql_and_table_functions(
                     &error,
-                    &self.tables,
+                    &tables,
                     &self.table_functions,
                     Some(sql),
                 )
@@ -878,6 +873,35 @@ impl QueryRuntimeAdapter {
             return error;
         }
         datafusion_to_core(error, &self.tables)
+    }
+
+    async fn table_context_for_planning_error(
+        &self,
+        error: &DataFusionError,
+        sql: &str,
+    ) -> Vec<TableInfo> {
+        let qualifier = missing_table_reference(error, Some(sql))
+            .and_then(|reference| table_context_qualifier(reference.parts.as_slice()));
+        let Some((catalog_name, schema_name)) = qualifier else {
+            return self.tables.clone();
+        };
+        match catalog::collect_table_metadata(
+            &self.ctx,
+            catalog_name.as_deref(),
+            Some(&schema_name),
+            None,
+        )
+        .await
+        {
+            Ok(tables) => tables,
+            Err(error) => {
+                tracing::debug!(
+                    detail = %error,
+                    "failed to collect dynamic table metadata for error context"
+                );
+                self.tables.clone()
+            }
+        }
     }
 
     fn observe_query_result(
@@ -1398,6 +1422,20 @@ fn name_to_source_names(sources: &[QuerySource]) -> HashMap<String, String> {
         .collect()
 }
 
+fn table_context_qualifier(parts: &[String]) -> Option<(Option<String>, String)> {
+    let parts = match parts {
+        [catalog, rest @ ..] if catalog == "datafusion" => rest,
+        _ => parts,
+    };
+    match parts {
+        [schema_name, _table_name] => Some((None, schema_name.clone())),
+        [catalog_name, schema_name, _table_name] => {
+            Some((Some(catalog_name.clone()), schema_name.clone()))
+        }
+        _ => None,
+    }
+}
+
 fn relation_parts(table_reference: &TableReference) -> Option<(&str, &str)> {
     let schema_name = table_reference.schema()?;
     Some((schema_name, table_reference.table()))
@@ -1437,38 +1475,52 @@ mod tests {
     use datafusion::execution::memory_pool::MemoryConsumer;
 
     use super::*;
+    use crate::backends::common::RegisteredColumn;
+    use crate::backends::{RegisteredTable, SourceQualifiedName};
     use crate::{
-        ColumnInfo, DependentJoinConfig, MemorySize, QueryMemoryConfig, QueryRuntimeContext,
+        DependentJoinConfig, MemorySize, QueryMemoryConfig, QueryRuntimeContext,
         UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn,
         UdfRuntimeTableFunctionPublish,
     };
 
-    fn adapter_with_table() -> QueryRuntimeAdapter {
-        QueryRuntimeAdapter {
-            ctx: Arc::new(SessionContext::new()),
-            fallback_runtime: None,
-            memory: QueryMemoryConfig::default(),
-            active_sources: Vec::new(),
-            source_function_names: HashSet::new(),
-            udfs_installed: false,
-            tables: vec![TableInfo {
-                catalog_name: None,
-                schema_name: "demo".to_string(),
+    async fn adapter_with_table() -> QueryRuntimeAdapter {
+        let active_sources = vec![RegisteredSource {
+            qualified_name: SourceQualifiedName::Schema("demo".to_string()),
+            tables: vec![RegisteredTable {
+                schema_name: None,
                 table_name: "events".to_string(),
                 description: "Event rows".to_string(),
                 guide: "Query event rows.".to_string(),
                 require_guide_read: false,
-                columns: vec![ColumnInfo {
+                columns: vec![RegisteredColumn {
                     name: "event_id".to_string(),
                     data_type: "Utf8".to_string(),
                     nullable: false,
                     is_virtual: false,
                     is_required_filter: false,
+                    filter_mode: None,
                     description: "Event ID".to_string(),
-                    ordinal_position: 0,
                 }],
+                filters: Vec::new(),
                 required_filters: vec!["owner".to_string()],
+                search_limits: None,
             }],
+            table_functions: Vec::new(),
+            inputs: Vec::new(),
+        }];
+        let ctx = Arc::new(SessionContext::new());
+        catalog::register(&ctx, &active_sources, &[])
+            .await
+            .expect("catalog should register");
+        let tables = catalog::collect_static_tables(&active_sources);
+        QueryRuntimeAdapter {
+            ctx,
+            fallback_runtime: None,
+            memory: QueryMemoryConfig::default(),
+            active_sources,
+            source_function_names: HashSet::new(),
+            udfs_installed: false,
+            tables,
             table_functions: vec![TableFunctionInfo {
                 schema_name: "demo".to_string(),
                 function_name: "search_events".to_string(),
@@ -1486,44 +1538,58 @@ mod tests {
         }
     }
 
-    #[test]
-    fn describe_table_hit_returns_full_table_without_missing_context() {
-        let result = adapter_with_table().describe_table(None, "demo", "events");
+    #[tokio::test]
+    async fn describe_table_hit_returns_full_table_without_missing_context() {
+        let result = adapter_with_table()
+            .await
+            .describe_table(None, "demo", "events")
+            .await
+            .expect("describe table");
 
         let table = result.table.expect("exact table");
         assert_eq!(table.columns.len(), 1);
         assert!(result.missing_context_tables.is_empty());
     }
 
-    #[test]
-    fn describe_table_miss_returns_columnless_context_tables() {
-        let result = adapter_with_table().describe_table(None, "demo", "missing");
+    #[tokio::test]
+    async fn describe_table_miss_returns_columnless_context_tables() {
+        let result = adapter_with_table()
+            .await
+            .describe_table(None, "demo", "missing")
+            .await
+            .expect("describe table miss");
 
         assert!(result.table.is_none());
-        assert_eq!(result.missing_context_tables.len(), 1);
         let context_table = result
             .missing_context_tables
-            .first()
+            .iter()
+            .find(|table| table.schema_name == "demo" && table.table_name == "events")
             .expect("missing context table");
         assert!(context_table.columns.is_empty());
         assert_eq!(context_table.required_filters, ["owner".to_string()]);
     }
 
-    #[test]
-    fn explicit_datafusion_catalog_filters_schema_metadata() {
-        let adapter = adapter_with_table();
+    #[tokio::test]
+    async fn explicit_datafusion_catalog_filters_schema_metadata() {
+        let adapter = adapter_with_table().await;
 
-        let tables = adapter.list_tables(
-            Some(crate::runtime::DATAFUSION_DEFAULT_CATALOG),
-            Some("demo"),
-            None,
-        );
+        let tables = adapter
+            .list_tables(
+                Some(crate::runtime::DATAFUSION_DEFAULT_CATALOG),
+                Some("demo"),
+                None,
+            )
+            .await
+            .expect("list tables");
         assert_eq!(tables.len(), 1);
 
-        let catalog = adapter.catalog_info(
-            Some(crate::runtime::DATAFUSION_DEFAULT_CATALOG),
-            Some("demo"),
-        );
+        let catalog = adapter
+            .catalog_info(
+                Some(crate::runtime::DATAFUSION_DEFAULT_CATALOG),
+                Some("demo"),
+            )
+            .await
+            .expect("catalog info");
         assert_eq!(catalog.tables.len(), 1);
         assert_eq!(catalog.table_functions.len(), 1);
     }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -1222,8 +1222,10 @@ async fn mcp_catalog_helpers_expose_coral_system_tables_from_sql_catalog() {
         .expect("list system columns")
         .structured_content
         .expect("structured columns");
-    assert_eq!(columns["total"], 7);
+    assert_eq!(columns["total"], 8);
     assert_eq!(columns["rows"][0][0], "schema_name");
+    assert_eq!(columns["rows"][4][0], "require_guide_read");
+    assert_eq!(columns["rows"][4][1], "Boolean");
 
     session.shutdown().await;
 }


### PR DESCRIPTION
## Summary

- add a relational database backend for PostgreSQL, MySQL, and SQLite catalogs
- structure database discovery behind reusable provider strategies for additional database types
- add bounded metadata discovery, connection timeouts, and redacted compiled-source debug output

## Stack

- Depends on: #1927
- Next: #1928

## Validation

- make rust-checks: 1879 tests passed, 2 skipped; clippy and rustdoc passed

This is PR 4 of 7 in the relational database source MVP stack.