### PR TITLE
feat(app): connect DSL v4 database sources

### DIFF
--- a/apps/docs/guides/use-coral-over-mcp.mdx
+++ b/apps/docs/guides/use-coral-over-mcp.mdx
@@ -212,6 +212,11 @@ Coral gives your agent a read-only SQL view over the sources you have installed 
 - join and aggregate across sources when the question needs more than one API call
 - use the same local credentials and workspace state as the Coral CLI
 
+Catalog results expose `catalog_name`, `schema_name`, and `sql_reference`
+separately. Ordinary Coral sources use `schema.table`; database sources use
+`catalog.schema.table`. Pass `catalog` alongside `schema` to catalog tools when
+addressing a database table.
+
 Set up and update sources with the CLI. The MCP server is the agent-facing query surface, not a source installer.
 
 Only connect Coral to agents you trust. A connected agent can query any source installed in that Coral workspace. See [Security](/project/security) for more detail.

--- a/apps/docs/reference/configuration.mdx
+++ b/apps/docs/reference/configuration.mdx
@@ -122,6 +122,7 @@ Feature values must be booleans. Unknown feature keys are preserved in `config.t
 
 | Feature | Default | Description |
 | ------- | ------- | ----------- |
+| `database_sources` | `false` | Experimental. Enables installing and querying database sources. |
 | `feedback` | `false` | Experimental. Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral. |
 | `observed_values_search` | `false` | Experimental. Collects, indexes, retrieves, and maintains values observed during earlier queries. |
 

--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -119,7 +119,8 @@ root.
 - An installed source's persisted credential-storage route is authoritative.
   A missing route is legacy file storage, not an instruction to re-run global
   backend selection.
-- Source `name` is the canonical installed identifier and SQL schema name.
+- Source `name` is the canonical installed identifier and SQL namespace: a
+  schema for ordinary sources and a catalog for database sources.
 - `coral-client::local` intentionally depends on `coral-app::ServerBuilder` for
   the explicit local bootstrap seam.
 - Prefer documenting `coral-client` as the public local entrypoint and

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -384,6 +384,10 @@ impl ServerBuilder {
     /// Returns [`AppError`] if the config directory cannot be determined,
     /// required directories cannot be created, the config or credential backends
     /// fail to initialize, or the gRPC server cannot be started.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "the server composition root wires shared application services explicitly"
+    )]
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir.clone())?;

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -384,10 +384,6 @@ impl ServerBuilder {
     /// Returns [`AppError`] if the config directory cannot be determined,
     /// required directories cannot be created, the config or credential backends
     /// fail to initialize, or the gRPC server cannot be started.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "the server composition root wires shared application services explicitly"
-    )]
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
         let layout = env.app_state_layout(self.config.config_dir.clone())?;

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -407,6 +407,7 @@ impl ServerBuilder {
         let workspace_lifecycle_lock = WorkspaceLifecycleLock::default();
         let workspace_pool_registry = Arc::new(WorkspacePoolRegistry::default());
         let diagnostic_reporter = SourceDiagnosticReporter::default();
+        let database_sources_enabled = features.enabled(Feature::DatabaseSources);
         let source_manager = SourceManager::with_diagnostic_reporter(
             config_store.clone(),
             credential_manager.clone(),
@@ -414,7 +415,8 @@ impl ServerBuilder {
             workspace_lifecycle_lock.clone(),
             diagnostic_reporter.clone(),
         )
-        .with_pool_registry(Arc::clone(&workspace_pool_registry));
+        .with_pool_registry(Arc::clone(&workspace_pool_registry))
+        .with_database_sources_enabled(database_sources_enabled);
         let workspace_manager = WorkspaceManager::new(
             config_store.clone(),
             credential_manager.clone(),
@@ -445,7 +447,8 @@ impl ServerBuilder {
             self.config.engine_extensions_providers,
             diagnostic_reporter.clone(),
             workspace_pool_registry,
-        );
+        )
+        .with_database_sources_enabled(database_sources_enabled);
         let observed_values_search_enabled = features.enabled(Feature::ObservedValuesSearch);
         let search_observations =
             observed_values_search_enabled.then(|| SearchObservationHandle::new(layout.clone()));

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -495,7 +495,11 @@ observed_values_search = true
         let keys = Feature::all().map(Feature::key).collect::<Vec<_>>();
         let error = unknown_feature_error("tasks");
 
-        assert_eq!(keys, vec!["feedback", "observed_values_search"]);
+        assert_eq!(
+            keys,
+            vec!["database_sources", "feedback", "observed_values_search"]
+        );
+        assert!(!features.enabled(Feature::DatabaseSources));
         assert!(!features.enabled(Feature::Feedback));
         assert!(!features.enabled(Feature::ObservedValuesSearch));
         assert!(error.to_string().contains("unknown feature 'tasks'"));

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -13,6 +13,8 @@ use crate::state::{
 /// Runtime feature keys recognized by Coral.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Feature {
+    /// Enable relational database source installation and runtime loading.
+    DatabaseSources,
     /// Expose the optional MCP `feedback` tool.
     Feedback,
     /// Enable observed-value collection, storage, retrieval, and maintenance
@@ -69,6 +71,14 @@ struct FeatureSpec {
 }
 
 const FEATURE_SPECS: &[FeatureSpec] = &[
+    FeatureSpec {
+        feature: Feature::DatabaseSources,
+        key: "database_sources",
+        default_enabled: false,
+        description: "Enables installing and querying database sources. Off by default.",
+        enable_flag: "enable-database-sources",
+        disable_flag: "disable-database-sources",
+    },
     FeatureSpec {
         feature: Feature::Feedback,
         key: "feedback",

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -466,7 +466,10 @@ observed_values_search = true
             .iter()
             .map(|spec| status_from_raw(spec, &raw, &features))
             .collect::<Vec<_>>();
-        let status = statuses.first().expect("feedback status");
+        let status = statuses
+            .iter()
+            .find(|status| status.key == "feedback")
+            .expect("feedback status");
 
         assert_eq!(status.key, "feedback");
         assert_eq!(status.configured, FeatureConfiguredState::InvalidValue);

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -32,13 +32,13 @@ use crate::query::input_resolver::{
     CredentialRefreshingInputResolver, SourceCredentialSnapshot, StoredCredentialInputResolver,
 };
 use crate::search::observed::{SearchObservationHandle, SearchObservationSource};
-use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::materialization::{SourceDiagnosticReporter, SourceLoadDiagnosticStage};
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::{
     RuntimeContractFingerprint, query_source_from_installed_manifest,
 };
+use crate::sources::{SourceName, ensure_database_source_feature_enabled};
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::task::id::TaskId;
 use crate::telemetry::app_error_type;
@@ -187,6 +187,7 @@ pub(crate) struct QueryManager {
     diagnostic_reporter: SourceDiagnosticReporter,
     search_observations: Option<SearchObservationHandle>,
     pool_registry: Arc<WorkspacePoolRegistry>,
+    database_sources_enabled: bool,
 }
 
 impl QueryManager {
@@ -231,6 +232,7 @@ impl QueryManager {
             SourceDiagnosticReporter::default(),
             Arc::new(WorkspacePoolRegistry::default()),
         )
+        .with_database_sources_enabled(true)
     }
 
     #[expect(
@@ -262,7 +264,13 @@ impl QueryManager {
             diagnostic_reporter,
             search_observations: None,
             pool_registry,
+            database_sources_enabled: false,
         }
+    }
+
+    pub(crate) fn with_database_sources_enabled(mut self, enabled: bool) -> Self {
+        self.database_sources_enabled = enabled;
+        self
     }
 
     pub(crate) fn with_search_observation_handle(
@@ -673,6 +681,7 @@ impl QueryManager {
     ) -> Result<(LoadedQuerySource, Option<String>), AppError> {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
         let source_spec = &installed.source_spec;
+        ensure_database_source_feature_enabled(source_spec, self.database_sources_enabled)?;
         validate_required_variables(source, source_spec.declared_inputs())?;
         let stored_secrets =
             if let Some(credential_storage) = source.credential_storage_for_material() {

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -529,7 +529,7 @@ impl SourceManager {
         materialization_manifest_yaml: String,
         origin: SourceOrigin,
     ) -> Result<InstalledSource, AppError> {
-        self.validate_source_features(materialization_manifest_yaml)?;
+        self.validate_source_features(&materialization_manifest_yaml)?;
         self.validate_runtime_schema_names_available(
             &workspace_name,
             &candidate.name,

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -24,7 +24,7 @@ use crate::sources::catalog::{
 use crate::sources::materialization::{
     MaterializationBuild, MaterializationInputs, SourceDiagnosticReporter,
     build_v4_materialization_tmp, canonicalize_file_descriptor, cleanup_materialization_backup,
-    cleanup_materialization_tmp, new_materialization_suffix, replace_v4_materialization,
+    cleanup_materialization_tmp, new_materialization_suffix, replace_or_retire_v4_materialization,
     restore_materialization_backup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
@@ -847,30 +847,25 @@ impl SourceManager {
                 (Vec::new(), None)
             };
 
-        let materialization_backup =
-            if let Some(materialization_tmp) = request.materialization_tmp.as_ref() {
-                match replace_v4_materialization(
-                    &self.layout,
+        let materialization_backup = match replace_or_retire_v4_materialization(
+            &self.layout,
+            workspace_name,
+            &source_name,
+            request.materialization_tmp.as_deref(),
+        ) {
+            Ok(backup) => backup,
+            Err(error) => {
+                cleanup_materialization_tmp(request.materialization_tmp.as_deref());
+                self.restore_source_rollback_state_with_state_lock_held(
                     workspace_name,
                     &source_name,
-                    materialization_tmp,
-                ) {
-                    Ok(backup) => backup,
-                    Err(error) => {
-                        cleanup_materialization_tmp(request.materialization_tmp.as_deref());
-                        self.restore_source_rollback_state_with_state_lock_held(
-                            workspace_name,
-                            &source_name,
-                            previous,
-                            credential_storage,
-                            &credential_guard,
-                        );
-                        return Err(error);
-                    }
-                }
-            } else {
-                None
-            };
+                    previous,
+                    credential_storage,
+                    &credential_guard,
+                );
+                return Err(error);
+            }
+        };
 
         let persisted_version = match request.origin {
             SourceOrigin::Bundled => None,

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -18,7 +18,6 @@ use crate::credentials::{
 };
 use crate::search::observed::SearchObservationHandle;
 use crate::search::sqlite_store::SqliteSearchStore;
-use crate::sources::SourceName;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
 };
@@ -29,6 +28,7 @@ use crate::sources::materialization::{
     restore_materialization_backup,
 };
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
+use crate::sources::{SourceName, ensure_database_source_feature_enabled};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs;
 use crate::workspaces::{
@@ -50,6 +50,7 @@ pub(crate) struct SourceManager {
     diagnostic_reporter: SourceDiagnosticReporter,
     search_observations: Option<SearchObservationHandle>,
     pool_registry: Arc<WorkspacePoolRegistry>,
+    database_sources_enabled: bool,
 }
 
 pub(crate) struct CreateBundledSourceCommand {
@@ -220,6 +221,7 @@ impl SourceManager {
             lifecycle_lock,
             SourceDiagnosticReporter::default(),
         )
+        .with_database_sources_enabled(true)
     }
 
     pub(crate) fn with_diagnostic_reporter(
@@ -238,7 +240,13 @@ impl SourceManager {
             diagnostic_reporter,
             search_observations: None,
             pool_registry: Arc::new(WorkspacePoolRegistry::default()),
+            database_sources_enabled: false,
         }
+    }
+
+    pub(crate) fn with_database_sources_enabled(mut self, enabled: bool) -> Self {
+        self.database_sources_enabled = enabled;
+        self
     }
 
     pub(crate) fn with_pool_registry(mut self, pool_registry: Arc<WorkspacePoolRegistry>) -> Self {
@@ -465,6 +473,7 @@ impl SourceManager {
         materialization_manifest_yaml: &str,
         origin: SourceOrigin,
     ) -> Result<InstalledSource, AppError> {
+        self.validate_source_features(materialization_manifest_yaml)?;
         self.validate_runtime_schema_names_available(
             workspace_name,
             &candidate.name,
@@ -520,6 +529,7 @@ impl SourceManager {
         materialization_manifest_yaml: String,
         origin: SourceOrigin,
     ) -> Result<InstalledSource, AppError> {
+        self.validate_source_features(materialization_manifest_yaml)?;
         self.validate_runtime_schema_names_available(
             &workspace_name,
             &candidate.name,
@@ -1010,6 +1020,12 @@ impl SourceManager {
             &new_materialization_suffix(suffix_prefix),
         )
         .map(Some)
+    }
+
+    fn validate_source_features(&self, manifest_yaml: &str) -> Result<(), AppError> {
+        let manifest = parse_source_manifest_yaml(manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        ensure_database_source_feature_enabled(&manifest, self.database_sources_enabled)
     }
 
     fn validate_runtime_schema_names_available(

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use coral_spec::v4::SurfaceDescriptor;
+use coral_spec::v4::{SurfaceDescriptor, SurfaceType};
 use serde_yaml::Value as YamlValue;
 
 use crate::bootstrap::AppError;
@@ -986,6 +986,9 @@ impl SourceManager {
         let Some(v4) = manifest.as_v4() else {
             return Ok(None);
         };
+        if v4.surface.surface_type == SurfaceType::Database {
+            return Ok(None);
+        }
         if matches!(origin, SourceOrigin::Bundled)
             && matches!(
                 v4.surface.descriptor,
@@ -1781,7 +1784,9 @@ mod tests {
     use crate::search::observed::{SearchObservationHandle, SqliteObservedValuesStore};
     use crate::sources::SourceName;
     use crate::sources::catalog::describe_manifest;
-    use crate::sources::materialization::{FINGERPRINT_FILENAME, PROJECTIONS_FILENAME};
+    use crate::sources::materialization::{
+        FINGERPRINT_FILENAME, MaterializationInputs, PROJECTIONS_FILENAME,
+    };
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::{WorkspaceLifecycleRevision, WorkspaceName};
@@ -2505,6 +2510,62 @@ surface:
             inputs.secrets.get("OPTIONAL_TOKEN").map(String::as_str),
             Some("persisted-secret")
         );
+    }
+
+    #[test]
+    fn database_source_skips_v4_materialization() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(CredentialStore::new(layout.clone()));
+        let manager = SourceManager::new_for_tests(config_store, credential_manager, layout);
+        let candidate = CandidateSource {
+            name: SourceName::parse("coral_db").expect("source"),
+            description: String::new(),
+            version: None,
+            inputs: vec![ManifestInputSpec {
+                key: "DB_PASSWORD".to_string(),
+                kind: ManifestInputKind::Secret,
+                required: true,
+                default_value: String::new(),
+                hint: None,
+                credential: None,
+            }],
+            installed: false,
+            origin: SourceOrigin::Imported,
+            credential_storage: Some(CredentialStorageKind::File),
+        };
+        let manifest_yaml = r#"
+name: coral_db
+dsl_version: 4
+inputs:
+  DB_PASSWORD:
+    kind: secret
+surface:
+  type: database
+  provider: postgres
+  connection:
+    host: localhost
+    port: "5432"
+    database: coral
+    user: coral_reader
+    password: "{{input.DB_PASSWORD}}"
+"#;
+
+        let materialization = manager
+            .prepare_v4_materialization(
+                &default_workspace(),
+                &candidate,
+                manifest_yaml,
+                &MaterializationInputs::default(),
+                SourceOrigin::Imported,
+                "test",
+            )
+            .expect("database materialization decision");
+
+        assert!(materialization.is_none());
     }
 
     #[test]

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -846,16 +846,17 @@ fn validate_semantic_ir(
     {
         return Err("semantic IR identity mismatch".to_string());
     }
-    if semantic_ir.importer_version != expected_importer_version(manifest.surface.surface_type) {
+    if semantic_ir.importer_version != expected_importer_version(manifest.surface.surface_type)? {
         return Err("semantic IR importer version mismatch".to_string());
     }
     Ok(())
 }
 
-fn expected_importer_version(surface_type: SurfaceType) -> &'static str {
+fn expected_importer_version(surface_type: SurfaceType) -> Result<&'static str, String> {
     match surface_type {
-        SurfaceType::OpenApi => OPENAPI_IMPORTER_VERSION,
-        SurfaceType::Mcp => MCP_IMPORTER_VERSION,
+        SurfaceType::OpenApi => Ok(OPENAPI_IMPORTER_VERSION),
+        SurfaceType::Mcp => Ok(MCP_IMPORTER_VERSION),
+        SurfaceType::Database => Err("database surfaces are not materialized".to_string()),
     }
 }
 
@@ -972,6 +973,10 @@ fn materialize_surface(
     match surface.surface_type {
         SurfaceType::OpenApi => materialize_openapi_surface(manifest, surface),
         SurfaceType::Mcp => materialize_mcp_surface(manifest, surface, inputs),
+        SurfaceType::Database => Err(AppError::FailedPrecondition(format!(
+            "database source '{}' must be registered directly, not materialized",
+            manifest.common.name
+        ))),
     }
 }
 
@@ -1122,6 +1127,9 @@ fn read_descriptor(surface: &coral_spec::v4::V4Surface) -> Result<Vec<u8>, AppEr
         coral_spec::v4::SurfaceDescriptor::Url { url } => read_url_descriptor(url),
         coral_spec::v4::SurfaceDescriptor::McpServer { .. } => Err(AppError::FailedPrecondition(
             "DSL v4 MCP surface does not have an OpenAPI descriptor".to_string(),
+        )),
+        coral_spec::v4::SurfaceDescriptor::Database { .. } => Err(AppError::FailedPrecondition(
+            "DSL v4 database surface does not have an OpenAPI descriptor".to_string(),
         )),
     }
 }
@@ -1448,6 +1456,14 @@ mod tests {
 
     fn source_name() -> SourceName {
         SourceName::parse("github_v4_materialization_test").expect("source name")
+    }
+
+    #[test]
+    fn database_surface_reports_that_it_cannot_be_materialized() {
+        let error = expected_importer_version(SurfaceType::Database)
+            .expect_err("database surfaces have no importer version");
+
+        assert_eq!(error, "database surfaces are not materialized");
     }
 
     fn openapi_fixture() -> &'static str {

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -284,13 +284,21 @@ pub(crate) fn build_v4_materialization_tmp(
     }
 }
 
-pub(crate) fn replace_v4_materialization(
+/// Stages the desired materialization state and returns any previous state for rollback.
+///
+/// A missing replacement retires an existing materialization while the source
+/// update is committed.
+pub(crate) fn replace_or_retire_v4_materialization(
     layout: &AppStateLayout,
     workspace_name: &WorkspaceName,
     source_name: &SourceName,
-    temp_dir: &Path,
+    replacement: Option<&Path>,
 ) -> Result<Option<PathBuf>, AppError> {
     let target = layout.v4_materialized_dir(workspace_name, source_name);
+    let had_existing = target.exists();
+    if replacement.is_none() && !had_existing {
+        return Ok(None);
+    }
     let backup = layout.v4_materialized_tmp_dir(
         workspace_name,
         source_name,
@@ -302,11 +310,12 @@ pub(crate) fn replace_v4_materialization(
     if backup.exists() {
         std::fs::remove_dir_all(&backup)?;
     }
-    let had_existing = target.exists();
     if had_existing {
         std::fs::rename(&target, &backup)?;
     }
-    if let Err(error) = std::fs::rename(temp_dir, &target) {
+    if let Some(replacement) = replacement
+        && let Err(error) = std::fs::rename(replacement, &target)
+    {
         if had_existing
             && backup.exists()
             && let Err(rollback_error) = std::fs::rename(&backup, &target)
@@ -1635,8 +1644,13 @@ surface:
             "test",
         )
         .expect("build materialization");
-        replace_v4_materialization(&layout, &workspace_name(), &source_name(), &build.temp_dir)
-            .expect("install materialization");
+        replace_or_retire_v4_materialization(
+            &layout,
+            &workspace_name(),
+            &source_name(),
+            Some(&build.temp_dir),
+        )
+        .expect("install materialization");
         (state_temp, descriptor_temp, layout, manifest_yaml, manifest)
     }
 
@@ -1671,6 +1685,25 @@ surface:
             !materialized_dir.join("surfaces").exists(),
             "singular materializations must not create a surfaces directory"
         );
+    }
+
+    #[test]
+    fn retiring_materialization_preserves_rollback_state() {
+        let (_state, _descriptor, layout, _manifest_yaml, _manifest) = setup_materialization();
+        let materialized_dir = layout.v4_materialized_dir(&workspace_name(), &source_name());
+
+        let backup =
+            replace_or_retire_v4_materialization(&layout, &workspace_name(), &source_name(), None)
+                .expect("retire materialization")
+                .expect("existing materialization backup");
+
+        assert!(!materialized_dir.exists());
+        assert!(backup.exists());
+
+        restore_materialization_backup(&layout, &workspace_name(), &source_name(), Some(backup))
+            .expect("restore materialization");
+
+        assert!(materialized_dir.join(PROJECTIONS_FILENAME).exists());
     }
 
     #[test]

--- a/crates/coral-app/src/sources/mod.rs
+++ b/crates/coral-app/src/sources/mod.rs
@@ -1,5 +1,10 @@
 //! Source lifecycle workflow, catalog inspection, and transport adapters.
 
+use coral_spec::ValidatedSourceManifest;
+use coral_spec::v4::SurfaceType;
+
+use crate::bootstrap::AppError;
+
 pub(crate) mod catalog;
 pub(crate) mod manager;
 pub(crate) mod materialization;
@@ -9,3 +14,19 @@ pub(crate) mod runtime_package;
 pub(crate) mod service;
 
 pub(crate) use name::SourceName;
+
+pub(crate) fn ensure_database_source_feature_enabled(
+    manifest: &ValidatedSourceManifest,
+    database_sources_enabled: bool,
+) -> Result<(), AppError> {
+    let is_database_source = manifest
+        .as_v4()
+        .is_some_and(|v4| v4.surface.surface_type == SurfaceType::Database);
+    if database_sources_enabled || !is_database_source {
+        return Ok(());
+    }
+    Err(AppError::FailedPrecondition(format!(
+        "database source '{}' requires the disabled `database_sources` feature; enable it with `coral features enable database_sources` and retry",
+        manifest.schema_name()
+    )))
+}

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -96,13 +96,6 @@ pub(crate) fn runtime_contract_fingerprint(
                 "DSL v4 runtime fingerprint received a file component".to_string(),
             ));
         }
-        // The engine models database components here, but no app path installs
-        // one until DSL v4 database sources are connected.
-        Some(RuntimeSourceComponent::Database(_)) => {
-            return Err(AppError::Internal(
-                "DSL v4 runtime fingerprint received a database component".to_string(),
-            ));
-        }
         None => None,
     };
     let input = RuntimeContractFingerprintInput {

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use coral_engine::{QuerySource, RuntimeSourceComponent, RuntimeSourcePackage};
+use coral_spec::backends::database::DatabaseSourceManifest;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 use coral_spec::backends::mcp::{
     McpSourceManifest, McpTableFilterBinding, McpTableFunctionSpec, McpTableSpec,
@@ -71,6 +72,7 @@ struct RuntimeContractFingerprintInput<'a> {
 #[derive(Serialize)]
 #[serde(tag = "backend", rename_all = "snake_case")]
 enum V4RuntimeContract<'a> {
+    Database(&'a coral_spec::backends::database::DatabaseSourceManifest),
     Http(&'a coral_spec::backends::http::HttpSourceManifest),
     Mcp(&'a coral_spec::backends::mcp::McpSourceManifest),
 }
@@ -84,6 +86,9 @@ pub(crate) fn runtime_contract_fingerprint(
     v4_component: Option<&RuntimeSourceComponent>,
 ) -> Result<RuntimeContractFingerprint, AppError> {
     let v4_runtime_contract = match v4_component {
+        Some(RuntimeSourceComponent::Database(database)) => {
+            Some(V4RuntimeContract::Database(database))
+        }
         Some(RuntimeSourceComponent::Http(http)) => Some(V4RuntimeContract::Http(http)),
         Some(RuntimeSourceComponent::Mcp(mcp)) => Some(V4RuntimeContract::Mcp(mcp)),
         Some(RuntimeSourceComponent::File(_)) => {
@@ -131,22 +136,25 @@ pub(crate) fn query_source_from_installed_manifest(
 ) -> Result<LoadedRuntimeSource, AppError> {
     let source_spec = &installed.source_spec;
     let (query_source, runtime_contract_fingerprint) = if let Some(v4) = source_spec.as_v4() {
-        let materialized = load_v4_materialization_with_reporter(
-            layout,
-            workspace_name,
-            &source.name,
-            &installed.manifest_yaml,
-            v4,
-            diagnostic_reporter,
-        )?;
-        let component =
+        let component = if v4.surface.surface_type == SurfaceType::Database {
+            Some(runtime_component_for_v4_database_source(v4)?)
+        } else {
+            let materialized = load_v4_materialization_with_reporter(
+                layout,
+                workspace_name,
+                &source.name,
+                &installed.manifest_yaml,
+                v4,
+                diagnostic_reporter,
+            )?;
             runtime_component_for_v4_source(v4, &materialized).map_err(|error| match error {
                 error @ AppError::UnsupportedV4IdentityRequirements { .. } => error,
                 error => incompatible_materialization_error(
                     &source.name,
                     format!("failed to assemble runtime package: {error}"),
                 ),
-            })?;
+            })?
+        };
         let runtime_contract_fingerprint = runtime_contract_fingerprint(
             &installed.manifest_yaml,
             &source.variables,
@@ -200,7 +208,27 @@ pub(crate) fn runtime_component_for_v4_source(
             manifest,
             materialized,
         )?))),
+        SurfaceType::Database => Ok(Some(runtime_component_for_v4_database_source(manifest)?)),
     }
+}
+
+pub(crate) fn runtime_component_for_v4_database_source(
+    manifest: &V4SourceManifest,
+) -> Result<RuntimeSourceComponent, AppError> {
+    let database_runtime = manifest.surface.database_runtime().ok_or_else(|| {
+        AppError::FailedPrecondition("DSL v4 surface is not a database surface".to_string())
+    })?;
+    Ok(RuntimeSourceComponent::Database(DatabaseSourceManifest {
+        common: SourceManifestCommon {
+            dsl_version: manifest.common.dsl_version,
+            name: manifest.common.name.clone(),
+            version: String::new(),
+            description: manifest.common.description.clone(),
+            test_queries: Vec::new(),
+        },
+        connection: database_runtime.connection.clone(),
+        declared_inputs: manifest.declared_inputs.clone(),
+    }))
 }
 
 fn has_published_projection(materialized: &V4MaterializedSource) -> bool {
@@ -537,6 +565,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::path::PathBuf;
 
+    use coral_engine::RuntimeSourceComponent;
     use coral_spec::backends::http::{AuthSpec, RateLimitSpec};
     use coral_spec::backends::mcp::{McpOffsetPaginationSpec, McpPaginationSpec, McpServerSpec};
     use coral_spec::v4::{
@@ -553,13 +582,16 @@ mod tests {
         V4MaterializedSource, V4SourceCommon, V4SourceManifest, V4Surface, ValidatedSurfacePlan,
     };
     use coral_spec::{
-        ManifestDataType, PageSizeSpec, PaginationMode, PaginationSpec, ResponseSpec,
-        SourceTableFunctionKind,
+        DatabaseConnectionSpec, ManifestDataType, ManifestInputKind, PageSizeSpec, PaginationMode,
+        PaginationSpec, ResponseSpec, SourceTableFunctionKind, parse_source_manifest_yaml,
     };
 
     use crate::bootstrap::AppError;
 
-    use super::{runtime_component_for_v4_source, runtime_contract_fingerprint, surface_base_url};
+    use super::{
+        runtime_component_for_v4_database_source, runtime_component_for_v4_source,
+        runtime_contract_fingerprint, surface_base_url,
+    };
 
     fn surface_without_authored_base_url() -> V4Surface {
         openapi_surface_with_base_url("")
@@ -1064,6 +1096,52 @@ mod tests {
             operation_metadata_generator_version: OPERATION_METADATA_GENERATOR_VERSION.to_string(),
             projection_generator_version: PROJECTION_GENERATOR_VERSION.to_string(),
         }
+    }
+
+    #[test]
+    fn database_runtime_component_preserves_connection_and_declared_inputs() {
+        let manifest = parse_source_manifest_yaml(
+            r#"
+name: coral_db
+dsl_version: 4
+description: Read-only reporting database.
+test_queries:
+  - SELECT 1
+inputs:
+  DB_PASSWORD:
+    kind: secret
+surface:
+  type: database
+  provider: postgres
+  connection:
+    host: localhost
+    port: "5432"
+    database: coral
+    user: coral_reader
+    password: "{{input.DB_PASSWORD}}"
+"#,
+        )
+        .expect("database manifest");
+        let v4 = manifest.as_v4().expect("v4 manifest");
+
+        let component =
+            runtime_component_for_v4_database_source(v4).expect("database runtime component");
+        let RuntimeSourceComponent::Database(database) = component else {
+            panic!("database component");
+        };
+
+        assert_eq!(database.common.name, "coral_db");
+        assert_eq!(database.common.description, "Read-only reporting database.");
+        assert!(database.common.test_queries.is_empty());
+        assert_eq!(database.declared_inputs.len(), 1);
+        let input = database.declared_inputs.first().expect("declared input");
+        assert_eq!(input.key, "DB_PASSWORD");
+        assert_eq!(input.kind, ManifestInputKind::Secret);
+        let DatabaseConnectionSpec::Postgres(connection) = database.connection else {
+            panic!("PostgreSQL connection");
+        };
+        assert_eq!(connection.database.raw(), "coral");
+        assert_eq!(connection.password.raw(), "{{input.DB_PASSWORD}}");
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -308,6 +308,7 @@ fn backend_kind_label(kind: SourceBackend) -> &'static str {
         SourceBackend::Http => "http",
         SourceBackend::File => "file",
         SourceBackend::Mcp => "mcp",
+        SourceBackend::Database => "database",
     }
 }
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -622,9 +622,12 @@ impl QueryRuntimeAdapter {
     ) -> Result<CatalogInfo, CoreError> {
         let includes_schema_sources =
             catalog_filter.is_none_or(|value| normalize_catalog_name(Some(value)).is_none());
-        let tables = catalog::collect_tables(&self.ctx, catalog_filter, schema_filter, None)
-            .await
-            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+        // Catalog summaries never surface columns, so skip the coral.columns
+        // expansion (and the remote database inventory fetches behind it).
+        let tables =
+            catalog::collect_table_metadata(&self.ctx, catalog_filter, schema_filter, None)
+                .await
+                .map_err(|err| datafusion_to_core(&err, &self.tables))?;
         Ok(CatalogInfo {
             tables,
             table_functions: if includes_schema_sources {

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -622,12 +622,9 @@ impl QueryRuntimeAdapter {
     ) -> Result<CatalogInfo, CoreError> {
         let includes_schema_sources =
             catalog_filter.is_none_or(|value| normalize_catalog_name(Some(value)).is_none());
-        // Catalog summaries never surface columns, so skip the coral.columns
-        // expansion (and the remote database inventory fetches behind it).
-        let tables =
-            catalog::collect_table_metadata(&self.ctx, catalog_filter, schema_filter, None)
-                .await
-                .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+        let tables = catalog::collect_tables(&self.ctx, catalog_filter, schema_filter, None)
+            .await
+            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
         Ok(CatalogInfo {
             tables,
             table_functions: if includes_schema_sources {

--- a/crates/coral-spec/src/backends/database.rs
+++ b/crates/coral-spec/src/backends/database.rs
@@ -6,9 +6,29 @@
 //! Backend-owned manifest model for relational database sources.
 
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::{ManifestInputSpec, ParsedTemplate, SourceManifestCommon};
+
+/// Provider selected by an authored database surface.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DatabaseProvider {
+    Postgres,
+    #[serde(rename = "mysql")]
+    MySql,
+    Sqlite,
+}
+
+impl DatabaseProvider {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Postgres => "postgres",
+            Self::MySql => "mysql",
+            Self::Sqlite => "sqlite",
+        }
+    }
+}
 
 /// Validated database source manifest consumed by the query engine.
 #[derive(Debug, Clone)]

--- a/crates/coral-spec/src/backends/database.rs
+++ b/crates/coral-spec/src/backends/database.rs
@@ -31,15 +31,19 @@ impl DatabaseProvider {
 }
 
 /// Validated database source manifest consumed by the query engine.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct DatabaseSourceManifest {
     pub common: SourceManifestCommon,
     pub connection: DatabaseConnectionSpec,
+    /// Skipped when serializing: declared inputs come verbatim from the
+    /// authored manifest, which fingerprinting hashes separately.
+    #[serde(skip)]
     pub declared_inputs: Vec<ManifestInputSpec>,
 }
 
 /// Provider-specific database connection configuration.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum DatabaseConnectionSpec {
     Postgres(PostgresConnectionSpec),
     MySql(MySqlConnectionSpec),
@@ -47,7 +51,7 @@ pub enum DatabaseConnectionSpec {
 }
 
 /// `PostgreSQL` connection configuration.
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct PostgresConnectionSpec {
     pub host: ParsedTemplate,
@@ -60,7 +64,7 @@ pub struct PostgresConnectionSpec {
 }
 
 /// `MySQL` connection configuration.
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct MySqlConnectionSpec {
     pub host: ParsedTemplate,
@@ -71,7 +75,7 @@ pub struct MySqlConnectionSpec {
 }
 
 /// `SQLite` connection configuration.
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SqliteConnectionSpec {
     pub path: ParsedTemplate,

--- a/crates/coral-spec/src/backends/database.rs
+++ b/crates/coral-spec/src/backends/database.rs
@@ -46,6 +46,7 @@ pub struct DatabaseSourceManifest {
 #[serde(rename_all = "snake_case")]
 pub enum DatabaseConnectionSpec {
     Postgres(PostgresConnectionSpec),
+    #[serde(rename = "mysql")]
     MySql(MySqlConnectionSpec),
     Sqlite(SqliteConnectionSpec),
 }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -22,7 +22,8 @@ use crate::{ManifestError, ParsedTemplate, Result};
 /// Source SQL names the runtime owns. Kept in step with `RESERVED_SCHEMA_NAMES`
 /// in `coral-engine`'s registry: a name the engine refuses at registration has
 /// to fail manifest validation too, or the manifest validator accepts a source
-/// that can never register.
+/// that can never register. `datafusion` is `DataFusion`'s synthetic default
+/// catalog.
 const RESERVED_SOURCE_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin", "datafusion", "public"];
 
 /// Arrow field metadata key marking a source-authored column as excluded from
@@ -94,6 +95,7 @@ pub enum SourceBackend {
     Http,
     File,
     Mcp,
+    Database,
 }
 
 /// The normalized scalar type vocabulary shared by source specs, the query

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -94,8 +94,8 @@ pub mod v4;
 mod validate;
 
 pub use backends::database::{
-    DatabaseConnectionSpec, DatabaseSourceManifest, MySqlConnectionSpec, PostgresConnectionSpec,
-    SqliteConnectionSpec,
+    DatabaseConnectionSpec, DatabaseProvider, DatabaseSourceManifest, MySqlConnectionSpec,
+    PostgresConnectionSpec, SqliteConnectionSpec,
 };
 pub use backends::http::{AuthSpec, BasicAuthSpec, CustomAuthSpec, HeaderAuthSpec};
 pub use backends::mcp::{

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -48,6 +48,7 @@ impl ValidatedSourceManifest {
             ValidatedManifestKind::V4(manifest) => match manifest.surface.surface_type {
                 crate::v4::SurfaceType::OpenApi => SourceBackend::Http,
                 crate::v4::SurfaceType::Mcp => SourceBackend::Mcp,
+                crate::v4::SurfaceType::Database => SourceBackend::Database,
             },
         }
     }
@@ -240,6 +241,9 @@ pub fn parse_source_manifest_value(value: Value) -> Result<ValidatedSourceManife
         SourceBackend::Mcp => Ok(ValidatedSourceManifest {
             inner: ValidatedManifestKind::Mcp(McpSourceManifest::parse_manifest_value(value)?),
         }),
+        SourceBackend::Database => Err(ManifestError::validation(
+            "database sources require dsl_version 4",
+        )),
     }
 }
 
@@ -330,9 +334,10 @@ tables:
 
     #[test]
     fn reserved_source_name_is_rejected() {
-        let error = parse_source_manifest_yaml(
-            r"
-name: public
+        for name in ["coral", "coral_admin", "datafusion", "public"] {
+            let raw = format!(
+                r"
+name: {name}
 version: 1.0.0
 dsl_version: 3
 backend: file
@@ -345,16 +350,18 @@ tables:
     columns:
       - name: kind
         type: Utf8
-",
-        )
-        .expect_err("reserved source name should fail");
+"
+            );
+            let error =
+                parse_source_manifest_yaml(&raw).expect_err("reserved source name should fail");
 
-        assert!(
-            error
-                .to_string()
-                .contains("source name 'public' is reserved"),
-            "unexpected error: {error}"
-        );
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("source name '{name}' is reserved")),
+                "unexpected error: {error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/coral-spec/src/schema/source_manifest_v4.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest_v4.schema.json
@@ -824,6 +824,19 @@
             "type",
             "server"
           ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "database"
+            }
+          },
+          "$ref": "#/$defs/V4DatabaseSurfaceSchema",
+          "required": [
+            "type"
+          ]
         }
       ]
     },
@@ -1822,6 +1835,159 @@
       "type": "string",
       "enum": [
         "bearer"
+      ]
+    },
+    "V4PostgresDatabaseSurfaceSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "database"
+        },
+        "provider": {
+          "type": "string",
+          "const": "postgres"
+        },
+        "connection": {
+          "$ref": "#/$defs/V4PostgresConnectionSchema"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "provider",
+        "connection"
+      ]
+    },
+    "V4PostgresConnectionSchema": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "sslmode": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "host",
+        "port",
+        "database",
+        "user",
+        "password"
+      ]
+    },
+    "V4MySqlDatabaseSurfaceSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "database"
+        },
+        "provider": {
+          "type": "string",
+          "const": "mysql"
+        },
+        "connection": {
+          "$ref": "#/$defs/V4MySqlConnectionSchema"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "provider",
+        "connection"
+      ]
+    },
+    "V4MySqlConnectionSchema": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        },
+        "user": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "host",
+        "port",
+        "database",
+        "user",
+        "password"
+      ]
+    },
+    "V4SqliteDatabaseSurfaceSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "database"
+        },
+        "provider": {
+          "type": "string",
+          "const": "sqlite"
+        },
+        "connection": {
+          "$ref": "#/$defs/V4SqliteConnectionSchema"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "provider",
+        "connection"
+      ]
+    },
+    "V4SqliteConnectionSchema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "path"
+      ]
+    },
+    "V4DatabaseSurfaceSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/V4PostgresDatabaseSurfaceSchema"
+        },
+        {
+          "$ref": "#/$defs/V4MySqlDatabaseSurfaceSchema"
+        },
+        {
+          "$ref": "#/$defs/V4SqliteDatabaseSurfaceSchema"
+        }
       ]
     }
   },

--- a/crates/coral-spec/src/v4/artifacts.rs
+++ b/crates/coral-spec/src/v4/artifacts.rs
@@ -191,6 +191,9 @@ surface:
                 importer_version: match surface_type {
                     SurfaceType::OpenApi => OPENAPI_IMPORTER_VERSION,
                     SurfaceType::Mcp => MCP_IMPORTER_VERSION,
+                    SurfaceType::Database => {
+                        panic!("database surfaces do not have materialized plans")
+                    }
                 }
                 .to_string(),
                 operations: Vec::new(),

--- a/crates/coral-spec/src/v4/manifest.rs
+++ b/crates/coral-spec/src/v4/manifest.rs
@@ -11,8 +11,10 @@ use crate::inputs::{
     validate_oauth_endpoint_templates_with_scope,
 };
 use crate::{
-    HeaderSpec, ManifestError, ManifestInputKind, ManifestInputSpec, ParsedTemplate, Result,
-    TemplateNamespace, validate_identifier, validate_source_name, validate_test_queries,
+    DatabaseConnectionSpec, DatabaseProvider, HeaderSpec, ManifestError, ManifestInputKind,
+    ManifestInputSpec, MySqlConnectionSpec, ParsedTemplate, PostgresConnectionSpec, Result,
+    SqliteConnectionSpec, TemplateNamespace, validate_identifier, validate_source_name,
+    validate_test_queries,
 };
 
 #[derive(Debug, Clone)]
@@ -44,6 +46,7 @@ pub struct V4Surface {
 pub enum SurfaceType {
     OpenApi,
     Mcp,
+    Database,
 }
 
 #[derive(Debug, Clone)]
@@ -51,6 +54,7 @@ pub enum SurfaceDescriptor {
     Url { url: String },
     File { file: PathBuf },
     McpServer { location: String },
+    Database { provider: DatabaseProvider },
 }
 
 impl SurfaceDescriptor {
@@ -59,6 +63,7 @@ impl SurfaceDescriptor {
             Self::Url { .. } => "url",
             Self::File { .. } => "file",
             Self::McpServer { .. } => "mcp_server",
+            Self::Database { .. } => "database",
         }
     }
 
@@ -67,6 +72,7 @@ impl SurfaceDescriptor {
             Self::Url { url, .. } => url.clone(),
             Self::File { file, .. } => file.display().to_string(),
             Self::McpServer { location } => location.clone(),
+            Self::Database { provider } => provider.as_str().to_string(),
         }
     }
 }
@@ -75,6 +81,7 @@ impl SurfaceDescriptor {
 pub enum SurfaceRuntimeConfig {
     OpenApi(OpenApiRuntimeConfig),
     Mcp(McpRuntimeConfig),
+    Database(DatabaseRuntimeConfig),
 }
 
 #[derive(Debug, Clone)]
@@ -88,6 +95,11 @@ pub struct OpenApiRuntimeConfig {
 #[derive(Debug, Clone)]
 pub struct McpRuntimeConfig {
     pub server: McpServerSpec,
+}
+
+#[derive(Debug, Clone)]
+pub struct DatabaseRuntimeConfig {
+    pub connection: DatabaseConnectionSpec,
 }
 
 /// Identity authentication contract declared by a DSL v4 source.
@@ -117,14 +129,21 @@ impl V4Surface {
     pub fn openapi_runtime(&self) -> Option<&OpenApiRuntimeConfig> {
         match &self.runtime {
             SurfaceRuntimeConfig::OpenApi(runtime) => Some(runtime),
-            SurfaceRuntimeConfig::Mcp(_) => None,
+            SurfaceRuntimeConfig::Mcp(_) | SurfaceRuntimeConfig::Database(_) => None,
         }
     }
 
     pub fn mcp_runtime(&self) -> Option<&McpRuntimeConfig> {
         match &self.runtime {
             SurfaceRuntimeConfig::Mcp(runtime) => Some(runtime),
-            SurfaceRuntimeConfig::OpenApi(_) => None,
+            SurfaceRuntimeConfig::OpenApi(_) | SurfaceRuntimeConfig::Database(_) => None,
+        }
+    }
+
+    pub fn database_runtime(&self) -> Option<&DatabaseRuntimeConfig> {
+        match &self.runtime {
+            SurfaceRuntimeConfig::Database(runtime) => Some(runtime),
+            SurfaceRuntimeConfig::OpenApi(_) | SurfaceRuntimeConfig::Mcp(_) => None,
         }
     }
 }
@@ -166,6 +185,10 @@ struct RawV4Surface {
     rate_limit: RateLimitSpec,
     #[serde(default)]
     server: Option<McpServerSpec>,
+    #[serde(default)]
+    provider: Option<DatabaseProvider>,
+    #[serde(default)]
+    connection: Option<Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -174,6 +197,8 @@ enum RawSurfaceType {
     OpenApi,
     #[serde(rename = "mcp")]
     Mcp,
+    #[serde(rename = "database")]
+    Database,
 }
 
 impl V4SourceManifest {
@@ -243,6 +268,7 @@ fn parse_surface(
     match raw_surface.surface_type {
         RawSurfaceType::OpenApi => parse_openapi_surface(source_name, raw_surface, inputs),
         RawSurfaceType::Mcp => parse_mcp_surface(source_name, raw_surface, surface_value, inputs),
+        RawSurfaceType::Database => parse_database_surface(source_name, raw_surface, surface_value),
     }
 }
 
@@ -251,9 +277,12 @@ fn parse_openapi_surface(
     raw_surface: RawV4Surface,
     inputs: &[ManifestInputSpec],
 ) -> Result<V4Surface> {
-    if raw_surface.server.is_some() {
+    if raw_surface.server.is_some()
+        || raw_surface.provider.is_some()
+        || raw_surface.connection.is_some()
+    {
         return Err(ManifestError::validation(format!(
-            "source '{source_name}' OpenAPI surface must not declare server"
+            "source '{source_name}' OpenAPI surface must not declare server, provider, or connection"
         )));
     }
     if let Some(base_url) = raw_surface.base_url.as_ref() {
@@ -285,6 +314,11 @@ fn parse_mcp_surface(
             "source '{source_name}' MCP surface must not declare url or file"
         )));
     }
+    if raw_surface.provider.is_some() || raw_surface.connection.is_some() {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' MCP surface must not declare provider or connection"
+        )));
+    }
     for field in ["base_url", "auth", "request_headers", "rate_limit"] {
         if surface_value.get(field).is_some() {
             return Err(ManifestError::validation(format!(
@@ -304,6 +338,126 @@ fn parse_mcp_surface(
             location: mcp_server_location(&server),
         },
         runtime: SurfaceRuntimeConfig::Mcp(McpRuntimeConfig { server }),
+    })
+}
+
+fn parse_database_surface(
+    source_name: &str,
+    raw_surface: RawV4Surface,
+    surface_value: &Value,
+) -> Result<V4Surface> {
+    if raw_surface.url.is_some() || raw_surface.file.is_some() || raw_surface.server.is_some() {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' database surface must not declare url, file, or server"
+        )));
+    }
+    for field in ["base_url", "auth", "request_headers", "rate_limit"] {
+        if surface_value.get(field).is_some() {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' database surface must not declare OpenAPI field '{field}'"
+            )));
+        }
+    }
+    let provider = raw_surface.provider.ok_or_else(|| {
+        ManifestError::validation(format!(
+            "source '{source_name}' database surface must declare provider"
+        ))
+    })?;
+    let connection = raw_surface.connection.ok_or_else(|| {
+        ManifestError::validation(format!(
+            "source '{source_name}' database surface must declare connection"
+        ))
+    })?;
+    let connection = parse_database_connection(source_name, provider, connection)?;
+    validate_database_connection_templates(source_name, &connection)?;
+    Ok(V4Surface {
+        surface_type: SurfaceType::Database,
+        descriptor: SurfaceDescriptor::Database { provider },
+        runtime: SurfaceRuntimeConfig::Database(DatabaseRuntimeConfig { connection }),
+    })
+}
+
+fn validate_database_connection_templates(
+    source_name: &str,
+    connection: &DatabaseConnectionSpec,
+) -> Result<()> {
+    visit_database_connection_templates(connection, |field, template| {
+        validate_database_connection_template(source_name, field, template)
+    })
+}
+
+fn visit_database_connection_templates(
+    connection: &DatabaseConnectionSpec,
+    mut visit: impl FnMut(&str, &ParsedTemplate) -> Result<()>,
+) -> Result<()> {
+    match connection {
+        DatabaseConnectionSpec::Postgres(connection) => {
+            for (field, template) in [
+                ("host", &connection.host),
+                ("port", &connection.port),
+                ("database", &connection.database),
+                ("user", &connection.user),
+                ("password", &connection.password),
+            ] {
+                visit(field, template)?;
+            }
+            if let Some(sslmode) = &connection.sslmode {
+                visit("sslmode", sslmode)?;
+            }
+        }
+        DatabaseConnectionSpec::MySql(connection) => {
+            for (field, template) in [
+                ("host", &connection.host),
+                ("port", &connection.port),
+                ("database", &connection.database),
+                ("user", &connection.user),
+                ("password", &connection.password),
+            ] {
+                visit(field, template)?;
+            }
+        }
+        DatabaseConnectionSpec::Sqlite(connection) => visit("path", &connection.path)?,
+    }
+    Ok(())
+}
+
+fn validate_database_connection_template(
+    source_name: &str,
+    field: &str,
+    template: &ParsedTemplate,
+) -> Result<()> {
+    for token in template.tokens() {
+        match token.namespace() {
+            TemplateNamespace::Input => {}
+            _ => {
+                return Err(ManifestError::validation(format!(
+                    "source '{source_name}' database surface connection.{field} may only reference top-level inputs; unsupported template token '{{{{{}}}}}'",
+                    token.raw()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parse_database_connection(
+    source_name: &str,
+    provider: DatabaseProvider,
+    connection: Value,
+) -> Result<DatabaseConnectionSpec> {
+    match provider {
+        DatabaseProvider::Postgres => serde_json::from_value::<PostgresConnectionSpec>(connection)
+            .map(DatabaseConnectionSpec::Postgres),
+        DatabaseProvider::MySql => serde_json::from_value::<MySqlConnectionSpec>(connection)
+            .map(DatabaseConnectionSpec::MySql),
+        DatabaseProvider::Sqlite => serde_json::from_value::<SqliteConnectionSpec>(connection)
+            .map(DatabaseConnectionSpec::Sqlite),
+    }
+    .map_err(|error| {
+        ManifestError::validation(format!(
+            "source '{source_name}' database surface connection is invalid for provider '{}': {error}",
+            provider.as_str()
+        ))
     })
 }
 

--- a/crates/coral-spec/src/v4/manifest_tests.rs
+++ b/crates/coral-spec/src/v4/manifest_tests.rs
@@ -1,8 +1,16 @@
+use crate::v4::{SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType, V4SourceManifest};
 use crate::{
-    ManifestCredentialMethodKind, ManifestOAuthDynamicClientRegistrationAuthMethod,
-    ManifestOAuthFlowKind, ManifestOAuthPkceMode, ManifestOAuthRedirectUriPortMode,
-    ManifestOAuthScopeDelimiter, parse_source_manifest_yaml,
+    DatabaseConnectionSpec, DatabaseProvider, ManifestCredentialMethodKind,
+    ManifestOAuthDynamicClientRegistrationAuthMethod, ManifestOAuthFlowKind, ManifestOAuthPkceMode,
+    ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter, parse_source_manifest_yaml,
 };
+
+fn parse_v4_without_schema(
+    raw: &str,
+) -> std::result::Result<V4SourceManifest, crate::ManifestError> {
+    let value = serde_yaml::from_str(raw).map_err(crate::ManifestError::parse_yaml)?;
+    V4SourceManifest::parse_manifest_value(value)
+}
 
 #[test]
 fn parses_v4_manifest_top_level_inputs() {
@@ -64,24 +72,280 @@ surface:
 }
 
 #[test]
-fn reserved_source_namespace_is_rejected() {
-    let error = parse_source_manifest_yaml(
+fn parses_v4_database_surface_with_provider_specific_connection() {
+    let manifest = parse_source_manifest_yaml(
+        r#"
+name: coral_db
+dsl_version: 4
+inputs:
+  DB_HOST:
+    kind: variable
+    default: localhost
+  DB_PORT:
+    kind: variable
+    default: "5432"
+  DB_USER:
+    kind: variable
+    default: coral_reader
+  DB_PASSWORD:
+    kind: secret
+surface:
+  type: database
+  provider: postgres
+  connection:
+    host: "{{input.DB_HOST}}"
+    port: "{{input.DB_PORT}}"
+    database: coral
+    user: "{{input.DB_USER}}"
+    password: "{{input.DB_PASSWORD}}"
+    sslmode: require
+"#,
+    )
+    .expect("v4 manifest");
+
+    let v4 = manifest.as_v4().expect("v4");
+    let surface = &v4.surface;
+    assert_eq!(surface.surface_type, SurfaceType::Database);
+    assert!(matches!(
+        &surface.descriptor,
+        SurfaceDescriptor::Database {
+            provider: DatabaseProvider::Postgres,
+        }
+    ));
+
+    let SurfaceRuntimeConfig::Database(runtime) = &surface.runtime else {
+        panic!("database runtime");
+    };
+    let DatabaseConnectionSpec::Postgres(connection) = &runtime.connection else {
+        panic!("postgres connection");
+    };
+    assert_eq!(connection.host.raw(), "{{input.DB_HOST}}");
+    assert_eq!(connection.port.raw(), "{{input.DB_PORT}}");
+    assert_eq!(connection.database.raw(), "coral");
+    assert_eq!(connection.user.raw(), "{{input.DB_USER}}");
+    assert_eq!(connection.password.raw(), "{{input.DB_PASSWORD}}");
+    assert_eq!(
+        connection.sslmode.as_ref().expect("sslmode template").raw(),
+        "require"
+    );
+}
+
+#[test]
+fn parses_v4_mysql_database_surface() {
+    let manifest = parse_source_manifest_yaml(
+        r#"
+name: coral_mysql
+dsl_version: 4
+inputs:
+  DB_PASSWORD:
+    kind: secret
+surface:
+  type: database
+  provider: mysql
+  connection:
+    host: localhost
+    port: "3306"
+    database: coral
+    user: coral_reader
+    password: "{{input.DB_PASSWORD}}"
+"#,
+    )
+    .expect("MySQL database manifest");
+
+    let runtime = manifest
+        .as_v4()
+        .expect("v4 manifest")
+        .surface
+        .database_runtime()
+        .expect("database runtime");
+    let DatabaseConnectionSpec::MySql(connection) = &runtime.connection else {
+        panic!("MySQL connection");
+    };
+    assert_eq!(connection.port.raw(), "3306");
+    assert_eq!(connection.password.raw(), "{{input.DB_PASSWORD}}");
+}
+
+#[test]
+fn parses_v4_sqlite_database_surface() {
+    let manifest = parse_source_manifest_yaml(
         r"
-name: public
+name: coral_sqlite
 dsl_version: 4
 surface:
-    type: openapi
-    file: /tmp/openapi.yaml
+  type: database
+  provider: sqlite
+  connection:
+    path: /tmp/coral.sqlite
 ",
     )
-    .expect_err("reserved relation namespace should fail");
+    .expect("SQLite database manifest");
+
+    let runtime = manifest
+        .as_v4()
+        .expect("v4 manifest")
+        .surface
+        .database_runtime()
+        .expect("database runtime");
+    let DatabaseConnectionSpec::Sqlite(connection) = &runtime.connection else {
+        panic!("SQLite connection");
+    };
+    assert_eq!(connection.path.raw(), "/tmp/coral.sqlite");
+}
+
+#[test]
+fn v4_database_surface_requires_provider_and_connection() {
+    let cases = [
+        (
+            r"
+name: coral_db
+dsl_version: 4
+surface:
+  type: database
+  connection:
+    path: /tmp/coral.sqlite
+",
+            "database surface must declare provider",
+        ),
+        (
+            r"
+name: coral_db
+dsl_version: 4
+surface:
+  type: database
+  provider: sqlite
+",
+            "database surface must declare connection",
+        ),
+    ];
+
+    for (raw, expected) in cases {
+        let error = parse_v4_without_schema(raw).expect_err("invalid database surface");
+        assert!(
+            error.to_string().contains(expected),
+            "unexpected error: {error}"
+        );
+    }
+}
+
+#[test]
+fn v4_database_connection_must_match_provider() {
+    let error = parse_v4_without_schema(
+        r#"
+name: coral_db
+dsl_version: 4
+surface:
+  type: database
+  provider: sqlite
+  connection:
+    host: localhost
+    port: "5432"
+    database: coral
+    user: coral_reader
+    password: ignored
+"#,
+    )
+    .expect_err("provider-specific connection must be rejected");
 
     assert!(
         error
             .to_string()
-            .contains("source name 'public' is reserved"),
+            .contains("connection is invalid for provider 'sqlite'"),
         "unexpected error: {error}"
     );
+}
+
+#[test]
+fn v4_database_surface_rejects_fields_from_other_surface_types() {
+    let cases = [
+        (
+            r"
+name: coral_db
+dsl_version: 4
+surface:
+  type: database
+  provider: sqlite
+  url: https://example.com/openapi.json
+  connection:
+    path: /tmp/coral.sqlite
+",
+            "must not declare url, file, or server",
+        ),
+        (
+            r"
+name: coral_db
+dsl_version: 4
+surface:
+  type: database
+  provider: sqlite
+  base_url: https://example.com
+  connection:
+    path: /tmp/coral.sqlite
+",
+            "must not declare OpenAPI field 'base_url'",
+        ),
+    ];
+
+    for (raw, expected) in cases {
+        let error = parse_v4_without_schema(raw).expect_err("foreign field must be rejected");
+        assert!(
+            error.to_string().contains(expected),
+            "unexpected error: {error}"
+        );
+    }
+}
+
+#[test]
+fn rejects_v4_database_connection_templates_referencing_runtime_tokens() {
+    let error = parse_source_manifest_yaml(
+        r#"
+name: coral_db
+dsl_version: 4
+inputs:
+  DB_PASSWORD:
+    kind: secret
+surface:
+  type: database
+  provider: postgres
+  connection:
+    host: localhost
+    port: "5432"
+    database: "{{filter.tenant}}"
+    user: coral_reader
+    password: "{{input.DB_PASSWORD}}"
+"#,
+    )
+    .expect_err("runtime token should fail");
+
+    assert!(
+        error.to_string().contains(
+            "connection.database may only reference top-level inputs; unsupported template token '{{filter.tenant}}'"
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn reserved_source_namespace_is_rejected() {
+    for name in ["coral", "coral_admin", "datafusion", "public"] {
+        let raw = format!(
+            r"
+name: {name}
+dsl_version: 4
+surface:
+    type: openapi
+    file: /tmp/openapi.yaml
+"
+        );
+        let error =
+            parse_source_manifest_yaml(&raw).expect_err("reserved relation namespace should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("source name '{name}' is reserved")),
+            "unexpected error: {error}"
+        );
+    }
 }
 
 #[test]

--- a/crates/coral-spec/src/v4/mod.rs
+++ b/crates/coral-spec/src/v4/mod.rs
@@ -44,9 +44,9 @@ pub use ir::{
     RestRequestBody, RestResponseAttachment, SemanticIr,
 };
 pub use manifest::{
-    AcceptedIdentityRequirement, IdentityRequirements, McpRuntimeConfig, OpenApiRuntimeConfig,
-    SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType, V4SourceCommon, V4SourceManifest,
-    V4Surface, validate_openapi_base_url_template,
+    AcceptedIdentityRequirement, DatabaseRuntimeConfig, IdentityRequirements, McpRuntimeConfig,
+    OpenApiRuntimeConfig, SurfaceDescriptor, SurfaceRuntimeConfig, SurfaceType, V4SourceCommon,
+    V4SourceManifest, V4Surface, validate_openapi_base_url_template,
 };
 pub use naming::normalize_identifier;
 pub(crate) use operation_metadata::resolve_output_row_type_ref;

--- a/crates/coral-spec/src/v4/projection_tests.rs
+++ b/crates/coral-spec/src/v4/projection_tests.rs
@@ -1,6 +1,5 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
-
 use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use super::test_support::github_openapi;
 use super::*;

--- a/crates/coral-spec/src/v4/schema.rs
+++ b/crates/coral-spec/src/v4/schema.rs
@@ -45,6 +45,7 @@ struct V4SourceManifestSchema {
 enum V4SurfaceSchema {
     Openapi(V4OpenApiSurfaceSchema),
     Mcp(V4McpSurfaceSchema),
+    Database(V4DatabaseSurfaceSchema),
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -72,6 +73,75 @@ struct V4OpenApiSurfaceSchema {
 #[serde(deny_unknown_fields)]
 struct V4McpSurfaceSchema {
     server: McpServerSpec,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum V4DatabaseSurfaceSchema {
+    Postgres(V4PostgresDatabaseSurfaceSchema),
+    MySql(V4MySqlDatabaseSurfaceSchema),
+    Sqlite(V4SqliteDatabaseSurfaceSchema),
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4PostgresDatabaseSurfaceSchema {
+    #[serde(rename = "type")]
+    #[schemars(extend("const" = "database"))]
+    surface_type: String,
+    #[schemars(extend("const" = "postgres"))]
+    provider: String,
+    connection: V4PostgresConnectionSchema,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4MySqlDatabaseSurfaceSchema {
+    #[serde(rename = "type")]
+    #[schemars(extend("const" = "database"))]
+    surface_type: String,
+    #[schemars(extend("const" = "mysql"))]
+    provider: String,
+    connection: V4MySqlConnectionSchema,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4SqliteDatabaseSurfaceSchema {
+    #[serde(rename = "type")]
+    #[schemars(extend("const" = "database"))]
+    surface_type: String,
+    #[schemars(extend("const" = "sqlite"))]
+    provider: String,
+    connection: V4SqliteConnectionSchema,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4PostgresConnectionSchema {
+    host: String,
+    port: String,
+    database: String,
+    user: String,
+    password: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sslmode: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4MySqlConnectionSchema {
+    host: String,
+    port: String,
+    database: String,
+    user: String,
+    password: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct V4SqliteConnectionSchema {
+    path: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -511,6 +581,33 @@ surface:
             "generated schema should accept MCP surface: {errors:?}"
         );
         parse_source_manifest_yaml(raw).expect("parser accepts MCP surface");
+    }
+
+    #[test]
+    fn generated_schema_accepts_database_surface() {
+        let raw = r#"
+name: coral_db
+dsl_version: 4
+inputs:
+  DB_PASSWORD:
+    kind: secret
+surface:
+  type: database
+  provider: postgres
+  connection:
+    host: localhost
+    port: "5432"
+    database: coral
+    user: coral_reader
+    password: "{{input.DB_PASSWORD}}"
+"#;
+
+        let errors = validation_errors(&validator(), &manifest_json(raw));
+        assert!(
+            errors.is_empty(),
+            "generated schema should accept database surface: {errors:?}"
+        );
+        parse_source_manifest_yaml(raw).expect("parser accepts database surface");
     }
 
     #[test]

--- a/xtask/src/metadata_report.rs
+++ b/xtask/src/metadata_report.rs
@@ -174,11 +174,24 @@ pub(crate) fn run(args: &Args) -> Result<bool> {
             eprintln!("skipping {schema_name}: not a DSL v4 manifest");
             continue;
         };
-        // An MCP surface enumerates its operations by calling a live,
-        // authenticated server, so it cannot be imported from a checkout.
-        if v4.surface.surface_type == SurfaceType::Mcp {
-            eprintln!("skipping {schema_name}: MCP surfaces need a live server to enumerate tools");
-            continue;
+        match v4.surface.surface_type {
+            SurfaceType::OpenApi => {}
+            // An MCP surface enumerates its operations by calling a live,
+            // authenticated server, so it cannot be imported from a checkout.
+            SurfaceType::Mcp => {
+                eprintln!(
+                    "skipping {schema_name}: MCP surfaces need a live server to enumerate tools"
+                );
+                continue;
+            }
+            // Database surfaces discover relations from a live database rather
+            // than importing operation metadata from an OpenAPI descriptor.
+            SurfaceType::Database => {
+                eprintln!(
+                    "skipping {schema_name}: database surfaces need a live database to enumerate relations"
+                );
+                continue;
+            }
         }
         eprintln!("importing {schema_name} ...");
         rows.extend(
@@ -331,6 +344,9 @@ fn load_descriptor(
         SurfaceDescriptor::Url { url } => fetch_descriptor(url)?,
         SurfaceDescriptor::McpServer { .. } => {
             bail!("MCP surfaces have no OpenAPI descriptor")
+        }
+        SurfaceDescriptor::Database { .. } => {
+            bail!("database surfaces have no OpenAPI descriptor")
         }
     };
     if bytes.len() as u64 > MAX_DESCRIPTOR_BYTES {


### PR DESCRIPTION
## Summary

- parse PostgreSQL, MySQL, and SQLite database surfaces in DSL v4 source manifests
- assemble database runtime components without materializing remote descriptors
- validate database connection templates and reserve the DataFusion namespace
- cover runtime assembly, materialization bypass, snapshot behavior, and parse failures

## Stack

- Depends on: #1929
- Final PR in the stack

## Validation

- make schema-check: passed
- make rust-checks: 1891 tests passed, 2 skipped; clippy and rustdoc passed
- make perf-check: release build passed; benchmark was not executed because hyperfine is unavailable locally

This is PR 7 of 7 in the relational database source MVP stack.