### PR TITLE
feat(search): boost workspace functions

### DIFF
--- a/crates/coral-app/src/search/catalog/provider.rs
+++ b/crates/coral-app/src/search/catalog/provider.rs
@@ -1072,6 +1072,7 @@ mod tests {
                 description: format!("Alpha {index}"),
                 matched_fields: vec!["field_name".to_string()],
                 retrieval_score: 1,
+                is_workspace_function: false,
             })
             .collect()
     }

--- a/crates/coral-app/src/search/catalog/ranking.rs
+++ b/crates/coral-app/src/search/catalog/ranking.rs
@@ -6,6 +6,7 @@ use crate::search::catalog::sqlite_index::{CatalogIndexDocumentKind, CatalogSear
 
 const PARENT_CATALOG_SURFACE_RELEVANCE_BOOST: u32 = 20_000;
 const COLUMN_HINT_RELEVANCE_BOOST: u32 = 0;
+const WORKSPACE_FUNCTION_RELEVANCE_BOOST: u32 = 4_000;
 const EXACT_QUALIFIED_NAME_TERM_RELEVANCE_BOOST: u32 = 12_000;
 const EXACT_SOURCE_NAME_TERM_RELEVANCE_BOOST: u32 = 9_000;
 const EXACT_TITLE_SURFACE_OR_FIELD_TERM_RELEVANCE_BOOST: u32 = 8_000;
@@ -69,6 +70,9 @@ fn catalog_relevance_score(hit: &CatalogSearchHit, terms: &[String]) -> u32 {
     let description = hit.description.to_lowercase();
     let searchable_text = searchable_text(hit, &description);
     let mut score = doc_kind_boost(hit.doc_kind);
+    if hit.doc_kind == CatalogIndexDocumentKind::CatalogTableFunction && hit.is_workspace_function {
+        score = score.saturating_add(WORKSPACE_FUNCTION_RELEVANCE_BOOST);
+    }
     let required_term_count = terms
         .iter()
         .filter(|term| is_required_query_term(term))
@@ -307,6 +311,45 @@ mod tests {
     }
 
     #[test]
+    fn workspace_function_beats_equally_relevant_source_function() {
+        let source_function = hit(HitInput {
+            doc_id: "catalog:function:a_source.deploy",
+            doc_kind: CatalogIndexDocumentKind::CatalogTableFunction,
+            source_name: "a_source",
+            surface_kind: "table_function",
+            surface_name: "deploy",
+            field_name: "",
+            field_role: "",
+            description: "",
+            matched_fields: vec!["qualified_name", "title"],
+            retrieval_score: EQUAL_RETRIEVAL_SCORE_FIXTURE,
+        });
+        let mut workspace_function = hit(HitInput {
+            doc_id: "catalog:function:z_workspace.deploy",
+            doc_kind: CatalogIndexDocumentKind::CatalogTableFunction,
+            source_name: "z_workspace",
+            surface_kind: "table_function",
+            surface_name: "deploy",
+            field_name: "",
+            field_role: "",
+            description: "",
+            matched_fields: vec!["qualified_name", "title"],
+            retrieval_score: EQUAL_RETRIEVAL_SCORE_FIXTURE,
+        });
+        workspace_function.is_workspace_function = true;
+
+        let hits = rank_catalog_hits(
+            vec![source_function, workspace_function],
+            &["deploy".to_string()],
+        );
+
+        assert_eq!(
+            hits.first().expect("top ranked hit").hit.doc_id,
+            "catalog:function:z_workspace.deploy"
+        );
+    }
+
+    #[test]
     fn multi_term_identifier_prefix_intent_beats_same_source_noise() {
         let hits = rank_catalog_hits(
             vec![
@@ -503,6 +546,7 @@ mod tests {
                 .map(str::to_string)
                 .collect(),
             retrieval_score: input.retrieval_score,
+            is_workspace_function: false,
         }
     }
 }

--- a/crates/coral-app/src/search/catalog/snapshot.rs
+++ b/crates/coral-app/src/search/catalog/snapshot.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use coral_engine::{
-    CatalogInfo, ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo,
+    CatalogInfo, ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionProvenance,
     TableFunctionResultColumnInfo, TableInfo,
 };
 use coral_spec::SourceTableFunctionKind;
@@ -14,7 +14,7 @@ use crate::search::catalog::sqlite_index::{
 };
 use crate::search::result::{SearchFieldRole, SearchSurfaceKind};
 
-const CATALOG_SEARCH_SNAPSHOT_VERSION: &str = "catalog-search-snapshot-v3";
+const CATALOG_SEARCH_SNAPSHOT_VERSION: &str = "catalog-search-snapshot-v4";
 
 #[derive(Debug, Clone)]
 pub(crate) struct CatalogSearchSnapshot {
@@ -85,6 +85,7 @@ pub(crate) struct CatalogDocument {
     pub(crate) title: String,
     pub(crate) description: String,
     pub(crate) searchable_text: String,
+    pub(crate) is_workspace_function: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -109,6 +110,7 @@ impl CatalogDocument {
             title: self.title.clone(),
             description: self.description.clone(),
             searchable_text: self.searchable_text.clone(),
+            is_workspace_function: self.is_workspace_function,
             payload_json: "{}".to_string(),
         }
     }
@@ -214,6 +216,7 @@ fn table_documents(table: &TableInfo, documents: &mut Vec<CatalogDocument>) {
             table.guide.as_str(),
             table.required_filters.join(" ").as_str(),
         ]),
+        is_workspace_function: false,
     });
 
     for column in &table.columns {
@@ -249,6 +252,7 @@ fn table_column_document(
             column.data_type.as_str(),
             column.description.as_str(),
         ]),
+        is_workspace_function: false,
     });
 }
 
@@ -276,6 +280,7 @@ fn table_required_filter_document(
             filter,
             "required table filter",
         ]),
+        is_workspace_function: false,
     });
 }
 
@@ -320,6 +325,7 @@ fn table_function_documents(function: &TableFunctionInfo, documents: &mut Vec<Ca
             arguments.as_str(),
             result_columns.as_str(),
         ]),
+        is_workspace_function: is_workspace_function(function),
     });
 
     for argument in &function.arguments {
@@ -359,6 +365,7 @@ fn table_function_argument_document(
             values.as_str(),
             "table function argument",
         ]),
+        is_workspace_function: is_workspace_function(function),
     });
 }
 
@@ -391,7 +398,12 @@ fn table_function_result_column_document(
             column.description.as_str(),
             "table function result column",
         ]),
+        is_workspace_function: is_workspace_function(function),
     });
+}
+
+fn is_workspace_function(function: &TableFunctionInfo) -> bool {
+    function.provenance == TableFunctionProvenance::WorkspaceFunction
 }
 
 fn qualified_name(schema_name: &str, surface_name: &str) -> String {
@@ -457,6 +469,13 @@ fn catalog_snapshot_fingerprint(
         update_hash(&mut hasher, &function.function_name);
         update_hash(&mut hasher, &function.description);
         update_hash(&mut hasher, function.kind.as_str());
+        update_hash(
+            &mut hasher,
+            match function.provenance {
+                TableFunctionProvenance::Source => "source",
+                TableFunctionProvenance::WorkspaceFunction => "workspace_function",
+            },
+        );
         let search_limits_json = function
             .search_limits
             .as_ref()
@@ -513,7 +532,7 @@ fn update_hash(hasher: &mut Sha256, value: &str) {
 mod tests {
     use std::collections::BTreeMap;
 
-    use coral_engine::{CatalogInfo, TableInfo};
+    use coral_engine::{CatalogInfo, TableFunctionInfo, TableFunctionProvenance, TableInfo};
 
     use super::{CatalogDocumentKind, CatalogSearchSnapshot};
 
@@ -569,6 +588,27 @@ mod tests {
             && doc.field_name == "title"));
     }
 
+    #[test]
+    fn snapshot_preserves_workspace_function_provenance() {
+        let source = CatalogSearchSnapshot::from_catalog(&catalog_with_function(
+            TableFunctionProvenance::Source,
+        ));
+        let workspace = CatalogSearchSnapshot::from_catalog(&catalog_with_function(
+            TableFunctionProvenance::WorkspaceFunction,
+        ));
+
+        assert_ne!(source.fingerprint, workspace.fingerprint);
+        assert!(
+            workspace
+                .index_snapshot()
+                .documents
+                .iter()
+                .any(|document| document.doc_kind
+                    == crate::search::catalog::sqlite_index::CatalogIndexDocumentKind::CatalogTableFunction
+                    && document.is_workspace_function)
+        );
+    }
+
     fn catalog_with_table(table_name: &str) -> CatalogInfo {
         CatalogInfo {
             tables: vec![TableInfo {
@@ -588,6 +628,22 @@ mod tests {
                 required_filters: Vec::new(),
             }],
             table_functions: Vec::new(),
+        }
+    }
+
+    fn catalog_with_function(provenance: TableFunctionProvenance) -> CatalogInfo {
+        CatalogInfo {
+            tables: Vec::new(),
+            table_functions: vec![TableFunctionInfo {
+                schema_name: "workspace".to_string(),
+                function_name: "deploy".to_string(),
+                description: "Deploy the current release".to_string(),
+                arguments: Vec::new(),
+                result_columns: Vec::new(),
+                kind: coral_spec::SourceTableFunctionKind::Table,
+                search_limits: None,
+                provenance,
+            }],
         }
     }
 }

--- a/crates/coral-app/src/search/catalog/sqlite_index.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index.rs
@@ -129,9 +129,27 @@ impl SqliteCatalogIndex {
         let mut retrieval_limited = false;
 
         if let Some(match_query) = fts_match_query(&terms) {
-            let mut fts_hits = fts_search(connection, workspace_name, &match_query, &terms, limit)?;
+            let mut fts_hits = fts_search(
+                connection,
+                workspace_name,
+                &match_query,
+                &terms,
+                limit,
+                false,
+            )?;
             retrieval_limited |= truncate_probe_hits(&mut fts_hits, limit);
             merge_hits(&mut hits, fts_hits);
+
+            let mut workspace_function_hits = fts_search(
+                connection,
+                workspace_name,
+                &match_query,
+                &terms,
+                limit,
+                true,
+            )?;
+            retrieval_limited |= truncate_probe_hits(&mut workspace_function_hits, limit);
+            merge_hits(&mut hits, workspace_function_hits);
         }
 
         let exact_hits = exact_prefix_search(
@@ -228,6 +246,7 @@ pub(crate) struct CatalogIndexDocument {
     pub(crate) title: String,
     pub(crate) description: String,
     pub(crate) searchable_text: String,
+    pub(crate) is_workspace_function: bool,
     pub(crate) payload_json: String,
 }
 
@@ -295,6 +314,7 @@ pub(crate) struct CatalogSearchHit {
     pub(crate) description: String,
     pub(crate) matched_fields: Vec<String>,
     pub(crate) retrieval_score: u32,
+    pub(crate) is_workspace_function: bool,
 }
 
 fn replace_catalog_documents(
@@ -377,10 +397,10 @@ fn insert_catalog_snapshot_documents(
         INSERT INTO catalog_documents (
             workspace, doc_id, doc_kind, source_name, surface_kind, surface_name,
             field_name, field_role, qualified_name, title, description, payload_json,
-            snapshot_fingerprint, updated_at
+            snapshot_fingerprint, updated_at, is_workspace_function
         )
         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
-            strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), ?14)
         ",
     )?;
     let mut fts_insert = transaction.prepare(
@@ -408,6 +428,7 @@ fn insert_catalog_snapshot_documents(
             &document.description,
             &document.payload_json,
             &snapshot.fingerprint,
+            document.is_workspace_function,
         ])?;
         fts_insert.execute(params![
             workspace_name.as_str(),
@@ -611,6 +632,7 @@ fn fts_search(
     match_query: &str,
     terms: &[String],
     limit: usize,
+    workspace_functions_only: bool,
 ) -> Result<Vec<CatalogSearchHit>, SqliteSearchError> {
     let mut statement = connection.prepare(
         "
@@ -628,21 +650,28 @@ fn fts_search(
             f.title,
             f.qualified_name,
             f.description,
-            f.searchable_text
+            f.searchable_text,
+            d.is_workspace_function
         FROM catalog_documents_fts f
         JOIN catalog_documents d
             ON d.workspace = f.workspace AND d.doc_id = f.doc_id
-        WHERE f.workspace = ?1 AND catalog_documents_fts MATCH ?2
+        WHERE f.workspace = ?1
+            AND catalog_documents_fts MATCH ?2
+            AND (
+                ?3 = 0
+                OR (d.doc_kind = 'catalog_table_function' AND d.is_workspace_function)
+            )
         ORDER BY bm25(catalog_documents_fts, 1.0, 1.0, 6.0, 8.0, 2.0, 1.0) ASC,
             d.doc_kind ASC,
             d.doc_id ASC
-        LIMIT ?3
+        LIMIT ?4
         ",
     )?;
     let rows = statement.query_map(
         params![
             workspace_name.as_str(),
             match_query,
+            workspace_functions_only,
             i64::try_from(probe_limit(limit)).unwrap_or(i64::MAX),
         ],
         |row| hit_from_row(row, terms, 2_000),
@@ -676,7 +705,8 @@ fn exact_prefix_search(
             d.title,
             d.qualified_name,
             d.description,
-            ''
+            '',
+            d.is_workspace_function
         FROM catalog_documents d
         WHERE d.workspace = ?1
             AND (
@@ -703,6 +733,10 @@ fn exact_prefix_search(
                 THEN 3
                 ELSE 4
             END,
+            CASE
+                WHEN d.doc_kind = 'catalog_table_function' THEN d.is_workspace_function
+                ELSE 0
+            END DESC,
             d.doc_kind ASC,
             d.doc_id ASC
         LIMIT ?4
@@ -791,6 +825,7 @@ fn hit_from_row(
         description: row.get(9)?,
         matched_fields,
         retrieval_score: base_score,
+        is_workspace_function: row.get(14)?,
     })
 }
 

--- a/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
+++ b/crates/coral-app/src/search/catalog/sqlite_index/tests.rs
@@ -49,7 +49,8 @@ fn refresh_and_search_catalog_metadata() {
 
     assert!(hits.hits.iter().any(|hit| hit.doc_kind
         == CatalogIndexDocumentKind::CatalogTableFunction
-        && hit.surface_name == "search_deployments"));
+        && hit.surface_name == "search_deployments"
+        && hit.is_workspace_function));
     assert_eq!(hits.document_count, 3);
     let sha_hit = hits
         .hits
@@ -671,6 +672,40 @@ fn fts_ranking_weights_qualified_name_before_title_inside_limit() {
 }
 
 #[test]
+fn workspace_function_is_retained_before_candidate_limit() {
+    let temp = tempdir().expect("tempdir");
+    let store = catalog_store(&temp);
+    let snapshot = workspace_function_priority_snapshot();
+    store
+        .refresh_catalog_projection(&snapshot)
+        .expect("refresh");
+
+    let hits = store
+        .search_catalog(&["deploy".to_string()], 1)
+        .expect("search");
+
+    assert!(hits.hits.iter().any(|hit| hit.is_workspace_function));
+    assert!(hits.retrieval_limited);
+}
+
+#[test]
+fn workspace_function_fts_match_is_retained_outside_bm25_window() {
+    let temp = tempdir().expect("tempdir");
+    let store = catalog_store(&temp);
+    let snapshot = workspace_function_fts_priority_snapshot();
+    store
+        .refresh_catalog_projection(&snapshot)
+        .expect("refresh");
+
+    let hits = store
+        .search_catalog(&["needle".to_string()], 1)
+        .expect("search");
+
+    assert!(hits.hits.iter().any(|hit| hit.is_workspace_function));
+    assert!(hits.retrieval_limited);
+}
+
+#[test]
 fn exact_identifier_is_retained_before_prefix_limit() {
     let temp = tempdir().expect("tempdir");
     let store = catalog_store(&temp);
@@ -877,7 +912,7 @@ fn catalog_index_snapshot() -> CatalogIndexSnapshot {
     CatalogIndexSnapshot {
         fingerprint: "catalog-fixture-v1".to_string(),
         documents: vec![
-            document(DocumentInput {
+            workspace_function_document(DocumentInput {
                 doc_id: "catalog:function:github.search_deployments",
                 doc_kind: CatalogIndexDocumentKind::CatalogTableFunction,
                 source_name: "github",
@@ -951,6 +986,82 @@ fn fts_weight_snapshot() -> CatalogIndexSnapshot {
                 searchable_text: "",
             }),
         ],
+    }
+}
+
+fn workspace_function_priority_snapshot() -> CatalogIndexSnapshot {
+    let mut documents = ["alpha", "beta", "gamma"]
+        .into_iter()
+        .map(|source_name| {
+            document(DocumentInput {
+                doc_id: source_name,
+                doc_kind: CatalogIndexDocumentKind::CatalogTableFunction,
+                source_name,
+                surface_kind: "table_function",
+                surface_name: "deploy",
+                field_name: "",
+                field_role: "",
+                qualified_name: source_name,
+                title: "deploy",
+                description: "",
+                searchable_text: "deploy",
+            })
+        })
+        .collect::<Vec<_>>();
+    documents.push(workspace_function_document(DocumentInput {
+        doc_id: "workspace-deploy",
+        doc_kind: CatalogIndexDocumentKind::CatalogTableFunction,
+        source_name: "coral",
+        surface_kind: "table_function",
+        surface_name: "deploy",
+        field_name: "",
+        field_role: "",
+        qualified_name: "coral.deploy",
+        title: "deploy",
+        description: "",
+        searchable_text: "deploy",
+    }));
+    CatalogIndexSnapshot {
+        fingerprint: "workspace-function-priority-fixture-v1".to_string(),
+        documents,
+    }
+}
+
+fn workspace_function_fts_priority_snapshot() -> CatalogIndexSnapshot {
+    let mut documents = ["alpha", "beta", "gamma"]
+        .into_iter()
+        .map(|source_name| {
+            document(DocumentInput {
+                doc_id: source_name,
+                doc_kind: CatalogIndexDocumentKind::CatalogTableFunction,
+                source_name,
+                surface_kind: "table_function",
+                surface_name: source_name,
+                field_name: "",
+                field_role: "",
+                qualified_name: source_name,
+                title: source_name,
+                description: "needle",
+                searchable_text: "",
+            })
+        })
+        .collect::<Vec<_>>();
+    documents.push(workspace_function_document(DocumentInput {
+        doc_id: "workspace-local",
+        doc_kind: CatalogIndexDocumentKind::CatalogTableFunction,
+        source_name: "coral",
+        surface_kind: "table_function",
+        surface_name: "local",
+        field_name: "",
+        field_role: "",
+        qualified_name: "coral.local",
+        title: "local",
+        description: "needle in a deliberately longer description",
+        searchable_text: "",
+    }));
+    CatalogIndexSnapshot {
+        fingerprint: "workspace-function-fts-priority-fixture-v1".to_string(),
+        documents,
     }
 }
 
@@ -1098,6 +1209,12 @@ fn document(input: DocumentInput<'_>) -> CatalogIndexDocument {
     owned_document(input.source_name, input)
 }
 
+fn workspace_function_document(input: DocumentInput<'_>) -> CatalogIndexDocument {
+    let mut document = document(input);
+    document.is_workspace_function = true;
+    document
+}
+
 fn owned_document(owner_source_name: &str, input: DocumentInput<'_>) -> CatalogIndexDocument {
     CatalogIndexDocument {
         doc_id: input.doc_id.to_string(),
@@ -1112,6 +1229,7 @@ fn owned_document(owner_source_name: &str, input: DocumentInput<'_>) -> CatalogI
         title: input.title.to_string(),
         description: input.description.to_string(),
         searchable_text: input.searchable_text.to_string(),
+        is_workspace_function: false,
         payload_json: "{}".to_string(),
     }
 }

--- a/crates/coral-app/src/search/migrations/0005_catalog_function_provenance.sql
+++ b/crates/coral-app/src/search/migrations/0005_catalog_function_provenance.sql
@@ -1,0 +1,3 @@
+ALTER TABLE catalog_documents
+ADD COLUMN is_workspace_function INTEGER NOT NULL DEFAULT 0
+CHECK (is_workspace_function IN (0, 1));

--- a/crates/coral-app/src/search/sqlite_store.rs
+++ b/crates/coral-app/src/search/sqlite_store.rs
@@ -19,7 +19,7 @@ use crate::state::AppStateLayout;
 use crate::storage::fs::create_new_file_private;
 use crate::workspaces::WorkspaceName;
 
-pub(crate) const SEARCH_SQLITE_SCHEMA_VERSION: u32 = 4;
+pub(crate) const SEARCH_SQLITE_SCHEMA_VERSION: u32 = 5;
 
 struct SearchSqliteMigration {
     version: u32,
@@ -45,6 +45,10 @@ const SEARCH_SQLITE_MIGRATIONS: &[SearchSqliteMigration] = &[
     SearchSqliteMigration {
         version: 4,
         sql: include_str!("migrations/0004_catalog_source_ownership.sql"),
+    },
+    SearchSqliteMigration {
+        version: 5,
+        sql: include_str!("migrations/0005_catalog_function_provenance.sql"),
     },
 ];
 
@@ -617,7 +621,14 @@ fn apply_migration(
     let transaction = connection.transaction()?;
     let initializes_catalog_source_ownership =
         migration.version == 4 && !tables_exist(&transaction, &["catalog_source_owners"])?;
-    transaction.execute_batch(migration.sql)?;
+    let adds_catalog_function_provenance = migration.version == 5
+        && !schema_query_is_valid(
+            &transaction,
+            "SELECT is_workspace_function FROM catalog_documents LIMIT 0",
+        )?;
+    if migration.version != 5 || adds_catalog_function_provenance {
+        transaction.execute_batch(migration.sql)?;
+    }
     if initializes_catalog_source_ownership {
         // Existing catalog rows predate durable installed-owner identity. They
         // are disposable and cannot be safely backfilled for multi-component
@@ -687,7 +698,8 @@ fn catalog_schema_is_current(connection: &Connection) -> Result<bool, SqliteSear
             description,
             payload_json,
             snapshot_fingerprint,
-            updated_at
+            updated_at,
+            is_workspace_function
         FROM catalog_documents
         LIMIT 0
         ",
@@ -987,6 +999,30 @@ mod tests {
             &connection,
             "idx_catalog_source_owners_workspace_owner"
         ));
+    }
+
+    #[test]
+    fn opening_v4_adds_catalog_function_provenance_without_dropping_catalog_rows() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("search.sqlite3");
+        let mut connection = Connection::open(&path).expect("raw v4 connection");
+        for migration in SEARCH_SQLITE_MIGRATIONS.iter().take(4) {
+            super::apply_migration(&mut connection, migration).expect("apply v4 history");
+        }
+        seed_catalog_document(&connection);
+        drop(connection);
+
+        let connection = open_current_search_connection(&path);
+        let is_workspace_function: bool = connection
+            .query_row(
+                "SELECT is_workspace_function FROM catalog_documents WHERE workspace = 'default'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("catalog function provenance");
+
+        assert_eq!(catalog_document_count(&connection), 1);
+        assert!(!is_workspace_function);
     }
 
     #[test]
@@ -1673,6 +1709,7 @@ mod tests {
             title: surface_name.to_string(),
             description: String::new(),
             searchable_text: surface_name.to_string(),
+            is_workspace_function: false,
             payload_json: "{}".to_string(),
         }
     }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -872,6 +872,7 @@ mod tests {
             result_columns: Vec::new(),
             kind: SourceTableFunctionKind::Search,
             search_limits: None,
+            provenance: coral_engine::TableFunctionProvenance::Source,
         };
 
         let proto = table_function_to_proto(&workspace_name, function);

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -97,4 +97,15 @@ pub struct TableFunctionInfo {
     pub kind: SourceTableFunctionKind,
     /// Provider search limit metadata, when declared by the source.
     pub search_limits: Option<SearchLimitsSpec>,
+    /// How the function entered the query-visible catalog.
+    pub provenance: TableFunctionProvenance,
+}
+
+/// Provenance of a query-visible table function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TableFunctionProvenance {
+    /// Function declared by an installed source.
+    Source,
+    /// Function installed in the workspace function inventory.
+    WorkspaceFunction,
 }

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -8,7 +8,7 @@ mod udfs;
 
 pub use catalog::{
     CatalogInfo, ColumnInfo, DescribeTableInfo, TableFunctionArgumentInfo, TableFunctionInfo,
-    TableFunctionResultColumnInfo, TableInfo,
+    TableFunctionProvenance, TableFunctionResultColumnInfo, TableInfo,
 };
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -675,6 +675,7 @@ mod tests {
             result_columns: vec![],
             kind: coral_spec::SourceTableFunctionKind::Table,
             search_limits: None,
+            provenance: crate::TableFunctionProvenance::Source,
         }
     }
 

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -75,10 +75,10 @@ pub use contracts::{
     QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage,
     QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
     RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
-    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
-    UdfRuntimeArgument, UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimePublish,
-    UdfRuntimeResultColumn, UdfRuntimeSignature, UdfRuntimeSqlDefinition,
-    UdfRuntimeTableFunctionPublish,
+    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionProvenance,
+    TableFunctionResultColumnInfo, TableInfo, UdfRuntimeArgument, UdfRuntimeDefinition,
+    UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn, UdfRuntimeSignature,
+    UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
 };
 
 /// High-level query operations for the local query engine.

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -14,8 +14,8 @@ use serde::Serialize;
 use crate::backends::RegisteredSource;
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
-    ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
-    TableInfo,
+    ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionProvenance,
+    TableFunctionResultColumnInfo, TableInfo,
 };
 
 /// Schema name for source metadata tables such as `coral.tables`.
@@ -31,6 +31,7 @@ pub(crate) struct CatalogTableFunction {
     pub(crate) result_columns: Vec<CatalogTableFunctionResultColumn>,
     pub(crate) kind: SourceTableFunctionKind,
     pub(crate) search_limits: Option<SearchLimitsSpec>,
+    pub(crate) provenance: TableFunctionProvenance,
 }
 
 #[derive(Debug, Clone)]
@@ -585,6 +586,7 @@ pub(crate) fn collect_table_functions(
                 .collect(),
             kind: function.kind,
             search_limits: function.search_limits,
+            provenance: function.provenance,
         })
         .collect()
 }
@@ -624,6 +626,7 @@ fn catalog_table_functions(
                         .collect(),
                     kind: function.kind,
                     search_limits: function.search_limits.clone(),
+                    provenance: TableFunctionProvenance::Source,
                 })
         })
         .chain(catalog_only_table_functions.iter().cloned())

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -347,6 +347,7 @@ mod tests {
             result_columns: vec![],
             kind: coral_spec::SourceTableFunctionKind::Table,
             search_limits: None,
+            provenance: crate::TableFunctionProvenance::Source,
         }
     }
 

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -181,6 +181,7 @@ fn catalog_table_function(
             })
             .collect(),
         search_limits: None,
+        provenance: crate::TableFunctionProvenance::WorkspaceFunction,
     }
 }
 

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 
-use coral_engine::{CoralQuery, CoreError, QuerySource, TableInfo};
+use coral_engine::{CoralQuery, CoreError, QuerySource, TableFunctionProvenance, TableInfo};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -759,6 +759,7 @@ async fn list_catalog_matches_table_function_metadata() {
     assert_eq!(function.schema_name, "searchy");
     assert_eq!(function.function_name, "search_issues");
     assert_eq!(function.description, "Search issues");
+    assert_eq!(function.provenance, TableFunctionProvenance::Source);
     assert_eq!(function.arguments.len(), 4);
     assert_eq!(function.arguments[0].name, "q");
     assert!(function.arguments[0].required);

--- a/crates/coral-engine/tests/engine/udf_tests.rs
+++ b/crates/coral-engine/tests/engine/udf_tests.rs
@@ -7,9 +7,9 @@ use arrow::record_batch::RecordBatch;
 use coral_engine::{
     CoralQuery, CoreError, EngineExtensions, QueryExecutionProvenance, QueryParameterValue,
     QueryParameters, QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig,
-    QueryRuntimeContext, StatusCode, UdfRuntimeArgument, UdfRuntimeDefinition,
-    UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn, UdfRuntimeSignature,
-    UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
+    QueryRuntimeContext, StatusCode, TableFunctionProvenance, UdfRuntimeArgument,
+    UdfRuntimeDefinition, UdfRuntimeImplementation, UdfRuntimePublish, UdfRuntimeResultColumn,
+    UdfRuntimeSignature, UdfRuntimeSqlDefinition, UdfRuntimeTableFunctionPublish,
 };
 use coral_spec::ManifestDataType;
 use serde_json::{Value, json};
@@ -1005,6 +1005,10 @@ async fn published_udf_table_function_is_cataloged() {
     let function = catalog.table_functions.first().expect("udf table function");
     assert_eq!(function.schema_name, "udfs");
     assert_eq!(function.function_name, "review_queue");
+    assert_eq!(
+        function.provenance,
+        TableFunctionProvenance::WorkspaceFunction
+    );
     let [_min_score, _mode, payload, _query, _since] = function.arguments.as_slice() else {
         panic!("expected five review queue arguments");
     };


### PR DESCRIPTION
## Intent

Prefer workspace-defined functions in universal search when they are as relevant as source-provided functions. The provenance name describes where a function comes from, so it also remains correct if workspace functions are generated in future.

## What Changed

- Add typed `Source` / `WorkspaceFunction` provenance to engine table-function catalog metadata.
- Carry provenance through catalog snapshot fingerprinting and the SQLite search projection, including an idempotent schema migration.
- Reserve matching workspace functions across bounded FTS retrieval, then apply a 4,000-point boost in the existing post-SQLite relevance ranking.
- Add regression coverage for source/workspace assembly, migration, fingerprinting, final ranking, and exact-prefix/FTS candidate cutoffs.

## Ownership / Boundaries

`coral-engine` assigns provenance when runtime functions enter the catalog. `coral-app` owns derived search persistence, candidate retrieval, and ranking. The protobuf and rendered search-result contracts remain unchanged because provenance is currently an internal ranking signal.

## Compatibility / User Impact

Existing source functions retain their current scores. Workspace functions can rank above otherwise equivalent source functions. Existing search databases migrate in place, and catalog snapshot versioning rebuilds derived documents with provenance.

## Not in This PR

- Exposing provenance for client display or filtering.
- Retuning unrelated universal-search boosts.

## Validation

- `make rust-checks`
- Focused engine catalog/UDF provenance tests
- Focused catalog snapshot, SQLite migration/index, and ranking tests
- `git diff --check`
- Structured autoreview: clean after addressing bounded-candidate retrieval findings