### PR TITLE
ci(desktop): remove nightly packaging build

### DIFF
--- a/.github/workflows/desktop-package.yml
+++ b/.github/workflows/desktop-package.yml
@@ -3,8 +3,6 @@ name: Desktop macOS package
 on:
   workflow_call:
   workflow_dispatch:
-  schedule:
-    - cron: "17 3 * * *"
 
 permissions:
   contents: read
@@ -34,17 +32,17 @@ jobs:
         with:
           shared-key: coral-desktop-macos-universal
           cache-on-failure: true
-          save-if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+          save-if: ${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Set up Node without npm cache
-        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'schedule' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/desktop/.node-version
           package-manager-cache: false
 
       - name: Set up Node with trusted npm cache
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: apps/desktop/.node-version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,9 @@
   latency. CI installs the bundled `github` source with fake credentials and
   fails when release `coral sql "select * from coral.tables"` has a hyperfine
   mean above 750 ms.
-- Pull requests do not automatically build macOS Desktop packages. A scheduled
-  workflow builds and verifies the unsigned universal package from `main`
-  nightly; use manual dispatch for a preflight when a distribution-sensitive
-  pull request warrants one. Validation artifacts stay unsigned and must not be
+- Pull requests do not automatically build macOS Desktop packages. Use manual
+  dispatch for an unsigned packaging preflight when a distribution-sensitive
+  change warrants one. Validation artifacts stay unsigned and must not be
   reused for a release; Desktop release publishing must rebuild from a clean
   checkout with signing and notarization.
 - The `Validate` workflow intentionally skips draft pull request runs, starts


### PR DESCRIPTION
This reverts commit a452cf42f514498436149970131d5b07570e880d. (reverts #1891)

We want to have a better testing strategy altogether; we can save some resources, as this nightly job wouldn't catch burning user issues anyway.