### PR TITLE
fix(telemetry): redact caller-controlled error details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,6 +1396,7 @@ dependencies = [
  "coral-telemetry",
  "jsonschema",
  "opentelemetry",
+ "opentelemetry_sdk",
  "regex",
  "rmcp",
  "schemars",
@@ -1408,6 +1409,7 @@ dependencies = [
  "tonic-types",
  "tracing",
  "tracing-opentelemetry",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -24,7 +24,7 @@ use tonic::metadata::MetadataMap;
 use tonic::{Code, Request, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
 use tower::Layer;
-use tracing::{Instrument as _, field};
+use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::{AppError, app_status, core_status, status_with_bounded_detail};
@@ -43,6 +43,7 @@ use crate::workspaces::WorkspaceName;
 struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
 
 const USER_PRINCIPAL_PROVIDER_TIMEOUT: Duration = Duration::from_secs(30);
+const GRPC_REQUEST_ERROR_MESSAGE: &str = "gRPC request failed";
 
 #[derive(Clone)]
 struct GrpcServerSpan(tracing::Span);
@@ -324,41 +325,24 @@ fn record_grpc_status(span: &tracing::Span, code: Code, status: Option<&Status>)
         span.record("status", "ok");
         span.set_status(OtelStatus::Ok);
     } else {
-        let error = status.map_or_else(
-            || GrpcErrorTelemetry {
-                error_type: response_status_code.to_string(),
-                message: response_status_code.to_string(),
-            },
-            decode_grpc_error,
-        );
+        let error_type = status.map_or_else(|| response_status_code.to_string(), grpc_error_type);
         span.record("status", "error");
-        span.record("error.type", error.error_type.as_str());
-        span.record("exception.message", field::display(error.message.as_str()));
-        span.set_status(OtelStatus::error(error.message));
+        span.record("error.type", error_type.as_str());
+        span.record("exception.message", GRPC_REQUEST_ERROR_MESSAGE);
+        span.set_status(OtelStatus::error(GRPC_REQUEST_ERROR_MESSAGE));
     }
 }
 
-struct GrpcErrorTelemetry {
-    error_type: String,
-    message: String,
-}
-
-fn decode_grpc_error(status: &Status) -> GrpcErrorTelemetry {
+fn grpc_error_type(status: &Status) -> String {
     for detail in status.get_error_details_vec() {
         if let ErrorDetail::ErrorInfo(info) = detail
             && info.domain == CORAL_ERROR_DOMAIN
         {
-            return GrpcErrorTelemetry {
-                error_type: info.reason,
-                message: status.message().to_string(),
-            };
+            return info.reason;
         }
     }
 
-    GrpcErrorTelemetry {
-        error_type: grpc_response_status_code(status.code()).to_string(),
-        message: status.message().to_string(),
-    }
+    grpc_response_status_code(status.code()).to_string()
 }
 
 pub(crate) fn query_status(error: QueryManagerError) -> Status {
@@ -617,14 +601,23 @@ mod tests {
         reason = "proto shape assertions intentionally fail loudly in tests"
     )]
 
+    use std::collections::HashMap;
+
     use coral_api::{
-        CORAL_TASK_ID_METADATA_KEY, grpc_response_status_code,
+        CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_SUMMARY, CORAL_TASK_ID_METADATA_KEY,
+        grpc_response_status_code,
         v1::{QueryTestFailure, Workspace, query_test_result},
     };
-    use tonic::{Code, Request};
+    use opentelemetry::Value;
+    use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
+    use tonic::{Code, Request, Status};
+    use tonic_types::{ErrorDetail, StatusExt as _};
+    use tracing_subscriber::layer::SubscriberExt as _;
 
     use super::{
-        GrpcMethodMetadata, GrpcServerMethod, annotate_request_context, grpc_method, query_status,
+        GRPC_REQUEST_ERROR_MESSAGE, GrpcMethodMetadata, GrpcServerMethod, annotate_request_context,
+        grpc_method, grpc_span_for_metadata, instrument_grpc, query_status,
         query_test_result_to_proto, table_function_to_proto, table_summary_to_proto,
         table_to_proto, user_principal_provider_status, workspace_name_from_proto,
         workspace_to_proto,
@@ -668,6 +661,99 @@ mod tests {
             "INVALID_ARGUMENT"
         );
         assert_eq!(grpc_response_status_code(Code::Unavailable), "UNAVAILABLE");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn plain_grpc_status_message_is_not_exported() {
+        let sentinel = "SENSITIVE_SERVER_GRPC_ERROR_MARKER";
+        let status = Status::invalid_argument(format!("invalid input: {sentinel}"));
+
+        let (returned_status, span) = export_grpc_status(status).await;
+
+        assert!(returned_status.message().contains(sentinel));
+        assert_eq!(
+            string_attribute(&span, "error.type"),
+            Some("INVALID_ARGUMENT".to_string())
+        );
+        assert_eq!(
+            string_attribute(&span, "exception.message"),
+            Some(GRPC_REQUEST_ERROR_MESSAGE.to_string())
+        );
+        assert_eq!(span.status, OtelStatus::error(GRPC_REQUEST_ERROR_MESSAGE));
+        assert!(!format!("{span:?}").contains(sentinel));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn structured_grpc_status_keeps_only_its_categorical_reason() {
+        let sentinel = "SENSITIVE_SERVER_STRUCTURED_ERROR_MARKER";
+        let metadata = HashMap::from([(
+            CORAL_ERROR_METADATA_SUMMARY.to_string(),
+            format!("summary containing {sentinel}"),
+        )]);
+        let status = Status::with_error_details_vec(
+            Code::InvalidArgument,
+            format!("fallback containing {sentinel}"),
+            vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
+                "INVALID_CATALOG_KIND",
+                CORAL_ERROR_DOMAIN,
+                metadata,
+            ))],
+        );
+
+        let (returned_status, span) = export_grpc_status(status).await;
+
+        assert!(returned_status.message().contains(sentinel));
+        assert_eq!(
+            string_attribute(&span, "error.type"),
+            Some("INVALID_CATALOG_KIND".to_string())
+        );
+        assert_eq!(
+            string_attribute(&span, "exception.message"),
+            Some(GRPC_REQUEST_ERROR_MESSAGE.to_string())
+        );
+        assert_eq!(span.status, OtelStatus::error(GRPC_REQUEST_ERROR_MESSAGE));
+        assert!(!format!("{span:?}").contains(sentinel));
+    }
+
+    async fn export_grpc_status(status: Status) -> (Status, SpanData) {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("coral-server-error-privacy-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let guard = tracing::subscriber::set_default(subscriber);
+        let span = grpc_span_for_metadata(
+            &GrpcMethodMetadata::new("coral.v1.QueryService", "ExecuteSql"),
+            &tonic::metadata::MetadataMap::new(),
+        );
+
+        let returned_status = instrument_grpc(span, async { Err::<(), Status>(status) })
+            .await
+            .expect_err("gRPC status should be returned to the caller");
+        drop(guard);
+
+        provider.force_flush().expect("spans should flush");
+        let span = exporter
+            .get_finished_spans()
+            .expect("finished spans should be readable")
+            .into_iter()
+            .find(|span| span.name == "coral.v1.QueryService/ExecuteSql")
+            .expect("server span should export");
+        (returned_status, span)
+    }
+
+    fn string_attribute(span: &SpanData, name: &str) -> Option<String> {
+        span.attributes.iter().find_map(|attribute| {
+            if attribute.key.as_str() == name
+                && let Value::String(value) = &attribute.value
+            {
+                Some(value.as_ref().to_string())
+            } else {
+                None
+            }
+        })
     }
 
     #[test]

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -17,6 +17,7 @@ use coral_api::{
     },
 };
 use coral_spec::{SearchLimitsSpec, SourceTableFunctionKind};
+use coral_telemetry::{GRPC_REQUEST_ERROR_MESSAGE, record_failure};
 use opentelemetry::propagation::Extractor;
 use opentelemetry::trace::Status as OtelStatus;
 use tonic::codegen::{Service, http};
@@ -43,7 +44,6 @@ use crate::workspaces::WorkspaceName;
 struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
 
 const USER_PRINCIPAL_PROVIDER_TIMEOUT: Duration = Duration::from_secs(30);
-const GRPC_REQUEST_ERROR_MESSAGE: &str = "gRPC request failed";
 
 #[derive(Clone)]
 struct GrpcServerSpan(tracing::Span);
@@ -326,10 +326,7 @@ fn record_grpc_status(span: &tracing::Span, code: Code, status: Option<&Status>)
         span.set_status(OtelStatus::Ok);
     } else {
         let error_type = status.map_or_else(|| response_status_code.to_string(), grpc_error_type);
-        span.record("status", "error");
-        span.record("error.type", error_type.as_str());
-        span.record("exception.message", GRPC_REQUEST_ERROR_MESSAGE);
-        span.set_status(OtelStatus::error(GRPC_REQUEST_ERROR_MESSAGE));
+        record_failure(span, error_type.as_str(), GRPC_REQUEST_ERROR_MESSAGE);
     }
 }
 

--- a/crates/coral-client/src/grpc.rs
+++ b/crates/coral-client/src/grpc.rs
@@ -20,6 +20,7 @@ use crate::status_error::{DecodedStatusError, decode_status_error};
 
 const MISSING_GRPC_STATUS_ERROR_TYPE: &str = "MISSING_GRPC_STATUS";
 const MISSING_GRPC_STATUS_MESSAGE: &str = "missing gRPC response status";
+const GRPC_REQUEST_ERROR_MESSAGE: &str = "gRPC request failed";
 
 /// Tonic `Service` wrapper that records one client span per gRPC request.
 #[derive(Clone)]
@@ -266,8 +267,8 @@ fn record_grpc_status(span: &tracing::Span, code: Code, status: &Status) {
         span.record("status", "ok");
         span.set_status(OtelStatus::Ok);
     } else {
-        let error = decode_grpc_client_error(status);
-        record_error(span, error.error_type.as_str(), error.message);
+        let error_type = grpc_client_error_type(status);
+        record_error(span, error_type.as_str(), GRPC_REQUEST_ERROR_MESSAGE);
     }
 }
 
@@ -291,47 +292,37 @@ fn record_transport_error(span: &tracing::Span) {
     record_error(span, "TRANSPORT", "gRPC transport error");
 }
 
-fn record_error(
-    span: &tracing::Span,
-    error_type: impl AsRef<str>,
-    message: impl std::fmt::Display,
-) {
-    let message = message.to_string();
+fn record_error(span: &tracing::Span, error_type: impl AsRef<str>, message: &'static str) {
     span.record("status", "error");
     span.record("error.type", error_type.as_ref());
-    span.record("exception.message", field::display(&message));
+    span.record("exception.message", message);
     span.set_status(OtelStatus::error(message));
 }
 
-struct GrpcClientError {
-    error_type: String,
-    message: String,
-}
-
-fn decode_grpc_client_error(status: &Status) -> GrpcClientError {
+fn grpc_client_error_type(status: &Status) -> String {
     match decode_status_error(status) {
-        DecodedStatusError::Structured(error) => GrpcClientError {
-            error_type: error.reason,
-            message: error.message,
-        },
-        DecodedStatusError::Plain(message) => GrpcClientError {
-            error_type: grpc_response_status_code(status.code()).to_string(),
-            message,
-        },
+        DecodedStatusError::Structured(error) => error.reason,
+        DecodedStatusError::Plain(_) => grpc_response_status_code(status.code()).to_string(),
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_SUMMARY};
     use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
     use opentelemetry::{KeyValue, Value};
-    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
     use tonic::codegen::http;
+    use tonic::{Code, Status};
+    use tonic_types::{ErrorDetail, StatusExt as _};
     use tracing_subscriber::prelude::*;
 
     use super::{
-        GrpcClientEndpoint, GrpcClientSpanMetadata, MISSING_GRPC_STATUS_ERROR_TYPE,
-        MISSING_GRPC_STATUS_MESSAGE, grpc_client_span, record_missing_grpc_status,
+        GRPC_REQUEST_ERROR_MESSAGE, GrpcClientEndpoint, GrpcClientSpanMetadata,
+        MISSING_GRPC_STATUS_ERROR_TYPE, MISSING_GRPC_STATUS_MESSAGE, grpc_client_span,
+        record_grpc_status, record_missing_grpc_status,
     };
 
     #[test]
@@ -414,6 +405,82 @@ mod tests {
             Some(MISSING_GRPC_STATUS_ERROR_TYPE)
         );
         assert_eq!(span.status, OtelStatus::error(MISSING_GRPC_STATUS_MESSAGE));
+    }
+
+    #[test]
+    fn plain_grpc_status_message_is_not_exported() {
+        let sentinel = "SENSITIVE_CLIENT_GRPC_ERROR_MARKER";
+        let status = Status::invalid_argument(format!("invalid input: {sentinel}"));
+
+        let span = export_grpc_status(&status);
+
+        assert!(status.message().contains(sentinel));
+        assert_eq!(
+            string_attr(&span.attributes, "error.type"),
+            Some("INVALID_ARGUMENT")
+        );
+        assert_eq!(
+            string_attr(&span.attributes, "exception.message"),
+            Some(GRPC_REQUEST_ERROR_MESSAGE)
+        );
+        assert_eq!(span.status, OtelStatus::error(GRPC_REQUEST_ERROR_MESSAGE));
+        assert!(!format!("{span:?}").contains(sentinel));
+    }
+
+    #[test]
+    fn structured_grpc_status_keeps_only_its_categorical_reason() {
+        let sentinel = "SENSITIVE_CLIENT_STRUCTURED_ERROR_MARKER";
+        let metadata = HashMap::from([(
+            CORAL_ERROR_METADATA_SUMMARY.to_string(),
+            format!("summary containing {sentinel}"),
+        )]);
+        let status = Status::with_error_details_vec(
+            Code::InvalidArgument,
+            format!("fallback containing {sentinel}"),
+            vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
+                "INVALID_CATALOG_KIND",
+                CORAL_ERROR_DOMAIN,
+                metadata,
+            ))],
+        );
+
+        let span = export_grpc_status(&status);
+
+        assert!(status.message().contains(sentinel));
+        assert_eq!(
+            string_attr(&span.attributes, "error.type"),
+            Some("INVALID_CATALOG_KIND")
+        );
+        assert_eq!(
+            string_attr(&span.attributes, "exception.message"),
+            Some(GRPC_REQUEST_ERROR_MESSAGE)
+        );
+        assert_eq!(span.status, OtelStatus::error(GRPC_REQUEST_ERROR_MESSAGE));
+        assert!(!format!("{span:?}").contains(sentinel));
+    }
+
+    fn export_grpc_status(status: &Status) -> SpanData {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("coral-client-error-privacy-test");
+        let subscriber =
+            tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let metadata = GrpcClientSpanMetadata::new("coral.v1.QueryService", "ExecuteSql");
+            let span = grpc_client_span(&metadata, &GrpcClientEndpoint::default());
+            record_grpc_status(&span, status.code(), status);
+        });
+
+        provider.force_flush().expect("spans should flush");
+        exporter
+            .get_finished_spans()
+            .expect("finished spans should be readable")
+            .into_iter()
+            .find(|span| span.name == "coral.v1.QueryService/ExecuteSql")
+            .expect("client span should export")
     }
 
     fn i64_attr(attributes: &[KeyValue], key: &str) -> Option<i64> {

--- a/crates/coral-client/src/grpc.rs
+++ b/crates/coral-client/src/grpc.rs
@@ -10,6 +10,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use coral_api::grpc_response_status_code;
+use coral_telemetry::{GRPC_REQUEST_ERROR_MESSAGE, record_failure};
 use opentelemetry::trace::Status as OtelStatus;
 use tonic::codegen::{Body, Bytes, Service, StdError, http};
 use tonic::{Code, Status};
@@ -20,7 +21,6 @@ use crate::status_error::{DecodedStatusError, decode_status_error};
 
 const MISSING_GRPC_STATUS_ERROR_TYPE: &str = "MISSING_GRPC_STATUS";
 const MISSING_GRPC_STATUS_MESSAGE: &str = "missing gRPC response status";
-const GRPC_REQUEST_ERROR_MESSAGE: &str = "gRPC request failed";
 
 /// Tonic `Service` wrapper that records one client span per gRPC request.
 #[derive(Clone)]
@@ -135,7 +135,7 @@ impl<B> InstrumentedGrpcBody<B> {
 
     fn record_body_error(&mut self) {
         if !self.status_recorded {
-            record_error(&self.span, "TRANSPORT", "gRPC response body error");
+            record_failure(&self.span, "TRANSPORT", "gRPC response body error");
             self.status_recorded = true;
         }
     }
@@ -268,7 +268,7 @@ fn record_grpc_status(span: &tracing::Span, code: Code, status: &Status) {
         span.set_status(OtelStatus::Ok);
     } else {
         let error_type = grpc_client_error_type(status);
-        record_error(span, error_type.as_str(), GRPC_REQUEST_ERROR_MESSAGE);
+        record_failure(span, error_type.as_str(), GRPC_REQUEST_ERROR_MESSAGE);
     }
 }
 
@@ -281,7 +281,7 @@ fn record_grpc_status_attributes(span: &tracing::Span, code: Code) {
 
 fn record_missing_grpc_status(span: &tracing::Span) {
     record_grpc_status_attributes(span, Code::Unknown);
-    record_error(
+    record_failure(
         span,
         MISSING_GRPC_STATUS_ERROR_TYPE,
         MISSING_GRPC_STATUS_MESSAGE,
@@ -289,14 +289,7 @@ fn record_missing_grpc_status(span: &tracing::Span) {
 }
 
 fn record_transport_error(span: &tracing::Span) {
-    record_error(span, "TRANSPORT", "gRPC transport error");
-}
-
-fn record_error(span: &tracing::Span, error_type: impl AsRef<str>, message: &'static str) {
-    span.record("status", "error");
-    span.record("error.type", error_type.as_ref());
-    span.record("exception.message", message);
-    span.set_status(OtelStatus::error(message));
+    record_failure(span, "TRANSPORT", "gRPC transport error");
 }
 
 fn grpc_client_error_type(status: &Status) -> String {

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -30,5 +30,7 @@ coral-telemetry.workspace = true
 [dev-dependencies]
 coral-app.workspace = true
 jsonschema.workspace = true
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 tempfile.workspace = true
 tonic-types.workspace = true
+tracing-subscriber.workspace = true

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -120,7 +120,6 @@ impl ToolCallOutcome {
 struct TaskCallContext {
     task_id: Option<TaskId>,
     task_id_metadata: Option<MetadataValue<Ascii>>,
-    intent: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -154,10 +153,9 @@ impl TaskCallContext {
         if requirement == TaskContextRequirement::None {
             return Ok(Self::default());
         }
-        let intent = requirement
-            .requires_intent()
-            .then(|| required_tool_intent_argument(arguments, "intent"))
-            .transpose()?;
+        if requirement.requires_intent() {
+            required_tool_intent_argument(arguments, "intent")?;
+        }
         let task_id = requirement
             .requires_task_id()
             .then(|| required_task_id_argument(arguments, "task_id"))
@@ -177,16 +175,12 @@ impl TaskCallContext {
         Ok(Self {
             task_id,
             task_id_metadata,
-            intent,
         })
     }
 
     fn record_telemetry(&self, span: &tracing::Span) {
         if let Some(task_id) = self.task_id.as_ref() {
             telemetry::record_task_id(span, &task_id.to_string());
-        }
-        if let Some(intent) = self.intent.as_ref() {
-            telemetry::record_tool_intent(span, intent);
         }
     }
 
@@ -1125,5 +1119,70 @@ mod startup_context_tests {
             context.query_examples().last().map(McpQueryExample::sql),
             Some("SELECT 4")
         );
+    }
+}
+
+#[cfg(test)]
+mod tool_call_telemetry_tests {
+    use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
+    use serde_json::{Map, Value};
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    use super::finish_tool_call;
+    use crate::surface::list_catalog_arguments;
+    use crate::telemetry::{self, MCP_PROTOCOL_ERROR_MESSAGE};
+
+    #[test]
+    fn finish_tool_call_returns_details_without_recording_them() {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("mcp-tool-error-privacy-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let sentinel = "SENSITIVE_LIST_CATALOG_KIND_MARKER";
+        let arguments = Map::from_iter([("kind".to_string(), Value::String(sentinel.to_string()))]);
+        let Err(error) = list_catalog_arguments(Some(&arguments)) else {
+            panic!("unknown list_catalog kind should fail argument parsing");
+        };
+        let span = telemetry::call_tool_span("list_catalog", None);
+        let returned = finish_tool_call(&span, Err(error))
+            .expect_err("invalid list_catalog kind should remain a caller-visible protocol error");
+        assert!(returned.message.contains(sentinel));
+        drop(span);
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let tool_call = spans
+            .iter()
+            .find(|span| span.name == "coral.mcp.call_tool")
+            .expect("tool call span");
+
+        assert_eq!(
+            string_attribute(tool_call, "error.type"),
+            Some("INVALID_PARAMS".to_string())
+        );
+        assert_eq!(
+            string_attribute(tool_call, "exception.message"),
+            Some(MCP_PROTOCOL_ERROR_MESSAGE.to_string())
+        );
+        assert_eq!(
+            tool_call.status,
+            OtelStatus::error(MCP_PROTOCOL_ERROR_MESSAGE)
+        );
+        assert!(!format!("{tool_call:?}").contains(sentinel));
+
+        provider.shutdown().expect("provider shutdown");
+    }
+
+    fn string_attribute(span: &SpanData, name: &str) -> Option<String> {
+        span.attributes
+            .iter()
+            .find(|attribute| attribute.key.as_str() == name)
+            .map(|attribute| attribute.value.as_str().into_owned())
     }
 }

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -4,6 +4,7 @@ use std::future::Future;
 
 use coral_api::grpc_response_status_code;
 use coral_client::{DecodedStatusError, decode_status_error};
+use coral_telemetry::record_failure;
 use opentelemetry::trace::Status as OtelStatus;
 use rmcp::{ErrorData, model::ErrorCode};
 use tracing::{Instrument as _, field};
@@ -106,7 +107,7 @@ pub(crate) fn record_protocol_result<T>(span: &tracing::Span, result: &Result<T,
 }
 
 pub(crate) fn record_protocol_error(span: &tracing::Span, error: &ErrorData) {
-    record_error(span, mcp_error_type(error.code), MCP_PROTOCOL_ERROR_MESSAGE);
+    record_failure(span, mcp_error_type(error.code), MCP_PROTOCOL_ERROR_MESSAGE);
 }
 
 pub(crate) fn record_tonic_status(span: &tracing::Span, status: &tonic::Status) {
@@ -114,11 +115,11 @@ pub(crate) fn record_tonic_status(span: &tracing::Span, status: &tonic::Status) 
         DecodedStatusError::Structured(error) => error.reason,
         DecodedStatusError::Plain(_) => grpc_response_status_code(status.code()).to_string(),
     };
-    record_error(span, error_type.as_str(), MCP_TOOL_ERROR_MESSAGE);
+    record_failure(span, error_type.as_str(), MCP_TOOL_ERROR_MESSAGE);
 }
 
 pub(crate) fn record_sql_batch_partial_failure(span: &tracing::Span) {
-    record_error(
+    record_failure(
         span,
         "sql_batch_partial_failure",
         "One or more SQL queries failed",
@@ -132,13 +133,6 @@ pub(crate) fn record_success(span: &tracing::Span) {
 
 pub(crate) fn record_task_id(span: &tracing::Span, task_id: &str) {
     span.record("task.id", task_id);
-}
-
-fn record_error(span: &tracing::Span, error_type: &str, message: &'static str) {
-    span.record("status", "error");
-    span.record("error.type", error_type);
-    span.record("exception.message", message);
-    span.set_status(OtelStatus::error(message));
 }
 
 fn mcp_error_type(code: ErrorCode) -> &'static str {

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -9,6 +9,9 @@ use rmcp::{ErrorData, model::ErrorCode};
 use tracing::{Instrument as _, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
+pub(crate) const MCP_PROTOCOL_ERROR_MESSAGE: &str = "MCP request failed";
+pub(crate) const MCP_TOOL_ERROR_MESSAGE: &str = "MCP tool call failed";
+
 pub(crate) async fn instrument<T, F>(span: tracing::Span, future: F) -> T
 where
     F: Future<Output = T>,
@@ -51,7 +54,6 @@ pub(crate) fn call_tool_span(tool_name: &str, trace_parent: Option<&str>) -> tra
         exception.message = field::Empty,
         mcp.method = "tools/call",
         mcp.tool.name = tool_name,
-        mcp.tool.intent = field::Empty,
         otel.kind = "server",
         otel.name = "coral.mcp.call_tool",
         task.id = field::Empty,
@@ -104,18 +106,15 @@ pub(crate) fn record_protocol_result<T>(span: &tracing::Span, result: &Result<T,
 }
 
 pub(crate) fn record_protocol_error(span: &tracing::Span, error: &ErrorData) {
-    record_error(span, mcp_error_type(error.code), error.message.as_ref());
+    record_error(span, mcp_error_type(error.code), MCP_PROTOCOL_ERROR_MESSAGE);
 }
 
 pub(crate) fn record_tonic_status(span: &tracing::Span, status: &tonic::Status) {
-    match decode_status_error(status) {
-        DecodedStatusError::Structured(error) => {
-            record_error(span, error.reason.as_str(), error.summary);
-        }
-        DecodedStatusError::Plain(message) => {
-            record_error(span, grpc_response_status_code(status.code()), message);
-        }
-    }
+    let error_type = match decode_status_error(status) {
+        DecodedStatusError::Structured(error) => error.reason,
+        DecodedStatusError::Plain(_) => grpc_response_status_code(status.code()).to_string(),
+    };
+    record_error(span, error_type.as_str(), MCP_TOOL_ERROR_MESSAGE);
 }
 
 pub(crate) fn record_sql_batch_partial_failure(span: &tracing::Span) {
@@ -135,15 +134,10 @@ pub(crate) fn record_task_id(span: &tracing::Span, task_id: &str) {
     span.record("task.id", task_id);
 }
 
-pub(crate) fn record_tool_intent(span: &tracing::Span, intent: &str) {
-    span.record("mcp.tool.intent", intent);
-}
-
-fn record_error(span: &tracing::Span, error_type: &str, message: impl std::fmt::Display) {
-    let message = message.to_string();
+fn record_error(span: &tracing::Span, error_type: &str, message: &'static str) {
     span.record("status", "error");
     span.record("error.type", error_type);
-    span.record("exception.message", field::display(&message));
+    span.record("exception.message", message);
     span.set_status(OtelStatus::error(message));
 }
 
@@ -157,5 +151,155 @@ fn mcp_error_type(code: ErrorCode) -> &'static str {
         ErrorCode::PARSE_ERROR => "PARSE_ERROR",
         ErrorCode::URL_ELICITATION_REQUIRED => "URL_ELICITATION_REQUIRED",
         _ => "MCP_PROTOCOL",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_SUMMARY};
+    use opentelemetry::Value;
+    use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
+    use tonic::{Code, Status};
+    use tonic_types::{ErrorDetail, StatusExt as _};
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    use super::{MCP_TOOL_ERROR_MESSAGE, call_tool_span, record_tonic_status};
+
+    #[test]
+    fn tool_call_span_does_not_record_intent_or_arguments() {
+        let (exporter, provider, subscriber) = telemetry_fixture();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let span = call_tool_span("future_tool", None);
+        span.in_scope(|| {});
+        drop(span);
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let tool_call = spans
+            .iter()
+            .find(|span| span.name == "coral.mcp.call_tool")
+            .expect("tool call span");
+
+        assert_eq!(
+            string_attribute(tool_call, "mcp.tool.name"),
+            Some("future_tool".to_string())
+        );
+        assert_eq!(attribute(tool_call, "mcp.tool.intent"), None);
+        assert!(
+            tool_call
+                .attributes
+                .iter()
+                .all(|attribute| !attribute.key.as_str().contains("argument"))
+        );
+
+        provider.shutdown().expect("provider shutdown");
+    }
+
+    #[test]
+    fn tonic_error_details_are_not_recorded_on_tool_spans() {
+        let (exporter, provider, subscriber) = telemetry_fixture();
+        let _guard = tracing::subscriber::set_default(subscriber);
+        let sentinel = "SENSITIVE_TONIC_ERROR_MARKER";
+
+        let span = call_tool_span("list_catalog", None);
+        record_tonic_status(
+            &span,
+            &tonic::Status::invalid_argument(format!("invalid kind: {sentinel}")),
+        );
+        drop(span);
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let tool_call = spans
+            .iter()
+            .find(|span| span.name == "coral.mcp.call_tool")
+            .expect("tool call span");
+
+        assert_eq!(
+            string_attribute(tool_call, "error.type"),
+            Some("INVALID_ARGUMENT".to_string())
+        );
+        assert_eq!(
+            string_attribute(tool_call, "exception.message"),
+            Some(MCP_TOOL_ERROR_MESSAGE.to_string())
+        );
+        assert_eq!(tool_call.status, OtelStatus::error(MCP_TOOL_ERROR_MESSAGE));
+        assert!(!format!("{tool_call:?}").contains(sentinel));
+
+        provider.shutdown().expect("provider shutdown");
+    }
+
+    #[test]
+    fn structured_tonic_error_keeps_only_its_categorical_reason() {
+        let (exporter, provider, subscriber) = telemetry_fixture();
+        let _guard = tracing::subscriber::set_default(subscriber);
+        let sentinel = "SENSITIVE_STRUCTURED_ERROR_MARKER";
+        let metadata = HashMap::from([(
+            CORAL_ERROR_METADATA_SUMMARY.to_string(),
+            format!("summary containing {sentinel}"),
+        )]);
+        let status = Status::with_error_details_vec(
+            Code::InvalidArgument,
+            format!("fallback containing {sentinel}"),
+            vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
+                "INVALID_CATALOG_KIND",
+                CORAL_ERROR_DOMAIN,
+                metadata,
+            ))],
+        );
+
+        let span = call_tool_span("list_catalog", None);
+        record_tonic_status(&span, &status);
+        drop(span);
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let tool_call = spans
+            .iter()
+            .find(|span| span.name == "coral.mcp.call_tool")
+            .expect("tool call span");
+
+        assert_eq!(
+            string_attribute(tool_call, "error.type"),
+            Some("INVALID_CATALOG_KIND".to_string())
+        );
+        assert_eq!(
+            string_attribute(tool_call, "exception.message"),
+            Some(MCP_TOOL_ERROR_MESSAGE.to_string())
+        );
+        assert_eq!(tool_call.status, OtelStatus::error(MCP_TOOL_ERROR_MESSAGE));
+        assert!(!format!("{tool_call:?}").contains(sentinel));
+
+        provider.shutdown().expect("provider shutdown");
+    }
+
+    fn telemetry_fixture() -> (
+        InMemorySpanExporter,
+        SdkTracerProvider,
+        impl tracing::Subscriber + Send + Sync,
+    ) {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("mcp-error-privacy-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        (exporter, provider, subscriber)
+    }
+
+    fn attribute<'a>(span: &'a SpanData, name: &str) -> Option<&'a Value> {
+        span.attributes
+            .iter()
+            .find(|attribute| attribute.key.as_str() == name)
+            .map(|attribute| &attribute.value)
+    }
+
+    fn string_attribute(span: &SpanData, name: &str) -> Option<String> {
+        attribute(span, name).map(|value| value.as_str().into_owned())
     }
 }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -13,6 +13,8 @@ use coral_client::{
     local::{RunningServer, ServerBuilder},
 };
 use jsonschema::Validator;
+use opentelemetry::trace::{SpanKind, TracerProvider as _};
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
 use rmcp::{
     RoleClient, ServerHandler, ServiceExt,
     model::{CallToolRequestParams, CallToolResult, ReadResourceRequestParams, Tool},
@@ -21,6 +23,9 @@ use rmcp::{
 use serde_json::{Map, Value, json};
 use tempfile::TempDir;
 use tonic::Request;
+use tracing_subscriber::Layer as _;
+use tracing_subscriber::filter::Targets;
+use tracing_subscriber::layer::SubscriberExt as _;
 
 use crate::{CoralMcpServerFactory, McpOptions};
 
@@ -747,6 +752,106 @@ async fn mcp_task_tools_persist_lifecycle_and_tag_follow_up_calls() {
     assert_eq!(raw_after_error.lines().count(), 2);
 
     session.shutdown().await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn task_intent_is_persisted_but_not_exported_to_telemetry() {
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = provider.tracer("mcp-task-intent-privacy-test");
+    let trace_targets = "coral_mcp=trace,coral_client::grpc=trace,coral_app::transport=trace"
+        .parse::<Targets>()
+        .expect("MCP and gRPC trace filter");
+    let subscriber = tracing_subscriber::Registry::default().with(
+        tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_filter(trace_targets),
+    );
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_session_with_options(
+        &temp,
+        McpOptions {
+            tasks_enabled: true,
+            ..McpOptions::default()
+        },
+    )
+    .await;
+    let sentinel = "SENSITIVE_RAW_TASK_INTENT_TELEMETRY_MARKER";
+
+    let started = session
+        .client
+        .call_tool(
+            CallToolRequestParams::new("start_task").with_arguments(json_object(&json!({
+                "intent": sentinel
+            }))),
+        )
+        .await
+        .expect("start task");
+    assert_eq!(started.is_error, Some(false));
+    assert_structured_content_only(&started);
+    let task_id = started
+        .structured_content
+        .expect("start task structured content")["task_id"]
+        .as_str()
+        .expect("task id")
+        .to_string();
+    uuid::Uuid::parse_str(&task_id).expect("task id is a UUID");
+
+    let tasks_path = temp
+        .path()
+        .join("coral-config/workspaces/default/tasks/tasks.jsonl");
+    let persisted = fs::read_to_string(tasks_path).expect("task file should exist");
+    let start_record = persisted
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("task JSONL should parse"))
+        .find(|record| record["task_id"] == task_id && record["event"] == "start")
+        .expect("task start record");
+    assert_eq!(start_record["intent"], sentinel);
+
+    session.shutdown().await;
+    provider.force_flush().expect("flush spans");
+    let spans = exporter.get_finished_spans().expect("finished spans");
+    let tool_call = spans
+        .iter()
+        .find(|span| {
+            span.name == "coral.mcp.call_tool"
+                && span.attributes.iter().any(|attribute| {
+                    attribute.key.as_str() == "mcp.tool.name"
+                        && attribute.value.as_str() == "start_task"
+                })
+        })
+        .expect("start_task tool call span");
+    assert!(
+        tool_call
+            .attributes
+            .iter()
+            .all(|attribute| attribute.key.as_str() != "mcp.tool.intent")
+    );
+    assert!(
+        spans.iter().any(|span| {
+            span.name == "coral.v1.TaskService/StartTask" && span.span_kind == SpanKind::Client
+        }),
+        "start_task should export its client gRPC span"
+    );
+    assert!(
+        spans.iter().any(|span| {
+            span.name == "coral.v1.TaskService/StartTask" && span.span_kind == SpanKind::Server
+        }),
+        "start_task should export its server gRPC span"
+    );
+    let leaked = spans
+        .iter()
+        .filter(|span| format!("{span:?}").contains(sentinel))
+        .collect::<Vec<_>>();
+    assert!(
+        leaked.is_empty(),
+        "exported spans contained the raw intent: {leaked:#?}"
+    );
+
+    provider.shutdown().expect("provider shutdown");
 }
 
 #[tokio::test]

--- a/crates/coral-telemetry/src/lib.rs
+++ b/crates/coral-telemetry/src/lib.rs
@@ -6,12 +6,27 @@
 
 use opentelemetry::Context;
 use opentelemetry::propagation::{Extractor, Injector, TextMapPropagator as _};
-use opentelemetry::trace::TraceContextExt as _;
+use opentelemetry::trace::{Status as OtelStatus, TraceContextExt as _};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 const TRACEPARENT_HEADER: &str = "traceparent";
 const TRACESTATE_HEADER: &str = "tracestate";
+
+/// Stable message recorded for failed gRPC requests.
+pub const GRPC_REQUEST_ERROR_MESSAGE: &str = "gRPC request failed";
+
+/// Records a categorical failure without accepting caller-controlled message text.
+pub fn record_failure(
+    span: &tracing::Span,
+    error_type: impl AsRef<str>,
+    stable_message: &'static str,
+) {
+    span.record("status", "error");
+    span.record("error.type", error_type.as_ref());
+    span.record("exception.message", stable_message);
+    span.set_status(OtelStatus::error(stable_message));
+}
 
 struct TraceHeaders<'a> {
     traceparent: &'a str,
@@ -97,14 +112,63 @@ fn context_has_valid_span(context: &Context) -> bool {
 mod tests {
     use std::collections::HashMap;
 
-    use opentelemetry::trace::{SpanId, TraceContextExt as _, TraceId, TracerProvider as _};
+    use opentelemetry::trace::{
+        SpanId, Status as OtelStatus, TraceContextExt as _, TraceId, TracerProvider as _,
+    };
     use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
     use tracing_subscriber::prelude::*;
 
     use super::{
         TRACEPARENT_HEADER, TRACESTATE_HEADER, context_from_extractor, context_from_trace_headers,
-        inject_context, set_parent_from_trace_headers,
+        inject_context, record_failure, set_parent_from_trace_headers,
     };
+
+    #[test]
+    fn record_failure_sets_shared_error_fields() {
+        let memory = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(memory.clone())
+            .build();
+        let tracer = provider.tracer("failure-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "failure",
+                error.type = tracing::field::Empty,
+                exception.message = tracing::field::Empty,
+                status = tracing::field::Empty,
+            );
+            record_failure(&span, "INVALID_ARGUMENT", "request failed");
+            span.in_scope(|| {});
+        });
+        provider.force_flush().expect("flush spans");
+
+        let spans = memory.get_finished_spans().expect("finished spans");
+        let failure = spans
+            .iter()
+            .find(|span| span.name == "failure")
+            .expect("failure span");
+        let string_attribute = |name: &str| {
+            failure
+                .attributes
+                .iter()
+                .find(|attribute| attribute.key.as_str() == name)
+                .map(|attribute| attribute.value.as_str().into_owned())
+        };
+        assert_eq!(string_attribute("status").as_deref(), Some("error"));
+        assert_eq!(
+            string_attribute("error.type").as_deref(),
+            Some("INVALID_ARGUMENT")
+        );
+        assert_eq!(
+            string_attribute("exception.message").as_deref(),
+            Some("request failed")
+        );
+        assert_eq!(failure.status, OtelStatus::error("request failed"));
+        provider.shutdown().expect("provider shutdown");
+    }
 
     #[test]
     fn extracts_valid_traceparent_and_tracestate() {


### PR DESCRIPTION
## Summary

- replace caller-controlled gRPC and MCP error text in exported telemetry with stable messages
- preserve categorical gRPC codes and structured Coral error reasons for diagnosis
- keep detailed errors visible to callers while preventing those details from entering span attributes or status
- stop exporting raw `mcp.tool.intent`; task intent is still validated and persisted for task behavior
- add regression tests covering server gRPC, client gRPC, MCP protocol/tool errors, and a real `start_task` call

## Stack boundary

- Layer 1 of 6
- Base: `main`
- Next: #1901
- This PR only hardens telemetry privacy. It does not add Query Stream operation markers, projection, detail selection, or Reef changes.
- It changes newly emitted telemetry only; retained or previously exported telemetry is not rewritten.

## Operational impact

- Caller-visible gRPC and MCP errors keep their original detail, but exported traces intentionally replace free-form error text with stable messages.
- Later layers improve operation attribution and presentation; they do not restore the removed free-form error detail.
- Diagnose trace failures using `error.type`, the RPC status code, service/method fields, and the operation metadata added by later layers.
- `mcp.tool.intent` is no longer exported. Task intent is still validated and persisted for task behavior, but external dashboards or queries that read this telemetry field must migrate.

## Deferred follow-ups

- centralize categorical gRPC error extraction, including an explicit first-versus-last policy if a status contains multiple Coral `ErrorInfo` details
- audit dynamic span events and add a durable sanitization or allowlist boundary; this PR's regression tests prove the exercised request paths, not every future event call site
- review whether the stable `exception.message` attribute should be removed after checking external telemetry consumers

## Validation

- `cargo test -p coral-mcp --all-features`: 87 passed; the end-to-end intent regression explicitly captures MCP, client gRPC, and server gRPC spans
- `cargo fmt --all --check`
- current top-of-stack `npm test --prefix apps/reef`: 88 files and 387 tests passed
- current top-of-stack `npm run check --prefix apps/reef`
- current top-of-stack `npm run typecheck --prefix apps/reef`
- current top-of-stack `npm run build --prefix apps/reef`
- `git diff --check`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
