### PR TITLE
feat(telemetry): mark user-visible operations

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1338,9 +1338,11 @@ enabled = false
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
         std::fs::create_dir_all(&config_dir).expect("create config dir");
+        // Keep this server-start test from populating process-global tracing
+        // state and making telemetry unit tests depend on execution order.
         std::fs::write(
             config_dir.join("config.toml"),
-            "[server]\nbind_addr = '127.0.0.1:0'\n",
+            "[server]\nbind_addr = '127.0.0.1:0'\n\n[trace_history]\nenabled = false\n",
         )
         .expect("write config");
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1153,6 +1153,7 @@ where
         query_span.set_status(OtelStatus::error(error_message));
     }
 
+    drop(query_span);
     result
 }
 
@@ -1563,6 +1564,51 @@ mod tests {
             span_attr(query_span, coral_telemetry::QUERY_STREAM_NAME_ATTRIBUTE),
             Some("execute_sql".to_string())
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn query_span_finishes_before_completed_future_is_dropped() {
+        use std::future::poll_fn;
+
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("query-span-lifecycle-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let workspace = WorkspaceName::default();
+        let mut operation = Box::pin(run_query_operation(
+            QueryOperation::ListTables,
+            &workspace,
+            "LIST TABLES *.*",
+            None,
+            async { Ok::<(), QueryManagerError>(()) },
+            |()| None,
+            |_, ()| {},
+        ));
+        poll_fn(|context| operation.as_mut().poll(context))
+            .await
+            .expect("query operation should succeed");
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let query_span = spans
+            .iter()
+            .find(|span| span.name == "coral.query")
+            .expect("completed operation should finish its query span");
+        assert_eq!(
+            span_attr(query_span, "operation"),
+            Some("list_tables".to_string())
+        );
+
+        drop(operation);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -41,7 +41,7 @@ use crate::sources::runtime_package::{
 };
 use crate::state::{AppConfig, AppStateLayout, ConfigStore};
 use crate::task::id::TaskId;
-use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
+use crate::telemetry::app_error_type;
 use crate::workspaces::{
     WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceManager, WorkspaceName,
 };
@@ -577,7 +577,10 @@ impl QueryManager {
             workspace = tracing::field::Empty,
             source.count = tracing::field::Empty,
         );
-        span.record(WORKSPACE_SPAN_ATTRIBUTE, workspace_name.as_str());
+        span.record(
+            coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE,
+            workspace_name.as_str(),
+        );
         let _guard = span.enter();
         let mut loaded_sources = Vec::new();
         let mut failed_source_names = BTreeSet::new();
@@ -1182,7 +1185,10 @@ fn create_query_span(
     if let Some(task_id) = task_id {
         span.record("task.id", tracing::field::display(task_id));
     }
-    span.record(WORKSPACE_SPAN_ATTRIBUTE, workspace_name.as_str());
+    span.record(
+        coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE,
+        workspace_name.as_str(),
+    );
     span
 }
 
@@ -1254,45 +1260,6 @@ fn query_error_message(error: &QueryManagerError) -> String {
         QueryManagerError::App(error) => error.to_string(),
         QueryManagerError::Core(CoreError::QueryFailure(error)) => error.summary().to_string(),
         QueryManagerError::Core(error) => error.to_string(),
-    }
-}
-
-pub(crate) fn app_error_type(error: &AppError) -> &'static str {
-    match error {
-        AppError::Unauthenticated(_) => "UNAUTHENTICATED",
-        AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
-        AppError::FunctionNotFound(_) => "FUNCTION_NOT_FOUND",
-        AppError::FunctionAlreadyExists(_) => "FUNCTION_ALREADY_EXISTS",
-        AppError::WorkspaceNotFound(_) => "WORKSPACE_NOT_FOUND",
-        AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",
-        AppError::InvalidInput(_) => "INVALID_INPUT",
-        AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
-        AppError::MissingSourceInputs { .. } => "MISSING_SOURCE_INPUTS",
-        AppError::UnsupportedV4IdentityRequirements { .. } => {
-            "UNSUPPORTED_V4_IDENTITY_REQUIREMENTS"
-        }
-        AppError::MissingOrIncompatibleV4Materialization { .. } => {
-            "MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION"
-        }
-        AppError::IncompatibleInstalledV4Manifest { .. } => "INCOMPATIBLE_INSTALLED_V4_MANIFEST",
-        AppError::InvalidV4ProjectionOverride { .. } => "INVALID_V4_PROJECTION_OVERRIDE",
-        AppError::InvalidV4OperationMetadataOverride { .. } => {
-            "INVALID_V4_OPERATION_METADATA_OVERRIDE"
-        }
-        AppError::CredentialRefresh(_) => "CREDENTIAL_REFRESH",
-        AppError::Unavailable(_) => "UNAVAILABLE",
-        AppError::ResourceExhausted(_) => "RESOURCE_EXHAUSTED",
-        AppError::Internal(_) => "INTERNAL",
-        AppError::Io(_) => "IO",
-        AppError::Yaml(_) => "YAML",
-        AppError::TomlDecode(_) | AppError::TomlEditDecode(_) => "TOML_DECODE",
-        AppError::TomlEncode(_) => "TOML_ENCODE",
-        AppError::Json(_) => "JSON",
-        AppError::Transport(_) => "TRANSPORT",
-        AppError::TaskJoin(_) => "TASK_JOIN",
-        AppError::Credentials(_) => "CREDENTIALS",
-        AppError::Database(_) => "DATABASE",
-        AppError::MissingConfigDir => "MISSING_CONFIG_DIR",
     }
 }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1162,6 +1162,9 @@ fn create_query_span(
     let operation = operation.as_str();
     let span = tracing::info_span!(
         "coral.query",
+        coral.stream.entry = true,
+        coral.stream.kind = coral_telemetry::QUERY_STREAM_KIND_QUERY,
+        coral.stream.name = operation,
         otel.name = "coral.query",
         operation = operation,
         workspace = tracing::field::Empty,
@@ -1254,7 +1257,7 @@ fn query_error_message(error: &QueryManagerError) -> String {
     }
 }
 
-fn app_error_type(error: &AppError) -> &'static str {
+pub(crate) fn app_error_type(error: &AppError) -> &'static str {
     match error {
         AppError::Unauthenticated(_) => "UNAUTHENTICATED",
         AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
@@ -1581,6 +1584,18 @@ mod tests {
             .find(|attribute| attribute.key.as_str() == "task.id")
             .expect("task.id attribute present");
         assert_eq!(task_attr.value.as_str(), task_id);
+        assert!(query_span.attributes.iter().any(|attribute| {
+            attribute.key.as_str() == coral_telemetry::QUERY_STREAM_ENTRY_ATTRIBUTE
+                && attribute.value == opentelemetry::Value::Bool(true)
+        }));
+        assert_eq!(
+            span_attr(query_span, coral_telemetry::QUERY_STREAM_KIND_ATTRIBUTE),
+            Some(coral_telemetry::QUERY_STREAM_KIND_QUERY.to_string())
+        );
+        assert_eq!(
+            span_attr(query_span, coral_telemetry::QUERY_STREAM_NAME_ATTRIBUTE),
+            Some("execute_sql".to_string())
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -1,14 +1,18 @@
 //! App-level Universal Search manager.
 
+use std::future::Future;
 use std::time::{Duration, Instant};
 
+use opentelemetry::trace::Status as OtelStatus;
 use tokio::task;
+use tracing::{Instrument as _, field};
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::AppError;
 use crate::catalog::discovery::CatalogDiscovery;
 use crate::catalog::model::CatalogResolution;
 use crate::query::QueryAttribution;
-use crate::query::manager::QueryManagerError;
+use crate::query::manager::{QueryManagerError, app_error_type};
 use crate::search::catalog::provider::{CatalogMetadataProvider, catalog_clear_provider_result};
 use crate::search::engine::UniversalSearchEngine;
 use crate::search::maintenance::{
@@ -34,6 +38,8 @@ use crate::search::sqlite_store::{
 };
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::state::{AppStateLayout, ConfigStore};
+use crate::task::id::TaskId;
+use crate::telemetry::{WORKSPACE_SPAN_ATTRIBUTE, record_local_only_span_attribute};
 use crate::workspaces::{
     WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceManager, WorkspaceName,
 };
@@ -57,6 +63,7 @@ const MANUAL_DRAIN_MAX_JOBS: usize = 10_000;
 const SHUTDOWN_DRAIN_SOFT_BUDGET: Duration = Duration::from_secs(1);
 const WORKSPACE_SNAPSHOT_ATTEMPTS: usize = 2;
 const OBSERVED_STALE_AFTER_LAST_OBSERVED_DAYS: u32 = 365;
+const SEARCH_TELEMETRY_ERROR_MESSAGE: &str = "Search operation failed";
 const OBSERVED_VALUES_SEARCH_DISABLED_MAINTENANCE_NOTE: &str = "observed value search maintenance is disabled; enable `observed_values_search` to rebuild or drain observed values";
 
 enum CatalogPreload {
@@ -130,47 +137,57 @@ impl SearchManager {
         request: &SearchRequest,
         attribution: &QueryAttribution,
     ) -> Result<SearchResponse, SearchManagerError> {
-        let request_started_at = Instant::now();
-        for _ in 0..WORKSPACE_SNAPSHOT_ATTEMPTS {
-            let CatalogPreload::Ready {
-                revision,
-                resolution,
-            } = self
-                .preload_catalog(&request.workspace_name, attribution)
-                .await?
-            else {
-                continue;
-            };
-            let Some(lifecycle_lease) = self
-                .lifecycle_lock
-                .read_lease_if_unchanged(revision, &request.workspace_name)
-                .await
-            else {
-                continue;
-            };
-            let (observed_values_policy, lifecycle_lease) = if self.observed_values_search_enabled {
-                let search = self.clone();
-                let workspace_name = request.workspace_name.clone();
-                run_blocking_search_operation(move || {
-                    Ok((
-                        Some(search.observed_retrieval_policy(&workspace_name)),
+        // The retry/preload path makes this future large enough to trigger
+        // Clippy's `large_futures` lint when it is awaited inline.
+        Box::pin(run_search_operation(
+            request,
+            attribution.task_id.as_ref(),
+            async {
+                let request_started_at = Instant::now();
+                for _ in 0..WORKSPACE_SNAPSHOT_ATTEMPTS {
+                    let CatalogPreload::Ready {
+                        revision,
+                        resolution,
+                    } = self
+                        .preload_catalog(&request.workspace_name, attribution)
+                        .await?
+                    else {
+                        continue;
+                    };
+                    let Some(lifecycle_lease) = self
+                        .lifecycle_lock
+                        .read_lease_if_unchanged(revision, &request.workspace_name)
+                        .await
+                    else {
+                        continue;
+                    };
+                    let (observed_values_policy, lifecycle_lease) =
+                        if self.observed_values_search_enabled {
+                            let search = self.clone();
+                            let workspace_name = request.workspace_name.clone();
+                            run_blocking_search_operation(move || {
+                                Ok((
+                                    Some(search.observed_retrieval_policy(&workspace_name)),
+                                    lifecycle_lease,
+                                ))
+                            })
+                            .await?
+                        } else {
+                            (None, lifecycle_lease)
+                        };
+                    let context = SearchExecutionContext::new(
+                        request_started_at,
                         lifecycle_lease,
-                    ))
-                })
-                .await?
-            } else {
-                (None, lifecycle_lease)
-            };
-            let context = SearchExecutionContext::new(
-                request_started_at,
-                lifecycle_lease,
-                request.clone(),
-                resolution,
-                observed_values_policy,
-            );
-            return Ok(self.engine.search(context).await);
-        }
-        Err(workspace_changed_error("searching"))
+                        request.clone(),
+                        resolution,
+                        observed_values_policy,
+                    );
+                    return Ok(self.engine.search(context).await);
+                }
+                Err(workspace_changed_error("searching"))
+            },
+        ))
+        .await
     }
 
     pub(crate) async fn rebuild_index(
@@ -556,6 +573,65 @@ fn workspace_changed_error(operation: &str) -> SearchManagerError {
     .into()
 }
 
+async fn run_search_operation<F>(
+    request: &SearchRequest,
+    task_id: Option<&TaskId>,
+    operation: F,
+) -> Result<SearchResponse, SearchManagerError>
+where
+    F: Future<Output = Result<SearchResponse, SearchManagerError>>,
+{
+    let span = create_search_span(request, task_id);
+    let result = operation.instrument(span.clone()).await;
+    match &result {
+        Ok(response) => {
+            span.record(
+                "result_count",
+                u64::try_from(response.results.len()).unwrap_or(u64::MAX),
+            );
+            span.record("status", "ok");
+            span.set_status(OtelStatus::Ok);
+        }
+        Err(SearchManagerError::App(error)) => {
+            span.record("error.type", app_error_type(error));
+            span.record("exception.message", SEARCH_TELEMETRY_ERROR_MESSAGE);
+            span.record("status", "error");
+            span.set_status(OtelStatus::error(SEARCH_TELEMETRY_ERROR_MESSAGE));
+        }
+    }
+    result
+}
+
+fn create_search_span(request: &SearchRequest, task_id: Option<&TaskId>) -> tracing::Span {
+    let span = tracing::info_span!(
+        "coral.search",
+        coral.stream.entry = true,
+        coral.stream.kind = coral_telemetry::QUERY_STREAM_KIND_SEARCH,
+        coral.stream.name = "search",
+        coral.local.search.query = field::Empty,
+        otel.name = "coral.search",
+        operation = "search",
+        workspace = field::Empty,
+        query_len_bytes = request.query.len(),
+        limit = request.limit,
+        task.id = field::Empty,
+        result_count = field::Empty,
+        status = field::Empty,
+        error.type = field::Empty,
+        exception.message = field::Empty,
+    );
+    record_local_only_span_attribute(
+        &span,
+        coral_telemetry::QUERY_STREAM_SEARCH_QUERY_ATTRIBUTE,
+        request.query.as_str(),
+    );
+    span.record(WORKSPACE_SPAN_ATTRIBUTE, request.workspace_name.as_str());
+    if let Some(task_id) = task_id {
+        span.record("task.id", field::display(task_id));
+    }
+    span
+}
+
 async fn run_blocking_search_operation<T, F>(operation: F) -> Result<T, SearchManagerError>
 where
     T: Send + 'static,
@@ -667,5 +743,172 @@ fn search_storage_cleanup_result(
     SearchStorageCleanupResult {
         state,
         note: note.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    use super::{
+        SEARCH_TELEMETRY_ERROR_MESSAGE, run_search_operation, search_manager_error_message,
+    };
+    use crate::bootstrap::AppError;
+    use crate::search::result::{
+        SearchManagerError, SearchRequest, SearchResponse, SearchTruncation,
+    };
+    use crate::task::id::TaskId;
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn search_operation_records_safe_summary_metadata() {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("search-summary-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let raw_query = "sensitive search marker";
+        let request = SearchRequest::new(WorkspaceName::default(), raw_query, 7)
+            .expect("valid search request");
+        let task_id = TaskId::parse("550e8400-e29b-41d4-a716-446655440000").expect("valid task id");
+        let response = SearchResponse {
+            workspace_name: request.workspace_name.clone(),
+            results: Vec::new(),
+            provider_statuses: Vec::new(),
+            truncation: SearchTruncation {
+                truncated: false,
+                returned_count: 0,
+                max_results: request.limit,
+                note: "all results returned".to_string(),
+            },
+        };
+
+        run_search_operation(&request, Some(&task_id), async { Ok(response) })
+            .await
+            .expect("search operation");
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let search_span = spans
+            .iter()
+            .find(|span| span.name == "coral.search")
+            .expect("coral.search span recorded");
+        let attribute = |name: &str| {
+            search_span
+                .attributes
+                .iter()
+                .find(|attribute| attribute.key.as_str() == name)
+                .unwrap_or_else(|| panic!("missing {name} attribute"))
+        };
+
+        assert_eq!(attribute("operation").value.as_str(), "search");
+        assert_eq!(
+            attribute(coral_telemetry::QUERY_STREAM_ENTRY_ATTRIBUTE).value,
+            opentelemetry::Value::Bool(true)
+        );
+        assert_eq!(
+            attribute(coral_telemetry::QUERY_STREAM_KIND_ATTRIBUTE)
+                .value
+                .as_str(),
+            coral_telemetry::QUERY_STREAM_KIND_SEARCH
+        );
+        assert_eq!(
+            attribute(coral_telemetry::QUERY_STREAM_NAME_ATTRIBUTE)
+                .value
+                .as_str(),
+            "search"
+        );
+        assert_eq!(attribute("workspace").value.as_str(), "default");
+        assert_eq!(
+            attribute("task.id").value.as_str(),
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+        assert_eq!(attribute("status").value.as_str(), "ok");
+        assert!(
+            search_span
+                .attributes
+                .iter()
+                .any(|attribute| attribute.key.as_str() == "query_len_bytes")
+        );
+        assert!(
+            search_span
+                .attributes
+                .iter()
+                .any(|attribute| attribute.key.as_str() == "limit")
+        );
+        assert!(
+            search_span
+                .attributes
+                .iter()
+                .any(|attribute| attribute.key.as_str() == "result_count")
+        );
+        assert!(
+            search_span.attributes.iter().all(|attribute| {
+                !attribute
+                    .key
+                    .as_str()
+                    .starts_with(coral_telemetry::LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX)
+            }),
+            "a subscriber not installed by Coral must not receive local-only attributes"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn search_operation_redacts_caller_visible_error_details_from_telemetry() {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("search-error-privacy-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let query = "local search text";
+        let error_sentinel = "SENSITIVE_SEARCH_ERROR_PATH_MARKER";
+        let request =
+            SearchRequest::new(WorkspaceName::default(), query, 7).expect("valid search request");
+        let error = run_search_operation(&request, None, async {
+            Err::<SearchResponse, SearchManagerError>(
+                AppError::Internal(format!("failed while handling {error_sentinel}")).into(),
+            )
+        })
+        .await
+        .expect_err("search operation should return its detailed error");
+
+        assert!(search_manager_error_message(&error).contains(error_sentinel));
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let search_span = spans
+            .iter()
+            .find(|span| span.name == "coral.search")
+            .expect("coral.search span recorded");
+        let attribute = |name: &str| {
+            search_span
+                .attributes
+                .iter()
+                .find(|attribute| attribute.key.as_str() == name)
+                .unwrap_or_else(|| panic!("missing {name} attribute"))
+        };
+
+        assert_eq!(attribute("status").value.as_str(), "error");
+        assert_eq!(attribute("error.type").value.as_str(), "INTERNAL");
+        assert_eq!(
+            attribute("exception.message").value.as_str(),
+            SEARCH_TELEMETRY_ERROR_MESSAGE
+        );
+        assert_eq!(
+            search_span.status,
+            OtelStatus::error(SEARCH_TELEMETRY_ERROR_MESSAGE)
+        );
+        assert!(!format!("{search_span:?}").contains(query));
+        assert!(!format!("{search_span:?}").contains(error_sentinel));
     }
 }

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -64,6 +64,8 @@ const SHUTDOWN_DRAIN_SOFT_BUDGET: Duration = Duration::from_secs(1);
 const WORKSPACE_SNAPSHOT_ATTEMPTS: usize = 2;
 const OBSERVED_STALE_AFTER_LAST_OBSERVED_DAYS: u32 = 365;
 const SEARCH_TELEMETRY_ERROR_MESSAGE: &str = "Search operation failed";
+const SEARCH_MAINTENANCE_TELEMETRY_ERROR_MESSAGE: &str = "Search maintenance operation failed";
+const REBUILD_SEARCH_INDEX_OPERATION: &str = "rebuild_search_index";
 const OBSERVED_VALUES_SEARCH_DISABLED_MAINTENANCE_NOTE: &str = "observed value search maintenance is disabled; enable `observed_values_search` to rebuild or drain observed values";
 
 enum CatalogPreload {
@@ -191,6 +193,18 @@ impl SearchManager {
     }
 
     pub(crate) async fn rebuild_index(
+        &self,
+        request: &RebuildSearchIndexRequest,
+    ) -> Result<RebuildSearchIndexResponse, SearchManagerError> {
+        Box::pin(run_search_maintenance_operation(
+            &request.workspace_name,
+            REBUILD_SEARCH_INDEX_OPERATION,
+            self.rebuild_index_inner(request),
+        ))
+        .await
+    }
+
+    async fn rebuild_index_inner(
         &self,
         request: &RebuildSearchIndexRequest,
     ) -> Result<RebuildSearchIndexResponse, SearchManagerError> {
@@ -573,6 +587,47 @@ fn workspace_changed_error(operation: &str) -> SearchManagerError {
     .into()
 }
 
+async fn run_search_maintenance_operation<T, F>(
+    workspace_name: &WorkspaceName,
+    operation_name: &'static str,
+    operation: F,
+) -> Result<T, SearchManagerError>
+where
+    F: Future<Output = Result<T, SearchManagerError>>,
+{
+    let span = tracing::info_span!(
+        "coral.search.maintenance",
+        coral.stream.entry = true,
+        coral.stream.kind = coral_telemetry::QUERY_STREAM_KIND_OTHER,
+        coral.stream.name = operation_name,
+        otel.name = "coral.search.maintenance",
+        operation = operation_name,
+        workspace = field::Empty,
+        status = field::Empty,
+        error.type = field::Empty,
+        exception.message = field::Empty,
+    );
+    span.record(
+        coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE,
+        workspace_name.as_str(),
+    );
+    let result = operation.instrument(span.clone()).await;
+    match &result {
+        Ok(_) => {
+            span.record("status", "ok");
+            span.set_status(OtelStatus::Ok);
+        }
+        Err(SearchManagerError::App(error)) => {
+            coral_telemetry::record_failure(
+                &span,
+                app_error_type(error),
+                SEARCH_MAINTENANCE_TELEMETRY_ERROR_MESSAGE,
+            );
+        }
+    }
+    result
+}
+
 async fn run_search_operation<F>(
     request: &SearchRequest,
     task_id: Option<&TaskId>,
@@ -753,10 +808,12 @@ fn search_storage_cleanup_result(
 mod tests {
     use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
     use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+    use tracing::Instrument as _;
     use tracing_subscriber::layer::SubscriberExt as _;
 
     use super::{
-        SEARCH_TELEMETRY_ERROR_MESSAGE, run_search_operation, search_manager_error_message,
+        REBUILD_SEARCH_INDEX_OPERATION, SEARCH_TELEMETRY_ERROR_MESSAGE,
+        run_search_maintenance_operation, run_search_operation, search_manager_error_message,
     };
     use crate::bootstrap::AppError;
     use crate::search::result::{
@@ -764,6 +821,81 @@ mod tests {
     };
     use crate::task::id::TaskId;
     use crate::workspaces::WorkspaceName;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn search_maintenance_operation_marks_the_outer_query_stream_entry() {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("search-maintenance-summary-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        run_search_maintenance_operation(
+            &WorkspaceName::default(),
+            REBUILD_SEARCH_INDEX_OPERATION,
+            async {
+                async {}
+                    .instrument(tracing::info_span!(
+                        "coral.query",
+                        coral.stream.entry = true,
+                        coral.stream.kind = coral_telemetry::QUERY_STREAM_KIND_QUERY,
+                        coral.stream.name = "LIST CATALOG",
+                    ))
+                    .await;
+                Ok::<_, SearchManagerError>(())
+            },
+        )
+        .await
+        .expect("search maintenance operation");
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let maintenance_span = spans
+            .iter()
+            .find(|span| span.name == "coral.search.maintenance")
+            .expect("search maintenance span recorded");
+        let query_span = spans
+            .iter()
+            .find(|span| span.name == "coral.query")
+            .expect("nested query span recorded");
+        assert!(query_span.attributes.iter().any(|attribute| {
+            attribute.key.as_str() == coral_telemetry::QUERY_STREAM_ENTRY_ATTRIBUTE
+                && attribute.value == opentelemetry::Value::Bool(true)
+        }));
+        let attribute = |name: &str| {
+            maintenance_span
+                .attributes
+                .iter()
+                .find(|attribute| attribute.key.as_str() == name)
+                .unwrap_or_else(|| panic!("missing {name} attribute"))
+        };
+
+        assert_eq!(
+            attribute(coral_telemetry::QUERY_STREAM_ENTRY_ATTRIBUTE).value,
+            opentelemetry::Value::Bool(true)
+        );
+        assert_eq!(
+            attribute(coral_telemetry::QUERY_STREAM_KIND_ATTRIBUTE)
+                .value
+                .as_str(),
+            coral_telemetry::QUERY_STREAM_KIND_OTHER
+        );
+        assert_eq!(
+            attribute(coral_telemetry::QUERY_STREAM_NAME_ATTRIBUTE)
+                .value
+                .as_str(),
+            REBUILD_SEARCH_INDEX_OPERATION
+        );
+        assert_eq!(attribute("workspace").value.as_str(), "default");
+        assert_eq!(attribute("status").value.as_str(), "ok");
+        assert_eq!(
+            query_span.parent_span_id,
+            maintenance_span.span_context.span_id()
+        );
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn search_operation_records_safe_summary_metadata() {

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -65,6 +65,7 @@ const WORKSPACE_SNAPSHOT_ATTEMPTS: usize = 2;
 const OBSERVED_STALE_AFTER_LAST_OBSERVED_DAYS: u32 = 365;
 const SEARCH_TELEMETRY_ERROR_MESSAGE: &str = "Search operation failed";
 const SEARCH_MAINTENANCE_TELEMETRY_ERROR_MESSAGE: &str = "Search maintenance operation failed";
+const SEARCH_MAINTENANCE_PROVIDER_FAILURE_ERROR_TYPE: &str = "PROVIDER_FAILURE";
 const REBUILD_SEARCH_INDEX_OPERATION: &str = "rebuild_search_index";
 const OBSERVED_VALUES_SEARCH_DISABLED_MAINTENANCE_NOTE: &str = "observed value search maintenance is disabled; enable `observed_values_search` to rebuild or drain observed values";
 
@@ -587,13 +588,13 @@ fn workspace_changed_error(operation: &str) -> SearchManagerError {
     .into()
 }
 
-async fn run_search_maintenance_operation<T, F>(
+async fn run_search_maintenance_operation<F>(
     workspace_name: &WorkspaceName,
     operation_name: &'static str,
     operation: F,
-) -> Result<T, SearchManagerError>
+) -> Result<RebuildSearchIndexResponse, SearchManagerError>
 where
-    F: Future<Output = Result<T, SearchManagerError>>,
+    F: Future<Output = Result<RebuildSearchIndexResponse, SearchManagerError>>,
 {
     let span = tracing::info_span!(
         "coral.search.maintenance",
@@ -613,9 +614,21 @@ where
     );
     let result = operation.instrument(span.clone()).await;
     match &result {
-        Ok(_) => {
-            span.record("status", "ok");
-            span.set_status(OtelStatus::Ok);
+        Ok(response) => {
+            if response
+                .results
+                .iter()
+                .any(|result| result.state == SearchMaintenanceState::Failed)
+            {
+                coral_telemetry::record_failure(
+                    &span,
+                    SEARCH_MAINTENANCE_PROVIDER_FAILURE_ERROR_TYPE,
+                    SEARCH_MAINTENANCE_TELEMETRY_ERROR_MESSAGE,
+                );
+            } else {
+                span.record("status", "ok");
+                span.set_status(OtelStatus::Ok);
+            }
         }
         Err(SearchManagerError::App(error)) => {
             coral_telemetry::record_failure(
@@ -625,6 +638,7 @@ where
             );
         }
     }
+    drop(span);
     result
 }
 
@@ -812,12 +826,16 @@ mod tests {
     use tracing_subscriber::layer::SubscriberExt as _;
 
     use super::{
-        REBUILD_SEARCH_INDEX_OPERATION, SEARCH_TELEMETRY_ERROR_MESSAGE,
+        REBUILD_SEARCH_INDEX_OPERATION, SEARCH_MAINTENANCE_PROVIDER_FAILURE_ERROR_TYPE,
+        SEARCH_MAINTENANCE_TELEMETRY_ERROR_MESSAGE, SEARCH_TELEMETRY_ERROR_MESSAGE,
         run_search_maintenance_operation, run_search_operation, search_manager_error_message,
     };
     use crate::bootstrap::AppError;
+    use crate::search::maintenance::{
+        RebuildSearchIndexResponse, SearchMaintenanceResult, SearchMaintenanceState,
+    };
     use crate::search::result::{
-        SearchManagerError, SearchRequest, SearchResponse, SearchTruncation,
+        SearchManagerError, SearchProviderKind, SearchRequest, SearchResponse, SearchTruncation,
     };
     use crate::task::id::TaskId;
     use crate::workspaces::WorkspaceName;
@@ -845,7 +863,14 @@ mod tests {
                         coral.stream.name = "LIST CATALOG",
                     ))
                     .await;
-                Ok::<_, SearchManagerError>(())
+                Ok::<_, SearchManagerError>(RebuildSearchIndexResponse {
+                    results: vec![SearchMaintenanceResult {
+                        provider: SearchProviderKind::ObservedValues,
+                        state: SearchMaintenanceState::Partial,
+                        note: "maintenance partially completed".to_string(),
+                        detail: None,
+                    }],
+                })
             },
         )
         .await
@@ -895,6 +920,72 @@ mod tests {
             query_span.parent_span_id,
             maintenance_span.span_context.span_id()
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn search_maintenance_operation_records_failed_provider_as_an_error() {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("search-maintenance-provider-failure-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let _guard = tracing::subscriber::set_default(subscriber);
+        let failure_detail = "SENSITIVE_SEARCH_MAINTENANCE_FAILURE";
+
+        let response = run_search_maintenance_operation(
+            &WorkspaceName::default(),
+            REBUILD_SEARCH_INDEX_OPERATION,
+            async {
+                Ok::<_, SearchManagerError>(RebuildSearchIndexResponse {
+                    results: vec![SearchMaintenanceResult {
+                        provider: SearchProviderKind::ObservedValues,
+                        state: SearchMaintenanceState::Failed,
+                        note: failure_detail.to_string(),
+                        detail: None,
+                    }],
+                })
+            },
+        )
+        .await
+        .expect("maintenance response should preserve provider results");
+
+        let provider_result = response
+            .results
+            .first()
+            .expect("failed provider result preserved");
+        assert_eq!(provider_result.state, SearchMaintenanceState::Failed);
+        assert_eq!(provider_result.note, failure_detail);
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        let maintenance_span = spans
+            .iter()
+            .find(|span| span.name == "coral.search.maintenance")
+            .expect("search maintenance span recorded");
+        let attribute = |name: &str| {
+            maintenance_span
+                .attributes
+                .iter()
+                .find(|attribute| attribute.key.as_str() == name)
+                .unwrap_or_else(|| panic!("missing {name} attribute"))
+        };
+
+        assert_eq!(attribute("status").value.as_str(), "error");
+        assert_eq!(
+            attribute("error.type").value.as_str(),
+            SEARCH_MAINTENANCE_PROVIDER_FAILURE_ERROR_TYPE
+        );
+        assert_eq!(
+            attribute("exception.message").value.as_str(),
+            SEARCH_MAINTENANCE_TELEMETRY_ERROR_MESSAGE
+        );
+        assert_eq!(
+            maintenance_span.status,
+            OtelStatus::error(SEARCH_MAINTENANCE_TELEMETRY_ERROR_MESSAGE)
+        );
+        assert!(!format!("{maintenance_span:?}").contains(failure_detail));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -609,7 +609,6 @@ fn create_search_span(request: &SearchRequest, task_id: Option<&TaskId>) -> trac
         coral.stream.entry = true,
         coral.stream.kind = coral_telemetry::QUERY_STREAM_KIND_SEARCH,
         coral.stream.name = "search",
-        coral.local.search.query = field::Empty,
         otel.name = "coral.search",
         operation = "search",
         workspace = field::Empty,

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -12,7 +12,7 @@ use crate::bootstrap::AppError;
 use crate::catalog::discovery::CatalogDiscovery;
 use crate::catalog::model::CatalogResolution;
 use crate::query::QueryAttribution;
-use crate::query::manager::{QueryManagerError, app_error_type};
+use crate::query::manager::QueryManagerError;
 use crate::search::catalog::provider::{CatalogMetadataProvider, catalog_clear_provider_result};
 use crate::search::engine::UniversalSearchEngine;
 use crate::search::maintenance::{
@@ -39,7 +39,7 @@ use crate::search::sqlite_store::{
 use crate::sources::materialization::SourceDiagnosticReporter;
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::task::id::TaskId;
-use crate::telemetry::{WORKSPACE_SPAN_ATTRIBUTE, record_local_only_span_attribute};
+use crate::telemetry::{app_error_type, record_local_only_span_attribute};
 use crate::workspaces::{
     WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceManager, WorkspaceName,
 };
@@ -593,10 +593,11 @@ where
             span.set_status(OtelStatus::Ok);
         }
         Err(SearchManagerError::App(error)) => {
-            span.record("error.type", app_error_type(error));
-            span.record("exception.message", SEARCH_TELEMETRY_ERROR_MESSAGE);
-            span.record("status", "error");
-            span.set_status(OtelStatus::error(SEARCH_TELEMETRY_ERROR_MESSAGE));
+            coral_telemetry::record_failure(
+                &span,
+                app_error_type(error),
+                SEARCH_TELEMETRY_ERROR_MESSAGE,
+            );
         }
     }
     result
@@ -625,7 +626,10 @@ fn create_search_span(request: &SearchRequest, task_id: Option<&TaskId>) -> trac
         coral_telemetry::QUERY_STREAM_SEARCH_QUERY_ATTRIBUTE,
         request.query.as_str(),
     );
-    span.record(WORKSPACE_SPAN_ATTRIBUTE, request.workspace_name.as_str());
+    span.record(
+        coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE,
+        request.workspace_name.as_str(),
+    );
     if let Some(task_id) = task_id {
         span.record("task.id", field::display(task_id));
     }

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -19,8 +19,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue, json};
 use tokio::task;
 
+use coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE;
+
 use crate::storage::fs as storage_fs;
-use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
 
 const JSONL_MAX_FILE_BYTES: u64 = 16 * 1024 * 1024;
 const JSONL_MAX_FILE_ROWS: usize = 50_000;
@@ -1976,7 +1977,7 @@ mod tests {
         JSONL_MAX_FILE_AGE, JsonlSpanExporter, RollingJsonlWriter, StoredTraceStatus,
         TraceSpanRecord, TraceStore, unix_nanos,
     };
-    use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
+    use coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE;
 
     const TRACE_RETENTION: Duration = Duration::from_hours(7 * 24);
 

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -1608,13 +1608,7 @@ fn summary_from_list_aggregate(
         },
         |primary| {
             let attributes = parse_attributes(&primary.attributes_json);
-            let status = status_from_attributes(attributes.as_ref()).unwrap_or_else(|| {
-                if primary.status == StoredTraceStatus::Unspecified {
-                    fallback_status
-                } else {
-                    primary.status
-                }
-            });
+            let status = summary_status(aggregate, attributes.as_ref(), primary.status);
             let row_count = attributes
                 .as_ref()
                 .and_then(|attrs| attr_u64(attrs, "row_count"));
@@ -1668,13 +1662,7 @@ fn summary_from_aggregate(
         },
         |primary| {
             let attributes = parse_attributes(&primary.attributes_json);
-            let status = status_from_attributes(attributes.as_ref()).unwrap_or_else(|| {
-                if primary.status == StoredTraceStatus::Unspecified {
-                    fallback_status
-                } else {
-                    primary.status
-                }
-            });
+            let status = summary_status(aggregate, attributes.as_ref(), primary.status);
             let row_count = attributes
                 .as_ref()
                 .and_then(|attrs| attr_u64(attrs, "row_count"));
@@ -1697,6 +1685,18 @@ fn summary_from_aggregate(
             }
         },
     )
+}
+
+fn summary_status(
+    aggregate: &TraceAggregate,
+    primary_attributes: Option<&JsonValue>,
+    primary_status: StoredTraceStatus,
+) -> StoredTraceStatus {
+    if aggregate.error_count > 0 {
+        StoredTraceStatus::Error
+    } else {
+        status_from_attributes(primary_attributes).unwrap_or(primary_status)
+    }
 }
 
 fn span_record(resource_json: &str, span: &SpanData) -> TraceSpanRecord {
@@ -2118,6 +2118,51 @@ mod tests {
             detail.spans.first().expect("trace span").span_id,
             summary.root_span_id
         );
+    }
+
+    #[test]
+    fn trace_summary_reports_error_when_a_later_query_in_the_trace_fails() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+
+        let mut tool = trace_record("mixed-batch", "tool");
+        tool.name = "coral.mcp.call_tool".to_string();
+        tool.status = StoredTraceStatus::Unspecified;
+        tool.start_time_unix_nanos = 1;
+        tool.end_time_unix_nanos = 6;
+
+        let mut first_query = trace_record("mixed-batch", "first-query");
+        first_query.parent_span_id = Some(tool.span_id.clone());
+        first_query.attributes_json = r#"{"sql":"SELECT 1","status":"ok"}"#.to_string();
+        first_query.start_time_unix_nanos = 2;
+        first_query.end_time_unix_nanos = 3;
+
+        let mut failed_query = trace_record("mixed-batch", "failed-query");
+        failed_query.parent_span_id = Some(tool.span_id.clone());
+        failed_query.status = StoredTraceStatus::Error;
+        failed_query.attributes_json = r#"{"sql":"SELECT missing","status":"error"}"#.to_string();
+        failed_query.start_time_unix_nanos = 4;
+        failed_query.end_time_unix_nanos = 5;
+
+        write_record_file_lines(
+            &dir.join(timestamped_jsonl_path(SystemTime::now())),
+            &[tool, first_query, failed_query],
+        );
+
+        let store = TraceStore::new(dir);
+        let summary = store
+            .list_traces_sync(10, 0)
+            .expect("list traces")
+            .into_iter()
+            .next()
+            .expect("trace summary");
+        let detail = store.get_trace_sync("mixed-batch").expect("trace detail");
+
+        assert_eq!(summary.root_span_id, "first-query");
+        assert_eq!(summary.query, "SELECT 1");
+        assert_eq!(summary.status, StoredTraceStatus::Error);
+        assert_eq!(detail.summary.status, StoredTraceStatus::Error);
     }
 
     #[test]

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -46,11 +46,39 @@ static METER_PROVIDER: Mutex<Option<SdkMeterProvider>> = Mutex::new(None);
 
 const METRICS_INTERVAL: Duration = Duration::from_secs(5);
 const OTLP_TRACE_DENIED_TARGETS: &[&str] = &["coral.http.body", "coral.mcp.body"];
+const OTLP_STRIPPED_SPAN_ATTRIBUTE_PREFIXES: &[&str] =
+    &[coral_telemetry::LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX];
 const LOCAL_TRACE_EXCLUDED_RPC_SERVICES: &[&str] = &["coral.v1.TraceService"];
 pub(crate) const QUERY_TRACE_SOURCES_ATTR: &str = "coral.query.sources";
 pub(crate) const QUERY_TRACE_TABLES_ATTR: &str = "coral.query.tables";
 pub(crate) const QUERY_TRACE_TABLE_FUNCTIONS_ATTR: &str = "coral.query.table_functions";
 pub(crate) const WORKSPACE_SPAN_ATTRIBUTE: &str = "workspace";
+
+/// Records a span attribute only when Coral owns an installed local trace store.
+///
+/// The field must also use the local-only prefix so Coral's OTLP exporter strips
+/// it when local trace history and OTLP export are enabled together.
+pub(crate) fn record_local_only_span_attribute(
+    span: &tracing::Span,
+    field: &'static str,
+    value: &str,
+) {
+    let is_local_only = field.starts_with(coral_telemetry::LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX);
+    debug_assert!(
+        is_local_only,
+        "local-only attribute must use the reserved prefix"
+    );
+    if !is_local_only {
+        return;
+    }
+    let local_trace_store_is_installed = INIT
+        .get()
+        .and_then(|state| state.as_ref().ok())
+        .is_some_and(|state| state.local_trace_store.is_some());
+    if local_trace_store_is_installed {
+        span.record(field, value);
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct InstalledLocalTraceStore {
@@ -75,6 +103,7 @@ struct TargetFilteringSpanExporter<E> {
     targets: Targets,
     denied_targets: &'static [&'static str],
     excluded_rpc_services: &'static [&'static str],
+    stripped_attribute_prefixes: &'static [&'static str],
 }
 
 impl<E> TargetFilteringSpanExporter<E> {
@@ -84,6 +113,7 @@ impl<E> TargetFilteringSpanExporter<E> {
             targets,
             denied_targets: &[],
             excluded_rpc_services: &[],
+            stripped_attribute_prefixes: &[],
         }
     }
 
@@ -94,6 +124,11 @@ impl<E> TargetFilteringSpanExporter<E> {
 
     fn excluding_rpc_services(mut self, services: &'static [&'static str]) -> Self {
         self.excluded_rpc_services = services;
+        self
+    }
+
+    fn stripping_attribute_prefixes(mut self, prefixes: &'static [&'static str]) -> Self {
+        self.stripped_attribute_prefixes = prefixes;
         self
     }
 }
@@ -108,6 +143,14 @@ where
                 && !span_matches_denied_target(span, self.denied_targets)
                 && !span_matches_excluded_rpc_service(span, self.excluded_rpc_services)
         });
+        for span in &mut batch {
+            span.attributes.retain(|attribute| {
+                !self
+                    .stripped_attribute_prefixes
+                    .iter()
+                    .any(|prefix| attribute.key.as_str().starts_with(prefix))
+            });
+        }
         if batch.is_empty() {
             return Ok(());
         }
@@ -302,7 +345,8 @@ fn build_otlp_trace_exporter(
         .build()
         .map_err(|e| AppError::InvalidInput(e.to_string()))?;
     Ok(TargetFilteringSpanExporter::new(exporter, targets)
-        .denying_targets(OTLP_TRACE_DENIED_TARGETS))
+        .denying_targets(OTLP_TRACE_DENIED_TARGETS)
+        .stripping_attribute_prefixes(OTLP_STRIPPED_SPAN_ATTRIBUTE_PREFIXES))
 }
 
 fn add_otlp_trace_exporter(
@@ -626,9 +670,9 @@ mod tests {
 
     use super::{
         DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTER,
-        LOCAL_TRACE_EXCLUDED_RPC_SERVICES, OTLP_TRACE_DENIED_TARGETS, TargetFilteringSpanExporter,
-        build_log_filter, build_trace_targets, normalize_otlp_endpoint, parse_headers,
-        trace_layer_filter,
+        LOCAL_TRACE_EXCLUDED_RPC_SERVICES, OTLP_STRIPPED_SPAN_ATTRIBUTE_PREFIXES,
+        OTLP_TRACE_DENIED_TARGETS, TargetFilteringSpanExporter, build_log_filter,
+        build_trace_targets, normalize_otlp_endpoint, parse_headers, trace_layer_filter,
     };
 
     #[test]
@@ -799,6 +843,50 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(span_names, vec!["kept"]);
+        provider.shutdown().expect("provider shutdown");
+    }
+
+    #[test]
+    fn target_filtering_exporter_strips_local_only_span_attributes() {
+        let memory = InMemorySpanExporter::default();
+        let (targets, error) = build_trace_targets("coral_app=trace", DEFAULT_TRACE_FILTER);
+        assert!(error.is_none());
+        let exporter = TargetFilteringSpanExporter::new(memory.clone(), targets)
+            .stripping_attribute_prefixes(OTLP_STRIPPED_SPAN_ATTRIBUTE_PREFIXES);
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter)
+            .build();
+        let tracer = provider.tracer("local-only-attribute-test");
+        let layer = tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_level(true);
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::trace_span!(
+                target: "coral_app",
+                "search",
+                public = "kept",
+                coral.local.search.query = "LOCAL_ONLY_SENTINEL",
+            );
+            let _span = span.enter();
+        });
+        provider.force_flush().expect("flush spans");
+
+        let spans = memory.get_finished_spans().expect("finished spans");
+        let span = spans.first().expect("exported span");
+        assert!(
+            span.attributes
+                .iter()
+                .any(|attribute| attribute.key.as_str() == "public")
+        );
+        assert!(span.attributes.iter().all(|attribute| {
+            !attribute
+                .key
+                .as_str()
+                .starts_with(coral_telemetry::LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX)
+        }));
+        assert!(!format!("{span:?}").contains("LOCAL_ONLY_SENTINEL"));
         provider.shutdown().expect("provider shutdown");
     }
 

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -730,11 +730,17 @@ mod tests {
 
     impl std::io::Write for CapturedWriter {
         fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
-            self.0.lock().expect("capture lock").write(bytes)
+            self.0
+                .lock()
+                .map_err(|_error| std::io::Error::other("capture lock poisoned"))?
+                .write(bytes)
         }
 
         fn flush(&mut self) -> std::io::Result<()> {
-            self.0.lock().expect("capture lock").flush()
+            self.0
+                .lock()
+                .map_err(|_error| std::io::Error::other("capture lock poisoned"))?
+                .flush()
         }
     }
 
@@ -917,7 +923,7 @@ mod tests {
     }
 
     #[test]
-    fn target_filtering_exporter_strips_local_only_span_attributes() {
+    fn target_filtering_exporter_strips_local_only_trace_attributes() {
         let local_memory = InMemorySpanExporter::default();
         let memory = InMemorySpanExporter::default();
         let (targets, error) = build_trace_targets("coral_app=trace", DEFAULT_TRACE_FILTER);

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -6,9 +6,9 @@ use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
-use opentelemetry::Value as OtelValue;
 use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
+use opentelemetry::{KeyValue as OtelKeyValue, Value as OtelValue};
 use opentelemetry_otlp::{
     LogExporter, MetricExporter, SpanExporter as OtlpSpanExporter, WithExportConfig, WithHttpConfig,
 };
@@ -114,7 +114,7 @@ pub(crate) fn record_local_only_span_attribute(
         .and_then(|state| state.as_ref().ok())
         .is_some_and(|state| state.local_trace_store.is_some());
     if local_trace_store_is_installed {
-        span.record(field, value);
+        span.set_attribute(field, value.to_owned());
     }
 }
 
@@ -182,12 +182,19 @@ where
                 && !span_matches_excluded_rpc_service(span, self.excluded_rpc_services)
         });
         for span in &mut batch {
-            span.attributes.retain(|attribute| {
-                !self
-                    .stripped_attribute_prefixes
-                    .iter()
-                    .any(|prefix| attribute.key.as_str().starts_with(prefix))
-            });
+            strip_attributes_with_prefixes(&mut span.attributes, self.stripped_attribute_prefixes);
+            for event in &mut span.events.events {
+                strip_attributes_with_prefixes(
+                    &mut event.attributes,
+                    self.stripped_attribute_prefixes,
+                );
+            }
+            for link in &mut span.links.links {
+                strip_attributes_with_prefixes(
+                    &mut link.attributes,
+                    self.stripped_attribute_prefixes,
+                );
+            }
         }
         if batch.is_empty() {
             return Ok(());
@@ -209,6 +216,14 @@ where
     fn set_resource(&mut self, resource: &opentelemetry_sdk::Resource) {
         self.inner.set_resource(resource);
     }
+}
+
+fn strip_attributes_with_prefixes(attributes: &mut Vec<OtelKeyValue>, prefixes: &[&str]) {
+    attributes.retain(|attribute| {
+        !prefixes
+            .iter()
+            .any(|prefix| attribute.key.as_str().starts_with(prefix))
+    });
 }
 
 fn span_matches_targets(span: &SpanData, targets: &Targets) -> bool {
@@ -701,10 +716,27 @@ pub fn shutdown_tracing() {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
 
+    use opentelemetry::KeyValue;
     use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceId, TraceState};
     use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
     use tracing_subscriber::layer::SubscriberExt as _;
+
+    #[derive(Clone)]
+    struct CapturedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CapturedWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().expect("capture lock").write(bytes)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.0.lock().expect("capture lock").flush()
+        }
+    }
 
     use super::{
         DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTER,
@@ -886,12 +918,14 @@ mod tests {
 
     #[test]
     fn target_filtering_exporter_strips_local_only_span_attributes() {
+        let local_memory = InMemorySpanExporter::default();
         let memory = InMemorySpanExporter::default();
         let (targets, error) = build_trace_targets("coral_app=trace", DEFAULT_TRACE_FILTER);
         assert!(error.is_none());
         let exporter = TargetFilteringSpanExporter::new(memory.clone(), targets)
             .stripping_attribute_prefixes(OTLP_STRIPPED_SPAN_ATTRIBUTE_PREFIXES);
         let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(local_memory.clone())
             .with_simple_exporter(exporter)
             .build();
         let tracer = provider.tracer("local-only-attribute-test");
@@ -905,11 +939,40 @@ mod tests {
                 target: "coral_app",
                 "search",
                 public = "kept",
-                coral.local.search.query = "LOCAL_ONLY_SENTINEL",
+            );
+            span.set_attribute(
+                coral_telemetry::QUERY_STREAM_SEARCH_QUERY_ATTRIBUTE,
+                "LOCAL_ONLY_SENTINEL",
+            );
+            span.add_event(
+                "search event",
+                vec![
+                    KeyValue::new("event.public", "kept"),
+                    KeyValue::new("coral.local.event.detail", "LOCAL_ONLY_EVENT_SENTINEL"),
+                ],
+            );
+            span.add_link_with_attributes(
+                SpanContext::new(
+                    TraceId::from(1),
+                    SpanId::from(2),
+                    TraceFlags::SAMPLED,
+                    false,
+                    TraceState::default(),
+                ),
+                vec![
+                    KeyValue::new("link.public", "kept"),
+                    KeyValue::new("coral.local.link.detail", "LOCAL_ONLY_LINK_SENTINEL"),
+                ],
             );
             let _span = span.enter();
         });
         provider.force_flush().expect("flush spans");
+
+        let local_spans = local_memory.get_finished_spans().expect("local spans");
+        let local_span = local_spans.first().expect("locally exported span");
+        assert!(format!("{local_span:?}").contains("LOCAL_ONLY_SENTINEL"));
+        assert!(format!("{local_span:?}").contains("LOCAL_ONLY_EVENT_SENTINEL"));
+        assert!(format!("{local_span:?}").contains("LOCAL_ONLY_LINK_SENTINEL"));
 
         let spans = memory.get_finished_spans().expect("finished spans");
         let span = spans.first().expect("exported span");
@@ -924,7 +987,60 @@ mod tests {
                 .as_str()
                 .starts_with(coral_telemetry::LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX)
         }));
+        assert!(
+            span.events
+                .events
+                .iter()
+                .all(|event| event.attributes.iter().all(|attribute| !attribute
+                    .key
+                    .as_str()
+                    .starts_with(coral_telemetry::LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX)))
+        );
+        assert!(
+            span.links
+                .links
+                .iter()
+                .all(|link| link.attributes.iter().all(|attribute| !attribute
+                    .key
+                    .as_str()
+                    .starts_with(coral_telemetry::LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX)))
+        );
         assert!(!format!("{span:?}").contains("LOCAL_ONLY_SENTINEL"));
+        assert!(!format!("{span:?}").contains("LOCAL_ONLY_EVENT_SENTINEL"));
+        assert!(!format!("{span:?}").contains("LOCAL_ONLY_LINK_SENTINEL"));
+        provider.shutdown().expect("provider shutdown");
+    }
+
+    #[test]
+    fn direct_otel_span_attributes_are_not_formatted_as_logs() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let output_writer = output.clone();
+        let memory = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(memory)
+            .build();
+        let tracer = provider.tracer("local-only-format-test");
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .compact()
+                    .with_writer(move || CapturedWriter(output_writer.clone())),
+            )
+            .with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("search", public = "kept");
+            span.set_attribute(
+                coral_telemetry::QUERY_STREAM_SEARCH_QUERY_ATTRIBUTE,
+                "LOCAL_ONLY_STDERR_SENTINEL",
+            );
+            span.in_scope(|| tracing::warn!("provider task failed"));
+        });
+
+        let formatted = String::from_utf8(output.lock().expect("capture lock").clone())
+            .expect("formatter output is utf-8");
+        assert!(formatted.contains("provider task failed"));
+        assert!(!formatted.contains("LOCAL_ONLY_STDERR_SENTINEL"));
         provider.shutdown().expect("provider shutdown");
     }
 

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -52,7 +52,45 @@ const LOCAL_TRACE_EXCLUDED_RPC_SERVICES: &[&str] = &["coral.v1.TraceService"];
 pub(crate) const QUERY_TRACE_SOURCES_ATTR: &str = "coral.query.sources";
 pub(crate) const QUERY_TRACE_TABLES_ATTR: &str = "coral.query.tables";
 pub(crate) const QUERY_TRACE_TABLE_FUNCTIONS_ATTR: &str = "coral.query.table_functions";
-pub(crate) const WORKSPACE_SPAN_ATTRIBUTE: &str = "workspace";
+
+pub(crate) fn app_error_type(error: &AppError) -> &'static str {
+    match error {
+        AppError::Unauthenticated(_) => "UNAUTHENTICATED",
+        AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
+        AppError::FunctionNotFound(_) => "FUNCTION_NOT_FOUND",
+        AppError::FunctionAlreadyExists(_) => "FUNCTION_ALREADY_EXISTS",
+        AppError::WorkspaceNotFound(_) => "WORKSPACE_NOT_FOUND",
+        AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",
+        AppError::InvalidInput(_) => "INVALID_INPUT",
+        AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
+        AppError::MissingSourceInputs { .. } => "MISSING_SOURCE_INPUTS",
+        AppError::UnsupportedV4IdentityRequirements { .. } => {
+            "UNSUPPORTED_V4_IDENTITY_REQUIREMENTS"
+        }
+        AppError::MissingOrIncompatibleV4Materialization { .. } => {
+            "MISSING_OR_INCOMPATIBLE_V4_MATERIALIZATION"
+        }
+        AppError::IncompatibleInstalledV4Manifest { .. } => "INCOMPATIBLE_INSTALLED_V4_MANIFEST",
+        AppError::InvalidV4ProjectionOverride { .. } => "INVALID_V4_PROJECTION_OVERRIDE",
+        AppError::InvalidV4OperationMetadataOverride { .. } => {
+            "INVALID_V4_OPERATION_METADATA_OVERRIDE"
+        }
+        AppError::CredentialRefresh(_) => "CREDENTIAL_REFRESH",
+        AppError::Unavailable(_) => "UNAVAILABLE",
+        AppError::ResourceExhausted(_) => "RESOURCE_EXHAUSTED",
+        AppError::Internal(_) => "INTERNAL",
+        AppError::Io(_) => "IO",
+        AppError::Yaml(_) => "YAML",
+        AppError::TomlDecode(_) | AppError::TomlEditDecode(_) => "TOML_DECODE",
+        AppError::TomlEncode(_) => "TOML_ENCODE",
+        AppError::Json(_) => "JSON",
+        AppError::Transport(_) => "TRANSPORT",
+        AppError::TaskJoin(_) => "TASK_JOIN",
+        AppError::Credentials(_) => "CREDENTIALS",
+        AppError::Database(_) => "DATABASE",
+        AppError::MissingConfigDir => "MISSING_CONFIG_DIR",
+    }
+}
 
 /// Records a span attribute only when Coral owns an installed local trace store.
 ///

--- a/crates/coral-app/tests/telemetry_host_subscriber.rs
+++ b/crates/coral-app/tests/telemetry_host_subscriber.rs
@@ -1,4 +1,4 @@
-//! Pins the host-owned subscriber policy.
+//! Pins the host-owned subscriber startup and local-only attribute policies.
 //!
 //! `init_tracing` installs coral-app's own tracing subscriber as a side effect
 //! of `ServerBuilder::start`. When the host process has already installed a
@@ -6,6 +6,10 @@
 //! fail startup — telemetry init becomes a no-op (an explanatory warning is
 //! logged through the host's subscriber) and the gRPC server bootstraps
 //! normally.
+//!
+//! A host-owned subscriber still receives Coral's public spans, but Coral must
+//! not write local-only attributes into it because the host owns that
+//! subscriber's storage, retention, and deletion behavior.
 //!
 //! This test must live in its own integration test binary: `init_tracing`
 //! caches its outcome in a process-global `OnceLock`, so co-locating this
@@ -31,7 +35,7 @@ use tracing_subscriber::util::SubscriberInitExt as _;
 const SEARCH_SENTINEL: &str = "HOST_SUBSCRIBER_LOCAL_SEARCH_SENTINEL";
 
 #[tokio::test]
-async fn host_subscriber_does_not_block_server_startup() {
+async fn host_subscriber_keeps_server_available_without_local_only_attributes() {
     let exporter = InMemorySpanExporter::default();
     let provider = SdkTracerProvider::builder()
         .with_simple_exporter(exporter.clone())

--- a/crates/coral-app/tests/telemetry_host_subscriber.rs
+++ b/crates/coral-app/tests/telemetry_host_subscriber.rs
@@ -18,16 +18,27 @@
 )]
 
 use coral_api::v1::trace_service_client::TraceServiceClient;
-use coral_api::v1::{ListSourcesRequest, ListTracesRequest};
+use coral_api::v1::{ListSourcesRequest, ListTracesRequest, SearchRequest};
 use coral_client::{AppClient, default_workspace, local::ServerBuilder};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
 use tempfile::TempDir;
 use tonic::transport::Endpoint;
 use tonic::{Code, Request};
+use tracing_subscriber::layer::SubscriberExt as _;
 use tracing_subscriber::util::SubscriberInitExt as _;
+
+const SEARCH_SENTINEL: &str = "HOST_SUBSCRIBER_LOCAL_SEARCH_SENTINEL";
 
 #[tokio::test]
 async fn host_subscriber_does_not_block_server_startup() {
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = provider.tracer("host-subscriber-privacy-test");
     tracing_subscriber::registry()
+        .with(tracing_opentelemetry::layer().with_tracer(tracer))
         .try_init()
         .expect("install host subscriber once per test process");
 
@@ -54,6 +65,31 @@ async fn host_subscriber_does_not_block_server_startup() {
         .sources;
     assert!(sources.is_empty());
 
+    app.search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: SEARCH_SENTINEL.to_string(),
+            limit: 0,
+        }))
+        .await
+        .expect("search empty catalog");
+
+    provider.force_flush().expect("flush host spans");
+    let spans = exporter.get_finished_spans().expect("finished host spans");
+    assert!(
+        spans.iter().any(|span| span.name == "coral.search"),
+        "the host subscriber should still receive the public Search span"
+    );
+    assert!(spans.iter().all(|span| {
+        span.attributes.iter().all(|attribute| {
+            !attribute
+                .key
+                .as_str()
+                .starts_with(coral_telemetry::LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX)
+        })
+    }));
+    assert!(!format!("{spans:?}").contains(SEARCH_SENTINEL));
+
     let channel = Endpoint::from_shared(server.endpoint_uri().to_string())
         .expect("endpoint")
         .connect()
@@ -70,4 +106,5 @@ async fn host_subscriber_does_not_block_server_startup() {
     assert_eq!(trace_status.code(), Code::Unimplemented);
 
     server.shutdown().await.expect("shutdown server");
+    provider.shutdown().expect("shutdown host provider");
 }

--- a/crates/coral-app/tests/telemetry_otlp_loopback.rs
+++ b/crates/coral-app/tests/telemetry_otlp_loopback.rs
@@ -20,11 +20,12 @@ use tonic::Request;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, Request as WiremockRequest, ResponseTemplate};
 
-use coral_api::v1::ExecuteSqlRequest;
+use coral_api::v1::{ExecuteSqlRequest, SearchRequest};
 use coral_app::{ServerBuilder, shutdown_tracing};
 use coral_client::{AppClient, decode_execute_sql_response, default_workspace};
 
 const LOCAL_ONLY_SENTINEL: &str = "LOCAL_ONLY_FUTURE_TOOL_SENTINEL";
+const SEARCH_QUERY_SENTINEL: &str = "LOCAL_ONLY_SEARCH_QUERY_SENTINEL";
 
 #[tokio::test]
 async fn otlp_export_loopback_covers_traces_logs_and_metrics() {
@@ -115,6 +116,15 @@ async fn emit_test_telemetry(endpoint_uri: &str) {
         .into_inner();
     let result = decode_execute_sql_response(&response).expect("decode loopback query");
     assert_eq!(result.row_count(), 1);
+
+    app.search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: SEARCH_QUERY_SENTINEL.to_string(),
+            limit: 0,
+        }))
+        .await
+        .expect("search empty catalog");
 
     let query = tracing::info_span!(
         target: "coral_app",
@@ -231,6 +241,10 @@ fn assert_exported_trace_contract(trace_exports: &[ExportTraceServiceRequest], s
         trace_exports,
         LOCAL_ONLY_SENTINEL
     ));
+    assert!(!trace_exports_contain_string(
+        trace_exports,
+        SEARCH_QUERY_SENTINEL
+    ));
     assert!(spans.iter().all(|span| {
         span.attributes.iter().all(|attribute| {
             !attribute
@@ -256,6 +270,11 @@ fn assert_exported_log_contract(logs: &[LogRecord]) {
         logs.iter()
             .any(|log| log_contains_string(log, "loopback-log-value")),
         "OTLP log export should keep application log attributes: {logs:?}"
+    );
+    assert!(
+        logs.iter()
+            .all(|log| !log_contains_string(log, SEARCH_QUERY_SENTINEL)),
+        "OTLP logs must not contain local-only Search text: {logs:?}"
     );
 }
 
@@ -345,6 +364,7 @@ fn assert_local_trace_history_contract(local_trace_history: &str) {
         "loopback_mcp_body",
         "mcp-body-secret",
         LOCAL_ONLY_SENTINEL,
+        SEARCH_QUERY_SENTINEL,
     ] {
         assert!(
             local_trace_history.contains(expected),

--- a/crates/coral-app/tests/telemetry_otlp_loopback.rs
+++ b/crates/coral-app/tests/telemetry_otlp_loopback.rs
@@ -24,6 +24,8 @@ use coral_api::v1::ExecuteSqlRequest;
 use coral_app::{ServerBuilder, shutdown_tracing};
 use coral_client::{AppClient, decode_execute_sql_response, default_workspace};
 
+const LOCAL_ONLY_SENTINEL: &str = "LOCAL_ONLY_FUTURE_TOOL_SENTINEL";
+
 #[tokio::test]
 async fn otlp_export_loopback_covers_traces_logs_and_metrics() {
     let collector = MockServer::start().await;
@@ -118,6 +120,7 @@ async fn emit_test_telemetry(endpoint_uri: &str) {
         target: "coral_app",
         "loopback_query",
         sql = "SELECT 'secret-loopback-sql'",
+        coral.local.future_tool.input = LOCAL_ONLY_SENTINEL,
         status = "ok"
     );
     let _query = query.enter();
@@ -224,6 +227,17 @@ fn assert_exported_trace_contract(trace_exports: &[ExportTraceServiceRequest], s
         trace_exports,
         "mcp-body-secret"
     ));
+    assert!(!trace_exports_contain_string(
+        trace_exports,
+        LOCAL_ONLY_SENTINEL
+    ));
+    assert!(spans.iter().all(|span| {
+        span.attributes.iter().all(|attribute| {
+            !attribute
+                .key
+                .starts_with(coral_telemetry::LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX)
+        })
+    }));
     for expected in ["loopback.log", "loopback-log-value"] {
         assert!(
             trace_exports_contain_string(trace_exports, expected),
@@ -330,6 +344,7 @@ fn assert_local_trace_history_contract(local_trace_history: &str) {
         "trace-body-secret",
         "loopback_mcp_body",
         "mcp-body-secret",
+        LOCAL_ONLY_SENTINEL,
     ] {
         assert!(
             local_trace_history.contains(expected),

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -30,6 +30,7 @@ use tonic::{
     Request,
     metadata::{Ascii, MetadataValue},
 };
+use tracing::Instrument as _;
 
 use crate::{
     McpOptions, McpQueryExample,
@@ -556,13 +557,16 @@ impl CoralMcpServer {
             let server = self.clone();
             let task_id_metadata = task_id_metadata.clone();
             let shown_guide_ids = shown_guide_ids.clone();
-            tasks.spawn(async move {
-                with_task_metadata(
-                    task_id_metadata,
-                    server.execute_one_sql_query(index, sql, shown_guide_ids),
-                )
-                .await
-            });
+            tasks.spawn(
+                async move {
+                    with_task_metadata(
+                        task_id_metadata,
+                        server.execute_one_sql_query(index, sql, shown_guide_ids),
+                    )
+                    .await
+                }
+                .in_current_span(),
+            );
         }
 
         let mut results = Vec::new();
@@ -763,14 +767,9 @@ impl CoralMcpServer {
         request: CallToolRequestParams,
         task_id: Option<TaskId>,
         task_id_metadata: Option<MetadataValue<Ascii>>,
+        tool_name: Option<ToolName>,
     ) -> Result<ToolCallOutcome, ErrorData> {
-        let Some(tool) = request
-            .name
-            .as_ref()
-            .parse::<ToolName>()
-            .ok()
-            .filter(|tool| self.tool_allowed(*tool))
-        else {
+        let Some(tool) = tool_name.filter(|tool| self.tool_allowed(*tool)) else {
             return Err(ErrorData::invalid_params(
                 format!("tool '{}' not found", request.name),
                 None,
@@ -971,9 +970,12 @@ impl ServerHandler for CoralMcpServer {
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
-        let span =
-            telemetry::call_tool_span(request.name.as_ref(), self.options.trace_parent.as_deref());
         let tool_name = request.name.as_ref().parse::<ToolName>().ok();
+        let span = telemetry::call_tool_span(
+            tool_name,
+            &self.workspace().name,
+            self.options.trace_parent.as_deref(),
+        );
         let inject_task_metadata =
             !matches!(tool_name, Some(ToolName::StartTask | ToolName::EndTask));
         let task_context = TaskCallContext::from_tool_request(
@@ -993,7 +995,7 @@ impl ServerHandler for CoralMcpServer {
                     span.clone(),
                     with_task_metadata(
                         task_id_metadata,
-                        self.dispatch_tool(request, task_id, dispatch_task_id_metadata),
+                        self.dispatch_tool(request, task_id, dispatch_task_id_metadata, tool_name),
                     ),
                 )
                 .await;
@@ -1295,7 +1297,7 @@ mod tool_call_telemetry_tests {
     use tracing_subscriber::layer::SubscriberExt as _;
 
     use super::finish_tool_call;
-    use crate::surface::list_catalog_arguments;
+    use crate::surface::{ToolName, list_catalog_arguments};
     use crate::telemetry::{self, MCP_PROTOCOL_ERROR_MESSAGE};
 
     #[test]
@@ -1314,7 +1316,7 @@ mod tool_call_telemetry_tests {
         let Err(error) = list_catalog_arguments(Some(&arguments)) else {
             panic!("unknown list_catalog kind should fail argument parsing");
         };
-        let span = telemetry::call_tool_span("list_catalog", None);
+        let span = telemetry::call_tool_span(Some(ToolName::ListCatalog), "default", None);
         let returned = finish_tool_call(&span, Err(error))
             .expect_err("invalid list_catalog kind should remain a caller-visible protocol error");
         assert!(returned.message.contains(sentinel));

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -10,8 +10,11 @@ use rmcp::{ErrorData, model::ErrorCode};
 use tracing::{Instrument as _, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
+use crate::surface::ToolName;
+
 pub(crate) const MCP_PROTOCOL_ERROR_MESSAGE: &str = "MCP request failed";
 pub(crate) const MCP_TOOL_ERROR_MESSAGE: &str = "MCP tool call failed";
+pub(crate) const UNKNOWN_TOOL_NAME: &str = "unknown_tool";
 
 pub(crate) async fn instrument<T, F>(span: tracing::Span, future: F) -> T
 where
@@ -47,10 +50,18 @@ pub(crate) fn list_tools_span(trace_parent: Option<&str>) -> tracing::Span {
     span
 }
 
-pub(crate) fn call_tool_span(tool_name: &str, trace_parent: Option<&str>) -> tracing::Span {
+pub(crate) fn call_tool_span(
+    tool_name: Option<ToolName>,
+    workspace: &str,
+    trace_parent: Option<&str>,
+) -> tracing::Span {
+    let tool_name = tool_name.map_or(UNKNOWN_TOOL_NAME, ToolName::as_str);
     let span = tracing::info_span!(
         target: "coral_mcp::server",
         "coral.mcp.call_tool",
+        coral.stream.entry = true,
+        coral.stream.kind = coral_telemetry::QUERY_STREAM_KIND_TOOL,
+        coral.stream.name = tool_name,
         error.type = field::Empty,
         exception.message = field::Empty,
         mcp.method = "tools/call",
@@ -59,6 +70,7 @@ pub(crate) fn call_tool_span(tool_name: &str, trace_parent: Option<&str>) -> tra
         otel.name = "coral.mcp.call_tool",
         task.id = field::Empty,
         status = field::Empty,
+        workspace = workspace,
     );
     apply_trace_parent(&span, trace_parent);
     span
@@ -160,14 +172,18 @@ mod tests {
     use tonic_types::{ErrorDetail, StatusExt as _};
     use tracing_subscriber::layer::SubscriberExt as _;
 
-    use super::{MCP_TOOL_ERROR_MESSAGE, call_tool_span, record_tonic_status};
+    use super::{
+        MCP_TOOL_ERROR_MESSAGE, call_tool_span, list_resources_span, list_tools_span,
+        read_resource_span, record_tonic_status,
+    };
+    use crate::surface::ToolName;
 
     #[test]
-    fn tool_call_span_does_not_record_intent_or_arguments() {
+    fn tool_call_span_uses_the_canonical_tool_name() {
         let (exporter, provider, subscriber) = telemetry_fixture();
         let _guard = tracing::subscriber::set_default(subscriber);
 
-        let span = call_tool_span("future_tool", None);
+        let span = call_tool_span(Some(ToolName::ListCatalog), "alpha", None);
         span.in_scope(|| {});
         drop(span);
 
@@ -179,8 +195,24 @@ mod tests {
             .expect("tool call span");
 
         assert_eq!(
+            attribute(tool_call, coral_telemetry::QUERY_STREAM_ENTRY_ATTRIBUTE),
+            Some(&Value::Bool(true))
+        );
+        assert_eq!(
+            string_attribute(tool_call, coral_telemetry::QUERY_STREAM_KIND_ATTRIBUTE),
+            Some(coral_telemetry::QUERY_STREAM_KIND_TOOL.to_string())
+        );
+        assert_eq!(
+            string_attribute(tool_call, coral_telemetry::QUERY_STREAM_NAME_ATTRIBUTE),
+            Some("list_catalog".to_string())
+        );
+        assert_eq!(
+            string_attribute(tool_call, "workspace"),
+            Some("alpha".to_string())
+        );
+        assert_eq!(
             string_attribute(tool_call, "mcp.tool.name"),
-            Some("future_tool".to_string())
+            Some("list_catalog".to_string())
         );
         assert_eq!(attribute(tool_call, "mcp.tool.intent"), None);
         assert!(
@@ -199,7 +231,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
         let sentinel = "SENSITIVE_TONIC_ERROR_MARKER";
 
-        let span = call_tool_span("list_catalog", None);
+        let span = call_tool_span(Some(ToolName::ListCatalog), "default", None);
         record_tonic_status(
             &span,
             &tonic::Status::invalid_argument(format!("invalid kind: {sentinel}")),
@@ -246,7 +278,7 @@ mod tests {
             ))],
         );
 
-        let span = call_tool_span("list_catalog", None);
+        let span = call_tool_span(Some(ToolName::ListCatalog), "default", None);
         record_tonic_status(&span, &status);
         drop(span);
 
@@ -271,6 +303,40 @@ mod tests {
         provider.shutdown().expect("provider shutdown");
     }
 
+    #[test]
+    fn protocol_discovery_spans_are_not_stream_entries() {
+        let (exporter, provider, subscriber) = telemetry_fixture();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        for span in [
+            list_tools_span(None),
+            list_resources_span(None),
+            read_resource_span("coral://tables", None),
+        ] {
+            span.in_scope(|| {});
+        }
+
+        provider.force_flush().expect("flush spans");
+        let spans = exporter.get_finished_spans().expect("finished spans");
+        for name in [
+            "coral.mcp.list_tools",
+            "coral.mcp.list_resources",
+            "coral.mcp.read_resource",
+        ] {
+            let span = spans
+                .iter()
+                .find(|span| span.name == name)
+                .unwrap_or_else(|| panic!("missing {name} span"));
+            assert_eq!(
+                attribute(span, coral_telemetry::QUERY_STREAM_ENTRY_ATTRIBUTE),
+                None,
+                "{name} must remain protocol bookkeeping"
+            );
+        }
+
+        provider.shutdown().expect("provider shutdown");
+    }
+
     fn telemetry_fixture() -> (
         InMemorySpanExporter,
         SdkTracerProvider,
@@ -280,7 +346,7 @@ mod tests {
         let provider = SdkTracerProvider::builder()
             .with_simple_exporter(exporter.clone())
             .build();
-        let tracer = provider.tracer("mcp-error-privacy-test");
+        let tracer = provider.tracer("mcp-query-stream-test");
         let subscriber = tracing_subscriber::Registry::default()
             .with(tracing_opentelemetry::layer().with_tracer(tracer));
         (exporter, provider, subscriber)

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -70,8 +70,9 @@ pub(crate) fn call_tool_span(
         otel.name = "coral.mcp.call_tool",
         task.id = field::Empty,
         status = field::Empty,
-        workspace = workspace,
+        workspace = field::Empty,
     );
+    span.record(coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE, workspace);
     apply_trace_parent(&span, trace_parent);
     span
 }
@@ -207,7 +208,7 @@ mod tests {
             Some("list_catalog".to_string())
         );
         assert_eq!(
-            string_attribute(tool_call, "workspace"),
+            string_attribute(tool_call, coral_telemetry::WORKSPACE_SPAN_ATTRIBUTE),
             Some("alpha".to_string())
         );
         assert_eq!(

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -13,8 +13,8 @@ use coral_client::{
     local::{RunningServer, ServerBuilder},
 };
 use jsonschema::Validator;
-use opentelemetry::trace::{SpanKind, TracerProvider as _};
-use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+use opentelemetry::trace::{SpanId, SpanKind, TracerProvider as _};
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
 use rmcp::{
     RoleClient, ServerHandler, ServiceExt,
     model::{CallToolRequestParams, CallToolResult, ReadResourceRequestParams, Tool},
@@ -27,9 +27,39 @@ use tracing_subscriber::Layer as _;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::layer::SubscriberExt as _;
 
-use crate::{CoralMcpServerFactory, McpOptions};
+use crate::{
+    CoralMcpServerFactory, McpOptions,
+    telemetry::{MCP_PROTOCOL_ERROR_MESSAGE, UNKNOWN_TOOL_NAME},
+};
 
 type McpServerTask = tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>;
+
+fn span_string_attribute(span: &SpanData, name: &str) -> Option<String> {
+    span.attributes
+        .iter()
+        .find(|attribute| attribute.key.as_str() == name)
+        .map(|attribute| attribute.value.as_str().into_owned())
+}
+
+fn span_descends_from(spans: &[SpanData], span: &SpanData, ancestor_span_id: SpanId) -> bool {
+    let mut parent_span_id = span.parent_span_id;
+    for _ in 0..=spans.len() {
+        if parent_span_id == ancestor_span_id {
+            return true;
+        }
+        if parent_span_id == SpanId::INVALID {
+            return false;
+        }
+        let Some(parent) = spans
+            .iter()
+            .find(|candidate| candidate.span_context.span_id() == parent_span_id)
+        else {
+            return false;
+        };
+        parent_span_id = parent.parent_span_id;
+    }
+    false
+}
 
 fn write_fixture_manifest(root: &Path) -> PathBuf {
     let source_dir = root.join("fixture-source");
@@ -858,6 +888,171 @@ async fn task_intent_is_not_exported_to_telemetry() {
         leaked.is_empty(),
         "exported spans contained the raw intent: {leaked:#?}"
     );
+
+    provider.shutdown().expect("provider shutdown");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn unknown_tool_name_is_caller_visible_but_not_exported_to_telemetry() {
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = provider.tracer("mcp-unknown-tool-name-privacy-test");
+    // Match the production first-party telemetry surface without enabling
+    // third-party protocol debug targets that may record raw request data.
+    let trace_targets = "coral_=trace,coral_engine::datafusion=off"
+        .parse::<Targets>()
+        .expect("first-party Coral trace filter");
+    let subscriber = tracing_subscriber::Registry::default().with(
+        tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_filter(trace_targets),
+    );
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_session(&temp).await;
+    let sentinels = [
+        "SENSITIVE prose-shaped unknown tool",
+        "SENSITIVE_UNKNOWN_TOOL_7A9D3",
+    ];
+
+    for sentinel in sentinels {
+        let returned = session
+            .client
+            .call_tool(CallToolRequestParams::new(sentinel))
+            .await
+            .expect_err("unknown tool should remain a caller-visible protocol error");
+        assert!(returned.to_string().contains(sentinel));
+    }
+
+    session.shutdown().await;
+    provider.force_flush().expect("flush spans");
+    let spans = exporter.get_finished_spans().expect("finished spans");
+    let tool_calls = spans
+        .iter()
+        .filter(|span| span.name == "coral.mcp.call_tool")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        tool_calls.len(),
+        sentinels.len(),
+        "one span per unknown tool call"
+    );
+    for tool_call in tool_calls {
+        assert!(tool_call.attributes.iter().any(|attribute| {
+            attribute.key.as_str() == coral_telemetry::QUERY_STREAM_ENTRY_ATTRIBUTE
+                && attribute.value == opentelemetry::Value::Bool(true)
+        }));
+        assert_eq!(
+            span_string_attribute(tool_call, coral_telemetry::QUERY_STREAM_KIND_ATTRIBUTE),
+            Some(coral_telemetry::QUERY_STREAM_KIND_TOOL.to_string())
+        );
+        assert_eq!(
+            span_string_attribute(tool_call, coral_telemetry::QUERY_STREAM_NAME_ATTRIBUTE),
+            Some(UNKNOWN_TOOL_NAME.to_string())
+        );
+        assert_eq!(
+            span_string_attribute(tool_call, "mcp.tool.name"),
+            Some(UNKNOWN_TOOL_NAME.to_string())
+        );
+        assert_eq!(
+            span_string_attribute(tool_call, "error.type"),
+            Some("INVALID_PARAMS".to_string())
+        );
+        assert_eq!(
+            span_string_attribute(tool_call, "exception.message"),
+            Some(MCP_PROTOCOL_ERROR_MESSAGE.to_string())
+        );
+        for sentinel in sentinels {
+            assert!(!format!("{tool_call:?}").contains(sentinel));
+        }
+    }
+    for sentinel in sentinels {
+        let leaked = spans
+            .iter()
+            .filter(|span| format!("{span:?}").contains(sentinel))
+            .collect::<Vec<_>>();
+        assert!(
+            leaked.is_empty(),
+            "exported spans contained the raw unknown tool name: {leaked:#?}"
+        );
+    }
+
+    provider.shutdown().expect("provider shutdown");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn mcp_sql_batch_preserves_tool_trace_context_across_spawned_queries() {
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = provider.tracer("mcp-sql-batch-trace-context-test");
+    let trace_targets = concat!(
+        "coral_mcp=trace,",
+        "coral_client::grpc=trace,",
+        "coral_app::transport=trace,",
+        "coral_app::query::manager=trace"
+    )
+    .parse::<Targets>()
+    .expect("MCP, gRPC, and Query trace filter");
+    let subscriber = tracing_subscriber::Registry::default().with(
+        tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_filter(trace_targets),
+    );
+    let _guard = tracing::subscriber::set_default(subscriber);
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_session(&temp).await;
+    let task_id = start_test_task(&session.client).await;
+
+    let result = session
+        .client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(task_arguments(
+                &task_id,
+                &json!({
+                    "queries": ["SELECT 1 AS value", "SELECT 2 AS value"]
+                }),
+            )),
+        )
+        .await
+        .expect("SQL tool call");
+    assert_eq!(result.is_error, Some(false));
+    assert_structured_content_only(&result);
+
+    session.shutdown().await;
+    provider.force_flush().expect("flush spans");
+    let spans = exporter.get_finished_spans().expect("finished spans");
+    let tool_call = spans
+        .iter()
+        .find(|span| {
+            span.name == "coral.mcp.call_tool"
+                && span_string_attribute(span, "mcp.tool.name").as_deref() == Some("sql")
+        })
+        .expect("SQL tool call span");
+    let query_spans = spans
+        .iter()
+        .filter(|span| {
+            span.name == "coral.query"
+                && span_string_attribute(span, "operation").as_deref() == Some("execute_sql")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(query_spans.len(), 2, "one Query span per SQL batch item");
+
+    let tool_trace_id = tool_call.span_context.trace_id();
+    let tool_span_id = tool_call.span_context.span_id();
+    for query_span in query_spans {
+        assert_eq!(
+            query_span.span_context.trace_id(),
+            tool_trace_id,
+            "spawned SQL query should remain in the MCP tool trace"
+        );
+        assert!(
+            span_descends_from(&spans, query_span, tool_span_id),
+            "spawned SQL query should descend from the MCP tool span"
+        );
+    }
 
     provider.shutdown().expect("provider shutdown");
 }

--- a/crates/coral-telemetry/src/lib.rs
+++ b/crates/coral-telemetry/src/lib.rs
@@ -49,6 +49,8 @@ pub const QUERY_STREAM_KIND_QUERY: &str = "query";
 pub const QUERY_STREAM_KIND_SEARCH: &str = "search";
 /// Semantic Query Stream kind for MCP tool invocations.
 pub const QUERY_STREAM_KIND_TOOL: &str = "tool";
+/// Semantic Query Stream kind for another explicitly marked user-visible operation.
+pub const QUERY_STREAM_KIND_OTHER: &str = "other";
 
 struct TraceHeaders<'a> {
     traceparent: &'a str,

--- a/crates/coral-telemetry/src/lib.rs
+++ b/crates/coral-telemetry/src/lib.rs
@@ -16,6 +16,12 @@ const TRACESTATE_HEADER: &str = "tracestate";
 /// Stable message recorded for failed gRPC requests.
 pub const GRPC_REQUEST_ERROR_MESSAGE: &str = "gRPC request failed";
 
+/// Prefix for span attributes that may be retained in local trace history but
+/// must be removed before exporting spans over OTLP.
+pub const LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX: &str = "coral.local.";
+/// Local-only Universal Search text used by Query Stream.
+pub const QUERY_STREAM_SEARCH_QUERY_ATTRIBUTE: &str = "coral.local.search.query";
+
 /// Records a categorical failure without accepting caller-controlled message text.
 pub fn record_failure(
     span: &tracing::Span,
@@ -27,6 +33,20 @@ pub fn record_failure(
     span.record("exception.message", stable_message);
     span.set_status(OtelStatus::error(stable_message));
 }
+
+/// Boolean span attribute that opts an operation into Query Stream.
+pub const QUERY_STREAM_ENTRY_ATTRIBUTE: &str = "coral.stream.entry";
+/// Span attribute containing the semantic Query Stream operation kind.
+pub const QUERY_STREAM_KIND_ATTRIBUTE: &str = "coral.stream.kind";
+/// Span attribute containing the privacy-safe Query Stream operation name.
+pub const QUERY_STREAM_NAME_ATTRIBUTE: &str = "coral.stream.name";
+
+/// Semantic Query Stream kind for direct SQL and catalog query operations.
+pub const QUERY_STREAM_KIND_QUERY: &str = "query";
+/// Semantic Query Stream kind for direct Universal Search operations.
+pub const QUERY_STREAM_KIND_SEARCH: &str = "search";
+/// Semantic Query Stream kind for MCP tool invocations.
+pub const QUERY_STREAM_KIND_TOOL: &str = "tool";
 
 struct TraceHeaders<'a> {
     traceparent: &'a str,

--- a/crates/coral-telemetry/src/lib.rs
+++ b/crates/coral-telemetry/src/lib.rs
@@ -21,6 +21,8 @@ pub const GRPC_REQUEST_ERROR_MESSAGE: &str = "gRPC request failed";
 pub const LOCAL_ONLY_SPAN_ATTRIBUTE_PREFIX: &str = "coral.local.";
 /// Local-only Universal Search text used by Query Stream.
 pub const QUERY_STREAM_SEARCH_QUERY_ATTRIBUTE: &str = "coral.local.search.query";
+/// Span attribute containing the Coral workspace associated with an operation.
+pub const WORKSPACE_SPAN_ATTRIBUTE: &str = "workspace";
 
 /// Records a categorical failure without accepting caller-controlled message text.
 pub fn record_failure(


### PR DESCRIPTION
## TL;DR

PR #1901 labels trace spans so later Query Stream code can distinguish real user-visible operations from their internal work.

For example, an agent's Search call may internally run `LIST CATALOG`. This layer marks Search as the outer operation and the nested SQL as an implementation detail. Search-index rebuilds are likewise marked as their own maintenance operation instead of appearing as `LIST CATALOG`.

## Summary

- define shared `coral.stream.entry`, `coral.stream.kind`, and `coral.stream.name` attributes for Query, Search, MCP `tools/call`, and other explicit user-visible operations
- canonicalize MCP operation names through the same `ToolName` parser used for dispatch; rejected names are recorded only as `unknown_tool`
- preserve the active Tool trace context across spawned SQL work
- retain validated, bounded Search text as `coral.local.search.query` only when Coral has installed local trace history
- record Search text directly as an OpenTelemetry span attribute, so it is not formatted to stderr or bridged into OTLP logs
- strip local-only attributes from exported OTLP spans, span events, and links while retaining them in local JSONL history
- keep host-owned and OTLP-only subscribers from receiving populated local-only attributes
- mark search-index rebuilds as explicit `rebuild_search_index` operations above their nested catalog queries
- mark a rebuild trace as failed when an otherwise successful response contains a failed provider, without exporting the provider's detailed note
- report a trace as failed when any operation in a mixed batch fails, even if the primary SQL query succeeded
- share workspace and failure-recording telemetry helpers across the app and MCP crates
- keep MCP discovery calls unmarked and redact caller-controlled Search error details

## Stack boundary

- Layer 2 of 5; #1900 is merged into `main`
- Depends on: `main`
- Next: #2043
- This PR emits operation markers and establishes the local-only span-attribute boundary. It does not read the markers, change the trace API, project Query Stream rows, or change Reef.

## Validation

- `make rust-checks` passed on the final #1901 head: formatting, workspace-wide all-features Clippy, 2,376 nextest tests passed with 6 configured skips, and docs with warnings denied
- focused Search-maintenance tests cover Partial-as-success, failed-provider error classification, unchanged provider results, and provider-note privacy
- focused Search-operation, mixed-batch summary, server-order, host-subscriber, and OTLP loopback tests passed
- the real OTLP loopback proves exact Search text is retained in local history but absent from outgoing OTLP traces and logs
- descendant `range-diff` checks were patch-identical after restacking #2043, #1876, and #1904
- `git diff --check` passed
