### PR TITLE
feat(traces): scope detail to Query Stream operations

### DIFF
--- a/crates/coral-api/proto/coral/v1/traces.proto
+++ b/crates/coral-api/proto/coral/v1/traces.proto
@@ -104,6 +104,10 @@ message GetTraceRequest {
   // Optional workspace that the trace must belong to. Omit for the global
   // trace lookup.
   Workspace workspace = 2;
+  // Optional operation span selected from a multi-operation distributed trace.
+  // When set, the response is scoped to that Query Stream operation and the
+  // descendant spans it owns.
+  string root_span_id = 3;
 }
 
 // One stored trace span.

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -669,6 +669,20 @@ impl TraceStore {
         .map_err(|source| TraceStoreError::Worker { source })?
     }
 
+    pub(crate) async fn get_query_stream_entry(
+        &self,
+        trace_id: String,
+        root_span_id: String,
+        workspace_name: Option<String>,
+    ) -> Result<TraceDetailRecord, TraceStoreError> {
+        let traces = self.clone();
+        task::spawn_blocking(move || {
+            traces.get_query_stream_entry_sync(&trace_id, &root_span_id, workspace_name.as_deref())
+        })
+        .await
+        .map_err(|source| TraceStoreError::Worker { source })?
+    }
+
     pub(crate) async fn delete_traces_for_workspace(
         &self,
         workspace_name: String,
@@ -817,6 +831,15 @@ impl TraceStore {
         } else {
             Err(TraceStoreError::NotFound(trace_id.to_string()))
         }
+    }
+
+    fn get_query_stream_entry_sync(
+        &self,
+        trace_id: &str,
+        root_span_id: &str,
+        workspace_name: Option<&str>,
+    ) -> Result<TraceDetailRecord, TraceStoreError> {
+        query_stream::get(self, trace_id, root_span_id, workspace_name)
     }
 
     pub(crate) fn list_query_history_sync(

--- a/crates/coral-app/src/telemetry/local_store/query_stream.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream.rs
@@ -1,19 +1,20 @@
-//! Query Stream LIST projection over locally captured JSONL spans.
+//! Query Stream projection over locally captured JSONL spans.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 mod classification;
 
 use classification::{
     QueryStreamMetadata, QueryStreamPrimaryOperation, QueryStreamWorkspaceEvidence,
-    is_unmarked_mcp_protocol_attributes, operation_text_from_attributes,
-    operation_text_is_semantic, query_stream_metadata,
+    is_unmarked_mcp_protocol_attributes, is_unmarked_mcp_protocol_span,
+    operation_text_from_attributes, operation_text_is_semantic, query_stream_metadata,
+    query_stream_metadata_from_attributes, query_stream_summaries,
 };
 
 use super::{
-    StoredTraceOperationKind, StoredTraceStatus, TraceListSpanRecord, TraceStore, TraceStoreError,
-    TraceStoreFile, TraceSummaryRecord, attr_string, attr_u64, parse_attributes,
-    read_list_spans_file, status_from_attributes, usize_to_u32,
+    StoredTraceOperationKind, StoredTraceStatus, TraceDetailRecord, TraceListSpanRecord,
+    TraceSpanRecord, TraceStore, TraceStoreError, TraceStoreFile, TraceSummaryRecord, attr_string,
+    attr_u64, parse_attributes, read_list_spans_file, status_from_attributes, usize_to_u32,
 };
 use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
 
@@ -81,6 +82,41 @@ fn equal_mtime_file_bucket(
     start..end
 }
 
+pub(super) fn get(
+    store: &TraceStore,
+    trace_id: &str,
+    root_span_id: &str,
+    workspace_name: Option<&str>,
+) -> Result<TraceDetailRecord, TraceStoreError> {
+    let trace = store.get_trace_sync(trace_id)?;
+    let spans_by_id = trace
+        .spans
+        .iter()
+        .map(|span| (span.span_id.as_str(), span))
+        .collect::<HashMap<_, _>>();
+    let root = spans_by_id
+        .get(root_span_id)
+        .copied()
+        .ok_or_else(|| TraceStoreError::NotFound(trace_id.to_string()))?;
+    if query_stream_metadata(root).is_none() || !query_stream_root_is_visible(root, &spans_by_id) {
+        return Err(TraceStoreError::NotFound(trace_id.to_string()));
+    }
+
+    let mut spans = collect_query_stream_operation_spans(trace.spans, trace_id, root_span_id)?;
+    let span_refs = spans.iter().collect::<Vec<_>>();
+    let summary = query_stream_summaries(&span_refs, workspace_name)
+        .into_iter()
+        .find(|summary| summary.root_span_id == root_span_id)
+        .ok_or_else(|| TraceStoreError::NotFound(trace_id.to_string()))?;
+    spans.sort_by(|left, right| {
+        left.start_time_unix_nanos
+            .cmp(&right.start_time_unix_nanos)
+            .then_with(|| left.span_id.cmp(&right.span_id))
+    });
+    debug_assert_eq!(spans.len(), summary.span_count as usize);
+    Ok(TraceDetailRecord { summary, spans })
+}
+
 // LIST projection. This section owns bounded JSONL scanning, completion
 // watermarks, pagination, and streaming aggregation.
 
@@ -116,7 +152,7 @@ struct ProjectedQueryStreamSpan {
 impl ProjectedQueryStreamSpan {
     fn from_record(span: TraceListSpanRecord) -> Self {
         let attributes = parse_attributes(&span.attributes_json);
-        let metadata = query_stream_metadata(&span, attributes.as_ref());
+        let metadata = query_stream_metadata_from_attributes(&span, attributes.as_ref());
         let protocol = attributes
             .as_ref()
             .is_some_and(is_unmarked_mcp_protocol_attributes);
@@ -527,6 +563,114 @@ fn take_indexed_values_after<T>(index: &mut BTreeMap<i64, Vec<T>>, watermark: i6
         return Vec::new();
     };
     index.split_off(&split_at).into_values().flatten().collect()
+}
+
+// Selected-operation DETAIL. This layer applies operation ownership semantics
+// to a complete locally stored trace. A later stack layer narrows the file
+// reads without changing the selection result.
+
+fn query_stream_root_is_visible(
+    root: &TraceSpanRecord,
+    spans_by_id: &HashMap<&str, &TraceSpanRecord>,
+) -> bool {
+    let mut parent_span_id = root.parent_span_id.as_deref();
+    let mut parent_span_is_remote = root.parent_span_is_remote;
+    let mut visited = HashSet::new();
+    while let Some(current_parent_span_id) = parent_span_id {
+        if parent_span_is_remote {
+            return true;
+        }
+        if !visited.insert(current_parent_span_id) {
+            return false;
+        }
+        let Some(parent) = spans_by_id.get(current_parent_span_id).copied() else {
+            return false;
+        };
+        if query_stream_metadata(parent).is_some_and(|metadata| metadata.explicit)
+            || is_unmarked_mcp_protocol_span(parent)
+        {
+            return false;
+        }
+        parent_span_id = parent.parent_span_id.as_deref();
+        parent_span_is_remote = parent.parent_span_is_remote;
+    }
+    true
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SelectedOperationNodeState {
+    suppresses_entries: bool,
+}
+
+fn collect_query_stream_operation_spans(
+    spans: Vec<TraceSpanRecord>,
+    trace_id: &str,
+    root_span_id: &str,
+) -> Result<Vec<TraceSpanRecord>, TraceStoreError> {
+    let mut candidates = spans
+        .into_iter()
+        .map(|span| (span.span_id.clone(), span))
+        .collect::<HashMap<_, _>>();
+    let root = candidates
+        .remove(root_span_id)
+        .ok_or_else(|| TraceStoreError::NotFound(trace_id.to_string()))?;
+    let root_metadata = query_stream_metadata(&root)
+        .expect("query stream root metadata was validated before collecting descendants");
+    let root_state = SelectedOperationNodeState {
+        suppresses_entries: root_metadata.explicit || is_unmarked_mcp_protocol_span(&root),
+    };
+    let mut node_states = HashMap::from([(root_span_id.to_string(), root_state)]);
+    let mut selected = HashMap::from([(root_span_id.to_string(), root)]);
+    let mut children_by_parent = HashMap::<String, Vec<TraceSpanRecord>>::new();
+    for span in candidates.into_values() {
+        let Some(parent_span_id) = span.parent_span_id.as_deref() else {
+            continue;
+        };
+        children_by_parent
+            .entry(parent_span_id.to_string())
+            .or_default()
+            .push(span);
+    }
+    let mut ready = children_by_parent.remove(root_span_id).unwrap_or_default();
+
+    while let Some(span) = ready.pop() {
+        if node_states.contains_key(&span.span_id) {
+            continue;
+        }
+        let Some(parent) = span
+            .parent_span_id
+            .as_deref()
+            .and_then(|parent_span_id| node_states.get(parent_span_id))
+            .copied()
+        else {
+            continue;
+        };
+        let metadata = query_stream_metadata(&span);
+        let starts_nested_visible_operation = metadata.is_some() && !parent.suppresses_entries;
+        if starts_nested_visible_operation {
+            // This is the root of a separate visible operation. Prune its
+            // branch instead of retaining false ownership state for it.
+            continue;
+        }
+        let state = SelectedOperationNodeState {
+            suppresses_entries: parent.suppresses_entries
+                || is_unmarked_mcp_protocol_span(&span)
+                || metadata.as_ref().is_some_and(|metadata| metadata.explicit),
+        };
+        let span_id = span.span_id.clone();
+        node_states.insert(span_id.clone(), state);
+        selected.insert(span_id.clone(), span);
+        if let Some(children) = children_by_parent.remove(&span_id) {
+            ready.extend(children);
+        }
+    }
+
+    debug_assert_eq!(
+        node_states.len(),
+        selected.len(),
+        "detail projection must not retain state for pruned operation branches"
+    );
+    Ok(selected.into_values().collect())
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/telemetry/local_store/query_stream/classification.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/classification.rs
@@ -1,5 +1,7 @@
 //! Shared Query Stream operation classification and aggregation policy.
 
+use std::collections::{HashMap, HashSet};
+
 use coral_telemetry::{
     QUERY_STREAM_ENTRY_ATTRIBUTE, QUERY_STREAM_KIND_ATTRIBUTE, QUERY_STREAM_KIND_QUERY,
     QUERY_STREAM_KIND_SEARCH, QUERY_STREAM_KIND_TOOL, QUERY_STREAM_NAME_ATTRIBUTE,
@@ -7,7 +9,11 @@ use coral_telemetry::{
 };
 use serde_json::Value as JsonValue;
 
-use super::super::{StoredTraceOperationKind, TraceListSpanRecord, attr_bool, attr_string};
+use super::super::{
+    StoredTraceOperationKind, StoredTraceStatus, TraceListSpanRecord, TraceSpanRecord,
+    TraceSummaryRecord, attr_bool, attr_string, attr_u64, parse_attributes, status_from_attributes,
+    usize_to_u32, workspace_attribute,
+};
 
 const MCP_METHOD_ATTRIBUTE: &str = "mcp.method";
 const MCP_TOOL_NAME_ATTRIBUTE: &str = "mcp.tool.name";
@@ -15,15 +21,84 @@ const MCP_CALL_TOOL_METHOD: &str = "tools/call";
 pub(super) const UNKNOWN_TOOL_OPERATION_NAME: &str = "unknown_tool";
 pub(super) const MAX_LEGACY_TOOL_OPERATION_NAME_LEN: usize = 128;
 
-// Shared operation semantics used by the LIST projector.
+// Shared operation semantics used by LIST and selected DETAIL.
 
 pub(super) trait QueryStreamSpan {
+    fn trace_id(&self) -> &str;
+    fn span_id(&self) -> &str;
+    fn parent_span_id(&self) -> Option<&str>;
     fn name(&self) -> &str;
+    fn status(&self) -> StoredTraceStatus;
+    fn start_time_unix_nanos(&self) -> i64;
+    fn end_time_unix_nanos(&self) -> i64;
+    fn attributes_json(&self) -> &str;
 }
 
 impl QueryStreamSpan for TraceListSpanRecord {
+    fn trace_id(&self) -> &str {
+        &self.trace_id
+    }
+
+    fn span_id(&self) -> &str {
+        &self.span_id
+    }
+
+    fn parent_span_id(&self) -> Option<&str> {
+        self.parent_span_id.as_deref()
+    }
+
     fn name(&self) -> &str {
         &self.name
+    }
+
+    fn status(&self) -> StoredTraceStatus {
+        self.status
+    }
+
+    fn start_time_unix_nanos(&self) -> i64 {
+        self.start_time_unix_nanos
+    }
+
+    fn end_time_unix_nanos(&self) -> i64 {
+        self.end_time_unix_nanos
+    }
+
+    fn attributes_json(&self) -> &str {
+        &self.attributes_json
+    }
+}
+
+impl QueryStreamSpan for TraceSpanRecord {
+    fn trace_id(&self) -> &str {
+        &self.trace_id
+    }
+
+    fn span_id(&self) -> &str {
+        &self.span_id
+    }
+
+    fn parent_span_id(&self) -> Option<&str> {
+        self.parent_span_id.as_deref()
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn status(&self) -> StoredTraceStatus {
+        self.status
+    }
+
+    fn start_time_unix_nanos(&self) -> i64 {
+        self.start_time_unix_nanos
+    }
+
+    fn end_time_unix_nanos(&self) -> i64 {
+        self.end_time_unix_nanos
+    }
+
+    fn attributes_json(&self) -> &str {
+        &self.attributes_json
     }
 }
 
@@ -34,7 +109,160 @@ pub(super) struct QueryStreamMetadata {
     pub(super) name: String,
 }
 
-pub(super) fn query_stream_metadata<T>(
+struct QueryStreamEntryAggregate<'a, T> {
+    span_count: usize,
+    primary_descendant_operation: Option<QueryStreamPrimaryOperation>,
+    text_enrichment: Option<(StoredTraceOperationKind, usize, &'a T)>,
+    workspace_evidence: QueryStreamWorkspaceEvidence,
+}
+
+impl<T> Default for QueryStreamEntryAggregate<'_, T> {
+    fn default() -> Self {
+        Self {
+            span_count: 0,
+            primary_descendant_operation: None,
+            text_enrichment: None,
+            workspace_evidence: QueryStreamWorkspaceEvidence::default(),
+        }
+    }
+}
+
+pub(super) fn query_stream_summaries<T>(
+    spans: &[&T],
+    workspace_name: Option<&str>,
+) -> Vec<TraceSummaryRecord>
+where
+    T: QueryStreamSpan,
+{
+    let mut spans_by_trace = HashMap::<&str, Vec<&T>>::new();
+    for span in spans {
+        spans_by_trace
+            .entry(span.trace_id())
+            .or_default()
+            .push(*span);
+    }
+
+    spans_by_trace
+        .into_values()
+        .flat_map(|trace_spans| query_stream_summaries_for_trace(&trace_spans, workspace_name))
+        .collect()
+}
+
+fn query_stream_summaries_for_trace<T>(
+    spans: &[&T],
+    workspace_name: Option<&str>,
+) -> Vec<TraceSummaryRecord>
+where
+    T: QueryStreamSpan,
+{
+    let spans_by_id = spans
+        .iter()
+        .map(|span| (span.span_id(), *span))
+        .collect::<HashMap<_, _>>();
+    let metadata_by_id = spans
+        .iter()
+        .map(|span| (span.span_id(), query_stream_metadata(*span)))
+        .collect::<HashMap<_, _>>();
+    let protocol_span_ids = spans
+        .iter()
+        .filter(|span| is_unmarked_mcp_protocol_span(**span))
+        .map(|span| span.span_id())
+        .collect::<HashSet<_>>();
+    let visible_entries = spans
+        .iter()
+        .filter_map(|span| {
+            let metadata = metadata_by_id.get(span.span_id())?.as_ref()?.clone();
+            is_visible_query_stream_entry(*span, &spans_by_id, &metadata_by_id, &protocol_span_ids)
+                .then_some((*span, metadata))
+        })
+        .collect::<Vec<_>>();
+    let visible_entry_ids = visible_entries
+        .iter()
+        .map(|(entry, _metadata)| entry.span_id())
+        .collect::<HashSet<_>>();
+    let mut aggregates: HashMap<&str, QueryStreamEntryAggregate<'_, T>> = visible_entry_ids
+        .iter()
+        .map(|span_id| (*span_id, QueryStreamEntryAggregate::default()))
+        .collect::<HashMap<_, _>>();
+
+    for span in spans {
+        let Some((owner_span_id, depth)) =
+            nearest_visible_entry(*span, &spans_by_id, &visible_entry_ids)
+        else {
+            continue;
+        };
+        let Some(aggregate) = aggregates.get_mut(owner_span_id) else {
+            continue;
+        };
+        aggregate.span_count = aggregate.span_count.saturating_add(1);
+        let span_workspace = workspace_attribute(span.attributes_json());
+        aggregate
+            .workspace_evidence
+            .record(span_workspace.as_deref());
+        let metadata = metadata_by_id.get(span.span_id()).and_then(Option::as_ref);
+        if depth > 0
+            && let Some(metadata) = metadata
+        {
+            let operation = QueryStreamPrimaryOperation::new(
+                metadata.kind,
+                depth,
+                span.start_time_unix_nanos(),
+                span.span_id(),
+            );
+            if aggregate
+                .primary_descendant_operation
+                .as_ref()
+                .is_none_or(|current| operation.sort_key() < current.sort_key())
+            {
+                aggregate.primary_descendant_operation = Some(operation);
+            }
+        }
+        let text_kind = metadata.and_then(|metadata| {
+            parse_attributes(span.attributes_json())
+                .as_ref()
+                .and_then(|attributes| operation_text_from_attributes(metadata.kind, attributes))
+                .map(|_text| metadata.kind)
+        });
+        if let Some(text_kind) = text_kind
+            && aggregate
+                .text_enrichment
+                .is_none_or(|(_current_kind, current_depth, current)| {
+                    (depth, span.start_time_unix_nanos(), span.span_id())
+                        < (
+                            current_depth,
+                            current.start_time_unix_nanos(),
+                            current.span_id(),
+                        )
+                })
+        {
+            aggregate.text_enrichment = Some((text_kind, depth, *span));
+        }
+    }
+
+    visible_entries
+        .into_iter()
+        .filter_map(|(entry, metadata)| {
+            let aggregate = aggregates.remove(entry.span_id()).unwrap_or_default();
+            let workspace = workspace_attribute(entry.attributes_json());
+            let workspace = workspace
+                .as_deref()
+                .or_else(|| aggregate.workspace_evidence.unique());
+            workspace_name
+                .is_none_or(|workspace_name| workspace == Some(workspace_name))
+                .then(|| query_stream_summary(entry, metadata, &aggregate))
+        })
+        .collect()
+}
+
+pub(super) fn query_stream_metadata<T>(span: &T) -> Option<QueryStreamMetadata>
+where
+    T: QueryStreamSpan,
+{
+    let attributes = parse_attributes(span.attributes_json());
+    query_stream_metadata_from_attributes(span, attributes.as_ref())
+}
+
+pub(super) fn query_stream_metadata_from_attributes<T>(
     span: &T,
     attributes: Option<&JsonValue>,
 ) -> Option<QueryStreamMetadata>
@@ -141,6 +369,78 @@ where
     }
 }
 
+/// Precondition: every candidate entry has complete local ancestry in
+/// `spans_by_id`, unless omitted ancestry was already validated against the
+/// full store. DETAIL does this with `query_stream_root_is_visible`. A missing
+/// parent is treated as a batch boundary, not as an unfinished local parent.
+fn is_visible_query_stream_entry<T>(
+    span: &T,
+    spans_by_id: &HashMap<&str, &T>,
+    metadata_by_id: &HashMap<&str, Option<QueryStreamMetadata>>,
+    protocol_span_ids: &HashSet<&str>,
+) -> bool
+where
+    T: QueryStreamSpan,
+{
+    let mut ancestor_id = span.parent_span_id();
+    let mut visited = HashSet::new();
+    while let Some(span_id) = ancestor_id {
+        if !visited.insert(span_id) {
+            return false;
+        }
+        let Some(ancestor) = spans_by_id.get(span_id).copied() else {
+            break;
+        };
+        if metadata_by_id
+            .get(span_id)
+            .and_then(Option::as_ref)
+            .is_some_and(|metadata| metadata.explicit)
+        {
+            return false;
+        }
+        if protocol_span_ids.contains(span_id) {
+            return false;
+        }
+        ancestor_id = ancestor.parent_span_id();
+    }
+    true
+}
+
+fn nearest_visible_entry<'a, T>(
+    span: &'a T,
+    spans_by_id: &HashMap<&str, &'a T>,
+    visible_entry_ids: &HashSet<&str>,
+) -> Option<(&'a str, usize)>
+where
+    T: QueryStreamSpan,
+{
+    let mut span_id = Some(span.span_id());
+    let mut visited = HashSet::new();
+    let mut depth = 0_usize;
+    while let Some(current_span_id) = span_id {
+        if !visited.insert(current_span_id) {
+            return None;
+        }
+        if visible_entry_ids.contains(current_span_id) {
+            return Some((current_span_id, depth));
+        }
+        let current = spans_by_id.get(current_span_id).copied()?;
+        span_id = current.parent_span_id();
+        depth = depth.saturating_add(1);
+    }
+    None
+}
+
+pub(super) fn is_unmarked_mcp_protocol_span<T>(span: &T) -> bool
+where
+    T: QueryStreamSpan,
+{
+    let Some(attributes) = parse_attributes(span.attributes_json()) else {
+        return false;
+    };
+    is_unmarked_mcp_protocol_attributes(&attributes)
+}
+
 pub(super) fn is_unmarked_mcp_protocol_attributes(attributes: &JsonValue) -> bool {
     let is_marked = attr_bool(attributes, QUERY_STREAM_ENTRY_ATTRIBUTE).unwrap_or(false);
     !is_marked
@@ -170,6 +470,67 @@ pub(super) fn operation_text_is_semantic(
     entry_kind == text_kind
         || (entry_kind == StoredTraceOperationKind::Tool
             && primary_descendant.is_some_and(|operation| operation.kind == text_kind))
+}
+
+fn query_stream_summary<T>(
+    entry: &T,
+    metadata: QueryStreamMetadata,
+    aggregate: &QueryStreamEntryAggregate<'_, T>,
+) -> TraceSummaryRecord
+where
+    T: QueryStreamSpan,
+{
+    let entry_attributes = parse_attributes(entry.attributes_json());
+    let enrichment = aggregate.text_enrichment.and_then(|(kind, _depth, span)| {
+        operation_text_is_semantic(
+            metadata.kind,
+            kind,
+            aggregate.primary_descendant_operation.as_ref(),
+        )
+        .then_some((kind, span))
+    });
+    let enrichment_attributes =
+        enrichment.and_then(|(_kind, span)| parse_attributes(span.attributes_json()));
+    let query = entry_attributes
+        .as_ref()
+        .and_then(|attributes| operation_text_from_attributes(metadata.kind, attributes))
+        .or_else(|| {
+            enrichment.zip(enrichment_attributes.as_ref()).and_then(
+                |((kind, _span), attributes)| operation_text_from_attributes(kind, attributes),
+            )
+        })
+        .unwrap_or_default();
+    let row_count = (metadata.kind == StoredTraceOperationKind::Query)
+        .then(|| {
+            entry_attributes
+                .as_ref()
+                .and_then(|attributes| attr_u64(attributes, "row_count"))
+        })
+        .flatten()
+        .or_else(|| {
+            enrichment
+                .filter(|(kind, _span)| *kind == StoredTraceOperationKind::Query)
+                .zip(enrichment_attributes.as_ref())
+                .and_then(|((_kind, _span), attributes)| attr_u64(attributes, "row_count"))
+        });
+    let status = status_from_attributes(entry_attributes.as_ref()).unwrap_or(entry.status());
+    TraceSummaryRecord {
+        trace_id: entry.trace_id().to_string(),
+        root_span_id: entry.span_id().to_string(),
+        name: entry.name().to_string(),
+        query,
+        status,
+        start_time_unix_nanos: entry.start_time_unix_nanos(),
+        end_time_unix_nanos: entry.end_time_unix_nanos(),
+        duration_nanos: entry
+            .end_time_unix_nanos()
+            .saturating_sub(entry.start_time_unix_nanos()),
+        span_count: usize_to_u32(aggregate.span_count),
+        row_count: row_count.unwrap_or_default(),
+        row_count_recorded: row_count.is_some(),
+        operation_kind: metadata.kind,
+        operation_name: metadata.name,
+    }
 }
 
 #[derive(Debug)]

--- a/crates/coral-app/src/telemetry/local_store/query_stream/semantics_tests.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/semantics_tests.rs
@@ -3,17 +3,17 @@ use std::collections::HashSet;
 use serde_json::json;
 
 use super::super::tests::trace_record;
-use super::super::{StoredTraceOperationKind, StoredTraceStatus};
+use super::super::{StoredTraceOperationKind, StoredTraceStatus, TraceStoreError};
 use super::classification::{
     MAX_LEGACY_TOOL_OPERATION_NAME_LEN, UNKNOWN_TOOL_OPERATION_NAME,
-    privacy_safe_legacy_tool_operation_name,
+    privacy_safe_legacy_tool_operation_name, query_stream_summaries,
 };
-use super::test_support::{project, project_page, span};
+use super::test_support::{TraceFiles, project, project_page, span};
 
 // Shared classification and ownership behavior.
 
 #[test]
-fn query_stream_projects_outer_operations() {
+fn query_stream_projects_outer_operations_and_selects_details_by_span() {
     let sql_tool = span("shared-trace", "sql-tool")
         .named("coral.mcp.call_tool")
         .remote_root()
@@ -33,7 +33,8 @@ fn query_stream_projects_outer_operations() {
         .times(20, 30)
         .build();
 
-    let summaries = project(&[sql_tool, nested_query], None);
+    let files = TraceFiles::with_records(&[sql_tool, nested_query]);
+    let summaries = files.list(10, 0, None);
     assert_eq!(summaries.len(), 1);
     let sql_summary = summaries.first().expect("SQL summary");
     assert_eq!(sql_summary.root_span_id, "sql-tool");
@@ -47,6 +48,20 @@ fn query_stream_projects_outer_operations() {
     assert_eq!(sql_summary.end_time_unix_nanos, 40);
     assert_eq!(sql_summary.duration_nanos, 30);
     assert_eq!(sql_summary.span_count, 2);
+
+    let detail = files
+        .get("shared-trace", "sql-tool", Some("alpha"))
+        .expect("get selected operation");
+    assert_eq!(detail.summary, *sql_summary);
+    assert_eq!(detail.spans.len(), 2);
+    assert!(
+        files.get("shared-trace", "nested-query", None).is_err(),
+        "a collapsed nested entry is not independently addressable"
+    );
+    assert!(
+        files.get("shared-trace", "sql-tool", Some("beta")).is_err(),
+        "workspace filtering applies to the selected operation"
+    );
 }
 
 #[test]
@@ -167,11 +182,105 @@ fn query_stream_hides_entries_with_unfinished_local_parents() {
     })
     .to_string();
 
-    let summaries = project(&[unfinished_child, remote_root], Some("alpha"));
+    let files = TraceFiles::with_records(&[unfinished_child, remote_root]);
+    let summaries = files.list(10, 0, Some("alpha"));
     assert_eq!(summaries.len(), 1);
     assert_eq!(
         summaries.first().expect("remote summary").root_span_id,
         "remote-query"
+    );
+
+    assert!(matches!(
+        files.get("unfinished-trace", "unfinished-query", Some("alpha")),
+        Err(TraceStoreError::NotFound(_))
+    ));
+    assert!(
+        files
+            .get("remote-root-trace", "remote-query", Some("alpha"))
+            .is_ok(),
+        "a missing remote parent is a valid local operation root"
+    );
+}
+
+#[test]
+fn query_stream_hides_malformed_parent_cycles_in_list_and_detail() {
+    let mut entry = trace_record("cyclic-trace", "cyclic-query");
+    entry.parent_span_id = Some("cyclic-parent".to_string());
+    entry.parent_span_is_remote = false;
+    entry.name = "coral.query".to_string();
+    entry.attributes_json = json!({
+        "workspace": "alpha",
+        "operation": "sql",
+        "sql": "SELECT 'cycle'",
+    })
+    .to_string();
+
+    let mut parent = trace_record("cyclic-trace", "cyclic-parent");
+    parent.parent_span_id = Some(entry.span_id.clone());
+    parent.parent_span_is_remote = false;
+    parent.name = "internal.cycle".to_string();
+    parent.attributes_json = json!({"workspace": "alpha"}).to_string();
+
+    let span_refs = [&entry, &parent];
+    assert!(
+        query_stream_summaries(&span_refs, Some("alpha")).is_empty(),
+        "batch projection hides malformed cycles"
+    );
+
+    let files = TraceFiles::with_records(&[entry, parent]);
+    assert!(
+        files.list(10, 0, Some("alpha")).is_empty(),
+        "streaming projection hides malformed cycles"
+    );
+    assert!(matches!(
+        files.get("cyclic-trace", "cyclic-query", Some("alpha")),
+        Err(TraceStoreError::NotFound(_))
+    ));
+}
+
+#[test]
+fn query_stream_detail_excludes_nested_visible_operations() {
+    let mut outer = trace_record("nested-trace", "outer-query");
+    outer.parent_span_id = Some("remote-parent".to_string());
+    outer.parent_span_is_remote = true;
+    outer.attributes_json = json!({
+        "workspace": "alpha",
+        "operation": "sql",
+        "sql": "SELECT 1",
+    })
+    .to_string();
+
+    let mut nested = trace_record("nested-trace", "nested-operation");
+    nested.parent_span_id = Some(outer.span_id.clone());
+    nested.name = "coral.future.operation".to_string();
+    nested.attributes_json = json!({
+        "coral.stream.entry": true,
+        "coral.stream.kind": "future_kind",
+        "coral.stream.name": "future_operation",
+        "workspace": "beta",
+    })
+    .to_string();
+
+    let mut nested_child = trace_record("nested-trace", "nested-child");
+    nested_child.parent_span_id = Some(nested.span_id.clone());
+    nested_child.name = "coral.future.child".to_string();
+
+    let files = TraceFiles::with_records(&[outer, nested, nested_child]);
+    let summaries = files.list(10, 0, None);
+    assert_eq!(summaries.len(), 2);
+
+    let detail = files
+        .get("nested-trace", "outer-query", Some("alpha"))
+        .expect("get outer operation");
+    assert_eq!(detail.summary.root_span_id, "outer-query");
+    assert_eq!(detail.spans.len(), detail.summary.span_count as usize);
+    assert_eq!(
+        detail
+            .spans
+            .iter()
+            .map(|span| span.span_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["outer-query"]
     );
 }
 
@@ -301,18 +410,16 @@ fn query_stream_supports_legacy_operations_and_protocol_suppression() {
     search_catalog_query.start_time_unix_nanos = 22;
     search_catalog_query.end_time_unix_nanos = 23;
 
-    let summaries = project(
-        &[
-            protocol,
-            hidden_query,
-            legacy_tool,
-            visible_query,
-            search_tool,
-            search,
-            search_catalog_query,
-        ],
-        Some("alpha"),
-    );
+    let files = TraceFiles::with_records(&[
+        protocol,
+        hidden_query,
+        legacy_tool,
+        visible_query,
+        search_tool,
+        search,
+        search_catalog_query,
+    ]);
+    let summaries = files.list(10, 0, Some("alpha"));
     assert_eq!(summaries.len(), 2);
     let search_summary = summaries.first().expect("legacy search summary");
     assert_eq!(search_summary.root_span_id, "legacy-search-tool");
@@ -327,6 +434,77 @@ fn query_stream_supports_legacy_operations_and_protocol_suppression() {
     assert_eq!(tool_summary.operation_kind, StoredTraceOperationKind::Tool);
     assert_eq!(tool_summary.operation_name, "list_catalog");
     assert_eq!(tool_summary.query, "LIST CATALOG");
+
+    let search_detail = files
+        .get("search-trace", "legacy-search-tool", Some("alpha"))
+        .expect("get legacy search entry");
+    assert_eq!(search_detail.summary, *search_summary);
+    assert!(
+        search_detail
+            .spans
+            .iter()
+            .any(|span| span.span_id == "legacy-search-catalog-query"),
+        "the internal catalog query remains available in detail spans"
+    );
+    assert!(
+        search_detail.summary.query.is_empty(),
+        "Tool -> Search -> Query must not present internal SQL as the Tool query"
+    );
+}
+
+#[test]
+fn query_stream_detail_uses_search_text_without_inheriting_internal_query() {
+    let tool = span("marked-search-trace", "search-tool")
+        .named("coral.mcp.call_tool")
+        .remote_root()
+        .entry("tool", "search", "alpha")
+        .attrs(json!({
+            "mcp.method": "tools/call",
+            "mcp.tool.name": "search",
+        }))
+        .times(10, 40)
+        .build();
+    let search = span("marked-search-trace", "search-operation")
+        .named("coral.search")
+        .child_of(&tool)
+        .entry("search", "search", "alpha")
+        .attrs(json!({"coral.local.search.query": "find customer churn"}))
+        .times(15, 35)
+        .build();
+    let query = span("marked-search-trace", "catalog-query")
+        .child_of(&search)
+        .entry("query", "sql", "alpha")
+        .attrs(json!({"sql": "LIST CATALOG", "row_count": 7}))
+        .times(20, 30)
+        .build();
+
+    let files = TraceFiles::with_records(&[tool, search, query]);
+    let summaries = files.list(10, 0, Some("alpha"));
+    assert_eq!(summaries.len(), 1);
+    let summary = summaries.first().expect("search tool summary");
+    assert_eq!(summary.root_span_id, "search-tool");
+    assert_eq!(summary.query, "find customer churn");
+    assert_ne!(summary.query, "LIST CATALOG");
+    assert!(!summary.row_count_recorded);
+    assert_eq!(summary.row_count, 0);
+
+    let detail = files
+        .get("marked-search-trace", "search-tool", Some("alpha"))
+        .expect("get marked search tool detail");
+    assert_eq!(detail.summary, *summary);
+    assert_eq!(detail.spans.len(), 3);
+    assert!(
+        detail
+            .spans
+            .iter()
+            .any(|span| span.span_id == "catalog-query")
+    );
+    for hidden_span_id in ["search-operation", "catalog-query"] {
+        assert!(matches!(
+            files.get("marked-search-trace", hidden_span_id, Some("alpha")),
+            Err(TraceStoreError::NotFound(_))
+        ));
+    }
 }
 
 #[test]

--- a/crates/coral-app/src/telemetry/local_store/query_stream/test_support.rs
+++ b/crates/coral-app/src/telemetry/local_store/query_stream/test_support.rs
@@ -8,7 +8,10 @@ use super::super::tests::{
     set_modified_time, timestamped_jsonl_path, trace_record, write_record_file,
     write_record_file_lines,
 };
-use super::super::{StoredTraceStatus, TraceSpanRecord, TraceStore, TraceSummaryRecord};
+use super::super::{
+    StoredTraceStatus, TraceDetailRecord, TraceSpanRecord, TraceStore, TraceStoreError,
+    TraceSummaryRecord,
+};
 
 pub(super) fn span(trace_id: &str, span_id: &str) -> TestSpan {
     TestSpan {
@@ -108,6 +111,12 @@ impl TraceFiles {
         }
     }
 
+    pub(super) fn with_records(records: &[TraceSpanRecord]) -> Self {
+        let files = Self::new();
+        files.write("spans-test.jsonl", records);
+        files
+    }
+
     pub(super) fn write(&self, name: &str, records: &[TraceSpanRecord]) {
         write_record_file_lines(&self.temp.path().join(name), records);
     }
@@ -142,5 +151,18 @@ impl TraceFiles {
         TraceStore::new(self.temp.path().to_path_buf())
             .list_query_stream_sync(limit, offset, workspace_name)
             .expect("list query stream")
+    }
+
+    pub(super) fn get(
+        &self,
+        trace_id: &str,
+        root_span_id: &str,
+        workspace_name: Option<&str>,
+    ) -> Result<TraceDetailRecord, TraceStoreError> {
+        TraceStore::new(self.temp.path().to_path_buf()).get_query_stream_entry_sync(
+            trace_id,
+            root_span_id,
+            workspace_name,
+        )
     }
 }

--- a/crates/coral-app/src/telemetry/manager.rs
+++ b/crates/coral-app/src/telemetry/manager.rs
@@ -27,9 +27,16 @@ pub(crate) struct TraceListPage {
 }
 
 #[derive(Debug)]
+pub(crate) enum TraceDetailSelection {
+    Full,
+    QueryStreamOperation { root_span_id: String },
+}
+
+#[derive(Debug)]
 pub(crate) struct GetTraceQuery {
     pub(crate) trace_id: String,
     pub(crate) workspace: Option<WorkspaceName>,
+    pub(crate) selection: TraceDetailSelection,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -105,14 +112,23 @@ impl TraceManager {
         let GetTraceQuery {
             trace_id,
             workspace,
+            selection,
         } = query;
-        match workspace {
-            Some(workspace) => {
+        let workspace = workspace.map(|workspace| workspace.as_str().to_string());
+        match selection {
+            TraceDetailSelection::Full => match workspace {
+                Some(workspace) => {
+                    self.traces
+                        .get_trace_for_workspace(trace_id, workspace)
+                        .await
+                }
+                None => self.traces.get_trace(trace_id).await,
+            },
+            TraceDetailSelection::QueryStreamOperation { root_span_id } => {
                 self.traces
-                    .get_trace_for_workspace(trace_id, workspace.as_str().to_string())
+                    .get_query_stream_entry(trace_id, root_span_id, workspace)
                     .await
             }
-            None => self.traces.get_trace(trace_id).await,
         }
         .map_err(TraceManagerError::from)
     }
@@ -125,7 +141,10 @@ mod tests {
     use serde_json::json;
     use tempfile::TempDir;
 
-    use super::{GetTraceQuery, ListTracesQuery, TraceListView, TraceManager, TraceManagerError};
+    use super::{
+        GetTraceQuery, ListTracesQuery, TraceDetailSelection, TraceListView, TraceManager,
+        TraceManagerError,
+    };
     use crate::workspaces::WorkspaceName;
 
     #[tokio::test]
@@ -174,6 +193,7 @@ mod tests {
             .get_trace(GetTraceQuery {
                 trace_id: "beta".to_string(),
                 workspace: None,
+                selection: TraceDetailSelection::Full,
             })
             .await
             .expect("unscoped beta trace");
@@ -183,6 +203,7 @@ mod tests {
             .get_trace(GetTraceQuery {
                 trace_id: "beta".to_string(),
                 workspace: Some(WorkspaceName::parse("alpha").expect("alpha workspace")),
+                selection: TraceDetailSelection::Full,
             })
             .await
             .expect_err("beta trace must not match alpha workspace");
@@ -190,6 +211,18 @@ mod tests {
             error,
             TraceManagerError::NotFound { trace_id } if trace_id == "beta"
         ));
+
+        let detail = manager
+            .get_trace(GetTraceQuery {
+                trace_id: "alpha-new".to_string(),
+                workspace: Some(WorkspaceName::parse("alpha").expect("alpha workspace")),
+                selection: TraceDetailSelection::QueryStreamOperation {
+                    root_span_id: "alpha-new-span".to_string(),
+                },
+            })
+            .await
+            .expect("selected alpha operation");
+        assert_eq!(detail.summary.root_span_id, "alpha-new-span");
     }
 
     fn trace_manager_fixture() -> (TempDir, TraceManager) {

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -13,7 +13,8 @@ use crate::telemetry::local_store::{
     TraceSummaryRecord,
 };
 use crate::telemetry::manager::{
-    GetTraceQuery, ListTracesQuery, TraceListView, TraceManager, TraceManagerError,
+    GetTraceQuery, ListTracesQuery, TraceDetailSelection, TraceListView, TraceManager,
+    TraceManagerError,
 };
 use crate::transport::{grpc_span, instrument_grpc};
 use crate::workspaces::WorkspaceName;
@@ -86,10 +87,12 @@ impl TraceServiceApi for TraceService {
                 ));
             }
             let workspace = workspace_filter_from_proto(request.workspace.as_ref())?;
+            let selection = trace_detail_selection_from_proto(&request.root_span_id);
             let trace = traces
                 .get_trace(GetTraceQuery {
                     trace_id: request.trace_id,
                     workspace,
+                    selection,
                 })
                 .await
                 .map_err(trace_manager_status)?;
@@ -138,6 +141,17 @@ fn workspace_filter_from_proto(
     workspace
         .map(|workspace| WorkspaceName::parse(&workspace.name).map_err(app_status))
         .transpose()
+}
+
+fn trace_detail_selection_from_proto(root_span_id: &str) -> TraceDetailSelection {
+    let root_span_id = root_span_id.trim();
+    if root_span_id.is_empty() {
+        TraceDetailSelection::Full
+    } else {
+        TraceDetailSelection::QueryStreamOperation {
+            root_span_id: root_span_id.to_string(),
+        }
+    }
 }
 
 fn trace_manager_status(error: TraceManagerError) -> Status {
@@ -299,6 +313,7 @@ mod tests {
             Request::new(GetTraceRequest {
                 trace_id: "alpha-trace".to_string(),
                 workspace: Some(workspace("alpha")),
+                root_span_id: String::new(),
             }),
         )
         .await
@@ -311,6 +326,7 @@ mod tests {
             Request::new(GetTraceRequest {
                 trace_id: "beta-trace".to_string(),
                 workspace: Some(workspace("alpha")),
+                root_span_id: String::new(),
             }),
         )
         .await
@@ -319,7 +335,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trace_service_projects_query_stream_entries() {
+    async fn trace_service_projects_and_selects_query_stream_entries() {
         let temp = TempDir::new().expect("temp dir");
         let trace_store = temp.path().join("trace-store");
         std::fs::create_dir_all(&trace_store).expect("trace store dir");
@@ -346,6 +362,34 @@ mod tests {
         assert_eq!(summary.query, "SELECT 42");
         assert_eq!(summary.start_time_unix_nanos, 10);
         assert_eq!(summary.end_time_unix_nanos, 40);
+
+        let detail = TraceServiceApi::get_trace(
+            &service,
+            Request::new(GetTraceRequest {
+                trace_id: "shared-trace".to_string(),
+                workspace: Some(workspace("alpha")),
+                root_span_id: "tool-span".to_string(),
+            }),
+        )
+        .await
+        .expect("get selected query stream entry")
+        .into_inner();
+        assert_eq!(
+            detail.summary.expect("selected summary").root_span_id,
+            "tool-span"
+        );
+
+        let internal_status = TraceServiceApi::get_trace(
+            &service,
+            Request::new(GetTraceRequest {
+                trace_id: "shared-trace".to_string(),
+                workspace: Some(workspace("alpha")),
+                root_span_id: "nested-query".to_string(),
+            }),
+        )
+        .await
+        .expect_err("collapsed nested entry is not addressable");
+        assert_eq!(internal_status.code(), Code::NotFound);
 
         let unknown_view = TraceServiceApi::list_traces(
             &service,


### PR DESCRIPTION
## Summary

- add optional `root_span_id` selection to `GetTrace`
- load a trace through the existing reader, then select one Query Stream operation and only the descendant spans it owns
- exclude sibling operations and prune nested visible operations from selected detail
- preserve legacy full-trace detail when `root_span_id` is omitted
- derive LIST and DETAIL summaries from the same operation semantics
- preserve locally retained Search text for direct and MCP Search detail without substituting Search-internal SQL or row counts
- accept remote-parent operation roots, reject missing local ancestry, and fail closed on malformed parent cycles

## Stack boundary

- Layer 5 of 8
- Depends on: #1876
- Next: #1949
- This PR establishes the operation-selection contract using the existing full-trace reader. #1949 replaces that reader with bounded storage access without changing the API or result.

## Validation

- `make rust-checks`: passed at the final stack tip (format, Clippy, 2,399 tests passed / 6 skipped, rustdoc)
- `cargo test -p coral-app query_stream_ --lib --locked`: 25 passed at the final stack tip
- regressions cover selected-operation scoping, workspace filtering, nested-operation pruning, malformed cycles, missing and remote parents, LIST/DETAIL parity, Search text, and internal SQL suppression
- `git diff --check`: passed
