### PR TITLE
feat(reef): bridge typed Query Stream operations

### DIFF
--- a/apps/reef/app/routes/trace-detail-loader.server.test.ts
+++ b/apps/reef/app/routes/trace-detail-loader.server.test.ts
@@ -29,7 +29,9 @@ function detail(traceId: string): TraceDetailData {
 }
 
 describe('trace detail loader', () => {
-  const request = new Request('http://reef.test/workspaces/analytics/traces/trace-07')
+  const request = new Request(
+    'http://reef.test/workspaces/analytics/traces/trace-07?pro&rootSpanId=root%2Fspan',
+  )
   const workspace = create(WorkspaceSchema, { name: 'analytics' })
 
   it('loads the URL-selected trace without decoding it again', async () => {
@@ -38,7 +40,7 @@ describe('trace detail loader', () => {
     await expect(
       loadTraceDetailRouteData(request, 'trace/with?reserved', workspace, getTrace),
     ).resolves.toEqual({ detail: detail('trace/with?reserved'), loadError: null })
-    expect(getTrace).toHaveBeenCalledWith(request, 'trace/with?reserved', workspace)
+    expect(getTrace).toHaveBeenCalledWith(request, 'trace/with?reserved', 'root/span', workspace)
   })
 
   it('returns an inline error for a missing trace ID', async () => {

--- a/apps/reef/app/routes/trace-detail-loader.ts
+++ b/apps/reef/app/routes/trace-detail-loader.ts
@@ -7,6 +7,7 @@ import { GetTraceRequestSchema } from '@/generated/coral/v1/traces_pb'
 import { traceClientForRequest } from '@/lib/coral-request.server'
 import { errorMessage } from '@/lib/utils'
 import { workspaceFromParams } from '@/lib/workspace-routing'
+import { rootSpanIdFromSearch } from '@/views/traces/trace-location'
 import { formatTraceError, type TraceDetailData } from '@/views/traces/trace-utils'
 
 export interface TraceDetailRouteData {
@@ -17,6 +18,7 @@ export interface TraceDetailRouteData {
 export type GetTraceForRequest = (
   request: Request,
   traceId: string,
+  rootSpanId: string,
   workspace: Workspace,
 ) => Promise<TraceDetailData>
 
@@ -33,7 +35,15 @@ export async function loadTraceDetailRouteData(
   if (!traceId) return { detail: null, loadError: 'Missing trace ID' }
 
   try {
-    return { detail: await getTrace(request, traceId, workspace), loadError: null }
+    return {
+      detail: await getTrace(
+        request,
+        traceId,
+        rootSpanIdFromSearch(new URL(request.url).search),
+        workspace,
+      ),
+      loadError: null,
+    }
   } catch (error) {
     return { detail: null, loadError: formatTraceError(errorMessage(error)) }
   }
@@ -42,9 +52,10 @@ export async function loadTraceDetailRouteData(
 async function getTraceForRequest(
   request: Request,
   traceId: string,
+  rootSpanId: string,
   workspace: Workspace,
 ): Promise<TraceDetailData> {
   return traceClientForRequest(request).getTrace(
-    create(GetTraceRequestSchema, { traceId, workspace }),
+    create(GetTraceRequestSchema, { rootSpanId, traceId, workspace }),
   )
 }

--- a/apps/reef/app/routes/traces-loader.server.test.ts
+++ b/apps/reef/app/routes/traces-loader.server.test.ts
@@ -1,19 +1,25 @@
 import { create } from '@bufbuild/protobuf'
 
 import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
-import { TraceOperationKind, TraceStatus } from '@/generated/coral/v1/traces_pb'
+import { TraceOperationKind, TraceStatus, TraceView } from '@/generated/coral/v1/traces_pb'
 import type { TraceSummaryData } from '@/views/traces/trace-utils'
 import { describe, expect, it, vi } from 'vitest'
 
 import { listQueryTraces, loadTracesRouteData, traceEndpointLabel } from './traces-loader'
 
-function summary(traceId: string, query = `select '${traceId}'`): TraceSummaryData {
+function summary(
+  traceId: string,
+  query = `select '${traceId}'`,
+  name = query ? 'coral.query' : 'http.request',
+  operationKind = TraceOperationKind.QUERY,
+  operationName = 'sql',
+): TraceSummaryData {
   return {
     durationNanos: '1000000',
     endTimeUnixNanos: '2000000',
-    name: query ? 'coral.query' : 'http.request',
-    operationKind: TraceOperationKind.UNSPECIFIED,
-    operationName: '',
+    name,
+    operationKind,
+    operationName,
     query,
     rootSpanId: `root-${traceId}`,
     rowCount: '1',
@@ -25,29 +31,52 @@ function summary(traceId: string, query = `select '${traceId}'`): TraceSummaryDa
   }
 }
 
+function legacySummary(
+  traceId: string,
+  query = `select '${traceId}'`,
+  name = query ? 'coral.query' : 'http.request',
+): TraceSummaryData {
+  return summary(traceId, query, name, TraceOperationKind.UNSPECIFIED, '')
+}
+
 describe('traces list loader', () => {
   const request = new Request('http://reef.test/workspaces/analytics/traces')
   const workspace = create(WorkspaceSchema, { name: 'analytics' })
 
-  it('filters query traces and returns a deterministic endpoint label', async () => {
+  it('requests the typed Query Stream view and keeps future operation kinds', async () => {
     vi.spyOn(Date, 'now').mockReturnValue(123_456)
+    const search = summary('search', '', 'coral.mcp.call_tool', TraceOperationKind.TOOL, 'search')
+    const futureTool = summary(
+      'future',
+      '',
+      'coral.mcp.call_tool',
+      TraceOperationKind.OTHER,
+      'future_lookup',
+    )
     const listPage = vi.fn().mockResolvedValue({
       nextPageToken: '',
-      traces: [summary('query'), summary('http', '')],
+      traces: [
+        summary('query'),
+        search,
+        futureTool,
+        legacySummary('discovery', '', 'coral.mcp.list_tools'),
+      ],
     })
 
     await expect(loadTracesRouteData(request, workspace, listPage)).resolves.toEqual({
       endpointLabel: 'reef.test',
       loadError: null,
       referenceTimeMs: 123_456,
-      traces: [summary('query')],
+      traces: [summary('query'), search, futureTool],
     })
-    expect(listPage).toHaveBeenCalledWith(request, workspace, 100, '')
+    expect(listPage).toHaveBeenCalledWith(request, workspace, 100, '', TraceView.QUERY_STREAM)
   })
 
-  it('loads at most two pages, preserves ordering, and caps query traces at 80', async () => {
-    const firstPage = Array.from({ length: 60 }, (_, index) => summary(`trace-${index}`))
-    const secondPage = Array.from({ length: 60 }, (_, index) => summary(`trace-${index + 60}`))
+  it('uses bounded client filtering only for legacy servers', async () => {
+    const firstPage = Array.from({ length: 60 }, (_, index) => legacySummary(`trace-${index}`))
+    const secondPage = Array.from({ length: 60 }, (_, index) =>
+      legacySummary(`trace-${index + 60}`),
+    )
     const listPage = vi
       .fn()
       .mockResolvedValueOnce({ nextPageToken: 'page-2', traces: firstPage })
@@ -56,11 +85,28 @@ describe('traces list loader', () => {
     const traces = await listQueryTraces(request, workspace, listPage)
 
     expect(listPage).toHaveBeenCalledTimes(2)
-    expect(listPage).toHaveBeenNthCalledWith(2, request, workspace, 100, 'page-2')
+    expect(listPage).toHaveBeenNthCalledWith(
+      2,
+      request,
+      workspace,
+      100,
+      'page-2',
+      TraceView.QUERY_STREAM,
+    )
     expect(traces).toHaveLength(80)
     expect(traces.map(({ traceId }) => traceId)).toEqual(
       Array.from({ length: 80 }, (_, index) => `trace-${index}`),
     )
+  })
+
+  it('does not scan general trace pages after receiving typed operations', async () => {
+    const listPage = vi.fn().mockResolvedValue({
+      nextPageToken: 'unused-page',
+      traces: [summary('typed')],
+    })
+
+    await expect(listQueryTraces(request, workspace, listPage)).resolves.toEqual([summary('typed')])
+    expect(listPage).toHaveBeenCalledOnce()
   })
 
   it('maps unavailable and generic failures into route data', async () => {

--- a/apps/reef/app/routes/traces-loader.ts
+++ b/apps/reef/app/routes/traces-loader.ts
@@ -3,15 +3,20 @@ import { create } from '@bufbuild/protobuf'
 import type { Route } from './+types/traces'
 
 import type { Workspace } from '@/generated/coral/v1/resources_pb'
-import { ListTracesRequestSchema } from '@/generated/coral/v1/traces_pb'
+import { ListTracesRequestSchema, TraceView } from '@/generated/coral/v1/traces_pb'
 import { traceClientForRequest } from '@/lib/coral-request.server'
 import { errorMessage } from '@/lib/utils'
 import { workspaceFromParams } from '@/lib/workspace-routing'
-import { formatTraceError, isQueryTrace, type TraceSummaryData } from '@/views/traces/trace-utils'
+import {
+  formatTraceError,
+  hasTypedOperation,
+  isLegacyQueryTrace,
+  type TraceSummaryData,
+} from '@/views/traces/trace-utils'
 
 const MAX_QUERY_TRACES = 80
 const TRACE_LIST_PAGE_SIZE = 100
-const MAX_TRACE_LIST_PAGES = 2
+const MAX_LEGACY_TRACE_LIST_PAGES = 2
 
 export interface TracesRouteData {
   endpointLabel: string
@@ -25,6 +30,7 @@ export type ListTracePage = (
   workspace: Workspace,
   pageSize: number,
   pageToken: string,
+  view: TraceView,
 ) => Promise<{ nextPageToken: string; traces: TraceSummaryData[] }>
 
 export async function loader({ params, request }: Route.LoaderArgs): Promise<TracesRouteData> {
@@ -59,18 +65,39 @@ export async function listQueryTraces(
   workspace: Workspace,
   listPage: ListTracePage = listTracePageForRequest,
 ): Promise<TraceSummaryData[]> {
-  const queryTraces: TraceSummaryData[] = []
-  let pageToken = ''
+  const firstPage = await listPage(
+    request,
+    workspace,
+    TRACE_LIST_PAGE_SIZE,
+    '',
+    TraceView.QUERY_STREAM,
+  )
+  const typedOperations = firstPage.traces.filter(hasTypedOperation)
+
+  // New servers apply Query Stream projection and pagination before returning data.
+  // A non-empty response without operation metadata came from an older server that
+  // ignored the unknown `view` field, so retain the bounded client-side fallback.
+  if (firstPage.traces.length === 0 || typedOperations.length > 0) {
+    return typedOperations.slice(0, MAX_QUERY_TRACES)
+  }
+
+  const queryTraces = firstPage.traces.filter(isLegacyQueryTrace)
+  let pageToken = firstPage.nextPageToken
 
   for (
-    let page = 0;
-    page < MAX_TRACE_LIST_PAGES && queryTraces.length < MAX_QUERY_TRACES;
+    let page = 1;
+    page < MAX_LEGACY_TRACE_LIST_PAGES && pageToken && queryTraces.length < MAX_QUERY_TRACES;
     page += 1
   ) {
-    const response = await listPage(request, workspace, TRACE_LIST_PAGE_SIZE, pageToken)
-    queryTraces.push(...response.traces.filter(isQueryTrace))
+    const response = await listPage(
+      request,
+      workspace,
+      TRACE_LIST_PAGE_SIZE,
+      pageToken,
+      TraceView.QUERY_STREAM,
+    )
+    queryTraces.push(...response.traces.filter(isLegacyQueryTrace))
     pageToken = response.nextPageToken
-    if (!pageToken) break
   }
 
   return queryTraces.slice(0, MAX_QUERY_TRACES)
@@ -89,8 +116,9 @@ async function listTracePageForRequest(
   workspace: Workspace,
   pageSize: number,
   pageToken: string,
+  view: TraceView,
 ): Promise<{ nextPageToken: string; traces: TraceSummaryData[] }> {
   return traceClientForRequest(request).listTraces(
-    create(ListTracesRequestSchema, { pageSize, pageToken, workspace }),
+    create(ListTracesRequestSchema, { pageSize, pageToken, view, workspace }),
   )
 }

--- a/apps/reef/app/routes/traces.test.tsx
+++ b/apps/reef/app/routes/traces.test.tsx
@@ -11,7 +11,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-react'
 
 import { shouldRevalidate } from './traces'
-import { traceLocation } from '@/views/traces/trace-location'
+import { listSearch, rootSpanIdFromSearch, traceLocation } from '@/views/traces/trace-location'
 import { routePath } from '@/routing/routemap'
 
 const WORKSPACE_ID = 'analytics'
@@ -73,6 +73,17 @@ describe('traces shouldRevalidate', () => {
     ).toBe(false)
     expect(
       shouldRevalidate(
+        revalidationArgs(
+          `${TRACES_PATH}/trace-a?rootSpanId=root-a`,
+          `${TRACES_PATH}/trace-a?rootSpanId=root-a`,
+          'trace-a',
+          'trace-a',
+          { defaultShouldRevalidate: true },
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      shouldRevalidate(
         revalidationArgs(TRACES_PATH, '/workspaces/analytics/sources', undefined, undefined, {
           defaultShouldRevalidate: true,
         }),
@@ -103,6 +114,20 @@ describe('traces shouldRevalidate', () => {
           {
             defaultShouldRevalidate: false,
           },
+        ),
+      ),
+    ).toBe(false)
+  })
+
+  it('does not reload the parent list when only a same-trace root selector changes', () => {
+    expect(
+      shouldRevalidate(
+        revalidationArgs(
+          `${TRACES_PATH}/trace-a?search=kept&rootSpanId=root-a`,
+          `${TRACES_PATH}/trace-a?search=kept&rootSpanId=root-b`,
+          'trace-a',
+          'trace-a',
+          { defaultShouldRevalidate: true },
         ),
       ),
     ).toBe(false)
@@ -156,6 +181,28 @@ describe('nested traces data routing', () => {
       pathname: '/workspaces/analytics/traces/trace%2Fwith%3Freserved',
       search: '?search=playwright&pro',
     })
+  })
+
+  it('replaces and removes only the operation root span selector', () => {
+    const location = traceLocation(
+      WORKSPACE_ID,
+      'shared-trace',
+      '?search=playwright&rootSpanId=stale&pro',
+      'root/next',
+    )
+
+    expect(location).toEqual({
+      pathname: `${TRACES_PATH}/shared-trace`,
+      search: '?search=playwright&pro&rootSpanId=root%2Fnext',
+    })
+    expect(rootSpanIdFromSearch(location.search)).toBe('root/next')
+    expect(listSearch(location.search)).toBe('?search=playwright&pro')
+  })
+
+  it('preserves malformed encoding while removing only root span selectors', () => {
+    expect(
+      listSearch('?filter=%E0%A4%A&bad%ZZ=value&rootSpanId=stale%ZZ&pro&root%53panId=encoded'),
+    ).toBe('?filter=%E0%A4%A&bad%ZZ=value&pro')
   })
   it('preserves the list while detail is open and refreshes it immediately on close', async () => {
     const parentLoader = vi.fn().mockResolvedValue({ traces: ['trace-a', 'trace-b'] })
@@ -217,5 +264,45 @@ describe('nested traces data routing', () => {
     await router.navigate(-1)
     expect(router.state.location.pathname).toBe(TRACES_PATH)
     await expect.element(screen.getByRole('link', { name: 'trace-a' })).toBeVisible()
+  })
+
+  it('reloads only child detail for same-trace root navigation and honors explicit refresh', async () => {
+    const parentLoader = vi.fn().mockResolvedValue({ traces: ['trace-a'] })
+    const childLoader = vi.fn(({ request }: { request: Request }) => {
+      const rootSpanId = new URL(request.url).searchParams.get('rootSpanId')
+      return rootSpanId
+    })
+    const router = createMemoryRouter(
+      [
+        {
+          children: [
+            {
+              element: <DetailRoute />,
+              loader: childLoader,
+              path: ':traceId',
+            },
+          ],
+          element: <ParentRoute />,
+          loader: parentLoader,
+          path: TRACES_PATH,
+          shouldRevalidate,
+        },
+      ],
+      { initialEntries: [`${TRACES_PATH}/trace-a?rootSpanId=root-a`] },
+    )
+    const screen = await render(<RouterProvider router={router} />)
+
+    await expect.element(screen.getByText('detail root-a')).toBeVisible()
+    expect(parentLoader).toHaveBeenCalledOnce()
+    expect(childLoader).toHaveBeenCalledOnce()
+
+    await router.navigate(`${TRACES_PATH}/trace-a?rootSpanId=root-b`)
+    await expect.element(screen.getByText('detail root-b')).toBeVisible()
+    expect(parentLoader).toHaveBeenCalledOnce()
+    expect(childLoader).toHaveBeenCalledTimes(2)
+
+    await router.revalidate()
+    expect(parentLoader).toHaveBeenCalledTimes(2)
+    expect(childLoader).toHaveBeenCalledTimes(3)
   })
 })

--- a/apps/reef/app/routes/traces.tsx
+++ b/apps/reef/app/routes/traces.tsx
@@ -2,6 +2,7 @@ import type { ShouldRevalidateFunctionArgs } from 'react-router'
 
 import type { Route } from './+types/traces'
 
+import { ROOT_SPAN_ID_PARAM } from '@/views/traces/trace-location'
 import { TracesIndex } from '@/views/traces/traces-index'
 
 export { loader } from './traces-loader'
@@ -16,13 +17,21 @@ export const middleware: Route.MiddlewareFunction[] = [
 
 export function shouldRevalidate({
   currentParams,
+  currentUrl,
   defaultShouldRevalidate,
   formMethod,
   nextParams,
+  nextUrl,
 }: ShouldRevalidateFunctionArgs) {
   if (formMethod && formMethod.toUpperCase() !== 'GET') return true
   if (currentParams.workspaceId !== nextParams.workspaceId) return true
   if (currentParams.traceId !== nextParams.traceId) return nextParams.traceId === undefined
+  if (
+    currentParams.traceId &&
+    currentUrl.searchParams.get(ROOT_SPAN_ID_PARAM) !== nextUrl.searchParams.get(ROOT_SPAN_ID_PARAM)
+  ) {
+    return false
+  }
   return defaultShouldRevalidate
 }
 

--- a/apps/reef/app/views/traces/trace-detail.test.tsx
+++ b/apps/reef/app/views/traces/trace-detail.test.tsx
@@ -106,7 +106,12 @@ function renderDetail(
   loadError: string | null,
   loadedDetail: TraceDetailData | null,
   traces = loadedDetail?.summary ? [loadedDetail.summary] : [],
+  initialEntries?: string[],
 ) {
+  const rootSpanId = loadedDetail?.summary?.rootSpanId
+  const entries = initialEntries ?? [
+    `${TRACES_PATH}/trace-07?pro${rootSpanId ? `&rootSpanId=${encodeURIComponent(rootSpanId)}` : ''}`,
+  ]
   const router = createMemoryRouter(
     [
       {
@@ -120,7 +125,7 @@ function renderDetail(
         path: TRACES_PATH,
       },
     ],
-    { initialEntries: [`${TRACES_PATH}/trace-07?pro`] },
+    { initialEntries: entries, initialIndex: entries.length - 1 },
   )
   return { router, screen: render(<RouterProvider router={router} />) }
 }
@@ -147,6 +152,47 @@ describe('TraceDetail', () => {
       .element((await screen).getByText('select * from github.pull_requests'))
       .toBeVisible()
     await expect.element((await screen).getByText('7')).toBeVisible()
+  })
+
+  it('canonicalizes a selector-less legacy URL to the matching typed detail operation', async () => {
+    const first = { ...detail().summary!, query: 'select 1', rootSpanId: 'root-a' }
+    const second = { ...detail().summary!, query: 'select 2', rootSpanId: 'root-b' }
+    const selectedDetail = detail()
+    selectedDetail.summary = {
+      ...second,
+      operationKind: TraceOperationKind.QUERY,
+      operationName: 'sql',
+    }
+    const { router, screen } = renderDetail(
+      null,
+      selectedDetail,
+      [first, second],
+      [TRACES_PATH, `${TRACES_PATH}/trace-07?pro`],
+    )
+
+    await expect
+      .poll(() => new URLSearchParams(router.state.location.search).get('rootSpanId'))
+      .toBe('root-b')
+    await expect.element((await screen).getByText('select 2')).toBeVisible()
+
+    await router.navigate(-1)
+    expect(router.state.location.pathname).toBe(TRACES_PATH)
+  })
+
+  it('falls back to the first visible operation when legacy detail has no typed match', async () => {
+    const first = { ...detail().summary!, query: 'select 1', rootSpanId: 'root-a' }
+    const second = { ...detail().summary!, query: 'select 2', rootSpanId: 'root-b' }
+    const { router, screen } = renderDetail(
+      null,
+      null,
+      [first, second],
+      [`${TRACES_PATH}/trace-07?pro`],
+    )
+
+    await expect
+      .poll(() => new URLSearchParams(router.state.location.search).get('rootSpanId'))
+      .toBe('root-a')
+    await expect.element((await screen).getByText('select 1')).toBeVisible()
   })
 
   it('keeps route loader failures closable', async () => {
@@ -196,19 +242,34 @@ describe('TraceDetail', () => {
       traceId,
     }))
     const { router } = renderDetail(null, detail(), traces)
-    await router.navigate(`${TRACES_PATH}/trace-07?search=playwright&pro`)
+    await router.navigate(`${TRACES_PATH}/trace-07?search=playwright&pro&rootSpanId=root`)
 
     dispatchModArrow('ArrowDown')
     await expect.poll(() => router.state.location.pathname).toBe(`${TRACES_PATH}/older`)
-    expect(router.state.location.search).toBe('?search=playwright&pro')
+    expect(router.state.location.search).toBe('?search=playwright&pro&rootSpanId=root')
 
-    await router.navigate(`${TRACES_PATH}/trace-07?search=playwright&pro`)
+    await router.navigate(`${TRACES_PATH}/trace-07?search=playwright&pro&rootSpanId=root`)
     dispatchModArrow('ArrowUp')
     await expect.poll(() => router.state.location.pathname).toBe(`${TRACES_PATH}/newer`)
 
     await userEvent.keyboard('{Escape}')
     await expect.poll(() => router.state.location.pathname).toBe(TRACES_PATH)
     expect(router.state.location.search).toBe('?search=playwright&pro')
+  })
+
+  it('navigates adjacent operations that share a trace ID by root span', async () => {
+    const current = detail().summary!
+    const first = { ...current, query: 'select 1', rootSpanId: 'root-a' }
+    const second = { ...current, query: 'select 2', rootSpanId: 'root-b' }
+    const selectedDetail = detail()
+    selectedDetail.summary = first
+    const { router } = renderDetail(null, selectedDetail, [first, second])
+    await router.navigate(`${TRACES_PATH}/trace-07?pro&rootSpanId=root-a`)
+
+    dispatchModArrow('ArrowDown')
+    await expect
+      .poll(() => new URLSearchParams(router.state.location.search).get('rootSpanId'))
+      .toBe('root-b')
   })
 
   it('renders the no-summary state and keeps it closable', async () => {

--- a/apps/reef/app/views/traces/trace-detail.tsx
+++ b/apps/reef/app/views/traces/trace-detail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import classNames from 'classnames'
-import { useLocation, useNavigate, useOutletContext } from 'react-router'
+import { Navigate, useLocation, useNavigate, useOutletContext } from 'react-router'
 
 import { Button, ScrollArea } from '@/wax/components'
 import { Icon } from '@/wax/components/icon'
@@ -12,7 +12,7 @@ import { TraceStatus } from '@/generated/coral/v1/traces_pb'
 
 import * as s from './traces.css'
 import { HttpSpanDetail } from './http-span-detail'
-import { traceLocation } from './trace-location'
+import { listSearch, rootSpanIdFromSearch, traceLocation } from './trace-location'
 import type { TracesOutletContext } from './traces-index'
 import { routePath } from '@/routing/routemap'
 import { useTimelineTree, type TimelineRow } from './use-timeline-tree'
@@ -20,6 +20,7 @@ import {
   formatDuration,
   formatDurationFromNanos,
   formatRows,
+  hasTypedOperation,
   isHttpSpan,
   nanosToMs,
   spanDisplayLabel,
@@ -390,9 +391,15 @@ function TimelineWaterfall({
   const [renderedHttpSpanId, setRenderedHttpSpanId] = useState<string | null>(expandedHttpSpanId)
   const [detailPanelVisible, setDetailPanelVisible] = useState(Boolean(expandedHttpSpanId))
   const [detailPanelSettled, setDetailPanelSettled] = useState(Boolean(expandedHttpSpanId))
-  useEffect(() => onExpandedHttpSpanIdChange(null), [onExpandedHttpSpanIdChange, summary?.traceId])
-  useEffect(() => setHoveredSpanId(null), [summary?.traceId])
-  useEffect(() => setDetailPanelRatio(DETAIL_PANEL_DEFAULT_RATIO), [summary?.traceId])
+  useEffect(
+    () => onExpandedHttpSpanIdChange(null),
+    [onExpandedHttpSpanIdChange, summary?.rootSpanId, summary?.traceId],
+  )
+  useEffect(() => setHoveredSpanId(null), [summary?.rootSpanId, summary?.traceId])
+  useEffect(
+    () => setDetailPanelRatio(DETAIL_PANEL_DEFAULT_RATIO),
+    [summary?.rootSpanId, summary?.traceId],
+  )
   useEffect(() => {
     if (panelAnimationFrame.current !== null) {
       window.cancelAnimationFrame(panelAnimationFrame.current)
@@ -653,24 +660,24 @@ function DetailTabs({
 
 function TraceDetailContent({
   detail,
+  entryKey,
   extraTabs,
   initialSummary,
   loadError,
-  newerTraceId,
-  olderTraceId,
+  newerTrace,
+  olderTrace,
   onClose,
   onSelectTrace,
-  traceId,
 }: {
   detail: TraceDetailData | null
+  entryKey: string
   extraTabs?: (detail: TraceDetailData) => ExtraDetailTab[]
   initialSummary?: TraceSummaryData
   loadError: string | null
-  newerTraceId?: string | null
-  olderTraceId?: string | null
+  newerTrace?: TraceSummaryData | null
+  olderTrace?: TraceSummaryData | null
   onClose: () => void
-  onSelectTrace?: (traceId: string) => void
-  traceId: string
+  onSelectTrace?: (trace: TraceSummaryData) => void
 }) {
   const [activeTab, setActiveTab] = useState<string>('timeline')
   const [expandedHttpSpanId, setExpandedHttpSpanId] = useState<string | null>(null)
@@ -678,7 +685,7 @@ function TraceDetailContent({
   useEffect(() => {
     setActiveTab('timeline')
     setExpandedHttpSpanId(null)
-  }, [traceId])
+  }, [entryKey])
 
   const selectAdjacentSpan = useCallback(
     (direction: -1 | 1) => {
@@ -694,20 +701,20 @@ function TraceDetailContent({
 
   const handleNewerTraceShortcut = useCallback(
     (event: KeyboardEvent) => {
-      if (!newerTraceId) return
+      if (!newerTrace) return
       event.preventDefault()
-      onSelectTrace?.(newerTraceId)
+      onSelectTrace?.(newerTrace)
     },
-    [newerTraceId, onSelectTrace],
+    [newerTrace, onSelectTrace],
   )
 
   const handleOlderTraceShortcut = useCallback(
     (event: KeyboardEvent) => {
-      if (!olderTraceId) return
+      if (!olderTrace) return
       event.preventDefault()
-      onSelectTrace?.(olderTraceId)
+      onSelectTrace?.(olderTrace)
     },
-    [olderTraceId, onSelectTrace],
+    [olderTrace, onSelectTrace],
   )
 
   const handleEscapeShortcut = useCallback(
@@ -809,9 +816,9 @@ function TraceDetailContent({
           >
             <Button.IconButton
               ariaLabel="Newer query"
-              disabled={!newerTraceId}
+              disabled={!newerTrace}
               name="ArrowUp"
-              onClick={() => newerTraceId && onSelectTrace?.(newerTraceId)}
+              onClick={() => newerTrace && onSelectTrace?.(newerTrace)}
               size="32"
               variant="bare"
             />
@@ -824,9 +831,9 @@ function TraceDetailContent({
           >
             <Button.IconButton
               ariaLabel="Older query"
-              disabled={!olderTraceId}
+              disabled={!olderTrace}
               name="ArrowDown"
-              onClick={() => olderTraceId && onSelectTrace?.(olderTraceId)}
+              onClick={() => olderTrace && onSelectTrace?.(olderTrace)}
               size="32"
               variant="bare"
             />
@@ -910,33 +917,60 @@ export function TraceDetail({
   const { traces, workspaceId } = useOutletContext<TracesOutletContext>()
   const location = useLocation()
   const navigate = useNavigate()
-  const selectedIndex = traces.findIndex((trace) => trace.traceId === traceId)
-  const newerTraceId = selectedIndex > 0 ? traces[selectedIndex - 1].traceId : null
-  const olderTraceId =
-    selectedIndex >= 0 && selectedIndex < traces.length - 1
-      ? traces[selectedIndex + 1].traceId
-      : null
+  const selectedRootSpanId = rootSpanIdFromSearch(location.search)
+  const traceEntries = traces.filter((trace) => trace.traceId === traceId)
+  const detailSummary = detail?.summary
+  const matchingTypedDetailEntry =
+    detailSummary && hasTypedOperation(detailSummary)
+      ? traceEntries.find((trace) => trace.rootSpanId === detailSummary.rootSpanId)
+      : undefined
+  const canonicalEntry = selectedRootSpanId
+    ? undefined
+    : (matchingTypedDetailEntry ?? traceEntries[0])
+
+  if (canonicalEntry?.rootSpanId) {
+    return (
+      <Navigate
+        replace
+        to={traceLocation(
+          workspaceId,
+          canonicalEntry.traceId,
+          location.search,
+          canonicalEntry.rootSpanId,
+        )}
+      />
+    )
+  }
+
+  const selectedIndex = traces.findIndex(
+    (trace) =>
+      trace.traceId === traceId && (!selectedRootSpanId || trace.rootSpanId === selectedRootSpanId),
+  )
+  const newerTrace = selectedIndex > 0 ? traces[selectedIndex - 1] : null
+  const olderTrace =
+    selectedIndex >= 0 && selectedIndex < traces.length - 1 ? traces[selectedIndex + 1] : null
   const initialSummary = selectedIndex >= 0 ? traces[selectedIndex] : detail?.summary
+  const entryKey = `${traceId}\u0000${selectedRootSpanId}`
 
   return (
     <div className={s.detailOverlay}>
       <TraceDetailContent
         detail={detail}
+        entryKey={entryKey}
         extraTabs={extraTabs}
         initialSummary={initialSummary}
         loadError={loadError}
-        newerTraceId={newerTraceId}
-        olderTraceId={olderTraceId}
+        newerTrace={newerTrace}
+        olderTrace={olderTrace}
         onClose={() =>
           navigate({
             pathname: routePath('workspaceTraces', { workspaceId }),
-            search: location.search,
+            search: listSearch(location.search),
           })
         }
-        onSelectTrace={(nextTraceId) =>
-          navigate(traceLocation(workspaceId, nextTraceId, location.search))
+        onSelectTrace={(trace) =>
+          navigate(traceLocation(workspaceId, trace.traceId, location.search, trace.rootSpanId))
         }
-        traceId={traceId}
       />
     </div>
   )

--- a/apps/reef/app/views/traces/trace-list.test.tsx
+++ b/apps/reef/app/views/traces/trace-list.test.tsx
@@ -3,7 +3,7 @@ import { TraceOperationKind, TraceStatus } from '@/generated/coral/v1/traces_pb'
 import { describe, expect, it } from 'vitest'
 import { render } from 'vitest-browser-react'
 
-import type { TraceSummaryData } from './trace-utils'
+import { traceEntryKey, type TraceSummaryData } from './trace-utils'
 import { TraceList } from './trace-list'
 
 function summary(traceId: string): TraceSummaryData {
@@ -46,7 +46,10 @@ describe('TraceList', () => {
 
     await expect
       .element(screen.getByRole('link', { name: /select 'trace\/with\?reserved'/i }))
-      .toHaveAttribute('href', '/workspaces/analytics/traces/trace%2Fwith%3Freserved?pro')
+      .toHaveAttribute(
+        'href',
+        '/workspaces/analytics/traces/trace%2Fwith%3Freserved?pro&rootSpanId=root-trace%2Fwith%3Freserved',
+      )
   })
 
   it('marks the URL-selected row current independently from keyboard highlighting', async () => {
@@ -56,7 +59,7 @@ describe('TraceList', () => {
           children: [{ element: null, path: ':traceId' }],
           element: (
             <TraceList
-              activeTraceId="keyboard-active"
+              activeTraceKey={traceEntryKey(summary('keyboard-active'))}
               referenceTimeMs={2_000_000}
               traces={[summary('selected'), summary('keyboard-active')]}
               workspaceId="analytics"
@@ -76,5 +79,39 @@ describe('TraceList', () => {
     await expect
       .element(screen.getByRole('link', { name: /select 'keyboard-active'/i }))
       .toHaveAttribute('data-active', 'true')
+  })
+
+  it('selects duplicate trace IDs by root span and gives each row a distinct link', async () => {
+    const first = { ...summary('shared'), query: 'select 1', rootSpanId: 'root-a' }
+    const second = { ...summary('shared'), query: 'select 2', rootSpanId: 'root-b' }
+    const router = createMemoryRouter(
+      [
+        {
+          children: [{ element: null, path: ':traceId' }],
+          element: (
+            <TraceList
+              referenceTimeMs={2_000_000}
+              traces={[first, second]}
+              workspaceId="analytics"
+            />
+          ),
+          path: '/workspaces/:workspaceId/traces',
+        },
+      ],
+      { initialEntries: ['/workspaces/analytics/traces/shared?pro&rootSpanId=root-b'] },
+    )
+
+    const screen = await render(<RouterProvider router={router} />)
+    const firstLink = screen.getByRole('link', { name: /select 1/i })
+    const secondLink = screen.getByRole('link', { name: /select 2/i })
+
+    await expect.element(firstLink).not.toHaveAttribute('aria-current')
+    await expect.element(secondLink).toHaveAttribute('aria-current', 'page')
+    await expect
+      .element(firstLink)
+      .toHaveAttribute('href', '/workspaces/analytics/traces/shared?pro&rootSpanId=root-a')
+    await expect
+      .element(secondLink)
+      .toHaveAttribute('href', '/workspaces/analytics/traces/shared?pro&rootSpanId=root-b')
   })
 })

--- a/apps/reef/app/views/traces/trace-list.tsx
+++ b/apps/reef/app/views/traces/trace-list.tsx
@@ -1,12 +1,12 @@
 import classNames from 'classnames'
-import { NavLink, useLocation } from 'react-router'
+import { Link, useLocation, useParams } from 'react-router'
 
 import { HighlightedCode } from '@/components/code-block'
-import { routePath } from '@/routing/routemap'
 import { Tooltip } from '@/wax/components/tooltip'
 import { Typography } from '@/wax/components/typography'
 
 import * as s from './traces.css'
+import { rootSpanIdFromSearch, traceLocation } from './trace-location'
 import {
   durationClass,
   formatDurationFromNanos,
@@ -14,6 +14,8 @@ import {
   startMs,
   statusTone,
   timeAgo,
+  traceEntryKey,
+  traceRowId,
   type TraceSummaryData,
 } from './trace-utils'
 
@@ -21,24 +23,24 @@ function TraceRow({
   active,
   referenceTimeMs,
   search,
+  selected,
   trace,
   workspaceId,
 }: {
   active: boolean
   referenceTimeMs: number
   search: string
+  selected: boolean
   trace: TraceSummaryData
   workspaceId: string
 }) {
   return (
-    <NavLink
+    <Link
+      aria-current={selected ? 'page' : undefined}
       className={s.fullRow}
       data-active={active || undefined}
-      data-trace-row-id={trace.traceId}
-      to={{
-        pathname: routePath('workspaceTrace', { traceId: trace.traceId, workspaceId }),
-        search,
-      }}
+      data-trace-row-id={traceRowId(trace)}
+      to={traceLocation(workspaceId, trace.traceId, search, trace.rootSpanId)}
     >
       <span className={s.statusDot} data-tone={statusTone(trace.status)} />
       <div className={classNames(s.cell, s.cellTimestamp)}>
@@ -64,30 +66,39 @@ function TraceRow({
       >
         <Typography.Body as="span">{formatDurationFromNanos(trace.durationNanos)}</Typography.Body>
       </div>
-    </NavLink>
+    </Link>
   )
 }
 
 export function TraceList({
-  activeTraceId,
+  activeTraceKey,
   referenceTimeMs,
   traces,
   workspaceId,
 }: {
-  activeTraceId?: string | null
+  activeTraceKey?: string | null
   referenceTimeMs: number
   traces: TraceSummaryData[]
   workspaceId: string
 }) {
   const location = useLocation()
+  const { traceId: selectedTraceId } = useParams()
+  const selectedRootSpanId = rootSpanIdFromSearch(location.search)
+  const selectedTrace = traces.find(
+    (trace) =>
+      trace.traceId === selectedTraceId &&
+      (!selectedRootSpanId || trace.rootSpanId === selectedRootSpanId),
+  )
+  const selectedTraceKey = selectedTrace ? traceEntryKey(selectedTrace) : null
   return (
     <div className={s.traceList}>
       {traces.map((trace) => (
         <TraceRow
-          active={trace.traceId === activeTraceId}
-          key={trace.traceId}
+          active={traceEntryKey(trace) === activeTraceKey}
+          key={traceEntryKey(trace)}
           referenceTimeMs={referenceTimeMs}
           search={location.search}
+          selected={traceEntryKey(trace) === selectedTraceKey}
           trace={trace}
           workspaceId={workspaceId}
         />

--- a/apps/reef/app/views/traces/trace-location.ts
+++ b/apps/reef/app/views/traces/trace-location.ts
@@ -1,5 +1,43 @@
 import { routePath } from '@/routing/routemap'
 
-export function traceLocation(workspaceId: string, traceId: string, search: string) {
-  return { pathname: routePath('workspaceTrace', { traceId, workspaceId }), search }
+export const ROOT_SPAN_ID_PARAM = 'rootSpanId'
+
+function searchWithRootSpanId(search: string, rootSpanId: string): string {
+  const base = listSearch(search)
+  if (!rootSpanId) return base
+  return `${base || '?'}${base ? '&' : ''}${ROOT_SPAN_ID_PARAM}=${encodeURIComponent(rootSpanId)}`
+}
+
+export function listSearch(search: string): string {
+  // Parse manually so removing rootSpanId preserves every other parameter's raw spelling and
+  // valueless flags instead of normalizing them through URLSearchParams.
+  const parts = search
+    .replace(/^\?/, '')
+    .split('&')
+    .filter(Boolean)
+    .filter((part) => {
+      const rawName = part.split('=', 1)[0]
+      try {
+        return decodeURIComponent(rawName.replace(/\+/g, ' ')) !== ROOT_SPAN_ID_PARAM
+      } catch {
+        return rawName !== ROOT_SPAN_ID_PARAM
+      }
+    })
+  return parts.length > 0 ? `?${parts.join('&')}` : ''
+}
+
+export function rootSpanIdFromSearch(search: string): string {
+  return new URLSearchParams(search).get(ROOT_SPAN_ID_PARAM) ?? ''
+}
+
+export function traceLocation(
+  workspaceId: string,
+  traceId: string,
+  search: string,
+  rootSpanId?: string,
+) {
+  return {
+    pathname: routePath('workspaceTrace', { traceId, workspaceId }),
+    search: rootSpanId === undefined ? search : searchWithRootSpanId(search, rootSpanId),
+  }
 }

--- a/apps/reef/app/views/traces/trace-utils.ts
+++ b/apps/reef/app/views/traces/trace-utils.ts
@@ -1,4 +1,9 @@
-import { TraceStatus, type TraceSpan, type TraceSummary } from '@/generated/coral/v1/traces_pb'
+import {
+  TraceOperationKind,
+  TraceStatus,
+  type TraceSpan,
+  type TraceSummary,
+} from '@/generated/coral/v1/traces_pb'
 
 export type JsonObject = Record<string, unknown>
 export type TraceSpanData = Omit<TraceSpan, '$typeName' | '$unknown'>
@@ -210,8 +215,22 @@ export function sortedSpans(spans: TraceSpanData[]): TraceSpanData[] {
   })
 }
 
-export function isQueryTrace(trace: TraceSummaryData): boolean {
-  return trace.name === 'coral.query' || trace.query.trim().length > 0
+export function isLegacyQueryTrace(trace: TraceSummaryData): boolean {
+  return (
+    trace.name === 'coral.query' || trace.name === 'coral.search' || trace.query.trim().length > 0
+  )
+}
+
+export function hasTypedOperation(trace: TraceSummaryData): boolean {
+  return trace.operationKind !== TraceOperationKind.UNSPECIFIED
+}
+
+export function traceEntryKey(trace: Pick<TraceSummaryData, 'rootSpanId' | 'traceId'>): string {
+  return `${trace.traceId}\u0000${trace.rootSpanId}`
+}
+
+export function traceRowId(trace: Pick<TraceSummaryData, 'rootSpanId' | 'traceId'>): string {
+  return `${encodeURIComponent(trace.traceId)}:${encodeURIComponent(trace.rootSpanId)}`
 }
 
 export function sourceNames(spans: TraceSpanData[]): string[] {

--- a/apps/reef/app/views/traces/traces-index.test.tsx
+++ b/apps/reef/app/views/traces/traces-index.test.tsx
@@ -25,7 +25,7 @@ interface Data {
 const WORKSPACE_ID = 'analytics'
 const TRACES_PATH = routePath('workspaceTraces', { workspaceId: WORKSPACE_ID })
 
-function summary(traceId: string): TraceSummaryData {
+function summary(traceId: string, rootSpanId = `root-${traceId}`): TraceSummaryData {
   return {
     durationNanos: '1000000',
     endTimeUnixNanos: '2000000',
@@ -33,7 +33,7 @@ function summary(traceId: string): TraceSummaryData {
     operationKind: TraceOperationKind.UNSPECIFIED,
     operationName: '',
     query: `select '${traceId}'`,
-    rootSpanId: `root-${traceId}`,
+    rootSpanId,
     rowCount: '1',
     rowCountRecorded: true,
     spanCount: 1,
@@ -182,7 +182,7 @@ describe('TracesIndex route behavior', () => {
     expect(scrollIntoView).toHaveBeenCalled()
     await userEvent.keyboard('{Enter}')
     expect(router.state.location.pathname).toBe(`${TRACES_PATH}/alpha`)
-    expect(router.state.location.search).toBe('?pro')
+    expect(router.state.location.search).toBe('?pro&rootSpanId=root-alpha')
     HTMLElement.prototype.scrollIntoView = original
   })
 
@@ -205,5 +205,27 @@ describe('TracesIndex route behavior', () => {
     }))
     await expect.element((await unavailable.screen).getByText('Tracing unavailable')).toBeVisible()
     await expect.element((await unavailable.screen).getByText('Disconnected')).toBeVisible()
+  })
+
+  it('navigates duplicate trace IDs by root span', async () => {
+    const { router, screen } = renderIndex(() => ({
+      endpointLabel: 'reef.test',
+      referenceTimeMs: 120_000,
+      loadError: null,
+      traces: [
+        { ...summary('shared', 'root-a'), query: 'select 1' },
+        { ...summary('shared', 'root-b'), query: 'select 2' },
+      ],
+    }))
+    const rendered = await screen
+
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}')
+    await expect
+      .element(rendered.getByRole('link', { name: /select 2/i }))
+      .toHaveAttribute('data-active', 'true')
+    await userEvent.keyboard('{Enter}')
+
+    expect(router.state.location.pathname).toBe(`${TRACES_PATH}/shared`)
+    expect(new URLSearchParams(router.state.location.search).get('rootSpanId')).toBe('root-b')
   })
 })

--- a/apps/reef/app/views/traces/traces-index.tsx
+++ b/apps/reef/app/views/traces/traces-index.tsx
@@ -12,7 +12,8 @@ import * as s from './traces.css'
 import { PageHeader } from './page-header'
 import { StatusBar } from './status-bar'
 import { TraceList } from './trace-list'
-import type { TraceSummaryData } from './trace-utils'
+import { traceLocation } from './trace-location'
+import { traceEntryKey, traceRowId, type TraceSummaryData } from './trace-utils'
 
 const TRACE_LIST_REFRESH_MS = 30_000
 
@@ -160,13 +161,8 @@ export function TracesIndex({
         )
           return
         event.preventDefault()
-        navigate({
-          pathname: routePath('workspaceTrace', {
-            traceId: filtered[activeIndex].traceId,
-            workspaceId,
-          }),
-          search: location.search,
-        })
+        const trace = filtered[activeIndex]
+        navigate(traceLocation(workspaceId, trace.traceId, location.search, trace.rootSpanId))
       }
     }
     window.addEventListener('keydown', handler)
@@ -177,7 +173,7 @@ export function TracesIndex({
     if (activeIndex === null) return
     const trace = filtered[activeIndex]
     if (!trace) return
-    const escaped = trace.traceId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+    const escaped = traceRowId(trace).replace(/\\/g, '\\\\').replace(/"/g, '\\"')
     document.querySelector(`[data-trace-row-id="${escaped}"]`)?.scrollIntoView({ block: 'nearest' })
   }, [activeIndex, filtered])
 
@@ -232,7 +228,11 @@ export function TracesIndex({
       ) : (
         <div className={s.queryScroll}>
           <TraceList
-            activeTraceId={activeIndex !== null ? filtered[activeIndex]?.traceId : null}
+            activeTraceKey={
+              activeIndex !== null && filtered[activeIndex]
+                ? traceEntryKey(filtered[activeIndex])
+                : null
+            }
             referenceTimeMs={referenceTimeMs}
             traces={filtered}
             workspaceId={workspaceId}


### PR DESCRIPTION
## Summary

- request the server-side `QUERY_STREAM` view from Reef
- retain a bounded compatibility path for older servers that return non-empty, untyped trace summaries
- stop scanning legacy pages once typed operation rows are returned
- pass `rootSpanId` through detail requests and operation links
- use `(traceId, rootSpanId)` as row, selection, navigation, and React identity
- support multiple operations that share one distributed trace
- carry the summary's generic `query` value unchanged, including Search text projected by the backend
- canonicalize selector-less legacy URLs and reload only detail when the selected root changes within one trace
- preserve unrelated query parameters when adding or removing the root selector

## Stack boundary

- Layer 7 of 8
- Depends on: #1949
- Next: #1904
- This PR is the Reef transport, routing, and identity bridge. Labels, previews, filtering language, and Search-text presentation remain in #1904. It contains no backend or proto changes.

## Validation

- `npm run check --prefix apps/reef`: passed at the final stack tip
- `npm run typecheck --prefix apps/reef`: passed
- `npm test --prefix apps/reef`: 107 files / 469 tests passed
- `npm run build --prefix apps/reef`: passed
- loader and routing regressions cover typed responses, bounded legacy fallback, canonicalization, revalidation, parameter preservation, and duplicate trace IDs
- `git range-diff` confirms this PR's patch is unchanged after its ancestors were rewritten
- `git diff --check`: passed
