### PR TITLE
refactor(app): make workspace lifecycle locking async

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,9 @@
 - Keep shared Arrow IPC decoding and result rendering in `coral-client`.
 - Treat `coral-app` as an internal composition root even if sibling crates use
   its bootstrap seam today.
+- Acquire the workspace lifecycle write guard before opening a database
+  transaction or awaiting a database connection. Keep that order consistent
+  across lifecycle mutations so pool contention cannot invert the locks.
 - If a caller needs explicit local server control, prefer `coral-client::local`
   over widening the default client surface.
 - Keep process environment access owned by the right crate. `coral-app` owns

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -83,7 +83,7 @@ impl FunctionManager {
     }
 
     #[cfg(test)]
-    pub(crate) fn install_validated_user_function(
+    pub(crate) async fn install_validated_user_function(
         &self,
         workspace_name: &WorkspaceName,
         raw_sql: &str,
@@ -91,9 +91,10 @@ impl FunctionManager {
     ) -> Result<InstalledFunction, AppError> {
         let function_name = validated_function_name(raw_sql, runtime_function)?;
         self.install_user_function_artifact(workspace_name, &function_name, raw_sql)
+            .await
     }
 
-    pub(crate) fn install_validated_user_function_if_unchanged(
+    pub(crate) async fn install_validated_user_function_if_unchanged(
         &self,
         workspace_name: &WorkspaceName,
         raw_sql: &str,
@@ -101,7 +102,11 @@ impl FunctionManager {
         revision: WorkspaceLifecycleRevision,
     ) -> Result<ValidatedFunctionInstall, AppError> {
         let function_name = validated_function_name(raw_sql, runtime_function)?;
-        let Some(_lifecycle_guard) = self.lifecycle_lock.lock_if_unchanged(revision) else {
+        let Some(_lifecycle_guard) = self
+            .lifecycle_lock
+            .lock_if_unchanged(workspace_name, revision)
+            .await
+        else {
             return Ok(ValidatedFunctionInstall::WorkspaceChanged);
         };
         self.install_user_function_artifact_with_lifecycle_lock(
@@ -113,13 +118,13 @@ impl FunctionManager {
     }
 
     #[cfg(test)]
-    fn install_user_function_artifact(
+    async fn install_user_function_artifact(
         &self,
         workspace_name: &WorkspaceName,
         function_name: &FunctionName,
         raw_sql: &str,
     ) -> Result<InstalledFunction, AppError> {
-        let _lifecycle_guard = self.lifecycle_lock.lock();
+        let _lifecycle_guard = self.lifecycle_lock.lock(workspace_name).await;
         self.install_user_function_artifact_with_lifecycle_lock(
             workspace_name,
             function_name,
@@ -299,12 +304,12 @@ impl FunctionManager {
             .collect()
     }
 
-    pub(crate) fn remove_user_function(
+    pub(crate) async fn remove_user_function(
         &self,
         workspace_name: &WorkspaceName,
         function_name: &FunctionName,
     ) -> Result<(), AppError> {
-        let _lifecycle_guard = self.lifecycle_lock.lock();
+        let _lifecycle_guard = self.lifecycle_lock.lock(workspace_name).await;
         let _state_lock = self.config_store.state_lock_exclusive()?;
         self.config_store
             .get_function_unlocked(workspace_name, function_name)?;
@@ -543,7 +548,7 @@ select 1 as id
         }
     }
 
-    fn install_fixture_function(
+    async fn install_fixture_function(
         manager: &FunctionManager,
         workspace: &WorkspaceName,
         raw_sql: &str,
@@ -551,6 +556,7 @@ select 1 as id
         let runtime_function = validated_function(raw_sql);
         manager
             .install_validated_user_function(workspace, raw_sql, &runtime_function)
+            .await
             .expect("install function")
     }
 
@@ -559,7 +565,7 @@ select 1 as id
         let (_temp, layout, _config_store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql_with_owner_query("review_queue");
-        install_fixture_function(&manager, &workspace, &raw_sql);
+        install_fixture_function(&manager, &workspace, &raw_sql).await;
         let function_name = FunctionName::parse("review_queue").expect("function name");
         std::fs::write(
             layout.function_file(&workspace, &function_name),
@@ -595,8 +601,8 @@ select 1 as id
     async fn list_functions_builds_one_inference_runtime_for_all_functions() {
         let (_temp, _layout, _config_store, manager) = fixture();
         let workspace = workspace();
-        install_fixture_function(&manager, &workspace, &function_sql("first"));
-        install_fixture_function(&manager, &workspace, &function_sql("second"));
+        install_fixture_function(&manager, &workspace, &function_sql("first")).await;
+        install_fixture_function(&manager, &workspace, &function_sql("second")).await;
         let runtime_builds = std::sync::atomic::AtomicUsize::new(0);
 
         let listed = manager
@@ -616,7 +622,7 @@ select 1 as id
         let (_temp, layout, _config_store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql_with_owner_query("review_queue");
-        let installed = install_fixture_function(&manager, &workspace, &raw_sql);
+        let installed = install_fixture_function(&manager, &workspace, &raw_sql).await;
         std::fs::write(
             layout.function_file(&workspace, &installed.name),
             raw_sql.replace(
@@ -644,7 +650,7 @@ select 1 as id
         let (_temp, layout, _config_store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql("review_queue");
-        let installed = install_fixture_function(&manager, &workspace, &raw_sql);
+        let installed = install_fixture_function(&manager, &workspace, &raw_sql).await;
         std::fs::write(
             layout.function_file(&workspace, &installed.name),
             raw_sql.replace("name: review_queue", "name: renamed"),
@@ -664,6 +670,7 @@ select 1 as id
         assert!(error.contains("declares name 'renamed'"));
         manager
             .remove_user_function(&workspace, &installed.name)
+            .await
             .expect("inventory name remains removable");
     }
 
@@ -672,7 +679,7 @@ select 1 as id
         let (_temp, layout, _config_store, manager) = fixture();
         let workspace = workspace();
         let installed =
-            install_fixture_function(&manager, &workspace, &function_sql("missing_artifact"));
+            install_fixture_function(&manager, &workspace, &function_sql("missing_artifact")).await;
         std::fs::remove_file(layout.function_file(&workspace, &installed.name))
             .expect("remove existing artifact");
 
@@ -694,7 +701,7 @@ select 1 as id
         let (_temp, _layout, _config_store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql("review_queue");
-        install_fixture_function(&manager, &workspace, &raw_sql);
+        install_fixture_function(&manager, &workspace, &raw_sql).await;
         let runtime = coral_engine::CoralQuery::prepare(&[], QueryRuntimeConfig::default())
             .await
             .expect("prepare runtime");
@@ -710,15 +717,16 @@ select 1 as id
         assert_eq!(runtime_function.result_columns.len(), 1);
     }
 
-    #[test]
-    fn remove_user_function_removes_inventory_and_artifacts() {
+    #[tokio::test]
+    async fn remove_user_function_removes_inventory_and_artifacts() {
         let (_temp, layout, config_store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql("review_queue");
-        let installed = install_fixture_function(&manager, &workspace, &raw_sql);
+        let installed = install_fixture_function(&manager, &workspace, &raw_sql).await;
 
         manager
             .remove_user_function(&workspace, &installed.name)
+            .await
             .expect("remove function");
 
         assert!(
@@ -733,13 +741,14 @@ select 1 as id
         );
     }
 
-    #[test]
-    fn remove_user_function_reports_typed_missing_function() {
+    #[tokio::test]
+    async fn remove_user_function_reports_typed_missing_function() {
         let (_temp, _layout, _config_store, manager) = fixture();
         let function_name = FunctionName::parse("missing").expect("function name");
 
         let error = manager
             .remove_user_function(&workspace(), &function_name)
+            .await
             .expect_err("missing function should fail");
 
         assert!(matches!(
@@ -748,16 +757,16 @@ select 1 as id
         ));
     }
 
-    #[test]
-    fn install_user_function_waits_for_workspace_lifecycle_lock() {
+    #[tokio::test]
+    async fn install_user_function_waits_for_workspace_lifecycle_lock() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
         let config_store = ConfigStore::new(layout.clone());
         let lifecycle_lock = WorkspaceLifecycleLock::default();
         let manager = FunctionManager::new(config_store, &layout, lifecycle_lock.clone());
-        let lifecycle_guard = lifecycle_lock.lock();
         let workspace = workspace();
+        let lifecycle_guard = lifecycle_lock.lock(&workspace).await;
 
         let install_manager = manager.clone();
         let install_workspace = workspace.clone();
@@ -767,8 +776,15 @@ select 1 as id
             started_tx.send(()).expect("send started");
             let raw_sql = function_sql("review_queue");
             let runtime_function = validated_function(&raw_sql);
-            let result = install_manager
-                .install_validated_user_function(&install_workspace, &raw_sql, &runtime_function)
+            let result = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build runtime")
+                .block_on(install_manager.install_validated_user_function(
+                    &install_workspace,
+                    &raw_sql,
+                    &runtime_function,
+                ))
                 .map(|function| function.name.to_string())
                 .map_err(|error| error.to_string());
             done_tx.send(result).expect("send install result");
@@ -794,12 +810,12 @@ select 1 as id
         handle.join().expect("join install thread");
     }
 
-    #[test]
-    fn install_user_function_reports_inventory_and_restore_failures() {
+    #[tokio::test]
+    async fn install_user_function_reports_inventory_and_restore_failures() {
         let (_temp, layout, config_store, manager) = fixture();
         let workspace = workspace();
         let original_sql = function_sql("review_queue");
-        install_fixture_function(&manager, &workspace, &original_sql);
+        install_fixture_function(&manager, &workspace, &original_sql).await;
 
         let function_name = FunctionName::parse("review_queue").expect("function name");
         let replacement_sql = format!("{original_sql}\n");
@@ -816,6 +832,7 @@ select 1 as id
         let runtime_function = validated_function(&replacement_sql);
         let error = manager
             .install_validated_user_function(&workspace, &replacement_sql, &runtime_function)
+            .await
             .expect_err("inventory and restore failures should be reported together");
 
         let AppError::FailedPrecondition(message) = error else {

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -88,6 +88,7 @@ impl FunctionServiceApi for FunctionService {
             queries
                 .function_manager()
                 .remove_user_function(&workspace_name, &function_name)
+                .await
                 .map_err(app_status)?;
             Ok(Response::new(DeleteFunctionResponse {}))
         })

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -743,7 +743,7 @@ impl QueryManager {
         self.require_workspace(workspace_name)
             .await
             .map_err(QueryManagerError::App)?;
-        let _lifecycle_snapshot = self.lifecycle_lock.snapshot();
+        let _lifecycle_snapshot = self.lifecycle_lock.snapshot(workspace_name).await;
         let (loaded_sources, config) = self.load_function_validation_sources(workspace_name)?;
         self.validate_udf_sql_against_snapshot(workspace_name, raw_sql, &loaded_sources, &config)
             .await
@@ -755,12 +755,17 @@ impl QueryManager {
         raw_sql: &str,
     ) -> Result<UdfRuntimeDefinition, QueryManagerError> {
         for _ in 0..2 {
-            let revision = self.lifecycle_lock.snapshot().revision();
+            let revision = self
+                .lifecycle_lock
+                .snapshot(workspace_name)
+                .await
+                .revision();
             self.require_workspace(workspace_name)
                 .await
                 .map_err(QueryManagerError::App)?;
-            let Some((loaded_sources, config)) =
-                self.function_validation_snapshot_if_unchanged(workspace_name, revision)?
+            let Some((loaded_sources, config)) = self
+                .function_validation_snapshot_if_unchanged(workspace_name, revision)
+                .await?
             else {
                 continue;
             };
@@ -780,6 +785,7 @@ impl QueryManager {
                     &runtime_function,
                     revision,
                 )
+                .await
                 .map_err(QueryManagerError::App)?
             {
                 ValidatedFunctionInstall::Installed => return Ok(runtime_function),
@@ -792,12 +798,12 @@ impl QueryManager {
         )))
     }
 
-    fn function_validation_snapshot_if_unchanged(
+    async fn function_validation_snapshot_if_unchanged(
         &self,
         workspace_name: &WorkspaceName,
         revision: WorkspaceLifecycleRevision,
     ) -> Result<Option<(Vec<LoadedQuerySource>, AppConfig)>, QueryManagerError> {
-        let lifecycle_snapshot = self.lifecycle_lock.snapshot();
+        let lifecycle_snapshot = self.lifecycle_lock.snapshot(workspace_name).await;
         if lifecycle_snapshot.revision() != revision {
             return Ok(None);
         }
@@ -1734,7 +1740,7 @@ mod tests {
         )
         .await;
         let workspace_name = WorkspaceName::default();
-        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path()).await;
         let function_sql = r"/*
 name: demo_items
 schema: functions
@@ -1752,6 +1758,7 @@ select text from function_demo.messages
             .manager
             .function_manager
             .install_validated_user_function(&workspace_name, function_sql, &validated)
+            .await
             .expect("install function");
 
         let manager =
@@ -1933,6 +1940,7 @@ surface:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect("import v4 source");
         std::fs::remove_file(&openapi_file).expect("remove authored descriptor after import");
 
@@ -2007,6 +2015,7 @@ surface:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect("import identity-gated v4 source");
         std::fs::remove_file(&openapi_file).expect("remove authored descriptor after import");
 
@@ -2078,6 +2087,7 @@ surface:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect("import v4 source");
 
         let source_name = SourceName::parse("github_v4_pagination_override").expect("source name");
@@ -2186,7 +2196,7 @@ pagination:
             .collect()
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn add_user_function_revalidates_when_source_changes_before_commit() {
         let fake_home = tempfile::tempdir().expect("fake home");
         let mut fixture = query_manager_with(
@@ -2198,7 +2208,7 @@ pagination:
         )
         .await;
         let workspace_name = WorkspaceName::default();
-        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path()).await;
         let calls = Arc::new(AtomicUsize::new(0));
         let config_store = fixture.manager.config_store.clone();
         let lifecycle_lock = fixture.manager.lifecycle_lock.clone();
@@ -2208,10 +2218,13 @@ pagination:
             PrepareCountingExtensionsProvider {
                 calls: Arc::clone(&calls),
                 on_first_prepare: Some(Arc::new(move || {
-                    let _lifecycle_guard = lifecycle_lock.lock();
-                    config_store
-                        .remove_source(&workspace, &source_name)
-                        .expect("remove source during function validation");
+                    tokio::task::block_in_place(|| {
+                        let _lifecycle_guard = tokio::runtime::Handle::current()
+                            .block_on(lifecycle_lock.lock(&workspace));
+                        config_store
+                            .remove_source(&workspace, &source_name)
+                            .expect("remove source during function validation");
+                    });
                 })),
             },
         ));
@@ -2262,7 +2275,7 @@ select text from function_demo.messages
         )
         .await;
         let workspace_name = WorkspaceName::default();
-        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path()).await;
         let function_sql = r"/*
 name: messages_by_type
 schema: functions
@@ -2282,6 +2295,7 @@ where type = $kind
             .manager
             .function_manager
             .install_validated_user_function(&workspace_name, function_sql, &validated_function)
+            .await
             .expect("install function");
 
         let catalog = fixture
@@ -2336,7 +2350,7 @@ where type = $kind
         );
     }
 
-    fn install_function_demo_source(
+    async fn install_function_demo_source(
         manager: &QueryManager,
         workspace_name: &WorkspaceName,
         fake_home: &std::path::Path,
@@ -2381,6 +2395,7 @@ tables:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect("import source");
     }
 
@@ -2504,7 +2519,7 @@ tables:
         )
         .await;
         let workspace_name = WorkspaceName::default();
-        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path()).await;
         let failed_source =
             install_missing_v4_materialization_source(&fixture.manager, &workspace_name);
 
@@ -2535,7 +2550,7 @@ tables:
         )
         .await;
         let workspace_name = WorkspaceName::default();
-        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path());
+        install_function_demo_source(&fixture.manager, &workspace_name, fake_home.path()).await;
         let failed_source =
             install_corrupt_parquet_source(&fixture.manager, &workspace_name, fake_home.path());
 
@@ -2600,6 +2615,7 @@ select 1 as value
             .manager
             .function_manager
             .install_validated_user_function(&workspace_name, function_sql, &validated)
+            .await
             .expect("install constant function");
         install_keychain_github_source(&fixture.manager.config_store, &workspace_name);
 
@@ -2693,6 +2709,7 @@ select 1 as value
             .manager
             .function_manager
             .install_validated_user_function(&workspace_name, function_sql, &validated)
+            .await
             .expect("install constant function");
         calls.store(0, Ordering::SeqCst);
 

--- a/crates/coral-app/src/search/manager.rs
+++ b/crates/coral-app/src/search/manager.rs
@@ -64,11 +64,6 @@ enum CatalogPreload {
     WorkspaceChanged,
 }
 
-enum SnapshotOperation<T> {
-    Complete(T),
-    WorkspaceChanged,
-}
-
 impl SearchManager {
     #[cfg(test)]
     pub(crate) fn new(
@@ -134,30 +129,30 @@ impl SearchManager {
             else {
                 continue;
             };
+            let Some(snapshot) = self
+                .lifecycle_lock
+                .snapshot_if_unchanged(revision, &request.workspace_name)
+                .await
+            else {
+                continue;
+            };
             let search = self.clone();
             let request = request.clone();
             let attribution = attribution.clone();
-            let operation = run_blocking_search_operation(move || {
-                let Some(_snapshot) = search
-                    .lifecycle_lock
-                    .snapshot_if_unchanged(revision, &request.workspace_name)
-                else {
-                    return Ok(SnapshotOperation::WorkspaceChanged);
-                };
+            let response = run_blocking_search_operation(move || {
+                let _snapshot = snapshot;
                 let observed_policy = search
                     .observed_values_search_enabled
                     .then(|| search.observed_retrieval_policy(&request.workspace_name));
-                Ok(SnapshotOperation::Complete(search.engine.search(
+                Ok(search.engine.search(
                     &request,
                     &attribution,
                     resolution.as_ref(),
                     observed_policy.as_ref().map(Result::as_ref),
-                )))
+                ))
             })
             .await?;
-            if let SnapshotOperation::Complete(response) = operation {
-                return Ok(response);
-            }
+            return Ok(response);
         }
         Err(workspace_changed_error("searching"))
     }
@@ -187,6 +182,7 @@ impl SearchManager {
                 let Some(revision) = self
                     .lifecycle_lock
                     .revision_if_active(&request.workspace_name)
+                    .await
                 else {
                     continue;
                 };
@@ -195,15 +191,17 @@ impl SearchManager {
                     .await?;
                 (revision, None)
             };
+            let Some(snapshot) = self
+                .lifecycle_lock
+                .snapshot_if_unchanged(revision, &request.workspace_name)
+                .await
+            else {
+                continue;
+            };
             let search = self.clone();
             let request = request.clone();
-            let operation = run_blocking_search_operation(move || {
-                let Some(_snapshot) = search
-                    .lifecycle_lock
-                    .snapshot_if_unchanged(revision, &request.workspace_name)
-                else {
-                    return Ok(SnapshotOperation::WorkspaceChanged);
-                };
+            let response = run_blocking_search_operation(move || {
+                let _snapshot = snapshot;
                 let resolution = resolution
                     .map(|resolution| resolution.map_err(catalog_resolution_error))
                     .transpose()?;
@@ -229,14 +227,10 @@ impl SearchManager {
                         search.rebuild_observed_index(&request),
                     ],
                 };
-                Ok(SnapshotOperation::Complete(RebuildSearchIndexResponse {
-                    results,
-                }))
+                Ok(RebuildSearchIndexResponse { results })
             })
             .await?;
-            if let SnapshotOperation::Complete(response) = operation {
-                return Ok(response);
-            }
+            return Ok(response);
         }
         Err(workspace_changed_error("rebuilding the search index"))
     }
@@ -281,29 +275,28 @@ impl SearchManager {
             let Some(revision) = self
                 .lifecycle_lock
                 .revision_if_active(&request.workspace_name)
+                .await
             else {
                 continue;
             };
             self.workspaces
                 .require_workspace(&request.workspace_name)
                 .await?;
+            let Some(snapshot) = self
+                .lifecycle_lock
+                .snapshot_if_unchanged(revision, &request.workspace_name)
+                .await
+            else {
+                continue;
+            };
             let search = self.clone();
             let request = request.clone();
-            let operation = run_blocking_search_operation(move || {
-                let Some(_snapshot) = search
-                    .lifecycle_lock
-                    .snapshot_if_unchanged(revision, &request.workspace_name)
-                else {
-                    return Ok(SnapshotOperation::WorkspaceChanged);
-                };
-                Ok(SnapshotOperation::Complete(
-                    search.clear_data_blocking(&request)?,
-                ))
+            let response = run_blocking_search_operation(move || {
+                let _snapshot = snapshot;
+                search.clear_data_blocking(&request)
             })
             .await?;
-            if let SnapshotOperation::Complete(response) = operation {
-                return Ok(response);
-            }
+            return Ok(response);
         }
         Err(workspace_changed_error("clearing search data"))
     }
@@ -456,7 +449,7 @@ impl SearchManager {
         workspace_name: &WorkspaceName,
         attribution: &QueryAttribution,
     ) -> Result<CatalogPreload, SearchManagerError> {
-        let Some(revision) = self.lifecycle_lock.revision_if_active(workspace_name) else {
+        let Some(revision) = self.lifecycle_lock.revision_if_active(workspace_name).await else {
             return Ok(CatalogPreload::WorkspaceChanged);
         };
         self.workspaces.require_workspace(workspace_name).await?;

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -30,7 +30,7 @@ use crate::sources::materialization::{
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::storage::fs;
-use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceName};
+use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceName};
 use coral_spec::{ManifestCredentialMethodKind, ManifestInputKind, ManifestOAuthCredentialSpec};
 use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 use tokio::sync::{mpsc, oneshot};
@@ -70,12 +70,13 @@ pub(crate) struct ImportSourceWithCredentialsCommand {
     pub(crate) oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct SourceBindings {
     pub(crate) variables: Vec<SourceBinding>,
     pub(crate) secrets: Vec<SourceBinding>,
 }
 
+#[derive(Clone)]
 pub(crate) struct SourceBinding {
     pub(crate) key: String,
     pub(crate) value: String,
@@ -307,10 +308,11 @@ impl SourceManager {
         Ok(candidates)
     }
 
-    pub(crate) fn create_bundled_source(
+    pub(crate) async fn create_bundled_source_if_unchanged(
         &self,
         workspace_name: &WorkspaceName,
         command: &CreateBundledSourceCommand,
+        revision: WorkspaceLifecycleRevision,
     ) -> Result<InstalledSource, AppError> {
         let bundled = load_bundled_source(&command.name)?;
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
@@ -321,14 +323,17 @@ impl SourceManager {
             None,
             &bundled.manifest_yaml,
             SourceOrigin::Bundled,
+            revision,
         )
+        .await
     }
 
-    pub(crate) async fn create_bundled_source_with_oauth(
+    pub(crate) async fn create_bundled_source_with_oauth_if_unchanged(
         &self,
         workspace_name: &WorkspaceName,
         command: CreateBundledSourceWithOAuthCommand,
         events: ImportSourceEventSender,
+        revision: WorkspaceLifecycleRevision,
     ) -> Result<InstalledSource, AppError> {
         let bundled = load_bundled_source(&command.name)?;
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
@@ -341,14 +346,31 @@ impl SourceManager {
             None,
             &bundled.manifest_yaml,
             SourceOrigin::Bundled,
+            revision,
         )
         .await
     }
 
-    pub(crate) fn import_source(
+    #[cfg(test)]
+    pub(crate) async fn import_source(
         &self,
         workspace_name: &WorkspaceName,
         command: &ImportSourceCommand,
+    ) -> Result<InstalledSource, AppError> {
+        let revision = self
+            .lifecycle_lock
+            .snapshot(workspace_name)
+            .await
+            .revision();
+        self.import_source_if_unchanged(workspace_name, command, revision)
+            .await
+    }
+
+    pub(crate) async fn import_source_if_unchanged(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: &ImportSourceCommand,
+        revision: WorkspaceLifecycleRevision,
     ) -> Result<InstalledSource, AppError> {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
@@ -362,15 +384,34 @@ impl SourceManager {
             Some(&manifest_yaml),
             &manifest_yaml,
             SourceOrigin::Imported,
+            revision,
         )
+        .await
     }
 
+    #[cfg(test)]
     pub(crate) async fn import_source_with_credentials(
         &self,
         workspace_name: &WorkspaceName,
         command: ImportSourceWithCredentialsCommand,
         events: ImportSourceEventSender,
     ) -> Result<InstalledSource, AppError> {
+        let revision = self
+            .lifecycle_lock
+            .snapshot(workspace_name)
+            .await
+            .revision();
+        self.import_source_with_credentials_if_unchanged(workspace_name, command, events, revision)
+            .await
+    }
+
+    pub(crate) async fn import_source_with_credentials_if_unchanged(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: ImportSourceWithCredentialsCommand,
+        events: ImportSourceEventSender,
+        revision: WorkspaceLifecycleRevision,
+    ) -> Result<InstalledSource, AppError> {
         let manifest = parse_source_manifest_yaml(&command.manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let manifest_yaml = durable_import_manifest_yaml(&command.manifest_yaml, &manifest)?;
@@ -385,6 +426,7 @@ impl SourceManager {
             Some(&manifest_yaml),
             &manifest_yaml,
             SourceOrigin::Imported,
+            revision,
         )
         .await
     }
@@ -393,7 +435,11 @@ impl SourceManager {
     /// the source. Shared tail of the non-OAuth install entry points; the
     /// caller supplies the resolved `candidate` plus the per-origin
     /// `manifest_yaml`/`origin`.
-    fn install_validated_source(
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the install tail receives validated source state plus the workspace revision it commits against"
+    )]
+    async fn install_validated_source(
         &self,
         workspace_name: &WorkspaceName,
         candidate: &CandidateSource,
@@ -401,41 +447,57 @@ impl SourceManager {
         manifest_yaml: Option<&str>,
         materialization_manifest_yaml: &str,
         origin: SourceOrigin,
+        revision: WorkspaceLifecycleRevision,
     ) -> Result<InstalledSource, AppError> {
-        let _lifecycle_guard = self.lifecycle_lock.lock();
-        self.validate_runtime_schema_names_available(
-            workspace_name,
-            &candidate.name,
-            materialization_manifest_yaml,
-        )?;
-        let stored_material = self.source_stored_material_for_validation(
-            workspace_name,
-            candidate,
-            bindings,
-            &BTreeSet::new(),
-        )?;
-        let bindings = validate_bindings(candidate, bindings, &stored_material)?;
-        let materialization_inputs =
-            materialization_inputs_from_bindings(&bindings, &stored_material);
-        self.persist_source(
-            workspace_name,
-            PersistSourceRequest {
-                candidate,
-                manifest_yaml,
-                bindings,
-                origin,
-                materialization_tmp: self
-                    .prepare_v4_materialization(
-                        workspace_name,
-                        candidate,
-                        materialization_manifest_yaml,
-                        &materialization_inputs,
-                        origin,
-                        "tmp",
-                    )?
-                    .map(|build| build.temp_dir),
-            },
-        )
+        let guard = self
+            .lifecycle_lock
+            .lock_if_unchanged(workspace_name, revision)
+            .await
+            .ok_or_else(workspace_changed_during_source_mutation)?;
+        let manager = self.clone();
+        let workspace_name = workspace_name.clone();
+        let candidate = candidate.clone();
+        let bindings = bindings.clone();
+        let manifest_yaml = manifest_yaml.map(str::to_owned);
+        let materialization_manifest_yaml = materialization_manifest_yaml.to_owned();
+        run_blocking_source_operation(move || {
+            let _lifecycle_guard = guard;
+            manager.validate_runtime_schema_names_available(
+                &workspace_name,
+                &candidate.name,
+                &materialization_manifest_yaml,
+            )?;
+            let stored_material = manager.source_stored_material_for_validation(
+                &workspace_name,
+                &candidate,
+                &bindings,
+                &BTreeSet::new(),
+            )?;
+            let bindings = validate_bindings(&candidate, &bindings, &stored_material)?;
+            let materialization_inputs =
+                materialization_inputs_from_bindings(&bindings, &stored_material);
+            let materialization_tmp = manager
+                .prepare_v4_materialization(
+                    &workspace_name,
+                    &candidate,
+                    &materialization_manifest_yaml,
+                    &materialization_inputs,
+                    origin,
+                    "tmp",
+                )?
+                .map(|build| build.temp_dir);
+            manager.persist_source(
+                &workspace_name,
+                PersistSourceRequest {
+                    candidate: &candidate,
+                    manifest_yaml: manifest_yaml.as_deref(),
+                    bindings,
+                    origin,
+                    materialization_tmp,
+                },
+            )
+        })
+        .await
     }
 
     /// Resolves OAuth credential material (driving the authorization flow over
@@ -456,6 +518,7 @@ impl SourceManager {
         manifest_yaml: Option<&str>,
         materialization_manifest_yaml: &str,
         origin: SourceOrigin,
+        revision: WorkspaceLifecycleRevision,
     ) -> Result<InstalledSource, AppError> {
         self.validate_runtime_schema_names_available(
             workspace_name,
@@ -486,53 +549,104 @@ impl SourceManager {
                 events,
             )
             .await?;
-        let _lifecycle_guard = self.lifecycle_lock.lock();
-        self.validate_runtime_schema_names_available(
-            workspace_name,
-            &candidate.name,
-            materialization_manifest_yaml,
-        )?;
-        let stored_material = self.source_stored_material_for_validation(
-            workspace_name,
-            candidate,
-            bindings,
-            &oauth_input_keys,
-        )?;
-        let mut validation_material = stored_material.clone();
-        for material in &oauth_material {
-            validation_material.insert(material.input_key.clone(), material.access_token.clone());
-        }
-        let mut bindings = validate_bindings(candidate, bindings, &validation_material)?;
-        merge_oauth_material_into_bindings(&mut bindings, oauth_material)?;
-        let materialization_inputs =
-            materialization_inputs_from_bindings(&bindings, &stored_material);
-        self.persist_source(
-            workspace_name,
-            PersistSourceRequest {
-                candidate,
-                manifest_yaml,
-                bindings,
-                origin,
-                materialization_tmp: self
-                    .prepare_v4_materialization(
-                        workspace_name,
-                        candidate,
-                        materialization_manifest_yaml,
-                        &materialization_inputs,
-                        origin,
-                        "tmp",
-                    )?
-                    .map(|build| build.temp_dir),
-            },
-        )
+        let guard = self
+            .lifecycle_lock
+            .lock_if_unchanged(workspace_name, revision)
+            .await
+            .ok_or_else(workspace_changed_during_source_mutation)?;
+        let manager = self.clone();
+        let workspace_name = workspace_name.clone();
+        let candidate = candidate.clone();
+        let bindings = bindings.clone();
+        let manifest_yaml = manifest_yaml.map(str::to_owned);
+        let materialization_manifest_yaml = materialization_manifest_yaml.to_owned();
+        run_blocking_source_operation(move || {
+            let _lifecycle_guard = guard;
+            manager.validate_runtime_schema_names_available(
+                &workspace_name,
+                &candidate.name,
+                &materialization_manifest_yaml,
+            )?;
+            let stored_material = manager.source_stored_material_for_validation(
+                &workspace_name,
+                &candidate,
+                &bindings,
+                &oauth_input_keys,
+            )?;
+            let mut validation_material = stored_material.clone();
+            for material in &oauth_material {
+                validation_material
+                    .insert(material.input_key.clone(), material.access_token.clone());
+            }
+            let mut bindings = validate_bindings(&candidate, &bindings, &validation_material)?;
+            merge_oauth_material_into_bindings(&mut bindings, oauth_material)?;
+            let materialization_inputs =
+                materialization_inputs_from_bindings(&bindings, &stored_material);
+            let materialization_tmp = manager
+                .prepare_v4_materialization(
+                    &workspace_name,
+                    &candidate,
+                    &materialization_manifest_yaml,
+                    &materialization_inputs,
+                    origin,
+                    "tmp",
+                )?
+                .map(|build| build.temp_dir);
+            manager.persist_source(
+                &workspace_name,
+                PersistSourceRequest {
+                    candidate: &candidate,
+                    manifest_yaml: manifest_yaml.as_deref(),
+                    bindings,
+                    origin,
+                    materialization_tmp,
+                },
+            )
+        })
+        .await
     }
 
-    pub(crate) fn delete_source(
+    #[cfg(test)]
+    pub(crate) async fn delete_source(
         &self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<InstalledSource, AppError> {
-        let _lifecycle_guard = self.lifecycle_lock.lock();
+        let revision = self
+            .lifecycle_lock
+            .snapshot(workspace_name)
+            .await
+            .revision();
+        self.delete_source_if_unchanged(workspace_name, source_name, revision)
+            .await
+    }
+
+    pub(crate) async fn delete_source_if_unchanged(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        revision: WorkspaceLifecycleRevision,
+    ) -> Result<InstalledSource, AppError> {
+        let guard = self
+            .lifecycle_lock
+            .lock_if_unchanged(workspace_name, revision)
+            .await
+            .ok_or_else(workspace_changed_during_source_mutation)?;
+        let manager = self.clone();
+        let workspace_name = workspace_name.clone();
+        let source_name = source_name.clone();
+        run_blocking_source_operation(move || {
+            let _lifecycle_guard = guard;
+            manager.delete_source_locked(&workspace_name, &source_name)
+        })
+        .await
+    }
+
+    fn delete_source_locked(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<InstalledSource, AppError> {
         let source_dir = self.layout.source_dir(workspace_name, source_name);
         let credential_set_id = CredentialSetId::for_source(source_name);
         let credential_guard = self
@@ -1612,6 +1726,24 @@ fn cleanup_empty_parent(root: &std::path::Path, path: Option<&std::path::Path>) 
     }
 }
 
+async fn run_blocking_source_operation<T>(
+    operation: impl FnOnce() -> Result<T, AppError> + Send + 'static,
+) -> Result<T, AppError>
+where
+    T: Send + 'static,
+{
+    let span = tracing::Span::current();
+    tokio::task::spawn_blocking(move || span.in_scope(operation))
+        .await
+        .map_err(AppError::from)?
+}
+
+fn workspace_changed_during_source_mutation() -> AppError {
+    AppError::FailedPrecondition(
+        "workspace changed while applying the source lifecycle operation".to_string(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
@@ -1844,8 +1976,8 @@ tables:
         .to_string()
     }
 
-    #[test]
-    fn readd_source_waits_for_state_lock_before_replacing_manifest() {
+    #[tokio::test]
+    async fn readd_source_waits_for_state_lock_before_replacing_manifest() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -1869,6 +2001,7 @@ tables:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect("initial import");
 
         let source_name = SourceName::parse("public_messages").expect("source");
@@ -1934,8 +2067,46 @@ tables:
         assert!(stored_after.contains("https://replacement.example.com"));
     }
 
-    #[test]
-    fn readd_source_revalidates_required_secret_material_under_state_lock() {
+    #[tokio::test]
+    async fn import_rejects_a_workspace_revision_invalidated_while_waiting() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let lifecycle_lock = crate::workspaces::WorkspaceLifecycleLock::default();
+        let workspace = default_workspace();
+        let revision = lifecycle_lock.snapshot(&workspace).await.revision();
+        let manager = SourceManager::new(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            layout,
+            lifecycle_lock.clone(),
+        );
+        drop(lifecycle_lock.lock(&workspace).await);
+
+        let error = manager
+            .import_source_if_unchanged(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_without_secrets(),
+                    bindings: SourceBindings::default(),
+                },
+                revision,
+            )
+            .await
+            .expect_err("stale workspace revision should reject import");
+
+        assert!(error.to_string().contains("workspace changed"));
+        assert!(
+            manager
+                .list_workspace_sources(&default_workspace())
+                .expect("list sources")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn readd_source_revalidates_required_secret_material_under_state_lock() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -1964,6 +2135,7 @@ tables:
                     },
                 },
             )
+            .await
             .expect("initial import");
 
         let source_name = SourceName::parse("secured_messages").expect("source");
@@ -2003,8 +2175,8 @@ tables:
         );
     }
 
-    #[test]
-    fn delete_source_waits_for_state_lock_before_removing_credentials() {
+    #[tokio::test]
+    async fn delete_source_waits_for_state_lock_before_removing_credentials() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -2033,6 +2205,7 @@ tables:
                     },
                 },
             )
+            .await
             .expect("initial import");
 
         let source_name = SourceName::parse("secured_messages").expect("source");
@@ -2045,8 +2218,11 @@ tables:
         let (done_tx, done_rx) = std_mpsc::channel();
         let handle = thread::spawn(move || {
             started_tx.send(()).expect("send started");
-            let result = delete_manager
-                .delete_source(&delete_workspace_name, &delete_source_name)
+            let result = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build runtime")
+                .block_on(delete_manager.delete_source(&delete_workspace_name, &delete_source_name))
                 .map(|source| source.name.as_str().to_string())
                 .map_err(|error| error.to_string());
             done_tx.send(result).expect("send delete result");
@@ -2094,8 +2270,8 @@ tables:
     }
 
     #[cfg(unix)]
-    #[test]
-    fn delete_source_preserves_credentials_when_directory_staging_fails() {
+    #[tokio::test]
+    async fn delete_source_preserves_credentials_when_directory_staging_fails() {
         use std::os::unix::fs::PermissionsExt as _;
 
         let temp = TempDir::new().expect("temp dir");
@@ -2126,6 +2302,7 @@ tables:
                     },
                 },
             )
+            .await
             .expect("initial import");
 
         let source_name = SourceName::parse("secured_messages").expect("source");
@@ -2139,7 +2316,7 @@ tables:
         std::fs::set_permissions(source_parent, readonly_permissions)
             .expect("make source parent unwritable");
 
-        let delete_result = manager.delete_source(&workspace_name, &source_name);
+        let delete_result = manager.delete_source(&workspace_name, &source_name).await;
 
         std::fs::set_permissions(source_parent, original_permissions)
             .expect("restore source parent permissions");
@@ -2464,8 +2641,8 @@ surface:
         );
     }
 
-    #[test]
-    fn import_v4_source_writes_materialized_artifacts() {
+    #[tokio::test]
+    async fn import_v4_source_writes_materialized_artifacts() {
         let temp = TempDir::new().expect("temp dir");
         let descriptor_temp = TempDir::new().expect("descriptor temp dir");
         let layout =
@@ -2487,6 +2664,7 @@ surface:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect("import v4 source");
 
         assert_eq!(installed.name.as_str(), "github_v4_test");
@@ -2502,8 +2680,8 @@ surface:
         assert_eq!(info.name.as_str(), "github_v4_test");
     }
 
-    #[test]
-    fn import_v4_source_rejects_derived_base_url_input_token_defaults() {
+    #[tokio::test]
+    async fn import_v4_source_rejects_derived_base_url_input_token_defaults() {
         let temp = TempDir::new().expect("temp dir");
         let descriptor_temp = TempDir::new().expect("descriptor temp dir");
         let layout =
@@ -2529,6 +2707,7 @@ surface:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect_err("source add should reject derived base_url input token defaults");
 
         let message = error.to_string();
@@ -2547,8 +2726,8 @@ surface:
         );
     }
 
-    #[test]
-    fn import_v4_source_rejects_unresolved_relative_descriptor() {
+    #[tokio::test]
+    async fn import_v4_source_rejects_unresolved_relative_descriptor() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -2567,6 +2746,7 @@ surface:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect_err("raw relative descriptors should fail in app import");
 
         assert!(
@@ -2577,8 +2757,8 @@ surface:
         );
     }
 
-    #[test]
-    fn import_v4_source_preserves_intent_yaml_without_openapi_metadata() {
+    #[tokio::test]
+    async fn import_v4_source_preserves_intent_yaml_without_openapi_metadata() {
         let temp = TempDir::new().expect("temp dir");
         let descriptor_temp = TempDir::new().expect("descriptor temp dir");
         let layout =
@@ -2600,6 +2780,7 @@ surface:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect("import v4 source");
 
         let source_name = SourceName::parse("github_v4_test").expect("source");
@@ -2616,8 +2797,8 @@ surface:
         );
     }
 
-    #[test]
-    fn import_restores_prior_state_when_secret_persistence_fails() {
+    #[tokio::test]
+    async fn import_restores_prior_state_when_secret_persistence_fails() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -2651,6 +2832,7 @@ surface:
                     },
                 },
             )
+            .await
             .expect_err("secret persistence should fail");
 
         assert!(
@@ -2719,8 +2901,8 @@ surface:
         );
     }
 
-    #[test]
-    fn import_materializes_variable_defaults_server_side() {
+    #[tokio::test]
+    async fn import_materializes_variable_defaults_server_side() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -2744,6 +2926,7 @@ surface:
                     },
                 },
             )
+            .await
             .expect("import source");
 
         assert_eq!(
@@ -2752,8 +2935,8 @@ surface:
         );
     }
 
-    #[test]
-    fn import_new_source_uses_keychain_when_auto_probe_succeeds() {
+    #[tokio::test]
+    async fn import_new_source_uses_keychain_when_auto_probe_succeeds() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -2783,6 +2966,7 @@ surface:
                     },
                 },
             )
+            .await
             .expect("import source");
 
         assert_eq!(
@@ -2809,6 +2993,7 @@ surface:
 
         manager
             .delete_source(&default_workspace(), &source_name)
+            .await
             .expect("delete source");
         assert!(
             credential_manager
@@ -2823,8 +3008,8 @@ surface:
         );
     }
 
-    #[test]
-    fn import_source_without_secret_material_does_not_probe_keychain() {
+    #[tokio::test]
+    async fn import_source_without_secret_material_does_not_probe_keychain() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -2847,6 +3032,7 @@ surface:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect("import source");
 
         assert!(source.secrets.is_empty());
@@ -2865,8 +3051,8 @@ surface:
         );
     }
 
-    #[test]
-    fn import_missing_secret_does_not_probe_keychain_for_new_source() {
+    #[tokio::test]
+    async fn import_missing_secret_does_not_probe_keychain_for_new_source() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -2887,6 +3073,7 @@ surface:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect_err("missing required secret should fail validation");
 
         assert!(
@@ -2897,8 +3084,8 @@ surface:
         );
     }
 
-    #[test]
-    fn import_replaces_malformed_existing_credential_material() {
+    #[tokio::test]
+    async fn import_replaces_malformed_existing_credential_material() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -2924,6 +3111,7 @@ surface:
                     },
                 },
             )
+            .await
             .expect("initial import");
 
         let secret_path = layout.secret_file(&default_workspace(), &source_name);
@@ -2943,6 +3131,7 @@ surface:
                     },
                 },
             )
+            .await
             .expect("replace malformed credential material");
 
         assert_eq!(
@@ -2951,8 +3140,8 @@ surface:
         );
     }
 
-    #[test]
-    fn credential_revision_rotates_only_when_credential_material_is_replaced() {
+    #[tokio::test]
+    async fn credential_revision_rotates_only_when_credential_material_is_replaced() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -2977,6 +3166,7 @@ surface:
                     },
                 },
             )
+            .await
             .expect("initial import");
         assert!(!first.credential_revision.is_nil());
 
@@ -2988,6 +3178,7 @@ surface:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect("reimport with stored credential material");
         assert_eq!(unchanged.credential_revision, first.credential_revision);
 
@@ -3005,12 +3196,13 @@ surface:
                     },
                 },
             )
+            .await
             .expect("credential replacement");
         assert_ne!(replaced.credential_revision, first.credential_revision);
     }
 
-    #[test]
-    fn delete_removes_source_with_malformed_credential_material() {
+    #[tokio::test]
+    async fn delete_removes_source_with_malformed_credential_material() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -3036,6 +3228,7 @@ surface:
                     },
                 },
             )
+            .await
             .expect("initial import");
 
         let secret_path = layout.secret_file(&default_workspace(), &source_name);
@@ -3043,6 +3236,7 @@ surface:
 
         manager
             .delete_source(&default_workspace(), &source_name)
+            .await
             .expect("delete source with malformed credential material");
 
         assert!(
@@ -3058,8 +3252,8 @@ surface:
         );
     }
 
-    #[test]
-    fn import_accepts_secret_already_populated_in_credential_material() {
+    #[tokio::test]
+    async fn import_accepts_secret_already_populated_in_credential_material() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -3094,6 +3288,7 @@ surface:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect("import source");
 
         assert_eq!(source.secrets, vec!["API_TOKEN"]);
@@ -3116,8 +3311,8 @@ surface:
         );
     }
 
-    #[test]
-    fn import_preserves_credential_store_io_errors_when_material_is_needed() {
+    #[tokio::test]
+    async fn import_preserves_credential_store_io_errors_when_material_is_needed() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -3139,6 +3334,7 @@ surface:
                     bindings: SourceBindings::default(),
                 },
             )
+            .await
             .expect_err("stored material I/O error should fail import");
 
         assert!(
@@ -3152,8 +3348,8 @@ surface:
         );
     }
 
-    #[test]
-    fn manual_secret_reimport_clears_prior_oauth_material() {
+    #[tokio::test]
+    async fn manual_secret_reimport_clears_prior_oauth_material() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -3198,6 +3394,7 @@ surface:
                     },
                 },
             )
+            .await
             .expect("import source");
 
         let material = credential_manager
@@ -3219,8 +3416,8 @@ surface:
         );
     }
 
-    #[test]
-    fn source_rollback_snapshots_credentials_after_refresh_lock() {
+    #[tokio::test]
+    async fn source_rollback_snapshots_credentials_after_refresh_lock() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -3247,6 +3444,7 @@ surface:
                     },
                 },
             )
+            .await
             .expect("install source");
         let refresh_lock = credential_store
             .credential_refresh_lock(&workspace_name, &credential_set_id)
@@ -3260,19 +3458,23 @@ surface:
         let import_workspace = workspace_name.clone();
         let import_handle = thread::spawn(move || {
             started_tx.send(()).expect("signal import start");
-            import_manager.import_source(
-                &import_workspace,
-                &ImportSourceCommand {
-                    manifest_yaml: manifest_with_secret(),
-                    bindings: SourceBindings {
-                        variables: Vec::new(),
-                        secrets: vec![SourceBinding {
-                            key: "API_TOKEN".to_string(),
-                            value: "manual-token".to_string(),
-                        }],
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build runtime")
+                .block_on(import_manager.import_source(
+                    &import_workspace,
+                    &ImportSourceCommand {
+                        manifest_yaml: manifest_with_secret(),
+                        bindings: SourceBindings {
+                            variables: Vec::new(),
+                            secrets: vec![SourceBinding {
+                                key: "API_TOKEN".to_string(),
+                                value: "manual-token".to_string(),
+                            }],
+                        },
                     },
-                },
-            )
+                ))
         });
         started_rx.recv().expect("wait for import thread");
         thread::sleep(Duration::from_millis(50));
@@ -3498,6 +3700,7 @@ surface:
                     },
                 },
             )
+            .await
             .expect("install source");
 
         let redirect_port = free_loopback_port();

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -50,7 +50,6 @@ use crate::transport::{
 };
 use crate::workspaces::{WorkspaceManager, WorkspaceName};
 use tokio::sync::mpsc;
-use tokio::task;
 use tokio_stream::Stream;
 use tokio_stream::StreamExt as _;
 
@@ -178,17 +177,20 @@ impl SourceServiceApi for SourceService {
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            require_workspace(&workspaces, &workspace_name).await?;
+            let revision = workspaces
+                .require_workspace_revision(&workspace_name)
+                .await
+                .map_err(app_status)?;
             let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
             let command = CreateBundledSourceCommand {
                 name: bundled_name,
                 bindings: source_bindings_from_proto(request.variables, request.secrets),
             };
             let response_workspace_name = workspace_name.clone();
-            let installed = run_blocking_source_operation(move || {
-                sources.create_bundled_source(&workspace_name, &command)
-            })
-            .await?;
+            let installed = sources
+                .create_bundled_source_if_unchanged(&workspace_name, &command, revision)
+                .await
+                .map_err(app_status)?;
             Ok(Response::new(CreateBundledSourceResponse {
                 source: Some(installed_source_to_proto(
                     &response_workspace_name,
@@ -209,7 +211,10 @@ impl SourceServiceApi for SourceService {
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            require_workspace(&workspaces, &workspace_name).await?;
+            let revision = workspaces
+                .require_workspace_revision(&workspace_name)
+                .await
+                .map_err(app_status)?;
             let response_workspace_name = workspace_name.clone();
             let command = CreateBundledSourceWithOAuthCommand {
                 name: SourceName::parse(&request.name).map_err(app_status)?,
@@ -225,10 +230,11 @@ impl SourceServiceApi for SourceService {
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
                         sources
-                            .create_bundled_source_with_oauth(
+                            .create_bundled_source_with_oauth_if_unchanged(
                                 &workspace_name,
                                 command,
                                 event_sender,
+                                revision,
                             )
                             .await
                             .map_err(app_status)
@@ -252,17 +258,20 @@ impl SourceServiceApi for SourceService {
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            require_workspace(&workspaces, &workspace_name).await?;
+            let revision = workspaces
+                .require_workspace_revision(&workspace_name)
+                .await
+                .map_err(app_status)?;
             let response_workspace_name = workspace_name.clone();
             if request.oauth_credential_retrievals.is_empty() {
                 let command = ImportSourceCommand {
                     manifest_yaml: request.manifest_yaml,
                     bindings: source_bindings_from_proto(request.variables, request.secrets),
                 };
-                let installed = run_blocking_source_operation(move || {
-                    sources.import_source(&workspace_name, &command)
-                })
-                .await?;
+                let installed = sources
+                    .import_source_if_unchanged(&workspace_name, &command, revision)
+                    .await
+                    .map_err(app_status)?;
                 let response = ImportSourceResponse {
                     event: Some(import_source_response::Event::Source(
                         installed_source_to_proto(&response_workspace_name, installed),
@@ -286,7 +295,12 @@ impl SourceServiceApi for SourceService {
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
                         sources
-                            .import_source_with_credentials(&workspace_name, command, event_sender)
+                            .import_source_with_credentials_if_unchanged(
+                                &workspace_name,
+                                command,
+                                event_sender,
+                                revision,
+                            )
                             .await
                             .map_err(app_status)
                     })
@@ -306,12 +320,15 @@ impl SourceServiceApi for SourceService {
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            require_workspace(&workspaces, &workspace_name).await?;
+            let revision = workspaces
+                .require_workspace_revision(&workspace_name)
+                .await
+                .map_err(app_status)?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
-            run_blocking_source_operation(move || {
-                sources.delete_source(&workspace_name, &source_name)
-            })
-            .await?;
+            sources
+                .delete_source_if_unchanged(&workspace_name, &source_name, revision)
+                .await
+                .map_err(app_status)?;
             Ok(Response::new(DeleteSourceResponse {}))
         })
         .await
@@ -360,18 +377,6 @@ type CreateBundledSourceWithOAuthResponseStreamBox =
 type ImportSourceResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 type ImportSourceFuture = Pin<Box<dyn Future<Output = Result<InstalledSource, Status>> + Send>>;
-
-async fn run_blocking_source_operation<T, F>(operation: F) -> Result<T, Status>
-where
-    T: Send + 'static,
-    F: FnOnce() -> Result<T, AppError> + Send + 'static,
-{
-    let span = tracing::Span::current();
-    task::spawn_blocking(move || span.in_scope(operation))
-        .await
-        .map_err(|error| Status::internal(format!("source operation task failed: {error}")))?
-        .map_err(app_status)
-}
 
 fn import_source_response_stream<F, Fut>(
     response_workspace_name: WorkspaceName,

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -10,7 +10,8 @@ use crate::state::ConfigStore;
 use crate::state::db::{CoralDb, DbRepos, now_unix_nanos_i64};
 use crate::storage::fs::DirectoryBackup;
 use crate::workspaces::{
-    DeletedWorkspace, WorkspaceLifecycleLock, WorkspaceName, WorkspacePaths, WorkspaceRecord,
+    DeletedWorkspace, WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceName,
+    WorkspacePaths, WorkspaceRecord,
 };
 
 /// App-owned workspace lifecycle behavior.
@@ -98,6 +99,15 @@ impl WorkspaceManager {
         }
     }
 
+    pub(crate) async fn require_workspace_revision(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<WorkspaceLifecycleRevision, AppError> {
+        let snapshot = self.lifecycle_lock.snapshot(workspace_name).await;
+        self.require_workspace(workspace_name).await?;
+        Ok(snapshot.revision())
+    }
+
     #[cfg(test)]
     pub(crate) fn lifecycle_lock(&self) -> WorkspaceLifecycleLock {
         self.lifecycle_lock.clone()
@@ -142,14 +152,10 @@ impl WorkspaceManager {
             ));
         }
 
-        let deletion_marker = self
-            .lifecycle_lock
-            .mark_workspace_deleting(workspace_name)
-            .ok_or_else(|| {
-                AppError::FailedPrecondition(format!(
-                    "workspace '{workspace_name}' is already being deleted"
-                ))
-            })?;
+        // Lifecycle mutations acquire this guard before database work. Keeping
+        // that order consistent prevents a pool waiter from deadlocking with a
+        // mutation that already owns a database transaction.
+        let lifecycle_guard = self.lifecycle_lock.lock(workspace_name).await;
 
         let (deleted, workspace_dir_backup) = {
             let mut tx = self.db.begin().await?;
@@ -162,11 +168,9 @@ impl WorkspaceManager {
                 return Err(AppError::WorkspaceNotFound(workspace_name.to_string()));
             }
             tx.workspaces().delete(workspace_name.as_str()).await?;
-            let deleted = {
-                let _lifecycle_guard = self.lifecycle_lock.lock();
-                self.config_store
-                    .remove_workspace_config_entries(workspace_name)
-            };
+            let deleted = self
+                .config_store
+                .remove_workspace_config_entries(workspace_name);
             let deleted = match deleted {
                 Ok(deleted) => deleted.unwrap_or_else(|| DeletedWorkspace {
                     workspace: WorkspaceRecord {
@@ -189,7 +193,7 @@ impl WorkspaceManager {
             let workspace_dir_backup = self.stage_deleted_workspace_dir(&deleted.workspace.name);
             (deleted, workspace_dir_backup)
         };
-        drop(deletion_marker);
+        drop(lifecycle_guard);
 
         let deleted_workspace_name = deleted.workspace.name.clone();
         self.diagnostic_reporter

--- a/crates/coral-app/src/workspaces/model.rs
+++ b/crates/coral-app/src/workspaces/model.rs
@@ -1,5 +1,7 @@
-use std::collections::BTreeSet;
-use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
 
 use crate::sources::model::InstalledSource;
 use crate::workspaces::WorkspaceName;
@@ -20,8 +22,7 @@ pub(crate) struct DeletedWorkspace {
 
 #[derive(Debug, Default)]
 struct WorkspaceLifecycleState {
-    revision: u64,
-    deleting_workspaces: BTreeSet<WorkspaceName>,
+    revisions: BTreeMap<WorkspaceName, u64>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -33,121 +34,97 @@ impl WorkspaceLifecycleLock {
     /// Serializes a workspace lifecycle write and advances the revision when
     /// the write guard is released.
     #[must_use = "bind the returned guard for the full critical section"]
-    pub(crate) fn lock(&self) -> WorkspaceLifecycleGuard<'_> {
+    pub(crate) async fn lock(&self, workspace_name: &WorkspaceName) -> WorkspaceLifecycleGuard {
         WorkspaceLifecycleGuard {
-            guard: self.write_inner(),
+            guard: Arc::clone(&self.inner).write_owned().await,
+            workspace_name: workspace_name.clone(),
         }
     }
 
     #[must_use = "bind the returned snapshot while loading workspace state"]
-    pub(crate) fn snapshot(&self) -> WorkspaceLifecycleSnapshot<'_> {
+    pub(crate) async fn snapshot(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> WorkspaceLifecycleSnapshot {
         WorkspaceLifecycleSnapshot {
-            guard: self.read_inner(),
+            guard: Arc::clone(&self.inner).read_owned().await,
+            workspace_name: workspace_name.clone(),
         }
     }
 
-    pub(crate) fn snapshot_if_unchanged(
+    pub(crate) async fn snapshot_if_unchanged(
         &self,
         revision: WorkspaceLifecycleRevision,
         workspace_name: &WorkspaceName,
-    ) -> Option<WorkspaceLifecycleSnapshot<'_>> {
-        let guard = self.read_inner();
-        (guard.revision == revision.0 && !guard.deleting_workspaces.contains(workspace_name))
-            .then_some(WorkspaceLifecycleSnapshot { guard })
-    }
-
-    pub(crate) fn revision_if_active(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Option<WorkspaceLifecycleRevision> {
-        let snapshot = self.snapshot();
-        (!snapshot.workspace_is_deleting(workspace_name)).then(|| snapshot.revision())
-    }
-
-    pub(crate) fn mark_workspace_deleting(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Option<WorkspaceDeletionMarker> {
-        let mut guard = self.write_inner();
-        if !guard.deleting_workspaces.insert(workspace_name.clone()) {
-            return None;
-        }
-        guard.revision = guard.revision.wrapping_add(1);
-        Some(WorkspaceDeletionMarker {
-            lifecycle: self.clone(),
-            workspace_name: workspace_name.clone(),
+    ) -> Option<WorkspaceLifecycleSnapshot> {
+        let guard = Arc::clone(&self.inner).read_owned().await;
+        (workspace_revision(&guard, workspace_name) == revision.0).then(|| {
+            WorkspaceLifecycleSnapshot {
+                guard,
+                workspace_name: workspace_name.clone(),
+            }
         })
     }
 
-    pub(crate) fn lock_if_unchanged(
+    pub(crate) async fn revision_if_active(
         &self,
+        workspace_name: &WorkspaceName,
+    ) -> Option<WorkspaceLifecycleRevision> {
+        Some(self.snapshot(workspace_name).await.revision())
+    }
+
+    pub(crate) async fn lock_if_unchanged(
+        &self,
+        workspace_name: &WorkspaceName,
         revision: WorkspaceLifecycleRevision,
-    ) -> Option<WorkspaceLifecycleGuard<'_>> {
-        let guard = self.write_inner();
-        if guard.revision == revision.0 {
-            Some(WorkspaceLifecycleGuard { guard })
+    ) -> Option<WorkspaceLifecycleGuard> {
+        let guard = Arc::clone(&self.inner).write_owned().await;
+        if workspace_revision(&guard, workspace_name) == revision.0 {
+            Some(WorkspaceLifecycleGuard {
+                guard,
+                workspace_name: workspace_name.clone(),
+            })
         } else {
             None
         }
     }
-
-    fn read_inner(&self) -> RwLockReadGuard<'_, WorkspaceLifecycleState> {
-        self.inner
-            .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
-
-    fn write_inner(&self) -> RwLockWriteGuard<'_, WorkspaceLifecycleState> {
-        self.inner
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
-
-    fn unmark_workspace_deleting(&self, workspace_name: &WorkspaceName) {
-        let mut guard = self.write_inner();
-        if guard.deleting_workspaces.remove(workspace_name) {
-            guard.revision = guard.revision.wrapping_add(1);
-        }
-    }
 }
 
 #[must_use]
-pub(crate) struct WorkspaceLifecycleGuard<'a> {
-    guard: RwLockWriteGuard<'a, WorkspaceLifecycleState>,
-}
-
-impl Drop for WorkspaceLifecycleGuard<'_> {
-    fn drop(&mut self) {
-        self.guard.revision = self.guard.revision.wrapping_add(1);
-    }
-}
-
-#[must_use]
-pub(crate) struct WorkspaceLifecycleSnapshot<'a> {
-    guard: RwLockReadGuard<'a, WorkspaceLifecycleState>,
-}
-
-impl WorkspaceLifecycleSnapshot<'_> {
-    pub(crate) fn revision(&self) -> WorkspaceLifecycleRevision {
-        WorkspaceLifecycleRevision(self.guard.revision)
-    }
-
-    pub(crate) fn workspace_is_deleting(&self, workspace_name: &WorkspaceName) -> bool {
-        self.guard.deleting_workspaces.contains(workspace_name)
-    }
-}
-
-#[must_use]
-pub(crate) struct WorkspaceDeletionMarker {
-    lifecycle: WorkspaceLifecycleLock,
+pub(crate) struct WorkspaceLifecycleGuard {
+    guard: OwnedRwLockWriteGuard<WorkspaceLifecycleState>,
     workspace_name: WorkspaceName,
 }
 
-impl Drop for WorkspaceDeletionMarker {
+impl Drop for WorkspaceLifecycleGuard {
     fn drop(&mut self) {
-        self.lifecycle
-            .unmark_workspace_deleting(&self.workspace_name);
+        let revision = self
+            .guard
+            .revisions
+            .entry(self.workspace_name.clone())
+            .or_default();
+        *revision = revision.wrapping_add(1);
     }
+}
+
+#[must_use]
+pub(crate) struct WorkspaceLifecycleSnapshot {
+    guard: OwnedRwLockReadGuard<WorkspaceLifecycleState>,
+    workspace_name: WorkspaceName,
+}
+
+impl WorkspaceLifecycleSnapshot {
+    pub(crate) fn revision(&self) -> WorkspaceLifecycleRevision {
+        WorkspaceLifecycleRevision(workspace_revision(&self.guard, &self.workspace_name))
+    }
+}
+
+fn workspace_revision(state: &WorkspaceLifecycleState, workspace_name: &WorkspaceName) -> u64 {
+    state
+        .revisions
+        .get(workspace_name)
+        .copied()
+        .unwrap_or_default()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -157,82 +134,91 @@ pub(crate) struct WorkspaceLifecycleRevision(u64);
 mod tests {
     use super::*;
 
-    #[test]
-    fn deletion_marker_marks_workspace_and_advances_revision_at_each_transition() {
+    #[tokio::test]
+    async fn write_guard_advances_revision_when_released() {
         let lifecycle = WorkspaceLifecycleLock::default();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
         let initial_revision = lifecycle
             .revision_if_active(&workspace)
+            .await
             .expect("workspace starts active");
 
-        let marker = lifecycle
-            .mark_workspace_deleting(&workspace)
-            .expect("mark workspace deleting");
+        drop(lifecycle.lock(&workspace).await);
 
-        let deleting_snapshot = lifecycle.snapshot();
         assert_eq!(
-            deleting_snapshot.revision().0,
+            lifecycle.snapshot(&workspace).await.revision().0,
             initial_revision.0.wrapping_add(1)
         );
-        assert!(deleting_snapshot.workspace_is_deleting(&workspace));
-        let deleting_revision = deleting_snapshot.revision();
-        drop(deleting_snapshot);
-        assert_eq!(lifecycle.revision_if_active(&workspace), None);
-        assert!(
-            lifecycle
-                .snapshot_if_unchanged(deleting_revision, &workspace)
-                .is_none()
-        );
-        assert!(lifecycle.mark_workspace_deleting(&workspace).is_none());
-
-        drop(marker);
-
-        let active_snapshot = lifecycle.snapshot();
-        assert_eq!(
-            active_snapshot.revision().0,
-            initial_revision.0.wrapping_add(2)
-        );
-        assert!(!active_snapshot.workspace_is_deleting(&workspace));
     }
 
-    #[test]
-    fn stale_revision_cannot_acquire_a_snapshot_or_write_guard() {
+    #[tokio::test]
+    async fn stale_revision_cannot_acquire_a_snapshot_or_write_guard() {
         let lifecycle = WorkspaceLifecycleLock::default();
         let workspace = WorkspaceName::parse("acme").expect("workspace");
-        let stale_revision = lifecycle.snapshot().revision();
+        let stale_revision = lifecycle.snapshot(&workspace).await.revision();
 
-        drop(lifecycle.lock());
+        drop(lifecycle.lock(&workspace).await);
 
         assert!(
             lifecycle
                 .snapshot_if_unchanged(stale_revision, &workspace)
+                .await
                 .is_none()
         );
-        assert!(lifecycle.lock_if_unchanged(stale_revision).is_none());
+        assert!(
+            lifecycle
+                .lock_if_unchanged(&workspace, stale_revision)
+                .await
+                .is_none()
+        );
 
-        let current_revision = lifecycle.snapshot().revision();
+        let current_revision = lifecycle.snapshot(&workspace).await.revision();
         assert!(
             lifecycle
                 .snapshot_if_unchanged(current_revision, &workspace)
+                .await
                 .is_some()
         );
-        assert!(lifecycle.lock_if_unchanged(current_revision).is_some());
+        assert!(
+            lifecycle
+                .lock_if_unchanged(&workspace, current_revision)
+                .await
+                .is_some()
+        );
     }
 
-    #[test]
-    fn read_snapshot_excludes_lifecycle_writes_until_it_is_released() {
+    #[tokio::test]
+    async fn unrelated_workspace_write_does_not_invalidate_revision() {
         let lifecycle = WorkspaceLifecycleLock::default();
-        let snapshot = lifecycle.snapshot();
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let unrelated = WorkspaceName::parse("other").expect("workspace");
+        let revision = lifecycle.snapshot(&workspace).await.revision();
+
+        drop(lifecycle.lock(&unrelated).await);
+
+        assert!(
+            lifecycle
+                .snapshot_if_unchanged(revision, &workspace)
+                .await
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn read_snapshot_excludes_lifecycle_writes_until_it_is_released() {
+        let lifecycle = WorkspaceLifecycleLock::default();
+        let workspace = WorkspaceName::parse("acme").expect("workspace");
+        let snapshot = lifecycle.snapshot(&workspace).await;
         let initial_revision = snapshot.revision();
-        let Err(_write_error) = lifecycle.inner.try_write() else {
+        let Err(_write_error) = Arc::clone(&lifecycle.inner).try_write_owned() else {
             panic!("read snapshot should exclude lifecycle writes");
         };
 
         drop(snapshot);
-        drop(lifecycle.lock());
+        drop(lifecycle.lock(&workspace).await);
 
         assert_eq!(
-            lifecycle.snapshot().revision().0,
+            lifecycle.snapshot(&workspace).await.revision().0,
             initial_revision.0.wrapping_add(1)
         );
     }


### PR DESCRIPTION
## Intent

Make workspace lifecycle coordination safe across async request paths before database-backed function storage begins awaiting database work while holding the workspace lifecycle guard.

## What changed

- Replaced the synchronous lifecycle lock with an owned Tokio `RwLock` guard so guarded futures remain `Send`.
- Kept revision-bump-on-drop behavior while tracking revisions per workspace.
- Standardized mutation ordering as lifecycle guard first, database work second.
- Moved synchronous source persistence behind `spawn_blocking` after the async guard is acquired.
- Released the delete guard after the database transaction commits and before post-commit cleanup.
- Added stale-revision and cross-workspace revision coverage.

## Ownership and boundaries

This remains app-owned lifecycle coordination in `coral-app`. It does not change protobufs, gRPC behavior, the public CLI surface, or database schema. The lock ordering invariant is recorded in `AGENTS.md`: never open a database transaction or reserve a pool connection before acquiring the lifecycle guard.

## Not in this PR

Function persistence remains unchanged here. The child PR moves function inventory and SQL into CoralDB.

## Validation

- Focused workspace, source, query, and search manager tests
- `cargo clippy --locked -p coral-app --all-targets --all-features -- -D warnings`
- Autoreview: clean
