### PR TITLE
refactor(app): persist functions in CoralDB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,8 @@
 - Acquire the workspace lifecycle write guard before opening a database
   transaction or awaiting a database connection. Keep that order consistent
   across lifecycle mutations so pool contention cannot invert the locks.
+- Store installed function inventory and SQL in CoralDB. `config.toml` and the
+  workspace filesystem are not function state authorities.
 - If a caller needs explicit local server control, prefer `coral-client::local`
   over widening the default client surface.
 - Keep process environment access owned by the right crate. `coral-app` owns

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ postgres-tests: postgres-start
 	url="postgres://postgres:postgres@127.0.0.1:$$host_port/$$db_name"; \
 	echo "Running Postgres tests against $$url"; \
 	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app --lib \
-	  state::db::repositories::workspaces::tests::workspace_repository_round_trips_against_postgres \
+	  state::db::repositories:: \
 	  -- --ignored; \
 	CORAL_TEST_POSTGRES_URL="$$url" cargo test --locked -p coral-app \
 	  --test postgres_database_tests \

--- a/apps/docs/reference/cli-reference.mdx
+++ b/apps/docs/reference/cli-reference.mdx
@@ -392,7 +392,7 @@ List configured functions.
 coral functions list
 ```
 
-The list includes every installed function. Runtime-ready entries show their inferred arguments, table-function target, and result-column preview. An artifact that is missing, invalid, or no longer plans successfully stays visible with an `invalid` status and an actionable reason below the table.
+The list includes every installed function. Runtime-ready entries show their inferred arguments, table-function target, and result-column preview. A function whose stored SQL is invalid or no longer plans successfully stays visible with an `invalid` status and an actionable reason below the table.
 
 If a function publishes a SQL table function and declares required inputs, call it with named arguments:
 

--- a/crates/coral-app/migrations/0003_functions.sql
+++ b/crates/coral-app/migrations/0003_functions.sql
@@ -1,0 +1,7 @@
+CREATE TABLE functions (
+    workspace_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    artifact_sql TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, name),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -1,4 +1,4 @@
-//! Owns user-installed function files and workspace inventory.
+//! Owns workspace-scoped function validation and durable storage.
 
 use std::collections::BTreeSet;
 use std::future::Future;
@@ -13,29 +13,22 @@ use crate::functions::runtime::{
     infer_runtime_function, infer_runtime_functions, infer_runtime_functions_in_prepared_runtime,
     runtime_function_without_signature,
 };
-use crate::functions::store::{FsFunctionArtifactStore, FunctionArtifactStore};
+use crate::functions::store::FunctionStore;
 use crate::functions::validation::{
     SqlPublishTargets, initial_sql_publish_targets, record_sql_publish_target,
     source_sql_publish_targets_for_schemas, unchecked_source_publish_schemas,
 };
-use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::{WorkspaceLifecycleLock, WorkspaceLifecycleRevision, WorkspaceName};
 
 #[derive(Clone)]
 pub(crate) struct FunctionManager {
-    config_store: ConfigStore,
-    artifacts: Arc<dyn FunctionArtifactStore>,
+    store: Arc<dyn FunctionStore>,
     lifecycle_lock: WorkspaceLifecycleLock,
 }
 
 struct FunctionArtifact {
     name: FunctionName,
-    content: FunctionArtifactContent,
-}
-
-enum FunctionArtifactContent {
-    Sql(String),
-    Unavailable(String),
+    sql: String,
 }
 
 /// One function as listed by the app inventory surface.
@@ -66,18 +59,16 @@ enum FunctionCandidate {
 
 impl FunctionManager {
     #[cfg(test)]
-    pub(crate) fn new_for_tests(config_store: ConfigStore, layout: &AppStateLayout) -> Self {
-        Self::new(config_store, layout, WorkspaceLifecycleLock::default())
+    pub(crate) fn new_for_tests(store: Arc<dyn FunctionStore>) -> Self {
+        Self::new(store, WorkspaceLifecycleLock::default())
     }
 
     pub(crate) fn new(
-        config_store: ConfigStore,
-        layout: &AppStateLayout,
+        store: Arc<dyn FunctionStore>,
         lifecycle_lock: WorkspaceLifecycleLock,
     ) -> Self {
         Self {
-            config_store,
-            artifacts: Arc::new(FsFunctionArtifactStore::new(layout.clone())),
+            store,
             lifecycle_lock,
         }
     }
@@ -113,7 +104,8 @@ impl FunctionManager {
             workspace_name,
             &function_name,
             raw_sql,
-        )?;
+        )
+        .await?;
         Ok(ValidatedFunctionInstall::Installed)
     }
 
@@ -130,38 +122,21 @@ impl FunctionManager {
             function_name,
             raw_sql,
         )
+        .await
     }
 
-    fn install_user_function_artifact_with_lifecycle_lock(
+    async fn install_user_function_artifact_with_lifecycle_lock(
         &self,
         workspace_name: &WorkspaceName,
         function_name: &FunctionName,
         raw_sql: &str,
     ) -> Result<InstalledFunction, AppError> {
-        let _state_lock = self.config_store.state_lock_exclusive()?;
         let installed = InstalledFunction {
             name: function_name.clone(),
         };
-
-        let previous_artifact =
-            self.artifacts
-                .write_user_function_artifact(workspace_name, function_name, raw_sql)?;
-        if let Err(error) = self
-            .config_store
-            .upsert_function_unlocked(workspace_name, installed.clone())
-        {
-            if let Err(restore_error) = self.artifacts.restore_user_function_artifact(
-                workspace_name,
-                function_name,
-                &previous_artifact,
-            ) {
-                return Err(AppError::FailedPrecondition(format!(
-                    "failed to install function '{function_name}': {error}; failed to restore function artifact: {restore_error}"
-                )));
-            }
-            return Err(error);
-        }
-
+        self.store
+            .upsert(workspace_name, function_name, raw_sql)
+            .await?;
         Ok(installed)
     }
 
@@ -181,7 +156,8 @@ impl FunctionManager {
             workspace_name,
             &function_name,
             &mut sql_publish_targets,
-        )?;
+        )
+        .await?;
         let runtime_function =
             infer_runtime_function(selected_sources, runtime_config()?, &function).await?;
         record_sql_publish_target(&runtime_function, &mut sql_publish_targets)?;
@@ -235,7 +211,7 @@ impl FunctionManager {
         Infer: FnOnce(Vec<UdfRuntimeDefinition>) -> InferFuture,
         InferFuture: Future<Output = Result<Vec<Result<UdfRuntimeDefinition, AppError>>, AppError>>,
     {
-        let artifacts = self.load_function_artifacts(workspace_name)?;
+        let artifacts = self.load_function_artifacts(workspace_name).await?;
         if artifacts.is_empty() {
             return Ok(Vec::new());
         }
@@ -310,70 +286,35 @@ impl FunctionManager {
         function_name: &FunctionName,
     ) -> Result<(), AppError> {
         let _lifecycle_guard = self.lifecycle_lock.lock(workspace_name).await;
-        let _state_lock = self.config_store.state_lock_exclusive()?;
-        self.config_store
-            .get_function_unlocked(workspace_name, function_name)?;
-        let removed_artifact = self
-            .artifacts
-            .remove_user_function_artifact(workspace_name, function_name)?;
-        if let Err(error) = self
-            .config_store
-            .remove_function_unlocked(workspace_name, function_name)
-        {
-            if let Err(restore_error) = self.artifacts.restore_user_function_artifact(
-                workspace_name,
-                function_name,
-                &removed_artifact,
-            ) {
-                return Err(AppError::FailedPrecondition(format!(
-                    "failed to remove function '{function_name}': {error}; failed to restore function artifact: {restore_error}"
-                )));
-            }
-            return Err(error);
+        if !self.store.delete(workspace_name, function_name).await? {
+            return Err(AppError::FunctionNotFound(function_name.to_string()));
         }
         Ok(())
     }
 
-    fn load_function_artifacts(
+    async fn load_function_artifacts(
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<FunctionArtifact>, AppError> {
-        let _state_lock = self.config_store.state_lock_shared()?;
-        let mut artifacts = Vec::new();
-        for installed in self
-            .config_store
-            .list_workspace_functions_unlocked(workspace_name)?
-        {
-            let content = match self
-                .artifacts
-                .read_function_sql(workspace_name, &installed.name)
-            {
-                Ok(Some(raw_sql)) => FunctionArtifactContent::Sql(raw_sql),
-                Ok(None) => FunctionArtifactContent::Unavailable(
-                    "installed function file is missing".to_string(),
-                ),
-                Err(error) => FunctionArtifactContent::Unavailable(format!(
-                    "installed function file could not be read: {error}"
-                )),
-            };
-            let function_name = installed.name;
-            artifacts.push(FunctionArtifact {
-                name: function_name,
-                content,
-            });
-        }
-
-        artifacts.sort_by(|left, right| left.name.as_str().cmp(right.name.as_str()));
-        Ok(artifacts)
+        Ok(self
+            .store
+            .list(workspace_name)
+            .await?
+            .into_iter()
+            .map(|stored| FunctionArtifact {
+                name: stored.name,
+                sql: stored.artifact_sql,
+            })
+            .collect())
     }
 
-    fn record_installed_function_sql_publish_targets(
+    async fn record_installed_function_sql_publish_targets(
         &self,
         workspace_name: &WorkspaceName,
         replacing_function: &FunctionName,
         publish_targets: &mut SqlPublishTargets,
     ) -> Result<(), AppError> {
-        for artifact in self.load_function_artifacts(workspace_name)? {
+        for artifact in self.load_function_artifacts(workspace_name).await? {
             if artifact.name == *replacing_function {
                 continue;
             }
@@ -412,16 +353,12 @@ fn validated_function_name(
 }
 
 fn parse_function_artifact(artifact: &FunctionArtifact) -> Result<FunctionSpec, String> {
-    let raw_sql = match &artifact.content {
-        FunctionArtifactContent::Sql(raw_sql) => raw_sql,
-        FunctionArtifactContent::Unavailable(error) => return Err(error.clone()),
-    };
-    let spec =
-        parse_function_sql(raw_sql).map_err(|error| format!("function is invalid: {error}"))?;
+    let spec = parse_function_sql(&artifact.sql)
+        .map_err(|error| format!("function is invalid: {error}"))?;
     let declared_name = FunctionName::parse(spec.name()).map_err(|error| error.to_string())?;
     if declared_name != artifact.name {
         return Err(format!(
-            "function file declares name '{declared_name}' but its inventory name is '{}'",
+            "stored function SQL declares name '{declared_name}' but its row name is '{}'",
             artifact.name
         ));
     }
@@ -448,18 +385,13 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
-    use tempfile::TempDir;
-
     use super::*;
-    use crate::state::AppStateLayout;
+    use crate::functions::store::tests::InMemoryFunctionStore;
 
-    fn fixture() -> (TempDir, AppStateLayout, ConfigStore, FunctionManager) {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        let config_store = ConfigStore::new(layout.clone());
-        let manager = FunctionManager::new_for_tests(config_store.clone(), &layout);
-        (temp, layout, config_store, manager)
+    fn fixture() -> (Arc<InMemoryFunctionStore>, FunctionManager) {
+        let store = Arc::new(InMemoryFunctionStore::default());
+        let manager = FunctionManager::new_for_tests(store.clone());
+        (store, manager)
     }
 
     fn workspace() -> WorkspaceName {
@@ -503,51 +435,6 @@ select 1 as id
         runtime_function_without_signature(&spec)
     }
 
-    #[derive(Clone)]
-    struct RestoreFailingArtifactStore {
-        inner: FsFunctionArtifactStore,
-    }
-
-    impl FunctionArtifactStore for RestoreFailingArtifactStore {
-        fn read_function_sql(
-            &self,
-            _workspace_name: &WorkspaceName,
-            _function_name: &FunctionName,
-        ) -> Result<Option<String>, AppError> {
-            unreachable!("rollback test does not read function artifacts")
-        }
-
-        fn write_user_function_artifact(
-            &self,
-            workspace_name: &WorkspaceName,
-            function_name: &FunctionName,
-            raw_sql: &str,
-        ) -> Result<crate::functions::store::FunctionArtifactSnapshot, AppError> {
-            self.inner
-                .write_user_function_artifact(workspace_name, function_name, raw_sql)
-        }
-
-        fn remove_user_function_artifact(
-            &self,
-            workspace_name: &WorkspaceName,
-            function_name: &FunctionName,
-        ) -> Result<crate::functions::store::FunctionArtifactSnapshot, AppError> {
-            self.inner
-                .remove_user_function_artifact(workspace_name, function_name)
-        }
-
-        fn restore_user_function_artifact(
-            &self,
-            _workspace_name: &WorkspaceName,
-            _function_name: &FunctionName,
-            _snapshot: &crate::functions::store::FunctionArtifactSnapshot,
-        ) -> Result<(), AppError> {
-            Err(AppError::FailedPrecondition(
-                "injected restore failure".to_string(),
-            ))
-        }
-    }
-
     async fn install_fixture_function(
         manager: &FunctionManager,
         workspace: &WorkspaceName,
@@ -562,19 +449,22 @@ select 1 as id
 
     #[tokio::test]
     async fn list_functions_infers_columns_from_sql_body() {
-        let (_temp, layout, _config_store, manager) = fixture();
+        let (store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql_with_owner_query("review_queue");
         install_fixture_function(&manager, &workspace, &raw_sql).await;
         let function_name = FunctionName::parse("review_queue").expect("function name");
-        std::fs::write(
-            layout.function_file(&workspace, &function_name),
-            raw_sql.replace(
-                "select cast($owner as VARCHAR) as owner",
-                "select cast($owner as VARCHAR) as reviewer",
-            ),
-        )
-        .expect("rewrite function sql");
+        store
+            .upsert(
+                &workspace,
+                &function_name,
+                &raw_sql.replace(
+                    "select cast($owner as VARCHAR) as owner",
+                    "select cast($owner as VARCHAR) as reviewer",
+                ),
+            )
+            .await
+            .expect("rewrite function sql");
 
         let listed = manager
             .list_functions(&workspace, &[], || Ok(QueryRuntimeConfig::default()))
@@ -599,7 +489,7 @@ select 1 as id
 
     #[tokio::test]
     async fn list_functions_builds_one_inference_runtime_for_all_functions() {
-        let (_temp, _layout, _config_store, manager) = fixture();
+        let (_store, manager) = fixture();
         let workspace = workspace();
         install_fixture_function(&manager, &workspace, &function_sql("first")).await;
         install_fixture_function(&manager, &workspace, &function_sql("second")).await;
@@ -619,18 +509,21 @@ select 1 as id
 
     #[tokio::test]
     async fn list_functions_keeps_runtime_invalid_artifacts_visible() {
-        let (_temp, layout, _config_store, manager) = fixture();
+        let (store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql_with_owner_query("review_queue");
         let installed = install_fixture_function(&manager, &workspace, &raw_sql).await;
-        std::fs::write(
-            layout.function_file(&workspace, &installed.name),
-            raw_sql.replace(
-                "select cast($owner as VARCHAR) as owner",
-                "select $owner as owner",
-            ),
-        )
-        .expect("rewrite invalid function sql");
+        store
+            .upsert(
+                &workspace,
+                &installed.name,
+                &raw_sql.replace(
+                    "select cast($owner as VARCHAR) as owner",
+                    "select $owner as owner",
+                ),
+            )
+            .await
+            .expect("rewrite invalid function sql");
 
         let listed = manager
             .list_functions(&workspace, &[], || Ok(QueryRuntimeConfig::default()))
@@ -647,15 +540,18 @@ select 1 as id
 
     #[tokio::test]
     async fn list_functions_rejects_artifact_name_drift_under_inventory_name() {
-        let (_temp, layout, _config_store, manager) = fixture();
+        let (store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql("review_queue");
         let installed = install_fixture_function(&manager, &workspace, &raw_sql).await;
-        std::fs::write(
-            layout.function_file(&workspace, &installed.name),
-            raw_sql.replace("name: review_queue", "name: renamed"),
-        )
-        .expect("rewrite function name");
+        store
+            .upsert(
+                &workspace,
+                &installed.name,
+                &raw_sql.replace("name: review_queue", "name: renamed"),
+            )
+            .await
+            .expect("rewrite function name");
 
         let listed = manager
             .list_functions(&workspace, &[], || Ok(QueryRuntimeConfig::default()))
@@ -675,30 +571,8 @@ select 1 as id
     }
 
     #[tokio::test]
-    async fn validate_function_ignores_unrelated_missing_artifact() {
-        let (_temp, layout, _config_store, manager) = fixture();
-        let workspace = workspace();
-        let installed =
-            install_fixture_function(&manager, &workspace, &function_sql("missing_artifact")).await;
-        std::fs::remove_file(layout.function_file(&workspace, &installed.name))
-            .expect("remove existing artifact");
-
-        let validated = manager
-            .validate_user_function_sql(
-                &workspace,
-                &[],
-                || Ok(QueryRuntimeConfig::default()),
-                &function_sql("new_function"),
-            )
-            .await
-            .expect("unrelated broken artifact should not block validation");
-
-        assert_eq!(validated.name, "new_function");
-    }
-
-    #[tokio::test]
     async fn load_runtime_udfs_uses_only_runtime_ready_functions() {
-        let (_temp, _layout, _config_store, manager) = fixture();
+        let (_store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql("review_queue");
         install_fixture_function(&manager, &workspace, &raw_sql).await;
@@ -718,8 +592,8 @@ select 1 as id
     }
 
     #[tokio::test]
-    async fn remove_user_function_removes_inventory_and_artifacts() {
-        let (_temp, layout, config_store, manager) = fixture();
+    async fn remove_user_function_removes_stored_row() {
+        let (store, manager) = fixture();
         let workspace = workspace();
         let raw_sql = function_sql("review_queue");
         let installed = install_fixture_function(&manager, &workspace, &raw_sql).await;
@@ -730,20 +604,17 @@ select 1 as id
             .expect("remove function");
 
         assert!(
-            config_store
-                .list_workspace_functions(&workspace)
-                .expect("list function inventory")
+            store
+                .list(&workspace)
+                .await
+                .expect("list functions")
                 .is_empty()
-        );
-        assert!(
-            !layout.function_dir(&workspace, &installed.name).exists(),
-            "function artifact directory should be removed"
         );
     }
 
     #[tokio::test]
     async fn remove_user_function_reports_typed_missing_function() {
-        let (_temp, _layout, _config_store, manager) = fixture();
+        let (_store, manager) = fixture();
         let function_name = FunctionName::parse("missing").expect("function name");
 
         let error = manager
@@ -759,12 +630,11 @@ select 1 as id
 
     #[tokio::test]
     async fn install_user_function_waits_for_workspace_lifecycle_lock() {
-        let temp = TempDir::new().expect("temp dir");
-        let layout =
-            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
-        let config_store = ConfigStore::new(layout.clone());
         let lifecycle_lock = WorkspaceLifecycleLock::default();
-        let manager = FunctionManager::new(config_store, &layout, lifecycle_lock.clone());
+        let manager = FunctionManager::new(
+            Arc::new(InMemoryFunctionStore::default()),
+            lifecycle_lock.clone(),
+        );
         let workspace = workspace();
         let lifecycle_guard = lifecycle_lock.lock(&workspace).await;
 
@@ -808,52 +678,5 @@ select 1 as id
             .expect("install should succeed");
         assert_eq!(installed, "review_queue");
         handle.join().expect("join install thread");
-    }
-
-    #[tokio::test]
-    async fn install_user_function_reports_inventory_and_restore_failures() {
-        let (_temp, layout, config_store, manager) = fixture();
-        let workspace = workspace();
-        let original_sql = function_sql("review_queue");
-        install_fixture_function(&manager, &workspace, &original_sql).await;
-
-        let function_name = FunctionName::parse("review_queue").expect("function name");
-        let replacement_sql = format!("{original_sql}\n");
-        std::fs::remove_file(layout.config_file()).expect("remove config file");
-        std::fs::create_dir(layout.config_file()).expect("replace config file with directory");
-
-        let manager = FunctionManager {
-            config_store,
-            artifacts: Arc::new(RestoreFailingArtifactStore {
-                inner: FsFunctionArtifactStore::new(layout.clone()),
-            }),
-            lifecycle_lock: WorkspaceLifecycleLock::default(),
-        };
-        let runtime_function = validated_function(&replacement_sql);
-        let error = manager
-            .install_validated_user_function(&workspace, &replacement_sql, &runtime_function)
-            .await
-            .expect_err("inventory and restore failures should be reported together");
-
-        let AppError::FailedPrecondition(message) = error else {
-            panic!("unexpected error: {error}");
-        };
-        assert!(
-            message.contains("failed to install function 'review_queue'"),
-            "unexpected error: {message}"
-        );
-        assert!(
-            message.contains("failed to restore function artifact"),
-            "unexpected error: {message}"
-        );
-        assert!(
-            message.contains("injected restore failure"),
-            "unexpected error: {message}"
-        );
-        assert_eq!(
-            std::fs::read_to_string(layout.function_file(&workspace, &function_name))
-                .expect("read unrestored function artifact"),
-            replacement_sql
-        );
     }
 }

--- a/crates/coral-app/src/functions/mod.rs
+++ b/crates/coral-app/src/functions/mod.rs
@@ -6,5 +6,3 @@ mod runtime;
 pub(crate) mod service;
 mod store;
 mod validation;
-
-pub(crate) use model::FunctionName;

--- a/crates/coral-app/src/functions/store.rs
+++ b/crates/coral-app/src/functions/store.rs
@@ -1,163 +1,143 @@
-//! Storage seams for workspace function inventory and artifacts.
-
-use std::io::ErrorKind;
+//! Durable storage seam for workspace functions.
 
 use crate::bootstrap::AppError;
 use crate::functions::model::FunctionName;
-use crate::state::AppStateLayout;
-use crate::storage::fs;
+use crate::state::db::{CoralDb, DbRepos};
 use crate::workspaces::WorkspaceName;
 
-pub(crate) trait FunctionArtifactStore: Send + Sync {
-    fn read_function_sql(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-    ) -> Result<Option<String>, AppError>;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StoredFunction {
+    pub(crate) name: FunctionName,
+    pub(crate) artifact_sql: String,
+}
 
-    fn write_user_function_artifact(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-        raw_sql: &str,
-    ) -> Result<FunctionArtifactSnapshot, AppError>;
+#[tonic::async_trait]
+pub(crate) trait FunctionStore: Send + Sync {
+    async fn list(&self, workspace_name: &WorkspaceName) -> Result<Vec<StoredFunction>, AppError>;
 
-    fn remove_user_function_artifact(
+    async fn upsert(
         &self,
         workspace_name: &WorkspaceName,
         function_name: &FunctionName,
-    ) -> Result<FunctionArtifactSnapshot, AppError>;
-
-    fn restore_user_function_artifact(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-        snapshot: &FunctionArtifactSnapshot,
+        artifact_sql: &str,
     ) -> Result<(), AppError>;
-}
 
-#[derive(Clone)]
-pub(crate) struct FsFunctionArtifactStore {
-    layout: AppStateLayout,
-}
-
-impl FsFunctionArtifactStore {
-    pub(crate) fn new(layout: AppStateLayout) -> Self {
-        Self { layout }
-    }
-
-    fn snapshot(
+    async fn delete(
         &self,
         workspace_name: &WorkspaceName,
         function_name: &FunctionName,
-    ) -> Result<FunctionArtifactSnapshot, AppError> {
-        Ok(FunctionArtifactSnapshot {
-            function_sql: read_optional_bytes(
-                &self.layout.function_file(workspace_name, function_name),
-            )?,
-        })
+    ) -> Result<bool, AppError>;
+}
+
+#[tonic::async_trait]
+impl FunctionStore for CoralDb {
+    async fn list(&self, workspace_name: &WorkspaceName) -> Result<Vec<StoredFunction>, AppError> {
+        let mut session = self;
+        let functions = session
+            .functions()
+            .list(workspace_name.as_str())
+            .await?
+            .into_iter()
+            .map(|record| {
+                Ok(StoredFunction {
+                    name: FunctionName::parse(&record.name)?,
+                    artifact_sql: record.artifact_sql,
+                })
+            })
+            .collect::<Result<Vec<_>, AppError>>()?;
+        Ok(functions)
     }
 
-    fn write_user_function_artifact_inner(
+    async fn upsert(
         &self,
         workspace_name: &WorkspaceName,
         function_name: &FunctionName,
-        raw_sql: &str,
+        artifact_sql: &str,
     ) -> Result<(), AppError> {
-        let function_dir = self.layout.function_dir(workspace_name, function_name);
-        let function_file = self.layout.function_file(workspace_name, function_name);
-
-        fs::ensure_private_dir(&function_dir)?;
-        fs::write_atomic(&function_file, raw_sql.as_bytes())?;
+        let mut session = self;
+        session
+            .functions()
+            .upsert(
+                workspace_name.as_str(),
+                function_name.as_str(),
+                artifact_sql,
+            )
+            .await?;
         Ok(())
     }
+
+    async fn delete(
+        &self,
+        workspace_name: &WorkspaceName,
+        function_name: &FunctionName,
+    ) -> Result<bool, AppError> {
+        let mut session = self;
+        Ok(session
+            .functions()
+            .delete(workspace_name.as_str(), function_name.as_str())
+            .await?)
+    }
 }
 
-impl FunctionArtifactStore for FsFunctionArtifactStore {
-    fn read_function_sql(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-    ) -> Result<Option<String>, AppError> {
-        match std::fs::read_to_string(self.layout.function_file(workspace_name, function_name)) {
-            Ok(raw_sql) => Ok(Some(raw_sql)),
-            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
-            Err(error) => Err(error.into()),
-        }
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::RwLock;
+
+    use super::*;
+
+    #[derive(Default)]
+    pub(crate) struct InMemoryFunctionStore {
+        functions: RwLock<BTreeMap<(WorkspaceName, FunctionName), String>>,
     }
 
-    fn write_user_function_artifact(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-        raw_sql: &str,
-    ) -> Result<FunctionArtifactSnapshot, AppError> {
-        let previous = self.snapshot(workspace_name, function_name)?;
-        if let Err(error) =
-            self.write_user_function_artifact_inner(workspace_name, function_name, raw_sql)
-        {
-            if let Err(restore_error) =
-                self.restore_user_function_artifact(workspace_name, function_name, &previous)
-            {
-                tracing::warn!(
-                    function = %function_name,
-                    detail = %restore_error,
-                    "failed to restore previous function artifact after write failure"
+    #[tonic::async_trait]
+    impl FunctionStore for InMemoryFunctionStore {
+        async fn list(
+            &self,
+            workspace_name: &WorkspaceName,
+        ) -> Result<Vec<StoredFunction>, AppError> {
+            let functions = self
+                .functions
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            Ok(functions
+                .iter()
+                .filter(|((workspace, _), _)| workspace == workspace_name)
+                .map(|((_, name), artifact_sql)| StoredFunction {
+                    name: name.clone(),
+                    artifact_sql: artifact_sql.clone(),
+                })
+                .collect())
+        }
+
+        async fn upsert(
+            &self,
+            workspace_name: &WorkspaceName,
+            function_name: &FunctionName,
+            artifact_sql: &str,
+        ) -> Result<(), AppError> {
+            self.functions
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .insert(
+                    (workspace_name.clone(), function_name.clone()),
+                    artifact_sql.to_owned(),
                 );
-            }
-            return Err(error);
+            Ok(())
         }
-        Ok(previous)
-    }
 
-    fn remove_user_function_artifact(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-    ) -> Result<FunctionArtifactSnapshot, AppError> {
-        let previous = self.snapshot(workspace_name, function_name)?;
-        let function_dir = self.layout.function_dir(workspace_name, function_name);
-        match std::fs::remove_dir_all(function_dir) {
-            Ok(()) => {}
-            Err(error) if error.kind() == ErrorKind::NotFound => {}
-            Err(error) => return Err(error.into()),
+        async fn delete(
+            &self,
+            workspace_name: &WorkspaceName,
+            function_name: &FunctionName,
+        ) -> Result<bool, AppError> {
+            Ok(self
+                .functions
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .remove(&(workspace_name.clone(), function_name.clone()))
+                .is_some())
         }
-        Ok(previous)
-    }
-
-    fn restore_user_function_artifact(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-        snapshot: &FunctionArtifactSnapshot,
-    ) -> Result<(), AppError> {
-        let function_dir = self.layout.function_dir(workspace_name, function_name);
-        let function_file = self.layout.function_file(workspace_name, function_name);
-
-        let Some(raw_sql) = &snapshot.function_sql else {
-            match std::fs::remove_dir_all(function_dir) {
-                Ok(()) => {}
-                Err(error) if error.kind() == ErrorKind::NotFound => {}
-                Err(error) => return Err(error.into()),
-            }
-            return Ok(());
-        };
-
-        fs::ensure_private_dir(&function_dir)?;
-        fs::write_atomic(&function_file, raw_sql)?;
-        Ok(())
-    }
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct FunctionArtifactSnapshot {
-    function_sql: Option<Vec<u8>>,
-}
-
-fn read_optional_bytes(path: &std::path::Path) -> Result<Option<Vec<u8>>, AppError> {
-    match std::fs::read(path) {
-        Ok(bytes) => Ok(Some(bytes)),
-        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error.into()),
     }
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -210,7 +210,7 @@ impl QueryManager {
         diagnostic_reporter: SourceDiagnosticReporter,
     ) -> Self {
         let function_manager =
-            FunctionManager::new(config_store.clone(), &layout, lifecycle_lock.clone());
+            FunctionManager::new(workspace_manager.database(), lifecycle_lock.clone());
         Self {
             config_store,
             workspace_manager: Arc::new(workspace_manager),

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -10,7 +10,6 @@ use uuid::Uuid;
 
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialStorageKind;
-use crate::functions::model::{FunctionName, InstalledFunction};
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
@@ -23,7 +22,6 @@ pub(crate) struct AppConfig {
     engine: PersistedEngineConfig,
     workspaces: WorkspaceCatalog,
     catalog: SourceCatalog,
-    functions: FunctionCatalog,
 }
 
 impl Default for AppConfig {
@@ -33,7 +31,6 @@ impl Default for AppConfig {
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
-            functions: FunctionCatalog::default(),
         }
     }
 }
@@ -185,14 +182,8 @@ pub(crate) enum RawFeatureValue {
 struct PersistedWorkspaceConfig {
     #[serde(default)]
     sources: BTreeMap<String, PersistedInstalledSource>,
-    // The persisted TOML shape is `functions.<name> = {}` so existing workspace
-    // configs keep round-tripping even though installed functions are membership-only.
-    #[expect(
-        clippy::zero_sized_map_values,
-        reason = "persisted function membership uses the existing TOML map shape"
-    )]
-    #[serde(default)]
-    functions: BTreeMap<String, PersistedInstalledFunction>,
+    #[serde(default, rename = "functions", skip_serializing)]
+    _legacy_functions: BTreeMap<String, toml::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -264,23 +255,6 @@ impl WorkspaceCatalog {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct PersistedInstalledFunction {}
-
-impl PersistedInstalledFunction {
-    fn into_installed_function(function_name: FunctionName) -> InstalledFunction {
-        InstalledFunction {
-            name: function_name,
-        }
-    }
-}
-
-impl From<&InstalledFunction> for PersistedInstalledFunction {
-    fn from(_value: &InstalledFunction) -> Self {
-        Self {}
-    }
-}
-
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SourceCatalog(BTreeMap<WorkspaceName, BTreeMap<SourceName, InstalledSource>>);
 
@@ -349,73 +323,6 @@ impl SourceCatalog {
         &mut self,
         workspace_name: &WorkspaceName,
     ) -> Option<BTreeMap<SourceName, InstalledSource>> {
-        self.0.remove(workspace_name)
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub(crate) struct FunctionCatalog(
-    BTreeMap<WorkspaceName, BTreeMap<FunctionName, InstalledFunction>>,
-);
-
-impl FunctionCatalog {
-    pub(crate) fn workspace_functions(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Vec<InstalledFunction> {
-        self.0
-            .get(workspace_name)
-            .map(|functions| functions.values().cloned().collect())
-            .unwrap_or_default()
-    }
-
-    pub(crate) fn get_function(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-    ) -> Option<InstalledFunction> {
-        self.0
-            .get(workspace_name)
-            .and_then(|functions| functions.get(function_name))
-            .cloned()
-    }
-
-    pub(crate) fn upsert_function(
-        &mut self,
-        workspace_name: &WorkspaceName,
-        function: InstalledFunction,
-    ) {
-        self.0
-            .entry(workspace_name.clone())
-            .or_default()
-            .insert(function.name.clone(), function);
-    }
-
-    pub(crate) fn remove_function(
-        &mut self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-    ) -> Option<InstalledFunction> {
-        let mut removed = None;
-        let remove_workspace = match self.0.get_mut(workspace_name) {
-            Some(functions) => {
-                removed = functions.remove(function_name);
-                functions.is_empty()
-            }
-            None => false,
-        };
-
-        if remove_workspace {
-            self.0.remove(workspace_name);
-        }
-
-        removed
-    }
-
-    pub(crate) fn remove_workspace(
-        &mut self,
-        workspace_name: &WorkspaceName,
-    ) -> Option<BTreeMap<FunctionName, InstalledFunction>> {
         self.0.remove(workspace_name)
     }
 }
@@ -633,7 +540,6 @@ impl ConfigStore {
                     .map(BTreeMap::into_values)
                     .map(Iterator::collect)
                     .unwrap_or_default();
-                config.functions.remove_workspace(workspace_name);
                 return Ok(Some(DeletedWorkspace {
                     workspace: WorkspaceRecord {
                         name: workspace_name.clone(),
@@ -727,108 +633,6 @@ impl ConfigStore {
     }
 }
 
-impl ConfigStore {
-    /// Lists installed functions without taking the app state lock.
-    ///
-    /// Callers must already hold the state lock while using function artifacts
-    /// associated with the returned inventory.
-    pub(crate) fn list_workspace_functions_unlocked(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<Vec<InstalledFunction>, AppError> {
-        let config = self.load_config_unlocked()?;
-        Ok(config.functions.workspace_functions(workspace_name))
-    }
-
-    #[cfg(test)]
-    pub(crate) fn list_workspace_functions(
-        &self,
-        workspace_name: &WorkspaceName,
-    ) -> Result<Vec<InstalledFunction>, AppError> {
-        let _state_lock = self.state_lock_shared()?;
-        self.list_workspace_functions_unlocked(workspace_name)
-    }
-
-    /// Loads one installed function without taking the app state lock.
-    ///
-    /// Callers must already hold the state lock while using the associated
-    /// function artifact.
-    pub(crate) fn get_function_unlocked(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-    ) -> Result<InstalledFunction, AppError> {
-        let config = self.load_config_unlocked()?;
-        config
-            .functions
-            .get_function(workspace_name, function_name)
-            .ok_or_else(|| AppError::FunctionNotFound(function_name.to_string()))
-    }
-
-    #[cfg(test)]
-    pub(crate) fn get_function(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-    ) -> Result<InstalledFunction, AppError> {
-        let _state_lock = self.state_lock_shared()?;
-        self.get_function_unlocked(workspace_name, function_name)
-    }
-
-    /// Upserts one installed function without taking the app state lock.
-    ///
-    /// Callers must already hold the state lock in exclusive mode.
-    pub(crate) fn upsert_function_unlocked(
-        &self,
-        workspace_name: &WorkspaceName,
-        function: InstalledFunction,
-    ) -> Result<(), AppError> {
-        self.update_config_unlocked(|config| {
-            config.functions.upsert_function(workspace_name, function);
-            Ok(())
-        })
-    }
-
-    #[cfg(test)]
-    pub(crate) fn upsert_function(
-        &self,
-        workspace_name: &WorkspaceName,
-        function: InstalledFunction,
-    ) -> Result<(), AppError> {
-        let _state_lock = self.state_lock_exclusive()?;
-        self.upsert_function_unlocked(workspace_name, function)
-    }
-
-    /// Removes one installed function without taking the app state lock.
-    ///
-    /// Callers must already hold the state lock in exclusive mode.
-    pub(crate) fn remove_function_unlocked(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-    ) -> Result<(), AppError> {
-        self.update_config_unlocked(|config| {
-            let removed = config
-                .functions
-                .remove_function(workspace_name, function_name);
-            if removed.is_none() {
-                return Err(AppError::FunctionNotFound(function_name.to_string()));
-            }
-            Ok(())
-        })
-    }
-
-    #[cfg(test)]
-    pub(crate) fn remove_function(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-    ) -> Result<(), AppError> {
-        let _state_lock = self.state_lock_exclusive()?;
-        self.remove_function_unlocked(workspace_name, function_name)
-    }
-}
-
 #[expect(
     clippy::indexing_slicing,
     reason = "toml_edit indexing creates or accesses document paths while rebuilding the config table"
@@ -888,22 +692,6 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
                 source_item["credential_revision"] = value(source.credential_revision.to_string());
             }
             source_item["origin"] = value(source.origin.as_config_value());
-        }
-
-        for function_name in workspace.functions.keys() {
-            ensure_implicit_table(&mut doc["workspaces"]);
-            ensure_implicit_table(&mut doc["workspaces"][workspace_name]);
-            ensure_implicit_table(&mut doc["workspaces"][workspace_name]["functions"]);
-
-            let function_item = &mut doc["workspaces"][workspace_name]["functions"][function_name];
-            if !function_item.is_table() {
-                *function_item = toml_edit::table();
-            }
-            let function_table = function_item
-                .as_table_mut()
-                .expect("function config entry should be a table after initialization");
-            function_table.remove("origin");
-            function_table.remove("enabled");
         }
     }
 
@@ -989,7 +777,6 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
     fn try_from(value: PersistedAppConfig) -> Result<Self, Self::Error> {
         let mut workspaces = WorkspaceCatalog::default();
         let mut catalog = SourceCatalog::default();
-        let mut functions = FunctionCatalog::default();
         for (workspace_name, workspace_config) in value.workspaces {
             let workspace_name = WorkspaceName::parse(&workspace_name)?;
             workspaces.insert(workspace_name.clone());
@@ -997,20 +784,12 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
                 let source_name = SourceName::parse(&source_name)?;
                 catalog.upsert_source(&workspace_name, source.into_installed_source(source_name));
             }
-            for (function_name, _function) in workspace_config.functions {
-                let function_name = FunctionName::parse(&function_name)?;
-                functions.upsert_function(
-                    &workspace_name,
-                    PersistedInstalledFunction::into_installed_function(function_name),
-                );
-            }
         }
         Ok(Self {
             version: value.version,
             engine: value.engine,
             workspaces,
             catalog,
-            functions,
         })
     }
 }
@@ -1031,17 +810,6 @@ impl From<&AppConfig> for PersistedAppConfig {
                 workspace_config.sources.insert(
                     source.name.as_str().to_string(),
                     PersistedInstalledSource::from(source),
-                );
-            }
-        }
-        for (workspace_name, functions) in &value.functions.0 {
-            let workspace_config = workspaces
-                .entry(workspace_name.as_str().to_string())
-                .or_insert_with(PersistedWorkspaceConfig::default);
-            for function in functions.values() {
-                workspace_config.functions.insert(
-                    function.name.as_str().to_string(),
-                    PersistedInstalledFunction::from(function),
                 );
             }
         }
@@ -1220,13 +988,11 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        AppConfig, AppError, ConfigStore, FunctionCatalog, PersistedAppConfig,
-        PersistedEngineConfig, PersistedMemoryConfig, RawFeatureContainerState, RawFeatureValue,
-        SourceCatalog, WorkspaceCatalog, load_raw_feature_overrides, render_config,
-        set_raw_feature_override,
+        AppConfig, AppError, ConfigStore, PersistedAppConfig, PersistedEngineConfig,
+        PersistedMemoryConfig, RawFeatureContainerState, RawFeatureValue, SourceCatalog,
+        WorkspaceCatalog, load_raw_feature_overrides, render_config, set_raw_feature_override,
     };
     use crate::credentials::CredentialStorageKind;
-    use crate::functions::model::{FunctionName, InstalledFunction};
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::AppStateLayout;
@@ -1248,12 +1014,6 @@ mod tests {
             credential_storage: None,
             credential_revision: uuid::Uuid::default(),
             origin: SourceOrigin::Imported,
-        }
-    }
-
-    fn installed_function(name: &str) -> InstalledFunction {
-        InstalledFunction {
-            name: FunctionName::parse(name).expect("function"),
         }
     }
 
@@ -1305,7 +1065,6 @@ mod tests {
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog,
-            functions: FunctionCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -1327,7 +1086,6 @@ mod tests {
             engine: PersistedEngineConfig::default(),
             workspaces,
             catalog: SourceCatalog::default(),
-            functions: FunctionCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -1360,53 +1118,6 @@ version = 1
     }
 
     #[test]
-    fn renders_functions_under_workspace_keyed_tables() {
-        let workspace_name = default_workspace();
-        let mut functions = FunctionCatalog::default();
-        functions.upsert_function(&workspace_name, installed_function("review_queue"));
-        let config = AppConfig {
-            version: 1,
-            engine: PersistedEngineConfig::default(),
-            workspaces: WorkspaceCatalog::default(),
-            catalog: SourceCatalog::default(),
-            functions,
-        };
-
-        let raw = render_config(&PersistedAppConfig::from(&config), None);
-
-        assert!(raw.contains("[workspaces.default.functions.review_queue]"));
-        assert!(!raw.contains("origin = \"user\""));
-        assert!(!raw.contains("enabled = true"));
-    }
-
-    #[test]
-    fn removes_legacy_function_origin_and_enabled_when_rendering() {
-        let existing = r#"
-version = 1
-
-[workspaces.default.functions.review_queue]
-origin = "user"
-enabled = true
-"#;
-        let workspace_name = default_workspace();
-        let mut functions = FunctionCatalog::default();
-        functions.upsert_function(&workspace_name, installed_function("review_queue"));
-        let config = AppConfig {
-            version: 1,
-            engine: PersistedEngineConfig::default(),
-            workspaces: WorkspaceCatalog::default(),
-            catalog: SourceCatalog::default(),
-            functions,
-        };
-
-        let raw = render_config(&PersistedAppConfig::from(&config), Some(existing));
-
-        assert!(raw.contains("[workspaces.default.functions.review_queue]"));
-        assert!(!raw.contains("origin = \"user\""));
-        assert!(!raw.contains("enabled = true"));
-    }
-
-    #[test]
     fn omits_empty_versions_from_rendered_source_entries() {
         let workspace_name = default_workspace();
         let mut source = installed_source("github");
@@ -1419,7 +1130,6 @@ enabled = true
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog,
-            functions: FunctionCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -1465,7 +1175,6 @@ origin = "bundled"
         let store = ConfigStore::new(test_layout(&temp));
         let missing_workspace = WorkspaceName::parse("missing").expect("workspace");
         let source_name = SourceName::parse("github").expect("source");
-        let function_name = FunctionName::parse("review_queue").expect("function");
 
         assert!(
             store
@@ -1494,37 +1203,10 @@ origin = "bundled"
             store.get_source(&missing_workspace, &source_name),
             Err(AppError::SourceNotFound(_))
         ));
-        assert!(
-            store
-                .list_workspace_functions(&missing_workspace)
-                .expect("list function definitions")
-                .is_empty()
-        );
-        assert!(matches!(
-            store.get_function(&missing_workspace, &function_name),
-            Err(AppError::FunctionNotFound(_))
-        ));
-        store
-            .upsert_function(&missing_workspace, installed_function("review_queue"))
-            .expect("upsert function definition");
-        assert_eq!(
-            store
-                .get_function(&missing_workspace, &function_name)
-                .expect("get function definition")
-                .name,
-            function_name
-        );
-        store
-            .remove_function(&missing_workspace, &function_name)
-            .expect("remove function definition");
-        assert!(matches!(
-            store.get_function(&missing_workspace, &function_name),
-            Err(AppError::FunctionNotFound(_))
-        ));
     }
 
     #[test]
-    fn remove_workspace_config_entries_removes_sources_and_functions() {
+    fn remove_workspace_config_entries_removes_sources() {
         let temp = TempDir::new().expect("temp dir");
         let store = ConfigStore::new(test_layout(&temp));
         let workspace_name = WorkspaceName::parse("work").expect("workspace");
@@ -1535,9 +1217,6 @@ origin = "bundled"
         store
             .upsert_source(&workspace_name, installed_source("github"))
             .expect("upsert source");
-        store
-            .upsert_function(&workspace_name, installed_function("review_queue"))
-            .expect("upsert function");
 
         let deleted = store
             .remove_workspace_config_entries(&workspace_name)
@@ -1553,19 +1232,10 @@ origin = "bundled"
                 .expect("list source definitions")
                 .is_empty()
         );
-        assert!(
-            store
-                .list_workspace_functions(&deleted.workspace.name)
-                .expect("list function definitions")
-                .is_empty()
-        );
-
-        let rendered = std::fs::read_to_string(store.layout.config_file()).expect("read config");
-        assert!(!rendered.contains("[workspaces.work.functions.review_queue]"));
     }
 
     #[test]
-    fn loads_functions_from_workspace_keyed_tables() {
+    fn legacy_function_entries_parse_and_drop_on_rewrite() {
         let raw = r"
 version = 1
 
@@ -1576,10 +1246,9 @@ version = 1
             toml::from_str::<PersistedAppConfig>(raw).expect("workspace-keyed config should parse"),
         )
         .expect("config");
-        let functions = config.functions.workspace_functions(&default_workspace());
+        let rendered = render_config(&PersistedAppConfig::from(&config), Some(raw));
 
-        assert_eq!(functions.len(), 1);
-        assert_eq!(functions[0].name.as_str(), "review_queue");
+        assert!(!rendered.contains("functions.review_queue"));
     }
 
     #[test]
@@ -1711,7 +1380,6 @@ limit = 2147483648
             },
             workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
-            functions: FunctionCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -1738,7 +1406,6 @@ flag = true
             },
             workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
-            functions: FunctionCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), Some(existing_raw));
@@ -1765,7 +1432,6 @@ flag = true
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog: SourceCatalog::default(),
-            functions: FunctionCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), Some(existing_raw));
@@ -1901,7 +1567,6 @@ max_concurrency = 0
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog,
-            functions: FunctionCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -1931,7 +1596,6 @@ max_concurrency = 0
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog,
-            functions: FunctionCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), None);
@@ -2063,7 +1727,6 @@ origin = "bundled"
             engine: PersistedEngineConfig::default(),
             workspaces: WorkspaceCatalog::default(),
             catalog,
-            functions: FunctionCatalog::default(),
         };
 
         let raw = render_config(&PersistedAppConfig::from(&config), Some(existing));
@@ -2153,18 +1816,6 @@ origin = "bundled"
         )
         .expect_err("invalid source key should fail");
         assert!(error.to_string().contains("source name"));
-
-        let invalid_function = r#"
-version = 1
-
-	[workspaces.default.functions."bad\\function"]
-	"#;
-        let error = AppConfig::try_from(
-            toml::from_str::<PersistedAppConfig>(invalid_function)
-                .expect("quoted function key should parse"),
-        )
-        .expect_err("invalid function key should fail");
-        assert!(error.to_string().contains("function name"));
     }
 
     #[test]

--- a/crates/coral-app/src/state/db/repositories/functions.rs
+++ b/crates/coral-app/src/state/db/repositories/functions.rs
@@ -1,0 +1,199 @@
+use sea_query::{Expr, ExprTrait, OnConflict, Query};
+
+use crate::state::db::schema::Functions;
+use crate::state::db::{DbError, DbSession};
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub(crate) struct FunctionRecord {
+    pub(crate) workspace_id: String,
+    pub(crate) name: String,
+    pub(crate) artifact_sql: String,
+}
+
+pub(crate) struct FunctionsRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> FunctionsRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn list(
+        &mut self,
+        workspace_id: &str,
+    ) -> Result<Vec<FunctionRecord>, DbError> {
+        let statement = Query::select()
+            .columns([
+                Functions::WorkspaceId,
+                Functions::Name,
+                Functions::ArtifactSql,
+            ])
+            .from(Functions::Table)
+            .and_where(Expr::col(Functions::WorkspaceId).eq(workspace_id))
+            .to_owned();
+        let mut functions: Vec<FunctionRecord> = self.session.fetch_all(statement).await?;
+        functions.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(functions)
+    }
+
+    pub(crate) async fn upsert(
+        &mut self,
+        workspace_id: &str,
+        name: &str,
+        artifact_sql: &str,
+    ) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(Functions::Table)
+            .columns([
+                Functions::WorkspaceId,
+                Functions::Name,
+                Functions::ArtifactSql,
+            ])
+            .values_panic([
+                Expr::val(workspace_id.to_owned()),
+                Expr::val(name.to_owned()),
+                Expr::val(artifact_sql.to_owned()),
+            ])
+            .on_conflict(
+                OnConflict::columns([Functions::WorkspaceId, Functions::Name])
+                    .update_column(Functions::ArtifactSql)
+                    .to_owned(),
+            )
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    pub(crate) async fn delete(&mut self, workspace_id: &str, name: &str) -> Result<bool, DbError> {
+        let statement = Query::delete()
+            .from_table(Functions::Table)
+            .and_where(Expr::col(Functions::WorkspaceId).eq(workspace_id))
+            .and_where(Expr::col(Functions::Name).eq(name))
+            .to_owned();
+        Ok(self.session.execute_affected(statement).await? > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use tempfile::tempdir;
+
+    use super::FunctionRecord;
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::{CoralDb, DatabaseConfig, DbRepos, ResolvedDatabaseConfig};
+
+    #[tokio::test]
+    async fn function_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        let DatabaseConfig::Sqlite { path } = DatabaseConfig::load(&layout).expect("db config")
+        else {
+            panic!("default test database should be SQLite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+
+        assert_function_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn function_repository_round_trips_against_postgres() {
+        let Some(url) = bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+            .expect("read CORAL_TEST_POSTGRES_URL")
+            .filter(|value| !value.is_empty())
+        else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_function_repository_round_trip(&db).await;
+    }
+
+    async fn assert_function_repository_round_trip(db: &CoralDb) {
+        let workspace_id = format!(
+            "functions_{}_{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock")
+                .as_nanos()
+        );
+        let mut session = db;
+        session
+            .workspaces()
+            .ensure(&workspace_id, 1)
+            .await
+            .expect("ensure workspace");
+        session
+            .functions()
+            .upsert(&workspace_id, "a_name", "select 1")
+            .await
+            .expect("insert function");
+        session
+            .functions()
+            .upsert(&workspace_id, "aaname", "select 2")
+            .await
+            .expect("insert collation pair");
+        session
+            .functions()
+            .upsert(&workspace_id, "a_name", "select 3")
+            .await
+            .expect("replace function");
+
+        assert_eq!(
+            session.functions().list(&workspace_id).await.expect("list"),
+            vec![
+                FunctionRecord {
+                    workspace_id: workspace_id.clone(),
+                    name: "a_name".to_string(),
+                    artifact_sql: "select 3".to_string(),
+                },
+                FunctionRecord {
+                    workspace_id: workspace_id.clone(),
+                    name: "aaname".to_string(),
+                    artifact_sql: "select 2".to_string(),
+                },
+            ]
+        );
+        assert!(
+            !session
+                .functions()
+                .delete(&workspace_id, "missing")
+                .await
+                .expect("delete missing")
+        );
+        assert!(
+            session
+                .functions()
+                .delete(&workspace_id, "aaname")
+                .await
+                .expect("delete existing")
+        );
+
+        session
+            .workspaces()
+            .delete(&workspace_id)
+            .await
+            .expect("delete workspace");
+        assert!(
+            session
+                .functions()
+                .list(&workspace_id)
+                .await
+                .expect("list after cascade")
+                .is_empty()
+        );
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod functions;
 pub(crate) mod state_migrations;
 pub(crate) mod workspaces;

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -13,3 +13,11 @@ pub(in crate::state::db) enum AppStateMigrations {
     Id,
     CompletedAtUnixNanos,
 }
+
+#[derive(Iden)]
+pub(in crate::state::db) enum Functions {
+    Table,
+    WorkspaceId,
+    Name,
+    ArtifactSql,
+}

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -6,11 +6,16 @@ use sqlx::{FromRow, Postgres, Sqlite};
 
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
+use crate::state::db::repositories::functions::FunctionsRepo;
 use crate::state::db::repositories::state_migrations::StateMigrationsRepo;
 use crate::state::db::repositories::workspaces::WorkspacesRepo;
 
 pub(crate) trait DbSession {
     async fn execute<S>(&mut self, statement: S) -> Result<(), DbError>
+    where
+        S: SqlxBinder;
+
+    async fn execute_affected<S>(&mut self, statement: S) -> Result<u64, DbError>
     where
         S: SqlxBinder;
 
@@ -32,6 +37,10 @@ pub(crate) trait DbRepos: DbSession + Sized {
         StateMigrationsRepo::new(self)
     }
 
+    fn functions(&mut self) -> FunctionsRepo<'_, Self> {
+        FunctionsRepo::new(self)
+    }
+
     fn workspaces(&mut self) -> WorkspacesRepo<'_, Self> {
         WorkspacesRepo::new(self)
     }
@@ -45,6 +54,13 @@ impl DbSession for &CoralDb {
         S: SqlxBinder,
     {
         execute_statement(&self.backend, statement).await
+    }
+
+    async fn execute_affected<S>(&mut self, statement: S) -> Result<u64, DbError>
+    where
+        S: SqlxBinder,
+    {
+        execute_affected_statement(&self.backend, statement).await
     }
 
     async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
@@ -74,6 +90,13 @@ impl DbSession for CoralTx<'_> {
         self.execute(statement).await
     }
 
+    async fn execute_affected<S>(&mut self, statement: S) -> Result<u64, DbError>
+    where
+        S: SqlxBinder,
+    {
+        self.execute_affected(statement).await
+    }
+
     async fn fetch_optional<T>(&mut self, statement: SelectStatement) -> Result<Option<T>, DbError>
     where
         T: Send + Unpin,
@@ -90,6 +113,35 @@ impl DbSession for CoralTx<'_> {
         for<'r> T: FromRow<'r, PgRow>,
     {
         self.fetch_all(statement).await
+    }
+}
+
+pub(super) async fn execute_affected_statement<S>(
+    backend: &CoralDbBackend,
+    statement: S,
+) -> Result<u64, DbError>
+where
+    S: SqlxBinder,
+{
+    match backend {
+        CoralDbBackend::Sqlite(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+            Ok(
+                sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+                    .execute(&db.pool)
+                    .await?
+                    .rows_affected(),
+            )
+        }
+        CoralDbBackend::Postgres(db) => {
+            let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+            Ok(
+                sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+                    .execute(&db.pool)
+                    .await?
+                    .rows_affected(),
+            )
+        }
     }
 }
 

--- a/crates/coral-app/src/state/db/transaction.rs
+++ b/crates/coral-app/src/state/db/transaction.rs
@@ -62,6 +62,32 @@ impl<'a> CoralTx<'a> {
         Ok(())
     }
 
+    pub(super) async fn execute_affected<S>(&mut self, statement: S) -> Result<u64, DbError>
+    where
+        S: SqlxBinder,
+    {
+        match &mut self.backend {
+            CoralTxBackend::Sqlite(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::SqliteQueryBuilder);
+                Ok(
+                    sqlx::query_with::<Sqlite, _>(sqlx::AssertSqlSafe(sql), values)
+                        .execute(&mut **tx)
+                        .await?
+                        .rows_affected(),
+                )
+            }
+            CoralTxBackend::Postgres(tx) => {
+                let (sql, values) = statement.build_sqlx(sea_query::PostgresQueryBuilder);
+                Ok(
+                    sqlx::query_with::<Postgres, _>(sqlx::AssertSqlSafe(sql), values)
+                        .execute(&mut **tx)
+                        .await?
+                        .rows_affected(),
+                )
+            }
+        }
+    }
+
     pub(super) async fn fetch_optional<T>(
         &mut self,
         statement: SelectStatement,

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use etcetera::app_strategy::{AppStrategy, AppStrategyArgs, choose_native_strategy};
 
 use crate::bootstrap::AppError;
-use crate::functions::FunctionName;
 use crate::sources::SourceName;
 use crate::sources::materialization::{
     DIAGNOSTICS_FILENAME, FINGERPRINT_FILENAME, PARAMETER_METADATA_OVERRIDE_FILENAME,
@@ -15,7 +14,6 @@ use crate::storage::fs::ensure_dir;
 use crate::workspaces::{WorkspaceName, WorkspacePaths};
 
 pub(crate) const INSTALLED_MANIFEST_FILE_NAME: &str = "manifest.yaml";
-pub(crate) const INSTALLED_FUNCTION_FILE_NAME: &str = "function.sql";
 pub(crate) const INSTALLED_SECRETS_FILE_NAME: &str = "secrets.env";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -106,28 +104,6 @@ impl AppStateLayout {
 
     pub(crate) fn feedback_reports_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
         self.feedback_dir(workspace_name).join("reports.jsonl")
-    }
-
-    pub(crate) fn functions_root(&self, workspace_name: &WorkspaceName) -> PathBuf {
-        self.workspace_dir(workspace_name).join("functions")
-    }
-
-    pub(crate) fn function_dir(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-    ) -> PathBuf {
-        self.functions_root(workspace_name)
-            .join(function_name.as_str())
-    }
-
-    pub(crate) fn function_file(
-        &self,
-        workspace_name: &WorkspaceName,
-        function_name: &FunctionName,
-    ) -> PathBuf {
-        self.function_dir(workspace_name, function_name)
-            .join(INSTALLED_FUNCTION_FILE_NAME)
     }
 
     pub(crate) fn credential_encryption_key_file(&self) -> PathBuf {
@@ -279,7 +255,6 @@ mod tests {
     use std::fs;
 
     use super::AppStateLayout;
-    use crate::functions::FunctionName;
     use crate::sources::SourceName;
     use crate::sources::materialization::PROJECTIONS_FILENAME;
     use crate::workspaces::WorkspaceName;
@@ -292,7 +267,6 @@ mod tests {
         let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
         let workspace_name = WorkspaceName::parse("default").expect("workspace");
         let source_name = SourceName::parse("github").expect("source");
-        let function_name = FunctionName::parse("review_queue").expect("function");
 
         assert_eq!(layout.config_file(), config_dir.join("config.toml"));
         assert_eq!(layout.database_file(), config_dir.join("coral.db"));
@@ -321,15 +295,6 @@ mod tests {
                 .join("default")
                 .join("feedback")
                 .join("reports.jsonl")
-        );
-        assert_eq!(
-            layout.function_file(&workspace_name, &function_name),
-            config_dir
-                .join("workspaces")
-                .join("default")
-                .join("functions")
-                .join("review_queue")
-                .join("function.sql")
         );
         assert_eq!(
             layout.search_sqlite_file(&workspace_name),

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -113,6 +113,10 @@ impl WorkspaceManager {
         self.lifecycle_lock.clone()
     }
 
+    pub(crate) fn database(&self) -> Arc<CoralDb> {
+        Arc::clone(&self.db)
+    }
+
     pub(crate) async fn create_workspace(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
@@ -74,6 +74,9 @@ async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
         .into_inner()
         .functions;
     assert_eq!(work_functions.len(), 1);
+    let config =
+        std::fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
+    assert!(!config.contains("functions"));
 
     harness
         .function_client()
@@ -94,6 +97,36 @@ async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
         .into_inner()
         .functions;
     assert!(remaining.is_empty());
+}
+
+#[tokio::test]
+async fn installed_function_survives_server_restart() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+    harness
+        .function_client()
+        .add_function(Request::new(AddFunctionRequest {
+            workspace: Some(default_workspace()),
+            sql: function_sql("select cast($value as VARCHAR) as value"),
+        }))
+        .await
+        .expect("add function");
+    drop(harness);
+
+    let restarted = GrpcHarness::start_with_config_dir(config_dir).await;
+    let functions = restarted
+        .function_client()
+        .list_functions(Request::new(ListFunctionsRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await
+        .expect("list functions after restart")
+        .into_inner()
+        .functions;
+
+    assert_eq!(functions.len(), 1);
+    assert_eq!(functions.first().expect("one function").name, "echo_value");
 }
 
 #[tokio::test]
@@ -120,10 +153,4 @@ async fn untyped_function_is_not_persisted() {
         .into_inner()
         .functions;
     assert!(functions.is_empty());
-    assert!(
-        !harness
-            .config_dir()
-            .join("workspaces/default/functions/echo_value")
-            .exists()
-    );
 }


### PR DESCRIPTION
## Intent

Make CoralDB the single authority for installed function inventory and SQL, following the existing workspace repository pattern.

## What changed

- Added the workspace-scoped `functions` table with a foreign key to `workspaces(id)` and cascade deletion.
- Added direct function repository operations on `CoralDb`: deterministic list, upsert, and delete with affected-row reporting.
- Reworked `FunctionStore` and `FunctionManager` around async database reads and writes; there is no database wrapper store.
- Removed function inventory from `config.toml` and SQL artifacts from the workspace filesystem layout.
- Injected database-backed function storage into query management.
- Added SQLite/Postgres repository coverage, manager drift/error coverage through the in-memory store, restart durability, and config compatibility tests.

## Compatibility and user impact

Functions shipped in v0.7.0. This change deliberately does not import their legacy `config.toml` inventory or filesystem SQL artifacts, so users upgrading from v0.7.0 must re-add installed functions. Existing `functions.<name>` config entries still parse because the persisted config does not deny unknown fields; Coral ignores them and drops them on the next config rewrite. No separate legacy migration is included.

## Ownership and boundaries

CoralDB now owns installed function inventory and SQL. `config.toml` and workspace artifact paths are no longer function authorities. Function parsing and validation remain in the app function layer; no protobuf, gRPC, or CLI contract changes are introduced.

## Validation

- `make rust-checks` — 2,004 tests passed, 3 skipped; clippy and rustdoc passed
- `make postgres-tests` — SQLite/Postgres repository harness and Postgres server startup passed
- `make perf-check` — `coral.tables` mean 212 ms against the 750 ms limit
- `make docs-check`
- Autoreview: clean with the deliberate no-import compatibility decision supplied as review context
