### PR TITLE
feat(reef): show table functions in schema explorer

### DIFF
--- a/apps/reef/app/__tests__/architecture.test.ts
+++ b/apps/reef/app/__tests__/architecture.test.ts
@@ -367,6 +367,9 @@ describe('Architectural Tests', () => {
       expect(routeConfig).toContain("route(routePattern('workspaceSchema'), 'routes/schema.tsx', [")
       expect(routeConfig).toContain("index('routes/schema-empty.tsx')")
       expect(routeConfig).toContain("route(':schemaName/:tableName', 'routes/schema-table.tsx')")
+      expect(routeConfig).toContain(
+        "route(':schemaName/functions/:functionName', 'routes/schema-table-function.tsx')",
+      )
       expect(routeConfig).toContain("route(routePattern('workspaceTraces'), 'routes/traces.tsx', [")
       expect(routeConfig).toContain("route(':traceId', 'routes/trace-detail.tsx')")
       // Settings stays in the shared app shell; desktop-only sections are gated in the route.

--- a/apps/reef/app/lib/schema-explorer.test.ts
+++ b/apps/reef/app/lib/schema-explorer.test.ts
@@ -1,0 +1,99 @@
+import { create } from '@bufbuild/protobuf'
+import { describe, expect, it, vi } from 'vitest'
+
+import { CatalogItemKind } from '@/generated/coral/v1/catalog_pb'
+import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
+
+import { fetchSchemaFromCoral } from './schema-explorer'
+import type { CatalogClient } from './schema-explorer'
+
+describe('fetchSchemaFromCoral', () => {
+  it('groups tables and table functions from the unified catalog response', async () => {
+    const listCatalog = vi.fn().mockResolvedValue({
+      items: [
+        {
+          item: {
+            case: 'tableFunction',
+            value: {
+              arguments: [
+                {
+                  name: 'channel',
+                  required: true,
+                  values: ['general', 'random'],
+                },
+              ],
+              description: 'Lists messages in a channel.',
+              name: 'messages',
+              resultColumns: [
+                {
+                  dataType: 'Utf8',
+                  description: 'Message text.',
+                  name: 'text',
+                  nullable: false,
+                },
+              ],
+              schemaName: 'slack',
+            },
+          },
+        },
+        {
+          item: {
+            case: 'table',
+            value: {
+              description: 'Slack users.',
+              name: 'users',
+              requiredFilters: [],
+              schemaName: 'slack',
+            },
+          },
+        },
+      ],
+    })
+    const workspace = create(WorkspaceSchema, { name: 'analytics' })
+
+    await expect(
+      fetchSchemaFromCoral({ listCatalog } as unknown as CatalogClient, workspace),
+    ).resolves.toEqual({
+      connectors: [
+        {
+          items: [
+            {
+              arguments: [
+                {
+                  name: 'channel',
+                  required: true,
+                  values: ['general', 'random'],
+                },
+              ],
+              description: 'Lists messages in a channel.',
+              kind: 'tableFunction',
+              name: 'messages',
+              resultColumns: [
+                {
+                  description: 'Message text.',
+                  name: 'text',
+                  nullable: false,
+                  type: 'Utf8',
+                },
+              ],
+            },
+            {
+              columns: [],
+              columnsLoaded: false,
+              description: 'Slack users.',
+              kind: 'table',
+              name: 'users',
+              requiredFilters: [],
+            },
+          ],
+          name: 'slack',
+        },
+      ],
+    })
+    expect(listCatalog).toHaveBeenCalledOnce()
+    expect(listCatalog.mock.calls[0]?.[0]).toMatchObject({
+      kind: CatalogItemKind.UNSPECIFIED,
+      workspace,
+    })
+  })
+})

--- a/apps/reef/app/lib/schema-explorer.ts
+++ b/apps/reef/app/lib/schema-explorer.ts
@@ -5,9 +5,9 @@ import {
   CatalogItemKind,
   ListCatalogRequestSchema,
   ListColumnsRequestSchema,
+  type CatalogItem,
   type CatalogService,
   type ListColumnsResponse,
-  type TableSummary,
 } from '@/generated/coral/v1/catalog_pb'
 import type { Workspace } from '@/generated/coral/v1/resources_pb'
 
@@ -27,13 +27,37 @@ export interface TableDef {
   columns: ColumnDef[]
   columnsLoaded: boolean
   description?: string
+  kind: 'table'
   name: string
   requiredFilters: string[]
 }
 
-export interface SchemaGroup {
+export interface TableFunctionArgumentDef {
   name: string
-  tables: TableDef[]
+  required: boolean
+  values: string[]
+}
+
+export interface TableFunctionResultColumnDef {
+  description?: string
+  name: string
+  nullable: boolean
+  type: string
+}
+
+export interface TableFunctionDef {
+  arguments: TableFunctionArgumentDef[]
+  description?: string
+  kind: 'tableFunction'
+  name: string
+  resultColumns: TableFunctionResultColumnDef[]
+}
+
+export type SchemaItemDef = TableDef | TableFunctionDef
+
+export interface SchemaGroup {
+  items: SchemaItemDef[]
+  name: string
 }
 
 export interface SchemaResponse {
@@ -48,48 +72,72 @@ export async function fetchSchemaFromCoral(
   workspace: Workspace,
   signal?: AbortSignal,
 ): Promise<SchemaResponse> {
-  const tableSummaries = await listTables(catalogClient, workspace, signal)
-  if (tableSummaries.length === 0) return { connectors: [] }
+  const catalogItems = await listCatalogItems(catalogClient, workspace, signal)
+  if (catalogItems.length === 0) return { connectors: [] }
 
-  const schemaMap = new Map<string, TableDef[]>()
-  for (const summary of tableSummaries) {
-    if (!summary.schemaName || !summary.name) continue
+  const schemaMap = new Map<string, SchemaItemDef[]>()
+  for (const item of catalogItems) {
+    if (item.item.case === 'table') {
+      const table = item.item.value
+      if (!table.schemaName || !table.name) continue
 
-    const tables = schemaMap.get(summary.schemaName) ?? []
-    tables.push({
-      columns: [],
-      columnsLoaded: false,
-      description: optional(summary.description),
-      name: summary.name,
-      requiredFilters: summary.requiredFilters,
-    })
-    schemaMap.set(summary.schemaName, tables)
+      const schemaItems = schemaMap.get(table.schemaName) ?? []
+      schemaItems.push({
+        columns: [],
+        columnsLoaded: false,
+        description: optional(table.description),
+        kind: 'table',
+        name: table.name,
+        requiredFilters: table.requiredFilters,
+      })
+      schemaMap.set(table.schemaName, schemaItems)
+      continue
+    }
+
+    if (item.item.case === 'tableFunction') {
+      const tableFunction = item.item.value
+      if (!tableFunction.schemaName || !tableFunction.name) continue
+
+      const schemaItems = schemaMap.get(tableFunction.schemaName) ?? []
+      schemaItems.push({
+        arguments: tableFunction.arguments.map((argument) => ({
+          name: argument.name,
+          required: argument.required,
+          values: argument.values,
+        })),
+        description: optional(tableFunction.description),
+        kind: 'tableFunction',
+        name: tableFunction.name,
+        resultColumns: tableFunction.resultColumns.map((column) => ({
+          description: optional(column.description),
+          name: column.name,
+          nullable: column.nullable,
+          type: column.dataType || 'unknown',
+        })),
+      })
+      schemaMap.set(tableFunction.schemaName, schemaItems)
+    }
   }
 
   return {
-    connectors: [...schemaMap.entries()]
-      .toSorted(([left], [right]) => left.localeCompare(right))
-      .map(([name, tables]) => ({
-        name,
-        tables: tables.toSorted((left, right) => left.name.localeCompare(right.name)),
-      })),
+    connectors: [...schemaMap.entries()].map(([name, items]) => ({ items, name })),
   }
 }
 
-async function listTables(
+async function listCatalogItems(
   catalogClient: CatalogClient,
   workspace: Workspace,
   signal?: AbortSignal,
-): Promise<TableSummary[]> {
+): Promise<CatalogItem[]> {
   const response = await catalogClient.listCatalog(
     create(ListCatalogRequestSchema, {
-      kind: CatalogItemKind.TABLE,
+      kind: CatalogItemKind.UNSPECIFIED,
       workspace,
     }),
     { signal },
   )
 
-  return response.items.flatMap((item) => (item.item.case === 'table' ? [item.item.value] : []))
+  return response.items
 }
 
 export async function fetchTableColumnsFromCoral(

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -19,6 +19,7 @@ export default [
     route(routePattern('workspaceSchema'), 'routes/schema.tsx', [
       index('routes/schema-empty.tsx'),
       route(':schemaName/:tableName', 'routes/schema-table.tsx'),
+      route(':schemaName/functions/:functionName', 'routes/schema-table-function.tsx'),
     ]),
     route(routePattern('workspaceTraces'), 'routes/traces.tsx', [
       route(':traceId', 'routes/trace-detail.tsx'),

--- a/apps/reef/app/routes/schema-table-function.tsx
+++ b/apps/reef/app/routes/schema-table-function.tsx
@@ -1,0 +1,1 @@
+export { SchemaTableFunctionView as default } from '@/views/schema-explorer/schema-table-function'

--- a/apps/reef/app/routing/routemap.test.ts
+++ b/apps/reef/app/routing/routemap.test.ts
@@ -9,6 +9,8 @@ const CANONICAL_PATTERNS = {
   workspaces: '/workspaces',
   workspaceSchema: '/workspaces/:workspaceId/schema',
   workspaceSchemaTable: '/workspaces/:workspaceId/schema/:schemaName/:tableName',
+  workspaceSchemaTableFunction:
+    '/workspaces/:workspaceId/schema/:schemaName/functions/:functionName',
   workspaceSource: '/workspaces/:workspaceId/sources/:sourceName',
   workspaceSourceDiscovery: '/workspaces/:workspaceId/sources/discover',
   workspaceSourceInstall: '/workspaces/:workspaceId/sources/install',
@@ -42,6 +44,11 @@ describe('route map', () => {
         tableName: 'issues',
         workspaceId: 'analytics',
       }),
+      workspaceSchemaTableFunction: routePath('workspaceSchemaTableFunction', {
+        functionName: 'search_issues',
+        schemaName: 'github',
+        workspaceId: 'analytics',
+      }),
       workspaceSource: routePath('workspaceSource', {
         sourceName: 'github',
         workspaceId: 'analytics',
@@ -64,6 +71,7 @@ describe('route map', () => {
       workspaces: '/workspaces',
       workspaceSchema: '/workspaces/analytics/schema',
       workspaceSchemaTable: '/workspaces/analytics/schema/github/issues',
+      workspaceSchemaTableFunction: '/workspaces/analytics/schema/github/functions/search_issues',
       workspaceSource: '/workspaces/analytics/sources/github',
       workspaceSourceDiscovery: '/workspaces/analytics/sources/discover',
       workspaceSourceInstall: '/workspaces/analytics/sources/install',

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -5,6 +5,8 @@ const HOME_PATH = '/'
 const WORKSPACES_PATH = '/workspaces'
 const WORKSPACE_SCHEMA_PATH = '/workspaces/:workspaceId/schema'
 const WORKSPACE_SCHEMA_TABLE_PATH = '/workspaces/:workspaceId/schema/:schemaName/:tableName'
+const WORKSPACE_SCHEMA_TABLE_FUNCTION_PATH =
+  '/workspaces/:workspaceId/schema/:schemaName/functions/:functionName'
 const WORKSPACE_SOURCE_DISCOVERY_PATH = '/workspaces/:workspaceId/sources/discover'
 const WORKSPACE_SOURCE_INSTALL_PATH = '/workspaces/:workspaceId/sources/install'
 const WORKSPACE_SOURCES_PATH = '/workspaces/:workspaceId/sources'
@@ -39,6 +41,15 @@ export const routeDefinitions = {
       generatePath(WORKSPACE_SCHEMA_TABLE_PATH, {
         schemaName: params.schemaName,
         tableName: params.tableName,
+        workspaceId: params.workspaceId,
+      }),
+  },
+  workspaceSchemaTableFunction: {
+    path: WORKSPACE_SCHEMA_TABLE_FUNCTION_PATH,
+    toPath: (params: { functionName: string; schemaName: string; workspaceId: string }) =>
+      generatePath(WORKSPACE_SCHEMA_TABLE_FUNCTION_PATH, {
+        functionName: params.functionName,
+        schemaName: params.schemaName,
         workspaceId: params.workspaceId,
       }),
   },

--- a/apps/reef/app/views/schema-explorer/schema-empty.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-empty.tsx
@@ -2,12 +2,12 @@ import { Typography } from '@/wax/components/typography'
 
 import * as styles from './schema-explorer.css'
 
-// Rendered at /schema (index) before a table is selected.
+// Rendered at /schema (index) before a catalog item is selected.
 export function TableDetailEmpty() {
   return (
     <div className={styles.detailEmpty}>
       <Typography.Body variant="secondary">
-        Select a table from the schema tree to inspect its columns.
+        Select a table or table function from the schema tree to inspect it.
       </Typography.Body>
     </div>
   )

--- a/apps/reef/app/views/schema-explorer/schema-explorer.css.ts
+++ b/apps/reef/app/views/schema-explorer/schema-explorer.css.ts
@@ -81,7 +81,7 @@ export const connectorName = style({
   whiteSpace: 'nowrap',
 })
 
-export const connectorTableCount = style({
+export const connectorItemCount = style({
   color: theme.content.tertiary,
   marginInlineStart: 'auto',
 })
@@ -92,7 +92,7 @@ export const connectorChildren = style({
   marginInlineStart: 16,
 })
 
-export const tableName = style({
+export const itemName = style({
   minWidth: 0,
   overflow: 'hidden',
   textOverflow: 'ellipsis',

--- a/apps/reef/app/views/schema-explorer/schema-table-function.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table-function.test.tsx
@@ -1,0 +1,70 @@
+import { createMemoryRouter, Outlet, RouterProvider } from 'react-router'
+import { expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import type { SchemaResponse } from '@/lib/schema-explorer'
+import { routePath, routePattern } from '@/routing/routemap'
+
+import { SchemaTableFunctionView } from './schema-table-function'
+
+const SCHEMA = {
+  connectors: [
+    {
+      items: [
+        {
+          arguments: [
+            { name: 'channel', required: true, values: ['general', 'random'] },
+            { name: 'cursor', required: false, values: [] },
+          ],
+          description: 'Lists messages in a channel.',
+          kind: 'tableFunction',
+          name: 'messages',
+          resultColumns: [
+            {
+              description: 'Message text.',
+              name: 'text',
+              nullable: false,
+              type: 'Utf8',
+            },
+          ],
+        },
+      ],
+      name: 'slack',
+    },
+  ],
+} satisfies SchemaResponse
+
+it('shows table-function arguments and result columns from the parent schema response', async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        children: [
+          {
+            element: <SchemaTableFunctionView />,
+            path: ':schemaName/functions/:functionName',
+          },
+        ],
+        element: <Outlet context={SCHEMA} />,
+        path: routePattern('workspaceSchema'),
+      },
+    ],
+    {
+      initialEntries: [
+        routePath('workspaceSchemaTableFunction', {
+          functionName: 'messages',
+          schemaName: 'slack',
+          workspaceId: 'analytics',
+        }),
+      ],
+    },
+  )
+  const screen = await render(<RouterProvider router={router} />)
+
+  await expect
+    .element(screen.getByRole('heading', { name: 'slack.messages(channel, ...)' }))
+    .toBeVisible()
+  await expect.element(screen.getByText('Lists messages in a channel.')).toBeVisible()
+  await expect.element(screen.getByLabelText('Required argument')).toHaveTextContent('*')
+  await expect.element(screen.getByRole('cell', { name: 'general, random' })).toBeVisible()
+  await expect.element(screen.getByRole('cell', { name: 'Message text.' })).toBeVisible()
+})

--- a/apps/reef/app/views/schema-explorer/schema-table-function.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table-function.tsx
@@ -1,0 +1,95 @@
+import { useOutletContext, useParams } from 'react-router'
+
+import type { SchemaResponse } from '@/lib/schema-explorer'
+import { Table } from '@/wax/components/table'
+import { Tooltip } from '@/wax/components/tooltip'
+import { Typography } from '@/wax/components/typography'
+
+import * as styles from './schema-explorer.css'
+import { findSchemaTableFunction, tableFunctionTreeArguments } from './schema'
+import { SchemaColumnsTable } from './schema-table'
+
+export function SchemaTableFunctionView() {
+  const schema = useOutletContext<SchemaResponse>()
+  const params = useParams()
+  const schemaName = params.schemaName ?? ''
+  const functionName = params.functionName ?? ''
+  const tableFunction = findSchemaTableFunction(schema, schemaName, functionName)
+
+  if (!tableFunction) {
+    return (
+      <div className={styles.detailEmpty}>
+        <Typography.Body variant="secondary">Table function not found.</Typography.Body>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.detailContent}>
+      <div className={styles.detailHeader}>
+        <div>
+          <Typography.HeadingSmall as="h2">
+            {schemaName}.{tableFunction.name}
+            <Typography.Body>{tableFunctionTreeArguments(tableFunction)}</Typography.Body>
+          </Typography.HeadingSmall>
+          {tableFunction.description ? (
+            <Typography.BodySmall as="p" className={styles.description}>
+              {tableFunction.description}
+            </Typography.BodySmall>
+          ) : null}
+        </div>
+      </div>
+
+      <div className={styles.section}>
+        <Typography.BodySmallStrong>Arguments</Typography.BodySmallStrong>
+        {tableFunction.arguments.length === 0 ? (
+          <Typography.BodySmall className={styles.emptyInline} variant="tertiary">
+            This table function accepts no arguments.
+          </Typography.BodySmall>
+        ) : (
+          <Table.Wrapper style="compact">
+            <Table.Root>
+              <Table.Head>
+                <Table.Row>
+                  <Table.HeaderCell>name</Table.HeaderCell>
+                  <Table.HeaderCell>allowed values</Table.HeaderCell>
+                </Table.Row>
+              </Table.Head>
+              <Table.Body>
+                {tableFunction.arguments.map((argument) => (
+                  <Table.Row key={argument.name}>
+                    <Table.Cell mono>
+                      {argument.name}
+                      {argument.required ? (
+                        <Tooltip content="Required argument" side="top">
+                          <span
+                            aria-label="Required argument"
+                            className={styles.requiredStar}
+                            tabIndex={0}
+                          >
+                            *
+                          </span>
+                        </Tooltip>
+                      ) : null}
+                    </Table.Cell>
+                    <Table.Cell mono>
+                      {argument.values.length > 0 ? argument.values.join(', ') : '-'}
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+              </Table.Body>
+            </Table.Root>
+          </Table.Wrapper>
+        )}
+      </div>
+
+      <div className={styles.section}>
+        <Typography.BodySmallStrong>Result columns</Typography.BodySmallStrong>
+        <SchemaColumnsTable
+          columns={tableFunction.resultColumns}
+          emptyMessage="No result columns reported for this table function."
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/reef/app/views/schema-explorer/schema-table.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table.tsx
@@ -11,6 +11,15 @@ import * as styles from './schema-explorer.css'
 import { findSchemaTable } from './schema'
 import { formatError, useRouteRetry } from './shared'
 
+interface DisplayColumn {
+  description?: string
+  filterable?: boolean
+  name: string
+  nullable: boolean
+  type: string
+  virtual?: boolean
+}
+
 // The parent schema layout resolves its schema before rendering this Outlet, so
 // table metadata (description, required filters) is available synchronously.
 function useSelectedTable(): { schemaName: string; tableName: string; table?: TableDef } {
@@ -82,53 +91,60 @@ export function SchemaTableError() {
 export function SchemaTableView({ columns }: { columns: ColumnDef[] }) {
   return (
     <TableDetailLayout>
-      {columns.length === 0 ? (
-        <Typography.BodySmall className={styles.emptyInline} variant="tertiary">
-          No columns reported for this table.
-        </Typography.BodySmall>
-      ) : (
-        <Table.Wrapper style="compact">
-          <Table.Root>
-            <Table.Head>
-              <Table.Row>
-                <Table.HeaderCell>name</Table.HeaderCell>
-                <Table.HeaderCell>type</Table.HeaderCell>
-                <Table.HeaderCell>nullable</Table.HeaderCell>
-                <Table.HeaderCell>description</Table.HeaderCell>
-              </Table.Row>
-            </Table.Head>
-            <Table.Body>
-              {columns.map((column) => (
-                <Table.Row
-                  className={column.virtual ? styles.virtualRow : undefined}
-                  key={column.name}
-                >
-                  <Table.Cell mono>
-                    {column.name}
-                    {column.filterable ? (
-                      <Tooltip
-                        content="Required filter: queries for this table must include a filter on this field."
-                        side="top"
-                      >
-                        <span
-                          aria-label="Required filter"
-                          className={styles.requiredStar}
-                          tabIndex={0}
-                        >
-                          *
-                        </span>
-                      </Tooltip>
-                    ) : null}
-                  </Table.Cell>
-                  <Table.Cell mono>{column.type}</Table.Cell>
-                  <Table.Cell mono>{column.nullable ? 'yes' : 'no'}</Table.Cell>
-                  <Table.Cell>{column.description ?? '-'}</Table.Cell>
-                </Table.Row>
-              ))}
-            </Table.Body>
-          </Table.Root>
-        </Table.Wrapper>
-      )}
+      <SchemaColumnsTable columns={columns} emptyMessage="No columns reported for this table." />
     </TableDetailLayout>
+  )
+}
+
+export function SchemaColumnsTable({
+  columns,
+  emptyMessage,
+}: {
+  columns: DisplayColumn[]
+  emptyMessage: string
+}) {
+  if (columns.length === 0) {
+    return (
+      <Typography.BodySmall className={styles.emptyInline} variant="tertiary">
+        {emptyMessage}
+      </Typography.BodySmall>
+    )
+  }
+
+  return (
+    <Table.Wrapper style="compact">
+      <Table.Root>
+        <Table.Head>
+          <Table.Row>
+            <Table.HeaderCell>name</Table.HeaderCell>
+            <Table.HeaderCell>type</Table.HeaderCell>
+            <Table.HeaderCell>nullable</Table.HeaderCell>
+            <Table.HeaderCell>description</Table.HeaderCell>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          {columns.map((column) => (
+            <Table.Row className={column.virtual ? styles.virtualRow : undefined} key={column.name}>
+              <Table.Cell mono>
+                {column.name}
+                {column.filterable ? (
+                  <Tooltip
+                    content="Required filter: queries for this table must include a filter on this field."
+                    side="top"
+                  >
+                    <span aria-label="Required filter" className={styles.requiredStar} tabIndex={0}>
+                      *
+                    </span>
+                  </Tooltip>
+                ) : null}
+              </Table.Cell>
+              <Table.Cell mono>{column.type}</Table.Cell>
+              <Table.Cell mono>{column.nullable ? 'yes' : 'no'}</Table.Cell>
+              <Table.Cell>{column.description ?? '-'}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </Table.Wrapper>
   )
 }

--- a/apps/reef/app/views/schema-explorer/schema.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema.test.tsx
@@ -11,12 +11,22 @@ const SCHEMA = {
   connectors: [
     {
       name: 'github?api',
-      tables: [
+      items: [
         {
           columns: [],
           columnsLoaded: false,
+          kind: 'table',
           name: 'issues/closed',
           requiredFilters: [],
+        },
+        {
+          arguments: [
+            { name: 'channel', required: true, values: [] },
+            { name: 'cursor', required: false, values: [] },
+          ],
+          kind: 'tableFunction',
+          name: 'messages',
+          resultColumns: [],
         },
       ],
     },
@@ -36,6 +46,8 @@ it('links tables within the active workspace schema route', async () => {
   )
   const screen = await render(<RouterProvider router={router} />)
 
+  await expect.element(screen.getByPlaceholder('Filter schemas and tables')).toBeVisible()
+  await expect.element(screen.getByText(/schemas \/.*tables/)).not.toBeInTheDocument()
   await screen.getByRole('button', { name: /github\?api/ }).click()
   await expect.element(screen.getByRole('link', { name: 'issues/closed' })).toHaveAttribute(
     'href',
@@ -45,4 +57,14 @@ it('links tables within the active workspace schema route', async () => {
       workspaceId,
     }),
   )
+  await expect
+    .element(screen.getByRole('link', { name: 'messages(channel, ...)' }))
+    .toHaveAttribute(
+      'href',
+      routePath('workspaceSchemaTableFunction', {
+        functionName: 'messages',
+        schemaName: 'github?api',
+        workspaceId,
+      }),
+    )
 })

--- a/apps/reef/app/views/schema-explorer/schema.tsx
+++ b/apps/reef/app/views/schema-explorer/schema.tsx
@@ -2,7 +2,13 @@ import { useMemo, useState } from 'react'
 import { NavLink, Outlet, useParams, useRouteError } from 'react-router'
 
 import { ErrorBanner } from '@/components/error-banner'
-import type { SchemaGroup, SchemaResponse, TableDef } from '@/lib/schema-explorer'
+import type {
+  SchemaGroup,
+  SchemaItemDef,
+  SchemaResponse,
+  TableDef,
+  TableFunctionDef,
+} from '@/lib/schema-explorer'
 import { routePath } from '@/routing/routemap'
 import { PageHeader } from '@/views/traces/page-header'
 import { Container as ButtonContainer } from '@/wax/components/button'
@@ -21,14 +27,27 @@ export function findSchemaTable(
 ): TableDef | undefined {
   return schema.connectors
     .find((connector) => connector.name === schemaName)
-    ?.tables.find((table) => table.name === tableName)
+    ?.items.find((item): item is TableDef => item.kind === 'table' && item.name === tableName)
+}
+
+export function findSchemaTableFunction(
+  schema: SchemaResponse,
+  schemaName: string,
+  functionName: string,
+): TableFunctionDef | undefined {
+  return schema.connectors
+    .find((connector) => connector.name === schemaName)
+    ?.items.find(
+      (item): item is TableFunctionDef =>
+        item.kind === 'tableFunction' && item.name === functionName,
+    )
 }
 
 function schemaMatchesSearch(schema: SchemaGroup, search: string) {
   if (!search) return true
   return (
     schemaNameMatchesSearch(schema, search) ||
-    schema.tables.some((table) => tableMatchesSearch(table, search))
+    schema.items.some((item) => catalogItemMatchesSearch(item, search))
   )
 }
 
@@ -36,20 +55,44 @@ function schemaNameMatchesSearch(schema: SchemaGroup, search: string) {
   return schema.name.toLowerCase().includes(search)
 }
 
-function tableMatchesSearch(table: TableDef, search: string) {
+function catalogItemMatchesSearch(item: SchemaItemDef, search: string) {
   if (!search) return true
-  if (table.name.toLowerCase().includes(search)) return true
-  if (table.description?.toLowerCase().includes(search)) return true
+  if (item.name.toLowerCase().includes(search)) return true
+  if (item.description?.toLowerCase().includes(search)) return true
+  if (
+    item.kind === 'tableFunction' &&
+    item.arguments.some((argument) => argument.name.toLowerCase().includes(search))
+  ) {
+    return true
+  }
   return false
 }
 
-function visibleTablesForSchema(schema: SchemaGroup, search: string) {
-  if (!search || schemaNameMatchesSearch(schema, search)) return schema.tables
-  return schema.tables.filter((table) => tableMatchesSearch(table, search))
+function visibleItemsForSchema(schema: SchemaGroup, search: string) {
+  if (!search || schemaNameMatchesSearch(schema, search)) return schema.items
+  return schema.items.filter((item) => catalogItemMatchesSearch(item, search))
 }
 
 function tablePath(workspaceId: string, schemaName: string, tableName: string) {
   return routePath('workspaceSchemaTable', { schemaName, tableName, workspaceId })
+}
+
+function tableFunctionPath(workspaceId: string, schemaName: string, functionName: string) {
+  return routePath('workspaceSchemaTableFunction', { functionName, schemaName, workspaceId })
+}
+
+function catalogItemPath(workspaceId: string, schemaName: string, item: SchemaItemDef) {
+  return item.kind === 'table'
+    ? tablePath(workspaceId, schemaName, item.name)
+    : tableFunctionPath(workspaceId, schemaName, item.name)
+}
+
+export function tableFunctionTreeArguments(tableFunction: TableFunctionDef) {
+  const argumentsToShow = tableFunction.arguments
+    .filter((argument) => argument.required)
+    .map((argument) => argument.name)
+  if (tableFunction.arguments.some((argument) => !argument.required)) argumentsToShow.push('...')
+  return `(${argumentsToShow.join(', ')})`
 }
 
 // Header + two-panel scaffold for the error state so it looks like the loaded page.
@@ -98,10 +141,10 @@ export function SchemaExplorer({
   schema: SchemaResponse
   workspaceId: string
 }) {
-  const activeTable = useParams()
+  const activeItem = useParams()
   const [search, setSearch] = useState('')
   // Collapsed by default so the initial render is one row per schema, not one per
-  // table — expanding every schema up front renders hundreds of rows and makes the
+  // catalog item — expanding every schema up front renders hundreds of rows and makes the
   // first paint sluggish. A search expands matching schemas (see `expanded` below).
   const [expandedSchemas, setExpandedSchemas] = useState<Set<string>>(() => new Set())
 
@@ -109,11 +152,6 @@ export function SchemaExplorer({
   const filteredSchemas = useMemo(
     () => schema.connectors.filter((connector) => schemaMatchesSearch(connector, normalizedSearch)),
     [normalizedSearch, schema],
-  )
-
-  const filteredTableCount = filteredSchemas.reduce(
-    (count, connector) => count + visibleTablesForSchema(connector, normalizedSearch).length,
-    0,
   )
 
   const toggleSchema = (name: string) => {
@@ -127,17 +165,7 @@ export function SchemaExplorer({
 
   return (
     <section aria-label="Schema explorer" className={styles.root}>
-      <PageHeader
-        title={
-          <>
-            <Typography.BodyStrong variant="secondary">Schema explorer</Typography.BodyStrong>
-            <Typography.BodySmall variant="tertiary">
-              {filteredSchemas.length} {filteredSchemas.length === 1 ? 'schema' : 'schemas'} /{' '}
-              {filteredTableCount} {filteredTableCount === 1 ? 'table' : 'tables'}
-            </Typography.BodySmall>
-          </>
-        }
-      >
+      <PageHeader title="Schema explorer">
         <div className={styles.headerSearch}>
           <TextInput
             icon="Search"
@@ -162,7 +190,7 @@ export function SchemaExplorer({
               ) : filteredSchemas.length === 0 ? (
                 <div className={styles.treeEmpty}>
                   <Typography.BodySmall variant="tertiary">
-                    No queryable tables in this workspace.
+                    No queryable tables or table functions in this workspace.
                   </Typography.BodySmall>
                 </div>
               ) : (
@@ -170,8 +198,8 @@ export function SchemaExplorer({
                   {filteredSchemas.map((connector) => {
                     // A search forces matching schemas open so results are visible.
                     const expanded = normalizedSearch !== '' || expandedSchemas.has(connector.name)
-                    const connectorChildrenId = `schema-${connector.name}-tables`
-                    const visibleTables = visibleTablesForSchema(connector, normalizedSearch)
+                    const connectorChildrenId = `schema-${connector.name}-items`
+                    const visibleItems = visibleItemsForSchema(connector, normalizedSearch)
                     return (
                       <div key={connector.name}>
                         <ButtonContainer
@@ -192,35 +220,53 @@ export function SchemaExplorer({
                             {connector.name}
                           </Typography.BodyStrong>
                           <Typography.BodySmall
-                            className={styles.connectorTableCount}
+                            className={styles.connectorItemCount}
                             variant="tertiary"
                           >
-                            {visibleTables.length}
+                            {visibleItems.length}
                           </Typography.BodySmall>
                         </ButtonContainer>
 
                         {expanded ? (
                           <div className={styles.connectorChildren} id={connectorChildrenId}>
-                            {visibleTables.map((table) => (
-                              <ButtonContainer
-                                as={NavLink}
-                                className={styles.treeRow}
-                                fullWidth
-                                isActive={
-                                  activeTable.schemaName === connector.name &&
-                                  activeTable.tableName === table.name
-                                }
-                                key={tablePath(workspaceId, connector.name, table.name)}
-                                size="22"
-                                to={tablePath(workspaceId, connector.name, table.name)}
-                                variant="bare"
-                              >
-                                <Icon color="secondary" name="Table2" size="14" />
-                                <Typography.BodyStrong className={styles.tableName}>
-                                  {table.name}
-                                </Typography.BodyStrong>
-                              </ButtonContainer>
-                            ))}
+                            {visibleItems.map((item) => {
+                              const path = catalogItemPath(workspaceId, connector.name, item)
+                              const active =
+                                activeItem.schemaName === connector.name &&
+                                (item.kind === 'table'
+                                  ? activeItem.tableName === item.name
+                                  : activeItem.functionName === item.name)
+                              return (
+                                <ButtonContainer
+                                  as={NavLink}
+                                  className={styles.treeRow}
+                                  fullWidth
+                                  isActive={active}
+                                  key={path}
+                                  size="22"
+                                  to={path}
+                                  variant="bare"
+                                >
+                                  <Icon
+                                    color="secondary"
+                                    name={item.kind === 'table' ? 'Table2' : 'SquareFunction'}
+                                    size="14"
+                                  />
+                                  {item.kind === 'table' ? (
+                                    <Typography.BodyStrong className={styles.itemName}>
+                                      {item.name}
+                                    </Typography.BodyStrong>
+                                  ) : (
+                                    <span className={styles.itemName}>
+                                      <Typography.BodyStrong>{item.name}</Typography.BodyStrong>
+                                      <Typography.Body>
+                                        {tableFunctionTreeArguments(item)}
+                                      </Typography.Body>
+                                    </span>
+                                  )}
+                                </ButtonContainer>
+                              )
+                            })}
                           </div>
                         ) : null}
                       </div>


### PR DESCRIPTION
List the table functions as well.  
![CleanShot 2026-07-22 at 22.03.01@2x.png](https://app.graphite.com/user-attachments/assets/3166e908-4a84-44b5-9267-5abb94f09b2c.png)





Only show the required args, and ... for optional.  
![CleanShot 2026-07-22 at 16.15.10@2x.png](https://app.graphite.com/user-attachments/assets/3242b66b-7060-42fa-ab07-29dbc2b662c8.png)

We

Constraint: Reuse the unified catalog response and keep Coral access in the server loader.
Rejected: Fetch table functions separately | ListCatalog already returns both catalog item kinds.
Confidence: high
Scope-risk: narrow
Directive: Preserve distinct table and table-function detail routes when extending schema explorer navigation.
Tested: Reef formatting and lint; npm run typecheck; npm test (362 tests); npm run build; git diff --check.
Not-tested: Live sidecar smoke test with an installed table-function source.