### PR TITLE
feat(app): persist GUI onboarding completion in local DB

### DIFF
--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -29,6 +29,7 @@ fn main() {
                 "proto/coral/v1/search.proto",
                 "proto/coral/v1/functions.proto",
                 "proto/coral/v1/traces.proto",
+                "proto/coral/v1/gui_onboarding.proto",
             ],
             &["proto"],
         )

--- a/crates/coral-api/proto/coral/v1/gui_onboarding.proto
+++ b/crates/coral-api/proto/coral/v1/gui_onboarding.proto
@@ -2,16 +2,16 @@ syntax = "proto3";
 
 package coral.v1;
 
-// Requests the current principal's persistent completion state for Coral GUI onboarding.
+// Requests the current user's persistent completion state for Coral GUI onboarding.
 message GetGuiOnboardingStateRequest {}
 
-// Returns the current principal's persistent completion state for Coral GUI onboarding.
+// Returns the current user's persistent completion state for Coral GUI onboarding.
 message GetGuiOnboardingStateResponse {
-  // Whether the current principal has completed Coral GUI onboarding.
+  // Whether the current user has completed Coral GUI onboarding.
   bool completed = 1;
 }
 
-// Requests one-way completion of Coral GUI onboarding for the current principal.
+// Requests one-way completion of Coral GUI onboarding for the current user.
 message CompleteGuiOnboardingRequest {}
 
 // Confirms that Coral GUI onboarding was completed successfully.
@@ -19,8 +19,8 @@ message CompleteGuiOnboardingResponse {}
 
 // Persistent first-run onboarding APIs for Coral's graphical interfaces.
 service GuiOnboardingService {
-  // Gets the current principal's persistent Coral GUI onboarding completion state.
+  // Gets the current user's persistent Coral GUI onboarding completion state.
   rpc GetGuiOnboardingState(GetGuiOnboardingStateRequest) returns (GetGuiOnboardingStateResponse);
-  // Idempotently marks Coral GUI onboarding as complete for the current principal.
+  // Idempotently marks Coral GUI onboarding as complete for the current user.
   rpc CompleteGuiOnboarding(CompleteGuiOnboardingRequest) returns (CompleteGuiOnboardingResponse);
 }

--- a/crates/coral-api/proto/coral/v1/gui_onboarding.proto
+++ b/crates/coral-api/proto/coral/v1/gui_onboarding.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package coral.v1;
+
+// Requests the current principal's persistent completion state for Coral GUI onboarding.
+message GetGuiOnboardingStateRequest {}
+
+// Returns the current principal's persistent completion state for Coral GUI onboarding.
+message GetGuiOnboardingStateResponse {
+  // Whether the current principal has completed Coral GUI onboarding.
+  bool completed = 1;
+}
+
+// Requests one-way completion of Coral GUI onboarding for the current principal.
+message CompleteGuiOnboardingRequest {}
+
+// Confirms that Coral GUI onboarding was completed successfully.
+message CompleteGuiOnboardingResponse {}
+
+// Persistent first-run onboarding APIs for Coral's graphical interfaces.
+service GuiOnboardingService {
+  // Gets the current principal's persistent Coral GUI onboarding completion state.
+  rpc GetGuiOnboardingState(GetGuiOnboardingStateRequest) returns (GetGuiOnboardingStateResponse);
+  // Idempotently marks Coral GUI onboarding as complete for the current principal.
+  rpc CompleteGuiOnboarding(CompleteGuiOnboardingRequest) returns (CompleteGuiOnboardingResponse);
+}

--- a/crates/coral-app/migrations/0006_gui_onboarding_completions.sql
+++ b/crates/coral-app/migrations/0006_gui_onboarding_completions.sql
@@ -1,0 +1,3 @@
+CREATE TABLE gui_onboarding_completions (
+    principal_id TEXT NOT NULL PRIMARY KEY
+);

--- a/crates/coral-app/migrations/0006_gui_onboarding_completions.sql
+++ b/crates/coral-app/migrations/0006_gui_onboarding_completions.sql
@@ -1,3 +1,4 @@
 CREATE TABLE gui_onboarding_completions (
-    principal_id TEXT NOT NULL PRIMARY KEY
+    principal_id TEXT NOT NULL PRIMARY KEY,
+    completed_at_unix_nanos BIGINT NOT NULL
 );

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -17,6 +17,7 @@ use coral_api::v1::catalog_service_server::CatalogServiceServer;
 use coral_api::v1::feature_service_server::FeatureServiceServer;
 use coral_api::v1::feedback_service_server::FeedbackServiceServer;
 use coral_api::v1::function_service_server::FunctionServiceServer;
+use coral_api::v1::gui_onboarding_service_server::GuiOnboardingServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::search_service_server::SearchServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
@@ -56,6 +57,8 @@ use crate::feedback::publisher::{
 };
 use crate::feedback::service::FeedbackService;
 use crate::functions::service::FunctionService;
+use crate::gui_onboarding::manager::GuiOnboardingManager;
+use crate::gui_onboarding::service::GuiOnboardingService;
 use crate::identity::{LocalPrincipalProvider, PrincipalProvider};
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
@@ -468,6 +471,7 @@ impl ServerBuilder {
         let trace_components = trace_components_for_store(active_trace_store);
         start_server(
             ServerDependencies {
+                gui_onboarding: GuiOnboardingManager::new(Arc::clone(&coral_db)),
                 source: source_manager,
                 workspace: workspace_manager,
                 query: query_manager,
@@ -682,6 +686,7 @@ struct TraceServerComponents {
 }
 
 struct ServerDependencies {
+    gui_onboarding: GuiOnboardingManager,
     source: SourceManager,
     workspace: WorkspaceManager,
     query: QueryManager,
@@ -702,6 +707,7 @@ fn application_routes(
     trace_service: Option<TraceService>,
 ) -> (Routes, QueryManager) {
     let ServerDependencies {
+        gui_onboarding,
         source,
         workspace,
         query,
@@ -729,7 +735,9 @@ fn application_routes(
     let feedback_service = FeedbackService::new(feedback, task.clone());
     let feature_service = FeatureService::new(feature_store, active_features);
     let task_service = TaskService::new(task);
+    let gui_onboarding_service = GuiOnboardingService::new(gui_onboarding);
     let mut routes = Routes::default()
+        .add_service(GuiOnboardingServiceServer::new(gui_onboarding_service))
         .add_service(
             SourceServiceServer::new(source_service)
                 .max_encoding_message_size(SOURCE_RESPONSE_MAX_MESSAGE_SIZE),
@@ -1038,14 +1046,15 @@ mod tests {
     use std::task::Poll;
     use std::time::Duration;
 
+    use coral_api::v1::gui_onboarding_service_client::GuiOnboardingServiceClient;
     use coral_api::v1::query_service_client::QueryServiceClient;
     use coral_api::v1::source_service_client::SourceServiceClient;
     use coral_api::v1::task_service_client::TaskServiceClient;
     use coral_api::v1::trace_service_client::TraceServiceClient;
     use coral_api::v1::{
-        EndTaskRequest, ExecuteSqlRequest, ImportSourceRequest, ImportSourceResponse,
-        ListSourcesRequest, ListTracesRequest, StartTaskRequest, TaskStatus, TraceView, Workspace,
-        import_source_response,
+        EndTaskRequest, ExecuteSqlRequest, GetGuiOnboardingStateRequest, ImportSourceRequest,
+        ImportSourceResponse, ListSourcesRequest, ListTracesRequest, StartTaskRequest, TaskStatus,
+        TraceView, Workspace, import_source_response,
     };
     use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
@@ -1064,6 +1073,7 @@ mod tests {
     use crate::credentials::{CredentialManager, CredentialStore};
     use crate::features::{Feature, FeatureOverrides, FeatureStore, Features};
     use crate::feedback::manager::FeedbackManager;
+    use crate::gui_onboarding::manager::GuiOnboardingManager;
     use crate::query::manager::QueryManager;
     use crate::search::manager::SearchManager;
     use crate::search::observed::{
@@ -1792,6 +1802,7 @@ backend = "unsupported"
         ));
         let server = start_server(
             ServerDependencies {
+                gui_onboarding: GuiOnboardingManager::new(Arc::clone(&db)),
                 source: source_manager,
                 workspace: workspace_manager,
                 query: query_manager,
@@ -1892,13 +1903,19 @@ backend = "unsupported"
             .await
             .expect("connect");
 
-        let status = SourceServiceClient::new(channel)
+        let status = SourceServiceClient::new(channel.clone())
             .list_sources(Request::new(ListSourcesRequest {
                 workspace: Some(default_workspace()),
             }))
             .await
             .expect_err("request should be rejected");
 
+        assert_eq!(status.code(), Code::Unauthenticated);
+
+        let status = GuiOnboardingServiceClient::new(channel)
+            .get_gui_onboarding_state(Request::new(GetGuiOnboardingStateRequest {}))
+            .await
+            .expect_err("onboarding request should be rejected");
         assert_eq!(status.code(), Code::Unauthenticated);
         server.shutdown().await.expect("shutdown");
     }
@@ -2246,6 +2263,7 @@ tables:
         );
         let running = start_server(
             ServerDependencies {
+                gui_onboarding: GuiOnboardingManager::new(Arc::clone(&db)),
                 source: source_manager,
                 workspace: workspace_manager,
                 query: query_manager,
@@ -2377,6 +2395,7 @@ tables:
         );
         let running = start_server(
             ServerDependencies {
+                gui_onboarding: GuiOnboardingManager::new(Arc::clone(&db)),
                 source: source_manager,
                 workspace: workspace_manager,
                 query: query_manager,
@@ -2508,6 +2527,7 @@ tables:
         );
         let running = start_server(
             ServerDependencies {
+                gui_onboarding: GuiOnboardingManager::new(Arc::clone(&db)),
                 source: source_manager,
                 workspace: workspace_manager,
                 query: query_manager,

--- a/crates/coral-app/src/gui_onboarding/manager.rs
+++ b/crates/coral-app/src/gui_onboarding/manager.rs
@@ -1,0 +1,34 @@
+use std::sync::Arc;
+
+use crate::bootstrap::AppError;
+use crate::identity::Principal;
+use crate::state::db::{CoralDb, DbRepos};
+
+#[derive(Clone)]
+pub(crate) struct GuiOnboardingManager {
+    db: Arc<CoralDb>,
+}
+
+impl GuiOnboardingManager {
+    pub(crate) fn new(db: Arc<CoralDb>) -> Self {
+        Self { db }
+    }
+
+    pub(crate) async fn is_completed(&self, principal: &Principal) -> Result<bool, AppError> {
+        let mut session = self.db.as_ref();
+        session
+            .gui_onboarding()
+            .is_completed(principal.id().as_str())
+            .await
+            .map_err(Into::into)
+    }
+
+    pub(crate) async fn complete(&self, principal: &Principal) -> Result<(), AppError> {
+        let mut session = self.db.as_ref();
+        session
+            .gui_onboarding()
+            .complete(principal.id().as_str())
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/coral-app/src/gui_onboarding/manager.rs
+++ b/crates/coral-app/src/gui_onboarding/manager.rs
@@ -1,8 +1,10 @@
+//! App-owned per-user GUI onboarding completion behavior.
+
 use std::sync::Arc;
 
 use crate::bootstrap::AppError;
 use crate::identity::Principal;
-use crate::state::db::{CoralDb, DbRepos};
+use crate::state::db::{CoralDb, DbRepos, now_unix_nanos_i64};
 
 #[derive(Clone)]
 pub(crate) struct GuiOnboardingManager {
@@ -27,7 +29,7 @@ impl GuiOnboardingManager {
         let mut session = self.db.as_ref();
         session
             .gui_onboarding()
-            .complete(principal.id().as_str())
+            .complete(principal.id().as_str(), now_unix_nanos_i64()?)
             .await?;
         Ok(())
     }

--- a/crates/coral-app/src/gui_onboarding/mod.rs
+++ b/crates/coral-app/src/gui_onboarding/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod manager;
+pub(crate) mod service;

--- a/crates/coral-app/src/gui_onboarding/mod.rs
+++ b/crates/coral-app/src/gui_onboarding/mod.rs
@@ -1,2 +1,4 @@
+//! User-scoped GUI onboarding completion workflow.
+
 pub(crate) mod manager;
 pub(crate) mod service;

--- a/crates/coral-app/src/gui_onboarding/service.rs
+++ b/crates/coral-app/src/gui_onboarding/service.rs
@@ -1,0 +1,68 @@
+use coral_api::v1::gui_onboarding_service_server::GuiOnboardingService as GuiOnboardingServiceApi;
+use coral_api::v1::{
+    CompleteGuiOnboardingRequest, CompleteGuiOnboardingResponse, GetGuiOnboardingStateRequest,
+    GetGuiOnboardingStateResponse,
+};
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::app_status;
+use crate::gui_onboarding::manager::GuiOnboardingManager;
+use crate::identity::Principal;
+use crate::request_context::RequestContext;
+use crate::transport::{grpc_span, instrument_grpc};
+
+#[derive(Clone)]
+pub(crate) struct GuiOnboardingService {
+    gui_onboarding: GuiOnboardingManager,
+}
+
+impl GuiOnboardingService {
+    pub(crate) fn new(gui_onboarding: GuiOnboardingManager) -> Self {
+        Self { gui_onboarding }
+    }
+}
+
+#[tonic::async_trait]
+impl GuiOnboardingServiceApi for GuiOnboardingService {
+    async fn get_gui_onboarding_state(
+        &self,
+        request: Request<GetGuiOnboardingStateRequest>,
+    ) -> Result<Response<GetGuiOnboardingStateResponse>, Status> {
+        let span = grpc_span(&request);
+        let principal = request_principal(&request)?;
+        let gui_onboarding = self.gui_onboarding.clone();
+        instrument_grpc(span, async move {
+            let completed = gui_onboarding
+                .is_completed(&principal)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(GetGuiOnboardingStateResponse { completed }))
+        })
+        .await
+    }
+
+    async fn complete_gui_onboarding(
+        &self,
+        request: Request<CompleteGuiOnboardingRequest>,
+    ) -> Result<Response<CompleteGuiOnboardingResponse>, Status> {
+        let span = grpc_span(&request);
+        let principal = request_principal(&request)?;
+        let gui_onboarding = self.gui_onboarding.clone();
+        instrument_grpc(span, async move {
+            gui_onboarding
+                .complete(&principal)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(CompleteGuiOnboardingResponse {}))
+        })
+        .await
+    }
+}
+
+fn request_principal<T>(request: &Request<T>) -> Result<Principal, Status> {
+    request
+        .extensions()
+        .get::<RequestContext>()
+        .map(|context| context.principal().clone())
+        .ok_or_else(|| Status::internal("missing authenticated request context"))
+}

--- a/crates/coral-app/src/gui_onboarding/service.rs
+++ b/crates/coral-app/src/gui_onboarding/service.rs
@@ -1,3 +1,5 @@
+//! Implements the gRPC `GuiOnboardingService`.
+
 use coral_api::v1::gui_onboarding_service_server::GuiOnboardingService as GuiOnboardingServiceApi;
 use coral_api::v1::{
     CompleteGuiOnboardingRequest, CompleteGuiOnboardingResponse, GetGuiOnboardingStateRequest,
@@ -7,9 +9,8 @@ use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
 use crate::gui_onboarding::manager::GuiOnboardingManager;
-use crate::identity::Principal;
-use crate::request_context::RequestContext;
-use crate::transport::{grpc_span, instrument_grpc};
+use crate::identity::{Principal, PrincipalKind};
+use crate::transport::{grpc_span, instrument_grpc, request_context};
 
 #[derive(Clone)]
 pub(crate) struct GuiOnboardingService {
@@ -29,9 +30,9 @@ impl GuiOnboardingServiceApi for GuiOnboardingService {
         request: Request<GetGuiOnboardingStateRequest>,
     ) -> Result<Response<GetGuiOnboardingStateResponse>, Status> {
         let span = grpc_span(&request);
-        let principal = request_principal(&request)?;
         let gui_onboarding = self.gui_onboarding.clone();
         instrument_grpc(span, async move {
+            let principal = request_user_principal(&request)?;
             let completed = gui_onboarding
                 .is_completed(&principal)
                 .await
@@ -46,9 +47,9 @@ impl GuiOnboardingServiceApi for GuiOnboardingService {
         request: Request<CompleteGuiOnboardingRequest>,
     ) -> Result<Response<CompleteGuiOnboardingResponse>, Status> {
         let span = grpc_span(&request);
-        let principal = request_principal(&request)?;
         let gui_onboarding = self.gui_onboarding.clone();
         instrument_grpc(span, async move {
+            let principal = request_user_principal(&request)?;
             gui_onboarding
                 .complete(&principal)
                 .await
@@ -59,10 +60,12 @@ impl GuiOnboardingServiceApi for GuiOnboardingService {
     }
 }
 
-fn request_principal<T>(request: &Request<T>) -> Result<Principal, Status> {
-    request
-        .extensions()
-        .get::<RequestContext>()
-        .map(|context| context.principal().clone())
-        .ok_or_else(|| Status::internal("missing authenticated request context"))
+fn request_user_principal<T>(request: &Request<T>) -> Result<Principal, Status> {
+    let principal = request_context(request)?.principal().clone();
+    if principal.kind() != PrincipalKind::User {
+        return Err(Status::permission_denied(
+            "GUI onboarding is only available to user principals",
+        ));
+    }
+    Ok(principal)
 }

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -50,6 +50,7 @@ mod encrypted_document;
 pub mod features;
 mod feedback;
 mod functions;
+mod gui_onboarding;
 mod hash;
 mod identity;
 mod oauth_resource;

--- a/crates/coral-app/src/state/db/repositories/gui_onboarding.rs
+++ b/crates/coral-app/src/state/db/repositories/gui_onboarding.rs
@@ -25,11 +25,21 @@ where
         Ok(completion.is_some())
     }
 
-    pub(crate) async fn complete(&mut self, principal_id: &str) -> Result<(), DbError> {
+    pub(crate) async fn complete(
+        &mut self,
+        principal_id: &str,
+        completed_at_unix_nanos: i64,
+    ) -> Result<(), DbError> {
         let statement = Query::insert()
             .into_table(GuiOnboardingCompletions::Table)
-            .columns([GuiOnboardingCompletions::PrincipalId])
-            .values_panic([Expr::val(principal_id.to_string())])
+            .columns([
+                GuiOnboardingCompletions::PrincipalId,
+                GuiOnboardingCompletions::CompletedAtUnixNanos,
+            ])
+            .values_panic([
+                Expr::val(principal_id.to_string()),
+                Expr::val(completed_at_unix_nanos),
+            ])
             .on_conflict(
                 OnConflict::column(GuiOnboardingCompletions::PrincipalId)
                     .do_nothing()
@@ -37,6 +47,20 @@ where
             )
             .to_owned();
         self.session.execute(statement).await
+    }
+
+    #[cfg(test)]
+    async fn completed_at_unix_nanos(
+        &mut self,
+        principal_id: &str,
+    ) -> Result<Option<i64>, DbError> {
+        let statement = Query::select()
+            .column(GuiOnboardingCompletions::CompletedAtUnixNanos)
+            .from(GuiOnboardingCompletions::Table)
+            .and_where(Expr::col(GuiOnboardingCompletions::PrincipalId).eq(principal_id))
+            .to_owned();
+        let completion: Option<(i64,)> = self.session.fetch_optional(statement).await?;
+        Ok(completion.map(|(completed_at_unix_nanos,)| completed_at_unix_nanos))
     }
 
     #[cfg(test)]
@@ -58,9 +82,6 @@ mod tests {
     use crate::state::db::session::DbRepos;
     use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
 
-    const ALICE_PRINCIPAL_ID: &str = "alice";
-    const BOB_PRINCIPAL_ID: &str = "bob";
-
     #[tokio::test]
     async fn gui_onboarding_repository_round_trips_against_sqlite() {
         let temp = tempdir().expect("temp dir");
@@ -72,7 +93,7 @@ mod tests {
         assert!(
             !fresh_session
                 .gui_onboarding()
-                .is_completed(ALICE_PRINCIPAL_ID)
+                .is_completed("fresh_sqlite_principal")
                 .await
                 .expect("get completion from freshly migrated SQLite database"),
             "the migration must create an empty completion table"
@@ -109,49 +130,82 @@ mod tests {
     async fn assert_gui_onboarding_repository_round_trip(db: &CoralDb) {
         db.ping().await.expect("ping database");
 
-        let mut tx = db.begin().await.expect("begin state transition tx");
-        tx.gui_onboarding()
-            .delete_completion(ALICE_PRINCIPAL_ID)
-            .await
-            .expect("clear Alice completion in test transaction");
-        tx.gui_onboarding()
-            .delete_completion(BOB_PRINCIPAL_ID)
-            .await
-            .expect("clear Bob completion in test transaction");
-        assert!(
-            !tx.gui_onboarding()
-                .is_completed(ALICE_PRINCIPAL_ID)
+        let test_id = uuid::Uuid::new_v4();
+        let alice_principal_id = format!("gui_onboarding_alice_{test_id}");
+        let bob_principal_id = format!("gui_onboarding_bob_{test_id}");
+        {
+            let mut session = db;
+            assert!(
+                !session
+                    .gui_onboarding()
+                    .is_completed(&alice_principal_id)
+                    .await
+                    .expect("get missing Alice completion")
+            );
+            assert!(
+                !session
+                    .gui_onboarding()
+                    .is_completed(&bob_principal_id)
+                    .await
+                    .expect("get missing Bob completion")
+            );
+
+            session
+                .gui_onboarding()
+                .complete(&alice_principal_id, 42)
                 .await
-                .expect("get missing Alice completion")
+                .expect("complete Alice onboarding");
+            session
+                .gui_onboarding()
+                .complete(&alice_principal_id, 99)
+                .await
+                .expect("complete Alice onboarding again");
+        }
+
+        let mut session = db;
+        assert!(
+            session
+                .gui_onboarding()
+                .is_completed(&alice_principal_id)
+                .await
+                .expect("get committed Alice completion")
         );
         assert!(
-            !tx.gui_onboarding()
-                .is_completed(BOB_PRINCIPAL_ID)
+            !session
+                .gui_onboarding()
+                .is_completed(&bob_principal_id)
                 .await
-                .expect("get missing Bob completion")
+                .expect("get missing Bob completion after commit")
+        );
+        assert_eq!(
+            session
+                .gui_onboarding()
+                .completed_at_unix_nanos(&alice_principal_id)
+                .await
+                .expect("get Alice completion timestamp"),
+            Some(42),
+            "idempotent completion must preserve the first timestamp"
         );
 
-        tx.gui_onboarding()
-            .complete(ALICE_PRINCIPAL_ID)
+        let mut cleanup_tx = db.begin().await.expect("begin cleanup tx");
+        cleanup_tx
+            .gui_onboarding()
+            .delete_completion(&alice_principal_id)
             .await
-            .expect("complete Alice onboarding");
-        tx.gui_onboarding()
-            .complete(ALICE_PRINCIPAL_ID)
+            .expect("clean up Alice completion");
+        cleanup_tx
+            .gui_onboarding()
+            .delete_completion(&bob_principal_id)
             .await
-            .expect("complete Alice onboarding again");
+            .expect("clean up Bob completion");
+        cleanup_tx.commit().await.expect("commit cleanup tx");
         assert!(
-            tx.gui_onboarding()
-                .is_completed(ALICE_PRINCIPAL_ID)
+            !session
+                .gui_onboarding()
+                .is_completed(&alice_principal_id)
                 .await
-                .expect("get Alice completion")
+                .expect("get cleaned-up Alice completion")
         );
-        assert!(
-            !tx.gui_onboarding()
-                .is_completed(BOB_PRINCIPAL_ID)
-                .await
-                .expect("get Bob completion")
-        );
-        tx.rollback().await.expect("roll back state transition tx");
     }
 
     fn postgres_test_url() -> Option<String> {

--- a/crates/coral-app/src/state/db/repositories/gui_onboarding.rs
+++ b/crates/coral-app/src/state/db/repositories/gui_onboarding.rs
@@ -1,0 +1,162 @@
+use sea_query::{Expr, ExprTrait, OnConflict, Query};
+
+use crate::state::db::schema::GuiOnboardingCompletions;
+use crate::state::db::{DbError, DbSession};
+
+pub(crate) struct GuiOnboardingRepo<'a, S> {
+    session: &'a mut S,
+}
+
+impl<'a, S> GuiOnboardingRepo<'a, S>
+where
+    S: DbSession,
+{
+    pub(crate) fn new(session: &'a mut S) -> Self {
+        Self { session }
+    }
+
+    pub(crate) async fn is_completed(&mut self, principal_id: &str) -> Result<bool, DbError> {
+        let statement = Query::select()
+            .column(GuiOnboardingCompletions::PrincipalId)
+            .from(GuiOnboardingCompletions::Table)
+            .and_where(Expr::col(GuiOnboardingCompletions::PrincipalId).eq(principal_id))
+            .to_owned();
+        let completion: Option<(String,)> = self.session.fetch_optional(statement).await?;
+        Ok(completion.is_some())
+    }
+
+    pub(crate) async fn complete(&mut self, principal_id: &str) -> Result<(), DbError> {
+        let statement = Query::insert()
+            .into_table(GuiOnboardingCompletions::Table)
+            .columns([GuiOnboardingCompletions::PrincipalId])
+            .values_panic([Expr::val(principal_id.to_string())])
+            .on_conflict(
+                OnConflict::column(GuiOnboardingCompletions::PrincipalId)
+                    .do_nothing()
+                    .to_owned(),
+            )
+            .to_owned();
+        self.session.execute(statement).await
+    }
+
+    #[cfg(test)]
+    async fn delete_completion(&mut self, principal_id: &str) -> Result<(), DbError> {
+        let statement = Query::delete()
+            .from_table(GuiOnboardingCompletions::Table)
+            .and_where(Expr::col(GuiOnboardingCompletions::PrincipalId).eq(principal_id))
+            .to_owned();
+        self.session.execute(statement).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use crate::bootstrap;
+    use crate::state::AppStateLayout;
+    use crate::state::db::session::DbRepos;
+    use crate::state::db::{CoralDb, DatabaseConfig, ResolvedDatabaseConfig};
+
+    const ALICE_PRINCIPAL_ID: &str = "alice";
+    const BOB_PRINCIPAL_ID: &str = "bob";
+
+    #[tokio::test]
+    async fn gui_onboarding_repository_round_trips_against_sqlite() {
+        let temp = tempdir().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral"))).expect("layout");
+        layout.ensure().expect("layout dirs");
+        let db = open_sqlite(&layout).await;
+
+        let mut fresh_session = &db;
+        assert!(
+            !fresh_session
+                .gui_onboarding()
+                .is_completed(ALICE_PRINCIPAL_ID)
+                .await
+                .expect("get completion from freshly migrated SQLite database"),
+            "the migration must create an empty completion table"
+        );
+        assert_gui_onboarding_repository_round_trip(&db).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "set CORAL_TEST_POSTGRES_URL to run the shared repository harness against Postgres"]
+    async fn gui_onboarding_repository_round_trips_against_postgres() {
+        let Some(url) = postgres_test_url() else {
+            return;
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Postgres { url })
+            .await
+            .expect("open postgres");
+        db.migrate().await.expect("migrate postgres");
+
+        assert_gui_onboarding_repository_round_trip(&db).await;
+    }
+
+    async fn open_sqlite(layout: &AppStateLayout) -> CoralDb {
+        let config = DatabaseConfig::load(layout).expect("db config");
+        let DatabaseConfig::Sqlite { path } = config else {
+            panic!("default test config should be sqlite");
+        };
+        let db = CoralDb::open(ResolvedDatabaseConfig::Sqlite { path })
+            .await
+            .expect("open sqlite");
+        db.migrate().await.expect("migrate sqlite");
+        db
+    }
+
+    async fn assert_gui_onboarding_repository_round_trip(db: &CoralDb) {
+        db.ping().await.expect("ping database");
+
+        let mut tx = db.begin().await.expect("begin state transition tx");
+        tx.gui_onboarding()
+            .delete_completion(ALICE_PRINCIPAL_ID)
+            .await
+            .expect("clear Alice completion in test transaction");
+        tx.gui_onboarding()
+            .delete_completion(BOB_PRINCIPAL_ID)
+            .await
+            .expect("clear Bob completion in test transaction");
+        assert!(
+            !tx.gui_onboarding()
+                .is_completed(ALICE_PRINCIPAL_ID)
+                .await
+                .expect("get missing Alice completion")
+        );
+        assert!(
+            !tx.gui_onboarding()
+                .is_completed(BOB_PRINCIPAL_ID)
+                .await
+                .expect("get missing Bob completion")
+        );
+
+        tx.gui_onboarding()
+            .complete(ALICE_PRINCIPAL_ID)
+            .await
+            .expect("complete Alice onboarding");
+        tx.gui_onboarding()
+            .complete(ALICE_PRINCIPAL_ID)
+            .await
+            .expect("complete Alice onboarding again");
+        assert!(
+            tx.gui_onboarding()
+                .is_completed(ALICE_PRINCIPAL_ID)
+                .await
+                .expect("get Alice completion")
+        );
+        assert!(
+            !tx.gui_onboarding()
+                .is_completed(BOB_PRINCIPAL_ID)
+                .await
+                .expect("get Bob completion")
+        );
+        tx.rollback().await.expect("roll back state transition tx");
+    }
+
+    fn postgres_test_url() -> Option<String> {
+        bootstrap::env_var("CORAL_TEST_POSTGRES_URL")
+            .expect("read CORAL_TEST_POSTGRES_URL")
+            .filter(|value| !value.is_empty())
+    }
+}

--- a/crates/coral-app/src/state/db/repositories/mod.rs
+++ b/crates/coral-app/src/state/db/repositories/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod gui_onboarding;
 pub(crate) mod identity_specs;
 pub(crate) mod state_migrations;
 pub(crate) mod task_queries;

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -82,4 +82,5 @@ pub(in crate::state::db) enum IdentitySpecDocuments {
 pub(in crate::state::db) enum GuiOnboardingCompletions {
     Table,
     PrincipalId,
+    CompletedAtUnixNanos,
 }

--- a/crates/coral-app/src/state/db/schema.rs
+++ b/crates/coral-app/src/state/db/schema.rs
@@ -77,3 +77,9 @@ pub(in crate::state::db) enum IdentitySpecDocuments {
     CreatedAtUnixNanos,
     UpdatedAtUnixNanos,
 }
+
+#[derive(Iden)]
+pub(in crate::state::db) enum GuiOnboardingCompletions {
+    Table,
+    PrincipalId,
+}

--- a/crates/coral-app/src/state/db/session.rs
+++ b/crates/coral-app/src/state/db/session.rs
@@ -6,6 +6,7 @@ use sqlx::{FromRow, Postgres, Sqlite};
 
 use super::backend::CoralDbBackend;
 use super::{CoralDb, CoralTx, DbError};
+use crate::state::db::repositories::gui_onboarding::GuiOnboardingRepo;
 use crate::state::db::repositories::identity_specs::{
     IdentitySpecDocumentsRepo, IdentitySpecsRepo,
 };
@@ -37,6 +38,10 @@ pub(crate) trait DbSession {
 }
 
 pub(crate) trait DbRepos: DbSession + Sized {
+    fn gui_onboarding(&mut self) -> GuiOnboardingRepo<'_, Self> {
+        GuiOnboardingRepo::new(self)
+    }
+
     fn state_migrations(&mut self) -> StateMigrationsRepo<'_, Self> {
         StateMigrationsRepo::new(self)
     }

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -11,6 +11,8 @@ mod catalog_discovery_tests;
 mod feature_service_tests;
 #[path = "grpc/function_lifecycle_tests.rs"]
 mod function_lifecycle_tests;
+#[path = "grpc/gui_onboarding_tests.rs"]
+mod gui_onboarding_tests;
 #[path = "grpc/harness.rs"]
 mod harness;
 #[path = "grpc/health_service_tests.rs"]

--- a/crates/coral-app/tests/grpc/gui_onboarding_tests.rs
+++ b/crates/coral-app/tests/grpc/gui_onboarding_tests.rs
@@ -1,17 +1,22 @@
+//! Exercises the user-scoped GUI onboarding gRPC contract.
+
+use std::path::Path;
 use std::sync::Arc;
 
 use coral_api::v1::gui_onboarding_service_client::GuiOnboardingServiceClient;
 use coral_api::v1::{CompleteGuiOnboardingRequest, GetGuiOnboardingStateRequest};
 use coral_app::{Principal, PrincipalKind, PrincipalProvider, PrincipalProviderError};
-use coral_client::local::ServerBuilder;
+use coral_client::local::{RunningServer, ServerBuilder};
 use tempfile::TempDir;
-use tonic::Request;
 use tonic::metadata::MetadataMap;
 use tonic::transport::{Channel, Endpoint};
+use tonic::{Code, Request};
 
 const ALICE_PRINCIPAL_ID: &str = "alice";
 const BOB_PRINCIPAL_ID: &str = "bob";
+const AGENT_PRINCIPAL_ID: &str = "setup-agent";
 const PRINCIPAL_ID_METADATA_KEY: &str = "x-coral-test-principal";
+const PRINCIPAL_KIND_METADATA_KEY: &str = "x-coral-test-principal-kind";
 
 #[derive(Debug)]
 struct MetadataPrincipalProvider;
@@ -27,60 +32,132 @@ impl PrincipalProvider for MetadataPrincipalProvider {
             .ok_or_else(|| PrincipalProviderError::unauthenticated("missing test principal"))?
             .to_str()
             .map_err(|error| PrincipalProviderError::unauthenticated(error.to_string()))?;
-        Principal::parse(principal_id, PrincipalKind::User)
+        let kind = match metadata
+            .get(PRINCIPAL_KIND_METADATA_KEY)
+            .map(|value| value.to_str())
+            .transpose()
+            .map_err(|error| PrincipalProviderError::unauthenticated(error.to_string()))?
+        {
+            None | Some("user") => PrincipalKind::User,
+            Some("agent") => PrincipalKind::Agent,
+            Some(_) => {
+                return Err(PrincipalProviderError::unauthenticated(
+                    "invalid test principal kind",
+                ));
+            }
+        };
+        Principal::parse(principal_id, kind)
             .map_err(|error| PrincipalProviderError::unauthenticated(error.to_string()))
     }
 }
 
 #[tokio::test]
-async fn gui_onboarding_is_per_principal_idempotent_concurrent_and_persistent_across_restart() {
+async fn gui_onboarding_completion_is_scoped_to_the_user() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
-    let server = ServerBuilder::new()
-        .with_config_dir(&config_dir)
-        .with_principal_provider(Arc::new(MetadataPrincipalProvider))
-        .start()
-        .await
-        .expect("start server");
-    let mut client = connect_client(server.endpoint_uri()).await;
+    let (server, mut client) = start_server(&config_dir).await;
 
     assert!(!get_completed(&mut client, ALICE_PRINCIPAL_ID).await);
     assert!(!get_completed(&mut client, BOB_PRINCIPAL_ID).await);
+    complete(&mut client, ALICE_PRINCIPAL_ID).await;
+    assert!(get_completed(&mut client, ALICE_PRINCIPAL_ID).await);
+    assert!(!get_completed(&mut client, BOB_PRINCIPAL_ID).await);
 
+    server.shutdown().await.expect("shutdown server");
+}
+
+#[tokio::test]
+async fn gui_onboarding_rejects_agent_principals() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let (server, mut client) = start_server(&config_dir).await;
+
+    let get_status = client
+        .get_gui_onboarding_state(request_for_agent(
+            AGENT_PRINCIPAL_ID,
+            GetGuiOnboardingStateRequest {},
+        ))
+        .await
+        .expect_err("agent must not read GUI onboarding state");
+    assert_eq!(get_status.code(), Code::PermissionDenied);
+    assert_eq!(
+        get_status.message(),
+        "GUI onboarding is only available to user principals"
+    );
+
+    let complete_status = client
+        .complete_gui_onboarding(request_for_agent(
+            AGENT_PRINCIPAL_ID,
+            CompleteGuiOnboardingRequest {},
+        ))
+        .await
+        .expect_err("agent must not complete GUI onboarding");
+    assert_eq!(complete_status.code(), Code::PermissionDenied);
+    assert_eq!(
+        complete_status.message(),
+        "GUI onboarding is only available to user principals"
+    );
+
+    server.shutdown().await.expect("shutdown server");
+}
+
+#[tokio::test]
+async fn gui_onboarding_completion_is_idempotent() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let (server, mut client) = start_server(&config_dir).await;
+
+    complete(&mut client, ALICE_PRINCIPAL_ID).await;
+    complete(&mut client, ALICE_PRINCIPAL_ID).await;
+
+    assert!(get_completed(&mut client, ALICE_PRINCIPAL_ID).await);
+    server.shutdown().await.expect("shutdown server");
+}
+
+#[tokio::test]
+async fn gui_onboarding_completion_is_safe_under_concurrency() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let (server, client) = start_server(&config_dir).await;
     let mut tasks = tokio::task::JoinSet::new();
     for _ in 0..8 {
         let mut client = client.clone();
         tasks.spawn(async move {
-            client
-                .complete_gui_onboarding(request_for_principal(
-                    ALICE_PRINCIPAL_ID,
-                    CompleteGuiOnboardingRequest {},
-                ))
-                .await
-                .expect("complete Alice onboarding concurrently");
+            complete(&mut client, ALICE_PRINCIPAL_ID).await;
         });
     }
     while let Some(result) = tasks.join_next().await {
         result.expect("join concurrent completion");
     }
+
+    let mut client = client;
     assert!(get_completed(&mut client, ALICE_PRINCIPAL_ID).await);
-    assert!(!get_completed(&mut client, BOB_PRINCIPAL_ID).await);
-    drop(client);
+    server.shutdown().await.expect("shutdown server");
+}
+
+#[tokio::test]
+async fn gui_onboarding_completion_persists_across_restart() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let (server, mut client) = start_server(&config_dir).await;
+
+    complete(&mut client, ALICE_PRINCIPAL_ID).await;
     server.shutdown().await.expect("shutdown server");
 
-    let restarted = ServerBuilder::new()
-        .with_config_dir(&config_dir)
+    let (server, mut client) = start_server(&config_dir).await;
+    assert!(get_completed(&mut client, ALICE_PRINCIPAL_ID).await);
+    server.shutdown().await.expect("shutdown restarted server");
+}
+
+async fn start_server(config_dir: &Path) -> (RunningServer, GuiOnboardingServiceClient<Channel>) {
+    let server = ServerBuilder::new()
+        .with_config_dir(config_dir)
         .with_principal_provider(Arc::new(MetadataPrincipalProvider))
         .start()
         .await
-        .expect("restart server");
-    let mut restarted_client = connect_client(restarted.endpoint_uri()).await;
-    assert!(get_completed(&mut restarted_client, ALICE_PRINCIPAL_ID).await);
-    assert!(!get_completed(&mut restarted_client, BOB_PRINCIPAL_ID).await);
-    restarted
-        .shutdown()
-        .await
-        .expect("shutdown restarted server");
+        .expect("start server");
+    let client = connect_client(server.endpoint_uri()).await;
+    (server, client)
 }
 
 async fn connect_client(endpoint_uri: &str) -> GuiOnboardingServiceClient<Channel> {
@@ -90,6 +167,16 @@ async fn connect_client(endpoint_uri: &str) -> GuiOnboardingServiceClient<Channe
         .await
         .expect("connect");
     GuiOnboardingServiceClient::new(channel)
+}
+
+async fn complete(client: &mut GuiOnboardingServiceClient<Channel>, principal_id: &str) {
+    client
+        .complete_gui_onboarding(request_for_principal(
+            principal_id,
+            CompleteGuiOnboardingRequest {},
+        ))
+        .await
+        .expect("complete onboarding");
 }
 
 async fn get_completed(
@@ -112,6 +199,15 @@ fn request_for_principal<T>(principal_id: &str, message: T) -> Request<T> {
     request.metadata_mut().insert(
         PRINCIPAL_ID_METADATA_KEY,
         principal_id.parse().expect("valid test principal metadata"),
+    );
+    request
+}
+
+fn request_for_agent<T>(principal_id: &str, message: T) -> Request<T> {
+    let mut request = request_for_principal(principal_id, message);
+    request.metadata_mut().insert(
+        PRINCIPAL_KIND_METADATA_KEY,
+        "agent".parse().expect("valid test principal kind metadata"),
     );
     request
 }

--- a/crates/coral-app/tests/grpc/gui_onboarding_tests.rs
+++ b/crates/coral-app/tests/grpc/gui_onboarding_tests.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+
+use coral_api::v1::gui_onboarding_service_client::GuiOnboardingServiceClient;
+use coral_api::v1::{CompleteGuiOnboardingRequest, GetGuiOnboardingStateRequest};
+use coral_app::{Principal, PrincipalKind, PrincipalProvider, PrincipalProviderError};
+use coral_client::local::ServerBuilder;
+use tempfile::TempDir;
+use tonic::Request;
+use tonic::metadata::MetadataMap;
+use tonic::transport::{Channel, Endpoint};
+
+const ALICE_PRINCIPAL_ID: &str = "alice";
+const BOB_PRINCIPAL_ID: &str = "bob";
+const PRINCIPAL_ID_METADATA_KEY: &str = "x-coral-test-principal";
+
+#[derive(Debug)]
+struct MetadataPrincipalProvider;
+
+#[tonic::async_trait]
+impl PrincipalProvider for MetadataPrincipalProvider {
+    async fn principal_for_metadata(
+        &self,
+        metadata: &MetadataMap,
+    ) -> Result<Principal, PrincipalProviderError> {
+        let principal_id = metadata
+            .get(PRINCIPAL_ID_METADATA_KEY)
+            .ok_or_else(|| PrincipalProviderError::unauthenticated("missing test principal"))?
+            .to_str()
+            .map_err(|error| PrincipalProviderError::unauthenticated(error.to_string()))?;
+        Principal::parse(principal_id, PrincipalKind::User)
+            .map_err(|error| PrincipalProviderError::unauthenticated(error.to_string()))
+    }
+}
+
+#[tokio::test]
+async fn gui_onboarding_is_per_principal_idempotent_concurrent_and_persistent_across_restart() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let server = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .with_principal_provider(Arc::new(MetadataPrincipalProvider))
+        .start()
+        .await
+        .expect("start server");
+    let mut client = connect_client(server.endpoint_uri()).await;
+
+    assert!(!get_completed(&mut client, ALICE_PRINCIPAL_ID).await);
+    assert!(!get_completed(&mut client, BOB_PRINCIPAL_ID).await);
+
+    let mut tasks = tokio::task::JoinSet::new();
+    for _ in 0..8 {
+        let mut client = client.clone();
+        tasks.spawn(async move {
+            client
+                .complete_gui_onboarding(request_for_principal(
+                    ALICE_PRINCIPAL_ID,
+                    CompleteGuiOnboardingRequest {},
+                ))
+                .await
+                .expect("complete Alice onboarding concurrently");
+        });
+    }
+    while let Some(result) = tasks.join_next().await {
+        result.expect("join concurrent completion");
+    }
+    assert!(get_completed(&mut client, ALICE_PRINCIPAL_ID).await);
+    assert!(!get_completed(&mut client, BOB_PRINCIPAL_ID).await);
+    drop(client);
+    server.shutdown().await.expect("shutdown server");
+
+    let restarted = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .with_principal_provider(Arc::new(MetadataPrincipalProvider))
+        .start()
+        .await
+        .expect("restart server");
+    let mut restarted_client = connect_client(restarted.endpoint_uri()).await;
+    assert!(get_completed(&mut restarted_client, ALICE_PRINCIPAL_ID).await);
+    assert!(!get_completed(&mut restarted_client, BOB_PRINCIPAL_ID).await);
+    restarted
+        .shutdown()
+        .await
+        .expect("shutdown restarted server");
+}
+
+async fn connect_client(endpoint_uri: &str) -> GuiOnboardingServiceClient<Channel> {
+    let channel = Endpoint::from_shared(endpoint_uri.to_string())
+        .expect("endpoint")
+        .connect()
+        .await
+        .expect("connect");
+    GuiOnboardingServiceClient::new(channel)
+}
+
+async fn get_completed(
+    client: &mut GuiOnboardingServiceClient<Channel>,
+    principal_id: &str,
+) -> bool {
+    client
+        .get_gui_onboarding_state(request_for_principal(
+            principal_id,
+            GetGuiOnboardingStateRequest {},
+        ))
+        .await
+        .expect("get onboarding state")
+        .into_inner()
+        .completed
+}
+
+fn request_for_principal<T>(principal_id: &str, message: T) -> Request<T> {
+    let mut request = Request::new(message);
+    request.metadata_mut().insert(
+        PRINCIPAL_ID_METADATA_KEY,
+        principal_id.parse().expect("valid test principal metadata"),
+    );
+    request
+}


### PR DESCRIPTION
## Summary

Adding a table to the local DB that stores userIDs that have completed onboarding; so that we can show them the onboarding only once.

## Test plan

npm run dev
migration runs
check table exists

<img width="218" height="105" alt="image" src="https://github.com/user-attachments/assets/14a256b0-026b-49fa-bbdc-f708b9a30c86" />
