### PR TITLE
feat(reef): persist onboarding completion

### DIFF
--- a/apps/reef/app/components/onboarding/onboarding-next-steps-page.css.ts
+++ b/apps/reef/app/components/onboarding/onboarding-next-steps-page.css.ts
@@ -12,11 +12,6 @@ export const panel = style({
   padding: 24,
 })
 
-export const actionError = style({
-  flexShrink: 0,
-  marginBlockEnd: 24,
-})
-
 export const tabs = style({
   display: 'flex',
   flex: 1,

--- a/apps/reef/app/components/onboarding/onboarding-next-steps-page.css.ts
+++ b/apps/reef/app/components/onboarding/onboarding-next-steps-page.css.ts
@@ -12,6 +12,11 @@ export const panel = style({
   padding: 24,
 })
 
+export const actionError = style({
+  flexShrink: 0,
+  marginBlockEnd: 24,
+})
+
 export const tabs = style({
   display: 'flex',
   flex: 1,

--- a/apps/reef/app/components/onboarding/onboarding-next-steps-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-next-steps-page.tsx
@@ -1,3 +1,4 @@
+import { ErrorBanner } from '@/components/error-banner'
 import { McpClientsList, type McpClientsConnectionState } from '@/components/mcp-clients-list'
 import { Inputs, ScrollArea, Tabs, Typography } from '@/wax/components'
 import { CopyButton } from '@/wax/components/button'
@@ -59,6 +60,8 @@ interface ConnectClientsProps {
 
 /** Only Desktop can write a client's config, so only Desktop carries the clients. */
 export type OnboardingNextStepsPageProps = {
+  completionError?: string | null
+  completing?: boolean
   onContinue?: () => void
   step: OnboardingStepState
 } & (
@@ -67,6 +70,8 @@ export type OnboardingNextStepsPageProps = {
 )
 
 export function OnboardingNextStepsPage({
+  completionError = null,
+  completing = false,
   mcpClients,
   onContinue,
   runtime,
@@ -77,7 +82,11 @@ export function OnboardingNextStepsPage({
 
   return (
     <OnboardingPage
-      action={{ label: "Take me to Coral's dashboard", onClick: onContinue }}
+      action={{
+        disabled: completing,
+        label: completing ? 'Finishing setup…' : "Take me to Coral's dashboard",
+        onClick: onContinue,
+      }}
       ariaLabel="Set up Coral with an agent"
       step={step}
       sideContent={
@@ -100,6 +109,11 @@ export function OnboardingNextStepsPage({
       sideTitle="Teach your agents how to use Coral"
     >
       <div className={styles.panel}>
+        {completionError ? (
+          <div className={styles.actionError}>
+            <ErrorBanner message={completionError} title="Couldn't finish setup" />
+          </div>
+        ) : null}
         <Tabs.Root className={styles.tabs} defaultValue="ai-assisted">
           <Tabs.List aria-label="Coral setup method" className={styles.tabList}>
             <Tabs.Tab value="ai-assisted">AI-assisted</Tabs.Tab>

--- a/apps/reef/app/components/onboarding/onboarding-next-steps-page.tsx
+++ b/apps/reef/app/components/onboarding/onboarding-next-steps-page.tsx
@@ -1,4 +1,3 @@
-import { ErrorBanner } from '@/components/error-banner'
 import { McpClientsList, type McpClientsConnectionState } from '@/components/mcp-clients-list'
 import { Inputs, ScrollArea, Tabs, Typography } from '@/wax/components'
 import { CopyButton } from '@/wax/components/button'
@@ -60,7 +59,6 @@ interface ConnectClientsProps {
 
 /** Only Desktop can write a client's config, so only Desktop carries the clients. */
 export type OnboardingNextStepsPageProps = {
-  completionError?: string | null
   completing?: boolean
   onContinue?: () => void
   step: OnboardingStepState
@@ -70,7 +68,6 @@ export type OnboardingNextStepsPageProps = {
 )
 
 export function OnboardingNextStepsPage({
-  completionError = null,
   completing = false,
   mcpClients,
   onContinue,
@@ -109,11 +106,6 @@ export function OnboardingNextStepsPage({
       sideTitle="Teach your agents how to use Coral"
     >
       <div className={styles.panel}>
-        {completionError ? (
-          <div className={styles.actionError}>
-            <ErrorBanner message={completionError} title="Couldn't finish setup" />
-          </div>
-        ) : null}
         <Tabs.Root className={styles.tabs} defaultValue="ai-assisted">
           <Tabs.List aria-label="Coral setup method" className={styles.tabList}>
             <Tabs.Tab value="ai-assisted">AI-assisted</Tabs.Tab>

--- a/apps/reef/app/lib/coral-request.server.ts
+++ b/apps/reef/app/lib/coral-request.server.ts
@@ -12,6 +12,7 @@ import { reefAuthConfig } from '@/auth/config.server'
 import { CatalogService } from '@/generated/coral/v1/catalog_pb'
 import { FeatureService } from '@/generated/coral/v1/features_pb'
 import { FunctionService } from '@/generated/coral/v1/functions_pb'
+import { GuiOnboardingService } from '@/generated/coral/v1/gui_onboarding_pb'
 import { QueryService } from '@/generated/coral/v1/query_pb'
 import { SourceService } from '@/generated/coral/v1/sources_pb'
 import { TraceService } from '@/generated/coral/v1/traces_pb'
@@ -39,6 +40,10 @@ export function featureClientForRequest(request: Request, accessToken: string | 
 
 export function functionClientForRequest(request: Request, accessToken: string | null) {
   return createClient(FunctionService, coralTransportForRequest(request, accessToken))
+}
+
+export function guiOnboardingClientForRequest(request: Request, accessToken: string | null) {
+  return createClient(GuiOnboardingService, coralTransportForRequest(request, accessToken))
 }
 
 export function queryClientForRequest(request: Request, accessToken: string | null) {

--- a/apps/reef/app/lib/gui-onboarding.server.ts
+++ b/apps/reef/app/lib/gui-onboarding.server.ts
@@ -1,0 +1,13 @@
+import { create } from '@bufbuild/protobuf'
+
+import { CompleteGuiOnboardingRequestSchema } from '@/generated/coral/v1/gui_onboarding_pb'
+
+import { guiOnboardingClientForRequest } from './coral-request.server'
+
+export async function completeGuiOnboarding(
+  request: Request,
+  accessToken: string | null,
+): Promise<void> {
+  const client = guiOnboardingClientForRequest(request, accessToken)
+  await client.completeGuiOnboarding(create(CompleteGuiOnboardingRequestSchema))
+}

--- a/apps/reef/app/lib/gui-onboarding.ts
+++ b/apps/reef/app/lib/gui-onboarding.ts
@@ -1,0 +1,7 @@
+export const CORAL_UNAVAILABLE_STATUS = 503
+
+export type CompleteGuiOnboardingError = {
+  intent: 'complete-onboarding'
+  message: string
+  status: 'error'
+}

--- a/apps/reef/app/lib/gui-onboarding.ts
+++ b/apps/reef/app/lib/gui-onboarding.ts
@@ -1,5 +1,7 @@
+export const COMPLETE_ONBOARDING_INTENT = 'complete-onboarding'
+
 export type CompleteGuiOnboardingError = {
-  intent: 'complete-onboarding'
+  intent: typeof COMPLETE_ONBOARDING_INTENT
   message: string
   status: 'error'
 }

--- a/apps/reef/app/lib/gui-onboarding.ts
+++ b/apps/reef/app/lib/gui-onboarding.ts
@@ -1,5 +1,3 @@
-export const CORAL_UNAVAILABLE_STATUS = 503
-
 export type CompleteGuiOnboardingError = {
   intent: 'complete-onboarding'
   message: string

--- a/apps/reef/app/lib/workspace-redirect.server.ts
+++ b/apps/reef/app/lib/workspace-redirect.server.ts
@@ -3,11 +3,11 @@ import { redirect } from 'react-router'
 import { firstWorkspaceForRequest } from '@/lib/workspaces.server'
 import { routePath } from '@/routing/routemap'
 
-export async function redirectToFirstWorkspaceSources(
+export async function redirectToFirstWorkspaceTraces(
   request: Request,
   accessToken: string | null,
 ): Promise<Response> {
   const workspace = await firstWorkspaceForRequest(request, accessToken)
   const search = new URL(request.url).search
-  return redirect(`${routePath('workspaceSources', { workspaceId: workspace.name })}${search}`)
+  return redirect(`${routePath('workspaceTraces', { workspaceId: workspace.name })}${search}`)
 }

--- a/apps/reef/app/routes/index.tsx
+++ b/apps/reef/app/routes/index.tsx
@@ -1,10 +1,10 @@
 import type { Route } from './+types/index'
 
 import { requestAuthContext } from '@/auth/server-context'
-import { redirectToFirstWorkspaceSources } from '@/lib/workspace-redirect.server'
+import { redirectToFirstWorkspaceTraces } from '@/lib/workspace-redirect.server'
 
 export async function loader({ context, request }: Route.LoaderArgs) {
-  return redirectToFirstWorkspaceSources(request, context.get(requestAuthContext).accessToken)
+  return redirectToFirstWorkspaceTraces(request, context.get(requestAuthContext).accessToken)
 }
 
 export default function AppIndex() {

--- a/apps/reef/app/routes/onboarding-action.ts
+++ b/apps/reef/app/routes/onboarding-action.ts
@@ -1,0 +1,31 @@
+import { data, redirect } from 'react-router'
+
+import { completeGuiOnboarding } from '@/lib/gui-onboarding.server'
+import { COMPLETE_ONBOARDING_INTENT, type CompleteGuiOnboardingError } from '@/lib/gui-onboarding'
+import { errorMessage } from '@/lib/utils'
+import { firstWorkspaceForRequest } from '@/lib/workspaces.server'
+import { routePath } from '@/routing/routemap'
+
+/**
+ * Marks onboarding complete, then lands on the workspace traces. A missing
+ * workspace is a route `Response`, so it keeps its own status instead of
+ * becoming a completion error.
+ */
+export async function runCompleteOnboardingAction(request: Request, accessToken: string | null) {
+  try {
+    const workspace = await firstWorkspaceForRequest(request, accessToken)
+    await completeGuiOnboarding(request, accessToken)
+    return redirect(routePath('workspaceTraces', { workspaceId: workspace.name }))
+  } catch (error) {
+    if (error instanceof Response) throw error
+
+    return data(
+      {
+        intent: COMPLETE_ONBOARDING_INTENT,
+        message: errorMessage(error),
+        status: 'error',
+      } satisfies CompleteGuiOnboardingError,
+      { status: 500 },
+    )
+  }
+}

--- a/apps/reef/app/routes/onboarding.server.test.ts
+++ b/apps/reef/app/routes/onboarding.server.test.ts
@@ -2,12 +2,14 @@ import { create } from '@bufbuild/protobuf'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
+  completeGuiOnboarding,
   firstWorkspaceForRequest,
   listWorkspacesForRequest,
   loadOnboardingSampleQuery,
   loadSourcesRouteData,
   runSourcesAction,
 } = vi.hoisted(() => ({
+  completeGuiOnboarding: vi.fn(),
   firstWorkspaceForRequest: vi.fn(),
   listWorkspacesForRequest: vi.fn(),
   loadOnboardingSampleQuery: vi.fn(),
@@ -21,6 +23,7 @@ vi.mock('@/lib/workspaces.server', () => ({
   firstWorkspaceForRequest,
   listWorkspacesForRequest,
 }))
+vi.mock('@/lib/gui-onboarding.server', () => ({ completeGuiOnboarding }))
 vi.mock('@/lib/onboarding-query.server', () => ({ loadOnboardingSampleQuery }))
 vi.mock('./sources-loader', () => ({ loadSourcesRouteData }))
 vi.mock('./sources-action', () => ({ runSourcesAction }))
@@ -32,22 +35,23 @@ import { action, loader } from './onboarding'
 
 const workspace = create(WorkspaceSchema, { name: 'analytics' })
 
-describe('onboarding route authentication', () => {
-  beforeEach(() => {
-    firstWorkspaceForRequest.mockReset()
-    listWorkspacesForRequest.mockReset()
-    loadOnboardingSampleQuery.mockReset()
-    loadSourcesRouteData.mockReset()
-    runSourcesAction.mockReset()
-    firstWorkspaceForRequest.mockResolvedValue(workspace)
-    listWorkspacesForRequest.mockResolvedValue([workspace])
-    loadSourcesRouteData.mockResolvedValue({
-      entries: [{ installed: true, name: 'github' }],
-      loadError: null,
-    })
-    loadOnboardingSampleQuery.mockResolvedValue({ rows: [], status: 'success' })
+beforeEach(() => {
+  completeGuiOnboarding.mockReset()
+  firstWorkspaceForRequest.mockReset()
+  listWorkspacesForRequest.mockReset()
+  loadOnboardingSampleQuery.mockReset()
+  loadSourcesRouteData.mockReset()
+  runSourcesAction.mockReset()
+  firstWorkspaceForRequest.mockResolvedValue(workspace)
+  listWorkspacesForRequest.mockResolvedValue([workspace])
+  loadSourcesRouteData.mockResolvedValue({
+    entries: [{ installed: true, name: 'github' }],
+    loadError: null,
   })
+  loadOnboardingSampleQuery.mockResolvedValue({ rows: [], status: 'success' })
+})
 
+describe('onboarding route authentication', () => {
   it('passes the hosted token through workspace, source, and query loading', async () => {
     const request = new Request('http://reef.test/onboarding?step=query')
 
@@ -84,7 +88,7 @@ describe('onboarding route authentication', () => {
   })
 
   it('passes the hosted token through source actions', async () => {
-    const request = new Request('http://reef.test/onboarding', { method: 'POST' })
+    const request = formRequest({ _intent: 'install', name: 'github' })
     runSourcesAction.mockResolvedValue({ ok: true })
 
     await action(authRouteTestArgs(request, {}, 'coral-access-token'))
@@ -92,4 +96,63 @@ describe('onboarding route authentication', () => {
     expect(firstWorkspaceForRequest).toHaveBeenCalledWith(request, 'coral-access-token')
     expect(runSourcesAction).toHaveBeenCalledWith(request, workspace, 'coral-access-token')
   })
+
+  it('passes the hosted token through onboarding completion', async () => {
+    completeGuiOnboarding.mockResolvedValue(undefined)
+
+    await action(authRouteTestArgs(completionRequest(), {}, 'coral-access-token'))
+
+    expect(completeGuiOnboarding).toHaveBeenCalledWith(expect.any(Request), 'coral-access-token')
+  })
 })
+
+describe('onboarding server route', () => {
+  it('persists completion before redirecting to the normal app', async () => {
+    completeGuiOnboarding.mockResolvedValue(undefined)
+    const request = completionRequest()
+
+    const response = await action(authRouteTestArgs(request, {}, null))
+
+    expect(completeGuiOnboarding).toHaveBeenCalledWith(request, null)
+    expect(response).toBeInstanceOf(Response)
+    expect((response as Response).headers.get('Location')).toBe('/workspaces/analytics/sources')
+    expect(runSourcesAction).not.toHaveBeenCalled()
+  })
+
+  it('returns typed non-2xx action data when finishing setup fails', async () => {
+    firstWorkspaceForRequest.mockRejectedValueOnce(new Error('workspace lookup failed'))
+
+    const result = await action(authRouteTestArgs(completionRequest(), {}, null))
+
+    expect(result).toMatchObject({
+      data: {
+        intent: 'complete-onboarding',
+        message: 'workspace lookup failed',
+        status: 'error',
+      },
+      init: { status: 503 },
+    })
+    expect(completeGuiOnboarding).not.toHaveBeenCalled()
+  })
+
+  it('keeps source intents on the existing source-action path', async () => {
+    const result = { intent: 'install', name: 'github', status: 'success' }
+    runSourcesAction.mockResolvedValue(result)
+    const request = formRequest({ _intent: 'install', name: 'github' })
+
+    await expect(action(authRouteTestArgs(request, {}, null))).resolves.toBe(result)
+    expect(runSourcesAction).toHaveBeenCalledWith(request, workspace, null)
+    expect(completeGuiOnboarding).not.toHaveBeenCalled()
+  })
+})
+
+function completionRequest() {
+  return formRequest({ _intent: 'complete-onboarding' })
+}
+
+function formRequest(fields: Record<string, string>) {
+  return new Request('http://reef.test/onboarding?step=next-steps', {
+    body: new URLSearchParams(fields),
+    method: 'POST',
+  })
+}

--- a/apps/reef/app/routes/onboarding.server.test.ts
+++ b/apps/reef/app/routes/onboarding.server.test.ts
@@ -115,24 +115,37 @@ describe('onboarding server route', () => {
 
     expect(completeGuiOnboarding).toHaveBeenCalledWith(request, null)
     expect(response).toBeInstanceOf(Response)
-    expect((response as Response).headers.get('Location')).toBe('/workspaces/analytics/sources')
+    expect((response as Response).headers.get('Location')).toBe('/workspaces/analytics/traces')
     expect(runSourcesAction).not.toHaveBeenCalled()
   })
 
-  it('returns typed non-2xx action data when finishing setup fails', async () => {
-    firstWorkspaceForRequest.mockRejectedValueOnce(new Error('workspace lookup failed'))
+  it('preserves route responses when the workspace is unavailable', async () => {
+    const missingWorkspace = new Response('No Coral workspace is configured.', {
+      status: 404,
+      statusText: 'Workspace Not Found',
+    })
+    firstWorkspaceForRequest.mockRejectedValueOnce(missingWorkspace)
+
+    await expect(action(authRouteTestArgs(completionRequest(), {}, null))).rejects.toBe(
+      missingWorkspace,
+    )
+    expect(completeGuiOnboarding).not.toHaveBeenCalled()
+  })
+
+  it('returns typed internal-error action data when completion fails', async () => {
+    completeGuiOnboarding.mockRejectedValueOnce(new Error('completion database failed'))
 
     const result = await action(authRouteTestArgs(completionRequest(), {}, null))
 
     expect(result).toMatchObject({
       data: {
         intent: 'complete-onboarding',
-        message: 'workspace lookup failed',
+        message: 'completion database failed',
         status: 'error',
       },
-      init: { status: 503 },
+      init: { status: 500 },
     })
-    expect(completeGuiOnboarding).not.toHaveBeenCalled()
+    expect(completeGuiOnboarding).toHaveBeenCalledOnce()
   })
 
   it('keeps source intents on the existing source-action path', async () => {
@@ -147,7 +160,7 @@ describe('onboarding server route', () => {
 })
 
 function completionRequest() {
-  return formRequest({ _intent: 'complete-onboarding' })
+  return formRequest({ intent: 'complete-onboarding' })
 }
 
 function formRequest(fields: Record<string, string>) {

--- a/apps/reef/app/routes/onboarding.tsx
+++ b/apps/reef/app/routes/onboarding.tsx
@@ -1,18 +1,17 @@
 import type { Route } from './+types/onboarding'
 
-import { data, redirect, useFetcher } from 'react-router'
+import { useFetcher } from 'react-router'
 
 import { requestAuthContext } from '@/auth/server-context'
 import { getOnboardingStepState } from '@/components/onboarding/onboarding-steps'
 import { isCoralDesktopBuild } from '@/lib/coral-desktop'
-import { completeGuiOnboarding } from '@/lib/gui-onboarding.server'
-import type { CompleteGuiOnboardingError } from '@/lib/gui-onboarding'
+import { COMPLETE_ONBOARDING_INTENT } from '@/lib/gui-onboarding'
 import { loadOnboardingSampleQuery } from '@/lib/onboarding-query.server'
-import { errorMessage } from '@/lib/utils'
 import { firstWorkspaceForRequest, listWorkspacesForRequest } from '@/lib/workspaces.server'
-import { routePath } from '@/routing/routemap'
 import { OnboardingView } from '@/views/onboarding/onboarding'
+import { addToast } from '@/wax/components/toast'
 
+import { runCompleteOnboardingAction } from './onboarding-action'
 import { runSourcesAction } from './sources-action'
 import { loadSourcesRouteData } from './sources-loader'
 import {
@@ -55,23 +54,8 @@ export async function action({ context, request }: Route.ActionArgs) {
   const accessToken = context.get(requestAuthContext).accessToken
   const intent = (await request.clone().formData()).get('intent')
 
-  if (intent === 'complete-onboarding') {
-    try {
-      const workspace = await firstWorkspaceForRequest(request, accessToken)
-      await completeGuiOnboarding(request, accessToken)
-      return redirect(routePath('workspaceTraces', { workspaceId: workspace.name }))
-    } catch (error) {
-      if (error instanceof Response) throw error
-
-      return data(
-        {
-          intent: 'complete-onboarding',
-          message: errorMessage(error),
-          status: 'error',
-        } satisfies CompleteGuiOnboardingError,
-        { status: 500 },
-      )
-    }
+  if (intent === COMPLETE_ONBOARDING_INTENT) {
+    return runCompleteOnboardingAction(request, accessToken)
   }
 
   return runSourcesAction(
@@ -95,10 +79,18 @@ clientLoader.hydrate = true as const
 
 export async function clientAction({ request, serverAction }: Route.ClientActionArgs) {
   const formData = await request.clone().formData()
-  if (formData.get('_intent') !== 'update-mcp-client') return serverAction()
+  if (formData.get('_intent') === 'update-mcp-client') {
+    await updateDesktopMcpClient(formData)
+    return null
+  }
 
-  await updateDesktopMcpClient(formData)
-  return null
+  const result = await serverAction()
+
+  if (result?.intent === COMPLETE_ONBOARDING_INTENT && result.status === 'error') {
+    addToast('error', { description: result.message, title: "Couldn't finish setup" })
+  }
+
+  return result
 }
 
 export default function OnboardingRoute({ actionData, loaderData }: Route.ComponentProps) {

--- a/apps/reef/app/routes/onboarding.tsx
+++ b/apps/reef/app/routes/onboarding.tsx
@@ -6,7 +6,7 @@ import { requestAuthContext } from '@/auth/server-context'
 import { getOnboardingStepState } from '@/components/onboarding/onboarding-steps'
 import { isCoralDesktopBuild } from '@/lib/coral-desktop'
 import { completeGuiOnboarding } from '@/lib/gui-onboarding.server'
-import { CORAL_UNAVAILABLE_STATUS, type CompleteGuiOnboardingError } from '@/lib/gui-onboarding'
+import type { CompleteGuiOnboardingError } from '@/lib/gui-onboarding'
 import { loadOnboardingSampleQuery } from '@/lib/onboarding-query.server'
 import { errorMessage } from '@/lib/utils'
 import { firstWorkspaceForRequest, listWorkspacesForRequest } from '@/lib/workspaces.server'
@@ -53,21 +53,23 @@ export async function loader({ context, request }: Route.LoaderArgs) {
 
 export async function action({ context, request }: Route.ActionArgs) {
   const accessToken = context.get(requestAuthContext).accessToken
-  const intent = (await request.clone().formData()).get('_intent')
+  const intent = (await request.clone().formData()).get('intent')
 
   if (intent === 'complete-onboarding') {
     try {
       const workspace = await firstWorkspaceForRequest(request, accessToken)
       await completeGuiOnboarding(request, accessToken)
-      return redirect(routePath('workspaceSources', { workspaceId: workspace.name }))
+      return redirect(routePath('workspaceTraces', { workspaceId: workspace.name }))
     } catch (error) {
+      if (error instanceof Response) throw error
+
       return data(
         {
           intent: 'complete-onboarding',
           message: errorMessage(error),
           status: 'error',
         } satisfies CompleteGuiOnboardingError,
-        { status: CORAL_UNAVAILABLE_STATUS },
+        { status: 500 },
       )
     }
   }

--- a/apps/reef/app/routes/onboarding.tsx
+++ b/apps/reef/app/routes/onboarding.tsx
@@ -1,12 +1,16 @@
 import type { Route } from './+types/onboarding'
-import { useFetcher } from 'react-router'
-import type { SourcesActionData } from './sources-action'
+
+import { data, redirect, useFetcher } from 'react-router'
 
 import { requestAuthContext } from '@/auth/server-context'
 import { getOnboardingStepState } from '@/components/onboarding/onboarding-steps'
 import { isCoralDesktopBuild } from '@/lib/coral-desktop'
+import { completeGuiOnboarding } from '@/lib/gui-onboarding.server'
+import { CORAL_UNAVAILABLE_STATUS, type CompleteGuiOnboardingError } from '@/lib/gui-onboarding'
 import { loadOnboardingSampleQuery } from '@/lib/onboarding-query.server'
+import { errorMessage } from '@/lib/utils'
 import { firstWorkspaceForRequest, listWorkspacesForRequest } from '@/lib/workspaces.server'
+import { routePath } from '@/routing/routemap'
 import { OnboardingView } from '@/views/onboarding/onboarding'
 
 import { runSourcesAction } from './sources-action'
@@ -47,8 +51,27 @@ export async function loader({ context, request }: Route.LoaderArgs) {
   }
 }
 
-export async function action({ context, request }: Route.ActionArgs): Promise<SourcesActionData> {
+export async function action({ context, request }: Route.ActionArgs) {
   const accessToken = context.get(requestAuthContext).accessToken
+  const intent = (await request.clone().formData()).get('_intent')
+
+  if (intent === 'complete-onboarding') {
+    try {
+      const workspace = await firstWorkspaceForRequest(request, accessToken)
+      await completeGuiOnboarding(request, accessToken)
+      return redirect(routePath('workspaceSources', { workspaceId: workspace.name }))
+    } catch (error) {
+      return data(
+        {
+          intent: 'complete-onboarding',
+          message: errorMessage(error),
+          status: 'error',
+        } satisfies CompleteGuiOnboardingError,
+        { status: CORAL_UNAVAILABLE_STATUS },
+      )
+    }
+  }
+
   return runSourcesAction(
     request,
     await firstWorkspaceForRequest(request, accessToken),

--- a/apps/reef/app/views/onboarding/onboarding.tsx
+++ b/apps/reef/app/views/onboarding/onboarding.tsx
@@ -38,7 +38,7 @@ export function OnboardingView({
   const submit = useSubmit()
   const { step } = loaderData
   const completing =
-    navigation.state !== 'idle' && navigation.formData?.get('_intent') === 'complete-onboarding'
+    navigation.state !== 'idle' && navigation.formData?.get('intent') === 'complete-onboarding'
   const completionError =
     !completing && actionData?.intent === 'complete-onboarding' ? actionData.message : null
   const sourcesActionData = actionData?.intent === 'complete-onboarding' ? undefined : actionData
@@ -97,7 +97,7 @@ export function OnboardingView({
           completing={completing}
           mcpClients={mcpClients}
           onContinue={() =>
-            submit({ _intent: 'complete-onboarding' }, { method: 'post', replace: true })
+            submit({ intent: 'complete-onboarding' }, { method: 'post', replace: true })
           }
           runtime={loaderData.runtime}
           step={step}

--- a/apps/reef/app/views/onboarding/onboarding.tsx
+++ b/apps/reef/app/views/onboarding/onboarding.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useEffect, useState } from 'react'
-import { Await, useNavigate, useNavigation, useRevalidator } from 'react-router'
+import { Await, useNavigate, useNavigation, useRevalidator, useSubmit } from 'react-router'
 
 import type { SourcesActionData } from '@/routes/sources-action'
 
@@ -9,9 +9,9 @@ import { OnboardingSampleQueryPage } from '@/components/onboarding/onboarding-sa
 import type { SampleQueryLoadState } from '@/components/onboarding/onboarding-sample-query-page'
 import { OnboardingSourcesPage } from '@/components/onboarding/onboarding-sources-page'
 import type { OnboardingStepState } from '@/components/onboarding/onboarding-steps'
+import type { CompleteGuiOnboardingError } from '@/lib/gui-onboarding'
 import type { OnboardingSampleQueryResult } from '@/lib/onboarding-query'
 import type { CatalogEntry } from '@/lib/sources'
-import { routePath } from '@/routing/routemap'
 import { SourceDetailDialog } from '@/views/sources/source-detail'
 import { SourceInstallDialog } from '@/views/sources/source-install'
 import { ToastContainer } from '@/wax/components/toast'
@@ -21,7 +21,7 @@ export function OnboardingView({
   loaderData,
   mcpClients,
 }: {
-  actionData: SourcesActionData
+  actionData: CompleteGuiOnboardingError | SourcesActionData
   loaderData: {
     entries: CatalogEntry[]
     loadError: string | null
@@ -34,13 +34,20 @@ export function OnboardingView({
   mcpClients: McpClientsConnectionState
 }) {
   const navigate = useNavigate()
+  const navigation = useNavigation()
+  const submit = useSubmit()
   const { step } = loaderData
+  const completing =
+    navigation.state !== 'idle' && navigation.formData?.get('_intent') === 'complete-onboarding'
+  const completionError =
+    !completing && actionData?.intent === 'complete-onboarding' ? actionData.message : null
+  const sourcesActionData = actionData?.intent === 'complete-onboarding' ? undefined : actionData
 
   switch (step.step) {
     case 'sources':
       return (
         <SourcesStep
-          actionData={actionData}
+          actionData={sourcesActionData}
           entries={loaderData.entries}
           loadError={loaderData.loadError}
           step={step}
@@ -86,9 +93,11 @@ export function OnboardingView({
     case 'next-steps':
       return (
         <OnboardingNextStepsStep
+          completionError={completionError}
+          completing={completing}
           mcpClients={mcpClients}
           onContinue={() =>
-            navigate(routePath('workspaceSources', { workspaceId: loaderData.workspaceId }))
+            submit({ _intent: 'complete-onboarding' }, { method: 'post', replace: true })
           }
           runtime={loaderData.runtime}
           step={step}
@@ -103,12 +112,16 @@ export function OnboardingView({
 }
 
 function OnboardingNextStepsStep({
+  completionError,
+  completing,
   mcpClients,
   onContinue,
   runtime,
   step,
   workspaces,
 }: {
+  completionError: string | null
+  completing: boolean
   mcpClients: McpClientsConnectionState
   onContinue: () => void
   runtime: 'desktop' | 'web'
@@ -119,6 +132,8 @@ function OnboardingNextStepsStep({
     <>
       {runtime === 'desktop' ? (
         <OnboardingNextStepsPage
+          completionError={completionError}
+          completing={completing}
           mcpClients={mcpClients}
           onContinue={onContinue}
           runtime="desktop"
@@ -126,7 +141,13 @@ function OnboardingNextStepsStep({
           workspaces={workspaces}
         />
       ) : (
-        <OnboardingNextStepsPage onContinue={onContinue} runtime="web" step={step} />
+        <OnboardingNextStepsPage
+          completionError={completionError}
+          completing={completing}
+          onContinue={onContinue}
+          runtime="web"
+          step={step}
+        />
       )}
       {/*
         Onboarding renders outside the app shell, which is where the rest of the app

--- a/apps/reef/app/views/onboarding/onboarding.tsx
+++ b/apps/reef/app/views/onboarding/onboarding.tsx
@@ -9,7 +9,7 @@ import { OnboardingSampleQueryPage } from '@/components/onboarding/onboarding-sa
 import type { SampleQueryLoadState } from '@/components/onboarding/onboarding-sample-query-page'
 import { OnboardingSourcesPage } from '@/components/onboarding/onboarding-sources-page'
 import type { OnboardingStepState } from '@/components/onboarding/onboarding-steps'
-import type { CompleteGuiOnboardingError } from '@/lib/gui-onboarding'
+import { COMPLETE_ONBOARDING_INTENT, type CompleteGuiOnboardingError } from '@/lib/gui-onboarding'
 import type { OnboardingSampleQueryResult } from '@/lib/onboarding-query'
 import type { CatalogEntry } from '@/lib/sources'
 import { SourceDetailDialog } from '@/views/sources/source-detail'
@@ -38,10 +38,9 @@ export function OnboardingView({
   const submit = useSubmit()
   const { step } = loaderData
   const completing =
-    navigation.state !== 'idle' && navigation.formData?.get('intent') === 'complete-onboarding'
-  const completionError =
-    !completing && actionData?.intent === 'complete-onboarding' ? actionData.message : null
-  const sourcesActionData = actionData?.intent === 'complete-onboarding' ? undefined : actionData
+    navigation.state !== 'idle' && navigation.formData?.get('intent') === COMPLETE_ONBOARDING_INTENT
+  const sourcesActionData =
+    actionData?.intent === COMPLETE_ONBOARDING_INTENT ? undefined : actionData
 
   switch (step.step) {
     case 'sources':
@@ -93,11 +92,10 @@ export function OnboardingView({
     case 'next-steps':
       return (
         <OnboardingNextStepsStep
-          completionError={completionError}
           completing={completing}
           mcpClients={mcpClients}
           onContinue={() =>
-            submit({ intent: 'complete-onboarding' }, { method: 'post', replace: true })
+            submit({ intent: COMPLETE_ONBOARDING_INTENT }, { method: 'post', replace: true })
           }
           runtime={loaderData.runtime}
           step={step}
@@ -112,7 +110,6 @@ export function OnboardingView({
 }
 
 function OnboardingNextStepsStep({
-  completionError,
   completing,
   mcpClients,
   onContinue,
@@ -120,7 +117,6 @@ function OnboardingNextStepsStep({
   step,
   workspaces,
 }: {
-  completionError: string | null
   completing: boolean
   mcpClients: McpClientsConnectionState
   onContinue: () => void
@@ -132,7 +128,6 @@ function OnboardingNextStepsStep({
     <>
       {runtime === 'desktop' ? (
         <OnboardingNextStepsPage
-          completionError={completionError}
           completing={completing}
           mcpClients={mcpClients}
           onContinue={onContinue}
@@ -142,7 +137,6 @@ function OnboardingNextStepsStep({
         />
       ) : (
         <OnboardingNextStepsPage
-          completionError={completionError}
           completing={completing}
           onContinue={onContinue}
           runtime="web"

--- a/apps/reef/buf.gen.yaml
+++ b/apps/reef/buf.gen.yaml
@@ -12,6 +12,7 @@ inputs:
       - ../../crates/coral-api/proto/coral/v1/catalog.proto
       - ../../crates/coral-api/proto/coral/v1/features.proto
       - ../../crates/coral-api/proto/coral/v1/functions.proto
+      - ../../crates/coral-api/proto/coral/v1/gui_onboarding.proto
       - ../../crates/coral-api/proto/coral/v1/query.proto
       - ../../crates/coral-api/proto/coral/v1/sources.proto
       - ../../crates/coral-api/proto/coral/v1/task.proto


### PR DESCRIPTION
## Summary

Wiring up the onboarding UI to actually call the server to persist the onboarding complete to the DB.
Ie when clicking the last button of the onboarding, we fire the request to mark onboarding completed for your userId.


## Test plan

Finish onboarding in the UI, check my userId gets added to the onboarding completion

<img width="339" height="136" alt="image" src="https://github.com/user-attachments/assets/bc50661a-e21d-4917-82f1-f1f3ce5d6bee" />
