### PR TITLE
feat(reef): skip onboarding after completion

### DIFF
--- a/apps/coral-ui/app/lib/gui-onboarding.server.ts
+++ b/apps/coral-ui/app/lib/gui-onboarding.server.ts
@@ -1,8 +1,22 @@
 import { create } from '@bufbuild/protobuf'
 
-import { CompleteGuiOnboardingRequestSchema } from '@/generated/coral/v1/gui_onboarding_pb'
+import {
+  CompleteGuiOnboardingRequestSchema,
+  GetGuiOnboardingStateRequestSchema,
+} from '@/generated/coral/v1/gui_onboarding_pb'
 
 import { guiOnboardingClientForRequest } from './coral-request.server'
+
+export async function getGuiOnboardingCompleted(
+  request: Request,
+  accessToken: string | null,
+): Promise<boolean> {
+  const client = guiOnboardingClientForRequest(request, accessToken)
+  const response = await client.getGuiOnboardingState(create(GetGuiOnboardingStateRequestSchema), {
+    signal: request.signal,
+  })
+  return response.completed
+}
 
 export async function completeGuiOnboarding(
   request: Request,

--- a/apps/coral-ui/app/routes/index.server.test.ts
+++ b/apps/coral-ui/app/routes/index.server.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getGuiOnboardingCompleted, redirectToFirstWorkspaceTraces } = vi.hoisted(() => ({
+  getGuiOnboardingCompleted: vi.fn(),
+  redirectToFirstWorkspaceTraces: vi.fn(),
+}))
+
+vi.mock('@/lib/gui-onboarding.server', () => ({ getGuiOnboardingCompleted }))
+vi.mock('@/lib/workspace-redirect.server', () => ({ redirectToFirstWorkspaceTraces }))
+
+import { authRouteTestArgs } from '@/auth/server-context.test-helper'
+
+import { loader } from './index'
+
+describe('app index loader', () => {
+  beforeEach(() => {
+    getGuiOnboardingCompleted.mockReset()
+    redirectToFirstWorkspaceTraces.mockReset()
+  })
+
+  it('starts incomplete users in onboarding', async () => {
+    getGuiOnboardingCompleted.mockResolvedValue(false)
+    const request = new Request('http://coral-ui.test/')
+
+    const response = await loader(authRouteTestArgs(request, {}, null))
+
+    expect(response).toBeInstanceOf(Response)
+    expect(response.status).toBe(302)
+    expect(response.headers.get('Location')).toBe('/onboarding')
+    expect(response.headers.get('X-Remix-Replace')).toBe('true')
+    expect(getGuiOnboardingCompleted).toHaveBeenCalledWith(request, null)
+    expect(redirectToFirstWorkspaceTraces).not.toHaveBeenCalled()
+  })
+
+  it('starts completed users in the normal app', async () => {
+    getGuiOnboardingCompleted.mockResolvedValue(true)
+    const request = new Request('http://coral-ui.test/')
+    const response = new Response(null, {
+      headers: { Location: '/workspaces/default/traces' },
+      status: 302,
+    })
+    redirectToFirstWorkspaceTraces.mockResolvedValue(response)
+
+    await expect(loader(authRouteTestArgs(request, {}, 'coral-access-token'))).resolves.toBe(
+      response,
+    )
+    expect(getGuiOnboardingCompleted).toHaveBeenCalledWith(request, 'coral-access-token')
+    expect(redirectToFirstWorkspaceTraces).toHaveBeenCalledWith(request, 'coral-access-token')
+  })
+})

--- a/apps/coral-ui/app/routes/index.tsx
+++ b/apps/coral-ui/app/routes/index.tsx
@@ -1,10 +1,16 @@
 import type { Route } from './+types/index'
 
+import { replace } from 'react-router'
+
 import { requestAuthContext } from '@/auth/server-context'
+import { getGuiOnboardingCompleted } from '@/lib/gui-onboarding.server'
 import { redirectToFirstWorkspaceTraces } from '@/lib/workspace-redirect.server'
 
 export async function loader({ context, request }: Route.LoaderArgs) {
-  return redirectToFirstWorkspaceTraces(request, context.get(requestAuthContext).accessToken)
+  const accessToken = context.get(requestAuthContext).accessToken
+  if (!(await getGuiOnboardingCompleted(request, accessToken))) return replace('/onboarding')
+
+  return redirectToFirstWorkspaceTraces(request, accessToken)
 }
 
 export default function AppIndex() {

--- a/apps/coral-ui/app/routes/onboarding.server.test.ts
+++ b/apps/coral-ui/app/routes/onboarding.server.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   completeGuiOnboarding,
   firstWorkspaceForRequest,
+  getGuiOnboardingCompleted,
   listWorkspacesForRequest,
   loadOnboardingSampleQuery,
   loadSourcesRouteData,
@@ -11,6 +12,7 @@ const {
 } = vi.hoisted(() => ({
   completeGuiOnboarding: vi.fn(),
   firstWorkspaceForRequest: vi.fn(),
+  getGuiOnboardingCompleted: vi.fn(),
   listWorkspacesForRequest: vi.fn(),
   loadOnboardingSampleQuery: vi.fn(),
   loadSourcesRouteData: vi.fn(),
@@ -23,7 +25,10 @@ vi.mock('@/lib/workspaces.server', () => ({
   firstWorkspaceForRequest,
   listWorkspacesForRequest,
 }))
-vi.mock('@/lib/gui-onboarding.server', () => ({ completeGuiOnboarding }))
+vi.mock('@/lib/gui-onboarding.server', () => ({
+  completeGuiOnboarding,
+  getGuiOnboardingCompleted,
+}))
 vi.mock('@/lib/onboarding-query.server', () => ({ loadOnboardingSampleQuery }))
 vi.mock('./sources-loader', () => ({ loadSourcesRouteData }))
 vi.mock('./sources-action', () => ({ runSourcesAction }))
@@ -39,9 +44,11 @@ beforeEach(() => {
   completeGuiOnboarding.mockReset()
   firstWorkspaceForRequest.mockReset()
   listWorkspacesForRequest.mockReset()
+  getGuiOnboardingCompleted.mockReset()
   loadOnboardingSampleQuery.mockReset()
   loadSourcesRouteData.mockReset()
   runSourcesAction.mockReset()
+  getGuiOnboardingCompleted.mockResolvedValue(false)
   firstWorkspaceForRequest.mockResolvedValue(workspace)
   listWorkspacesForRequest.mockResolvedValue([workspace])
   loadSourcesRouteData.mockResolvedValue({
@@ -104,9 +111,30 @@ describe('onboarding route authentication', () => {
 
     expect(completeGuiOnboarding).toHaveBeenCalledWith(expect.any(Request), 'coral-access-token')
   })
+
+  it('passes the hosted token through the completion-state check', async () => {
+    await loader(
+      authRouteTestArgs(new Request('http://coral-ui.test/onboarding'), {}, 'coral-token'),
+    )
+
+    expect(getGuiOnboardingCompleted).toHaveBeenCalledWith(expect.any(Request), 'coral-token')
+  })
 })
 
 describe('onboarding server route', () => {
+  it('redirects completed users before loading onboarding data', async () => {
+    getGuiOnboardingCompleted.mockResolvedValue(true)
+    const request = new Request('http://coral-ui.test/onboarding')
+
+    const response = await loader(authRouteTestArgs(request, {}, null))
+
+    expect(response).toBeInstanceOf(Response)
+    expect((response as Response).status).toBe(302)
+    expect((response as Response).headers.get('Location')).toBe('/')
+    expect(listWorkspacesForRequest).not.toHaveBeenCalled()
+    expect(loadSourcesRouteData).not.toHaveBeenCalled()
+  })
+
   it('persists completion before redirecting to the normal app', async () => {
     completeGuiOnboarding.mockResolvedValue(undefined)
     const request = completionRequest()

--- a/apps/coral-ui/app/routes/onboarding.server.test.ts
+++ b/apps/coral-ui/app/routes/onboarding.server.test.ts
@@ -1,4 +1,5 @@
 import { create } from '@bufbuild/protobuf'
+import { createMemoryRouter, redirect } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -33,7 +34,7 @@ vi.mock('@/lib/onboarding-query.server', () => ({ loadOnboardingSampleQuery }))
 vi.mock('./sources-loader', () => ({ loadSourcesRouteData }))
 vi.mock('./sources-action', () => ({ runSourcesAction }))
 
-import { authRouteTestArgs } from '@/auth/server-context.test-helper'
+import { authRouteTestArgs, authTestContext } from '@/auth/server-context.test-helper'
 import { WorkspaceSchema } from '@/generated/coral/v1/resources_pb'
 
 import { action, loader } from './onboarding'
@@ -122,7 +123,7 @@ describe('onboarding route authentication', () => {
 })
 
 describe('onboarding server route', () => {
-  it('redirects completed users before loading onboarding data', async () => {
+  it('replaces completed users directly into the normal app before loading onboarding data', async () => {
     getGuiOnboardingCompleted.mockResolvedValue(true)
     const request = new Request('http://coral-ui.test/onboarding')
 
@@ -130,9 +131,46 @@ describe('onboarding server route', () => {
 
     expect(response).toBeInstanceOf(Response)
     expect((response as Response).status).toBe(302)
-    expect((response as Response).headers.get('Location')).toBe('/')
+    expect((response as Response).headers.get('Location')).toBe('/workspaces/analytics/traces')
+    expect((response as Response).headers.get('X-Remix-Replace')).toBe('true')
+    expect(firstWorkspaceForRequest).toHaveBeenCalledWith(request, null)
     expect(listWorkspacesForRequest).not.toHaveBeenCalled()
     expect(loadSourcesRouteData).not.toHaveBeenCalled()
+  })
+
+  it('does not trap completed users when they navigate back into onboarding history', async () => {
+    getGuiOnboardingCompleted.mockResolvedValue(true)
+    const router = createMemoryRouter(
+      [
+        { path: '/before' },
+        { loader: () => redirect(`/workspaces/${workspace.name}/traces`), path: '/' },
+        { loader, path: '/onboarding' },
+        { path: '/workspaces/:workspaceId/traces' },
+      ],
+      {
+        getContext: () => authTestContext(null),
+        initialEntries: [
+          '/before',
+          '/onboarding?step=query',
+          `/workspaces/${workspace.name}/traces`,
+        ],
+        initialIndex: 2,
+      },
+    )
+
+    try {
+      await router.navigate(-1)
+
+      expect(router.state.location.pathname).toBe(`/workspaces/${workspace.name}/traces`)
+      expect(router.state.historyAction).toBe('REPLACE')
+
+      await router.navigate(-1)
+
+      expect(router.state.location.pathname).toBe('/before')
+      expect(getGuiOnboardingCompleted).toHaveBeenCalledOnce()
+    } finally {
+      router.dispose()
+    }
   })
 
   it('persists completion before redirecting to the normal app', async () => {

--- a/apps/coral-ui/app/routes/onboarding.tsx
+++ b/apps/coral-ui/app/routes/onboarding.tsx
@@ -1,6 +1,6 @@
 import type { Route } from './+types/onboarding'
 
-import { redirect, useFetcher } from 'react-router'
+import { replace, useFetcher } from 'react-router'
 
 import { requestAuthContext } from '@/auth/server-context'
 import { getOnboardingStepState } from '@/components/onboarding/onboarding-steps'
@@ -24,7 +24,10 @@ import {
 
 export async function loader({ context, request }: Route.LoaderArgs) {
   const accessToken = context.get(requestAuthContext).accessToken
-  if (await getGuiOnboardingCompleted(request, accessToken)) return redirect(routePath('home'))
+  if (await getGuiOnboardingCompleted(request, accessToken)) {
+    const workspace = await firstWorkspaceForRequest(request, accessToken)
+    return replace(routePath('workspaceTraces', { workspaceId: workspace.name }))
+  }
 
   const workspaces = await listWorkspacesForRequest(request, accessToken)
   const [workspace] = workspaces

--- a/apps/coral-ui/app/routes/onboarding.tsx
+++ b/apps/coral-ui/app/routes/onboarding.tsx
@@ -1,13 +1,15 @@
 import type { Route } from './+types/onboarding'
 
-import { useFetcher } from 'react-router'
+import { redirect, useFetcher } from 'react-router'
 
 import { requestAuthContext } from '@/auth/server-context'
 import { getOnboardingStepState } from '@/components/onboarding/onboarding-steps'
 import { isCoralDesktopBuild } from '@/lib/coral-desktop'
 import { COMPLETE_ONBOARDING_INTENT } from '@/lib/gui-onboarding'
+import { getGuiOnboardingCompleted } from '@/lib/gui-onboarding.server'
 import { loadOnboardingSampleQuery } from '@/lib/onboarding-query.server'
 import { firstWorkspaceForRequest, listWorkspacesForRequest } from '@/lib/workspaces.server'
+import { routePath } from '@/routing/routemap'
 import { OnboardingView } from '@/views/onboarding/onboarding'
 import { addToast } from '@/wax/components/toast'
 
@@ -22,6 +24,8 @@ import {
 
 export async function loader({ context, request }: Route.LoaderArgs) {
   const accessToken = context.get(requestAuthContext).accessToken
+  if (await getGuiOnboardingCompleted(request, accessToken)) return redirect(routePath('home'))
+
   const workspaces = await listWorkspacesForRequest(request, accessToken)
   const [workspace] = workspaces
   if (!workspace) {


### PR DESCRIPTION
## Summary

Let's check if `onboarding` was completed (by reading the local DB), and NOT redirect to onboarding if that's the case.

## Test plan

Open app
See onboarding
Complete onboarding
Re-open app, I land in home rather than onboarding.