### PR TITLE
feat(api): expose table function argument types

### DIFF
--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -88,6 +88,8 @@ message TableFunctionArgument {
   bool required = 2;
   // Allowed values, if the source declares an enum-like value set.
   repeated string values = 3;
+  // The DataFusion/Arrow argument type rendered as text.
+  string data_type = 4;
 }
 
 // A result column returned by a query-visible table function.

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -445,6 +445,7 @@ pub(crate) fn table_function_to_proto(
             .into_iter()
             .map(|argument| TableFunctionArgument {
                 name: argument.name,
+                data_type: argument.data_type,
                 required: argument.required,
                 values: argument.values,
             })
@@ -949,6 +950,7 @@ mod tests {
             description: "Search demo records".to_string(),
             arguments: vec![coral_engine::TableFunctionArgumentInfo {
                 name: "payload".to_string(),
+                data_type: "Json".to_string(),
                 required: true,
                 values: Vec::new(),
             }],
@@ -965,6 +967,7 @@ mod tests {
         assert_eq!(proto.description, "Search demo records");
         assert_eq!(proto.arguments.len(), 1);
         assert_eq!(proto.arguments[0].name, "payload");
+        assert_eq!(proto.arguments[0].data_type, "Json");
         assert!(proto.arguments[0].required);
         assert!(proto.arguments[0].values.is_empty());
     }

--- a/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
+++ b/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
@@ -117,6 +117,7 @@ async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagina
     };
     assert_eq!(function.schema_name, "searchy");
     assert_eq!(function.name, "lookup_issue");
+    assert_eq!(function.arguments[0].data_type, "Utf8");
     let table = match response.items[1].item.as_ref().expect("catalog item") {
         catalog_item::Item::Table(table) => table,
         catalog_item::Item::TableFunction(_) => panic!("expected table"),

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -267,6 +267,7 @@ async fn validate_source_returns_table_functions() {
     assert_eq!(function.name, "search_issues");
     assert_eq!(function.arguments.len(), 1);
     assert_eq!(function.arguments[0].name, "q");
+    assert_eq!(function.arguments[0].data_type, "Utf8");
     assert_eq!(function.result_columns.len(), 1);
     assert_eq!(function.result_columns[0].name, "title");
     assert!(validated.query_tests.is_empty());

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -61,6 +61,8 @@ pub struct DescribeTableInfo {
 pub struct TableFunctionArgumentInfo {
     /// Argument name as used in a named SQL function call.
     pub name: String,
+    /// Data type rendered in `Arrow`/`DataFusion` string form.
+    pub data_type: String,
     /// Whether callers must provide this argument.
     pub required: bool,
     /// Allowed values, if the source declares an enum-like value set.

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -36,6 +36,7 @@ pub(crate) struct CatalogTableFunction {
 #[derive(Debug, Clone)]
 pub(crate) struct CatalogTableFunctionArgument {
     pub(crate) name: String,
+    pub(crate) data_type: String,
     pub(crate) required: bool,
     pub(crate) values: Vec<String>,
 }
@@ -164,6 +165,8 @@ fn search_limits_json(limits: Option<&SearchLimitsSpec>) -> Result<Option<String
 #[derive(Serialize)]
 struct TableFunctionArgumentJson<'a> {
     name: &'a str,
+    #[serde(rename = "type")]
+    data_type: &'a str,
     required: bool,
     values: &'a [String],
 }
@@ -172,6 +175,7 @@ impl<'a> From<&'a CatalogTableFunctionArgument> for TableFunctionArgumentJson<'a
     fn from(argument: &'a CatalogTableFunctionArgument) -> Self {
         Self {
             name: &argument.name,
+            data_type: &argument.data_type,
             required: argument.required,
             values: &argument.values,
         }
@@ -569,6 +573,7 @@ pub(crate) fn collect_table_functions(
                 .into_iter()
                 .map(|argument| TableFunctionArgumentInfo {
                     name: argument.name,
+                    data_type: argument.data_type,
                     required: argument.required,
                     values: argument.values,
                 })
@@ -608,6 +613,7 @@ fn catalog_table_functions(
                         .iter()
                         .map(|argument| CatalogTableFunctionArgument {
                             name: argument.name.clone(),
+                            data_type: argument.data_type.as_manifest_str().to_string(),
                             required: argument.required,
                             values: argument.values.clone(),
                         })

--- a/crates/coral-engine/src/runtime/udfs.rs
+++ b/crates/coral-engine/src/runtime/udfs.rs
@@ -166,6 +166,7 @@ fn catalog_table_function(
             .iter()
             .map(|argument| CatalogTableFunctionArgument {
                 name: argument.name.clone(),
+                data_type: argument.data_type.to_string(),
                 required: true,
                 values: Vec::new(),
             })

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -394,9 +394,8 @@ fn http_manifest_with_function() -> Value {
                     "values": ["lexical", "semantic", "hybrid"],
                     "bind": { "arg": "search_type" }
                 },
-                // OpenAPI v4 generation does not produce Json HTTP function args.
-                // This fixture verifies typed args still register and list even
-                // though public catalog metadata does not expose arg types yet.
+                // OpenAPI v4 generation does not produce Json HTTP function args;
+                // this fixture verifies typed args still register and list.
                 {
                     "name": "metadata",
                     "type": "Json",
@@ -498,10 +497,10 @@ async fn coral_table_functions_lists_source_functions() {
     assert_eq!(
         serde_json::from_str::<Value>(row["arguments_json"].as_str().unwrap()).unwrap(),
         json!([
-            { "name": "q", "required": true, "values": [] },
-            { "name": "mode", "required": false, "values": ["lexical", "semantic", "hybrid"] },
-            { "name": "metadata", "required": false, "values": [] },
-            { "name": "since", "required": false, "values": [] }
+            { "name": "q", "type": "Utf8", "required": true, "values": [] },
+            { "name": "mode", "type": "Utf8", "required": false, "values": ["lexical", "semantic", "hybrid"] },
+            { "name": "metadata", "type": "Json", "required": false, "values": [] },
+            { "name": "since", "type": "Timestamp", "required": false, "values": [] }
         ])
     );
     assert_eq!(

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -599,6 +599,7 @@ struct CatalogTableFunctionValue<'a> {
 #[schemars(deny_unknown_fields)]
 struct TableFunctionArgumentValue<'a> {
     name: &'a str,
+    data_type: &'a str,
     required: bool,
     values: &'a [String],
 }
@@ -607,6 +608,7 @@ impl<'a> From<&'a ProtoTableFunctionArgument> for TableFunctionArgumentValue<'a>
     fn from(argument: &'a ProtoTableFunctionArgument) -> Self {
         Self {
             name: &argument.name,
+            data_type: &argument.data_type,
             required: argument.required,
             values: &argument.values,
         }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -1518,6 +1518,10 @@ async fn list_catalog_surfaces_table_functions() {
         "number"
     );
     assert_eq!(
+        catalog["items"][0]["table_function"]["arguments"][0]["data_type"],
+        "Utf8"
+    );
+    assert_eq!(
         catalog["items"][0]["table_function"]["result_columns"][0]["column_name"],
         "title"
     );


### PR DESCRIPTION
It seems it is always UTF-8. So is it even worth doing?

Constraint: Preserve the existing catalog response while adding typed argument metadata for Reef and MCP consumers.
Rejected: Infer argument types in Reef | The runtime catalog already owns canonical manifest and UDF argument types.
Confidence: high
Scope-risk: moderate
Directive: Keep argument type metadata additive and sourced from runtime registration.
Tested: Buf lint; Cargo fmt, Clippy, full workspace tests, and rustdoc.
Not-tested: Ignored Postgres-backed tests.