### PR TITLE
feat(reef): show table function argument types

### DIFF
--- a/apps/reef/app/lib/schema-explorer.test.ts
+++ b/apps/reef/app/lib/schema-explorer.test.ts
@@ -17,6 +17,7 @@ describe('fetchSchemaFromCoral', () => {
             value: {
               arguments: [
                 {
+                  dataType: 'Utf8',
                   name: 'channel',
                   required: true,
                   values: ['general', 'random'],
@@ -62,6 +63,7 @@ describe('fetchSchemaFromCoral', () => {
                 {
                   name: 'channel',
                   required: true,
+                  type: 'Utf8',
                   values: ['general', 'random'],
                 },
               ],

--- a/apps/reef/app/lib/schema-explorer.ts
+++ b/apps/reef/app/lib/schema-explorer.ts
@@ -35,6 +35,7 @@ export interface TableDef {
 export interface TableFunctionArgumentDef {
   name: string
   required: boolean
+  type: string
   values: string[]
 }
 
@@ -103,6 +104,7 @@ export async function fetchSchemaFromCoral(
         arguments: tableFunction.arguments.map((argument) => ({
           name: argument.name,
           required: argument.required,
+          type: argument.dataType || 'unknown',
           values: argument.values,
         })),
         description: optional(tableFunction.description),

--- a/apps/reef/app/views/schema-explorer/schema-table-function.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table-function.test.tsx
@@ -13,8 +13,8 @@ const SCHEMA = {
       items: [
         {
           arguments: [
-            { name: 'channel', required: true, values: ['general', 'random'] },
-            { name: 'cursor', required: false, values: [] },
+            { name: 'channel', required: true, type: 'LargeUtf8', values: ['general', 'random'] },
+            { name: 'cursor', required: false, type: 'Utf8', values: [] },
           ],
           description: 'Lists messages in a channel.',
           kind: 'tableFunction',
@@ -65,6 +65,7 @@ it('shows table-function arguments and result columns from the parent schema res
     .toBeVisible()
   await expect.element(screen.getByText('Lists messages in a channel.')).toBeVisible()
   await expect.element(screen.getByLabelText('Required argument')).toHaveTextContent('*')
+  await expect.element(screen.getByRole('cell', { name: 'LargeUtf8' })).toBeVisible()
   await expect.element(screen.getByRole('cell', { name: 'general, random' })).toBeVisible()
   await expect.element(screen.getByRole('cell', { name: 'Message text.' })).toBeVisible()
 })

--- a/apps/reef/app/views/schema-explorer/schema-table-function.tsx
+++ b/apps/reef/app/views/schema-explorer/schema-table-function.tsx
@@ -52,6 +52,7 @@ export function SchemaTableFunctionView() {
               <Table.Head>
                 <Table.Row>
                   <Table.HeaderCell>name</Table.HeaderCell>
+                  <Table.HeaderCell>type</Table.HeaderCell>
                   <Table.HeaderCell>allowed values</Table.HeaderCell>
                 </Table.Row>
               </Table.Head>
@@ -72,6 +73,7 @@ export function SchemaTableFunctionView() {
                         </Tooltip>
                       ) : null}
                     </Table.Cell>
+                    <Table.Cell mono>{argument.type}</Table.Cell>
                     <Table.Cell mono>
                       {argument.values.length > 0 ? argument.values.join(', ') : '-'}
                     </Table.Cell>

--- a/apps/reef/app/views/schema-explorer/schema.test.tsx
+++ b/apps/reef/app/views/schema-explorer/schema.test.tsx
@@ -21,8 +21,8 @@ const SCHEMA = {
         },
         {
           arguments: [
-            { name: 'channel', required: true, values: [] },
-            { name: 'cursor', required: false, values: [] },
+            { name: 'channel', required: true, type: 'Utf8', values: [] },
+            { name: 'cursor', required: false, type: 'Utf8', values: [] },
           ],
           kind: 'tableFunction',
           name: 'messages',


### PR DESCRIPTION
Constraint: Depend on the additive catalog argument-type field introduced by the parent PR.
Rejected: Guess missing argument types in Reef | Older sidecars may omit the field and explicit types are not always Utf8.
Confidence: high
Scope-risk: narrow
Directive: Keep unknown as the compatibility fallback for pre-type catalog responses.
Tested: Reef formatting, lint, typecheck, browser tests, and production build.
Not-tested: Live Reef session against a freshly rebuilt sidecar.