### PR TITLE
feat(reef): manage functions in Desktop

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -29,7 +29,8 @@
         "react-markdown": "10.1.0",
         "react-router": "7.17.0",
         "react-toastify": "11.1.0",
-        "tinykeys": "4.0.0"
+        "tinykeys": "4.0.0",
+        "yaml": "2.9.0"
       },
       "devDependencies": {
         "@types/node": "^22.19.2",
@@ -8028,6 +8029,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yallist": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -50,7 +50,8 @@
     "react-markdown": "10.1.0",
     "react-router": "7.17.0",
     "react-toastify": "11.1.0",
-    "tinykeys": "4.0.0"
+    "tinykeys": "4.0.0",
+    "yaml": "2.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.19.2",

--- a/apps/reef/app/components/sidebar/sidebar.test.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.test.tsx
@@ -48,6 +48,10 @@ async function renderSidebar(
       },
       {
         element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
+        path: routePattern('workspaceFunctions'),
+      },
+      {
+        element: <Sidebar initialIsMinimized={initialIsMinimized} workspaces={workspaces} />,
         path: routePattern('workspaceTrace'),
       },
       {
@@ -158,6 +162,15 @@ describe('Sidebar', () => {
     await expect
       .element(screen.getByRole('link', { name: 'Schema' }))
       .toHaveAttribute('href', routePath('workspaceSchema', { workspaceId: 'analytics' }))
+  })
+
+  it('keeps function navigation in the active workspace', async () => {
+    const functionsPath = routePath('workspaceFunctions', { workspaceId: 'analytics' })
+    const screen = await renderSidebar(false, functionsPath, WORKSPACES)
+
+    await expect
+      .element(screen.getByRole('link', { name: 'Functions' }))
+      .toHaveAttribute('href', functionsPath)
   })
 
   it('shows the active workspace and lists every local workspace', async () => {

--- a/apps/reef/app/components/sidebar/sidebar.tsx
+++ b/apps/reef/app/components/sidebar/sidebar.tsx
@@ -51,9 +51,13 @@ export function Sidebar({ initialIsMinimized, workspaces }: SidebarProps) {
   const tracesPath = workspaceNavTarget
     ? routePath('workspaceTraces', { workspaceId: workspaceNavTarget.name })
     : routePath('home')
+  const functionsPath = workspaceNavTarget
+    ? routePath('workspaceFunctions', { workspaceId: workspaceNavTarget.name })
+    : routePath('home')
   const workspaceNavItems = [
     { icon: 'Plug', label: 'Sources', paths: [routePath('home'), sourcesPath], to: sourcesPath },
     { icon: 'Database', label: 'Schema', paths: [schemaPath], to: schemaPath },
+    { icon: 'Braces', label: 'Functions', paths: [functionsPath], to: functionsPath },
     { icon: 'Activity', label: 'Traces', paths: [tracesPath], to: tracesPath },
   ] satisfies NavItem[]
   const settingsPath = routePath('settings')

--- a/apps/reef/app/lib/coral-request.server.ts
+++ b/apps/reef/app/lib/coral-request.server.ts
@@ -2,6 +2,7 @@ import { createClient } from '@connectrpc/connect'
 import { createGrpcWebTransport } from '@connectrpc/connect-web'
 
 import { CatalogService } from '@/generated/coral/v1/catalog_pb'
+import { FunctionService } from '@/generated/coral/v1/functions_pb'
 import { QueryService } from '@/generated/coral/v1/query_pb'
 import { SourceService } from '@/generated/coral/v1/sources_pb'
 import { TraceService } from '@/generated/coral/v1/traces_pb'
@@ -12,6 +13,10 @@ import { isLocalDevOrigin, trimTrailingSlash } from './utils'
 
 export function sourceClientForRequest(request: Request) {
   return createClient(SourceService, coralTransportForRequest(request))
+}
+
+export function functionClientForRequest(request: Request) {
+  return createClient(FunctionService, coralTransportForRequest(request))
 }
 
 export function workspaceClientForRequest(request: Request) {

--- a/apps/reef/app/lib/function-artifact.server.test.ts
+++ b/apps/reef/app/lib/function-artifact.server.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatFunctionArtifact, parseFunctionArtifact } from './function-artifact.server'
+
+describe('function artifacts', () => {
+  it('round-trips individual editor fields through YAML frontmatter', () => {
+    const artifact = {
+      description: 'Pull requests:\n  ready for review\n',
+      name: 'retrieve_pull_requests',
+      schema: 'github',
+      sql: 'select * from github.pulls(owner => $owner, repo => $repo)',
+    }
+
+    expect(parseFunctionArtifact(formatFunctionArtifact(artifact))).toEqual(artifact)
+  })
+
+  it('rejects frontmatter values that terminate the SQL comment', () => {
+    expect(() =>
+      formatFunctionArtifact({
+        description: 'Computes */ safely',
+        name: 'unsafe_comment',
+        schema: 'github',
+        sql: 'select 1',
+      }),
+    ).toThrow("description cannot contain '*/'")
+  })
+
+  it('reports malformed frontmatter before opening it in the editor', () => {
+    expect(() => parseFunctionArtifact('/*\nname: [broken\n*/\nselect 1')).toThrow()
+  })
+})

--- a/apps/reef/app/lib/function-artifact.server.ts
+++ b/apps/reef/app/lib/function-artifact.server.ts
@@ -1,0 +1,56 @@
+import { parse, stringify } from 'yaml'
+
+export interface FunctionArtifact {
+  description: string
+  name: string
+  schema: string
+  sql: string
+}
+
+const fields = new Set(['description', 'name', 'schema'])
+
+export function parseFunctionArtifact(raw: string): FunctionArtifact {
+  if (!raw.startsWith('/*')) throw new Error('Function artifact must start with frontmatter')
+
+  const commentEnd = raw.indexOf('*/', 2)
+  if (commentEnd === -1) throw new Error("Function frontmatter must end with '*/'")
+
+  const frontmatter = parse(raw.slice(2, commentEnd))
+  if (!isRecord(frontmatter)) throw new Error('Function frontmatter must be a mapping')
+  const unknownField = Object.keys(frontmatter).find((field) => !fields.has(field))
+  if (unknownField) throw new Error(`Function frontmatter has an unknown field: ${unknownField}`)
+
+  return {
+    description: stringField(frontmatter, 'description', false),
+    name: stringField(frontmatter, 'name', true),
+    schema: stringField(frontmatter, 'schema', true),
+    sql: raw.slice(commentEnd + 2).trim(),
+  }
+}
+
+export function formatFunctionArtifact(artifact: FunctionArtifact): string {
+  if (artifact.description.includes('*/')) {
+    throw new Error("description cannot contain '*/'")
+  }
+  const frontmatter = stringify({
+    name: artifact.name.trim(),
+    schema: artifact.schema.trim(),
+    description: artifact.description,
+  }).trim()
+  return `/*\n${frontmatter}\n*/\n\n${artifact.sql.trim()}`
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function stringField(
+  frontmatter: Record<string, unknown>,
+  field: 'description' | 'name' | 'schema',
+  required: boolean,
+): string {
+  const value = frontmatter[field]
+  if (value === undefined && !required) return ''
+  if (typeof value !== 'string') throw new Error(`Function ${field} must be a string`)
+  return value
+}

--- a/apps/reef/app/lib/workspace-routing.test.ts
+++ b/apps/reef/app/lib/workspace-routing.test.ts
@@ -11,6 +11,7 @@ describe('workspace routing', () => {
     ['/workspaces/default/sources/github', '/workspaces/team%20alpha/sources'],
     ['/workspaces/default/schema', '/workspaces/team%20alpha/schema'],
     ['/workspaces/default/schema/github/issues', '/workspaces/team%20alpha/schema'],
+    ['/workspaces/default/functions', '/workspaces/team%20alpha/functions'],
     ['/workspaces/default/traces/trace-1', '/workspaces/team%20alpha/traces'],
     ['/settings', '/workspaces/team%20alpha/sources'],
   ])('targets the corresponding section for %s', (pathname, expectedPath) => {

--- a/apps/reef/app/lib/workspace-routing.ts
+++ b/apps/reef/app/lib/workspace-routing.ts
@@ -16,6 +16,12 @@ export function workspaceFromParams(params: { workspaceId?: string }): Workspace
 }
 
 export function workspacePathForCurrentSection(workspaceId: string, pathname: string): string {
+  const isFunctionsSection = matchPath(
+    { end: false, path: routePattern('workspaceFunctions') },
+    pathname,
+  )
+  if (isFunctionsSection) return routePath('workspaceFunctions', { workspaceId })
+
   const isSchemaSection = matchPath({ end: false, path: routePattern('workspaceSchema') }, pathname)
   if (isSchemaSection) return routePath('workspaceSchema', { workspaceId })
 

--- a/apps/reef/app/routes.ts
+++ b/apps/reef/app/routes.ts
@@ -20,6 +20,7 @@ export default [
       index('routes/schema-empty.tsx'),
       route(':schemaName/:tableName', 'routes/schema-table.tsx'),
     ]),
+    route(routePattern('workspaceFunctions'), 'routes/functions.tsx'),
     route(routePattern('workspaceTraces'), 'routes/traces.tsx', [
       route(':traceId', 'routes/trace-detail.tsx'),
     ]),

--- a/apps/reef/app/routes/functions.server.test.ts
+++ b/apps/reef/app/routes/functions.server.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { addFunction, deleteFunction, getFunction, listFunctions } = vi.hoisted(() => ({
+  addFunction: vi.fn(),
+  deleteFunction: vi.fn(),
+  getFunction: vi.fn(),
+  listFunctions: vi.fn(),
+}))
+
+vi.mock('@/lib/coral-request.server', () => ({
+  functionClientForRequest: () => ({ addFunction, deleteFunction, getFunction, listFunctions }),
+}))
+
+import { action, loader } from './functions.server'
+
+describe('functions route server boundary', () => {
+  beforeEach(() => {
+    addFunction.mockReset().mockResolvedValue({})
+    deleteFunction.mockReset().mockResolvedValue({})
+    getFunction.mockReset()
+    listFunctions.mockReset().mockResolvedValue({ functions: [] })
+  })
+
+  it('loads function status for the route workspace', async () => {
+    listFunctions.mockResolvedValue({
+      functions: [
+        {
+          name: 'retrieve_pull_requests',
+          runtime: {
+            case: 'ready',
+            value: {
+              arguments: [{ dataType: 'Utf8', name: 'owner' }],
+              description: 'Retrieve pull requests',
+              tableFunction: { schemaName: 'github' },
+            },
+          },
+        },
+      ],
+    })
+
+    const result = await loader({
+      params: { workspaceId: 'analytics' },
+      request: new Request('http://reef.test/workspaces/analytics/functions'),
+    } as never)
+
+    expect(listFunctions).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace: expect.objectContaining({ name: 'analytics' }) }),
+    )
+    expect(result.functions).toEqual([
+      expect.objectContaining({
+        name: 'retrieve_pull_requests',
+        schema: 'github',
+        status: 'ready',
+      }),
+    ])
+  })
+
+  it('serializes editor fields and saves through add-as-upsert', async () => {
+    const request = new Request('http://reef.test/workspaces/analytics/functions?new', {
+      body: new URLSearchParams({
+        _intent: 'save',
+        description: 'Retrieve pull requests',
+        name: 'retrieve_pull_requests',
+        schema: 'github',
+        sql: 'select * from github.pulls(owner => $owner)',
+      }),
+      method: 'POST',
+    })
+
+    const response = await action({ params: { workspaceId: 'analytics' }, request } as never)
+
+    expect(addFunction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sql: expect.stringContaining('name: retrieve_pull_requests'),
+        workspace: expect.objectContaining({ name: 'analytics' }),
+      }),
+    )
+    expect(response).toBeInstanceOf(Response)
+    expect((response as Response).headers.get('location')).toBe('/workspaces/analytics/functions')
+  })
+
+  it('does not let the new-function flow replace an existing function', async () => {
+    addFunction.mockRejectedValue(new Error("function 'existing' already exists"))
+    const request = new Request('http://reef.test/workspaces/analytics/functions?new', {
+      body: new URLSearchParams({
+        _intent: 'save',
+        description: '',
+        name: 'existing',
+        schema: 'github',
+        sql: 'select 1',
+      }),
+      method: 'POST',
+    })
+
+    await expect(
+      action({ params: { workspaceId: 'analytics' }, request } as never),
+    ).resolves.toMatchObject({ message: "function 'existing' already exists", status: 'error' })
+    expect(addFunction).toHaveBeenCalledWith(expect.objectContaining({ failIfExists: true }))
+  })
+
+  it('refuses to edit an artifact whose name drifted from its inventory identity', async () => {
+    getFunction.mockResolvedValue({
+      sql: '/*\nname: other\nschema: github\ndescription: drifted\n*/\n\nselect 1',
+    })
+
+    const result = await loader({
+      params: { workspaceId: 'analytics' },
+      request: new Request('http://reef.test/workspaces/analytics/functions?edit=selected'),
+    } as never)
+
+    expect(result.editor).toMatchObject({
+      artifact: { name: 'selected' },
+      loadError: expect.stringContaining("declares 'other'"),
+      mode: 'edit',
+    })
+  })
+
+  it('rejects renaming an existing function before calling Coral', async () => {
+    const request = new Request('http://reef.test/workspaces/analytics/functions?edit=old_name', {
+      body: new URLSearchParams({
+        _intent: 'save',
+        description: '',
+        name: 'new_name',
+        originalName: 'old_name',
+        schema: 'github',
+        sql: 'select 1',
+      }),
+      method: 'POST',
+    })
+
+    await expect(
+      action({ params: { workspaceId: 'analytics' }, request } as never),
+    ).resolves.toMatchObject({
+      status: 'error',
+      message: expect.stringContaining('cannot be changed'),
+    })
+    expect(addFunction).not.toHaveBeenCalled()
+  })
+
+  it('deletes from the route workspace', async () => {
+    const request = new Request('http://reef.test/workspaces/analytics/functions?delete=test', {
+      body: new URLSearchParams({ _intent: 'delete', name: 'test' }),
+      method: 'POST',
+    })
+
+    await action({ params: { workspaceId: 'analytics' }, request } as never)
+
+    expect(deleteFunction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'test',
+        workspace: expect.objectContaining({ name: 'analytics' }),
+      }),
+    )
+  })
+})

--- a/apps/reef/app/routes/functions.server.ts
+++ b/apps/reef/app/routes/functions.server.ts
@@ -1,0 +1,196 @@
+import { create } from '@bufbuild/protobuf'
+import { redirect } from 'react-router'
+
+import type { Route } from './+types/functions'
+
+import {
+  AddFunctionRequestSchema,
+  DeleteFunctionRequestSchema,
+  GetFunctionRequestSchema,
+  ListFunctionsRequestSchema,
+} from '@/generated/coral/v1/functions_pb'
+import {
+  formatFunctionArtifact,
+  parseFunctionArtifact,
+  type FunctionArtifact,
+} from '@/lib/function-artifact.server'
+import { functionClientForRequest } from '@/lib/coral-request.server'
+import { errorMessage } from '@/lib/utils'
+import { workspaceFromParams } from '@/lib/workspace-routing'
+import { routePath } from '@/routing/routemap'
+
+export interface FunctionSummary {
+  arguments: { dataType: string; name: string }[]
+  description: string
+  error: string | null
+  name: string
+  schema: string | null
+  status: 'invalid' | 'ready'
+}
+
+export type FunctionEditor =
+  | { artifact: FunctionArtifact; loadError: string | null; mode: 'edit' | 'new' }
+  | { mode: 'delete'; name: string }
+  | null
+
+export interface FunctionsRouteData {
+  editor: FunctionEditor
+  functions: FunctionSummary[]
+  loadError: string | null
+}
+
+export type FunctionsActionData =
+  | { intent: 'delete' | 'save'; message: string; status: 'error' }
+  | undefined
+
+export async function loader({ params, request }: Route.LoaderArgs): Promise<FunctionsRouteData> {
+  const workspace = workspaceFromParams(params)
+  const client = functionClientForRequest(request)
+  const url = new URL(request.url)
+
+  let functions: FunctionSummary[] = []
+  let loadError: string | null = null
+  try {
+    const response = await client.listFunctions(create(ListFunctionsRequestSchema, { workspace }))
+    functions = response.functions.map(summarizeFunction)
+  } catch (error) {
+    loadError = errorMessage(error)
+  }
+
+  const editName = url.searchParams.get('edit')
+  if (editName) {
+    try {
+      const response = await client.getFunction(
+        create(GetFunctionRequestSchema, { name: editName, workspace }),
+      )
+      const artifact = parseFunctionArtifact(response.sql)
+      if (artifact.name !== editName) {
+        throw new Error(
+          `Function artifact declares '${artifact.name}' but inventory entry is '${editName}'`,
+        )
+      }
+      return {
+        editor: { artifact, loadError: null, mode: 'edit' },
+        functions,
+        loadError,
+      }
+    } catch (error) {
+      return {
+        editor: {
+          artifact: { description: '', name: editName, schema: '', sql: '' },
+          loadError: errorMessage(error),
+          mode: 'edit',
+        },
+        functions,
+        loadError,
+      }
+    }
+  }
+
+  const deleteName = url.searchParams.get('delete')
+  if (deleteName) return { editor: { mode: 'delete', name: deleteName }, functions, loadError }
+
+  const editor = url.searchParams.has('new')
+    ? {
+        artifact: { description: '', name: '', schema: '', sql: '' },
+        loadError: null,
+        mode: 'new' as const,
+      }
+    : null
+  return { editor, functions, loadError }
+}
+
+export async function action({ params, request }: Route.ActionArgs) {
+  const workspace = workspaceFromParams(params)
+  const formData = await request.formData()
+  const intent = formValue(formData, '_intent')
+  const path = routePath('workspaceFunctions', { workspaceId: workspace.name })
+
+  try {
+    if (intent === 'delete') {
+      const name = requiredFormValue(formData, 'name')
+      await functionClientForRequest(request).deleteFunction(
+        create(DeleteFunctionRequestSchema, { name, workspace }),
+      )
+      return redirect(path)
+    }
+    if (intent !== 'save') return actionError('save', 'Unknown function action')
+
+    const artifact = artifactFromForm(formData)
+    const originalName = formValue(formData, 'originalName')
+    if (originalName && originalName !== artifact.name) {
+      return actionError('save', 'Function names cannot be changed after creation')
+    }
+    await functionClientForRequest(request).addFunction(
+      create(AddFunctionRequestSchema, {
+        failIfExists: !originalName,
+        sql: formatFunctionArtifact(artifact),
+        workspace,
+      }),
+    )
+    return redirect(path)
+  } catch (error) {
+    return actionError(intent === 'delete' ? 'delete' : 'save', errorMessage(error))
+  }
+}
+
+function summarizeFunction(fn: {
+  name: string
+  runtime: {
+    case: 'invalid' | 'ready' | undefined
+    value?: {
+      arguments?: { dataType: string; name: string }[]
+      description?: string
+      reason?: string
+      tableFunction?: { schemaName: string }
+    }
+  }
+}): FunctionSummary {
+  if (fn.runtime.case === 'ready') {
+    const ready = fn.runtime.value
+    return {
+      arguments: ready?.arguments ?? [],
+      description: ready?.description ?? '',
+      error: null,
+      name: fn.name,
+      schema: ready?.tableFunction?.schemaName ?? null,
+      status: 'ready',
+    }
+  }
+  return {
+    arguments: [],
+    description: '',
+    error: fn.runtime.case === 'invalid' ? (fn.runtime.value?.reason ?? 'Validation failed') : null,
+    name: fn.name,
+    schema: null,
+    status: 'invalid',
+  }
+}
+
+function artifactFromForm(formData: FormData): FunctionArtifact {
+  return {
+    description: rawFormValue(formData, 'description'),
+    name: requiredFormValue(formData, 'name'),
+    schema: requiredFormValue(formData, 'schema'),
+    sql: requiredFormValue(formData, 'sql'),
+  }
+}
+
+function formValue(formData: FormData, key: string): string {
+  return rawFormValue(formData, key).trim()
+}
+
+function rawFormValue(formData: FormData, key: string): string {
+  const value = formData.get(key)
+  return typeof value === 'string' ? value : ''
+}
+
+function requiredFormValue(formData: FormData, key: string): string {
+  const value = formValue(formData, key)
+  if (!value) throw new Error(`${key === 'sql' ? 'SQL' : key} is required`)
+  return value
+}
+
+function actionError(intent: 'delete' | 'save', message: string): FunctionsActionData {
+  return { intent, message, status: 'error' }
+}

--- a/apps/reef/app/routes/functions.tsx
+++ b/apps/reef/app/routes/functions.tsx
@@ -1,0 +1,17 @@
+import type { Route } from './+types/functions'
+
+import { FunctionsIndex } from '@/views/functions/functions-index'
+
+export { action, loader } from './functions.server'
+
+export default function FunctionsRoute({ actionData, loaderData, params }: Route.ComponentProps) {
+  return (
+    <FunctionsIndex
+      actionData={actionData}
+      editor={loaderData.editor}
+      functions={loaderData.functions}
+      loadError={loaderData.loadError}
+      workspaceId={params.workspaceId}
+    />
+  )
+}

--- a/apps/reef/app/routing/routemap.test.ts
+++ b/apps/reef/app/routing/routemap.test.ts
@@ -7,6 +7,7 @@ const CANONICAL_PATTERNS = {
   home: '/',
   settings: '/settings',
   workspaces: '/workspaces',
+  workspaceFunctions: '/workspaces/:workspaceId/functions',
   workspaceSchema: '/workspaces/:workspaceId/schema',
   workspaceSchemaTable: '/workspaces/:workspaceId/schema/:schemaName/:tableName',
   workspaceSource: '/workspaces/:workspaceId/sources/:sourceName',
@@ -36,6 +37,7 @@ describe('route map', () => {
       home: routePath('home'),
       settings: routePath('settings'),
       workspaces: routePath('workspaces'),
+      workspaceFunctions: routePath('workspaceFunctions', { workspaceId: 'analytics' }),
       workspaceSchema: routePath('workspaceSchema', { workspaceId: 'analytics' }),
       workspaceSchemaTable: routePath('workspaceSchemaTable', {
         schemaName: 'github',
@@ -62,6 +64,7 @@ describe('route map', () => {
       home: '/',
       settings: '/settings',
       workspaces: '/workspaces',
+      workspaceFunctions: '/workspaces/analytics/functions',
       workspaceSchema: '/workspaces/analytics/schema',
       workspaceSchemaTable: '/workspaces/analytics/schema/github/issues',
       workspaceSource: '/workspaces/analytics/sources/github',

--- a/apps/reef/app/routing/routemap.ts
+++ b/apps/reef/app/routing/routemap.ts
@@ -5,6 +5,7 @@ const HOME_PATH = '/'
 const WORKSPACES_PATH = '/workspaces'
 const WORKSPACE_SCHEMA_PATH = '/workspaces/:workspaceId/schema'
 const WORKSPACE_SCHEMA_TABLE_PATH = '/workspaces/:workspaceId/schema/:schemaName/:tableName'
+const WORKSPACE_FUNCTIONS_PATH = '/workspaces/:workspaceId/functions'
 const WORKSPACE_SOURCE_DISCOVERY_PATH = '/workspaces/:workspaceId/sources/discover'
 const WORKSPACE_SOURCE_INSTALL_PATH = '/workspaces/:workspaceId/sources/install'
 const WORKSPACE_SOURCES_PATH = '/workspaces/:workspaceId/sources'
@@ -25,6 +26,13 @@ export const routeDefinitions = {
   workspaces: {
     path: WORKSPACES_PATH,
     toPath: () => WORKSPACES_PATH,
+  },
+  workspaceFunctions: {
+    path: WORKSPACE_FUNCTIONS_PATH,
+    toPath: (params: { workspaceId: string }) =>
+      generatePath(WORKSPACE_FUNCTIONS_PATH, {
+        workspaceId: params.workspaceId,
+      }),
   },
   workspaceSchema: {
     path: WORKSPACE_SCHEMA_PATH,

--- a/apps/reef/app/views/functions/functions-index.css.ts
+++ b/apps/reef/app/views/functions/functions-index.css.ts
@@ -1,0 +1,206 @@
+import { globalStyle, style } from '@vanilla-extract/css'
+
+import { breakpoints, fontFamily } from '@/styles/theme.css'
+import { lightTheme } from '@/wax/theme/theme-light.css'
+import { theme } from '@/wax/theme/theme.css'
+
+export const root = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  minHeight: 0,
+  overflow: 'hidden',
+})
+
+export const header = style({
+  alignItems: 'center',
+  boxSizing: 'border-box',
+  display: 'flex',
+  flexShrink: 0,
+  gap: 24,
+  justifyContent: 'space-between',
+  marginInline: 'auto',
+  maxWidth: 960,
+  paddingBlock: 24,
+  paddingInline: 32,
+  width: '100%',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      alignItems: 'flex-start',
+      paddingBlock: 20,
+      paddingInline: 16,
+    },
+  },
+})
+
+export const headerText = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  minWidth: 0,
+})
+
+export const statusPanel = style({
+  boxSizing: 'border-box',
+  flexShrink: 0,
+  marginInline: 'auto',
+  maxWidth: 960,
+  paddingBlock: 16,
+  paddingInline: 32,
+  width: '100%',
+})
+
+export const scroll = style({ flex: 1, minHeight: 0 })
+
+export const content = style({
+  boxSizing: 'border-box',
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  marginInline: 'auto',
+  maxWidth: 960,
+  minHeight: '100%',
+  paddingBlock: 32,
+  paddingInline: 32,
+  width: '100%',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: {
+      paddingBlock: 24,
+      paddingInline: 16,
+    },
+  },
+})
+
+export const list = style({ display: 'flex', flexDirection: 'column', gap: 12 })
+
+export const functionRow = style({
+  alignItems: 'center',
+  background: theme.surface.card,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 10,
+  display: 'flex',
+  gap: 14,
+  padding: 16,
+})
+
+export const functionIcon = style({
+  alignItems: 'center',
+  background: theme.surface.onMainContent,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 8,
+  display: 'flex',
+  flex: '0 0 38px',
+  height: 38,
+  justifyContent: 'center',
+})
+
+export const functionDetails = style({
+  display: 'flex',
+  flex: '1 1 auto',
+  flexDirection: 'column',
+  gap: 5,
+  minWidth: 0,
+})
+
+export const functionTitle = style({ alignItems: 'center', display: 'flex', gap: 8 })
+
+export const signature = style({
+  color: theme.content.secondary,
+  fontFamily: fontFamily.code,
+  fontSize: 12,
+  lineHeight: '18px',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+
+export const actions = style({ alignItems: 'center', display: 'flex', flexShrink: 0, gap: 4 })
+
+export const form = style({ display: 'flex', flexDirection: 'column', gap: 18, paddingTop: 20 })
+
+export const fieldsRow = style({
+  display: 'grid',
+  gap: 16,
+  gridTemplateColumns: '1fr 1fr',
+  '@media': {
+    [`screen and (max-width: ${breakpoints.mobile})`]: { gridTemplateColumns: '1fr' },
+  },
+})
+
+export const field = style({ display: 'flex', flexDirection: 'column', gap: 7 })
+
+const textarea = style({
+  background: theme.surface.onMainContent,
+  border: `1px solid ${theme.input.stroke.default}`,
+  borderRadius: 8,
+  boxSizing: 'border-box',
+  color: theme.content.primary,
+  fontFamily: fontFamily.code,
+  fontSize: 13,
+  lineHeight: '20px',
+  outline: 'none',
+  padding: 12,
+  resize: 'vertical',
+  width: '100%',
+  selectors: {
+    '&:focus': {
+      borderColor: theme.input.stroke.focus,
+      boxShadow: `0 0 0 1px ${theme.stroke.focused}`,
+    },
+    '&::placeholder': { color: theme.content.placeholder },
+  },
+})
+
+export const descriptionEditor = style([textarea, { minHeight: 72 }])
+
+export const sqlEditorShell = style({
+  background: theme.surface.onMainContent,
+  borderRadius: 8,
+  position: 'relative',
+})
+
+export const sqlHighlight = style({
+  bottom: 1,
+  boxSizing: 'border-box',
+  color: theme.content.primary,
+  fontFamily: fontFamily.code,
+  fontSize: 13,
+  left: 1,
+  lineHeight: '20px',
+  margin: 0,
+  overflow: 'hidden',
+  padding: 12,
+  pointerEvents: 'none',
+  position: 'absolute',
+  right: 1,
+  top: 1,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+})
+
+export const sqlEditor = style([
+  textarea,
+  {
+    background: 'transparent',
+    caretColor: theme.content.primary,
+    color: 'transparent',
+    minHeight: 220,
+    position: 'relative',
+    selectors: {
+      '&::selection': { background: 'rgba(86, 156, 214, 0.28)' },
+    },
+  },
+])
+
+globalStyle(`${sqlHighlight} .sql-keyword`, { color: '#569CD6', fontWeight: 600 })
+globalStyle(`body.${lightTheme} ${sqlHighlight} .sql-keyword`, { color: '#0000FF' })
+globalStyle(`${sqlHighlight} .sql-function`, { color: '#4EC9B0' })
+globalStyle(`body.${lightTheme} ${sqlHighlight} .sql-function`, { color: '#795E26' })
+globalStyle(`${sqlHighlight} .sql-string`, { color: '#CE9178' })
+globalStyle(`body.${lightTheme} ${sqlHighlight} .sql-string`, { color: '#A31515' })
+globalStyle(`${sqlHighlight} .sql-number`, { color: '#CE9178' })
+globalStyle(`body.${lightTheme} ${sqlHighlight} .sql-number`, { color: '#098658' })
+globalStyle(`${sqlHighlight} .sql-comment`, { color: '#6A9955', fontStyle: 'italic' })
+globalStyle(`body.${lightTheme} ${sqlHighlight} .sql-comment`, { color: '#008000' })
+globalStyle(`${sqlHighlight} .sql-identifier`, { color: '#9CDCFE' })
+globalStyle(`body.${lightTheme} ${sqlHighlight} .sql-identifier`, { color: '#001080' })

--- a/apps/reef/app/views/functions/functions-index.test.tsx
+++ b/apps/reef/app/views/functions/functions-index.test.tsx
@@ -1,0 +1,77 @@
+import { createMemoryRouter, RouterProvider } from 'react-router'
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+
+import { FunctionsIndex } from './functions-index'
+
+describe('FunctionsIndex', () => {
+  it('renders Desktop-style status and workspace-scoped actions', async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          element: (
+            <FunctionsIndex
+              actionData={undefined}
+              editor={null}
+              functions={[
+                {
+                  arguments: [{ dataType: 'Utf8', name: 'owner' }],
+                  description: 'Retrieve pull requests',
+                  error: null,
+                  name: 'retrieve_pull_requests',
+                  schema: 'github',
+                  status: 'ready',
+                },
+              ]}
+              loadError={null}
+              workspaceId="team alpha"
+            />
+          ),
+          path: '/',
+        },
+      ],
+      { initialEntries: ['/'] },
+    )
+    const screen = await render(<RouterProvider router={router} />)
+
+    await expect
+      .element(screen.getByText('github.retrieve_pull_requests(owner: Utf8)'))
+      .toBeVisible()
+    await expect.element(screen.getByText('Ready')).toBeVisible()
+    await expect
+      .element(screen.getByRole('link', { name: 'Edit retrieve_pull_requests' }))
+      .toHaveAttribute('href', '/workspaces/team%20alpha/functions?edit=retrieve_pull_requests')
+  })
+
+  it('highlights SQL while keeping the textarea editable', async () => {
+    const router = createMemoryRouter([
+      {
+        element: (
+          <FunctionsIndex
+            actionData={undefined}
+            editor={{
+              artifact: { description: '', name: '', schema: '', sql: 'select 1' },
+              loadError: null,
+              mode: 'new',
+            }}
+            functions={[]}
+            loadError={null}
+            workspaceId="default"
+          />
+        ),
+        path: '/',
+      },
+    ])
+    const screen = await render(<RouterProvider router={router} />)
+
+    const sql = screen.getByRole('textbox', { name: 'SQL' })
+    await expect.element(sql).toHaveValue('select 1')
+    expect(document.querySelector('.sql-keyword')?.textContent).toBe('select')
+    expect(document.querySelector('.sql-number')?.textContent).toBe('1')
+
+    await sql.fill('select count(*) from github.issues where number = 42')
+    await expect.element(sql).toHaveValue('select count(*) from github.issues where number = 42')
+    expect(document.querySelector('.sql-function')?.textContent).toBe('count')
+    expect(document.querySelector('.sql-number')?.textContent).toBe('42')
+  })
+})

--- a/apps/reef/app/views/functions/functions-index.tsx
+++ b/apps/reef/app/views/functions/functions-index.tsx
@@ -1,0 +1,334 @@
+import { useRef, useState } from 'react'
+import { Form, Link, useNavigate, useNavigation, useRevalidator } from 'react-router'
+
+import { Button, Dialog, Inputs, ScrollArea, Typography } from '@/wax/components'
+import { Icon } from '@/wax/components/icon'
+import { Pill } from '@/wax/components/pill'
+
+import { EmptyPage } from '@/components/empty-page'
+import { ErrorBanner } from '@/components/error-banner'
+import { highlightSQL } from '@/lib/sql-highlight'
+import type {
+  FunctionEditor,
+  FunctionsActionData,
+  FunctionSummary,
+} from '@/routes/functions.server'
+import { routePath } from '@/routing/routemap'
+
+import * as styles from './functions-index.css'
+
+export function FunctionsIndex({
+  actionData,
+  editor,
+  functions,
+  loadError,
+  workspaceId,
+}: {
+  actionData: FunctionsActionData
+  editor: FunctionEditor
+  functions: FunctionSummary[]
+  loadError: string | null
+  workspaceId: string
+}) {
+  const navigate = useNavigate()
+  const revalidator = useRevalidator()
+  const functionsPath = routePath('workspaceFunctions', { workspaceId })
+
+  return (
+    <section aria-label="Coral functions" className={styles.root}>
+      <div className={styles.header}>
+        <div className={styles.headerText}>
+          <Typography.HeadingLarge as="h1">Functions</Typography.HeadingLarge>
+          <Typography.Body variant="secondary">
+            Turn reusable SQL into table functions that agents and queries can call.
+          </Typography.Body>
+        </div>
+        <Button.Container as={Link} to={`${functionsPath}?new`}>
+          <Button.Icon name="Plus" />
+          <Button.Text>New function</Button.Text>
+        </Button.Container>
+      </div>
+
+      {loadError ? (
+        <div className={styles.statusPanel}>
+          <ErrorBanner
+            message={loadError}
+            onRetry={() => revalidator.revalidate()}
+            title="Couldn't load functions"
+          />
+        </div>
+      ) : null}
+
+      <ScrollArea.Container className={styles.scroll} constrainWidth fillContent>
+        <div className={styles.content}>
+          {!loadError && functions.length === 0 ? (
+            <EmptyPage
+              action={
+                <Button.Container as={Link} size="32" to={`${functionsPath}?new`}>
+                  <Button.Icon name="Plus" />
+                  <Button.Text>New function</Button.Text>
+                </Button.Container>
+              }
+              description="Create reusable, parameterized SQL for your workspace."
+              iconName="Braces"
+              title="No functions yet"
+            />
+          ) : null}
+          {functions.length > 0 ? (
+            <div className={styles.list}>
+              {functions.map((fn) => (
+                <FunctionRow fn={fn} functionsPath={functionsPath} key={fn.name} />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </ScrollArea.Container>
+
+      {editor?.mode === 'delete' ? (
+        <DeleteFunctionDialog
+          actionData={actionData}
+          name={editor.name}
+          onClose={() => navigate(functionsPath)}
+        />
+      ) : editor ? (
+        <FunctionEditorDialog
+          actionData={actionData}
+          editor={editor}
+          key={`${editor.mode}:${editor.artifact.name}`}
+          onClose={() => navigate(functionsPath)}
+        />
+      ) : null}
+    </section>
+  )
+}
+
+function FunctionRow({ fn, functionsPath }: { fn: FunctionSummary; functionsPath: string }) {
+  const signature = `${fn.schema ? `${fn.schema}.` : ''}${fn.name}(${fn.arguments
+    .map((argument) => `${argument.name}: ${argument.dataType}`)
+    .join(', ')})`
+
+  return (
+    <article className={styles.functionRow}>
+      <div className={styles.functionIcon}>
+        <Icon color="secondary" name="Braces" size="20" />
+      </div>
+      <div className={styles.functionDetails}>
+        <div className={styles.functionTitle}>
+          <Typography.BodyStrong>{fn.name}</Typography.BodyStrong>
+          <Pill color={fn.status === 'ready' ? 'green' : 'red'}>
+            {fn.status === 'ready' ? 'Ready' : 'Invalid'}
+          </Pill>
+        </div>
+        <code className={styles.signature}>{signature}</code>
+        <Typography.BodySmall variant={fn.error ? 'error' : 'secondary'}>
+          {fn.error || fn.description || 'No description'}
+        </Typography.BodySmall>
+      </div>
+      <div className={styles.actions}>
+        <Button.Container
+          ariaLabel={`Edit ${fn.name}`}
+          as={Link}
+          size="32"
+          to={`${functionsPath}?edit=${encodeURIComponent(fn.name)}`}
+          variant="secondary"
+        >
+          <Button.Icon name="Pencil" />
+        </Button.Container>
+        <Button.Container
+          ariaLabel={`Delete ${fn.name}`}
+          as={Link}
+          size="32"
+          to={`${functionsPath}?delete=${encodeURIComponent(fn.name)}`}
+          variant="bare"
+        >
+          <Button.Icon name="Trash2" />
+        </Button.Container>
+      </div>
+    </article>
+  )
+}
+
+function FunctionEditorDialog({
+  actionData,
+  editor,
+  onClose,
+}: {
+  actionData: FunctionsActionData
+  editor: Extract<FunctionEditor, { mode: 'edit' | 'new' }>
+  onClose: () => void
+}) {
+  const navigation = useNavigation()
+  const [artifact, setArtifact] = useState(editor.artifact)
+  const saving = navigation.state !== 'idle' && navigation.formData?.get('_intent') === 'save'
+  const error = editor.loadError || (actionData?.intent === 'save' ? actionData.message : null)
+
+  return (
+    <Dialog.Root onOpenChange={(open) => !open && onClose()} open>
+      <Dialog.Portal>
+        <Dialog.Backdrop />
+        <Dialog.Popup size="xl">
+          <Dialog.Title>
+            {editor.mode === 'new' ? 'New function' : `Edit ${artifact.name}`}
+          </Dialog.Title>
+          <Dialog.Description>
+            Define the SQL namespace, description, and query body. Coral infers parameters from the
+            SQL when it validates the function.
+          </Dialog.Description>
+          <Dialog.Close />
+          <Form className={styles.form} method="post">
+            <input name="_intent" type="hidden" value="save" />
+            {editor.mode === 'edit' ? (
+              <input name="originalName" type="hidden" value={editor.artifact.name} />
+            ) : null}
+            <div className={styles.fieldsRow}>
+              <FunctionField label="Name">
+                <Inputs.TextInput
+                  autoFocus={editor.mode === 'new'}
+                  name="name"
+                  onChange={(name) => setArtifact((value) => ({ ...value, name }))}
+                  placeholder="retrieve_pull_requests"
+                  readOnly={editor.mode === 'edit'}
+                  value={artifact.name}
+                />
+              </FunctionField>
+              <FunctionField label="Schema">
+                <Inputs.TextInput
+                  name="schema"
+                  onChange={(schema) => setArtifact((value) => ({ ...value, schema }))}
+                  placeholder="github"
+                  value={artifact.schema}
+                />
+              </FunctionField>
+            </div>
+            <FunctionField label="Description">
+              <textarea
+                aria-label="Description"
+                className={styles.descriptionEditor}
+                name="description"
+                onChange={(event) =>
+                  setArtifact((value) => ({ ...value, description: event.target.value }))
+                }
+                placeholder="Retrieve pull requests from a GitHub repository"
+                value={artifact.description}
+              />
+            </FunctionField>
+            <FunctionField label="SQL">
+              <SqlEditor
+                onChange={(sql) => setArtifact((value) => ({ ...value, sql }))}
+                value={artifact.sql}
+              />
+            </FunctionField>
+            {error ? (
+              <Typography.BodySmall as="p" role="alert" variant="error">
+                {error}
+              </Typography.BodySmall>
+            ) : null}
+            <Dialog.Actions>
+              <Button.TextButton
+                disabled={saving}
+                onClick={onClose}
+                type="button"
+                variant="secondary"
+              >
+                Cancel
+              </Button.TextButton>
+              <Button.TextButton disabled={saving || Boolean(editor.loadError)} type="submit">
+                {saving ? 'Saving…' : editor.mode === 'new' ? 'Create function' : 'Save changes'}
+              </Button.TextButton>
+            </Dialog.Actions>
+          </Form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function SqlEditor({ onChange, value }: { onChange: (value: string) => void; value: string }) {
+  const highlight = useRef<HTMLPreElement>(null)
+
+  return (
+    <div className={styles.sqlEditorShell}>
+      <pre
+        aria-hidden
+        className={styles.sqlHighlight}
+        dangerouslySetInnerHTML={{ __html: highlightSQL(`${value}\n`) }}
+        ref={highlight}
+      />
+      <textarea
+        aria-label="SQL"
+        className={styles.sqlEditor}
+        name="sql"
+        onChange={(event) => onChange(event.target.value)}
+        onScroll={(event) => {
+          if (!highlight.current) return
+          highlight.current.scrollTop = event.currentTarget.scrollTop
+          highlight.current.scrollLeft = event.currentTarget.scrollLeft
+        }}
+        placeholder={
+          'select number, title, html_url\nfrom github.pulls(owner => $owner, repo => $repo)'
+        }
+        spellCheck={false}
+        value={value}
+      />
+    </div>
+  )
+}
+
+function DeleteFunctionDialog({
+  actionData,
+  name,
+  onClose,
+}: {
+  actionData: FunctionsActionData
+  name: string
+  onClose: () => void
+}) {
+  const navigation = useNavigation()
+  const deleting = navigation.state !== 'idle' && navigation.formData?.get('_intent') === 'delete'
+  const error = actionData?.intent === 'delete' ? actionData.message : null
+
+  return (
+    <Dialog.Root onOpenChange={(open) => !open && onClose()} open>
+      <Dialog.Portal>
+        <Dialog.Backdrop />
+        <Dialog.Popup size="m">
+          <Form method="post">
+            <input name="_intent" type="hidden" value="delete" />
+            <input name="name" type="hidden" value={name} />
+            <Dialog.Title>Delete {name}?</Dialog.Title>
+            <Dialog.Description>
+              This removes the function from this workspace. Queries that call it will stop working.
+            </Dialog.Description>
+            {error ? (
+              <Typography.BodySmall as="p" role="alert" variant="error">
+                {error}
+              </Typography.BodySmall>
+            ) : null}
+            <Dialog.Actions>
+              <Button.TextButton
+                disabled={deleting}
+                onClick={onClose}
+                type="button"
+                variant="secondary"
+              >
+                Cancel
+              </Button.TextButton>
+              <Button.TextButton disabled={deleting} type="submit" variant="destructive">
+                {deleting ? 'Deleting…' : 'Delete function'}
+              </Button.TextButton>
+            </Dialog.Actions>
+          </Form>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function FunctionField({ children, label }: { children: React.ReactNode; label: string }) {
+  return (
+    <label className={styles.field}>
+      <Typography.BodySmallStrong>{label}</Typography.BodySmallStrong>
+      {children}
+    </label>
+  )
+}

--- a/apps/reef/buf.gen.yaml
+++ b/apps/reef/buf.gen.yaml
@@ -10,6 +10,7 @@ inputs:
     paths:
       - ../../crates/coral-api/proto/coral/v1/resources.proto
       - ../../crates/coral-api/proto/coral/v1/catalog.proto
+      - ../../crates/coral-api/proto/coral/v1/functions.proto
       - ../../crates/coral-api/proto/coral/v1/query.proto
       - ../../crates/coral-api/proto/coral/v1/sources.proto
       - ../../crates/coral-api/proto/coral/v1/traces.proto

--- a/apps/reef/package-lock.json
+++ b/apps/reef/package-lock.json
@@ -25,7 +25,8 @@
         "react-markdown": "^10.1.0",
         "react-router": "7.17.0",
         "react-toastify": "^11.1.0",
-        "tinykeys": "^4.0.0"
+        "tinykeys": "^4.0.0",
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@babel/core": "^7.29.7",
@@ -10045,6 +10046,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yallist": {

--- a/apps/reef/package.json
+++ b/apps/reef/package.json
@@ -39,7 +39,8 @@
     "react-markdown": "^10.1.0",
     "react-router": "7.17.0",
     "react-toastify": "^11.1.0",
-    "tinykeys": "^4.0.0"
+    "tinykeys": "^4.0.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/crates/coral-api/proto/coral/v1/functions.proto
+++ b/crates/coral-api/proto/coral/v1/functions.proto
@@ -64,12 +64,29 @@ message AddFunctionRequest {
   Workspace workspace = 1;
   // Raw function SQL artifact, including SQL comment frontmatter.
   string sql = 2;
+  // Reject the install if a function with the authored name already exists.
+  // The default remains replace-on-name-match for existing callers.
+  bool fail_if_exists = 3;
 }
 
 // Function install response.
 message AddFunctionResponse {
   // Installed runtime-ready function.
   Function function = 1;
+}
+
+// Reads one installed function's authored SQL artifact.
+message GetFunctionRequest {
+  // Workspace that owns the function.
+  Workspace workspace = 1;
+  // Stable function name.
+  string name = 2;
+}
+
+// Authored SQL for one installed function.
+message GetFunctionResponse {
+  // Raw function SQL artifact, including SQL comment frontmatter.
+  string sql = 1;
 }
 
 // Lists installed functions and their current runtime status in one workspace.
@@ -100,6 +117,8 @@ message DeleteFunctionResponse {}
 service FunctionService {
   // Installs or replaces one user function.
   rpc AddFunction(AddFunctionRequest) returns (AddFunctionResponse);
+  // Reads one installed function's authored SQL artifact.
+  rpc GetFunction(GetFunctionRequest) returns (GetFunctionResponse);
   // Lists installed functions and their current runtime status.
   rpc ListFunctions(ListFunctionsRequest) returns (ListFunctionsResponse);
   // Deletes one user function.

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -24,6 +24,9 @@ pub enum AppError {
     /// A requested function was not found in config.
     #[error("function '{0}' not found")]
     FunctionNotFound(String),
+    /// A requested function already exists in config.
+    #[error("function '{0}' already exists")]
+    FunctionAlreadyExists(String),
     /// A requested workspace was not found in config.
     #[error("workspace '{0}' not found")]
     WorkspaceNotFound(String),
@@ -294,7 +297,9 @@ fn app_code(error: &AppError) -> Code {
         AppError::SourceNotFound(_)
         | AppError::FunctionNotFound(_)
         | AppError::WorkspaceNotFound(_) => Code::NotFound,
-        AppError::WorkspaceAlreadyExists(_) => Code::AlreadyExists,
+        AppError::FunctionAlreadyExists(_) | AppError::WorkspaceAlreadyExists(_) => {
+            Code::AlreadyExists
+        }
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
         | AppError::MissingSourceInputs { .. }

--- a/crates/coral-app/src/functions/manager.rs
+++ b/crates/coral-app/src/functions/manager.rs
@@ -90,7 +90,7 @@ impl FunctionManager {
         runtime_function: &UdfRuntimeDefinition,
     ) -> Result<InstalledFunction, AppError> {
         let function_name = validated_function_name(raw_sql, runtime_function)?;
-        self.install_user_function_artifact(workspace_name, &function_name, raw_sql)
+        self.install_user_function_artifact(workspace_name, &function_name, raw_sql, false)
     }
 
     pub(crate) fn install_validated_user_function_if_unchanged(
@@ -99,6 +99,7 @@ impl FunctionManager {
         raw_sql: &str,
         runtime_function: &UdfRuntimeDefinition,
         revision: WorkspaceLifecycleRevision,
+        fail_if_exists: bool,
     ) -> Result<ValidatedFunctionInstall, AppError> {
         let function_name = validated_function_name(raw_sql, runtime_function)?;
         let Some(_lifecycle_guard) = self.lifecycle_lock.lock_if_unchanged(revision) else {
@@ -108,6 +109,7 @@ impl FunctionManager {
             workspace_name,
             &function_name,
             raw_sql,
+            fail_if_exists,
         )?;
         Ok(ValidatedFunctionInstall::Installed)
     }
@@ -118,12 +120,14 @@ impl FunctionManager {
         workspace_name: &WorkspaceName,
         function_name: &FunctionName,
         raw_sql: &str,
+        fail_if_exists: bool,
     ) -> Result<InstalledFunction, AppError> {
         let _lifecycle_guard = self.lifecycle_lock.lock();
         self.install_user_function_artifact_with_lifecycle_lock(
             workspace_name,
             function_name,
             raw_sql,
+            fail_if_exists,
         )
     }
 
@@ -132,8 +136,21 @@ impl FunctionManager {
         workspace_name: &WorkspaceName,
         function_name: &FunctionName,
         raw_sql: &str,
+        fail_if_exists: bool,
     ) -> Result<InstalledFunction, AppError> {
         let _state_lock = self.config_store.state_lock_exclusive()?;
+        if fail_if_exists {
+            match self
+                .config_store
+                .get_function_unlocked(workspace_name, function_name)
+            {
+                Ok(_) => {
+                    return Err(AppError::FunctionAlreadyExists(function_name.to_string()));
+                }
+                Err(AppError::FunctionNotFound(_)) => {}
+                Err(error) => return Err(error),
+            }
+        }
         let installed = InstalledFunction {
             name: function_name.clone(),
         };
@@ -158,6 +175,23 @@ impl FunctionManager {
         }
 
         Ok(installed)
+    }
+
+    pub(crate) fn get_user_function_sql(
+        &self,
+        workspace_name: &WorkspaceName,
+        function_name: &FunctionName,
+    ) -> Result<String, AppError> {
+        let _state_lock = self.config_store.state_lock_shared()?;
+        self.config_store
+            .get_function_unlocked(workspace_name, function_name)?;
+        self.artifacts
+            .read_function_sql(workspace_name, function_name)?
+            .ok_or_else(|| {
+                AppError::FailedPrecondition(format!(
+                    "installed function '{function_name}' has no SQL artifact; remove and re-add the function"
+                ))
+            })
     }
 
     pub(crate) async fn validate_user_function_sql(

--- a/crates/coral-app/src/functions/service.rs
+++ b/crates/coral-app/src/functions/service.rs
@@ -4,8 +4,8 @@ use coral_api::v1::function_service_server::FunctionService as FunctionServiceAp
 use coral_api::v1::{
     AddFunctionRequest, AddFunctionResponse, DeleteFunctionRequest, DeleteFunctionResponse,
     Function, FunctionArgument, FunctionRuntimeInvalid, FunctionRuntimeReady,
-    FunctionTableFunctionPublish, ListFunctionsRequest, ListFunctionsResponse,
-    TableFunctionResultColumn, function,
+    FunctionTableFunctionPublish, GetFunctionRequest, GetFunctionResponse, ListFunctionsRequest,
+    ListFunctionsResponse, TableFunctionResultColumn, function,
 };
 use coral_engine::{UdfRuntimeDefinition, UdfRuntimeTableFunctionPublish};
 use tonic::{Request, Response, Status};
@@ -44,7 +44,7 @@ impl FunctionServiceApi for FunctionService {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
             let runtime_function = queries
-                .add_user_function(&workspace_name, &inner.sql)
+                .add_user_function(&workspace_name, &inner.sql, inner.fail_if_exists)
                 .await
                 .map_err(query_status)?;
             Ok(Response::new(AddFunctionResponse {
@@ -71,6 +71,25 @@ impl FunctionServiceApi for FunctionService {
                 .map(|listing| function_listing_to_proto(&workspace_name, listing))
                 .collect();
             Ok(Response::new(ListFunctionsResponse { functions }))
+        })
+        .await
+    }
+
+    async fn get_function(
+        &self,
+        request: Request<GetFunctionRequest>,
+    ) -> Result<Response<GetFunctionResponse>, Status> {
+        let span = grpc_span(&request);
+        let queries = self.queries.clone();
+        instrument_grpc(span, async move {
+            let inner = request.into_inner();
+            let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            let function_name = FunctionName::parse(&inner.name).map_err(app_status)?;
+            let sql = queries
+                .function_manager()
+                .get_user_function_sql(&workspace_name, &function_name)
+                .map_err(app_status)?;
+            Ok(Response::new(GetFunctionResponse { sql }))
         })
         .await
     }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -753,6 +753,7 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         raw_sql: &str,
+        fail_if_exists: bool,
     ) -> Result<UdfRuntimeDefinition, QueryManagerError> {
         for _ in 0..2 {
             let revision = self.lifecycle_lock.snapshot().revision();
@@ -779,6 +780,7 @@ impl QueryManager {
                     raw_sql,
                     &runtime_function,
                     revision,
+                    fail_if_exists,
                 )
                 .map_err(QueryManagerError::App)?
             {
@@ -1123,6 +1125,7 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::Unauthenticated(_) => "UNAUTHENTICATED",
         AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
         AppError::FunctionNotFound(_) => "FUNCTION_NOT_FOUND",
+        AppError::FunctionAlreadyExists(_) => "FUNCTION_ALREADY_EXISTS",
         AppError::WorkspaceNotFound(_) => "WORKSPACE_NOT_FOUND",
         AppError::WorkspaceAlreadyExists(_) => "WORKSPACE_ALREADY_EXISTS",
         AppError::InvalidInput(_) => "INVALID_INPUT",
@@ -2226,7 +2229,7 @@ select text from function_demo.messages
 
         let error = fixture
             .manager
-            .add_user_function(&workspace_name, function_sql)
+            .add_user_function(&workspace_name, function_sql, false)
             .await
             .expect_err("source change should invalidate the original validation snapshot");
 

--- a/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/function_lifecycle_tests.rs
@@ -1,6 +1,6 @@
 use coral_api::v1::{
-    AddFunctionRequest, CreateWorkspaceRequest, DeleteFunctionRequest, ListFunctionsRequest,
-    Workspace, function,
+    AddFunctionRequest, CreateWorkspaceRequest, DeleteFunctionRequest, GetFunctionRequest,
+    ListFunctionsRequest, Workspace, function,
 };
 use coral_client::default_workspace;
 use tonic::Request;
@@ -26,23 +26,61 @@ description: Echo one value
     )
 }
 
+async fn create_workspace(harness: &GrpcHarness, workspace: &Workspace) {
+    harness
+        .workspace_client()
+        .create_workspace(Request::new(CreateWorkspaceRequest {
+            workspace: Some(workspace.clone()),
+        }))
+        .await
+        .expect("create workspace");
+}
+
+async fn get_function_sql(harness: &GrpcHarness, workspace: &Workspace) -> String {
+    harness
+        .function_client()
+        .get_function(Request::new(GetFunctionRequest {
+            workspace: Some(workspace.clone()),
+            name: "echo_value".to_string(),
+        }))
+        .await
+        .expect("get function")
+        .into_inner()
+        .sql
+}
+
+async fn assert_create_only_rejects_existing(
+    harness: &GrpcHarness,
+    workspace: &Workspace,
+    expected_sql: &str,
+) {
+    let duplicate = harness
+        .function_client()
+        .add_function(Request::new(AddFunctionRequest {
+            fail_if_exists: true,
+            workspace: Some(workspace.clone()),
+            sql: function_sql("select 'replacement' as value"),
+        }))
+        .await
+        .expect_err("create-only add should reject an existing function");
+    assert_eq!(duplicate.code(), tonic::Code::AlreadyExists);
+
+    assert_eq!(get_function_sql(harness, workspace).await, expected_sql);
+}
+
 #[tokio::test]
 async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
     let harness = GrpcHarness::new().await;
     let work = workspace("work");
-    harness
-        .workspace_client()
-        .create_workspace(Request::new(CreateWorkspaceRequest {
-            workspace: Some(work.clone()),
-        }))
-        .await
-        .expect("create workspace");
+    create_workspace(&harness, &work).await;
 
+    let original_sql = function_sql("select cast($value as VARCHAR) as value");
     let added = harness
         .function_client()
         .add_function(Request::new(AddFunctionRequest {
+            fail_if_exists: false,
             workspace: Some(work.clone()),
-            sql: function_sql("select cast($value as VARCHAR) as value"),
+            sql: original_sql.clone(),
         }))
         .await
         .expect("add function")
@@ -52,6 +90,20 @@ async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
     assert_eq!(added.name, "echo_value");
     assert_eq!(added.workspace.as_ref(), Some(&work));
     assert!(matches!(added.runtime, Some(function::Runtime::Ready(_))));
+
+    assert_eq!(get_function_sql(&harness, &work).await, original_sql);
+
+    assert_create_only_rejects_existing(&harness, &work, &original_sql).await;
+
+    let missing_from_default = harness
+        .function_client()
+        .get_function(Request::new(GetFunctionRequest {
+            workspace: Some(default_workspace()),
+            name: "echo_value".to_string(),
+        }))
+        .await
+        .expect_err("function should stay scoped to work workspace");
+    assert_eq!(missing_from_default.code(), tonic::Code::NotFound);
 
     let default_functions = harness
         .function_client()
@@ -74,6 +126,23 @@ async fn function_lifecycle_is_scoped_to_the_selected_workspace() {
         .into_inner()
         .functions;
     assert_eq!(work_functions.len(), 1);
+
+    let updated_sql = function_sql("select upper(cast($value as VARCHAR)) as value");
+    let updated = harness
+        .function_client()
+        .add_function(Request::new(AddFunctionRequest {
+            fail_if_exists: false,
+            workspace: Some(work.clone()),
+            sql: updated_sql.clone(),
+        }))
+        .await
+        .expect("replace function")
+        .into_inner()
+        .function
+        .expect("updated function");
+    assert_eq!(updated.name, "echo_value");
+
+    assert_eq!(get_function_sql(&harness, &work).await, updated_sql);
 
     harness
         .function_client()
@@ -103,6 +172,7 @@ async fn untyped_function_is_not_persisted() {
     let error = harness
         .function_client()
         .add_function(Request::new(AddFunctionRequest {
+            fail_if_exists: false,
             workspace: Some(default_workspace()),
             sql: function_sql("select $value as value"),
         }))

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -240,6 +240,7 @@ async fn search_and_list_catalog_share_installed_udf_metadata() {
     harness
         .function_client()
         .add_function(Request::new(AddFunctionRequest {
+            fail_if_exists: false,
             workspace: Some(workspace.clone()),
             sql: review_queue_function_sql(),
         }))
@@ -290,6 +291,7 @@ async fn natural_language_review_queue_query_ranks_installed_udf_in_top_three() 
     harness
         .function_client()
         .add_function(Request::new(AddFunctionRequest {
+            fail_if_exists: false,
             workspace: Some(default_workspace()),
             sql: review_queue_function_sql(),
         }))

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -1157,6 +1157,7 @@ async fn run_function(
             let mut client = app.function_client();
             let function = client
                 .add_function(Request::new(AddFunctionRequest {
+                    fail_if_exists: false,
                     workspace: Some(workspace.clone()),
                     sql,
                 }))

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -29,21 +29,21 @@ use coral_api::v1::{
     DeleteWorkspaceRequest, DeleteWorkspaceResponse, DescribeTableRequest, DescribeTableResponse,
     DiscoverSourcesRequest, DiscoverSourcesResponse, DrainSearchQueueRequest,
     DrainSearchQueueResponse, ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest,
-    ExplainSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
-    GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListCatalogRequest,
-    ListCatalogResponse, ListColumnsRequest, ListColumnsResponse, ListFunctionsRequest,
-    ListFunctionsResponse, ListSourcesRequest, ListSourcesResponse, ListWorkspacesRequest,
-    ListWorkspacesResponse, ObservedDrainResult, ObservedRebuildResult, PaginationRequest,
-    PaginationResponse, QueryPlan, RebuildSearchIndexRequest, RebuildSearchIndexResponse,
-    SearchCatalogRequest, SearchCatalogResponse, SearchFieldRole, SearchMaintenanceResult,
-    SearchMaintenanceState, SearchProvider, SearchProviderCoverage, SearchProviderState,
-    SearchRequest, SearchResponse, SearchResult, SearchResultTruncation,
-    SearchStorageCleanupResult, SearchSurfaceKind, SearchTableColumnPreview,
-    SearchTableColumnPreviewColumn, Source, SourceCredentialStorage, SourceInfo, SourceInputSpec,
-    SourceOrigin, SourceSecretInput, Table, TableFunction, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, Workspace, catalog_item, create_bundled_source_with_o_auth_response,
-    import_source_response, search_maintenance_result, search_result,
-    source_input_spec::Input as ProtoSourceInput,
+    ExplainSqlResponse, GetFunctionRequest, GetFunctionResponse, GetSourceInfoRequest,
+    GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
+    ImportSourceResponse, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
+    ListColumnsResponse, ListFunctionsRequest, ListFunctionsResponse, ListSourcesRequest,
+    ListSourcesResponse, ListWorkspacesRequest, ListWorkspacesResponse, ObservedDrainResult,
+    ObservedRebuildResult, PaginationRequest, PaginationResponse, QueryPlan,
+    RebuildSearchIndexRequest, RebuildSearchIndexResponse, SearchCatalogRequest,
+    SearchCatalogResponse, SearchFieldRole, SearchMaintenanceResult, SearchMaintenanceState,
+    SearchProvider, SearchProviderCoverage, SearchProviderState, SearchRequest, SearchResponse,
+    SearchResult, SearchResultTruncation, SearchStorageCleanupResult, SearchSurfaceKind,
+    SearchTableColumnPreview, SearchTableColumnPreviewColumn, Source, SourceCredentialStorage,
+    SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableFunction,
+    TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
+    create_bundled_source_with_o_auth_response, import_source_response, search_maintenance_result,
+    search_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_TASK_ID_METADATA_KEY,
@@ -692,6 +692,7 @@ pub(crate) struct MockServerConfig {
     validate_source: MockResult<ValidateSourceResponse>,
     delete_source: MockResult<()>,
     add_function: MockResult<AddFunctionResponse>,
+    get_function: MockResult<GetFunctionResponse>,
     list_functions: MockResult<ListFunctionsResponse>,
     delete_function: MockResult<()>,
 }
@@ -733,6 +734,7 @@ impl Default for MockServerConfig {
             validate_source: MockResult::ok(mock_validate_response()),
             delete_source: MockResult::ok(()),
             add_function: MockResult::ok(AddFunctionResponse { function: None }),
+            get_function: MockResult::ok(GetFunctionResponse { sql: String::new() }),
             list_functions: MockResult::ok(ListFunctionsResponse {
                 functions: Vec::new(),
             }),
@@ -772,6 +774,11 @@ impl MockServerConfig {
 
     pub(crate) fn with_add_function(mut self, response: AddFunctionResponse) -> Self {
         self.add_function = MockResult::ok(response);
+        self
+    }
+
+    pub(crate) fn with_get_function(mut self, response: GetFunctionResponse) -> Self {
+        self.get_function = MockResult::ok(response);
         self
     }
 
@@ -880,6 +887,7 @@ struct Captured {
     delete_source: Mutex<Vec<DeleteSourceRequest>>,
     validate_source: Mutex<Vec<ValidateSourceRequest>>,
     add_function: Mutex<Vec<AddFunctionRequest>>,
+    get_function: Mutex<Vec<GetFunctionRequest>>,
     list_functions: Mutex<Vec<ListFunctionsRequest>>,
     remove_function: Mutex<Vec<DeleteFunctionRequest>>,
     list_workspaces: Mutex<Vec<ListWorkspacesRequest>>,
@@ -1210,6 +1218,22 @@ impl FunctionService for MockFunctionService {
             .push(request.into_inner());
         self.config
             .add_function
+            .clone()
+            .into_tonic_result()
+            .map(Response::new)
+    }
+
+    async fn get_function(
+        &self,
+        request: Request<GetFunctionRequest>,
+    ) -> Result<Response<GetFunctionResponse>, Status> {
+        self.captured
+            .get_function
+            .lock()
+            .expect("get_function capture")
+            .push(request.into_inner());
+        self.config
+            .get_function
             .clone()
             .into_tonic_result()
             .map(Response::new)
@@ -1666,6 +1690,14 @@ impl MockServer {
             .add_function
             .lock()
             .expect("add_function capture")
+            .clone()
+    }
+
+    pub(crate) fn get_function_requests(&self) -> Vec<GetFunctionRequest> {
+        self.captured
+            .get_function
+            .lock()
+            .expect("get_function capture")
             .clone()
     }
 


### PR DESCRIPTION
## Intent

https://cleanshot.com/share/qJQJRFDm

Add function management to the Desktop app so users can create, inspect, edit, and delete workspace-scoped SQL functions without using the deprecated embedded UI.

## What Changed

- Add a Desktop/ Reef Functions route, sidebar entry, list, create/edit/delete dialogs, individual frontmatter fields, and live SQL syntax highlighting.
- Keep Coral access behind React Router loaders/actions and preserve authored SQL frontmatter when editing.
- Add `GetFunction` for retrieving the authored artifact and a create-only `fail_if_exists` option for race-free creation.
- Surface invalid functions in inventory while keeping execution fail-closed.

## Ownership / Boundaries

- `apps/reef` owns the Desktop UI and server-side route wiring.
- `coral-api` owns the gRPC contract.
- `coral-app` owns workspace-scoped function lifecycle, atomic collision checks, and structured errors.
- Existing `AddFunction` replacement behavior remains the edit path; this does not add an `UpdateFunction` RPC.

## Compatibility / User Impact

- Existing callers retain replace-by-default behavior because `fail_if_exists` defaults to false.
- New creates return `ALREADY_EXISTS` atomically instead of overwriting an existing function.
- The deprecated `apps/ui` surface is unchanged.

## Not in This PR

- Function execution or planner changes.
- A separate update RPC.
- Removal of the deprecated embedded UI.

## Validation

- `make rust-checks` — 2,029 tests passed; clippy, fmt, and rustdoc clean.
- `npm run check --prefix apps/reef`
- `npm run typecheck --prefix apps/reef`
- `npm test --prefix apps/reef` — 425 tests passed.
- `npm run build --prefix apps/reef`
- `npm run check --prefix apps/desktop`
- `npm test --prefix apps/desktop` — 16 tests passed.
- Structured autoreview was clean before the final rebase; the rebased route conflict was limited to preserving both route constants and all post-rebase repository gates pass.