### PR TITLE
feat(reef): handle Coral connection failures

### DIFF
--- a/apps/coral-ui/app/lib/coral-endpoint.server.ts
+++ b/apps/coral-ui/app/lib/coral-endpoint.server.ts
@@ -1,3 +1,5 @@
+import { Code, ConnectError } from '@connectrpc/connect'
+
 import { DEFAULT_DEV_CORAL_ENDPOINT, DEFAULT_DEV_CORAL_PORT } from './constants'
 import { isExplicitLoopbackUrl } from './loopback.server'
 import { trimTrailingSlash } from './utils'
@@ -22,7 +24,12 @@ export function resolveCoralEndpoint({
   if (!configured) {
     if (authenticated)
       throw new Error('CORAL_ENDPOINT must be set when Coral authentication is enabled')
-    if (env.NODE_ENV === 'production') throw new Error('CORAL_ENDPOINT must be set in production')
+    if (env.NODE_ENV === 'production') {
+      // Unavailable, not a plain Error: a Coral UI deployed without a Coral
+      // endpoint has no Coral to reach, so it renders the Coral-unavailable
+      // boundary alongside every other failure to reach Coral.
+      throw new ConnectError('CORAL_ENDPOINT must be set in production', Code.Unavailable)
+    }
 
     const requestUrl = new URL(request.url)
     return policy(

--- a/apps/coral-ui/app/lib/coral-request-transport.server.test.ts
+++ b/apps/coral-ui/app/lib/coral-request-transport.server.test.ts
@@ -1,0 +1,29 @@
+import { Code, ConnectError } from '@connectrpc/connect'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { guiOnboardingClientForRequest } from './coral-request.server'
+import { isCoralUnavailableError } from './coral-unavailable'
+
+// Kept out of `coral-request.server.test.ts`: that file mocks the Connect
+// transport away, and this case needs the real one so the connection it opens
+// actually fails.
+const request = new Request('http://coral-ui.test/onboarding')
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+it('classifies connection failures as unavailable', async () => {
+  vi.stubEnv('CORAL_UI_AUTH_MODE', 'disabled')
+  // Port 1 is privileged and unbound, so the connection is refused rather than
+  // left to time out.
+  vi.stubEnv('CORAL_ENDPOINT', 'http://127.0.0.1:1')
+
+  const error = await guiOnboardingClientForRequest(request, null)
+    .getGuiOnboardingState({})
+    .catch((caught) => caught)
+
+  expect(error).toBeInstanceOf(ConnectError)
+  expect(error).toMatchObject({ code: Code.Unavailable })
+  expect(isCoralUnavailableError(error)).toBe(true)
+})

--- a/apps/coral-ui/app/lib/coral-unavailable.server.ts
+++ b/apps/coral-ui/app/lib/coral-unavailable.server.ts
@@ -1,0 +1,20 @@
+import { data } from 'react-router'
+
+import {
+  CORAL_UNAVAILABLE_STATUS,
+  CORAL_UNAVAILABLE_STATUS_TEXT,
+  isCoralUnavailableError,
+} from './coral-unavailable'
+
+// React Router converts loader failures into rendered responses before route
+// middleware regains control. Call this from the loader catch itself so the
+// typed 503 survives production error sanitization and reaches the boundary.
+export function rethrowAsCoralUnavailableRouteError(request: Request, error: unknown): never {
+  if (request.signal.aborted || !isCoralUnavailableError(error)) throw error
+
+  console.error('Coral request failed:', error)
+  throw data(null, {
+    status: CORAL_UNAVAILABLE_STATUS,
+    statusText: CORAL_UNAVAILABLE_STATUS_TEXT,
+  })
+}

--- a/apps/coral-ui/app/lib/coral-unavailable.ts
+++ b/apps/coral-ui/app/lib/coral-unavailable.ts
@@ -1,0 +1,8 @@
+import { Code, ConnectError } from '@connectrpc/connect'
+
+export const CORAL_UNAVAILABLE_STATUS = 503
+export const CORAL_UNAVAILABLE_STATUS_TEXT = 'Coral unavailable'
+
+export function isCoralUnavailableError(error: unknown): boolean {
+  return error instanceof ConnectError && error.code === Code.Unavailable
+}

--- a/apps/coral-ui/app/root.css.ts
+++ b/apps/coral-ui/app/root.css.ts
@@ -1,0 +1,9 @@
+import { style } from '@vanilla-extract/css'
+
+import { theme } from '@/wax/theme/theme.css'
+
+export const unavailable = style({
+  background: theme.surface.mainContent,
+  display: 'flex',
+  minHeight: '100dvh',
+})

--- a/apps/coral-ui/app/root.tsx
+++ b/apps/coral-ui/app/root.tsx
@@ -1,4 +1,12 @@
-import { isRouteErrorResponse, Links, Meta, Outlet, Scripts, ScrollRestoration } from 'react-router'
+import {
+  isRouteErrorResponse,
+  Links,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+  useRevalidator,
+} from 'react-router'
 
 import type { Route } from './+types/root'
 import {
@@ -6,7 +14,11 @@ import {
   readSidebarCollapsedCookieValue,
 } from './components/sidebar/sidebar-state'
 import { NavigationProgressBar } from './components/navigation-progress-bar'
+import { EmptyPage } from './components/empty-page'
+import { CORAL_UNAVAILABLE_STATUS, CORAL_UNAVAILABLE_STATUS_TEXT } from './lib/coral-unavailable'
+import * as styles from './root.css'
 import './styles/globals.css'
+import { Button } from './wax/components'
 import './wax/theme/global.css'
 import { darkTheme } from './wax/theme/theme-dark.css'
 import { lightTheme } from './wax/theme/theme-light.css'
@@ -115,6 +127,12 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
   let stack: string | undefined
 
   if (isRouteErrorResponse(error)) {
+    if (
+      error.status === CORAL_UNAVAILABLE_STATUS &&
+      error.statusText === CORAL_UNAVAILABLE_STATUS_TEXT
+    ) {
+      return <CoralUnavailableRouteError />
+    }
     message = error.status === 404 ? '404' : 'Error'
     details =
       error.status === 404 ? 'The requested page could not be found.' : error.statusText || details
@@ -132,6 +150,29 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
           <code>{stack}</code>
         </pre>
       )}
+    </main>
+  )
+}
+
+function CoralUnavailableRouteError() {
+  const revalidator = useRevalidator()
+
+  return <CoralUnavailable onRetry={() => revalidator.revalidate()} />
+}
+
+export function CoralUnavailable({ onRetry }: { onRetry: () => void }) {
+  return (
+    <main className={styles.unavailable}>
+      <EmptyPage
+        action={
+          <Button.TextButton onClick={onRetry} variant="secondary">
+            Retry
+          </Button.TextButton>
+        }
+        description="Couldn't connect to Coral. Check that Coral is installed and try again."
+        iconName="CircleAlert"
+        title="Coral is unavailable"
+      />
     </main>
   )
 }

--- a/apps/coral-ui/app/routes/app-shell.tsx
+++ b/apps/coral-ui/app/routes/app-shell.tsx
@@ -5,6 +5,8 @@ import type { Route } from './+types/app-shell'
 import { ContentContainer } from '@/components/content-container'
 import { Sidebar } from '@/components/sidebar'
 import { requestAuthContext } from '@/auth/server-context'
+import { rethrowAsCoralUnavailableRouteError } from '@/lib/coral-unavailable.server'
+import { isCoralUnavailableError } from '@/lib/coral-unavailable'
 import { listWorkspacesForRequest } from '@/lib/workspaces.server'
 import { routePath } from '@/routing/routemap'
 import { ToastContainer } from '@/wax/components/toast'
@@ -30,6 +32,10 @@ export async function loader({ context, request }: Route.LoaderArgs) {
     }
   } catch (error) {
     if (error instanceof Response) throw error
+    if (isCoralUnavailableError(error)) {
+      rethrowAsCoralUnavailableRouteError(request, error)
+    }
+
     console.error('Failed to load sidebar workspaces:', error)
     return { auth, workspaces: [] }
   }

--- a/apps/coral-ui/app/routes/index.tsx
+++ b/apps/coral-ui/app/routes/index.tsx
@@ -3,14 +3,19 @@ import type { Route } from './+types/index'
 import { replace } from 'react-router'
 
 import { requestAuthContext } from '@/auth/server-context'
+import { rethrowAsCoralUnavailableRouteError } from '@/lib/coral-unavailable.server'
 import { getGuiOnboardingCompleted } from '@/lib/gui-onboarding.server'
 import { redirectToFirstWorkspaceTraces } from '@/lib/workspace-redirect.server'
 
 export async function loader({ context, request }: Route.LoaderArgs) {
   const accessToken = context.get(requestAuthContext).accessToken
-  if (!(await getGuiOnboardingCompleted(request, accessToken))) return replace('/onboarding')
+  try {
+    if (!(await getGuiOnboardingCompleted(request, accessToken))) return replace('/onboarding')
 
-  return redirectToFirstWorkspaceTraces(request, accessToken)
+    return await redirectToFirstWorkspaceTraces(request, accessToken)
+  } catch (error) {
+    rethrowAsCoralUnavailableRouteError(request, error)
+  }
 }
 
 export default function AppIndex() {

--- a/apps/coral-ui/app/routes/onboarding.server.test.ts
+++ b/apps/coral-ui/app/routes/onboarding.server.test.ts
@@ -1,6 +1,7 @@
 import { create } from '@bufbuild/protobuf'
+import { Code, ConnectError } from '@connectrpc/connect'
 import { createMemoryRouter, redirect } from 'react-router'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   completeGuiOnboarding,
@@ -123,6 +124,10 @@ describe('onboarding route authentication', () => {
 })
 
 describe('onboarding server route', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('replaces completed users directly into the normal app before loading onboarding data', async () => {
     getGuiOnboardingCompleted.mockResolvedValue(true)
     const request = new Request('http://coral-ui.test/onboarding')
@@ -171,6 +176,19 @@ describe('onboarding server route', () => {
     } finally {
       router.dispose()
     }
+  })
+
+  it('maps an unavailable completion-state lookup before React Router consumes it', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    getGuiOnboardingCompleted.mockRejectedValue(new ConnectError('sidecar down', Code.Unavailable))
+    const request = new Request('http://coral-ui.test/onboarding')
+
+    const caught = await loader(authRouteTestArgs(request, {}, null)).catch((thrown) => thrown)
+
+    expect(caught).toMatchObject({
+      data: null,
+      init: { status: 503, statusText: 'Coral unavailable' },
+    })
   })
 
   it('persists completion before redirecting to the normal app', async () => {

--- a/apps/coral-ui/app/routes/onboarding.tsx
+++ b/apps/coral-ui/app/routes/onboarding.tsx
@@ -5,6 +5,7 @@ import { replace, useFetcher } from 'react-router'
 import { requestAuthContext } from '@/auth/server-context'
 import { getOnboardingStepState } from '@/components/onboarding/onboarding-steps'
 import { isCoralDesktopBuild } from '@/lib/coral-desktop'
+import { rethrowAsCoralUnavailableRouteError } from '@/lib/coral-unavailable.server'
 import { COMPLETE_ONBOARDING_INTENT } from '@/lib/gui-onboarding'
 import { getGuiOnboardingCompleted } from '@/lib/gui-onboarding.server'
 import { loadOnboardingSampleQuery } from '@/lib/onboarding-query.server'
@@ -24,36 +25,40 @@ import {
 
 export async function loader({ context, request }: Route.LoaderArgs) {
   const accessToken = context.get(requestAuthContext).accessToken
-  if (await getGuiOnboardingCompleted(request, accessToken)) {
-    const workspace = await firstWorkspaceForRequest(request, accessToken)
-    return replace(routePath('workspaceTraces', { workspaceId: workspace.name }))
-  }
+  try {
+    if (await getGuiOnboardingCompleted(request, accessToken)) {
+      const workspace = await firstWorkspaceForRequest(request, accessToken)
+      return replace(routePath('workspaceTraces', { workspaceId: workspace.name }))
+    }
 
-  const workspaces = await listWorkspacesForRequest(request, accessToken)
-  const [workspace] = workspaces
-  if (!workspace) {
-    throw new Response('No Coral workspace is configured.', {
-      status: 404,
-      statusText: 'Workspace Not Found',
-    })
-  }
+    const workspaces = await listWorkspacesForRequest(request, accessToken)
+    const [workspace] = workspaces
+    if (!workspace) {
+      throw new Response('No Coral workspace is configured.', {
+        status: 404,
+        statusText: 'Workspace Not Found',
+      })
+    }
 
-  const sources = await loadSourcesRouteData(request, workspace, accessToken)
-  const step = getOnboardingStepState(new URL(request.url).searchParams.get('step'))
-  const shouldRunSampleQuery =
-    step.step === 'query' &&
-    sources.loadError === null &&
-    sources.entries.some((entry) => entry.installed)
+    const sources = await loadSourcesRouteData(request, workspace, accessToken)
+    const step = getOnboardingStepState(new URL(request.url).searchParams.get('step'))
+    const shouldRunSampleQuery =
+      step.step === 'query' &&
+      sources.loadError === null &&
+      sources.entries.some((entry) => entry.installed)
 
-  return {
-    ...sources,
-    runtime: isCoralDesktopBuild() ? ('desktop' as const) : ('web' as const),
-    sampleQuery: shouldRunSampleQuery
-      ? loadOnboardingSampleQuery(request, accessToken, workspace.name)
-      : null,
-    step,
-    workspaceId: workspace.name,
-    workspaces: workspaces.map(({ name }) => ({ name })),
+    return {
+      ...sources,
+      runtime: isCoralDesktopBuild() ? ('desktop' as const) : ('web' as const),
+      sampleQuery: shouldRunSampleQuery
+        ? loadOnboardingSampleQuery(request, accessToken, workspace.name)
+        : null,
+      step,
+      workspaceId: workspace.name,
+      workspaces: workspaces.map(({ name }) => ({ name })),
+    }
+  } catch (error) {
+    rethrowAsCoralUnavailableRouteError(request, error)
   }
 }
 

--- a/apps/coral-ui/app/routes/source-oauth-install.ts
+++ b/apps/coral-ui/app/routes/source-oauth-install.ts
@@ -41,8 +41,11 @@ export async function action({ context, params, request }: Route.ActionArgs): Pr
     return oauthStreamErrorResponse(errorMessage(error), 400)
   }
 
-  const sourceClient = sourceClientForRequest(request, context.get(requestAuthContext).accessToken)
   try {
+    const sourceClient = sourceClientForRequest(
+      request,
+      context.get(requestAuthContext).accessToken,
+    )
     const workspace = workspaceFromParams(params)
     const info = await getSourceInfo(sourceClient, name, workspace)
     if (info.installed && originLabel(info.origin) !== 'bundled') {

--- a/apps/coral-ui/app/routes/sources-action.ts
+++ b/apps/coral-ui/app/routes/sources-action.ts
@@ -84,8 +84,8 @@ export async function runSourcesAction(
   const name = formValue(formData, 'name')
   if (!name) return actionError('install', '', 'Missing source name')
 
-  const sourceClient = sourceClientForRequest(request, accessToken)
   try {
+    const sourceClient = sourceClientForRequest(request, accessToken)
     if (intent === 'install') {
       const info = await getSourceInfo(sourceClient, workspace, name)
       if (info.installed && originLabel(info.origin) !== 'bundled') {


### PR DESCRIPTION
## Summary

Gently handle Coral failures, showing a full page error with retry button rather than crashing with a 5xx error

## Test plan

<img width="576" height="305" alt="image" src="https://github.com/user-attachments/assets/86424865-2f50-4632-a16b-126a20d7f5d4" />
